### PR TITLE
fix(tasks): fix cross-column drag-and-drop and preserve drop position

### DIFF
--- a/.claude/knowledge/tasks-plugin.md
+++ b/.claude/knowledge/tasks-plugin.md
@@ -152,6 +152,20 @@ confirmed  → done, todo
 | `plugins/tasks/components/task-metrics.tsx` | Summary metrics row (counts by column) |
 | `plugins/tasks/components/task-log-table.tsx` | Table view of tasks (alternative to kanban) |
 
+### Drag-and-Drop (dnd-kit)
+
+The kanban board uses `@dnd-kit/core` v6 + `@dnd-kit/sortable` v10 for drag-and-drop:
+
+- **Sortable IDs** are plain `task.id` (not composite), so dnd-kit tracks items across containers.
+- **`useSortable` data** includes custom `{ task, columnId }` plus dnd-kit's internal `sortable: { containerId, index, items }`.
+- **Collision detection** uses `pointerWithin` + `closestCenter` fallback for reliable multi-container detection.
+- **`handleDragOver`** moves items between columns in optimistic state (via `setOptimistic`) so dnd-kit shows displacement in the target column during drag.
+- **`handleDragCancel`** restores the drag-start column snapshot.
+
+**Critical: stale-ref pitfall.** `active.data.current.columnId` is a live ref that `useSortable` updates when the component re-renders in a new column (after `handleDragOver`). In `handleDragEnd`, it reflects the *target* column, not the source. The source column must be captured in a ref at drag start (`dragFromColRef`). Similarly, target column must be read from `over.data.current` / `over.id`, not from optimistic state (which may be stale in the `useCallback` closure).
+
+**Ordering.** Tasks within columns are ordered by `updated_at DESC`. The `/reorder` endpoint stamps `updated_at` values (now-0, now-1, ...) to encode position. Cross-column moves call `/move` then `/reorder` to persist drop position.
+
 ### Real-Time Updates (SSE)
 
 1. Every write operation in `flow-store.ts` calls `broadcastChange()` which fires `globalThis.__bakinBroadcast({ type: 'taskboard' })`

--- a/plugins/tasks/components/kanban-board.tsx
+++ b/plugins/tasks/components/kanban-board.tsx
@@ -152,6 +152,7 @@ export function KanbanBoard() {
   const [activeTask, setActiveTask] = useState<Task | null>(null)
   const [activeColumnId, setActiveColumnId] = useState<ColumnId | null>(null)
   const dragStartColumnsRef = useRef<TaskColumns | null>(null)
+  const dragFromColRef = useRef<ColumnId | null>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -163,6 +164,7 @@ export function KanbanBoard() {
     setActiveTask(data.task)
     setActiveColumnId(data.columnId as ColumnId)
     dragStartColumnsRef.current = optimistic?.columns ?? parsed.columns
+    dragFromColRef.current = data.columnId as ColumnId
   }, [optimistic, parsed.columns])
 
   // Move items between columns in state so dnd-kit can show displacement in the target column.
@@ -242,9 +244,11 @@ export function KanbanBoard() {
     setActiveColumnId(null)
 
     const originalColumns = dragStartColumnsRef.current
+    const fromCol = dragFromColRef.current
     dragStartColumnsRef.current = null
+    dragFromColRef.current = null
 
-    if (!over || !originalColumns) {
+    if (!over || !originalColumns || !fromCol) {
       setOptimistic(null)
       return
     }
@@ -255,23 +259,30 @@ export function KanbanBoard() {
       return
     }
     const task = activeData.task
-    const fromCol = activeData.columnId as ColumnId
 
-    // Find which column currently holds the task (after onDragOver moves)
-    const currentColumns = optimistic?.columns ?? originalColumns
-    let targetCol: ColumnId = fromCol
-    for (const colId of COLUMN_ORDER) {
-      if (currentColumns[colId].some(t => t.id === task.id)) {
-        targetCol = colId
-        break
+    // Determine target column from the drop event. We cannot use
+    // active.data.current.columnId here — useSortable updates it live when
+    // handleDragOver moves the task between columns in optimistic state, so it
+    // reflects the current (target) column, not the original source column.
+    // fromCol is captured at drag start via dragFromColRef.
+    const overId = String(over.id)
+    let targetCol: ColumnId
+    if (COLUMN_ORDER.includes(overId as ColumnId)) {
+      targetCol = overId as ColumnId
+    } else {
+      const overData = over.data.current as { columnId: string } | undefined
+      if (overData?.columnId && COLUMN_ORDER.includes(overData.columnId as ColumnId)) {
+        targetCol = overData.columnId as ColumnId
+      } else {
+        setOptimistic(null)
+        return
       }
     }
 
     if (fromCol === targetCol) {
       // Same-column reorder — onDragOver skips same-column, compute new order here
-      const colTasks = [...currentColumns[fromCol]]
+      const colTasks = [...originalColumns[fromCol]]
       const oldIndex = colTasks.findIndex(t => t.id === task.id)
-      const overId = String(over.id)
       const newIndex = !COLUMN_ORDER.includes(overId as ColumnId)
         ? colTasks.findIndex(t => t.id === overId)
         : colTasks.length - 1
@@ -284,7 +295,7 @@ export function KanbanBoard() {
       const reordered = arrayMove(colTasks, oldIndex, newIndex)
 
       setOptimistic(prev => {
-        const base = prev?.columns ?? currentColumns
+        const base = prev?.columns ?? originalColumns
         return { columns: { ...base, [fromCol]: reordered } }
       })
 
@@ -297,24 +308,45 @@ export function KanbanBoard() {
       await refreshTaskboard()
       setOptimistic(null)
     } else {
-      // Cross-column move — task already in target column via onDragOver
+      // Cross-column move — insert at the drop position
       const movedTask = { ...task, checked: targetCol === 'done' || targetCol === 'confirmed' }
-      const updatedTarget = currentColumns[targetCol].map(
-        t => t.id === task.id ? movedTask : t
-      )
-      setOptimistic({
-        columns: { ...currentColumns, [targetCol]: updatedTarget },
-      })
+      const targetTasks = [...originalColumns[targetCol]]
+
+      if (COLUMN_ORDER.includes(overId as ColumnId)) {
+        // Dropped on the column itself — append
+        targetTasks.push(movedTask)
+      } else {
+        // Dropped on a specific task — insert at its position
+        const insertIdx = targetTasks.findIndex(t => t.id === overId)
+        if (insertIdx !== -1) {
+          targetTasks.splice(insertIdx, 0, movedTask)
+        } else {
+          targetTasks.push(movedTask)
+        }
+      }
+
+      const updatedColumns = { ...originalColumns }
+      updatedColumns[fromCol] = originalColumns[fromCol].filter(t => t.id !== task.id)
+      updatedColumns[targetCol] = targetTasks
+      setOptimistic({ columns: updatedColumns })
 
       const ok = await apiFetch('/api/plugins/tasks/' + task.id + '/move', {
         id: task.id, title: task.title, from: fromCol, to: targetCol, agent: 'roscoe',
       })
 
-      if (!ok) toast(`Failed to move "${task.title}"`, 'error')
+      if (!ok) {
+        toast(`Failed to move "${task.title}"`, 'error')
+      } else {
+        // Persist drop position — reorder uses updated_at stamps to encode order
+        await apiFetch('/api/plugins/tasks/reorder', {
+          columnId: targetCol,
+          orderedIds: targetTasks.map(t => t.id),
+        })
+      }
       await refreshTaskboard()
       setOptimistic(null)
     }
-  }, [parsed.columns, optimistic, refreshTaskboard])
+  }, [refreshTaskboard])
 
   const handleAssign = useCallback(async (task: Task, agent: string) => {
     const ok = await apiFetch('/api/plugins/tasks/' + task.id + '/assign', { id: task.id, title: task.title, agent })

--- a/tests/components/kanban-dnd.test.tsx
+++ b/tests/components/kanban-dnd.test.tsx
@@ -450,6 +450,86 @@ describe('KanbanBoard drag and drop', () => {
     })
   })
 
+  it('cross-column move preserves drop position and calls /reorder', async () => {
+    const task1 = makeTask('task-1', 'Move Me')
+    const task2 = makeTask('task-2', 'First In Progress')
+    const task3 = makeTask('task-3', 'Second In Progress')
+
+    await renderBoard({ todo: [task1], inProgress: [task2, task3] })
+
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Drop on task-3 — should insert before task-3 in inProgress
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'task-3',
+        { task: task3, columnId: 'inProgress' },
+      ))
+    })
+
+    await waitFor(() => {
+      const moveCall = fetchCalls.find(c => c.url.includes('/move'))
+      expect(moveCall).toBeTruthy()
+      expect(moveCall!.body.from).toBe('todo')
+      expect(moveCall!.body.to).toBe('inProgress')
+
+      // After /move, a /reorder call should persist the drop position
+      const reorderCall = fetchCalls.find(c => c.url.includes('/reorder'))
+      expect(reorderCall).toBeTruthy()
+      expect(reorderCall!.body.columnId).toBe('inProgress')
+      // task-1 inserted before task-3 → [task-2, task-1, task-3]
+      expect(reorderCall!.body.orderedIds).toEqual(['task-2', 'task-1', 'task-3'])
+    })
+  })
+
+  it('cross-column move uses drag-start column, not stale active.data.current.columnId', async () => {
+    const task1 = makeTask('task-1', 'Move Me')
+
+    await renderBoard({ todo: [task1], inProgress: [] })
+
+    // Start drag — captures fromCol as 'todo'
+    act(() => {
+      capturedDndProps.onDragStart(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+      ))
+    })
+
+    // Simulate what happens in real dnd-kit: handleDragOver moves the task,
+    // useSortable re-renders with new columnId, and active.data.current updates
+    act(() => {
+      capturedDndProps.onDragOver(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'todo' },
+        'inProgress',
+      ))
+    })
+
+    // Drop — active.data.current.columnId is now 'inProgress' (stale ref from
+    // useSortable re-render), but the handler should use the drag-start ref
+    await act(async () => {
+      capturedDndProps.onDragEnd(makeDragEvent(
+        'task-1',
+        { task: task1, columnId: 'inProgress' }, // simulates stale useSortable data
+        'inProgress',
+      ))
+    })
+
+    await waitFor(() => {
+      const moveCall = fetchCalls.find(c => c.url.includes('/move'))
+      expect(moveCall).toBeTruthy()
+      expect(moveCall!.body.from).toBe('todo') // from drag-start ref, not stale 'inProgress'
+      expect(moveCall!.body.to).toBe('inProgress')
+    })
+  })
+
   it('same-column reorder with no change is a no-op', async () => {
     const task1 = makeTask('task-1', 'First')
     const task2 = makeTask('task-2', 'Second')


### PR DESCRIPTION
## Summary

- **Cross-column moves were silently failing** — dragging a card between columns produced no API call and the card snapped back. Root cause: `handleDragEnd` read the source column from `active.data.current.columnId`, but `useSortable` updates that ref live when `handleDragOver` moves the card in optimistic state. By drop time, `fromCol === targetCol` and the move was treated as a same-column no-op. Fixed by capturing source column in a ref (`dragFromColRef`) at drag start.
- **Drop position wasn't preserved** — cross-column moves always landed at the top of the target column because `moveTask` sets `updated_at = Date.now()` and columns sort by `updated_at DESC`. Fixed by calling `/reorder` after `/move` to persist the insertion position.
- **Removed `optimistic` from `handleDragEnd` deps** — target column is now determined from the `over` element's data (always fresh), not from potentially stale optimistic state in the closure.
- Added 2 new tests: drop-position preservation and stale-ref regression.
- Updated `.claude/knowledge/tasks-plugin.md` with dnd-kit architecture notes and the stale-ref pitfall.

## Test plan

- [ ] Drag a task from one column to another — should move and call the API
- [ ] Drag a task between two existing tasks in the target column — should land at the drop position, not the top
- [ ] Drag a task to an empty column — should append
- [ ] Same-column reorder still works
- [ ] Cancel (Escape) still restores original state
- [ ] `npx vitest run tests/components/kanban-dnd.test.tsx` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)