### PR TITLE
fix(onboarding): handle all OpenClaw auth-profiles.json shapes in LLM check

### DIFF
--- a/src/core/onboarding/credentials.ts
+++ b/src/core/onboarding/credentials.ts
@@ -63,16 +63,36 @@ async function checkLlm(): Promise<CheckResult> {
   try {
     const raw = readFileSync(profilePath, 'utf-8')
     const parsed = JSON.parse(raw)
-    if (!Array.isArray(parsed)) {
+    // OpenClaw has produced multiple shapes over its versions:
+    //   1. Bare array:   [{ provider, apiKey }]       (imitation crab)
+    //   2. Object+array: { profiles: [{ provider }] } (docker setup)
+    //   3. Object+dict:  { profiles: { k: { provider } } }
+    // Normalize into a flat array of entry objects for scanning.
+    let entries: unknown[]
+    if (Array.isArray(parsed)) {
+      entries = parsed
+    } else if (parsed !== null && typeof parsed === 'object') {
+      const inner = (parsed as Record<string, unknown>).profiles
+      if (Array.isArray(inner)) {
+        entries = inner
+      } else if (inner !== null && typeof inner === 'object') {
+        entries = Object.values(inner as Record<string, unknown>)
+      } else {
+        entries = []
+      }
+    } else {
+      entries = []
+    }
+    if (entries.length === 0) {
       return {
         name: 'llm',
         status: 'warn',
-        message: `auth-profiles.json is not an array — cannot tell if any provider is configured`,
-        remediation: `Check the file's shape or regenerate it via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
+        message: `auth-profiles.json has no provider entries`,
+        remediation: `Configure at least one LLM provider via OpenClaw. Docs: ${OPENCLAW_DOCS}`,
         details: { profilePath },
       }
     }
-    const providers = parsed
+    const providers = entries
       .filter((p): p is { provider?: string; apiKey?: string } => p !== null && typeof p === 'object')
       .filter((p) => typeof p.provider === 'string' && typeof p.apiKey === 'string' && p.apiKey.trim().length > 0)
       .map((p) => p.provider as string)

--- a/tests/core/onboarding/credentials.test.ts
+++ b/tests/core/onboarding/credentials.test.ts
@@ -71,18 +71,18 @@ describe('onboarding credentials component', () => {
       expect(result.remediation).toContain('OpenClaw')
     })
 
-    it('reports warn when the file is not an array', async () => {
-      writeFileSync(authProfilesPath(), JSON.stringify({ notAnArray: true }))
+    it('reports warn when file has no recognizable entries', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify({ unrelated: true }))
       const result = await llmComponent.check()
       expect(result.status).toBe('warn')
-      expect(result.message).toContain('not an array')
+      expect(result.message).toContain('no provider entries')
     })
 
-    it('reports warn when the array is empty', async () => {
+    it('reports warn when the bare array is empty', async () => {
       writeFileSync(authProfilesPath(), JSON.stringify([]))
       const result = await llmComponent.check()
       expect(result.status).toBe('warn')
-      expect(result.message).toContain('non-empty apiKey')
+      expect(result.message).toContain('no provider entries')
     })
 
     it('reports warn when all entries have empty apiKeys', async () => {
@@ -94,11 +94,35 @@ describe('onboarding credentials component', () => {
       expect(result.status).toBe('warn')
     })
 
-    it('reports ok when at least one provider has a non-empty apiKey', async () => {
+    it('reports ok from bare array shape (imitation crab)', async () => {
       writeFileSync(authProfilesPath(), JSON.stringify([
         { provider: 'anthropic', apiKey: 'sk-ant-fake' },
         { provider: 'openai', apiKey: '' },
       ]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.providers).toEqual(['anthropic'])
+    })
+
+    it('reports ok from { profiles: [...] } shape (real OpenClaw)', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify({
+        profiles: [
+          { provider: 'anthropic', apiKey: 'sk-ant-real' },
+          { provider: 'openai', apiKey: 'sk-oai-real' },
+        ],
+      }))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.providers).toEqual(['anthropic', 'openai'])
+    })
+
+    it('reports ok from { profiles: { key: {...} } } dict shape', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify({
+        profiles: {
+          'default-anthropic': { provider: 'anthropic', apiKey: 'sk-ant-dict' },
+          'codex-oauth': { provider: 'openai-codex', mode: 'oauth' },
+        },
+      }))
       const result = await llmComponent.check()
       expect(result.status).toBe('ok')
       expect(result.details?.providers).toEqual(['anthropic'])


### PR DESCRIPTION
## Summary

- The LLM credential check assumed `auth-profiles.json` was a bare array `[{provider, apiKey}]` (imitation crab shape). Real OpenClaw installs produce `{ profiles: [...] }` or `{ profiles: { key: {...} } }`, causing a false "not an array" warning on correctly configured machines.
- Now normalizes all three shapes into a flat entry array before scanning for providers with non-empty apiKey values.
- Two new test cases cover the `{ profiles: [...] }` (real OpenClaw) and `{ profiles: { key: {...} } }` (dict) shapes.

## Test plan

- [x] `pnpm test` — 1,745/1,745 pass
- [x] New tests cover bare array, object+array, and object+dict shapes
- [ ] Verify on the OpenClaw box: `pnpm run cli check llm` should now report `[OK]` instead of `[WARN]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)