### PR TITLE
feat: first-run onboarding — bakin onboard + granular commands + doctor gate

### DIFF
--- a/.claude/specs/first-run-onboarding.md
+++ b/.claude/specs/first-run-onboarding.md
@@ -1,0 +1,513 @@
+# SPEC: First-run onboarding — granular commands + aggregated `bakin onboard`
+
+**Status:** Draft — awaiting confirmation
+**Branch:** `feat/first-run-onboarding` (created off `main` at `8e59e40`)
+**Author:** Mark + Claude
+**Date:** 2026-04-12
+**Predecessor work:** `feat/multimodal-search` (PR #77, merged) — introduced the Termite models, search migration, and exposed the onboarding gap this spec fixes
+
+---
+
+## 1. Objective
+
+A new user clones Bakin (or installs the future binary) and follows the README. Their machine has **nothing**: no OpenClaw, no Antfly, no Termite models, no `~/.bakin/`, no credentials. They run one command and either (a) have a fully working Bakin, or (b) see a clear list of exactly what they need to do next and why.
+
+This spec adds:
+
+1. **Granular single-purpose commands** — one per piece of first-run work (`bakin mkdir`, `bakin install antfly`, `bakin install models`, etc.). Users can run any one on its own to update, repair, or install a specific component.
+2. **An aggregated `bakin onboard` command** that runs the whole chain interactively, with sensible defaults, clear progress, and actionable error messages for anything it can't auto-fix.
+3. **A `.onboarded` marker file** persisting "this machine has been through first-run setup" state, versioned so future updates can require re-onboarding.
+4. **Doctor integration** — `bakin doctor` (periodic health check) refuses to run its normal checks and returns a single blocking error if the `.onboarded` marker is missing. Controlled by `settings.doctor.requireOnboard`.
+
+**Non-goals — explicitly deferred:**
+
+- **Managing OpenClaw itself.** OpenClaw is a hard prerequisite. Bakin detects its presence and prints `OpenClaw is required. Install it from https://openclaw.ai/` if missing, then exits. No automated install, no managing `~/.openclaw/openclaw.json`, no prompting for Discord tokens / Anthropic keys / guild IDs — all that is OpenClaw's own setup territory.
+- **Interactive credential entry.** Bakin reads LLM keys and messaging channel config from OpenClaw's existing files. It verifies at least one provider / one channel is present and warns if not, but does not prompt users to paste secrets.
+- **LaunchAgent / systemd service install.** The commented-out `bakin setup service` path stays commented out. Separate spec if/when that happens.
+- **Windows support.** macOS + Linux. Windows is a future concern.
+
+## 2. Target audience
+
+Two distinct audiences — the spec must serve both:
+
+1. **Cloner / developer (today).** Runs `pnpm install && pnpm cli onboard` from the repo. Knows what a terminal is, may not know what Termite is. Expects each step to either work or tell them exactly how to fix it.
+2. **Binary user (future).** Runs `bakin onboard` from a system-installed binary. Has no checked-out repo, no `pnpm`, no dev tooling. Same command, same UX, same outcome.
+
+The code must run in both contexts. That means:
+- No reliance on `pnpm` / `npm run` to invoke subcommands (shell out to external binaries by absolute path)
+- No reliance on the repo layout (resolve paths via `getContentDir()` / `getBakinPaths()`, never `./plugins/...`)
+- Interactive prompts via Node `readline` stdlib — no `inquirer` / `prompts` deps to bundle
+
+## 3. Command surface
+
+### 3.1 Granular commands (top-level, flat)
+
+| Command | Purpose | Modifies system? |
+|---|---|---|
+| `bakin mkdir` | Create/verify `~/.bakin/` directory tree. Idempotent. Replaces the existing `bakin init` (kept as a deprecation-warning alias). | ✅ Creates dirs under `~/.bakin/` |
+| `bakin settings init` | Seed `~/.bakin/settings.json` with current defaults if missing or empty. | ✅ Writes `settings.json` |
+| `bakin check openclaw` | Detect OpenClaw binary + `~/.openclaw/openclaw.json`. Print install URL if missing. Read-only. | ❌ |
+| `bakin check llm` | Verify at least one LLM provider is configured in `~/.openclaw/agents/main/agent/auth-profiles.json`. Warn if none. Read-only. | ❌ |
+| `bakin check channels` | Verify at least one messaging channel (Discord, Telegram, Slack, …) is configured in `~/.openclaw/openclaw.json#channels`. Warn if none. Read-only. | ❌ |
+| `bakin check all` | Run every check in order, report status for each, exit 0 if ready / 1 if broken / 2 if degraded. No side effects. | ❌ |
+| `bakin install antfly` | Install Antfly binary via `brew install --cask antflydb/antfly/antfly`. Replaces existing `bakin setup antfly`. | ✅ Runs brew |
+| `bakin install models` | Pull Termite models (BGE, CLIP, mxbai-rerank) via `antfly termite pull`. | ✅ ~1.5GB download to `~/.termite/models/` |
+| `bakin install mcporter` | Install mcporter globally + sync per-agent config. Replaces existing `bakin setup mcporter`. | ✅ `npm install -g`, writes `~/.mcporter/mcporter.json` |
+| `bakin onboard` | Interactive aggregated flow. Runs all of the above in order with prompts. | ✅ All of the above |
+| `bakin onboard --check` | Non-destructive — equivalent to `bakin check all` with the same exit codes. | ❌ |
+| `bakin onboard --yes` | Non-interactive — auto-approve every `[Y/n]` prompt. For CI and scripted installs. | ✅ All of the above, no prompts |
+| `bakin onboard --json` | Machine-readable output (each step's status as a line of JSON). Pairs with `--yes`. | ✅ |
+
+### 3.2 Flow of `bakin onboard`
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ bakin onboard                                                       │
+│                                                                     │
+│  STEP 1 — Prerequisites check (blocking)                            │
+│    ✓ check openclaw                                                 │
+│      └─ MISSING → print "OpenClaw is required. https://openclaw.ai/"│
+│                   exit 1. No further steps.                         │
+│                                                                     │
+│  STEP 2 — Bakin state (auto, no prompt)                             │
+│    ✓ mkdir          — creates ~/.bakin/* directory tree             │
+│    ✓ settings init  — writes default settings.json if empty         │
+│                                                                     │
+│  STEP 3 — Search infrastructure (prompt per component)              │
+│    ⚠ install antfly — "Install Antfly via brew? ~25MB [Y/n]"       │
+│      └─ declined → warn, skip model pull, continue                  │
+│    ⚠ install models — "Download 1.5GB of ML models to              │
+│                        ~/.termite/? [Y/n]"                          │
+│      └─ declined → warn, skip, continue                             │
+│                                                                     │
+│  STEP 4 — Agent infrastructure (prompt per component)               │
+│    ⚠ install mcporter — "Install mcporter globally via npm [Y/n]" │
+│      └─ declined → warn, skip, continue                             │
+│                                                                     │
+│  STEP 5 — Configuration verification (warn-only)                    │
+│    ✓ check llm       — "At least one LLM provider configured?"     │
+│      └─ none         → warn: "Configure at least one LLM via       │
+│                                OpenClaw. Docs: …"                   │
+│    ✓ check channels  — "At least one messaging channel configured?"│
+│      └─ none         → warn: "Configure Discord/Telegram/etc via  │
+│                                OpenClaw. Docs: …"                   │
+│                                                                     │
+│  STEP 6 — Finalize                                                  │
+│    ✓ Write .onboarded state file with version + timestamp +         │
+│      per-component status                                           │
+│    ✓ Print success banner + next step (`pnpm dev` / `bakin start`)  │
+│                                                                     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Exit codes (for scripts)
+
+| Exit | Meaning |
+|---|---|
+| `0` | Everything green. Bakin is ready to run. |
+| `1` | Hard failure. OpenClaw missing, `~/.bakin/` not writable, user declined a required step. |
+| `2` | Degraded. All required components present, but one or more warnings (no LLM configured, no channels configured, user declined Antfly install, etc.). Bakin will start but features may be missing. |
+
+`bakin onboard --check` uses the same exit codes.
+
+### 3.4 The `.onboarded` marker file
+
+**Path:** `~/.bakin/.onboarded` (or `$BAKIN_HOME/.onboarded` — uses `getContentDir()`)
+
+**Shape:**
+```json
+{
+  "version": 1,
+  "completedAt": "2026-04-12T03:14:15.926Z",
+  "bakinVersion": "1.0.0",
+  "components": {
+    "mkdir": "ok",
+    "settings": "ok",
+    "openclaw": "ok",
+    "antfly": "ok",
+    "models": "ok",
+    "mcporter": "ok",
+    "llm": "warn",
+    "channels": "warn"
+  }
+}
+```
+
+**Behavior:**
+- `bakin onboard` writes this file on completion — even if some components are `warn` or `skipped`, as long as nothing is `error`.
+- If a component is `error`, the file is NOT written. User must fix and re-run.
+- `version` is bumped in code when onboarding requirements change. On next run, if stored version < current version, `bakin onboard` reports "onboarding is out of date, re-run" rather than "already done."
+- `bakinVersion` is the Bakin release the marker was written by. Informational only — we don't gate on it.
+
+## 4. Doctor integration
+
+### 4.1 Read the marker at check time
+
+`src/core/doctor.ts` gains a new first-priority check: does `~/.bakin/.onboarded` exist and have `version >= ONBOARDING_VERSION`?
+
+```
+if (settings.doctor.requireOnboard) {
+  if (!isOnboarded()) {
+    return [{
+      check: 'onboarded',
+      status: 'error',
+      message: 'Bakin is not onboarded on this machine. Run `bakin onboard` to complete first-run setup.',
+      autoFixable: false,
+    }]
+  }
+}
+```
+
+If this check fails, doctor **returns early** with just the one error. It does not run its existing checks — they'd all be noise because nothing is set up yet. This keeps doctor fast in the common case (onboarded = proceed, not onboarded = one error).
+
+### 4.2 Config flag
+
+New setting: `settings.doctor.requireOnboard: boolean` (default `true`).
+
+Power users who know what they're doing and don't want the onboard gate can set this to `false`. Doctor reverts to its current behavior.
+
+The flag lives in the `doctor` subtree of settings, joining the existing `doctor.intervalMs` and `doctor.autoFixSkill`.
+
+### 4.3 Performance division
+
+The user's guidance: **doctor is lightweight and logs; setup is heavy-handed and interactive.** After this spec:
+
+| Concern | Doctor | Setup |
+|---|---|---|
+| Runs on a timer (every 30min) | ✅ | ❌ |
+| Non-interactive | ✅ | ❌ (onboard is interactive; check is non-interactive) |
+| Fast (< 1s) | ✅ | ❌ (model pull can take minutes) |
+| Writes files | Minimal (persona stubs, skill sync) | Yes (dirs, settings, models, marker) |
+| Shells out to package managers | ❌ | ✅ |
+| Used for daily health monitoring | ✅ | ❌ |
+| Used for one-time installation | ❌ | ✅ |
+
+Doctor is the "is everything still OK?" loop. Setup is the "fix what isn't OK yet" tool.
+
+## 5. Component checklist
+
+Each component is a separate module with a `check()` function (non-destructive diagnostic) and an `install()` function (destructive remediation where applicable).
+
+| # | Component | Detect by | Remediation | Module |
+|---|---|---|---|---|
+| 1 | `mkdir` | `existsSync(getContentDir())` + key subdirs | Call `initBakinHome()` | `src/core/onboarding/mkdir.ts` |
+| 2 | `settings` | `existsSync(settings.json)` + JSON parses + not empty | Write deep-merged defaults | `src/core/onboarding/settings.ts` |
+| 3 | `openclaw` | Binary in `$OPENCLAW_PATH` / `/opt/homebrew/bin/openclaw` / etc. AND `~/.openclaw/openclaw.json` parseable | **None.** Print install URL + exit 1 if run alone, or mark as `error` and skip remaining steps if run via `onboard`. | `src/core/onboarding/openclaw.ts` |
+| 4 | `antfly` | Binary via existing `findBinary()` in `antfly-server.ts` | Shell `brew install --cask antflydb/antfly/antfly` with prompt. Fall back to printing the command if brew is missing. | `src/core/onboarding/antfly.ts` |
+| 5 | `models` | `existsSync()` for `~/.termite/models/embedders/BAAI/bge-small-en-v1.5/`, `.../openai/clip-vit-base-patch32/`, `~/.termite/models/rerankers/mixedbread-ai/mxbai-rerank-base-v1/` | Shell `antfly termite pull <model>` for each missing, with progress streamed | `src/core/onboarding/models.ts` |
+| 6 | `mcporter` | `which mcporter` + per-agent config entries in `~/.mcporter/mcporter.json` | Shell `npm install -g mcporter` + sync config (reuses existing `mcporter.ts` logic) | `src/core/onboarding/mcporter.ts` |
+| 7 | `llm` | Parse `~/.openclaw/agents/main/agent/auth-profiles.json`, check for at least one provider entry with a non-empty key | **None.** Warn with a pointer to OpenClaw's LLM config docs. | `src/core/onboarding/credentials.ts` |
+| 8 | `channels` | Parse `~/.openclaw/openclaw.json`, check for at least one entry in `channels.*` with a non-empty `token` / `apiKey` / equivalent | **None.** Warn with a pointer to OpenClaw's channel config docs. | `src/core/onboarding/credentials.ts` |
+
+**Not included (intentionally):**
+
+- Persona stubs — `doctor` already auto-creates these on first boot. Leaves doctor's existing autofix logic untouched.
+- SQLite `flow_runs` table — OpenClaw-managed, not Bakin's concern.
+- `~/.openclaw/openclaw.json` content — OpenClaw's own setup populates this.
+- Discord bot registration — the user creates the bot in Discord's developer portal, OpenClaw stores the token.
+- LLM API keys — same, user enters these via OpenClaw.
+- Plugin settings (`~/.bakin/plugin-settings/*.json`) — auto-created on first plugin use.
+- LaunchAgent service install — separate spec.
+- Vault initialization — vault reads from files populated by OpenClaw, no separate init needed.
+
+## 6. Architecture
+
+### 6.1 File layout
+
+```
+src/core/onboarding/
+  index.ts              — public API: runOnboard(), checkAll(), loadState(), saveState()
+  state.ts              — .onboarded marker file I/O, ONBOARDING_VERSION constant
+  types.ts              — CheckResult, InstallResult, OnboardingComponent interfaces
+  prompts.ts            — tiny readline wrappers: askYesNo(), readLine(), spinner()
+  mkdir.ts              — component 1
+  settings.ts           — component 2
+  openclaw.ts           — component 3
+  antfly.ts             — component 4
+  models.ts             — component 5
+  mcporter.ts           — component 6
+  credentials.ts        — components 7 & 8
+
+cli/bakin.ts            — add top-level subcommands that import from src/core/onboarding
+                          and wire TTY I/O
+```
+
+### 6.2 Component interface
+
+Every component module exports:
+
+```ts
+import type { CheckResult, InstallResult, OnboardingOptions } from './types'
+
+export const name: string  // 'mkdir', 'antfly', etc.
+
+export async function check(): Promise<CheckResult>
+export async function install(opts: OnboardingOptions): Promise<InstallResult>
+```
+
+Where:
+
+```ts
+interface CheckResult {
+  name: string
+  status: 'ok' | 'missing' | 'broken' | 'warn' | 'error'
+  message: string
+  remediation?: string  // human-readable next step
+  details?: Record<string, unknown>  // for --json output
+}
+
+interface InstallResult {
+  name: string
+  status: 'installed' | 'skipped' | 'failed' | 'noop'
+  message: string
+  error?: unknown
+  durationMs: number
+}
+
+interface OnboardingOptions {
+  interactive: boolean   // if false, never prompts — auto-approve or auto-skip based on defaults
+  autoApprove: boolean   // --yes flag — skip confirmation prompts
+  json: boolean          // --json flag — emit structured output instead of TTY
+  skipInstall?: string[] // component names to check-only
+}
+```
+
+The aggregate `runOnboard(opts)` in `src/core/onboarding/index.ts` is a pure orchestrator. It calls each component's `check()`, decides whether to call `install()`, aggregates results, writes the state file. All TTY I/O happens via `prompts.ts` helpers, which can be stubbed for tests.
+
+### 6.3 Why this design
+
+- **Shared detection code between doctor and setup.** `doctor.ts` imports and calls the same `check()` functions that `cli/bakin.ts` does. No duplication, no drift.
+- **Unit-testable.** Each component is a pure module that takes filesystem and process state, returns a result. Mock `fs` and `child_process.spawn` and you test the whole thing without brew or npm.
+- **Binary-future ready.** Nothing in `src/core/onboarding/` depends on pnpm, the repo layout, or the monorepo structure. When Bakin ships as a single binary, this module bundles cleanly.
+- **Extensible.** Adding a new component (e.g., `redis`, `ollama`) is one new file in `src/core/onboarding/` plus one entry in the orchestrator's component list. No changes to existing components.
+
+## 7. Acceptance criteria
+
+1. **Fresh machine onboarding works.**
+   - Starting from a machine with no `~/.bakin/`, no Antfly, no `~/.termite/`, and no mcporter, running `bakin onboard` (with `--yes` for non-interactive) completes successfully and leaves Bakin bootable via `pnpm dev`.
+   - First `pnpm dev` after `bakin onboard --yes` boots cleanly with no `[search-migration]` errors, no `ANTFLY_PATH not found`, no `Termite models missing` warnings, no `mcporter not installed` warnings.
+
+2. **Granular commands run independently.**
+   - `bakin mkdir` on a machine where `~/.bakin/` already exists is a no-op, exits 0, prints "Already initialized."
+   - `bakin install antfly` on a machine where Antfly is already installed exits 0 with "Antfly is already installed at /opt/homebrew/bin/antfly."
+   - `bakin install models` re-run with all three models present exits 0 with "All 3 models present."
+
+3. **OpenClaw missing is a hard stop.**
+   - `bakin check openclaw` with OpenClaw missing prints the install URL and exits 1.
+   - `bakin onboard` with OpenClaw missing prints the same URL, does NOT run any other steps, does NOT write `.onboarded`, exits 1.
+
+4. **LLM and channels missing are warnings, not errors.**
+   - With `~/.openclaw/` present but no LLM provider configured, `bakin onboard` completes and writes `.onboarded` with `components.llm: "warn"`. Exit code 2.
+   - Same for channels.
+
+5. **`.onboarded` marker is accurate.**
+   - Written only when all components are `ok`, `warn`, or `skipped`. Not written if any component is `error`.
+   - Contains the exact per-component statuses from the run.
+   - On re-run when `version` matches, `bakin onboard` exits 0 with "Already onboarded on 2026-04-12. Re-run with `--force` to onboard again."
+
+6. **Doctor respects the marker.**
+   - With `settings.doctor.requireOnboard: true` and no `.onboarded` marker, `bakin doctor` returns exactly one diagnostic: `{ check: 'onboarded', status: 'error', message: '...' }` and none of its other checks run.
+   - With the marker present, doctor runs its existing checks unchanged.
+   - With `settings.doctor.requireOnboard: false` and no marker, doctor runs its existing checks unchanged (regression protection).
+
+7. **Non-interactive mode works for CI.**
+   - `bakin onboard --yes --json` emits one line of JSON per component with no prompts.
+   - Exit code reflects the worst status across components.
+   - Can be scripted end-to-end on a fresh macOS runner.
+
+8. **All tests pass.**
+   - New unit tests for each component's `check()` and `install()` with mocked fs + spawn.
+   - New integration test for `runOnboard()` with mocked components.
+   - Existing `doctor` tests updated to cover the onboarded-gate behavior.
+   - Existing `bakin init` tests renamed / updated for `bakin mkdir`.
+
+9. **README updated.**
+   - New first-run section lists exactly `pnpm install && pnpm cli onboard && pnpm dev` as the happy path.
+   - References the individual commands for users who want to run them piecemeal.
+
+10. **CLAUDE.md updated.**
+    - New "Onboarding" section explains the command structure so future agents know to use `bakin onboard` when setting up a fresh machine.
+
+## 8. Project structure (files we'll touch or add)
+
+### Add
+
+```
+src/core/onboarding/
+  index.ts                                 — public API (runOnboard, checkAll, state I/O)
+  state.ts                                 — .onboarded file I/O, ONBOARDING_VERSION
+  types.ts                                 — CheckResult, InstallResult, etc.
+  prompts.ts                               — readline helpers
+  mkdir.ts
+  settings.ts
+  openclaw.ts
+  antfly.ts
+  models.ts
+  mcporter.ts
+  credentials.ts
+
+tests/core/onboarding/
+  index.test.ts                            — orchestrator unit tests
+  state.test.ts                            — marker file I/O
+  mkdir.test.ts
+  settings.test.ts
+  openclaw.test.ts
+  antfly.test.ts
+  models.test.ts
+  mcporter.test.ts
+  credentials.test.ts
+```
+
+### Modify
+
+```
+cli/bakin.ts                               — add new subcommands, deprecate bakin init
+packages/core/src/settings.ts              — add doctor.requireOnboard setting
+src/core/doctor.ts                         — import onboarding check, gate on .onboarded
+src/core/mcporter.ts                       — expose install logic as a reusable function
+src/core/antfly-server.ts                  — expose findBinary() for onboarding.antfly
+README.md                                  — first-run section
+CLAUDE.md                                  — onboarding reference
+```
+
+### Deprecate
+
+- `bakin init` — aliased to `bakin mkdir` for one release with a deprecation warning, then remove
+- `bakin setup antfly` — aliased to `bakin install antfly`
+- `bakin setup mcporter` — aliased to `bakin install mcporter`
+
+## 9. Testing strategy
+
+### Unit tests (mocked fs + child_process.spawn)
+
+- **Each component's `check()`** — covers `status: 'ok' | 'missing' | 'broken' | 'warn' | 'error'` paths by mocking filesystem state
+- **Each component's `install()`** — mocks `spawn()` to simulate brew/npm/antfly subprocess success and failure
+- **State file I/O** — writes and reads roundtrip, handles missing file (returns null), handles corrupt JSON (returns null + warns)
+- **Orchestrator `runOnboard()`** — mocks all components, verifies:
+  - Hard fail on OpenClaw missing stops the flow
+  - Warn-only components don't block completion
+  - Partial status aggregates correctly
+  - `.onboarded` written at the right time
+  - `--yes` skips prompts
+  - `--check` never calls any `install()`
+  - Dependency order: mkdir → settings → openclaw → antfly → models → mcporter → credentials
+
+### Doctor integration tests
+
+- `requireOnboard: true` + no marker → single error, no other checks run
+- `requireOnboard: true` + marker → existing checks run
+- `requireOnboard: false` + no marker → existing checks run
+- Marker version older than code → treat as not onboarded
+
+### Manual smoke test (me, before merging)
+
+Run on a freshly-created Mac user account (or a `nuke-bakin-state.sh` script that wipes `~/.bakin/`, `~/.termite/`, and uninstalls Antfly):
+
+```bash
+# 1. Start from nothing
+rm -rf ~/.bakin ~/.termite
+brew uninstall antfly
+
+# 2. Install Bakin dependencies
+pnpm install
+
+# 3. Run aggregated onboard
+pnpm cli onboard
+
+# 4. Verify each step prompted or auto-ran with clear feedback
+# 5. Verify ~/.bakin/.onboarded is written
+# 6. Start Bakin
+pnpm dev
+
+# 7. Verify search works (reindex + query for a body term from a dropped PDF)
+```
+
+Same run on a machine that has OpenClaw missing — expect exit 1 with the https://openclaw.ai/ message.
+
+### Mandatory test hygiene
+
+Every new test mocks `getContentDir()`, `logger`, `watcher`, `openclaw-client` per `CLAUDE.md` rules. No test touches the real `~/.bakin/`.
+
+## 10. Code style
+
+Inherits all `CLAUDE.md` conventions. Specific notes:
+
+- **Logger per module.** `const log = createLogger('onboarding:antfly')`, etc.
+- **No `any` across module boundaries.** Component check/install return types are strictly typed.
+- **Pure functions where possible.** The check functions should be easy to stub in tests — take explicit `{ contentDir, env }` parameters rather than reading from module-level globals.
+- **Shell out via `child_process.spawn`, not `exec`.** Stream stdout/stderr to the logger and, in interactive mode, to the TTY. Never use `shell: true` — pass args as an array.
+- **Never `shell: true`.** Security and arg-escaping.
+- **TTY detection.** `process.stdout.isTTY` determines whether interactive prompts are valid. In non-TTY contexts (CI, scripts), default to `--yes --json` behavior.
+- **No new third-party dependencies.** Use Node stdlib only — `readline`, `child_process`, `fs`, `path`, `os`. The whole `onboarding/` module should add zero lines to `package.json`.
+
+## 11. Boundaries
+
+### Always do
+- Honor the OpenClaw Adapter Principle. We detect OpenClaw but never write to `~/.openclaw/`.
+- Use `getContentDir()` / `getBakinPaths()` for every filesystem path.
+- Stream subprocess output in real time so users see progress during long pulls.
+- Make every component idempotent — re-running is always safe, no side effects beyond the first successful run.
+- Write the `.onboarded` marker only after all non-error components complete.
+
+### Ask first
+- Before running any destructive command (`brew install`, `npm install -g`, `antfly termite pull`), the interactive flow prompts `[Y/n]` with default `Y`. In `--yes` mode, auto-approves. In `--check` mode, never runs them.
+- Before adding a new component beyond the 8 listed above.
+- Before touching files outside `~/.bakin/`, `~/.termite/`, `~/.mcporter/`, or user-approved brew/npm targets.
+
+### Never do
+- Touch `~/.openclaw/*`. Read-only, and only for `check llm` / `check channels`.
+- Auto-install OpenClaw itself. Print the install URL and stop.
+- Prompt for secrets (Anthropic keys, Discord tokens) via the CLI.
+- Write the `.onboarded` marker if any component errored.
+- Use `shell: true` in `child_process.spawn`.
+- Add new runtime dependencies for interactive prompts.
+- Run setup logic during `pnpm install` / `npm install` (no `postinstall` hooks). Setup is always explicit.
+
+## 12. Commit strategy
+
+**Branch:** `feat/first-run-onboarding` (already created)
+
+**Commits — one per vertical slice, in order:**
+
+1. `feat(onboarding): add src/core/onboarding skeleton and .onboarded marker` — empty module structure, state file I/O, types, orchestrator stub, state tests
+2. `feat(onboarding): add mkdir component wrapping initBakinHome` — first real component, simplest check/install
+3. `feat(onboarding): add settings component` — writes default settings.json
+4. `feat(onboarding): add openclaw detection and install-message component` — check-only, no install side
+5. `feat(onboarding): add antfly component and reuse findBinary from antfly-server` — shells out to brew
+6. `feat(onboarding): add models component for termite pull` — shells out to antfly termite pull
+7. `feat(onboarding): add mcporter component by extracting install logic` — refactor mcporter.ts to expose reusable install function
+8. `feat(onboarding): add credentials component for LLM and channels` — warn-only
+9. `feat(onboarding): implement runOnboard orchestrator with dependency order and TTY prompts` — ties everything together
+10. `feat(cli): add granular bakin commands for each onboarding component` — mkdir, install antfly, install models, install mcporter, check *, settings init
+11. `feat(cli): add bakin onboard aggregated command with --check, --yes, --json flags` — the top-level wizard
+12. `feat(cli): deprecate bakin init, bakin setup antfly, bakin setup mcporter as aliases` — backward compat for one release
+13. `feat(doctor): gate normal checks on .onboarded marker when requireOnboard is true` — doctor integration
+14. `docs(onboarding): README first-run section, CLAUDE.md onboarding reference` — docs
+
+Each commit is independently buildable with tests green. PR opens after commit 14 with a checklist mirroring §7 acceptance criteria.
+
+## 13. Open questions (answer before `/agent-skills:plan`)
+
+1. **Command naming: `bakin install antfly` vs `bakin antfly install`?** Proposed: `install <thing>` for consistency (`install antfly`, `install models`, `install mcporter`). Alternative: `<thing> install` for discoverability under `bakin <thing> --help`. Lean: `install <thing>`.
+2. **`settings.doctor.requireOnboard` default: `true` or `false`?** Proposed: `true` — strict by default, power users opt out. Rationale: new users are the ones who'd hit this and the error message is the whole point.
+3. **Keep `bakin init` as an alias or just rename?** Proposed: keep as deprecation-warning alias for one release. Cost is ~5 lines, prevents breaking any existing scripts.
+4. **Model pull progress display.** `antfly termite pull` writes progress bars to stderr. Proposed: pipe directly to the TTY when interactive, swallow when `--json`. Worth flagging because it affects whether the command is "silent" in CI logs.
+
+## 14. Lifecycle
+
+```
+spec-driven-development (this doc)
+  → planning-and-task-breakdown    (/agent-skills:plan)
+    → incremental-implementation   (/agent-skills:build)
+      → test-driven-development    (/agent-skills:test)
+        → code-review-and-quality  (/agent-skills:review)
+          → git-workflow           (PR + merge to main)
+            → docs                 (bundled into commit 14)
+```
+
+## 15. Related
+
+- **`feat/multimodal-search` (PR #77, merged)** — introduced the Termite models that this spec now automates installing. Also exposed the onboarding gap when the user had to run `antfly termite pull ...` from memory.
+- **[#72 Antfly upstream fixes](https://github.com/madeinwyo/bakin/issues/72)** — upstream bugs we worked around in the multimodal branch. Not blocking here, but if any resolve they simplify the setup story.
+- **`.claude/knowledge/search-system.md`** — the search-system doc that now has a clean migration story (§Schema Migration). Onboarding uses the same state-file pattern.
+- **`.claude/specs/multimodal-search.md`** — template for this spec's structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,9 @@ All user-facing filter/view state **must** be backed by URL query parameters so 
 ### Search Indexing
 Plugins register content types via `ctx.search.registerContentType()` during `activate()`. Mutations dual-write to source and index via `ctx.search.index()`. Deletions sync via `ctx.search.remove()` (called from the watcher unlink hook). Orphan cleanup runs on a periodic timer via `src/core/search-cleanup.ts`. All Antfly tables use the `bakin_` prefix. Config in `settings.antfly.*`. Antfly is optional — all calls are no-ops when disabled. See `.claude/knowledge/search-system.md`.
 
+### Onboarding
+`src/core/onboarding/` — eight component modules (mkdir, settings, openclaw, antfly, models, mcporter, llm, channels) with a shared `check()` + `install()` contract. The orchestrator in `index.ts` runs them in a fixed dependency order, writes `~/.bakin/.onboarded` on completion, and the doctor gates on the marker via `settings.doctor.requireOnboard`. CLI surface: `bakin onboard` (aggregated), `bakin mkdir`, `bakin install {antfly,models,mcporter}`, `bakin check {openclaw,llm,channels,all}`, `bakin settings init`. On a fresh machine, use `bakin onboard --yes` to set everything up non-interactively.
+
 ### Debug Mode
 Global client-side debug toggle. State lives in Zustand (`useContentStore`) + localStorage (`bakin-debug`). Access via `useDebug()` from `src/hooks/use-debug.ts` — returns `[debug, toggleDebug]`. Toggle button in the header (Bug icon). URL `?debug=true` on any page activates debug mode as a one-shot seed. Currently controls: activity feed duplicate event visibility, Antfly search score overlays on asset cards. Plugins and components should use `useDebug()` to conditionally render debug info.
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,45 @@ Built with Next.js, TypeScript, and Tailwind CSS. Runs alongside the OpenClaw ga
 
 ## Quick Start
 
+### First-run onboarding
+
+New to Bakin? Run the onboarding flow to set everything up:
+
 ```bash
-# Install dependencies
+pnpm install
+pnpm cli onboard
+pnpm dev
+```
+
+`bakin onboard` walks you through: creating `~/.bakin/`, seeding settings, checking for OpenClaw, installing AntflyDB + Termite ML models, syncing mcporter, and verifying LLM + channel config. At the end it writes a `~/.bakin/.onboarded` marker so `bakin doctor` knows the machine is ready.
+
+For CI or scripted installs, use `--yes` (auto-approve) and `--json` (structured output):
+
+```bash
+pnpm cli onboard --yes --json
+```
+
+Individual commands are available for piecemeal use:
+
+| Command | Purpose |
+|---|---|
+| `bakin mkdir` | Create/verify `~/.bakin/` directory tree |
+| `bakin settings init` | Seed default `settings.json` |
+| `bakin check openclaw` | Detect OpenClaw binary + config |
+| `bakin check llm` | Verify at least one LLM provider |
+| `bakin check channels` | Verify at least one messaging channel |
+| `bakin check all` | Run all checks, report each |
+| `bakin install antfly` | Install AntflyDB via Homebrew |
+| `bakin install models` | Download Termite ML models (~1.5GB) |
+| `bakin install mcporter` | Install mcporter + sync per-agent config |
+
+### Existing install
+
+If you're already set up:
+
+```bash
 npm install
-
-# Start the dev server (Next.js + custom backend on port 3737)
 npm run dev
-
-# Open the dashboard
 open http://localhost:3737
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ New to Bakin? Run the onboarding flow to set everything up:
 
 ```bash
 pnpm install
-pnpm cli onboard
+pnpm run cli onboard
 pnpm dev
 ```
 
@@ -23,7 +23,7 @@ pnpm dev
 For CI or scripted installs, use `--yes` (auto-approve) and `--json` (structured output):
 
 ```bash
-pnpm cli onboard --yes --json
+pnpm run cli onboard --yes --json
 ```
 
 Individual commands are available for piecemeal use:

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1700,9 +1700,11 @@ async function main(): Promise<void> {
           const uninstall = args.includes('--uninstall')
           await cmdSetupService({ uninstall })
         } else if (sub === 'antfly') {
-          await cmdSetupAntfly()
+          console.error('[deprecated] `bakin setup antfly` is now `bakin install antfly`. Delegating...')
+          await cmdOnboardingInstallSingle('antfly', args)
         } else if (sub === 'mcporter') {
-          await cmdSetupMcporter()
+          console.error('[deprecated] `bakin setup mcporter` is now `bakin install mcporter`. Delegating...')
+          await cmdOnboardingInstallSingle('mcporter', args)
         } else {
           console.error(`Unknown setup target: ${sub}`)
           console.error('Available: bakin setup service | bakin setup antfly | bakin setup mcporter')
@@ -1754,7 +1756,8 @@ async function main(): Promise<void> {
         break
 
       case 'init':
-        await cmdInit()
+        console.error('[deprecated] `bakin init` is now `bakin mkdir`. Delegating...')
+        await cmdOnboardingMkdir()
         break
 
       case 'doctor':

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1353,6 +1353,20 @@ Commands:
   setup mcporter                   Install mcporter + sync per-agent MCP config
   paths [key]                      Show content directory paths (keys: home, assets, projects, etc.)
   init                             Initialize ~/.bakin/ directory with defaults
+  mkdir                            Create/verify ~/.bakin/ directory tree (replaces init)
+  settings init                    Seed ~/.bakin/settings.json with defaults if missing
+  check openclaw                   Detect OpenClaw binary + config
+  check llm                        Verify at least one LLM provider configured
+  check channels                   Verify at least one messaging channel configured
+  check all                        Run all onboarding checks, report each
+  install antfly                   Install AntflyDB via Homebrew
+  install models                   Download Termite ML models (BGE, CLIP, mxbai-rerank)
+  install mcporter                 Install mcporter + sync per-agent MCP config
+  onboard                          Run full first-run onboarding (all checks + installs)
+    --check                          Check-only mode (no installs, exit 0/1/2)
+    --yes                            Auto-approve all prompts (for CI/scripts)
+    --json                           Emit one JSON line per component to stdout
+    --force                          Delete .onboarded marker and replay from scratch
   agent-rules [--apply|--check]    Manage orchestrator rules block in AGENTS.md
   agent-rules --apply-all          Apply all managed blocks to all agent AGENTS.md files
   agent-rules --check-all          Check all managed blocks across all agents
@@ -1393,6 +1407,154 @@ Commands:
 Environment:
   BAKIN_URL    Base URL (default: http://localhost:3737)
 `
+
+// ---------------------------------------------------------------------------
+// Onboarding CLI handlers
+// ---------------------------------------------------------------------------
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'ok': return '[OK]'
+    case 'warn': return '[WARN]'
+    case 'error': return '[FAIL]'
+    case 'missing': return '[MISS]'
+    case 'broken': return '[FAIL]'
+    case 'skipped': return '[SKIP]'
+    default: return `[${status.toUpperCase()}]`
+  }
+}
+
+async function cmdOnboardingMkdir(): Promise<void> {
+  const { mkdirComponent } = await import('../src/core/onboarding/mkdir')
+  const opts = {
+    interactive: Boolean(process.stdout.isTTY),
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const result = await mkdirComponent.install(opts)
+  console.log(`${statusIcon(result.status)} ${result.message}`)
+  if (result.status === 'failed') process.exit(1)
+}
+
+async function cmdOnboardingSettingsInit(): Promise<void> {
+  const { settingsComponent } = await import('../src/core/onboarding/settings')
+  const opts = {
+    interactive: Boolean(process.stdout.isTTY),
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const result = await settingsComponent.install(opts)
+  console.log(`${statusIcon(result.status)} ${result.message}`)
+  if (result.status === 'failed') process.exit(1)
+}
+
+async function cmdOnboardingCheckSingle(target: 'openclaw' | 'llm' | 'channels'): Promise<void> {
+  const componentMap: Record<string, () => Promise<{ check(): Promise<import('../src/core/onboarding/types').CheckResult> }>> = {
+    openclaw: async () => (await import('../src/core/onboarding/openclaw')).openclawComponent,
+    llm: async () => (await import('../src/core/onboarding/credentials')).llmComponent,
+    channels: async () => (await import('../src/core/onboarding/credentials')).channelsComponent,
+  }
+  const component = await componentMap[target]()
+  const result = await component.check()
+  console.log(`${statusIcon(result.status)} ${result.message}`)
+  if (result.remediation) console.log(`  → ${result.remediation}`)
+  if (result.status === 'missing' || result.status === 'error' || result.status === 'broken') process.exit(1)
+  if (result.status === 'warn') process.exit(2)
+}
+
+async function cmdOnboardingCheckAll(): Promise<void> {
+  const { checkAll } = await import('../src/core/onboarding/index')
+  const results = await checkAll()
+  for (const r of results) {
+    console.log(`${statusIcon(r.status)} ${r.name.padEnd(10)} ${r.message}`)
+    if (r.remediation) console.log(`  → ${r.remediation}`)
+  }
+  const hasError = results.some(r => r.status === 'error' || r.status === 'missing' || r.status === 'broken')
+  const hasWarn = results.some(r => r.status === 'warn')
+  process.exit(hasError ? 1 : hasWarn ? 2 : 0)
+}
+
+async function cmdOnboardingInstallSingle(target: string, args: string[]): Promise<void> {
+  const componentMap: Record<string, () => Promise<import('../src/core/onboarding/types').OnboardingComponent>> = {
+    antfly: async () => (await import('../src/core/onboarding/antfly')).antflyComponent,
+    models: async () => (await import('../src/core/onboarding/models')).modelsComponent,
+    mcporter: async () => (await import('../src/core/onboarding/mcporter')).mcporterComponent,
+  }
+  const component = await componentMap[target]()
+  const isTTY = Boolean(process.stdout.isTTY)
+  const autoApprove = args.includes('--yes')
+  const json = args.includes('--json')
+  const opts = {
+    interactive: isTTY && !json,
+    autoApprove: autoApprove || (!isTTY && !json),
+    json,
+    checkOnly: false,
+    force: false,
+  }
+  const result = await component.install(opts)
+  if (json) {
+    console.log(JSON.stringify({ component: component.name, status: result.status, message: result.message, durationMs: result.durationMs }))
+  } else {
+    console.log(`${statusIcon(result.status)} ${result.message}`)
+  }
+  if (result.status === 'failed') process.exit(1)
+}
+
+async function cmdOnboard(args: string[]): Promise<void> {
+  const { runOnboard, isOnboarded, loadState } = await import('../src/core/onboarding/index')
+  const checkOnly = args.includes('--check')
+  const yes = args.includes('--yes')
+  const json = args.includes('--json')
+  const force = args.includes('--force')
+  const isTTY = Boolean(process.stdout.isTTY)
+
+  // Early exit for already-onboarded machines unless --force or --check
+  if (!force && !checkOnly && isOnboarded()) {
+    const state = loadState()
+    if (!json) {
+      console.log(`[OK] Already onboarded on ${state?.completedAt?.slice(0, 10) ?? 'unknown date'}.`)
+      console.log('     Re-run with --force to replay the full flow.')
+    } else {
+      console.log(JSON.stringify({ status: 'already_onboarded', completedAt: state?.completedAt }))
+    }
+    process.exit(0)
+  }
+
+  const opts = {
+    interactive: isTTY && !json && !checkOnly,
+    autoApprove: yes || (!isTTY && !json),
+    json,
+    checkOnly,
+    force,
+  }
+
+  const result = await runOnboard(opts)
+
+  if (!json) {
+    console.log('')
+    for (const o of result.outcomes) {
+      console.log(`${statusIcon(o.finalStatus)} ${o.name.padEnd(10)} ${o.message}`)
+      if (o.remediation && o.finalStatus !== 'ok') {
+        console.log(`  → ${o.remediation}`)
+      }
+    }
+    console.log('')
+    if (result.exitCode === 0) {
+      console.log('Onboarding complete. Run `pnpm dev` to start Bakin.')
+    } else if (result.exitCode === 2) {
+      console.log('Onboarding finished with warnings. Bakin will start but some features may be limited.')
+      console.log('Run `pnpm dev` to start Bakin.')
+    } else {
+      console.log('Onboarding failed. Fix the errors above and rerun `bakin onboard`.')
+    }
+  }
+
+  process.exit(result.exitCode)
+}
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2)
@@ -1498,6 +1660,8 @@ async function main(): Promise<void> {
         } else if (sub === 'set') {
           if (!args[2] || !args[3]) { console.error('Usage: bakin settings set <key> <value>'); process.exit(1) }
           await cmdSettingsSet(args[2], args[3])
+        } else if (sub === 'init') {
+          await cmdOnboardingSettingsInit()
         } else {
           console.error(`Unknown settings subcommand: ${sub}`)
           process.exit(1)
@@ -1558,6 +1722,36 @@ async function main(): Promise<void> {
         await cmdAgentRules({ apply, check, applyAll, checkAll })
         break
       }
+
+      case 'mkdir':
+        await cmdOnboardingMkdir()
+        break
+
+      case 'check':
+        if (sub === 'openclaw' || sub === 'llm' || sub === 'channels') {
+          await cmdOnboardingCheckSingle(sub)
+        } else if (sub === 'all') {
+          await cmdOnboardingCheckAll()
+        } else {
+          console.error(`Unknown check target: ${sub}`)
+          console.error('Available: bakin check openclaw | llm | channels | all')
+          process.exit(1)
+        }
+        break
+
+      case 'install':
+        if (sub === 'antfly' || sub === 'models' || sub === 'mcporter') {
+          await cmdOnboardingInstallSingle(sub, args)
+        } else {
+          console.error(`Unknown install target: ${sub}`)
+          console.error('Available: bakin install antfly | models | mcporter')
+          process.exit(1)
+        }
+        break
+
+      case 'onboard':
+        await cmdOnboard(args)
+        break
 
       case 'init':
         await cmdInit()

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "docker:up": "docker compose -f dev/docker/docker-compose.yml up -d openclaw-gateway",
     "docker:down": "docker compose -f dev/docker/docker-compose.yml down",
     "mock:start": "npx tsx dev/imitation-crab/index.ts",
-    "mock:seed": "npx tsx dev/imitation-crab/seed.ts"
+    "mock:seed": "npx tsx dev/imitation-crab/seed.ts",
+    "cli": "npx tsx cli/bakin.ts"
   },
   "dependencies": {
     "@antfly/sdk": "^0.0.14",

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -93,6 +93,14 @@ export interface BakinSettings {
   doctor: {
     intervalMs: number
     autoFixSkill: boolean
+    /**
+     * When true, `runDiagnostics()` refuses to run its normal checks and
+     * returns a single `onboarded: error` result until `~/.bakin/.onboarded`
+     * exists with a version matching `ONBOARDING_VERSION`. Keeps doctor
+     * quiet on a fresh machine and points new users at `bakin onboard`
+     * instead of drowning them in unrelated errors.
+     */
+    requireOnboard: boolean
   }
   service: {
     enabled: boolean
@@ -176,6 +184,7 @@ const DEFAULTS: BakinSettings = {
   doctor: {
     intervalMs: 30 * 60 * 1000, // 30 minutes
     autoFixSkill: true,
+    requireOnboard: true,
   },
   service: {
     enabled: false,

--- a/src/core/antfly-server.ts
+++ b/src/core/antfly-server.ts
@@ -15,9 +15,12 @@ let antflyProcess: ChildProcess | null = null
 let isRunning = false
 
 /**
- * Find the antfly binary on the system.
+ * Find the antfly binary on the system. Exported for reuse by the
+ * first-run onboarding antfly component — its `check()` needs the
+ * exact same binary discovery logic that the server boot path uses,
+ * and duplicating the candidate list would invite drift.
  */
-function findBinary(): string | null {
+export function findBinary(): string | null {
   const candidates = [
     process.env.ANTFLY_PATH,
     '/opt/homebrew/bin/antfly',

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -18,6 +18,7 @@ import { appendAudit } from './audit'
 import { isUsingBakinHome, getContentDir } from './content-dir'
 import * as openclaw from './openclaw-client'
 import * as mcporter from './mcporter'
+import { isOnboarded } from './onboarding/state'
 import { getAllExecTools } from '../../scripts/lib/registry'
 import { getHookRegistry } from '../lib/plugin-registry'
 
@@ -1613,6 +1614,21 @@ export async function runDiagnostics(
   projectRoot: string
 ): Promise<DiagnosticResult[]> {
   const settings = getSettings()
+
+  // Gate: if the machine has never been through first-run onboarding and
+  // the config says to enforce it, return a single actionable error and
+  // skip all the normal checks. Keeps doctor quiet on a fresh machine
+  // and points the user at `bakin onboard` instead of drowning them in
+  // unrelated errors about missing personas, gateway down, etc.
+  if (settings.doctor.requireOnboard && !isOnboarded()) {
+    return [{
+      check: 'onboarded',
+      status: 'error',
+      message: 'Bakin is not onboarded on this machine. Run `bakin onboard` to complete first-run setup.',
+      autoFixable: false,
+    }]
+  }
+
   const autoFix = settings.doctor.autoFixSkill // reuse as general autoFix flag
 
   const results: DiagnosticResult[] = []

--- a/src/core/onboarding/antfly.ts
+++ b/src/core/onboarding/antfly.ts
@@ -1,0 +1,188 @@
+/**
+ * antfly component — installs the AntflyDB binary via Homebrew.
+ *
+ * check() reuses `findBinary()` from antfly-server so the discovery
+ * logic stays in one place (env var → /opt/homebrew/bin → /usr/local/bin
+ * → ~/.antfly/bin). install() shells out to `brew install --cask
+ * antflydb/antfly/antfly` via child_process.spawn — never with
+ * `shell: true`, arguments always passed as an array.
+ *
+ * If Homebrew itself is not on the machine we return `failed` with a
+ * human-readable message pointing at the upstream install docs rather
+ * than silently swallowing the failure. The Antfly install is a large
+ * download, so we also refuse to proceed in non-interactive mode unless
+ * `autoApprove` is true — keeps `bakin onboard --check` honest.
+ */
+import { spawn } from 'child_process'
+import { existsSync } from 'fs'
+import { createLogger } from '../logger'
+import { findBinary } from '../antfly-server'
+import { askYesNo } from './prompts'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:antfly')
+
+const BREW_CANDIDATES = ['/opt/homebrew/bin/brew', '/usr/local/bin/brew']
+const BREW_CASK = 'antflydb/antfly/antfly'
+const BREW_INSTALL_DOCS = 'https://brew.sh/'
+
+function findBrew(): string | null {
+  for (const candidate of BREW_CANDIDATES) {
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+async function check(): Promise<CheckResult> {
+  const binary = findBinary()
+  if (binary) {
+    return {
+      name: 'antfly',
+      status: 'ok',
+      message: `Antfly is installed at ${binary}`,
+      details: { binary },
+    }
+  }
+  return {
+    name: 'antfly',
+    status: 'missing',
+    message: 'Antfly binary not found on any known install path',
+    remediation: `Run \`bakin install antfly\` to install via Homebrew (${BREW_CASK}).`,
+  }
+}
+
+/**
+ * Stream a subprocess to completion, forwarding stdout/stderr to the
+ * parent TTY when interactive (so the user sees brew's download
+ * progress) or collecting them as strings when not. Returns the exit
+ * code. Never uses `shell: true`.
+ */
+function runSpawn(
+  cmd: string,
+  args: string[],
+  opts: { interactive: boolean }
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: opts.interactive ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    if (!opts.interactive) {
+      child.stdout?.on('data', (chunk) => {
+        stdout += chunk.toString()
+      })
+      child.stderr?.on('data', (chunk) => {
+        stderr += chunk.toString()
+      })
+    }
+    child.on('error', (err) => reject(err))
+    child.on('close', (code) => resolve({ code, stdout, stderr }))
+  })
+}
+
+async function install(opts: OnboardingOptions): Promise<InstallResult> {
+  const start = Date.now()
+
+  // Already installed? Short-circuit. The orchestrator calls check() up
+  // front anyway, but we re-verify here because an individual CLI
+  // invocation (`bakin install antfly`) may be run standalone.
+  const existing = findBinary()
+  if (existing) {
+    return {
+      name: 'antfly',
+      status: 'noop',
+      message: `Antfly is already installed at ${existing}`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  const brew = findBrew()
+  if (!brew) {
+    return {
+      name: 'antfly',
+      status: 'failed',
+      message: `Homebrew not found at ${BREW_CANDIDATES.join(' or ')}. Install Homebrew first (${BREW_INSTALL_DOCS}) and rerun, or install Antfly manually.`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  // Confirm with the user unless they've passed --yes. Bakin should
+  // never run a ~25MB download without consent.
+  if (opts.interactive && !opts.autoApprove) {
+    const proceed = await askYesNo(
+      `Install Antfly via Homebrew? This will download ~25MB and run \`brew install --cask ${BREW_CASK}\`.`,
+      true
+    )
+    if (!proceed) {
+      return {
+        name: 'antfly',
+        status: 'skipped',
+        message: 'User declined Antfly install.',
+        durationMs: Date.now() - start,
+      }
+    }
+  } else if (!opts.autoApprove) {
+    // Non-interactive + no --yes = refuse. Keeps `bakin onboard --check`
+    // honest — it should never install anything.
+    return {
+      name: 'antfly',
+      status: 'skipped',
+      message: 'Non-interactive run without --yes; skipping Antfly install.',
+      durationMs: Date.now() - start,
+    }
+  }
+
+  log.info('Installing Antfly via brew', { brew, cask: BREW_CASK })
+  try {
+    const { code, stderr } = await runSpawn(
+      brew,
+      ['install', '--cask', BREW_CASK],
+      { interactive: opts.interactive && !opts.json }
+    )
+    const durationMs = Date.now() - start
+    if (code !== 0) {
+      return {
+        name: 'antfly',
+        status: 'failed',
+        message: `brew install exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`,
+        durationMs,
+      }
+    }
+    // Verify the binary is now discoverable.
+    const installed = findBinary()
+    if (!installed) {
+      return {
+        name: 'antfly',
+        status: 'failed',
+        message: 'brew install reported success but antfly binary is still not discoverable',
+        durationMs,
+      }
+    }
+    log.info('Antfly installed successfully', { binary: installed, durationMs })
+    return {
+      name: 'antfly',
+      status: 'installed',
+      message: `Installed Antfly to ${installed}`,
+      durationMs,
+    }
+  } catch (err) {
+    log.error('Failed to spawn brew', err)
+    return {
+      name: 'antfly',
+      status: 'failed',
+      message: `Failed to run brew install: ${err instanceof Error ? err.message : String(err)}`,
+      error: err,
+      durationMs: Date.now() - start,
+    }
+  }
+}
+
+export const antflyComponent: OnboardingComponent = {
+  name: 'antfly',
+  check,
+  install,
+}
+
+// Exported for testability of the brew discovery path without re-import games.
+export const _internals = { findBrew, runSpawn, BREW_CASK, BREW_CANDIDATES }

--- a/src/core/onboarding/credentials.ts
+++ b/src/core/onboarding/credentials.ts
@@ -1,0 +1,199 @@
+/**
+ * credentials component — warn-only checks for LLM providers and
+ * messaging channels configured in OpenClaw's own files.
+ *
+ * Bakin does NOT prompt users to paste secrets (that would be OpenClaw's
+ * territory — OpenClaw has its own `openclaw setup` flow that knows
+ * about Anthropic keys, Discord bot tokens, guild IDs, etc.). What this
+ * module does is *verify* that OpenClaw has at least one provider and
+ * one channel configured, so we can tell a new user "your agents won't
+ * be able to reach any LLM until you run OpenClaw's setup" instead of
+ * letting them discover that from a broken dispatch at 3am.
+ *
+ * Both checks are **warn-only** — they never return `error`, and
+ * `install()` is always a noop with a remediation pointer. The
+ * orchestrator in T9 writes `components.llm: "warn"` and
+ * `components.channels: "warn"` to the .onboarded marker on decline;
+ * Bakin still starts.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { createLogger } from '../logger'
+import { getOpenClawPath } from '@bakin/core/openclaw-home'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:credentials')
+
+const OPENCLAW_DOCS = 'https://openclaw.ai/docs/'
+
+/**
+ * Fields on a channel entry in openclaw.json that count as "a credential
+ * is present." OpenClaw's own channel drivers accept different key names
+ * (token for Discord/Slack, apiKey for some skill plugins, etc.) so we
+ * check for any of them.
+ */
+const CHANNEL_CREDENTIAL_FIELDS = ['token', 'apiKey', 'api_key', 'botToken', 'bot_token']
+
+function hasCredentialField(entry: unknown): boolean {
+  if (entry === null || typeof entry !== 'object') return false
+  const obj = entry as Record<string, unknown>
+  for (const field of CHANNEL_CREDENTIAL_FIELDS) {
+    const value = obj[field]
+    if (typeof value === 'string' && value.trim().length > 0) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// LLM component
+// ---------------------------------------------------------------------------
+
+async function checkLlm(): Promise<CheckResult> {
+  const profilePath = getOpenClawPath('agents', 'main', 'agent', 'auth-profiles.json')
+
+  if (!existsSync(profilePath)) {
+    return {
+      name: 'llm',
+      status: 'warn',
+      message: `No LLM provider configured — ${profilePath} is missing`,
+      remediation: `Configure at least one LLM provider via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+      details: { profilePath, installUrl: OPENCLAW_DOCS },
+    }
+  }
+
+  try {
+    const raw = readFileSync(profilePath, 'utf-8')
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return {
+        name: 'llm',
+        status: 'warn',
+        message: `auth-profiles.json is not an array — cannot tell if any provider is configured`,
+        remediation: `Check the file's shape or regenerate it via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+        details: { profilePath },
+      }
+    }
+    const providers = parsed
+      .filter((p): p is { provider?: string; apiKey?: string } => p !== null && typeof p === 'object')
+      .filter((p) => typeof p.provider === 'string' && typeof p.apiKey === 'string' && p.apiKey.trim().length > 0)
+      .map((p) => p.provider as string)
+    if (providers.length === 0) {
+      return {
+        name: 'llm',
+        status: 'warn',
+        message: 'No LLM provider in auth-profiles.json has a non-empty apiKey',
+        remediation: `Configure at least one LLM provider via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+        details: { profilePath, installUrl: OPENCLAW_DOCS },
+      }
+    }
+    return {
+      name: 'llm',
+      status: 'ok',
+      message: `${providers.length} LLM provider${providers.length === 1 ? '' : 's'} configured: ${providers.join(', ')}`,
+      details: { profilePath, providers },
+    }
+  } catch (err) {
+    log.warn('Failed to read auth-profiles.json', err)
+    return {
+      name: 'llm',
+      status: 'warn',
+      message: `Could not parse ${profilePath}: ${err instanceof Error ? err.message : String(err)}`,
+      remediation: `Fix or regenerate the file via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+      details: { profilePath },
+    }
+  }
+}
+
+async function installLlm(_opts: OnboardingOptions): Promise<InstallResult> {
+  log.info('llm.install() is a noop — LLM credentials are user-managed via OpenClaw')
+  return {
+    name: 'llm',
+    status: 'noop',
+    message: `LLM credentials must be configured via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+    durationMs: 0,
+  }
+}
+
+export const llmComponent: OnboardingComponent = {
+  name: 'llm',
+  check: checkLlm,
+  install: installLlm,
+}
+
+// ---------------------------------------------------------------------------
+// Channels component
+// ---------------------------------------------------------------------------
+
+async function checkChannels(): Promise<CheckResult> {
+  const configPath = getOpenClawPath('openclaw.json')
+
+  if (!existsSync(configPath)) {
+    return {
+      name: 'channels',
+      status: 'warn',
+      message: `No messaging channels configured — ${configPath} is missing`,
+      remediation: `Configure at least one channel (Discord, Telegram, Slack) via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+      details: { configPath, installUrl: OPENCLAW_DOCS },
+    }
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8')
+    const parsed = JSON.parse(raw) as { channels?: Record<string, unknown> }
+    const channels = parsed.channels ?? {}
+    if (typeof channels !== 'object' || channels === null) {
+      return {
+        name: 'channels',
+        status: 'warn',
+        message: `openclaw.json "channels" key is not an object`,
+        remediation: `Check the file's shape or regenerate it via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+        details: { configPath },
+      }
+    }
+    const configured = Object.entries(channels)
+      .filter(([, entry]) => hasCredentialField(entry))
+      .map(([name]) => name)
+    if (configured.length === 0) {
+      return {
+        name: 'channels',
+        status: 'warn',
+        message: 'No messaging channel in openclaw.json has a non-empty credential field',
+        remediation: `Configure at least one channel (Discord, Telegram, Slack) via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+        details: { configPath, installUrl: OPENCLAW_DOCS },
+      }
+    }
+    return {
+      name: 'channels',
+      status: 'ok',
+      message: `${configured.length} channel${configured.length === 1 ? '' : 's'} configured: ${configured.join(', ')}`,
+      details: { configPath, channels: configured },
+    }
+  } catch (err) {
+    log.warn('Failed to read openclaw.json', err)
+    return {
+      name: 'channels',
+      status: 'warn',
+      message: `Could not parse ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+      remediation: `Fix or regenerate the file via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+      details: { configPath },
+    }
+  }
+}
+
+async function installChannels(_opts: OnboardingOptions): Promise<InstallResult> {
+  log.info('channels.install() is a noop — channel credentials are user-managed via OpenClaw')
+  return {
+    name: 'channels',
+    status: 'noop',
+    message: `Channel credentials must be configured via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+    durationMs: 0,
+  }
+}
+
+export const channelsComponent: OnboardingComponent = {
+  name: 'channels',
+  check: checkChannels,
+  install: installChannels,
+}
+
+export const OPENCLAW_DOCS_URL = OPENCLAW_DOCS
+export const _internals = { CHANNEL_CREDENTIAL_FIELDS, hasCredentialField }

--- a/src/core/onboarding/index.ts
+++ b/src/core/onboarding/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Onboarding orchestrator — public API for `bakin onboard` and doctor.
+ *
+ * T1 note: this is the skeleton. `runOnboard()` and `checkAll()` throw until
+ * components are wired in through T2–T9. `isOnboarded()` and the state
+ * helpers are live from day one so `src/core/doctor.ts` can start consulting
+ * the marker file as soon as the gate is added (T13).
+ */
+import type { CheckResult, OnboardingOptions } from './types'
+
+export { isOnboarded, loadState, saveState, clearMarker, ONBOARDING_VERSION } from './state'
+export type { CheckResult, InstallResult, OnboardingOptions, OnboardingComponent, CheckStatus, InstallStatus } from './types'
+
+export interface RunOnboardResult {
+  results: CheckResult[]
+  exitCode: 0 | 1 | 2
+  markerWritten: boolean
+}
+
+/**
+ * Run every component's `check()` in dependency order and return the results.
+ * Never mutates the system — safe to call from doctor or CI.
+ *
+ * T1: stub. T9 wires in the real component chain.
+ */
+export async function checkAll(): Promise<CheckResult[]> {
+  throw new Error('checkAll() not yet implemented — wired up in T9')
+}
+
+/**
+ * Run the full aggregated `bakin onboard` flow: check each component, install
+ * missing ones (subject to opts), write the .onboarded marker on success.
+ *
+ * T1: stub. T9 wires in the real orchestrator.
+ */
+export async function runOnboard(_opts: OnboardingOptions): Promise<RunOnboardResult> {
+  throw new Error('runOnboard() not yet implemented — wired up in T9')
+}

--- a/src/core/onboarding/index.ts
+++ b/src/core/onboarding/index.ts
@@ -1,38 +1,424 @@
 /**
  * Onboarding orchestrator — public API for `bakin onboard` and doctor.
  *
- * T1 note: this is the skeleton. `runOnboard()` and `checkAll()` throw until
- * components are wired in through T2–T9. `isOnboarded()` and the state
- * helpers are live from day one so `src/core/doctor.ts` can start consulting
- * the marker file as soon as the gate is added (T13).
+ * runOnboard() walks every component in a fixed dependency order:
+ *
+ *   mkdir → settings → openclaw → antfly → models → mcporter → llm → channels
+ *
+ * For each component:
+ *   1. Call `check()`. If it reports `ok` or `warn`, record and move on.
+ *   2. If it reports `missing` or `broken`:
+ *        - In --check mode: record as `skipped`, never call install()
+ *        - Otherwise: call `install(opts)` — the component itself prompts
+ *          interactively (via askYesNo in prompts.ts) and respects the
+ *          non-interactive-requires-yes rule. The orchestrator never
+ *          double-prompts.
+ *   3. Translate the install status into the final component status:
+ *        installed | noop → 'ok'
+ *        skipped           → 'skipped'
+ *        failed            → 'error'
+ *
+ * Special cases baked into the flow:
+ *   - OpenClaw missing/broken is a hard stop: the orchestrator records
+ *     the openclaw status, marks every downstream component as 'skipped'
+ *     with an "OpenClaw required" message, and returns without writing
+ *     the marker. Exit code 1.
+ *   - Antfly missing that cascades into models: if antfly's post-install
+ *     status is not 'ok', models is force-skipped with the reason
+ *     "Antfly binary required." No point shelling to a binary that
+ *     doesn't exist.
+ *
+ * Marker-write rule (matches the spec and Mark's sign-off):
+ *   - exitCode 0 (all ok) → write marker
+ *   - exitCode 2 (any warn/skipped, no errors) → write marker
+ *   - exitCode 1 (any error/failed) → do NOT write marker. The user
+ *     must fix the broken component and rerun.
+ *
+ * checkAll() is the read-only equivalent: it calls every component's
+ * `check()` and returns the results, never running install. Used by
+ * `bakin check all` and by the doctor gate in T13 when it wants to
+ * surface which pieces are wired up (not just whether the marker
+ * exists).
  */
-import type { CheckResult, OnboardingOptions } from './types'
+import { createLogger } from '../logger'
+import { mkdirComponent } from './mkdir'
+import { settingsComponent } from './settings'
+import { openclawComponent } from './openclaw'
+import { antflyComponent } from './antfly'
+import { modelsComponent } from './models'
+import { mcporterComponent } from './mcporter'
+import { llmComponent, channelsComponent } from './credentials'
+import { saveState, clearMarker } from './state'
+import type { CheckResult, OnboardingComponent, OnboardingOptions } from './types'
+import type { ComponentStatus } from './state'
+
+const log = createLogger('onboarding:orchestrator')
 
 export { isOnboarded, loadState, saveState, clearMarker, ONBOARDING_VERSION } from './state'
 export type { CheckResult, InstallResult, OnboardingOptions, OnboardingComponent, CheckStatus, InstallStatus } from './types'
+export type { OnboardingState, ComponentStatus } from './state'
+
+/**
+ * Fixed component order. This is the single source of truth for which
+ * components run and in what sequence. Adding a new component is one
+ * entry in this array plus one bump to ONBOARDING_VERSION in state.ts.
+ */
+export const COMPONENT_ORDER: readonly OnboardingComponent[] = [
+  mkdirComponent,
+  settingsComponent,
+  openclawComponent,
+  antflyComponent,
+  modelsComponent,
+  mcporterComponent,
+  llmComponent,
+  channelsComponent,
+] as const
+
+/**
+ * Result of a single component's full check+install cycle, as seen by
+ * the orchestrator. Status is already normalized to ComponentStatus
+ * (the marker-file shape) for easy aggregation.
+ */
+export interface ComponentOutcome {
+  name: string
+  finalStatus: ComponentStatus
+  /** Result of the initial check() call. Always populated. */
+  check: CheckResult
+  /** The final message to print/return to the user. */
+  message: string
+  /** Remediation text, populated when finalStatus is 'warn' or 'error'. */
+  remediation?: string
+  /** Extra details for --json output. */
+  details?: Record<string, unknown>
+  /** Milliseconds the component took (check + optional install). */
+  durationMs: number
+}
 
 export interface RunOnboardResult {
-  results: CheckResult[]
+  outcomes: ComponentOutcome[]
   exitCode: 0 | 1 | 2
   markerWritten: boolean
 }
 
-/**
- * Run every component's `check()` in dependency order and return the results.
- * Never mutates the system — safe to call from doctor or CI.
- *
- * T1: stub. T9 wires in the real component chain.
- */
-export async function checkAll(): Promise<CheckResult[]> {
-  throw new Error('checkAll() not yet implemented — wired up in T9')
+const DEFAULT_BAKIN_VERSION = '0.0.0'
+
+function resolveBakinVersion(): string {
+  // Best-effort: the real version comes from package.json at build time.
+  // We read it here via require so the value stays in sync with whatever
+  // is in the repo when the orchestrator runs. Failure is non-fatal —
+  // the marker's bakinVersion is informational only.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require('../../../package.json') as { version?: string }
+    return pkg.version ?? DEFAULT_BAKIN_VERSION
+  } catch {
+    return DEFAULT_BAKIN_VERSION
+  }
+}
+
+function emitJson(outcome: ComponentOutcome): void {
+  const line = {
+    component: outcome.name,
+    status: outcome.finalStatus,
+    message: outcome.message,
+    ...(outcome.remediation ? { remediation: outcome.remediation } : {}),
+    ...(outcome.details ? { details: outcome.details } : {}),
+    durationMs: outcome.durationMs,
+  }
+  // One JSON object per line, flushed immediately so CI logs stream.
+  process.stdout.write(JSON.stringify(line) + '\n')
 }
 
 /**
- * Run the full aggregated `bakin onboard` flow: check each component, install
- * missing ones (subject to opts), write the .onboarded marker on success.
- *
- * T1: stub. T9 wires in the real orchestrator.
+ * Run one component through the full check → (optional install) → outcome
+ * pipeline. Never throws — all errors are converted into an outcome with
+ * `finalStatus: 'error'`.
  */
-export async function runOnboard(_opts: OnboardingOptions): Promise<RunOnboardResult> {
-  throw new Error('runOnboard() not yet implemented — wired up in T9')
+async function runComponent(
+  component: OnboardingComponent,
+  opts: OnboardingOptions
+): Promise<ComponentOutcome> {
+  const start = Date.now()
+  let check: CheckResult
+  try {
+    check = await component.check()
+  } catch (err) {
+    log.error('Component check() threw', { component: component.name, error: String(err) })
+    return {
+      name: component.name,
+      finalStatus: 'error',
+      check: {
+        name: component.name,
+        status: 'error',
+        message: `check() threw: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      message: `check() threw: ${err instanceof Error ? err.message : String(err)}`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  // ok / warn → no install, outcome matches check
+  if (check.status === 'ok') {
+    return {
+      name: component.name,
+      finalStatus: 'ok',
+      check,
+      message: check.message,
+      details: check.details,
+      durationMs: Date.now() - start,
+    }
+  }
+  if (check.status === 'warn') {
+    return {
+      name: component.name,
+      finalStatus: 'warn',
+      check,
+      message: check.message,
+      remediation: check.remediation,
+      details: check.details,
+      durationMs: Date.now() - start,
+    }
+  }
+  if (check.status === 'error') {
+    return {
+      name: component.name,
+      finalStatus: 'error',
+      check,
+      message: check.message,
+      remediation: check.remediation,
+      details: check.details,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  // missing or broken — install time (unless --check)
+  if (opts.checkOnly) {
+    return {
+      name: component.name,
+      finalStatus: 'skipped',
+      check,
+      message: `${check.message} (check-only mode, not installing)`,
+      remediation: check.remediation,
+      details: check.details,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  try {
+    const install = await component.install(opts)
+    const durationMs = Date.now() - start
+    switch (install.status) {
+      case 'installed':
+      case 'noop':
+        return {
+          name: component.name,
+          finalStatus: 'ok',
+          check,
+          message: install.message,
+          details: check.details,
+          durationMs,
+        }
+      case 'skipped':
+        return {
+          name: component.name,
+          finalStatus: 'skipped',
+          check,
+          message: install.message,
+          remediation: check.remediation,
+          details: check.details,
+          durationMs,
+        }
+      case 'failed':
+        return {
+          name: component.name,
+          finalStatus: 'error',
+          check,
+          message: install.message,
+          remediation: check.remediation,
+          details: check.details,
+          durationMs,
+        }
+    }
+  } catch (err) {
+    log.error('Component install() threw', { component: component.name, error: String(err) })
+    return {
+      name: component.name,
+      finalStatus: 'error',
+      check,
+      message: `install() threw: ${err instanceof Error ? err.message : String(err)}`,
+      remediation: check.remediation,
+      details: check.details,
+      durationMs: Date.now() - start,
+    }
+  }
+}
+
+/**
+ * Special-case handling for openclaw. Its install() is always a noop —
+ * Bakin does not manage OpenClaw, it only detects it. So we read the
+ * check result directly and translate any non-ok status into the
+ * appropriate outcome for the orchestrator to cascade-skip on.
+ */
+async function runOpenclawInline(component: OnboardingComponent): Promise<ComponentOutcome> {
+  const start = Date.now()
+  let check: CheckResult
+  try {
+    check = await component.check()
+  } catch (err) {
+    return {
+      name: component.name,
+      finalStatus: 'error',
+      check: {
+        name: component.name,
+        status: 'error',
+        message: `check() threw: ${err instanceof Error ? err.message : String(err)}`,
+      },
+      message: `check() threw: ${err instanceof Error ? err.message : String(err)}`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  const base = {
+    name: component.name,
+    check,
+    message: check.message,
+    remediation: check.remediation,
+    details: check.details,
+    durationMs: Date.now() - start,
+  }
+
+  switch (check.status) {
+    case 'ok':
+      return { ...base, finalStatus: 'ok' }
+    case 'warn':
+      return { ...base, finalStatus: 'warn' }
+    case 'missing':
+      // A missing prerequisite isn't an "error" per se — we just can't
+      // proceed. Record as 'error' so the orchestrator writes no marker
+      // and the CLI exits 1. The remediation message is the key output.
+      return { ...base, finalStatus: 'error' }
+    case 'broken':
+    case 'error':
+      return { ...base, finalStatus: 'error' }
+  }
+}
+
+/**
+ * Run every component's `check()` in dependency order and return the
+ * results. Never touches install() — safe for doctor or CI auditing.
+ */
+export async function checkAll(): Promise<CheckResult[]> {
+  const results: CheckResult[] = []
+  for (const component of COMPONENT_ORDER) {
+    try {
+      results.push(await component.check())
+    } catch (err) {
+      results.push({
+        name: component.name,
+        status: 'error',
+        message: `check() threw: ${err instanceof Error ? err.message : String(err)}`,
+      })
+    }
+  }
+  return results
+}
+
+/**
+ * Run the full aggregated onboard flow. Safe to call repeatedly —
+ * every component is idempotent and the marker file is only written
+ * when no component errored.
+ */
+export async function runOnboard(opts: OnboardingOptions): Promise<RunOnboardResult> {
+  // Clear the marker upfront if --force was passed. The user wants to
+  // replay the whole flow regardless of prior state.
+  if (opts.force) {
+    clearMarker()
+  }
+
+  const outcomes: ComponentOutcome[] = []
+
+  for (let i = 0; i < COMPONENT_ORDER.length; i++) {
+    const component = COMPONENT_ORDER[i]
+
+    // Cascade skip: if antfly is not ok, models has nothing to pull with.
+    // Skip it before even calling check().
+    if (component.name === 'models') {
+      const antfly = outcomes.find((o) => o.name === 'antfly')
+      if (antfly && antfly.finalStatus !== 'ok') {
+        const skip: ComponentOutcome = {
+          name: 'models',
+          finalStatus: 'skipped',
+          check: {
+            name: 'models',
+            status: 'missing',
+            message: 'Skipped: Antfly binary is required to pull Termite models',
+          },
+          message: 'Skipped: Antfly binary is required to pull Termite models',
+          remediation: 'Install Antfly first via `bakin install antfly`, then rerun onboarding.',
+          durationMs: 0,
+        }
+        outcomes.push(skip)
+        if (opts.json) emitJson(skip)
+        continue
+      }
+    }
+
+    // OpenClaw is a user-managed prerequisite. Its install() is
+    // intentionally a noop (we point at https://openclaw.ai/), so the
+    // generic runComponent path — which maps install:noop to ok —
+    // would incorrectly mark a missing openclaw as ready. Handle it
+    // inline: call check() only, derive the outcome from that, and
+    // cascade-skip downstream if anything other than ok.
+    if (component.name === 'openclaw') {
+      const outcome = await runOpenclawInline(component)
+      outcomes.push(outcome)
+      if (opts.json) emitJson(outcome)
+      if (outcome.finalStatus !== 'ok') {
+        log.warn('OpenClaw is not ready; aborting remaining onboarding steps')
+        for (let j = i + 1; j < COMPONENT_ORDER.length; j++) {
+          const remaining = COMPONENT_ORDER[j]
+          const skip: ComponentOutcome = {
+            name: remaining.name,
+            finalStatus: 'skipped',
+            check: {
+              name: remaining.name,
+              status: 'missing',
+              message: 'Skipped: OpenClaw is a prerequisite and is not ready',
+            },
+            message: 'Skipped: OpenClaw is a prerequisite and is not ready',
+            remediation: outcome.remediation,
+            durationMs: 0,
+          }
+          outcomes.push(skip)
+          if (opts.json) emitJson(skip)
+        }
+        break
+      }
+      continue
+    }
+
+    const outcome = await runComponent(component, opts)
+    outcomes.push(outcome)
+    if (opts.json) emitJson(outcome)
+  }
+
+  // Aggregate exit code
+  const hasError = outcomes.some((o) => o.finalStatus === 'error')
+  const hasSkippedOrWarn = outcomes.some((o) => o.finalStatus === 'warn' || o.finalStatus === 'skipped')
+  const exitCode: 0 | 1 | 2 = hasError ? 1 : hasSkippedOrWarn ? 2 : 0
+
+  // Marker: write iff no errors. Warn/skipped are valid end-states.
+  let markerWritten = false
+  if (!hasError) {
+    const components: Record<string, ComponentStatus> = {}
+    for (const o of outcomes) components[o.name] = o.finalStatus
+    try {
+      saveState(components, resolveBakinVersion())
+      markerWritten = true
+    } catch (err) {
+      log.error('Failed to write .onboarded marker', err)
+    }
+  }
+
+  return { outcomes, exitCode, markerWritten }
 }

--- a/src/core/onboarding/mcporter.ts
+++ b/src/core/onboarding/mcporter.ts
@@ -1,0 +1,154 @@
+/**
+ * mcporter component — thin wrapper around the existing src/core/mcporter
+ * module. We intentionally do not duplicate the install logic; mcporter.ts
+ * already exports `isMcporterInstalled()`, `installMcporter()`, and
+ * `syncConfig()` which the server boot path and `bakin setup mcporter`
+ * both use. This component reuses them so the onboarding flow and the
+ * existing code paths stay in sync.
+ *
+ * What this component adds:
+ *   - A CheckResult/InstallResult surface for the T9 orchestrator
+ *   - Interactive confirmation + non-interactive-requires-yes guard rails
+ *     matching antfly/models
+ *   - Post-install verification: the binary must be discoverable AND at
+ *     least one per-agent entry must be present in ~/.mcporter/mcporter.json
+ */
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { createLogger } from '../logger'
+import { isMcporterInstalled, installMcporter, syncConfig } from '../mcporter'
+import { askYesNo } from './prompts'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:mcporter')
+
+function mcporterConfigPath(): string {
+  return join(process.env.HOME || '~', '.mcporter', 'mcporter.json')
+}
+
+function getPort(): number {
+  return Number(process.env.PORT || 3737)
+}
+
+async function check(): Promise<CheckResult> {
+  const installed = isMcporterInstalled()
+  if (!installed) {
+    return {
+      name: 'mcporter',
+      status: 'missing',
+      message: 'mcporter binary not found on PATH',
+      remediation: 'Run `bakin install mcporter` to install via `npm install -g mcporter`.',
+    }
+  }
+  const configPath = mcporterConfigPath()
+  if (!existsSync(configPath)) {
+    return {
+      name: 'mcporter',
+      status: 'broken',
+      message: `mcporter installed but ${configPath} is missing`,
+      remediation: 'Run `bakin install mcporter` to seed the per-agent entries.',
+      details: { configPath },
+    }
+  }
+  return {
+    name: 'mcporter',
+    status: 'ok',
+    message: `mcporter is installed and configured at ${configPath}`,
+    details: { configPath, port: getPort() },
+  }
+}
+
+async function install(opts: OnboardingOptions): Promise<InstallResult> {
+  const start = Date.now()
+
+  // Gate on user consent before shelling out to npm.
+  const alreadyInstalled = isMcporterInstalled()
+  if (!alreadyInstalled) {
+    if (opts.interactive && !opts.autoApprove) {
+      const proceed = await askYesNo(
+        'Install mcporter globally via `npm install -g mcporter`? Requires npm on PATH.',
+        true
+      )
+      if (!proceed) {
+        return {
+          name: 'mcporter',
+          status: 'skipped',
+          message: 'User declined mcporter install.',
+          durationMs: Date.now() - start,
+        }
+      }
+    } else if (!opts.autoApprove) {
+      return {
+        name: 'mcporter',
+        status: 'skipped',
+        message: 'Non-interactive run without --yes; skipping mcporter install.',
+        durationMs: Date.now() - start,
+      }
+    }
+
+    log.info('Installing mcporter via npm install -g mcporter')
+    const ok = installMcporter()
+    if (!ok) {
+      return {
+        name: 'mcporter',
+        status: 'failed',
+        message: 'npm install -g mcporter failed — check that npm is on PATH and rerun.',
+        durationMs: Date.now() - start,
+      }
+    }
+    if (!isMcporterInstalled()) {
+      return {
+        name: 'mcporter',
+        status: 'failed',
+        message: 'npm reported success but mcporter is still not discoverable on PATH.',
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+
+  // Sync per-agent MCP server entries. syncConfig is already idempotent —
+  // it only writes when the computed entries differ from what's on disk,
+  // and it returns the list of changes it made.
+  const port = getPort()
+  let changes: string[] = []
+  try {
+    changes = syncConfig(port)
+  } catch (err) {
+    log.error('Failed to sync mcporter config', err)
+    return {
+      name: 'mcporter',
+      status: 'failed',
+      message: `mcporter is installed but syncConfig failed: ${err instanceof Error ? err.message : String(err)}`,
+      error: err,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  const durationMs = Date.now() - start
+  if (alreadyInstalled && changes.length === 0) {
+    return {
+      name: 'mcporter',
+      status: 'noop',
+      message: 'mcporter already installed; config already up to date.',
+      durationMs,
+    }
+  }
+
+  log.info('mcporter ready', { changes, port, alreadyInstalled })
+  return {
+    name: 'mcporter',
+    status: 'installed',
+    message: alreadyInstalled
+      ? `mcporter config synced (${changes.length} change${changes.length === 1 ? '' : 's'})`
+      : `Installed mcporter and synced config (${changes.length} change${changes.length === 1 ? '' : 's'})`,
+    durationMs,
+  }
+}
+
+export const mcporterComponent: OnboardingComponent = {
+  name: 'mcporter',
+  check,
+  install,
+}
+
+export const _internals = { mcporterConfigPath, getPort }

--- a/src/core/onboarding/mkdir.ts
+++ b/src/core/onboarding/mkdir.ts
@@ -1,0 +1,90 @@
+/**
+ * mkdir component — ensures the ~/.bakin/ directory tree exists.
+ *
+ * Thin wrapper around `initBakinHome()` from content-dir. Idempotent:
+ * re-running against an already-seeded tree is a no-op that returns `ok`.
+ */
+import { existsSync } from 'fs'
+import { createLogger } from '../logger'
+import { getBakinPaths, initBakinHome, getContentDir } from '../content-dir'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:mkdir')
+
+/**
+ * Key subdirectories we require present for mkdir to report `ok`. Missing
+ * any one of these means the tree has not been seeded (or was partially
+ * wiped) and `install()` should rerun `initBakinHome()`.
+ */
+function requiredDirs(): string[] {
+  const paths = getBakinPaths()
+  return [
+    paths.home,
+    paths.assets,
+    paths['assets.text'],
+    paths['assets.images'],
+    paths['assets.other'],
+    paths.agents,
+    paths.heartbeats,
+    paths.projects,
+    paths.workflows,
+    paths.team,
+  ]
+}
+
+async function check(): Promise<CheckResult> {
+  const dirs = requiredDirs()
+  const missing = dirs.filter((d) => !existsSync(d))
+  if (missing.length === 0) {
+    return {
+      name: 'mkdir',
+      status: 'ok',
+      message: `Bakin home directory is initialized at ${getContentDir()}`,
+    }
+  }
+  return {
+    name: 'mkdir',
+    status: 'missing',
+    message: `${missing.length} required director${missing.length === 1 ? 'y' : 'ies'} missing under ${getContentDir()}`,
+    remediation: 'Run `bakin mkdir` to create the directory tree.',
+    details: { missing },
+  }
+}
+
+async function install(_opts: OnboardingOptions): Promise<InstallResult> {
+  const start = Date.now()
+  try {
+    const result = initBakinHome(getContentDir())
+    const durationMs = Date.now() - start
+    if (result.created.length === 0 && result.seeded.length === 0) {
+      return {
+        name: 'mkdir',
+        status: 'noop',
+        message: `Already initialized at ${getContentDir()}`,
+        durationMs,
+      }
+    }
+    log.info('Bakin home initialized', { created: result.created.length, seeded: result.seeded.length })
+    return {
+      name: 'mkdir',
+      status: 'installed',
+      message: `Created ${result.created.length} path${result.created.length === 1 ? '' : 's'}, seeded ${result.seeded.length} file${result.seeded.length === 1 ? '' : 's'}`,
+      durationMs,
+    }
+  } catch (err) {
+    log.error('Failed to initialize Bakin home', err)
+    return {
+      name: 'mkdir',
+      status: 'failed',
+      message: `Failed to create directory tree: ${err instanceof Error ? err.message : String(err)}`,
+      error: err,
+      durationMs: Date.now() - start,
+    }
+  }
+}
+
+export const mkdirComponent: OnboardingComponent = {
+  name: 'mkdir',
+  check,
+  install,
+}

--- a/src/core/onboarding/models.ts
+++ b/src/core/onboarding/models.ts
@@ -1,0 +1,208 @@
+/**
+ * models component — ensures the Termite ML models Bakin relies on are
+ * downloaded to ~/.termite/models/.
+ *
+ * Bakin's search system uses three Termite-hosted models:
+ *   1. BAAI/bge-small-en-v1.5 — default text embedder (BM25 + semantic)
+ *   2. openai/clip-vit-base-patch32 — visual embedder for the assets
+ *      plugin's multimodal index
+ *   3. mixedbread-ai/mxbai-rerank-base-v1 — cross-encoder reranker
+ *
+ * All three are referenced by default in settings.antfly and the live
+ * server boot path will spew `[search-migration]` errors if any one is
+ * missing. This component detects which models are present on disk and
+ * runs `antfly termite pull <model>` for each missing one.
+ *
+ * Requires the antfly binary to already be installed — the T9
+ * orchestrator runs this component after T5 (antfly) so the binary is
+ * guaranteed to exist in the happy path. If someone calls
+ * `bakin install models` directly before installing antfly, the component
+ * returns 'failed' with a remediation pointing at `bakin install antfly`.
+ */
+import { spawn } from 'child_process'
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { createLogger } from '../logger'
+import { findBinary as findAntflyBinary } from '../antfly-server'
+import { askYesNo } from './prompts'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:models')
+
+/**
+ * The three Termite models Bakin needs at boot. Each entry has a
+ * human-readable label, the model ID to pass to `antfly termite pull`,
+ * and the directory that should appear under ~/.termite/models/ once
+ * the pull completes successfully. The kind decides which top-level
+ * subdirectory the model lands in (embedders vs rerankers).
+ */
+export interface TermiteModel {
+  label: string
+  model: string
+  kind: 'embedder' | 'reranker'
+}
+
+export const REQUIRED_MODELS: TermiteModel[] = [
+  { label: 'BGE text embedder', model: 'BAAI/bge-small-en-v1.5', kind: 'embedder' },
+  { label: 'CLIP visual embedder', model: 'openai/clip-vit-base-patch32', kind: 'embedder' },
+  { label: 'mxbai reranker', model: 'mixedbread-ai/mxbai-rerank-base-v1', kind: 'reranker' },
+]
+
+export function termiteModelsRoot(): string {
+  return join(homedir(), '.termite', 'models')
+}
+
+function modelPath(m: TermiteModel): string {
+  const bucket = m.kind === 'embedder' ? 'embedders' : 'rerankers'
+  return join(termiteModelsRoot(), bucket, m.model)
+}
+
+function missingModels(): TermiteModel[] {
+  return REQUIRED_MODELS.filter((m) => !existsSync(modelPath(m)))
+}
+
+async function check(): Promise<CheckResult> {
+  const missing = missingModels()
+  if (missing.length === 0) {
+    return {
+      name: 'models',
+      status: 'ok',
+      message: `All ${REQUIRED_MODELS.length} Termite models present at ${termiteModelsRoot()}`,
+      details: { root: termiteModelsRoot(), models: REQUIRED_MODELS.map((m) => m.model) },
+    }
+  }
+  return {
+    name: 'models',
+    status: 'missing',
+    message: `${missing.length} of ${REQUIRED_MODELS.length} Termite model${missing.length === 1 ? '' : 's'} missing`,
+    remediation: 'Run `bakin install models` to download the missing Termite models.',
+    details: {
+      root: termiteModelsRoot(),
+      missing: missing.map((m) => ({ label: m.label, model: m.model, path: modelPath(m) })),
+    },
+  }
+}
+
+/** Shell out to `antfly termite pull <model>`, forwarding output to TTY. */
+function runPull(
+  antfly: string,
+  model: string,
+  interactive: boolean
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(antfly, ['termite', 'pull', model], {
+      stdio: interactive ? 'inherit' : ['ignore', 'pipe', 'pipe'],
+    })
+    let stderr = ''
+    if (!interactive) {
+      child.stderr?.on('data', (chunk) => {
+        stderr += chunk.toString()
+      })
+    }
+    child.on('error', (err) => reject(err))
+    child.on('close', (code) => resolve({ code, stderr }))
+  })
+}
+
+async function install(opts: OnboardingOptions): Promise<InstallResult> {
+  const start = Date.now()
+
+  const antfly = findAntflyBinary()
+  if (!antfly) {
+    return {
+      name: 'models',
+      status: 'failed',
+      message: 'antfly binary not found — Termite models cannot be pulled until Antfly is installed.',
+      durationMs: Date.now() - start,
+    }
+  }
+
+  const missing = missingModels()
+  if (missing.length === 0) {
+    return {
+      name: 'models',
+      status: 'noop',
+      message: `All ${REQUIRED_MODELS.length} Termite models already present.`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  // Guard on consent — model downloads are ~1.5GB total
+  if (opts.interactive && !opts.autoApprove) {
+    const proceed = await askYesNo(
+      `Download ${missing.length} Termite model${missing.length === 1 ? '' : 's'} (~1.5GB total) to ${termiteModelsRoot()}?`,
+      true
+    )
+    if (!proceed) {
+      return {
+        name: 'models',
+        status: 'skipped',
+        message: 'User declined Termite model download.',
+        durationMs: Date.now() - start,
+      }
+    }
+  } else if (!opts.autoApprove) {
+    return {
+      name: 'models',
+      status: 'skipped',
+      message: 'Non-interactive run without --yes; skipping Termite model download.',
+      durationMs: Date.now() - start,
+    }
+  }
+
+  log.info('Pulling Termite models', { count: missing.length, antfly })
+  const pulledLabels: string[] = []
+  for (const m of missing) {
+    log.info('Pulling model', { model: m.model, label: m.label })
+    try {
+      const { code, stderr } = await runPull(antfly, m.model, opts.interactive && !opts.json)
+      if (code !== 0) {
+        return {
+          name: 'models',
+          status: 'failed',
+          message: `antfly termite pull ${m.model} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`,
+          durationMs: Date.now() - start,
+        }
+      }
+      // Verify the directory now exists — catches brew-like "success but
+      // no file" failure modes.
+      if (!existsSync(modelPath(m))) {
+        return {
+          name: 'models',
+          status: 'failed',
+          message: `antfly termite pull ${m.model} reported success but ${modelPath(m)} is still missing`,
+          durationMs: Date.now() - start,
+        }
+      }
+      pulledLabels.push(m.label)
+    } catch (err) {
+      log.error('Failed to spawn antfly termite pull', err)
+      return {
+        name: 'models',
+        status: 'failed',
+        message: `Failed to pull ${m.model}: ${err instanceof Error ? err.message : String(err)}`,
+        error: err,
+        durationMs: Date.now() - start,
+      }
+    }
+  }
+
+  const durationMs = Date.now() - start
+  log.info('Termite models installed', { pulled: pulledLabels, durationMs })
+  return {
+    name: 'models',
+    status: 'installed',
+    message: `Pulled ${pulledLabels.length} model${pulledLabels.length === 1 ? '' : 's'}: ${pulledLabels.join(', ')}`,
+    durationMs,
+  }
+}
+
+export const modelsComponent: OnboardingComponent = {
+  name: 'models',
+  check,
+  install,
+}
+
+// Exported for tests.
+export const _internals = { missingModels, modelPath, runPull }

--- a/src/core/onboarding/openclaw.ts
+++ b/src/core/onboarding/openclaw.ts
@@ -1,0 +1,137 @@
+/**
+ * openclaw component — detects that OpenClaw is installed.
+ *
+ * OpenClaw is a **hard prerequisite**, not something Bakin manages. This
+ * component is check-only — `install()` is a noop that always returns a
+ * message pointing at the OpenClaw install docs. The orchestrator is
+ * responsible for using the `missing`/`error` status from `check()` to
+ * abort the remaining onboarding steps: without OpenClaw there is no
+ * agent runtime, and everything downstream of this point (LLM keys,
+ * channel config, credential discovery) would be meaningless.
+ *
+ * Detection criteria (all must hold for status: ok):
+ * 1. The OpenClaw home directory exists (`$OPENCLAW_HOME` or ~/.openclaw/)
+ * 2. The openclaw binary is discoverable on a well-known path
+ * 3. `openclaw.json` parses as JSON
+ *
+ * If any one of those is missing we report `missing` (not `error`) and
+ * leave the hard-stop decision to the orchestrator — a single `bakin check
+ * openclaw` invocation should still be able to surface the same result
+ * without hard-exiting the process.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { createLogger } from '../logger'
+import { getOpenClawHome, getOpenClawPath } from '@bakin/core/openclaw-home'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:openclaw')
+
+const INSTALL_URL = 'https://openclaw.ai/'
+const INSTALL_MESSAGE = `OpenClaw is required. Install it from ${INSTALL_URL} and rerun onboarding.`
+
+/**
+ * Candidate paths for the openclaw binary, in order. Mirrors
+ * `antfly-server.findBinary()` — same shape, different binary name.
+ * Exported for tests so we can verify the candidate ordering without
+ * touching the real filesystem.
+ */
+export function openClawBinaryCandidates(): string[] {
+  return [
+    process.env.OPENCLAW_PATH,
+    '/opt/homebrew/bin/openclaw',
+    '/usr/local/bin/openclaw',
+    join(homedir(), '.openclaw', 'bin', 'openclaw'),
+  ].filter((p): p is string => typeof p === 'string' && p.length > 0)
+}
+
+function findBinary(): string | null {
+  for (const candidate of openClawBinaryCandidates()) {
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+async function check(): Promise<CheckResult> {
+  const home = getOpenClawHome()
+  if (!existsSync(home)) {
+    return {
+      name: 'openclaw',
+      status: 'missing',
+      message: `OpenClaw home directory not found at ${home}`,
+      remediation: INSTALL_MESSAGE,
+      details: { homeChecked: home, installUrl: INSTALL_URL },
+    }
+  }
+
+  const binary = findBinary()
+  if (!binary) {
+    return {
+      name: 'openclaw',
+      status: 'missing',
+      message: 'OpenClaw binary not found on any known install path',
+      remediation: INSTALL_MESSAGE,
+      details: {
+        candidatesChecked: openClawBinaryCandidates(),
+        homeChecked: home,
+        installUrl: INSTALL_URL,
+      },
+    }
+  }
+
+  // openclaw.json is the file OpenClaw's own setup populates with channel
+  // config, guild IDs, etc. Its presence is a good signal that OpenClaw
+  // has been at least minimally configured, even if individual keys are
+  // still empty (that's the `llm` and `channels` components' problem).
+  const configPath = getOpenClawPath('openclaw.json')
+  if (!existsSync(configPath)) {
+    return {
+      name: 'openclaw',
+      status: 'broken',
+      message: `OpenClaw is installed at ${binary} but ${configPath} is missing`,
+      remediation: 'Run OpenClaw once to generate its default config, then rerun onboarding.',
+      details: { binary, configPath, installUrl: INSTALL_URL },
+    }
+  }
+
+  try {
+    JSON.parse(readFileSync(configPath, 'utf-8'))
+  } catch (err) {
+    return {
+      name: 'openclaw',
+      status: 'broken',
+      message: `openclaw.json at ${configPath} is not valid JSON`,
+      remediation: 'Fix or regenerate the file via OpenClaw, then rerun onboarding.',
+      details: { binary, configPath, parseError: String(err) },
+    }
+  }
+
+  return {
+    name: 'openclaw',
+    status: 'ok',
+    message: `OpenClaw is installed at ${binary}`,
+    details: { binary, home, configPath },
+  }
+}
+
+async function install(_opts: OnboardingOptions): Promise<InstallResult> {
+  // OpenClaw is never auto-installed by Bakin. Emit a noop with a helpful
+  // message so the orchestrator can log it and exit cleanly.
+  log.info('openclaw.install() is a noop — OpenClaw is a user-managed prerequisite')
+  return {
+    name: 'openclaw',
+    status: 'noop',
+    message: INSTALL_MESSAGE,
+    durationMs: 0,
+  }
+}
+
+export const openclawComponent: OnboardingComponent = {
+  name: 'openclaw',
+  check,
+  install,
+}
+
+export const OPENCLAW_INSTALL_URL = INSTALL_URL
+export const OPENCLAW_INSTALL_MESSAGE = INSTALL_MESSAGE

--- a/src/core/onboarding/prompts.ts
+++ b/src/core/onboarding/prompts.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal readline wrappers for the interactive onboarding flow.
+ *
+ * Uses Node's stdlib only — no inquirer/prompts dependency so the whole
+ * module bundles cleanly into a future single-binary build. Callers are
+ * expected to pre-check `process.stdout.isTTY` before calling these; in
+ * non-TTY contexts the orchestrator should pass `interactive: false` and
+ * never route through this file.
+ */
+import { createInterface } from 'readline'
+
+/**
+ * Read a single line from stdin. Resolves with trimmed user input.
+ * Caller supplies the prompt text (no trailing space needed — added here).
+ */
+export function readLine(prompt: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    rl.question(`${prompt} `, (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
+
+/**
+ * Ask a yes/no question. Returns true for y/yes (case-insensitive), false
+ * for n/no, and `defaultValue` when the user hits Enter without typing.
+ *
+ * The prompt is rendered with a bracketed default indicator — `[Y/n]` when
+ * default is true, `[y/N]` when default is false.
+ */
+export async function askYesNo(question: string, defaultValue = true): Promise<boolean> {
+  const hint = defaultValue ? '[Y/n]' : '[y/N]'
+  const answer = (await readLine(`${question} ${hint}`)).toLowerCase()
+  if (answer === '') return defaultValue
+  if (answer === 'y' || answer === 'yes') return true
+  if (answer === 'n' || answer === 'no') return false
+  // Anything else — re-ask once, then fall through to default.
+  const retry = (await readLine(`Please answer y or n. ${hint}`)).toLowerCase()
+  if (retry === 'y' || retry === 'yes') return true
+  if (retry === 'n' || retry === 'no') return false
+  return defaultValue
+}

--- a/src/core/onboarding/settings.ts
+++ b/src/core/onboarding/settings.ts
@@ -1,0 +1,109 @@
+/**
+ * settings component — ensures ~/.bakin/settings.json exists and parses.
+ *
+ * `initBakinHome()` already drops an empty `{}` settings.json during mkdir,
+ * but this component exists as a standalone check because (a) a user could
+ * have deleted or corrupted the file after mkdir, and (b) the orchestrator's
+ * dependency graph needs a discrete "settings is usable" gate before any
+ * later component reads `getSettings()`.
+ *
+ * install() writes a well-formed (empty override) file via `updateSettings({})`,
+ * which forces a full defaults merge on the next `getSettings()` call.
+ */
+import { existsSync, readFileSync, statSync } from 'fs'
+import { createLogger } from '../logger'
+import { getBakinPaths } from '../content-dir'
+import { resetSettingsCache, updateSettings } from '../settings'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+const log = createLogger('onboarding:settings')
+
+function settingsPath(): string {
+  return getBakinPaths().settings
+}
+
+async function check(): Promise<CheckResult> {
+  const path = settingsPath()
+  if (!existsSync(path)) {
+    return {
+      name: 'settings',
+      status: 'missing',
+      message: `settings.json not found at ${path}`,
+      remediation: 'Run `bakin settings init` to seed the file with defaults.',
+    }
+  }
+
+  // Zero-byte file counts as missing — deep-merge against `{}` at load time
+  // would still "work," but a user who sees an empty file will (rightly)
+  // think something is wrong. Force a re-seed.
+  try {
+    const size = statSync(path).size
+    if (size === 0) {
+      return {
+        name: 'settings',
+        status: 'broken',
+        message: `settings.json at ${path} is empty`,
+        remediation: 'Run `bakin settings init` to rewrite the file.',
+      }
+    }
+  } catch (err) {
+    return {
+      name: 'settings',
+      status: 'broken',
+      message: `Failed to stat settings.json: ${err instanceof Error ? err.message : String(err)}`,
+      remediation: 'Run `bakin settings init` to rewrite the file.',
+    }
+  }
+
+  // Must parse as JSON — a malformed file would cause every later getSettings()
+  // call to silently fall back to defaults, which is confusing.
+  try {
+    JSON.parse(readFileSync(path, 'utf-8'))
+    return {
+      name: 'settings',
+      status: 'ok',
+      message: `settings.json is present and parses at ${path}`,
+    }
+  } catch (err) {
+    return {
+      name: 'settings',
+      status: 'broken',
+      message: `settings.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      remediation: 'Fix the file manually or run `bakin settings init` to reseed (will overwrite).',
+    }
+  }
+}
+
+async function install(_opts: OnboardingOptions): Promise<InstallResult> {
+  const start = Date.now()
+  try {
+    // updateSettings({}) writes the current override file (or seeds `{}`
+    // if missing), invalidates the cache, and returns a fully merged
+    // BakinSettings. It is the canonical way to ensure the file exists
+    // in a state the rest of the system can read.
+    resetSettingsCache()
+    updateSettings({})
+    log.info('Settings file initialized', { path: settingsPath() })
+    return {
+      name: 'settings',
+      status: 'installed',
+      message: `Wrote ${settingsPath()}`,
+      durationMs: Date.now() - start,
+    }
+  } catch (err) {
+    log.error('Failed to initialize settings file', err)
+    return {
+      name: 'settings',
+      status: 'failed',
+      message: `Failed to write settings.json: ${err instanceof Error ? err.message : String(err)}`,
+      error: err,
+      durationMs: Date.now() - start,
+    }
+  }
+}
+
+export const settingsComponent: OnboardingComponent = {
+  name: 'settings',
+  check,
+  install,
+}

--- a/src/core/onboarding/state.ts
+++ b/src/core/onboarding/state.ts
@@ -1,0 +1,104 @@
+/**
+ * .onboarded marker file — "this machine has been through first-run setup."
+ *
+ * Lives at {BAKIN_HOME}/.onboarded. Doctor refuses to run its normal checks
+ * when the marker is missing and `settings.doctor.requireOnboard` is true —
+ * instead it returns a single actionable error pointing the user at
+ * `bakin onboard`.
+ *
+ * Bump ONBOARDING_VERSION when onboarding requirements change. A marker with
+ * a lower version is treated as missing, forcing users through `bakin onboard`
+ * again.
+ */
+import { existsSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname, join } from 'path'
+import { createLogger } from '../logger'
+import { getContentDir } from '../content-dir'
+
+const log = createLogger('onboarding:state')
+
+/**
+ * Marker schema version. Increment when the set of components or their
+ * contract changes such that an existing marker no longer proves the
+ * machine is ready.
+ */
+export const ONBOARDING_VERSION = 1
+
+export type ComponentStatus = 'ok' | 'warn' | 'skipped' | 'error'
+
+export interface OnboardingState {
+  version: number
+  completedAt: string
+  bakinVersion: string
+  components: Record<string, ComponentStatus>
+}
+
+function getMarkerPath(): string {
+  return join(getContentDir(), '.onboarded')
+}
+
+/**
+ * Read the marker file. Returns null if missing, unreadable, or corrupt —
+ * callers should treat all three as "not onboarded."
+ */
+export function loadState(): OnboardingState | null {
+  const path = getMarkerPath()
+  if (!existsSync(path)) return null
+  try {
+    const raw = readFileSync(path, 'utf-8')
+    const parsed = JSON.parse(raw) as OnboardingState
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof parsed.version !== 'number' ||
+      typeof parsed.completedAt !== 'string' ||
+      typeof parsed.components !== 'object'
+    ) {
+      log.warn('Marker file has unexpected shape, treating as not onboarded', { path })
+      return null
+    }
+    return parsed
+  } catch (err) {
+    log.warn('Failed to read marker file, treating as not onboarded', { path, error: String(err) })
+    return null
+  }
+}
+
+/**
+ * Write the marker. Creates the parent directory if missing so this is safe
+ * to call even before `bakin mkdir` has seeded ~/.bakin/.
+ */
+export function saveState(components: Record<string, ComponentStatus>, bakinVersion = '0.0.0'): OnboardingState {
+  const path = getMarkerPath()
+  mkdirSync(dirname(path), { recursive: true })
+  const state: OnboardingState = {
+    version: ONBOARDING_VERSION,
+    completedAt: new Date().toISOString(),
+    bakinVersion,
+    components,
+  }
+  writeFileSync(path, JSON.stringify(state, null, 2), 'utf-8')
+  log.info('Onboarding marker written', { path, components })
+  return state
+}
+
+/**
+ * True iff a valid marker exists and its version matches the current code.
+ * A mismatched (older) version is treated as not onboarded so users get
+ * walked through any new components added since their last run.
+ */
+export function isOnboarded(): boolean {
+  const state = loadState()
+  return state !== null && state.version >= ONBOARDING_VERSION
+}
+
+/**
+ * Delete the marker. Used by `bakin onboard --force` to replay the flow.
+ */
+export function clearMarker(): void {
+  const path = getMarkerPath()
+  if (existsSync(path)) {
+    rmSync(path, { force: true })
+    log.info('Onboarding marker cleared', { path })
+  }
+}

--- a/src/core/onboarding/types.ts
+++ b/src/core/onboarding/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared types for the first-run onboarding module.
+ *
+ * Every component module (mkdir, antfly, models, …) exports a `check()` that
+ * returns CheckResult and an `install()` that returns InstallResult. The
+ * orchestrator in index.ts calls them in a fixed dependency order and
+ * aggregates the results into the .onboarded marker file.
+ */
+
+export type CheckStatus = 'ok' | 'missing' | 'broken' | 'warn' | 'error'
+export type InstallStatus = 'installed' | 'skipped' | 'failed' | 'noop'
+
+export interface CheckResult {
+  name: string
+  status: CheckStatus
+  message: string
+  /** Human-readable next step when status is missing/broken/warn/error. */
+  remediation?: string
+  /** Extra structured info for --json output. */
+  details?: Record<string, unknown>
+}
+
+export interface InstallResult {
+  name: string
+  status: InstallStatus
+  message: string
+  error?: unknown
+  durationMs: number
+}
+
+export interface OnboardingOptions {
+  /** TTY prompts are allowed. False implies --yes or --json. */
+  interactive: boolean
+  /** --yes flag. Skip confirmation prompts, auto-approve installs. */
+  autoApprove: boolean
+  /** --json flag. Emit one structured line per component to stdout. */
+  json: boolean
+  /** --check flag. Run check() only, never install(). */
+  checkOnly: boolean
+  /** --force flag. Delete the existing marker before running. */
+  force: boolean
+}
+
+export interface OnboardingComponent {
+  /** Stable identifier. Matches the key under components[] in the marker file. */
+  readonly name: string
+  check(): Promise<CheckResult>
+  install(opts: OnboardingOptions): Promise<InstallResult>
+}

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -37,6 +37,12 @@ vi.mock('better-sqlite3', () => {
   }
 })
 
+// Mock onboarding state — controls the requireOnboard gate
+let mockIsOnboarded = true
+vi.mock('@/core/onboarding/state', () => ({
+  isOnboarded: () => mockIsOnboarded,
+}))
+
 // Mock mcporter (avoid install/config in tests)
 vi.mock('@/core/mcporter', () => ({
   isMcporterInstalled: vi.fn(() => true),
@@ -62,6 +68,7 @@ describe('doctor', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'bakin-doctor-test-'))
     contentDir = join(tempDir, 'content')
     mkdirSync(join(contentDir, 'team', 'personas'), { recursive: true })
+    mockIsOnboarded = true // default: gate passes
   })
 
   afterEach(() => {
@@ -179,6 +186,69 @@ describe('doctor', () => {
 
       // Verify the mismatched sidecar was removed
       expect(existsSync(join(taskDir, 'pop-tart.meta.json'))).toBe(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Onboarding gate: requireOnboard + .onboarded marker
+  // ---------------------------------------------------------------------------
+
+  describe('requireOnboard gate', () => {
+    it('returns single error when requireOnboard=true and machine is not onboarded', async () => {
+      mockIsOnboarded = false
+      const { getSettings } = await import('@/core/settings')
+      const settings = (getSettings as unknown as ReturnType<typeof vi.fn>)
+      settings.mockReturnValueOnce({
+        agents: [],
+        antfly: { enabled: false },
+        doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: true },
+        openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },
+        service: { enabled: false },
+      })
+      vi.resetModules()
+      const { runDiagnostics } = await import('@/core/doctor')
+      const results = await runDiagnostics(contentDir, tempDir)
+      expect(results).toHaveLength(1)
+      expect(results[0].check).toBe('onboarded')
+      expect(results[0].status).toBe('error')
+      expect(results[0].message).toContain('bakin onboard')
+    })
+
+    it('runs normal checks when requireOnboard=true and machine IS onboarded', async () => {
+      mockIsOnboarded = true
+      const { getSettings } = await import('@/core/settings')
+      const settings = (getSettings as unknown as ReturnType<typeof vi.fn>)
+      settings.mockReturnValueOnce({
+        agents: ['roscoe'],
+        antfly: { enabled: false },
+        doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: true },
+        openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },
+        service: { enabled: false },
+      })
+      vi.resetModules()
+      const { runDiagnostics } = await import('@/core/doctor')
+      const results = await runDiagnostics(contentDir, tempDir)
+      // Should have many results from the normal check suite, not just 1
+      expect(results.length).toBeGreaterThan(1)
+      expect(results.find(r => r.check === 'onboarded')).toBeUndefined()
+    })
+
+    it('runs normal checks when requireOnboard=false and machine is NOT onboarded', async () => {
+      mockIsOnboarded = false
+      const { getSettings } = await import('@/core/settings')
+      const settings = (getSettings as unknown as ReturnType<typeof vi.fn>)
+      settings.mockReturnValueOnce({
+        agents: ['roscoe'],
+        antfly: { enabled: false },
+        doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: false },
+        openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },
+        service: { enabled: false },
+      })
+      vi.resetModules()
+      const { runDiagnostics } = await import('@/core/doctor')
+      const results = await runDiagnostics(contentDir, tempDir)
+      expect(results.length).toBeGreaterThan(1)
+      expect(results.find(r => r.check === 'onboarded')).toBeUndefined()
     })
   })
 })

--- a/tests/core/onboarding/antfly.test.ts
+++ b/tests/core/onboarding/antfly.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for the antfly onboarding component.
+ *
+ * Strategy:
+ *   - Mock antfly-server so `findBinary()` returns a test-controlled value
+ *   - Mock child_process.spawn to return a fake ChildProcess that emits a
+ *     configurable exit code on `close` — no real brew runs
+ *   - Mock fs.existsSync so the `findBrew()` helper inside the component
+ *     only resolves paths we explicitly whitelist
+ *   - Mock prompts so interactive confirmation is scripted
+ *
+ * This is the first component that shells out to a package manager, so
+ * the mock ergonomics here will be reused by T6 (models) and T7 (mcporter).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+// Per-test state for the mocks. Must be `let` so the mock closures can
+// read the current value on each call. `findBinaryQueue` is a queue so
+// the install() code path can see different values on successive calls
+// (before spawn = missing, after spawn = installed, etc.).
+let findBinaryQueue: Array<string | null>
+let brewExists: boolean
+let spawnExitCode: number | null
+let spawnError: Error | null
+let lastSpawnArgs: { cmd: string; args: string[]; opts: Record<string, unknown> } | null
+let askYesNoReturn: boolean
+
+vi.mock('../../../src/core/antfly-server', () => ({
+  findBinary: () => {
+    // Pop the next queued value; if the queue is empty, repeat the last
+    // one. Lets tests set [null, '/path/to/binary'] to mean "missing on
+    // first call, installed on second" without manual timing tricks.
+    if (findBinaryQueue.length === 0) return null
+    if (findBinaryQueue.length === 1) return findBinaryQueue[0]
+    return findBinaryQueue.shift()!
+  },
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: (p: unknown) => {
+      const path = String(p)
+      if (path === '/opt/homebrew/bin/brew' || path === '/usr/local/bin/brew') {
+        return brewExists
+      }
+      return actual.existsSync(p as never)
+    },
+  }
+})
+
+vi.mock('child_process', () => ({
+  spawn: (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    lastSpawnArgs = { cmd, args, opts }
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter | null
+      stderr: EventEmitter | null
+    }
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    // Async emit so .on('close', ...) is registered before it fires
+    setImmediate(() => {
+      if (spawnError) {
+        child.emit('error', spawnError)
+        return
+      }
+      child.stderr?.emit('data', Buffer.from(''))
+      child.emit('close', spawnExitCode)
+    })
+    return child
+  },
+}))
+
+vi.mock('../../../src/core/onboarding/prompts', () => ({
+  askYesNo: () => Promise.resolve(askYesNoReturn),
+  readLine: () => Promise.resolve(''),
+}))
+
+describe('onboarding antfly component', () => {
+  let antflyComponent: typeof import('../../../src/core/onboarding/antfly').antflyComponent
+
+  beforeEach(async () => {
+    findBinaryQueue = [null]
+    brewExists = true
+    spawnExitCode = 0
+    spawnError = null
+    lastSpawnArgs = null
+    askYesNoReturn = true
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/antfly')
+    antflyComponent = mod.antflyComponent
+  })
+
+  afterEach(() => {
+    lastSpawnArgs = null
+  })
+
+  const optsAutoYes = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const optsInteractive = {
+    interactive: true,
+    autoApprove: false,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const optsNonInteractiveNoYes = {
+    interactive: false,
+    autoApprove: false,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  describe('check()', () => {
+    it('reports ok when the antfly binary is found', async () => {
+      findBinaryQueue = ['/opt/homebrew/bin/antfly']
+      const result = await antflyComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.binary).toBe('/opt/homebrew/bin/antfly')
+    })
+
+    it('reports missing when the binary is not found', async () => {
+      findBinaryQueue = [null]
+      const result = await antflyComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.remediation).toContain('bakin install antfly')
+    })
+  })
+
+  describe('install()', () => {
+    it('is a noop when antfly is already installed', async () => {
+      findBinaryQueue = ['/opt/homebrew/bin/antfly']
+      const result = await antflyComponent.install(optsAutoYes)
+      expect(result.status).toBe('noop')
+      expect(lastSpawnArgs).toBeNull()
+    })
+
+    it('fails cleanly when Homebrew is missing', async () => {
+      findBinaryQueue = [null]
+      brewExists = false
+      const result = await antflyComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('Homebrew not found')
+      expect(lastSpawnArgs).toBeNull()
+    })
+
+    it('runs brew install --cask with the correct argument shape', async () => {
+      // First findBinary call (pre-spawn) returns null → missing.
+      // Second (post-spawn verification) returns the installed path.
+      findBinaryQueue = [null, '/opt/homebrew/bin/antfly']
+      brewExists = true
+      const result = await antflyComponent.install(optsAutoYes)
+
+      expect(lastSpawnArgs).not.toBeNull()
+      expect(lastSpawnArgs!.cmd).toBe('/opt/homebrew/bin/brew')
+      expect(lastSpawnArgs!.args).toEqual(['install', '--cask', 'antflydb/antfly/antfly'])
+      // Never uses shell: true — that's a hard rule in the spec
+      expect(lastSpawnArgs!.opts).not.toHaveProperty('shell', true)
+      expect(result.status).toBe('installed')
+      expect(result.message).toContain('/opt/homebrew/bin/antfly')
+    })
+
+    it('reports failed when brew exits non-zero', async () => {
+      findBinaryQueue = [null]
+      spawnExitCode = 1
+      const result = await antflyComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('exited with code 1')
+    })
+
+    it('reports failed when brew succeeds but binary is still missing', async () => {
+      findBinaryQueue = [null]
+      spawnExitCode = 0
+      // Never flip findBinaryReturn — simulates brew silently doing nothing
+      const result = await antflyComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('still not discoverable')
+    })
+
+    it('skips install when user declines the prompt', async () => {
+      findBinaryQueue = [null]
+      askYesNoReturn = false
+      const result = await antflyComponent.install(optsInteractive)
+      expect(result.status).toBe('skipped')
+      expect(lastSpawnArgs).toBeNull()
+    })
+
+    it('skips install in non-interactive mode without --yes', async () => {
+      findBinaryQueue = [null]
+      const result = await antflyComponent.install(optsNonInteractiveNoYes)
+      expect(result.status).toBe('skipped')
+      expect(result.message).toContain('Non-interactive')
+      expect(lastSpawnArgs).toBeNull()
+    })
+
+    it('reports failed when spawn emits an error event', async () => {
+      findBinaryQueue = [null]
+      spawnError = new Error('ENOENT')
+      const result = await antflyComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('ENOENT')
+    })
+  })
+})

--- a/tests/core/onboarding/credentials.test.ts
+++ b/tests/core/onboarding/credentials.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the credentials onboarding component (LLM + channels).
+ *
+ * Both checks are warn-only — they never return 'error' and never
+ * mutate the filesystem. Tests verify:
+ *   - Each granular warn state (file missing, wrong shape, empty,
+ *     valid) surfaces correctly in CheckResult
+ *   - install() for both subcomponents is a hard noop — no fs writes
+ *
+ * Uses a real temp directory plus a mock on @bakin/core/openclaw-home
+ * so the component reads from files we control.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let fakeHome: string
+
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => fakeHome,
+  getOpenClawPath: (...segments: string[]) => join(fakeHome, ...segments),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+describe('onboarding credentials component', () => {
+  let llmComponent: typeof import('../../../src/core/onboarding/credentials').llmComponent
+  let channelsComponent: typeof import('../../../src/core/onboarding/credentials').channelsComponent
+
+  beforeEach(async () => {
+    fakeHome = mkdtempSync(join(tmpdir(), 'bakin-onboarding-creds-'))
+    mkdirSync(join(fakeHome, 'agents', 'main', 'agent'), { recursive: true })
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/credentials')
+    llmComponent = mod.llmComponent
+    channelsComponent = mod.channelsComponent
+  })
+
+  afterEach(() => {
+    rmSync(fakeHome, { recursive: true, force: true })
+  })
+
+  const opts = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  const authProfilesPath = () => join(fakeHome, 'agents', 'main', 'agent', 'auth-profiles.json')
+  const configPath = () => join(fakeHome, 'openclaw.json')
+
+  // -------------------------------------------------------------------------
+  // llm component
+  // -------------------------------------------------------------------------
+
+  describe('llm.check()', () => {
+    it('reports warn when auth-profiles.json is missing', async () => {
+      const result = await llmComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('missing')
+      expect(result.remediation).toContain('OpenClaw')
+    })
+
+    it('reports warn when the file is not an array', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify({ notAnArray: true }))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('not an array')
+    })
+
+    it('reports warn when the array is empty', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify([]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('non-empty apiKey')
+    })
+
+    it('reports warn when all entries have empty apiKeys', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify([
+        { provider: 'anthropic', apiKey: '' },
+        { provider: 'openai', apiKey: '   ' },
+      ]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('warn')
+    })
+
+    it('reports ok when at least one provider has a non-empty apiKey', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify([
+        { provider: 'anthropic', apiKey: 'sk-ant-fake' },
+        { provider: 'openai', apiKey: '' },
+      ]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.providers).toEqual(['anthropic'])
+    })
+
+    it('reports ok with multiple providers when several are configured', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify([
+        { provider: 'anthropic', apiKey: 'sk-ant-fake' },
+        { provider: 'openai', apiKey: 'sk-fake' },
+        { provider: 'grok', apiKey: 'xai-fake' },
+      ]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('ok')
+      expect((result.details?.providers as string[]).length).toBe(3)
+    })
+
+    it('reports warn when auth-profiles.json is malformed', async () => {
+      writeFileSync(authProfilesPath(), 'not-json {{{')
+      const result = await llmComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('Could not parse')
+    })
+  })
+
+  describe('llm.install()', () => {
+    it('is a noop that returns the OpenClaw docs URL', async () => {
+      const result = await llmComponent.install(opts)
+      expect(result.status).toBe('noop')
+      expect(result.message).toContain('OpenClaw')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // channels component
+  // -------------------------------------------------------------------------
+
+  describe('channels.check()', () => {
+    it('reports warn when openclaw.json is missing', async () => {
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('missing')
+    })
+
+    it('reports warn when openclaw.json has no channels key', async () => {
+      writeFileSync(configPath(), JSON.stringify({ gateway: { auth: { token: 'x' } } }))
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('non-empty credential field')
+    })
+
+    it('reports warn when channels is not an object', async () => {
+      writeFileSync(configPath(), JSON.stringify({ channels: 'wrong-type' }))
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('not an object')
+    })
+
+    it('reports warn when channels exist but all credentials are empty', async () => {
+      writeFileSync(configPath(), JSON.stringify({
+        channels: {
+          discord: { token: '' },
+          telegram: { apiKey: '   ' },
+        },
+      }))
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('warn')
+    })
+
+    it('reports ok when any channel has a token', async () => {
+      writeFileSync(configPath(), JSON.stringify({
+        channels: {
+          discord: { token: 'fake-discord-token' },
+          telegram: { apiKey: '' },
+        },
+      }))
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.channels).toEqual(['discord'])
+    })
+
+    it('reports ok when multiple channels are configured', async () => {
+      writeFileSync(configPath(), JSON.stringify({
+        channels: {
+          discord: { token: 'fake-discord' },
+          slack: { token: 'xoxb-fake' },
+          telegram: { botToken: 'fake-bot' },
+        },
+      }))
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('ok')
+      expect((result.details?.channels as string[]).length).toBe(3)
+    })
+
+    it('reports warn when openclaw.json is malformed', async () => {
+      writeFileSync(configPath(), 'not-json {{{')
+      const result = await channelsComponent.check()
+      expect(result.status).toBe('warn')
+      expect(result.message).toContain('Could not parse')
+    })
+  })
+
+  describe('channels.install()', () => {
+    it('is a noop that returns the OpenClaw docs URL', async () => {
+      const result = await channelsComponent.install(opts)
+      expect(result.status).toBe('noop')
+      expect(result.message).toContain('OpenClaw')
+    })
+  })
+})

--- a/tests/core/onboarding/index.test.ts
+++ b/tests/core/onboarding/index.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Tests for the runOnboard orchestrator.
+ *
+ * Every component is mocked at the module level so we can script the
+ * check()/install() return values per test and verify the orchestrator's
+ * decision logic (ordering, cascade skips, exit code aggregation, marker
+ * write rules) in isolation from the component implementations.
+ *
+ * state.ts is mocked at the module level too so we can assert exactly
+ * when saveState/clearMarker are called without touching the real
+ * filesystem.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CheckResult, InstallResult, OnboardingComponent } from '../../../src/core/onboarding/types'
+
+// ---------------------------------------------------------------------------
+// Per-test mock state. The mocks below read these objects on every call,
+// so tests can script behavior by mutating them in beforeEach / per-it.
+// ---------------------------------------------------------------------------
+
+interface ScriptedComponent {
+  check: CheckResult
+  install: InstallResult
+  checkCalls: number
+  installCalls: number
+}
+
+const COMPONENT_NAMES = ['mkdir', 'settings', 'openclaw', 'antfly', 'models', 'mcporter', 'llm', 'channels'] as const
+
+let scripts: Record<(typeof COMPONENT_NAMES)[number], ScriptedComponent>
+
+let saveStateCalls: Array<{ components: Record<string, string>; bakinVersion: string }>
+let clearMarkerCalls: number
+
+function makeMock(name: (typeof COMPONENT_NAMES)[number]): OnboardingComponent {
+  return {
+    name,
+    check: async () => {
+      scripts[name].checkCalls++
+      return scripts[name].check
+    },
+    install: async () => {
+      scripts[name].installCalls++
+      return scripts[name].install
+    },
+  }
+}
+
+vi.mock('../../../src/core/onboarding/mkdir', () => ({ mkdirComponent: makeMock('mkdir') }))
+vi.mock('../../../src/core/onboarding/settings', () => ({ settingsComponent: makeMock('settings') }))
+vi.mock('../../../src/core/onboarding/openclaw', () => ({ openclawComponent: makeMock('openclaw') }))
+vi.mock('../../../src/core/onboarding/antfly', () => ({ antflyComponent: makeMock('antfly') }))
+vi.mock('../../../src/core/onboarding/models', () => ({ modelsComponent: makeMock('models') }))
+vi.mock('../../../src/core/onboarding/mcporter', () => ({ mcporterComponent: makeMock('mcporter') }))
+vi.mock('../../../src/core/onboarding/credentials', () => ({
+  llmComponent: makeMock('llm'),
+  channelsComponent: makeMock('channels'),
+}))
+
+vi.mock('../../../src/core/onboarding/state', () => ({
+  saveState: (components: Record<string, string>, bakinVersion: string) => {
+    saveStateCalls.push({ components, bakinVersion })
+    return {
+      version: 1,
+      completedAt: '2026-04-11T00:00:00.000Z',
+      bakinVersion,
+      components,
+    }
+  },
+  clearMarker: () => {
+    clearMarkerCalls++
+  },
+  isOnboarded: () => false,
+  loadState: () => null,
+  ONBOARDING_VERSION: 1,
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+describe('runOnboard orchestrator', () => {
+  let runOnboard: typeof import('../../../src/core/onboarding/index').runOnboard
+  let checkAll: typeof import('../../../src/core/onboarding/index').checkAll
+  let COMPONENT_ORDER: typeof import('../../../src/core/onboarding/index').COMPONENT_ORDER
+  let stdoutLines: string[]
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
+
+  /** Build a fresh "all green" script where every component reports ok. */
+  function freshScripts(): typeof scripts {
+    const out = {} as typeof scripts
+    for (const name of COMPONENT_NAMES) {
+      out[name] = {
+        check: { name, status: 'ok', message: `${name} ok` },
+        install: { name, status: 'noop', message: `${name} noop`, durationMs: 0 },
+        checkCalls: 0,
+        installCalls: 0,
+      }
+    }
+    return out
+  }
+
+  beforeEach(async () => {
+    scripts = freshScripts()
+    saveStateCalls = []
+    clearMarkerCalls = 0
+    stdoutLines = []
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdoutLines.push(String(chunk))
+      return true
+    })
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/index')
+    runOnboard = mod.runOnboard
+    checkAll = mod.checkAll
+    COMPONENT_ORDER = mod.COMPONENT_ORDER
+  })
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore()
+  })
+
+  const opts = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  // ---------------------------------------------------------------------------
+  // Component ordering
+  // ---------------------------------------------------------------------------
+
+  describe('COMPONENT_ORDER', () => {
+    it('contains exactly the 8 expected components in the spec order', () => {
+      expect(COMPONENT_ORDER.map((c) => c.name)).toEqual([
+        'mkdir',
+        'settings',
+        'openclaw',
+        'antfly',
+        'models',
+        'mcporter',
+        'llm',
+        'channels',
+      ])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Happy path — every component ok
+  // ---------------------------------------------------------------------------
+
+  describe('all ok', () => {
+    it('returns exit code 0, writes marker, no installs called', async () => {
+      const result = await runOnboard(opts)
+      expect(result.exitCode).toBe(0)
+      expect(result.markerWritten).toBe(true)
+      expect(result.outcomes.map((o) => o.finalStatus)).toEqual([
+        'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok',
+      ])
+      // check() was called on every component
+      for (const n of COMPONENT_NAMES) {
+        expect(scripts[n].checkCalls).toBe(1)
+      }
+      // install() was never called — nothing was missing
+      for (const n of COMPONENT_NAMES) {
+        expect(scripts[n].installCalls).toBe(0)
+      }
+      expect(saveStateCalls).toHaveLength(1)
+      expect(saveStateCalls[0].components).toEqual({
+        mkdir: 'ok',
+        settings: 'ok',
+        openclaw: 'ok',
+        antfly: 'ok',
+        models: 'ok',
+        mcporter: 'ok',
+        llm: 'ok',
+        channels: 'ok',
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Install triggered by missing/broken check
+  // ---------------------------------------------------------------------------
+
+  describe('missing components trigger install', () => {
+    it('calls install() when check reports missing', async () => {
+      scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
+      scripts.antfly.install = { name: 'antfly', status: 'installed', message: 'antfly installed', durationMs: 100 }
+      const result = await runOnboard(opts)
+      expect(scripts.antfly.installCalls).toBe(1)
+      expect(result.outcomes.find((o) => o.name === 'antfly')?.finalStatus).toBe('ok')
+      expect(result.exitCode).toBe(0)
+      expect(result.markerWritten).toBe(true)
+    })
+
+    it('treats install:failed as an error (exit 1, no marker)', async () => {
+      scripts.mcporter.check = { name: 'mcporter', status: 'missing', message: 'mcporter missing' }
+      scripts.mcporter.install = { name: 'mcporter', status: 'failed', message: 'npm failed', durationMs: 0 }
+      const result = await runOnboard(opts)
+      expect(result.outcomes.find((o) => o.name === 'mcporter')?.finalStatus).toBe('error')
+      expect(result.exitCode).toBe(1)
+      expect(result.markerWritten).toBe(false)
+      expect(saveStateCalls).toHaveLength(0)
+    })
+
+    it('treats install:skipped as skipped (exit 2, marker still written)', async () => {
+      scripts.mcporter.check = { name: 'mcporter', status: 'missing', message: 'mcporter missing' }
+      scripts.mcporter.install = { name: 'mcporter', status: 'skipped', message: 'user declined', durationMs: 0 }
+      const result = await runOnboard(opts)
+      expect(result.outcomes.find((o) => o.name === 'mcporter')?.finalStatus).toBe('skipped')
+      expect(result.exitCode).toBe(2)
+      expect(result.markerWritten).toBe(true)
+    })
+
+    it('treats install:noop as ok', async () => {
+      scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
+      scripts.antfly.install = { name: 'antfly', status: 'noop', message: 'antfly already installed', durationMs: 0 }
+      const result = await runOnboard(opts)
+      expect(result.outcomes.find((o) => o.name === 'antfly')?.finalStatus).toBe('ok')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // --check mode never installs
+  // ---------------------------------------------------------------------------
+
+  describe('checkOnly mode', () => {
+    it('never calls install() even when check reports missing', async () => {
+      scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
+      scripts.mcporter.check = { name: 'mcporter', status: 'missing', message: 'mcporter missing' }
+      const result = await runOnboard({ ...opts, checkOnly: true })
+      expect(scripts.antfly.installCalls).toBe(0)
+      expect(scripts.mcporter.installCalls).toBe(0)
+      expect(result.outcomes.find((o) => o.name === 'antfly')?.finalStatus).toBe('skipped')
+      expect(result.outcomes.find((o) => o.name === 'mcporter')?.finalStatus).toBe('skipped')
+      // check-only is non-destructive → marker still written iff no errors
+      expect(result.exitCode).toBe(2)
+      expect(result.markerWritten).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Warn-only components
+  // ---------------------------------------------------------------------------
+
+  describe('warn status handling', () => {
+    it('llm warn does not block marker write', async () => {
+      scripts.llm.check = { name: 'llm', status: 'warn', message: 'no LLM configured' }
+      const result = await runOnboard(opts)
+      expect(result.outcomes.find((o) => o.name === 'llm')?.finalStatus).toBe('warn')
+      expect(result.exitCode).toBe(2)
+      expect(result.markerWritten).toBe(true)
+      // install() is never called for warn components
+      expect(scripts.llm.installCalls).toBe(0)
+    })
+
+    it('channels warn aggregates to exit 2', async () => {
+      scripts.channels.check = { name: 'channels', status: 'warn', message: 'no channels' }
+      const result = await runOnboard(opts)
+      expect(result.outcomes.find((o) => o.name === 'channels')?.finalStatus).toBe('warn')
+      expect(result.exitCode).toBe(2)
+      expect(scripts.channels.installCalls).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // OpenClaw cascade — missing openclaw aborts the entire flow
+  // ---------------------------------------------------------------------------
+
+  describe('openclaw cascade', () => {
+    it('openclaw missing halts the flow and skips every downstream component', async () => {
+      scripts.openclaw.check = {
+        name: 'openclaw',
+        status: 'missing',
+        message: 'openclaw not installed',
+        remediation: 'Install from https://openclaw.ai/',
+      }
+      // install() is never called for openclaw — the orchestrator runs
+      // it inline, skipping install because openclaw is user-managed.
+      const result = await runOnboard(opts)
+      // mkdir and settings still run (before openclaw in the order)
+      expect(scripts.mkdir.checkCalls).toBe(1)
+      expect(scripts.settings.checkCalls).toBe(1)
+      expect(scripts.openclaw.checkCalls).toBe(1)
+      expect(scripts.openclaw.installCalls).toBe(0) // never called
+      // Everything downstream is NOT run — check is never called on them
+      expect(scripts.antfly.checkCalls).toBe(0)
+      expect(scripts.models.checkCalls).toBe(0)
+      expect(scripts.mcporter.checkCalls).toBe(0)
+      expect(scripts.llm.checkCalls).toBe(0)
+      expect(scripts.channels.checkCalls).toBe(0)
+      // All 8 components still appear in outcomes
+      expect(result.outcomes).toHaveLength(8)
+      // OpenClaw is error (missing prerequisite), downstream all skipped
+      expect(result.outcomes.find((o) => o.name === 'openclaw')?.finalStatus).toBe('error')
+      expect(result.outcomes.find((o) => o.name === 'antfly')?.finalStatus).toBe('skipped')
+      expect(result.outcomes.find((o) => o.name === 'channels')?.finalStatus).toBe('skipped')
+      // Per spec: OpenClaw missing is a hard stop — exit 1, no marker
+      expect(result.exitCode).toBe(1)
+      expect(result.markerWritten).toBe(false)
+    })
+
+    it('openclaw broken halts the flow with error status', async () => {
+      scripts.openclaw.check = {
+        name: 'openclaw',
+        status: 'broken',
+        message: 'openclaw.json corrupt',
+      }
+      const result = await runOnboard(opts)
+      expect(result.outcomes.find((o) => o.name === 'openclaw')?.finalStatus).toBe('error')
+      // install() is never called — openclaw is inline
+      expect(scripts.openclaw.installCalls).toBe(0)
+      // Downstream components never ran
+      expect(scripts.antfly.checkCalls).toBe(0)
+      // Error → exit 1, no marker
+      expect(result.exitCode).toBe(1)
+      expect(result.markerWritten).toBe(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Antfly → models cascade — models needs the antfly binary
+  // ---------------------------------------------------------------------------
+
+  describe('antfly → models cascade', () => {
+    it('skips models when antfly failed to install', async () => {
+      scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
+      scripts.antfly.install = { name: 'antfly', status: 'failed', message: 'brew missing', durationMs: 0 }
+      const result = await runOnboard(opts)
+      expect(scripts.antfly.installCalls).toBe(1)
+      // models never even has check() called — it's pre-skipped
+      expect(scripts.models.checkCalls).toBe(0)
+      expect(result.outcomes.find((o) => o.name === 'models')?.finalStatus).toBe('skipped')
+      expect(result.outcomes.find((o) => o.name === 'models')?.message).toContain('Antfly binary is required')
+      // mcporter and credentials still run (not dependent on antfly)
+      expect(scripts.mcporter.checkCalls).toBe(1)
+      expect(scripts.llm.checkCalls).toBe(1)
+    })
+
+    it('runs models when antfly is ok', async () => {
+      const result = await runOnboard(opts)
+      expect(scripts.models.checkCalls).toBe(1)
+      expect(result.outcomes.find((o) => o.name === 'models')?.finalStatus).toBe('ok')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // --force clears the marker upfront
+  // ---------------------------------------------------------------------------
+
+  describe('force flag', () => {
+    it('calls clearMarker when force=true', async () => {
+      await runOnboard({ ...opts, force: true })
+      expect(clearMarkerCalls).toBe(1)
+    })
+
+    it('does not call clearMarker when force=false', async () => {
+      await runOnboard({ ...opts, force: false })
+      expect(clearMarkerCalls).toBe(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // --json output
+  // ---------------------------------------------------------------------------
+
+  describe('json output', () => {
+    it('emits one JSON line per outcome', async () => {
+      await runOnboard({ ...opts, json: true })
+      expect(stdoutLines).toHaveLength(8)
+      for (const line of stdoutLines) {
+        const parsed = JSON.parse(line)
+        expect(COMPONENT_NAMES).toContain(parsed.component)
+        expect(parsed.status).toBe('ok')
+      }
+    })
+
+    it('emits JSON for cascaded skips from OpenClaw', async () => {
+      scripts.openclaw.check = { name: 'openclaw', status: 'missing', message: 'openclaw missing' }
+      scripts.openclaw.install = { name: 'openclaw', status: 'noop', message: 'required', durationMs: 0 }
+      await runOnboard({ ...opts, json: true })
+      // Should emit 8 lines total: 3 that actually ran + 5 cascade-skipped
+      expect(stdoutLines).toHaveLength(8)
+    })
+
+    it('does not emit JSON when json flag is false', async () => {
+      await runOnboard({ ...opts, json: false })
+      expect(stdoutLines).toHaveLength(0)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // checkAll() never calls install
+  // ---------------------------------------------------------------------------
+
+  describe('checkAll', () => {
+    it('calls check() on every component and never install()', async () => {
+      scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
+      const results = await checkAll()
+      expect(results).toHaveLength(8)
+      expect(results.map((r) => r.name)).toEqual([...COMPONENT_NAMES])
+      for (const n of COMPONENT_NAMES) {
+        expect(scripts[n].checkCalls).toBe(1)
+        expect(scripts[n].installCalls).toBe(0)
+      }
+    })
+
+    it('catches thrown errors from check() and returns them as error status', async () => {
+      scripts.mcporter.check = { name: 'mcporter', status: 'ok', message: 'ok' }
+      // Replace the mock to make mcporter.check throw
+      const mod = await import('../../../src/core/onboarding/mcporter')
+      vi.spyOn(mod.mcporterComponent, 'check').mockRejectedValueOnce(new Error('boom'))
+      const results = await checkAll()
+      const mcp = results.find((r) => r.name === 'mcporter')
+      expect(mcp?.status).toBe('error')
+      expect(mcp?.message).toContain('boom')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Exception handling inside runOnboard
+  // ---------------------------------------------------------------------------
+
+  describe('exception handling', () => {
+    it('converts a thrown check() error into an error outcome', async () => {
+      const mod = await import('../../../src/core/onboarding/mcporter')
+      vi.spyOn(mod.mcporterComponent, 'check').mockRejectedValueOnce(new Error('boom'))
+      const result = await runOnboard(opts)
+      const mcp = result.outcomes.find((o) => o.name === 'mcporter')
+      expect(mcp?.finalStatus).toBe('error')
+      expect(result.exitCode).toBe(1)
+      expect(result.markerWritten).toBe(false)
+    })
+
+    it('converts a thrown install() error into an error outcome', async () => {
+      scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
+      const mod = await import('../../../src/core/onboarding/antfly')
+      vi.spyOn(mod.antflyComponent, 'install').mockRejectedValueOnce(new Error('spawn failed'))
+      const result = await runOnboard(opts)
+      const antfly = result.outcomes.find((o) => o.name === 'antfly')
+      expect(antfly?.finalStatus).toBe('error')
+      expect(antfly?.message).toContain('spawn failed')
+    })
+  })
+})

--- a/tests/core/onboarding/mcporter.test.ts
+++ b/tests/core/onboarding/mcporter.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for the mcporter onboarding component.
+ *
+ * This component is a thin wrapper over the existing src/core/mcporter
+ * module — we mock the underlying module directly rather than mocking
+ * child_process or fs, because the wrapper's whole job is to translate
+ * isMcporterInstalled/installMcporter/syncConfig into CheckResult and
+ * InstallResult shapes. Testing the underlying module's behavior is
+ * already covered by tests/core/mcporter.test.ts.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let isInstalledReturn: boolean | (() => boolean)
+let installMcporterReturn: boolean
+let installMcporterCalls: number
+let syncConfigReturn: string[] | (() => string[])
+let syncConfigCalls: number[]
+let syncConfigError: Error | null
+let configFileExists: boolean
+let askYesNoReturn: boolean
+
+vi.mock('../../../src/core/mcporter', () => ({
+  isMcporterInstalled: () =>
+    typeof isInstalledReturn === 'function' ? isInstalledReturn() : isInstalledReturn,
+  installMcporter: () => {
+    installMcporterCalls++
+    // A successful install mutates isInstalledReturn so the post-install
+    // re-check passes. Failed installs leave it alone.
+    if (installMcporterReturn) isInstalledReturn = true
+    return installMcporterReturn
+  },
+  syncConfig: (port: number) => {
+    syncConfigCalls.push(port)
+    if (syncConfigError) throw syncConfigError
+    return typeof syncConfigReturn === 'function' ? syncConfigReturn() : syncConfigReturn
+  },
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: (p: unknown) => {
+      const path = String(p)
+      if (path.endsWith('.mcporter/mcporter.json')) return configFileExists
+      return actual.existsSync(p as never)
+    },
+  }
+})
+
+vi.mock('../../../src/core/onboarding/prompts', () => ({
+  askYesNo: () => Promise.resolve(askYesNoReturn),
+  readLine: () => Promise.resolve(''),
+}))
+
+describe('onboarding mcporter component', () => {
+  let mcporterComponent: typeof import('../../../src/core/onboarding/mcporter').mcporterComponent
+
+  beforeEach(async () => {
+    isInstalledReturn = false
+    installMcporterReturn = true
+    installMcporterCalls = 0
+    syncConfigReturn = []
+    syncConfigCalls = []
+    syncConfigError = null
+    configFileExists = true
+    askYesNoReturn = true
+    process.env.PORT = '3737'
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/mcporter')
+    mcporterComponent = mod.mcporterComponent
+  })
+
+  afterEach(() => {
+    delete process.env.PORT
+  })
+
+  const optsAutoYes = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const optsInteractive = {
+    interactive: true,
+    autoApprove: false,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const optsNonInteractiveNoYes = {
+    interactive: false,
+    autoApprove: false,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  describe('check()', () => {
+    it('reports ok when mcporter is installed and config file exists', async () => {
+      isInstalledReturn = true
+      configFileExists = true
+      const result = await mcporterComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.port).toBe(3737)
+    })
+
+    it('reports missing when mcporter is not installed', async () => {
+      isInstalledReturn = false
+      const result = await mcporterComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.remediation).toContain('bakin install mcporter')
+    })
+
+    it('reports broken when installed but config file is missing', async () => {
+      isInstalledReturn = true
+      configFileExists = false
+      const result = await mcporterComponent.check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('missing')
+    })
+  })
+
+  describe('install()', () => {
+    it('installs mcporter and syncs config when not already installed', async () => {
+      isInstalledReturn = false
+      installMcporterReturn = true
+      syncConfigReturn = ['added bakin-roscoe', 'added bakin-pixel']
+      const result = await mcporterComponent.install(optsAutoYes)
+      expect(result.status).toBe('installed')
+      expect(installMcporterCalls).toBe(1)
+      expect(syncConfigCalls).toEqual([3737])
+      expect(result.message).toContain('2 change')
+    })
+
+    it('is a noop when already installed with no config changes', async () => {
+      isInstalledReturn = true
+      syncConfigReturn = []
+      const result = await mcporterComponent.install(optsAutoYes)
+      expect(result.status).toBe('noop')
+      expect(installMcporterCalls).toBe(0)
+      expect(syncConfigCalls).toEqual([3737])
+    })
+
+    it('reports installed (not noop) when already installed but config was updated', async () => {
+      isInstalledReturn = true
+      syncConfigReturn = ['updated bakin-roscoe']
+      const result = await mcporterComponent.install(optsAutoYes)
+      expect(result.status).toBe('installed')
+      expect(result.message).toContain('synced')
+      expect(installMcporterCalls).toBe(0)
+    })
+
+    it('fails cleanly when installMcporter returns false', async () => {
+      isInstalledReturn = false
+      installMcporterReturn = false
+      const result = await mcporterComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('npm install -g mcporter failed')
+    })
+
+    it('fails when syncConfig throws', async () => {
+      isInstalledReturn = true
+      syncConfigError = new Error('EACCES')
+      const result = await mcporterComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('EACCES')
+    })
+
+    it('skips install when user declines the prompt', async () => {
+      isInstalledReturn = false
+      askYesNoReturn = false
+      const result = await mcporterComponent.install(optsInteractive)
+      expect(result.status).toBe('skipped')
+      expect(installMcporterCalls).toBe(0)
+    })
+
+    it('skips install in non-interactive mode without --yes when not installed', async () => {
+      isInstalledReturn = false
+      const result = await mcporterComponent.install(optsNonInteractiveNoYes)
+      expect(result.status).toBe('skipped')
+      expect(result.message).toContain('Non-interactive')
+      expect(installMcporterCalls).toBe(0)
+    })
+
+    it('still syncs config in non-interactive mode when mcporter is already installed', async () => {
+      isInstalledReturn = true
+      syncConfigReturn = []
+      const result = await mcporterComponent.install(optsNonInteractiveNoYes)
+      // No install prompt because nothing to install
+      expect(installMcporterCalls).toBe(0)
+      // syncConfig still runs
+      expect(syncConfigCalls).toEqual([3737])
+      expect(result.status).toBe('noop')
+    })
+  })
+})

--- a/tests/core/onboarding/mkdir.test.ts
+++ b/tests/core/onboarding/mkdir.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the mkdir onboarding component.
+ *
+ * Uses a real temp directory rather than mocking fs — the whole component is
+ * a thin wrapper around `initBakinHome`, which in turn is essentially mkdirs
+ * against the filesystem. Mocking fs here would just re-implement the
+ * function under test. Content-dir is mocked so the temp dir stands in for
+ * ~/.bakin/. Logger is stubbed to silence output.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, rmSync, rmdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let testDir: string
+
+vi.mock('../../../src/core/content-dir', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/core/content-dir')>(
+    '../../../src/core/content-dir'
+  )
+  return {
+    ...actual,
+    getContentDir: () => testDir,
+    getBakinPaths: () => {
+      const home = testDir
+      const assets = join(home, 'assets')
+      return {
+        home,
+        memoryLog: join(home, 'MEMORY-LOG.md'),
+        messaging: join(home, 'messaging.json'),
+        audit: join(home, 'audit.jsonl'),
+        assets,
+        'assets.text': join(assets, 'text'),
+        'assets.images': join(assets, 'images'),
+        'assets.video': join(assets, 'video'),
+        'assets.audio': join(assets, 'audio'),
+        'assets.plans': join(assets, 'plans'),
+        'assets.data': join(assets, 'data'),
+        'assets.other': join(assets, 'other'),
+        agents: join(home, 'agents'),
+        personas: join(home, 'team', 'personas'),
+        team: join(home, 'team'),
+        heartbeats: join(home, 'heartbeats'),
+        inbox: join(home, 'inbox'),
+        projects: join(home, 'projects'),
+        workflows: join(home, 'workflows'),
+        settings: join(home, 'settings.json'),
+      }
+    },
+  }
+})
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+describe('onboarding mkdir component', () => {
+  let mkdirComponent: typeof import('../../../src/core/onboarding/mkdir').mkdirComponent
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'bakin-onboarding-mkdir-'))
+    // Create the outer dir but delete it so the component sees a missing home
+    rmSync(testDir, { recursive: true, force: true })
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/mkdir')
+    mkdirComponent = mod.mkdirComponent
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  describe('check()', () => {
+    it('reports missing when the home directory does not exist', async () => {
+      const result = await mkdirComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.name).toBe('mkdir')
+      expect(result.remediation).toContain('bakin mkdir')
+      expect(result.details?.missing).toBeDefined()
+      expect(Array.isArray(result.details!.missing)).toBe(true)
+    })
+
+    it('reports ok after install completes', async () => {
+      await mkdirComponent.install({
+        interactive: false,
+        autoApprove: true,
+        json: false,
+        checkOnly: false,
+        force: false,
+      })
+      const result = await mkdirComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain(testDir)
+    })
+
+    it('reports missing when a single required subdirectory is removed', async () => {
+      await mkdirComponent.install({
+        interactive: false,
+        autoApprove: true,
+        json: false,
+        checkOnly: false,
+        force: false,
+      })
+      // Delete one required subdirectory
+      rmdirSync(join(testDir, 'heartbeats'))
+      const result = await mkdirComponent.check()
+      expect(result.status).toBe('missing')
+      expect((result.details!.missing as string[]).some((d) => d.endsWith('heartbeats'))).toBe(true)
+    })
+  })
+
+  describe('install()', () => {
+    const opts = {
+      interactive: false,
+      autoApprove: true,
+      json: false,
+      checkOnly: false,
+      force: false,
+    }
+
+    it('creates the full directory tree on first run', async () => {
+      const result = await mkdirComponent.install(opts)
+      expect(result.status).toBe('installed')
+      expect(result.durationMs).toBeGreaterThanOrEqual(0)
+      expect(existsSync(join(testDir, 'assets', 'text'))).toBe(true)
+      expect(existsSync(join(testDir, 'agents'))).toBe(true)
+      expect(existsSync(join(testDir, 'heartbeats'))).toBe(true)
+      expect(existsSync(join(testDir, 'settings.json'))).toBe(true)
+    })
+
+    it('is idempotent — second install is a noop', async () => {
+      await mkdirComponent.install(opts)
+      const second = await mkdirComponent.install(opts)
+      expect(second.status).toBe('noop')
+      expect(second.message).toContain('Already initialized')
+    })
+
+    it('re-creates only the missing pieces on partial wipe', async () => {
+      await mkdirComponent.install(opts)
+      rmSync(join(testDir, 'projects'), { recursive: true, force: true })
+      const second = await mkdirComponent.install(opts)
+      // Not a noop — something was missing
+      expect(second.status).toBe('installed')
+      expect(existsSync(join(testDir, 'projects'))).toBe(true)
+    })
+  })
+})

--- a/tests/core/onboarding/models.test.ts
+++ b/tests/core/onboarding/models.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the models onboarding component (Termite model downloads).
+ *
+ * Strategy mirrors the antfly test suite:
+ *   - Mock antfly-server so the test can assert what happens when the
+ *     antfly binary is present vs missing
+ *   - Mock child_process.spawn to fire configurable exit codes without
+ *     launching real processes
+ *   - Mock fs.existsSync so the "is this model present on disk" check
+ *     can be scripted per-test. A small in-memory set holds the paths
+ *     the mock should report as existing.
+ *   - Mock prompts so interactive confirmation is deterministic
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { homedir } from 'os'
+import { join } from 'path'
+
+let antflyBinary: string | null
+let existingPaths: Set<string>
+let spawnExitCode: number | null
+let spawnError: Error | null
+let spawnCalls: Array<{ cmd: string; args: string[] }>
+let askYesNoReturn: boolean
+/**
+ * When true, every successful spawn('antfly termite pull <model>') also
+ * "creates" the model directory in the fake fs — simulating a real pull
+ * that actually populates the target dir. When false, spawn exits 0 but
+ * existsSync still reports missing, exercising the "success but file
+ * still missing" guard in the component.
+ */
+let spawnCreatesFiles: boolean
+
+vi.mock('../../../src/core/antfly-server', () => ({
+  findBinary: () => antflyBinary,
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: (p: unknown) => existingPaths.has(String(p)),
+  }
+})
+
+vi.mock('child_process', () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnCalls.push({ cmd, args })
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter | null
+      stderr: EventEmitter | null
+    }
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+    setImmediate(() => {
+      if (spawnError) {
+        child.emit('error', spawnError)
+        return
+      }
+      if (spawnExitCode === 0 && spawnCreatesFiles && args[0] === 'termite' && args[1] === 'pull') {
+        const modelId = args[2]
+        // Termite stores embedders under embedders/<model>, rerankers
+        // under rerankers/<model>. Pick both so the existsSync lookup
+        // inside the component will find whatever path it queries.
+        const root = join(homedir(), '.termite', 'models')
+        existingPaths.add(join(root, 'embedders', modelId))
+        existingPaths.add(join(root, 'rerankers', modelId))
+      }
+      child.stderr?.emit('data', Buffer.from(''))
+      child.emit('close', spawnExitCode)
+    })
+    return child
+  },
+}))
+
+vi.mock('../../../src/core/onboarding/prompts', () => ({
+  askYesNo: () => Promise.resolve(askYesNoReturn),
+  readLine: () => Promise.resolve(''),
+}))
+
+describe('onboarding models component', () => {
+  let modelsComponent: typeof import('../../../src/core/onboarding/models').modelsComponent
+  let REQUIRED_MODELS: typeof import('../../../src/core/onboarding/models').REQUIRED_MODELS
+  let termiteModelsRoot: typeof import('../../../src/core/onboarding/models').termiteModelsRoot
+
+  beforeEach(async () => {
+    antflyBinary = '/opt/homebrew/bin/antfly'
+    existingPaths = new Set()
+    spawnExitCode = 0
+    spawnError = null
+    spawnCalls = []
+    askYesNoReturn = true
+    spawnCreatesFiles = true
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/models')
+    modelsComponent = mod.modelsComponent
+    REQUIRED_MODELS = mod.REQUIRED_MODELS
+    termiteModelsRoot = mod.termiteModelsRoot
+  })
+
+  afterEach(() => {
+    spawnCalls = []
+  })
+
+  const optsAutoYes = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const optsInteractive = {
+    interactive: true,
+    autoApprove: false,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+  const optsNonInteractiveNoYes = {
+    interactive: false,
+    autoApprove: false,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  /** Seed existingPaths with every required model so the fs mock says they exist. */
+  function seedAllModelsPresent() {
+    const root = termiteModelsRoot()
+    for (const m of REQUIRED_MODELS) {
+      const bucket = m.kind === 'embedder' ? 'embedders' : 'rerankers'
+      existingPaths.add(join(root, bucket, m.model))
+    }
+  }
+
+  describe('REQUIRED_MODELS', () => {
+    it('contains exactly the three expected Termite models', () => {
+      expect(REQUIRED_MODELS).toHaveLength(3)
+      const ids = REQUIRED_MODELS.map((m) => m.model)
+      expect(ids).toContain('BAAI/bge-small-en-v1.5')
+      expect(ids).toContain('openai/clip-vit-base-patch32')
+      expect(ids).toContain('mixedbread-ai/mxbai-rerank-base-v1')
+    })
+  })
+
+  describe('check()', () => {
+    it('reports ok when all three models are present', async () => {
+      seedAllModelsPresent()
+      const result = await modelsComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('3 Termite models')
+    })
+
+    it('reports missing with details when all models are absent', async () => {
+      const result = await modelsComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.message).toContain('3 of 3')
+      const missing = result.details?.missing as Array<{ model: string }>
+      expect(missing).toHaveLength(3)
+    })
+
+    it('reports missing with partial list when only some are absent', async () => {
+      // Seed just the BGE embedder as present
+      existingPaths.add(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
+      const result = await modelsComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.message).toContain('2 of 3')
+      const missing = result.details?.missing as Array<{ model: string }>
+      expect(missing).toHaveLength(2)
+      expect(missing.map((m) => m.model)).not.toContain('BAAI/bge-small-en-v1.5')
+    })
+  })
+
+  describe('install()', () => {
+    it('fails cleanly when the antfly binary is missing', async () => {
+      antflyBinary = null
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('antfly binary not found')
+      expect(spawnCalls).toHaveLength(0)
+    })
+
+    it('is a noop when all models are already present', async () => {
+      seedAllModelsPresent()
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('noop')
+      expect(spawnCalls).toHaveLength(0)
+    })
+
+    it('pulls each missing model via antfly termite pull', async () => {
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('installed')
+      expect(spawnCalls).toHaveLength(3)
+      for (const call of spawnCalls) {
+        expect(call.cmd).toBe('/opt/homebrew/bin/antfly')
+        expect(call.args[0]).toBe('termite')
+        expect(call.args[1]).toBe('pull')
+      }
+      const pulledIds = spawnCalls.map((c) => c.args[2])
+      expect(pulledIds).toContain('BAAI/bge-small-en-v1.5')
+      expect(pulledIds).toContain('openai/clip-vit-base-patch32')
+      expect(pulledIds).toContain('mixedbread-ai/mxbai-rerank-base-v1')
+    })
+
+    it('pulls only the missing subset when some models already exist', async () => {
+      existingPaths.add(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('installed')
+      expect(spawnCalls).toHaveLength(2)
+      const pulledIds = spawnCalls.map((c) => c.args[2])
+      expect(pulledIds).not.toContain('BAAI/bge-small-en-v1.5')
+    })
+
+    it('stops on the first failed pull and returns failed', async () => {
+      spawnExitCode = 1
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('exited with code 1')
+      // Bailed after the first failure — no retries of the other two
+      expect(spawnCalls).toHaveLength(1)
+    })
+
+    it('reports failed when spawn succeeds but model directory is still missing', async () => {
+      spawnExitCode = 0
+      spawnCreatesFiles = false
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('still missing')
+    })
+
+    it('skips install when user declines the interactive prompt', async () => {
+      askYesNoReturn = false
+      const result = await modelsComponent.install(optsInteractive)
+      expect(result.status).toBe('skipped')
+      expect(spawnCalls).toHaveLength(0)
+    })
+
+    it('skips install in non-interactive mode without --yes', async () => {
+      const result = await modelsComponent.install(optsNonInteractiveNoYes)
+      expect(result.status).toBe('skipped')
+      expect(result.message).toContain('Non-interactive')
+      expect(spawnCalls).toHaveLength(0)
+    })
+
+    it('reports failed when spawn emits an error event', async () => {
+      spawnError = new Error('EPIPE')
+      const result = await modelsComponent.install(optsAutoYes)
+      expect(result.status).toBe('failed')
+      expect(result.message).toContain('EPIPE')
+    })
+  })
+})

--- a/tests/core/onboarding/openclaw.test.ts
+++ b/tests/core/onboarding/openclaw.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the openclaw onboarding component.
+ *
+ * OpenClaw is a hard prerequisite — Bakin never installs it automatically.
+ * This test suite verifies:
+ *   - Detection reports the right granular failure state (home missing /
+ *     binary missing / config missing / config corrupt / all ok)
+ *   - install() is a noop that never touches the filesystem
+ *   - The install-URL message is consistent across all failure paths
+ *
+ * Uses vi.mock for @bakin/core/openclaw-home (aliased in vitest.config.ts)
+ * so the component's `getOpenClawHome()` call redirects to a temp dir we
+ * control, and for `fs.existsSync` on the binary candidate paths — the
+ * latter we mock because the candidate list includes real system paths
+ * like /opt/homebrew/bin/openclaw that a dev machine may actually have.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync as realExistsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let fakeHome: string
+
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => fakeHome,
+  getOpenClawPath: (...segments: string[]) => join(fakeHome, ...segments),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+// Gate fs.existsSync so binary-candidate lookups (which include real
+// system paths like /opt/homebrew/bin/openclaw) only succeed for files
+// inside the per-test sandbox. Everything else, including whatever the
+// machine running the suite has in /opt/homebrew/, looks absent.
+// readFileSync is passed through unchanged so JSON parsing still works.
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: (p: fs.PathLike) => {
+      const path = String(p)
+      if (path.startsWith(fakeHome)) return actual.existsSync(p)
+      return false
+    },
+  }
+})
+import type * as fs from 'fs'
+
+describe('onboarding openclaw component', () => {
+  let openclawComponent: typeof import('../../../src/core/onboarding/openclaw').openclawComponent
+  let OPENCLAW_INSTALL_URL: string
+
+  beforeEach(async () => {
+    fakeHome = mkdtempSync(join(tmpdir(), 'bakin-onboarding-openclaw-'))
+    delete process.env.OPENCLAW_PATH
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/openclaw')
+    openclawComponent = mod.openclawComponent
+    OPENCLAW_INSTALL_URL = mod.OPENCLAW_INSTALL_URL
+  })
+
+  afterEach(() => {
+    if (realExistsSync(fakeHome)) {
+      rmSync(fakeHome, { recursive: true, force: true })
+    }
+  })
+
+  const opts = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  describe('check()', () => {
+    it('reports missing when the OpenClaw home directory does not exist', async () => {
+      rmSync(fakeHome, { recursive: true, force: true })
+      // fakeHome reference still points at the deleted path — component sees missing
+      const result = await openclawComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.remediation).toContain(OPENCLAW_INSTALL_URL)
+      expect(result.message).toContain('home directory not found')
+      // Re-create before afterEach tries to clean it up
+      mkdirSync(fakeHome, { recursive: true })
+    })
+
+    it('reports missing when home exists but no binary is discoverable', async () => {
+      // home dir exists (created by mkdtemp) but no binary in the sandbox
+      const result = await openclawComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.message).toContain('binary not found')
+      expect(result.details?.candidatesChecked).toBeDefined()
+    })
+
+    it('finds a binary via $OPENCLAW_PATH env var', async () => {
+      const binaryDir = join(fakeHome, 'bin')
+      const binaryPath = join(binaryDir, 'openclaw')
+      mkdirSync(binaryDir, { recursive: true })
+      writeFileSync(binaryPath, '#!/bin/sh\n', { mode: 0o755 })
+      writeFileSync(join(fakeHome, 'openclaw.json'), JSON.stringify({ channels: {} }))
+      process.env.OPENCLAW_PATH = binaryPath
+      // Re-import to pick up the env var in the candidate builder
+      vi.resetModules()
+      const mod = await import('../../../src/core/onboarding/openclaw')
+
+      const result = await mod.openclawComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.binary).toBe(binaryPath)
+    })
+
+    it('reports broken when binary exists but openclaw.json is missing', async () => {
+      const binaryDir = join(fakeHome, 'bin')
+      const binaryPath = join(binaryDir, 'openclaw')
+      mkdirSync(binaryDir, { recursive: true })
+      writeFileSync(binaryPath, '#!/bin/sh\n', { mode: 0o755 })
+      process.env.OPENCLAW_PATH = binaryPath
+      vi.resetModules()
+      const mod = await import('../../../src/core/onboarding/openclaw')
+
+      const result = await mod.openclawComponent.check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('openclaw.json')
+      expect(result.message).toContain('missing')
+    })
+
+    it('reports broken when openclaw.json is not valid JSON', async () => {
+      const binaryDir = join(fakeHome, 'bin')
+      const binaryPath = join(binaryDir, 'openclaw')
+      mkdirSync(binaryDir, { recursive: true })
+      writeFileSync(binaryPath, '#!/bin/sh\n', { mode: 0o755 })
+      writeFileSync(join(fakeHome, 'openclaw.json'), 'not-json {{{')
+      process.env.OPENCLAW_PATH = binaryPath
+      vi.resetModules()
+      const mod = await import('../../../src/core/onboarding/openclaw')
+
+      const result = await mod.openclawComponent.check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('not valid JSON')
+    })
+  })
+
+  describe('install()', () => {
+    it('is a noop that returns the install URL message', async () => {
+      const result = await openclawComponent.install(opts)
+      expect(result.status).toBe('noop')
+      expect(result.message).toContain(OPENCLAW_INSTALL_URL)
+      expect(result.durationMs).toBe(0)
+    })
+
+    it('does not create the home directory', async () => {
+      rmSync(fakeHome, { recursive: true, force: true })
+      await openclawComponent.install(opts)
+      // Noop → still missing
+      expect(realExistsSync(fakeHome)).toBe(false)
+    })
+  })
+})

--- a/tests/core/onboarding/settings.test.ts
+++ b/tests/core/onboarding/settings.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the settings onboarding component.
+ *
+ * Uses CONTENT_DIR env var rather than a vi.mock on content-dir because
+ * the component imports `updateSettings` from src/core/settings, which
+ * reads its target path through `getContentDir()` at call time. Setting
+ * the env var lets the real module cooperate with a temp directory
+ * without having to mock two layers of re-exports.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const TEST_CONTENT_DIR = path.join(process.cwd(), 'test-content-onboarding-settings')
+const SETTINGS_FILE = path.join(TEST_CONTENT_DIR, 'settings.json')
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+describe('onboarding settings component', () => {
+  let settingsComponent: typeof import('../../../src/core/onboarding/settings').settingsComponent
+  let resetSettingsCache: typeof import('../../../src/core/settings').resetSettingsCache
+
+  beforeEach(async () => {
+    process.env.CONTENT_DIR = TEST_CONTENT_DIR
+    if (fs.existsSync(TEST_CONTENT_DIR)) {
+      fs.rmSync(TEST_CONTENT_DIR, { recursive: true, force: true })
+    }
+    fs.mkdirSync(TEST_CONTENT_DIR, { recursive: true })
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/settings')
+    settingsComponent = mod.settingsComponent
+    const settingsMod = await import('../../../src/core/settings')
+    resetSettingsCache = settingsMod.resetSettingsCache
+    resetSettingsCache()
+  })
+
+  afterEach(() => {
+    delete process.env.CONTENT_DIR
+    if (fs.existsSync(TEST_CONTENT_DIR)) {
+      fs.rmSync(TEST_CONTENT_DIR, { recursive: true, force: true })
+    }
+  })
+
+  const opts = {
+    interactive: false,
+    autoApprove: true,
+    json: false,
+    checkOnly: false,
+    force: false,
+  }
+
+  describe('check()', () => {
+    it('reports missing when settings.json does not exist', async () => {
+      const result = await settingsComponent.check()
+      expect(result.status).toBe('missing')
+      expect(result.remediation).toContain('bakin settings init')
+    })
+
+    it('reports broken when settings.json is zero bytes', async () => {
+      fs.writeFileSync(SETTINGS_FILE, '', 'utf-8')
+      const result = await settingsComponent.check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('empty')
+    })
+
+    it('reports broken when settings.json is not valid JSON', async () => {
+      fs.writeFileSync(SETTINGS_FILE, 'not json at all {{{', 'utf-8')
+      const result = await settingsComponent.check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('not valid JSON')
+    })
+
+    it('reports ok when settings.json is present and parses', async () => {
+      fs.writeFileSync(SETTINGS_FILE, JSON.stringify({ dispatch: { intervalMs: 123 } }), 'utf-8')
+      const result = await settingsComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('parses')
+    })
+  })
+
+  describe('install()', () => {
+    it('creates settings.json when missing', async () => {
+      const result = await settingsComponent.install(opts)
+      expect(result.status).toBe('installed')
+      expect(fs.existsSync(SETTINGS_FILE)).toBe(true)
+      // File must parse and not be empty — updateSettings({}) writes {} or
+      // whatever override currently exists.
+      const onDisk = fs.readFileSync(SETTINGS_FILE, 'utf-8')
+      expect(onDisk.length).toBeGreaterThan(0)
+      JSON.parse(onDisk) // throws if invalid
+    })
+
+    it('leaves existing overrides intact when called on a populated file', async () => {
+      fs.writeFileSync(SETTINGS_FILE, JSON.stringify({ dispatch: { intervalMs: 42 } }), 'utf-8')
+      resetSettingsCache()
+      await settingsComponent.install(opts)
+      const onDisk = JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf-8'))
+      // install() uses updateSettings({}) which deep-merges {} onto the
+      // existing override — so our 42 value must survive.
+      expect(onDisk.dispatch?.intervalMs).toBe(42)
+    })
+
+    it('post-install check reports ok', async () => {
+      await settingsComponent.install(opts)
+      const result = await settingsComponent.check()
+      expect(result.status).toBe('ok')
+    })
+  })
+})

--- a/tests/core/onboarding/state.test.ts
+++ b/tests/core/onboarding/state.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the .onboarded marker file I/O.
+ *
+ * Test hygiene: content-dir is mocked to a temp directory so no real
+ * ~/.bakin/ is touched. The logger is stubbed to keep warnings out of the
+ * test output.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+let testDir: string
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+describe('onboarding state', () => {
+  let loadState: typeof import('../../../src/core/onboarding/state').loadState
+  let saveState: typeof import('../../../src/core/onboarding/state').saveState
+  let isOnboarded: typeof import('../../../src/core/onboarding/state').isOnboarded
+  let clearMarker: typeof import('../../../src/core/onboarding/state').clearMarker
+  let ONBOARDING_VERSION: typeof import('../../../src/core/onboarding/state').ONBOARDING_VERSION
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'bakin-onboarding-state-'))
+    vi.resetModules()
+    const mod = await import('../../../src/core/onboarding/state')
+    loadState = mod.loadState
+    saveState = mod.saveState
+    isOnboarded = mod.isOnboarded
+    clearMarker = mod.clearMarker
+    ONBOARDING_VERSION = mod.ONBOARDING_VERSION
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('loadState returns null when the marker is missing', () => {
+    expect(loadState()).toBeNull()
+    expect(isOnboarded()).toBe(false)
+  })
+
+  it('saveState writes a well-formed marker and loadState reads it back', () => {
+    const state = saveState({ mkdir: 'ok', antfly: 'ok', llm: 'warn' }, '1.2.3')
+
+    expect(state.version).toBe(ONBOARDING_VERSION)
+    expect(state.bakinVersion).toBe('1.2.3')
+    expect(state.components).toEqual({ mkdir: 'ok', antfly: 'ok', llm: 'warn' })
+    expect(typeof state.completedAt).toBe('string')
+
+    const onDisk = JSON.parse(readFileSync(join(testDir, '.onboarded'), 'utf-8'))
+    expect(onDisk).toEqual(state)
+
+    const reloaded = loadState()
+    expect(reloaded).toEqual(state)
+  })
+
+  it('saveState creates parent directory when content dir is missing', () => {
+    const nested = join(testDir, 'not-yet-created')
+    testDir = nested
+    saveState({ mkdir: 'ok' })
+    expect(existsSync(join(nested, '.onboarded'))).toBe(true)
+  })
+
+  it('isOnboarded returns true for a fresh write', () => {
+    saveState({ mkdir: 'ok' })
+    expect(isOnboarded()).toBe(true)
+  })
+
+  it('isOnboarded returns false when stored version is older than code', () => {
+    const olderMarker = {
+      version: ONBOARDING_VERSION - 1,
+      completedAt: '2020-01-01T00:00:00.000Z',
+      bakinVersion: '0.0.1',
+      components: { mkdir: 'ok' },
+    }
+    writeFileSync(join(testDir, '.onboarded'), JSON.stringify(olderMarker), 'utf-8')
+    expect(isOnboarded()).toBe(false)
+  })
+
+  it('loadState returns null for corrupt JSON', () => {
+    writeFileSync(join(testDir, '.onboarded'), 'not-json{', 'utf-8')
+    expect(loadState()).toBeNull()
+    expect(isOnboarded()).toBe(false)
+  })
+
+  it('loadState returns null for a marker with unexpected shape', () => {
+    writeFileSync(join(testDir, '.onboarded'), JSON.stringify({ foo: 'bar' }), 'utf-8')
+    expect(loadState()).toBeNull()
+  })
+
+  it('clearMarker removes the file and is idempotent', () => {
+    saveState({ mkdir: 'ok' })
+    expect(existsSync(join(testDir, '.onboarded'))).toBe(true)
+    clearMarker()
+    expect(existsSync(join(testDir, '.onboarded'))).toBe(false)
+    // Second call must not throw.
+    clearMarker()
+    expect(existsSync(join(testDir, '.onboarded'))).toBe(false)
+  })
+})

--- a/tests/core/settings.test.ts
+++ b/tests/core/settings.test.ts
@@ -31,6 +31,28 @@ describe('Settings', () => {
     expect(settings.antfly.enabled).toBe(true)
   })
 
+  it('returns doctor defaults including requireOnboard', () => {
+    const settings = getSettings()
+    expect(settings.doctor.intervalMs).toBe(30 * 60 * 1000)
+    expect(settings.doctor.autoFixSkill).toBe(true)
+    // First-run onboarding gate — default true so new users get walked
+    // through `bakin onboard` before doctor runs its full check suite.
+    expect(settings.doctor.requireOnboard).toBe(true)
+  })
+
+  it('allows disabling doctor.requireOnboard via override', () => {
+    fs.mkdirSync(TEST_CONTENT_DIR, { recursive: true })
+    fs.writeFileSync(SETTINGS_FILE, JSON.stringify({
+      doctor: { requireOnboard: false },
+    }))
+
+    const settings = getSettings()
+    expect(settings.doctor.requireOnboard).toBe(false)
+    // Other doctor defaults preserved
+    expect(settings.doctor.intervalMs).toBe(30 * 60 * 1000)
+    expect(settings.doctor.autoFixSkill).toBe(true)
+  })
+
   it('returns antfly search defaults', () => {
     const settings = getSettings()
     expect(settings.antfly.search.strategy).toBe('rrf')


### PR DESCRIPTION
## Summary

Adds a complete first-run onboarding system so new users go from zero (`no ~/.bakin/`, no Antfly, no Termite models, no mcporter) to a fully working Bakin in one command.

- **`bakin onboard`** — interactive aggregated flow that walks through 8 components in dependency order: `mkdir → settings → openclaw → antfly → models → mcporter → llm → channels`
- **Granular commands** — `bakin mkdir`, `bakin install {antfly,models,mcporter}`, `bakin check {openclaw,llm,channels,all}`, `bakin settings init` for piecemeal use
- **`.onboarded` marker** at `~/.bakin/.onboarded` with version + per-component status so re-runs and version bumps work correctly
- **Doctor gate** — `settings.doctor.requireOnboard: true` (default) makes `bakin doctor` return a single "run `bakin onboard`" error on fresh machines instead of 16+ noisy failures
- **Deprecation aliases** — `bakin init` → `bakin mkdir`, `bakin setup antfly` → `bakin install antfly`, `bakin setup mcporter` → `bakin install mcporter` with stderr warnings

### Design highlights

- 8 self-contained component modules in `src/core/onboarding/`, each exporting `check()` + `install()` with typed `CheckResult` / `InstallResult` contracts
- OpenClaw is detect-only (points at https://openclaw.ai/), LLM + channels are warn-only — Bakin still starts with degraded features
- `--check` (read-only), `--yes` (auto-approve for CI), `--json` (structured output), `--force` (replay from scratch)
- No new runtime dependencies — pure Node stdlib (readline, child\_process, fs)
- All spawns use `shell: false` with args as arrays

### Stats

- **14 commits** (one per vertical slice)
- **179 new tests** across 11 test files (128 onboarding + 3 doctor gate + 2 settings + 42 CLI regression + 4 mcporter regression)
- **1,743 total tests pass** (full suite, zero failures)
- Zero new tsc errors in touched files

## Test plan

- [x] `pnpm test` — 1,743/1,743 pass
- [x] `pnpm run cli check all` — reports all 8 components with correct status
- [x] `pnpm run cli onboard --check` — non-destructive audit works
- [x] `pnpm run cli mkdir` — idempotent directory creation
- [x] `pnpm run cli init` — deprecated alias prints warning, still works
- [x] Smoke tested `bakin check openclaw` on machine without native OpenClaw binary (docker setup) — correctly reports [MISS] with install URL
- [ ] Manual: wipe `~/.bakin/` + `~/.termite/`, run `pnpm run cli onboard`, verify clean `pnpm dev` boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)