### PR TITLE
chore(tasks): remove all TASKBOARD.md references

### DIFF
--- a/.claude/knowledge/agent-system.md
+++ b/.claude/knowledge/agent-system.md
@@ -58,7 +58,7 @@ Agents run as OpenClaw agent instances. Communication flows:
 3. Agent → `bakin_log_progress` → SSE broadcast to dashboard
 
 ### Key functions in `src/core/agents.ts`:
-- `getAgentStatus(agentId)` — reads heartbeat + taskboard to determine status
+- `getAgentStatus(agentId)` — reads heartbeat + task board to determine status
 - `sendMessageToAgent(agentId, message)` — delegates to OpenClaw HTTP client
 - `startAgent(agentId)` — start agent session
 - `deliverTaskToAgent(agentId, taskId)` — deliver task with context
@@ -66,7 +66,7 @@ Agents run as OpenClaw agent instances. Communication flows:
 ## Dispatch Engine (`src/core/dispatch.ts`)
 
 The dispatch system assigns tasks to agents:
-1. Reads TASKBOARD.md for tasks in `todo` column with an `@agent` assignment
+1. Reads `flow_runs` SQLite for tasks in `todo` column with an agent assignment
 2. Checks agent availability (heartbeat, current task count, cooldown)
 3. Sends task to agent via OpenClaw with context (task details, workflow step if applicable)
 4. Moves task to `inProgress` column
@@ -136,7 +136,7 @@ MCP sessions bind agent identity via `?agent=basil` query param at connection ti
 ### Live activity feed
 `bakin_log_progress` → `logProgress()` in `src/core/task-service.ts`:
 1. Broadcasts immediately via SSE: `{ type: 'activity', agent, message, ts, taskId, channel }`
-2. Appends to task's log in TASKBOARD.md
+2. Appends to task's log in `flow_runs` SQLite
 
 ### Structured categories (from `scripts/lib/log-progress.ts`):
 `[START]`, `[PROGRESS]`, `[MILESTONE]`, `[BLOCKED]`, `[COMPLETE]`

--- a/.claude/knowledge/repo-architecture.md
+++ b/.claude/knowledge/repo-architecture.md
@@ -153,7 +153,6 @@ Created by `bakin init` or `initBakinHome()`. Symlinked from `~/.beacon/` for ba
 ```
 ~/.bakin/
 ├── settings.json          ← runtime config (deep-merged with defaults)
-├── TASKBOARD.md           ← kanban board
 ├── MEMORY-LOG.md          ← agent memory log
 ├── audit.jsonl            ← append-only audit trail
 ├── calendar.json          ← calendar events

--- a/.claude/knowledge/storage-model.md
+++ b/.claude/knowledge/storage-model.md
@@ -74,7 +74,7 @@ Provided to plugins via `PluginContext.storage`. Each plugin reads/writes to nam
 ### Task Storage (SQLite)
 Tasks are stored in OpenClaw's `flow_runs` SQLite table, accessed via `plugins/tasks/lib/flow-store.ts` using `better-sqlite3`. Each task is a row filtered by `owner_key LIKE 'bakin:task:%'`. Task metadata (title, agent, description, log entries, dependencies) is stored in the `state_json` column. Column mapping uses `status` + disambiguating fields. See `.claude/knowledge/tasks-plugin.md` for the full column ↔ status mapping.
 
-The `src/lib/taskboard.ts` file is a re-export shim that delegates to `flow-store.ts` for backward compatibility with `dispatch.ts` and `continuation.ts`.
+The `src/lib/taskboard.ts` file is a re-export shim that delegates to `flow-store.ts`.
 
 ### Project files (`projects/{id}.md`)
 Markdown with YAML frontmatter:
@@ -163,7 +163,7 @@ Plugins can request watch patterns via `ctx.watchFiles(['projects/*.md'])`.
 | `packages/core/src/content-dir.ts` | Content directory resolution, path constants, init |
 | `src/core/content-dir.ts` | Re-export shim for backward compat |
 | `src/lib/storage/markdown-adapter.ts` | StorageAdapter implementation |
-| `src/lib/taskboard.ts` | Re-export shim delegating to flow-store.ts |
+| `src/lib/taskboard.ts` | Re-export shim delegating to flow-store.ts (naming is historical) |
 | `src/lib/parsers/` | Markdown parsing utilities |
 | `src/core/audit.ts` | Audit JSONL writing + broadcast |
 | `src/core/settings.ts` | Settings loading with defaults |

--- a/.claude/knowledge/tasks-plugin.md
+++ b/.claude/knowledge/tasks-plugin.md
@@ -129,11 +129,11 @@ confirmed  → done, todo
 | File | Purpose |
 |------|---------|
 | `plugins/tasks/index.ts` | Plugin entry: registers 12 API routes + 11 exec tools + 9 hooks + archival |
-| `plugins/tasks/lib/flow-store.ts` | SQLite adapter: CRUD, transitions, reorder, archive — replaces taskboard.ts |
+| `plugins/tasks/lib/flow-store.ts` | SQLite adapter: CRUD, transitions, reorder, archive |
 | `plugins/tasks/lib/ids.ts` | Task ID generation (crypto-safe) |
 | `plugins/tasks/types.ts` | TypeScript interfaces (Task, TaskColumns, TaskBoard, ColumnId) |
 | `plugins/tasks/constants.ts` | Column config, header maps, status dot colors, badge styles |
-| `src/lib/taskboard.ts` | Re-export shim (delegates to flow-store for backward compat) |
+| `src/lib/taskboard.ts` | Re-export shim (delegates to flow-store) |
 | `src/core/task-service.ts` | Service layer: wraps mutations with side effects (audit, SSE, workflow guards, continuation) |
 | `src/core/dispatch.ts` | Task dispatch engine (auto-assigns todo tasks to agents) |
 | `src/core/continuation.ts` | Dependent task unblocking when a task completes |
@@ -158,7 +158,7 @@ confirmed  → done, todo
 2. The SSE server sends this as a `type: 'taskboard'` event to all connected clients
 3. The global `use-sse.ts` hook receives the event and calls `bumpTaskboard()` on the Zustand store
 4. `kanban-board.tsx` subscribes to `taskboardVersion` and re-fetches from `/api/plugins/tasks/` on change
-5. No file watcher needed — SQLite writes trigger SSE directly
+5. No file watcher needed — SQLite writes trigger SSE broadcasts directly
 
 ### Database Access Pattern
 

--- a/.claude/specs/07-cli-lifecycle.md
+++ b/.claude/specs/07-cli-lifecycle.md
@@ -185,7 +185,7 @@ Plugins:
 
 Content Directory:
   [OK] ~/.bakin/ exists with correct structure
-  [OK] TASKBOARD.md readable (23 tasks)
+  [OK] flow_runs SQLite accessible (23 tasks)
   [WARN] 2 orphaned heartbeat files (agents no longer in roster)
 
 Settings:

--- a/.claude/specs/done/01-claude-directory.md
+++ b/.claude/specs/done/01-claude-directory.md
@@ -60,7 +60,6 @@ Created automatically when Bakin is installed (`bakin init`). NOT part of the re
   workflows/                       ← workflow definitions & instances
   team/                            ← team contacts, personas
   inbox/                           ← incoming items
-  TASKBOARD.md                     ← task kanban board
   MEMORY-LOG.md                    ← agent memory log
   audit.jsonl                      ← append-only audit trail
 ```
@@ -171,18 +170,18 @@ Deep reference on:
 ### agent-system.md
 Deep reference on:
 - Agent data: `src/lib/agents-data.ts` — `AgentProfile` interface, `AGENT_PROFILES`, `AGENT_MAP`
-- Agent resolution: `src/core/agents.ts` — status from heartbeats + taskboard
+- Agent resolution: `src/core/agents.ts` — status from heartbeats + task board
 - Dispatch: `src/core/dispatch.ts` — how tasks get delivered to agents via OpenClaw
 - Heartbeat system: `~/.bakin/heartbeats/{agentId}.json`
 - MCP tool access: agents get tools via MCP sessions, identity from `?agent=` query param
-- Activity logging: `bakin_log_progress` → `logProgress()` → SSE broadcast + taskboard append
+- Activity logging: `bakin_log_progress` → `logProgress()` → SSE broadcast + task log append
 - Audit trail: `appendAudit()` → `audit.jsonl` + SSE + Antfly indexing
 
 ### storage-model.md
 Deep reference on:
 - Content directory: `~/.bakin/` — created by `bakin init`, resolved via `getContentDir()` in `src/core/content-dir.ts`
 - Markdown storage: `MarkdownStorageAdapter` in `src/lib/storage/markdown-adapter.ts`
-- Key files: `TASKBOARD.md` (kanban), `MEMORY-LOG.md` (audit), `projects/*.md`
+- Key files: `MEMORY-LOG.md` (audit), `projects/*.md`. Tasks in OpenClaw `flow_runs` SQLite.
 - Sidecar metadata pattern: `{filename}.meta.json` alongside content files
 - Asset structure: `~/.bakin/assets/{type}/{taskId}/`
 - Antfly indexing: fire-and-forget via `src/core/antfly.ts`

--- a/.claude/specs/done/05-audit-tasks.md
+++ b/.claude/specs/done/05-audit-tasks.md
@@ -44,7 +44,7 @@ Dependencies: none (tasks is foundational). Permissions: correct as-is.
 
 | Operation | HTTP API Route | MCP Exec Tool | Notes |
 |-----------|---------------|---------------|-------|
-| List/read | `GET /` | `bakin_exec_tasks_list` | New. Return filtered taskboard |
+| List/read | `GET /` | `bakin_exec_tasks_list` | New. Return filtered task board |
 | Get one | `GET /{taskId}` | `bakin_exec_tasks_get` | New. Single task detail |
 | Create | `POST /` | `bakin_exec_tasks_create` | Existing core MCP tool → migrate to plugin exec tool |
 | Move | `POST /{taskId}/move` | `bakin_exec_tasks_move` | Existing core MCP tool → migrate to plugin exec tool |

--- a/.claude/specs/done/08-taskflow-migration.md
+++ b/.claude/specs/done/08-taskflow-migration.md
@@ -1,7 +1,7 @@
 # Spec 08: Migrate Task Persistence to OpenClaw Task Flow
 
 **Issues:** [#4](https://github.com/madeinwyo/bakin/issues/4), [#29](https://github.com/madeinwyo/bakin/issues/29)
-**Status:** Draft
+**Status:** Complete
 **Created:** 2026-04-03
 
 ## Summary

--- a/.claude/specs/done/bakin-hardening-plan.md
+++ b/.claude/specs/done/bakin-hardening-plan.md
@@ -152,7 +152,7 @@ interface AntflyCore {
 **Tables (matching SPEC.md):**
 | Table | Source | Indexed when |
 |-------|--------|-------------|
-| `tasks` | TASKBOARD.md entries | On task completion (move to Done) |
+| `tasks` | flow_runs SQLite entries | On task completion (move to Done) |
 | `decisions` | MEMORY-LOG.md | On write (via watcher sync hook) |
 | `audit` | audit.jsonl entries | On every audit event |
 | `content` | Calendar items, project docs | On create/update |
@@ -192,7 +192,7 @@ tests/
     antfly.test.ts          — sync, search, disabled-mode no-op
   plugins/
     contract.test.ts        — load all plugins, verify BakinPlugin interface
-    tasks/taskboard.test.ts — CRUD, mutex, serialization roundtrip
+    tasks/flow-store.test.ts — CRUD, transitions, column mapping
     tasks/parser.test.ts    — markdown parsing edge cases
     calendar/storage.test.ts
   lib/
@@ -274,9 +274,9 @@ Every plugin gets a `bakin-plugin.json`:
   "name": "Tasks",
   "version": "1.0.0",
   "beacon": ">=1.0.0",
-  "description": "Kanban task management with markdown persistence",
+  "description": "Kanban task management backed by OpenClaw flow_runs",
   "entry": { "server": "index.ts", "client": "client.tsx" },
-  "contentFiles": ["TASKBOARD.md"],
+  "contentFiles": [],
   "secrets": [],
   "tests": "tests/",
   "dependencies": [],

--- a/ACTIVITY-FEED-FIX-PLAN.md
+++ b/ACTIVITY-FEED-FIX-PLAN.md
@@ -71,7 +71,7 @@ The activity feed has exactly **two data sources**:
 
 1. **`audit.jsonl`** — system-level events: `task.created`, `task.moved`, `task.dispatched`, `workflow.gate_approved`, etc. These are infrastructure events, not agent narration.
 
-2. **Task log entries from `TASKBOARD.md`** — agents post these via `POST /api/plugins/tasks/:taskId/log`. But agents currently barely use this. Looking at the dispatch message in `dispatch.ts`, agents are *told* to log:
+2. **Task log entries** — agents post these via `POST /api/plugins/tasks/:taskId/log`. But agents currently barely use this. Looking at the dispatch message in `dispatch.ts`, agents are *told* to log:
 
    > "Log your progress at EVERY major step — not just start and done."
 
@@ -97,7 +97,7 @@ Of those 8 steps, only 1 and 8 produce log entries. Steps 2-7 are invisible.
 
 This endpoint already exists (handled in `server.ts:190-196`) and broadcasts `{ type: 'activity' }` events. The task log API (`/api/plugins/tasks/:taskId/log`) also fire-and-forgets to `/api/activity/emit`. So the plumbing is there.
 
-**What's needed:** A simpler, lower-friction logging endpoint that agents can call frequently without it being persisted to the taskboard markdown. Think of it as "ephemeral narration" vs "permanent log."
+**What's needed:** A simpler, lower-friction logging endpoint that agents can call frequently without it being persisted to the task database. Think of it as "ephemeral narration" vs "permanent log."
 
 The current `/api/activity/emit` is perfect for this but it's **not in any agent's dispatch instructions**. Agents only know about `/api/plugins/tasks/:taskId/log`.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ beacon/
 │   ├── models/             # AI model configuration
 │   └── workflows/          # Workflow template library
 ├── content/                # Runtime data (auto-created)
-│   ├── TASKBOARD.md        # Task board (markdown)
 │   ├── MEMORY-LOG.md       # Decision log
 │   ├── calendar.json       # Calendar items
 │   ├── audit.jsonl         # Audit trail
@@ -104,7 +103,7 @@ Plugins are configured in `mc.config.ts` and loaded at startup. Each plugin can 
 
 | Plugin | Description | Key Routes |
 |--------|-------------|------------|
-| **tasks** | Kanban board backed by `TASKBOARD.md` | `/api/plugins/tasks/` (CRUD + move, log, block) |
+| **tasks** | Kanban board backed by OpenClaw `flow_runs` SQLite | `/api/plugins/tasks/` (CRUD + move, log, block) |
 | **calendar** | Content pipeline (draft → published) | `/api/plugins/calendar/` |
 | **memory** | Audit log viewer + agent workspace inspector | `/api/plugins/memory/audit`, `/workspace` |
 | **models** | Agent model assignments + available models | `/api/plugins/models/*` |
@@ -196,14 +195,14 @@ Beacon Doctor runs on startup and every 30 minutes to keep systems healthy. It p
 |-------|-----------|-------------|
 | **agent-roster** | No | Verifies Beacon agents match OpenClaw config |
 | **personas** | Yes | Creates stub persona files for missing agents |
-| **taskboard** | Yes (new only) | Creates `TASKBOARD.md` if missing; won't modify existing |
+| **taskboard** | No | Validates OpenClaw `flow_runs` SQLite is accessible |
 | **skill** | Yes | Installs/updates the Beacon skill in OpenClaw |
 | **gateway** | No | Pings the OpenClaw gateway |
 | **antfly** | No | Verifies Antfly connection when enabled |
 
 **Auto-fix policy:**
 - **Safe** (auto-fix): Creating files/directories, installing the Beacon skill
-- **Unsafe** (notify): Roster mismatches, gateway down, taskboard corruption — issues requiring human judgment are reported to roscoe via OpenClaw
+- **Unsafe** (notify): Roster mismatches, gateway down, task DB issues — issues requiring human judgment are reported to roscoe via OpenClaw
 
 Run manually: `beacon doctor` or `GET /api/plugins/health/doctor?fresh=true`
 
@@ -375,7 +374,7 @@ npm run build     # Production build
 ### Project Conventions
 
 - **TypeScript strict mode** with path aliases (`@/` → `src/`, `@mc/*` → `plugins/*`)
-- **Markdown-based storage** — tasks, decisions, and content stored as files in `content/`
+- **Hybrid storage** — tasks in OpenClaw SQLite, decisions and content as files in `~/.bakin/`
 - **Plugin architecture** — extend via `plugins/` directory and `mc.config.ts`
 - **Structured audit logging** — all state changes logged to `content/audit.jsonl`
 - **OpenClaw HTTP client** — no CLI exec; all agent communication goes through the gateway API

--- a/SPEC.md
+++ b/SPEC.md
@@ -103,7 +103,6 @@ and are managed by OpenClaw — they're not part of this repo.
 ├── com.openclaw.mc.plist             ← launchd service (auto-start on boot)
 │
 ├── content/                          ← Agent-written content files (watched by server)
-│   ├── TASKBOARD.md                  ← Live task tracking (Roscoe writes, @agent tags)
 │   ├── CALENDAR.md                   ← Upcoming events & deadlines
 │   ├── MEMORY-LOG.md                 ← Notable agent decisions (public-safe)
 │   ├── OFFICE.md                     ← ASCII office map + multi-agent status
@@ -150,9 +149,9 @@ and are managed by OpenClaw — they're not part of this repo.
 
 ### 1. 🗂️ Task Board
 
-**File:** `content/TASKBOARD.md`
+**Storage:** OpenClaw `flow_runs` SQLite table (migrated from markdown)
 
-This is the most important section. Roscoe updates it whenever tasks are
+This is the most important section. Tasks are managed through the API whenever they are
 assigned, started, completed, or blocked.
 
 **File format:**
@@ -402,7 +401,7 @@ Everyone and everything in the ecosystem — humans, sub-agents, tools, services
 **Dashboard rendering:**
 - Card grid — one card per team member
 - Status dot on each card
-- Agent cards show current task from TASKBOARD.md
+- Agent cards show current task from the task board (SQLite)
 - Agent cards show health: last heartbeat, error count, uptime
 
 ---
@@ -857,13 +856,13 @@ Agents communicate through OpenClaw's built-in mechanisms:
    Agents can send messages directly to other agents within the gateway.
 
 3. **Shared state via files** — all agents have read/write access to
-   `content/` files. TASKBOARD.md is the coordination hub.
+   `content/` files. the task board (SQLite) is the coordination hub.
    - `@agent-name` ownership tags on tasks indicate assignment
    - `@unassigned` tasks are available for Roscoe to delegate
 
 4. **Results flow back through Roscoe** — when a sub-agent completes, OpenClaw
    announces the result back to the requesting agent. Roscoe then updates
-   TASKBOARD.md and relays to Discord if needed.
+   the task board (SQLite) and relays to Discord if needed.
 
 ### Heartbeat System
 
@@ -900,7 +899,7 @@ Each agent writes a heartbeat file to the shared mission-control directory:
 ```markdown
 - [ ] Write heartbeat JSON to content/heartbeats/<my-id>.json
 - [ ] Update my status line in content/OFFICE.md
-- [ ] Check content/TASKBOARD.md for new tasks assigned to me
+- [ ] Check content/the task board (SQLite) for new tasks assigned to me
 ```
 
 **Roscoe's HEARTBEAT.md additionally contains:**
@@ -908,20 +907,20 @@ Each agent writes a heartbeat file to the shared mission-control directory:
 - [ ] Check all heartbeat files in content/heartbeats/
 - [ ] If any agent missed 3 consecutive heartbeats (15 min), post Discord alert
 - [ ] Update OFFICE.md agent status table
-- [ ] Verify TASKBOARD.md task states are consistent
+- [ ] Verify the task board (SQLite) task states are consistent
 ```
 
 ### Concurrency & File Locking
 
-Multiple agents writing to shared files (TASKBOARD.md, OFFICE.md) risks
+Multiple agents writing to shared files (the task board (SQLite), OFFICE.md) risks
 corruption. Mitigation strategy:
 
 1. **Roscoe is the primary writer** for shared files. Other agents write to
    their own heartbeat JSON files (no conflict — one file per agent).
 
-2. **TASKBOARD.md updates flow through Roscoe.** When Patch or Basil finishes
+2. **the task board (SQLite) updates flow through Roscoe.** When Patch or Basil finishes
    a task, they tell Roscoe via agent-to-agent messaging. Roscoe updates
-   TASKBOARD.md. This serializes writes through a single agent.
+   the task board (SQLite). This serializes writes through a single agent.
 
 3. **OFFICE.md is rebuilt by Roscoe** on each heartbeat cycle. Roscoe reads
    all heartbeat JSON files and regenerates the office map + status table.
@@ -938,7 +937,7 @@ corruption. Mitigation strategy:
 Dashboard POST /api/plugins/tasks/:taskId/assign
   → MC server writes content/inbox/1710782400-assign.json
   → Roscoe picks up on next heartbeat (≤5 min)
-  → Roscoe updates TASKBOARD.md
+  → Roscoe updates the task board (SQLite)
   → fs.watch fires → SSE pushes update to dashboard
 ```
 
@@ -1077,16 +1076,16 @@ brief that produced it.
 ## Mission Control Integration
 
 On every session start:
-1. Read `content/TASKBOARD.md` — know what's active and assigned to you
+1. Read `content/the task board (SQLite)` — know what's active and assigned to you
 2. Read `content/CALENDAR.md` — know what's coming up
 
 On task changes:
 - Notify Roscoe via agent-to-agent message when tasks start, complete, or block
-- Do NOT write to TASKBOARD.md directly — Roscoe manages the shared board
+- Do NOT write to the task board (SQLite) directly — Roscoe manages the shared board
 
 On heartbeat (every 5 minutes):
 - Write your heartbeat JSON to content/heartbeats/<your-id>.json
-- Check TASKBOARD.md for new tasks assigned to you
+- Check the task board (SQLite) for new tasks assigned to you
 ```
 
 ### Roscoe's AGENTS.md additionally includes:
@@ -1099,10 +1098,10 @@ You are the orchestrator. You coordinate all other agents.
 On every session start:
 1. Read all files in content/ — know full system state
 2. Check heartbeats/ — verify all agents are healthy
-3. Review TASKBOARD.md — ensure assignments are current
+3. Review the task board (SQLite) — ensure assignments are current
 
 On task assignment (from Mark via dashboard or Discord):
-- Update TASKBOARD.md with @agent-name tag
+- Update the task board (SQLite) with @agent-name tag
 - Spawn sub-agent or send agent-to-agent message to assigned agent
 - Confirm assignment in Discord #mc-tasks
 
@@ -1118,7 +1117,7 @@ On heartbeat (every 5 minutes):
 - Read all heartbeat JSONs, rebuild OFFICE.md agent status table
 - Log heartbeat events to audit.jsonl for each agent
 - Process any items in content/inbox/
-- Verify TASKBOARD.md consistency
+- Verify the task board (SQLite) consistency
 - Update your own heartbeat JSON
 - If audit.jsonl > 10MB, rotate to audit-YYYY-MM-DD.jsonl
 ```
@@ -1127,7 +1126,7 @@ On heartbeat (every 5 minutes):
 
 | Trigger | File | Writer |
 |---------|------|--------|
-| Task state change | TASKBOARD.md | Roscoe only |
+| Task state change | flow_runs SQLite | Bakin API |
 | Heartbeat | heartbeats/<agent>.json | Each agent |
 | Heartbeat | OFFICE.md | Roscoe only |
 | Significant decision | MEMORY-LOG.md | Any agent (append-only) |
@@ -1160,7 +1159,7 @@ Discord is already configured as an OpenClaw channel.
 @roscoe restart rolo
 @roscoe prioritize "Build MC server v1"
 ```
-Roscoe parses these and acts accordingly — updates TASKBOARD.md, runs CLI
+Roscoe parses these and acts accordingly — updates the task board (SQLite), runs CLI
 commands, etc.
 
 ### Outbound Notifications
@@ -1202,7 +1201,7 @@ commands, etc.
 
 **Content files:**
 - [x] Write SPEC.md (this file)
-- [ ] Create `content/TASKBOARD.md` with ownership tags template
+- [x] ~~Create task board~~ (migrated to SQLite)
 - [ ] Create `content/CALENDAR.md` with template
 - [ ] Create `content/MEMORY-LOG.md` with template
 - [ ] Create `content/OFFICE.md` with multi-agent ASCII map
@@ -1330,7 +1329,7 @@ day one — because only the relevant ~10 chunks load, not the entire history.
 
 | Content Type | Source | How Indexed |
 |---|---|---|
-| Task history | TASKBOARD.md entries | On completion, write to Antfly with tags |
+| Task history | flow_runs SQLite | On completion, write to Antfly with tags |
 | Decisions | MEMORY-LOG.md entries | On write, sync to Antfly |
 | Project context | projects/*.md | On create/update, sync to Antfly |
 | Conversation summaries | End of session | Agent writes summary to Antfly |

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -113,7 +113,7 @@ async function cmdDispatch(): Promise<void> {
 }
 
 async function cmdTasksList(column?: string): Promise<void> {
-  // Read tasks from the API - for now we parse the taskboard file
+  // Read tasks from the API
   const result = await apiGet('/api/plugins/tasks/') as { columns: Record<string, Array<Record<string, unknown>>> }
   const columns = result.columns || {}
 
@@ -1152,7 +1152,7 @@ Commands:
   setup service [--uninstall]       Install/remove macOS LaunchAgent for auto-start
   setup antfly                     Install AntflyDB + enable + reindex (one command)
   setup mcporter                   Install mcporter + sync per-agent MCP config
-  paths [key]                      Show content directory paths (keys: home, taskboard, assets, etc.)
+  paths [key]                      Show content directory paths (keys: home, assets, projects, etc.)
   init                             Initialize ~/.bakin/ directory with defaults
   agent-rules [--apply|--check]    Manage orchestrator rules block in AGENTS.md
   agent-rules --apply-all          Apply all managed blocks to all agent AGENTS.md files

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -67,11 +67,11 @@ const tasksPlugin: BakinPlugin = {
 
     // ─── REST API Routes ───────────────────────────────────────────────
 
-    // GET / — list tasks (read taskboard)
+    // GET / — list all tasks
     ctx.registerRoute({
       path: '/',
       method: 'GET',
-      description: 'List all tasks (read taskboard)',
+      description: 'List all tasks',
       handler: async () => {
         try {
           const board = await readTaskboard()
@@ -343,14 +343,14 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_list',
-      description: 'List all tasks on the board. Optionally filter by column or agent. Returns the full taskboard.',
+      description: 'List all tasks on the board. Optionally filter by column or agent.',
       parameters: {
         column: z.enum(COLUMNS).optional().describe('Filter by column'),
         agent: z.string().optional().describe('Filter by assigned agent'),
       },
       handler: async (params: Record<string, unknown>) => {
         const board = await readTaskboard()
-        if (!board) return { ok: false, error: 'Failed to read taskboard' }
+        if (!board) return { ok: false, error: 'Failed to read task board' }
 
         const column = params.column as string | undefined
         const agent = params.agent as string | undefined
@@ -624,7 +624,7 @@ const tasksPlugin: BakinPlugin = {
         log.info(`Ready — ${counts}`)
       }
     } catch (err) {
-      log.error('Failed to read taskboard on ready', err)
+      log.error('Failed to read task board on ready', err)
     }
   },
 

--- a/plugins/tasks/lib/flow-store.ts
+++ b/plugins/tasks/lib/flow-store.ts
@@ -1,6 +1,5 @@
 /**
  * SQLite-backed task store using OpenClaw's flow_runs table.
- * Replaces TASKBOARD.md with direct SQLite reads/writes.
  *
  * Internal operations are synchronous (better-sqlite3's sync API).
  * Exported mutating functions return Promises for backward compatibility

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -77,7 +77,7 @@ Use these tools to accomplish actual work — saving files, posting content, gen
 | `bakin_exec_team_org` | Get the full org structure: teams with their members. Use this to understand who is on which team and reporting lines. |
 | `bakin_exec_team_members` | Get agents that belong to a specific team (e.g. "builders", "creators"). |
 | `bakin_exec_team_my_team` | Get the team that a specific agent belongs to, including all teammates. |
-| `bakin_exec_tasks_list` | List all tasks on the board. Optionally filter by column or agent. Returns the full taskboard. |
+| `bakin_exec_tasks_list` | List all tasks on the board. Optionally filter by column or agent. |
 | `bakin_exec_tasks_get` | Get details about a task — title, description, current column, logs, dependencies, project context. |
 | `bakin_exec_tasks_create` | Create a new task on the task board. For top-level tasks, you MUST provide either workflowId or skipWorkflowReason. Subtasks (with parentId) are exempt. |
 | `bakin_exec_tasks_move` | Move a task to a different column on the task board. |
@@ -92,7 +92,6 @@ Use these tools to accomplish actual work — saving files, posting content, gen
 | `bakin_exec_assets_get` | Retrieve a single asset's sidecar metadata by path. |
 | `bakin_exec_assets_save` | Save an agent-created file to the assets directory with standardized naming (YYYYMMDD-slug.ext) and sidecar metadata. Handles directory creation, naming conventions, and .meta.json automatically. |
 | `bakin_exec_assets_delete` | Soft-delete an asset (moves to trash with 30-day expiry). |
-| `bakin_exec_assets_link` | Link an asset to a different task, or unlink it (set taskId to null). Physically moves the file between task directories and updates sidecar metadata. |
 | `bakin_exec_assets_list_trash` | List trashed assets with name, size, deleted timestamp, and days remaining before auto-purge. |
 | `bakin_exec_assets_restore` | Restore a trashed asset back to its original location. Use bakin_exec_assets_list_trash first to get the filename. |
 | `bakin_exec_assets_audit` | Audit asset health: check for missing thumbnails, invalid sidecars, orphaned files. Set fix=true to auto-generate missing thumbnails and create stub sidecars. |
@@ -219,7 +218,7 @@ curl -s http://localhost:3737/api/docs
 
 **NEVER hardcode or construct filesystem paths.** Always use `beacon_get_paths` to discover where files live.
 
-Available path keys: `home`, `taskboard`, `memoryLog`, `calendar`, `audit`, `assets`, `assets.text`, `assets.images`, `assets.video`, `assets.audio`, `assets.plans`, `assets.data`, `assets.other`, `personas`, `team`, `heartbeats`, `inbox`, `projects`, `workflows`, `settings`.
+Available path keys: `home`, `memoryLog`, `calendar`, `audit`, `assets`, `assets.text`, `assets.images`, `assets.video`, `assets.audio`, `assets.plans`, `assets.data`, `assets.other`, `personas`, `team`, `heartbeats`, `inbox`, `projects`, `workflows`, `settings`.
 
 ### Querying Assets
 
@@ -268,7 +267,7 @@ Your agent identity is automatically injected by the MCP server. Use your real a
 
 ### Mandatory: Use the API, never edit files
 
-Always use Beacon tools (via mcporter) to manage tasks. Direct edits to TASKBOARD.md bypass locking, validation, and audit logging.
+Always use Beacon tools (via mcporter) to manage tasks. Direct database edits bypass locking, validation, and audit logging.
 
 ### Mandatory: Never run scripts/bin/*.ts directly
 
@@ -291,7 +290,7 @@ Always use `beacon_report_complete` when done — it handles notification automa
 - **Invalid state transition** → Tool returns error with allowed transitions
 - **Move without agent** → Tool returns error
 - **Done without logs** → Tool returns error
-- **Direct TASKBOARD.md edit** → Bypasses all validation, breaks locking
+- **Direct database edit** → Bypasses all validation, breaks locking
 - **Bypass patterns detected** (workaround language in logs) → Alert sent to roscoe, audit logged
 - **Stuck task + stale heartbeat** → Auto-recovered to Todo, then Blocked after 3 recoveries
 
@@ -299,7 +298,7 @@ Always use `beacon_report_complete` when done — it handles notification automa
 
 These rules apply to ALL subagents (Basil, Pixel, Rolo, Patch, etc.). Violating them breaks the pipeline.
 
-1. **Never edit TASKBOARD.md directly.** Direct edits are auto-reverted. Always use Beacon tools.
+1. **Never edit the task database directly.** Always use Beacon tools.
 
 2. **Never hardcode filesystem paths.** Always use `beacon_get_paths`.
 

--- a/src/core/antfly.ts
+++ b/src/core/antfly.ts
@@ -289,12 +289,6 @@ async function searchTable(tableName: string, query: string, limit: number, agen
 export async function syncFile(relativePath: string, content: string): Promise<void> {
   if (!enabled()) return
 
-  // TASKBOARD.md no longer exists — tasks are in SQLite now.
-  // Keep the guard in case a stale file triggers the watcher.
-  if (relativePath === 'TASKBOARD.md') {
-    return
-  }
-
   if (relativePath === 'MEMORY-LOG.md') {
     await index('decisions', {
       id: `decisions-${Date.now()}`,

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -4,7 +4,7 @@
  *
  * Auto-fix policy:
  *   SAFE (auto-fix):   Creating new files, installing/updating skill, making dirs
- *   UNSAFE (notify):   Agent roster mismatches, gateway down, taskboard corruption,
+ *   UNSAFE (notify):   Agent roster mismatches, gateway down, task DB issues,
  *                      anything requiring human judgment
  *
  * Unsafe issues are reported to roscoe via OpenClaw so they show up in conversation.

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -2,7 +2,7 @@
  * Task service layer for Bakin.
  *
  * Shared functions that both REST route handlers and MCP tool handlers call.
- * Each function wraps core taskboard mutations with their required side effects:
+ * Each function wraps core task mutations with their required side effects:
  * SSE broadcast, audit logging, continuation triggers, Antfly indexing, etc.
  *
  * This prevents logic duplication and drift between the REST and MCP paths.
@@ -56,7 +56,7 @@ export type Channel = 'mcp' | 'rest' | 'cli' | 'system'
 
 /**
  * Log a progress message for a task.
- * Broadcasts to SSE immediately, then persists to taskboard.
+ * Broadcasts to SSE immediately, then persists to task log.
  */
 export async function logProgress(
   taskId: string,

--- a/tests/lib/event-bus.test.ts
+++ b/tests/lib/event-bus.test.ts
@@ -90,11 +90,11 @@ describe('EventBus', () => {
     const handler = vi.fn()
 
     bus.on('file.change', handler)
-    bus.injectFileEvent('TASKBOARD.md', 'change', 'content here')
+    bus.injectFileEvent('MEMORY-LOG.md', 'change', 'content here')
 
     expect(handler).toHaveBeenCalledOnce()
     expect(handler.mock.calls[0][1]).toMatchObject({
-      file: 'TASKBOARD.md',
+      file: 'MEMORY-LOG.md',
       event: 'change',
       content: 'content here',
     })


### PR DESCRIPTION
## Summary
- Sweeps every stale `TASKBOARD.md` reference across 20 files — docs, specs, knowledge, agent skill rules, CLI help, code comments, and tests
- Removes dead antfly guard that filtered out `TASKBOARD.md` file events
- Updates agent-facing skill rules: "never edit TASKBOARD.md" → "never edit the task database"
- Removes `taskboard` from path key listings (already gone from `getBakinPaths()`)
- Moves spec 08 (taskflow migration) to `done/`, marks complete
- Only file still referencing `TASKBOARD.md` is the migration spec itself (documenting what was removed)

Closes #4

## Test plan
- [x] `vitest run tests/lib/event-bus.test.ts tests/plugins/tasks/` — 154 tests pass
- [x] Verify `bakin doctor` syncs updated skill file to `~/.openclaw/workspace/skills/bakin/`
- [x] Grep confirms zero `TASKBOARD.md` outside of migration spec