### PR TITLE
fix(core): resolve activity feed hydration mismatch

### DIFF
--- a/src/context/activity-context.tsx
+++ b/src/context/activity-context.tsx
@@ -1,24 +1,27 @@
 "use client"
 
-import { createContext, useContext, useState } from "react"
+import { createContext, useContext, useEffect, useState } from "react"
 
 const STORAGE_KEY = 'bakin-activity-log-open'
 
-function getInitialState(): boolean {
-  if (typeof window === 'undefined') return true
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    return stored === null ? true : stored === 'true'
-  } catch {
-    return true
-  }
-}
+/** SSR-safe default — always true on first render, synced from localStorage in effect */
+const DEFAULT_OPEN = true
 
 export const ActivityContext = createContext({ open: false, toggle: () => {} })
 export const useActivityContext = () => useContext(ActivityContext)
 
 export function ActivityProvider({ children }: { children: React.ReactNode }) {
-  const [open, setOpen] = useState(getInitialState)
+  const [open, setOpen] = useState(DEFAULT_OPEN)
+
+  // Sync from localStorage after hydration to avoid server/client mismatch
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored !== null) {
+        setOpen(stored === 'true')
+      }
+    } catch {}
+  }, [])
   const toggle = () => setOpen((prev) => {
     const next = !prev
     try { localStorage.setItem(STORAGE_KEY, String(next)) } catch {}


### PR DESCRIPTION
## Summary
- `ActivityProvider` used `typeof window` branching during `useState` init to read localStorage, causing server/client HTML divergence when the stored activity feed state differed from the default
- Replaced with a static default + `useEffect` sync after hydration — same pattern `useSidebar` already uses

## Test plan
- [ ] Load dashboard with activity feed previously closed (localStorage `bakin-activity-log-open` = `false`) — no hydration warning in console
- [ ] Activity feed still remembers open/closed state across refreshes
- [ ] Toggle works as before