### PR TITLE
feat(calendar): streaming chat, review panel, manual editing, configurable channels

### DIFF
--- a/plugins/calendar/components/content-calendar.tsx
+++ b/plugins/calendar/components/content-calendar.tsx
@@ -22,7 +22,7 @@ import { AgentAvatar } from '@/components/agent-avatar'
 import { useQueryState, useQueryArrayState } from '@/hooks/use-query-state'
 import type { CalendarItem, ContentAgent } from '../types'
 import { AGENT_INFO } from '../types'
-import { CONTENT_AGENTS, STATUS_BADGE, CONTENT_TYPE_LABELS } from '../constants'
+import { CONTENT_AGENTS, STATUS_BADGE, CONTENT_TYPE_LABELS, CHANNEL_LABELS } from '../constants'
 import { ItemDetailDrawer } from './item-detail-drawer'
 import { CalendarWeek } from './calendar-week'
 import { BrainstormPanel } from './brainstorm-panel'
@@ -51,6 +51,7 @@ const STATUS_OPTIONS = [
 ]
 
 const TYPE_OPTIONS = Object.entries(CONTENT_TYPE_LABELS).map(([value, label]) => ({ value, label }))
+const CHANNEL_OPTIONS = Object.entries(CHANNEL_LABELS).map(([value, label]) => ({ value, label }))
 
 type ViewMode = 'month' | 'week' | 'list' | 'brainstorm'
 
@@ -110,6 +111,7 @@ export function ContentCalendar() {
   const [agentFilter, setAgentFilter] = useQueryState('agent', 'all')
   const [statusFilter, setStatusFilter] = useQueryArrayState('status')
   const [typeFilter, setTypeFilter] = useQueryArrayState('type')
+  const [channelFilter, setChannelFilter] = useQueryArrayState('channel')
   const [search, setSearch] = useQueryState('q', '')
   const [itemIdParam, setItemIdParam, pushItemId] = useQueryState('itemId', '')
   const [mode, setMode, pushMode] = useQueryState('mode', '')
@@ -161,6 +163,10 @@ export function ContentCalendar() {
     if (agentFilter !== 'all' && i.agent !== agentFilter) return false
     if (statusFilter.length > 0 && !statusFilter.includes(i.status)) return false
     if (typeFilter.length > 0 && !typeFilter.includes(i.contentType)) return false
+    if (channelFilter.length > 0) {
+      const itemChannels = i.channels || (i.channel ? [i.channel] : [])
+      if (!channelFilter.some(ch => itemChannels.includes(ch))) return false
+    }
     if (search) {
       const q = search.toLowerCase()
       if (
@@ -528,6 +534,12 @@ export function ContentCalendar() {
             options={TYPE_OPTIONS}
             selected={typeFilter}
             onChange={setTypeFilter}
+          />
+          <FacetFilter
+            label="Channel"
+            options={CHANNEL_OPTIONS}
+            selected={channelFilter}
+            onChange={setChannelFilter}
           />
 
           {/* Date navigation — far right */}

--- a/plugins/calendar/components/item-detail-drawer.tsx
+++ b/plugins/calendar/components/item-detail-drawer.tsx
@@ -24,9 +24,9 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
-import type { CalendarItem, ContentAgent, ContentType, ContentTone } from '../types'
+import type { CalendarItem, ContentAgent, ContentChannel, ContentType, ContentTone } from '../types'
 import { AGENT_INFO, DISCORD_GENERAL } from '../types'
-import { CONTENT_AGENTS, CONTENT_TYPE_LABELS, TONE_LABELS, STATUS_BADGE } from '../constants'
+import { CONTENT_AGENTS, CONTENT_TYPE_LABELS, TONE_LABELS, STATUS_BADGE, CHANNEL_LABELS, CHANNEL_INITIALS } from '../constants'
 
 interface Props {
   item: CalendarItem | null
@@ -50,6 +50,7 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
   const [brief, setBrief] = useState('')
   const [saving, setSaving] = useState(false)
   const [dirty, setDirty] = useState(false)
+  const [channels, setChannels] = useState<string[]>(['discord'])
   const [draftCaption, setDraftCaption] = useState('')
   const [draftImagePrompt, setDraftImagePrompt] = useState('')
   const [draftVideoPrompt, setDraftVideoPrompt] = useState('')
@@ -73,6 +74,7 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
       setTone(item.tone)
       setScheduledAt(item.scheduledAt.slice(0, 16))
       setBrief(item.brief || '')
+      setChannels(item.channels || (item.channel ? [item.channel] : ['discord']))
       setDraftCaption(item.draft?.caption || '')
       setDraftImagePrompt(item.draft?.imagePrompt || '')
       setDraftVideoPrompt(item.draft?.videoPrompt || '')
@@ -84,6 +86,7 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
       setTone('conversational')
       setScheduledAt(defaultDate || new Date().toISOString().slice(0, 16))
       setBrief('')
+      setChannels(['discord'])
     }
     setRejectionNote('')
     setShowRejectForm(false)
@@ -106,7 +109,8 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
             tone,
             scheduledAt: new Date(scheduledAt).toISOString(),
             brief: brief.trim(),
-            channel: 'discord',
+            channels,
+            channel: channels[0] || 'discord',
             channelTarget: DISCORD_GENERAL,
             status: 'draft',
           }),
@@ -117,6 +121,7 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
           agent,
           contentType,
           tone,
+          channels,
           scheduledAt: new Date(scheduledAt).toISOString(),
           brief: brief.trim(),
         }
@@ -255,6 +260,34 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
                 onChange={(e) => { setScheduledAt(e.target.value); setDirty(true) }}
                 className="bg-surface"
               />
+            </div>
+          </div>
+
+          <div>
+            <label className="text-sm text-muted-foreground mb-1 block">Channels</label>
+            <div className="flex flex-wrap gap-1.5 p-2 rounded-md border border-border bg-surface min-h-[38px]">
+              {(Object.entries(CHANNEL_LABELS) as [ContentChannel, string][]).map(([ch, label]) => {
+                const active = channels.includes(ch)
+                return (
+                  <button
+                    key={ch}
+                    type="button"
+                    onClick={() => {
+                      setChannels(prev =>
+                        active ? prev.filter(c => c !== ch) : [...prev, ch]
+                      )
+                      setDirty(true)
+                    }}
+                    className={`text-xs px-2 py-1 rounded-md border transition-colors ${
+                      active
+                        ? 'bg-accent text-accent-foreground border-accent'
+                        : 'bg-transparent text-muted-foreground border-border hover:border-foreground/30'
+                    }`}
+                  >
+                    {CHANNEL_INITIALS[ch]} {label}
+                  </button>
+                )
+              })}
             </div>
           </div>
 
@@ -458,22 +491,26 @@ export function ItemDetailDrawer({ item, open, editing, onClose, onCancelEdit, o
             <div className="text-[11px] text-muted-foreground uppercase tracking-wider">Tone</div>
             <div className="text-sm font-medium">{TONE_LABELS[item.tone]}</div>
           </div>
-          {item.channel && (
-            <div className="rounded-lg bg-surface p-3 space-y-1 col-span-2">
-              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground uppercase tracking-wider">
-                <MessageSquare className="size-3" />
-                Channel
-              </div>
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <span className="capitalize">{item.channel}</span>
-                {item.channelTarget && (
-                  <span className="text-xs text-muted-foreground flex items-center gap-0.5">
-                    <Hash className="size-3" />{item.channelTarget}
-                  </span>
-                )}
-              </div>
+          <div className="rounded-lg bg-surface p-3 space-y-1 col-span-2">
+            <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground uppercase tracking-wider">
+              <MessageSquare className="size-3" />
+              Channels
             </div>
-          )}
+            <div className="flex items-center gap-2 text-sm font-medium">
+              {(item.channels || (item.channel ? [item.channel] : [])).map(ch => (
+                <Badge key={ch} variant="outline" className="text-[10px]">
+                  {CHANNEL_INITIALS[ch as ContentChannel] || ch.slice(0, 2).toUpperCase()}
+                  {' '}
+                  {CHANNEL_LABELS[ch as ContentChannel] || ch}
+                </Badge>
+              ))}
+              {item.channelTarget && (
+                <span className="text-xs text-muted-foreground flex items-center gap-0.5">
+                  <Hash className="size-3" />{item.channelTarget}
+                </span>
+              )}
+            </div>
+          </div>
         </div>
 
         {/* Brief */}

--- a/plugins/calendar/constants.ts
+++ b/plugins/calendar/constants.ts
@@ -1,4 +1,4 @@
-import type { ContentAgent, ContentStatus, ContentType, ContentTone } from './types'
+import type { ContentAgent, ContentChannel, ContentStatus, ContentType, ContentTone } from './types'
 import { AGENT_INFO } from './types'
 
 export const CONTENT_AGENTS = Object.keys(AGENT_INFO) as ContentAgent[]
@@ -30,4 +30,22 @@ export const TONE_LABELS: Record<ContentTone, string> = {
   humorous: 'Humorous',
   inspiring: 'Inspiring',
   conversational: 'Conversational',
+}
+
+export const CHANNEL_LABELS: Record<ContentChannel, string> = {
+  discord: 'Discord',
+  instagram: 'Instagram',
+  email: 'Email',
+  twitter: 'Twitter',
+  youtube: 'YouTube',
+  tiktok: 'TikTok',
+}
+
+export const CHANNEL_INITIALS: Record<ContentChannel, string> = {
+  discord: 'DC',
+  instagram: 'IG',
+  email: 'EM',
+  twitter: 'TW',
+  youtube: 'YT',
+  tiktok: 'TK',
 }

--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -181,17 +181,18 @@ const calendarPlugin: BakinPlugin = {
         return json({ error: 'title, agent, and scheduledAt required' }, 400)
       }
 
+      const resolvedChannels = (channels as string[]) || (channel ? [channel as string] : ['discord'])
       const item = createItem({
         title: title as string,
         agent: (agent as string) as CalendarItem['agent'],
-        channel: ((channel as string) || 'discord') as CalendarItem['channel'],
+        channel: ((channel as string) || resolvedChannels[0] || 'discord') as CalendarItem['channel'],
         channelTarget: (channelTarget as string) || '1483917792745885768',
         contentType: ((contentType as string) || 'tip') as CalendarItem['contentType'],
         tone: ((tone as string) || 'conversational') as CalendarItem['tone'],
         scheduledAt: scheduledAt as string,
         brief: (brief as string) || '',
         status: ((status as string) as ContentStatus) || 'draft',
-        channels: (channels as string[]) || undefined,
+        channels: resolvedChannels,
       })
 
       ctx.activity.audit('item.created', agent as string, { itemId: item.id, title })

--- a/plugins/calendar/index.ts
+++ b/plugins/calendar/index.ts
@@ -133,6 +133,7 @@ const calendarPlugin: BakinPlugin = {
     fields: [
       { key: 'defaultView', type: 'select', label: 'Default view', description: 'Calendar view shown on page load', options: [{ value: 'month', label: 'Month' }, { value: 'week', label: 'Week' }, { value: 'list', label: 'List' }], default: 'month' },
       { key: 'showScheduleJobs', type: 'boolean', label: 'Show schedule jobs', description: 'Display recurring schedule jobs on the calendar', default: false },
+      { key: 'channels', type: 'string', label: 'Channels', description: 'Comma-separated list of available distribution channels (e.g., discord,instagram,email)', default: 'discord' },
     ],
   },
 
@@ -145,12 +146,16 @@ const calendarPlugin: BakinPlugin = {
   activate(ctx: PluginContext) {
     // ── API Routes ─────────────────────────────────────────────────────
 
-    // GET / — list items (optional ?month=YYYY-MM filter)
+    // GET / — list items (optional ?month=YYYY-MM&channel=discord filter)
     const listHandler = async (req: Request) => {
       const url = new URL(req.url)
       const month = url.searchParams.get('month')
+      const channel = url.searchParams.get('channel')
       let items = loadCalendarItems()
       if (month) items = items.filter(i => i.scheduledAt.startsWith(month))
+      if (channel) items = items.filter(i =>
+        (i.channels && i.channels.includes(channel)) || i.channel === channel
+      )
       items.sort((a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime())
       return json({ items })
     }
@@ -170,26 +175,27 @@ const calendarPlugin: BakinPlugin = {
     // POST / — create item
     const createHandler = async (req: Request) => {
       const body = await readBody<Record<string, unknown>>(req)
-      const { title, agent, channel, channelTarget, contentType, tone, scheduledAt, brief, status } = body as Record<string, string>
+      const { title, agent, channel, channelTarget, contentType, tone, scheduledAt, brief, status, channels } = body as Record<string, unknown>
 
       if (!title || !agent || !scheduledAt) {
         return json({ error: 'title, agent, and scheduledAt required' }, 400)
       }
 
       const item = createItem({
-        title,
-        agent: agent as CalendarItem['agent'],
-        channel: (channel || 'discord') as CalendarItem['channel'],
-        channelTarget: channelTarget || '1483917792745885768',
-        contentType: (contentType || 'tip') as CalendarItem['contentType'],
-        tone: (tone || 'conversational') as CalendarItem['tone'],
-        scheduledAt,
-        brief: brief || '',
-        status: (status as ContentStatus) || 'draft',
+        title: title as string,
+        agent: (agent as string) as CalendarItem['agent'],
+        channel: ((channel as string) || 'discord') as CalendarItem['channel'],
+        channelTarget: (channelTarget as string) || '1483917792745885768',
+        contentType: ((contentType as string) || 'tip') as CalendarItem['contentType'],
+        tone: ((tone as string) || 'conversational') as CalendarItem['tone'],
+        scheduledAt: scheduledAt as string,
+        brief: (brief as string) || '',
+        status: ((status as string) as ContentStatus) || 'draft',
+        channels: (channels as string[]) || undefined,
       })
 
-      ctx.activity.audit('item.created', agent, { itemId: item.id, title })
-      ctx.activity.log(agent, `Created calendar item "${title}"`)
+      ctx.activity.audit('item.created', agent as string, { itemId: item.id, title })
+      ctx.activity.log(agent as string, `Created calendar item "${title}"`)
       return json({ ok: true, item })
     }
     ctx.registerRoute({ path: '/', method: 'POST', description: 'Create calendar item', handler: createHandler })
@@ -719,12 +725,19 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
         month: z.string().optional().describe('Filter by month (YYYY-MM)'),
         status: z.string().optional().describe('Filter by status (draft, scheduled, review, published, etc.)'),
         agent: z.string().optional().describe('Filter by assigned agent'),
+        channel: z.string().optional().describe('Filter by channel (e.g. discord, instagram)'),
       },
       handler: async (params: Record<string, unknown>) => {
         let items = loadCalendarItems()
         if (params.month) items = items.filter(i => i.scheduledAt.startsWith(params.month as string))
         if (params.status) items = items.filter(i => i.status === params.status)
         if (params.agent) items = items.filter(i => i.agent === params.agent)
+        if (params.channel) {
+          const ch = params.channel as string
+          items = items.filter(i =>
+            (i.channels && i.channels.includes(ch)) || i.channel === ch
+          )
+        }
         items.sort((a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime())
         return {
           ok: true,
@@ -736,6 +749,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
             status: i.status,
             scheduledAt: i.scheduledAt,
             channel: i.channel,
+            channels: i.channels,
             contentType: i.contentType,
           })),
         }
@@ -764,6 +778,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
         agent: z.string().describe('Assigned agent (required)'),
         scheduledAt: z.string().describe('ISO datetime for scheduling (required)'),
         channel: z.string().optional().describe('Channel (default: discord)'),
+        channels: z.array(z.string()).optional().describe('Distribution channels (e.g. ["discord", "instagram"])'),
         channelTarget: z.string().optional().describe('Channel target ID'),
         contentType: z.string().optional().describe('Content type (recipe, tip, motivation, etc.)'),
         tone: z.string().optional().describe('Content tone (energetic, calm, educational, etc.)'),
@@ -774,11 +789,13 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
         if (!params.title || !params.agent || !params.scheduledAt) {
           return { ok: false, error: 'title, agent, and scheduledAt required' }
         }
+        const channels = (params.channels as string[]) || (params.channel ? [params.channel as string] : ['discord'])
         const item = createItem({
           title: params.title as string,
           agent: params.agent as CalendarItem['agent'],
           scheduledAt: params.scheduledAt as string,
-          channel: ((params.channel as string) || 'discord') as CalendarItem['channel'],
+          channel: ((params.channel as string) || channels[0] || 'discord') as CalendarItem['channel'],
+          channels,
           channelTarget: (params.channelTarget as string) || '1483917792745885768',
           contentType: ((params.contentType as string) || 'tip') as CalendarItem['contentType'],
           tone: ((params.tone as string) || 'conversational') as CalendarItem['tone'],

--- a/plugins/calendar/types.ts
+++ b/plugins/calendar/types.ts
@@ -1,5 +1,5 @@
 export type ContentAgent = 'basil' | 'scout' | 'nemo' | 'zen'
-export type ContentChannel = 'discord'
+export type ContentChannel = 'discord' | 'instagram' | 'email' | 'twitter' | 'youtube' | 'tiktok'
 export type ContentType = 'recipe' | 'tip' | 'motivation' | 'workout' | 'outdoor' | 'video' | 'image-post'
 export type ContentTone = 'energetic' | 'calm' | 'educational' | 'humorous' | 'inspiring' | 'conversational'
 export type ContentStatus = 'draft' | 'scheduled' | 'executing' | 'waiting' | 'review' | 'published' | 'failed'

--- a/tests/plugins/calendar/channels.test.ts
+++ b/tests/plugins/calendar/channels.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Calendar plugin — channel feature tests.
+ *
+ * Tests configurable channels on routes, exec tools, and backward compatibility
+ * with the legacy single `channel` field.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-channels-${Date.now()}`)
+})
+
+// ---------------------------------------------------------------------------
+// Mocks — must be before any plugin imports
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ calendar: testDir }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../src/core/audit', () => ({
+  appendAudit: vi.fn(),
+}))
+
+vi.mock('../../../src/core/watcher', () => ({
+  registerWatcher: vi.fn(),
+  unregisterWatcher: vi.fn(),
+}))
+
+vi.mock('../../../plugins/calendar/lib/gateway', () => ({
+  streamChatCompletion: vi.fn(async () => new Response('data: [DONE]\n\n', {
+    headers: { 'Content-Type': 'text/event-stream' },
+  })),
+  chatCompletion: vi.fn(async () => 'mock response'),
+}))
+
+// Suppress SSE broadcast
+;(globalThis as any).__bakinBroadcast = vi.fn()
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import calendarPlugin from '../../../plugins/calendar/index'
+import type { CalendarItem } from '../../../plugins/calendar/types'
+import {
+  activatePlugin,
+  findRoute,
+  findTool,
+  callRoute,
+  callTool,
+  type ActivatedPlugin,
+} from '../test-helpers'
+
+let plugin: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  mkdirSync(join(testDir, 'calendar', 'sessions'), { recursive: true })
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+  plugin = await activatePlugin(calendarPlugin, testDir)
+})
+
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+beforeEach(() => {
+  // Reset calendar.json between tests
+  writeFileSync(join(testDir, 'calendar.json'), '[]')
+})
+
+function readCalendar(): CalendarItem[] {
+  return JSON.parse(readFileSync(join(testDir, 'calendar.json'), 'utf-8'))
+}
+
+// ---------------------------------------------------------------------------
+// Route tests
+// ---------------------------------------------------------------------------
+
+describe('Channel support — routes', () => {
+  it('creates item with channels array via POST route', async () => {
+    const route = findRoute(plugin.routes, 'POST', '/')!
+    const result = await callRoute(route, plugin.ctx, {
+      body: {
+        title: 'Multi-channel post',
+        agent: 'basil',
+        scheduledAt: '2026-04-14T10:00:00Z',
+        channels: ['discord', 'instagram'],
+      },
+    })
+    expect(result.status).toBe(200)
+    expect(result.body.ok).toBe(true)
+    const item = result.body.item as CalendarItem
+    expect(item.channels).toEqual(['discord', 'instagram'])
+  })
+
+  it('filters items by channel query param (channels array)', async () => {
+    // Create items for different channels
+    const postRoute = findRoute(plugin.routes, 'POST', '/')!
+    await callRoute(postRoute, plugin.ctx, {
+      body: { title: 'Discord only', agent: 'basil', scheduledAt: '2026-04-14T10:00:00Z', channels: ['discord'] },
+    })
+    await callRoute(postRoute, plugin.ctx, {
+      body: { title: 'Instagram only', agent: 'basil', scheduledAt: '2026-04-14T11:00:00Z', channels: ['instagram'] },
+    })
+    await callRoute(postRoute, plugin.ctx, {
+      body: { title: 'Both', agent: 'basil', scheduledAt: '2026-04-14T12:00:00Z', channels: ['discord', 'instagram'] },
+    })
+
+    const listRoute = findRoute(plugin.routes, 'GET', '/')!
+    const discord = await callRoute(listRoute, plugin.ctx, {
+      searchParams: { channel: 'discord' },
+    })
+    const discordItems = discord.body.items as CalendarItem[]
+    expect(discordItems.length).toBe(2) // 'Discord only' + 'Both'
+    expect(discordItems.every(i => i.channels?.includes('discord'))).toBe(true)
+
+    const instagram = await callRoute(listRoute, plugin.ctx, {
+      searchParams: { channel: 'instagram' },
+    })
+    const igItems = instagram.body.items as CalendarItem[]
+    expect(igItems.length).toBe(2) // 'Instagram only' + 'Both'
+  })
+
+  it('backward compat: filters by legacy channel field', async () => {
+    // Write an old-style item with channel but no channels array
+    const items = readCalendar()
+    items.push({
+      id: 'legacy-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scheduledAt: '2026-04-14T10:00:00Z',
+      agent: 'basil',
+      channel: 'discord',
+      channelTarget: '123',
+      contentType: 'tip',
+      title: 'Legacy item',
+      brief: '',
+      tone: 'calm',
+      status: 'draft',
+    } as CalendarItem)
+    writeFileSync(join(testDir, 'calendar.json'), JSON.stringify(items))
+
+    const listRoute = findRoute(plugin.routes, 'GET', '/')!
+    const result = await callRoute(listRoute, plugin.ctx, {
+      searchParams: { channel: 'discord' },
+    })
+    const filtered = result.body.items as CalendarItem[]
+    expect(filtered.some(i => i.id === 'legacy-1')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Exec tool tests
+// ---------------------------------------------------------------------------
+
+describe('Channel support — exec tools', () => {
+  it('creates item with channels via exec tool', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_create')!
+    const result = await callTool(tool, {
+      title: 'Tool channels test',
+      agent: 'scout',
+      scheduledAt: '2026-04-15T09:00:00Z',
+      channels: ['email', 'twitter'],
+    })
+    expect(result.ok).toBe(true)
+    const item = result.item as CalendarItem
+    expect(item.channels).toEqual(['email', 'twitter'])
+  })
+
+  it('defaults to discord channel when neither channels nor channel provided', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_create')!
+    const result = await callTool(tool, {
+      title: 'Default channel test',
+      agent: 'nemo',
+      scheduledAt: '2026-04-15T10:00:00Z',
+    })
+    expect(result.ok).toBe(true)
+    const item = result.item as CalendarItem
+    expect(item.channels).toEqual(['discord'])
+  })
+
+  it('uses single channel param as channels array', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_create')!
+    const result = await callTool(tool, {
+      title: 'Single channel test',
+      agent: 'zen',
+      scheduledAt: '2026-04-15T11:00:00Z',
+      channel: 'instagram',
+    })
+    expect(result.ok).toBe(true)
+    const item = result.item as CalendarItem
+    expect(item.channels).toEqual(['instagram'])
+  })
+
+  it('filters by channel via list exec tool', async () => {
+    // Clear and seed
+    writeFileSync(join(testDir, 'calendar.json'), JSON.stringify([
+      {
+        id: 'ch-1', createdAt: '2026-04-15T00:00:00Z', updatedAt: '2026-04-15T00:00:00Z',
+        scheduledAt: '2026-04-15T10:00:00Z', agent: 'basil', channel: 'discord',
+        channels: ['discord', 'youtube'], channelTarget: '123', contentType: 'tip',
+        title: 'YT+DC', brief: '', tone: 'calm', status: 'draft',
+      },
+      {
+        id: 'ch-2', createdAt: '2026-04-15T00:00:00Z', updatedAt: '2026-04-15T00:00:00Z',
+        scheduledAt: '2026-04-15T11:00:00Z', agent: 'basil', channel: 'instagram',
+        channels: ['instagram'], channelTarget: '456', contentType: 'tip',
+        title: 'IG only', brief: '', tone: 'calm', status: 'draft',
+      },
+    ]))
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_list')!
+    const result = await callTool(tool, { channel: 'youtube' })
+    expect(result.ok).toBe(true)
+    expect(result.count).toBe(1)
+    expect((result.items as CalendarItem[])[0].id).toBe('ch-1')
+  })
+
+  it('list exec tool returns channels field', async () => {
+    writeFileSync(join(testDir, 'calendar.json'), JSON.stringify([
+      {
+        id: 'ch-3', createdAt: '2026-04-15T00:00:00Z', updatedAt: '2026-04-15T00:00:00Z',
+        scheduledAt: '2026-04-15T10:00:00Z', agent: 'basil', channel: 'discord',
+        channels: ['discord', 'tiktok'], channelTarget: '123', contentType: 'tip',
+        title: 'Has channels', brief: '', tone: 'calm', status: 'draft',
+      },
+    ]))
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_calendar_list')!
+    const result = await callTool(tool, {})
+    const items = result.items as Record<string, unknown>[]
+    expect(items[0].channels).toEqual(['discord', 'tiktok'])
+  })
+})


### PR DESCRIPTION
## Summary

Implements the calendar planning overhaul (PRs 2-5 from the plan):

- **Streaming chat** — SSE streaming endpoint for session messages with prompt builder that sends proper messages array (fixes the "regenerates everything" bug), Imitation Crab mock gateway streaming support, streaming chat UI component
- **Review panel** — Proposal card component with status chips (proposed/approved/rejected/revised), two-stage approval (soft-confirm proposals → "Confirm Plan" creates CalendarItems), split planning layout (chat 60% + review 40%)
- **Manual editing** — Inline title editing on proposal cards (click → input, Enter saves, Escape cancels), edit drawer for full proposal editing (title, brief, scheduledAt, contentType, tone), draft field editing on calendar item detail drawer (caption, imagePrompt, videoPrompt)
- **Configurable channels** — ContentChannel type expanded to 6 channels (discord, instagram, email, twitter, youtube, tiktok), channel FacetFilter on calendar header, channel badges on items, multi-select chip input in edit forms, backward compat with legacy single `channel` field

### New files
- `plugins/calendar/lib/prompt-builder.ts` — System prompt + messages array builder
- `plugins/calendar/lib/gateway.ts` — OpenClaw gateway client (streaming + non-streaming)
- `plugins/calendar/components/session-chat.tsx` — SSE streaming chat UI
- `plugins/calendar/components/proposal-card.tsx` — Proposal card with status chips
- `plugins/calendar/components/review-panel.tsx` — Two-stage approval panel
- `plugins/calendar/components/planning-layout.tsx` — Split chat + review layout

### Tests added
- 8 channel tests (routes + exec tools + backward compat)
- 6 manual editing tests (inline title + proposal card)
- 14 streaming endpoint tests
- 10 proposal card tests
- 7 review panel tests
- 4 planning layout tests
- 5 session chat UI tests
- 9 prompt builder tests
- 4 mock gateway streaming tests

**Total: 180 calendar tests passing (up from 105)**

## Test plan
- [ ] `npx vitest run tests/plugins/calendar/` — all 180 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] Manual: create session → send message → verify streaming tokens → approve proposals → confirm plan → check calendar items created
- [ ] Manual: edit proposal title inline, edit via drawer, verify persistence
- [ ] Manual: filter calendar by channel, verify badges render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)