### PR TITLE
docs(search): update knowledge docs for file-backed helper

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -66,7 +66,8 @@ Provided to `activate()`. This is the plugin's only interface to the system:
 | `hooks.register(name, handler)` | Register a hook handler (returns unsubscribe fn) |
 | `hooks.has(name)` | Check if any handlers registered for a hook |
 | `hooks.invoke<R>(name, data)` | Invoke a hook and get its result (RPC-style) |
-| `search.registerContentType(def)` | Register a searchable content type (call during `activate()`) |
+| `search.registerContentType(def)` | Register a searchable content type (call during `activate()`). Use this for non-filesystem-backed plugins (SQLite, OpenClaw, etc.) — the plugin owns its own sync calls. |
+| `search.registerFileBackedContentType(def)` | File-backed variant that auto-wires watcher sync/unlink hooks AND schedules a startup mtime reconcile. Default for plugins whose source of truth is files under `~/.bakin/`. See `search-plugin-guide.md`. |
 | `search.index(key, doc)` | Upsert a document into the Antfly index (fire-and-forget safe) |
 | `search.remove(key)` | Remove a document from the index |
 | `search.transform(key, ops)` | Atomic metadata update without re-embedding |

--- a/.claude/knowledge/storage-model.md
+++ b/.claude/knowledge/storage-model.md
@@ -155,10 +155,10 @@ Antfly is the search index layer. The filesystem (and SQLite for tasks) remains 
 Mutations write to the source (filesystem or SQLite) **and** fire `ctx.search.index(key, doc)` to update the Antfly index. Indexing is fire-and-forget — a failure does not block the mutation. The index may be stale; it is always reconstructable via `def.reindex()`.
 
 ### Deletion sync
-When the file watcher detects an unlink event, `ctx.search.remove(key)` is called to remove the document from Antfly. This keeps the index consistent without a scheduled scan.
+When the file watcher detects an unlink event, the watcher unlink hook (auto-wired by `ctx.search.registerFileBackedContentType()`) calls `ctx.search.remove(key)` to remove the document from Antfly within ~300ms. This is the primary consistency path for file-backed plugins — no scheduled scan required for the common case.
 
-### Orphan cleanup
-`src/core/search-cleanup.ts` runs a periodic scan (interval from `settings.antfly.cleanupInterval`). For each registered content type it calls `def.verifyExists(key)` per indexed document and removes any whose source no longer exists. This is a safety net for missed unlink events or external deletions.
+### Orphan backstop scan
+`src/core/search-cleanup.ts` runs a periodic scan (default 7d, `settings.antfly.cleanupInterval`). For each registered content type it calls `def.verifyExists(key)` per indexed document and removes any whose source no longer exists. This is a **backstop**, not the primary path — it only catches the rare events the watcher missed (process down during the delete, fs event lost, etc.).
 
 ### Not a replacement
 Antfly is the search index, not a database. Do not read authoritative state from Antfly — always read from the filesystem or SQLite and treat Antfly results as pointers to source documents.


### PR DESCRIPTION
## Summary
- Follow-up to #87 — the docs-only commit that didn't make it into that PR before merge.
- Updates `.claude/knowledge/plugin-system.md` to list both `registerContentType` and `registerFileBackedContentType` in the PluginContext method table.
- Updates `.claude/knowledge/storage-model.md` Antfly section: renames "Orphan cleanup" → "Orphan backstop scan" and rewrites the deletion sync paragraph so it describes the watcher hook as the primary consistency path (not the 7d scan).

## Why
After #87 shipped the watcher unlink hook + `registerFileBackedContentType` helper, the knowledge docs still framed the periodic cleanup as the primary deletion path. This corrects the framing so future agents understand the new three-path model.

## Test plan
- [x] `npx vitest run` — 1829 pass / 1 skip (117 files)
- [x] `npx tsc --noEmit` — no new errors (pre-existing antfly-reranker errors unchanged)
- [x] Docs-only change, no runtime code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)