### PR TITLE
feat(search): reindex enrichment observability (#74)

### DIFF
--- a/.claude/knowledge/search-api-reference.md
+++ b/.claude/knowledge/search-api-reference.md
@@ -48,6 +48,7 @@ Response:
 Query params:
 - `table` — reindex a specific table only (optional)
 - `rebuild=true` — drop and recreate indexes before reindexing
+- `verify=true` — re-query tables after reindex to verify doc counts (opt-in, adds latency)
 
 Response:
 ```json
@@ -55,14 +56,25 @@ Response:
   "ok": true,
   "total": 142,
   "errors": 0,
+  "enrichmentErrors": 0,
   "tables": [
-    { "table": "bakin_tasks", "pluginId": "tasks", "indexed": 45 },
-    { "table": "bakin_assets", "pluginId": "assets", "indexed": 67 }
+    {
+      "table": "bakin_tasks",
+      "pluginId": "tasks",
+      "indexed": 45,
+      "enrichment": {
+        "indexes": [
+          { "name": "search", "type": "full_text", "totalIndexed": 45, "walBacklog": 0, "rebuilding": false },
+          { "name": "embeddings", "type": "embeddings", "totalIndexed": 45, "walBacklog": 0, "rebuilding": false }
+        ],
+        "healthy": true
+      }
+    }
   ]
 }
 ```
 
-`ok` is `true` only when `errors === 0`. Per-table failures appear as an `error` string on the corresponding `tables[]` entry.
+`ok` is `true` only when both `errors === 0` and `enrichmentErrors === 0`. Per-table failures appear as an `error` string on the corresponding `tables[]` entry. `enrichment` surfaces Antfly's async enrichment status per index — `healthy: false` when any index has an `error` or non-zero `walBacklog`. When `verify=true`, each table entry also includes `verified` (actual doc count) and `verifyDiscrepancy` (difference from indexed count).
 
 ### GET /api/antfly/health — Search system health
 
@@ -71,7 +83,16 @@ Response:
 {
   "enabled": true,
   "tables": [
-    { "table": "bakin_tasks", "pluginId": "tasks", "stats": { "num_docs": 45, "num_shards": 1 } }
+    {
+      "table": "bakin_tasks",
+      "pluginId": "tasks",
+      "stats": { "num_docs": 45, "num_shards": 1 },
+      "indexHealth": [
+        { "name": "search", "type": "full_text", "totalIndexed": 45, "walBacklog": 0, "rebuilding": false },
+        { "name": "embeddings", "type": "embeddings", "totalIndexed": 45, "walBacklog": 0, "rebuilding": false }
+      ],
+      "healthy": true
+    }
   ]
 }
 ```

--- a/.claude/knowledge/search-system.md
+++ b/.claude/knowledge/search-system.md
@@ -380,6 +380,75 @@ The health page consumes these via the global SSE connection (`useSSE` → `useC
 
 **Counter accuracy:** `count += await antfly.batchIndex(...)` — the actual inserted count from Antfly's response, not the batch size. If a batch fails after retries, `batchIndex` returns 0 and the counter doesn't advance for that batch, so the reported `indexed: N` matches what's actually in the table.
 
+## Enrichment Observability (#74)
+
+Antfly's enrichment (chunking, embedding, indexing) is **async** — documents land in the WAL before enrichment completes. The reindex pipeline previously only reported whether Antfly accepted the batch, not whether enrichment succeeded. Four layers close this gap:
+
+### Post-batch enrichment audit (Layer 1)
+
+After all batches complete for each table, `reindexContentTypes()` calls `antfly.getIndexHealth(tableName)` which wraps the SDK's `client.indexes.list()`. This returns per-index stats including:
+
+- `error` — enrichment error (e.g. "embedder model not found") → logged as ERROR
+- `wal_backlog` — docs pending enrichment → logged as WARN
+- `rebuilding` / `backfill_progress` — active rebuild status → logged as INFO
+
+The audit is best-effort: it never fails the reindex pipeline. If `getIndexHealth()` throws, the error is caught and logged.
+
+### Enriched reindex response (Layer 2)
+
+`reindexContentTypes()` returns `ReindexTableResult[]` which includes an optional `enrichment` field:
+
+```typescript
+interface ReindexTableResult {
+  table: string
+  pluginId: string
+  indexed: number           // docs Antfly accepted
+  error?: string            // batch-level error
+  enrichment?: IndexHealth  // per-index enrichment status
+  verified?: number         // docs actually findable (verify mode only)
+  verifyDiscrepancy?: number // indexed - verified (verify mode only)
+}
+```
+
+The `/api/reindex` HTTP response includes `enrichmentErrors` (count of tables where enrichment is unhealthy) alongside the existing `errors` count. The `ok` flag is `false` when either count is non-zero.
+
+### Verify mode (Layer 3)
+
+`POST /api/reindex?verify=true` adds a post-reindex verification pass. After all batches for a table complete, it calls `getTableStats()` to get the actual doc count in the table and compares against the `indexed` count. If they diverge, it logs the discrepancy as an error and includes `verified` and `verifyDiscrepancy` in the result.
+
+This is opt-in because it adds one query per table. Intended for smoke tests and CI, not routine reindexes.
+
+### Health endpoint enrichment status (Layer 4)
+
+`GET /api/antfly/health` includes `indexHealth` (array of per-index status) and `healthy` (aggregate boolean) for each table. The health page shows visual indicators:
+
+- Green `CircleCheck` — all indexes healthy
+- Amber `Clock` — WAL backlog (enrichment in progress)
+- Red `AlertCircle` — enrichment error, tooltip shows the message
+
+### Key types
+
+The foundation type is `IndexHealth` from `src/core/antfly.ts`:
+
+```typescript
+interface IndexHealthEntry {
+  name: string           // e.g. 'embeddings', 'assets_text'
+  type: string           // 'full_text' | 'embeddings'
+  totalIndexed: number   // docs in the index
+  walBacklog: number     // docs pending enrichment
+  error?: string         // enrichment error message
+  rebuilding: boolean    // active rebuild
+  backfillProgress?: number // 0.0 to 1.0
+}
+
+interface IndexHealth {
+  indexes: IndexHealthEntry[]
+  healthy: boolean       // true when no errors and no WAL backlog
+}
+```
+
+These map directly from the Antfly SDK's `IndexStatus.status` fields (`EmbeddingsIndexStats` and `FullTextIndexStats`).
+
 ## Client-side Search Pattern
 
 All plugin pages follow the same pattern for search:

--- a/.claude/specs/reindex-enrichment-observability.md
+++ b/.claude/specs/reindex-enrichment-observability.md
@@ -1,0 +1,197 @@
+# SPEC: Reindex Enrichment Observability (#74)
+
+## Objective
+
+Close the observability gap between "Antfly accepted the batch" and "Antfly actually enriched the documents." Today, Bakin's reindex pipeline reports success the moment `batchIndex()` returns — but Antfly's async enrichment (chunking, embedding, indexing) can silently fail for individual documents, leaving partial/empty embeddings in the search index with no log line or API response surfacing the failure.
+
+This has caused real diagnostic dead ends three times on the multimodal-search branch (PDF extraction failures, SVG decode errors, shard-init races). Each required curling Antfly directly to diagnose.
+
+**Target user:** The single operator of this Bakin instance (via health page + server logs).
+
+**Non-goal:** This is not about UI polish or new pages. It's about making the existing reindex pipeline honest about what actually landed in the index.
+
+## Scope
+
+Four layers, ordered by value-to-effort:
+
+### Layer 1: Post-batch enrichment audit (highest value)
+
+After each reindex completes, poll Antfly's `indexes.list()` for every table that was reindexed. The SDK returns per-shard stats including `error`, `wal_backlog`, `rebuilding`, and `backfill_progress` for each index. Log any anomalies as Bakin-level errors (not warnings) so they surface in `server.log` and the audit trail.
+
+**What to check per index:**
+- `error` is non-empty -> log as error with table + index + shard ID + message
+- `wal_backlog > 0` -> log as warning (enrichment still in progress)
+- `backfill_progress < 1.0` when `rebuilding === true` -> log as info (expected during rebuild)
+
+**New function:** `getIndexHealth(tableName)` in `src/core/antfly.ts` — wraps `client.indexes.list()` and returns a structured per-index health summary.
+
+### Layer 2: Enriched reindex response
+
+Change the `/api/reindex` response and `reindexContentTypes()` return type to include post-batch enrichment status:
+
+```typescript
+// Current per-table result
+{ table: string; pluginId: string; indexed: number; error?: string }
+
+// Proposed per-table result
+{
+  table: string
+  pluginId: string
+  indexed: number          // docs Antfly accepted into the batch
+  error?: string           // batch-level error (unchanged)
+  enrichment?: {           // NEW — per-index enrichment status
+    indexes: Array<{
+      name: string
+      totalIndexed: number
+      walBacklog: number
+      error?: string
+      rebuilding: boolean
+      backfillProgress?: number
+    }>
+    healthy: boolean       // true when all indexes have no errors and wal_backlog === 0
+  }
+}
+```
+
+The `/api/reindex` response shape changes from `{ok, total, errors, tables}` to:
+
+```typescript
+{
+  ok: boolean              // false if any table had batch errors OR enrichment errors
+  total: number            // total docs accepted
+  errors: number           // tables with batch-level errors (unchanged)
+  enrichmentErrors: number // NEW — tables with enrichment-level errors
+  tables: [...]            // per-table results with enrichment field
+}
+```
+
+### Layer 3: Verified reindex mode (`?verify=true`)
+
+Add an opt-in verification pass to `/api/reindex?verify=true`. After the full reindex completes for a table, query the table for the inserted keys and count how many are actually findable. Only count verified docs in a separate `verified` field. This is slow but honest — intended for smoke tests and CI, not routine reindexes.
+
+**Implementation:** After all batches for a table complete, do a `matchAll` query with `limit: 0` to get the doc count. Compare against the `indexed` count. If they diverge significantly, log the discrepancy. Also spot-check a sample of inserted keys via individual queries.
+
+**New fields in per-table result:**
+```typescript
+{
+  verified?: number        // only present when verify=true — docs actually findable
+  verifyDiscrepancy?: number // difference between indexed and verified
+}
+```
+
+### Layer 4: Enrichment status on health endpoint
+
+Extend `GET /api/antfly/health` to include per-index enrichment status alongside the existing per-table stats. The health page can then show "7 docs in `bakin_assets` but 2 had enrichment failures" at a glance.
+
+**Health response changes:**
+```typescript
+// Current per-table entry
+{ table: string; pluginId: string; stats: Record<string, unknown> | null }
+
+// Proposed per-table entry
+{
+  table: string
+  pluginId: string
+  stats: Record<string, unknown> | null  // unchanged
+  indexHealth?: Array<{                   // NEW
+    name: string
+    type: string                         // 'full_text' | 'embeddings'
+    totalIndexed: number
+    walBacklog: number
+    error?: string
+    rebuilding: boolean
+    backfillProgress?: number
+  }>
+  healthy: boolean                        // NEW — aggregate: all indexes clean
+}
+```
+
+**Health page UI changes:** Add an indicator to each table card:
+- Green checkmark when `healthy === true`
+- Amber warning icon when `walBacklog > 0` (enrichment in progress)
+- Red error icon when any index has `error` set, with tooltip showing the error message
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/core/antfly.ts` | Add `getIndexHealth()` function |
+| `src/core/search-registry.ts` | Add post-batch enrichment audit in `reindexContentTypes()`, add `verify` mode, update `getSearchHealth()` |
+| `server.ts` | Update `/api/reindex` handler to pass `verify` param and include `enrichmentErrors` in response |
+| `plugins/health/components/health-page.tsx` | Add enrichment status indicators to table cards |
+| `tests/core/antfly.test.ts` | Tests for `getIndexHealth()` |
+| `tests/core/search-registry.test.ts` | Tests for enrichment audit, verify mode, updated health response |
+| `.claude/knowledge/search-system.md` | Document enrichment observability pipeline |
+
+## Files NOT to Modify
+
+- No plugin `index.ts` files — this is all core infrastructure
+- No new plugins or pages — enrichment status lives on the existing health page
+- No changes to the search query path — this is write-side observability only
+- No changes to `SearchContentTypeDefinition` or `SearchAPI` — plugin registration interface is unchanged
+
+## Technical Constraints
+
+1. **Antfly SDK available types:** `indexes.list()` returns per-index `IndexStatus` with `shard_status` map. Each shard has `error?`, `total_indexed?`, `wal_backlog?`, `rebuilding?`, `backfill_progress?`. These are the exact signals we need.
+
+2. **Batch response limitations:** `tables.batch()` returns `{ inserted?, deleted?, transformed? }` — aggregate counts only, no per-document errors. This is why Layer 3 (verify mode) uses a re-query approach rather than parsing batch results.
+
+3. **Timing:** Antfly enrichment is async. After `batchIndex()` returns, the documents are in the WAL but may not be enriched yet. The enrichment audit (Layer 1) runs after ALL batches for a table complete, giving enrichment time to catch up. The verify mode (Layer 3) adds a query after all batches complete.
+
+4. **Performance:** Layer 1 adds one `indexes.list()` call per table after reindex (7 calls for a full reindex). Layer 4 adds the same per health poll. Both are metadata-only calls, not queries. Layer 3 adds one query per table (moderately expensive — hence opt-in).
+
+5. **No Antfly required for tests:** All tests mock the Antfly module. The existing mock infrastructure in `tests/core/` already covers `batchIndex`, `listTables`, `createTable`. We add mocks for the new `getIndexHealth()` function.
+
+## Testing Strategy
+
+### Unit tests (mock Antfly)
+
+**`tests/core/antfly.test.ts`:**
+- `getIndexHealth()` returns structured health when indexes have no errors
+- `getIndexHealth()` surfaces shard errors when present
+- `getIndexHealth()` returns null when client unavailable
+- `getIndexHealth()` handles WAL backlog reporting
+
+**`tests/core/search-registry.test.ts`:**
+- `reindexContentTypes()` includes enrichment status in results
+- `reindexContentTypes()` logs errors when enrichment reports failures
+- `reindexContentTypes({ verify: true })` verifies documents post-reindex
+- `reindexContentTypes({ verify: true })` reports discrepancies
+- `getSearchHealth()` includes per-index health in response
+- `getSearchHealth()` sets `healthy: false` when indexes have errors
+
+### Integration validation (requires real Antfly — not in scope for this PR)
+
+- Reindex with a known-bad PDF and verify enrichment error surfaces
+- Reindex with embedder model mismatch and verify error surfaces
+- Health page shows correct indicators after reindex with errors
+
+## Acceptance Criteria
+
+1. After a reindex, any Antfly enrichment errors appear in `~/.bakin/logs/server.log` as ERROR-level entries with table name, index name, and error message
+2. `POST /api/reindex` response includes `enrichment` field per table with index-level health
+3. `POST /api/reindex?verify=true` re-queries inserted documents and reports discrepancies
+4. `GET /api/antfly/health` response includes `indexHealth` and `healthy` per table
+5. Health page table cards show visual enrichment status (green/amber/red)
+6. All new code paths have unit tests with mocked Antfly
+7. `.claude/knowledge/search-system.md` updated with enrichment observability section
+
+## Boundaries
+
+### Always do
+- Mock `getContentDir` in every test
+- Use existing `createLogger` for all new log lines
+- Return structured data — no string-only error reporting
+- Keep enrichment audit non-blocking (log and continue, never fail the reindex)
+- Cap verify error lists to prevent unbounded response sizes
+
+### Never do
+- Change the plugin registration interface (`SearchContentTypeDefinition`)
+- Add new SSE event types (use existing `reindex.*` events, extend payloads)
+- Block on enrichment completion (audit is best-effort, not a gate)
+- Hardcode Antfly URLs or table names
+- Add backwards-compatibility shims for the response shape changes
+
+### Ask first
+- If enrichment audit latency becomes noticeable (>2s per table), consider making it opt-in
+- If `wal_backlog` is always >0 immediately after batch (expected), consider adding a small delay before the audit poll

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -841,7 +841,7 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
     ok: boolean
     total: number
     errors: number
-    enrichmentErrors: number
+    enrichmentErrors?: number
     tables: Array<{
       table: string
       indexed: number
@@ -862,7 +862,7 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
     }
   }
   console.log(`Done. ${result.total} total documents indexed.`)
-  if (result.enrichmentErrors > 0) {
+  if ((result.enrichmentErrors ?? 0) > 0) {
     console.log(`WARNING: ${result.enrichmentErrors} table(s) have enrichment errors — check health page for details.`)
   }
 }

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -352,13 +352,27 @@ async function cmdSearch(query: string, options: { table?: string; limit?: numbe
 async function cmdSearchStats(): Promise<void> {
   const result = await apiGet('/api/antfly/health') as {
     enabled: boolean
-    tables: Array<{ table: string; pluginId: string; stats: Record<string, unknown> | null }>
+    tables: Array<{
+      table: string
+      pluginId: string
+      stats: Record<string, unknown> | null
+      indexHealth?: Array<{ name: string; error?: string; walBacklog: number; rebuilding: boolean }>
+      healthy?: boolean
+    }>
   }
   console.log(`Antfly: ${result.enabled ? 'enabled' : 'disabled'}`)
   if (result.tables?.length) {
     for (const t of result.tables) {
       const docs = (t.stats as any)?.num_docs ?? '?'
-      console.log(`  ${t.table} (${t.pluginId}): ${docs} docs`)
+      const healthTag = t.healthy === false ? ' [unhealthy]'
+        : t.indexHealth?.some(i => i.walBacklog > 0) ? ' [enriching]'
+        : ''
+      console.log(`  ${t.table} (${t.pluginId}): ${docs} docs${healthTag}`)
+      if (t.healthy === false && t.indexHealth) {
+        for (const idx of t.indexHealth) {
+          if (idx.error) console.log(`    ${idx.name}: ERROR — ${idx.error}`)
+        }
+      }
     }
   }
 }
@@ -823,17 +837,34 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
   if (params.length) url += `?${params.join('&')}`
 
   console.log(`Reindexing ${options.table || 'all content'} to Antfly${options.rebuild ? ' (rebuild indexes)' : ''}...`)
-  const result = await apiPost(url) as { ok: boolean; total: number; tables: Array<{ table: string; indexed: number; error?: string }> }
+  const result = await apiPost(url) as {
+    ok: boolean
+    total: number
+    errors: number
+    enrichmentErrors: number
+    tables: Array<{
+      table: string
+      indexed: number
+      error?: string
+      enrichment?: { healthy: boolean; indexes: Array<{ name: string; error?: string; walBacklog: number }> }
+    }>
+  }
   if (result.tables?.length) {
     for (const t of result.tables) {
       if (t.error) {
         console.log(`  ${t.table}: ERROR — ${t.error}`)
       } else {
-        console.log(`  ${t.table}: ${t.indexed} documents`)
+        const enrichTag = t.enrichment
+          ? t.enrichment.healthy ? '' : ' [enrichment unhealthy]'
+          : ''
+        console.log(`  ${t.table}: ${t.indexed} documents${enrichTag}`)
       }
     }
   }
   console.log(`Done. ${result.total} total documents indexed.`)
+  if (result.enrichmentErrors > 0) {
+    console.log(`WARNING: ${result.enrichmentErrors} table(s) have enrichment errors — check health page for details.`)
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { PluginHeader } from '@/components/plugin-header'
-import { ExternalLink, Search } from 'lucide-react'
+import { ExternalLink, Search, CircleCheck, Clock, AlertCircle } from 'lucide-react'
 
 interface McpSession {
   agent: string
@@ -275,7 +275,21 @@ export function HealthPage() {
   const [lastRefresh, setLastRefresh] = useState<Date>(new Date())
   const [searchHealth, setSearchHealth] = useState<{
     enabled: boolean
-    tables: Array<{ table: string; pluginId: string; stats: Record<string, unknown> | null }>
+    tables: Array<{
+      table: string
+      pluginId: string
+      stats: Record<string, unknown> | null
+      indexHealth?: Array<{
+        name: string
+        type: string
+        totalIndexed: number
+        walBacklog: number
+        error?: string
+        rebuilding: boolean
+        backfillProgress?: number
+      }>
+      healthy?: boolean
+    }>
   } | null>(null)
   const [reindexing, setReindexing] = useState(false)
   const reindexProgress = useContentStore((s) => s.reindexProgress)
@@ -558,9 +572,27 @@ export function HealthPage() {
                   const docs = (t.stats as any)?.num_docs ?? 0
                   const progress = reindexProgress[t.table]
                   const isActive = reindexing && progress && !progress.done
+                  const hasEnrichmentError = t.indexHealth?.some(i => i.error)
+                  const hasWalBacklog = t.indexHealth?.some(i => i.walBacklog > 0)
+                  const enrichmentError = t.indexHealth?.find(i => i.error)?.error
                   return (
                     <div key={t.table} className={`rounded-lg border p-3 transition-colors ${isActive ? 'border-amber-500/50 bg-amber-500/5' : progress?.done ? 'border-emerald-500/50 bg-emerald-500/5' : 'border-border'}`}>
-                      <p className="text-xs text-muted-foreground">{t.pluginId}</p>
+                      <div className="flex items-center justify-between">
+                        <p className="text-xs text-muted-foreground">{t.pluginId}</p>
+                        {t.indexHealth && (
+                          hasEnrichmentError ? (
+                            <span title={enrichmentError ?? 'Enrichment error'}>
+                              <AlertCircle className="h-3.5 w-3.5 text-red-400" />
+                            </span>
+                          ) : hasWalBacklog ? (
+                            <span title="Enrichment in progress">
+                              <Clock className="h-3.5 w-3.5 text-amber-400" />
+                            </span>
+                          ) : (
+                            <CircleCheck className="h-3.5 w-3.5 text-emerald-400" />
+                          )
+                        )}
+                      </div>
                       {isActive ? (
                         <p className="text-lg font-semibold tabular-nums text-amber-400">{progress.indexed}...</p>
                       ) : progress?.done ? (

--- a/scripts/lib/search-tools.ts
+++ b/scripts/lib/search-tools.ts
@@ -152,11 +152,13 @@ addExecTool({
   parameters: {
     table: z.string().optional().describe('Specific table to reindex (optional — omit for all)'),
     rebuild: z.boolean().optional().describe('Drop and recreate indexes before reindexing (default: false)'),
+    verify: z.boolean().optional().describe('Re-query tables after reindex to verify doc counts (default: false)'),
   },
   handler: async (params) => {
     const results = await reindexContentTypes({
       table: params.table as string | undefined,
       rebuild: params.rebuild as boolean | undefined,
+      verify: params.verify as boolean | undefined,
     })
     const total = results.reduce((sum, r) => sum + r.indexed, 0)
     const errors = results.filter(r => r.error).length

--- a/scripts/lib/search-tools.ts
+++ b/scripts/lib/search-tools.ts
@@ -159,7 +159,9 @@ addExecTool({
       rebuild: params.rebuild as boolean | undefined,
     })
     const total = results.reduce((sum, r) => sum + r.indexed, 0)
-    return { ok: true, total, tables: results }
+    const errors = results.filter(r => r.error).length
+    const enrichmentErrors = results.filter(r => r.enrichment && !r.enrichment.healthy).length
+    return { ok: errors === 0 && enrichmentErrors === 0, total, errors, enrichmentErrors, tables: results }
   },
 })
 

--- a/server.ts
+++ b/server.ts
@@ -333,15 +333,26 @@ app.prepare().then(async () => {
       return
     }
 
-    // Reindex endpoint — per-table or all, with optional rebuild
+    // Reindex endpoint — per-table or all, with optional rebuild and verify
     if (url.pathname === '/api/reindex' && req.method === 'POST') {
       const { reindexContentTypes } = require('./src/core/search-registry')
       const table = url.searchParams.get('table') || undefined
       const rebuild = url.searchParams.get('rebuild') === 'true'
-      reindexContentTypes({ table, rebuild }).then((results: Array<Record<string, unknown>>) => {
+      const verify = url.searchParams.get('verify') === 'true'
+      reindexContentTypes({ table, rebuild, verify }).then((results: Array<Record<string, unknown>>) => {
         const total = results.reduce((sum: number, r: Record<string, unknown>) => sum + (r.indexed as number || 0), 0)
         const errors = results.filter((r) => r.error).length
-        jsonResponse(res, 200, { ok: errors === 0, total, errors, tables: results })
+        const enrichmentErrors = results.filter((r) => {
+          const enrichment = r.enrichment as { healthy?: boolean } | undefined
+          return enrichment && !enrichment.healthy
+        }).length
+        jsonResponse(res, 200, {
+          ok: errors === 0 && enrichmentErrors === 0,
+          total,
+          errors,
+          enrichmentErrors,
+          tables: results,
+        })
       }).catch((err: unknown) => {
         log.error('Reindex failed', err, { table, rebuild })
         jsonResponse(res, 500, { error: err instanceof Error ? err.message : String(err) })

--- a/src/core/antfly.ts
+++ b/src/core/antfly.ts
@@ -629,6 +629,73 @@ export async function* scanTable(
 }
 
 // ---------------------------------------------------------------------------
+// Index health — enrichment observability (#74)
+// ---------------------------------------------------------------------------
+
+export interface IndexHealthEntry {
+  name: string
+  type: string
+  totalIndexed: number
+  walBacklog: number
+  error?: string
+  rebuilding: boolean
+  backfillProgress?: number
+}
+
+export interface IndexHealth {
+  indexes: IndexHealthEntry[]
+  healthy: boolean
+}
+
+/**
+ * Get per-index enrichment health for a table. Wraps `indexes.list()` and
+ * returns a structured summary. Returns null when the client is unavailable.
+ * Never throws — logs warnings and returns null on error.
+ */
+export async function getIndexHealth(tableName: string): Promise<IndexHealth | null> {
+  const client = getClient()
+  if (!client) return null
+
+  try {
+    const indexStatuses = await client.indexes.list(tableName)
+    const indexes: IndexHealthEntry[] = []
+    let healthy = true
+
+    for (const [indexName, indexInfo] of Object.entries(indexStatuses)) {
+      const config = 'config' in indexInfo ? indexInfo.config : null
+      const status = 'status' in indexInfo ? indexInfo.status : null
+      const s = (status ?? {}) as Record<string, unknown>
+
+      const entry: IndexHealthEntry = {
+        name: indexName,
+        type: (config as Record<string, unknown>)?.type as string ?? 'unknown',
+        totalIndexed: (s.total_indexed as number) ?? 0,
+        walBacklog: (s.wal_backlog as number) ?? 0,
+        rebuilding: (s.rebuilding as boolean) ?? false,
+      }
+
+      if (s.error) {
+        entry.error = s.error as string
+        healthy = false
+      }
+      if (entry.walBacklog > 0) {
+        healthy = false
+      }
+      if (typeof s.backfill_progress === 'number') {
+        entry.backfillProgress = s.backfill_progress
+      }
+
+      indexes.push(entry)
+    }
+
+    return { indexes, healthy }
+  } catch (err) {
+    log.warn(`Failed to get index health for ${tableName}`, err)
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Index management
 // ---------------------------------------------------------------------------
 

--- a/src/core/antfly.ts
+++ b/src/core/antfly.ts
@@ -658,6 +658,9 @@ export async function getIndexHealth(tableName: string): Promise<IndexHealth | n
 
   try {
     const indexStatuses = await client.indexes.list(tableName)
+    if (!indexStatuses || typeof indexStatuses !== 'object') {
+      return { indexes: [], healthy: true }
+    }
     const indexes: IndexHealthEntry[] = []
     let healthy = true
 

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -14,6 +14,7 @@ import type {
   SearchTransformOp,
 } from '../../packages/core/src/plugin-types'
 import * as antfly from './antfly'
+import type { IndexHealth } from './antfly'
 import { broadcast } from './sse'
 import { createLogger } from './logger'
 import { getSettings } from './settings'
@@ -402,12 +403,20 @@ export function buildSearchAPI(pluginId: string): SearchAPI {
  *   - Aggregate: reindex.batch_start / reindex.batch_pulse / reindex.batch_complete
  *     (drives a single Live Activity entry instead of one per table)
  */
+export interface ReindexTableResult {
+  table: string
+  pluginId: string
+  indexed: number
+  error?: string
+  enrichment?: IndexHealth
+}
+
 export async function reindexContentTypes(opts?: {
   table?: string
   rebuild?: boolean
-}): Promise<Array<{ table: string; pluginId: string; indexed: number; error?: string }>> {
+}): Promise<ReindexTableResult[]> {
   const registry = getRegistry()
-  const results: Array<{ table: string; pluginId: string; indexed: number; error?: string }> = []
+  const results: ReindexTableResult[] = []
 
   // Self-heal: make sure tables exist on Antfly before we try to write to
   // them. Cheap when nothing's missing (one list call); critical when
@@ -502,7 +511,30 @@ export async function reindexContentTypes(opts?: {
         }
 
         broadcast({ type: 'reindex.complete', table: tableName, pluginId: def.pluginId, indexed: count })
-        results.push({ table: tableName, pluginId: def.pluginId, indexed: count })
+
+        // Enrichment audit — poll index health after all batches complete.
+        // Best-effort: never fails the reindex, just surfaces what Antfly reports.
+        const result: ReindexTableResult = { table: tableName, pluginId: def.pluginId, indexed: count }
+        try {
+          const health = await antfly.getIndexHealth(tableName)
+          if (health) {
+            result.enrichment = health
+            if (!health.healthy) {
+              for (const idx of health.indexes) {
+                if (idx.error) {
+                  log.error(`Enrichment error in ${tableName}/${idx.name}: ${idx.error}`)
+                }
+                if (idx.walBacklog > 0) {
+                  log.warn(`Enrichment pending in ${tableName}/${idx.name}: ${idx.walBacklog} docs in WAL`)
+                }
+              }
+            }
+          }
+        } catch (err) {
+          log.warn(`Enrichment audit failed for ${tableName}`, err)
+        }
+
+        results.push(result)
         totalIndexed += count
       } catch (err) {
         results.push({ table: tableName, pluginId: def.pluginId, indexed: 0, error: String(err) })

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -544,8 +544,8 @@ export async function reindexContentTypes(opts?: {
             const docCount = (stats as Record<string, unknown> | null)?.num_docs as number ?? 0
             result.verified = docCount
             result.verifyDiscrepancy = count - docCount
-            if (result.verifyDiscrepancy > 0) {
-              log.error(`Verify discrepancy in ${tableName}: indexed ${count} but only ${docCount} findable`)
+            if (result.verifyDiscrepancy !== 0) {
+              log.error(`Verify discrepancy in ${tableName}: indexed ${count} but ${docCount} findable (delta: ${result.verifyDiscrepancy})`)
             }
           } catch (err) {
             log.warn(`Verify pass failed for ${tableName}`, err)

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -409,11 +409,14 @@ export interface ReindexTableResult {
   indexed: number
   error?: string
   enrichment?: IndexHealth
+  verified?: number
+  verifyDiscrepancy?: number
 }
 
 export async function reindexContentTypes(opts?: {
   table?: string
   rebuild?: boolean
+  verify?: boolean
 }): Promise<ReindexTableResult[]> {
   const registry = getRegistry()
   const results: ReindexTableResult[] = []
@@ -532,6 +535,21 @@ export async function reindexContentTypes(opts?: {
           }
         } catch (err) {
           log.warn(`Enrichment audit failed for ${tableName}`, err)
+        }
+
+        // Verify pass — opt-in re-query to check how many docs are actually findable.
+        if (opts?.verify && count > 0) {
+          try {
+            const stats = await antfly.getTableStats(tableName)
+            const docCount = (stats as Record<string, unknown> | null)?.num_docs as number ?? 0
+            result.verified = docCount
+            result.verifyDiscrepancy = count - docCount
+            if (result.verifyDiscrepancy > 0) {
+              log.error(`Verify discrepancy in ${tableName}: indexed ${count} but only ${docCount} findable`)
+            }
+          } catch (err) {
+            log.warn(`Verify pass failed for ${tableName}`, err)
+          }
         }
 
         results.push(result)

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -631,11 +631,18 @@ export async function crossTableSearch(q: string, opts?: {
 }
 
 /**
- * Get health/stats for all registered search tables.
+ * Get health/stats for all registered search tables, including per-index
+ * enrichment status from getIndexHealth().
  */
 export async function getSearchHealth(): Promise<{
   enabled: boolean
-  tables: Array<{ table: string; pluginId: string; stats: Record<string, unknown> | null }>
+  tables: Array<{
+    table: string
+    pluginId: string
+    stats: Record<string, unknown> | null
+    indexHealth?: IndexHealth['indexes']
+    healthy: boolean
+  }>
 }> {
   const registry = getRegistry()
   const isEnabled = antfly.enabled()
@@ -644,14 +651,31 @@ export async function getSearchHealth(): Promise<{
     return { enabled: false, tables: [] }
   }
 
-  const tables: Array<{ table: string; pluginId: string; stats: Record<string, unknown> | null }> = []
+  const tables: Array<{
+    table: string
+    pluginId: string
+    stats: Record<string, unknown> | null
+    indexHealth?: IndexHealth['indexes']
+    healthy: boolean
+  }> = []
+
   for (const [tableName, def] of registry.contentTypes) {
+    let stats: Record<string, unknown> | null = null
     try {
-      const stats = await antfly.getTableStats(tableName)
-      tables.push({ table: tableName, pluginId: def.pluginId, stats })
-    } catch {
-      tables.push({ table: tableName, pluginId: def.pluginId, stats: null })
-    }
+      stats = await antfly.getTableStats(tableName)
+    } catch { /* stats unavailable */ }
+
+    let indexHealth: IndexHealth['indexes'] | undefined
+    let healthy = true
+    try {
+      const health = await antfly.getIndexHealth(tableName)
+      if (health) {
+        indexHealth = health.indexes
+        healthy = health.healthy
+      }
+    } catch { /* index health unavailable — default to healthy */ }
+
+    tables.push({ table: tableName, pluginId: def.pluginId, stats, indexHealth, healthy })
   }
 
   return { enabled: isEnabled, tables }

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,0 +1,211 @@
+# Plan: Reindex Enrichment Observability (#74)
+
+**Spec:** `.claude/specs/reindex-enrichment-observability.md`
+**Branch:** `fix/issue-74-reindex-enrichment-observability`
+
+## Dependency Graph
+
+```
+T1: getIndexHealth() in antfly.ts
+ ├── T2: enrichment audit + enriched response in search-registry.ts
+ │    └── T3: server.ts reindex handler update
+ ├── T4: getSearchHealth() enrichment extension
+ │    └── T5: health page UI indicators
+ └── T6: verify mode in search-registry.ts + server.ts
+T7: knowledge doc update (after all implementation)
+```
+
+T1 is the foundation. T2 and T4 can start after T1. T3 depends on T2. T5 depends on T4. T6 depends on T1 but is otherwise independent. T7 is last.
+
+## Commit Strategy
+
+Each task maps to exactly one commit. This gives clean rollback points:
+
+| Commit | Task | Rollback impact |
+|--------|------|-----------------|
+| C1 | T1: `getIndexHealth()` + tests | Zero — new function, nothing calls it yet |
+| C2 | T2: enrichment audit in reindex + tests | Reindex response shape changes — revert C2 to restore old shape |
+| C3 | T3: server.ts handler update | Reverts the API surface — C2 still works but response isn't exposed via HTTP |
+| C4 | T4: health endpoint enrichment + tests | Independent of C2/C3 — revert without affecting reindex |
+| C5 | T5: health page UI indicators | Pure frontend — revert without affecting any API |
+| C6 | T6: verify mode + tests | Opt-in feature behind `?verify=true` — revert cleanly |
+| C7 | T7: knowledge doc | Docs only |
+
+**Safe rollback to any checkpoint:** Commits are ordered so reverting later commits never breaks earlier ones. The only "breaking" change is C2+C3 together (response shape change), but per spec we're not maintaining backwards compat.
+
+## Task Details
+
+### T1: Add `getIndexHealth()` to antfly.ts
+
+**What:** New exported function that wraps `client.indexes.list()` and returns a structured, typed health summary per index.
+
+**Where:** `src/core/antfly.ts` (after `rebuildIndexes()` at ~line 664)
+
+**Interface:**
+```typescript
+export interface IndexHealthEntry {
+  name: string
+  type: string           // from config.type: 'full_text' | 'embeddings'
+  totalIndexed: number
+  walBacklog: number
+  error?: string
+  rebuilding: boolean
+  backfillProgress?: number
+}
+
+export interface IndexHealth {
+  indexes: IndexHealthEntry[]
+  healthy: boolean
+}
+
+export async function getIndexHealth(tableName: string): Promise<IndexHealth | null>
+```
+
+**Implementation notes:**
+- Calls `client.indexes.list(tableName)` (already used in `rebuildIndexes()` at line 645)
+- Iterates each index entry, reads the aggregate `status` field (not per-shard — aggregate is sufficient for observability)
+- Sets `healthy = true` when no index has `error` set and all `walBacklog === 0`
+- Returns `null` when client unavailable (matches `getTableStats` pattern)
+- Swallows errors with `log.warn` — never throws
+
+**Tests:** `tests/core/antfly.test.ts`
+- Export exists and is a function
+- Returns `null` when Antfly disabled (existing pattern)
+- Returns structured health when indexes are healthy (mock `indexes.list` with clean data)
+- Surfaces errors from shard stats (mock with `error` field set)
+- Reports WAL backlog (mock with `wal_backlog > 0`)
+
+**Verification:** `npx vitest run tests/core/antfly.test.ts`
+
+---
+
+### T2: Enrichment audit in `reindexContentTypes()`
+
+**What:** After all batches complete for each table, call `getIndexHealth()` and:
+1. Log any enrichment errors at ERROR level
+2. Log WAL backlog at WARN level
+3. Attach enrichment status to the per-table result
+
+**Where:** `src/core/search-registry.ts`, inside the `for` loop at ~line 461, after line 504 (`broadcast reindex.complete`)
+
+**Changes:**
+- Import `getIndexHealth` from `./antfly`
+- After `broadcast({ type: 'reindex.complete', ... })`, call `getIndexHealth(tableName)`
+- Log anomalies via the existing `log` instance
+- Extend the result object with `enrichment?: IndexHealth`
+- Update the return type annotation
+
+**Also update `server.ts` reindex handler** (line 337-350):
+- Parse `verify` query param (used in T6, but wire it now)
+- Add `enrichmentErrors` count to response (count of tables where `enrichment?.healthy === false`)
+- Update `ok` to also check enrichment health
+
+**Tests:** `tests/core/search-registry.test.ts`
+- Mock `antfly.getIndexHealth` to return healthy status — verify result includes `enrichment.healthy: true`
+- Mock `getIndexHealth` with errors — verify result includes the errors and `enrichment.healthy: false`
+- Mock `getIndexHealth` returning `null` (Antfly unavailable) — verify enrichment field is omitted, no crash
+- Verify `reindex.complete` broadcast still fires before enrichment audit (no regression)
+
+**Verification:** `npx vitest run tests/core/search-registry.test.ts`
+
+---
+
+### T3: Update server.ts reindex handler
+
+**What:** Update the `/api/reindex` HTTP handler to expose the enriched response shape.
+
+**Where:** `server.ts` lines 337-350
+
+**Changes:**
+- Add `verify` param parsing: `const verify = url.searchParams.get('verify') === 'true'`
+- Pass `verify` to `reindexContentTypes({ table, rebuild, verify })` (verify logic added in T6; passing it now is harmless — it's ignored until T6)
+- Compute `enrichmentErrors`: count of tables where `r.enrichment && !r.enrichment.healthy`
+- Update `ok`: `errors === 0 && enrichmentErrors === 0`
+- Response: `{ ok, total, errors, enrichmentErrors, tables: results }`
+
+**Tests:** No separate test file for server.ts routes — verification is via the search-registry tests (T2) and manual curl. The handler is a thin passthrough.
+
+**Verification:** Read the diff and confirm the handler passes params through correctly.
+
+---
+
+### T4: Extend `getSearchHealth()` with index health
+
+**What:** Add per-index enrichment status to the health endpoint response.
+
+**Where:** `src/core/search-registry.ts`, `getSearchHealth()` function at line 604
+
+**Changes:**
+- After getting `stats` via `antfly.getTableStats(tableName)`, also call `antfly.getIndexHealth(tableName)`
+- Add `indexHealth` and `healthy` fields to each table entry
+- `healthy` is `true` when `indexHealth` reports no errors, or when `indexHealth` is null (Antfly unavailable = skip, don't red-flag)
+
+**Tests:** `tests/core/search-registry.test.ts`
+- `getSearchHealth()` includes `indexHealth` array when available
+- `getSearchHealth()` sets `healthy: true` for clean indexes
+- `getSearchHealth()` sets `healthy: false` when any index has errors
+- `getSearchHealth()` handles `getIndexHealth` returning null gracefully
+
+**Verification:** `npx vitest run tests/core/search-registry.test.ts`
+
+---
+
+### T5: Health page UI enrichment indicators
+
+**What:** Add visual enrichment status to each table card on the health page.
+
+**Where:** `plugins/health/components/health-page.tsx`, table card rendering at ~line 557-574
+
+**Changes:**
+- Update the `searchHealth` TypeScript interface to include `indexHealth` and `healthy`
+- In each table card, add a status indicator:
+  - `healthy === true` or `healthy` undefined: green `CircleCheck` icon
+  - Any index with `walBacklog > 0`: amber `Clock` icon with "Enriching..." text
+  - Any index with `error`: red `AlertCircle` icon with tooltip showing error
+- Show per-index breakdown on hover or in an expandable section (keep it minimal — just icon + tooltip)
+
+**Tests:** This is a UI component — verification is visual. No unit test needed for the indicator rendering.
+
+**Verification:** Start dev server, trigger a reindex via the health page button, confirm indicators render. Since we're on Imitation Crab (no real Antfly), the health endpoint will return `enabled: false` and the section won't render with live data — but we can verify the component compiles and doesn't crash.
+
+---
+
+### T6: Verify mode (`?verify=true`)
+
+**What:** Add opt-in post-reindex verification that re-queries inserted documents.
+
+**Where:** `src/core/search-registry.ts`, inside `reindexContentTypes()`
+
+**Changes:**
+- Accept `verify?: boolean` in the options parameter
+- After all batches for a table complete (and after enrichment audit), if `verify` is true:
+  - Call `antfly.queryTable(tableName, matchAll, { limit: 0 })` to get total doc count
+  - Compare against `count` (number of docs we inserted)
+  - If `indexed > 0` and the table count is significantly lower, log as error
+  - Add `verified` and `verifyDiscrepancy` to the result
+- Keep it simple: one query per table, compare totals. Don't do per-key lookups (too expensive).
+
+**Tests:** `tests/core/search-registry.test.ts`
+- `reindexContentTypes({ verify: true })` queries the table after reindex
+- Result includes `verified` count matching the mock query response
+- Result includes `verifyDiscrepancy` when counts differ
+- `verify: false` (default) does not query — no `verified` field in result
+
+**Verification:** `npx vitest run tests/core/search-registry.test.ts`
+
+---
+
+### T7: Update knowledge doc
+
+**What:** Add an "Enrichment Observability" section to `.claude/knowledge/search-system.md`.
+
+**Where:** After the "Reindexing" section (~line 381)
+
+**Content:**
+- Describe the enrichment audit pipeline (Layer 1)
+- Document the enriched response shape (Layer 2)
+- Document verify mode (Layer 3)
+- Document the health endpoint enrichment fields (Layer 4)
+- Note which SDK types drive the data (`IndexStatus`, `EmbeddingsIndexStats`, etc.)
+
+**Verification:** Read the doc and confirm accuracy against implementation.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,13 +2,13 @@
 
 ## Tasks
 
-- [ ] **T1:** Add `getIndexHealth()` to `src/core/antfly.ts` + tests in `tests/core/antfly.test.ts`
+- [x] **T1:** Add `getIndexHealth()` to `src/core/antfly.ts` + tests in `tests/core/antfly.test.ts`
   - AC: New function exported, wraps `indexes.list()`, returns `IndexHealth | null`
   - AC: 5 new test cases pass (export, disabled, healthy, errors, wal_backlog)
   - Verify: `npx vitest run tests/core/antfly.test.ts`
   - Commit: `feat(search): add getIndexHealth() for enrichment status (#74)`
 
-- [ ] **T2:** Enrichment audit in `reindexContentTypes()` + tests
+- [x] **T2:** Enrichment audit in `reindexContentTypes()` + tests
   - Depends: T1
   - AC: After each table reindex, `getIndexHealth()` called and anomalies logged
   - AC: Per-table result includes `enrichment` field with index health
@@ -16,7 +16,7 @@
   - Verify: `npx vitest run tests/core/search-registry.test.ts`
   - Commit: `feat(search): enrichment audit after reindex with enriched response (#74)`
 
-- [ ] **T3:** Update `server.ts` reindex handler for enriched response
+- [x] **T3:** Update `server.ts` reindex handler for enriched response
   - Depends: T2
   - AC: `/api/reindex` response includes `enrichmentErrors` count
   - AC: `ok` reflects both batch and enrichment errors
@@ -26,14 +26,14 @@
 
   **--- Checkpoint: Layers 1+2 complete. Reindex now surfaces enrichment failures in logs and API. ---**
 
-- [ ] **T4:** Extend `getSearchHealth()` with per-index health + tests
+- [x] **T4:** Extend `getSearchHealth()` with per-index health + tests
   - Depends: T1
   - AC: Health response includes `indexHealth` array and `healthy` boolean per table
   - AC: 4 new test cases pass (with health, healthy true, healthy false, null handling)
   - Verify: `npx vitest run tests/core/search-registry.test.ts`
   - Commit: `feat(search): add enrichment status to health endpoint (#74)`
 
-- [ ] **T5:** Health page UI enrichment indicators
+- [x] **T5:** Health page UI enrichment indicators
   - Depends: T4
   - AC: Table cards show green/amber/red indicator based on enrichment health
   - AC: Error tooltip shows the actual error message
@@ -43,7 +43,7 @@
 
   **--- Checkpoint: Layer 4 complete. Health page shows enrichment status at a glance. ---**
 
-- [ ] **T6:** Verify mode (`?verify=true`) in `reindexContentTypes()` + server.ts + tests
+- [x] **T6:** Verify mode (`?verify=true`) in `reindexContentTypes()` + server.ts + tests
   - Depends: T1
   - AC: `reindexContentTypes({ verify: true })` re-queries table after reindex
   - AC: Result includes `verified` and `verifyDiscrepancy` when verify=true
@@ -54,7 +54,7 @@
 
   **--- Checkpoint: Layer 3 complete. Full pipeline honest about what landed. ---**
 
-- [ ] **T7:** Update `.claude/knowledge/search-system.md` with enrichment observability docs
+- [x] **T7:** Update `.claude/knowledge/search-system.md` with enrichment observability docs
   - Depends: T1-T6
   - AC: New "Enrichment Observability" section documents all four layers
   - AC: Response shapes documented with examples

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,76 @@
+# TODO: Reindex Enrichment Observability (#74)
+
+## Tasks
+
+- [ ] **T1:** Add `getIndexHealth()` to `src/core/antfly.ts` + tests in `tests/core/antfly.test.ts`
+  - AC: New function exported, wraps `indexes.list()`, returns `IndexHealth | null`
+  - AC: 5 new test cases pass (export, disabled, healthy, errors, wal_backlog)
+  - Verify: `npx vitest run tests/core/antfly.test.ts`
+  - Commit: `feat(search): add getIndexHealth() for enrichment status (#74)`
+
+- [ ] **T2:** Enrichment audit in `reindexContentTypes()` + tests
+  - Depends: T1
+  - AC: After each table reindex, `getIndexHealth()` called and anomalies logged
+  - AC: Per-table result includes `enrichment` field with index health
+  - AC: 4 new test cases pass (healthy, errors, null/unavailable, broadcast order)
+  - Verify: `npx vitest run tests/core/search-registry.test.ts`
+  - Commit: `feat(search): enrichment audit after reindex with enriched response (#74)`
+
+- [ ] **T3:** Update `server.ts` reindex handler for enriched response
+  - Depends: T2
+  - AC: `/api/reindex` response includes `enrichmentErrors` count
+  - AC: `ok` reflects both batch and enrichment errors
+  - AC: `verify` query param parsed and passed through
+  - Verify: Read diff, confirm passthrough logic
+  - Commit: `feat(search): expose enrichment errors in reindex API response (#74)`
+
+  **--- Checkpoint: Layers 1+2 complete. Reindex now surfaces enrichment failures in logs and API. ---**
+
+- [ ] **T4:** Extend `getSearchHealth()` with per-index health + tests
+  - Depends: T1
+  - AC: Health response includes `indexHealth` array and `healthy` boolean per table
+  - AC: 4 new test cases pass (with health, healthy true, healthy false, null handling)
+  - Verify: `npx vitest run tests/core/search-registry.test.ts`
+  - Commit: `feat(search): add enrichment status to health endpoint (#74)`
+
+- [ ] **T5:** Health page UI enrichment indicators
+  - Depends: T4
+  - AC: Table cards show green/amber/red indicator based on enrichment health
+  - AC: Error tooltip shows the actual error message
+  - AC: Component compiles without TypeScript errors
+  - Verify: `npx tsc --noEmit`, visual check in browser
+  - Commit: `feat(health): enrichment status indicators on search table cards (#74)`
+
+  **--- Checkpoint: Layer 4 complete. Health page shows enrichment status at a glance. ---**
+
+- [ ] **T6:** Verify mode (`?verify=true`) in `reindexContentTypes()` + server.ts + tests
+  - Depends: T1
+  - AC: `reindexContentTypes({ verify: true })` re-queries table after reindex
+  - AC: Result includes `verified` and `verifyDiscrepancy` when verify=true
+  - AC: Default (no verify) does not add extra queries
+  - AC: 4 new test cases pass
+  - Verify: `npx vitest run tests/core/search-registry.test.ts`
+  - Commit: `feat(search): add opt-in verify mode to reindex (#74)`
+
+  **--- Checkpoint: Layer 3 complete. Full pipeline honest about what landed. ---**
+
+- [ ] **T7:** Update `.claude/knowledge/search-system.md` with enrichment observability docs
+  - Depends: T1-T6
+  - AC: New "Enrichment Observability" section documents all four layers
+  - AC: Response shapes documented with examples
+  - AC: SDK types referenced for future maintainers
+  - Verify: Read and confirm accuracy
+  - Commit: `docs(search): document enrichment observability pipeline (#74)`
+
+## Summary
+
+| Task | Layer | Files | Test count |
+|------|-------|-------|------------|
+| T1 | Foundation | antfly.ts, antfly.test.ts | 5 |
+| T2 | L1+L2 | search-registry.ts, search-registry.test.ts | 4 |
+| T3 | L2 | server.ts | 0 (passthrough) |
+| T4 | L4 | search-registry.ts, search-registry.test.ts | 4 |
+| T5 | L4 | health-page.tsx | 0 (visual) |
+| T6 | L3 | search-registry.ts, search-registry.test.ts | 4 |
+| T7 | Docs | search-system.md | 0 |
+| **Total** | | **7 files** | **17 tests** |

--- a/tests/core/antfly.test.ts
+++ b/tests/core/antfly.test.ts
@@ -1,6 +1,51 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Mock settings with antfly disabled
+// Use vi.hoisted so mock variables survive vi.mock hoisting
+const {
+  mockGetStatus, mockTablesList, mockTablesCreate, mockTablesDrop,
+  mockTablesGet, mockTablesQuery, mockTablesBatch, mockTablesScan,
+  mockIndexesList, mockIndexesCreate, mockIndexesDrop, mockMultiquery,
+  mockClientInstance,
+} = vi.hoisted(() => {
+  const mockGetStatus = vi.fn()
+  const mockTablesList = vi.fn(async () => [])
+  const mockTablesCreate = vi.fn()
+  const mockTablesDrop = vi.fn()
+  const mockTablesGet = vi.fn()
+  const mockTablesQuery = vi.fn()
+  const mockTablesBatch = vi.fn()
+  const mockTablesScan = vi.fn(async function* () {})
+  const mockIndexesList = vi.fn(async () => ({}))
+  const mockIndexesCreate = vi.fn()
+  const mockIndexesDrop = vi.fn()
+  const mockMultiquery = vi.fn()
+  const mockClientInstance = {
+    getStatus: mockGetStatus,
+    tables: {
+      list: mockTablesList,
+      create: mockTablesCreate,
+      drop: mockTablesDrop,
+      get: mockTablesGet,
+      query: mockTablesQuery,
+      multiquery: vi.fn(),
+      batch: mockTablesBatch,
+      scan: mockTablesScan,
+    },
+    indexes: {
+      list: mockIndexesList,
+      create: mockIndexesCreate,
+      drop: mockIndexesDrop,
+    },
+    multiquery: mockMultiquery,
+  }
+  return {
+    mockGetStatus, mockTablesList, mockTablesCreate, mockTablesDrop,
+    mockTablesGet, mockTablesQuery, mockTablesBatch, mockTablesScan,
+    mockIndexesList, mockIndexesCreate, mockIndexesDrop, mockMultiquery,
+    mockClientInstance,
+  }
+})
+
 vi.mock('@/core/settings', () => ({
   getSettings: vi.fn(() => ({
     antfly: {
@@ -22,52 +67,41 @@ vi.mock('@/core/settings', () => ({
   })),
 }))
 
-// Mock @antfly/sdk — prevent real HTTP calls
-vi.mock('@antfly/sdk', () => {
-  return {
-    default: vi.fn().mockImplementation(() => ({
-      getStatus: vi.fn(),
-      tables: {
-        list: vi.fn(async () => []),
-        create: vi.fn(),
-        drop: vi.fn(),
-        get: vi.fn(),
-        query: vi.fn(),
-        multiquery: vi.fn(),
-        batch: vi.fn(),
-        scan: vi.fn(async function* () {}),
-      },
-      indexes: {
-        list: vi.fn(async () => ({})),
-        create: vi.fn(),
-        drop: vi.fn(),
-      },
-      multiquery: vi.fn(),
-    })),
-    AntflyClient: vi.fn().mockImplementation(() => ({
-      getStatus: vi.fn(),
-      tables: {
-        list: vi.fn(async () => []),
-        create: vi.fn(),
-        drop: vi.fn(),
-        get: vi.fn(),
-        query: vi.fn(),
-        multiquery: vi.fn(),
-        batch: vi.fn(),
-        scan: vi.fn(async function* () {}),
-      },
-      indexes: {
-        list: vi.fn(async () => ({})),
-        create: vi.fn(),
-        drop: vi.fn(),
-      },
-      multiquery: vi.fn(),
-    })),
-    matchAll: vi.fn(() => ({ match_all: {} })),
-  }
-})
+vi.mock('@antfly/sdk', () => ({
+  default: vi.fn().mockImplementation(() => mockClientInstance),
+  AntflyClient: vi.fn().mockImplementation(() => mockClientInstance),
+  matchAll: vi.fn(() => ({ match_all: {} })),
+}))
+
+vi.mock('@/core/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+/** Install the mock client on the globalThis singleton that antfly.ts uses. */
+function installMockClient() {
+  const g = globalThis as any
+  g.__bakinAntflyClient = mockClientInstance
+  g.__bakinAntflyReady = true
+}
+
+function resetAntflyGlobals() {
+  const g = globalThis as any
+  delete g.__bakinAntflyClient
+  delete g.__bakinAntflyReady
+  delete g.__bakinAntflyEmbedderHash
+}
 
 describe('antfly', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetAntflyGlobals()
+  })
+
   it('should export core functions', async () => {
     const antfly = await import('@/core/antfly')
     expect(typeof antfly.enabled).toBe('function')
@@ -126,5 +160,106 @@ describe('antfly', () => {
     const tableValues = Object.values(antfly.TABLES)
     expect(tableValues.every(t => t.startsWith('bakin_'))).toBe(true)
     expect(tableValues.some(t => t.startsWith('beacon_'))).toBe(false)
+  })
+
+  // ── getIndexHealth ─────────────────────────────────────────────────
+
+  it('should export getIndexHealth as a function', async () => {
+    const antfly = await import('@/core/antfly')
+    expect(typeof antfly.getIndexHealth).toBe('function')
+  })
+
+  it('getIndexHealth returns null when Antfly disabled', async () => {
+    // No client installed — simulates disabled state
+    const antfly = await import('@/core/antfly')
+    const result = await antfly.getIndexHealth('bakin_tasks')
+    expect(result).toBeNull()
+  })
+
+  it('getIndexHealth returns structured health for clean indexes', async () => {
+    installMockClient()
+    mockIndexesList.mockResolvedValue({
+      search: {
+        config: { name: 'search', type: 'full_text' },
+        status: { total_indexed: 50, rebuilding: false },
+        shard_status: {},
+      },
+      embeddings: {
+        config: { name: 'embeddings', type: 'embeddings' },
+        status: { total_indexed: 50, wal_backlog: 0, rebuilding: false, backfill_progress: 1.0 },
+        shard_status: {},
+      },
+    })
+
+    const antfly = await import('@/core/antfly')
+    const result = await antfly.getIndexHealth('bakin_tasks')
+
+    expect(result).not.toBeNull()
+    expect(result!.healthy).toBe(true)
+    expect(result!.indexes).toHaveLength(2)
+    expect(result!.indexes[0]).toMatchObject({
+      name: 'search',
+      type: 'full_text',
+      rebuilding: false,
+    })
+    expect(result!.indexes[1]).toMatchObject({
+      name: 'embeddings',
+      type: 'embeddings',
+      totalIndexed: 50,
+      walBacklog: 0,
+      rebuilding: false,
+    })
+  })
+
+  it('getIndexHealth surfaces index errors', async () => {
+    installMockClient()
+    mockIndexesList.mockResolvedValue({
+      embeddings: {
+        config: { name: 'embeddings', type: 'embeddings' },
+        status: {
+          total_indexed: 10,
+          wal_backlog: 0,
+          rebuilding: false,
+          error: 'embedder model not found: BAAI/bge-small-en-v1.5',
+        },
+        shard_status: {},
+      },
+    })
+
+    const antfly = await import('@/core/antfly')
+    const result = await antfly.getIndexHealth('bakin_tasks')
+
+    expect(result).not.toBeNull()
+    expect(result!.healthy).toBe(false)
+    expect(result!.indexes[0]!.error).toBe('embedder model not found: BAAI/bge-small-en-v1.5')
+  })
+
+  it('getIndexHealth reports WAL backlog', async () => {
+    installMockClient()
+    mockIndexesList.mockResolvedValue({
+      embeddings: {
+        config: { name: 'embeddings', type: 'embeddings' },
+        status: {
+          total_indexed: 30,
+          wal_backlog: 15,
+          rebuilding: true,
+          backfill_progress: 0.67,
+        },
+        shard_status: {},
+      },
+    })
+
+    const antfly = await import('@/core/antfly')
+    const result = await antfly.getIndexHealth('bakin_tasks')
+
+    expect(result).not.toBeNull()
+    expect(result!.healthy).toBe(false)
+    expect(result!.indexes[0]).toMatchObject({
+      name: 'embeddings',
+      totalIndexed: 30,
+      walBacklog: 15,
+      rebuilding: true,
+      backfillProgress: 0.67,
+    })
   })
 })

--- a/tests/core/antfly.test.ts
+++ b/tests/core/antfly.test.ts
@@ -262,4 +262,26 @@ describe('antfly', () => {
       backfillProgress: 0.67,
     })
   })
+
+  it('getIndexHealth returns null when indexes.list throws', async () => {
+    installMockClient()
+    mockIndexesList.mockRejectedValue(new Error('network timeout'))
+
+    const antfly = await import('@/core/antfly')
+    const result = await antfly.getIndexHealth('bakin_tasks')
+
+    expect(result).toBeNull()
+  })
+
+  it('getIndexHealth returns healthy with empty indexes when none exist', async () => {
+    installMockClient()
+    mockIndexesList.mockResolvedValue({})
+
+    const antfly = await import('@/core/antfly')
+    const result = await antfly.getIndexHealth('bakin_tasks')
+
+    expect(result).not.toBeNull()
+    expect(result!.healthy).toBe(true)
+    expect(result!.indexes).toHaveLength(0)
+  })
 })

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -21,6 +21,8 @@ vi.mock('@/core/antfly', () => ({
     took: 12,
     total: 1,
   })),
+  getIndexHealth: vi.fn(async () => null),
+  getTableStats: vi.fn(async () => null),
 }))
 
 vi.mock('@/core/settings', () => ({
@@ -481,6 +483,77 @@ describe('search-registry', () => {
     expect(results).toHaveLength(1)
     expect(results[0]!.error).toContain('boom')
     expect(results[0]!.indexed).toBe(0)
+  })
+
+  // ── enrichment audit (#74) ──────────────────────────────────────────
+
+  it('reindexContentTypes includes enrichment status when healthy', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [
+        { name: 'search', type: 'full_text', totalIndexed: 1, walBacklog: 0, rebuilding: false },
+        { name: 'embeddings', type: 'embeddings', totalIndexed: 1, walBacklog: 0, rebuilding: false },
+      ],
+      healthy: true,
+    })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes()
+
+    expect(results[0]!.enrichment).toBeDefined()
+    expect(results[0]!.enrichment!.healthy).toBe(true)
+    expect(results[0]!.enrichment!.indexes).toHaveLength(2)
+    expect(antfly.getIndexHealth).toHaveBeenCalledWith('bakin_tasks')
+  })
+
+  it('reindexContentTypes includes enrichment errors when unhealthy', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [
+        { name: 'embeddings', type: 'embeddings', totalIndexed: 0, walBacklog: 0, rebuilding: false, error: 'model not found' },
+      ],
+      healthy: false,
+    })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes()
+
+    expect(results[0]!.enrichment).toBeDefined()
+    expect(results[0]!.enrichment!.healthy).toBe(false)
+    expect(results[0]!.enrichment!.indexes[0]!.error).toBe('model not found')
+  })
+
+  it('reindexContentTypes omits enrichment when getIndexHealth returns null', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes()
+
+    expect(results[0]!.enrichment).toBeUndefined()
+    // Should not crash — enrichment is best-effort
+    expect(results[0]!.indexed).toBe(1)
+  })
+
+  it('reindexContentTypes broadcasts reindex.complete before enrichment audit', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [{ name: 'embeddings', type: 'embeddings', totalIndexed: 1, walBacklog: 0, rebuilding: false }],
+      healthy: true,
+    })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    await reindexContentTypes()
+
+    // reindex.complete should fire before the enrichment audit runs —
+    // verify it was called (existing behavior preserved)
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'reindex.complete', table: 'bakin_tasks' }),
+    )
   })
 
   // ── crossTableSearch ────────────────────────────────────────────────

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -76,8 +76,14 @@ describe('search-registry', () => {
   beforeEach(() => {
     resetSearchRegistry()
     vi.clearAllMocks()
-    // Restore default — clearAllMocks resets mockReturnValue
+    // Restore defaults — clearAllMocks resets call history but not implementations.
+    // resetAllMocks on specific mocks clears the once-queue too, preventing leaks.
     vi.mocked(antfly.enabled).mockReturnValue(true)
+    vi.mocked(antfly.getIndexHealth).mockReset().mockResolvedValue(null)
+    vi.mocked(antfly.getTableStats).mockReset().mockResolvedValue(null)
+    vi.mocked(antfly.batchIndex).mockReset().mockImplementation(
+      async (_table: string, docs: Record<string, unknown>) => Object.keys(docs).length,
+    )
   })
 
   function makeDef(table = 'tasks') {
@@ -557,6 +563,63 @@ describe('search-registry', () => {
     )
   })
 
+  // ── verify mode (#74) ───────────────────────────────────────────────
+
+  it('reindexContentTypes with verify=true checks table doc count', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+    // Mock getTableStats to return doc count matching indexed
+    vi.mocked(antfly.getTableStats).mockResolvedValueOnce({ num_docs: 1 })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes({ verify: true })
+
+    expect(results[0]!.verified).toBe(1)
+    expect(results[0]!.verifyDiscrepancy).toBe(0)
+    expect(antfly.getTableStats).toHaveBeenCalledWith('bakin_tasks')
+  })
+
+  it('reindexContentTypes with verify=true reports discrepancy', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+    // Mock getTableStats to return fewer docs than indexed
+    vi.mocked(antfly.getTableStats).mockResolvedValueOnce({ num_docs: 0 })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes({ verify: true })
+
+    expect(results[0]!.verified).toBe(0)
+    expect(results[0]!.verifyDiscrepancy).toBe(1)
+  })
+
+  it('reindexContentTypes without verify does not check doc count', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes()
+
+    expect(results[0]!.verified).toBeUndefined()
+    expect(antfly.getTableStats).not.toHaveBeenCalled()
+  })
+
+  it('reindexContentTypes verify handles getTableStats errors gracefully', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+    vi.mocked(antfly.getTableStats).mockRejectedValueOnce(new Error('stats failed'))
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes({ verify: true })
+
+    // Should not crash — verify is best-effort
+    expect(results[0]!.indexed).toBe(1)
+    expect(results[0]!.verified).toBeUndefined()
+  })
+
   // ── crossTableSearch ────────────────────────────────────────────────
 
   it('crossTableSearch returns fallback when antfly disabled', async () => {
@@ -675,8 +738,8 @@ describe('search-registry', () => {
     const api = buildSearchAPI('tasks')
     api.registerContentType(makeDef('tasks'))
 
-    vi.mocked(antfly.getTableStats).mockResolvedValue({ num_docs: 5 })
-    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+    vi.mocked(antfly.getTableStats).mockResolvedValueOnce({ num_docs: 5 })
+    vi.mocked(antfly.getIndexHealth).mockResolvedValueOnce(null)
 
     const health = await getSearchHealth()
 

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -67,6 +67,7 @@ import {
   resetSearchRegistry,
   reindexContentTypes,
   crossTableSearch,
+  getSearchHealth,
 } from '@/core/search-registry'
 import * as antfly from '@/core/antfly'
 import { broadcast } from '@/core/sse'
@@ -626,5 +627,71 @@ describe('search-registry', () => {
     )
     expect(result.results).toHaveLength(2)
     expect(result.meta.source).toBe('antfly')
+  })
+
+  // ── getSearchHealth with index health (#74) ────────────────────────
+
+  it('getSearchHealth includes indexHealth when available', async () => {
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    vi.mocked(antfly.getTableStats).mockResolvedValue({ num_docs: 42 })
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [
+        { name: 'search', type: 'full_text', totalIndexed: 42, walBacklog: 0, rebuilding: false },
+        { name: 'embeddings', type: 'embeddings', totalIndexed: 42, walBacklog: 0, rebuilding: false },
+      ],
+      healthy: true,
+    })
+
+    const health = await getSearchHealth()
+
+    expect(health.enabled).toBe(true)
+    expect(health.tables).toHaveLength(1)
+    expect(health.tables[0]!.indexHealth).toBeDefined()
+    expect(health.tables[0]!.indexHealth).toHaveLength(2)
+    expect(health.tables[0]!.healthy).toBe(true)
+  })
+
+  it('getSearchHealth sets healthy false when indexes have errors', async () => {
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    vi.mocked(antfly.getTableStats).mockResolvedValue({ num_docs: 10 })
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [
+        { name: 'embeddings', type: 'embeddings', totalIndexed: 0, walBacklog: 0, rebuilding: false, error: 'model missing' },
+      ],
+      healthy: false,
+    })
+
+    const health = await getSearchHealth()
+
+    expect(health.tables[0]!.healthy).toBe(false)
+    expect(health.tables[0]!.indexHealth![0]!.error).toBe('model missing')
+  })
+
+  it('getSearchHealth handles getIndexHealth returning null', async () => {
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    vi.mocked(antfly.getTableStats).mockResolvedValue({ num_docs: 5 })
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue(null)
+
+    const health = await getSearchHealth()
+
+    expect(health.tables[0]!.stats).toEqual({ num_docs: 5 })
+    expect(health.tables[0]!.indexHealth).toBeUndefined()
+    // When index health unavailable, default to healthy (don't red-flag)
+    expect(health.tables[0]!.healthy).toBe(true)
+  })
+
+  it('getSearchHealth returns enabled false when antfly disabled', async () => {
+    vi.mocked(antfly.enabled).mockReturnValueOnce(false)
+
+    const health = await getSearchHealth()
+
+    expect(health.enabled).toBe(false)
+    expect(health.tables).toEqual([])
   })
 })

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -620,6 +620,48 @@ describe('search-registry', () => {
     expect(results[0]!.verified).toBeUndefined()
   })
 
+  it('reindexContentTypes runs enrichment audit even when batchIndex returns 0', async () => {
+    vi.mocked(antfly.batchIndex).mockResolvedValue(0)
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [
+        { name: 'embeddings', type: 'embeddings', totalIndexed: 0, walBacklog: 5, rebuilding: false },
+      ],
+      healthy: false,
+    })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes()
+
+    expect(results[0]!.indexed).toBe(0)
+    expect(results[0]!.enrichment).toBeDefined()
+    expect(results[0]!.enrichment!.healthy).toBe(false)
+    // verify skipped when indexed === 0
+    expect(results[0]!.verified).toBeUndefined()
+    expect(antfly.getTableStats).not.toHaveBeenCalled()
+  })
+
+  it('reindexContentTypes populates both enrichment and verify fields together', async () => {
+    vi.mocked(antfly.getIndexHealth).mockResolvedValue({
+      indexes: [
+        { name: 'embeddings', type: 'embeddings', totalIndexed: 1, walBacklog: 3, rebuilding: false },
+      ],
+      healthy: false,
+    })
+    vi.mocked(antfly.getTableStats).mockResolvedValueOnce({ num_docs: 1 })
+
+    const api = buildSearchAPI('tasks')
+    api.registerContentType(makeDef('tasks'))
+
+    const results = await reindexContentTypes({ verify: true })
+
+    expect(results[0]!.enrichment).toBeDefined()
+    expect(results[0]!.enrichment!.healthy).toBe(false)
+    expect(results[0]!.verified).toBe(1)
+    expect(results[0]!.verifyDiscrepancy).toBe(0)
+  })
+
   // ── crossTableSearch ────────────────────────────────────────────────
 
   it('crossTableSearch returns fallback when antfly disabled', async () => {


### PR DESCRIPTION
## Summary

Closes #74. Closes the observability gap between "Antfly accepted the batch" and "Antfly actually enriched the documents."

- **Layer 1 — Post-batch enrichment audit:** After each table reindex, polls `indexes.list()` for per-index health (errors, WAL backlog, rebuild progress). Logs enrichment errors at ERROR level so they surface in `server.log`.
- **Layer 2 — Enriched reindex response:** `/api/reindex` response now includes `enrichmentErrors` count and per-table `enrichment` field with index-level health. `ok` is false when either batch or enrichment errors exist.
- **Layer 3 — Verify mode:** `POST /api/reindex?verify=true` re-queries each table after reindex to check actual doc count vs indexed count. Reports `verified` and `verifyDiscrepancy`. Opt-in (adds latency).
- **Layer 4 — Health endpoint + UI:** `GET /api/antfly/health` includes `indexHealth` array and `healthy` boolean per table. Health page shows green/amber/red indicators on each table card.

Also updates CLI (`bakin reindex`, `bakin search stats`), MCP exec tool (`bakin_exec_search_reindex`), and API reference docs to consume the new fields.

**Files changed:** `antfly.ts`, `search-registry.ts`, `server.ts`, `health-page.tsx`, `bakin.ts` (CLI), `search-tools.ts` (MCP), knowledge docs, spec, plan.

## Test plan

- [x] 16 new unit tests across `antfly.test.ts` and `search-registry.test.ts`
- [x] Full suite: 1770 pass, 0 regressions
- [x] Edge cases: null client, empty indexes, throws path, batchIndex=0, negative verify discrepancy
- [x] Verified fresh-install safety: all paths guard on `antfly.enabled()`, `getIndexHealth()` returns null, health page guards with `{t.indexHealth && (...)}`
- [ ] Integration validation against real Antfly (not in scope — requires live instance)