### PR TITLE
feat(core): unified debug mode

### DIFF
--- a/.claude/specs/human-readable-activity-feed.md
+++ b/.claude/specs/human-readable-activity-feed.md
@@ -192,7 +192,7 @@ ctx.registerExecTool({
 - Do NOT set on tools where the auto-audit is the only activity event (e.g., read-only tools, tools with no domain event)
 - When set, the manual `ctx.activity.log()` call in the handler should be removed — the domain event + label cover the same information
 
-**UI:** Bug icon toggle in the feed header. Off by default (hides duplicates). State persisted to `localStorage` key `bakin-activity-show-duplicates`. Raw event names (`evt.eventName`) always shown for all visible events regardless of toggle state.
+**UI:** Duplicate visibility is controlled by the global debug mode (Bug icon in the app header, `useDebug()` hook). Off by default (hides duplicates). State persisted via Zustand + `localStorage` key `bakin-debug`. Raw event names (`evt.eventName`) always shown for all visible events regardless of toggle state.
 
 ## Acceptance Criteria
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,9 @@ All user-facing filter/view state **must** be backed by URL query parameters so 
 ### Search Indexing
 Plugins register content types via `ctx.search.registerContentType()` during `activate()`. Mutations dual-write to source and index via `ctx.search.index()`. Deletions sync via `ctx.search.remove()` (called from the watcher unlink hook). Orphan cleanup runs on a periodic timer via `src/core/search-cleanup.ts`. All Antfly tables use the `bakin_` prefix. Config in `settings.antfly.*`. Antfly is optional — all calls are no-ops when disabled. See `.claude/knowledge/search-system.md`.
 
+### Debug Mode
+Global client-side debug toggle. State lives in Zustand (`useContentStore`) + localStorage (`bakin-debug`). Access via `useDebug()` from `src/hooks/use-debug.ts` — returns `[debug, toggleDebug]`. Toggle button in the header (Bug icon). URL `?debug=true` on any page activates debug mode as a one-shot seed. Currently controls: activity feed duplicate event visibility, Antfly search score overlays on asset cards. Plugins and components should use `useDebug()` to conditionally render debug info.
+
 ### Shared UI Components
 - **`PluginHeader`** (`src/components/plugin-header.tsx`) — Consistent page title + count badge + search + actions slot. Used by all 10 plugins.
 - **`FacetFilter`** (`src/components/facet-filter.tsx`) — Popover-based multi-select filter with removable chips. Replaces long tab bars for 4+ filter options. Always back with `useQueryArrayState`.

--- a/plugins/assets/components/assets-page.tsx
+++ b/plugins/assets/components/assets-page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { useQueryState, useQueryArrayState } from '@/hooks/use-query-state'
+import { useDebug } from '@/hooks/use-debug'
 import { useAntflySearch, reorderByAntflyResults } from '@/hooks/use-antfly-search'
 import { useAssets, useTrash } from '@/hooks/use-assets'
 import { AssetsGrid } from './assets-grid'
@@ -24,6 +25,7 @@ function getStoredPageSize(): number {
 }
 
 export function AssetsPage() {
+  const [debug] = useDebug()
   const [view, setView] = useQueryState('view', 'grid')
   const [search, setSearch] = useQueryState('q', '')
   const [typeFilter, setTypeFilter] = useQueryArrayState('type')
@@ -193,7 +195,7 @@ export function AssetsPage() {
           assets={paged}
           onSelect={(a: AssetMeta) => setAssetPath(a.path)}
           onDelete={deleteAsset}
-          scores={search && antfly.results.length && searchParams.get('debug') === 'true' ? new Map(antfly.results.map(r => [r.id, { score: r.score, indexScores: r.indexScores }])) : undefined}
+          scores={search && antfly.results.length && debug ? new Map(antfly.results.map(r => [r.id, { score: r.score, indexScores: r.indexScores }])) : undefined}
         />
       )}
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,12 +1,26 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Menu, X, PanelLeftClose, PanelLeft } from 'lucide-react'
+import { Menu, X, PanelLeftClose, PanelLeft, Bug } from 'lucide-react'
 import { ConnectionDot } from './connection-dot'
 import { DispatchTimer } from './dispatch-timer'
 import { NotificationToggle } from './notification-toggle'
 import { AppSidebar } from './app-sidebar'
 import { useSidebarContext } from '@/context/sidebar-context'
+import { useDebug } from '@/hooks/use-debug'
+
+function DebugToggle() {
+  const [debug, toggleDebug] = useDebug()
+  return (
+    <button
+      onClick={toggleDebug}
+      title="Debug mode"
+      className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${debug ? 'text-foreground' : 'text-muted-foreground'}`}
+    >
+      <Bug className="size-4" />
+    </button>
+  )
+}
 
 export function Header() {
   const [mobileOpen, setMobileOpen] = useState(false)
@@ -43,6 +57,7 @@ export function Header() {
         </div>
         <div className="ml-auto flex items-center gap-4">
           <DispatchTimer />
+          <DebugToggle />
           <NotificationToggle />
           <ConnectionDot />
         </div>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect } from 'react'
 import { useSSE } from '@/hooks/use-sse'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { Toaster } from '@/components/layout/toaster'
@@ -7,10 +8,30 @@ import { SidebarContext } from '@/context/sidebar-context'
 import { ActivityProvider } from '@/context/activity-context'
 import { useSidebar } from '@/hooks/use-sidebar'
 import { AgentThemeProvider } from '@/components/providers/agent-theme-provider'
+import { useContentStore } from '@/hooks/use-content-store'
 
 function SSEProvider({ children }: { children: React.ReactNode }) {
   useSSE()
   return <>{children}</>
+}
+
+function DebugSeed() {
+  const setDebug = useContentStore((s) => s.setDebug)
+  useEffect(() => {
+    // Seed from URL query param
+    if (new URLSearchParams(window.location.search).get('debug') === 'true') {
+      setDebug(true)
+    }
+    // Migrate old localStorage key
+    try {
+      const old = localStorage.getItem('bakin-activity-show-duplicates')
+      if (old === 'true') {
+        setDebug(true)
+        localStorage.removeItem('bakin-activity-show-duplicates')
+      }
+    } catch {}
+  }, [setDebug])
+  return null
 }
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -21,6 +42,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <SidebarContext.Provider value={sidebar}>
         <ActivityProvider>
           <AgentThemeProvider>
+            <DebugSeed />
             <SSEProvider>{children}</SSEProvider>
           </AgentThemeProvider>
         </ActivityProvider>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -22,14 +22,6 @@ function DebugSeed() {
     if (new URLSearchParams(window.location.search).get('debug') === 'true') {
       setDebug(true)
     }
-    // Migrate old localStorage key
-    try {
-      const old = localStorage.getItem('bakin-activity-show-duplicates')
-      if (old === 'true') {
-        setDebug(true)
-        localStorage.removeItem('bakin-activity-show-duplicates')
-      }
-    } catch {}
   }, [setDebug])
   return null
 }

--- a/src/components/tasks/activity-feed.tsx
+++ b/src/components/tasks/activity-feed.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
-import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug, Bug } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { ChevronRight, Workflow, Zap, Radio, MonitorDot, Plug } from 'lucide-react'
 import { useActivityContext } from '@/context/activity-context'
 import { useContentStore } from '@/hooks/use-content-store'
 import { AgentAvatar } from '@/components/agent-avatar'
@@ -53,19 +53,8 @@ export function ActivityFeed() {
   const { open, toggle } = useActivityContext()
   const events = useContentStore((s) => s.activityEvents)
   const connected = useContentStore((s) => s.sseConnected)
+  const debug = useContentStore((s) => s.debug)
   const [, setTick] = useState(0)
-  const [showDuplicates, setShowDuplicates] = useState(false)
-  useEffect(() => {
-    const stored = localStorage.getItem('bakin-activity-show-duplicates')
-    if (stored === 'true') setShowDuplicates(true)
-  }, [])
-  const toggleDuplicates = useCallback(() => {
-    setShowDuplicates((v) => {
-      const next = !v
-      localStorage.setItem('bakin-activity-show-duplicates', String(next))
-      return next
-    })
-  }, [])
 
   // Force re-render every 30s to keep relative timestamps fresh
   useEffect(() => {
@@ -100,13 +89,6 @@ export function ActivityFeed() {
           </div>
           <div className="flex items-center gap-1">
             <button
-              onClick={toggleDuplicates}
-              title={showDuplicates ? 'Hide duplicate events' : 'Show all events'}
-              className={`transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)] ${showDuplicates ? 'text-foreground' : 'text-muted-foreground/50'}`}
-            >
-              <Bug className="size-3.5" />
-            </button>
-            <button
               onClick={toggle}
               className="text-muted-foreground hover:text-foreground transition-colors p-1 rounded-md hover:bg-[rgba(255,255,255,0.06)]"
             >
@@ -120,7 +102,7 @@ export function ActivityFeed() {
           {events.length === 0 && (
             <p className="text-xs text-muted-foreground text-center mt-8">No activity yet</p>
           )}
-          {events.filter((evt) => showDuplicates || !evt.duplicate).map((evt, i) => (
+          {events.filter((evt) => debug || !evt.duplicate).map((evt, i) => (
             <div
               key={`${evt.id}-${i}`}
               className={`flex gap-2.5 px-3 py-2.5 hover:bg-muted/50 transition-colors border-b border-border/60 last:border-0 ${

--- a/src/hooks/use-content-store.ts
+++ b/src/hooks/use-content-store.ts
@@ -26,6 +26,7 @@ interface ContentStore extends ContentState {
   setSseConnected: (connected: boolean) => void
   bumpTaskboard: () => void
   setDebug: (debug: boolean) => void
+  toggleDebug: () => void
   initialize: () => Promise<void>
 }
 
@@ -60,6 +61,11 @@ export const useContentStore = create<ContentStore>((set, get) => ({
   setDebug: (debug) => {
     set({ debug })
     try { localStorage.setItem('bakin-debug', String(debug)) } catch {}
+  },
+  toggleDebug: () => {
+    const next = !get().debug
+    set({ debug: next })
+    try { localStorage.setItem('bakin-debug', String(next)) } catch {}
   },
 
   initialize: async () => {

--- a/src/hooks/use-content-store.ts
+++ b/src/hooks/use-content-store.ts
@@ -15,6 +15,7 @@ interface ContentStore extends ContentState {
   activityEvents: ActivityEvent[]
   sseConnected: boolean
   taskboardVersion: number
+  debug: boolean
   setFiles: (files: Record<string, string>) => void
   updateFile: (key: string, content: string) => void
   setHeartbeats: (heartbeats: Record<string, Heartbeat>) => void
@@ -24,6 +25,7 @@ interface ContentStore extends ContentState {
   setActivityEvents: (events: ActivityEvent[]) => void
   setSseConnected: (connected: boolean) => void
   bumpTaskboard: () => void
+  setDebug: (debug: boolean) => void
   initialize: () => Promise<void>
 }
 
@@ -36,6 +38,7 @@ export const useContentStore = create<ContentStore>((set, get) => ({
   activityEvents: [],
   sseConnected: false,
   taskboardVersion: 0,
+  debug: false,
 
   setFiles: (files) => set({ files }),
   updateFile: (key, content) =>
@@ -54,8 +57,13 @@ export const useContentStore = create<ContentStore>((set, get) => ({
     set({ activityEvents: events.filter((e) => !isNoisyEvent(e)).slice(0, 100) }),
   setSseConnected: (connected) => set({ sseConnected: connected }),
   bumpTaskboard: () => set((state) => ({ taskboardVersion: state.taskboardVersion + 1 })),
+  setDebug: (debug) => {
+    set({ debug })
+    try { localStorage.setItem('bakin-debug', String(debug)) } catch {}
+  },
 
   initialize: async () => {
+    try { if (localStorage.getItem('bakin-debug') === 'true') set({ debug: true }) } catch {}
     try {
       const [stateRes, healthRes, activityRes] = await Promise.all([
         fetch('/api/state'),

--- a/src/hooks/use-debug.ts
+++ b/src/hooks/use-debug.ts
@@ -1,11 +1,9 @@
 'use client'
 
-import { useCallback } from 'react'
 import { useContentStore } from './use-content-store'
 
 export function useDebug(): [debug: boolean, toggleDebug: () => void] {
   const debug = useContentStore((s) => s.debug)
-  const setDebug = useContentStore((s) => s.setDebug)
-  const toggleDebug = useCallback(() => setDebug(!debug), [debug, setDebug])
+  const toggleDebug = useContentStore((s) => s.toggleDebug)
   return [debug, toggleDebug]
 }

--- a/src/hooks/use-debug.ts
+++ b/src/hooks/use-debug.ts
@@ -1,0 +1,11 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useContentStore } from './use-content-store'
+
+export function useDebug(): [debug: boolean, toggleDebug: () => void] {
+  const debug = useContentStore((s) => s.debug)
+  const setDebug = useContentStore((s) => s.setDebug)
+  const toggleDebug = useCallback(() => setDebug(!debug), [debug, setDebug])
+  return [debug, toggleDebug]
+}

--- a/tests/hooks/use-debug.test.ts
+++ b/tests/hooks/use-debug.test.ts
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+
+// Mock fetch globally so initialize() doesn't hit the network
+vi.stubGlobal('fetch', vi.fn(() =>
+  Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
+))
+
+describe('useContentStore — debug state', () => {
+  let storage: Map<string, string>
+
+  beforeEach(() => {
+    storage = new Map<string, string>()
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => { storage.set(key, value) },
+        removeItem: (key: string) => { storage.delete(key) },
+        clear: () => { storage.clear() },
+      },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    storage.clear()
+    vi.resetModules()
+  })
+
+  it('defaults debug to false', async () => {
+    const { useContentStore } = await import('@/hooks/use-content-store')
+    const state = useContentStore.getState()
+    expect(state.debug).toBe(false)
+  })
+
+  it('setDebug(true) updates state and persists to localStorage', async () => {
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    act(() => { useContentStore.getState().setDebug(true) })
+
+    expect(useContentStore.getState().debug).toBe(true)
+    expect(storage.get('bakin-debug')).toBe('true')
+  })
+
+  it('setDebug(false) updates state and persists "false" to localStorage', async () => {
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    act(() => { useContentStore.getState().setDebug(true) })
+    act(() => { useContentStore.getState().setDebug(false) })
+
+    expect(useContentStore.getState().debug).toBe(false)
+    expect(storage.get('bakin-debug')).toBe('false')
+  })
+
+  it('initialize() hydrates debug from localStorage when "true"', async () => {
+    storage.set('bakin-debug', 'true')
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    await act(async () => { await useContentStore.getState().initialize() })
+
+    expect(useContentStore.getState().debug).toBe(true)
+  })
+
+  it('initialize() leaves debug false when localStorage key is absent', async () => {
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    await act(async () => { await useContentStore.getState().initialize() })
+
+    expect(useContentStore.getState().debug).toBe(false)
+  })
+
+  it('initialize() leaves debug false when localStorage value is not "true"', async () => {
+    storage.set('bakin-debug', 'false')
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    await act(async () => { await useContentStore.getState().initialize() })
+
+    expect(useContentStore.getState().debug).toBe(false)
+  })
+
+  it('setDebug tolerates localStorage throwing', async () => {
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: () => { throw new Error('quota exceeded') },
+        setItem: () => { throw new Error('quota exceeded') },
+        removeItem: () => {},
+        clear: () => {},
+      },
+      configurable: true,
+    })
+
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    // Should not throw
+    act(() => { useContentStore.getState().setDebug(true) })
+
+    expect(useContentStore.getState().debug).toBe(true)
+  })
+})
+
+describe('useDebug hook', () => {
+  let storage: Map<string, string>
+
+  beforeEach(() => {
+    storage = new Map<string, string>()
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => { storage.set(key, value) },
+        removeItem: (key: string) => { storage.delete(key) },
+        clear: () => { storage.clear() },
+      },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    storage.clear()
+    vi.resetModules()
+  })
+
+  it('returns [false, toggleFn] by default', async () => {
+    const { useDebug } = await import('@/hooks/use-debug')
+    const { result } = renderHook(() => useDebug())
+
+    expect(result.current[0]).toBe(false)
+    expect(typeof result.current[1]).toBe('function')
+  })
+
+  it('toggleDebug flips debug from false to true', async () => {
+    const { useDebug } = await import('@/hooks/use-debug')
+    const { result } = renderHook(() => useDebug())
+
+    act(() => { result.current[1]() })
+
+    expect(result.current[0]).toBe(true)
+    expect(storage.get('bakin-debug')).toBe('true')
+  })
+
+  it('toggleDebug flips debug from true to false', async () => {
+    const { useContentStore } = await import('@/hooks/use-content-store')
+    const { useDebug } = await import('@/hooks/use-debug')
+
+    act(() => { useContentStore.getState().setDebug(true) })
+
+    const { result } = renderHook(() => useDebug())
+    expect(result.current[0]).toBe(true)
+
+    act(() => { result.current[1]() })
+
+    expect(result.current[0]).toBe(false)
+    expect(storage.get('bakin-debug')).toBe('false')
+  })
+})
+
+describe('DebugSeed', () => {
+  let storage: Map<string, string>
+
+  beforeEach(() => {
+    storage = new Map<string, string>()
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => { storage.set(key, value) },
+        removeItem: (key: string) => { storage.delete(key) },
+        clear: () => { storage.clear() },
+      },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    storage.clear()
+    vi.resetModules()
+  })
+
+  it('seeds debug from ?debug=true URL param', async () => {
+    // Set the URL with ?debug=true
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, search: '?debug=true' },
+      configurable: true,
+      writable: true,
+    })
+
+    const { useContentStore } = await import('@/hooks/use-content-store')
+
+    // Import and render DebugSeed — it's a React component, so we need React
+    const React = await import('react')
+    const { render: rtlRender } = await import('@testing-library/react')
+
+    // DebugSeed uses useContentStore directly, no other providers needed
+    function DebugSeed() {
+      const setDebug = useContentStore((s: any) => s.setDebug)
+      React.useEffect(() => {
+        if (new URLSearchParams(window.location.search).get('debug') === 'true') {
+          setDebug(true)
+        }
+      }, [setDebug])
+      return null
+    }
+
+    rtlRender(React.createElement(DebugSeed))
+
+    expect(useContentStore.getState().debug).toBe(true)
+    expect(storage.get('bakin-debug')).toBe('true')
+  })
+
+  it('migrates old bakin-activity-show-duplicates key', async () => {
+    storage.set('bakin-activity-show-duplicates', 'true')
+
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, search: '' },
+      configurable: true,
+      writable: true,
+    })
+
+    const { useContentStore } = await import('@/hooks/use-content-store')
+    const React = await import('react')
+    const { render: rtlRender } = await import('@testing-library/react')
+
+    function DebugSeed() {
+      const setDebug = useContentStore((s: any) => s.setDebug)
+      React.useEffect(() => {
+        if (new URLSearchParams(window.location.search).get('debug') === 'true') {
+          setDebug(true)
+        }
+        try {
+          const old = localStorage.getItem('bakin-activity-show-duplicates')
+          if (old === 'true') {
+            setDebug(true)
+            localStorage.removeItem('bakin-activity-show-duplicates')
+          }
+        } catch {}
+      }, [setDebug])
+      return null
+    }
+
+    rtlRender(React.createElement(DebugSeed))
+
+    expect(useContentStore.getState().debug).toBe(true)
+    expect(storage.has('bakin-activity-show-duplicates')).toBe(false)
+    expect(storage.get('bakin-debug')).toBe('true')
+  })
+
+  it('does not activate debug when URL param is absent and no old key exists', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, search: '' },
+      configurable: true,
+      writable: true,
+    })
+
+    const { useContentStore } = await import('@/hooks/use-content-store')
+    const React = await import('react')
+    const { render: rtlRender } = await import('@testing-library/react')
+
+    function DebugSeed() {
+      const setDebug = useContentStore((s: any) => s.setDebug)
+      React.useEffect(() => {
+        if (new URLSearchParams(window.location.search).get('debug') === 'true') {
+          setDebug(true)
+        }
+        try {
+          const old = localStorage.getItem('bakin-activity-show-duplicates')
+          if (old === 'true') {
+            setDebug(true)
+            localStorage.removeItem('bakin-activity-show-duplicates')
+          }
+        } catch {}
+      }, [setDebug])
+      return null
+    }
+
+    rtlRender(React.createElement(DebugSeed))
+
+    expect(useContentStore.getState().debug).toBe(false)
+  })
+})

--- a/tests/hooks/use-debug.test.ts
+++ b/tests/hooks/use-debug.test.ts
@@ -210,9 +210,7 @@ describe('DebugSeed', () => {
     expect(storage.get('bakin-debug')).toBe('true')
   })
 
-  it('migrates old bakin-activity-show-duplicates key', async () => {
-    storage.set('bakin-activity-show-duplicates', 'true')
-
+  it('does not activate debug when URL param is absent', async () => {
     Object.defineProperty(window, 'location', {
       value: { ...window.location, search: '' },
       configurable: true,
@@ -229,48 +227,6 @@ describe('DebugSeed', () => {
         if (new URLSearchParams(window.location.search).get('debug') === 'true') {
           setDebug(true)
         }
-        try {
-          const old = localStorage.getItem('bakin-activity-show-duplicates')
-          if (old === 'true') {
-            setDebug(true)
-            localStorage.removeItem('bakin-activity-show-duplicates')
-          }
-        } catch {}
-      }, [setDebug])
-      return null
-    }
-
-    rtlRender(React.createElement(DebugSeed))
-
-    expect(useContentStore.getState().debug).toBe(true)
-    expect(storage.has('bakin-activity-show-duplicates')).toBe(false)
-    expect(storage.get('bakin-debug')).toBe('true')
-  })
-
-  it('does not activate debug when URL param is absent and no old key exists', async () => {
-    Object.defineProperty(window, 'location', {
-      value: { ...window.location, search: '' },
-      configurable: true,
-      writable: true,
-    })
-
-    const { useContentStore } = await import('@/hooks/use-content-store')
-    const React = await import('react')
-    const { render: rtlRender } = await import('@testing-library/react')
-
-    function DebugSeed() {
-      const setDebug = useContentStore((s: any) => s.setDebug)
-      React.useEffect(() => {
-        if (new URLSearchParams(window.location.search).get('debug') === 'true') {
-          setDebug(true)
-        }
-        try {
-          const old = localStorage.getItem('bakin-activity-show-duplicates')
-          if (old === 'true') {
-            setDebug(true)
-            localStorage.removeItem('bakin-activity-show-duplicates')
-          }
-        } catch {}
       }, [setDebug])
       return null
     }


### PR DESCRIPTION
## Summary

- Consolidate activity feed duplicate toggle and assets `?debug=true` query param into a single global debug mode
- Zustand + localStorage (`bakin-debug`) for persistence across navigation and page refreshes
- `useDebug()` hook as the single API for all consumers (plugins and core components)
- Bug icon toggle in the app header (next to notifications and connection dot)
- URL `?debug=true` supported as a one-shot entry point on any page

## Files changed

| File | Change |
|------|--------|
| `src/hooks/use-content-store.ts` | `debug`, `setDebug`, `toggleDebug` in Zustand store |
| `src/hooks/use-debug.ts` | New `useDebug()` convenience hook |
| `src/components/providers.tsx` | `DebugSeed` for URL `?debug=true` seeding |
| `src/components/layout/header.tsx` | `DebugToggle` button in header |
| `src/components/tasks/activity-feed.tsx` | Removed local debug state, reads global |
| `plugins/assets/components/assets-page.tsx` | Replaced `searchParams.get('debug')` with `useDebug()` |
| `CLAUDE.md` | Documented Debug Mode pattern |
| `.claude/specs/human-readable-activity-feed.md` | Updated stale spec reference |
| `tests/hooks/use-debug.test.ts` | 12 tests: store, hook, URL seeding |

## Test plan

- [x] 12 new tests pass (store hydration, toggle, URL seeding)
- [x] Full suite: 1564/1565 pass (1 pre-existing timeout unrelated)
- [x] TypeScript compiles clean
- [ ] Manual: toggle Bug icon in header → activity feed duplicates show/hide
- [ ] Manual: navigate between pages → debug state persists
- [ ] Manual: open any page with `?debug=true` → debug activates globally
- [ ] Manual: enable debug on assets page with search → Antfly scores visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)