### PR TITLE
feat(calendar): add session list UI with agent grouping

### DIFF
--- a/plugins/calendar/components/content-calendar.tsx
+++ b/plugins/calendar/components/content-calendar.tsx
@@ -26,6 +26,8 @@ import { CONTENT_AGENTS, STATUS_BADGE, CONTENT_TYPE_LABELS, CHANNEL_LABELS } fro
 import { ItemDetailDrawer } from './item-detail-drawer'
 import { CalendarWeek } from './calendar-week'
 import { BrainstormPanel } from './brainstorm-panel'
+import { SessionList } from './session-list'
+import { PlanningLayout } from './planning-layout'
 
 /**
  * Agent colors use CSS custom properties from the agent settings system.
@@ -112,6 +114,7 @@ export function ContentCalendar() {
   const [statusFilter, setStatusFilter] = useQueryArrayState('status')
   const [typeFilter, setTypeFilter] = useQueryArrayState('type')
   const [channelFilter, setChannelFilter] = useQueryArrayState('channel')
+  const [sessionId, setSessionId, pushSessionId] = useQueryState('session', '')
   const [search, setSearch] = useQueryState('q', '')
   const [itemIdParam, setItemIdParam, pushItemId] = useQueryState('itemId', '')
   const [mode, setMode, pushMode] = useQueryState('mode', '')
@@ -580,7 +583,17 @@ export function ContentCalendar() {
           )}
           {view === 'list' && renderList()}
           {view === 'brainstorm' && (
-            <BrainstormPanel onItemCreated={fetchItems} />
+            sessionId ? (
+              <div className="h-[calc(100vh-180px)]">
+                <PlanningLayout
+                  sessionId={sessionId}
+                  onBack={() => setSessionId('')}
+                  onSessionUpdated={fetchItems}
+                />
+              </div>
+            ) : (
+              <SessionList onSelectSession={pushSessionId} />
+            )
           )}
         </>
       )}

--- a/plugins/calendar/components/session-list.tsx
+++ b/plugins/calendar/components/session-list.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { AgentAvatar } from '@/components/agent-avatar'
+import { Plus, MessageSquare, CheckCircle } from 'lucide-react'
+import type { ContentAgent } from '../types'
+import { AGENT_INFO } from '../types'
+
+const CONTENT_AGENTS = Object.keys(AGENT_INFO) as ContentAgent[]
+
+interface SessionSummary {
+  id: string
+  agentId: string
+  title: string
+  status: 'active' | 'completed'
+  createdAt: string
+  updatedAt: string
+  proposalCount: number
+  approvedCount: number
+}
+
+interface Props {
+  onSelectSession: (sessionId: string) => void
+}
+
+export function SessionList({ onSelectSession }: Props) {
+  const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [showAgentPicker, setShowAgentPicker] = useState(false)
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const res = await fetch('/api/plugins/calendar/sessions')
+      if (res.ok) {
+        const data = await res.json()
+        setSessions(data.sessions ?? [])
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchSessions()
+  }, [fetchSessions])
+
+  const handleCreateSession = async (agentId: string) => {
+    setCreating(true)
+    try {
+      const res = await fetch('/api/plugins/calendar/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentId }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        onSelectSession(data.session.id)
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setCreating(false)
+      setShowAgentPicker(false)
+    }
+  }
+
+  // Group by agent, active before completed, sorted by updatedAt desc
+  const grouped = useMemo(() => {
+    const active = sessions
+      .filter(s => s.status === 'active')
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    const completed = sessions
+      .filter(s => s.status === 'completed')
+      .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    return [...active, ...completed]
+  }, [sessions])
+
+  const sessionsByAgent = useMemo(() => {
+    const groups: Record<string, SessionSummary[]> = {}
+    for (const s of grouped) {
+      if (!groups[s.agentId]) groups[s.agentId] = []
+      groups[s.agentId].push(s)
+    }
+    return groups
+  }, [grouped])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <span className="text-sm">Loading sessions...</span>
+      </div>
+    )
+  }
+
+  // Empty state
+  if (sessions.length === 0 && !showAgentPicker) {
+    return (
+      <div className="flex flex-col items-center justify-center text-center py-16 px-4 gap-6" data-testid="empty-state">
+        <div className="space-y-2 max-w-md">
+          <h3 className="text-base font-medium text-foreground">Plan your content calendar</h3>
+          <p className="text-sm text-muted-foreground">
+            Start a planning session with one of your agents. They&apos;ll help brainstorm content ideas,
+            propose items for your calendar, and you can approve or revise before confirming.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 max-w-lg w-full">
+          {CONTENT_AGENTS.map(agentId => {
+            const info = AGENT_INFO[agentId]
+            return (
+              <button
+                key={agentId}
+                onClick={() => handleCreateSession(agentId)}
+                disabled={creating}
+                className="flex items-center gap-3 p-4 rounded-lg border border-border bg-surface hover:bg-muted/50 transition-colors text-left"
+                data-testid={`agent-card-${agentId}`}
+              >
+                <AgentAvatar agentId={agentId} size="md" />
+                <div>
+                  <div className="text-sm font-medium text-foreground">{info.name}</div>
+                  <div className="text-xs text-muted-foreground">Start planning</div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <h3 className="text-sm font-medium">Planning Sessions</h3>
+        <div className="relative">
+          <Button
+            size="sm"
+            onClick={() => setShowAgentPicker(!showAgentPicker)}
+            disabled={creating}
+          >
+            <Plus className="size-3.5 mr-1" />
+            New Session
+          </Button>
+
+          {showAgentPicker && (
+            <div className="absolute right-0 top-full mt-1 z-10 bg-popover border border-border rounded-lg shadow-lg p-2 min-w-[200px]">
+              {CONTENT_AGENTS.map(agentId => {
+                const info = AGENT_INFO[agentId]
+                return (
+                  <button
+                    key={agentId}
+                    onClick={() => handleCreateSession(agentId)}
+                    disabled={creating}
+                    className="flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm text-left hover:bg-muted/50 transition-colors"
+                    data-testid={`agent-option-${agentId}`}
+                  >
+                    <AgentAvatar agentId={agentId} size="xs" />
+                    <span>{info.name}</span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Session list grouped by agent */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-6">
+        {Object.entries(sessionsByAgent).map(([agentId, agentSessions]) => {
+          const info = AGENT_INFO[agentId as ContentAgent]
+          return (
+            <div key={agentId} data-testid={`agent-group-${agentId}`}>
+              <div className="flex items-center gap-2 mb-2">
+                <AgentAvatar agentId={agentId} size="xs" />
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  {info?.name || agentId}
+                </span>
+                <Badge variant="outline" className="text-[10px]">
+                  {agentSessions.length}
+                </Badge>
+              </div>
+
+              <div className="space-y-1.5">
+                {agentSessions.map(session => (
+                  <button
+                    key={session.id}
+                    onClick={() => onSelectSession(session.id)}
+                    className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg border border-border bg-surface hover:bg-muted/50 transition-colors text-left"
+                    data-testid={`session-entry-${session.id}`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium text-foreground truncate">
+                        {session.title}
+                      </div>
+                      <div className="flex items-center gap-2 mt-0.5 text-[11px] text-muted-foreground">
+                        <span>{new Date(session.updatedAt).toLocaleDateString()}</span>
+                        <span className="flex items-center gap-0.5">
+                          <MessageSquare className="size-3" />
+                          {session.proposalCount} proposals
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2 shrink-0">
+                      {session.proposalCount > 0 && (
+                        <Badge variant="outline" className="text-[10px]">
+                          {session.approvedCount}/{session.proposalCount}
+                        </Badge>
+                      )}
+                      {session.status === 'completed' ? (
+                        <CheckCircle className="size-3.5 text-emerald-400" />
+                      ) : (
+                        <Badge variant="outline" className="text-[10px] text-amber-400 border-amber-400/30">
+                          Active
+                        </Badge>
+                      )}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/tests/plugins/calendar/session-list.test.tsx
+++ b/tests/plugins/calendar/session-list.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...props }: Record<string, unknown>) => (
+    <button onClick={onClick as () => void} disabled={disabled as boolean} {...props}>
+      {children as React.ReactNode}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: Record<string, unknown>) => (
+    <span data-testid="badge" {...props}>{children as React.ReactNode}</span>
+  ),
+}))
+
+vi.mock('@/components/agent-avatar', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => (
+    <span data-testid={`avatar-${agentId}`} />
+  ),
+}))
+
+vi.mock('lucide-react', () => ({
+  Plus: () => <span />,
+  MessageSquare: () => <span />,
+  CheckCircle: () => <span data-testid="check-circle" />,
+}))
+
+import { SessionList } from '../../../plugins/calendar/components/session-list'
+
+afterEach(() => cleanup())
+
+const mockSessions = [
+  {
+    id: 's1',
+    agentId: 'basil',
+    title: 'Week 15 recipes',
+    status: 'active' as const,
+    createdAt: '2026-04-07T10:00:00Z',
+    updatedAt: '2026-04-09T15:00:00Z',
+    proposalCount: 5,
+    approvedCount: 3,
+  },
+  {
+    id: 's2',
+    agentId: 'basil',
+    title: 'Week 14 recipes',
+    status: 'completed' as const,
+    createdAt: '2026-03-31T10:00:00Z',
+    updatedAt: '2026-04-04T12:00:00Z',
+    proposalCount: 7,
+    approvedCount: 7,
+  },
+  {
+    id: 's3',
+    agentId: 'scout',
+    title: 'Outdoor content sprint',
+    status: 'active' as const,
+    createdAt: '2026-04-08T09:00:00Z',
+    updatedAt: '2026-04-09T14:00:00Z',
+    proposalCount: 3,
+    approvedCount: 1,
+  },
+]
+
+function mockFetch(sessions = mockSessions) {
+  return vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+    if (url === '/api/plugins/calendar/sessions' && (!opts || opts.method !== 'POST')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ sessions }),
+      })
+    }
+    if (url === '/api/plugins/calendar/sessions' && opts?.method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          session: { id: 'new-session-id', agentId: 'basil', title: 'New planning session' },
+        }),
+      })
+    }
+    return Promise.resolve({ ok: false })
+  })
+}
+
+describe('SessionList', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows empty state when no sessions', async () => {
+    globalThis.fetch = mockFetch([])
+    render(<SessionList onSelectSession={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeDefined()
+    })
+    expect(screen.getByText('Plan your content calendar')).toBeDefined()
+  })
+
+  it('shows agent cards in empty state', async () => {
+    globalThis.fetch = mockFetch([])
+    render(<SessionList onSelectSession={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-card-basil')).toBeDefined()
+    })
+    expect(screen.getByTestId('agent-card-scout')).toBeDefined()
+    expect(screen.getByTestId('agent-card-nemo')).toBeDefined()
+    expect(screen.getByTestId('agent-card-zen')).toBeDefined()
+  })
+
+  it('renders session entries with correct data', async () => {
+    globalThis.fetch = mockFetch()
+    render(<SessionList onSelectSession={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText('Week 15 recipes')).toBeDefined()
+    })
+    expect(screen.getByText('Week 14 recipes')).toBeDefined()
+    expect(screen.getByText('Outdoor content sprint')).toBeDefined()
+  })
+
+  it('groups sessions by agent', async () => {
+    globalThis.fetch = mockFetch()
+    render(<SessionList onSelectSession={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-group-basil')).toBeDefined()
+    })
+    expect(screen.getByTestId('agent-group-scout')).toBeDefined()
+  })
+
+  it('shows proposal counts on entries', async () => {
+    globalThis.fetch = mockFetch()
+    render(<SessionList onSelectSession={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByText('5 proposals')).toBeDefined()
+    })
+    expect(screen.getByText('3 proposals')).toBeDefined()
+  })
+
+  it('shows active before completed (sorting)', async () => {
+    globalThis.fetch = mockFetch()
+    render(<SessionList onSelectSession={vi.fn()} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('session-entry-s1')).toBeDefined()
+    })
+    // Active sessions should appear before completed in the basil group
+    const s1 = screen.getByTestId('session-entry-s1')
+    const s2 = screen.getByTestId('session-entry-s2')
+    // s1 (active) should come before s2 (completed) in DOM order
+    expect(s1.compareDocumentPosition(s2) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('calls onSelectSession when clicking a session', async () => {
+    globalThis.fetch = mockFetch()
+    const onSelect = vi.fn()
+    render(<SessionList onSelectSession={onSelect} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('session-entry-s1')).toBeDefined()
+    })
+    fireEvent.click(screen.getByTestId('session-entry-s1'))
+    expect(onSelect).toHaveBeenCalledWith('s1')
+  })
+
+  it('creates new session via empty state agent card', async () => {
+    globalThis.fetch = mockFetch([])
+    const onSelect = vi.fn()
+    render(<SessionList onSelectSession={onSelect} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('agent-card-basil')).toBeDefined()
+    })
+    fireEvent.click(screen.getByTestId('agent-card-basil'))
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('new-session-id')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `SessionList` component that replaces brainstorm empty state as the entry point for planning sessions
- Sessions fetched from `GET /sessions`, grouped by agent, active before completed, sorted by updatedAt
- New Session button with agent picker dropdown, empty state shows agent cards with "Start planning" CTA
- Wire into content-calendar: brainstorm view shows session list or `PlanningLayout` based on `?session=` URL param
- 8 new tests covering empty state, grouping, sorting, click handling, and session creation

## Test plan
- [ ] `npx vitest run tests/plugins/calendar/session-list.test.tsx` — 8 tests pass
- [ ] `npx vitest run tests/plugins/calendar/` — 188 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] Manual: navigate to Calendar > Brainstorm view, verify session list renders
- [ ] Manual: click agent card in empty state, verify session creates and opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)