### PR TITLE
feat(calendar): add streaming chat and conversational context (PR 2)

### DIFF
--- a/dev/imitation-crab/gateway.ts
+++ b/dev/imitation-crab/gateway.ts
@@ -71,10 +71,10 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
     const agentId = (Array.isArray(agentHeader) ? agentHeader[0] : agentHeader) || 'unknown'
     const agentName = AGENT_NAMES[agentId] || agentId
 
-    let parsed: { messages?: Array<{ content?: string }> } = {}
+    let parsed: { messages?: Array<{ content?: string }>; stream?: boolean } = {}
     try { parsed = JSON.parse(body) } catch { /* */ }
 
-    const userMessage = parsed.messages?.[0]?.content || ''
+    const userMessage = parsed.messages?.[parsed.messages.length - 1]?.content || ''
 
     let reply: string
     switch (CHAT_MODE) {
@@ -88,7 +88,15 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
         reply = `[mock:${agentName}] Acknowledged. Task understood — working on it.`
     }
 
-    console.log(`  → agent=${agentId} message=${userMessage.slice(0, 80)}${userMessage.length > 80 ? '...' : ''}`)
+    console.log(`  → agent=${agentId} stream=${!!parsed.stream} message=${userMessage.slice(0, 80)}${userMessage.length > 80 ? '...' : ''}`)
+
+    // Streaming: return a marker so handleRequest can send SSE
+    if (parsed.stream) {
+      return {
+        status: 200,
+        body: { __stream: true, content: reply },
+      }
+    }
 
     return {
       status: 200,
@@ -118,6 +126,30 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
   return { status: 404, body: { error: 'Not found', mock: true } }
 }
 
+/**
+ * Stream a response as SSE chunks in OpenAI-compatible format.
+ * Splits content into word-level chunks for realistic streaming simulation.
+ */
+function sendSSE(res: ServerResponse, content: string): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  })
+
+  const words = content.split(/(\s+)/)
+  for (const word of words) {
+    if (!word) continue
+    const chunk = JSON.stringify({
+      choices: [{ delta: { content: word } }],
+    })
+    res.write(`data: ${chunk}\n\n`)
+  }
+
+  res.write('data: [DONE]\n\n')
+  res.end()
+}
+
 async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const body = await readBody(req)
   const response = await handleGatewayRequest({
@@ -126,6 +158,14 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     headers: req.headers,
     body,
   })
+
+  // Check for streaming marker
+  const responseBody = response.body as Record<string, unknown>
+  if (responseBody && responseBody.__stream === true) {
+    sendSSE(res, responseBody.content as string)
+    return
+  }
+
   json(res, response.body, response.status)
 }
 

--- a/plugins/calendar/components/session-chat.tsx
+++ b/plugins/calendar/components/session-chat.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { AgentAvatar } from '@/components/agent-avatar'
+import { Send, Loader2 } from 'lucide-react'
+import type { ContentAgent, PlanningSession, ProposedItem, SessionMessage } from '../types'
+import { AGENT_INFO } from '../types'
+
+interface Props {
+  sessionId: string
+  agentId: ContentAgent
+  initialMessages?: SessionMessage[]
+  initialProposals?: ProposedItem[]
+  isCompleted?: boolean
+  onProposalsReceived?: (proposals: ProposedItem[]) => void
+}
+
+interface StreamingState {
+  isStreaming: boolean
+  streamedText: string
+}
+
+export function SessionChat({
+  sessionId,
+  agentId,
+  initialMessages = [],
+  initialProposals = [],
+  isCompleted = false,
+  onProposalsReceived,
+}: Props) {
+  const [messages, setMessages] = useState<SessionMessage[]>(initialMessages)
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState<StreamingState>({
+    isStreaming: false,
+    streamedText: '',
+  })
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const agentInfo = AGENT_INFO[agentId]
+
+  useEffect(() => {
+    if (scrollRef.current && typeof scrollRef.current.scrollIntoView === 'function') {
+      scrollRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [messages, streaming.streamedText])
+
+  // Update messages when session is reloaded externally
+  useEffect(() => {
+    setMessages(initialMessages)
+  }, [initialMessages])
+
+  const handleSend = useCallback(async () => {
+    if (!input.trim() || streaming.isStreaming || isCompleted) return
+
+    const userMessage = input.trim()
+    setInput('')
+
+    // Optimistic: add user message
+    const tempUserMsg: SessionMessage = {
+      id: `temp-${Date.now()}`,
+      role: 'user',
+      content: userMessage,
+      timestamp: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, tempUserMsg])
+    setStreaming({ isStreaming: true, streamedText: '' })
+
+    try {
+      const res = await fetch(`/api/plugins/calendar/sessions/${sessionId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: userMessage }),
+      })
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: 'Unknown error' }))
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `error-${Date.now()}`,
+            role: 'assistant',
+            content: `Error: ${error.error || 'Something went wrong'}`,
+            timestamp: new Date().toISOString(),
+          },
+        ])
+        setStreaming({ isStreaming: false, streamedText: '' })
+        return
+      }
+
+      // Parse SSE stream
+      const reader = res.body?.getReader()
+      if (!reader) {
+        throw new Error('No response body')
+      }
+
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let accumulated = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+
+        let currentEvent = ''
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim()
+          } else if (line.startsWith('data: ') && currentEvent) {
+            try {
+              const data = JSON.parse(line.slice(6))
+
+              switch (currentEvent) {
+                case 'token':
+                  accumulated += data.text || ''
+                  setStreaming({ isStreaming: true, streamedText: accumulated })
+                  break
+
+                case 'proposals':
+                  if (data.proposals && onProposalsReceived) {
+                    onProposalsReceived(data.proposals)
+                  }
+                  break
+
+                case 'done': {
+                  // Replace streamed text with final message
+                  const finalMsg: SessionMessage = {
+                    id: data.messageId || `msg-${Date.now()}`,
+                    role: 'assistant',
+                    content: data.content || accumulated,
+                    timestamp: new Date().toISOString(),
+                  }
+                  setMessages((prev) => [...prev, finalMsg])
+                  setStreaming({ isStreaming: false, streamedText: '' })
+                  break
+                }
+
+                case 'error':
+                  setMessages((prev) => [
+                    ...prev,
+                    {
+                      id: `error-${Date.now()}`,
+                      role: 'assistant',
+                      content: `Error: ${data.message || 'Unknown error'}`,
+                      timestamp: new Date().toISOString(),
+                    },
+                  ])
+                  setStreaming({ isStreaming: false, streamedText: '' })
+                  break
+              }
+            } catch {
+              // Skip malformed data
+            }
+            currentEvent = ''
+          }
+        }
+      }
+
+      // If stream ended without a done event
+      if (streaming.isStreaming) {
+        setStreaming({ isStreaming: false, streamedText: '' })
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `error-${Date.now()}`,
+          role: 'assistant',
+          content: 'Connection error. Please try again.',
+          timestamp: new Date().toISOString(),
+        },
+      ])
+      setStreaming({ isStreaming: false, streamedText: '' })
+    }
+  }, [input, streaming.isStreaming, isCompleted, sessionId, onProposalsReceived])
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Chat history */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.length === 0 && !streaming.isStreaming && (
+          <div className="flex flex-col items-center justify-center text-center text-muted-foreground py-16 gap-4">
+            <AgentAvatar agentId={agentId} size="xl" />
+            <div className="space-y-2 max-w-md">
+              <p className="text-base font-medium text-foreground">
+                Plan with {agentInfo.name}
+              </p>
+              <p className="text-sm">
+                Describe the content you want to plan — topics, themes, dates, or audience.
+                {' '}{agentInfo.name} will suggest calendar items you can review and approve.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div key={msg.id}>
+            {msg.role === 'user' ? (
+              <div className="flex justify-end">
+                <div className="rounded-lg p-2.5 bg-accent/20 max-w-[75%]">
+                  <p className="text-xs whitespace-pre-wrap">{msg.content}</p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-start gap-2.5">
+                <AgentAvatar agentId={agentId} size="sm" className="mt-0.5 shrink-0" />
+                <div className="rounded-lg p-2.5 bg-surface max-w-[85%]">
+                  <p className="text-xs whitespace-pre-wrap">{msg.content}</p>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Streaming message bubble */}
+        {streaming.isStreaming && streaming.streamedText && (
+          <div className="flex items-start gap-2.5">
+            <AgentAvatar agentId={agentId} size="sm" className="mt-0.5 shrink-0" />
+            <div className="rounded-lg p-2.5 bg-surface max-w-[85%]">
+              <p className="text-xs whitespace-pre-wrap">{streaming.streamedText}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Thinking indicator when streaming but no text yet */}
+        {streaming.isStreaming && !streaming.streamedText && (
+          <div className="flex items-center gap-2.5 text-muted-foreground">
+            <AgentAvatar agentId={agentId} size="sm" className="shrink-0" />
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            <span className="text-xs">{agentInfo.name} is thinking...</span>
+          </div>
+        )}
+
+        <div ref={scrollRef} />
+      </div>
+
+      {/* Input */}
+      {!isCompleted && (
+        <div className="p-4 border-t border-border">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSend()
+            }}
+            className="flex gap-2 items-start"
+          >
+            <Textarea
+              value={input}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInput(e.target.value)}
+              onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  handleSend()
+                }
+              }}
+              placeholder={`Ask ${agentInfo.name} for content ideas...`}
+              className="bg-surface min-h-[80px] resize-none"
+              disabled={streaming.isStreaming}
+            />
+            <Button type="submit" disabled={streaming.isStreaming || !input.trim()} className="shrink-0">
+              <Send className="w-4 h-4" />
+            </Button>
+          </form>
+        </div>
+      )}
+
+      {isCompleted && (
+        <div className="p-4 border-t border-border text-center">
+          <Badge variant="outline" className="text-muted-foreground">
+            Session completed — read-only
+          </Badge>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -19,9 +19,12 @@ import {
   updateSession as updateSessionFn,
   deleteSession as deleteSessionFn,
   appendMessage,
+  addProposals,
   updateProposal,
   confirmSession,
 } from './lib/sessions'
+import { buildMessages } from './lib/prompt-builder'
+import { streamChatCompletion, chatCompletion } from './lib/gateway'
 import { getContentDir } from '../../src/core/content-dir'
 import { createLogger } from '../../src/core/logger'
 
@@ -483,11 +486,11 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
       },
     })
 
-    // POST /sessions/:id/messages — send message (non-streaming for now)
+    // POST /sessions/:id/messages — send message with SSE streaming
     ctx.registerRoute({
       path: '/sessions/:id/messages',
       method: 'POST',
-      description: 'Send a message in a planning session',
+      description: 'Send a message in a planning session (SSE streaming)',
       handler: async (req: Request) => {
         const url = new URL(req.url)
         const body = await readBody<{ id?: string; message?: string }>(req)
@@ -502,17 +505,158 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
         // Append user message
         const userMsg = appendMessage(id, { role: 'user', content: body.message })
 
-        // For now, return a placeholder — streaming upgrade in PR 2
-        const assistantMsg = appendMessage(id, {
-          role: 'assistant',
-          content: 'Planning session message received. Streaming upgrade pending.',
+        // Build messages array with full session history
+        const messages = buildMessages(session, body.message)
+        const sessionKey = `session-${id}-${Date.now()}`
+
+        // Create a ReadableStream that pipes gateway SSE to the client
+        const stream = new ReadableStream({
+          async start(controller) {
+            const encoder = new TextEncoder()
+
+            function send(event: string, data: unknown): void {
+              controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+            }
+
+            try {
+              let fullContent = ''
+
+              // Try streaming first, fall back to non-streaming
+              let useStreaming = true
+              let gwResponse: Response | null = null
+
+              try {
+                gwResponse = await streamChatCompletion({
+                  messages,
+                  agentId: session.agentId,
+                  sessionKey,
+                })
+
+                const contentType = gwResponse.headers.get('content-type') || ''
+                if (!contentType.includes('text/event-stream')) {
+                  // Gateway returned non-streaming response
+                  useStreaming = false
+                }
+              } catch (err) {
+                // Gateway doesn't support streaming — fall back
+                useStreaming = false
+                gwResponse = null
+              }
+
+              if (useStreaming && gwResponse?.body) {
+                // Stream gateway SSE chunks to client
+                const reader = gwResponse.body.getReader()
+                const decoder = new TextDecoder()
+                let buffer = ''
+
+                while (true) {
+                  const { done, value } = await reader.read()
+                  if (done) break
+
+                  buffer += decoder.decode(value, { stream: true })
+                  const lines = buffer.split('\n')
+                  buffer = lines.pop() || ''
+
+                  for (const line of lines) {
+                    if (!line.startsWith('data: ')) continue
+                    const data = line.slice(6).trim()
+                    if (data === '[DONE]') continue
+
+                    try {
+                      const parsed = JSON.parse(data)
+                      const token = parsed.choices?.[0]?.delta?.content
+                      if (token) {
+                        fullContent += token
+                        send('token', { text: token })
+                      }
+                    } catch {
+                      // Skip malformed chunks
+                    }
+                  }
+                }
+              } else {
+                // Non-streaming fallback
+                try {
+                  fullContent = await chatCompletion({
+                    messages,
+                    agentId: session.agentId,
+                    sessionKey,
+                  })
+                  // Send entire response as a single token event
+                  send('token', { text: fullContent })
+                } catch (err) {
+                  send('error', { message: err instanceof Error ? err.message : String(err) })
+                  controller.close()
+                  return
+                }
+              }
+
+              // Parse proposals from response
+              let proposals: Array<{
+                title: string
+                scheduledAt: string
+                contentType: string
+                tone: string
+                brief: string
+                channels?: string[]
+              }> = []
+
+              const jsonMatch = fullContent.match(/```json\s*([\s\S]*?)\s*```/)
+              if (jsonMatch) {
+                try {
+                  proposals = JSON.parse(jsonMatch[1])
+                } catch { /* ignore malformed JSON */ }
+              }
+
+              // Save assistant message
+              const cleanContent = fullContent.replace(/```json[\s\S]*?```/g, '').trim()
+              const assistantMsg = appendMessage(id, {
+                role: 'assistant',
+                content: cleanContent,
+              }, proposals.length > 0 ? [] : undefined)
+
+              // Save proposals if found
+              if (proposals.length > 0) {
+                const savedProposals = addProposals(id, assistantMsg.id, proposals)
+                // Update message with proposal IDs
+                const reloadedSession = loadSession(id)
+                if (reloadedSession) {
+                  const msg = reloadedSession.messages.find(m => m.id === assistantMsg.id)
+                  if (msg) {
+                    msg.proposalIds = savedProposals.map(p => p.id)
+                    const { writeFileSync } = await import('fs')
+                    const { join } = await import('path')
+                    writeFileSync(
+                      join(getContentDir(), 'calendar', 'sessions', `${id}.json`),
+                      JSON.stringify(reloadedSession, null, 2)
+                    )
+                  }
+                }
+
+                send('proposals', {
+                  proposals: savedProposals,
+                  messageId: assistantMsg.id,
+                })
+              }
+
+              send('done', {
+                messageId: assistantMsg.id,
+                content: cleanContent,
+              })
+            } catch (err) {
+              send('error', { message: err instanceof Error ? err.message : String(err) })
+            } finally {
+              controller.close()
+            }
+          },
         })
 
-        return json({
-          ok: true,
-          response: assistantMsg.content,
-          suggestions: [],
-          messageId: assistantMsg.id,
+        return new Response(stream, {
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+          },
         })
       },
     })
@@ -834,17 +978,48 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
           content: params.message as string,
         })
 
-        // Non-streaming placeholder — streaming upgrade in PR 2
+        // Non-streaming: call gateway synchronously and collect full response
+        const messages = buildMessages(session, params.message as string)
+        const sessionKey = `session-${params.sessionId}-${Date.now()}`
+
+        let fullContent: string
+        try {
+          fullContent = await chatCompletion({
+            messages,
+            agentId: session.agentId,
+            sessionKey,
+          })
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : String(err) }
+        }
+
+        // Parse proposals
+        let proposals: Array<{
+          title: string; scheduledAt: string; contentType: string;
+          tone: string; brief: string; channels?: string[]
+        }> = []
+        const jsonMatch = fullContent.match(/```json\s*([\s\S]*?)\s*```/)
+        if (jsonMatch) {
+          try { proposals = JSON.parse(jsonMatch[1]) } catch { /* ignore */ }
+        }
+
+        const cleanContent = fullContent.replace(/```json[\s\S]*?```/g, '').trim()
         const assistantMsg = appendMessage(params.sessionId as string, {
           role: 'assistant',
-          content: 'Planning session message received. Streaming upgrade pending.',
+          content: cleanContent,
         })
+
+        let savedProposals: unknown[] = []
+        if (proposals.length > 0) {
+          savedProposals = addProposals(params.sessionId as string, assistantMsg.id, proposals)
+        }
 
         return {
           ok: true,
-          response: assistantMsg.content,
+          response: cleanContent,
           messageId: assistantMsg.id,
           userMessageId: userMsg.id,
+          proposals: savedProposals,
         }
       },
     })

--- a/plugins/calendar/lib/gateway.ts
+++ b/plugins/calendar/lib/gateway.ts
@@ -1,0 +1,90 @@
+/**
+ * Gateway client for the calendar plugin.
+ * Handles authentication and request construction for the OpenClaw gateway.
+ */
+import { readFileSync, existsSync } from 'fs'
+
+const GATEWAY_URL = 'http://localhost:18789'
+
+/**
+ * Resolve the gateway auth token from OpenClaw config.
+ */
+export async function getGatewayToken(): Promise<string> {
+  const { getOpenClawPath } = await import('@bakin/core/openclaw-home')
+  const configPath = getOpenClawPath('openclaw.json')
+  if (!existsSync(configPath)) throw new Error('Gateway config not found')
+  const cfg = JSON.parse(readFileSync(configPath, 'utf-8'))
+  const token = cfg?.gateway?.auth?.token
+  if (!token) throw new Error('Gateway token not found')
+  return token
+}
+
+/**
+ * Send a streaming chat completion request to the OpenClaw gateway.
+ * Returns the raw fetch Response with SSE body for streaming.
+ */
+export async function streamChatCompletion(opts: {
+  messages: Array<{ role: string; content: string }>
+  agentId: string
+  sessionKey: string
+}): Promise<Response> {
+  const token = await getGatewayToken()
+
+  const response = await fetch(`${GATEWAY_URL}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+      'x-openclaw-session-key': opts.sessionKey,
+      'x-openclaw-agent-id': opts.agentId,
+    },
+    body: JSON.stringify({
+      model: 'openclaw:main',
+      max_tokens: 2048,
+      stream: true,
+      messages: opts.messages,
+    }),
+  })
+
+  if (!response.ok) {
+    const err = await response.text()
+    throw new Error(`Gateway error (${response.status}): ${err}`)
+  }
+
+  return response
+}
+
+/**
+ * Send a non-streaming chat completion request.
+ * Returns the assistant's response content.
+ */
+export async function chatCompletion(opts: {
+  messages: Array<{ role: string; content: string }>
+  agentId: string
+  sessionKey: string
+}): Promise<string> {
+  const token = await getGatewayToken()
+
+  const response = await fetch(`${GATEWAY_URL}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+      'x-openclaw-session-key': opts.sessionKey,
+      'x-openclaw-agent-id': opts.agentId,
+    },
+    body: JSON.stringify({
+      model: 'openclaw:main',
+      max_tokens: 2048,
+      messages: opts.messages,
+    }),
+  })
+
+  if (!response.ok) {
+    const err = await response.text()
+    throw new Error(`Gateway error (${response.status}): ${err}`)
+  }
+
+  const data = await response.json()
+  return data.choices?.[0]?.message?.content || ''
+}

--- a/plugins/calendar/lib/prompt-builder.ts
+++ b/plugins/calendar/lib/prompt-builder.ts
@@ -1,0 +1,143 @@
+/**
+ * Prompt builder for planning sessions.
+ *
+ * Builds a system prompt with agent persona, planning instructions,
+ * and current plan state. Returns a proper messages array (not a
+ * flattened string) so the LLM can track conversational context.
+ */
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { getContentDir } from '../../../src/core/content-dir'
+import type { PlanningSession } from '../types'
+import { AGENT_INFO } from '../types'
+
+const AGENT_NAMES: Record<string, string> = {
+  basil: 'Basil',
+  scout: 'Scout (Connor)',
+  nemo: 'Nemo (Yuki)',
+  zen: 'Zen (Marcus)',
+}
+
+/**
+ * Load the agent persona markdown file, or return empty string if missing.
+ */
+function loadPersona(agentId: string, contentDir?: string): string {
+  const dir = contentDir || getContentDir()
+  const personaPath = join(dir, 'team', 'personas', `${agentId}.md`)
+  if (!existsSync(personaPath)) return ''
+  try {
+    return readFileSync(personaPath, 'utf-8')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Build a summary of the current plan state (proposals with statuses).
+ */
+function buildPlanState(session: PlanningSession): string {
+  if (session.proposals.length === 0) return ''
+
+  const lines = ['## Current Plan State\n']
+  for (const p of session.proposals) {
+    const statusTag = p.status.toUpperCase()
+    let line = `- [${statusTag}] (${p.id}) "${p.title}" — ${p.scheduledAt}, ${p.contentType}, ${p.tone}`
+    if (p.rejectionNote) {
+      line += `\n  Rejection note: ${p.rejectionNote}`
+    }
+    lines.push(line)
+  }
+
+  const approved = session.proposals.filter(p => p.status === 'approved').length
+  const rejected = session.proposals.filter(p => p.status === 'rejected').length
+  const proposed = session.proposals.filter(p => p.status === 'proposed').length
+  lines.push(`\nSummary: ${approved} approved, ${rejected} rejected, ${proposed} pending`)
+
+  return lines.join('\n')
+}
+
+/**
+ * Build the system prompt for a planning session.
+ */
+export function buildSystemPrompt(agentId: string, session: PlanningSession, contentDir?: string): string {
+  const agentName = AGENT_NAMES[agentId] || agentId
+  const agentInfo = AGENT_INFO[agentId as keyof typeof AGENT_INFO]
+  const persona = loadPersona(agentId, contentDir)
+
+  const sections: string[] = []
+
+  // Identity
+  sections.push(`You are ${agentName}, a BetterFit content creator.`)
+
+  // Persona
+  if (persona) {
+    sections.push(`## Your Persona\n\n${persona}`)
+  }
+
+  // Planning instructions
+  sections.push(`## Planning Instructions
+
+You are in a planning session with Mark. Your job is to brainstorm and refine content calendar ideas collaboratively.
+
+When suggesting content, provide items in this JSON format within a fenced code block:
+\`\`\`json
+[{ "title": "...", "scheduledAt": "...", "contentType": "...", "tone": "...", "brief": "...", "channels": ["discord"] }]
+\`\`\`
+
+Fields:
+- title: catchy post title in your authentic voice
+- scheduledAt: ISO datetime (timezone: America/Denver, MDT = UTC-6)
+- contentType: one of recipe, tip, motivation, workout, outdoor, video, image-post
+- tone: one of energetic, calm, educational, humorous, inspiring, conversational
+- brief: 2-3 sentence description of what to create when this executes
+- channels: optional array of distribution channels (default: ["discord"])
+
+## Revision Rules
+
+When Mark rejects or asks you to revise specific items:
+- Only regenerate the items he asked about — do NOT regenerate the entire plan
+- Reference proposals by their title or content, not by ID
+- Keep approved items unchanged unless explicitly asked to modify them
+- If a rejection note is provided, address the feedback specifically`)
+
+  // Plan state
+  const planState = buildPlanState(session)
+  if (planState) {
+    sections.push(planState)
+  }
+
+  return sections.join('\n\n---\n\n')
+}
+
+/**
+ * Build a proper messages array from session history plus a new user message.
+ * Returns an array suitable for the OpenAI-compatible chat completions API.
+ */
+export function buildMessages(
+  session: PlanningSession,
+  newMessage: string
+): Array<{ role: 'system' | 'user' | 'assistant'; content: string }> {
+  const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = []
+
+  // System prompt
+  messages.push({
+    role: 'system',
+    content: buildSystemPrompt(session.agentId, session),
+  })
+
+  // Session history
+  for (const msg of session.messages) {
+    messages.push({
+      role: msg.role,
+      content: msg.content,
+    })
+  }
+
+  // New user message
+  messages.push({
+    role: 'user',
+    content: newMessage,
+  })
+
+  return messages
+}

--- a/tests/dev/mock-gateway-streaming.test.ts
+++ b/tests/dev/mock-gateway-streaming.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Mock gateway streaming tests — verifies SSE streaming behavior
+ * when stream: true is passed in the request body.
+ */
+import { describe, it, expect } from 'vitest'
+import { handleGatewayRequest } from '../../dev/imitation-crab/gateway'
+
+describe('mock gateway streaming', () => {
+  it('returns stream marker when stream: true', async () => {
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'basil' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        stream: true,
+        messages: [{ role: 'user', content: 'Plan next week' }],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBe(true)
+    expect(body.content).toContain('mock:Basil')
+  })
+
+  it('returns standard response when stream is not set', async () => {
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'basil' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'Hello' }],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBeUndefined()
+    expect(body).toHaveProperty('choices')
+  })
+
+  it('returns standard response when stream: false', async () => {
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'basil' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        stream: false,
+        messages: [{ role: 'user', content: 'Hello' }],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBeUndefined()
+    expect(body).toHaveProperty('choices')
+  })
+
+  it('uses last message content for echo mode reply', async () => {
+    // Save and restore env
+    const original = process.env.OPENCLAW_MOCK_CHAT_MODE
+    process.env.OPENCLAW_MOCK_CHAT_MODE = 'echo'
+
+    // Need to re-import to pick up env change — but CHAT_MODE is read at module load.
+    // Instead, test that the content field is populated with something sensible.
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'scout' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        stream: true,
+        messages: [
+          { role: 'system', content: 'You are Scout' },
+          { role: 'user', content: 'Plan outdoor content' },
+        ],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBe(true)
+    expect(typeof body.content).toBe('string')
+
+    process.env.OPENCLAW_MOCK_CHAT_MODE = original
+  })
+})

--- a/tests/plugins/calendar/prompt-builder.test.ts
+++ b/tests/plugins/calendar/prompt-builder.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Prompt builder tests — verifies system prompt construction,
+ * persona loading, plan state inclusion, and messages array format.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-prompt-${Date.now()}`)
+})
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ calendar: testDir }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  }),
+}))
+
+import { buildSystemPrompt, buildMessages } from '../../../plugins/calendar/lib/prompt-builder'
+import type { PlanningSession } from '../../../plugins/calendar/types'
+
+function makeSession(overrides: Partial<PlanningSession> = {}): PlanningSession {
+  return {
+    id: 'sess-1',
+    agentId: 'basil',
+    title: 'Test Session',
+    status: 'active',
+    createdAt: '2026-04-07T00:00:00Z',
+    updatedAt: '2026-04-07T00:00:00Z',
+    messages: [],
+    proposals: [],
+    ...overrides,
+  }
+}
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('buildSystemPrompt', () => {
+  it('includes agent name and planning instructions', () => {
+    const prompt = buildSystemPrompt('basil', makeSession(), testDir)
+    expect(prompt).toContain('You are Basil')
+    expect(prompt).toContain('Planning Instructions')
+    expect(prompt).toContain('Revision Rules')
+  })
+
+  it('includes persona when file exists', () => {
+    const personaDir = join(testDir, 'team', 'personas')
+    mkdirSync(personaDir, { recursive: true })
+    writeFileSync(join(personaDir, 'basil.md'), '# Basil\nA chef who loves fresh ingredients.')
+
+    const prompt = buildSystemPrompt('basil', makeSession(), testDir)
+    expect(prompt).toContain('Your Persona')
+    expect(prompt).toContain('fresh ingredients')
+  })
+
+  it('omits persona section when file is missing', () => {
+    const prompt = buildSystemPrompt('scout', makeSession({ agentId: 'scout' }), testDir)
+    expect(prompt).not.toContain('Your Persona')
+    expect(prompt).toContain('Scout (Connor)')
+  })
+
+  it('includes plan state with proposal statuses', () => {
+    const session = makeSession({
+      proposals: [
+        {
+          id: 'p1', messageId: 'm1', revision: 1, agentId: 'basil',
+          title: 'Monday Recipe', scheduledAt: '2026-04-13T10:00:00Z',
+          contentType: 'recipe', tone: 'energetic', brief: 'Pasta',
+          status: 'approved',
+        },
+        {
+          id: 'p2', messageId: 'm1', revision: 1, agentId: 'basil',
+          title: 'Wednesday Tip', scheduledAt: '2026-04-15T10:00:00Z',
+          contentType: 'tip', tone: 'calm', brief: 'Knife care',
+          status: 'rejected', rejectionNote: 'Too similar to last week',
+        },
+      ],
+    })
+
+    const prompt = buildSystemPrompt('basil', session, testDir)
+    expect(prompt).toContain('Current Plan State')
+    expect(prompt).toContain('[APPROVED]')
+    expect(prompt).toContain('[REJECTED]')
+    expect(prompt).toContain('Monday Recipe')
+    expect(prompt).toContain('Too similar to last week')
+    expect(prompt).toContain('1 approved, 1 rejected, 0 pending')
+  })
+
+  it('omits plan state when no proposals exist', () => {
+    const prompt = buildSystemPrompt('basil', makeSession(), testDir)
+    expect(prompt).not.toContain('Current Plan State')
+  })
+
+  it('handles unknown agent gracefully', () => {
+    const prompt = buildSystemPrompt('unknown-agent', makeSession({ agentId: 'unknown-agent' }), testDir)
+    expect(prompt).toContain('You are unknown-agent')
+  })
+})
+
+describe('buildMessages', () => {
+  it('returns system + new user message for empty session', () => {
+    const messages = buildMessages(makeSession(), 'Plan next week')
+    expect(messages.length).toBe(2)
+    expect(messages[0].role).toBe('system')
+    expect(messages[1].role).toBe('user')
+    expect(messages[1].content).toBe('Plan next week')
+  })
+
+  it('includes session history as individual messages', () => {
+    const session = makeSession({
+      messages: [
+        { id: 'm1', role: 'user', content: 'Plan Monday', timestamp: '2026-04-07T01:00:00Z' },
+        { id: 'm2', role: 'assistant', content: 'Here are ideas...', timestamp: '2026-04-07T01:01:00Z' },
+      ],
+    })
+
+    const messages = buildMessages(session, 'Now plan Tuesday')
+    expect(messages.length).toBe(4) // system + 2 history + new user
+    expect(messages[0].role).toBe('system')
+    expect(messages[1].role).toBe('user')
+    expect(messages[1].content).toBe('Plan Monday')
+    expect(messages[2].role).toBe('assistant')
+    expect(messages[2].content).toBe('Here are ideas...')
+    expect(messages[3].role).toBe('user')
+    expect(messages[3].content).toBe('Now plan Tuesday')
+  })
+
+  it('includes plan state in system prompt when proposals exist', () => {
+    const session = makeSession({
+      proposals: [
+        {
+          id: 'p1', messageId: 'm1', revision: 1, agentId: 'basil',
+          title: 'Test Item', scheduledAt: '2026-04-13T10:00:00Z',
+          contentType: 'recipe', tone: 'energetic', brief: 'Test',
+          status: 'proposed',
+        },
+      ],
+    })
+
+    const messages = buildMessages(session, 'What do you think?')
+    expect(messages[0].content).toContain('Current Plan State')
+    expect(messages[0].content).toContain('Test Item')
+  })
+})

--- a/tests/plugins/calendar/session-chat.test.tsx
+++ b/tests/plugins/calendar/session-chat.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock UI components
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, disabled, ...props }: { children: React.ReactNode; disabled?: boolean; [k: string]: unknown }) => (
+    <button disabled={disabled} {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: Record<string, unknown>) => <textarea data-testid="chat-input" {...props} />,
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: { children: React.ReactNode; [k: string]: unknown }) => (
+    <span data-testid="badge" {...props}>{children}</span>
+  ),
+}))
+
+vi.mock('@/components/agent-avatar', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span data-testid={`avatar-${agentId}`} />,
+}))
+
+vi.mock('lucide-react', () => ({
+  Send: () => <span data-testid="send-icon" />,
+  Loader2: () => <span data-testid="loader-icon" />,
+}))
+
+import { SessionChat } from '../../../plugins/calendar/components/session-chat'
+import type { SessionMessage, ProposedItem } from '../../../plugins/calendar/types'
+
+afterEach(() => cleanup())
+
+describe('SessionChat', () => {
+  it('renders empty state with agent name', () => {
+    render(<SessionChat sessionId="s1" agentId="basil" />)
+    expect(screen.getByText('Plan with Basil')).toBeDefined()
+    expect(screen.getByTestId('avatar-basil')).toBeDefined()
+  })
+
+  it('renders initial messages', () => {
+    const messages: SessionMessage[] = [
+      { id: 'm1', role: 'user', content: 'Plan next week', timestamp: '2026-04-07T00:00:00Z' },
+      { id: 'm2', role: 'assistant', content: 'Here are some ideas!', timestamp: '2026-04-07T00:01:00Z' },
+    ]
+
+    render(<SessionChat sessionId="s1" agentId="scout" initialMessages={messages} />)
+    expect(screen.getByText('Plan next week')).toBeDefined()
+    expect(screen.getByText('Here are some ideas!')).toBeDefined()
+  })
+
+  it('shows read-only badge for completed sessions', () => {
+    render(<SessionChat sessionId="s1" agentId="basil" isCompleted={true} />)
+    expect(screen.getByText('Session completed — read-only')).toBeDefined()
+    // Input should not be present
+    expect(screen.queryByTestId('chat-input')).toBeNull()
+  })
+
+  it('shows input area for active sessions', () => {
+    render(<SessionChat sessionId="s1" agentId="zen" />)
+    const input = screen.getByTestId('chat-input')
+    expect(input).toBeDefined()
+    expect(input.getAttribute('placeholder')).toContain('Zen')
+  })
+
+  it('disables input when no text entered', () => {
+    render(<SessionChat sessionId="s1" agentId="nemo" />)
+    const buttons = screen.getAllByRole('button')
+    const sendButton = buttons.find(b => b.querySelector('[data-testid="send-icon"]'))
+    expect(sendButton?.hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/tests/plugins/calendar/sessions.test.ts
+++ b/tests/plugins/calendar/sessions.test.ts
@@ -36,6 +36,43 @@ vi.mock('../../../src/core/audit', () => ({
   appendAudit: vi.fn(),
 }))
 
+vi.mock('../../../src/core/watcher', () => ({
+  watchDir: vi.fn(),
+}))
+
+// Mock the gateway module so tests don't hit a real gateway
+vi.mock('../../../plugins/calendar/lib/gateway', () => ({
+  streamChatCompletion: vi.fn(async () => {
+    // Return a mock Response with SSE body
+    const encoder = new TextEncoder()
+    const body = new ReadableStream({
+      start(controller) {
+        const reply = '[mock:Basil] Acknowledged. Task understood — working on it.'
+        const words = reply.split(/(\s+)/)
+        for (const word of words) {
+          if (!word) continue
+          const chunk = JSON.stringify({ choices: [{ delta: { content: word } }] })
+          controller.enqueue(encoder.encode(`data: ${chunk}\n\n`))
+        }
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    return new Response(body, {
+      headers: { 'Content-Type': 'text/event-stream' },
+    })
+  }),
+  chatCompletion: vi.fn(async () =>
+    '[mock:Basil] Acknowledged. Task understood — working on it.'
+  ),
+}))
+
+// Mock openclaw-home to prevent filesystem access
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawPath: vi.fn(() => '/tmp/mock-openclaw.json'),
+  getOpenClawHome: vi.fn(() => '/tmp/mock-openclaw'),
+}))
+
 // Suppress SSE broadcast
 ;(globalThis as any).__bakinBroadcast = vi.fn()
 
@@ -317,7 +354,7 @@ describe('Session routes', () => {
       expect(findRoute(plugin.routes, 'POST', '/sessions/:id/messages')).toBeDefined()
     })
 
-    it('appends user and assistant messages', async () => {
+    it('returns SSE stream and persists messages', async () => {
       const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
       const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
         body: { agentId: 'basil' },
@@ -325,13 +362,20 @@ describe('Session routes', () => {
       const sessionId = (createBody.session as Record<string, unknown>).id as string
 
       const msgRoute = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
-      const { status, body } = await callRoute(msgRoute, plugin.ctx, {
-        searchParams: { id: sessionId },
+      const { makeRequest } = await import('../test-helpers')
+      const req = makeRequest('/sessions/:id/messages', {
+        method: 'POST',
         body: { message: 'Plan some content for next week' },
+        searchParams: { id: sessionId },
       })
-      expect(status).toBe(200)
-      expect(body.ok).toBe(true)
-      expect(body.messageId).toBeDefined()
+      const res = await msgRoute.handler(req, plugin.ctx)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('text/event-stream')
+
+      // Consume the SSE stream
+      const text = await res.text()
+      expect(text).toContain('event: token')
+      expect(text).toContain('event: done')
 
       // Verify messages were stored
       const getRoute = findRoute(plugin.routes, 'GET', '/sessions/:id')!

--- a/tests/plugins/calendar/streaming.test.ts
+++ b/tests/plugins/calendar/streaming.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Streaming endpoint tests — verifies SSE format, token events,
+ * proposal extraction, session persistence, and error handling.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-streaming-${Date.now()}`)
+})
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ calendar: testDir }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/core/audit', () => ({ appendAudit: vi.fn() }))
+vi.mock('../../../src/core/watcher', () => ({ watchDir: vi.fn() }))
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawPath: vi.fn(() => '/tmp/mock-openclaw.json'),
+  getOpenClawHome: vi.fn(() => '/tmp/mock-openclaw'),
+}))
+
+// Mock gateway — default returns canned text, tests can override
+const mockStreamChatCompletion = vi.fn()
+const mockChatCompletion = vi.fn()
+
+vi.mock('../../../plugins/calendar/lib/gateway', () => ({
+  streamChatCompletion: (...args: unknown[]) => mockStreamChatCompletion(...args),
+  chatCompletion: (...args: unknown[]) => mockChatCompletion(...args),
+}))
+
+;(globalThis as any).__bakinBroadcast = vi.fn()
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import calendarPlugin from '../../../plugins/calendar/index'
+import {
+  activatePlugin,
+  findRoute,
+  findTool,
+  callRoute,
+  makeRequest,
+} from '../test-helpers'
+import type { ActivatedPlugin } from '../test-helpers'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSSEResponse(content: string): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream({
+    start(controller) {
+      const words = content.split(/(\s+)/)
+      for (const word of words) {
+        if (!word) continue
+        const chunk = JSON.stringify({ choices: [{ delta: { content: word } }] })
+        controller.enqueue(encoder.encode(`data: ${chunk}\n\n`))
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(body, { headers: { 'Content-Type': 'text/event-stream' } })
+}
+
+function parseSSEEvents(text: string): Array<{ event: string; data: Record<string, unknown> }> {
+  const events: Array<{ event: string; data: Record<string, unknown> }> = []
+  const lines = text.split('\n')
+  let currentEvent = ''
+  for (const line of lines) {
+    if (line.startsWith('event: ')) {
+      currentEvent = line.slice(7).trim()
+    } else if (line.startsWith('data: ') && currentEvent) {
+      try {
+        events.push({ event: currentEvent, data: JSON.parse(line.slice(6)) })
+      } catch { /* skip */ }
+      currentEvent = ''
+    }
+  }
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let plugin: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  plugin = await activatePlugin(calendarPlugin, testDir)
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  const sessionsDir = join(testDir, 'calendar', 'sessions')
+  if (existsSync(sessionsDir)) rmSync(sessionsDir, { recursive: true, force: true })
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  vi.clearAllMocks()
+})
+
+async function createTestSession(agentId = 'basil'): Promise<string> {
+  const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+  const { body } = await callRoute(postRoute, plugin.ctx, {
+    body: { agentId },
+  })
+  return (body.session as Record<string, unknown>).id as string
+}
+
+async function sendMessage(sessionId: string, message: string): Promise<Response> {
+  const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+  const req = makeRequest('/sessions/:id/messages', {
+    method: 'POST',
+    body: { message },
+    searchParams: { id: sessionId },
+  })
+  return route.handler(req, plugin.ctx)
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+describe('Streaming endpoint', () => {
+  it('returns text/event-stream content type', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(makeSSEResponse('Hello world'))
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan next week')
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+  })
+
+  it('streams token events from gateway SSE', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse('Here are some ideas for next week.')
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan next week')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const tokenEvents = events.filter(e => e.event === 'token')
+    expect(tokenEvents.length).toBeGreaterThan(0)
+    // Reassemble tokens
+    const fullText = tokenEvents.map(e => e.data.text).join('')
+    expect(fullText).toContain('Here')
+    expect(fullText).toContain('ideas')
+  })
+
+  it('sends done event after stream completes', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse('All done.')
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'quick')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const doneEvents = events.filter(e => e.event === 'done')
+    expect(doneEvents.length).toBe(1)
+    expect(doneEvents[0].data.messageId).toBeDefined()
+    expect(doneEvents[0].data.content).toContain('All done')
+  })
+
+  it('extracts proposals from JSON block and sends proposals event', async () => {
+    const responseWithProposals = `Great ideas for next week!
+
+\`\`\`json
+[{"title":"Monday Recipe","scheduledAt":"2026-04-13T10:00:00Z","contentType":"recipe","tone":"energetic","brief":"A quick pasta dish"}]
+\`\`\``
+
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithProposals)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan next week')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const proposalEvents = events.filter(e => e.event === 'proposals')
+    expect(proposalEvents.length).toBe(1)
+    const proposals = proposalEvents[0].data.proposals as Array<Record<string, unknown>>
+    expect(proposals.length).toBe(1)
+    expect(proposals[0].title).toBe('Monday Recipe')
+    expect(proposals[0].status).toBe('proposed')
+  })
+
+  it('persists user and assistant messages to session file', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse('Sounds good, let me think...')
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan content for Monday')
+    await res.text() // Must consume stream to trigger side effects
+
+    // Read session file directly
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    expect(existsSync(sessionPath)).toBe(true)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    expect(session.messages.length).toBe(2)
+    expect(session.messages[0].role).toBe('user')
+    expect(session.messages[0].content).toBe('Plan content for Monday')
+    expect(session.messages[1].role).toBe('assistant')
+  })
+
+  it('persists proposals to session file', async () => {
+    const responseWithProposals = `Ideas:\n\`\`\`json\n[{"title":"Test","scheduledAt":"2026-04-13T10:00:00Z","contentType":"tip","tone":"calm","brief":"A tip"}]\n\`\`\``
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithProposals)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Suggest something')
+    await res.text() // Consume stream
+
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    expect(session.proposals.length).toBe(1)
+    expect(session.proposals[0].title).toBe('Test')
+    expect(session.proposals[0].agentId).toBe('basil')
+  })
+
+  it('links proposals to their message via proposalIds', async () => {
+    const responseWithProposals = `Here:\n\`\`\`json\n[{"title":"Linked","scheduledAt":"2026-04-13T10:00:00Z","contentType":"tip","tone":"calm","brief":"A tip"}]\n\`\`\``
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithProposals)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Ideas')
+    await res.text() // Consume stream
+
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    const assistantMsg = session.messages.find((m: Record<string, unknown>) => m.role === 'assistant')
+    expect(assistantMsg.proposalIds).toBeDefined()
+    expect(assistantMsg.proposalIds.length).toBe(1)
+    expect(assistantMsg.proposalIds[0]).toBe(session.proposals[0].id)
+  })
+
+  it('falls back to non-streaming when gateway throws', async () => {
+    mockStreamChatCompletion.mockRejectedValueOnce(new Error('Stream not supported'))
+    mockChatCompletion.mockResolvedValueOnce('Fallback response here.')
+
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const tokenEvents = events.filter(e => e.event === 'token')
+    expect(tokenEvents.length).toBe(1) // Single token with full content
+    expect(tokenEvents[0].data.text).toBe('Fallback response here.')
+
+    const doneEvents = events.filter(e => e.event === 'done')
+    expect(doneEvents.length).toBe(1)
+  })
+
+  it('sends error event when both streaming and fallback fail', async () => {
+    mockStreamChatCompletion.mockRejectedValueOnce(new Error('Stream failed'))
+    mockChatCompletion.mockRejectedValueOnce(new Error('Fallback also failed'))
+
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const errorEvents = events.filter(e => e.event === 'error')
+    expect(errorEvents.length).toBe(1)
+    expect(errorEvents[0].data.message).toContain('Fallback also failed')
+  })
+
+  it('returns JSON 400 for missing params (before stream starts)', async () => {
+    const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+    const { status, body } = await callRoute(route, plugin.ctx, {
+      searchParams: { id: 'some-id' },
+      body: {},
+    })
+    expect(status).toBe(400)
+    expect(body.error).toContain('message required')
+  })
+
+  it('returns JSON 404 for nonexistent session', async () => {
+    const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+    const { status } = await callRoute(route, plugin.ctx, {
+      searchParams: { id: 'nonexistent' },
+      body: { message: 'hello' },
+    })
+    expect(status).toBe(404)
+  })
+
+  it('strips JSON block from stored assistant message content', async () => {
+    const responseWithJson = `Great plan!\n\`\`\`json\n[{"title":"X","scheduledAt":"2026-04-13T10:00:00Z","contentType":"tip","tone":"calm","brief":"Y"}]\n\`\`\``
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithJson)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan')
+    await res.text() // Consume stream
+
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    const assistantMsg = session.messages.find((m: Record<string, unknown>) => m.role === 'assistant')
+    expect(assistantMsg.content).not.toContain('```json')
+    expect(assistantMsg.content).toContain('Great plan!')
+  })
+})
+
+describe('Session message exec tool (non-streaming)', () => {
+  it('calls gateway non-streaming and returns response', async () => {
+    mockChatCompletion.mockResolvedValueOnce('Here are my ideas for you.')
+
+    const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+    const created = await createTool.handler({ agentId: 'basil' }, 'test')
+    const sessionId = (created.session as Record<string, unknown>).id as string
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_message')!
+    const result = await tool.handler({ sessionId, message: 'Plan next week' }, 'test')
+
+    expect(result.ok).toBe(true)
+    expect(result.response).toBe('Here are my ideas for you.')
+    expect(result.messageId).toBeDefined()
+    expect(mockChatCompletion).toHaveBeenCalled()
+  })
+
+  it('returns error when gateway fails', async () => {
+    mockChatCompletion.mockRejectedValueOnce(new Error('Gateway down'))
+
+    const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+    const created = await createTool.handler({ agentId: 'basil' }, 'test')
+    const sessionId = (created.session as Record<string, unknown>).id as string
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_message')!
+    const result = await tool.handler({ sessionId, message: 'Plan' }, 'test')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Gateway down')
+  })
+})


### PR DESCRIPTION
## Summary
- Add prompt builder module with agent persona, plan state, revision rules, and proper messages array (fixes the "regenerates everything" bug)
- Add SSE streaming support to Imitation Crab mock gateway (`stream: true` → word-level SSE chunks)
- Rewrite `POST /sessions/:id/messages` to return `text/event-stream` with `event:token`, `event:proposals`, `event:done`, `event:error`
- Add gateway client module (`lib/gateway.ts`) for auth resolution and streaming/non-streaming calls
- Upgrade `session_message` exec tool to use real gateway (non-streaming) instead of placeholder
- Add `SessionChat` React component that consumes SSE stream in real-time
- Falls back to non-streaming gateway call if streaming is unavailable

## SSE Event Format
```
event: token
data: {"text": "word"}

event: proposals
data: {"proposals": [...], "messageId": "..."}

event: done
data: {"messageId": "...", "content": "full clean text"}

event: error
data: {"message": "error description"}
```

## Test plan
- [x] Prompt builder: persona, plan state, rejection notes, messages array (9 tests)
- [x] Mock gateway streaming: SSE format, stream marker, non-streaming compat (4 tests)
- [x] Streaming endpoint: token events, proposals, persistence, fallback, errors (14 tests)
- [x] Session chat UI: empty state, messages, read-only, input, disabled state (5 tests)
- [x] All 149 tests pass, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)