### PR TITLE
feat(calendar): add persistent planning sessions (PR 1A)

### DIFF
--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -11,7 +11,17 @@ import {
   deleteItem,
   getItem,
 } from './lib/storage'
-import type { CalendarItem, ContentStatus } from './types'
+import type { CalendarItem, ContentStatus, ProposalStatus } from './types'
+import {
+  createSession,
+  loadSession,
+  listSessions,
+  updateSession as updateSessionFn,
+  deleteSession as deleteSessionFn,
+  appendMessage,
+  updateProposal,
+  confirmSession,
+} from './lib/sessions'
 import { getContentDir } from '../../src/core/content-dir'
 import { createLogger } from '../../src/core/logger'
 
@@ -387,7 +397,176 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
       },
     })
 
-    // ── Exec Tools (agent-facing) ──────��───────────────────────────────
+    // ── Session Routes ──────────────────────────────────────────────────
+
+    // GET /sessions — list planning sessions
+    ctx.registerRoute({
+      path: '/sessions',
+      method: 'GET',
+      description: 'List planning sessions',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const status = url.searchParams.get('status') || undefined
+        const agentId = url.searchParams.get('agentId') || undefined
+        const sessions = listSessions({ status, agentId })
+        return json({ sessions })
+      },
+    })
+
+    // GET /sessions/:id — get full session
+    ctx.registerRoute({
+      path: '/sessions/:id',
+      method: 'GET',
+      description: 'Get a planning session',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const id = url.searchParams.get('id')
+        if (!id) return json({ error: 'id required' }, 400)
+        const session = loadSession(id)
+        if (!session) return json({ error: 'Session not found' }, 404)
+        return json({ session })
+      },
+    })
+
+    // POST /sessions — create session
+    ctx.registerRoute({
+      path: '/sessions',
+      method: 'POST',
+      description: 'Create a planning session',
+      handler: async (req: Request) => {
+        const body = await readBody<{ agentId?: string; title?: string }>(req)
+        if (!body.agentId) return json({ error: 'agentId required' }, 400)
+        const session = createSession({ agentId: body.agentId, title: body.title })
+        ctx.activity.audit('session.created', body.agentId, { sessionId: session.id })
+        ctx.activity.log(body.agentId, `Created planning session "${session.title}"`)
+        return json({ ok: true, session })
+      },
+    })
+
+    // PUT /sessions/:id — update session metadata
+    ctx.registerRoute({
+      path: '/sessions/:id',
+      method: 'PUT',
+      description: 'Update a planning session',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<{ id?: string; title?: string; status?: 'active' | 'completed' }>(req)
+        const id = url.searchParams.get('id') || body.id
+        if (!id) return json({ error: 'id required' }, 400)
+        try {
+          const session = updateSessionFn(id, { title: body.title, status: body.status })
+          return json({ ok: true, session })
+        } catch (e: unknown) {
+          return json({ error: (e as Error).message }, 404)
+        }
+      },
+    })
+
+    // DELETE /sessions/:id — delete session
+    ctx.registerRoute({
+      path: '/sessions/:id',
+      method: 'DELETE',
+      description: 'Delete a planning session',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<{ id?: string }>(req).catch(() => ({} as { id?: string }))
+        const id = url.searchParams.get('id') || body.id
+        if (!id) return json({ error: 'id required' }, 400)
+        try {
+          deleteSessionFn(id)
+          ctx.activity.audit('session.deleted', 'system', { sessionId: id })
+          ctx.activity.log('system', `Deleted planning session ${id}`)
+          return json({ ok: true })
+        } catch (e: unknown) {
+          return json({ error: (e as Error).message }, 404)
+        }
+      },
+    })
+
+    // POST /sessions/:id/messages — send message (non-streaming for now)
+    ctx.registerRoute({
+      path: '/sessions/:id/messages',
+      method: 'POST',
+      description: 'Send a message in a planning session',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<{ id?: string; message?: string }>(req)
+        const id = url.searchParams.get('id') || body.id
+        if (!id) return json({ error: 'id required' }, 400)
+        if (!body.message) return json({ error: 'message required' }, 400)
+
+        const session = loadSession(id)
+        if (!session) return json({ error: 'Session not found' }, 404)
+        if (session.status === 'completed') return json({ error: 'Session is completed' }, 400)
+
+        // Append user message
+        const userMsg = appendMessage(id, { role: 'user', content: body.message })
+
+        // For now, return a placeholder — streaming upgrade in PR 2
+        const assistantMsg = appendMessage(id, {
+          role: 'assistant',
+          content: 'Planning session message received. Streaming upgrade pending.',
+        })
+
+        return json({
+          ok: true,
+          response: assistantMsg.content,
+          suggestions: [],
+          messageId: assistantMsg.id,
+        })
+      },
+    })
+
+    // PUT /sessions/:id/proposals/:proposalId — update proposal
+    ctx.registerRoute({
+      path: '/sessions/:id/proposals/:proposalId',
+      method: 'PUT',
+      description: 'Update a proposal in a planning session',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<Record<string, unknown>>(req)
+        const sessionId = url.searchParams.get('id')
+        const proposalId = url.searchParams.get('proposalId')
+        if (!sessionId || !proposalId) return json({ error: 'sessionId and proposalId required' }, 400)
+        try {
+          const proposal = updateProposal(sessionId, proposalId, {
+            status: body.status as ProposalStatus | undefined,
+            title: body.title as string | undefined,
+            brief: body.brief as string | undefined,
+            tone: body.tone as string | undefined,
+            scheduledAt: body.scheduledAt as string | undefined,
+            channels: body.channels as string[] | undefined,
+            rejectionNote: body.rejectionNote as string | undefined,
+          })
+          return json({ ok: true, proposal })
+        } catch (e: unknown) {
+          return json({ error: (e as Error).message }, 404)
+        }
+      },
+    })
+
+    // POST /sessions/:id/confirm — confirm plan
+    ctx.registerRoute({
+      path: '/sessions/:id/confirm',
+      method: 'POST',
+      description: 'Confirm plan and create calendar items',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<{ id?: string }>(req).catch(() => ({} as { id?: string }))
+        const id = url.searchParams.get('id') || body.id
+        if (!id) return json({ error: 'id required' }, 400)
+        try {
+          const result = confirmSession(id)
+          ctx.activity.audit('session.confirmed', 'system', { sessionId: id, itemsCreated: result.itemsCreated })
+          ctx.activity.log('system', `Confirmed planning session — ${result.itemsCreated} items created`)
+          return json({ ok: true, ...result })
+        } catch (e: unknown) {
+          return json({ error: (e as Error).message }, 400)
+        }
+      },
+    })
+
+    // ── Exec Tools (agent-facing) ─────────────────────────────────────
 
     ctx.registerExecTool({
       name: 'bakin_exec_calendar_list',

--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -903,7 +903,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
       },
     })
 
-    ctx.watchFiles(['calendar.json'])
+    ctx.watchFiles(['calendar.json', 'calendar/sessions/*.json'])
     log.info('Calendar plugin activated')
   },
 

--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -726,6 +726,183 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
       },
     })
 
+    // ── Session Exec Tools (agent-facing) ─────────────────────────────
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_list',
+      description: 'List planning sessions with optional filters',
+      parameters: {
+        status: z.string().optional().describe('Filter by status (active, completed)'),
+        agentId: z.string().optional().describe('Filter by agent ID'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        const sessions = listSessions({
+          status: params.status as string | undefined,
+          agentId: params.agentId as string | undefined,
+        })
+        return { ok: true, count: sessions.length, sessions }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_get',
+      description: 'Get a planning session with full message history and proposals',
+      parameters: {
+        sessionId: z.string().describe('Session ID (required)'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.sessionId) return { ok: false, error: 'sessionId required' }
+        const session = loadSession(params.sessionId as string)
+        if (!session) return { ok: false, error: 'Session not found' }
+        return { ok: true, session }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_create',
+      description: 'Create a new planning session for an agent',
+      parameters: {
+        agentId: z.string().describe('Agent ID (required)'),
+        title: z.string().optional().describe('Session title'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.agentId) return { ok: false, error: 'agentId required' }
+        const session = createSession({
+          agentId: params.agentId as string,
+          title: params.title as string | undefined,
+        })
+        ctx.activity.audit('session.created', params.agentId as string, { sessionId: session.id })
+        return { ok: true, session }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_update',
+      description: 'Update a planning session title or status',
+      parameters: {
+        sessionId: z.string().describe('Session ID (required)'),
+        title: z.string().optional().describe('New title'),
+        status: z.string().optional().describe('New status (active, completed)'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.sessionId) return { ok: false, error: 'sessionId required' }
+        try {
+          const session = updateSessionFn(params.sessionId as string, {
+            title: params.title as string | undefined,
+            status: params.status as 'active' | 'completed' | undefined,
+          })
+          return { ok: true, session }
+        } catch (e: unknown) {
+          return { ok: false, error: (e as Error).message }
+        }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_delete',
+      description: 'Delete a planning session',
+      parameters: {
+        sessionId: z.string().describe('Session ID (required)'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.sessionId) return { ok: false, error: 'sessionId required' }
+        try {
+          deleteSessionFn(params.sessionId as string)
+          ctx.activity.audit('session.deleted', 'system', { sessionId: params.sessionId })
+          return { ok: true }
+        } catch (e: unknown) {
+          return { ok: false, error: (e as Error).message }
+        }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_message',
+      description: 'Send a message in a planning session (non-streaming, returns full response)',
+      parameters: {
+        sessionId: z.string().describe('Session ID (required)'),
+        message: z.string().describe('User message content (required)'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.sessionId || !params.message) return { ok: false, error: 'sessionId and message required' }
+        const session = loadSession(params.sessionId as string)
+        if (!session) return { ok: false, error: 'Session not found' }
+        if (session.status === 'completed') return { ok: false, error: 'Session is completed' }
+
+        const userMsg = appendMessage(params.sessionId as string, {
+          role: 'user',
+          content: params.message as string,
+        })
+
+        // Non-streaming placeholder — streaming upgrade in PR 2
+        const assistantMsg = appendMessage(params.sessionId as string, {
+          role: 'assistant',
+          content: 'Planning session message received. Streaming upgrade pending.',
+        })
+
+        return {
+          ok: true,
+          response: assistantMsg.content,
+          messageId: assistantMsg.id,
+          userMessageId: userMsg.id,
+        }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_proposal_update',
+      description: 'Update a proposal status or fields (approve, reject, edit)',
+      parameters: {
+        sessionId: z.string().describe('Session ID (required)'),
+        proposalId: z.string().describe('Proposal ID (required)'),
+        status: z.string().optional().describe('New status (proposed, approved, rejected, revised)'),
+        title: z.string().optional().describe('Updated title'),
+        brief: z.string().optional().describe('Updated brief'),
+        tone: z.string().optional().describe('Updated tone'),
+        scheduledAt: z.string().optional().describe('Updated schedule datetime'),
+        channels: z.array(z.string()).optional().describe('Updated channels'),
+        rejectionNote: z.string().optional().describe('Note explaining rejection'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.sessionId || !params.proposalId) return { ok: false, error: 'sessionId and proposalId required' }
+        try {
+          const proposal = updateProposal(params.sessionId as string, params.proposalId as string, {
+            status: params.status as ProposalStatus | undefined,
+            title: params.title as string | undefined,
+            brief: params.brief as string | undefined,
+            tone: params.tone as string | undefined,
+            scheduledAt: params.scheduledAt as string | undefined,
+            channels: params.channels as string[] | undefined,
+            rejectionNote: params.rejectionNote as string | undefined,
+          })
+          return { ok: true, proposal }
+        } catch (e: unknown) {
+          return { ok: false, error: (e as Error).message }
+        }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_calendar_session_confirm',
+      description: 'Confirm a planning session — creates calendar items from approved proposals',
+      parameters: {
+        sessionId: z.string().describe('Session ID (required)'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        if (!params.sessionId) return { ok: false, error: 'sessionId required' }
+        try {
+          const result = confirmSession(params.sessionId as string)
+          ctx.activity.audit('session.confirmed', 'system', {
+            sessionId: params.sessionId,
+            itemsCreated: result.itemsCreated,
+          })
+          return { ok: true, ...result }
+        } catch (e: unknown) {
+          return { ok: false, error: (e as Error).message }
+        }
+      },
+    })
+
     ctx.watchFiles(['calendar.json'])
     log.info('Calendar plugin activated')
   },

--- a/plugins/calendar/lib/ids.ts
+++ b/plugins/calendar/lib/ids.ts
@@ -1,0 +1,15 @@
+/**
+ * Generate a short random ID. Works in both browser and Node.
+ * Returns an 8-character hex string.
+ */
+export function generateId(): string {
+  const bytes = new Uint8Array(4)
+  if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256)
+    }
+  }
+  return Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/plugins/calendar/lib/sessions.ts
+++ b/plugins/calendar/lib/sessions.ts
@@ -1,0 +1,279 @@
+/**
+ * Planning session storage — per-entity JSON files in ~/.bakin/calendar/sessions/
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { getContentDir } from '../../../src/core/content-dir'
+import { generateId } from './ids'
+import { createItem } from './storage'
+import type {
+  PlanningSession,
+  SessionMessage,
+  ProposedItem,
+  ProposalStatus,
+  CalendarItem,
+} from '../types'
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+function getSessionsDir(contentDir?: string): string {
+  return join(contentDir || getContentDir(), 'calendar', 'sessions')
+}
+
+function getSessionPath(sessionId: string, contentDir?: string): string {
+  return join(getSessionsDir(contentDir), `${sessionId}.json`)
+}
+
+function ensureSessionsDir(contentDir?: string): void {
+  const dir = getSessionsDir(contentDir)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export function createSession(opts: {
+  agentId: string
+  title?: string
+}): PlanningSession {
+  ensureSessionsDir()
+  const now = new Date().toISOString()
+  const session: PlanningSession = {
+    id: generateId(),
+    agentId: opts.agentId,
+    title: opts.title || 'New planning session',
+    status: 'active',
+    createdAt: now,
+    updatedAt: now,
+    messages: [],
+    proposals: [],
+  }
+  writeFileSync(getSessionPath(session.id), JSON.stringify(session, null, 2))
+  return session
+}
+
+export function loadSession(sessionId: string): PlanningSession | null {
+  const path = getSessionPath(sessionId)
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+export interface SessionSummary {
+  id: string
+  agentId: string
+  title: string
+  status: 'active' | 'completed'
+  createdAt: string
+  updatedAt: string
+  proposalCount: number
+  approvedCount: number
+}
+
+export function listSessions(opts?: {
+  status?: string
+  agentId?: string
+}): SessionSummary[] {
+  const dir = getSessionsDir()
+  if (!existsSync(dir)) return []
+
+  const files = readdirSync(dir).filter(f => f.endsWith('.json'))
+  const summaries: SessionSummary[] = []
+
+  for (const file of files) {
+    try {
+      const raw = readFileSync(join(dir, file), 'utf-8')
+      const session: PlanningSession = JSON.parse(raw)
+
+      if (opts?.status && session.status !== opts.status) continue
+      if (opts?.agentId && session.agentId !== opts.agentId) continue
+
+      summaries.push({
+        id: session.id,
+        agentId: session.agentId,
+        title: session.title,
+        status: session.status,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt,
+        proposalCount: session.proposals.length,
+        approvedCount: session.proposals.filter(p => p.status === 'approved').length,
+      })
+    } catch {
+      // skip malformed files
+    }
+  }
+
+  return summaries.sort((a, b) =>
+    new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  )
+}
+
+export function updateSession(
+  sessionId: string,
+  updates: { title?: string; status?: 'active' | 'completed' }
+): PlanningSession {
+  const session = loadSession(sessionId)
+  if (!session) throw new Error(`Session ${sessionId} not found`)
+
+  if (updates.title !== undefined) session.title = updates.title
+  if (updates.status !== undefined) session.status = updates.status
+  session.updatedAt = new Date().toISOString()
+
+  writeFileSync(getSessionPath(sessionId), JSON.stringify(session, null, 2))
+  return session
+}
+
+export function deleteSession(sessionId: string): void {
+  const path = getSessionPath(sessionId)
+  if (!existsSync(path)) throw new Error(`Session ${sessionId} not found`)
+  unlinkSync(path)
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+export function appendMessage(
+  sessionId: string,
+  message: { role: 'user' | 'assistant'; content: string },
+  proposalIds?: string[]
+): SessionMessage {
+  const session = loadSession(sessionId)
+  if (!session) throw new Error(`Session ${sessionId} not found`)
+
+  const msg: SessionMessage = {
+    id: generateId(),
+    role: message.role,
+    content: message.content,
+    timestamp: new Date().toISOString(),
+    proposalIds,
+  }
+
+  session.messages.push(msg)
+  session.updatedAt = new Date().toISOString()
+  writeFileSync(getSessionPath(sessionId), JSON.stringify(session, null, 2))
+  return msg
+}
+
+// ---------------------------------------------------------------------------
+// Proposals
+// ---------------------------------------------------------------------------
+
+export function addProposals(
+  sessionId: string,
+  messageId: string,
+  items: Array<{
+    title: string
+    scheduledAt: string
+    contentType: string
+    tone: string
+    brief: string
+    channels?: string[]
+  }>
+): ProposedItem[] {
+  const session = loadSession(sessionId)
+  if (!session) throw new Error(`Session ${sessionId} not found`)
+
+  const proposals: ProposedItem[] = items.map(item => ({
+    id: generateId(),
+    messageId,
+    revision: 1,
+    agentId: session.agentId,
+    title: item.title,
+    scheduledAt: item.scheduledAt,
+    contentType: item.contentType,
+    tone: item.tone,
+    brief: item.brief,
+    channels: item.channels,
+    status: 'proposed' as ProposalStatus,
+  }))
+
+  session.proposals.push(...proposals)
+  session.updatedAt = new Date().toISOString()
+  writeFileSync(getSessionPath(sessionId), JSON.stringify(session, null, 2))
+  return proposals
+}
+
+export function updateProposal(
+  sessionId: string,
+  proposalId: string,
+  updates: {
+    status?: ProposalStatus
+    title?: string
+    brief?: string
+    tone?: string
+    scheduledAt?: string
+    channels?: string[]
+    rejectionNote?: string
+  }
+): ProposedItem {
+  const session = loadSession(sessionId)
+  if (!session) throw new Error(`Session ${sessionId} not found`)
+
+  const idx = session.proposals.findIndex(p => p.id === proposalId)
+  if (idx === -1) throw new Error(`Proposal ${proposalId} not found`)
+
+  const proposal = session.proposals[idx]
+  if (updates.status !== undefined) proposal.status = updates.status
+  if (updates.title !== undefined) proposal.title = updates.title
+  if (updates.brief !== undefined) proposal.brief = updates.brief
+  if (updates.tone !== undefined) proposal.tone = updates.tone
+  if (updates.scheduledAt !== undefined) proposal.scheduledAt = updates.scheduledAt
+  if (updates.channels !== undefined) proposal.channels = updates.channels
+  if (updates.rejectionNote !== undefined) proposal.rejectionNote = updates.rejectionNote
+
+  session.updatedAt = new Date().toISOString()
+  writeFileSync(getSessionPath(sessionId), JSON.stringify(session, null, 2))
+  return proposal
+}
+
+// ---------------------------------------------------------------------------
+// Confirm plan
+// ---------------------------------------------------------------------------
+
+export function confirmSession(sessionId: string): {
+  itemsCreated: number
+  itemIds: string[]
+} {
+  const session = loadSession(sessionId)
+  if (!session) throw new Error(`Session ${sessionId} not found`)
+  if (session.status === 'completed') throw new Error('Session already completed')
+
+  const approved = session.proposals.filter(p => p.status === 'approved')
+  if (approved.length === 0) throw new Error('No approved proposals to confirm')
+
+  const itemIds: string[] = []
+
+  for (const proposal of approved) {
+    const item = createItem({
+      title: proposal.title,
+      agent: proposal.agentId as CalendarItem['agent'],
+      channel: 'discord',
+      channelTarget: '',
+      contentType: proposal.contentType as CalendarItem['contentType'],
+      tone: proposal.tone as CalendarItem['tone'],
+      scheduledAt: proposal.scheduledAt,
+      brief: proposal.brief,
+      status: 'draft',
+      sessionId,
+      channels: proposal.channels,
+    })
+
+    proposal.calendarItemId = item.id
+    itemIds.push(item.id)
+  }
+
+  session.status = 'completed'
+  session.updatedAt = new Date().toISOString()
+  writeFileSync(getSessionPath(sessionId), JSON.stringify(session, null, 2))
+
+  return { itemsCreated: itemIds.length, itemIds }
+}

--- a/plugins/calendar/types.ts
+++ b/plugins/calendar/types.ts
@@ -29,6 +29,49 @@ export interface CalendarItem {
   publishedMessageId?: string
   taskId?: string
   rejectionNote?: string
+  sessionId?: string
+  channels?: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Planning Sessions
+// ---------------------------------------------------------------------------
+
+export type ProposalStatus = 'proposed' | 'approved' | 'rejected' | 'revised'
+
+export interface ProposedItem {
+  id: string
+  messageId: string
+  revision: number
+  agentId: string
+  title: string
+  scheduledAt: string
+  contentType: string
+  tone: string
+  brief: string
+  channels?: string[]
+  status: ProposalStatus
+  calendarItemId?: string
+  rejectionNote?: string
+}
+
+export interface SessionMessage {
+  id: string
+  role: 'user' | 'assistant'
+  content: string
+  timestamp: string
+  proposalIds?: string[]
+}
+
+export interface PlanningSession {
+  id: string
+  agentId: string
+  title: string
+  status: 'active' | 'completed'
+  createdAt: string
+  updatedAt: string
+  messages: SessionMessage[]
+  proposals: ProposedItem[]
 }
 
 export const AGENT_INFO: Record<ContentAgent, { name: string; emoji: string; color: string }> = {

--- a/tests/plugins/calendar/routes.test.ts
+++ b/tests/plugins/calendar/routes.test.ts
@@ -1,7 +1,7 @@
 /**
  * Calendar plugin — route and exec tool tests.
  *
- * Tests all 7 HTTP routes and 6 exec tools registered by the calendar plugin.
+ * Tests the original 8 HTTP routes and 7 exec tools registered by the calendar plugin.
  * Uses a temp directory backed by the real storage module (calendar.json on disk).
  */
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
@@ -821,12 +821,12 @@ describe('Calendar exec tools', () => {
 // ===========================================================================
 
 describe('Calendar plugin registration', () => {
-  it('registers exactly 8 routes', () => {
-    expect(plugin.routes.length).toBe(8)
+  it('registers exactly 16 routes', () => {
+    expect(plugin.routes.length).toBe(16)
   })
 
-  it('registers exactly 7 exec tools', () => {
-    expect(plugin.execTools.length).toBe(7)
+  it('registers exactly 15 exec tools', () => {
+    expect(plugin.execTools.length).toBe(15)
   })
 
   it('called watchFiles with calendar.json during activation', async () => {

--- a/tests/plugins/calendar/routes.test.ts
+++ b/tests/plugins/calendar/routes.test.ts
@@ -832,6 +832,6 @@ describe('Calendar plugin registration', () => {
   it('called watchFiles with calendar.json during activation', async () => {
     // Re-activate to test this since beforeEach clears mocks
     const fresh = await activatePlugin(calendarPlugin, testDir)
-    expect(fresh.ctx.watchFiles).toHaveBeenCalledWith(['calendar.json'])
+    expect(fresh.ctx.watchFiles).toHaveBeenCalledWith(['calendar.json', 'calendar/sessions/*.json'])
   })
 })

--- a/tests/plugins/calendar/sessions.test.ts
+++ b/tests/plugins/calendar/sessions.test.ts
@@ -1,0 +1,700 @@
+/**
+ * Calendar plugin — planning session tests.
+ *
+ * Tests session CRUD routes, session exec tools, proposal lifecycle,
+ * and plan confirmation (creates CalendarItems from approved proposals).
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdirSync, rmSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-sessions-${Date.now()}`)
+})
+
+// ---------------------------------------------------------------------------
+// Mocks — must be before any plugin imports
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ calendar: testDir }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+// Suppress SSE broadcast
+;(globalThis as any).__bakinBroadcast = vi.fn()
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import calendarPlugin from '../../../plugins/calendar/index'
+import {
+  activatePlugin,
+  findRoute,
+  findTool,
+  callRoute,
+  callTool,
+} from '../test-helpers'
+import type { ActivatedPlugin } from '../test-helpers'
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let plugin: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  // Seed empty calendar.json for calendar item storage
+  const { writeFileSync } = await import('fs')
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  plugin = await activatePlugin(calendarPlugin, testDir)
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  // Clear sessions directory between tests
+  const sessionsDir = join(testDir, 'calendar', 'sessions')
+  if (existsSync(sessionsDir)) {
+    rmSync(sessionsDir, { recursive: true, force: true })
+  }
+  // Reset calendar.json
+  const { writeFileSync } = require('fs')
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  vi.clearAllMocks()
+})
+
+// ===========================================================================
+// SESSION ROUTES
+// ===========================================================================
+
+describe('Session routes', () => {
+  // ── GET /sessions ─────────────────────────────────────────────────────
+
+  describe('GET /sessions', () => {
+    it('is registered', () => {
+      expect(findRoute(plugin.routes, 'GET', '/sessions')).toBeDefined()
+    })
+
+    it('returns empty list when no sessions exist', async () => {
+      const route = findRoute(plugin.routes, 'GET', '/sessions')!
+      const { status, body } = await callRoute(route, plugin.ctx)
+      expect(status).toBe(200)
+      expect(body.sessions).toEqual([])
+    })
+
+    it('returns sessions after creation', async () => {
+      // Create a session first via POST
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil', title: 'Test Session' },
+      })
+
+      const route = findRoute(plugin.routes, 'GET', '/sessions')!
+      const { status, body } = await callRoute(route, plugin.ctx)
+      expect(status).toBe(200)
+      const sessions = body.sessions as Array<Record<string, unknown>>
+      expect(sessions.length).toBe(1)
+      expect(sessions[0].agentId).toBe('basil')
+      expect(sessions[0].title).toBe('Test Session')
+    })
+
+    it('filters by status', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil', title: 'Active One' },
+      })
+
+      const route = findRoute(plugin.routes, 'GET', '/sessions')!
+      const { body: active } = await callRoute(route, plugin.ctx, {
+        searchParams: { status: 'active' },
+      })
+      expect((active.sessions as unknown[]).length).toBe(1)
+
+      const { body: completed } = await callRoute(route, plugin.ctx, {
+        searchParams: { status: 'completed' },
+      })
+      expect((completed.sessions as unknown[]).length).toBe(0)
+    })
+
+    it('filters by agentId', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil', title: 'Basil Session' },
+      })
+      await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'scout', title: 'Scout Session' },
+      })
+
+      const route = findRoute(plugin.routes, 'GET', '/sessions')!
+      const { body } = await callRoute(route, plugin.ctx, {
+        searchParams: { agentId: 'scout' },
+      })
+      const sessions = body.sessions as Array<Record<string, unknown>>
+      expect(sessions.length).toBe(1)
+      expect(sessions[0].agentId).toBe('scout')
+    })
+  })
+
+  // ── POST /sessions ────────────────────────────────────────────────────
+
+  describe('POST /sessions', () => {
+    it('is registered', () => {
+      expect(findRoute(plugin.routes, 'POST', '/sessions')).toBeDefined()
+    })
+
+    it('creates a session with agentId and title', async () => {
+      const route = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        body: { agentId: 'basil', title: 'My Plan' },
+      })
+      expect(status).toBe(200)
+      expect(body.ok).toBe(true)
+      const session = body.session as Record<string, unknown>
+      expect(session.agentId).toBe('basil')
+      expect(session.title).toBe('My Plan')
+      expect(session.status).toBe('active')
+      expect(session.id).toBeDefined()
+    })
+
+    it('creates a session with default title', async () => {
+      const route = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body } = await callRoute(route, plugin.ctx, {
+        body: { agentId: 'nemo' },
+      })
+      const session = body.session as Record<string, unknown>
+      expect(session.title).toBe('New planning session')
+    })
+
+    it('returns 400 without agentId', async () => {
+      const route = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        body: { title: 'No Agent' },
+      })
+      expect(status).toBe(400)
+      expect(body.error).toBeDefined()
+    })
+
+    it('emits audit event on creation', async () => {
+      const route = findRoute(plugin.routes, 'POST', '/sessions')!
+      await callRoute(route, plugin.ctx, {
+        body: { agentId: 'basil', title: 'Audit Test' },
+      })
+      expect(plugin.ctx.activity.audit).toHaveBeenCalledWith(
+        'session.created',
+        'basil',
+        expect.objectContaining({ sessionId: expect.any(String) })
+      )
+    })
+  })
+
+  // ── GET /sessions/:id ─────────────────────────────────────────────────
+
+  describe('GET /sessions/:id', () => {
+    it('is registered', () => {
+      expect(findRoute(plugin.routes, 'GET', '/sessions/:id')).toBeDefined()
+    })
+
+    it('returns a session by id', async () => {
+      // Create first
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'zen', title: 'Zen Plan' },
+      })
+      const sessionId = (createBody.session as Record<string, unknown>).id as string
+
+      const route = findRoute(plugin.routes, 'GET', '/sessions/:id')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: sessionId },
+      })
+      expect(status).toBe(200)
+      const session = body.session as Record<string, unknown>
+      expect(session.id).toBe(sessionId)
+      expect(session.title).toBe('Zen Plan')
+    })
+
+    it('returns 404 for nonexistent session', async () => {
+      const route = findRoute(plugin.routes, 'GET', '/sessions/:id')!
+      const { status } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: 'nonexistent' },
+      })
+      expect(status).toBe(404)
+    })
+
+    it('returns 400 without id', async () => {
+      const route = findRoute(plugin.routes, 'GET', '/sessions/:id')!
+      const { status } = await callRoute(route, plugin.ctx)
+      expect(status).toBe(400)
+    })
+  })
+
+  // ── PUT /sessions/:id ─────────────────────────────────────────────────
+
+  describe('PUT /sessions/:id', () => {
+    it('updates session title', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil', title: 'Original' },
+      })
+      const sessionId = (createBody.session as Record<string, unknown>).id as string
+
+      const route = findRoute(plugin.routes, 'PUT', '/sessions/:id')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: sessionId },
+        body: { title: 'Updated Title' },
+      })
+      expect(status).toBe(200)
+      expect((body.session as Record<string, unknown>).title).toBe('Updated Title')
+    })
+
+    it('returns 404 for nonexistent session', async () => {
+      const route = findRoute(plugin.routes, 'PUT', '/sessions/:id')!
+      const { status } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: 'nonexistent' },
+        body: { title: 'X' },
+      })
+      expect(status).toBe(404)
+    })
+  })
+
+  // ── DELETE /sessions/:id ──────────────────────────────────────────────
+
+  describe('DELETE /sessions/:id', () => {
+    it('deletes a session', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil' },
+      })
+      const sessionId = (createBody.session as Record<string, unknown>).id as string
+
+      const route = findRoute(plugin.routes, 'DELETE', '/sessions/:id')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: sessionId },
+      })
+      expect(status).toBe(200)
+      expect(body.ok).toBe(true)
+
+      // Verify it's gone
+      const getRoute = findRoute(plugin.routes, 'GET', '/sessions/:id')!
+      const { status: getStatus } = await callRoute(getRoute, plugin.ctx, {
+        searchParams: { id: sessionId },
+      })
+      expect(getStatus).toBe(404)
+    })
+
+    it('returns 404 for nonexistent session', async () => {
+      const route = findRoute(plugin.routes, 'DELETE', '/sessions/:id')!
+      const { status } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: 'nonexistent' },
+      })
+      expect(status).toBe(404)
+    })
+  })
+
+  // ── POST /sessions/:id/messages ───────────────────────────────────────
+
+  describe('POST /sessions/:id/messages', () => {
+    it('is registered', () => {
+      expect(findRoute(plugin.routes, 'POST', '/sessions/:id/messages')).toBeDefined()
+    })
+
+    it('appends user and assistant messages', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil' },
+      })
+      const sessionId = (createBody.session as Record<string, unknown>).id as string
+
+      const msgRoute = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+      const { status, body } = await callRoute(msgRoute, plugin.ctx, {
+        searchParams: { id: sessionId },
+        body: { message: 'Plan some content for next week' },
+      })
+      expect(status).toBe(200)
+      expect(body.ok).toBe(true)
+      expect(body.messageId).toBeDefined()
+
+      // Verify messages were stored
+      const getRoute = findRoute(plugin.routes, 'GET', '/sessions/:id')!
+      const { body: getBody } = await callRoute(getRoute, plugin.ctx, {
+        searchParams: { id: sessionId },
+      })
+      const session = getBody.session as Record<string, unknown>
+      const messages = session.messages as Array<Record<string, unknown>>
+      expect(messages.length).toBe(2) // user + assistant
+      expect(messages[0].role).toBe('user')
+      expect(messages[1].role).toBe('assistant')
+    })
+
+    it('returns 404 for nonexistent session', async () => {
+      const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+      const { status } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: 'nonexistent' },
+        body: { message: 'hello' },
+      })
+      expect(status).toBe(404)
+    })
+
+    it('returns 400 without message', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil' },
+      })
+      const sessionId = (createBody.session as Record<string, unknown>).id as string
+
+      const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+      const { status } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: sessionId },
+        body: {},
+      })
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 for completed session', async () => {
+      const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+      const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
+        body: { agentId: 'basil' },
+      })
+      const sessionId = (createBody.session as Record<string, unknown>).id as string
+
+      // Mark as completed
+      const putRoute = findRoute(plugin.routes, 'PUT', '/sessions/:id')!
+      await callRoute(putRoute, plugin.ctx, {
+        searchParams: { id: sessionId },
+        body: { status: 'completed' },
+      })
+
+      const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+      const { status } = await callRoute(route, plugin.ctx, {
+        searchParams: { id: sessionId },
+        body: { message: 'hello' },
+      })
+      expect(status).toBe(400)
+    })
+  })
+
+  // ── PUT /sessions/:id/proposals/:proposalId ───────────────────────────
+
+  describe('PUT /sessions/:id/proposals/:proposalId', () => {
+    it('is registered', () => {
+      expect(findRoute(plugin.routes, 'PUT', '/sessions/:id/proposals/:proposalId')).toBeDefined()
+    })
+  })
+
+  // ── POST /sessions/:id/confirm ────────────────────────────────────────
+
+  describe('POST /sessions/:id/confirm', () => {
+    it('is registered', () => {
+      expect(findRoute(plugin.routes, 'POST', '/sessions/:id/confirm')).toBeDefined()
+    })
+  })
+})
+
+// ===========================================================================
+// SESSION EXEC TOOLS
+// ===========================================================================
+
+describe('Session exec tools', () => {
+  describe('session_list', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_list')).toBeDefined()
+    })
+
+    it('returns empty list initially', async () => {
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_list')!
+      const result = await callTool(tool, {})
+      expect(result.ok).toBe(true)
+      expect(result.count).toBe(0)
+      expect(result.sessions).toEqual([])
+    })
+  })
+
+  describe('session_create', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_create')).toBeDefined()
+    })
+
+    it('creates a session', async () => {
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const result = await callTool(tool, { agentId: 'scout', title: 'Scout Plan' })
+      expect(result.ok).toBe(true)
+      const session = result.session as Record<string, unknown>
+      expect(session.agentId).toBe('scout')
+      expect(session.title).toBe('Scout Plan')
+    })
+
+    it('returns error without agentId', async () => {
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const result = await callTool(tool, {})
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('session_get', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_get')).toBeDefined()
+    })
+
+    it('returns a session by id', async () => {
+      const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const created = await callTool(createTool, { agentId: 'zen' })
+      const sessionId = (created.session as Record<string, unknown>).id as string
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_get')!
+      const result = await callTool(tool, { sessionId })
+      expect(result.ok).toBe(true)
+      expect((result.session as Record<string, unknown>).id).toBe(sessionId)
+    })
+
+    it('returns error for nonexistent session', async () => {
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_get')!
+      const result = await callTool(tool, { sessionId: 'nope' })
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('session_update', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_update')).toBeDefined()
+    })
+
+    it('updates title', async () => {
+      const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const created = await callTool(createTool, { agentId: 'basil' })
+      const sessionId = (created.session as Record<string, unknown>).id as string
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_update')!
+      const result = await callTool(tool, { sessionId, title: 'New Title' })
+      expect(result.ok).toBe(true)
+      expect((result.session as Record<string, unknown>).title).toBe('New Title')
+    })
+  })
+
+  describe('session_delete', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_delete')).toBeDefined()
+    })
+
+    it('deletes a session', async () => {
+      const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const created = await callTool(createTool, { agentId: 'basil' })
+      const sessionId = (created.session as Record<string, unknown>).id as string
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_delete')!
+      const result = await callTool(tool, { sessionId })
+      expect(result.ok).toBe(true)
+
+      // Verify gone
+      const getTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_get')!
+      const getResult = await callTool(getTool, { sessionId })
+      expect(getResult.ok).toBe(false)
+    })
+  })
+
+  describe('session_message', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_message')).toBeDefined()
+    })
+
+    it('appends messages to session', async () => {
+      const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const created = await callTool(createTool, { agentId: 'basil' })
+      const sessionId = (created.session as Record<string, unknown>).id as string
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_message')!
+      const result = await callTool(tool, { sessionId, message: 'Plan next week' })
+      expect(result.ok).toBe(true)
+      expect(result.messageId).toBeDefined()
+      expect(result.userMessageId).toBeDefined()
+    })
+
+    it('returns error for completed session', async () => {
+      const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+      const created = await callTool(createTool, { agentId: 'basil' })
+      const sessionId = (created.session as Record<string, unknown>).id as string
+
+      // Mark completed
+      const updateTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_update')!
+      await callTool(updateTool, { sessionId, status: 'completed' })
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_message')!
+      const result = await callTool(tool, { sessionId, message: 'hello' })
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('proposal_update', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_proposal_update')).toBeDefined()
+    })
+  })
+
+  describe('session_confirm', () => {
+    it('is registered', () => {
+      expect(findTool(plugin.execTools, 'bakin_exec_calendar_session_confirm')).toBeDefined()
+    })
+  })
+})
+
+// ===========================================================================
+// PROPOSAL LIFECYCLE (direct storage module tests)
+// ===========================================================================
+
+describe('Proposal lifecycle', () => {
+  // Import storage module functions directly for deeper testing
+  let createSessionDirect: typeof import('../../../plugins/calendar/lib/sessions').createSession
+  let loadSessionDirect: typeof import('../../../plugins/calendar/lib/sessions').loadSession
+  let addProposalsDirect: typeof import('../../../plugins/calendar/lib/sessions').addProposals
+  let updateProposalDirect: typeof import('../../../plugins/calendar/lib/sessions').updateProposal
+  let confirmSessionDirect: typeof import('../../../plugins/calendar/lib/sessions').confirmSession
+  let appendMessageDirect: typeof import('../../../plugins/calendar/lib/sessions').appendMessage
+
+  beforeAll(async () => {
+    const sessions = await import('../../../plugins/calendar/lib/sessions')
+    createSessionDirect = sessions.createSession
+    loadSessionDirect = sessions.loadSession
+    addProposalsDirect = sessions.addProposals
+    updateProposalDirect = sessions.updateProposal
+    confirmSessionDirect = sessions.confirmSession
+    appendMessageDirect = sessions.appendMessage
+  })
+
+  it('creates proposals linked to a message', () => {
+    const session = createSessionDirect({ agentId: 'basil' })
+    const msg = appendMessageDirect(session.id, { role: 'assistant', content: 'Here are ideas' })
+
+    const proposals = addProposalsDirect(session.id, msg.id, [
+      {
+        title: 'Monday Recipe',
+        scheduledAt: '2026-04-13T10:00:00Z',
+        contentType: 'recipe',
+        tone: 'energetic',
+        brief: 'A quick pasta dish',
+      },
+      {
+        title: 'Wednesday Tip',
+        scheduledAt: '2026-04-15T10:00:00Z',
+        contentType: 'tip',
+        tone: 'educational',
+        brief: 'Kitchen knife care',
+      },
+    ])
+
+    expect(proposals.length).toBe(2)
+    expect(proposals[0].status).toBe('proposed')
+    expect(proposals[0].messageId).toBe(msg.id)
+    expect(proposals[0].agentId).toBe('basil')
+
+    // Verify stored in session
+    const loaded = loadSessionDirect(session.id)!
+    expect(loaded.proposals.length).toBe(2)
+  })
+
+  it('approves and rejects proposals', () => {
+    const session = createSessionDirect({ agentId: 'scout' })
+    const msg = appendMessageDirect(session.id, { role: 'assistant', content: 'Ideas' })
+    const proposals = addProposalsDirect(session.id, msg.id, [
+      { title: 'Hike A', scheduledAt: '2026-04-13T09:00:00Z', contentType: 'outdoor', tone: 'inspiring', brief: 'Mountain hike' },
+      { title: 'Hike B', scheduledAt: '2026-04-14T09:00:00Z', contentType: 'outdoor', tone: 'calm', brief: 'Lake walk' },
+    ])
+
+    // Approve first
+    const approved = updateProposalDirect(session.id, proposals[0].id, { status: 'approved' })
+    expect(approved.status).toBe('approved')
+
+    // Reject second with note
+    const rejected = updateProposalDirect(session.id, proposals[1].id, {
+      status: 'rejected',
+      rejectionNote: 'Too similar to last week',
+    })
+    expect(rejected.status).toBe('rejected')
+    expect(rejected.rejectionNote).toBe('Too similar to last week')
+  })
+
+  it('confirmSession creates CalendarItems from approved proposals', () => {
+    const session = createSessionDirect({ agentId: 'basil' })
+    const msg = appendMessageDirect(session.id, { role: 'assistant', content: 'Plan' })
+    const proposals = addProposalsDirect(session.id, msg.id, [
+      { title: 'Approved Item', scheduledAt: '2026-04-13T10:00:00Z', contentType: 'recipe', tone: 'energetic', brief: 'Good stuff' },
+      { title: 'Rejected Item', scheduledAt: '2026-04-14T10:00:00Z', contentType: 'tip', tone: 'calm', brief: 'Skipped' },
+    ])
+
+    updateProposalDirect(session.id, proposals[0].id, { status: 'approved' })
+    updateProposalDirect(session.id, proposals[1].id, { status: 'rejected' })
+
+    const result = confirmSessionDirect(session.id)
+    expect(result.itemsCreated).toBe(1)
+    expect(result.itemIds.length).toBe(1)
+
+    // Session should be completed
+    const loaded = loadSessionDirect(session.id)!
+    expect(loaded.status).toBe('completed')
+
+    // Approved proposal should have calendarItemId set
+    const approvedProposal = loaded.proposals.find(p => p.id === proposals[0].id)
+    expect(approvedProposal?.calendarItemId).toBe(result.itemIds[0])
+
+    // Verify calendar item was created on disk
+    const calendarData = JSON.parse(readFileSync(join(testDir, 'calendar.json'), 'utf-8'))
+    const created = calendarData.find((item: Record<string, unknown>) => item.id === result.itemIds[0])
+    expect(created).toBeDefined()
+    expect(created.title).toBe('Approved Item')
+    expect(created.sessionId).toBe(session.id)
+    expect(created.status).toBe('draft')
+  })
+
+  it('confirmSession throws when no approved proposals', () => {
+    const session = createSessionDirect({ agentId: 'basil' })
+    const msg = appendMessageDirect(session.id, { role: 'assistant', content: 'Ideas' })
+    addProposalsDirect(session.id, msg.id, [
+      { title: 'Proposed Only', scheduledAt: '2026-04-13T10:00:00Z', contentType: 'tip', tone: 'calm', brief: 'Not approved' },
+    ])
+
+    expect(() => confirmSessionDirect(session.id)).toThrow('No approved proposals')
+  })
+
+  it('confirmSession throws for already completed session', () => {
+    const session = createSessionDirect({ agentId: 'basil' })
+    const msg = appendMessageDirect(session.id, { role: 'assistant', content: 'Plan' })
+    const proposals = addProposalsDirect(session.id, msg.id, [
+      { title: 'Item', scheduledAt: '2026-04-13T10:00:00Z', contentType: 'recipe', tone: 'energetic', brief: 'Test' },
+    ])
+    updateProposalDirect(session.id, proposals[0].id, { status: 'approved' })
+    confirmSessionDirect(session.id)
+
+    expect(() => confirmSessionDirect(session.id)).toThrow('already completed')
+  })
+})
+
+// ===========================================================================
+// REGISTRATION COUNTS (updated)
+// ===========================================================================
+
+describe('Calendar plugin registration (updated)', () => {
+  it('registers exactly 16 routes', () => {
+    expect(plugin.routes.length).toBe(16)
+  })
+
+  it('registers exactly 15 exec tools', () => {
+    expect(plugin.execTools.length).toBe(15)
+  })
+})


### PR DESCRIPTION
## Summary
- Add `PlanningSession`, `ProposedItem`, `SessionMessage` types and `generateId()` utility
- Add session CRUD storage module (`lib/sessions.ts`) with file-per-session JSON storage at `~/.bakin/calendar/sessions/`
- Register 8 new HTTP routes: session CRUD, messaging, proposal updates, plan confirmation
- Register 8 new MCP exec tools mirroring the routes for agent access
- `confirmSession` creates CalendarItems from approved proposals, sets `sessionId` on items
- Add file watcher for `calendar/sessions/*.json`
- 49 new tests, 117 total passing, `tsc --noEmit` clean

## Routes added
| Method | Path | Description |
|--------|------|-------------|
| GET | /sessions | List sessions (filter by status, agentId) |
| POST | /sessions | Create session |
| GET | /sessions/:id | Get full session |
| PUT | /sessions/:id | Update session |
| DELETE | /sessions/:id | Delete session |
| POST | /sessions/:id/messages | Send message (non-streaming placeholder) |
| PUT | /sessions/:id/proposals/:proposalId | Update proposal |
| POST | /sessions/:id/confirm | Confirm plan → create CalendarItems |

## Test plan
- [x] Session CRUD lifecycle (create, read, update, delete)
- [x] Proposal state machine (proposed → approved/rejected)
- [x] confirmSession creates CalendarItems from approved proposals only
- [x] confirmSession sets calendarItemId on proposals and sessionId on items
- [x] Edge cases: missing params, nonexistent sessions, double confirm, empty approvals
- [x] Registration counts updated (8→16 routes, 7→15 tools)
- [x] File watcher includes sessions glob
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)