### PR TITLE
feat(calendar): add manual editing for proposals and items (PR 4)

### DIFF
--- a/plugins/calendar/components/item-detail-drawer.tsx
+++ b/plugins/calendar/components/item-detail-drawer.tsx
@@ -50,6 +50,9 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
   const [brief, setBrief] = useState('')
   const [saving, setSaving] = useState(false)
   const [dirty, setDirty] = useState(false)
+  const [draftCaption, setDraftCaption] = useState('')
+  const [draftImagePrompt, setDraftImagePrompt] = useState('')
+  const [draftVideoPrompt, setDraftVideoPrompt] = useState('')
 
   // Detail state
   const [rejectionNote, setRejectionNote] = useState('')
@@ -70,6 +73,9 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
       setTone(item.tone)
       setScheduledAt(item.scheduledAt.slice(0, 16))
       setBrief(item.brief || '')
+      setDraftCaption(item.draft?.caption || '')
+      setDraftImagePrompt(item.draft?.imagePrompt || '')
+      setDraftVideoPrompt(item.draft?.videoPrompt || '')
     } else if (isCreate) {
       // New item
       setTitle('')
@@ -106,17 +112,27 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
           }),
         })
       } else if (item) {
+        const updates: Record<string, unknown> = {
+          title: title.trim(),
+          agent,
+          contentType,
+          tone,
+          scheduledAt: new Date(scheduledAt).toISOString(),
+          brief: brief.trim(),
+        }
+        // Include draft fields if item has a draft or any draft field is filled
+        if (item.draft || draftCaption || draftImagePrompt || draftVideoPrompt) {
+          updates.draft = {
+            ...item.draft,
+            caption: draftCaption,
+            imagePrompt: draftImagePrompt,
+            videoPrompt: draftVideoPrompt,
+          }
+        }
         await fetch(`/api/plugins/calendar/${item.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: title.trim(),
-            agent,
-            contentType,
-            tone,
-            scheduledAt: new Date(scheduledAt).toISOString(),
-            brief: brief.trim(),
-          }),
+          body: JSON.stringify(updates),
         })
       }
       onUpdated()
@@ -251,6 +267,53 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
               className="bg-surface min-h-[100px]"
             />
           </div>
+
+          {/* Draft fields — only show when item has draft content or is being edited */}
+          {item?.draft !== undefined && (
+            <>
+              <Separator />
+              <h3 className="text-sm font-medium">Draft Content</h3>
+
+              <div>
+                <label className="text-sm text-muted-foreground mb-1 block">Caption</label>
+                <Textarea
+                  value={draftCaption}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => { setDraftCaption(e.target.value); setDirty(true) }}
+                  placeholder="Post caption..."
+                  className="bg-surface min-h-[80px]"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm text-muted-foreground mb-1 block">Image Prompt</label>
+                <Textarea
+                  value={draftImagePrompt}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => { setDraftImagePrompt(e.target.value); setDirty(true) }}
+                  placeholder="Image generation prompt..."
+                  className="bg-surface min-h-[60px]"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm text-muted-foreground mb-1 block">Video Prompt</label>
+                <Textarea
+                  value={draftVideoPrompt}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => { setDraftVideoPrompt(e.target.value); setDirty(true) }}
+                  placeholder="Video generation prompt..."
+                  className="bg-surface min-h-[60px]"
+                />
+              </div>
+
+              {item?.draft?.agentNotes && (
+                <div>
+                  <label className="text-sm text-muted-foreground mb-1 block">Agent Notes (read-only)</label>
+                  <p className="text-sm text-muted-foreground bg-surface rounded-lg p-3 italic">
+                    {item.draft.agentNotes}
+                  </p>
+                </div>
+              )}
+            </>
+          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button type="button" variant="outline" onClick={isCreate ? onClose : onCancelEdit}>

--- a/plugins/calendar/components/proposal-card.tsx
+++ b/plugins/calendar/components/proposal-card.tsx
@@ -19,11 +19,14 @@ interface Props {
   onApprove?: (id: string) => void
   onReject?: (id: string, note: string) => void
   onEdit?: (id: string) => void
+  onTitleChange?: (id: string, title: string) => void
 }
 
-export function ProposalCard({ proposal, onApprove, onReject, onEdit }: Props) {
+export function ProposalCard({ proposal, onApprove, onReject, onEdit, onTitleChange }: Props) {
   const [showRejectInput, setShowRejectInput] = useState(false)
   const [rejectionNote, setRejectionNote] = useState('')
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(proposal.title)
 
   const statusStyle = STATUS_STYLES[proposal.status]
   const canAct = proposal.status === 'proposed' || proposal.status === 'revised'
@@ -47,7 +50,46 @@ export function ProposalCard({ proposal, onApprove, onReject, onEdit }: Props) {
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
-          <h4 className="font-medium text-xs truncate">{proposal.title}</h4>
+          {editingTitle && canAct && onTitleChange ? (
+            <Input
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              className="h-6 text-xs font-medium"
+              data-testid="title-input"
+              autoFocus
+              onBlur={() => {
+                if (titleDraft.trim() && titleDraft !== proposal.title) {
+                  onTitleChange(proposal.id, titleDraft.trim())
+                }
+                setEditingTitle(false)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  if (titleDraft.trim() && titleDraft !== proposal.title) {
+                    onTitleChange(proposal.id, titleDraft.trim())
+                  }
+                  setEditingTitle(false)
+                }
+                if (e.key === 'Escape') {
+                  setTitleDraft(proposal.title)
+                  setEditingTitle(false)
+                }
+              }}
+            />
+          ) : (
+            <h4
+              className={`font-medium text-xs truncate ${canAct && onTitleChange ? 'cursor-pointer hover:underline' : ''}`}
+              onClick={() => {
+                if (canAct && onTitleChange) {
+                  setTitleDraft(proposal.title)
+                  setEditingTitle(true)
+                }
+              }}
+              data-testid="proposal-title"
+            >
+              {proposal.title}
+            </h4>
+          )}
           <div className="flex items-center gap-2 mt-1 flex-wrap">
             <span className="text-[11px] text-muted-foreground">
               {new Date(proposal.scheduledAt).toLocaleDateString('en-US', {

--- a/plugins/calendar/components/review-panel.tsx
+++ b/plugins/calendar/components/review-panel.tsx
@@ -3,6 +3,10 @@
 import { useState, useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { BakinDrawer } from '@/components/bakin-drawer'
 import { CheckCircle, Loader2 } from 'lucide-react'
 import { ProposalCard } from './proposal-card'
 import type { ProposedItem } from '../types'
@@ -28,6 +32,14 @@ export function ReviewPanel({
 }: Props) {
   const [confirming, setConfirming] = useState(false)
   const [confirmed, setConfirmed] = useState(false)
+  const [editingProposal, setEditingProposal] = useState<ProposedItem | null>(null)
+  const [editForm, setEditForm] = useState({
+    title: '',
+    brief: '',
+    scheduledAt: '',
+    contentType: '',
+    tone: '',
+  })
 
   const approvedCount = useMemo(
     () => proposals.filter((p) => p.status === 'approved').length,
@@ -109,6 +121,59 @@ export function ReviewPanel({
     }
   }
 
+  const handleOpenEdit = (proposalId: string) => {
+    const p = proposals.find((pr) => pr.id === proposalId)
+    if (!p) return
+    setEditingProposal(p)
+    setEditForm({
+      title: p.title,
+      brief: p.brief,
+      scheduledAt: p.scheduledAt.slice(0, 16), // trim to datetime-local format
+      contentType: p.contentType,
+      tone: p.tone,
+    })
+  }
+
+  const handleEditSave = async () => {
+    if (!editingProposal) return
+    try {
+      const res = await fetch(
+        `/api/plugins/calendar/sessions/${sessionId}/proposals/${editingProposal.id}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(editForm),
+        }
+      )
+      if (res.ok) {
+        const data = await res.json()
+        onProposalUpdate?.(data.proposal)
+        setEditingProposal(null)
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
+  const handleTitleChange = async (proposalId: string, title: string) => {
+    try {
+      const res = await fetch(
+        `/api/plugins/calendar/sessions/${sessionId}/proposals/${proposalId}`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title }),
+        }
+      )
+      if (res.ok) {
+        const data = await res.json()
+        onProposalUpdate?.(data.proposal)
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
   if (proposals.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center text-center text-muted-foreground py-16 px-4">
@@ -148,7 +213,8 @@ export function ReviewPanel({
                     proposal={proposal}
                     onApprove={!isCompleted && !confirmed ? handleApprove : undefined}
                     onReject={!isCompleted && !confirmed ? handleReject : undefined}
-                    onEdit={!isCompleted && !confirmed ? () => onEditProposal?.(proposal.id) : undefined}
+                    onEdit={!isCompleted && !confirmed ? () => handleOpenEdit(proposal.id) : undefined}
+                    onTitleChange={!isCompleted && !confirmed ? handleTitleChange : undefined}
                   />
                 </div>
               ))}
@@ -187,6 +253,79 @@ export function ReviewPanel({
           </Badge>
         </div>
       )}
+
+      {/* Edit drawer */}
+      <BakinDrawer
+        open={!!editingProposal}
+        onOpenChange={(open) => { if (!open) setEditingProposal(null) }}
+        title="Edit Proposal"
+        defaultWidth={480}
+        storageKey="proposal-edit"
+      >
+        {editingProposal && (
+          <div className="space-y-4 p-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-title">Title</Label>
+              <Input
+                id="edit-title"
+                value={editForm.title}
+                onChange={(e) => setEditForm((f) => ({ ...f, title: e.target.value }))}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-brief">Brief</Label>
+              <Textarea
+                id="edit-brief"
+                value={editForm.brief}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setEditForm((f) => ({ ...f, brief: e.target.value }))
+                }
+                className="min-h-[100px]"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="edit-scheduledAt">Scheduled At</Label>
+              <Input
+                id="edit-scheduledAt"
+                type="datetime-local"
+                value={editForm.scheduledAt}
+                onChange={(e) => setEditForm((f) => ({ ...f, scheduledAt: e.target.value }))}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-contentType">Content Type</Label>
+                <Input
+                  id="edit-contentType"
+                  value={editForm.contentType}
+                  onChange={(e) => setEditForm((f) => ({ ...f, contentType: e.target.value }))}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="edit-tone">Tone</Label>
+                <Input
+                  id="edit-tone"
+                  value={editForm.tone}
+                  onChange={(e) => setEditForm((f) => ({ ...f, tone: e.target.value }))}
+                />
+              </div>
+            </div>
+
+            <div className="flex gap-2 pt-2">
+              <Button onClick={handleEditSave} className="flex-1">
+                Save Changes
+              </Button>
+              <Button variant="outline" onClick={() => setEditingProposal(null)}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </BakinDrawer>
     </div>
   )
 }

--- a/tests/plugins/calendar/manual-editing.test.tsx
+++ b/tests/plugins/calendar/manual-editing.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...props }: Record<string, unknown>) => (
+    <button onClick={onClick as () => void} disabled={disabled as boolean} {...props}>
+      {children as React.ReactNode}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: Record<string, unknown>) => (
+    <span data-testid="badge" {...props}>{children as React.ReactNode}</span>
+  ),
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: ({ value, onChange, onBlur, onKeyDown, ...props }: Record<string, unknown>) => (
+    <input
+      value={value as string}
+      onChange={onChange as () => void}
+      onBlur={onBlur as () => void}
+      onKeyDown={onKeyDown as () => void}
+      {...props}
+    />
+  ),
+}))
+
+vi.mock('lucide-react', () => ({
+  Check: () => <span data-testid="check-icon" />,
+  X: () => <span data-testid="x-icon" />,
+  Pencil: () => <span data-testid="pencil-icon" />,
+}))
+
+import { ProposalCard } from '../../../plugins/calendar/components/proposal-card'
+import type { ProposedItem } from '../../../plugins/calendar/types'
+
+afterEach(() => cleanup())
+
+function makeProposal(overrides: Partial<ProposedItem> = {}): ProposedItem {
+  return {
+    id: 'p1',
+    messageId: 'm1',
+    revision: 1,
+    agentId: 'basil',
+    title: 'Monday Recipe',
+    scheduledAt: '2026-04-13T10:00:00Z',
+    contentType: 'recipe',
+    tone: 'energetic',
+    brief: 'A quick pasta dish',
+    status: 'proposed',
+    ...overrides,
+  }
+}
+
+describe('Inline title editing', () => {
+  it('shows title as text by default', () => {
+    render(
+      <ProposalCard
+        proposal={makeProposal()}
+        onTitleChange={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('proposal-title')).toBeDefined()
+    expect(screen.getByText('Monday Recipe')).toBeDefined()
+    expect(screen.queryByTestId('title-input')).toBeNull()
+  })
+
+  it('switches to input on title click', () => {
+    render(
+      <ProposalCard
+        proposal={makeProposal()}
+        onTitleChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByTestId('proposal-title'))
+    expect(screen.getByTestId('title-input')).toBeDefined()
+  })
+
+  it('calls onTitleChange on Enter', () => {
+    const onTitleChange = vi.fn()
+    render(
+      <ProposalCard
+        proposal={makeProposal()}
+        onTitleChange={onTitleChange}
+      />
+    )
+    fireEvent.click(screen.getByTestId('proposal-title'))
+    const input = screen.getByTestId('title-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Updated Title' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onTitleChange).toHaveBeenCalledWith('p1', 'Updated Title')
+  })
+
+  it('cancels on Escape without calling callback', () => {
+    const onTitleChange = vi.fn()
+    render(
+      <ProposalCard
+        proposal={makeProposal()}
+        onTitleChange={onTitleChange}
+      />
+    )
+    fireEvent.click(screen.getByTestId('proposal-title'))
+    const input = screen.getByTestId('title-input')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onTitleChange).not.toHaveBeenCalled()
+    // Should be back to text
+    expect(screen.getByTestId('proposal-title')).toBeDefined()
+  })
+
+  it('does not show editable title for approved proposals', () => {
+    render(
+      <ProposalCard
+        proposal={makeProposal({ status: 'approved' })}
+        onTitleChange={vi.fn()}
+      />
+    )
+    const title = screen.getByTestId('proposal-title')
+    fireEvent.click(title)
+    // Should NOT switch to input since canAct is false for approved
+    expect(screen.queryByTestId('title-input')).toBeNull()
+  })
+
+  it('does not show editable title without onTitleChange', () => {
+    render(<ProposalCard proposal={makeProposal()} />)
+    const title = screen.getByTestId('proposal-title')
+    fireEvent.click(title)
+    expect(screen.queryByTestId('title-input')).toBeNull()
+  })
+})

--- a/tests/plugins/calendar/review-panel.test.tsx
+++ b/tests/plugins/calendar/review-panel.test.tsx
@@ -29,6 +29,20 @@ vi.mock('lucide-react', () => ({
   Loader2: () => <span data-testid="loader" />,
 }))
 
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: Record<string, unknown>) => <textarea {...props} />,
+}))
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: Record<string, unknown>) => <label {...props}>{children as React.ReactNode}</label>,
+}))
+
+vi.mock('@/components/bakin-drawer', () => ({
+  BakinDrawer: ({ children, open }: { children: React.ReactNode; open: boolean }) => (
+    open ? <div data-testid="edit-drawer">{children}</div> : null
+  ),
+}))
+
 vi.mock('@/components/agent-avatar', () => ({
   AgentAvatar: () => <span />,
 }))


### PR DESCRIPTION
## Summary
- Add inline title editing on proposal cards (click title → input, Enter saves, Escape cancels)
- Add edit drawer for proposals in review panel (BakinDrawer with title, brief, scheduledAt, contentType, tone)
- Add draft field editing to calendar item drawer (caption, imagePrompt, videoPrompt editable; agentNotes read-only)
- 6 new tests, 176 total passing

## Test plan
- [x] Inline title: shows text by default, input on click, Enter saves, Escape cancels, no edit for approved, no edit without callback
- [x] Review panel mocks updated for BakinDrawer/Label/Textarea
- [x] `tsc --noEmit` clean, 176 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)