### PR TITLE
Persist Bakin drawer width

### DIFF
--- a/.claude/knowledge/assets-plugin.md
+++ b/.claude/knowledge/assets-plugin.md
@@ -39,9 +39,12 @@ Without a centralized asset system, agent-created files are scattered across tas
   "tool": "dall-e-3",
   "description": "Hero image for blog post",
   "tags": ["social", "blog"],
-  "originalFilename": "hero.png"
+  "originalFilename": "hero.png",
+  "source": "agent"
 }
 ```
+
+The `source` field tracks how the asset was created: `"agent"` (MCP tool), `"upload"` (manual UI upload), or `"clipboard"` (pasted into task description). Used for lifecycle management (e.g., auto-purging clipboard assets on task completion).
 
 Field aliases are auto-corrected: `author` -> `agent`, `createdAt` -> `created`, `task` -> `taskId`.
 
@@ -58,12 +61,14 @@ All under `/api/plugins/assets/`:
 | Route | Method | Params | Notes |
 |-------|--------|--------|-------|
 | `/` | GET | `type`, `agent`, `taskId`, `tag`, `includeChildren`, `grouped`, `path`, `limit`, `offset` | Main listing with pagination |
+| `/upload` | POST | multipart: `file`, `taskId?`, `description?`, `tags?`, `source?` | Upload files from UI or clipboard paste |
 | `/file` | GET | `path`, `v` (cache bust) | Serves file with MIME type + ETag |
 | `/` | DELETE | `path` | Soft-delete to .trash/ |
 | `/trash` | GET | — | Lists trashed items with expiry |
 | `/trash/:file/restore` | POST | — | Restores from trash to original location |
 | `/trash/:file` | DELETE | — | Permanently removes trashed item |
 | `/trash` | DELETE | — | Bulk delete all trash |
+| `/link` | PATCH | JSON: `path`, `taskId` (string \| null) | Relink asset to different task or unlink (null → `_unlinked`) |
 
 Alternative file serving at `/api/assets/[...path]` supports range requests (video seeking).
 
@@ -121,6 +126,7 @@ Registered in `plugins/assets/index.ts` via `ctx.hooks.register()`:
 - `assets.detectVariant(filename)` — check if file is a variant
 - `assets.getAssetTypes()` — return available asset type enum
 - `assets.listTrash()` / `assets.restoreAsset()` / `assets.emptyTrash()`
+- `assets.purgeClipboardForTask(taskId)` — soft-delete clipboard-source assets for a completed task (gated by `purgeClipboardOnComplete` setting)
 
 ## Key Files
 
@@ -128,6 +134,7 @@ Registered in `plugins/assets/index.ts` via `ctx.hooks.register()`:
 plugins/assets/
   index.ts                    — Plugin entry, hooks, routes, settings
   routes/list.ts              — Asset listing with filters + pagination
+  routes/upload.ts            — Multipart file upload handler
   routes/file.ts              — File serving with MIME types
   routes/delete.ts            — Soft-delete
   routes/list-trash.ts        — Trash listing
@@ -136,10 +143,13 @@ plugins/assets/
   lib/sidecar.ts              — Sidecar read/write/validate/normalize
   lib/constants.ts            — Asset types, extensions, MIME mapping
   lib/trash.ts                — Trash operations
+  lib/relink.ts               — Relink/unlink assets between tasks
+  routes/link.ts              — PATCH /link handler
 
 src/components/assets/
   assets-page.tsx             — Main page with URL state, pagination, sorting
-  asset-filters.tsx           — PluginHeader + FacetFilter + view toggle
+  asset-filters.tsx           — PluginHeader + FacetFilter + view toggle + Add button
+  upload-dialog.tsx           — Drag-drop upload dialog
   asset-card.tsx              — Grid card with thumbnail preview
   assets-grid.tsx             — Responsive grid layout
   assets-list.tsx             — Table layout with sortable columns
@@ -153,3 +163,29 @@ src/hooks/use-assets.ts       — Data fetching + SSE live updates
 scripts/lib/save-asset.ts     — MCP tool for standardized asset saving
 scripts/lib/audit-assets.ts   — Audit tool with thumbnail generation
 ```
+
+## Manual Upload & Clipboard Paste
+
+### Upload Route (`POST /upload`)
+Accepts multipart form data. Used by both the upload dialog and clipboard paste handler.
+- Auto-detects asset type from file extension via `getAssetType()`
+- Writes to temp dir, calls `saveAsset()`, cleans up
+- Sets `source` field: `"upload"` (dialog) or `"clipboard"` (paste)
+- SSE broadcast happens automatically via file watcher
+
+### Upload Dialog
+"Add" button in the Assets page header opens a dialog with drag-and-drop zone, file picker, and optional metadata fields (description, tags, task link). Supports multiple files.
+
+### Clipboard Paste in Task Details
+`onPaste` handler on the task description `<Textarea>`:
+- **Images**: Detected via `image/*` clipboard items. Uploaded as asset, markdown image ref inserted: `![pasted image](/api/assets/{path})`
+- **Long text** (20+ lines or 500+ chars): Saved as `.md` text asset. Compact reference inserted: `[Attached: filename (N lines)](/api/assets/{path})`
+- **Short text**: Passes through normally (no interception)
+
+Asset references use `/api/assets/` URLs, which render natively in `ReactMarkdown` and work in dispatch messages.
+
+### Dispatch Context
+`buildDispatchMessage()` scans task descriptions for `/api/assets/` references and appends an "Attached Context" section with filesystem paths so agents can read the files directly.
+
+### Clipboard Purge
+Plugin setting `purgeClipboardOnComplete` (default: false). When enabled, clipboard-source assets are soft-deleted to trash when their linked task moves to Done. Triggered via the `assets.purgeClipboardForTask` hook from `task-service.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ src/
 plugins/                   — Core plugins (each has bakin-plugin.json manifest)
   tasks/                   — Task board management
   workflows/               — Workflow execution engine (xyflow canvas)
-  assets/                  — Asset management with sidecar metadata
+  assets/                  — Asset management with sidecar metadata, manual upload, clipboard paste
   projects/                — Project tracking with checklists
   schedule/                — Cron job scheduling with OpenClaw bridge
   memory/                  — Audit logs and agent workspaces
@@ -94,7 +94,6 @@ Created by `bakin init`. Per-installation state, NOT in the repo.
   schedule/                — Cron job state
   workflows/               — Definitions, instances, skills
   team/                    — Contacts, personas
-  TASKBOARD.md             — Task kanban board
   MEMORY-LOG.md            — Agent memory log
   audit.jsonl              — Append-only audit trail
 ```
@@ -148,6 +147,30 @@ Conventional commits with scope:
 - `fix(schedule): handle timezone edge case`
 - `refactor(core): extract settings module`
 - `test(workflows): add gate approval test`
+
+## Testing Rules — CRITICAL
+
+**Every test file MUST mock `src/core/content-dir` to use a temp directory.** Tests that touch storage, assets, tasks, or any plugin MUST NOT read from or write to `~/.bakin/`. Leaked test data into the production instance has caused real incidents.
+
+Required mocks for any test that touches the filesystem:
+```typescript
+const testDir = join(tmpdir(), `bakin-test-${Date.now()}`)
+
+vi.mock('../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => { /* return paths under testDir */ },
+}))
+```
+
+Additional mandatory rules:
+- **Always clean up:** `afterAll(() => rmSync(testDir, { recursive: true, force: true }))`
+- **Mock the logger:** `vi.mock('../../src/core/logger', ...)` — prevents noise and avoids side effects
+- **Mock the watcher:** `vi.mock('../../src/core/watcher', ...)` — prevents chokidar from watching real dirs
+- **Mock openclaw-client:** Prevents tests from sending real messages to agents
+- **Never hardcode `~/.bakin/`** or `process.env.HOME` in test fixtures
+- **Use `tests/plugins/test-helpers.ts`** (`activatePlugin`, `callRoute`, `callTool`) for plugin tests — these provide properly isolated mock contexts
+
+If a test does not mock `getContentDir`, it **will** eventually write to `~/.bakin/` and corrupt production data. There are no exceptions to this rule.
 
 ## Key Patterns
 

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -36,7 +36,7 @@ export interface NavItem {
 
 export interface APIRoute {
   path: string
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
   handler: (req: Request, ctx: PluginContext) => Response | Promise<Response>
   description?: string
   params?: string

--- a/plugins/assets/bakin-plugin.json
+++ b/plugins/assets/bakin-plugin.json
@@ -3,7 +3,7 @@
   "name": "Assets",
   "version": "2.0.0",
   "bakin": ">=1.0.0",
-  "description": "Centralized content store for all agent-created artifacts with rich rendering, search, and task linking",
+  "description": "Centralized content store for all artifacts with rich rendering, search, task linking, manual upload, and clipboard paste",
   "entry": {
     "server": "index.ts"
   },

--- a/plugins/assets/components/asset-detail.tsx
+++ b/plugins/assets/components/asset-detail.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
 import { MarkdownContent } from '@/components/markdown-content'
-import { Trash2, ExternalLink, Download, Clock, User, Wrench, Tag, Layers, Eye } from 'lucide-react'
+import { Trash2, ExternalLink, Download, Clock, User, Wrench, Tag, Layers, Eye, Pencil, Check, X, Unlink } from 'lucide-react'
 import { formatSize } from '@/lib/format'
 import { DeleteAssetDialog } from './delete-asset-dialog'
 import type { AssetMeta } from '@/types'
@@ -18,6 +18,7 @@ interface AssetDetailProps {
   asset: AssetMeta | null
   onClose: () => void
   onDelete: (path: string) => void
+  onRelink?: () => void
 }
 
 function AssetRenderer({ asset }: { asset: AssetMeta }) {
@@ -176,9 +177,30 @@ export function AssetDetailModal({ assetPath, onClose }: { assetPath: string; on
   )
 }
 
-export function AssetDetail({ asset, onClose, onDelete, showOpenInAssets }: AssetDetailProps & { showOpenInAssets?: boolean }) {
+export function AssetDetail({ asset, onClose, onDelete, onRelink, showOpenInAssets }: AssetDetailProps & { showOpenInAssets?: boolean }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [activeVariantPath, setActiveVariantPath] = useState<string | null>(null)
+  const [editingTask, setEditingTask] = useState(false)
+  const [newTaskId, setNewTaskId] = useState('')
+  const [relinking, setRelinking] = useState(false)
+
+  const handleRelink = async (taskId: string | null) => {
+    if (!asset) return
+    setRelinking(true)
+    try {
+      const res = await fetch('/api/plugins/assets/link', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: asset.path, taskId }),
+      })
+      if (res.ok) {
+        setEditingTask(false)
+        onRelink?.()
+        onClose()
+      }
+    } catch { /* ignore */ }
+    finally { setRelinking(false) }
+  }
 
   if (!asset) return null
 
@@ -248,18 +270,55 @@ export function AssetDetail({ asset, onClose, onDelete, showOpenInAssets }: Asse
             )}
 
             {/* Task link */}
-            {asset.metadata.taskId && (
-              <div className="flex items-center gap-1.5">
-                <ExternalLink className="size-3 text-muted-foreground" />
-                <span className="text-muted-foreground">Task:</span>
-                <a
-                  href={`/tasks?taskId=${asset.metadata.taskId}`}
-                  className="text-blue-400 hover:text-blue-300"
-                >
-                  {asset.metadata.taskId.slice(0, 8)}...
-                </a>
-              </div>
-            )}
+            <div className="flex items-center gap-1.5">
+              <ExternalLink className="size-3 text-muted-foreground" />
+              <span className="text-muted-foreground">Task:</span>
+              {editingTask ? (
+                <div className="flex items-center gap-1 flex-1 min-w-0">
+                  <input
+                    type="text"
+                    value={newTaskId}
+                    onChange={(e) => setNewTaskId(e.target.value)}
+                    placeholder="Task ID or empty to unlink"
+                    className="flex-1 min-w-0 text-xs bg-zinc-800 border border-border rounded px-1.5 py-0.5 text-foreground"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleRelink(newTaskId.trim() || null)
+                      if (e.key === 'Escape') setEditingTask(false)
+                    }}
+                    disabled={relinking}
+                  />
+                  <button onClick={() => handleRelink(newTaskId.trim() || null)} disabled={relinking} className="text-green-400 hover:text-green-300" title="Save">
+                    <Check className="size-3" />
+                  </button>
+                  <button onClick={() => setEditingTask(false)} className="text-muted-foreground hover:text-foreground" title="Cancel">
+                    <X className="size-3" />
+                  </button>
+                </div>
+              ) : asset.metadata.taskId ? (
+                <>
+                  <a
+                    href={`/tasks?taskId=${asset.metadata.taskId}`}
+                    className="text-blue-400 hover:text-blue-300"
+                  >
+                    {asset.metadata.taskId.slice(0, 8)}...
+                  </a>
+                  <button onClick={() => { setNewTaskId(asset.metadata.taskId || ''); setEditingTask(true) }} className="text-muted-foreground hover:text-foreground" title="Edit task link">
+                    <Pencil className="size-3" />
+                  </button>
+                  <button onClick={() => handleRelink(null)} className="text-muted-foreground hover:text-red-400" title="Unlink from task">
+                    <Unlink className="size-3" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <span className="text-muted-foreground italic">Unlinked</span>
+                  <button onClick={() => { setNewTaskId(''); setEditingTask(true) }} className="text-muted-foreground hover:text-foreground" title="Link to task">
+                    <Pencil className="size-3" />
+                  </button>
+                </>
+              )}
+            </div>
 
             {/* Size */}
             <div className="text-muted-foreground">

--- a/plugins/assets/components/asset-filters.tsx
+++ b/plugins/assets/components/asset-filters.tsx
@@ -2,7 +2,8 @@
 
 import { PluginHeader } from '@/components/plugin-header'
 import { FacetFilter } from '@/components/facet-filter'
-import { FileText, Image, Video, Music, Map, Database, Package, LayoutGrid, List, ListFilter, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { FileText, Image, Video, Music, Map, Database, Package, LayoutGrid, List, ListFilter, Trash2, Plus } from 'lucide-react'
 
 const TYPE_OPTIONS = [
   { value: 'text', label: 'Text', icon: <FileText className="size-3.5" /> },
@@ -22,6 +23,7 @@ interface AssetFiltersProps {
   assetCount: number
   view: string
   onViewChange: (view: string) => void
+  onAdd?: () => void
 }
 
 const VIEW_OPTIONS = [
@@ -30,7 +32,7 @@ const VIEW_OPTIONS = [
   { key: 'trash', label: 'Trash', icon: Trash2 },
 ] as const
 
-export function AssetFilters({ typeFilter, onTypeChange, search, onSearchChange, assetCount, view, onViewChange }: AssetFiltersProps) {
+export function AssetFilters({ typeFilter, onTypeChange, search, onSearchChange, assetCount, view, onViewChange, onAdd }: AssetFiltersProps) {
   return (
     <div className="flex flex-col gap-3">
       <PluginHeader
@@ -38,7 +40,14 @@ export function AssetFilters({ typeFilter, onTypeChange, search, onSearchChange,
         count={assetCount}
         search={{ value: search, onChange: onSearchChange, placeholder: 'Search assets...' }}
         actions={
-          <div className="flex items-center bg-muted/50 rounded-lg p-0.5">
+          <div className="flex items-center gap-2">
+            {onAdd && (
+              <Button size="sm" variant="outline" onClick={onAdd}>
+                <Plus className="size-3.5 mr-1.5" />
+                Add
+              </Button>
+            )}
+            <div className="flex items-center bg-muted/50 rounded-lg p-0.5">
             {VIEW_OPTIONS.map(opt => {
               const Icon = opt.icon
               return (
@@ -56,6 +65,7 @@ export function AssetFilters({ typeFilter, onTypeChange, search, onSearchChange,
                 </button>
               )
             })}
+            </div>
           </div>
         }
       />

--- a/plugins/assets/components/assets-page.tsx
+++ b/plugins/assets/components/assets-page.tsx
@@ -10,6 +10,7 @@ import { TrashGrid } from './trash-grid'
 import { AssetDetail } from './asset-detail'
 import { AssetFilters } from './asset-filters'
 import { AssetPagination } from './asset-pagination'
+import { UploadDialog } from './upload-dialog'
 import type { AssetMeta } from '@/types'
 
 const DEFAULT_PAGE_SIZE = 24
@@ -50,6 +51,14 @@ export function AssetsPage() {
     const qs = params.toString()
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
   }, [router, pathname, searchParams])
+
+  const linkTo = searchParams.get('linkTo')
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  // Auto-open upload dialog when navigating from TaskAssets "Add" button
+  useEffect(() => {
+    if (linkTo) setUploadOpen(true)
+  }, [linkTo])
 
   const page = Math.max(1, parseInt(pageStr, 10) || 1)
   const isTrash = view === 'trash'
@@ -135,6 +144,7 @@ export function AssetsPage() {
         assetCount={activeCount}
         view={view}
         onViewChange={setView}
+        onAdd={() => setUploadOpen(true)}
       />
 
       {activeLoading ? (
@@ -185,6 +195,8 @@ export function AssetsPage() {
           }}
         />
       )}
+
+      <UploadDialog open={uploadOpen} onOpenChange={setUploadOpen} defaultTaskId={linkTo || undefined} />
     </div>
   )
 }

--- a/plugins/assets/components/task-assets.tsx
+++ b/plugins/assets/components/task-assets.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { FolderOpen, Image, Video, Music, FileText, Plus } from 'lucide-react'
+import { FolderOpen, Image, Video, Music, FileText, Plus, X } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { AssetDetailModal } from './asset-detail'
 import type { AssetMeta } from '@/types'
@@ -36,22 +36,53 @@ export function TaskAssets({ taskId, readOnly }: TaskAssetsProps) {
     fetchAssets()
   }, [fetchAssets])
 
-  // Listen for workflow step completions to auto-refresh assets
+  // Listen for asset-related events to auto-refresh
   useEffect(() => {
     const es = new EventSource('/api/events')
     esRef.current = es
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data)
+        // Refresh on workflow step completions
         if (data.type === 'plugin-event' && data.event === 'workflow.step_complete') {
           if (data.taskId === taskId || data.taskId?.startsWith(taskId + '--')) {
             fetchAssets()
           }
         }
+        // Refresh on asset uploads/changes for this task
+        if (data.type === 'activity' && data.pluginId === 'assets' && data.taskId === taskId) {
+          fetchAssets()
+        }
+        // Refresh on audit events from asset uploads
+        if (data.type === 'audit' && data.event?.startsWith('assets.') && data.taskId === taskId) {
+          fetchAssets()
+        }
       } catch { /* ignore */ }
     }
     return () => { es.close(); esRef.current = null }
   }, [taskId, fetchAssets])
+
+  // Listen for local asset upload events (e.g. clipboard paste in same dialog)
+  // SSE can miss events during React re-renders that recreate the EventSource
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      if (detail?.taskId === taskId) fetchAssets()
+    }
+    window.addEventListener('bakin:asset-uploaded', handler)
+    return () => window.removeEventListener('bakin:asset-uploaded', handler)
+  }, [taskId, fetchAssets])
+
+  const handleUnlink = async (path: string) => {
+    try {
+      const res = await fetch('/api/plugins/assets/link', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, taskId: null }),
+      })
+      if (res.ok) fetchAssets()
+    } catch { /* ignore */ }
+  }
 
   if (loading) return null
 
@@ -76,29 +107,42 @@ export function TaskAssets({ taskId, readOnly }: TaskAssetsProps) {
         {assets.map(asset => {
           const Icon = TYPE_ICONS[asset.type] || FileText
           return (
-            <button
+            <div
               key={asset.path}
-              onClick={() => setPreviewPath(asset.path)}
               className="flex items-center gap-2 rounded-md border border-border bg-background px-3 py-2 hover:border-[rgba(255,255,255,0.15)] transition-colors group text-left w-full"
             >
-              {asset.type === 'images' ? (
-                <img
-                  src={`/api/plugins/assets/file?path=${encodeURIComponent(asset.path)}`}
-                  alt={asset.filename}
-                  className="size-8 rounded object-cover shrink-0"
-                />
-              ) : (
-                <div className="size-8 rounded bg-muted flex items-center justify-center shrink-0">
-                  <Icon className="size-4 text-muted-foreground" />
-                </div>
-              )}
-              <div className="flex-1 min-w-0">
-                <p className="text-xs font-medium text-foreground truncate">{asset.filename}</p>
-                {asset.metadata.description && (
-                  <p className="text-[10px] text-muted-foreground truncate">{asset.metadata.description}</p>
+              <button
+                onClick={() => setPreviewPath(asset.path)}
+                className="flex items-center gap-2 flex-1 min-w-0"
+              >
+                {asset.type === 'images' ? (
+                  <img
+                    src={`/api/plugins/assets/file?path=${encodeURIComponent(asset.path)}`}
+                    alt={asset.filename}
+                    className="size-8 rounded object-cover shrink-0"
+                  />
+                ) : (
+                  <div className="size-8 rounded bg-muted flex items-center justify-center shrink-0">
+                    <Icon className="size-4 text-muted-foreground" />
+                  </div>
                 )}
-              </div>
-            </button>
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium text-foreground truncate">{asset.filename}</p>
+                  {asset.metadata.description && (
+                    <p className="text-[10px] text-muted-foreground truncate">{asset.metadata.description}</p>
+                  )}
+                </div>
+              </button>
+              {!readOnly && (
+                <button
+                  onClick={() => handleUnlink(asset.path)}
+                  className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground shrink-0 p-1 transition-opacity"
+                  title="Remove from task"
+                >
+                  <X className="size-3.5" />
+                </button>
+              )}
+            </div>
           )
         })}
       </div>

--- a/plugins/assets/components/upload-dialog.tsx
+++ b/plugins/assets/components/upload-dialog.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useState, useRef, useCallback } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Upload, X, FileText, Image, Video, Music, Map, Database, Package, Loader2 } from 'lucide-react'
+import { toast } from '@/hooks/use-toast'
+
+const TYPE_ICONS: Record<string, typeof FileText> = {
+  text: FileText,
+  images: Image,
+  video: Video,
+  audio: Music,
+  plans: Map,
+  data: Database,
+  other: Package,
+}
+
+const EXTENSION_TO_TYPE: Record<string, string> = {
+  '.md': 'text', '.txt': 'text', '.rtf': 'text',
+  '.png': 'images', '.jpg': 'images', '.jpeg': 'images', '.gif': 'images', '.webp': 'images', '.svg': 'images',
+  '.mp4': 'video', '.mov': 'video', '.webm': 'video', '.avi': 'video',
+  '.mp3': 'audio', '.wav': 'audio', '.m4a': 'audio', '.ogg': 'audio',
+  '.yaml': 'plans', '.yml': 'plans',
+  '.json': 'data', '.csv': 'data', '.xml': 'data',
+  '.pdf': 'other',
+}
+
+function detectType(filename: string): string {
+  const ext = filename.substring(filename.lastIndexOf('.')).toLowerCase()
+  return EXTENSION_TO_TYPE[ext] || 'other'
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+interface QueuedFile {
+  file: File
+  type: string
+}
+
+interface UploadDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  defaultTaskId?: string
+}
+
+export function UploadDialog({ open, onOpenChange, defaultTaskId }: UploadDialogProps) {
+  const [files, setFiles] = useState<QueuedFile[]>([])
+  const [description, setDescription] = useState('')
+  const [tags, setTags] = useState('')
+  const [taskId, setTaskId] = useState(defaultTaskId || '')
+  const [uploading, setUploading] = useState(false)
+  const [dragOver, setDragOver] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const addFiles = useCallback((newFiles: FileList | File[]) => {
+    const queued: QueuedFile[] = Array.from(newFiles).map(file => ({
+      file,
+      type: detectType(file.name),
+    }))
+    setFiles(prev => [...prev, ...queued])
+  }, [])
+
+  const removeFile = (index: number) => {
+    setFiles(prev => prev.filter((_, i) => i !== index))
+  }
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    if (e.dataTransfer.files.length > 0) {
+      addFiles(e.dataTransfer.files)
+    }
+  }, [addFiles])
+
+  const handleUpload = async () => {
+    if (files.length === 0) return
+    setUploading(true)
+
+    let successCount = 0
+    let failCount = 0
+
+    for (const { file } of files) {
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('source', 'upload')
+      if (taskId) formData.append('taskId', taskId)
+      if (description) formData.append('description', description)
+      if (tags) formData.append('tags', tags)
+
+      try {
+        const res = await fetch('/api/plugins/assets/upload', { method: 'POST', body: formData })
+        if (res.ok) {
+          successCount++
+        } else {
+          const data = await res.json().catch(() => ({ error: 'Upload failed' }))
+          toast(`Failed to upload "${file.name}": ${data.error}`, 'error')
+          failCount++
+        }
+      } catch {
+        toast(`Failed to upload "${file.name}"`, 'error')
+        failCount++
+      }
+    }
+
+    setUploading(false)
+
+    if (successCount > 0) {
+      toast(`Uploaded ${successCount} file${successCount > 1 ? 's' : ''}`, 'success')
+    }
+
+    // Close on full success
+    if (failCount === 0) {
+      setFiles([])
+      setDescription('')
+      setTags('')
+      setTaskId(defaultTaskId || '')
+      onOpenChange(false)
+    }
+  }
+
+  const handleClose = (isOpen: boolean) => {
+    if (!isOpen && !uploading) {
+      setFiles([])
+      setDescription('')
+      setTags('')
+      setTaskId(defaultTaskId || '')
+    }
+    if (!uploading) onOpenChange(isOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Upload Assets</DialogTitle>
+        </DialogHeader>
+
+        {/* Drop zone */}
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handleDrop}
+          onClick={() => inputRef.current?.click()}
+          className={`flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-8 cursor-pointer transition-colors ${
+            dragOver
+              ? 'border-primary bg-primary/5'
+              : 'border-muted-foreground/25 hover:border-muted-foreground/50'
+          }`}
+        >
+          <Upload className="size-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            Drop files here or <span className="text-primary font-medium">browse</span>
+          </p>
+          <input
+            ref={inputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(e) => {
+              if (e.target.files) addFiles(e.target.files)
+              e.target.value = ''
+            }}
+          />
+        </div>
+
+        {/* File list */}
+        {files.length > 0 && (
+          <div className="flex flex-col gap-1.5 max-h-40 overflow-y-auto">
+            {files.map((qf, i) => {
+              const Icon = TYPE_ICONS[qf.type] || Package
+              return (
+                <div key={i} className="flex items-center gap-2 text-sm px-2 py-1.5 rounded bg-muted/50">
+                  <Icon className="size-3.5 text-muted-foreground shrink-0" />
+                  <span className="truncate flex-1">{qf.file.name}</span>
+                  <span className="text-xs text-muted-foreground shrink-0">{formatSize(qf.file.size)}</span>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); removeFile(i) }}
+                    className="text-muted-foreground hover:text-foreground shrink-0"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Optional fields */}
+        <div className="flex flex-col gap-3">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Task ID (optional)</label>
+            <Input
+              value={taskId}
+              onChange={(e) => setTaskId(e.target.value)}
+              placeholder="Link to a task..."
+              className="bg-surface"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Description (optional)</label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What are these files?"
+              className="bg-surface"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Tags (optional, comma-separated)</label>
+            <Input
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="reference, design, brief"
+              className="bg-surface"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleClose(false)} disabled={uploading}>
+            Cancel
+          </Button>
+          <Button onClick={handleUpload} disabled={files.length === 0 || uploading}>
+            {uploading ? (
+              <>
+                <Loader2 className="size-4 animate-spin mr-1.5" />
+                Uploading...
+              </>
+            ) : (
+              `Upload ${files.length > 0 ? `(${files.length})` : ''}`
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -10,11 +10,14 @@ import type { BakinPlugin, PluginContext } from '../../src/lib/plugin-types'
 import { handleList } from './routes/list'
 import { handleFile } from './routes/file'
 import { handleDelete } from './routes/delete'
+import { handleUpload } from './routes/upload'
 import { handleListTrash } from './routes/list-trash'
 import { handleRestore } from './routes/restore'
 import { handlePermanentDelete } from './routes/permanent-delete'
 import { handleEmptyTrash } from './routes/empty-trash'
-import { buildIndex, upsertAsset, removeAsset, detectVariant } from './lib/asset-index'
+import { handleLink } from './routes/link'
+import { relinkAsset } from './lib/relink'
+import { buildIndex, upsertAsset, removeAsset, detectVariant, listAssets } from './lib/asset-index'
 import { validateSidecar, getSidecarPath, createStub } from './lib/sidecar'
 import { ASSET_TYPES } from './lib/constants'
 import { listTrash, restoreAsset, emptyTrash, permanentDelete, softDelete, type TrashedAsset } from './lib/trash'
@@ -45,6 +48,7 @@ const assetsPlugin: BakinPlugin = {
     fields: [
       { key: 'thumbnails', type: 'boolean', label: 'Generate thumbnails', description: 'Auto-create optimized thumbnails on upload', default: true },
       { key: 'maxFileSize', type: 'number', label: 'Max file size (MB)', description: 'Reject uploads larger than this', default: 50 },
+      { key: 'purgeClipboardOnComplete', type: 'boolean', label: 'Purge clipboard assets on task completion', description: 'Auto-delete clipboard-pasted assets when their linked task is marked done', default: false },
     ],
   },
 
@@ -59,6 +63,35 @@ const assetsPlugin: BakinPlugin = {
     ctx.hooks.register('assets.createStub', (d: Record<string, unknown>) => createStub(d.assetPath as string))
     ctx.hooks.register('assets.detectVariant', (d: Record<string, unknown>) => detectVariant(d.filename as string))
     ctx.hooks.register('assets.getAssetTypes', () => ASSET_TYPES)
+
+    // Purge clipboard-source assets when a task completes (if enabled)
+    ctx.hooks.register('assets.purgeClipboardForTask', async (d: Record<string, unknown>) => {
+      const settings = ctx.getSettings<{ purgeClipboardOnComplete?: boolean }>()
+      if (!settings.purgeClipboardOnComplete) return { purged: 0 }
+
+      const taskId = d.taskId as string
+      if (!taskId) return { purged: 0 }
+
+      const contentDir = getContentDir()
+      const assetsRoot = join(contentDir, 'assets')
+      const assets = listAssets({ taskId })
+      let purged = 0
+
+      for (const asset of assets) {
+        if (asset.metadata.source !== 'clipboard') continue
+        const fullPath = join(contentDir, asset.path)
+        if (softDelete(fullPath, assetsRoot)) {
+          removeAsset(asset.path)
+          purged++
+        }
+      }
+
+      if (purged > 0) {
+        log.info(`Purged ${purged} clipboard asset(s) for completed task ${taskId}`)
+        ctx.activity.log('system', `Purged ${purged} clipboard asset(s) for task ${taskId}`)
+      }
+      return { purged }
+    })
     ctx.hooks.register('assets.listTrash', (d: Record<string, unknown>) => listTrash(d.assetsRoot as string))
     ctx.hooks.register('assets.restoreAsset', (d: Record<string, unknown>) => restoreAsset(d.trashFilename as string, d.assetsRoot as string))
     ctx.hooks.register('assets.emptyTrash', (d: Record<string, unknown>) => emptyTrash(d.assetsRoot as string))
@@ -84,6 +117,14 @@ const assetsPlugin: BakinPlugin = {
     // GET / — list assets with filters
     ctx.registerRoute({ path: '/', method: 'GET', description: 'List assets with filters', handler: handleList })
 
+    // POST /upload — multipart file upload
+    ctx.registerRoute({
+      path: '/upload',
+      method: 'POST',
+      description: 'Upload asset files',
+      handler: async (req: Request) => handleUpload(req, ctx),
+    })
+
     // GET /file — serve asset file for rendering
     ctx.registerRoute({ path: '/file', method: 'GET', description: 'Serve asset file', handler: handleFile })
 
@@ -97,6 +138,22 @@ const assetsPlugin: BakinPlugin = {
         if (res.ok) {
           ctx.activity.audit('deleted', 'system')
           ctx.activity.log('system', 'Asset deleted')
+        }
+        return res
+      },
+    })
+
+    // PATCH /link — relink or unlink an asset from a task
+    ctx.registerRoute({
+      path: '/link',
+      method: 'PATCH',
+      description: 'Relink or unlink an asset',
+      handler: async (req: Request) => {
+        const res = await handleLink(req)
+        const data = await res.clone().json()
+        if (data.ok) {
+          ctx.activity.audit('asset.relinked', 'user', { oldPath: data.oldPath, newPath: data.newPath })
+          ctx.activity.log('user', `Relinked asset to ${data.newPath || '_unlinked'}`)
         }
         return res
       },
@@ -238,6 +295,26 @@ const assetsPlugin: BakinPlugin = {
         ctx.activity.log(agent, `Deleted asset "${assetPath}"`)
         ctx.activity.audit('asset.deleted', agent, { path: assetPath })
         return { ok: true, trashed: [assetPath] }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_assets_link',
+      description: 'Link an asset to a different task, or unlink it (set taskId to null). Physically moves the file between task directories and updates sidecar metadata.',
+      parameters: {
+        path: z.string().describe('Asset path relative to content dir (e.g. "assets/images/task123/file.png")'),
+        taskId: z.string().nullable().describe('Target task ID, or null to unlink'),
+      },
+      handler: async (params: Record<string, unknown>, agent: string) => {
+        const result = relinkAsset({
+          assetPath: params.path as string,
+          newTaskId: (params.taskId as string | null) ?? null,
+        })
+        if (result.ok) {
+          ctx.activity.log(agent, `Relinked asset to ${params.taskId ?? '_unlinked'}`)
+          ctx.activity.audit('asset.relinked', agent, { oldPath: result.oldPath, newPath: result.newPath })
+        }
+        return result
       },
     })
 

--- a/plugins/assets/lib/constants.ts
+++ b/plugins/assets/lib/constants.ts
@@ -37,6 +37,8 @@ export const EXTENSION_TO_TYPE: Record<string, AssetType> = {
   // Plans
   '.yaml': 'plans',
   '.yml': 'plans',
+  // Documents
+  '.pdf': 'other',
   // Data
   '.json': 'data',
   '.csv': 'data',
@@ -74,6 +76,8 @@ export const EXTENSION_TO_MIME: Record<string, string> = {
   // Plans
   '.yaml': 'text/yaml',
   '.yml': 'text/yaml',
+  // Documents
+  '.pdf': 'application/pdf',
   // Data
   '.json': 'application/json',
   '.csv': 'text/csv',

--- a/plugins/assets/lib/relink.ts
+++ b/plugins/assets/lib/relink.ts
@@ -1,0 +1,125 @@
+/**
+ * Relink/unlink an asset — physically moves it between task directories
+ * and updates sidecar metadata.
+ */
+import { existsSync, mkdirSync, renameSync, readdirSync } from 'fs'
+import { join, basename, dirname } from 'path'
+import { randomBytes } from 'crypto'
+import { getContentDir } from '../../../src/core/content-dir'
+import { readSidecar, writeSidecar, getSidecarPath } from './sidecar'
+import { removeAsset, detectVariant } from './asset-index'
+import { createLogger } from '../../../src/core/logger'
+
+const log = createLogger('assets:relink')
+
+export interface RelinkParams {
+  assetPath: string         // relative to content dir, e.g. "assets/images/task123/file.png"
+  newTaskId: string | null  // null = unlink → move to _unlinked/
+}
+
+export interface RelinkResult {
+  ok: boolean
+  oldPath: string
+  newPath?: string
+  error?: string
+  [key: string]: unknown
+}
+
+export function relinkAsset(params: RelinkParams): RelinkResult {
+  const { assetPath, newTaskId } = params
+  const contentDir = getContentDir()
+
+  // Validate path
+  if (assetPath.includes('..')) {
+    return { ok: false, oldPath: assetPath, error: 'Invalid path: contains ..' }
+  }
+  if (!assetPath.startsWith('assets/')) {
+    return { ok: false, oldPath: assetPath, error: 'Invalid path: must start with assets/' }
+  }
+
+  const fullPath = join(contentDir, assetPath)
+  if (!existsSync(fullPath)) {
+    return { ok: false, oldPath: assetPath, error: 'Asset not found' }
+  }
+
+  // Parse path: assets/{type}/{taskId}/{filename}
+  const parts = assetPath.split('/')
+  if (parts.length < 4) {
+    return { ok: false, oldPath: assetPath, error: 'Invalid asset path structure' }
+  }
+
+  const type = parts[1]
+  const oldTaskId = parts[2]
+  const filename = parts.slice(3).join('/')
+  const effectiveNewTaskId = newTaskId ?? '_unlinked'
+
+  // Validate newTaskId doesn't contain path separators or traversal
+  if (effectiveNewTaskId.includes('/') || effectiveNewTaskId.includes('\\') || effectiveNewTaskId.includes('..')) {
+    return { ok: false, oldPath: assetPath, error: 'Invalid taskId: contains path separators' }
+  }
+
+  // No-op if same task
+  if (oldTaskId === effectiveNewTaskId) {
+    return { ok: true, oldPath: assetPath, newPath: assetPath }
+  }
+
+  // Build target directory
+  const newTaskDir = join(contentDir, 'assets', type, effectiveNewTaskId)
+  mkdirSync(newTaskDir, { recursive: true })
+
+  // Handle filename collision in target
+  let destFilename = filename
+  if (existsSync(join(newTaskDir, destFilename))) {
+    const dotIdx = destFilename.lastIndexOf('.')
+    const stem = dotIdx > 0 ? destFilename.substring(0, dotIdx) : destFilename
+    const ext = dotIdx > 0 ? destFilename.substring(dotIdx) : ''
+    const suffix = randomBytes(2).toString('hex')
+    destFilename = `${stem}-${suffix}${ext}`
+  }
+
+  const newRelPath = `assets/${type}/${effectiveNewTaskId}/${destFilename}`
+  const newFullPath = join(newTaskDir, destFilename)
+
+  // Move primary file
+  renameSync(fullPath, newFullPath)
+  removeAsset(assetPath)
+
+  // Move sidecar
+  const oldSidecarPath = getSidecarPath(fullPath)
+  const newSidecarPath = getSidecarPath(newFullPath)
+  if (existsSync(oldSidecarPath)) {
+    renameSync(oldSidecarPath, newSidecarPath)
+  }
+
+  // Move variants (.thumb.*, .opt.*)
+  const oldDir = dirname(fullPath)
+  const primaryStem = getPrimaryStem(basename(fullPath))
+  try {
+    const dirFiles = readdirSync(oldDir)
+    for (const f of dirFiles) {
+      const variant = detectVariant(f)
+      if (variant && variant.baseStem === primaryStem) {
+        const oldVariantPath = join(oldDir, f)
+        const newVariantPath = join(newTaskDir, f)
+        renameSync(oldVariantPath, newVariantPath)
+        removeAsset(`assets/${type}/${oldTaskId}/${f}`)
+      }
+    }
+  } catch { /* variant move is non-critical */ }
+
+  // Update sidecar taskId
+  const meta = readSidecar(newFullPath)
+  if (meta) {
+    meta.taskId = newTaskId // null for unlinked, string for linked
+    writeSidecar(newFullPath, meta)
+  }
+
+  log.info('Asset relinked', { from: assetPath, to: newRelPath, taskId: newTaskId })
+  return { ok: true, oldPath: assetPath, newPath: newRelPath }
+}
+
+/** Extract the stem from a filename (without extension). */
+function getPrimaryStem(filename: string): string {
+  const dotIdx = filename.lastIndexOf('.')
+  return dotIdx > 0 ? filename.substring(0, dotIdx) : filename
+}

--- a/plugins/assets/lib/save-asset.ts
+++ b/plugins/assets/lib/save-asset.ts
@@ -5,7 +5,9 @@
 import { mkdirSync, copyFileSync, writeFileSync, existsSync } from 'fs'
 import { join, extname, basename } from 'path'
 import { execSync } from 'child_process'
+import { randomBytes } from 'crypto'
 import { getBakinPaths } from '../../../src/core/content-dir'
+import type { AssetSource } from './sidecar'
 
 const ASSET_TYPES = ['text', 'images', 'video', 'audio', 'plans', 'data', 'other'] as const
 type AssetType = typeof ASSET_TYPES[number]
@@ -19,6 +21,8 @@ export interface SaveAssetParams {
   tags?: string[]
   tool?: string
   slug?: string
+  source?: AssetSource
+  originalFilename?: string
 }
 
 export interface SaveAssetResult {
@@ -61,7 +65,7 @@ function generateThumbnail(inputPath: string, outputPath: string, widthPx = 400)
 }
 
 export async function saveAsset(params: SaveAssetParams): Promise<SaveAssetResult> {
-  const { filePath, taskId, type, agent, description, tags, tool, slug } = params
+  const { filePath, taskId, type, agent, description, tags, tool, slug, source, originalFilename } = params
 
   if (!existsSync(filePath)) {
     return { ok: false, error: `Source file not found: ${filePath}` }
@@ -79,8 +83,18 @@ export async function saveAsset(params: SaveAssetParams): Promise<SaveAssetResul
 
   const ext = extname(filePath).slice(1) || getExtension(filePath)
   const fileSlug = slug || slugify(basename(filePath, `.${ext}`))
-  const filename = datePrefixedFilename(fileSlug, ext)
-  const destPath = join(taskDir, filename)
+  let filename = datePrefixedFilename(fileSlug, ext)
+  let destPath = join(taskDir, filename)
+
+  // Handle duplicate filenames by appending a short random suffix
+  if (existsSync(destPath)) {
+    const suffix = randomBytes(2).toString('hex')
+    const dotIdx = filename.lastIndexOf('.')
+    const stem = dotIdx > 0 ? filename.substring(0, dotIdx) : filename
+    const extPart = dotIdx > 0 ? filename.substring(dotIdx) : ''
+    filename = `${stem}-${suffix}${extPart}`
+    destPath = join(taskDir, filename)
+  }
 
   copyFileSync(filePath, destPath)
 
@@ -89,6 +103,8 @@ export async function saveAsset(params: SaveAssetParams): Promise<SaveAssetResul
     ...(tool ? { tool } : {}),
     ...(description ? { description } : {}),
     ...(tags && tags.length > 0 ? { tags } : {}),
+    ...(source ? { source } : {}),
+    ...(originalFilename ? { originalFilename } : {}),
   }
   const metadataPath = join(taskDir, `${filename}.meta.json`)
   writeFileSync(metadataPath, JSON.stringify(sidecar, null, 2))

--- a/plugins/assets/lib/sidecar.ts
+++ b/plugins/assets/lib/sidecar.ts
@@ -6,6 +6,8 @@ import { createLogger } from '../../../src/core/logger'
 
 const log = createLogger('assets:sidecar')
 
+export type AssetSource = 'agent' | 'upload' | 'clipboard'
+
 export interface SidecarMeta {
   agent: string
   taskId: string | null
@@ -14,6 +16,7 @@ export interface SidecarMeta {
   description?: string
   tags?: string[]
   originalFilename?: string
+  source?: AssetSource
 }
 
 const REQUIRED_FIELDS = ['agent', 'taskId', 'created'] as const
@@ -31,7 +34,7 @@ export const FIELD_ALIASES: Record<string, string> = {
 
 /** All valid fields in a sidecar .meta.json file. */
 export const KNOWN_FIELDS = new Set([
-  'agent', 'taskId', 'created', 'tool', 'description', 'tags', 'originalFilename',
+  'agent', 'taskId', 'created', 'tool', 'description', 'tags', 'originalFilename', 'source',
 ])
 
 export function getSidecarPath(assetPath: string): string {
@@ -111,6 +114,7 @@ function validateAndNormalize(meta: Record<string, unknown>): SidecarMeta {
     description: typeof meta.description === 'string' ? meta.description : undefined,
     tags: Array.isArray(meta.tags) ? meta.tags.filter((t): t is string => typeof t === 'string') : undefined,
     originalFilename: typeof meta.originalFilename === 'string' ? meta.originalFilename : undefined,
+    source: typeof meta.source === 'string' && ['agent', 'upload', 'clipboard'].includes(meta.source) ? meta.source as AssetSource : undefined,
   }
 }
 

--- a/plugins/assets/routes/link.ts
+++ b/plugins/assets/routes/link.ts
@@ -1,0 +1,29 @@
+/**
+ * PATCH /api/plugins/assets/link — relink or unlink an asset from a task.
+ * Body: { path: string, taskId: string | null }
+ */
+import { relinkAsset } from '../lib/relink'
+
+export async function handleLink(req: Request): Promise<Response> {
+  let body: { path?: string; taskId?: string | null }
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (!body.path || typeof body.path !== 'string') {
+    return Response.json({ error: 'Missing required field: path' }, { status: 400 })
+  }
+
+  const newTaskId = body.taskId === undefined || body.taskId === null ? null : String(body.taskId)
+
+  const result = relinkAsset({ assetPath: body.path, newTaskId })
+
+  if (!result.ok) {
+    const status = result.error === 'Asset not found' ? 404 : 400
+    return Response.json(result, { status })
+  }
+
+  return Response.json(result)
+}

--- a/plugins/assets/routes/upload.ts
+++ b/plugins/assets/routes/upload.ts
@@ -1,0 +1,115 @@
+/**
+ * POST /api/plugins/assets/upload — multipart file upload.
+ * Accepts one or more files, auto-detects asset type, creates sidecar metadata.
+ */
+import { writeFileSync, mkdirSync, unlinkSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+import type { PluginContext } from '../../../src/lib/plugin-types'
+import { getAssetType } from '../lib/constants'
+import { saveAsset, type SaveAssetResult } from '../lib/save-asset'
+import type { AssetSource } from '../lib/sidecar'
+
+interface UploadSettings {
+  maxFileSize?: number
+}
+
+export async function handleUpload(req: Request, ctx: PluginContext): Promise<Response> {
+  let formData: FormData
+  try {
+    formData = await req.formData()
+  } catch {
+    return Response.json({ error: 'Invalid multipart form data' }, { status: 400 })
+  }
+
+  const settings = ctx.getSettings<UploadSettings>()
+  const maxFileSizeMB = settings.maxFileSize ?? 50
+  const maxFileSizeBytes = maxFileSizeMB * 1024 * 1024
+
+  // Extract and validate form fields
+  const rawTaskId = String(formData.get('taskId') || '').trim() || '_unlinked'
+  if (rawTaskId !== '_unlinked' && (rawTaskId.includes('/') || rawTaskId.includes('\\') || rawTaskId.includes('..'))) {
+    return Response.json({ error: 'Invalid taskId' }, { status: 400 })
+  }
+  const taskId = rawTaskId
+  const description = (formData.get('description') as string) || undefined
+  const tagsRaw = formData.get('tags') as string
+  const tags = tagsRaw ? tagsRaw.split(',').map(t => t.trim()).filter(Boolean) : undefined
+  const sourceStr = String(formData.get('source') || 'upload')
+  const source: AssetSource = (['agent', 'upload', 'clipboard'].includes(sourceStr) ? sourceStr : 'upload') as AssetSource
+
+  // Collect all file entries
+  const files: File[] = []
+  for (const [key, value] of formData.entries()) {
+    if ((key === 'file' || key === 'files') && value instanceof File) {
+      files.push(value)
+    }
+  }
+
+  if (files.length === 0) {
+    return Response.json({ error: 'No file(s) provided — use "file" or "files" form field' }, { status: 400 })
+  }
+
+  // Validate file sizes
+  for (const file of files) {
+    if (file.size > maxFileSizeBytes) {
+      return Response.json(
+        { error: `File "${file.name}" exceeds ${maxFileSizeMB}MB limit (${(file.size / 1024 / 1024).toFixed(1)}MB)` },
+        { status: 413 },
+      )
+    }
+    if (file.size === 0) {
+      return Response.json({ error: `File "${file.name}" is empty` }, { status: 400 })
+    }
+  }
+
+  const results: SaveAssetResult[] = []
+  const tmpDir = join(tmpdir(), `bakin-upload-${randomUUID()}`)
+  mkdirSync(tmpDir, { recursive: true })
+
+  try {
+    for (const file of files) {
+      const tmpPath = join(tmpDir, `${randomUUID()}-${file.name}`)
+
+      // Write uploaded file to temp location
+      const buffer = Buffer.from(await file.arrayBuffer())
+      writeFileSync(tmpPath, buffer)
+
+      const assetType = getAssetType(file.name)
+
+      const result = await saveAsset({
+        filePath: tmpPath,
+        taskId,
+        type: assetType,
+        agent: 'user',
+        description,
+        tags,
+        source,
+        originalFilename: file.name,
+      })
+
+      results.push(result)
+
+      // Clean up temp file
+      try { unlinkSync(tmpPath) } catch { /* best-effort */ }
+
+      if (result.ok) {
+        ctx.activity.log('user', `Uploaded "${file.name}"`, { taskId: taskId !== '_unlinked' ? taskId : undefined })
+        ctx.activity.audit('uploaded', 'user', { path: result.path, source, taskId })
+      }
+    }
+  } finally {
+    // Clean up temp directory
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
+
+  const allOk = results.every(r => r.ok)
+  const status = allOk ? 200 : 207 // 207 Multi-Status if partial failure
+
+  if (results.length === 1) {
+    return Response.json(results[0], { status: results[0].ok ? 200 : 500 })
+  }
+
+  return Response.json({ results, ok: allOk }, { status })
+}

--- a/plugins/tasks/components/task-detail-dialog.tsx
+++ b/plugins/tasks/components/task-detail-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { BakinDrawer } from '@/components/bakin-drawer'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -8,7 +8,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
-import { Send, Check, X, RefreshCw, MoreHorizontal, Copy, Trash2, Pencil } from 'lucide-react'
+import { Send, Check, X, RefreshCw, MoreHorizontal, Copy, Trash2, Pencil, Loader2 } from 'lucide-react'
 import { MarkdownContent } from '@/components/markdown-content'
 import { TaskAssets } from '@bakin/assets/components/task-assets'
 import { AgentAvatar } from '@/components/agent-avatar'
@@ -147,6 +147,10 @@ export function TaskDetailDrawer({ task, columnId, open, editing, onClose, onEdi
   const [workflows, setWorkflows] = useState<Workflow[]>([])
   const [saving, setSaving] = useState(false)
   const [dirty, setDirty] = useState(false)
+  const [pasting, setPasting] = useState(false)
+  const descriptionRef = useRef<HTMLTextAreaElement>(null)
+  // Provisional ID for new tasks — ensures pasted assets land in the right directory
+  const [provisionalId] = useState(() => crypto.randomUUID().slice(0, 8))
   const [logMessage, setLogMessage] = useState('')
   const [addingLog, setAddingLog] = useState(false)
   const [showAllNotes, setShowAllNotes] = useState(false)
@@ -276,6 +280,116 @@ export function TaskDetailDrawer({ task, columnId, open, editing, onClose, onEdi
 
   function markDirty() { setDirty(true) }
 
+  const CLIPBOARD_MAX_SIZE_MB = 10
+  const CLIPBOARD_MAX_SIZE_BYTES = CLIPBOARD_MAX_SIZE_MB * 1024 * 1024
+  const LONG_TEXT_LINE_THRESHOLD = 20
+  const LONG_TEXT_CHAR_THRESHOLD = 500
+
+  /** Insert text at the textarea cursor position and update description state. */
+  function insertAtCursor(text: string) {
+    const el = descriptionRef.current
+    if (!el) {
+      setDescription(prev => prev + text)
+      markDirty()
+      return
+    }
+    const start = el.selectionStart
+    const end = el.selectionEnd
+    const before = description.substring(0, start)
+    const after = description.substring(end)
+    const newValue = before + text + after
+    setDescription(newValue)
+    markDirty()
+    // Restore cursor after React re-render
+    requestAnimationFrame(() => {
+      el.selectionStart = el.selectionEnd = start + text.length
+      el.focus()
+    })
+  }
+
+  /** Upload a file to the assets system and return the result. */
+  async function uploadAsset(file: File, taskId: string, source: 'clipboard' | 'upload'): Promise<{ ok: boolean; path?: string; filename?: string; error?: string }> {
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('taskId', taskId)
+    formData.append('source', source)
+    const res = await fetch('/api/plugins/assets/upload', { method: 'POST', body: formData })
+    return res.json()
+  }
+
+  /** Handle paste events — intercepts images and long text, uploads as task assets. */
+  async function handleDescriptionPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const items = e.clipboardData?.items
+    if (!items) return
+
+    const currentTaskId = task?.id || provisionalId
+
+    // Check for image data first
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault()
+        const file = item.getAsFile()
+        if (!file) continue
+
+        if (file.size > CLIPBOARD_MAX_SIZE_BYTES) {
+          toast(`Pasted image exceeds ${CLIPBOARD_MAX_SIZE_MB}MB limit (${(file.size / 1024 / 1024).toFixed(1)}MB)`, 'error')
+          return
+        }
+
+        setPasting(true)
+        try {
+          const result = await uploadAsset(file, currentTaskId, 'clipboard')
+          if (result.ok) {
+            const ref = `![${result.filename || 'pasted image'}](/api/plugins/assets/file?path=${encodeURIComponent(result.path!)})`
+            insertAtCursor(ref)
+            window.dispatchEvent(new CustomEvent('bakin:asset-uploaded', { detail: { taskId: currentTaskId } }))
+            toast('Image added to task assets', 'success')
+          } else {
+            toast(result.error || 'Failed to upload pasted image', 'error')
+          }
+        } catch {
+          toast('Failed to upload pasted image', 'error')
+        } finally {
+          setPasting(false)
+        }
+        return
+      }
+    }
+
+    // Check for long text paste — save as text asset instead of bloating description
+    const text = e.clipboardData.getData('text/plain')
+    if (text) {
+      const lineCount = text.split('\n').length
+      if (lineCount >= LONG_TEXT_LINE_THRESHOLD || text.length >= LONG_TEXT_CHAR_THRESHOLD) {
+        e.preventDefault()
+        setPasting(true)
+        try {
+          const blob = new Blob([text], { type: 'text/markdown' })
+          const filename = `pasted-text-${Date.now()}.md`
+          const file = new File([blob], filename, { type: 'text/markdown' })
+          const result = await uploadAsset(file, currentTaskId, 'clipboard')
+          if (result.ok) {
+            const ref = `[Attached: ${result.filename} (${lineCount} lines)](/api/plugins/assets/file?path=${encodeURIComponent(result.path!)})`
+            insertAtCursor(ref)
+            window.dispatchEvent(new CustomEvent('bakin:asset-uploaded', { detail: { taskId: currentTaskId } }))
+            toast(`Text saved as task asset (${lineCount} lines)`, 'success')
+          } else {
+            // Fallback: paste text inline if upload fails
+            insertAtCursor(text)
+            toast(result.error || 'Failed to save as asset, pasted inline', 'error')
+          }
+        } catch {
+          // Fallback: paste text inline
+          insertAtCursor(text)
+          toast('Failed to save as asset, pasted inline', 'error')
+        } finally {
+          setPasting(false)
+        }
+        return
+      }
+    }
+  }
+
   async function handleCreate() {
     if (!title.trim()) return
     setSaving(true)
@@ -284,6 +398,7 @@ export function TaskDetailDrawer({ task, columnId, open, editing, onClose, onEdi
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          id: provisionalId,
           title: title.trim(),
           description: description.trim() || undefined,
           column,
@@ -629,11 +744,16 @@ export function TaskDetailDrawer({ task, columnId, open, editing, onClose, onEdi
           </div>
 
           <div>
-            <label className="text-sm text-muted-foreground mb-1 block">Details</label>
+            <label className="text-sm text-muted-foreground mb-1 block">
+              Details
+              {pasting && <Loader2 className="inline size-3.5 ml-1.5 animate-spin text-muted-foreground" />}
+            </label>
             <Textarea
+              ref={descriptionRef}
               value={description}
               onChange={(e) => { setDescription(e.target.value); markDirty() }}
-              placeholder="Describe what needs to happen, any constraints, links, or context the agent needs..."
+              onPaste={handleDescriptionPaste}
+              placeholder="Describe what needs to happen, any constraints, links, or context the agent needs... (paste images or long text to auto-attach)"
               rows={8}
               className="min-h-[120px] resize-y bg-surface"
             />

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -108,13 +108,13 @@ const tasksPlugin: BakinPlugin = {
       description: 'Create a new task',
       handler: async (req: Request) => {
         const body = await req.json()
-        const { title, description, column, assignee, workflowId, skipWorkflowReason, createdBy, parentId, projectId } = body
+        const { id, title, description, column, assignee, workflowId, skipWorkflowReason, createdBy, parentId, projectId } = body
         if (!title) {
           return Response.json({ error: 'title required' }, { status: 400 })
         }
         try {
           const result = await createTaskWithEffects({
-            title, column, assignee, description, workflowId, skipWorkflowReason,
+            id, title, column, assignee, description, workflowId, skipWorkflowReason,
             createdBy: createdBy || 'system', parentId, projectId, channel: 'rest',
           })
           ctx.activity.log(createdBy || 'system', `Created task "${title}"`, { taskId: result.id })

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -92,6 +92,7 @@ Use these tools to accomplish actual work — saving files, posting content, gen
 | `bakin_exec_assets_get` | Retrieve a single asset's sidecar metadata by path. |
 | `bakin_exec_assets_save` | Save an agent-created file to the assets directory with standardized naming (YYYYMMDD-slug.ext) and sidecar metadata. Handles directory creation, naming conventions, and .meta.json automatically. |
 | `bakin_exec_assets_delete` | Soft-delete an asset (moves to trash with 30-day expiry). |
+| `bakin_exec_assets_link` | Link an asset to a different task, or unlink it (set taskId to null). Physically moves the file between task directories and updates sidecar metadata. |
 | `bakin_exec_assets_list_trash` | List trashed assets with name, size, deleted timestamp, and days remaining before auto-purge. |
 | `bakin_exec_assets_restore` | Restore a trashed asset back to its original location. Use bakin_exec_assets_list_trash first to get the filename. |
 | `bakin_exec_assets_audit` | Audit asset health: check for missing thumbnails, invalid sidecars, orphaned files. Set fix=true to auto-generate missing thumbnails and create stub sidecars. |

--- a/src/app/api/plugins/[pluginId]/[[...path]]/route.ts
+++ b/src/app/api/plugins/[pluginId]/[[...path]]/route.ts
@@ -251,4 +251,5 @@ async function handleRequest(
 export const GET = handleRequest
 export const POST = handleRequest
 export const PUT = handleRequest
+export const PATCH = handleRequest
 export const DELETE = handleRequest

--- a/src/components/bakin-drawer.tsx
+++ b/src/components/bakin-drawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useState, useCallback, useEffect } from 'react'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -9,6 +9,35 @@ import { ArrowLeft, X } from 'lucide-react'
 const MIN_WIDTH = 320
 const MAX_WIDTH = 960
 const DEFAULT_WIDTH = 810
+const DRAWER_WIDTH_STORAGE_KEY = 'bakin-drawer-width'
+
+function clampDrawerWidth(width: number) {
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, width))
+}
+
+function getDrawerWidthStorageKey(storageKey?: string) {
+  return storageKey ? `${DRAWER_WIDTH_STORAGE_KEY}:${storageKey}` : DRAWER_WIDTH_STORAGE_KEY
+}
+
+function getStoredDrawerWidth(defaultWidth: number, storageKey?: string) {
+  const fallbackWidth = clampDrawerWidth(defaultWidth)
+
+  if (typeof window === 'undefined') {
+    return fallbackWidth
+  }
+
+  try {
+    const storedWidth = window.localStorage.getItem(getDrawerWidthStorageKey(storageKey))
+    if (!storedWidth) {
+      return fallbackWidth
+    }
+
+    const parsedWidth = Number.parseInt(storedWidth, 10)
+    return Number.isFinite(parsedWidth) ? clampDrawerWidth(parsedWidth) : fallbackWidth
+  } catch {
+    return fallbackWidth
+  }
+}
 
 export function BakinDrawer({
   open,
@@ -18,6 +47,7 @@ export function BakinDrawer({
   actions,
   children,
   defaultWidth = DEFAULT_WIDTH,
+  storageKey,
   onBack,
   dirty = false,
 }: {
@@ -28,32 +58,55 @@ export function BakinDrawer({
   actions?: React.ReactNode
   children: React.ReactNode
   defaultWidth?: number
+  /** Optional suffix for per-context drawer width persistence */
+  storageKey?: string
   /** When provided, a back arrow appears left of the title */
   onBack?: () => void
   /** When true, closing the drawer shows an "unsaved changes" confirmation */
   dirty?: boolean
 }) {
-  const [width, setWidth] = useState(defaultWidth)
+  const [width, setWidth] = useState(() => getStoredDrawerWidth(defaultWidth, storageKey))
   const [showDirtyConfirm, setShowDirtyConfirm] = useState(false)
   const dragging = useRef(false)
   const startX = useRef(0)
   const startWidth = useRef(0)
+  const widthRef = useRef(width)
+
+  useEffect(() => {
+    setWidth(getStoredDrawerWidth(defaultWidth, storageKey))
+  }, [defaultWidth, storageKey])
+
+  useEffect(() => {
+    widthRef.current = width
+  }, [width])
+
+  const persistWidth = useCallback((nextWidth: number) => {
+    if (typeof window === 'undefined') return
+
+    try {
+      window.localStorage.setItem(getDrawerWidthStorageKey(storageKey), String(clampDrawerWidth(nextWidth)))
+    } catch {
+      // Ignore storage failures; the drawer should still resize normally.
+    }
+  }, [storageKey])
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     dragging.current = true
     startX.current = e.clientX
-    startWidth.current = width
+    startWidth.current = widthRef.current
 
     const handleMouseMove = (ev: MouseEvent) => {
       if (!dragging.current) return
       const delta = startX.current - ev.clientX
-      const newWidth = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidth.current + delta))
+      const newWidth = clampDrawerWidth(startWidth.current + delta)
+      widthRef.current = newWidth
       setWidth(newWidth)
     }
 
     const handleMouseUp = () => {
       dragging.current = false
+      persistWidth(widthRef.current)
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
       document.body.style.cursor = ''
@@ -64,7 +117,7 @@ export function BakinDrawer({
     document.addEventListener('mouseup', handleMouseUp)
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
-  }, [width])
+  }, [persistWidth])
 
   const requestClose = useCallback(() => {
     if (dirty) {
@@ -161,4 +214,12 @@ export function BakinDrawer({
   )
 }
 
-export { MIN_WIDTH, MAX_WIDTH, DEFAULT_WIDTH }
+export {
+  MIN_WIDTH,
+  MAX_WIDTH,
+  DEFAULT_WIDTH,
+  DRAWER_WIDTH_STORAGE_KEY,
+  clampDrawerWidth,
+  getDrawerWidthStorageKey,
+  getStoredDrawerWidth,
+}

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -2,7 +2,7 @@
  * Task dispatch system for Bakin.
  * Periodically checks for TODO tasks and dispatches them to agents via OpenClaw.
  */
-import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { createLogger } from './logger'
 import { getSettings } from './settings'
@@ -321,13 +321,36 @@ export async function dispatchSingleTask(
   })
 }
 
-function buildDispatchMessage(
+/** @internal Exported for testing. */
+export function buildDispatchMessage(
   task: { id: string; title: string; description?: string; agent?: string; projectId?: string },
   agentName: string,
   contentDir: string,
   _port: number
 ): string {
   const detailsBlock = task.description ? `\n\nDetails:\n${task.description}` : ''
+
+  // List attached assets for this task by scanning the asset directories
+  let assetsBlock = ''
+  try {
+    const assetsRoot = join(contentDir, 'assets')
+    const assetTypes = ['text', 'images', 'video', 'audio', 'plans', 'data', 'other']
+    const assetPaths: string[] = []
+    for (const type of assetTypes) {
+      const taskDir = join(assetsRoot, type, task.id)
+      if (existsSync(taskDir)) {
+        const files = readdirSync(taskDir).filter(f => !f.endsWith('.meta.json') && !f.startsWith('.'))
+        for (const file of files) {
+          // Skip variants (thumbnails, optimized)
+          if (file.includes('.thumb.') || file.includes('.opt.')) continue
+          assetPaths.push(join(taskDir, file))
+        }
+      }
+    }
+    if (assetPaths.length > 0) {
+      assetsBlock = `\n\n## Attached Assets\nThis task has ${assetPaths.length} linked asset(s). Review them for context before starting:\n${assetPaths.map(p => `- ${p}`).join('\n')}\nFor images, view the file directly. For text/documents, read with cat. Use bakin_exec_assets_get for sidecar metadata.`
+    }
+  } catch { /* assets directory may not exist */ }
 
   // Project context — lightweight mention if task has a projectId
   let projectBlock = ''
@@ -346,14 +369,14 @@ function buildDispatchMessage(
   const mc = (tool: string, args: string) => `mcporter call ${server}.${tool} ${args}`
 
   if (!task.agent) {
-    return `Triage this task: "${task.title}".${detailsBlock}\n\nEither handle it yourself or assign it to the right agent (patch=execution, pixel=design/media, rolo=content/comms, basil=research/strategy) via \`${mc('bakin_exec_tasks_assign', `taskId=${task.id} agent="<agent>"`)}\`. ${contactsRef}\n\nLog progress: \`${mc('bakin_log_progress', `taskId=${task.id} message="<update>"`)}\``
+    return `Triage this task: "${task.title}".${detailsBlock}${assetsBlock}\n\nEither handle it yourself or assign it to the right agent (patch=execution, pixel=design/media, rolo=content/comms, basil=research/strategy) via \`${mc('bakin_exec_tasks_assign', `taskId=${task.id} agent="<agent>"`)}\`. ${contactsRef}\n\nLog progress: \`${mc('bakin_log_progress', `taskId=${task.id} message="<update>"`)}\``
   }
 
   if (task.agent === 'roscoe') {
-    return `Work on this task: "${task.title}".${detailsBlock}\n\n${contactsRef} When done: \`${mc('bakin_report_complete', `taskId=${task.id} summary="<what you did>"`)}\`\n\nLog progress: \`${mc('bakin_log_progress', `taskId=${task.id} message="<update>"`)}\``
+    return `Work on this task: "${task.title}".${detailsBlock}${assetsBlock}\n\n${contactsRef} When done: \`${mc('bakin_report_complete', `taskId=${task.id} summary="<what you did>"`)}\`\n\nLog progress: \`${mc('bakin_log_progress', `taskId=${task.id} message="<update>"`)}\``
   }
 
-  return `Work on this task: "${task.title}".${detailsBlock}${projectBlock}
+  return `Work on this task: "${task.title}".${detailsBlock}${assetsBlock}${projectBlock}
 
 ## PROGRESS LOGGING — MANDATORY
 

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -107,6 +107,8 @@ export async function moveTaskWithEffects(
     checkAndContinueDependents(taskId, title, getContentDir(), getPort()).catch((err) => {
       log.error('Continuation trigger failed', err)
     })
+    // Purge clipboard-source assets if the setting is enabled
+    hooks().invoke('assets.purgeClipboardForTask', { taskId }).catch(() => {})
   }
 
   // Auto-check project checklist items when task reaches done or confirmed
@@ -181,6 +183,7 @@ export async function blockTaskWithEffects(
  * Returns the created task.
  */
 export async function createTaskWithEffects(opts: {
+  id?: string
   title: string
   column?: string
   assignee?: string
@@ -197,6 +200,7 @@ export async function createTaskWithEffects(opts: {
   const effectiveWorkflowId = opts.workflowId || undefined
 
   const task = await hooks().invoke<{ id: string }>('tasks.createTask', {
+    id: opts.id,
     title: opts.title,
     column: opts.column,
     assignee: opts.assignee,

--- a/tests/components/bakin-drawer.test.tsx
+++ b/tests/components/bakin-drawer.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  BakinDrawer,
+  DEFAULT_WIDTH,
+  DRAWER_WIDTH_STORAGE_KEY,
+  MAX_WIDTH,
+  MIN_WIDTH,
+  getDrawerWidthStorageKey,
+  getStoredDrawerWidth,
+} from '@/components/bakin-drawer'
+
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({ children }: { children: React.ReactNode }) => <div data-testid="sheet">{children}</div>,
+  SheetContent: ({ children, style, className }: { children: React.ReactNode; style?: React.CSSProperties; className?: string }) => (
+    <div data-testid="sheet-content" style={style} className={className}>{children}</div>
+  ),
+  SheetHeader: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
+  SheetTitle: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
+  SheetDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => <button onClick={onClick}>{children}</button>,
+}))
+
+describe('BakinDrawer', () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>()
+
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          storage.set(key, value)
+        },
+        removeItem: (key: string) => {
+          storage.delete(key)
+        },
+        clear: () => {
+          storage.clear()
+        },
+      },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+  })
+
+  it('hydrates width from localStorage when available', () => {
+    window.localStorage.setItem(DRAWER_WIDTH_STORAGE_KEY, '640')
+
+    const { getByTestId } = render(
+      <BakinDrawer open onOpenChange={() => {}}>
+        <div>Body</div>
+      </BakinDrawer>,
+    )
+
+    expect(getByTestId('sheet-content').style.width).toBe('640px')
+  })
+
+  it('persists the resized width on drag end', async () => {
+    const { container, getByTestId } = render(
+      <BakinDrawer open onOpenChange={() => {}}>
+        <div>Body</div>
+      </BakinDrawer>,
+    )
+
+    const handle = container.querySelector('.cursor-col-resize')
+    expect(handle).toBeTruthy()
+
+    fireEvent.mouseDown(handle as Element, { clientX: 1000 })
+    fireEvent.mouseMove(document, { clientX: 900 })
+    fireEvent.mouseUp(document)
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(DRAWER_WIDTH_STORAGE_KEY)).toBe('910')
+      expect(getByTestId('sheet-content').style.width).toBe('910px')
+    })
+  })
+
+  it('supports per-context storage keys and clamps invalid stored widths', () => {
+    window.localStorage.setItem(getDrawerWidthStorageKey('tasks'), '1200')
+    window.localStorage.setItem(getDrawerWidthStorageKey('assets'), 'oops')
+
+    expect(getStoredDrawerWidth(DEFAULT_WIDTH, 'tasks')).toBe(MAX_WIDTH)
+    expect(getStoredDrawerWidth(DEFAULT_WIDTH, 'assets')).toBe(DEFAULT_WIDTH)
+    expect(getStoredDrawerWidth(100, 'missing')).toBe(MIN_WIDTH)
+  })
+})

--- a/tests/core/dispatch-assets.test.ts
+++ b/tests/core/dispatch-assets.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for attached asset context in dispatch messages.
+ * Assets are detected by scanning filesystem directories, not description URLs.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-dispatch-assets-${Date.now()}`)
+
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../src/core/settings', () => ({
+  getSettings: vi.fn().mockReturnValue({
+    dispatch: { intervalMs: 1000, maxRetries: 3, failureCooldownMs: 60000, maxDispatched: 500 },
+    agents: ['roscoe', 'pixel'],
+    watchdog: { stuckThresholdMs: 30 * 60 * 1000 },
+  }),
+}))
+
+vi.mock('../../src/core/audit', () => ({ appendAudit: vi.fn() }))
+vi.mock('../../src/core/openclaw-client', () => ({ sendMessage: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../../src/lib/taskboard', () => ({
+  getTodoTasks: vi.fn().mockReturnValue({ todoTasks: [] }),
+  moveTaskToInProgress: vi.fn(),
+  addTaskLog: vi.fn(),
+}))
+vi.mock('../../src/lib/plugin-registry', () => ({
+  getHookRegistry: vi.fn().mockReturnValue({
+    invoke: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn().mockReturnValue(false),
+    register: vi.fn(),
+  }),
+}))
+vi.mock('../../src/lib/format', () => ({ isStale: vi.fn().mockReturnValue(true) }))
+
+import { buildDispatchMessage } from '../../src/core/dispatch'
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true })
+
+  // Create asset fixtures for task-1
+  const imgDir = join(testDir, 'assets', 'images', 'task-1')
+  mkdirSync(imgDir, { recursive: true })
+  writeFileSync(join(imgDir, '20260404-reference.png'), 'fake-png')
+  writeFileSync(join(imgDir, '20260404-reference.png.meta.json'), '{}')
+  writeFileSync(join(imgDir, '20260404-reference.thumb.jpg'), 'fake-thumb') // variant, should be excluded
+
+  const txtDir = join(testDir, 'assets', 'text', 'task-1')
+  mkdirSync(txtDir, { recursive: true })
+  writeFileSync(join(txtDir, '20260404-brief.md'), '# Brief')
+  writeFileSync(join(txtDir, '20260404-brief.md.meta.json'), '{}')
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('buildDispatchMessage — attached assets', () => {
+  it('includes attached assets when task has linked files', () => {
+    const task = {
+      id: 'task-1',
+      title: 'Design banner',
+      agent: 'pixel',
+      description: 'Create a banner based on the reference images.',
+    }
+    const msg = buildDispatchMessage(task, 'pixel', testDir, 3737)
+    expect(msg).toContain('## Attached Assets')
+    expect(msg).toContain('20260404-reference.png')
+    expect(msg).toContain('20260404-brief.md')
+    expect(msg).toContain('bakin_exec_assets_get')
+    // Should NOT include variants
+    expect(msg).not.toContain('.thumb.')
+    // Should NOT include .meta.json files
+    expect(msg).not.toContain('.meta.json')
+  })
+
+  it('shows correct asset count', () => {
+    const task = { id: 'task-1', title: 'Test', agent: 'pixel' }
+    const msg = buildDispatchMessage(task, 'pixel', testDir, 3737)
+    expect(msg).toContain('2 linked asset(s)')
+  })
+
+  it('omits attached assets when task has no asset directories', () => {
+    const task = {
+      id: 'task-no-assets',
+      title: 'Simple task',
+      agent: 'pixel',
+      description: 'No assets here.',
+    }
+    const msg = buildDispatchMessage(task, 'pixel', testDir, 3737)
+    expect(msg).not.toContain('## Attached Assets')
+  })
+
+  it('includes attached assets in triage messages (no agent)', () => {
+    const task = {
+      id: 'task-1',
+      title: 'Triage with asset',
+      description: 'Look at the attached files.',
+    }
+    const msg = buildDispatchMessage(task, 'main', testDir, 3737)
+    expect(msg).toContain('## Attached Assets')
+  })
+
+  it('includes attached assets for roscoe-assigned tasks', () => {
+    const task = {
+      id: 'task-1',
+      title: 'My task',
+      agent: 'roscoe',
+    }
+    const msg = buildDispatchMessage(task, 'roscoe', testDir, 3737)
+    expect(msg).toContain('## Attached Assets')
+  })
+})

--- a/tests/plugins/assets/clipboard-purge.test.ts
+++ b/tests/plugins/assets/clipboard-purge.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for clipboard asset purge on task completion.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { activatePlugin, type ActivatedPlugin } from '../test-helpers'
+
+const testDir = join(tmpdir(), `bakin-test-clipboard-purge-${Date.now()}`)
+const assetsRoot = join(testDir, 'assets')
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => {
+    const base = join(testDir, 'assets')
+    return {
+      'assets.text': join(base, 'text'),
+      'assets.images': join(base, 'images'),
+      'assets.video': join(base, 'video'),
+      'assets.audio': join(base, 'audio'),
+      'assets.plans': join(base, 'plans'),
+      'assets.data': join(base, 'data'),
+      'assets.other': join(base, 'other'),
+    }
+  },
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/core/watcher', () => ({
+  registerSyncHook: vi.fn(),
+}))
+
+import assetsPlugin from '@bakin/assets'
+import { buildIndex } from '@bakin/assets/lib/asset-index'
+
+let plugin: ActivatedPlugin
+let purgeHandler: ((data: Record<string, unknown>) => Promise<unknown>) | undefined
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  plugin = await activatePlugin(assetsPlugin, testDir)
+
+  // Find the purge hook handler that was registered
+  const registerCalls = (plugin.ctx.hooks.register as ReturnType<typeof vi.fn>).mock.calls
+  const purgeCall = registerCalls.find((args: unknown[]) => args[0] === 'assets.purgeClipboardForTask')
+  purgeHandler = purgeCall?.[1] as typeof purgeHandler
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+function createAsset(
+  type: string,
+  taskId: string,
+  filename: string,
+  source: string,
+): string {
+  const dir = join(assetsRoot, type, taskId)
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, filename)
+  writeFileSync(filePath, 'test-content')
+  writeFileSync(`${filePath}.meta.json`, JSON.stringify({
+    agent: 'user',
+    taskId,
+    created: new Date().toISOString(),
+    source,
+  }))
+  // Also need trash directory
+  mkdirSync(join(assetsRoot, '.trash'), { recursive: true })
+  return filePath
+}
+
+describe('clipboard purge hook', () => {
+  it('registers the purgeClipboardForTask hook', () => {
+    expect(purgeHandler).toBeDefined()
+  })
+
+  it('does nothing when purgeClipboardOnComplete is disabled', async () => {
+    createAsset('images', 'task-purge-1', '20260404-clip.png', 'clipboard')
+    plugin.ctx.getSettings = (() => ({ purgeClipboardOnComplete: false })) as typeof plugin.ctx.getSettings
+
+    const result = await purgeHandler!({ taskId: 'task-purge-1' })
+    expect(result).toEqual({ purged: 0 })
+
+    // File should still exist
+    expect(existsSync(join(assetsRoot, 'images', 'task-purge-1', '20260404-clip.png'))).toBe(true)
+  })
+
+  it('does nothing when no taskId provided', async () => {
+    plugin.ctx.getSettings = (() => ({ purgeClipboardOnComplete: true })) as typeof plugin.ctx.getSettings
+    const result = await purgeHandler!({})
+    expect(result).toEqual({ purged: 0 })
+  })
+
+  it('purges clipboard assets when enabled', async () => {
+    const taskId = 'task-purge-2'
+    createAsset('images', taskId, '20260404-pasted.png', 'clipboard')
+    buildIndex() // Rebuild index to pick up the new file
+    plugin.ctx.getSettings = (() => ({ purgeClipboardOnComplete: true })) as typeof plugin.ctx.getSettings
+
+    const result = await purgeHandler!({ taskId }) as { purged: number }
+    expect(result.purged).toBeGreaterThanOrEqual(1)
+  })
+
+  it('preserves non-clipboard assets', async () => {
+    const taskId = 'task-purge-3'
+    createAsset('images', taskId, '20260404-agent-made.png', 'agent')
+    createAsset('images', taskId, '20260404-uploaded.jpg', 'upload')
+    buildIndex() // Rebuild index to pick up the new files
+    plugin.ctx.getSettings = (() => ({ purgeClipboardOnComplete: true })) as typeof plugin.ctx.getSettings
+
+    const result = await purgeHandler!({ taskId }) as { purged: number }
+    expect(result.purged).toBe(0)
+
+    // Files should still exist
+    expect(existsSync(join(assetsRoot, 'images', taskId, '20260404-agent-made.png'))).toBe(true)
+    expect(existsSync(join(assetsRoot, 'images', taskId, '20260404-uploaded.jpg'))).toBe(true)
+  })
+})

--- a/tests/plugins/assets/relink.test.ts
+++ b/tests/plugins/assets/relink.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for asset relink/unlink — relinkAsset() in plugins/assets/lib/relink.ts.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-relink-${Date.now()}`)
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => {
+    const base = join(testDir, 'assets')
+    return {
+      'assets.text': join(base, 'text'),
+      'assets.images': join(base, 'images'),
+      'assets.video': join(base, 'video'),
+      'assets.audio': join(base, 'audio'),
+      'assets.plans': join(base, 'plans'),
+      'assets.data': join(base, 'data'),
+      'assets.other': join(base, 'other'),
+    }
+  },
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+import { relinkAsset } from '@bakin/assets/lib/relink'
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+function createAssetFixture(type: string, taskId: string, filename: string, content = 'test') {
+  const dir = join(testDir, 'assets', type, taskId)
+  mkdirSync(dir, { recursive: true })
+  const filePath = join(dir, filename)
+  writeFileSync(filePath, content)
+  writeFileSync(filePath + '.meta.json', JSON.stringify({
+    agent: 'user',
+    taskId,
+    created: new Date().toISOString(),
+  }))
+  return `assets/${type}/${taskId}/${filename}`
+}
+
+describe('relinkAsset', () => {
+  it('moves asset from one task to another', () => {
+    const path = createAssetFixture('images', 'task-a', '20260404-photo.png')
+    const result = relinkAsset({ assetPath: path, newTaskId: 'task-b' })
+
+    expect(result.ok).toBe(true)
+    expect(result.newPath).toBe('assets/images/task-b/20260404-photo.png')
+
+    // Old file should be gone
+    expect(existsSync(join(testDir, path))).toBe(false)
+    // New file should exist
+    expect(existsSync(join(testDir, result.newPath!))).toBe(true)
+    // Sidecar should exist at new location
+    expect(existsSync(join(testDir, result.newPath! + '.meta.json'))).toBe(true)
+  })
+
+  it('unlinks asset to _unlinked directory', () => {
+    const path = createAssetFixture('text', 'task-c', '20260404-notes.md')
+    const result = relinkAsset({ assetPath: path, newTaskId: null })
+
+    expect(result.ok).toBe(true)
+    expect(result.newPath).toBe('assets/text/_unlinked/20260404-notes.md')
+    expect(existsSync(join(testDir, result.newPath!))).toBe(true)
+
+    // Sidecar should have taskId: null
+    const sidecar = JSON.parse(readFileSync(join(testDir, result.newPath! + '.meta.json'), 'utf-8'))
+    expect(sidecar.taskId).toBeNull()
+  })
+
+  it('updates sidecar taskId after relink', () => {
+    const path = createAssetFixture('images', 'task-d', '20260404-ref.png')
+    const result = relinkAsset({ assetPath: path, newTaskId: 'task-e' })
+
+    expect(result.ok).toBe(true)
+    const sidecar = JSON.parse(readFileSync(join(testDir, result.newPath! + '.meta.json'), 'utf-8'))
+    expect(sidecar.taskId).toBe('task-e')
+  })
+
+  it('returns no-op when relinking to same task', () => {
+    const path = createAssetFixture('text', 'task-f', '20260404-same.md')
+    const result = relinkAsset({ assetPath: path, newTaskId: 'task-f' })
+
+    expect(result.ok).toBe(true)
+    expect(result.newPath).toBe(path)
+    // File should still exist
+    expect(existsSync(join(testDir, path))).toBe(true)
+  })
+
+  it('rejects path traversal', () => {
+    const result = relinkAsset({ assetPath: 'assets/../etc/passwd', newTaskId: 'task-x' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('..')
+  })
+
+  it('rejects invalid path prefix', () => {
+    const result = relinkAsset({ assetPath: 'not-assets/foo/bar/file.png', newTaskId: 'task-x' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('must start with assets/')
+  })
+
+  it('returns error for non-existent asset', () => {
+    const result = relinkAsset({ assetPath: 'assets/images/ghost/20260404-nope.png', newTaskId: 'task-x' })
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+
+  it('handles filename collision in target directory', () => {
+    const path = createAssetFixture('images', 'task-g', '20260404-dup.png')
+    // Pre-create a file at the target location
+    const targetDir = join(testDir, 'assets', 'images', 'task-h')
+    mkdirSync(targetDir, { recursive: true })
+    writeFileSync(join(targetDir, '20260404-dup.png'), 'existing')
+
+    const result = relinkAsset({ assetPath: path, newTaskId: 'task-h' })
+
+    expect(result.ok).toBe(true)
+    // Should have a modified filename (with random suffix)
+    expect(result.newPath).not.toBe('assets/images/task-h/20260404-dup.png')
+    expect(result.newPath).toContain('assets/images/task-h/20260404-dup-')
+    expect(existsSync(join(testDir, result.newPath!))).toBe(true)
+  })
+
+  it('moves variants (.thumb.*) along with the primary file', () => {
+    const path = createAssetFixture('images', 'task-i', '20260404-hero.png')
+    // Create a thumbnail variant
+    const thumbPath = join(testDir, 'assets', 'images', 'task-i', '20260404-hero.thumb.jpg')
+    writeFileSync(thumbPath, 'thumb-data')
+
+    const result = relinkAsset({ assetPath: path, newTaskId: 'task-j' })
+
+    expect(result.ok).toBe(true)
+    // Thumbnail should have moved too
+    expect(existsSync(join(testDir, 'assets', 'images', 'task-j', '20260404-hero.thumb.jpg'))).toBe(true)
+    expect(existsSync(thumbPath)).toBe(false)
+  })
+})

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -140,13 +140,15 @@ afterAll(() => {
 // ===========================================================================
 
 describe('route registration', () => {
-  it('registers all 7 routes', () => {
-    expect(plugin.routes.length).toBe(7)
+  it('registers all 9 routes', () => {
+    expect(plugin.routes.length).toBe(9)
   })
 
   it.each([
     ['GET', '/'],
     ['GET', '/file'],
+    ['POST', '/upload'],
+    ['PATCH', '/link'],
     ['DELETE', '/'],
     ['GET', '/trash'],
     ['POST', '/trash/:file/restore'],
@@ -164,14 +166,15 @@ describe('route registration', () => {
 // ===========================================================================
 
 describe('exec tool registration', () => {
-  it('registers all 9 exec tools', () => {
-    expect(plugin.execTools.length).toBe(9)
+  it('registers all 10 exec tools', () => {
+    expect(plugin.execTools.length).toBe(10)
   })
 
   it.each([
     'bakin_exec_assets_list',
     'bakin_exec_assets_save',
     'bakin_exec_assets_delete',
+    'bakin_exec_assets_link',
     'bakin_exec_assets_list_trash',
     'bakin_exec_assets_restore',
     'bakin_exec_assets_audit',
@@ -949,6 +952,134 @@ describe('exec tool: bakin_exec_assets_audit', () => {
 // ===========================================================================
 // DELETE route integration — simulates the full URL path the browser sends
 // ===========================================================================
+
+// ===========================================================================
+// PATCH /link — relink/unlink asset
+// ===========================================================================
+
+describe('PATCH /link — relink/unlink asset', () => {
+  it('relinks asset from one task to another', async () => {
+    createAssetFixture('images', 'link-src', 'relink-test.png', 'img-data', {
+      agent: 'pixel', taskId: 'link-src', created: '2026-04-05T00:00:00Z',
+    })
+
+    const route = findRoute(plugin.routes, 'PATCH', '/link')!
+    const req = makeRequest('/link', {
+      method: 'PATCH',
+      body: { path: 'assets/images/link-src/relink-test.png', taskId: 'link-dest' },
+    })
+    const res = await route.handler(req, plugin.ctx)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.newPath).toBe('assets/images/link-dest/relink-test.png')
+    expect(existsSync(join(assetsRoot, 'images', 'link-dest', 'relink-test.png'))).toBe(true)
+    expect(existsSync(join(assetsRoot, 'images', 'link-src', 'relink-test.png'))).toBe(false)
+  })
+
+  it('unlinks asset to _unlinked', async () => {
+    createAssetFixture('text', 'link-unl', 'unlink-test.md', '# test', {
+      agent: 'user', taskId: 'link-unl', created: '2026-04-05T00:00:00Z',
+    })
+
+    const route = findRoute(plugin.routes, 'PATCH', '/link')!
+    const req = makeRequest('/link', {
+      method: 'PATCH',
+      body: { path: 'assets/text/link-unl/unlink-test.md', taskId: null },
+    })
+    const res = await route.handler(req, plugin.ctx)
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.newPath).toContain('_unlinked')
+    // Sidecar should have null taskId
+    const sidecar = JSON.parse(readFileSync(join(assetsRoot, 'text', '_unlinked', 'unlink-test.md.meta.json'), 'utf-8'))
+    expect(sidecar.taskId).toBeNull()
+  })
+
+  it('returns 400 for missing path', async () => {
+    const route = findRoute(plugin.routes, 'PATCH', '/link')!
+    const req = makeRequest('/link', {
+      method: 'PATCH',
+      body: { taskId: 'some-task' },
+    })
+    const res = await route.handler(req, plugin.ctx)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 for non-existent asset', async () => {
+    const route = findRoute(plugin.routes, 'PATCH', '/link')!
+    const req = makeRequest('/link', {
+      method: 'PATCH',
+      body: { path: 'assets/images/ghost/nope.png', taskId: 'x' },
+    })
+    const res = await route.handler(req, plugin.ctx)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 400 for path traversal', async () => {
+    const route = findRoute(plugin.routes, 'PATCH', '/link')!
+    const req = makeRequest('/link', {
+      method: 'PATCH',
+      body: { path: 'assets/../etc/passwd', taskId: 'x' },
+    })
+    const res = await route.handler(req, plugin.ctx)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for taskId with path separators', async () => {
+    createAssetFixture('images', 'link-sec', 'sec-test.png', 'data', {
+      agent: 'user', taskId: 'link-sec', created: '2026-04-05T00:00:00Z',
+    })
+    const route = findRoute(plugin.routes, 'PATCH', '/link')!
+    const req = makeRequest('/link', {
+      method: 'PATCH',
+      body: { path: 'assets/images/link-sec/sec-test.png', taskId: '../../etc' },
+    })
+    const res = await route.handler(req, plugin.ctx)
+    expect(res.status).toBe(400)
+  })
+})
+
+// ===========================================================================
+// exec tool: bakin_exec_assets_link
+// ===========================================================================
+
+describe('exec tool: bakin_exec_assets_link', () => {
+  it('relinks asset via MCP tool', async () => {
+    createAssetFixture('images', 'tool-src', 'tool-link.png', 'img-data', {
+      agent: 'pixel', taskId: 'tool-src', created: '2026-04-05T00:00:00Z',
+    })
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_link')!
+    const result = await callTool(tool, { path: 'assets/images/tool-src/tool-link.png', taskId: 'tool-dest' }, 'pixel')
+
+    expect(result.ok).toBe(true)
+    expect(result.newPath).toBe('assets/images/tool-dest/tool-link.png')
+  })
+
+  it('unlinks asset via MCP tool', async () => {
+    createAssetFixture('text', 'tool-unl', 'tool-unlink.md', '# hi', {
+      agent: 'user', taskId: 'tool-unl', created: '2026-04-05T00:00:00Z',
+    })
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_link')!
+    const result = await callTool(tool, { path: 'assets/text/tool-unl/tool-unlink.md', taskId: null }, 'pixel')
+
+    expect(result.ok).toBe(true)
+    expect(result.newPath).toContain('_unlinked')
+  })
+
+  it('returns error for invalid path', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_link')!
+    const result = await callTool(tool, { path: 'assets/images/ghost/nope.png', taskId: 'x' }, 'pixel')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+})
 
 describe('DELETE route integration — browser URL simulation', () => {
   /**

--- a/tests/plugins/assets/upload.test.ts
+++ b/tests/plugins/assets/upload.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the asset upload route (POST /api/plugins/assets/upload).
+ */
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
+import { mkdirSync, rmSync, existsSync, readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  activatePlugin,
+  findRoute,
+  type ActivatedPlugin,
+} from '../test-helpers'
+
+const testDir = join(tmpdir(), `bakin-test-upload-${Date.now()}`)
+const assetsRoot = join(testDir, 'assets')
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => {
+    const base = join(testDir, 'assets')
+    return {
+      'assets.text': join(base, 'text'),
+      'assets.images': join(base, 'images'),
+      'assets.video': join(base, 'video'),
+      'assets.audio': join(base, 'audio'),
+      'assets.plans': join(base, 'plans'),
+      'assets.data': join(base, 'data'),
+      'assets.other': join(base, 'other'),
+    }
+  },
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/core/watcher', () => ({
+  registerSyncHook: vi.fn(),
+}))
+
+import assetsPlugin from '@bakin/assets'
+
+let plugin: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  plugin = await activatePlugin(assetsPlugin, testDir)
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+function findUploadRoute() {
+  return findRoute(plugin.routes, 'POST', '/upload')
+}
+
+function createFormData(files: Array<{ name: string; content: string; type?: string }>, fields?: Record<string, string>): FormData {
+  const form = new FormData()
+  for (const f of files) {
+    const blob = new Blob([f.content], { type: f.type || 'application/octet-stream' })
+    form.append('file', new File([blob], f.name, { type: f.type || 'application/octet-stream' }))
+  }
+  if (fields) {
+    for (const [k, v] of Object.entries(fields)) {
+      form.append(k, v)
+    }
+  }
+  return form
+}
+
+async function callUpload(form: FormData): Promise<{ status: number; body: Record<string, unknown> }> {
+  const route = findUploadRoute()
+  expect(route).toBeDefined()
+  const req = new Request('http://localhost/api/plugins/assets/upload', {
+    method: 'POST',
+    body: form,
+  })
+  const res = await route!.handler(req, plugin.ctx)
+  return { status: res.status, body: await res.json() }
+}
+
+describe('POST /upload', () => {
+  it('registers the upload route', () => {
+    expect(findUploadRoute()).toBeDefined()
+  })
+
+  it('uploads an image file with auto-type detection', async () => {
+    const form = createFormData(
+      [{ name: 'test-photo.png', content: 'fake-png-data', type: 'image/png' }],
+      { taskId: 'task-upload-1' },
+    )
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.path).toMatch(/^assets\/images\/task-upload-1\//)
+    expect(body.filename).toMatch(/\.png$/)
+
+    // Verify sidecar was created with source field
+    const metaPath = join(testDir, body.metadataPath as string)
+    expect(existsSync(metaPath)).toBe(true)
+    const sidecar = JSON.parse(readFileSync(metaPath, 'utf-8'))
+    expect(sidecar.agent).toBe('user')
+    expect(sidecar.source).toBe('upload')
+    expect(sidecar.taskId).toBe('task-upload-1')
+    expect(sidecar.originalFilename).toBe('test-photo.png')
+  })
+
+  it('uploads a text file', async () => {
+    const form = createFormData(
+      [{ name: 'notes.md', content: '# Notes\nSome content', type: 'text/markdown' }],
+      { taskId: 'task-upload-2', description: 'My notes', tags: 'draft,notes' },
+    )
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(body.path).toMatch(/^assets\/text\/task-upload-2\//)
+
+    const metaPath = join(testDir, body.metadataPath as string)
+    const sidecar = JSON.parse(readFileSync(metaPath, 'utf-8'))
+    expect(sidecar.description).toBe('My notes')
+    expect(sidecar.tags).toEqual(['draft', 'notes'])
+  })
+
+  it('uses _unlinked when no taskId provided', async () => {
+    const form = createFormData(
+      [{ name: 'random.txt', content: 'hello', type: 'text/plain' }],
+    )
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(200)
+    expect(body.path).toMatch(/assets\/text\/_unlinked\//)
+  })
+
+  it('sets source to clipboard when specified', async () => {
+    const form = createFormData(
+      [{ name: 'screenshot.png', content: 'png-bytes', type: 'image/png' }],
+      { taskId: 'task-clip-1', source: 'clipboard' },
+    )
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(200)
+    const metaPath = join(testDir, body.metadataPath as string)
+    const sidecar = JSON.parse(readFileSync(metaPath, 'utf-8'))
+    expect(sidecar.source).toBe('clipboard')
+  })
+
+  it('rejects empty file', async () => {
+    const form = new FormData()
+    const blob = new Blob([], { type: 'image/png' })
+    form.append('file', new File([blob], 'empty.png', { type: 'image/png' }))
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(400)
+    expect(body.error).toMatch(/empty/i)
+  })
+
+  it('rejects request with no files', async () => {
+    const form = new FormData()
+    form.append('taskId', 'task-1')
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(400)
+    expect(body.error).toMatch(/no file/i)
+  })
+
+  it('rejects oversized files', async () => {
+    // Override settings to have tiny maxFileSize
+    const origGetSettings = plugin.ctx.getSettings
+    plugin.ctx.getSettings = (() => ({ maxFileSize: 0.0001 })) as typeof origGetSettings
+    try {
+      const form = createFormData(
+        [{ name: 'big.txt', content: 'x'.repeat(200), type: 'text/plain' }],
+      )
+      const { status, body } = await callUpload(form)
+      expect(status).toBe(413)
+      expect(body.error).toMatch(/exceeds/i)
+    } finally {
+      plugin.ctx.getSettings = origGetSettings
+    }
+  })
+
+  it('auto-detects PDF as other type', async () => {
+    const form = createFormData(
+      [{ name: 'document.pdf', content: '%PDF-fake', type: 'application/pdf' }],
+      { taskId: 'task-pdf-1' },
+    )
+    const { status, body } = await callUpload(form)
+    expect(status).toBe(200)
+    expect(body.path).toMatch(/assets\/other\/task-pdf-1\//)
+  })
+})

--- a/tests/plugins/workflows/runtime.test.ts
+++ b/tests/plugins/workflows/runtime.test.ts
@@ -3,6 +3,32 @@ import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+const testDir = join(tmpdir(), `bakin-test-runtime-${Date.now()}`)
+
+// ─── CRITICAL: Mock content-dir to prevent writes to ~/.bakin/ ─────────────
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: vi.fn(),
+  initBakinHome: vi.fn(),
+  isUsingBakinHome: () => false,
+}))
+
+// Mock audit to prevent writes to audit.jsonl
+vi.mock('../../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+// Mock logger to prevent noise
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
 // Mock flow-store so tests don't leak child-workflow tasks into the real board
 vi.mock('../../plugins/tasks/lib/flow-store', () => ({
   createTask: vi.fn(() => Promise.resolve({ id: 'mock-task' })),
@@ -29,7 +55,6 @@ import {
 import { invalidateSkillCache } from '@bakin/workflows/lib/skill-loader'
 
 describe('runtime', () => {
-  const testDir = join(tmpdir(), `bakin-test-runtime-${Date.now()}`)
   const defsDir = join(testDir, 'workflows', 'definitions')
   const skillsDir = join(testDir, 'workflows', 'skills')
   const instancesDir = join(testDir, 'workflows', 'instances')


### PR DESCRIPTION
## Summary\n- persist resized BakinDrawer widths to localStorage on drag end\n- hydrate the drawer width from storage on mount with safe fallback + clamping\n- support optional per-context storage keys and add component coverage for persistence behavior\n\n## Testing\n- pnpm exec vitest run tests/components/bakin-drawer.test.tsx\n- pnpm test\n- pnpm build\n\nCloses #5