### PR TITLE
fix(server): log localhost URL on boot (#75)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -487,8 +487,8 @@ app.prepare().then(async () => {
   dispatchState.serverStart = Date.now()
 
   server.listen(port, '0.0.0.0', () => {
-    log.info(`Bakin ready on http://0.0.0.0:${port}`)
-    log.info(`Tailscale: http://100.91.112.69:${port}`)
+    log.info(`Bakin ready on http://localhost:${port}`)
+    log.info(`Listening on 0.0.0.0:${port} (Tailscale: http://100.91.112.69:${port})`)
   })
 
   // Audit system init


### PR DESCRIPTION
## Summary
- Boot log now says `http://localhost:3737` instead of `http://0.0.0.0:3737`, so pasting it into a browser gives Next.js HMR a URL it can actually WebSocket back to.
- Second line keeps the operational info: `Listening on 0.0.0.0:${port} (Tailscale: ...)`.

## Why
`0.0.0.0` is a valid bind address but not a valid connect address from a browser. Users were copying the advertised URL, loading the app, and getting repeating `ws://0.0.0.0:3737/_next/webpack-hmr` failures until they manually retyped the URL as `localhost`. Pure dev-UX polish — no behavior change, no tests affected.

Closes #75

## Test plan
- [ ] `pnpm dev` and confirm the boot log shows `http://localhost:3737`
- [ ] Open that URL in Chrome and confirm no `ws://0.0.0.0` WebSocket errors in the console
- [ ] Confirm the second log line still shows the Tailscale URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)