### PR TITLE
feat(activity): human-readable labels and duplicate filtering

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -188,6 +188,40 @@ handler: (params: Record<string, unknown>, agent: string, ctx?: PluginToolContex
 
 The `getToolContext()` function in `scripts/lib/registry.ts` uses `eval('require')` to prevent Next.js webpack from tracing runtime-only imports (it's only called from the custom Node server's MCP handler, never from Next.js routes).
 
+### ExecToolDefinition fields
+
+```typescript
+interface ExecToolDefinition {
+  name: string                    // bakin_exec_{pluginId}_{action}
+  description: string             // MCP tool description
+  label?: string                  // Human-readable action phrase for activity feed (e.g., "Created a task")
+  activityDuplicate?: boolean     // true = handler already emits a domain audit event; auto-audit tagged duplicate
+  parameters: Record<string, unknown>
+  handler: (params, agent, ctx?) => Promise<ExecToolResult>
+  source?: string                 // 'plugin:{id}' or 'script'
+}
+```
+
+**`label`**: Short past-tense phrase displayed as primary text in the activity feed. Without it, `humanizeExecName()` derives a label from the tool name (strips `bakin_exec_` prefix, splits on `_`, capitalizes). Every exec tool should have an explicit label.
+
+**`activityDuplicate`**: Set `true` only when the handler (or an effect function it calls) already emits a meaningful domain event (e.g., `task.created`, `asset.deleted`) via `ctx.activity.audit()` or `appendAudit()`. The auto-audit event from `mcp-server.ts` is tagged `duplicate: true` and hidden by default in the activity feed. Do NOT set this flag on tools where the auto-audit is the only activity event.
+
+### Activity event flow for exec tools
+
+```
+Agent calls MCP tool
+  → mcp-server.ts runs handler
+  → Handler may emit domain audit event (e.g., appendAudit('task.created', ...))
+  → mcp-server.ts auto-appends audit: exec.{tool.name}.{ok|fail}
+    with { label: tool.label, duplicate: tool.activityDuplicate }
+  → SSE broadcasts both events
+  → mapAuditMessage() reads data.label for exec.* events (humanizeExecName fallback)
+  → Activity feed shows label as primary text, raw event name as muted mono text
+  → Duplicate events hidden by default (Bug icon toggle to show)
+```
+
+**Important**: Exec tool handlers should NOT call `ctx.activity.log()` — the auto-audit from `mcp-server.ts` with the tool's `label` replaces that pattern. Use `ctx.activity.audit()` for domain events that carry semantic meaning beyond "tool X was called."
+
 ### Naming convention
 `bakin_exec_{pluginId}_{action}` — e.g., `bakin_exec_project_list`, `bakin_exec_schedule_fire`
 

--- a/.claude/specs/human-readable-activity-feed.md
+++ b/.claude/specs/human-readable-activity-feed.md
@@ -1,0 +1,264 @@
+# Spec: Human-Readable Activity Feed
+
+## Objective
+
+The activity feed currently displays raw event/command names like `exec.bakin_exec_workflows_get_definition.ok` as the primary text. These are cryptic and meaningless to a human operator. This spec defines the work to give **every** activity event a human-readable label as the primary display text, with the raw command name shown as secondary muted text underneath.
+
+**Target user:** Single operator (roscoe) monitoring agent activity from the dashboard.
+
+**Desired outcome:** Glance at the activity feed and immediately understand what each agent is doing without mentally parsing `exec.bakin_exec_*` strings.
+
+## Current State
+
+### What exists
+- `mapAuditMessage()` in `src/lib/map-audit-message.ts` handles ~16 domain events (`task.created`, `workflow.step_complete`, etc.) with good human-readable text
+- For `exec.*` events (all MCP tool calls), the function falls through to `default: return event` — returning the raw event name as the message
+- The `ActivityEvent` type already has an `eventName` field, but it's only set for audit events
+- The UI (`activity-feed.tsx`) renders `evt.message` as the sole text line with no distinction between human label and raw command
+
+### What's broken
+- 77 exec tools generate audit events like `exec.bakin_exec_tasks_create.ok` with no human-readable mapping
+- All `exec.*` events show as raw strings in the feed (see screenshot)
+- No way to toggle verbosity — the raw command names are useful for debugging but shouldn't be the primary display
+
+## Design
+
+### 1. Add `label` and `activityDuplicate` to `ExecToolDefinition`
+
+Add optional fields to the `ExecToolDefinition` interface in `packages/core/src/plugin-types.ts`:
+
+```typescript
+export interface ExecToolDefinition {
+  name: string
+  description: string
+  label?: string              // Short human-readable action phrase for activity feed (e.g., "Created a task")
+  activityDuplicate?: boolean // Handler already emits a domain audit event — auto-audit tagged duplicate
+  parameters: Record<string, unknown>
+  handler: (params: Record<string, unknown>, agent: string, ctx?: PluginToolContext) => Promise<ExecToolResult>
+  source?: string
+}
+```
+
+Labels are co-located with each tool definition — plugins own their labels, no separate map needed.
+
+### 2. Add `label` to Every `registerExecTool()` Call
+
+Update all 77 `registerExecTool()` calls across plugins and script tools to include a `label` field. Examples:
+
+```typescript
+// plugins/tasks/index.ts
+ctx.registerExecTool({
+  name: 'bakin_exec_tasks_create',
+  label: 'Created a task',                    // NEW
+  description: 'Create a new task on the board...',
+  ...
+})
+
+// plugins/workflows/index.ts
+ctx.registerExecTool({
+  name: 'bakin_exec_workflows_complete_step',
+  label: 'Completed workflow step',           // NEW
+  description: 'Mark a workflow step as complete...',
+  ...
+})
+
+// scripts/lib/heartbeat.ts
+addExecTool({
+  name: 'bakin_exec_heartbeat',
+  label: 'Sent heartbeat',                    // NEW
+  description: '...',
+  ...
+})
+```
+
+Full label list for all 77 tools (grouped by plugin):
+
+**Tasks (11):** Listed tasks, Read task details, Created a task, Updated a task, Deleted a task, Moved a task, Completed a task, Blocked a task, Assigned a task, Logged progress, Set task dependency
+
+**Workflows (10):** Listed workflows, Listed workflow runs, Read workflow definition, Read workflow instance, Started a workflow, Read workflow step, Completed workflow step, Submitted workflow step, Checked workflow gates, Read workflow step
+
+**Assets (10):** Listed assets, Read asset details, Saved an asset, Deleted an asset, Linked an asset, Audited assets, Emptied asset trash, Listed trashed assets, Restored an asset, Permanently deleted an asset
+
+**Projects (15):** Listed projects, Read project details, Created a project, Updated a project, Deleted a project, Added project item, Marked project item, Removed project item, Linked project item, Updated project item, Promoted project item, Toggled project item, Attached asset to project, Detached asset from project, Asked project question
+
+**Schedule (10):** Listed scheduled jobs, Read schedule details, Created a scheduled job, Updated a scheduled job, Deleted a scheduled job, Paused a scheduled job, Triggered scheduled job, Listed schedule runs, Parsed cron expression, Generated schedule briefing
+
+**Messaging (15):** Listed messages, Read message details, Created a message, Updated a message, Deleted a message, Approved a message, Rejected a message, Listed brainstorm sessions, Read brainstorm session, Created brainstorm session, Updated brainstorm session, Deleted brainstorm session, Sent brainstorm message, Confirmed brainstorm proposal, Updated brainstorm proposal
+
+**Team (8):** Listed team, Listed team members, Read own team, Read organization, Read agent profile, Checked agent status, Read agent file, Sent a message
+
+**Models (2):** Listed models, Read model config
+
+**Health (2):** Checked system health, Ran diagnostics
+
+**Scripts (5):** Logged message, Sent heartbeat, Resolved paths, Generated an image, Posted to Discord
+
+### 3. Flow the Label Through Audit Data
+
+In `src/core/mcp-server.ts`, include `tool.label` in the audit data so it reaches the client via SSE:
+
+```typescript
+appendAudit(
+  getContentDir(),
+  result.ok ? `exec.${tool.name}.ok` : `exec.${tool.name}.fail`,
+  agent,
+  { taskId, label: tool.label, ...(result.ok ? {} : { error: result.error }) },  // label added
+  'mcp',
+)
+```
+
+This way `mapAuditMessage()` on the client can read `data.label` — no server-only registry lookup needed.
+
+### 4. Update `mapAuditMessage()`
+
+Extend `src/lib/map-audit-message.ts` to handle `exec.*` events using the label from data:
+
+```typescript
+// Before the default case, add:
+if (event.startsWith('exec.')) {
+  const suffix = event.endsWith('.fail') ? ' (failed)' : event.endsWith('.error') ? ' (error)' : ''
+  if (data.label) return `${data.label}${suffix}`
+  // Fallback for tools without a label: humanize the name
+  const toolName = event.replace(/^exec\./, '').replace(/\.(ok|fail|error)$/, '')
+  return humanizeExecName(toolName) + suffix
+}
+```
+
+Add a `humanizeExecName()` fallback that converts `bakin_exec_foo_bar` → `"Foo bar"` so any future tools registered without a label still render readably.
+
+### 5. Preserve Raw Event Name for Display
+
+The `eventName` field on `ActivityEvent` already exists and is set for audit events in `use-sse.ts:82`. No type changes needed — the field is already there. Just ensure it's always populated (it already is for audit events, which is the path exec events take).
+
+### 4. UI Changes — `activity-feed.tsx`
+
+Update the event rendering to show:
+1. **Primary line:** Human-readable message (already in `evt.message` after map-audit-message changes)
+2. **Secondary line:** Raw event name in small muted text (from `evt.eventName`)
+
+```tsx
+{/* Human-readable message — primary */}
+<p className="text-[12px] leading-snug break-words text-foreground/80">
+  {evt.message}
+</p>
+{/* Raw command name — secondary, muted, only when verbose + eventName exists */}
+{verbose && evt.eventName && (
+  <p className="text-[10px] text-muted-foreground/60 mt-0.5 truncate font-mono">
+    {evt.eventName}
+  </p>
+)}
+```
+
+### 5. Verbose Toggle
+
+Add a toggle button in the activity feed header bar (next to "Live Activity" text):
+
+- Label: "Verbose" (or just a code icon toggle)
+- State persisted to `localStorage` key `bakin-activity-verbose`
+- Default: **on** (show raw command names)
+- When off: hides the secondary `eventName` line from all events
+
+Implementation in `activity-feed.tsx`:
+```tsx
+const [verbose, setVerbose] = useState(() => {
+  if (typeof window === 'undefined') return true
+  return localStorage.getItem('bakin-activity-verbose') !== 'false'
+})
+```
+
+Toggle button in header alongside the close chevron.
+
+### 6. Activity API Hydration
+
+Update `src/app/api/activity/route.ts` to ensure the `eventName` field is included in the response for audit events (it already maps through `mapAuditMessage`, just verify `eventName` is passed through).
+
+### 7. Duplicate Event Filtering (`activityDuplicate`)
+
+Many exec tool handlers emit domain audit events (e.g., `task.created`, `asset.deleted`) via `ctx.activity.audit()` — then the auto-audit from `mcp-server.ts` adds a second event for the same action (`exec.bakin_exec_tasks_create.ok`). This creates noisy duplication in the feed.
+
+**Solution:** Add `activityDuplicate?: boolean` to `ExecToolDefinition`. When set, `mcp-server.ts` tags the auto-audit with `duplicate: true`. The activity feed hides duplicates by default, with a Bug icon toggle to show them.
+
+```typescript
+ctx.registerExecTool({
+  name: 'bakin_exec_tasks_create',
+  label: 'Created a task',
+  activityDuplicate: true,  // handler calls createTaskWithEffects → appendAudit('task.created')
+  ...
+})
+```
+
+**Rules for `activityDuplicate`:**
+- Set `true` only when the handler or its effect functions emit a domain audit event
+- Do NOT set on tools where the auto-audit is the only activity event (e.g., read-only tools, tools with no domain event)
+- When set, the manual `ctx.activity.log()` call in the handler should be removed — the domain event + label cover the same information
+
+**UI:** Bug icon toggle in the feed header. Off by default (hides duplicates). State persisted to `localStorage` key `bakin-activity-show-duplicates`. Raw event names (`evt.eventName`) always shown for all visible events regardless of toggle state.
+
+## Acceptance Criteria
+
+1. Every exec tool call shows a human-readable label as the primary text (e.g., "Completed workflow step" instead of `exec.bakin_exec_workflows_complete_step.ok`)
+2. Failed/errored exec calls append "(failed)" or "(error)" to the label
+3. Raw event name shown as small muted mono text below the message for all events
+4. Duplicate events (from tools with `activityDuplicate: true`) hidden by default
+5. Bug icon toggle in header to show/hide duplicates, persisted to localStorage
+6. Existing domain events (task.created, workflow.gate_reached, etc.) continue working unchanged
+7. Unknown future exec tools get a reasonable auto-humanized fallback
+8. The `/api/activity` hydration endpoint returns the same human-readable text as real-time SSE events
+9. No manual `ctx.activity.log()` calls in exec tool handlers that have `activityDuplicate: true`
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `packages/core/src/plugin-types.ts` | Add optional `label?: string` to `ExecToolDefinition` |
+| `plugins/tasks/index.ts` | Add `label` to all 11 `registerExecTool()` calls |
+| `plugins/workflows/index.ts` | Add `label` to all 10 `registerExecTool()` calls |
+| `plugins/assets/index.ts` | Add `label` to all 10 `registerExecTool()` calls |
+| `plugins/projects/index.ts` | Add `label` to all 15 `registerExecTool()` calls |
+| `plugins/schedule/index.ts` | Add `label` to all 10 `registerExecTool()` calls |
+| `plugins/messaging/index.ts` | Add `label` to all 15 `registerExecTool()` calls |
+| `plugins/team/index.ts` | Add `label` to all 8 `registerExecTool()` calls |
+| `plugins/models/index.ts` | Add `label` to all 2 `registerExecTool()` calls |
+| `plugins/health/index.ts` | Add `label` to all 2 `registerExecTool()` calls |
+| `scripts/lib/*.ts` | Add `label` to all 5 script `addExecTool()` calls |
+| `src/core/mcp-server.ts` | Include `tool.label` in `appendAudit()` data |
+| `src/lib/map-audit-message.ts` | Add `exec.*` handling using `data.label` + `humanizeExecName()` fallback |
+| `src/components/tasks/activity-feed.tsx` | Two-line rendering (message + eventName) + verbose toggle |
+| `src/app/api/activity/route.ts` | Verify `eventName` in hydrated responses (likely already works) |
+
+## Files Also Modified
+
+- `src/types/index.ts` — added `duplicate?: boolean` to `ActivityEvent`
+- `src/hooks/use-sse.ts` — propagates `duplicate` from audit entry data
+- `src/app/api/activity/route.ts` — propagates `duplicate` in hydration endpoint
+
+## Testing Strategy
+
+- **Unit test** `mapAuditMessage()`: verify exec event mapping (ok, fail, error suffixes), fallback humanization, and that existing domain events still pass (14 tests in `tests/lib/map-audit-message.test.ts`)
+- **Manual verification**: run the app, trigger agent activity, confirm the feed shows human-readable text with raw names underneath, verify duplicate toggle works
+
+## Boundaries
+
+### Always
+- Labels live on the `ExecToolDefinition` — plugins own their labels
+- Include a humanized fallback for tools without explicit labels
+- Preserve the raw event name for debugging (always visible as muted mono text)
+
+### Never
+- Create a centralized label map file — labels are co-located with tool registrations
+- Add `ctx.activity.log()` to exec tool handlers that have `activityDuplicate: true`
+- Add new dependencies
+
+### Ask first
+- If a tool's label is ambiguous or could be interpreted multiple ways
+
+## Commit Strategy
+
+1. **Commit 1:** `feat(core): add label field to ExecToolDefinition` — type change in `packages/core/src/plugin-types.ts`
+2. **Commit 2:** `feat(plugins): add labels to all exec tool registrations` — all 77 `registerExecTool()`/`addExecTool()` calls across 10 plugins + scripts
+3. **Commit 3:** `feat(activity): flow labels through audit and map to display text` — `mcp-server.ts` passes `tool.label` in audit data, `map-audit-message.ts` reads it with `humanizeExecName()` fallback
+4. **Commit 4:** `feat(activity): show human-readable labels with verbose toggle` — UI changes in `activity-feed.tsx` (two-line rendering + header toggle)
+5. **Commit 5:** `test(activity): add exec tool label and message mapping tests` — unit tests for mapAuditMessage exec handling
+6. **Commit 6:** `feat(activity): add duplicate filtering to reduce feed noise` — `activityDuplicate` field, duplicate tag in auto-audit, UI toggle with Bug icon
+7. **Commit 7:** `refactor(plugins): remove duplicate ctx.activity.log from exec handlers` — remove manual log calls where domain events + labels cover the same info
+8. **Commit 8:** `docs(knowledge): document exec tool label and duplicate patterns` — update plugin-system.md and spec

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -79,6 +79,7 @@ export interface PluginToolContext {
 export interface ExecToolDefinition {
   name: string
   description: string
+  label?: string // Short human-readable action phrase for activity feed (e.g., "Created a task")
   parameters: Record<string, unknown> // Zod schema shape
   handler: (params: Record<string, unknown>, agent: string, ctx?: PluginToolContext) => Promise<ExecToolResult>
   source?: string // 'core' | 'plugin:<id>' — set automatically on registration

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -80,6 +80,7 @@ export interface ExecToolDefinition {
   name: string
   description: string
   label?: string // Short human-readable action phrase for activity feed (e.g., "Created a task")
+  activityDuplicate?: boolean // true = handler already emits a meaningful activity event; auto-audit can be hidden
   parameters: Record<string, unknown> // Zod schema shape
   handler: (params: Record<string, unknown>, agent: string, ctx?: PluginToolContext) => Promise<ExecToolResult>
   source?: string // 'core' | 'plugin:<id>' — set automatically on registration

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -259,7 +259,6 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_save',
       label: 'Saved an asset',
-      activityDuplicate: true,
       description: 'Save an agent-created file to the assets directory with standardized naming (YYYYMMDD-slug.ext) and sidecar metadata. Handles directory creation, naming conventions, and .meta.json automatically.',
       parameters: {
         filePath: z.string().describe('Absolute path to the source file to save'),
@@ -272,9 +271,6 @@ const assetsPlugin: BakinPlugin = {
       },
       handler: async (params: Record<string, unknown>, agent: string) => {
         const result = await saveAsset({ ...params, agent } as Parameters<typeof saveAsset>[0])
-        if (result.ok) {
-          ctx.activity.log(agent, `Saved asset "${result.filename}"`, { taskId: params.taskId as string })
-        }
         return result
       },
     })
@@ -298,7 +294,6 @@ const assetsPlugin: BakinPlugin = {
         const success = softDelete(fullPath, assetsRoot)
         if (!success) return { ok: false, error: 'Failed to delete asset' }
         removeAsset(assetPath)
-        ctx.activity.log(agent, `Deleted asset "${assetPath}"`)
         ctx.activity.audit('asset.deleted', agent, { path: assetPath })
         return { ok: true, trashed: [assetPath] }
       },
@@ -319,7 +314,6 @@ const assetsPlugin: BakinPlugin = {
           newTaskId: (params.taskId as string | null) ?? null,
         })
         if (result.ok) {
-          ctx.activity.log(agent, `Relinked asset to ${params.taskId ?? '_unlinked'}`)
           ctx.activity.audit('asset.relinked', agent, { oldPath: result.oldPath, newPath: result.newPath })
         }
         return result
@@ -349,7 +343,6 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_restore',
       label: 'Restored an asset',
-      activityDuplicate: true,
       description: 'Restore a trashed asset back to its original location. Use bakin_exec_assets_list_trash first to get the filename.',
       parameters: {
         filename: z.string().describe('The trash filename (includes __deleted- suffix)'),
@@ -359,7 +352,6 @@ const assetsPlugin: BakinPlugin = {
         const assetsRoot = join(getContentDir(), 'assets')
         const restoredPath = await restoreAsset(filename, assetsRoot)
         if (!restoredPath) return { ok: false, error: 'Failed to restore asset — file may not exist in trash' }
-        ctx.activity.log(agent, `Restored asset "${filename}"`)
         return { ok: true, restoredPath }
       },
     })
@@ -501,7 +493,6 @@ const assetsPlugin: BakinPlugin = {
       handler: async (_params: Record<string, unknown>, agent: string) => {
         const assetsRoot = join(getContentDir(), 'assets')
         const deleted = emptyTrash(assetsRoot)
-        ctx.activity.log(agent, `Emptied trash (${deleted} items)`)
         ctx.activity.audit('assets.trash.emptied', agent, { deleted })
         return { ok: true, deleted }
       },
@@ -523,7 +514,6 @@ const assetsPlugin: BakinPlugin = {
         const assetsRoot = join(getContentDir(), 'assets')
         const success = permanentDelete(filename, assetsRoot)
         if (!success) return { ok: false, error: 'Failed to permanently delete — file may not exist in trash' }
-        ctx.activity.log(agent, `Permanently deleted "${filename}"`)
         ctx.activity.audit('assets.trash.permanent_delete', agent, { filename })
         return { ok: true }
       },

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -259,6 +259,7 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_save',
       label: 'Saved an asset',
+      activityDuplicate: true,
       description: 'Save an agent-created file to the assets directory with standardized naming (YYYYMMDD-slug.ext) and sidecar metadata. Handles directory creation, naming conventions, and .meta.json automatically.',
       parameters: {
         filePath: z.string().describe('Absolute path to the source file to save'),
@@ -281,6 +282,7 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_delete',
       label: 'Deleted an asset',
+      activityDuplicate: true,
       description: 'Soft-delete an asset (moves to trash with 30-day expiry).',
       parameters: {
         path: z.string().describe('Asset path relative to content dir (e.g. "assets/images/task123/file.png")'),
@@ -305,6 +307,7 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_link',
       label: 'Linked an asset',
+      activityDuplicate: true,
       description: 'Link an asset to a different task, or unlink it (set taskId to null). Physically moves the file between task directories and updates sidecar metadata.',
       parameters: {
         path: z.string().describe('Asset path relative to content dir (e.g. "assets/images/task123/file.png")'),
@@ -346,6 +349,7 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_restore',
       label: 'Restored an asset',
+      activityDuplicate: true,
       description: 'Restore a trashed asset back to its original location. Use bakin_exec_assets_list_trash first to get the filename.',
       parameters: {
         filename: z.string().describe('The trash filename (includes __deleted- suffix)'),
@@ -491,6 +495,7 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_empty_trash',
       label: 'Emptied asset trash',
+      activityDuplicate: true,
       description: 'Permanently delete all items from trash. This cannot be undone.',
       parameters: {},
       handler: async (_params: Record<string, unknown>, agent: string) => {
@@ -505,6 +510,7 @@ const assetsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_assets_permanent_delete',
       label: 'Permanently deleted an asset',
+      activityDuplicate: true,
       description: 'Permanently delete a specific trashed asset. This cannot be undone.',
       parameters: {
         filename: z.string().describe('The trash filename (includes __deleted- suffix)'),

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -211,6 +211,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_list',
+      label: 'Listed assets',
       description: 'List assets with optional type filter. Returns asset count and paths.',
       parameters: {
         type: z.enum(ASSET_TYPES).optional().describe('Filter by asset type'),
@@ -227,6 +228,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_get',
+      label: 'Read asset details',
       description: 'Retrieve a single asset\'s sidecar metadata by path.',
       parameters: {
         path: z.string().describe('Asset path relative to content dir (e.g. "assets/images/task123/file.png")'),
@@ -256,6 +258,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_save',
+      label: 'Saved an asset',
       description: 'Save an agent-created file to the assets directory with standardized naming (YYYYMMDD-slug.ext) and sidecar metadata. Handles directory creation, naming conventions, and .meta.json automatically.',
       parameters: {
         filePath: z.string().describe('Absolute path to the source file to save'),
@@ -277,6 +280,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_delete',
+      label: 'Deleted an asset',
       description: 'Soft-delete an asset (moves to trash with 30-day expiry).',
       parameters: {
         path: z.string().describe('Asset path relative to content dir (e.g. "assets/images/task123/file.png")'),
@@ -300,6 +304,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_link',
+      label: 'Linked an asset',
       description: 'Link an asset to a different task, or unlink it (set taskId to null). Physically moves the file between task directories and updates sidecar metadata.',
       parameters: {
         path: z.string().describe('Asset path relative to content dir (e.g. "assets/images/task123/file.png")'),
@@ -320,6 +325,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_list_trash',
+      label: 'Listed trashed assets',
       description: 'List trashed assets with name, size, deleted timestamp, and days remaining before auto-purge.',
       parameters: {},
       handler: async () => {
@@ -339,6 +345,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_restore',
+      label: 'Restored an asset',
       description: 'Restore a trashed asset back to its original location. Use bakin_exec_assets_list_trash first to get the filename.',
       parameters: {
         filename: z.string().describe('The trash filename (includes __deleted- suffix)'),
@@ -355,6 +362,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_audit',
+      label: 'Audited assets',
       description: 'Audit asset health: check for missing thumbnails, invalid sidecars, orphaned files. Set fix=true to auto-generate missing thumbnails and create stub sidecars.',
       parameters: {
         type: z.enum(ASSET_TYPES).optional().describe('Limit audit to a specific asset type'),
@@ -482,6 +490,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_empty_trash',
+      label: 'Emptied asset trash',
       description: 'Permanently delete all items from trash. This cannot be undone.',
       parameters: {},
       handler: async (_params: Record<string, unknown>, agent: string) => {
@@ -495,6 +504,7 @@ const assetsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_assets_permanent_delete',
+      label: 'Permanently deleted an asset',
       description: 'Permanently delete a specific trashed asset. This cannot be undone.',
       parameters: {
         filename: z.string().describe('The trash filename (includes __deleted- suffix)'),

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -160,6 +160,7 @@ const healthPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_health_status',
+      label: 'Checked system health',
       description: 'Get a quick system health summary — uptime, memory, active MCP sessions, and doctor error/warning counts. Useful for checking system state before starting work.',
       parameters: {},
       handler: async () => {
@@ -196,6 +197,7 @@ const healthPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_health_doctor',
+      label: 'Ran diagnostics',
       description: 'Run system diagnostics (agent roster, skill sync, gateway, taskboard, assets, etc.). Returns detailed check results. Use fresh=true to force a full re-check instead of returning cached results.',
       parameters: {
         fresh: z.boolean().optional().describe('Force fresh diagnostics instead of cached results'),

--- a/plugins/messaging/index.ts
+++ b/plugins/messaging/index.ts
@@ -805,6 +805,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_list',
+      label: 'Listed messages',
       description: 'List messaging items with optional filters',
       parameters: {
         month: z.string().optional().describe('Filter by month (YYYY-MM)'),
@@ -843,6 +844,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_get',
+      label: 'Read message details',
       description: 'Get details for a single messaging item',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -857,6 +859,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_create',
+      label: 'Created a message',
       description: 'Create a new messaging item',
       parameters: {
         title: z.string().describe('Item title (required)'),
@@ -895,6 +898,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_update',
+      label: 'Updated a message',
       description: 'Update a messaging item',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -919,6 +923,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_approve',
+      label: 'Approved a message',
       description: 'Approve a messaging item (draft → scheduled, review → published)',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -935,6 +940,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_reject',
+      label: 'Rejected a message',
       description: 'Reject a messaging item back to draft status',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -957,6 +963,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_delete',
+      label: 'Deleted a message',
       description: 'Delete a messaging item',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -976,6 +983,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_list',
+      label: 'Listed brainstorm sessions',
       description: 'List planning sessions with optional filters',
       parameters: {
         status: z.string().optional().describe('Filter by status (active, completed)'),
@@ -992,6 +1000,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_get',
+      label: 'Read brainstorm session',
       description: 'Get a planning session with full message history and proposals',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),
@@ -1006,6 +1015,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_create',
+      label: 'Created brainstorm session',
       description: 'Create a new planning session for an agent',
       parameters: {
         agentId: z.string().describe('Agent ID (required)'),
@@ -1024,6 +1034,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_update',
+      label: 'Updated brainstorm session',
       description: 'Update a planning session title or status',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),
@@ -1046,6 +1057,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_delete',
+      label: 'Deleted brainstorm session',
       description: 'Delete a planning session',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),
@@ -1064,6 +1076,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_message',
+      label: 'Sent brainstorm message',
       description: 'Send a message in a planning session (non-streaming, returns full response)',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),
@@ -1128,6 +1141,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_proposal_update',
+      label: 'Updated brainstorm proposal',
       description: 'Update a proposal status or fields (approve, reject, edit)',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),
@@ -1161,6 +1175,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
 
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_confirm',
+      label: 'Confirmed brainstorm proposal',
       description: 'Confirm a planning session — creates messaging items from approved proposals',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),

--- a/plugins/messaging/index.ts
+++ b/plugins/messaging/index.ts
@@ -860,6 +860,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_create',
       label: 'Created a message',
+      activityDuplicate: true,
       description: 'Create a new messaging item',
       parameters: {
         title: z.string().describe('Item title (required)'),
@@ -899,6 +900,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_update',
       label: 'Updated a message',
+      activityDuplicate: true,
       description: 'Update a messaging item',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -924,6 +926,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_approve',
       label: 'Approved a message',
+      activityDuplicate: true,
       description: 'Approve a messaging item (draft → scheduled, review → published)',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -941,6 +944,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_reject',
       label: 'Rejected a message',
+      activityDuplicate: true,
       description: 'Reject a messaging item back to draft status',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -964,6 +968,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_delete',
       label: 'Deleted a message',
+      activityDuplicate: true,
       description: 'Delete a messaging item',
       parameters: {
         itemId: z.string().describe('Item ID (required)'),
@@ -1016,6 +1021,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_create',
       label: 'Created brainstorm session',
+      activityDuplicate: true,
       description: 'Create a new planning session for an agent',
       parameters: {
         agentId: z.string().describe('Agent ID (required)'),
@@ -1058,6 +1064,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_delete',
       label: 'Deleted brainstorm session',
+      activityDuplicate: true,
       description: 'Delete a planning session',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),
@@ -1176,6 +1183,7 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
     ctx.registerExecTool({
       name: 'bakin_exec_messaging_session_confirm',
       label: 'Confirmed brainstorm proposal',
+      activityDuplicate: true,
       description: 'Confirm a planning session — creates messaging items from approved proposals',
       parameters: {
         sessionId: z.string().describe('Session ID (required)'),

--- a/plugins/messaging/index.ts
+++ b/plugins/messaging/index.ts
@@ -892,7 +892,6 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
           status: (params.status as ContentStatus) || 'draft',
         })
         ctx.activity.audit('item.created', params.agent as string, { itemId: item.id, title: params.title })
-        ctx.activity.log(params.agent as string, `Created messaging item "${params.title}"`)
         return { ok: true, item }
       },
     })
@@ -960,7 +959,6 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
           rejectionNote: (params.note as string) || undefined,
         })
         ctx.activity.audit('item.rejected', 'system', { itemId: params.itemId, note: params.note })
-        ctx.activity.log('system', `Messaging item "${item.title}" rejected → draft`)
         return { ok: true, item: updated }
       },
     })
@@ -979,7 +977,6 @@ ${historyContext ? `Conversation so far:\n${historyContext}\n\n` : ''}Mark says:
         if (!item) return { ok: false, error: 'Item not found' }
         deleteItem(params.itemId as string)
         ctx.activity.audit('item.deleted', 'system', { itemId: params.itemId })
-        ctx.activity.log('system', `Deleted messaging item "${item.title}"`)
         return { ok: true }
       },
     })

--- a/plugins/models/index.ts
+++ b/plugins/models/index.ts
@@ -667,6 +667,7 @@ const modelsPlugin: BakinPlugin = {
     // -------------------------------------------------------------------
     ctx.registerExecTool({
       name: 'bakin_exec_models_list',
+      label: 'Listed models',
       description: 'List available AI models with tier classification (budget/standard/premium). Use this to discover what models are available for assignment.',
       parameters: {
         tier: z.enum(['budget', 'standard', 'premium']).optional().describe('Filter by model tier'),
@@ -685,6 +686,7 @@ const modelsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_models_get_config',
+      label: 'Read model config',
       description: 'Get model configuration for all agents or a specific agent. Shows effective model (own override or default), subagent model, and system defaults.',
       parameters: {
         agentId: z.string().optional().describe('Specific agent ID to query (omit for all agents)'),

--- a/plugins/projects/index.ts
+++ b/plugins/projects/index.ts
@@ -575,7 +575,6 @@ const projectsPlugin: BakinPlugin = {
         const checked = params.checked as boolean
         const result = await markChecklistItem(projectId, itemId, checked)
         ctx.activity.audit('checklist.toggled', 'system', { projectId, checked })
-        ctx.activity.log('system', 'Toggled checklist item in project', { taskId: projectId })
         return { ok: true, ...result }
       },
     })
@@ -600,7 +599,6 @@ const projectsPlugin: BakinPlugin = {
             description: params.description as string | undefined,
           })
           ctx.activity.audit('checklist.updated', 'system', { projectId })
-          ctx.activity.log('system', 'Updated checklist item in project', { taskId: projectId })
           return { ok: true }
         } catch (err: unknown) {
           return { ok: false, error: (err as Error).message }
@@ -650,7 +648,6 @@ const projectsPlugin: BakinPlugin = {
           const agentId = (params.agent as string) || 'main'
           const reply = await sendMessage(agentId, context)
           ctx.activity.audit('project.asked', 'system', { projectId, agent: agentId })
-          ctx.activity.log('system', `Asked agent about project ${projectId}`, { taskId: projectId })
           return { ok: true, reply }
         } catch (err: unknown) {
           log.error('Agent ask failed', err)

--- a/plugins/projects/index.ts
+++ b/plugins/projects/index.ts
@@ -562,6 +562,7 @@ const projectsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_project_toggle_item',
       label: 'Toggled project item',
+      activityDuplicate: true,
       description: 'Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -582,6 +583,7 @@ const projectsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_project_update_item',
       label: 'Updated project item',
+      activityDuplicate: true,
       description: 'Update a checklist item\'s title and/or description.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -609,6 +611,7 @@ const projectsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_project_ask',
       label: 'Asked project question',
+      activityDuplicate: true,
       description: 'Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming.',
       parameters: {
         projectId: z.string().describe('Project ID'),

--- a/plugins/projects/index.ts
+++ b/plugins/projects/index.ts
@@ -333,6 +333,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_list',
+      label: 'Listed projects',
       description: 'List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount.',
       parameters: {
         status: z.enum(['draft', 'active', 'completed', 'archived']).optional().describe('Filter by status'),
@@ -348,6 +349,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_get',
+      label: 'Read project details',
       description: 'Get a project by ID including full spec, checklist, progress, and linked board task statuses.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -361,6 +363,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_create',
+      label: 'Created a project',
       description: 'Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs.',
       parameters: {
         title: z.string().describe('Project title'),
@@ -381,6 +384,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_update',
+      label: 'Updated a project',
       description: 'Update a project\'s title, status, body, or owner. Cannot set status to "completed" if unchecked items remain.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -406,6 +410,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_delete',
+      label: 'Deleted a project',
       description: 'Delete a project by ID.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -422,6 +427,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_add_item',
+      label: 'Added project item',
       description: 'Add a new checklist item to a project.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -435,6 +441,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_mark_item',
+      label: 'Marked project item',
       description: 'Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -453,6 +460,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_remove_item',
+      label: 'Removed project item',
       description: 'Remove a checklist item from a project.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -470,6 +478,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_link_item',
+      label: 'Linked project item',
       description: 'Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -492,6 +501,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_promote_item',
+      label: 'Promoted project item',
       description: 'Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -514,6 +524,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_attach_asset',
+      label: 'Attached asset to project',
       description: 'Attach an existing asset to a project. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -532,6 +543,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_detach_asset',
+      label: 'Detached asset from project',
       description: 'Remove an asset reference from a project. Does not delete the asset itself.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -549,6 +561,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_toggle_item',
+      label: 'Toggled project item',
       description: 'Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -568,6 +581,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_update_item',
+      label: 'Updated project item',
       description: 'Update a checklist item\'s title and/or description.',
       parameters: {
         projectId: z.string().describe('Project ID'),
@@ -594,6 +608,7 @@ const projectsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_project_ask',
+      label: 'Asked project question',
       description: 'Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming.',
       parameters: {
         projectId: z.string().describe('Project ID'),

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -453,6 +453,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_list',
+      label: 'Listed scheduled jobs',
       description: 'List all scheduled jobs (merged OpenClaw + Bakin view)',
       parameters: {
         filter: z.enum(['bakin', 'all']).optional().describe('Filter by job type'),
@@ -479,6 +480,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_create',
+      label: 'Created a scheduled job',
       description: 'Create a new scheduled job that creates tasks on the board',
       parameters: {
         name: z.string().describe('Job name (required)'),
@@ -530,6 +532,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_update',
+      label: 'Updated a scheduled job',
       description: 'Update an existing scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),
@@ -566,6 +569,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_pause',
+      label: 'Paused a scheduled job',
       description: 'Pause, resume, or skip runs for a scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),
@@ -606,6 +610,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_delete',
+      label: 'Deleted a scheduled job',
       description: 'Delete a scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),
@@ -620,6 +625,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_get',
+      label: 'Read schedule details',
       description: 'Get details for a single scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),
@@ -657,6 +663,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_run_now',
+      label: 'Triggered scheduled job',
       description: 'Trigger an immediate run of a scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),
@@ -674,6 +681,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_runs',
+      label: 'Listed schedule runs',
       description: 'Get run history for a scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),
@@ -689,6 +697,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_parse',
+      label: 'Parsed cron expression',
       description: 'Parse a natural language or raw cron schedule expression',
       parameters: {
         input: z.string().describe('Schedule expression to parse (required)'),
@@ -703,6 +712,7 @@ const schedulePlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_briefing',
+      label: 'Generated schedule briefing',
       description: "Today's schedule summary — which jobs fire, assigned agents, alerts. Designed for orchestrator daily briefing.",
       parameters: {
         date: z.string().optional().describe('ISO date to check (defaults to today)'),

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -664,6 +664,7 @@ const schedulePlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_schedule_run_now',
       label: 'Triggered scheduled job',
+      activityDuplicate: true,
       description: 'Trigger an immediate run of a scheduled job',
       parameters: {
         jobId: z.string().describe('Job ID (required)'),

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -675,7 +675,6 @@ const schedulePlugin: BakinPlugin = {
         if (!meta) return { ok: false, error: 'Job not found' }
         await cronRun(params.jobId as string, true)
         ctx.activity.audit('job.run_now', 'system', { jobId: params.jobId })
-        ctx.activity.log('system', `Triggered immediate run for "${meta.displayName || params.jobId}"`)
         return { ok: true, jobId: params.jobId }
       },
     })

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -365,6 +365,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_list',
+      label: 'Listed tasks',
       description: 'List all tasks on the board. Optionally filter by column or agent.',
       parameters: {
         column: z.enum(COLUMNS).optional().describe('Filter by column'),
@@ -394,6 +395,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_get',
+      label: 'Read task details',
       description: 'Get details about a task — title, description, current column, logs, dependencies, project context.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -422,6 +424,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_create',
+      label: 'Created a task',
       description: 'Create a new task on the task board. For top-level tasks, you MUST provide either workflowId or skipWorkflowReason. Subtasks (with parentId) are exempt.',
       parameters: {
         title: z.string().describe('Task title'),
@@ -464,6 +467,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_move',
+      label: 'Moved a task',
       description: 'Move a task to a different column on the task board.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -487,6 +491,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_block',
+      label: 'Blocked a task',
       description: 'Mark a task as blocked with a reason. Use when you cannot proceed.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -505,6 +510,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_complete',
+      label: 'Completed a task',
       description: 'Report that your task is complete. Moves the task to Done and notifies the orchestrator.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -523,6 +529,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_log_progress',
+      label: 'Logged progress',
       description: 'Log a human-readable progress update to the live activity feed. Call this at every significant step.',
       parameters: {
         taskId: z.string().describe('Task ID (e.g. "fe84ac51")'),
@@ -540,6 +547,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_set_dependency',
+      label: 'Set task dependency',
       description: 'Register a dependency between tasks. Your task will be auto-re-dispatched when the dependency completes. After registering, exit — do not wait.',
       parameters: {
         taskId: z.string().describe('Your task ID (the one that depends)'),
@@ -558,6 +566,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_update',
+      label: 'Updated a task',
       description: 'Update a task on the board — change title, description, or assigned agent.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -586,6 +595,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_delete',
+      label: 'Deleted a task',
       description: 'Delete a task from the board.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -605,6 +615,7 @@ const tasksPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_assign',
+      label: 'Assigned a task',
       description: 'Assign a task to an agent.',
       parameters: {
         taskId: z.string().describe('Task ID'),

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -453,7 +453,6 @@ const tasksPlugin: BakinPlugin = {
           })
           if (parentId || assignee) triggerDispatch()
 
-          ctx.activity.log(agent, `Created task "${title}"`, { taskId: result.id })
           return {
             ok: true,
             id: result.id,
@@ -483,7 +482,6 @@ const tasksPlugin: BakinPlugin = {
         }
         try {
           await moveTaskWithEffects(taskId, to, agent, { channel: 'mcp' })
-          ctx.activity.log(agent, `Moved task to "${to}"`, { taskId })
           return { ok: true }
         } catch (err) {
           return { ok: false, error: (err as Error).message }
@@ -503,7 +501,6 @@ const tasksPlugin: BakinPlugin = {
       handler: async (params: Record<string, unknown>, agent: string) => {
         try {
           await blockTaskWithEffects(params.taskId as string, params.reason as string, agent, 'mcp')
-          ctx.activity.log(agent, `Blocked task: ${params.reason}`, { taskId: params.taskId as string })
           return { ok: true }
         } catch (err) {
           return { ok: false, error: (err as Error).message }
@@ -523,7 +520,6 @@ const tasksPlugin: BakinPlugin = {
       handler: async (params: Record<string, unknown>, agent: string) => {
         try {
           await reportComplete(params.taskId as string, agent, params.summary as string, 'mcp')
-          ctx.activity.log(agent, `Completed task: ${params.summary}`, { taskId: params.taskId as string })
           return { ok: true }
         } catch (err) {
           return { ok: false, error: (err as Error).message }
@@ -562,7 +558,6 @@ const tasksPlugin: BakinPlugin = {
       handler: async (params: Record<string, unknown>, agent: string) => {
         try {
           await setDependencyWithEffects(params.taskId as string, params.dependsOn as string, 'mcp')
-          ctx.activity.log(agent, `Set dependency on ${params.dependsOn}`, { taskId: params.taskId as string })
           return { ok: true, message: `Dependency registered. You will be re-dispatched when ${params.dependsOn} completes. Stop now.` }
         } catch (err) {
           return { ok: false, error: (err as Error).message }
@@ -592,7 +587,6 @@ const tasksPlugin: BakinPlugin = {
           if (assignee !== undefined) updates.agent = assignee
           const result = await ctx.hooks.invoke('tasks.updateTask', { identifier: taskId, updates })
           ctx.activity.audit('updated', agent, { taskId })
-          ctx.activity.log(agent, `Updated task "${taskId}"`, { taskId })
           return { ok: true, result }
         } catch (err) {
           return { ok: false, error: (err as Error).message }
@@ -613,7 +607,6 @@ const tasksPlugin: BakinPlugin = {
         try {
           await ctx.hooks.invoke('tasks.deleteTask', { identifier: taskId })
           ctx.activity.audit('deleted', agent, { taskId })
-          ctx.activity.log(agent, `Deleted task "${taskId}"`, { taskId })
           return { ok: true }
         } catch (err) {
           return { ok: false, error: (err as Error).message }
@@ -636,7 +629,6 @@ const tasksPlugin: BakinPlugin = {
         try {
           await assignTask(taskId, targetAgent)
           ctx.activity.audit('assigned', callingAgent, { taskId, agent: targetAgent })
-          ctx.activity.log(callingAgent, `Assigned task to "${targetAgent}"`, { taskId })
           return { ok: true }
         } catch (err) {
           return { ok: false, error: (err as Error).message }

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -425,6 +425,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_create',
       label: 'Created a task',
+      activityDuplicate: true,
       description: 'Create a new task on the task board. For top-level tasks, you MUST provide either workflowId or skipWorkflowReason. Subtasks (with parentId) are exempt.',
       parameters: {
         title: z.string().describe('Task title'),
@@ -468,6 +469,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_move',
       label: 'Moved a task',
+      activityDuplicate: true,
       description: 'Move a task to a different column on the task board.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -492,6 +494,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_block',
       label: 'Blocked a task',
+      activityDuplicate: true,
       description: 'Mark a task as blocked with a reason. Use when you cannot proceed.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -511,6 +514,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_complete',
       label: 'Completed a task',
+      activityDuplicate: true,
       description: 'Report that your task is complete. Moves the task to Done and notifies the orchestrator.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -530,6 +534,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_log_progress',
       label: 'Logged progress',
+      activityDuplicate: true,
       description: 'Log a human-readable progress update to the live activity feed. Call this at every significant step.',
       parameters: {
         taskId: z.string().describe('Task ID (e.g. "fe84ac51")'),
@@ -548,6 +553,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_set_dependency',
       label: 'Set task dependency',
+      activityDuplicate: true,
       description: 'Register a dependency between tasks. Your task will be auto-re-dispatched when the dependency completes. After registering, exit — do not wait.',
       parameters: {
         taskId: z.string().describe('Your task ID (the one that depends)'),
@@ -567,6 +573,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_update',
       label: 'Updated a task',
+      activityDuplicate: true,
       description: 'Update a task on the board — change title, description, or assigned agent.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -596,6 +603,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_delete',
       label: 'Deleted a task',
+      activityDuplicate: true,
       description: 'Delete a task from the board.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -616,6 +624,7 @@ const tasksPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_tasks_assign',
       label: 'Assigned a task',
+      activityDuplicate: true,
       description: 'Assign a task to an agent.',
       parameters: {
         taskId: z.string().describe('Task ID'),

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -862,6 +862,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_list',
+      label: 'Listed team',
       description: 'List all agents with their current status (online/working/available/offline).',
       parameters: {},
       handler: async () => {
@@ -880,6 +881,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_profile',
+      label: 'Read agent profile',
       description: 'Get the full profile for an agent including soul, rules, and tools.',
       parameters: {
         agentId: z.string().describe('Agent ID'),
@@ -893,6 +895,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_status',
+      label: 'Checked agent status',
       description: 'Get the heartbeat and health status for an agent.',
       parameters: {
         agentId: z.string().describe('Agent ID'),
@@ -907,6 +910,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_read_file',
+      label: 'Read agent file',
       description: 'Read a workspace file for an agent (e.g., SOUL.md, AGENTS.md, TOOLS.md).',
       parameters: {
         agentId: z.string().describe('Agent ID'),
@@ -921,6 +925,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_message',
+      label: 'Sent a message',
       description: 'Send a message to an agent via OpenClaw.',
       parameters: {
         agentId: z.string().describe('Agent ID'),
@@ -934,6 +939,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_org',
+      label: 'Read organization',
       description: 'Get the full org structure: teams with their members. Use this to understand who is on which team and reporting lines.',
       parameters: {},
       handler: async () => {
@@ -943,6 +949,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_members',
+      label: 'Listed team members',
       description: 'Get agents that belong to a specific team (e.g. "builders", "creators").',
       parameters: {
         teamId: z.string().describe('Team ID (e.g. "builders", "creators")'),
@@ -961,6 +968,7 @@ const teamPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_team_my_team',
+      label: 'Read own team',
       description: 'Get the team that a specific agent belongs to, including all teammates.',
       parameters: {
         agentId: z.string().describe('Agent ID'),

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -516,6 +516,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_list',
+      label: 'Listed workflows',
       description: 'List all workflow definitions (templates). Returns name, filename, description, and step count for each.',
       parameters: {},
       handler: async () => {
@@ -534,6 +535,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_get_definition',
+      label: 'Read workflow definition',
       description: 'Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows.',
       parameters: {
         name: z.string().describe('Workflow definition filename (e.g. "content-pipeline")'),
@@ -551,6 +553,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_start',
+      label: 'Started a workflow',
       description: 'Start a workflow instance for a task. The task must exist on the board. Returns the created instance.',
       parameters: {
         taskId: z.string().describe('Task ID to start workflow for'),
@@ -590,6 +593,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_list_instances',
+      label: 'Listed workflow runs',
       description: 'List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled).',
       parameters: {
         status: z.enum(['in_progress', 'pending_approval', 'complete', 'failed', 'cancelled']).optional().describe('Filter by instance status'),
@@ -602,6 +606,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_get_instance',
+      label: 'Read workflow instance',
       description: 'Get the full state of a workflow instance for a task, including step states and history.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -615,6 +620,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_get_step',
+      label: 'Read workflow step',
       description: 'Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -629,6 +635,7 @@ const workflowsPlugin: BakinPlugin = {
 
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_complete_step',
+      label: 'Completed workflow step',
       description: 'Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -664,6 +671,7 @@ const workflowsPlugin: BakinPlugin = {
     // bakin_exec_get_step — human-readable step context formatter
     ctx.registerExecTool({
       name: 'bakin_exec_get_step',
+      label: 'Read workflow step',
       description: 'Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -683,6 +691,7 @@ const workflowsPlugin: BakinPlugin = {
     // bakin_exec_submit_step — local pre-validation before server submission
     ctx.registerExecTool({
       name: 'bakin_exec_submit_step',
+      label: 'Submitted workflow step',
       description: 'Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -737,6 +746,7 @@ const workflowsPlugin: BakinPlugin = {
     // bakin_exec_check_gates — human-readable gate status overview
     ctx.registerExecTool({
       name: 'bakin_exec_check_gates',
+      label: 'Checked workflow gates',
       description: 'Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending.',
       parameters: {
         taskId: z.string().describe('Task ID (or workflow instance ID)'),

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -554,6 +554,7 @@ const workflowsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_start',
       label: 'Started a workflow',
+      activityDuplicate: true,
       description: 'Start a workflow instance for a task. The task must exist on the board. Returns the created instance.',
       parameters: {
         taskId: z.string().describe('Task ID to start workflow for'),
@@ -636,6 +637,7 @@ const workflowsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_workflows_complete_step',
       label: 'Completed workflow step',
+      activityDuplicate: true,
       description: 'Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete.',
       parameters: {
         taskId: z.string().describe('Task ID'),
@@ -692,6 +694,7 @@ const workflowsPlugin: BakinPlugin = {
     ctx.registerExecTool({
       name: 'bakin_exec_submit_step',
       label: 'Submitted workflow step',
+      activityDuplicate: true,
       description: 'Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip.',
       parameters: {
         taskId: z.string().describe('Task ID'),

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -583,7 +583,6 @@ const workflowsPlugin: BakinPlugin = {
           } catch { /* non-fatal */ }
 
           ctx.activity.audit('started', agent, { taskId, workflowId })
-          ctx.activity.log(agent, `Started workflow "${workflowId}"`, { taskId })
 
           return { ok: true, instance }
         } catch (err) {
@@ -658,7 +657,6 @@ const workflowsPlugin: BakinPlugin = {
         }
 
         ctx.activity.audit('step.completed', agentId, { taskId, stepId, workflowComplete: result.workflowComplete })
-        ctx.activity.log(agentId, `Completed step "${stepId}"${result.workflowComplete ? ' — workflow complete' : ''}`, { taskId })
 
         if (!result.workflowComplete) {
           triggerDispatch()
@@ -729,7 +727,6 @@ const workflowsPlugin: BakinPlugin = {
           }
 
           ctx.activity.audit('step.completed', agent, { taskId, stepId, workflowComplete: result.workflowComplete })
-          ctx.activity.log(agent, `Completed step "${stepId}"${result.workflowComplete ? ' — workflow complete' : ''}`, { taskId })
 
           if (!result.workflowComplete) {
             triggerDispatch()

--- a/scripts/lib/generate-image.ts
+++ b/scripts/lib/generate-image.ts
@@ -312,6 +312,7 @@ export async function generateImage(params: GenImageParams): Promise<ExecToolRes
 
 addExecTool({
   name: 'bakin_exec_gen_image',
+  label: 'Generated an image',
   description: `Generate an image via Gemini Imagen (Nano Banana), or import an existing image file into the asset pipeline via filePath. Default model: flash (cheaper). Use model=pro for higher quality. Default: 1080x1920 portrait (9:16) for Stories/Reels. Presets: social-portrait, social-square, social-landscape, custom. Auto-generates thumbnail. Max ${MAX_IMAGE_EDGE}px on any edge.`,
   source: 'core',
   parameters: {

--- a/scripts/lib/get-paths.ts
+++ b/scripts/lib/get-paths.ts
@@ -8,6 +8,7 @@ import { addExecTool } from './registry'
 
 addExecTool({
   name: 'bakin_exec_get_paths',
+  label: 'Resolved paths',
   description: 'Get Bakin content directory paths — where to find assets, team info, docs, etc.',
   source: 'core',
   parameters: {},

--- a/scripts/lib/heartbeat.ts
+++ b/scripts/lib/heartbeat.ts
@@ -10,6 +10,7 @@ import { addExecTool } from './registry'
 
 addExecTool({
   name: 'bakin_exec_heartbeat',
+  label: 'Sent heartbeat',
   description:
     'Write a heartbeat signal. Call periodically (every 5-10 minutes) to indicate you are alive. Also call when starting or finishing a task.',
   source: 'core',

--- a/scripts/lib/log-progress.ts
+++ b/scripts/lib/log-progress.ts
@@ -44,6 +44,7 @@ export async function logProgressFormatted(params: LogProgressParams): Promise<E
 addExecTool({
   name: 'bakin_exec_log',
   label: 'Logged message',
+  activityDuplicate: true,
   description: 'Log a formatted progress update with category and stage tags. Categories: start, progress, milestone, blocked, complete. More structured than raw bakin_log_progress.',
   source: 'core',
   parameters: {

--- a/scripts/lib/log-progress.ts
+++ b/scripts/lib/log-progress.ts
@@ -43,6 +43,7 @@ export async function logProgressFormatted(params: LogProgressParams): Promise<E
 
 addExecTool({
   name: 'bakin_exec_log',
+  label: 'Logged message',
   description: 'Log a formatted progress update with category and stage tags. Categories: start, progress, milestone, blocked, complete. More structured than raw bakin_log_progress.',
   source: 'core',
   parameters: {

--- a/scripts/lib/post-discord.ts
+++ b/scripts/lib/post-discord.ts
@@ -184,6 +184,7 @@ export async function postDiscord(params: PostDiscordParams): Promise<ExecToolRe
 
 addExecTool({
   name: 'bakin_exec_post_discord',
+  label: 'Posted to Discord',
   description: 'Post a message to a Discord channel via bot. Resolves channel names to IDs automatically. Supports image/video attachments and embeds.',
   source: 'core',
   parameters: {

--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -36,6 +36,7 @@ export async function GET() {
             taskId: data.taskId as string | undefined,
             taskTitle: data.title as string | undefined,
             eventName: entry.event,
+            ...(data.duplicate ? { duplicate: true } : {}),
           })
         } catch { /* skip malformed lines */ }
       }

--- a/src/components/tasks/activity-feed.tsx
+++ b/src/components/tasks/activity-feed.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug, Code } from 'lucide-react'
+import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug, Terminal } from 'lucide-react'
 import { useActivityContext } from '@/context/activity-context'
 import { useContentStore } from '@/hooks/use-content-store'
 import { AgentAvatar } from '@/components/agent-avatar'
@@ -103,7 +103,7 @@ export function ActivityFeed() {
               title={verbose ? 'Hide command names' : 'Show command names'}
               className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${verbose ? 'text-foreground' : 'text-muted-foreground/50'}`}
             >
-              <Code className="size-3.5" />
+              <Terminal className="size-3.5" />
             </button>
             <button
               onClick={toggle}

--- a/src/components/tasks/activity-feed.tsx
+++ b/src/components/tasks/activity-feed.tsx
@@ -54,14 +54,14 @@ export function ActivityFeed() {
   const events = useContentStore((s) => s.activityEvents)
   const connected = useContentStore((s) => s.sseConnected)
   const [, setTick] = useState(0)
-  const [verbose, setVerbose] = useState(() => {
-    if (typeof window === 'undefined') return true
-    return localStorage.getItem('bakin-activity-verbose') !== 'false'
+  const [showDuplicates, setShowDuplicates] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return localStorage.getItem('bakin-activity-show-duplicates') === 'true'
   })
-  const toggleVerbose = useCallback(() => {
-    setVerbose((v) => {
+  const toggleDuplicates = useCallback(() => {
+    setShowDuplicates((v) => {
       const next = !v
-      localStorage.setItem('bakin-activity-verbose', String(next))
+      localStorage.setItem('bakin-activity-show-duplicates', String(next))
       return next
     })
   }, [])
@@ -99,9 +99,9 @@ export function ActivityFeed() {
           </div>
           <div className="flex items-center gap-1">
             <button
-              onClick={toggleVerbose}
-              title={verbose ? 'Hide command names' : 'Show command names'}
-              className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${verbose ? 'text-foreground' : 'text-muted-foreground/50'}`}
+              onClick={toggleDuplicates}
+              title={showDuplicates ? 'Hide duplicate events' : 'Show all events'}
+              className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${showDuplicates ? 'text-foreground' : 'text-muted-foreground/50'}`}
             >
               <Terminal className="size-3.5" />
             </button>
@@ -119,7 +119,7 @@ export function ActivityFeed() {
           {events.length === 0 && (
             <p className="text-xs text-muted-foreground text-center mt-8">No activity yet</p>
           )}
-          {events.map((evt, i) => (
+          {events.filter((evt) => showDuplicates || !evt.duplicate).map((evt, i) => (
             <div
               key={`${evt.id}-${i}`}
               className={`flex gap-2.5 px-3 py-2.5 hover:bg-muted/50 transition-colors border-b border-border/60 last:border-0 ${
@@ -143,7 +143,7 @@ export function ActivityFeed() {
                 <p className={`text-[12px] leading-snug break-words ${
                   evt.type === 'alert' ? 'text-warning' : 'text-foreground/80'
                 }`}>{evt.message}</p>
-                {verbose && evt.eventName && (
+                {evt.eventName && (
                   <p className="text-[10px] text-muted-foreground/60 mt-0.5 truncate font-mono">{evt.eventName}</p>
                 )}
               </div>

--- a/src/components/tasks/activity-feed.tsx
+++ b/src/components/tasks/activity-feed.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug, Terminal } from 'lucide-react'
+import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug, Bug } from 'lucide-react'
 import { useActivityContext } from '@/context/activity-context'
 import { useContentStore } from '@/hooks/use-content-store'
 import { AgentAvatar } from '@/components/agent-avatar'
@@ -103,7 +103,7 @@ export function ActivityFeed() {
               title={showDuplicates ? 'Hide duplicate events' : 'Show all events'}
               className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${showDuplicates ? 'text-foreground' : 'text-muted-foreground/50'}`}
             >
-              <Terminal className="size-3.5" />
+              <Bug className="size-3.5" />
             </button>
             <button
               onClick={toggle}

--- a/src/components/tasks/activity-feed.tsx
+++ b/src/components/tasks/activity-feed.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug, Code } from 'lucide-react'
 import { useActivityContext } from '@/context/activity-context'
 import { useContentStore } from '@/hooks/use-content-store'
 import { AgentAvatar } from '@/components/agent-avatar'
@@ -54,6 +54,17 @@ export function ActivityFeed() {
   const events = useContentStore((s) => s.activityEvents)
   const connected = useContentStore((s) => s.sseConnected)
   const [, setTick] = useState(0)
+  const [verbose, setVerbose] = useState(() => {
+    if (typeof window === 'undefined') return true
+    return localStorage.getItem('bakin-activity-verbose') !== 'false'
+  })
+  const toggleVerbose = useCallback(() => {
+    setVerbose((v) => {
+      const next = !v
+      localStorage.setItem('bakin-activity-verbose', String(next))
+      return next
+    })
+  }, [])
 
   // Force re-render every 30s to keep relative timestamps fresh
   useEffect(() => {
@@ -86,12 +97,21 @@ export function ActivityFeed() {
             <span className={`h-2 w-2 rounded-full ${connected ? 'bg-success animate-pulse' : 'bg-muted-foreground'}`} />
             <span className="text-sm font-medium text-foreground">Live Activity</span>
           </div>
-          <button
-            onClick={toggle}
-            className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)]"
-          >
-            <ChevronRight className="size-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={toggleVerbose}
+              title={verbose ? 'Hide command names' : 'Show command names'}
+              className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${verbose ? 'text-foreground' : 'text-muted-foreground/50'}`}
+            >
+              <Code className="size-3.5" />
+            </button>
+            <button
+              onClick={toggle}
+              className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)]"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          </div>
         </div>
 
         {/* Event list */}
@@ -123,6 +143,9 @@ export function ActivityFeed() {
                 <p className={`text-[12px] leading-snug break-words ${
                   evt.type === 'alert' ? 'text-warning' : 'text-foreground/80'
                 }`}>{evt.message}</p>
+                {verbose && evt.eventName && (
+                  <p className="text-[10px] text-muted-foreground/60 mt-0.5 truncate font-mono">{evt.eventName}</p>
+                )}
               </div>
             </div>
           ))}

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -111,7 +111,7 @@ function registerTools(server: McpServer, getAgent: () => string): void {
             getContentDir(),
             result.ok ? `exec.${tool.name}.ok` : `exec.${tool.name}.fail`,
             agent,
-            { taskId, ...(result.ok ? {} : { error: result.error }) },
+            { taskId, label: tool.label, ...(result.ok ? {} : { error: result.error }) },
             'mcp',
           )
 
@@ -120,7 +120,7 @@ function registerTools(server: McpServer, getAgent: () => string): void {
             : `ERROR: ${result.error}${result.details ? '\n' + JSON.stringify(result.details, null, 2) : ''}`
           return { content: [{ type: 'text' as const, text }], isError: !result.ok }
         } catch (err) {
-          appendAudit(getContentDir(), `exec.${tool.name}.error`, agent, { taskId, error: err instanceof Error ? err.message : String(err) }, 'mcp')
+          appendAudit(getContentDir(), `exec.${tool.name}.error`, agent, { taskId, label: tool.label, error: err instanceof Error ? err.message : String(err) }, 'mcp')
           return { content: [{ type: 'text' as const, text: `Exec tool error: ${err instanceof Error ? err.message : String(err)}` }], isError: true }
         }
       },

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -111,7 +111,7 @@ function registerTools(server: McpServer, getAgent: () => string): void {
             getContentDir(),
             result.ok ? `exec.${tool.name}.ok` : `exec.${tool.name}.fail`,
             agent,
-            { taskId, label: tool.label, ...(result.ok ? {} : { error: result.error }) },
+            { taskId, label: tool.label, ...(tool.activityDuplicate ? { duplicate: true } : {}), ...(result.ok ? {} : { error: result.error }) },
             'mcp',
           )
 
@@ -120,7 +120,7 @@ function registerTools(server: McpServer, getAgent: () => string): void {
             : `ERROR: ${result.error}${result.details ? '\n' + JSON.stringify(result.details, null, 2) : ''}`
           return { content: [{ type: 'text' as const, text }], isError: !result.ok }
         } catch (err) {
-          appendAudit(getContentDir(), `exec.${tool.name}.error`, agent, { taskId, label: tool.label, error: err instanceof Error ? err.message : String(err) }, 'mcp')
+          appendAudit(getContentDir(), `exec.${tool.name}.error`, agent, { taskId, label: tool.label, ...(tool.activityDuplicate ? { duplicate: true } : {}), error: err instanceof Error ? err.message : String(err) }, 'mcp')
           return { content: [{ type: 'text' as const, text: `Exec tool error: ${err instanceof Error ? err.message : String(err)}` }], isError: true }
         }
       },

--- a/src/hooks/use-sse.ts
+++ b/src/hooks/use-sse.ts
@@ -80,6 +80,7 @@ export function useSSE() {
               taskId: entryData.taskId as string | undefined,
               taskTitle: entryData.title as string | undefined,
               eventName: entry.event,
+              ...(entryData.duplicate ? { duplicate: true } : {}),
             })
           }
 

--- a/src/lib/map-audit-message.ts
+++ b/src/lib/map-audit-message.ts
@@ -19,8 +19,26 @@ export function mapAuditMessage(event: string, data: Record<string, unknown>): s
     case 'workflow.gate_approved': return `Approved: ${data.label || 'gate'}`
     case 'workflow.gate_rejected': return `Rejected: ${data.label || 'gate'}${data.reason ? ` — ${data.reason}` : ''}`
     case 'workflow.complete': return `Workflow complete${data.workflowId ? ` (${data.workflowId})` : ''}`
-    default: return event
+    default: {
+      // Exec tool events: use label from audit data, fall back to humanized name
+      if (event.startsWith('exec.')) {
+        const suffix = event.endsWith('.fail') ? ' (failed)' : event.endsWith('.error') ? ' (error)' : ''
+        if (data.label) return `${data.label}${suffix}`
+        const toolName = event.replace(/^exec\./, '').replace(/\.(ok|fail|error)$/, '')
+        return humanizeExecName(toolName) + suffix
+      }
+      return event
+    }
   }
+}
+
+/** Convert an exec tool name like "bakin_exec_foo_bar" into "Foo bar" */
+export function humanizeExecName(name: string): string {
+  const stripped = name.replace(/^bakin_exec_/, '')
+  const words = stripped.split('_')
+  if (words.length === 0) return name
+  words[0] = words[0].charAt(0).toUpperCase() + words[0].slice(1)
+  return words.join(' ')
 }
 
 /** Filter out infrastructure noise that isn't useful in the user-facing feed */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,7 @@ export interface ActivityEvent {
   taskId?: string
   taskTitle?: string
   eventName?: string
+  duplicate?: boolean
 }
 
 export interface ContentState {

--- a/tests/lib/map-audit-message.test.ts
+++ b/tests/lib/map-audit-message.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { mapAuditMessage, humanizeExecName } from '../../src/lib/map-audit-message'
+
+describe('mapAuditMessage', () => {
+  // Existing domain events should still work
+  it('maps task.created to human-readable text', () => {
+    expect(mapAuditMessage('task.created', { title: 'Fix bug' })).toBe('Created task: Fix bug')
+  })
+
+  it('maps task.moved with title and target', () => {
+    expect(mapAuditMessage('task.moved', { title: 'Fix bug', to: 'done' })).toBe('Moved "Fix bug" → done')
+  })
+
+  it('maps workflow.gate_reached', () => {
+    expect(mapAuditMessage('workflow.gate_reached', { label: 'Review' })).toBe('Awaiting approval: Review')
+  })
+
+  it('maps system.init', () => {
+    expect(mapAuditMessage('system.init', {})).toBe('Bakin started')
+  })
+
+  // Exec tool events with label in data
+  it('uses data.label for exec.*.ok events', () => {
+    expect(mapAuditMessage('exec.bakin_exec_tasks_create.ok', { label: 'Created a task' }))
+      .toBe('Created a task')
+  })
+
+  it('appends (failed) for exec.*.fail events', () => {
+    expect(mapAuditMessage('exec.bakin_exec_tasks_create.fail', { label: 'Created a task', error: 'oops' }))
+      .toBe('Created a task (failed)')
+  })
+
+  it('appends (error) for exec.*.error events', () => {
+    expect(mapAuditMessage('exec.bakin_exec_health_doctor.error', { label: 'Ran diagnostics', error: 'timeout' }))
+      .toBe('Ran diagnostics (error)')
+  })
+
+  // Exec tool events without label — fallback to humanized name
+  it('humanizes exec tool name when no label present', () => {
+    expect(mapAuditMessage('exec.bakin_exec_tasks_list.ok', {}))
+      .toBe('Tasks list')
+  })
+
+  it('humanizes and appends (failed) for exec.*.fail without label', () => {
+    expect(mapAuditMessage('exec.bakin_exec_schedule_create.fail', {}))
+      .toBe('Schedule create (failed)')
+  })
+
+  // Unknown events pass through
+  it('returns raw event name for unknown events', () => {
+    expect(mapAuditMessage('some.unknown.event', {})).toBe('some.unknown.event')
+  })
+})
+
+describe('humanizeExecName', () => {
+  it('strips bakin_exec_ prefix and capitalizes', () => {
+    expect(humanizeExecName('bakin_exec_tasks_list')).toBe('Tasks list')
+  })
+
+  it('handles multi-word tool names', () => {
+    expect(humanizeExecName('bakin_exec_workflows_complete_step')).toBe('Workflows complete step')
+  })
+
+  it('handles names without bakin_exec_ prefix', () => {
+    expect(humanizeExecName('custom_tool')).toBe('Custom tool')
+  })
+
+  it('handles single word after prefix', () => {
+    expect(humanizeExecName('bakin_exec_heartbeat')).toBe('Heartbeat')
+  })
+})

--- a/tests/lib/map-audit-message.test.ts
+++ b/tests/lib/map-audit-message.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { mapAuditMessage, humanizeExecName } from '../../src/lib/map-audit-message'
+import { mapAuditMessage, humanizeExecName, isNoisyEvent } from '../../src/lib/map-audit-message'
+import type { ActivityEvent } from '../../src/types'
 
 describe('mapAuditMessage', () => {
   // Existing domain events should still work
@@ -67,5 +68,61 @@ describe('humanizeExecName', () => {
 
   it('handles single word after prefix', () => {
     expect(humanizeExecName('bakin_exec_heartbeat')).toBe('Heartbeat')
+  })
+
+  it('returns input unchanged for empty string', () => {
+    expect(humanizeExecName('')).toBe('')
+  })
+})
+
+describe('mapAuditMessage — exec edge cases', () => {
+  it('handles exec event with no suffix (bare exec.tool_name)', () => {
+    // No .ok/.fail/.error suffix — should still use label or humanize
+    expect(mapAuditMessage('exec.bakin_exec_tasks_list', { label: 'Listed tasks' }))
+      .toBe('Listed tasks')
+  })
+
+  it('humanizes bare exec event without label', () => {
+    expect(mapAuditMessage('exec.bakin_exec_tasks_list', {}))
+      .toBe('Tasks list')
+  })
+
+  it('label takes precedence over humanized name for .ok events', () => {
+    expect(mapAuditMessage('exec.bakin_exec_assets_save.ok', { label: 'Saved an asset' }))
+      .toBe('Saved an asset')
+  })
+
+  it('preserves label text exactly (no trimming or transformation)', () => {
+    expect(mapAuditMessage('exec.bakin_exec_health_doctor.ok', { label: 'Ran diagnostics' }))
+      .toBe('Ran diagnostics')
+  })
+})
+
+describe('isNoisyEvent', () => {
+  function makeEvent(overrides: Partial<ActivityEvent>): ActivityEvent {
+    return {
+      id: 'test-1',
+      ts: '2026-04-10T00:00:00Z',
+      type: 'audit',
+      agent: 'system',
+      message: 'test',
+      ...overrides,
+    }
+  }
+
+  it('flags system dispatch errors as noisy', () => {
+    expect(isNoisyEvent(makeEvent({ agent: 'system', message: 'Dispatch failed: timeout' }))).toBe(true)
+  })
+
+  it('does not flag normal system events as noisy', () => {
+    expect(isNoisyEvent(makeEvent({ agent: 'system', message: 'Bakin started' }))).toBe(false)
+  })
+
+  it('does not flag agent events as noisy', () => {
+    expect(isNoisyEvent(makeEvent({ agent: 'pixel', message: 'Dispatch failed: something' }))).toBe(false)
+  })
+
+  it('does not flag duplicate events as noisy (separate concern)', () => {
+    expect(isNoisyEvent(makeEvent({ agent: 'system', message: 'Created a task', duplicate: true }))).toBe(false)
   })
 })

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -715,17 +715,14 @@ describe('exec tool: bakin_exec_assets_save', () => {
     writeFileSync(sourceFile, 'activity test')
 
     const tool = findTool(plugin.execTools, 'bakin_exec_assets_save')!
-    await callTool(tool, {
+    const result = await callTool(tool, {
       filePath: sourceFile,
       taskId: 'task-activity',
       type: 'text',
     }, 'scribe')
 
-    expect(plugin.ctx.activity.log).toHaveBeenCalledWith(
-      'scribe',
-      expect.stringContaining('Saved asset'),
-      expect.objectContaining({ taskId: 'task-activity' })
-    )
+    // ctx.activity.log removed — auto-audit from mcp-server.ts with label covers this
+    expect(result.ok).toBe(true)
   })
 })
 
@@ -836,12 +833,10 @@ describe('exec tool: bakin_exec_assets_restore', () => {
     })
 
     const tool = findTool(plugin.execTools, 'bakin_exec_assets_restore')!
-    await callTool(tool, { filename: trashFilename }, 'scribe')
+    const result = await callTool(tool, { filename: trashFilename }, 'scribe')
 
-    expect(plugin.ctx.activity.log).toHaveBeenCalledWith(
-      'scribe',
-      expect.stringContaining('Restored asset')
-    )
+    // ctx.activity.log removed — auto-audit from mcp-server.ts with label covers this
+    expect(result.ok).toBe(true)
   })
 
   it('returns error for nonexistent trash item', async () => {

--- a/tests/plugins/messaging/routes.test.ts
+++ b/tests/plugins/messaging/routes.test.ts
@@ -811,7 +811,6 @@ describe('Calendar exec tools', () => {
         'system',
         expect.objectContaining({ itemId: 'tool-rej-4', note: 'Feedback' }),
       )
-      expect(plugin.ctx.activity.log).toHaveBeenCalled()
     })
   })
 })

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -1167,7 +1167,6 @@ describe('schedule exec tools', () => {
       await callTool(tool, { jobId: 'job-rn-audit' })
 
       expect(plugin.ctx.activity.audit).toHaveBeenCalledWith('job.run_now', 'system', expect.objectContaining({ jobId: 'job-rn-audit' }))
-      expect(plugin.ctx.activity.log).toHaveBeenCalled()
     })
 
     it('returns error when jobId is missing', async () => {


### PR DESCRIPTION
## Summary

- Add `label` and `activityDuplicate` fields to `ExecToolDefinition` so plugins own their activity feed labels
- Add human-readable labels to all 77 exec tool registrations across 10 plugins + scripts
- Flow labels through audit data (`mcp-server.ts` → SSE → `mapAuditMessage()`) with `humanizeExecName()` fallback for unlabeled tools
- Add duplicate event filtering: tools that emit their own domain events (e.g., `task.created`) get their auto-audit tagged `duplicate: true`, hidden by default in the feed
- Remove 21 manual `ctx.activity.log()` calls from exec tool handlers where domain events + labels make them redundant
- Bug icon toggle in activity feed header to show/hide duplicate events
- Raw event names always shown as muted mono text for debugging
- 14 unit tests for `mapAuditMessage()` exec event handling
- Updated plugin-system.md knowledge and spec docs

## Test plan

- [x] `npx tsc --noEmit` passes (clean build)
- [x] `vitest run tests/lib/map-audit-message.test.ts` — 14/14 tests pass
- [ ] Run `pnpm dev:mock`, trigger agent activity, verify feed shows human-readable labels
- [ ] Verify duplicate toggle (Bug icon) hides/shows duplicate events
- [ ] Verify failed exec events show "(failed)" suffix
- [ ] Verify raw event names shown as muted mono text for all visible events
- [ ] Verify localStorage persistence for duplicate toggle preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)