### PR TITLE
test(core): add unit tests for core modules (batch 2)

### DIFF
--- a/tests/core/audit.test.ts
+++ b/tests/core/audit.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/core/antfly', () => ({
+  indexAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { appendAudit } from '../../src/core/audit'
+import { indexAuditEvent } from '../../src/core/antfly'
+
+describe('audit', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bakin-audit-'))
+    vi.clearAllMocks()
+    delete (globalThis as any).__bakinBroadcastAudit
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // ---------------------------------------------------------------------------
+  // appendAudit — file writing
+  // ---------------------------------------------------------------------------
+
+  describe('file writing', () => {
+    it('creates audit.jsonl and writes a JSONL entry', () => {
+      appendAudit(tempDir, 'test.event', 'pixel', { foo: 'bar' })
+
+      const auditFile = join(tempDir, 'audit.jsonl')
+      expect(existsSync(auditFile)).toBe(true)
+
+      const line = readFileSync(auditFile, 'utf-8').trim()
+      const entry = JSON.parse(line)
+      expect(entry.event).toBe('test.event')
+      expect(entry.agent).toBe('pixel')
+      expect(entry.data).toEqual({ foo: 'bar' })
+      expect(entry.ts).toBeDefined()
+    })
+
+    it('appends multiple entries as separate lines', () => {
+      appendAudit(tempDir, 'event.a', 'pixel')
+      appendAudit(tempDir, 'event.b', 'nemo')
+
+      const lines = readFileSync(join(tempDir, 'audit.jsonl'), 'utf-8')
+        .trim()
+        .split('\n')
+      expect(lines).toHaveLength(2)
+      expect(JSON.parse(lines[0]).event).toBe('event.a')
+      expect(JSON.parse(lines[1]).event).toBe('event.b')
+    })
+
+    it('defaults data to empty object', () => {
+      appendAudit(tempDir, 'no.data', 'pixel')
+
+      const line = readFileSync(join(tempDir, 'audit.jsonl'), 'utf-8').trim()
+      const entry = JSON.parse(line)
+      expect(entry.data).toEqual({})
+    })
+
+    it('includes channel when provided', () => {
+      appendAudit(tempDir, 'with.channel', 'pixel', { x: 1 }, 'mcp')
+
+      const line = readFileSync(join(tempDir, 'audit.jsonl'), 'utf-8').trim()
+      const entry = JSON.parse(line)
+      expect(entry.channel).toBe('mcp')
+    })
+
+    it('omits channel field when not provided', () => {
+      appendAudit(tempDir, 'no.channel', 'pixel')
+
+      const line = readFileSync(join(tempDir, 'audit.jsonl'), 'utf-8').trim()
+      const entry = JSON.parse(line)
+      expect(entry).not.toHaveProperty('channel')
+    })
+
+    it('creates parent directories if they do not exist', () => {
+      const nested = join(tempDir, 'deep', 'nested')
+      appendAudit(nested, 'nested.event', 'pixel')
+      expect(existsSync(join(nested, 'audit.jsonl'))).toBe(true)
+    })
+
+    it('does not throw on write failure', () => {
+      // Pass a path that can't be written (file as dir)
+      const badPath = join(tempDir, 'audit.jsonl', 'impossible')
+      expect(() => appendAudit(badPath, 'fail', 'pixel')).not.toThrow()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // SSE broadcast via globalThis
+  // ---------------------------------------------------------------------------
+
+  describe('SSE broadcast', () => {
+    it('calls globalThis.__bakinBroadcastAudit when set', () => {
+      const broadcastFn = vi.fn()
+      ;(globalThis as any).__bakinBroadcastAudit = broadcastFn
+
+      appendAudit(tempDir, 'sse.test', 'pixel', { key: 'value' })
+
+      expect(broadcastFn).toHaveBeenCalledOnce()
+      const entry = broadcastFn.mock.calls[0][0]
+      expect(entry.event).toBe('sse.test')
+      expect(entry.agent).toBe('pixel')
+      expect(entry.data).toEqual({ key: 'value' })
+    })
+
+    it('does not throw when broadcast is not available', () => {
+      delete (globalThis as any).__bakinBroadcastAudit
+      expect(() => appendAudit(tempDir, 'no.sse', 'pixel')).not.toThrow()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Antfly indexing
+  // ---------------------------------------------------------------------------
+
+  describe('Antfly indexing', () => {
+    it('calls indexAuditEvent with the entry', () => {
+      appendAudit(tempDir, 'antfly.test', 'nemo', { score: 42 })
+
+      expect(vi.mocked(indexAuditEvent)).toHaveBeenCalledOnce()
+      const entry = vi.mocked(indexAuditEvent).mock.calls[0][0]
+      expect(entry.event).toBe('antfly.test')
+      expect(entry.agent).toBe('nemo')
+      expect(entry.data).toEqual({ score: 42 })
+    })
+
+    it('does not throw when indexAuditEvent rejects', () => {
+      vi.mocked(indexAuditEvent).mockRejectedValueOnce(new Error('antfly down'))
+      expect(() => appendAudit(tempDir, 'antfly.fail', 'pixel')).not.toThrow()
+    })
+  })
+})

--- a/tests/core/continuation.test.ts
+++ b/tests/core/continuation.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+vi.mock('../../src/core/openclaw-client', () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Mock the taskboard module that gets dynamically imported
+// The source imports from '../lib/taskboard' which resolves to src/lib/taskboard
+// which re-exports from plugins/tasks/lib/taskboard — mock both paths
+const mockReadAllColumns = vi.fn()
+const mockClearDependency = vi.fn().mockResolvedValue(undefined)
+const mockAddTaskLog = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../../src/lib/taskboard', () => ({
+  readAllColumns: mockReadAllColumns,
+  clearDependency: mockClearDependency,
+  addTaskLog: mockAddTaskLog,
+}))
+
+import { checkAndContinueDependents } from '../../src/core/continuation'
+import { appendAudit } from '../../src/core/audit'
+import * as openclaw from '../../src/core/openclaw-client'
+
+describe('continuation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function mockColumns(columns: { todo?: any[]; inProgress?: any[]; blocked?: any[]; done?: any[] }) {
+    mockReadAllColumns.mockReturnValue({
+      todo: columns.todo || [],
+      inProgress: columns.inProgress || [],
+      blocked: columns.blocked || [],
+      done: columns.done || [],
+    })
+  }
+
+  it('does nothing when no tasks depend on completed task', async () => {
+    mockColumns({
+      todo: [{ id: 't1', title: 'Unrelated', agent: 'pixel' }],
+      inProgress: [],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+    expect(vi.mocked(openclaw.sendMessage)).not.toHaveBeenCalled()
+  })
+
+  it('dispatches continuation to dependent task in todo', async () => {
+    mockColumns({
+      todo: [{ id: 't2', title: 'Waiting Task', agent: 'pixel', dependsOn: 'completed-1' }],
+      inProgress: [],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    expect(vi.mocked(openclaw.sendMessage)).toHaveBeenCalledWith(
+      'pixel',
+      expect.stringContaining('Done Task'),
+    )
+
+    expect(mockClearDependency).toHaveBeenCalledWith('t2')
+  })
+
+  it('maps roscoe agent to main for OpenClaw', async () => {
+    mockColumns({
+      todo: [{ id: 't3', title: 'Roscoe Task', agent: 'roscoe', dependsOn: 'completed-1' }],
+      inProgress: [],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    expect(vi.mocked(openclaw.sendMessage)).toHaveBeenCalledWith(
+      'main',
+      expect.any(String),
+    )
+  })
+
+  it('defaults to main agent when task has no agent', async () => {
+    mockColumns({
+      todo: [{ id: 't4', title: 'No Agent', dependsOn: 'completed-1' }],
+      inProgress: [],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    expect(vi.mocked(openclaw.sendMessage)).toHaveBeenCalledWith('main', expect.any(String))
+  })
+
+  it('skips task already in progress (dedup)', async () => {
+    mockColumns({
+      inProgress: [{ id: 't5', title: 'Already Running', agent: 'pixel', dependsOn: 'completed-1' }],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    expect(vi.mocked(openclaw.sendMessage)).not.toHaveBeenCalled()
+    expect(mockClearDependency).toHaveBeenCalledWith('t5')
+  })
+
+  it('scans blocked column for dependents', async () => {
+    mockColumns({
+      todo: [],
+      inProgress: [],
+      blocked: [{ id: 't6', title: 'Blocked Task', agent: 'nemo', dependsOn: 'completed-1' }],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    expect(vi.mocked(openclaw.sendMessage)).toHaveBeenCalledWith('nemo', expect.any(String))
+  })
+
+  it('writes audit entry after dispatching', async () => {
+    mockColumns({
+      todo: [{ id: 't7', title: 'Audit Task', agent: 'pixel', dependsOn: 'completed-1' }],
+      inProgress: [],
+    })
+
+    await checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    expect(vi.mocked(appendAudit)).toHaveBeenCalledWith(
+      '/tmp/test',
+      'task.continuation',
+      'pixel',
+      expect.objectContaining({ id: 't7', sent: true, completedDep: 'completed-1' }),
+    )
+  })
+
+  it('retries on sendMessage failure and logs failure after max retries', async () => {
+    mockColumns({
+      todo: [{ id: 't8', title: 'Retry Task', agent: 'pixel', dependsOn: 'completed-1' }],
+      inProgress: [],
+    })
+
+    vi.mocked(openclaw.sendMessage).mockRejectedValue(new Error('unreachable'))
+    // Use real timers briefly for retry delays
+    vi.useFakeTimers()
+
+    const promise = checkAndContinueDependents('completed-1', 'Done Task', '/tmp/test', 3737)
+
+    // Advance through retry delays (3 retries × 5000ms)
+    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(5000)
+    await promise
+
+    // Should have attempted 3 times
+    expect(vi.mocked(openclaw.sendMessage)).toHaveBeenCalledTimes(3)
+
+    // Audit should show sent: false
+    expect(vi.mocked(appendAudit)).toHaveBeenCalledWith(
+      '/tmp/test',
+      'task.continuation',
+      'pixel',
+      expect.objectContaining({ sent: false }),
+    )
+
+    vi.useRealTimers()
+  })
+})

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/core/settings', () => ({
+  getSettings: vi.fn().mockReturnValue({
+    dispatch: {
+      intervalMs: 1000,
+      maxRetries: 3,
+      failureCooldownMs: 60000,
+      maxDispatched: 500,
+    },
+    agents: ['roscoe', 'pixel', 'nemo'],
+    watchdog: { stuckThresholdMs: 30 * 60 * 1000 },
+  }),
+}))
+
+vi.mock('../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+vi.mock('../../src/core/openclaw-client', () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../src/lib/plugin-registry', () => ({
+  getHookRegistry: vi.fn().mockReturnValue({
+    invoke: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockReturnValue(false),
+    register: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/lib/format', () => ({
+  isStale: vi.fn().mockReturnValue(true),
+}))
+
+import { loadDispatchState, start, stop, getDispatchInfo } from '../../src/core/dispatch'
+
+describe('dispatch', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bakin-dispatch-'))
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    stop()
+    vi.useRealTimers()
+    rmSync(tempDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // loadDispatchState
+  // -------------------------------------------------------------------------
+
+  describe('loadDispatchState', () => {
+    it('returns default state when no file exists', () => {
+      const state = loadDispatchState(tempDir)
+      expect(state.lastRun).toBeNull()
+      expect(state.dispatched).toEqual([])
+      expect(state.failedDispatches).toEqual({})
+      expect(state.serverStart).toBeGreaterThan(0)
+    })
+
+    it('reads existing state file', () => {
+      const stateFile = join(tempDir, '.dispatch-state.json')
+      writeFileSync(stateFile, JSON.stringify({
+        lastRun: 1000,
+        serverStart: 500,
+        dispatched: ['t1', 't2'],
+        failedDispatches: { t3: { lastAttempt: 900, count: 2 } },
+      }))
+
+      const state = loadDispatchState(tempDir)
+      expect(state.lastRun).toBe(1000)
+      expect(state.dispatched).toEqual(['t1', 't2'])
+      expect(state.failedDispatches.t3).toEqual({ lastAttempt: 900, count: 2 })
+    })
+
+    it('handles corrupted state file gracefully', () => {
+      writeFileSync(join(tempDir, '.dispatch-state.json'), '{ broken')
+      const state = loadDispatchState(tempDir)
+      expect(state.lastRun).toBeNull()
+      expect(state.dispatched).toEqual([])
+    })
+
+    it('normalizes missing dispatched array', () => {
+      writeFileSync(join(tempDir, '.dispatch-state.json'), JSON.stringify({
+        lastRun: 1000,
+        serverStart: 500,
+      }))
+
+      const state = loadDispatchState(tempDir)
+      expect(state.dispatched).toEqual([])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // start / stop
+  // -------------------------------------------------------------------------
+
+  describe('start and stop', () => {
+    it('starts dispatch timer', () => {
+      start(tempDir, 3737)
+      expect(() => vi.advanceTimersByTime(500)).not.toThrow()
+    })
+
+    it('stop clears the timer', () => {
+      start(tempDir, 3737)
+      stop()
+      expect(() => stop()).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getDispatchInfo
+  // -------------------------------------------------------------------------
+
+  describe('getDispatchInfo', () => {
+    it('returns dispatch info with no prior state', () => {
+      const info = getDispatchInfo(tempDir)
+      expect(info.intervalMs).toBe(1000)
+      expect(info.lastRun).toBeNull()
+      expect(info.dispatchedCount).toBe(0)
+      expect(info.secondsUntilNext).toBeGreaterThanOrEqual(0)
+    })
+
+    it('includes last run when state exists', () => {
+      const now = Date.now()
+      writeFileSync(join(tempDir, '.dispatch-state.json'), JSON.stringify({
+        lastRun: now - 500,
+        serverStart: now - 10000,
+        dispatched: ['t1'],
+        failedDispatches: {},
+      }))
+
+      const info = getDispatchInfo(tempDir)
+      expect(info.lastRun).not.toBeNull()
+      expect(info.dispatchedCount).toBe(1)
+    })
+
+    it('calculates next run in the future', () => {
+      const now = Date.now()
+      writeFileSync(join(tempDir, '.dispatch-state.json'), JSON.stringify({
+        lastRun: now - 5000, // 5 seconds ago, interval is 1s
+        serverStart: now - 10000,
+        dispatched: [],
+        failedDispatches: {},
+      }))
+
+      const info = getDispatchInfo(tempDir)
+      // secondsUntilNext should be > 0 (next tick in the future)
+      expect(info.secondsUntilNext).toBeGreaterThanOrEqual(0)
+    })
+  })
+})

--- a/tests/core/lifecycle.test.ts
+++ b/tests/core/lifecycle.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Server } from 'http'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+const mockAppendAudit = vi.fn()
+vi.mock('../../src/core/audit', () => ({
+  appendAudit: mockAppendAudit,
+}))
+
+const mockSseStop = vi.fn()
+vi.mock('../../src/core/sse', () => ({
+  stop: mockSseStop,
+}))
+
+const mockDispatchStop = vi.fn()
+vi.mock('../../src/core/dispatch', () => ({
+  stop: mockDispatchStop,
+}))
+
+const mockWatchdogStop = vi.fn()
+vi.mock('../../src/core/watchdog', () => ({
+  stop: mockWatchdogStop,
+}))
+
+const mockCalendarStop = vi.fn()
+vi.mock('../../src/core/calendar-cron', () => ({
+  stop: mockCalendarStop,
+}))
+
+const mockWatcherStop = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../src/core/watcher', () => ({
+  stop: mockWatcherStop,
+}))
+
+vi.mock('../../src/core/doctor', () => ({
+  stop: vi.fn(),
+}))
+
+vi.mock('../../src/core/antfly-server', () => ({
+  stop: vi.fn(),
+}))
+
+const mockShutdownAll = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../src/lib/plugin-registry', () => ({
+  pluginRegistry: {
+    shutdownAll: mockShutdownAll,
+  },
+}))
+
+describe('lifecycle', () => {
+  let processListeners: Record<string, Function>
+  let registerShutdownHandlers: typeof import('../../src/core/lifecycle').registerShutdownHandlers
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    processListeners = {}
+
+    vi.spyOn(process, 'on').mockImplementation((event: string | symbol, handler: any) => {
+      processListeners[event as string] = handler
+      return process
+    })
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    vi.useFakeTimers()
+
+    // Reset module to get fresh shutdownInProgress state
+    vi.resetModules()
+    const mod = await import('../../src/core/lifecycle')
+    registerShutdownHandlers = mod.registerShutdownHandlers
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function mockServer(): Server {
+    return { close: vi.fn((cb: () => void) => cb()) } as unknown as Server
+  }
+
+  it('registers SIGTERM and SIGINT handlers', () => {
+    registerShutdownHandlers(mockServer(), '/tmp/test')
+    expect(processListeners['SIGTERM']).toBeDefined()
+    expect(processListeners['SIGINT']).toBeDefined()
+  })
+
+  it('shutdown calls pluginRegistry.shutdownAll', async () => {
+    registerShutdownHandlers(mockServer(), '/tmp/test')
+    await processListeners['SIGTERM']()
+    expect(mockShutdownAll).toHaveBeenCalled()
+  })
+
+  it('shutdown stops dispatch, watchdog, calendar cron, watcher, and SSE', async () => {
+    registerShutdownHandlers(mockServer(), '/tmp/test')
+    await processListeners['SIGTERM']()
+
+    expect(mockDispatchStop).toHaveBeenCalled()
+    expect(mockWatchdogStop).toHaveBeenCalled()
+    expect(mockCalendarStop).toHaveBeenCalled()
+    expect(mockWatcherStop).toHaveBeenCalled()
+    expect(mockSseStop).toHaveBeenCalled()
+  })
+
+  it('shutdown closes the HTTP server', async () => {
+    const server = mockServer()
+    registerShutdownHandlers(server, '/tmp/test')
+    await processListeners['SIGTERM']()
+    expect(server.close).toHaveBeenCalled()
+  })
+
+  it('shutdown writes audit entry', async () => {
+    registerShutdownHandlers(mockServer(), '/tmp/test')
+    await processListeners['SIGINT']()
+    expect(mockAppendAudit).toHaveBeenCalledWith(
+      '/tmp/test',
+      'system.shutdown',
+      'system',
+      { signal: 'SIGINT' },
+    )
+  })
+
+  it('shutdown is idempotent — second signal is ignored', async () => {
+    registerShutdownHandlers(mockServer(), '/tmp/test')
+    await processListeners['SIGTERM']()
+    await processListeners['SIGTERM']()
+    expect(mockShutdownAll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/core/main-agent.test.ts
+++ b/tests/core/main-agent.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../packages/core/src/settings', () => ({
+  getSettings: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return { ...actual, readFileSync: vi.fn() }
+})
+
+import { getSettings } from '../../packages/core/src/settings'
+import { readFileSync } from 'fs'
+
+// Dynamic import to get fresh module per test
+let getMainAgentId: typeof import('../../packages/core/src/main-agent').getMainAgentId
+
+describe('main-agent', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.mocked(getSettings).mockReturnValue({} as any)
+    vi.mocked(readFileSync).mockImplementation(() => { throw new Error('ENOENT') })
+
+    const mod = await import('../../packages/core/src/main-agent')
+    getMainAgentId = mod.getMainAgentId
+  })
+
+  it('returns mainAgentId from settings when set', () => {
+    vi.mocked(getSettings).mockReturnValue({ mainAgentId: 'roscoe' } as any)
+    expect(getMainAgentId()).toBe('roscoe')
+  })
+
+  it('falls back to OpenClaw config when settings has no mainAgentId', () => {
+    vi.mocked(getSettings).mockReturnValue({} as any)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      agents: {
+        list: [{ id: 'main', identity: { name: 'Roscoe' } }],
+      },
+    }))
+    expect(getMainAgentId()).toBe('roscoe') // lowercased
+  })
+
+  it('returns "main" as final fallback', () => {
+    vi.mocked(getSettings).mockReturnValue({} as any)
+    vi.mocked(readFileSync).mockImplementation(() => { throw new Error('ENOENT') })
+    expect(getMainAgentId()).toBe('main')
+  })
+
+  it('returns "main" when OpenClaw has no main agent entry', () => {
+    vi.mocked(getSettings).mockReturnValue({} as any)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      agents: { list: [{ id: 'pixel' }] },
+    }))
+    expect(getMainAgentId()).toBe('main')
+  })
+
+  it('returns "main" when OpenClaw main agent has no identity.name', () => {
+    vi.mocked(getSettings).mockReturnValue({} as any)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      agents: { list: [{ id: 'main' }] },
+    }))
+    expect(getMainAgentId()).toBe('main')
+  })
+
+  it('prefers settings over OpenClaw', () => {
+    vi.mocked(getSettings).mockReturnValue({ mainAgentId: 'custom-agent' } as any)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      agents: { list: [{ id: 'main', identity: { name: 'Roscoe' } }] },
+    }))
+    expect(getMainAgentId()).toBe('custom-agent')
+  })
+
+  it('ignores empty string mainAgentId in settings', () => {
+    vi.mocked(getSettings).mockReturnValue({ mainAgentId: '' } as any)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      agents: { list: [{ id: 'main', identity: { name: 'Roscoe' } }] },
+    }))
+    expect(getMainAgentId()).toBe('roscoe')
+  })
+})

--- a/tests/core/middleware.test.ts
+++ b/tests/core/middleware.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Readable, PassThrough } from 'stream'
+import type { IncomingMessage, ServerResponse } from 'http'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+import {
+  parseJsonBody,
+  validateJsonContentType,
+  jsonResponse,
+  handleJsonPost,
+} from '../../src/core/middleware'
+
+/** Create a mock IncomingMessage from a string body. */
+function mockReq(opts: {
+  body?: string
+  method?: string
+  contentType?: string
+} = {}): IncomingMessage {
+  const stream = new PassThrough()
+  if (opts.body !== undefined) {
+    stream.end(opts.body)
+  } else {
+    stream.end()
+  }
+  const req = stream as unknown as IncomingMessage
+  req.method = opts.method || 'GET'
+  req.headers = {}
+  if (opts.contentType) req.headers['content-type'] = opts.contentType
+  return req
+}
+
+/** Create a mock ServerResponse that captures writeHead + end calls. */
+function mockRes() {
+  const res = {
+    writeHead: vi.fn(),
+    end: vi.fn(),
+  } as unknown as ServerResponse & { writeHead: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+  return res
+}
+
+describe('middleware', () => {
+  // -------------------------------------------------------------------------
+  // parseJsonBody
+  // -------------------------------------------------------------------------
+
+  describe('parseJsonBody', () => {
+    it('parses valid JSON body', async () => {
+      const req = mockReq({ body: '{"key":"value"}' })
+      const result = await parseJsonBody(req)
+      expect(result).toEqual({ key: 'value' })
+    })
+
+    it('returns null for invalid JSON', async () => {
+      const req = mockReq({ body: '{ broken' })
+      const result = await parseJsonBody(req)
+      expect(result).toBeNull()
+    })
+
+    it('returns null for empty body', async () => {
+      const req = mockReq({ body: '' })
+      const result = await parseJsonBody(req)
+      expect(result).toBeNull()
+    })
+
+    it('returns null on stream error', async () => {
+      const stream = new PassThrough()
+      const req = stream as unknown as IncomingMessage
+      req.method = 'POST'
+      req.headers = {}
+
+      const promise = parseJsonBody(req)
+      stream.emit('error', new Error('stream broke'))
+      const result = await promise
+      expect(result).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // validateJsonContentType
+  // -------------------------------------------------------------------------
+
+  describe('validateJsonContentType', () => {
+    it('returns true for GET requests regardless of content type', () => {
+      const req = mockReq({ method: 'GET' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(true)
+      expect(res.writeHead).not.toHaveBeenCalled()
+    })
+
+    it('returns true for POST with application/json', () => {
+      const req = mockReq({ method: 'POST', contentType: 'application/json' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(true)
+    })
+
+    it('returns true for POST with application/json; charset=utf-8', () => {
+      const req = mockReq({ method: 'POST', contentType: 'application/json; charset=utf-8' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(true)
+    })
+
+    it('returns false and sends 400 for POST without json content type', () => {
+      const req = mockReq({ method: 'POST', contentType: 'text/plain' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(false)
+      expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object))
+    })
+
+    it('returns false for POST with no content type header', () => {
+      const req = mockReq({ method: 'POST' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(false)
+    })
+
+    it('validates PUT requests', () => {
+      const req = mockReq({ method: 'PUT', contentType: 'text/html' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(false)
+    })
+
+    it('validates DELETE requests', () => {
+      const req = mockReq({ method: 'DELETE', contentType: 'application/json' })
+      const res = mockRes()
+      expect(validateJsonContentType(req, res)).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // jsonResponse
+  // -------------------------------------------------------------------------
+
+  describe('jsonResponse', () => {
+    it('sends JSON with correct status and content type', () => {
+      const res = mockRes()
+      jsonResponse(res, 200, { ok: true })
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' })
+      expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }))
+    })
+
+    it('handles error status codes', () => {
+      const res = mockRes()
+      jsonResponse(res, 404, { error: 'not found' })
+      expect(res.writeHead).toHaveBeenCalledWith(404, expect.any(Object))
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // handleJsonPost
+  // -------------------------------------------------------------------------
+
+  describe('handleJsonPost', () => {
+    it('calls handler with parsed body and sends result', async () => {
+      const req = mockReq({ method: 'POST', contentType: 'application/json', body: '{"name":"test"}' })
+      const res = mockRes()
+      const handler = vi.fn().mockResolvedValue({ created: true })
+
+      await handleJsonPost(req, res, handler)
+
+      expect(handler).toHaveBeenCalledWith({ name: 'test' })
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      const body = JSON.parse(res.end.mock.calls[0][0])
+      expect(body).toEqual({ created: true })
+    })
+
+    it('returns 400 when content type is wrong', async () => {
+      const req = mockReq({ method: 'POST', contentType: 'text/plain', body: '{}' })
+      const res = mockRes()
+      const handler = vi.fn()
+
+      await handleJsonPost(req, res, handler)
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object))
+    })
+
+    it('returns 400 when body is invalid JSON', async () => {
+      const req = mockReq({ method: 'POST', contentType: 'application/json', body: '{ broken' })
+      const res = mockRes()
+      const handler = vi.fn()
+
+      await handleJsonPost(req, res, handler)
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object))
+      const body = JSON.parse(res.end.mock.calls[0][0])
+      expect(body.error).toContain('Invalid JSON')
+    })
+
+    it('returns 500 when handler throws', async () => {
+      const req = mockReq({ method: 'POST', contentType: 'application/json', body: '{"ok":true}' })
+      const res = mockRes()
+      const handler = vi.fn().mockRejectedValue(new Error('handler boom'))
+
+      await handleJsonPost(req, res, handler)
+
+      expect(res.writeHead).toHaveBeenCalledWith(500, expect.any(Object))
+      const body = JSON.parse(res.end.mock.calls[0][0])
+      expect(body.error).toContain('handler boom')
+    })
+
+    it('returns { ok: true } when handler returns void', async () => {
+      const req = mockReq({ method: 'POST', contentType: 'application/json', body: '{}' })
+      const res = mockRes()
+      const handler = vi.fn().mockResolvedValue(undefined)
+
+      await handleJsonPost(req, res, handler)
+
+      const body = JSON.parse(res.end.mock.calls[0][0])
+      expect(body).toEqual({ ok: true })
+    })
+  })
+})

--- a/tests/core/watchdog.test.ts
+++ b/tests/core/watchdog.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/core/settings', () => ({
+  getSettings: vi.fn().mockReturnValue({
+    watchdog: {
+      intervalMs: 1000,
+      stuckThresholdMs: 30 * 60 * 1000,
+      autoRecover: true,
+      maxAutoRecoveries: 3,
+      alertChannelId: 'test-channel',
+    },
+    workflow: {
+      stepTimeoutMs: 60 * 60 * 1000,
+      maxRedispatches: 3,
+    },
+    notifications: { channel: 'none' },
+  }),
+}))
+
+vi.mock('../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+vi.mock('../../src/core/sse', () => ({
+  broadcast: vi.fn(),
+}))
+
+vi.mock('../../src/core/openclaw-client', () => ({
+  sendChannelMessage: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../src/lib/plugin-registry', () => ({
+  getHookRegistry: vi.fn().mockReturnValue({
+    invoke: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockReturnValue(false),
+    register: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/lib/format', () => ({
+  isStale: vi.fn().mockReturnValue(false),
+}))
+
+import { start, stop } from '../../src/core/watchdog'
+import { appendAudit } from '../../src/core/audit'
+import { broadcast } from '../../src/core/sse'
+import { getHookRegistry } from '../../src/lib/plugin-registry'
+import { isStale } from '../../src/lib/format'
+
+describe('watchdog', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bakin-watchdog-'))
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    stop()
+    vi.useRealTimers()
+    rmSync(tempDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // start / stop
+  // -------------------------------------------------------------------------
+
+  describe('start and stop', () => {
+    it('starts without throwing', () => {
+      expect(() => start(tempDir, 3737)).not.toThrow()
+    })
+
+    it('stop is idempotent', () => {
+      start(tempDir, 3737)
+      stop()
+      expect(() => stop()).not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Stuck task detection
+  // -------------------------------------------------------------------------
+
+  describe('stuck task detection', () => {
+    it('does nothing when taskboard hook returns undefined', async () => {
+      const hookRegistry = getHookRegistry()
+      vi.mocked(hookRegistry.invoke).mockResolvedValue(undefined)
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(vi.mocked(broadcast)).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when no in-progress tasks', async () => {
+      const hookRegistry = getHookRegistry()
+      vi.mocked(hookRegistry.invoke).mockResolvedValue({
+        columns: { todo: [], inProgress: [], done: [] },
+      })
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(vi.mocked(broadcast)).not.toHaveBeenCalled()
+    })
+
+    it('alerts on stuck task with stale log', async () => {
+      const hookRegistry = getHookRegistry()
+      vi.mocked(hookRegistry.invoke).mockResolvedValue({
+        columns: {
+          todo: [],
+          inProgress: [
+            {
+              id: 'task-1',
+              title: 'Stuck task',
+              agent: 'pixel',
+              log: [{ message: 'Started', timestamp: '2020-01-01T00:00:00Z' }],
+            },
+          ],
+          done: [],
+        },
+      })
+      // Agent is alive (not stale) — should alert but not auto-recover
+      vi.mocked(isStale).mockReturnValue(false)
+
+      // Write a heartbeat so isAgentHeartbeatStale returns false
+      mkdirSync(join(tempDir, 'heartbeats'), { recursive: true })
+      writeFileSync(
+        join(tempDir, 'heartbeats', 'pixel.json'),
+        JSON.stringify({ timestamp: new Date().toISOString() }),
+      )
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(vi.mocked(broadcast)).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'alert' }),
+      )
+    })
+
+    it('auto-recovers when agent heartbeat is stale', async () => {
+      const hookRegistry = getHookRegistry()
+      const invokeMock = vi.mocked(hookRegistry.invoke)
+
+      // First call: readTaskboard, subsequent: task operations
+      invokeMock.mockImplementation(async (name: string) => {
+        if (name === 'tasks.readTaskboard') {
+          return {
+            columns: {
+              todo: [],
+              inProgress: [
+                {
+                  id: 'task-2',
+                  title: 'Stale task',
+                  agent: 'pixel',
+                  log: [{ message: 'Started', timestamp: '2020-01-01T00:00:00Z' }],
+                },
+              ],
+              done: [],
+            },
+          }
+        }
+        return undefined
+      })
+
+      // Agent heartbeat is stale (no heartbeat file)
+      vi.mocked(isStale).mockReturnValue(true)
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      // Should have called moveTask to recover
+      expect(invokeMock).toHaveBeenCalledWith('tasks.addTaskLog', expect.objectContaining({
+        identifier: 'task-2',
+        message: expect.stringContaining('Auto-recovered'),
+      }))
+      expect(invokeMock).toHaveBeenCalledWith('tasks.moveTask', { identifier: 'task-2', to: 'todo' })
+      expect(vi.mocked(appendAudit)).toHaveBeenCalledWith(
+        tempDir,
+        'task.auto_recovered',
+        'watchdog',
+        expect.objectContaining({ id: 'task-2' }),
+      )
+    })
+
+    it('escalates to blocked after max auto-recoveries', async () => {
+      const hookRegistry = getHookRegistry()
+      const invokeMock = vi.mocked(hookRegistry.invoke)
+
+      invokeMock.mockImplementation(async (name: string) => {
+        if (name === 'tasks.readTaskboard') {
+          return {
+            columns: {
+              todo: [],
+              inProgress: [
+                {
+                  id: 'task-3',
+                  title: 'Exhausted task',
+                  agent: 'pixel',
+                  log: [
+                    { message: 'Auto-recovered: attempt 1', timestamp: '2020-01-01T00:00:00Z' },
+                    { message: 'Auto-recovered: attempt 2', timestamp: '2020-01-01T01:00:00Z' },
+                    { message: 'Auto-recovered: attempt 3', timestamp: '2020-01-01T02:00:00Z' },
+                  ],
+                },
+              ],
+              done: [],
+            },
+          }
+        }
+        return undefined
+      })
+
+      vi.mocked(isStale).mockReturnValue(true)
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(invokeMock).toHaveBeenCalledWith('tasks.blockTask', expect.objectContaining({
+        identifier: 'task-3',
+      }))
+      expect(vi.mocked(appendAudit)).toHaveBeenCalledWith(
+        tempDir,
+        'task.auto_recovery_exhausted',
+        'watchdog',
+        expect.objectContaining({ id: 'task-3', recoveryCount: 3 }),
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Bypass detection (via checkBypassPatterns)
+  // -------------------------------------------------------------------------
+
+  describe('bypass pattern detection', () => {
+    it('detects "working around" pattern in recent logs', async () => {
+      const hookRegistry = getHookRegistry()
+      vi.mocked(hookRegistry.invoke).mockResolvedValue({
+        columns: {
+          todo: [],
+          inProgress: [
+            {
+              id: 'task-bp',
+              title: 'Bypass task',
+              agent: 'pixel',
+              log: [
+                { message: 'Working around the error by skipping validation', timestamp: new Date().toISOString() },
+              ],
+            },
+          ],
+          done: [],
+        },
+      })
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(vi.mocked(broadcast)).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'alert', message: expect.stringContaining('bypass') }),
+      )
+      expect(vi.mocked(appendAudit)).toHaveBeenCalledWith(
+        tempDir,
+        'task.bypass_detected',
+        'watchdog',
+        expect.objectContaining({ id: 'task-bp' }),
+      )
+    })
+
+    it('ignores watchdog own log entries', async () => {
+      const hookRegistry = getHookRegistry()
+      vi.mocked(hookRegistry.invoke).mockResolvedValue({
+        columns: {
+          todo: [],
+          inProgress: [
+            {
+              id: 'task-safe',
+              title: 'Safe task',
+              agent: 'pixel',
+              log: [
+                { message: 'ALERT: No progress logged in 30+ minutes', timestamp: new Date().toISOString() },
+              ],
+            },
+          ],
+          done: [],
+        },
+      })
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      expect(vi.mocked(appendAudit)).not.toHaveBeenCalledWith(
+        tempDir,
+        'task.bypass_detected',
+        'watchdog',
+        expect.anything(),
+      )
+    })
+  })
+})

--- a/tests/core/watcher.test.ts
+++ b/tests/core/watcher.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/core/sse', () => ({
+  broadcast: vi.fn(),
+  broadcastAuditEvent: vi.fn(),
+}))
+
+vi.mock('../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+vi.mock('chokidar', () => ({
+  watch: vi.fn().mockReturnValue({
+    on: vi.fn().mockReturnThis(),
+    close: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+import { start, stop, registerSyncHook, createInboxHandler } from '../../src/core/watcher'
+import { broadcast } from '../../src/core/sse'
+import { appendAudit } from '../../src/core/audit'
+import { BakinEventBus } from '../../src/lib/events/event-bus'
+
+describe('watcher', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bakin-watcher-'))
+    vi.clearAllMocks()
+  })
+
+  afterEach(async () => {
+    await stop()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // -------------------------------------------------------------------------
+  // start / stop
+  // -------------------------------------------------------------------------
+
+  describe('start and stop', () => {
+    it('starts chokidar watcher', async () => {
+      const chokidar = await import('chokidar')
+      const eventBus = new BakinEventBus(() => {})
+      start({ contentDir: tempDir, eventBus, onInboxFile: vi.fn() })
+      expect(chokidar.watch).toHaveBeenCalledWith(tempDir, expect.any(Object))
+    })
+
+    it('stop is idempotent', async () => {
+      await stop()
+      await expect(stop()).resolves.not.toThrow()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // createInboxHandler
+  // -------------------------------------------------------------------------
+
+  describe('createInboxHandler', () => {
+    it('sends notification for task-complete inbox messages', () => {
+      const sendNotification = vi.fn()
+      const handler = createInboxHandler({ contentDir: tempDir, sendNotification })
+
+      const inboxFile = join(tempDir, 'inbox', 'report.json')
+      mkdirSync(join(tempDir, 'inbox'), { recursive: true })
+      writeFileSync(inboxFile, JSON.stringify({
+        type: 'task-complete',
+        title: 'Write blog post',
+        agent: 'nemo',
+        summary: 'Published blog post about AI',
+      }))
+
+      handler(inboxFile)
+
+      expect(sendNotification).toHaveBeenCalledOnce()
+      const msg = sendNotification.mock.calls[0][0]
+      expect(msg).toContain('nemo')
+      expect(msg).toContain('Write blog post')
+    })
+
+    it('calls appendAudit for completion reports', () => {
+      const handler = createInboxHandler({ contentDir: tempDir, sendNotification: vi.fn() })
+
+      const inboxFile = join(tempDir, 'inbox', 'report.json')
+      mkdirSync(join(tempDir, 'inbox'), { recursive: true })
+      writeFileSync(inboxFile, JSON.stringify({
+        type: 'task-complete',
+        title: 'Task X',
+        agent: 'pixel',
+        summary: 'Done',
+      }))
+
+      handler(inboxFile)
+
+      expect(vi.mocked(appendAudit)).toHaveBeenCalledWith(
+        tempDir,
+        'task.completion_report',
+        'pixel',
+        expect.objectContaining({ title: 'Task X' }),
+      )
+    })
+
+    it('ignores non task-complete messages', () => {
+      const sendNotification = vi.fn()
+      const handler = createInboxHandler({ contentDir: tempDir, sendNotification })
+
+      const inboxFile = join(tempDir, 'inbox', 'other.json')
+      mkdirSync(join(tempDir, 'inbox'), { recursive: true })
+      writeFileSync(inboxFile, JSON.stringify({ type: 'status-update', agent: 'nemo' }))
+
+      handler(inboxFile)
+      expect(sendNotification).not.toHaveBeenCalled()
+    })
+
+    it('handles invalid JSON gracefully', () => {
+      const sendNotification = vi.fn()
+      const handler = createInboxHandler({ contentDir: tempDir, sendNotification })
+
+      const inboxFile = join(tempDir, 'inbox', 'bad.json')
+      mkdirSync(join(tempDir, 'inbox'), { recursive: true })
+      writeFileSync(inboxFile, '{ broken json')
+
+      expect(() => handler(inboxFile)).not.toThrow()
+      expect(sendNotification).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // registerSyncHook
+  // -------------------------------------------------------------------------
+
+  describe('registerSyncHook', () => {
+    it('registers a hook without throwing', () => {
+      expect(() => registerSyncHook(() => {})).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unit tests for 8 core modules: audit, continuation, dispatch, lifecycle, main-agent, middleware, watchdog, watcher
- 1,386 lines of test code across 8 new test files
- Closes #13, #14, #15, #16, #17, #18, #19, #20

## Test plan
- [x] All tests pass (`npx vitest run tests/core/`)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)