### PR TITLE
fix(tasks): fix cross-column drag-and-drop

### DIFF
--- a/plugins/tasks/components/kanban-board.tsx
+++ b/plugins/tasks/components/kanban-board.tsx
@@ -4,12 +4,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   DndContext,
   DragEndEvent,
+  DragOverEvent,
   DragStartEvent,
   DragOverlay,
   PointerSensor,
   KeyboardSensor,
   useSensor,
   useSensors,
+  closestCenter,
+  pointerWithin,
+  type CollisionDetection,
 } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
 import { KanbanColumn } from './kanban-column'
@@ -32,10 +36,10 @@ import type { Task, TaskColumns, ColumnId } from '../types'
 
 const COLUMN_ORDER: ColumnId[] = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'confirmed']
 
-function parseCompositeId(id: string): { columnId: ColumnId; taskId: string } | null {
-  const parts = String(id).split('::')
-  if (parts.length !== 2) return null
-  return { columnId: parts[0] as ColumnId, taskId: parts[1] }
+const multiContainerCollision: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args)
+  if (pointerCollisions.length > 0) return pointerCollisions
+  return closestCenter(args)
 }
 
 async function apiFetch(url: string, body: Record<string, unknown>, method = 'POST'): Promise<boolean> {
@@ -147,6 +151,7 @@ export function KanbanBoard() {
   // Drag overlay state
   const [activeTask, setActiveTask] = useState<Task | null>(null)
   const [activeColumnId, setActiveColumnId] = useState<ColumnId | null>(null)
+  const dragStartColumnsRef = useRef<TaskColumns | null>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -157,53 +162,129 @@ export function KanbanBoard() {
     const data = event.active.data.current as { columnId: string; task: Task }
     setActiveTask(data.task)
     setActiveColumnId(data.columnId as ColumnId)
+    dragStartColumnsRef.current = optimistic?.columns ?? parsed.columns
+  }, [optimistic, parsed.columns])
+
+  // Move items between columns in state so dnd-kit can show displacement in the target column.
+  // Works because sortable IDs are plain task.id (not composite), so dnd-kit tracks the
+  // active item across containers.
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    const { active, over } = event
+    if (!over) return
+
+    const activeData = active.data.current as { columnId: string; task: Task } | undefined
+    if (!activeData?.task) return
+    const task = activeData.task
+
+    const overId = String(over.id)
+
+    // Determine target column
+    let targetCol: ColumnId
+    if (COLUMN_ORDER.includes(overId as ColumnId)) {
+      targetCol = overId as ColumnId
+    } else {
+      // over.id is a task ID — get its column from the sortable data
+      const overData = over.data.current as { columnId: string } | undefined
+      if (overData?.columnId) {
+        targetCol = overData.columnId as ColumnId
+      } else {
+        return
+      }
+    }
+
+    setOptimistic(prev => {
+      const currentColumns = prev?.columns ?? parsed.columns
+
+      // Find which column currently holds the active task
+      let currentCol: ColumnId | null = null
+      for (const colId of COLUMN_ORDER) {
+        if (currentColumns[colId].some(t => t.id === task.id)) {
+          currentCol = colId
+          break
+        }
+      }
+
+      if (!currentCol || currentCol === targetCol) return prev
+
+      const fromTasks = currentColumns[currentCol].filter(t => t.id !== task.id)
+      const toTasks = [...currentColumns[targetCol]]
+
+      // Insert at over position or append
+      if (!COLUMN_ORDER.includes(overId as ColumnId)) {
+        const idx = toTasks.findIndex(t => t.id === overId)
+        if (idx !== -1) {
+          toTasks.splice(idx, 0, task)
+        } else {
+          toTasks.push(task)
+        }
+      } else {
+        toTasks.push(task)
+      }
+
+      return { columns: { ...currentColumns, [currentCol]: fromTasks, [targetCol]: toTasks } }
+    })
+  }, [parsed.columns])
+
+  const handleDragCancel = useCallback(() => {
+    setActiveTask(null)
+    setActiveColumnId(null)
+    if (dragStartColumnsRef.current) {
+      setOptimistic({ columns: dragStartColumnsRef.current })
+    }
+    dragStartColumnsRef.current = null
+    setTimeout(() => setOptimistic(null), 0)
   }, [])
 
   const handleDragEnd = useCallback(async (event: DragEndEvent) => {
     const { active, over } = event
 
-    // Clear overlay state
     setActiveTask(null)
     setActiveColumnId(null)
 
-    if (!over) return
+    const originalColumns = dragStartColumnsRef.current
+    dragStartColumnsRef.current = null
 
-    const activeData = active.data.current as { columnId: string; task: Task }
+    if (!over || !originalColumns) {
+      setOptimistic(null)
+      return
+    }
+
+    const activeData = active.data.current as { columnId: string; task: Task } | undefined
+    if (!activeData?.task) {
+      setOptimistic(null)
+      return
+    }
     const task = activeData.task
     const fromCol = activeData.columnId as ColumnId
 
-    // Determine target column and position
-    const overId = String(over.id)
-    let targetCol: ColumnId
-    let overTaskId: string | null = null
-
-    if (COLUMN_ORDER.includes(overId as ColumnId)) {
-      // Dropped on the column droppable itself
-      targetCol = overId as ColumnId
-    } else {
-      // Dropped on a task — parse composite ID
-      const parsed = parseCompositeId(overId)
-      if (parsed) {
-        targetCol = parsed.columnId
-        overTaskId = parsed.taskId
-      } else {
-        const overData = over.data.current as { columnId: string } | undefined
-        targetCol = (overData?.columnId || overId) as ColumnId
+    // Find which column currently holds the task (after onDragOver moves)
+    const currentColumns = optimistic?.columns ?? originalColumns
+    let targetCol: ColumnId = fromCol
+    for (const colId of COLUMN_ORDER) {
+      if (currentColumns[colId].some(t => t.id === task.id)) {
+        targetCol = colId
+        break
       }
     }
 
     if (fromCol === targetCol) {
-      // Within-column reorder
-      const colTasks = [...(optimistic?.columns ?? parsed.columns)[fromCol]]
+      // Same-column reorder — onDragOver skips same-column, compute new order here
+      const colTasks = [...currentColumns[fromCol]]
       const oldIndex = colTasks.findIndex(t => t.id === task.id)
-      const newIndex = overTaskId ? colTasks.findIndex(t => t.id === overTaskId) : colTasks.length - 1
+      const overId = String(over.id)
+      const newIndex = !COLUMN_ORDER.includes(overId as ColumnId)
+        ? colTasks.findIndex(t => t.id === overId)
+        : colTasks.length - 1
 
-      if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return
+      if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+        setOptimistic(null)
+        return
+      }
 
       const reordered = arrayMove(colTasks, oldIndex, newIndex)
 
       setOptimistic(prev => {
-        const base = prev?.columns ?? parsed.columns
+        const base = prev?.columns ?? currentColumns
         return { columns: { ...base, [fromCol]: reordered } }
       })
 
@@ -212,45 +293,28 @@ export function KanbanBoard() {
         orderedIds: reordered.map(t => t.id),
       })
 
-      if (!ok) {
-        toast(`Failed to reorder tasks`, 'error')
-      }
+      if (!ok) toast('Failed to reorder tasks', 'error')
       await refreshTaskboard()
       setOptimistic(null)
     } else {
-      // Cross-column move
-      const base = optimistic?.columns ?? parsed.columns
-      const fromTasks = base[fromCol].filter(t => t.id !== task.id)
-      const toTasks = [...base[targetCol]]
+      // Cross-column move — task already in target column via onDragOver
       const movedTask = { ...task, checked: targetCol === 'done' || targetCol === 'confirmed' }
-
-      // Insert at the correct position
-      if (overTaskId) {
-        const idx = toTasks.findIndex(t => t.id === overTaskId)
-        if (idx !== -1) {
-          toTasks.splice(idx, 0, movedTask)
-        } else {
-          toTasks.push(movedTask)
-        }
-      } else {
-        toTasks.push(movedTask)
-      }
-
+      const updatedTarget = currentColumns[targetCol].map(
+        t => t.id === task.id ? movedTask : t
+      )
       setOptimistic({
-        columns: { ...base, [fromCol]: fromTasks, [targetCol]: toTasks },
+        columns: { ...currentColumns, [targetCol]: updatedTarget },
       })
 
       const ok = await apiFetch('/api/plugins/tasks/' + task.id + '/move', {
         id: task.id, title: task.title, from: fromCol, to: targetCol, agent: 'roscoe',
       })
 
-      if (!ok) {
-        toast(`Failed to move "${task.title}"`, 'error')
-      }
+      if (!ok) toast(`Failed to move "${task.title}"`, 'error')
       await refreshTaskboard()
       setOptimistic(null)
     }
-  }, [parsed.columns, optimistic])
+  }, [parsed.columns, optimistic, refreshTaskboard])
 
   const handleAssign = useCallback(async (task: Task, agent: string) => {
     const ok = await apiFetch('/api/plugins/tasks/' + task.id + '/assign', { id: task.id, title: task.title, agent })
@@ -360,7 +424,14 @@ export function KanbanBoard() {
         {/* Content — kanban or table */}
         {view === 'kanban' ? (
           <div className="flex-1 overflow-auto min-h-0">
-          <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={multiContainerCollision}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+          >
             <div className="inline-flex gap-4 items-start p-[25px] pt-0 md:pl-[25px] pl-4">
               {COLUMN_ORDER.map((colId) => (
                 <div key={colId} className="w-[75vw] sm:w-72 shrink-0">

--- a/plugins/tasks/components/kanban-column.tsx
+++ b/plugins/tasks/components/kanban-column.tsx
@@ -19,10 +19,9 @@ interface KanbanColumnProps {
 }
 
 export function KanbanColumn({ id, tasks, gateLabels, childTaskLabels, onAssign, onDelete, onTaskClick, onAddTask, footer }: KanbanColumnProps) {
-  const { setNodeRef, isOver, active } = useDroppable({ id })
+  const { setNodeRef } = useDroppable({ id })
   const config = COLUMN_CONFIG[id]
   const dotColor = STATUS_DOT_COLORS[id]
-  const showEmptyPlaceholder = isOver && !!active && tasks.length === 0
 
   return (
     <div className="flex flex-col">
@@ -49,7 +48,7 @@ export function KanbanColumn({ id, tasks, gateLabels, childTaskLabels, onAssign,
         </div>
 
         <SortableContext
-          items={tasks.map((t) => `${id}::${t.id}`)}
+          items={tasks.map((t) => t.id)}
           strategy={verticalListSortingStrategy}
         >
           <div className="flex flex-col gap-1.5 flex-1">
@@ -65,9 +64,6 @@ export function KanbanColumn({ id, tasks, gateLabels, childTaskLabels, onAssign,
                 onClick={onTaskClick}
               />
             ))}
-            {showEmptyPlaceholder && (
-              <div className="w-full min-h-[80px] rounded-xl border-2 border-dashed border-blue-500/50 bg-blue-500/5 animate-pulse" />
-            )}
           </div>
         </SortableContext>
       </div>

--- a/plugins/tasks/components/task-card.tsx
+++ b/plugins/tasks/components/task-card.tsx
@@ -120,7 +120,7 @@ interface TaskCardProps {
 
 export function TaskCard({ task, columnId, gateLabel, childTaskId, onAssign, onDelete, onClick }: TaskCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: `${columnId}::${task.id}`,
+    id: task.id,
     data: { task, columnId },
   })
 
@@ -134,8 +134,10 @@ export function TaskCard({ task, columnId, gateLabel, childTaskId, onAssign, onD
       <div
         ref={setNodeRef}
         style={style}
-        className="w-full min-h-[80px] rounded-xl border-2 border-dashed border-blue-500/50 bg-blue-500/5 animate-pulse"
-      />
+        className="rounded-xl border-2 border-dashed border-blue-500/30 bg-card/50 opacity-40"
+      >
+        <TaskCardContent task={task} columnId={columnId} className="p-4" />
+      </div>
     )
   }
 

--- a/tests/components/kanban-dnd.test.tsx
+++ b/tests/components/kanban-dnd.test.tsx
@@ -1,0 +1,572 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { Task, TaskColumns, ColumnId } from '../../plugins/tasks/types'
+
+// ── Capture DndContext props so tests can invoke handlers directly ──
+
+let capturedDndProps: Record<string, any> = {}
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: (props: any) => {
+    capturedDndProps = props
+    return <div data-testid="dnd-context">{props.children}</div>
+  },
+  DragOverlay: ({ children }: any) => <div data-testid="drag-overlay">{children}</div>,
+  PointerSensor: class {},
+  KeyboardSensor: class {},
+  useSensor: () => ({}),
+  useSensors: () => [],
+  closestCenter: vi.fn(),
+  pointerWithin: vi.fn(),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}))
+
+const mockUseSortable = vi.fn(({ id, data }: any) => ({
+  attributes: {},
+  listeners: {},
+  setNodeRef: vi.fn(),
+  transform: null,
+  transition: null,
+  isDragging: false,
+  active: null,
+  activeIndex: 0,
+  data: {},
+  index: 0,
+  isOver: false,
+  isSorting: false,
+  items: [],
+  newIndex: 0,
+  over: null,
+  overIndex: 0,
+  rect: { current: null },
+  setActivatorNodeRef: vi.fn(),
+  setDroppableNodeRef: vi.fn(),
+  setDraggableNodeRef: vi.fn(),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: any) => <div>{children}</div>,
+  verticalListSortingStrategy: {},
+  arrayMove: (arr: any[], from: number, to: number) => {
+    const result = [...arr]
+    const [removed] = result.splice(from, 1)
+    result.splice(to, 0, removed)
+    return result
+  },
+  useSortable: (...args: any[]) => mockUseSortable(...args),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => null } },
+}))
+
+// ── Mock child components: KanbanColumn renders task IDs for assertions ──
+
+vi.mock('../../plugins/tasks/components/kanban-column', () => ({
+  KanbanColumn: ({ id, tasks }: { id: string; tasks: Task[] }) => (
+    <div data-testid={`column-${id}`}>
+      {tasks.map((t: Task) => (
+        <div key={t.id} data-testid={`task-${t.id}`}>{t.title}</div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('../../plugins/tasks/components/task-card', () => ({
+  TaskCard: ({ task }: { task: Task }) => <div data-testid={`card-${task.id}`}>{task.title}</div>,
+  TaskCardOverlay: ({ task }: { task: Task }) => <div data-testid="overlay">{task.title}</div>,
+  TaskCardContent: ({ task, className }: { task: Task; className?: string }) => (
+    <div className={className}>{task.title}</div>
+  ),
+}))
+
+vi.mock('../../plugins/tasks/components/delete-task-dialog', () => ({
+  DeleteTaskDialog: () => null,
+}))
+
+vi.mock('../../plugins/tasks/components/task-detail-dialog', () => ({
+  TaskDetailDrawer: () => null,
+}))
+
+vi.mock('../../plugins/tasks/components/task-metrics', () => ({
+  TaskMetrics: () => null,
+}))
+
+vi.mock('../../plugins/tasks/components/task-filters', () => ({
+  TaskFilters: () => null,
+}))
+
+vi.mock('../../plugins/tasks/components/task-log-table', () => ({
+  TaskLogTable: () => null,
+}))
+
+vi.mock('@/components/plugin-header', () => ({
+  PluginHeader: () => null,
+}))
+
+vi.mock('@/components/layout/skeleton-loader', () => ({
+  WithLoading: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/agent-avatar', () => ({
+  AgentAvatar: ({ agentId }: any) => <div>{agentId}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+}))
+
+vi.mock('@/hooks/use-query-state', () => ({
+  useQueryState: (key: string, defaultValue: string) => {
+    const React = require('react') as typeof import('react')
+    return React.useState(defaultValue)
+  },
+  useQueryArrayState: () => {
+    const React = require('react') as typeof import('react')
+    return React.useState([])
+  },
+}))
+
+vi.mock('@/hooks/use-content-store', () => ({
+  useContentStore: () => 0,
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}))
+
+vi.mock('../../plugins/tasks/hooks/use-task-filters', () => ({
+  useTaskFilters: (columns: TaskColumns) => ({ filteredColumns: columns, allTasksFlat: [] }),
+}))
+
+vi.mock('../../plugins/tasks/hooks/use-gate-status', () => ({
+  useGateStatus: () => ({}),
+}))
+
+vi.mock('lucide-react', () => ({
+  Kanban: () => null,
+  Table2: () => null,
+  Plus: () => null,
+  X: () => null,
+}))
+
+// ── Helpers ──
+
+function makeTask(id: string, title: string, overrides?: Partial<Task>): Task {
+  return { id, title, checked: false, ...overrides }
+}
+
+function makeBoardResponse(columns: Partial<TaskColumns>) {
+  return {
+    columns: {
+      backlog: [], todo: [], blocked: [], inProgress: [], review: [], done: [], confirmed: [],
+      ...columns,
+    },
+    timestamp: '2026-04-07T00:00:00Z',
+  }
+}
+
+// Plain task IDs (not composite) — matches the new sortable ID scheme
+function makeDragEvent(activeId: string, activeData: any, overId?: string, overData?: any) {
+  return {
+    active: {
+      id: activeId,
+      data: { current: activeData },
+      rect: { current: { initial: null, translated: null } },
+    },
+    over: overId ? {
+      id: overId,
+      data: { current: overData },
+      rect: { width: 288, height: 100, top: 0, left: 0, right: 288, bottom: 100 },
+      disabled: false,
+    } : null,
+    activatorEvent: new Event('pointer'),
+    collisions: null,
+    delta: { x: 0, y: 0 },
+  }
+}
+
+// ── Tests ──
+
+describe('KanbanBoard drag and drop', () => {
+  let fetchCalls: Array<{ url: string; body: any; method: string }>
+
+  beforeEach(() => {
+    fetchCalls = []
+    capturedDndProps = {}
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  async function renderBoard(columns: Partial<TaskColumns>) {
+    const boardResponse = makeBoardResponse(columns)
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method && init.method !== 'GET') {
+        fetchCalls.push({
+          url,
+          body: init.body ? JSON.parse(init.body as string) : null,
+          method: init.method,
+        })
+        return { ok: true, json: async () => ({}) } as Response
+      }
+      return { ok: true, json: async () => boardResponse } as Response
+    }))
+
+    const { KanbanBoard } = await import('../../plugins/tasks/components/kanban-board')
+    let result: ReturnType<typeof render>
+    await act(async () => {
+      result = render(<KanbanBoard />)
+    })
+
+    // Wait for initial fetch
+    await waitFor(() => {
+      expect(screen.getByTestId('dnd-context')).toBeTruthy()
+    })
+
+    return result!
+  }
+
+  it('same-column reorder calls /reorder API with new order', async () => {
+    const task1 = makeTask('task-1', 'First')
+    const task2 = makeTask('task-2', 'Second')
+    const task3 = makeTask('task-3', 'Third')
+
+    await renderBoard({ todo: [task1, task2, task3] })
+
+    // Start dragging task-1
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Drop on task-3 position (within same column)
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'task-3',
+        { task: task3, columnId: 'todo' },
+      ))
+    })
+
+    await waitFor(() => {
+      const reorderCall = fetchCalls.find(c => c.url.includes('/reorder'))
+      expect(reorderCall).toBeTruthy()
+      expect(reorderCall!.body.columnId).toBe('todo')
+      expect(reorderCall!.body.orderedIds).toEqual(['task-2', 'task-3', 'task-1'])
+    })
+  })
+
+  it('cross-column move to populated column via onDragOver and calls /move API', async () => {
+    const task1 = makeTask('task-1', 'Move Me')
+    const task2 = makeTask('task-2', 'Existing A')
+    const task3 = makeTask('task-3', 'Existing B')
+
+    await renderBoard({ todo: [task1], inProgress: [task2, task3] })
+
+    // Start dragging task-1 from todo
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Drag over task-2 in inProgress — onDragOver moves it in state
+    act(() => {
+      capturedDndProps.onDragOver(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'task-2',
+        { task: task2, columnId: 'inProgress' },
+      ))
+    })
+
+    // Task-1 moved to inProgress column, gone from todo
+    await waitFor(() => {
+      expect(screen.getByTestId('column-inProgress').textContent).toContain('Move Me')
+      expect(screen.getByTestId('column-todo').textContent).not.toContain('Move Me')
+    })
+
+    // Drop
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'task-2',
+        { task: task2, columnId: 'inProgress' },
+      ))
+    })
+
+    await waitFor(() => {
+      const moveCall = fetchCalls.find(c => c.url.includes('/move'))
+      expect(moveCall).toBeTruthy()
+      expect(moveCall!.body.from).toBe('todo')
+      expect(moveCall!.body.to).toBe('inProgress')
+      expect(moveCall!.body.id).toBe('task-1')
+    })
+  })
+
+  it('cross-column move to empty column calls /move API', async () => {
+    const task1 = makeTask('task-1', 'Move Me')
+
+    await renderBoard({ todo: [task1], review: [] })
+
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Drag over the empty review column droppable
+    act(() => {
+      capturedDndProps.onDragOver(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'review',
+      ))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('column-review').textContent).toContain('Move Me')
+    })
+
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'review',
+      ))
+    })
+
+    await waitFor(() => {
+      const moveCall = fetchCalls.find(c => c.url.includes('/move'))
+      expect(moveCall).toBeTruthy()
+      expect(moveCall!.body.to).toBe('review')
+    })
+  })
+
+  it('drag cancel restores original state with no API calls', async () => {
+    const task1 = makeTask('task-1', 'Move Me')
+    const task2 = makeTask('task-2', 'Stay Here')
+
+    await renderBoard({ todo: [task1], inProgress: [task2] })
+
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Move to inProgress via onDragOver
+    act(() => {
+      capturedDndProps.onDragOver(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'inProgress',
+      ))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('column-inProgress').textContent).toContain('Move Me')
+    })
+
+    // Cancel
+    act(() => {
+      capturedDndProps.onDragCancel()
+    })
+
+    // Task restored to todo
+    await waitFor(() => {
+      expect(screen.getByTestId('column-todo').textContent).toContain('Move Me')
+    })
+
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  it('drag end with no over target is a no-op', async () => {
+    const task1 = makeTask('task-1', 'Task')
+
+    await renderBoard({ todo: [task1] })
+
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    expect(fetchCalls).toHaveLength(0)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('column-todo').textContent).toContain('Task')
+    })
+  })
+
+  it('onDragOver within same column is a no-op', async () => {
+    const task1 = makeTask('task-1', 'First')
+    const task2 = makeTask('task-2', 'Second')
+
+    await renderBoard({ todo: [task1, task2] })
+
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Drag over task-2 in the same column — should not move items in state
+    act(() => {
+      capturedDndProps.onDragOver(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'task-2',
+        { task: task2, columnId: 'todo' },
+      ))
+    })
+
+    await waitFor(() => {
+      const todoCol = screen.getByTestId('column-todo')
+      expect(todoCol.textContent).toContain('First')
+      expect(todoCol.textContent).toContain('Second')
+    })
+  })
+
+  it('same-column reorder with no change is a no-op', async () => {
+    const task1 = makeTask('task-1', 'First')
+    const task2 = makeTask('task-2', 'Second')
+
+    await renderBoard({ todo: [task1, task2] })
+
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    expect(fetchCalls.filter(c => c.url.includes('/reorder'))).toHaveLength(0)
+  })
+})
+
+describe('TaskCard ghost rendering', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders light clone placeholder when isDragging is true', async () => {
+    mockUseSortable.mockReturnValue({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: null,
+      isDragging: true,
+      active: null,
+      activeIndex: 0,
+      data: {},
+      index: 0,
+      isOver: false,
+      isSorting: false,
+      items: [],
+      newIndex: 0,
+      over: null,
+      overIndex: 0,
+      rect: { current: null },
+      setActivatorNodeRef: vi.fn(),
+      setDroppableNodeRef: vi.fn(),
+      setDraggableNodeRef: vi.fn(),
+    })
+
+    const { TaskCard } = await vi.importActual<typeof import('../../plugins/tasks/components/task-card')>('../../plugins/tasks/components/task-card')
+
+    const task = { id: 'task-1', title: 'Test Task', checked: false } as Task
+
+    const { container } = render(
+      <TaskCard
+        task={task}
+        columnId="todo"
+        onAssign={vi.fn()}
+        onDelete={vi.fn()}
+        onClick={vi.fn()}
+      />,
+    )
+
+    const placeholderEl = container.firstElementChild as HTMLElement
+    expect(placeholderEl.className).toContain('border-dashed')
+    expect(placeholderEl.className).toContain('opacity-40')
+    // Should show card content (light clone), not invisible
+    expect(placeholderEl.textContent).toContain('Test Task')
+  })
+
+  it('renders normal card when isDragging is false', async () => {
+    mockUseSortable.mockReturnValue({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: null,
+      isDragging: false,
+      active: null,
+      activeIndex: 0,
+      data: {},
+      index: 0,
+      isOver: false,
+      isSorting: false,
+      items: [],
+      newIndex: 0,
+      over: null,
+      overIndex: 0,
+      rect: { current: null },
+      setActivatorNodeRef: vi.fn(),
+      setDroppableNodeRef: vi.fn(),
+      setDraggableNodeRef: vi.fn(),
+    })
+
+    const { TaskCard } = await vi.importActual<typeof import('../../plugins/tasks/components/task-card')>('../../plugins/tasks/components/task-card')
+
+    const task = { id: 'task-1', title: 'Test Task', checked: false } as Task
+
+    const { container } = render(
+      <TaskCard
+        task={task}
+        columnId="todo"
+        onAssign={vi.fn()}
+        onDelete={vi.fn()}
+        onClick={vi.fn()}
+      />,
+    )
+
+    expect(container.textContent).toContain('Test Task')
+    const cardDiv = container.querySelector('.cursor-grab')
+    expect(cardDiv).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

- **Fixed cross-column DnD** — sortable items now use plain `task.id` instead of composite `columnId::taskId`, so dnd-kit tracks items across containers correctly
- **Added `onDragOver` handler** — moves tasks between columns in optimistic state for real-time visual feedback (items shift apart, placeholder appears)
- **Custom collision detection** — `pointerWithin` for container detection + `closestCenter` fallback for item positioning
- **Light-clone placeholder** — dragged card shows a faded copy at the drop position instead of the old generic blue pulsing box
- **Drag cancel support** — Escape restores original state via `onDragCancel`
- **9 new tests** covering same-column reorder, cross-column moves, cancel, edge cases, and ghost rendering

## Root cause

Sortable items used composite IDs (`columnId::taskId`). When `onDragOver` moved a task from column A to column B, the sortable ID changed (e.g., `todo::task-1` → `inProgress::task-1`). dnd-kit's active drag still referenced the old ID, so `isDragging` went false — the placeholder vanished and items in the target column didn't shift apart.

## Test plan

- [x] `npm run test:components` — all 9 new DnD tests pass
- [x] `npm test` — no regressions (1314 pass, 2 pre-existing failures unrelated)
- [ ] Manual: drag within same column — cards shift, drop works at any position
- [ ] Manual: drag to populated column — existing cards shift apart, placeholder visible
- [ ] Manual: drag to empty column — card lands correctly
- [ ] Manual: press Escape during drag — card returns to original position

🤖 Generated with [Claude Code](https://claude.com/claude-code)