### PR TITLE
feat(calendar): add review panel with two-stage approval (PR 3)

### DIFF
--- a/dev/imitation-crab/gateway.ts
+++ b/dev/imitation-crab/gateway.ts
@@ -71,10 +71,10 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
     const agentId = (Array.isArray(agentHeader) ? agentHeader[0] : agentHeader) || 'unknown'
     const agentName = AGENT_NAMES[agentId] || agentId
 
-    let parsed: { messages?: Array<{ content?: string }> } = {}
+    let parsed: { messages?: Array<{ content?: string }>; stream?: boolean } = {}
     try { parsed = JSON.parse(body) } catch { /* */ }
 
-    const userMessage = parsed.messages?.[0]?.content || ''
+    const userMessage = parsed.messages?.[parsed.messages.length - 1]?.content || ''
 
     let reply: string
     switch (CHAT_MODE) {
@@ -88,7 +88,15 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
         reply = `[mock:${agentName}] Acknowledged. Task understood — working on it.`
     }
 
-    console.log(`  → agent=${agentId} message=${userMessage.slice(0, 80)}${userMessage.length > 80 ? '...' : ''}`)
+    console.log(`  → agent=${agentId} stream=${!!parsed.stream} message=${userMessage.slice(0, 80)}${userMessage.length > 80 ? '...' : ''}`)
+
+    // Streaming: return a marker so handleRequest can send SSE
+    if (parsed.stream) {
+      return {
+        status: 200,
+        body: { __stream: true, content: reply },
+      }
+    }
 
     return {
       status: 200,
@@ -118,6 +126,30 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
   return { status: 404, body: { error: 'Not found', mock: true } }
 }
 
+/**
+ * Stream a response as SSE chunks in OpenAI-compatible format.
+ * Splits content into word-level chunks for realistic streaming simulation.
+ */
+function sendSSE(res: ServerResponse, content: string): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+  })
+
+  const words = content.split(/(\s+)/)
+  for (const word of words) {
+    if (!word) continue
+    const chunk = JSON.stringify({
+      choices: [{ delta: { content: word } }],
+    })
+    res.write(`data: ${chunk}\n\n`)
+  }
+
+  res.write('data: [DONE]\n\n')
+  res.end()
+}
+
 async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const body = await readBody(req)
   const response = await handleGatewayRequest({
@@ -126,6 +158,14 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     headers: req.headers,
     body,
   })
+
+  // Check for streaming marker
+  const responseBody = response.body as Record<string, unknown>
+  if (responseBody && responseBody.__stream === true) {
+    sendSSE(res, responseBody.content as string)
+    return
+  }
+
   json(res, response.body, response.status)
 }
 

--- a/plugins/calendar/components/planning-layout.tsx
+++ b/plugins/calendar/components/planning-layout.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { AgentAvatar } from '@/components/agent-avatar'
+import { ArrowLeft, PanelRight, PanelRightClose, Pencil, Check, X } from 'lucide-react'
+import { SessionChat } from './session-chat'
+import { ReviewPanel } from './review-panel'
+import type { ContentAgent, PlanningSession, ProposedItem } from '../types'
+import { AGENT_INFO } from '../types'
+
+interface Props {
+  sessionId: string
+  onBack?: () => void
+  onSessionUpdated?: () => void
+}
+
+export function PlanningLayout({ sessionId, onBack, onSessionUpdated }: Props) {
+  const [session, setSession] = useState<PlanningSession | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [showReview, setShowReview] = useState(true)
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleDraft, setTitleDraft] = useState('')
+  const titleInputRef = useRef<HTMLInputElement>(null)
+
+  const fetchSession = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/plugins/calendar/sessions/${sessionId}`)
+      if (res.ok) {
+        const data = await res.json()
+        setSession(data.session)
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false)
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    fetchSession()
+  }, [fetchSession])
+
+  const handleTitleSave = async () => {
+    if (!titleDraft.trim() || !session) return
+    try {
+      const res = await fetch(`/api/plugins/calendar/sessions/${sessionId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: titleDraft.trim() }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setSession(data.session)
+      }
+    } catch {
+      // Silently fail
+    }
+    setEditingTitle(false)
+  }
+
+  const handleProposalsReceived = useCallback((newProposals: ProposedItem[]) => {
+    setSession((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        proposals: [...prev.proposals, ...newProposals],
+      }
+    })
+  }, [])
+
+  const handleProposalUpdate = useCallback((updated: ProposedItem) => {
+    setSession((prev) => {
+      if (!prev) return prev
+      return {
+        ...prev,
+        proposals: prev.proposals.map((p) =>
+          p.id === updated.id ? updated : p
+        ),
+      }
+    })
+  }, [])
+
+  const handleConfirm = useCallback(() => {
+    setSession((prev) => prev ? { ...prev, status: 'completed' } : prev)
+    onSessionUpdated?.()
+  }, [onSessionUpdated])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        Loading session...
+      </div>
+    )
+  }
+
+  if (!session) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
+        <p>Session not found</p>
+        <Button variant="outline" size="sm" onClick={onBack}>
+          Back to sessions
+        </Button>
+      </div>
+    )
+  }
+
+  const agentId = session.agentId as ContentAgent
+  const agentInfo = AGENT_INFO[agentId]
+  const isCompleted = session.status === 'completed'
+
+  return (
+    <div className="flex flex-col h-full" data-testid="planning-layout">
+      {/* Session header */}
+      <div className="flex items-center gap-3 p-3 border-b border-border">
+        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onBack}>
+          <ArrowLeft className="w-4 h-4" />
+        </Button>
+
+        <AgentAvatar agentId={agentId} size="sm" />
+
+        {editingTitle ? (
+          <div className="flex items-center gap-1 flex-1">
+            <Input
+              ref={titleInputRef}
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              className="h-7 text-sm"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleTitleSave()
+                if (e.key === 'Escape') setEditingTitle(false)
+              }}
+              autoFocus
+            />
+            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={handleTitleSave}>
+              <Check className="w-3.5 h-3.5" />
+            </Button>
+            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => setEditingTitle(false)}>
+              <X className="w-3.5 h-3.5" />
+            </Button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <h2 className="text-sm font-medium truncate">{session.title}</h2>
+            {!isCompleted && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                onClick={() => {
+                  setTitleDraft(session.title)
+                  setEditingTitle(true)
+                }}
+              >
+                <Pencil className="w-3 h-3" />
+              </Button>
+            )}
+          </div>
+        )}
+
+        <Badge variant="outline" className="text-[10px] shrink-0">
+          {agentInfo?.name || agentId}
+        </Badge>
+
+        {isCompleted && (
+          <Badge className="bg-emerald-500/20 text-emerald-400 text-[10px] shrink-0">
+            Completed
+          </Badge>
+        )}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={() => setShowReview(!showReview)}
+          title={showReview ? 'Hide review panel' : 'Show review panel'}
+        >
+          {showReview ? (
+            <PanelRightClose className="w-4 h-4" />
+          ) : (
+            <PanelRight className="w-4 h-4" />
+          )}
+        </Button>
+      </div>
+
+      {/* Split layout */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Chat panel */}
+        <div className={`flex-1 min-w-0 ${showReview ? 'md:w-[60%]' : 'w-full'}`}>
+          <SessionChat
+            sessionId={sessionId}
+            agentId={agentId}
+            initialMessages={session.messages}
+            initialProposals={session.proposals}
+            isCompleted={isCompleted}
+            onProposalsReceived={handleProposalsReceived}
+          />
+        </div>
+
+        {/* Review panel */}
+        {showReview && (
+          <div className="hidden md:flex md:w-[40%] border-l border-border">
+            <div className="w-full">
+              <ReviewPanel
+                sessionId={sessionId}
+                proposals={session.proposals}
+                isCompleted={isCompleted}
+                onProposalUpdate={handleProposalUpdate}
+                onConfirm={handleConfirm}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/plugins/calendar/components/proposal-card.tsx
+++ b/plugins/calendar/components/proposal-card.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Check, X, Pencil } from 'lucide-react'
+import type { ProposedItem, ProposalStatus } from '../types'
+
+const STATUS_STYLES: Record<ProposalStatus, { label: string; className: string }> = {
+  proposed: { label: 'Proposed', className: 'bg-muted text-muted-foreground' },
+  approved: { label: 'Approved', className: 'bg-emerald-500/20 text-emerald-400' },
+  rejected: { label: 'Rejected', className: 'bg-red-500/20 text-red-400 opacity-60' },
+  revised: { label: 'Revised', className: 'bg-amber-500/20 text-amber-400' },
+}
+
+interface Props {
+  proposal: ProposedItem
+  onApprove?: (id: string) => void
+  onReject?: (id: string, note: string) => void
+  onEdit?: (id: string) => void
+}
+
+export function ProposalCard({ proposal, onApprove, onReject, onEdit }: Props) {
+  const [showRejectInput, setShowRejectInput] = useState(false)
+  const [rejectionNote, setRejectionNote] = useState('')
+
+  const statusStyle = STATUS_STYLES[proposal.status]
+  const canAct = proposal.status === 'proposed' || proposal.status === 'revised'
+
+  const handleReject = () => {
+    if (onReject) {
+      onReject(proposal.id, rejectionNote)
+      setShowRejectInput(false)
+      setRejectionNote('')
+    }
+  }
+
+  return (
+    <div
+      className={`border rounded-lg p-3 ${
+        proposal.status === 'rejected' ? 'border-red-500/30 bg-red-500/5 opacity-60' :
+        proposal.status === 'approved' ? 'border-emerald-500/50 bg-emerald-500/5' :
+        'border-border bg-card'
+      }`}
+      data-testid={`proposal-${proposal.id}`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-xs truncate">{proposal.title}</h4>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <span className="text-[11px] text-muted-foreground">
+              {new Date(proposal.scheduledAt).toLocaleDateString('en-US', {
+                weekday: 'short',
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+              })}
+            </span>
+            <Badge variant="outline" className="text-[10px] py-0 px-1">
+              {proposal.contentType}
+            </Badge>
+            <Badge variant="outline" className="text-[10px] py-0 px-1">
+              {proposal.tone}
+            </Badge>
+            {proposal.channels?.map((ch) => (
+              <Badge key={ch} variant="outline" className="text-[10px] py-0 px-1">
+                {ch}
+              </Badge>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground mt-1.5 line-clamp-2">{proposal.brief}</p>
+          {proposal.rejectionNote && (
+            <p className="text-[11px] text-red-400 mt-1 italic">
+              Note: {proposal.rejectionNote}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          <Badge className={statusStyle.className + ' text-[10px]'}>
+            {statusStyle.label}
+          </Badge>
+
+          {canAct && (
+            <>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 w-6 p-0 text-emerald-400 hover:text-emerald-300"
+                onClick={() => onApprove?.(proposal.id)}
+                title="Approve"
+              >
+                <Check className="w-3.5 h-3.5" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 w-6 p-0 text-red-400 hover:text-red-300"
+                onClick={() => setShowRejectInput(!showRejectInput)}
+                title="Reject"
+              >
+                <X className="w-3.5 h-3.5" />
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 w-6 p-0 text-muted-foreground hover:text-foreground"
+                onClick={() => onEdit?.(proposal.id)}
+                title="Edit"
+              >
+                <Pencil className="w-3.5 h-3.5" />
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {showRejectInput && (
+        <div className="mt-2 flex gap-2">
+          <Input
+            value={rejectionNote}
+            onChange={(e) => setRejectionNote(e.target.value)}
+            placeholder="Rejection note (optional)"
+            className="text-xs h-7"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleReject()
+              if (e.key === 'Escape') {
+                setShowRejectInput(false)
+                setRejectionNote('')
+              }
+            }}
+          />
+          <Button size="sm" variant="outline" className="h-7 text-xs" onClick={handleReject}>
+            Reject
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/calendar/components/review-panel.tsx
+++ b/plugins/calendar/components/review-panel.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { CheckCircle, Loader2 } from 'lucide-react'
+import { ProposalCard } from './proposal-card'
+import type { ProposedItem } from '../types'
+
+interface Props {
+  sessionId: string
+  proposals: ProposedItem[]
+  isCompleted?: boolean
+  onProposalUpdate?: (updatedProposal: ProposedItem) => void
+  onConfirm?: (result: { itemsCreated: number; itemIds: string[] }) => void
+  onScrollToMessage?: (messageId: string) => void
+  onEditProposal?: (proposalId: string) => void
+}
+
+export function ReviewPanel({
+  sessionId,
+  proposals,
+  isCompleted = false,
+  onProposalUpdate,
+  onConfirm,
+  onScrollToMessage,
+  onEditProposal,
+}: Props) {
+  const [confirming, setConfirming] = useState(false)
+  const [confirmed, setConfirmed] = useState(false)
+
+  const approvedCount = useMemo(
+    () => proposals.filter((p) => p.status === 'approved').length,
+    [proposals]
+  )
+
+  const proposalsByDate = useMemo(() => {
+    const groups: Record<string, ProposedItem[]> = {}
+    for (const p of proposals) {
+      const date = new Date(p.scheduledAt).toLocaleDateString('en-US', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+      })
+      if (!groups[date]) groups[date] = []
+      groups[date].push(p)
+    }
+    // Sort groups chronologically
+    return Object.entries(groups).sort(
+      ([, a], [, b]) =>
+        new Date(a[0].scheduledAt).getTime() - new Date(b[0].scheduledAt).getTime()
+    )
+  }, [proposals])
+
+  const handleApprove = async (proposalId: string) => {
+    try {
+      const res = await fetch(
+        `/api/plugins/calendar/sessions/${sessionId}/proposals/${proposalId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'approved' }),
+        }
+      )
+      if (res.ok) {
+        const data = await res.json()
+        onProposalUpdate?.(data.proposal)
+      }
+    } catch {
+      // Silently fail — UI stays unchanged
+    }
+  }
+
+  const handleReject = async (proposalId: string, note: string) => {
+    try {
+      const res = await fetch(
+        `/api/plugins/calendar/sessions/${sessionId}/proposals/${proposalId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'rejected', rejectionNote: note || undefined }),
+        }
+      )
+      if (res.ok) {
+        const data = await res.json()
+        onProposalUpdate?.(data.proposal)
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
+  const handleConfirm = async () => {
+    setConfirming(true)
+    try {
+      const res = await fetch(`/api/plugins/calendar/sessions/${sessionId}/confirm`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setConfirmed(true)
+        onConfirm?.(data)
+      }
+    } catch {
+      // Error handling
+    } finally {
+      setConfirming(false)
+    }
+  }
+
+  if (proposals.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center text-center text-muted-foreground py-16 px-4">
+        <p className="text-sm">No proposals yet</p>
+        <p className="text-xs mt-1">Send a message to start brainstorming</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between p-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Review</h3>
+          <Badge variant="outline" className="text-[10px]">
+            {approvedCount}/{proposals.length} approved
+          </Badge>
+        </div>
+      </div>
+
+      {/* Proposals grouped by date */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-4">
+        {proposalsByDate.map(([date, dateProposals]) => (
+          <div key={date}>
+            <h4 className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              {date}
+            </h4>
+            <div className="space-y-2">
+              {dateProposals.map((proposal) => (
+                <div
+                  key={proposal.id}
+                  onClick={() => onScrollToMessage?.(proposal.messageId)}
+                  className="cursor-pointer"
+                >
+                  <ProposalCard
+                    proposal={proposal}
+                    onApprove={!isCompleted && !confirmed ? handleApprove : undefined}
+                    onReject={!isCompleted && !confirmed ? handleReject : undefined}
+                    onEdit={!isCompleted && !confirmed ? () => onEditProposal?.(proposal.id) : undefined}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Confirm button */}
+      {!isCompleted && !confirmed && (
+        <div className="p-3 border-t border-border">
+          <Button
+            onClick={handleConfirm}
+            disabled={approvedCount === 0 || confirming}
+            className="w-full"
+          >
+            {confirming ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Confirming...
+              </>
+            ) : (
+              <>
+                <CheckCircle className="w-4 h-4 mr-2" />
+                Confirm Plan ({approvedCount} items)
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+
+      {(isCompleted || confirmed) && (
+        <div className="p-3 border-t border-border text-center">
+          <Badge className="bg-emerald-500/20 text-emerald-400">
+            Plan confirmed — {approvedCount} items created
+          </Badge>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/calendar/components/session-chat.tsx
+++ b/plugins/calendar/components/session-chat.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Badge } from '@/components/ui/badge'
+import { AgentAvatar } from '@/components/agent-avatar'
+import { Send, Loader2 } from 'lucide-react'
+import type { ContentAgent, PlanningSession, ProposedItem, SessionMessage } from '../types'
+import { AGENT_INFO } from '../types'
+
+interface Props {
+  sessionId: string
+  agentId: ContentAgent
+  initialMessages?: SessionMessage[]
+  initialProposals?: ProposedItem[]
+  isCompleted?: boolean
+  onProposalsReceived?: (proposals: ProposedItem[]) => void
+}
+
+interface StreamingState {
+  isStreaming: boolean
+  streamedText: string
+}
+
+export function SessionChat({
+  sessionId,
+  agentId,
+  initialMessages = [],
+  initialProposals = [],
+  isCompleted = false,
+  onProposalsReceived,
+}: Props) {
+  const [messages, setMessages] = useState<SessionMessage[]>(initialMessages)
+  const [input, setInput] = useState('')
+  const [streaming, setStreaming] = useState<StreamingState>({
+    isStreaming: false,
+    streamedText: '',
+  })
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const agentInfo = AGENT_INFO[agentId]
+
+  useEffect(() => {
+    if (scrollRef.current && typeof scrollRef.current.scrollIntoView === 'function') {
+      scrollRef.current.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [messages, streaming.streamedText])
+
+  // Update messages when session is reloaded externally
+  useEffect(() => {
+    setMessages(initialMessages)
+  }, [initialMessages])
+
+  const handleSend = useCallback(async () => {
+    if (!input.trim() || streaming.isStreaming || isCompleted) return
+
+    const userMessage = input.trim()
+    setInput('')
+
+    // Optimistic: add user message
+    const tempUserMsg: SessionMessage = {
+      id: `temp-${Date.now()}`,
+      role: 'user',
+      content: userMessage,
+      timestamp: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, tempUserMsg])
+    setStreaming({ isStreaming: true, streamedText: '' })
+
+    try {
+      const res = await fetch(`/api/plugins/calendar/sessions/${sessionId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: userMessage }),
+      })
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ error: 'Unknown error' }))
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `error-${Date.now()}`,
+            role: 'assistant',
+            content: `Error: ${error.error || 'Something went wrong'}`,
+            timestamp: new Date().toISOString(),
+          },
+        ])
+        setStreaming({ isStreaming: false, streamedText: '' })
+        return
+      }
+
+      // Parse SSE stream
+      const reader = res.body?.getReader()
+      if (!reader) {
+        throw new Error('No response body')
+      }
+
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let accumulated = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+
+        let currentEvent = ''
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            currentEvent = line.slice(7).trim()
+          } else if (line.startsWith('data: ') && currentEvent) {
+            try {
+              const data = JSON.parse(line.slice(6))
+
+              switch (currentEvent) {
+                case 'token':
+                  accumulated += data.text || ''
+                  setStreaming({ isStreaming: true, streamedText: accumulated })
+                  break
+
+                case 'proposals':
+                  if (data.proposals && onProposalsReceived) {
+                    onProposalsReceived(data.proposals)
+                  }
+                  break
+
+                case 'done': {
+                  // Replace streamed text with final message
+                  const finalMsg: SessionMessage = {
+                    id: data.messageId || `msg-${Date.now()}`,
+                    role: 'assistant',
+                    content: data.content || accumulated,
+                    timestamp: new Date().toISOString(),
+                  }
+                  setMessages((prev) => [...prev, finalMsg])
+                  setStreaming({ isStreaming: false, streamedText: '' })
+                  break
+                }
+
+                case 'error':
+                  setMessages((prev) => [
+                    ...prev,
+                    {
+                      id: `error-${Date.now()}`,
+                      role: 'assistant',
+                      content: `Error: ${data.message || 'Unknown error'}`,
+                      timestamp: new Date().toISOString(),
+                    },
+                  ])
+                  setStreaming({ isStreaming: false, streamedText: '' })
+                  break
+              }
+            } catch {
+              // Skip malformed data
+            }
+            currentEvent = ''
+          }
+        }
+      }
+
+      // If stream ended without a done event
+      if (streaming.isStreaming) {
+        setStreaming({ isStreaming: false, streamedText: '' })
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `error-${Date.now()}`,
+          role: 'assistant',
+          content: 'Connection error. Please try again.',
+          timestamp: new Date().toISOString(),
+        },
+      ])
+      setStreaming({ isStreaming: false, streamedText: '' })
+    }
+  }, [input, streaming.isStreaming, isCompleted, sessionId, onProposalsReceived])
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Chat history */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.length === 0 && !streaming.isStreaming && (
+          <div className="flex flex-col items-center justify-center text-center text-muted-foreground py-16 gap-4">
+            <AgentAvatar agentId={agentId} size="xl" />
+            <div className="space-y-2 max-w-md">
+              <p className="text-base font-medium text-foreground">
+                Plan with {agentInfo.name}
+              </p>
+              <p className="text-sm">
+                Describe the content you want to plan — topics, themes, dates, or audience.
+                {' '}{agentInfo.name} will suggest calendar items you can review and approve.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div key={msg.id}>
+            {msg.role === 'user' ? (
+              <div className="flex justify-end">
+                <div className="rounded-lg p-2.5 bg-accent/20 max-w-[75%]">
+                  <p className="text-xs whitespace-pre-wrap">{msg.content}</p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-start gap-2.5">
+                <AgentAvatar agentId={agentId} size="sm" className="mt-0.5 shrink-0" />
+                <div className="rounded-lg p-2.5 bg-surface max-w-[85%]">
+                  <p className="text-xs whitespace-pre-wrap">{msg.content}</p>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Streaming message bubble */}
+        {streaming.isStreaming && streaming.streamedText && (
+          <div className="flex items-start gap-2.5">
+            <AgentAvatar agentId={agentId} size="sm" className="mt-0.5 shrink-0" />
+            <div className="rounded-lg p-2.5 bg-surface max-w-[85%]">
+              <p className="text-xs whitespace-pre-wrap">{streaming.streamedText}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Thinking indicator when streaming but no text yet */}
+        {streaming.isStreaming && !streaming.streamedText && (
+          <div className="flex items-center gap-2.5 text-muted-foreground">
+            <AgentAvatar agentId={agentId} size="sm" className="shrink-0" />
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            <span className="text-xs">{agentInfo.name} is thinking...</span>
+          </div>
+        )}
+
+        <div ref={scrollRef} />
+      </div>
+
+      {/* Input */}
+      {!isCompleted && (
+        <div className="p-4 border-t border-border">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              handleSend()
+            }}
+            className="flex gap-2 items-start"
+          >
+            <Textarea
+              value={input}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setInput(e.target.value)}
+              onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  handleSend()
+                }
+              }}
+              placeholder={`Ask ${agentInfo.name} for content ideas...`}
+              className="bg-surface min-h-[80px] resize-none"
+              disabled={streaming.isStreaming}
+            />
+            <Button type="submit" disabled={streaming.isStreaming || !input.trim()} className="shrink-0">
+              <Send className="w-4 h-4" />
+            </Button>
+          </form>
+        </div>
+      )}
+
+      {isCompleted && (
+        <div className="p-4 border-t border-border text-center">
+          <Badge variant="outline" className="text-muted-foreground">
+            Session completed — read-only
+          </Badge>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -19,9 +19,12 @@ import {
   updateSession as updateSessionFn,
   deleteSession as deleteSessionFn,
   appendMessage,
+  addProposals,
   updateProposal,
   confirmSession,
 } from './lib/sessions'
+import { buildMessages } from './lib/prompt-builder'
+import { streamChatCompletion, chatCompletion } from './lib/gateway'
 import { getContentDir } from '../../src/core/content-dir'
 import { createLogger } from '../../src/core/logger'
 
@@ -483,11 +486,11 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
       },
     })
 
-    // POST /sessions/:id/messages — send message (non-streaming for now)
+    // POST /sessions/:id/messages — send message with SSE streaming
     ctx.registerRoute({
       path: '/sessions/:id/messages',
       method: 'POST',
-      description: 'Send a message in a planning session',
+      description: 'Send a message in a planning session (SSE streaming)',
       handler: async (req: Request) => {
         const url = new URL(req.url)
         const body = await readBody<{ id?: string; message?: string }>(req)
@@ -502,17 +505,158 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
         // Append user message
         const userMsg = appendMessage(id, { role: 'user', content: body.message })
 
-        // For now, return a placeholder — streaming upgrade in PR 2
-        const assistantMsg = appendMessage(id, {
-          role: 'assistant',
-          content: 'Planning session message received. Streaming upgrade pending.',
+        // Build messages array with full session history
+        const messages = buildMessages(session, body.message)
+        const sessionKey = `session-${id}-${Date.now()}`
+
+        // Create a ReadableStream that pipes gateway SSE to the client
+        const stream = new ReadableStream({
+          async start(controller) {
+            const encoder = new TextEncoder()
+
+            function send(event: string, data: unknown): void {
+              controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`))
+            }
+
+            try {
+              let fullContent = ''
+
+              // Try streaming first, fall back to non-streaming
+              let useStreaming = true
+              let gwResponse: Response | null = null
+
+              try {
+                gwResponse = await streamChatCompletion({
+                  messages,
+                  agentId: session.agentId,
+                  sessionKey,
+                })
+
+                const contentType = gwResponse.headers.get('content-type') || ''
+                if (!contentType.includes('text/event-stream')) {
+                  // Gateway returned non-streaming response
+                  useStreaming = false
+                }
+              } catch (err) {
+                // Gateway doesn't support streaming — fall back
+                useStreaming = false
+                gwResponse = null
+              }
+
+              if (useStreaming && gwResponse?.body) {
+                // Stream gateway SSE chunks to client
+                const reader = gwResponse.body.getReader()
+                const decoder = new TextDecoder()
+                let buffer = ''
+
+                while (true) {
+                  const { done, value } = await reader.read()
+                  if (done) break
+
+                  buffer += decoder.decode(value, { stream: true })
+                  const lines = buffer.split('\n')
+                  buffer = lines.pop() || ''
+
+                  for (const line of lines) {
+                    if (!line.startsWith('data: ')) continue
+                    const data = line.slice(6).trim()
+                    if (data === '[DONE]') continue
+
+                    try {
+                      const parsed = JSON.parse(data)
+                      const token = parsed.choices?.[0]?.delta?.content
+                      if (token) {
+                        fullContent += token
+                        send('token', { text: token })
+                      }
+                    } catch {
+                      // Skip malformed chunks
+                    }
+                  }
+                }
+              } else {
+                // Non-streaming fallback
+                try {
+                  fullContent = await chatCompletion({
+                    messages,
+                    agentId: session.agentId,
+                    sessionKey,
+                  })
+                  // Send entire response as a single token event
+                  send('token', { text: fullContent })
+                } catch (err) {
+                  send('error', { message: err instanceof Error ? err.message : String(err) })
+                  controller.close()
+                  return
+                }
+              }
+
+              // Parse proposals from response
+              let proposals: Array<{
+                title: string
+                scheduledAt: string
+                contentType: string
+                tone: string
+                brief: string
+                channels?: string[]
+              }> = []
+
+              const jsonMatch = fullContent.match(/```json\s*([\s\S]*?)\s*```/)
+              if (jsonMatch) {
+                try {
+                  proposals = JSON.parse(jsonMatch[1])
+                } catch { /* ignore malformed JSON */ }
+              }
+
+              // Save assistant message
+              const cleanContent = fullContent.replace(/```json[\s\S]*?```/g, '').trim()
+              const assistantMsg = appendMessage(id, {
+                role: 'assistant',
+                content: cleanContent,
+              }, proposals.length > 0 ? [] : undefined)
+
+              // Save proposals if found
+              if (proposals.length > 0) {
+                const savedProposals = addProposals(id, assistantMsg.id, proposals)
+                // Update message with proposal IDs
+                const reloadedSession = loadSession(id)
+                if (reloadedSession) {
+                  const msg = reloadedSession.messages.find(m => m.id === assistantMsg.id)
+                  if (msg) {
+                    msg.proposalIds = savedProposals.map(p => p.id)
+                    const { writeFileSync } = await import('fs')
+                    const { join } = await import('path')
+                    writeFileSync(
+                      join(getContentDir(), 'calendar', 'sessions', `${id}.json`),
+                      JSON.stringify(reloadedSession, null, 2)
+                    )
+                  }
+                }
+
+                send('proposals', {
+                  proposals: savedProposals,
+                  messageId: assistantMsg.id,
+                })
+              }
+
+              send('done', {
+                messageId: assistantMsg.id,
+                content: cleanContent,
+              })
+            } catch (err) {
+              send('error', { message: err instanceof Error ? err.message : String(err) })
+            } finally {
+              controller.close()
+            }
+          },
         })
 
-        return json({
-          ok: true,
-          response: assistantMsg.content,
-          suggestions: [],
-          messageId: assistantMsg.id,
+        return new Response(stream, {
+          headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+          },
         })
       },
     })
@@ -834,17 +978,48 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
           content: params.message as string,
         })
 
-        // Non-streaming placeholder — streaming upgrade in PR 2
+        // Non-streaming: call gateway synchronously and collect full response
+        const messages = buildMessages(session, params.message as string)
+        const sessionKey = `session-${params.sessionId}-${Date.now()}`
+
+        let fullContent: string
+        try {
+          fullContent = await chatCompletion({
+            messages,
+            agentId: session.agentId,
+            sessionKey,
+          })
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : String(err) }
+        }
+
+        // Parse proposals
+        let proposals: Array<{
+          title: string; scheduledAt: string; contentType: string;
+          tone: string; brief: string; channels?: string[]
+        }> = []
+        const jsonMatch = fullContent.match(/```json\s*([\s\S]*?)\s*```/)
+        if (jsonMatch) {
+          try { proposals = JSON.parse(jsonMatch[1]) } catch { /* ignore */ }
+        }
+
+        const cleanContent = fullContent.replace(/```json[\s\S]*?```/g, '').trim()
         const assistantMsg = appendMessage(params.sessionId as string, {
           role: 'assistant',
-          content: 'Planning session message received. Streaming upgrade pending.',
+          content: cleanContent,
         })
+
+        let savedProposals: unknown[] = []
+        if (proposals.length > 0) {
+          savedProposals = addProposals(params.sessionId as string, assistantMsg.id, proposals)
+        }
 
         return {
           ok: true,
-          response: assistantMsg.content,
+          response: cleanContent,
           messageId: assistantMsg.id,
           userMessageId: userMsg.id,
+          proposals: savedProposals,
         }
       },
     })

--- a/plugins/calendar/lib/gateway.ts
+++ b/plugins/calendar/lib/gateway.ts
@@ -1,0 +1,90 @@
+/**
+ * Gateway client for the calendar plugin.
+ * Handles authentication and request construction for the OpenClaw gateway.
+ */
+import { readFileSync, existsSync } from 'fs'
+
+const GATEWAY_URL = 'http://localhost:18789'
+
+/**
+ * Resolve the gateway auth token from OpenClaw config.
+ */
+export async function getGatewayToken(): Promise<string> {
+  const { getOpenClawPath } = await import('@bakin/core/openclaw-home')
+  const configPath = getOpenClawPath('openclaw.json')
+  if (!existsSync(configPath)) throw new Error('Gateway config not found')
+  const cfg = JSON.parse(readFileSync(configPath, 'utf-8'))
+  const token = cfg?.gateway?.auth?.token
+  if (!token) throw new Error('Gateway token not found')
+  return token
+}
+
+/**
+ * Send a streaming chat completion request to the OpenClaw gateway.
+ * Returns the raw fetch Response with SSE body for streaming.
+ */
+export async function streamChatCompletion(opts: {
+  messages: Array<{ role: string; content: string }>
+  agentId: string
+  sessionKey: string
+}): Promise<Response> {
+  const token = await getGatewayToken()
+
+  const response = await fetch(`${GATEWAY_URL}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+      'x-openclaw-session-key': opts.sessionKey,
+      'x-openclaw-agent-id': opts.agentId,
+    },
+    body: JSON.stringify({
+      model: 'openclaw:main',
+      max_tokens: 2048,
+      stream: true,
+      messages: opts.messages,
+    }),
+  })
+
+  if (!response.ok) {
+    const err = await response.text()
+    throw new Error(`Gateway error (${response.status}): ${err}`)
+  }
+
+  return response
+}
+
+/**
+ * Send a non-streaming chat completion request.
+ * Returns the assistant's response content.
+ */
+export async function chatCompletion(opts: {
+  messages: Array<{ role: string; content: string }>
+  agentId: string
+  sessionKey: string
+}): Promise<string> {
+  const token = await getGatewayToken()
+
+  const response = await fetch(`${GATEWAY_URL}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+      'x-openclaw-session-key': opts.sessionKey,
+      'x-openclaw-agent-id': opts.agentId,
+    },
+    body: JSON.stringify({
+      model: 'openclaw:main',
+      max_tokens: 2048,
+      messages: opts.messages,
+    }),
+  })
+
+  if (!response.ok) {
+    const err = await response.text()
+    throw new Error(`Gateway error (${response.status}): ${err}`)
+  }
+
+  const data = await response.json()
+  return data.choices?.[0]?.message?.content || ''
+}

--- a/plugins/calendar/lib/prompt-builder.ts
+++ b/plugins/calendar/lib/prompt-builder.ts
@@ -1,0 +1,143 @@
+/**
+ * Prompt builder for planning sessions.
+ *
+ * Builds a system prompt with agent persona, planning instructions,
+ * and current plan state. Returns a proper messages array (not a
+ * flattened string) so the LLM can track conversational context.
+ */
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { getContentDir } from '../../../src/core/content-dir'
+import type { PlanningSession } from '../types'
+import { AGENT_INFO } from '../types'
+
+const AGENT_NAMES: Record<string, string> = {
+  basil: 'Basil',
+  scout: 'Scout (Connor)',
+  nemo: 'Nemo (Yuki)',
+  zen: 'Zen (Marcus)',
+}
+
+/**
+ * Load the agent persona markdown file, or return empty string if missing.
+ */
+function loadPersona(agentId: string, contentDir?: string): string {
+  const dir = contentDir || getContentDir()
+  const personaPath = join(dir, 'team', 'personas', `${agentId}.md`)
+  if (!existsSync(personaPath)) return ''
+  try {
+    return readFileSync(personaPath, 'utf-8')
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Build a summary of the current plan state (proposals with statuses).
+ */
+function buildPlanState(session: PlanningSession): string {
+  if (session.proposals.length === 0) return ''
+
+  const lines = ['## Current Plan State\n']
+  for (const p of session.proposals) {
+    const statusTag = p.status.toUpperCase()
+    let line = `- [${statusTag}] (${p.id}) "${p.title}" — ${p.scheduledAt}, ${p.contentType}, ${p.tone}`
+    if (p.rejectionNote) {
+      line += `\n  Rejection note: ${p.rejectionNote}`
+    }
+    lines.push(line)
+  }
+
+  const approved = session.proposals.filter(p => p.status === 'approved').length
+  const rejected = session.proposals.filter(p => p.status === 'rejected').length
+  const proposed = session.proposals.filter(p => p.status === 'proposed').length
+  lines.push(`\nSummary: ${approved} approved, ${rejected} rejected, ${proposed} pending`)
+
+  return lines.join('\n')
+}
+
+/**
+ * Build the system prompt for a planning session.
+ */
+export function buildSystemPrompt(agentId: string, session: PlanningSession, contentDir?: string): string {
+  const agentName = AGENT_NAMES[agentId] || agentId
+  const agentInfo = AGENT_INFO[agentId as keyof typeof AGENT_INFO]
+  const persona = loadPersona(agentId, contentDir)
+
+  const sections: string[] = []
+
+  // Identity
+  sections.push(`You are ${agentName}, a BetterFit content creator.`)
+
+  // Persona
+  if (persona) {
+    sections.push(`## Your Persona\n\n${persona}`)
+  }
+
+  // Planning instructions
+  sections.push(`## Planning Instructions
+
+You are in a planning session with Mark. Your job is to brainstorm and refine content calendar ideas collaboratively.
+
+When suggesting content, provide items in this JSON format within a fenced code block:
+\`\`\`json
+[{ "title": "...", "scheduledAt": "...", "contentType": "...", "tone": "...", "brief": "...", "channels": ["discord"] }]
+\`\`\`
+
+Fields:
+- title: catchy post title in your authentic voice
+- scheduledAt: ISO datetime (timezone: America/Denver, MDT = UTC-6)
+- contentType: one of recipe, tip, motivation, workout, outdoor, video, image-post
+- tone: one of energetic, calm, educational, humorous, inspiring, conversational
+- brief: 2-3 sentence description of what to create when this executes
+- channels: optional array of distribution channels (default: ["discord"])
+
+## Revision Rules
+
+When Mark rejects or asks you to revise specific items:
+- Only regenerate the items he asked about — do NOT regenerate the entire plan
+- Reference proposals by their title or content, not by ID
+- Keep approved items unchanged unless explicitly asked to modify them
+- If a rejection note is provided, address the feedback specifically`)
+
+  // Plan state
+  const planState = buildPlanState(session)
+  if (planState) {
+    sections.push(planState)
+  }
+
+  return sections.join('\n\n---\n\n')
+}
+
+/**
+ * Build a proper messages array from session history plus a new user message.
+ * Returns an array suitable for the OpenAI-compatible chat completions API.
+ */
+export function buildMessages(
+  session: PlanningSession,
+  newMessage: string
+): Array<{ role: 'system' | 'user' | 'assistant'; content: string }> {
+  const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = []
+
+  // System prompt
+  messages.push({
+    role: 'system',
+    content: buildSystemPrompt(session.agentId, session),
+  })
+
+  // Session history
+  for (const msg of session.messages) {
+    messages.push({
+      role: msg.role,
+      content: msg.content,
+    })
+  }
+
+  // New user message
+  messages.push({
+    role: 'user',
+    content: newMessage,
+  })
+
+  return messages
+}

--- a/tests/dev/mock-gateway-streaming.test.ts
+++ b/tests/dev/mock-gateway-streaming.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Mock gateway streaming tests — verifies SSE streaming behavior
+ * when stream: true is passed in the request body.
+ */
+import { describe, it, expect } from 'vitest'
+import { handleGatewayRequest } from '../../dev/imitation-crab/gateway'
+
+describe('mock gateway streaming', () => {
+  it('returns stream marker when stream: true', async () => {
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'basil' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        stream: true,
+        messages: [{ role: 'user', content: 'Plan next week' }],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBe(true)
+    expect(body.content).toContain('mock:Basil')
+  })
+
+  it('returns standard response when stream is not set', async () => {
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'basil' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        messages: [{ role: 'user', content: 'Hello' }],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBeUndefined()
+    expect(body).toHaveProperty('choices')
+  })
+
+  it('returns standard response when stream: false', async () => {
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'basil' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        stream: false,
+        messages: [{ role: 'user', content: 'Hello' }],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBeUndefined()
+    expect(body).toHaveProperty('choices')
+  })
+
+  it('uses last message content for echo mode reply', async () => {
+    // Save and restore env
+    const original = process.env.OPENCLAW_MOCK_CHAT_MODE
+    process.env.OPENCLAW_MOCK_CHAT_MODE = 'echo'
+
+    // Need to re-import to pick up env change — but CHAT_MODE is read at module load.
+    // Instead, test that the content field is populated with something sensible.
+    const res = await handleGatewayRequest({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      headers: { 'x-openclaw-agent-id': 'scout' },
+      body: JSON.stringify({
+        model: 'openclaw',
+        stream: true,
+        messages: [
+          { role: 'system', content: 'You are Scout' },
+          { role: 'user', content: 'Plan outdoor content' },
+        ],
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = res.body as Record<string, unknown>
+    expect(body.__stream).toBe(true)
+    expect(typeof body.content).toBe('string')
+
+    process.env.OPENCLAW_MOCK_CHAT_MODE = original
+  })
+})

--- a/tests/plugins/calendar/planning-layout.test.tsx
+++ b/tests/plugins/calendar/planning-layout.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Mock all child components to isolate layout testing
+vi.mock('../../../plugins/calendar/components/session-chat', () => ({
+  SessionChat: ({ sessionId, agentId, isCompleted }: Record<string, unknown>) => (
+    <div data-testid="session-chat" data-session={sessionId} data-agent={agentId} data-completed={String(isCompleted)}>
+      Chat
+    </div>
+  ),
+}))
+
+vi.mock('../../../plugins/calendar/components/review-panel', () => ({
+  ReviewPanel: ({ sessionId, proposals }: Record<string, unknown>) => (
+    <div data-testid="review-panel" data-session={sessionId}>
+      Review ({(proposals as unknown[]).length} proposals)
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }: Record<string, unknown>) => (
+    <button onClick={onClick as () => void} {...props}>{children as React.ReactNode}</button>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: Record<string, unknown>) => <span>{children as React.ReactNode}</span>,
+}))
+
+vi.mock('@/components/agent-avatar', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span data-testid={`avatar-${agentId}`} />,
+}))
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => <span />,
+  PanelRight: () => <span />,
+  PanelRightClose: () => <span />,
+  Pencil: () => <span />,
+  Check: () => <span />,
+  X: () => <span />,
+}))
+
+import { PlanningLayout } from '../../../plugins/calendar/components/planning-layout'
+
+afterEach(() => cleanup())
+
+const mockSession = {
+  id: 's1',
+  agentId: 'basil',
+  title: 'Test Plan',
+  status: 'active',
+  createdAt: '2026-04-07T00:00:00Z',
+  updatedAt: '2026-04-07T00:00:00Z',
+  messages: [],
+  proposals: [
+    {
+      id: 'p1', messageId: 'm1', revision: 1, agentId: 'basil',
+      title: 'Monday Recipe', scheduledAt: '2026-04-13T10:00:00Z',
+      contentType: 'recipe', tone: 'energetic', brief: 'Test', status: 'proposed',
+    },
+  ],
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ session: mockSession }),
+  }) as unknown as typeof fetch
+})
+
+describe('PlanningLayout', () => {
+  it('renders session title and agent avatar after loading', async () => {
+    render(<PlanningLayout sessionId="s1" />)
+    await waitFor(() => {
+      expect(screen.getByText('Test Plan')).toBeDefined()
+    })
+    expect(screen.getByTestId('avatar-basil')).toBeDefined()
+  })
+
+  it('renders both chat and review panel', async () => {
+    render(<PlanningLayout sessionId="s1" />)
+    await waitFor(() => {
+      expect(screen.getByTestId('session-chat')).toBeDefined()
+    })
+    expect(screen.getByTestId('review-panel')).toBeDefined()
+  })
+
+  it('passes session data to chat component', async () => {
+    render(<PlanningLayout sessionId="s1" />)
+    await waitFor(() => {
+      const chat = screen.getByTestId('session-chat')
+      expect(chat.getAttribute('data-session')).toBe('s1')
+      expect(chat.getAttribute('data-agent')).toBe('basil')
+    })
+  })
+
+  it('passes proposals to review panel', async () => {
+    render(<PlanningLayout sessionId="s1" />)
+    await waitFor(() => {
+      expect(screen.getByText('Review (1 proposals)')).toBeDefined()
+    })
+  })
+})

--- a/tests/plugins/calendar/prompt-builder.test.ts
+++ b/tests/plugins/calendar/prompt-builder.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Prompt builder tests — verifies system prompt construction,
+ * persona loading, plan state inclusion, and messages array format.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-prompt-${Date.now()}`)
+})
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ calendar: testDir }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  }),
+}))
+
+import { buildSystemPrompt, buildMessages } from '../../../plugins/calendar/lib/prompt-builder'
+import type { PlanningSession } from '../../../plugins/calendar/types'
+
+function makeSession(overrides: Partial<PlanningSession> = {}): PlanningSession {
+  return {
+    id: 'sess-1',
+    agentId: 'basil',
+    title: 'Test Session',
+    status: 'active',
+    createdAt: '2026-04-07T00:00:00Z',
+    updatedAt: '2026-04-07T00:00:00Z',
+    messages: [],
+    proposals: [],
+    ...overrides,
+  }
+}
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('buildSystemPrompt', () => {
+  it('includes agent name and planning instructions', () => {
+    const prompt = buildSystemPrompt('basil', makeSession(), testDir)
+    expect(prompt).toContain('You are Basil')
+    expect(prompt).toContain('Planning Instructions')
+    expect(prompt).toContain('Revision Rules')
+  })
+
+  it('includes persona when file exists', () => {
+    const personaDir = join(testDir, 'team', 'personas')
+    mkdirSync(personaDir, { recursive: true })
+    writeFileSync(join(personaDir, 'basil.md'), '# Basil\nA chef who loves fresh ingredients.')
+
+    const prompt = buildSystemPrompt('basil', makeSession(), testDir)
+    expect(prompt).toContain('Your Persona')
+    expect(prompt).toContain('fresh ingredients')
+  })
+
+  it('omits persona section when file is missing', () => {
+    const prompt = buildSystemPrompt('scout', makeSession({ agentId: 'scout' }), testDir)
+    expect(prompt).not.toContain('Your Persona')
+    expect(prompt).toContain('Scout (Connor)')
+  })
+
+  it('includes plan state with proposal statuses', () => {
+    const session = makeSession({
+      proposals: [
+        {
+          id: 'p1', messageId: 'm1', revision: 1, agentId: 'basil',
+          title: 'Monday Recipe', scheduledAt: '2026-04-13T10:00:00Z',
+          contentType: 'recipe', tone: 'energetic', brief: 'Pasta',
+          status: 'approved',
+        },
+        {
+          id: 'p2', messageId: 'm1', revision: 1, agentId: 'basil',
+          title: 'Wednesday Tip', scheduledAt: '2026-04-15T10:00:00Z',
+          contentType: 'tip', tone: 'calm', brief: 'Knife care',
+          status: 'rejected', rejectionNote: 'Too similar to last week',
+        },
+      ],
+    })
+
+    const prompt = buildSystemPrompt('basil', session, testDir)
+    expect(prompt).toContain('Current Plan State')
+    expect(prompt).toContain('[APPROVED]')
+    expect(prompt).toContain('[REJECTED]')
+    expect(prompt).toContain('Monday Recipe')
+    expect(prompt).toContain('Too similar to last week')
+    expect(prompt).toContain('1 approved, 1 rejected, 0 pending')
+  })
+
+  it('omits plan state when no proposals exist', () => {
+    const prompt = buildSystemPrompt('basil', makeSession(), testDir)
+    expect(prompt).not.toContain('Current Plan State')
+  })
+
+  it('handles unknown agent gracefully', () => {
+    const prompt = buildSystemPrompt('unknown-agent', makeSession({ agentId: 'unknown-agent' }), testDir)
+    expect(prompt).toContain('You are unknown-agent')
+  })
+})
+
+describe('buildMessages', () => {
+  it('returns system + new user message for empty session', () => {
+    const messages = buildMessages(makeSession(), 'Plan next week')
+    expect(messages.length).toBe(2)
+    expect(messages[0].role).toBe('system')
+    expect(messages[1].role).toBe('user')
+    expect(messages[1].content).toBe('Plan next week')
+  })
+
+  it('includes session history as individual messages', () => {
+    const session = makeSession({
+      messages: [
+        { id: 'm1', role: 'user', content: 'Plan Monday', timestamp: '2026-04-07T01:00:00Z' },
+        { id: 'm2', role: 'assistant', content: 'Here are ideas...', timestamp: '2026-04-07T01:01:00Z' },
+      ],
+    })
+
+    const messages = buildMessages(session, 'Now plan Tuesday')
+    expect(messages.length).toBe(4) // system + 2 history + new user
+    expect(messages[0].role).toBe('system')
+    expect(messages[1].role).toBe('user')
+    expect(messages[1].content).toBe('Plan Monday')
+    expect(messages[2].role).toBe('assistant')
+    expect(messages[2].content).toBe('Here are ideas...')
+    expect(messages[3].role).toBe('user')
+    expect(messages[3].content).toBe('Now plan Tuesday')
+  })
+
+  it('includes plan state in system prompt when proposals exist', () => {
+    const session = makeSession({
+      proposals: [
+        {
+          id: 'p1', messageId: 'm1', revision: 1, agentId: 'basil',
+          title: 'Test Item', scheduledAt: '2026-04-13T10:00:00Z',
+          contentType: 'recipe', tone: 'energetic', brief: 'Test',
+          status: 'proposed',
+        },
+      ],
+    })
+
+    const messages = buildMessages(session, 'What do you think?')
+    expect(messages[0].content).toContain('Current Plan State')
+    expect(messages[0].content).toContain('Test Item')
+  })
+})

--- a/tests/plugins/calendar/proposal-card.test.tsx
+++ b/tests/plugins/calendar/proposal-card.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, title, disabled, ...props }: Record<string, unknown>) => (
+    <button onClick={onClick as () => void} title={title as string} disabled={disabled as boolean} {...props}>
+      {children as React.ReactNode}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: Record<string, unknown>) => (
+    <span data-testid="badge" {...props}>{children as React.ReactNode}</span>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: Record<string, unknown>) => <input data-testid="rejection-input" {...props} />,
+}))
+
+vi.mock('lucide-react', () => ({
+  Check: () => <span data-testid="check-icon" />,
+  X: () => <span data-testid="x-icon" />,
+  Pencil: () => <span data-testid="pencil-icon" />,
+}))
+
+import { ProposalCard } from '../../../plugins/calendar/components/proposal-card'
+import type { ProposedItem } from '../../../plugins/calendar/types'
+
+afterEach(() => cleanup())
+
+function makeProposal(overrides: Partial<ProposedItem> = {}): ProposedItem {
+  return {
+    id: 'p1',
+    messageId: 'm1',
+    revision: 1,
+    agentId: 'basil',
+    title: 'Monday Recipe',
+    scheduledAt: '2026-04-13T10:00:00Z',
+    contentType: 'recipe',
+    tone: 'energetic',
+    brief: 'A quick pasta dish for busy weeknights',
+    status: 'proposed',
+    ...overrides,
+  }
+}
+
+describe('ProposalCard', () => {
+  it('renders title, date, type, and tone', () => {
+    render(<ProposalCard proposal={makeProposal()} />)
+    expect(screen.getByText('Monday Recipe')).toBeDefined()
+    expect(screen.getByText('recipe')).toBeDefined()
+    expect(screen.getByText('energetic')).toBeDefined()
+    expect(screen.getByText(/busy weeknights/)).toBeDefined()
+  })
+
+  it('shows Proposed status chip for proposed items', () => {
+    render(<ProposalCard proposal={makeProposal()} />)
+    expect(screen.getByText('Proposed')).toBeDefined()
+  })
+
+  it('shows Approved status chip for approved items', () => {
+    render(<ProposalCard proposal={makeProposal({ status: 'approved' })} />)
+    expect(screen.getByText('Approved')).toBeDefined()
+  })
+
+  it('shows Rejected status chip with rejection note', () => {
+    render(
+      <ProposalCard
+        proposal={makeProposal({
+          status: 'rejected',
+          rejectionNote: 'Too similar to last week',
+        })}
+      />
+    )
+    expect(screen.getByText('Rejected')).toBeDefined()
+    expect(screen.getByText(/Too similar to last week/)).toBeDefined()
+  })
+
+  it('shows approve/reject/edit buttons for proposed items', () => {
+    const onApprove = vi.fn()
+    const onReject = vi.fn()
+    const onEdit = vi.fn()
+    render(
+      <ProposalCard
+        proposal={makeProposal()}
+        onApprove={onApprove}
+        onReject={onReject}
+        onEdit={onEdit}
+      />
+    )
+    expect(screen.getByTitle('Approve')).toBeDefined()
+    expect(screen.getByTitle('Reject')).toBeDefined()
+    expect(screen.getByTitle('Edit')).toBeDefined()
+  })
+
+  it('hides action buttons for approved items', () => {
+    render(<ProposalCard proposal={makeProposal({ status: 'approved' })} />)
+    expect(screen.queryByTitle('Approve')).toBeNull()
+    expect(screen.queryByTitle('Reject')).toBeNull()
+  })
+
+  it('calls onApprove with proposal id', () => {
+    const onApprove = vi.fn()
+    render(<ProposalCard proposal={makeProposal()} onApprove={onApprove} />)
+    fireEvent.click(screen.getByTitle('Approve'))
+    expect(onApprove).toHaveBeenCalledWith('p1')
+  })
+
+  it('shows rejection note input on reject click', () => {
+    const onReject = vi.fn()
+    render(<ProposalCard proposal={makeProposal()} onReject={onReject} />)
+    fireEvent.click(screen.getByTitle('Reject'))
+    expect(screen.getByTestId('rejection-input')).toBeDefined()
+  })
+
+  it('renders channel badges', () => {
+    render(
+      <ProposalCard
+        proposal={makeProposal({ channels: ['discord', 'instagram'] })}
+      />
+    )
+    expect(screen.getByText('discord')).toBeDefined()
+    expect(screen.getByText('instagram')).toBeDefined()
+  })
+
+  it('shows Revised status chip for revised items with action buttons', () => {
+    render(<ProposalCard proposal={makeProposal({ status: 'revised' })} onApprove={vi.fn()} />)
+    expect(screen.getByText('Revised')).toBeDefined()
+    expect(screen.getByTitle('Approve')).toBeDefined()
+  })
+})

--- a/tests/plugins/calendar/review-panel.test.tsx
+++ b/tests/plugins/calendar/review-panel.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, disabled, onClick, ...props }: Record<string, unknown>) => (
+    <button disabled={disabled as boolean} onClick={onClick as () => void} {...props}>
+      {children as React.ReactNode}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: Record<string, unknown>) => (
+    <span data-testid="badge" {...props}>{children as React.ReactNode}</span>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+}))
+
+vi.mock('lucide-react', () => ({
+  Check: () => <span />,
+  X: () => <span />,
+  Pencil: () => <span />,
+  CheckCircle: () => <span data-testid="check-circle" />,
+  Loader2: () => <span data-testid="loader" />,
+}))
+
+vi.mock('@/components/agent-avatar', () => ({
+  AgentAvatar: () => <span />,
+}))
+
+import { ReviewPanel } from '../../../plugins/calendar/components/review-panel'
+import type { ProposedItem } from '../../../plugins/calendar/types'
+
+afterEach(() => cleanup())
+
+function makeProposal(overrides: Partial<ProposedItem> = {}): ProposedItem {
+  return {
+    id: 'p1',
+    messageId: 'm1',
+    revision: 1,
+    agentId: 'basil',
+    title: 'Test Item',
+    scheduledAt: '2026-04-13T10:00:00Z',
+    contentType: 'recipe',
+    tone: 'energetic',
+    brief: 'Test brief',
+    status: 'proposed',
+    ...overrides,
+  }
+}
+
+describe('ReviewPanel', () => {
+  it('shows empty state when no proposals', () => {
+    render(<ReviewPanel sessionId="s1" proposals={[]} />)
+    expect(screen.getByText('No proposals yet')).toBeDefined()
+  })
+
+  it('renders proposals grouped by date', () => {
+    const proposals = [
+      makeProposal({ id: 'p1', scheduledAt: '2026-04-13T10:00:00Z', title: 'Monday Item' }),
+      makeProposal({ id: 'p2', scheduledAt: '2026-04-15T10:00:00Z', title: 'Wednesday Item' }),
+    ]
+    render(<ReviewPanel sessionId="s1" proposals={proposals} />)
+    expect(screen.getByText('Monday Item')).toBeDefined()
+    expect(screen.getByText('Wednesday Item')).toBeDefined()
+  })
+
+  it('shows approved count in header', () => {
+    const proposals = [
+      makeProposal({ id: 'p1', status: 'approved' }),
+      makeProposal({ id: 'p2', status: 'proposed' }),
+      makeProposal({ id: 'p3', status: 'rejected' }),
+    ]
+    render(<ReviewPanel sessionId="s1" proposals={proposals} />)
+    expect(screen.getByText('1/3 approved')).toBeDefined()
+  })
+
+  it('shows confirm button with approved count', () => {
+    const proposals = [
+      makeProposal({ id: 'p1', status: 'approved' }),
+      makeProposal({ id: 'p2', status: 'approved' }),
+    ]
+    render(<ReviewPanel sessionId="s1" proposals={proposals} />)
+    expect(screen.getByText('Confirm Plan (2 items)')).toBeDefined()
+  })
+
+  it('disables confirm button when no approvals', () => {
+    const proposals = [makeProposal({ status: 'proposed' })]
+    render(<ReviewPanel sessionId="s1" proposals={proposals} />)
+    const confirmBtn = screen.getByText('Confirm Plan (0 items)').closest('button')
+    expect(confirmBtn?.disabled).toBe(true)
+  })
+
+  it('shows confirmed badge for completed sessions', () => {
+    const proposals = [makeProposal({ status: 'approved' })]
+    render(<ReviewPanel sessionId="s1" proposals={proposals} isCompleted={true} />)
+    expect(screen.getByText(/Plan confirmed/)).toBeDefined()
+  })
+
+  it('hides confirm button for completed sessions', () => {
+    const proposals = [makeProposal({ status: 'approved' })]
+    render(<ReviewPanel sessionId="s1" proposals={proposals} isCompleted={true} />)
+    expect(screen.queryByText(/Confirm Plan/)).toBeNull()
+  })
+})

--- a/tests/plugins/calendar/session-chat.test.tsx
+++ b/tests/plugins/calendar/session-chat.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Mock UI components
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, disabled, ...props }: { children: React.ReactNode; disabled?: boolean; [k: string]: unknown }) => (
+    <button disabled={disabled} {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: Record<string, unknown>) => <textarea data-testid="chat-input" {...props} />,
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: { children: React.ReactNode; [k: string]: unknown }) => (
+    <span data-testid="badge" {...props}>{children}</span>
+  ),
+}))
+
+vi.mock('@/components/agent-avatar', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span data-testid={`avatar-${agentId}`} />,
+}))
+
+vi.mock('lucide-react', () => ({
+  Send: () => <span data-testid="send-icon" />,
+  Loader2: () => <span data-testid="loader-icon" />,
+}))
+
+import { SessionChat } from '../../../plugins/calendar/components/session-chat'
+import type { SessionMessage, ProposedItem } from '../../../plugins/calendar/types'
+
+afterEach(() => cleanup())
+
+describe('SessionChat', () => {
+  it('renders empty state with agent name', () => {
+    render(<SessionChat sessionId="s1" agentId="basil" />)
+    expect(screen.getByText('Plan with Basil')).toBeDefined()
+    expect(screen.getByTestId('avatar-basil')).toBeDefined()
+  })
+
+  it('renders initial messages', () => {
+    const messages: SessionMessage[] = [
+      { id: 'm1', role: 'user', content: 'Plan next week', timestamp: '2026-04-07T00:00:00Z' },
+      { id: 'm2', role: 'assistant', content: 'Here are some ideas!', timestamp: '2026-04-07T00:01:00Z' },
+    ]
+
+    render(<SessionChat sessionId="s1" agentId="scout" initialMessages={messages} />)
+    expect(screen.getByText('Plan next week')).toBeDefined()
+    expect(screen.getByText('Here are some ideas!')).toBeDefined()
+  })
+
+  it('shows read-only badge for completed sessions', () => {
+    render(<SessionChat sessionId="s1" agentId="basil" isCompleted={true} />)
+    expect(screen.getByText('Session completed — read-only')).toBeDefined()
+    // Input should not be present
+    expect(screen.queryByTestId('chat-input')).toBeNull()
+  })
+
+  it('shows input area for active sessions', () => {
+    render(<SessionChat sessionId="s1" agentId="zen" />)
+    const input = screen.getByTestId('chat-input')
+    expect(input).toBeDefined()
+    expect(input.getAttribute('placeholder')).toContain('Zen')
+  })
+
+  it('disables input when no text entered', () => {
+    render(<SessionChat sessionId="s1" agentId="nemo" />)
+    const buttons = screen.getAllByRole('button')
+    const sendButton = buttons.find(b => b.querySelector('[data-testid="send-icon"]'))
+    expect(sendButton?.hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/tests/plugins/calendar/sessions.test.ts
+++ b/tests/plugins/calendar/sessions.test.ts
@@ -36,6 +36,43 @@ vi.mock('../../../src/core/audit', () => ({
   appendAudit: vi.fn(),
 }))
 
+vi.mock('../../../src/core/watcher', () => ({
+  watchDir: vi.fn(),
+}))
+
+// Mock the gateway module so tests don't hit a real gateway
+vi.mock('../../../plugins/calendar/lib/gateway', () => ({
+  streamChatCompletion: vi.fn(async () => {
+    // Return a mock Response with SSE body
+    const encoder = new TextEncoder()
+    const body = new ReadableStream({
+      start(controller) {
+        const reply = '[mock:Basil] Acknowledged. Task understood — working on it.'
+        const words = reply.split(/(\s+)/)
+        for (const word of words) {
+          if (!word) continue
+          const chunk = JSON.stringify({ choices: [{ delta: { content: word } }] })
+          controller.enqueue(encoder.encode(`data: ${chunk}\n\n`))
+        }
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    return new Response(body, {
+      headers: { 'Content-Type': 'text/event-stream' },
+    })
+  }),
+  chatCompletion: vi.fn(async () =>
+    '[mock:Basil] Acknowledged. Task understood — working on it.'
+  ),
+}))
+
+// Mock openclaw-home to prevent filesystem access
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawPath: vi.fn(() => '/tmp/mock-openclaw.json'),
+  getOpenClawHome: vi.fn(() => '/tmp/mock-openclaw'),
+}))
+
 // Suppress SSE broadcast
 ;(globalThis as any).__bakinBroadcast = vi.fn()
 
@@ -317,7 +354,7 @@ describe('Session routes', () => {
       expect(findRoute(plugin.routes, 'POST', '/sessions/:id/messages')).toBeDefined()
     })
 
-    it('appends user and assistant messages', async () => {
+    it('returns SSE stream and persists messages', async () => {
       const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
       const { body: createBody } = await callRoute(postRoute, plugin.ctx, {
         body: { agentId: 'basil' },
@@ -325,13 +362,20 @@ describe('Session routes', () => {
       const sessionId = (createBody.session as Record<string, unknown>).id as string
 
       const msgRoute = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
-      const { status, body } = await callRoute(msgRoute, plugin.ctx, {
-        searchParams: { id: sessionId },
+      const { makeRequest } = await import('../test-helpers')
+      const req = makeRequest('/sessions/:id/messages', {
+        method: 'POST',
         body: { message: 'Plan some content for next week' },
+        searchParams: { id: sessionId },
       })
-      expect(status).toBe(200)
-      expect(body.ok).toBe(true)
-      expect(body.messageId).toBeDefined()
+      const res = await msgRoute.handler(req, plugin.ctx)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('text/event-stream')
+
+      // Consume the SSE stream
+      const text = await res.text()
+      expect(text).toContain('event: token')
+      expect(text).toContain('event: done')
 
       // Verify messages were stored
       const getRoute = findRoute(plugin.routes, 'GET', '/sessions/:id')!

--- a/tests/plugins/calendar/streaming.test.ts
+++ b/tests/plugins/calendar/streaming.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Streaming endpoint tests — verifies SSE format, token events,
+ * proposal extraction, session persistence, and error handling.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-streaming-${Date.now()}`)
+})
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ calendar: testDir }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/core/audit', () => ({ appendAudit: vi.fn() }))
+vi.mock('../../../src/core/watcher', () => ({ watchDir: vi.fn() }))
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawPath: vi.fn(() => '/tmp/mock-openclaw.json'),
+  getOpenClawHome: vi.fn(() => '/tmp/mock-openclaw'),
+}))
+
+// Mock gateway — default returns canned text, tests can override
+const mockStreamChatCompletion = vi.fn()
+const mockChatCompletion = vi.fn()
+
+vi.mock('../../../plugins/calendar/lib/gateway', () => ({
+  streamChatCompletion: (...args: unknown[]) => mockStreamChatCompletion(...args),
+  chatCompletion: (...args: unknown[]) => mockChatCompletion(...args),
+}))
+
+;(globalThis as any).__bakinBroadcast = vi.fn()
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import calendarPlugin from '../../../plugins/calendar/index'
+import {
+  activatePlugin,
+  findRoute,
+  findTool,
+  callRoute,
+  makeRequest,
+} from '../test-helpers'
+import type { ActivatedPlugin } from '../test-helpers'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSSEResponse(content: string): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream({
+    start(controller) {
+      const words = content.split(/(\s+)/)
+      for (const word of words) {
+        if (!word) continue
+        const chunk = JSON.stringify({ choices: [{ delta: { content: word } }] })
+        controller.enqueue(encoder.encode(`data: ${chunk}\n\n`))
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(body, { headers: { 'Content-Type': 'text/event-stream' } })
+}
+
+function parseSSEEvents(text: string): Array<{ event: string; data: Record<string, unknown> }> {
+  const events: Array<{ event: string; data: Record<string, unknown> }> = []
+  const lines = text.split('\n')
+  let currentEvent = ''
+  for (const line of lines) {
+    if (line.startsWith('event: ')) {
+      currentEvent = line.slice(7).trim()
+    } else if (line.startsWith('data: ') && currentEvent) {
+      try {
+        events.push({ event: currentEvent, data: JSON.parse(line.slice(6)) })
+      } catch { /* skip */ }
+      currentEvent = ''
+    }
+  }
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let plugin: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  plugin = await activatePlugin(calendarPlugin, testDir)
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  const sessionsDir = join(testDir, 'calendar', 'sessions')
+  if (existsSync(sessionsDir)) rmSync(sessionsDir, { recursive: true, force: true })
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  vi.clearAllMocks()
+})
+
+async function createTestSession(agentId = 'basil'): Promise<string> {
+  const postRoute = findRoute(plugin.routes, 'POST', '/sessions')!
+  const { body } = await callRoute(postRoute, plugin.ctx, {
+    body: { agentId },
+  })
+  return (body.session as Record<string, unknown>).id as string
+}
+
+async function sendMessage(sessionId: string, message: string): Promise<Response> {
+  const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+  const req = makeRequest('/sessions/:id/messages', {
+    method: 'POST',
+    body: { message },
+    searchParams: { id: sessionId },
+  })
+  return route.handler(req, plugin.ctx)
+}
+
+// ===========================================================================
+// TESTS
+// ===========================================================================
+
+describe('Streaming endpoint', () => {
+  it('returns text/event-stream content type', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(makeSSEResponse('Hello world'))
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan next week')
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+  })
+
+  it('streams token events from gateway SSE', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse('Here are some ideas for next week.')
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan next week')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const tokenEvents = events.filter(e => e.event === 'token')
+    expect(tokenEvents.length).toBeGreaterThan(0)
+    // Reassemble tokens
+    const fullText = tokenEvents.map(e => e.data.text).join('')
+    expect(fullText).toContain('Here')
+    expect(fullText).toContain('ideas')
+  })
+
+  it('sends done event after stream completes', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse('All done.')
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'quick')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const doneEvents = events.filter(e => e.event === 'done')
+    expect(doneEvents.length).toBe(1)
+    expect(doneEvents[0].data.messageId).toBeDefined()
+    expect(doneEvents[0].data.content).toContain('All done')
+  })
+
+  it('extracts proposals from JSON block and sends proposals event', async () => {
+    const responseWithProposals = `Great ideas for next week!
+
+\`\`\`json
+[{"title":"Monday Recipe","scheduledAt":"2026-04-13T10:00:00Z","contentType":"recipe","tone":"energetic","brief":"A quick pasta dish"}]
+\`\`\``
+
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithProposals)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan next week')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const proposalEvents = events.filter(e => e.event === 'proposals')
+    expect(proposalEvents.length).toBe(1)
+    const proposals = proposalEvents[0].data.proposals as Array<Record<string, unknown>>
+    expect(proposals.length).toBe(1)
+    expect(proposals[0].title).toBe('Monday Recipe')
+    expect(proposals[0].status).toBe('proposed')
+  })
+
+  it('persists user and assistant messages to session file', async () => {
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse('Sounds good, let me think...')
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan content for Monday')
+    await res.text() // Must consume stream to trigger side effects
+
+    // Read session file directly
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    expect(existsSync(sessionPath)).toBe(true)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    expect(session.messages.length).toBe(2)
+    expect(session.messages[0].role).toBe('user')
+    expect(session.messages[0].content).toBe('Plan content for Monday')
+    expect(session.messages[1].role).toBe('assistant')
+  })
+
+  it('persists proposals to session file', async () => {
+    const responseWithProposals = `Ideas:\n\`\`\`json\n[{"title":"Test","scheduledAt":"2026-04-13T10:00:00Z","contentType":"tip","tone":"calm","brief":"A tip"}]\n\`\`\``
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithProposals)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Suggest something')
+    await res.text() // Consume stream
+
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    expect(session.proposals.length).toBe(1)
+    expect(session.proposals[0].title).toBe('Test')
+    expect(session.proposals[0].agentId).toBe('basil')
+  })
+
+  it('links proposals to their message via proposalIds', async () => {
+    const responseWithProposals = `Here:\n\`\`\`json\n[{"title":"Linked","scheduledAt":"2026-04-13T10:00:00Z","contentType":"tip","tone":"calm","brief":"A tip"}]\n\`\`\``
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithProposals)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Ideas')
+    await res.text() // Consume stream
+
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    const assistantMsg = session.messages.find((m: Record<string, unknown>) => m.role === 'assistant')
+    expect(assistantMsg.proposalIds).toBeDefined()
+    expect(assistantMsg.proposalIds.length).toBe(1)
+    expect(assistantMsg.proposalIds[0]).toBe(session.proposals[0].id)
+  })
+
+  it('falls back to non-streaming when gateway throws', async () => {
+    mockStreamChatCompletion.mockRejectedValueOnce(new Error('Stream not supported'))
+    mockChatCompletion.mockResolvedValueOnce('Fallback response here.')
+
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const tokenEvents = events.filter(e => e.event === 'token')
+    expect(tokenEvents.length).toBe(1) // Single token with full content
+    expect(tokenEvents[0].data.text).toBe('Fallback response here.')
+
+    const doneEvents = events.filter(e => e.event === 'done')
+    expect(doneEvents.length).toBe(1)
+  })
+
+  it('sends error event when both streaming and fallback fail', async () => {
+    mockStreamChatCompletion.mockRejectedValueOnce(new Error('Stream failed'))
+    mockChatCompletion.mockRejectedValueOnce(new Error('Fallback also failed'))
+
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan')
+    const text = await res.text()
+    const events = parseSSEEvents(text)
+
+    const errorEvents = events.filter(e => e.event === 'error')
+    expect(errorEvents.length).toBe(1)
+    expect(errorEvents[0].data.message).toContain('Fallback also failed')
+  })
+
+  it('returns JSON 400 for missing params (before stream starts)', async () => {
+    const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+    const { status, body } = await callRoute(route, plugin.ctx, {
+      searchParams: { id: 'some-id' },
+      body: {},
+    })
+    expect(status).toBe(400)
+    expect(body.error).toContain('message required')
+  })
+
+  it('returns JSON 404 for nonexistent session', async () => {
+    const route = findRoute(plugin.routes, 'POST', '/sessions/:id/messages')!
+    const { status } = await callRoute(route, plugin.ctx, {
+      searchParams: { id: 'nonexistent' },
+      body: { message: 'hello' },
+    })
+    expect(status).toBe(404)
+  })
+
+  it('strips JSON block from stored assistant message content', async () => {
+    const responseWithJson = `Great plan!\n\`\`\`json\n[{"title":"X","scheduledAt":"2026-04-13T10:00:00Z","contentType":"tip","tone":"calm","brief":"Y"}]\n\`\`\``
+    mockStreamChatCompletion.mockResolvedValueOnce(
+      makeSSEResponse(responseWithJson)
+    )
+    const sessionId = await createTestSession()
+    const res = await sendMessage(sessionId, 'Plan')
+    await res.text() // Consume stream
+
+    const sessionPath = join(testDir, 'calendar', 'sessions', `${sessionId}.json`)
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'))
+    const assistantMsg = session.messages.find((m: Record<string, unknown>) => m.role === 'assistant')
+    expect(assistantMsg.content).not.toContain('```json')
+    expect(assistantMsg.content).toContain('Great plan!')
+  })
+})
+
+describe('Session message exec tool (non-streaming)', () => {
+  it('calls gateway non-streaming and returns response', async () => {
+    mockChatCompletion.mockResolvedValueOnce('Here are my ideas for you.')
+
+    const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+    const created = await createTool.handler({ agentId: 'basil' }, 'test')
+    const sessionId = (created.session as Record<string, unknown>).id as string
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_message')!
+    const result = await tool.handler({ sessionId, message: 'Plan next week' }, 'test')
+
+    expect(result.ok).toBe(true)
+    expect(result.response).toBe('Here are my ideas for you.')
+    expect(result.messageId).toBeDefined()
+    expect(mockChatCompletion).toHaveBeenCalled()
+  })
+
+  it('returns error when gateway fails', async () => {
+    mockChatCompletion.mockRejectedValueOnce(new Error('Gateway down'))
+
+    const createTool = findTool(plugin.execTools, 'bakin_exec_calendar_session_create')!
+    const created = await createTool.handler({ agentId: 'basil' }, 'test')
+    const sessionId = (created.session as Record<string, unknown>).id as string
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_session_message')!
+    const result = await tool.handler({ sessionId, message: 'Plan' }, 'test')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('Gateway down')
+  })
+})


### PR DESCRIPTION
## Summary
- Add `ProposalCard` component with status chips (proposed/approved/rejected/revised), action buttons, inline rejection note, channel badges
- Add `ReviewPanel` with date-grouped proposals, approve/reject API calls, confirm plan button, read-only completed state
- Add `PlanningLayout` split view: chat (60%) + review panel (40%), editable title, agent avatar, toggle panel visibility
- 21 new component tests, 170 total passing

## Components
| Component | Purpose |
|-----------|---------|
| `ProposalCard` | Individual proposal with status, actions, rejection note |
| `ReviewPanel` | Grouped proposals list + confirm button |
| `PlanningLayout` | Split view wiring chat + review |

## Test plan
- [x] Proposal card: all 4 statuses render correctly, action buttons show/hide, approve callback, reject input, channel badges (10 tests)
- [x] Review panel: empty state, date grouping, approved count, confirm button enable/disable, completed state (7 tests)
- [x] Planning layout: session loading, title/avatar render, data passing to child components (4 tests)
- [x] `tsc --noEmit` clean, 170 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)