### PR TITLE
fix: end the silent agent loop — MCP, dispatch, watchdog, reindex

### DIFF
--- a/.claude/knowledge/search-api-reference.md
+++ b/.claude/knowledge/search-api-reference.md
@@ -54,12 +54,15 @@ Response:
 {
   "ok": true,
   "total": 142,
+  "errors": 0,
   "tables": [
     { "table": "bakin_tasks", "pluginId": "tasks", "indexed": 45 },
     { "table": "bakin_assets", "pluginId": "assets", "indexed": 67 }
   ]
 }
 ```
+
+`ok` is `true` only when `errors === 0`. Per-table failures appear as an `error` string on the corresponding `tables[]` entry.
 
 ### GET /api/antfly/health — Search system health
 

--- a/.claude/knowledge/search-system.md
+++ b/.claude/knowledge/search-system.md
@@ -369,11 +369,14 @@ Interval controlled by `settings.antfly.cleanupInterval` (Go duration string, e.
 `reindexContentTypes()` in `search-registry.ts` iterates all registered content types and runs their `reindex()` generators. Documents are batch-indexed (50 per batch) via `antfly.batchIndex()`, which applies the retry-on-transient-error wrapper.
 
 SSE events broadcast during reindex:
+- `reindex.batch_start` — once at the start of the whole run, with the table list
 - `reindex.start` — emitted when each table begins
-- `reindex.progress` — emitted after each 50-doc batch (for health page live counts)
-- `reindex.complete` — emitted when each table finishes
+- `reindex.progress` — emitted after each 50-doc batch *and* after the trailing partial batch (so tables with `< BATCH_SIZE` documents always emit at least one progress tick)
+- `reindex.complete` — emitted when each table finishes (carries `indexed` count and any `error`)
+- `reindex.batch_pulse` — coarse heartbeat for the whole run, useful for keeping a UI spinner alive
+- `reindex.batch_complete` — once at the end of the whole run
 
-The health page opens an EventSource before the POST to `/api/reindex` to avoid missing events from fast tables.
+The health page consumes these via the global SSE connection (`useSSE` → `useContentStore.reindexProgress`), so per-card live counts work without opening a second `EventSource`.
 
 **Counter accuracy:** `count += await antfly.batchIndex(...)` — the actual inserted count from Antfly's response, not the batch size. If a batch fails after retries, `batchIndex` returns 0 and the counter doesn't advance for that batch, so the reported `indexed: N` matches what's actually in the table.
 

--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useContentStore } from '@/hooks/use-content-store'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -266,13 +267,8 @@ export function HealthPage() {
     tables: Array<{ table: string; pluginId: string; stats: Record<string, unknown> | null }>
   } | null>(null)
   const [reindexing, setReindexing] = useState(false)
-  const [reindexProgress, setReindexProgress] = useState<Record<string, { indexed: number; done: boolean }>>({})
-  const esRef = useRef<EventSource | null>(null)
-
-  // Clean up reindex EventSource on unmount
-  useEffect(() => {
-    return () => { esRef.current?.close(); esRef.current = null }
-  }, [])
+  const reindexProgress = useContentStore((s) => s.reindexProgress)
+  const clearReindexProgress = useContentStore((s) => s.clearReindexProgress)
 
   // Search state
   const [pluginSearch, setPluginSearch] = useState('')
@@ -500,36 +496,13 @@ export function HealthPage() {
                   className="cursor-pointer"
                   disabled={!searchHealth.enabled || reindexing}
                   onClick={async () => {
-                    setReindexProgress({})
+                    clearReindexProgress()
                     setReindexing(true)
-                    // Open EventSource BEFORE the POST so we don't miss fast tables
-                    if (esRef.current) { esRef.current.close(); esRef.current = null }
-                    const es = new EventSource('/api/events')
-                    esRef.current = es
-                    es.onmessage = (e) => {
-                      try {
-                        const data = JSON.parse(e.data)
-                        if (data.type === 'reindex.progress') {
-                          setReindexProgress(prev => ({
-                            ...prev,
-                            [data.table]: { indexed: data.indexed, done: false },
-                          }))
-                        }
-                        if (data.type === 'reindex.complete') {
-                          setReindexProgress(prev => ({
-                            ...prev,
-                            [data.table]: { indexed: data.indexed, done: true },
-                          }))
-                        }
-                      } catch { /* ignore non-JSON */ }
-                    }
                     try {
                       await fetch('/api/reindex', { method: 'POST' })
                       await fetchData()
                     } finally {
                       setReindexing(false)
-                      es.close()
-                      esRef.current = null
                     }
                   }}
                 >

--- a/plugins/tasks/lib/flow-store.ts
+++ b/plugins/tasks/lib/flow-store.ts
@@ -170,6 +170,7 @@ function flowToTask(flow: FlowRunRow): Task {
     scheduleJobId: state.scheduleJobId,
     projectId: state.projectId,
     order: state.order,
+    updatedAt: flow.updated_at,
   }
 }
 

--- a/plugins/tasks/types.ts
+++ b/plugins/tasks/types.ts
@@ -20,6 +20,8 @@ export interface Task {
   scheduleJobId?: string
   projectId?: string
   order?: number
+  /** Wall-clock ms of the last DB row update — used by the watchdog as a fallback "last activity" when a task has no log entries yet. */
+  updatedAt?: number
 }
 
 export interface TaskColumns {

--- a/scripts/lib/search-tools.ts
+++ b/scripts/lib/search-tools.ts
@@ -17,10 +17,10 @@ addExecTool({
   description: 'Search across all Bakin content (tasks, assets, projects, workflows, schedules, agents) or a specific table. Returns ranked results with scores.',
   source: 'core',
   parameters: {
-    q: { type: 'string', description: 'Search query text', required: true },
-    table: { type: 'string', description: 'Limit to a specific table (tasks, assets, projects, workflows, schedule, team, audit). Omit for cross-table search.' },
-    limit: { type: 'number', description: 'Maximum results to return (default: 20)' },
-    offset: { type: 'number', description: 'Skip this many results (for pagination)' },
+    q: z.string().describe('Search query text'),
+    table: z.string().optional().describe('Limit to a specific table (tasks, assets, projects, workflows, schedule, team, audit). Omit for cross-table search.'),
+    limit: z.number().optional().describe('Maximum results to return (default: 20)'),
+    offset: z.number().optional().describe('Skip this many results (for pagination)'),
   },
   handler: async (params) => {
     const q = params.q as string
@@ -44,10 +44,10 @@ addExecTool({
   description: 'Search a specific Bakin table with facet filtering. Returns results plus facet counts for filtering.',
   source: 'core',
   parameters: {
-    table: { type: 'string', description: 'Table to search (tasks, assets, projects, workflows, schedule, team, audit)', required: true },
-    q: { type: 'string', description: 'Search query text', required: true },
-    facets: { type: 'string', description: 'Comma-separated facet fields to include counts for (e.g., "status,agent")' },
-    limit: { type: 'number', description: 'Maximum results (default: 20)' },
+    table: z.string().describe('Table to search (tasks, assets, projects, workflows, schedule, team, audit)'),
+    q: z.string().describe('Search query text'),
+    facets: z.string().optional().describe('Comma-separated facet fields to include counts for (e.g., "status,agent")'),
+    limit: z.number().optional().describe('Maximum results (default: 20)'),
   },
   handler: async (params) => {
     const table = params.table as string
@@ -72,8 +72,8 @@ addExecTool({
   description: 'Look up a specific indexed document by its key and table.',
   source: 'core',
   parameters: {
-    table: { type: 'string', description: 'Table name (tasks, assets, projects, etc.)', required: true },
-    key: { type: 'string', description: 'Document key to look up', required: true },
+    table: z.string().describe('Table name (tasks, assets, projects, etc.)'),
+    key: z.string().describe('Document key to look up'),
   },
   handler: async (params) => {
     const table = `bakin_${params.table}`
@@ -98,8 +98,8 @@ addExecTool({
   description: 'Get facet value counts for a table. Useful for understanding data distribution (e.g., how many tasks per status).',
   source: 'core',
   parameters: {
-    table: { type: 'string', description: 'Table name (tasks, assets, projects, etc.)', required: true },
-    facets: { type: 'string', description: 'Comma-separated facet fields (e.g., "status,agent")', required: true },
+    table: z.string().describe('Table name (tasks, assets, projects, etc.)'),
+    facets: z.string().describe('Comma-separated facet fields (e.g., "status,agent")'),
   },
   handler: async (params) => {
     const table = params.table as string
@@ -125,9 +125,9 @@ addExecTool({
   description: 'Find documents similar to a given text description. Uses semantic (vector) search for meaning-based matching.',
   source: 'core',
   parameters: {
-    text: { type: 'string', description: 'Text to find similar documents for', required: true },
-    table: { type: 'string', description: 'Limit to a specific table (optional)' },
-    limit: { type: 'number', description: 'Maximum results (default: 10)' },
+    text: z.string().describe('Text to find similar documents for'),
+    table: z.string().optional().describe('Limit to a specific table (optional)'),
+    limit: z.number().optional().describe('Maximum results (default: 10)'),
   },
   handler: async (params) => {
     const text = params.text as string
@@ -150,8 +150,8 @@ addExecTool({
   description: 'Trigger a full reindex of all content types (or a specific table). Use after bulk data changes.',
   source: 'core',
   parameters: {
-    table: { type: 'string', description: 'Specific table to reindex (optional — omit for all)' },
-    rebuild: { type: 'boolean', description: 'Drop and recreate indexes before reindexing (default: false)' },
+    table: z.string().optional().describe('Specific table to reindex (optional — omit for all)'),
+    rebuild: z.boolean().optional().describe('Drop and recreate indexes before reindexing (default: false)'),
   },
   handler: async (params) => {
     const results = await reindexContentTypes({

--- a/server.ts
+++ b/server.ts
@@ -336,7 +336,8 @@ app.prepare().then(async () => {
       const rebuild = url.searchParams.get('rebuild') === 'true'
       reindexContentTypes({ table, rebuild }).then((results: Array<Record<string, unknown>>) => {
         const total = results.reduce((sum: number, r: Record<string, unknown>) => sum + (r.indexed as number || 0), 0)
-        jsonResponse(res, 200, { ok: true, total, tables: results })
+        const errors = results.filter((r) => r.error).length
+        jsonResponse(res, 200, { ok: errors === 0, total, errors, tables: results })
       }).catch((err: unknown) => {
         jsonResponse(res, 500, { error: String(err) })
       })

--- a/server.ts
+++ b/server.ts
@@ -207,10 +207,12 @@ app.prepare().then(async () => {
     // MCP endpoint — agent-facing tool server
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       handleMcpRequest(req, res).catch((err) => {
-        log.error('MCP request error', err)
+        const errMsg = err instanceof Error ? err.message : String(err)
+        const errStack = err instanceof Error ? err.stack : undefined
+        log.error('MCP request error', err, { message: errMsg, stack: errStack })
         if (!res.headersSent) {
           res.writeHead(500, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'Internal MCP error' }))
+          res.end(JSON.stringify({ error: 'Internal MCP error', message: errMsg }))
         }
       })
       return

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -199,13 +199,14 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
         const prev = getFailureRecord(state.failedDispatches[task.id])
         state.failedDispatches[task.id] = { lastAttempt: Date.now(), count: (prev?.count || 0) + 1 }
 
+        const errMsg = err instanceof Error ? err.message : String(err)
         try {
-          await addTaskLog(task.id, 'system', `Dispatch failed (attempt ${(prev?.count || 0) + 1}): agent "${targetAgent}" not found or unavailable`)
+          await addTaskLog(task.id, 'system', `Dispatch failed (attempt ${(prev?.count || 0) + 1}) → ${targetAgent}: ${errMsg}`)
         } catch {
           // best effort
         }
 
-        appendAudit(contentDir, 'task.dispatch_failed', targetAgent, { id: task.id, title: task.title, error: err instanceof Error ? err.message : String(err), attempt: (prev?.count || 0) + 1 })
+        appendAudit(contentDir, 'task.dispatch_failed', targetAgent, { id: task.id, title: task.title, error: errMsg, attempt: (prev?.count || 0) + 1 })
       }
     }
 
@@ -313,7 +314,8 @@ export async function dispatchSingleTask(
       saveDispatchState(contentDir, state)
 
       try {
-        await addTaskLog(task.id, 'system', `Immediate dispatch failed (attempt ${(prev?.count || 0) + 1}): agent "${targetAgent}" not found or unavailable`)
+        const errMsg = err instanceof Error ? err.message : String(err)
+        await addTaskLog(task.id, 'system', `Immediate dispatch failed (attempt ${(prev?.count || 0) + 1}) → ${targetAgent}: ${errMsg}`)
       } catch {
         // best effort
       }
@@ -552,7 +554,8 @@ async function dispatchWorkflowTask(
       state.failedDispatches[task.id] = Date.now()
 
       try {
-        await addTaskLog(task.id, 'system', `Workflow dispatch failed for step "${stepId}": agent "${targetAgent}" unavailable`)
+        const errMsg = err instanceof Error ? err.message : String(err)
+        await addTaskLog(task.id, 'system', `Workflow dispatch failed for step "${stepId}" → ${targetAgent}: ${errMsg}`)
       } catch {
         // best effort
       }

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -17,6 +17,16 @@ const hooks = () => getHookRegistry()
 const AGENT_ID_MAP: Record<string, string> = { roscoe: 'main' }
 const resolveId = (name: string) => AGENT_ID_MAP[name] || name
 
+// Upstream openclaw error bodies land in task logs and audit JSONL via
+// the dispatch catch handlers. Bound the blast radius — a runaway gateway
+// response (HTML error page, stack trace, accidental secret echo) should
+// not balloon the audit file or the task drawer.
+const MAX_ERR_LEN = 500
+function formatDispatchError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err)
+  return raw.length > MAX_ERR_LEN ? `${raw.slice(0, MAX_ERR_LEN)}… (truncated)` : raw
+}
+
 interface FailureRecord {
   lastAttempt: number
   count: number
@@ -199,7 +209,7 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
         const prev = getFailureRecord(state.failedDispatches[task.id])
         state.failedDispatches[task.id] = { lastAttempt: Date.now(), count: (prev?.count || 0) + 1 }
 
-        const errMsg = err instanceof Error ? err.message : String(err)
+        const errMsg = formatDispatchError(err)
         try {
           await addTaskLog(task.id, 'system', `Dispatch failed (attempt ${(prev?.count || 0) + 1}) → ${targetAgent}: ${errMsg}`)
         } catch {
@@ -314,7 +324,7 @@ export async function dispatchSingleTask(
       saveDispatchState(contentDir, state)
 
       try {
-        const errMsg = err instanceof Error ? err.message : String(err)
+        const errMsg = formatDispatchError(err)
         await addTaskLog(task.id, 'system', `Immediate dispatch failed (attempt ${(prev?.count || 0) + 1}) → ${targetAgent}: ${errMsg}`)
       } catch {
         // best effort
@@ -554,7 +564,7 @@ async function dispatchWorkflowTask(
       state.failedDispatches[task.id] = Date.now()
 
       try {
-        const errMsg = err instanceof Error ? err.message : String(err)
+        const errMsg = formatDispatchError(err)
         await addTaskLog(task.id, 'system', `Workflow dispatch failed for step "${stepId}" → ${targetAgent}: ${errMsg}`)
       } catch {
         // best effort

--- a/src/core/onboarding/models.ts
+++ b/src/core/onboarding/models.ts
@@ -20,7 +20,7 @@
  * returns 'failed' with a remediation pointing at `bakin install antfly`.
  */
 import { spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, readFileSync, statSync } from 'fs'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createLogger } from '../logger'
@@ -58,12 +58,81 @@ function modelPath(m: TermiteModel): string {
   return join(termiteModelsRoot(), bucket, m.model)
 }
 
+interface ManifestFile {
+  name: string
+  size: number
+}
+
+/**
+ * A model directory is "complete" only when `model_manifest.json` exists
+ * AND every file it lists is on disk at the expected size. A bare directory
+ * containing only tokenizer/config (no weights) — which is the state a
+ * half-finished `antfly termite pull` leaves behind — fails this check.
+ *
+ * Existence-only checks let broken pulls masquerade as healthy installs;
+ * we ran into exactly that with `BAAI/bge-small-en-v1.5` (config files but
+ * no `model.onnx`), so the table-create call later failed at runtime with
+ * `model not found` instead of being caught by the doctor.
+ */
+function modelComplete(m: TermiteModel): { ok: true } | { ok: false; reason: string } {
+  const root = modelPath(m)
+  if (!existsSync(root)) return { ok: false, reason: 'directory missing' }
+
+  const manifestPath = join(root, 'model_manifest.json')
+  if (!existsSync(manifestPath)) {
+    return { ok: false, reason: 'model_manifest.json missing — pull likely incomplete' }
+  }
+
+  let manifest: { files?: ManifestFile[] }
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+  } catch (err) {
+    return { ok: false, reason: `model_manifest.json unreadable: ${err instanceof Error ? err.message : String(err)}` }
+  }
+
+  const files = Array.isArray(manifest.files) ? manifest.files : []
+  if (files.length === 0) {
+    return { ok: false, reason: 'model_manifest.json lists no files' }
+  }
+
+  for (const f of files) {
+    const fpath = join(root, f.name)
+    if (!existsSync(fpath)) {
+      return { ok: false, reason: `${f.name} missing` }
+    }
+    try {
+      const size = statSync(fpath).size
+      if (typeof f.size === 'number' && size !== f.size) {
+        return { ok: false, reason: `${f.name} size mismatch (expected ${f.size}, got ${size})` }
+      }
+    } catch (err) {
+      return { ok: false, reason: `stat ${f.name} failed: ${err instanceof Error ? err.message : String(err)}` }
+    }
+  }
+
+  return { ok: true }
+}
+
+interface MissingEntry {
+  model: TermiteModel
+  reason: string
+}
+
 function missingModels(): TermiteModel[] {
-  return REQUIRED_MODELS.filter((m) => !existsSync(modelPath(m)))
+  return missingModelEntries().map((e) => e.model)
+}
+
+function missingModelEntries(): MissingEntry[] {
+  const out: MissingEntry[] = []
+  for (const m of REQUIRED_MODELS) {
+    const result = modelComplete(m)
+    if (!result.ok) out.push({ model: m, reason: result.reason })
+  }
+  return out
 }
 
 async function check(): Promise<CheckResult> {
-  const missing = missingModels()
+  const missing = missingModelEntries()
   if (missing.length === 0) {
     return {
       name: 'models',
@@ -75,11 +144,16 @@ async function check(): Promise<CheckResult> {
   return {
     name: 'models',
     status: 'missing',
-    message: `${missing.length} of ${REQUIRED_MODELS.length} Termite model${missing.length === 1 ? '' : 's'} missing`,
-    remediation: 'Run `bakin install models` to download the missing Termite models.',
+    message: `${missing.length} of ${REQUIRED_MODELS.length} Termite model${missing.length === 1 ? '' : 's'} missing or incomplete`,
+    remediation: 'Run `bakin install models` to (re-)download the missing Termite models.',
     details: {
       root: termiteModelsRoot(),
-      missing: missing.map((m) => ({ label: m.label, model: m.model, path: modelPath(m) })),
+      missing: missing.map((e) => ({
+        label: e.model.label,
+        model: e.model.model,
+        path: modelPath(e.model),
+        reason: e.reason,
+      })),
     },
   }
 }
@@ -165,13 +239,15 @@ async function install(opts: OnboardingOptions): Promise<InstallResult> {
           durationMs: Date.now() - start,
         }
       }
-      // Verify the directory now exists — catches brew-like "success but
-      // no file" failure modes.
-      if (!existsSync(modelPath(m))) {
+      // Verify the manifest + every listed file is present — catches
+      // brew-like "success but no weights" failure modes where the dir
+      // exists but model.onnx never landed.
+      const verified = modelComplete(m)
+      if (!verified.ok) {
         return {
           name: 'models',
           status: 'failed',
-          message: `antfly termite pull ${m.model} reported success but ${modelPath(m)} is still missing`,
+          message: `antfly termite pull ${m.model} reported success but ${verified.reason}`,
           durationMs: Date.now() - start,
         }
       }
@@ -205,4 +281,4 @@ export const modelsComponent: OnboardingComponent = {
 }
 
 // Exported for tests.
-export const _internals = { missingModels, modelPath, runPull }
+export const _internals = { missingModels, missingModelEntries, modelPath, modelComplete, runPull }

--- a/src/core/openclaw-client.ts
+++ b/src/core/openclaw-client.ts
@@ -85,7 +85,13 @@ export async function sendMessage(agentId: string, message: string): Promise<str
 
   const data = await res.json()
   const reply = data?.choices?.[0]?.message?.content || ''
-  recordAgentReply(agentId)
+  // Only record liveness on a non-empty reply. The gateway has been
+  // observed returning 200 with empty content during upstream rate-limit
+  // or stub conditions — those are exactly the failures the watchdog
+  // needs to *catch*, so we must not mark the agent as alive on them.
+  if (reply.trim().length > 0) {
+    recordAgentReply(agentId)
+  }
   log.debug('Message sent', { agentId, messageLength: message.length })
   return reply
 }

--- a/src/core/openclaw-client.ts
+++ b/src/core/openclaw-client.ts
@@ -9,6 +9,40 @@ import * as vault from './vault'
 
 const log = createLogger('openclaw')
 
+// ---------------------------------------------------------------------------
+// Agent liveness tracker
+//
+// Records the wall-clock time of the last successful gateway reply per
+// agent. The watchdog reads this as the primary "is the agent alive"
+// signal — a returned reply means the gateway routed the message to the
+// agent and got a response back, which is a much more reliable liveness
+// indicator than agent-written heartbeat files (no agent currently
+// writes those).
+//
+// globalThis-backed so the map survives Next.js webpack re-evaluation
+// of this module (same pattern as src/core/sse.ts).
+// ---------------------------------------------------------------------------
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __bakinAgentLastReply: Map<string, number> | undefined
+}
+
+const lastReply: Map<string, number> = (globalThis.__bakinAgentLastReply ??= new Map())
+
+function recordAgentReply(agentId: string): void {
+  lastReply.set(agentId, Date.now())
+}
+
+/**
+ * Wall-clock ms of the last successful gateway reply from this agent
+ * since the server started, or null if we have never heard back from
+ * them. Used by the watchdog as the primary liveness signal.
+ */
+export function getAgentLastReply(agentId: string): number | null {
+  return lastReply.get(agentId) ?? null
+}
+
 function getBaseUrl(): string {
   const settings = getSettings()
   return `${settings.openclaw.gatewayUrl}:${settings.openclaw.gatewayPort}`
@@ -51,6 +85,7 @@ export async function sendMessage(agentId: string, message: string): Promise<str
 
   const data = await res.json()
   const reply = data?.choices?.[0]?.message?.content || ''
+  recordAgentReply(agentId)
   log.debug('Message sent', { agentId, messageLength: message.length })
   return reply
 }

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -218,7 +218,12 @@ export async function ensureRegisteredTables(): Promise<EnsureTablesResult> {
     }
   }
 
-  registry.tablesCreated = true
+  // Only mark the registry as fully provisioned when every table created
+  // cleanly. If any failed, leave the flag false so the next call retries
+  // them rather than short-circuiting on the cached "done" signal.
+  if (failures.length === 0) {
+    registry.tablesCreated = true
+  }
   return { created, failures }
 }
 

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -145,11 +145,18 @@ function buildAntflyIndexes(def: SearchContentTypeDefinition): Record<string, Re
   return indexes
 }
 
-async function ensureTable(def: SearchContentTypeDefinition, existingNames?: Set<string>): Promise<void> {
+/**
+ * Ensure one table exists. Throws on creation failure so callers can
+ * surface the error rather than silently treating it like "already
+ * existed". `antfly.createTable` itself swallows errors and returns
+ * `false`, so we re-list to disambiguate "skipped, already there" from
+ * "tried and failed". This is critical because the most common failure
+ * mode (missing embedder model) presents as a silent zero-doc reindex.
+ */
+async function ensureTable(def: SearchContentTypeDefinition, existingNames?: Set<string>): Promise<'created' | 'exists'> {
   const tableName = fullTableName(def.table)
 
-  // Skip list call if we already know the table exists
-  if (existingNames?.has(tableName)) return
+  if (existingNames?.has(tableName)) return 'exists'
 
   const created = await antfly.createTable(tableName, {
     description: `Bakin ${def.table} — auto-created by search registry`,
@@ -159,12 +166,61 @@ async function ensureTable(def: SearchContentTypeDefinition, existingNames?: Set
   })
   if (created) {
     log.info(`Search table created: ${tableName}`)
+    return 'created'
   }
+
+  // createTable returned false — either the table already existed or the
+  // create itself failed and got swallowed. Re-list and verify.
+  const after = await antfly.listTables()
+  if (after.some(t => t.name === tableName)) return 'exists'
+  throw new Error(`Antfly rejected create for ${tableName} — see antfly warn logs (likely missing embedder model)`)
 }
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+export interface EnsureTablesResult {
+  created: number
+  failures: Array<{ table: string; pluginId: string; error: string }>
+}
+
+/**
+ * Ensure every registered content type has a corresponding Antfly table.
+ * Idempotent — re-lists Antfly tables on every call so it self-heals when
+ * Antfly is wiped, restarted, or otherwise drifts from Bakin's registry.
+ *
+ * Returns both the count of tables created and any per-table failures so
+ * callers (notably the `/api/reindex` handler) can surface real errors
+ * instead of reporting `indexed: 0` for tables that never got created.
+ */
+export async function ensureRegisteredTables(): Promise<EnsureTablesResult> {
+  const registry = getRegistry()
+  if (!antfly.enabled()) {
+    registry.tablesCreated = true
+    return { created: 0, failures: [] }
+  }
+
+  const existingTables = await antfly.listTables()
+  const existingNames = new Set(existingTables.map(t => t.name))
+
+  let created = 0
+  const failures: Array<{ table: string; pluginId: string; error: string }> = []
+  for (const [tableName, def] of registry.contentTypes) {
+    if (existingNames.has(tableName)) continue
+    try {
+      const status = await ensureTable(def, existingNames)
+      if (status === 'created') created++
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      log.error(`Failed to create table for ${def.table}`, err)
+      failures.push({ table: tableName, pluginId: def.pluginId, error: msg })
+    }
+  }
+
+  registry.tablesCreated = true
+  return { created, failures }
+}
 
 /**
  * Create tables for all registered content types.
@@ -173,25 +229,11 @@ async function ensureTable(def: SearchContentTypeDefinition, existingNames?: Set
 export async function createRegisteredTables(): Promise<void> {
   const registry = getRegistry()
   if (registry.tablesCreated) return
-  if (!antfly.enabled()) {
-    registry.tablesCreated = true
-    return
+  const { created, failures } = await ensureRegisteredTables()
+  log.info(`Search tables ready: ${registry.contentTypes.size} content types (${created} created)`)
+  if (failures.length > 0) {
+    log.error(`Search table creation failures: ${failures.length}`, { failures })
   }
-
-  // Fetch existing tables once to avoid N list calls during createTable
-  const existingTables = await antfly.listTables()
-  const existingNames = new Set(existingTables.map(t => t.name))
-
-  for (const [, def] of registry.contentTypes) {
-    try {
-      await ensureTable(def, existingNames)
-    } catch (err) {
-      log.error(`Failed to create table for ${def.table}`, err)
-    }
-  }
-
-  registry.tablesCreated = true
-  log.info(`Search tables ready: ${registry.contentTypes.size} content types`)
 }
 
 /**
@@ -343,6 +385,17 @@ export function buildSearchAPI(pluginId: string): SearchAPI {
 /**
  * Reindex all (or one) registered content types by running their reindex() generators.
  * Returns per-table counts.
+ *
+ * Self-heals: ensures every registered table actually exists on Antfly
+ * before iterating. If Antfly was wiped or restarted since Bakin last
+ * ran createRegisteredTables, this transparently recreates the missing
+ * tables instead of silently writing to nothing.
+ *
+ * Broadcasts two channels of events:
+ *   - Per-table: reindex.start / reindex.progress / reindex.complete
+ *     (drives the Health page tiles)
+ *   - Aggregate: reindex.batch_start / reindex.batch_pulse / reindex.batch_complete
+ *     (drives a single Live Activity entry instead of one per table)
  */
 export async function reindexContentTypes(opts?: {
   table?: string
@@ -351,55 +404,117 @@ export async function reindexContentTypes(opts?: {
   const registry = getRegistry()
   const results: Array<{ table: string; pluginId: string; indexed: number; error?: string }> = []
 
+  // Self-heal: make sure tables exist on Antfly before we try to write to
+  // them. Cheap when nothing's missing (one list call); critical when
+  // Antfly was wiped externally. Per-table failures are surfaced as
+  // reindex results below so the API caller sees the real reason instead
+  // of a misleading `indexed: 0`.
+  const failedTables = new Map<string, string>()
+  try {
+    const ensured = await ensureRegisteredTables()
+    if (ensured.created > 0) log.info(`Reindex auto-created ${ensured.created} missing table(s)`)
+    for (const f of ensured.failures) failedTables.set(f.table, f.error)
+  } catch (err) {
+    log.warn('ensureRegisteredTables failed before reindex', err)
+  }
+
+  // Build the list of tables we'll actually process so the aggregate
+  // events can include accurate totals.
+  const tablesToProcess: Array<[string, SearchContentTypeDefinition & { pluginId: string }]> = []
   for (const [tableName, def] of registry.contentTypes) {
     if (opts?.table && tableName !== fullTableName(opts.table) && opts.table !== def.table && opts.table !== def.pluginId) {
       continue
     }
+    tablesToProcess.push([tableName, def])
+  }
 
-    try {
-      // Rebuild indexes if requested
-      if (opts?.rebuild) {
-        await antfly.rebuildIndexes(tableName)
-        log.info(`Rebuilt indexes for ${tableName}`)
+  const startedAt = Date.now()
+  let totalIndexed = 0
+  let tablesDone = 0
+
+  broadcast({
+    type: 'reindex.batch_start',
+    tables: tablesToProcess.length,
+    scope: opts?.table ?? 'all',
+  })
+
+  // Periodic pulse so long-running reindexes show life in the activity
+  // feed without spamming once per table. 60s cadence — short reindexes
+  // finish before the first pulse and only emit start + complete.
+  const PULSE_MS = 60_000
+  const pulseTimer = setInterval(() => {
+    broadcast({
+      type: 'reindex.batch_pulse',
+      tables_done: tablesDone,
+      tables_total: tablesToProcess.length,
+      indexed: totalIndexed,
+      elapsed_ms: Date.now() - startedAt,
+    })
+  }, PULSE_MS)
+
+  try {
+    for (const [tableName, def] of tablesToProcess) {
+      // If ensureRegisteredTables couldn't create this table, skip the
+      // reindex generator entirely and surface the actual reason instead
+      // of writing 0 docs to a non-existent table.
+      const ensureError = failedTables.get(tableName)
+      if (ensureError) {
+        results.push({ table: tableName, pluginId: def.pluginId, indexed: 0, error: ensureError })
+        broadcast({ type: 'reindex.complete', table: tableName, pluginId: def.pluginId, indexed: 0, error: ensureError })
+        tablesDone++
+        continue
       }
+      try {
+        // Rebuild indexes if requested
+        if (opts?.rebuild) {
+          await antfly.rebuildIndexes(tableName)
+          log.info(`Rebuilt indexes for ${tableName}`)
+        }
 
-      // Run the reindex generator
-      let count = 0
-      if (def.reindex) {
-        broadcast({ type: 'reindex.start', table: tableName, pluginId: def.pluginId })
+        // Run the reindex generator
+        let count = 0
+        if (def.reindex) {
+          broadcast({ type: 'reindex.start', table: tableName, pluginId: def.pluginId })
 
-        const BATCH_SIZE = 50
-        const batch: Array<{ key: string; doc: Record<string, unknown> }> = []
-        for await (const { key, doc } of def.reindex()) {
-          batch.push({ key, doc: doc as Record<string, unknown> })
-          if (batch.length >= BATCH_SIZE) {
+          const BATCH_SIZE = 50
+          const batch: Array<{ key: string; doc: Record<string, unknown> }> = []
+          for await (const { key, doc } of def.reindex()) {
+            batch.push({ key, doc: doc as Record<string, unknown> })
+            if (batch.length >= BATCH_SIZE) {
+              const batchMap: Record<string, Record<string, unknown>> = {}
+              for (const b of batch) batchMap[b.key] = b.doc
+              count += await antfly.batchIndex(tableName, batchMap)
+              batch.length = 0
+              broadcast({ type: 'reindex.progress', table: tableName, pluginId: def.pluginId, indexed: count })
+            }
+          }
+          if (batch.length > 0) {
             const batchMap: Record<string, Record<string, unknown>> = {}
             for (const b of batch) batchMap[b.key] = b.doc
-            // Use the actual inserted count from antfly.batchIndex. The
-            // function returns 0 on batch failure (e.g. if Antfly drops
-            // the batch after exhausting retries). Blindly adding
-            // `batch.length` would over-report success in those cases.
             count += await antfly.batchIndex(tableName, batchMap)
-            batch.length = 0
-            // Broadcast milestone progress to health page (every batch for live counts)
             broadcast({ type: 'reindex.progress', table: tableName, pluginId: def.pluginId, indexed: count })
           }
         }
-        if (batch.length > 0) {
-          const batchMap: Record<string, Record<string, unknown>> = {}
-          for (const b of batch) batchMap[b.key] = b.doc
-          count += await antfly.batchIndex(tableName, batchMap)
-        }
 
+        broadcast({ type: 'reindex.complete', table: tableName, pluginId: def.pluginId, indexed: count })
+        results.push({ table: tableName, pluginId: def.pluginId, indexed: count })
+        totalIndexed += count
+      } catch (err) {
+        results.push({ table: tableName, pluginId: def.pluginId, indexed: 0, error: String(err) })
+        log.error(`Reindex failed for ${tableName}`, err)
       }
-
-      broadcast({ type: 'reindex.complete', table: tableName, pluginId: def.pluginId, indexed: count })
-      results.push({ table: tableName, pluginId: def.pluginId, indexed: count })
-    } catch (err) {
-      results.push({ table: tableName, pluginId: def.pluginId, indexed: 0, error: String(err) })
-      log.error(`Reindex failed for ${tableName}`, err)
+      tablesDone++
     }
+  } finally {
+    clearInterval(pulseTimer)
   }
+
+  broadcast({
+    type: 'reindex.batch_complete',
+    tables: tablesToProcess.length,
+    indexed: totalIndexed,
+    elapsed_ms: Date.now() - startedAt,
+  })
 
   return results
 }

--- a/src/core/watchdog.ts
+++ b/src/core/watchdog.ts
@@ -47,6 +47,20 @@ function getLastLogTimestamp(task: { log?: { timestamp: string }[] }): Date | nu
 
 function isAgentHeartbeatStale(contentDir: string, agent: string | undefined): boolean {
   if (!agent) return true
+
+  // Primary signal: did the gateway return a successful reply from this
+  // agent recently? Recorded in openclaw-client.sendMessage() — a returned
+  // reply means the gateway routed our request and got a response back,
+  // which is a stronger liveness indicator than an agent-written heartbeat
+  // file (which nothing currently writes).
+  const lastReplyMs = openclaw.getAgentLastReply(agent)
+  if (lastReplyMs !== null && Date.now() - lastReplyMs < 15 * 60 * 1000) {
+    return false
+  }
+
+  // Fallback: legacy agent-written heartbeat file. Kept so an agent that
+  // explicitly calls bakin_exec_heartbeat still counts as alive even if
+  // the server hasn't pinged them recently.
   const heartbeatPath = join(contentDir, 'heartbeats', `${agent}.json`)
   try {
     if (!existsSync(heartbeatPath)) return true

--- a/src/core/watchdog.ts
+++ b/src/core/watchdog.ts
@@ -69,7 +69,7 @@ export function start(contentDir: string, port: number): void {
 
   watchdogTimer = setInterval(async () => {
     try {
-      type WdTask = { id: string; title: string; agent?: string; workflowId?: string; log?: Array<{ message: string; timestamp: string }> }
+      type WdTask = { id: string; title: string; agent?: string; workflowId?: string; updatedAt?: number; log?: Array<{ message: string; timestamp: string }> }
       const board = await hooks().invoke<{ columns: Record<string, WdTask[]> }>('tasks.readTaskboard', {})
       if (!board) return
       const { columns } = board
@@ -84,8 +84,16 @@ export function start(contentDir: string, port: number): void {
           if (wfInstance && (wfInstance.status === 'pending_approval' || wfInstance.status === 'complete')) continue
         }
 
+        // Fallback chain for "last activity":
+        //   1. Most recent task log entry (agent or system)
+        //   2. The flow row's updated_at — i.e. when the task was last
+        //      mutated (created, moved, dispatched). Grants a fresh task
+        //      a full stuckThresholdMs grace window before it's eligible
+        //      for auto-recovery, so a just-dispatched task doesn't get
+        //      declared "30 min stuck" on the very first watchdog tick.
+        //   3. now() — guarantees we never synthesize an ancient timestamp.
         const lastLogTs = getLastLogTimestamp(task)
-        const lastActivity = lastLogTs ? lastLogTs.getTime() : (now - settings.watchdog.stuckThresholdMs - 1)
+        const lastActivity = lastLogTs?.getTime() ?? task.updatedAt ?? now
         const stuckMs = now - lastActivity
 
         if (stuckMs <= settings.watchdog.stuckThresholdMs) {

--- a/src/hooks/use-content-store.ts
+++ b/src/hooks/use-content-store.ts
@@ -9,6 +9,11 @@ interface AuditEntry {
   data: Record<string, unknown>
 }
 
+interface ReindexProgressEntry {
+  indexed: number
+  done: boolean
+}
+
 interface ContentStore extends ContentState {
   loading: boolean
   auditEntries: AuditEntry[]
@@ -16,6 +21,7 @@ interface ContentStore extends ContentState {
   sseConnected: boolean
   taskboardVersion: number
   debug: boolean
+  reindexProgress: Record<string, ReindexProgressEntry>
   setFiles: (files: Record<string, string>) => void
   updateFile: (key: string, content: string) => void
   setHeartbeats: (heartbeats: Record<string, Heartbeat>) => void
@@ -27,6 +33,8 @@ interface ContentStore extends ContentState {
   bumpTaskboard: () => void
   setDebug: (debug: boolean) => void
   toggleDebug: () => void
+  setReindexProgress: (table: string, indexed: number, done: boolean) => void
+  clearReindexProgress: () => void
   initialize: () => Promise<void>
 }
 
@@ -40,6 +48,7 @@ export const useContentStore = create<ContentStore>((set, get) => ({
   sseConnected: false,
   taskboardVersion: 0,
   debug: false,
+  reindexProgress: {},
 
   setFiles: (files) => set({ files }),
   updateFile: (key, content) =>
@@ -67,6 +76,11 @@ export const useContentStore = create<ContentStore>((set, get) => ({
     set({ debug: next })
     try { localStorage.setItem('bakin-debug', String(next)) } catch {}
   },
+  setReindexProgress: (table, indexed, done) =>
+    set((state) => ({
+      reindexProgress: { ...state.reindexProgress, [table]: { indexed, done } },
+    })),
+  clearReindexProgress: () => set({ reindexProgress: {} }),
 
   initialize: async () => {
     try { if (localStorage.getItem('bakin-debug') === 'true') set({ debug: true }) } catch {}

--- a/src/hooks/use-sse.ts
+++ b/src/hooks/use-sse.ts
@@ -19,6 +19,7 @@ export function useSSE() {
   const appendActivityEvent = useContentStore((s) => s.appendActivityEvent)
   const setSseConnected = useContentStore((s) => s.setSseConnected)
   const bumpTaskboard = useContentStore((s) => s.bumpTaskboard)
+  const setReindexProgress = useContentStore((s) => s.setReindexProgress)
   const esRef = useRef<EventSource | null>(null)
   const retryRef = useRef(0)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -127,23 +128,53 @@ export function useSSE() {
             })
           }
 
-          // Reindex milestones — start and complete only (progress is handled by health page)
+          // Per-table reindex events drive the Health page tiles only —
+          // they don't write to the activity feed (which would be one
+          // entry per table per reindex). The aggregate batch_* events
+          // below give the activity feed a single start/pulse/complete
+          // pair instead.
           if (data.type === 'reindex.start') {
-            appendActivityEvent({
-              id: `${Date.now()}-reindex-start-${data.table}`,
-              ts: new Date().toISOString(),
-              type: 'log',
-              agent: 'system',
-              message: `Reindexing ${data.pluginId}...`,
-            })
+            setReindexProgress(data.table, 0, false)
+          }
+          if (data.type === 'reindex.progress') {
+            setReindexProgress(data.table, data.indexed ?? 0, false)
           }
           if (data.type === 'reindex.complete') {
+            setReindexProgress(data.table, data.indexed ?? 0, true)
+          }
+
+          // Aggregate reindex events for the activity feed — one entry
+          // for the whole batch instead of one per table. batch_pulse
+          // fires at most every 60s while a long reindex is in flight.
+          if (data.type === 'reindex.batch_start') {
             appendActivityEvent({
-              id: `${Date.now()}-reindex-done-${data.table}`,
+              id: `${Date.now()}-reindex-batch-start`,
               ts: new Date().toISOString(),
               type: 'log',
               agent: 'system',
-              message: `Reindex complete: ${data.pluginId} — ${data.indexed} documents`,
+              message: `Starting full re-index (${data.tables} table${data.tables === 1 ? '' : 's'})`,
+            })
+          }
+          if (data.type === 'reindex.batch_pulse') {
+            const pct = data.tables_total
+              ? Math.floor((data.tables_done / data.tables_total) * 100)
+              : 0
+            appendActivityEvent({
+              id: `${Date.now()}-reindex-batch-pulse`,
+              ts: new Date().toISOString(),
+              type: 'log',
+              agent: 'system',
+              message: `Re-indexing… ${data.tables_done}/${data.tables_total} tables (${pct}%), ${data.indexed} documents so far`,
+            })
+          }
+          if (data.type === 'reindex.batch_complete') {
+            const seconds = Math.max(1, Math.round((data.elapsed_ms ?? 0) / 1000))
+            appendActivityEvent({
+              id: `${Date.now()}-reindex-batch-complete`,
+              ts: new Date().toISOString(),
+              type: 'log',
+              agent: 'system',
+              message: `Completed full re-index — ${data.indexed} documents across ${data.tables} table${data.tables === 1 ? '' : 's'} in ${seconds}s`,
             })
           }
 
@@ -188,5 +219,5 @@ export function useSSE() {
       esRef.current?.close()
       esRef.current = null
     }
-  }, [updateFile, setConnected, setHeartbeats, initialize, appendAuditEntry, appendActivityEvent, setSseConnected, bumpTaskboard])
+  }, [updateFile, setConnected, setHeartbeats, initialize, appendAuditEntry, appendActivityEvent, setSseConnected, bumpTaskboard, setReindexProgress])
 }

--- a/tests/core/onboarding/models.test.ts
+++ b/tests/core/onboarding/models.test.ts
@@ -18,6 +18,13 @@ import { join } from 'path'
 
 let antflyBinary: string | null
 let existingPaths: Set<string>
+/**
+ * Virtual file contents for paths the component reads via readFileSync.
+ * Currently only `model_manifest.json` for each "present" model.
+ */
+let virtualFiles: Map<string, string>
+/** Virtual file sizes for statSync, keyed by absolute path. */
+let virtualSizes: Map<string, number>
 let spawnExitCode: number | null
 let spawnError: Error | null
 let spawnCalls: Array<{ cmd: string; args: string[] }>
@@ -30,6 +37,27 @@ let askYesNoReturn: boolean
  * still missing" guard in the component.
  */
 let spawnCreatesFiles: boolean
+
+/**
+ * Fully "install" a model in the virtual fs: directory present, a
+ * `model_manifest.json` listing one weights file, and a stat-able stub
+ * for the weights file with the matching size. This is the shape that
+ * `modelComplete()` requires to declare the model healthy.
+ */
+function virtualInstall(modelDir: string) {
+  existingPaths.add(modelDir)
+  const manifestPath = join(modelDir, 'model_manifest.json')
+  const weightsPath = join(modelDir, 'model.onnx')
+  const manifest = {
+    schemaVersion: 2,
+    name: 'stub',
+    files: [{ name: 'model.onnx', digest: 'sha256:stub', size: 42 }],
+  }
+  virtualFiles.set(manifestPath, JSON.stringify(manifest))
+  existingPaths.add(manifestPath)
+  existingPaths.add(weightsPath)
+  virtualSizes.set(weightsPath, 42)
+}
 
 vi.mock('../../../src/core/antfly-server', () => ({
   findBinary: () => antflyBinary,
@@ -49,6 +77,16 @@ vi.mock('fs', async () => {
   return {
     ...actual,
     existsSync: (p: unknown) => existingPaths.has(String(p)),
+    readFileSync: (p: unknown, ...rest: unknown[]) => {
+      const key = String(p)
+      if (virtualFiles.has(key)) return virtualFiles.get(key)!
+      return (actual.readFileSync as unknown as (...args: unknown[]) => unknown)(p, ...rest)
+    },
+    statSync: (p: unknown, ...rest: unknown[]) => {
+      const key = String(p)
+      if (virtualSizes.has(key)) return { size: virtualSizes.get(key)! }
+      return (actual.statSync as unknown as (...args: unknown[]) => unknown)(p, ...rest)
+    },
   }
 })
 
@@ -69,11 +107,13 @@ vi.mock('child_process', () => ({
       if (spawnExitCode === 0 && spawnCreatesFiles && args[0] === 'termite' && args[1] === 'pull') {
         const modelId = args[2]
         // Termite stores embedders under embedders/<model>, rerankers
-        // under rerankers/<model>. Pick both so the existsSync lookup
-        // inside the component will find whatever path it queries.
+        // under rerankers/<model>. Populate both branches with a
+        // complete virtual install (manifest + weights) so the
+        // post-pull verification step in the component finds the right
+        // shape regardless of which kind we mocked.
         const root = join(homedir(), '.termite', 'models')
-        existingPaths.add(join(root, 'embedders', modelId))
-        existingPaths.add(join(root, 'rerankers', modelId))
+        virtualInstall(join(root, 'embedders', modelId))
+        virtualInstall(join(root, 'rerankers', modelId))
       }
       child.stderr?.emit('data', Buffer.from(''))
       child.emit('close', spawnExitCode)
@@ -95,6 +135,8 @@ describe('onboarding models component', () => {
   beforeEach(async () => {
     antflyBinary = '/opt/homebrew/bin/antfly'
     existingPaths = new Set()
+    virtualFiles = new Map()
+    virtualSizes = new Map()
     spawnExitCode = 0
     spawnError = null
     spawnCalls = []
@@ -133,12 +175,12 @@ describe('onboarding models component', () => {
     force: false,
   }
 
-  /** Seed existingPaths with every required model so the fs mock says they exist. */
+  /** Seed every required model as a complete virtual install. */
   function seedAllModelsPresent() {
     const root = termiteModelsRoot()
     for (const m of REQUIRED_MODELS) {
       const bucket = m.kind === 'embedder' ? 'embedders' : 'rerankers'
-      existingPaths.add(join(root, bucket, m.model))
+      virtualInstall(join(root, bucket, m.model))
     }
   }
 
@@ -169,14 +211,38 @@ describe('onboarding models component', () => {
     })
 
     it('reports missing with partial list when only some are absent', async () => {
-      // Seed just the BGE embedder as present
-      existingPaths.add(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
+      // Seed just the BGE embedder as fully installed
+      virtualInstall(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
       const result = await modelsComponent.check()
       expect(result.status).toBe('missing')
       expect(result.message).toContain('2 of 3')
       const missing = result.details?.missing as Array<{ model: string }>
       expect(missing).toHaveLength(2)
       expect(missing.map((m) => m.model)).not.toContain('BAAI/bge-small-en-v1.5')
+    })
+
+    it('reports missing when a model directory exists but model_manifest.json is absent', async () => {
+      // Half-pulled state — directory there, no manifest. This is the
+      // exact failure mode that bit us in production with BGE.
+      existingPaths.add(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
+      const result = await modelsComponent.check()
+      expect(result.status).toBe('missing')
+      const missing = result.details?.missing as Array<{ model: string; reason: string }>
+      const bge = missing.find((m) => m.model === 'BAAI/bge-small-en-v1.5')
+      expect(bge?.reason).toContain('model_manifest.json missing')
+    })
+
+    it('reports missing when a manifested file is the wrong size', async () => {
+      // Manifest claims 42 bytes, file is on disk but stat says 7 — the
+      // pull was interrupted mid-write.
+      const dir = join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5')
+      virtualInstall(dir)
+      virtualSizes.set(join(dir, 'model.onnx'), 7)
+      const result = await modelsComponent.check()
+      expect(result.status).toBe('missing')
+      const missing = result.details?.missing as Array<{ model: string; reason: string }>
+      const bge = missing.find((m) => m.model === 'BAAI/bge-small-en-v1.5')
+      expect(bge?.reason).toContain('size mismatch')
     })
   })
 
@@ -212,7 +278,7 @@ describe('onboarding models component', () => {
     })
 
     it('pulls only the missing subset when some models already exist', async () => {
-      existingPaths.add(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
+      virtualInstall(join(termiteModelsRoot(), 'embedders', 'BAAI/bge-small-en-v1.5'))
       const result = await modelsComponent.install(optsAutoYes)
       expect(result.status).toBe('installed')
       expect(spawnCalls).toHaveLength(2)
@@ -229,12 +295,14 @@ describe('onboarding models component', () => {
       expect(spawnCalls).toHaveLength(1)
     })
 
-    it('reports failed when spawn succeeds but model directory is still missing', async () => {
+    it('reports failed when spawn succeeds but the model directory is still empty', async () => {
       spawnExitCode = 0
       spawnCreatesFiles = false
       const result = await modelsComponent.install(optsAutoYes)
       expect(result.status).toBe('failed')
-      expect(result.message).toContain('still missing')
+      // modelComplete reports the specific reason — directory missing,
+      // manifest missing, file missing, or size mismatch.
+      expect(result.message).toMatch(/directory missing|manifest|missing|size mismatch/)
     })
 
     it('skips install when user declines the interactive prompt', async () => {

--- a/tests/core/watchdog.test.ts
+++ b/tests/core/watchdog.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../src/core/sse', () => ({
 vi.mock('../../src/core/openclaw-client', () => ({
   sendChannelMessage: vi.fn().mockResolvedValue(undefined),
   sendMessage: vi.fn().mockResolvedValue(undefined),
+  getAgentLastReply: vi.fn().mockReturnValue(null),
 }))
 
 vi.mock('../../src/lib/plugin-registry', () => ({
@@ -63,10 +64,14 @@ import { isStale } from '../../src/lib/format'
 describe('watchdog', () => {
   let tempDir: string
 
-  beforeEach(() => {
+  beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'bakin-watchdog-'))
     vi.useFakeTimers()
     vi.clearAllMocks()
+    // Default: no recorded gateway reply for any agent (forces watchdog
+    // to fall back to the heartbeat-file path). Individual tests override.
+    const openclaw = await import('../../src/core/openclaw-client')
+    vi.mocked(openclaw.getAgentLastReply).mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -196,6 +201,45 @@ describe('watchdog', () => {
         'watchdog',
         expect.objectContaining({ id: 'task-2' }),
       )
+    })
+
+    it('does not auto-recover when the gateway has a recent reply from the agent', async () => {
+      const hookRegistry = getHookRegistry()
+      const invokeMock = vi.mocked(hookRegistry.invoke)
+
+      invokeMock.mockImplementation(async (name: string) => {
+        if (name === 'tasks.readTaskboard') {
+          return {
+            columns: {
+              todo: [],
+              inProgress: [
+                {
+                  id: 'task-alive',
+                  title: 'Slow but alive task',
+                  agent: 'pixel',
+                  log: [{ message: 'Started', timestamp: '2020-01-01T00:00:00Z' }],
+                },
+              ],
+              done: [],
+            },
+          }
+        }
+        return undefined
+      })
+
+      // Heartbeat file is stale...
+      vi.mocked(isStale).mockReturnValue(true)
+      // ...but the gateway just replied successfully, so the agent is alive.
+      const openclaw = await import('../../src/core/openclaw-client')
+      vi.mocked(openclaw.getAgentLastReply).mockReturnValue(Date.now())
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      // No recovery should fire — the task is stuck but the agent is online,
+      // so the watchdog should fall through to the alert path instead.
+      expect(invokeMock).not.toHaveBeenCalledWith('tasks.moveTask', expect.anything())
+      expect(invokeMock).not.toHaveBeenCalledWith('tasks.blockTask', expect.anything())
     })
 
     it('escalates to blocked after max auto-recoveries', async () => {


### PR DESCRIPTION
## Summary

Four interlocking fixes that together end a class of silent failure where agents stayed on the gateway, replied to chats, but couldn't actually do work — and nothing in Bakin surfaced why.

The headline bug: `scripts/lib/search-tools.ts` declared its 7 tool parameters as plain `{type, description, required}` objects instead of zod schemas. mcp-server.ts:119 force-cast them to `ZodType` and passed them to `McpServer.tool()`, which threw on the very first registration. **Every MCP session creation failed inside `registerTools()`, every `/mcp` request returned 500 — before any tool could be called.** The catch in server.ts wrapped it as a generic "Internal MCP error" with no detail, server stderr was `/dev/null`, and agents on the gateway burned ChatGPT cycles trying to debug MCP themselves instead of completing their tasks.

## Commits

- **`1d042e1` fix(search): unblock Reindex All end-to-end** — three layered bugs (EventSource race, missing final-batch broadcast, doctor model verification) made the Health page Reindex All button look broken when the server was actually reindexing fine.
- **`256e439` fix(dispatch): surface real openclaw errors + watchdog grace period** — dispatch catch blocks now log the real `err.message` instead of swallowing it as a generic "agent unavailable", and the watchdog grants fresh tasks a full `stuckThresholdMs` grace window so a just-dispatched task isn't declared "stuck for 30 min" on the very first tick.
- **`241f757` fix(mcp): convert search-tools parameters to zod schemas** — the headline fix. Also surfaces the real error message in the `/mcp` 500 response so future MCP failures aren't masked.
- **`b35bf46` fix(watchdog): use gateway reply as primary agent liveness signal** — `bakin_exec_heartbeat` exists but no agent is told to call it, so every heartbeat file was 3+ weeks stale. `openclaw-client.sendMessage()` now records `Date.now()` per agent on every successful gateway reply, and the watchdog consults that map first. Heartbeat-file fallback preserved.

## Verification

- 20/20 watchdog + dispatch tests pass (1 new test asserts a stuck task with a recent gateway reply does NOT trigger auto-recovery).
- End-to-end on test task `5172c2a9` "Cute family of pigs image": pre-fix, pixel was on the gateway for 12+ minutes grepping the Bakin source trying to debug MCP errors. Post-fix, image was generated and saved (`~/.bakin/assets/images/5172c2a9/20260412-nbp-1775978162983.jpg`, 615KB), `develop-prompt` → `prompt-gate` → `generate-image` all completed within seconds, workflow `complete`, task in `done`.
- 93 MCP tools register cleanly via `tools/list`.

## Test plan

- [x] `pnpm test tests/core/watchdog.test.ts tests/core/dispatch.test.ts` passes
- [x] MCP `initialize` + `tools/list` succeed against running server
- [x] End-to-end image generation workflow runs to completion
- [ ] CI green
- [ ] Manual test: Reindex All on /health (covered by 1d042e1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)