### PR TITLE
fix(orchestrator): wire Main Operator MCP access and harden workflow preflight

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -405,62 +405,16 @@ async function cmdDoctor(): Promise<void> {
 // Agent Rules
 // ---------------------------------------------------------------------------
 
-const AGENT_RULES_BLOCK_START = '<!-- bakin:orchestrator-rules:start -->'
-const AGENT_RULES_BLOCK_END = '<!-- bakin:orchestrator-rules:end -->'
-
-const ORCHESTRATOR_RULES_CONTENT = `## Bakin Orchestrator Rules
-
-> Auto-managed by \`bakin agent-rules --apply\`. Do not edit this block manually.
-
-These rules govern Roscoe as orchestrator of the Bakin multi-agent system.
-
-1. **Every task gets logged before work begins.** Use \`bakin tasks create "<title>" <agent>\` before producing any deliverable. No exceptions.
-
-2. **Never do subagent work inline.** Roscoe delegates — Roscoe does not generate images, write long-form copy, or produce video. That's what the team is for.
-
-3. **Let Bakin dispatch — NEVER spawn subagents directly.** After \`bakin tasks create\`, Bakin's dispatch system sends the task to the agent automatically. Do NOT use \`openclaw agent\`, \`sessions_spawn\`, or agent-to-agent messages to assign work. That bypasses the entire pipeline (task tracking, audit, MCP tools, continuation).
-
-4. **High-level tasks only on the board.** Don't break tasks into subtasks yourself. Create one task, assign it, let the subagent decompose it.
-
-5. **Subagents own their handoffs.** If Basil needs Pixel, Basil creates that task via mcporter — not Roscoe. Let the pipeline flow naturally.
-
-6. **Approval gates are non-negotiable.** Before publishing, sending, or any external action: pause and confirm with Mark unless pre-approved.
-
-7. **Monitor the pipeline, don't micromanage.** Use \`bakin tasks list\`, \`bakin logs\`, or the dashboard. Don't shadow-execute tasks that are in flight.
-
-8. **One task per agent per piece of content.** Don't assign the same content to multiple agents in parallel. Let the assigned agent drive.
-
-9. **AGENTS.md is your rulebook, not the subagents'.** The Bakin skill (SKILL.md) governs subagents. AGENTS.md governs you.
-
-10. **Workflow tasks are hands-off.** If a task has a \`workflowId\`, the workflow engine manages step progression. Do not manually move workflow tasks between columns, do not produce step output yourself, and do not interfere with gates outside the Bakin UI.
-
-11. **Every task requires a workflow decision.** When creating a task, you MUST either specify a workflow or explain why none applies:
-    - With workflow: \`bakin tasks create "<title>" <agent> --workflow=<id>\`
-    - Without workflow: \`bakin tasks create "<title>" <agent> --no-workflow="<reason>"\`
-    Use \`bakin workflows list\` to see available workflows. The skip reason is logged to the audit trail.
-
-12. **Gate approvals go through the UI.** When a workflow gate is reached, tell Mark a gate is waiting — do NOT approve or reject gates yourself. Mark handles gates in the task drawer.
-
-### Bakin CLI Quick Reference
-
-\`\`\`bash
-bakin tasks create "<title>" <agent> [--workflow=<id>|--no-workflow="<reason>"]
-bakin tasks list                       # See all tasks
-bakin tasks get <id>                   # Task details
-bakin tasks log <id> "<message>"       # Log progress
-bakin tasks complete <id> "<summary>"  # Mark done
-bakin tasks block <id> "<reason>"      # Block task
-bakin workflows list                   # List available workflow definitions
-bakin workflows start <taskId> <wfId>  # Manually start a workflow for a task
-bakin workflows step <taskId>          # Get workflow step
-bakin workflows submit <t> <s> <json>  # Submit step output
-bakin status                           # System health
-bakin logs [filter]                    # Tail audit log
-\`\`\``
+// Orchestrator rules block constants and template are owned by src/core/doctor.ts.
+// Imported lazily inside cmdAgentRules so the CLI stays a pure entry point.
 
 async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyAll?: boolean; checkAll?: boolean } = {}): Promise<void> {
   const { readFileSync, writeFileSync, existsSync } = await import('fs')
-  const { join } = await import('path')
+  const {
+    AGENT_RULES_BLOCK_START,
+    AGENT_RULES_BLOCK_END,
+    resolveOrchestratorRules,
+  } = await import('../src/core/doctor')
 
   const agentsPath = getOpenClawPath('workspace', 'AGENTS.md')
 
@@ -471,6 +425,7 @@ async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyA
 
   const current = readFileSync(agentsPath, 'utf-8')
   const hasBlock = current.includes(AGENT_RULES_BLOCK_START)
+  const resolvedContent = await resolveOrchestratorRules()
 
   if (options.check) {
     if (hasBlock) {
@@ -482,7 +437,7 @@ async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyA
         process.exit(1)
       }
       const blockContent = current.slice(startIdx + AGENT_RULES_BLOCK_START.length, endIdx).trim()
-      const expected = ORCHESTRATOR_RULES_CONTENT.trim()
+      const expected = resolvedContent.trim()
       if (blockContent === expected) {
         console.log('[OK] Orchestrator rules block is present and up to date')
       } else {
@@ -523,7 +478,7 @@ async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyA
     return
   }
 
-  const block = `${AGENT_RULES_BLOCK_START}\n${ORCHESTRATOR_RULES_CONTENT}\n${AGENT_RULES_BLOCK_END}`
+  const block = `${AGENT_RULES_BLOCK_START}\n${resolvedContent}\n${AGENT_RULES_BLOCK_END}`
 
   let updated: string
   if (hasBlock) {

--- a/packages/core/src/main-agent.ts
+++ b/packages/core/src/main-agent.ts
@@ -12,12 +12,20 @@ import { getOpenClawPath } from './openclaw-home'
 const OPENCLAW_JSON = getOpenClawPath('openclaw.json')
 
 /**
+ * Fallback mapping from OpenClaw canonical agent ids to Bakin display names.
+ * Kept in sync with OPENCLAW_TO_BAKIN in packages/core/src/settings.ts — both
+ * exist because settings.ts can't import from here without a cycle.
+ */
+const OPENCLAW_ID_TO_BAKIN_NAME: Record<string, string> = { main: 'roscoe' }
+
+/**
  * Resolve the main/orchestrator agent ID.
  *
  * Resolution order:
  * 1. settings.json → mainAgentId
  * 2. OpenClaw config → agents.list → find id='main' → identity.name
- * 3. Fallback: 'main'
+ * 3. Hardcoded mapping (OpenClaw 'main' → Bakin 'roscoe')
+ * 4. Fallback: 'main'
  */
 export function getMainAgentId(): string {
   const settings = getSettings()
@@ -27,7 +35,7 @@ export function getMainAgentId(): string {
   const fromOpenClaw = detectFromOpenClaw()
   if (fromOpenClaw) return fromOpenClaw
 
-  return 'main'
+  return OPENCLAW_ID_TO_BAKIN_NAME.main ?? 'main'
 }
 
 function detectFromOpenClaw(): string | null {

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -31,6 +31,11 @@ export interface BakinSettings {
     mcpMinSamples: number
     /** Suppress duplicate MCP alerts within this window. */
     mcpAlertCooldownMs: number
+    /** Window for the rolling REST 5xx error-rate check (parallel to mcp*). */
+    restWindowMs: number
+    restErrorThreshold: number
+    restMinSamples: number
+    restAlertCooldownMs: number
   }
   messaging: {
     intervalMs: number
@@ -150,6 +155,10 @@ const DEFAULTS: BakinSettings = {
     mcpErrorThreshold: 0.5,
     mcpMinSamples: 3,
     mcpAlertCooldownMs: 5 * 60 * 1000,
+    restWindowMs: 60 * 1000,
+    restErrorThreshold: 0.5,
+    restMinSamples: 3,
+    restAlertCooldownMs: 5 * 60 * 1000,
   },
   messaging: {
     intervalMs: 5 * 60 * 1000,

--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -119,9 +119,28 @@ interface McpHealth {
   recent: { windowSec: number; total: number; errors: number }
 }
 
+interface RestPluginBucket {
+  pluginId: string
+  total: number
+  errors: number
+  successRate: number
+  perMethod: Record<string, number>
+  lastCalled: string | null
+}
+
+interface RestHealth {
+  windowSec: number
+  total: number
+  errors: number
+  successRate: number
+  byPlugin: RestPluginBucket[]
+  recent: { windowSec: number; total: number; errors: number; byPlugin: RestPluginBucket[] }
+}
+
 interface HealthSummary {
   mcp: McpData | null
   mcpHealth: McpHealth | null
+  restHealth: RestHealth | null
   doctor: DoctorData | null
   requests: RequestsData | null
   server: ServerData | null
@@ -487,6 +506,42 @@ export function HealthPage() {
 
         <Card size="sm">
           <CardContent className="pt-3">
+            <p className="text-xs text-muted-foreground">REST Health</p>
+            {(() => {
+              const rh = data?.restHealth
+              if (!rh || rh.total === 0) {
+                return (
+                  <>
+                    <p className="text-xl font-mono font-semibold text-muted-foreground">—</p>
+                    <p className="text-[10px] text-muted-foreground mt-0.5">no calls last hour</p>
+                  </>
+                )
+              }
+              const pct = Math.round(rh.successRate * 100)
+              const tone = pct >= 99
+                ? 'text-emerald-400'
+                : pct >= 95
+                ? 'text-amber-400'
+                : 'text-red-400'
+              return (
+                <>
+                  <p className={`text-xl font-mono font-semibold ${tone}`}>{pct}%</p>
+                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                    {rh.errors} err / {rh.total} req · 1h
+                    {rh.recent.errors > 0 && (
+                      <span className="ml-1 text-red-400">
+                        · {rh.recent.errors} in last {rh.recent.windowSec}s
+                      </span>
+                    )}
+                  </p>
+                </>
+              )
+            })()}
+          </CardContent>
+        </Card>
+
+        <Card size="sm">
+          <CardContent className="pt-3">
             <p className="text-xs text-muted-foreground">Active Sessions</p>
             <p className="text-xl font-mono font-semibold">
               {mcp?.activeSessions.length ?? 0}
@@ -516,6 +571,51 @@ export function HealthPage() {
           </CardContent>
         </Card>
       </div>
+
+      {/* REST traffic by plugin — agents should be using MCP exec tools,
+          not REST. Non-trivial REST traffic here flags bad habits. */}
+      {data?.restHealth && data.restHealth.byPlugin.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>REST traffic by plugin (last hour)</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                Agents should prefer MCP exec tools over REST
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2.5">
+              {data.restHealth.byPlugin.map((bucket, i) => {
+                const pct = Math.round(bucket.successRate * 100)
+                const tone = pct >= 99 ? 'text-emerald-400' : pct >= 95 ? 'text-amber-400' : 'text-red-400'
+                const methods = Object.entries(bucket.perMethod)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([m, n]) => `${m} ${n}`)
+                  .join(' · ')
+                return (
+                  <div key={bucket.pluginId}>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-xs font-mono truncate mr-2">{bucket.pluginId}</span>
+                      <span className="text-xs font-mono font-medium shrink-0">
+                        {bucket.total}
+                        <span className={`ml-2 ${tone}`}>{pct}%</span>
+                        <span className="text-muted-foreground font-normal ml-2">{methods}</span>
+                      </span>
+                    </div>
+                    <div className="h-1.5 rounded-full bg-white/5 overflow-hidden">
+                      <div
+                        className={`h-full rounded-full ${BAR_COLORS[i % BAR_COLORS.length]} transition-all duration-500`}
+                        style={{ width: `${(bucket.total / Math.max(...data.restHealth!.byPlugin.map(b => b.total), 1)) * 100}%` }}
+                      />
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Search / Antfly Section */}
       {searchHealth && (

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -5,7 +5,7 @@
 import { totalmem } from 'os'
 import { z } from 'zod'
 import type { BakinPlugin, PluginContext } from '../../src/lib/plugin-types'
-import { getRequestStats, getRecentStatsForPathPrefix } from '../../src/core/request-log'
+import { getRequestStats, getRecentStatsForPathPrefix, getRestStatsByPlugin } from '../../src/core/request-log'
 import { getLastResults, runDiagnostics } from '../../src/core/doctor'
 import { createLogger } from '../../src/core/logger'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
@@ -98,9 +98,25 @@ const healthPlugin: BakinPlugin = {
           recent: { windowSec: 60, total: mcpHot.total, errors: mcpHot.errors },
         }
 
+        // REST traffic bucketed by plugin id — surfaces which plugins
+        // agents are hitting via REST instead of MCP exec tools. Agents
+        // SHOULD be using MCP exclusively; any non-trivial REST traffic
+        // from an agent channel is a signal of a bad habit.
+        const restHour = getRestStatsByPlugin(60 * 60 * 1000)
+        const restHot = getRestStatsByPlugin(60 * 1000)
+        const restHealth = {
+          windowSec: 3600,
+          total: restHour.total,
+          errors: restHour.errors,
+          successRate: restHour.successRate,
+          byPlugin: restHour.byPlugin,
+          recent: { windowSec: 60, total: restHot.total, errors: restHot.errors, byPlugin: restHot.byPlugin },
+        }
+
         return Response.json({
           mcp,
           mcpHealth,
+          restHealth,
           doctor,
           requests,
           openclawPort: settings.openclaw.gatewayPort,

--- a/plugins/tasks/lib/flow-store.ts
+++ b/plugins/tasks/lib/flow-store.ts
@@ -629,19 +629,23 @@ export function updateTask(
       const state = parseStateJson(flow.state_json)
       const currentCol = getColumn(flow)
 
-      if (updates.title !== undefined) {
-        state.title = updates.title
+      // Use `'key' in updates` instead of `!== undefined` so callers can
+      // explicitly clear a field by passing `{ workflowId: undefined }`. The
+      // old guard silently no-op'd on explicit clears, which let bogus
+      // workflowIds survive the createTaskWithEffects cleanup path.
+      if ('title' in updates) {
+        if (updates.title !== undefined) state.title = updates.title
       }
-      if (updates.description !== undefined) {
+      if ('description' in updates) {
         state.description = updates.description || undefined
       }
-      if (updates.agent !== undefined) {
+      if ('agent' in updates) {
         state.agent = updates.agent || undefined
       }
-      if (updates.workflowId !== undefined) {
+      if ('workflowId' in updates) {
         state.workflowId = updates.workflowId || undefined
       }
-      if (updates.projectId !== undefined) {
+      if ('projectId' in updates) {
         state.projectId = updates.projectId || undefined
       }
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -64,9 +64,9 @@ Use these tools to accomplish actual work — saving files, posting content, gen
 
 | Tool | Purpose |
 |------|---------|
+| `bakin_exec_post_discord` | Post a message to a Discord channel via bot. Resolves channel names to IDs automatically. Supports image/video attachments and embeds. |
 | `bakin_exec_log` | Log a formatted progress update with category and stage tags. Categories: start, progress, milestone, blocked, complete. More structured than raw bakin_log_progress. |
 | `bakin_exec_gen_image` | Generate an image via Gemini Imagen (Nano Banana), or import an existing image file into the asset pipeline via filePath. Default model: flash (cheaper). Use model=pro for higher quality. Default: 1080x1920 portrait (9:16) for Stories/Reels. Presets: social-portrait, social-square, social-landscape, custom. Auto-generates thumbnail. Max 1200px on any edge. |
-| `bakin_exec_post_discord` | Post a message to a Discord channel via bot. Resolves channel names to IDs automatically. Supports image/video attachments and embeds. |
 | `bakin_exec_get_paths` | Get Bakin content directory paths — where to find assets, team info, docs, etc. |
 | `bakin_exec_heartbeat` | Write a heartbeat signal. Call periodically (every 5-10 minutes) to indicate you are alive. Also call when starting or finishing a task. |
 | `bakin_exec_search_query` | Search across all Bakin content (tasks, assets, projects, workflows, schedules, agents) or a specific table. Returns ranked results with scores. |
@@ -86,7 +86,7 @@ Use these tools to accomplish actual work — saving files, posting content, gen
 | `bakin_exec_team_my_team` | Get the team that a specific agent belongs to, including all teammates. |
 | `bakin_exec_tasks_list` | List all tasks on the board. Optionally filter by column or agent. |
 | `bakin_exec_tasks_get` | Get details about a task — title, description, current column, logs, dependencies, project context. |
-| `bakin_exec_tasks_create` | Create a new task on the task board. For top-level tasks, you MUST provide either workflowId or skipWorkflowReason. Subtasks (with parentId) are exempt. |
+| `bakin_exec_tasks_create` | Create a new task on the task board. Workflows are auto-matched by title when workflowId is not provided. Provide workflowId to force a specific workflow, or skipWorkflowReason to explicitly skip. |
 | `bakin_exec_tasks_move` | Move a task to a different column on the task board. |
 | `bakin_exec_tasks_block` | Mark a task as blocked with a reason. Use when you cannot proceed. |
 | `bakin_exec_tasks_complete` | Report that your task is complete. Moves the task to Done and notifies the orchestrator. |
@@ -198,6 +198,19 @@ Use `bakin_report_complete` — it moves the task to Done, logs the summary, and
 ## Creating Subtasks
 
 If your task requires work from another agent, create a subtask with `bakin_create_task`. Include `parentId` for immediate dispatch.
+
+### Workflow preflight — run this sequence every time before `bakin_create_task`
+
+Workflows are the default. Skipping one is the exception, and skipping silently is never allowed.
+
+1. **Check the catalog.** Call `bakin_exec_workflows_list` and read what's available.
+2. **Match against the subtask.** Does any workflow fit by title keywords, target agent, or intent? (e.g., a subtask for Pixel to produce an image matches `image-generation`.)
+3. **If a match exists, STOP. Do not create the task yet.** Message your parent task's requester (via `bakin_log_progress` on your own task, or by messaging roscoe if you need a decision back) and ask whether they want the full workflow or a one-off. Example: *"I need Pixel to produce a hero image — there's an `image-generation` workflow with a prompt-approval gate. Use the workflow, or one-off?"* Silence is not permission to skip.
+4. **Only after the decision**, call `bakin_create_task` with either `workflowId` set to the chosen workflow, or `skipWorkflowReason` citing the confirmation (e.g., `"roscoe confirmed one-off — no approval gate needed for quick reference image"`).
+
+**Chat requests that sound simple are still workflow candidates if a matching workflow exists.** "Quick image," "just a draft," and "one-off" are NOT reasons to bypass a workflow on your own. The user's phrasing doesn't change the rule — the catalog does.
+
+**Your judgment alone is not enough to skip.** The only valid reasons to skip without asking: (a) no workflow in the catalog matches, or (b) the requester has already said in this conversation they want a one-off.
 
 ## Dependencies
 

--- a/src/app/api/plugins/[pluginId]/[[...path]]/route.ts
+++ b/src/app/api/plugins/[pluginId]/[[...path]]/route.ts
@@ -10,6 +10,7 @@ import { BakinEventBus } from '@/lib/events/event-bus'
 import { getContentDir } from '@/core/content-dir'
 import { createLogger } from '@/core/logger'
 import { buildSearchAPI } from '@/core/search-registry'
+import { appendAudit } from '@/core/audit'
 import type { PluginContext, BakinPlugin, APIRoute, SearchAPI } from '@/lib/plugin-types'
 
 const log = createLogger('plugin-route')
@@ -242,6 +243,12 @@ async function handleRequest(
     )
   }
 
+  const startedAt = Date.now()
+  // Best-effort actor attribution: agents sending direct REST calls can
+  // identify themselves via X-Bakin-Agent. UI/human traffic won't set it
+  // and will land in the "unknown" bucket — which is the point.
+  const actor = req.headers.get('x-bakin-agent') || 'unknown'
+
   try {
     // Inject extracted path params into the request URL's searchParams
     // so handlers can read them the same way as query params
@@ -263,9 +270,35 @@ async function handleRequest(
     }
 
     const ctx = buildContext(pluginId)
-    return await match.route.handler(handlerReq, ctx)
+    const res = await match.route.handler(handlerReq, ctx)
+
+    // Audit write methods (and any failure) so we can see REST usage in
+    // memory/audit and trace agents who bypass MCP. Successful GETs are
+    // skipped to avoid drowning audit.jsonl under dashboard polling.
+    const durationMs = Date.now() - startedAt
+    const isWrite = method !== 'GET' && method !== 'HEAD'
+    const isError = res.status >= 400
+    if (isWrite || isError) {
+      const tag = isError ? 'fail' : 'ok'
+      appendAudit(
+        getContentDir(),
+        `rest.${pluginId}.${method.toLowerCase()}.${tag}`,
+        actor,
+        { path: routePath, status: res.status, durationMs, duplicate: true },
+        'rest',
+      )
+    }
+    return res
   } catch (err) {
+    const durationMs = Date.now() - startedAt
     log.error('Plugin route error', err, { pluginId, routePath, method })
+    appendAudit(
+      getContentDir(),
+      `rest.${pluginId}.${method.toLowerCase()}.error`,
+      actor,
+      { path: routePath, status: 500, durationMs, error: err instanceof Error ? err.message : String(err) },
+      'rest',
+    )
     return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
   }
 }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -411,13 +411,26 @@ These rules govern Roscoe as orchestrator of the Bakin multi-agent system.
 
 9. **Workflow tasks are hands-off.** If a task has a \`workflowId\`, the workflow engine manages step progression. Do not manually move workflow tasks between columns, do not produce step output yourself, and do not interfere with gates outside the Bakin UI.
 
-10. **Every task requires a workflow decision.** When calling \`bakin_exec_tasks_create\`, you MUST either specify a \`workflowId\` or explain why none applies via \`skipWorkflowReason\`:
+10. **Every task requires a workflow decision. Workflows are the default — skipping is the exception.** When calling \`bakin_exec_tasks_create\`, you MUST either specify a \`workflowId\` or explain why none applies via \`skipWorkflowReason\`:
     - With workflow: \`{ title, assignee, workflowId: "<id>" }\`
     - Without workflow: \`{ title, assignee, skipWorkflowReason: "<reason>" }\`
-    If you forget, Bakin will warn you and suggest a matching workflow if one exists. Call \`bakin_exec_workflows_list\` to see available workflows. The available workflows are:
+
+    **Preflight sequence — follow these steps in order, every time:**
+    1. Call \`bakin_exec_workflows_list\` and read the catalog.
+    2. Check if any workflow matches the request (by title keywords, agent, or intent).
+    3. **If a matching workflow exists, DO NOT create the task yet.** Reply to the requester with the workflow's tradeoffs and ask them to choose. Example: *"There's an \`image-generation\` workflow with a prompt-approval gate — want the full workflow, or should I do a quick one-off?"* **Silence is not permission to skip.** Wait for an explicit choice.
+    4. Only after the requester's decision, call \`bakin_exec_tasks_create\` — either with \`workflowId\` set to what they picked, or with \`skipWorkflowReason\` citing the confirmation (e.g., \`"Mark approved skipping image-generation in chat — one-off horse image, no approval gate needed"\`).
+
+    **Chat requests that sound simple are still workflow candidates if a matching workflow exists.** "Have Pixel make an image of a horse" is NOT a reason to bypass \`image-generation\`. The user's phrasing doesn't change the rule — the catalog does.
+
+    **Your judgment is not enough to skip.** "This feels heavier than needed," "this is a one-off," and "this is quick" are NOT valid reasons on their own. The only valid reasons to skip without asking first: (a) no workflow in the catalog matches the request, or (b) the requester has already said in this conversation that they want a one-off.
+
+    The catalog snapshot below is a hint, not the source of truth. **Always trust the live output of \`bakin_exec_workflows_list\` over any text in this file.** The snapshot is frozen at the last doctor run and may be stale, empty, or out of date; the tool is authoritative.
+
+    Workflow catalog snapshot (last rendered by \`bakin agent-rules --apply\`):
 WORKFLOW_CATALOG_PLACEHOLDER
 
-The skip reason is logged to the audit trail for debugging. Always check workflows first — most content tasks have one.
+The skip reason is logged to the audit trail for debugging. Always verify against \`bakin_exec_workflows_list\` before deciding a workflow doesn't exist.
 
 11. **Gate approvals go through the UI.** When a workflow gate is reached, a notification is sent and the task card shows "Awaiting Approval" in the Bakin UI. Tell Mark a gate is waiting — do NOT approve or reject gates yourself. Mark handles gates in the task drawer.
 

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -19,6 +19,7 @@ import { isUsingBakinHome, getContentDir } from './content-dir'
 import * as openclaw from './openclaw-client'
 import * as mcporter from './mcporter'
 import { isOnboarded } from './onboarding/state'
+import { getMainAgentId } from './main-agent'
 import { getAllExecTools } from '../../scripts/lib/registry'
 import { getHookRegistry } from '../lib/plugin-registry'
 
@@ -266,17 +267,26 @@ async function checkAntfly(): Promise<DiagnosticResult[]> {
     return [error('antfly', 'Antfly enabled but binary not found — install with: brew install --cask antflydb/antfly/antfly')]
   }
 
-  try {
-    const base = settings.antfly.url.replace(/\/api\/v1\/?$/, '')
-    const res = await fetch(`${base}/api/v1/status`, { signal: AbortSignal.timeout(3000) })
-    if (res.ok) {
-      const status = await res.json()
-      return [ok('antfly', `Antfly connected (health: ${status?.health})`)]
+  const urls = Array.from(new Set([
+    settings.antfly.url.replace(/\/api\/v1\/?$/, ''),
+    settings.antfly.url.replace('localhost', '127.0.0.1').replace(/\/api\/v1\/?$/, ''),
+  ]))
+
+  let lastErr: unknown
+  for (const base of urls) {
+    try {
+      const res = await fetch(`${base}/api/v1/status`, { signal: AbortSignal.timeout(3000) })
+      if (res.ok) {
+        const status = await res.json()
+        return [ok('antfly', `Antfly connected (health: ${status?.health})`)]
+      }
+      lastErr = new Error(`status ${res.status}`)
+    } catch (err) {
+      lastErr = err
     }
-    return [error('antfly', `Antfly returned status ${res.status}`)]
-  } catch (err) {
-    return [error('antfly', `Antfly connection failed: ${err}`)]
   }
+
+  return [error('antfly', `Antfly connection failed: ${lastErr}`)]
 }
 
 /**
@@ -309,7 +319,7 @@ async function checkSearchTables(): Promise<DiagnosticResult[]> {
     for (const t of health.tables) {
       if (!t.stats) {
         failedTables++
-        results.push(error('search-tables', `Table "${t.table}" (${t.pluginId}) — could not read stats`))
+        results.push(warn('search-tables', `Table "${t.table}" (${t.pluginId}) — stats unavailable, but table is registered${t.healthy ? ' and indexes look healthy' : ''}`))
         continue
       }
 
@@ -341,6 +351,8 @@ async function checkSearchTables(): Promise<DiagnosticResult[]> {
       if (totals.length > 0) {
         const total = totals.reduce((sum, n) => sum + n, 0)
         results.push(ok('search-tables', `${health.tables.length} tables, ${total} total documents indexed`))
+      } else if (failedTables > 0) {
+        results.push(warn('search-tables', `${health.tables.length} tables registered; ${failedTables} table stats unavailable, but registry metadata is readable`))
       } else {
         results.push(ok('search-tables', `${health.tables.length} tables registered; table metadata readable (document counts unavailable from current Antfly API)`))
       }
@@ -370,8 +382,8 @@ function checkContentDir(): DiagnosticResult[] {
  * Orchestrator rules: verify AGENTS.md has the Bakin rules block and it's current.
  * Auto-fixable — safe to write/update our own block in AGENTS.md.
  */
-const AGENT_RULES_BLOCK_START = '<!-- bakin:orchestrator-rules:start -->'
-const AGENT_RULES_BLOCK_END = '<!-- bakin:orchestrator-rules:end -->'
+export const AGENT_RULES_BLOCK_START = '<!-- bakin:orchestrator-rules:start -->'
+export const AGENT_RULES_BLOCK_END = '<!-- bakin:orchestrator-rules:end -->'
 
 const ORCHESTRATOR_RULES_CONTENT = `## Bakin Orchestrator Rules
 
@@ -379,7 +391,9 @@ const ORCHESTRATOR_RULES_CONTENT = `## Bakin Orchestrator Rules
 
 These rules govern Roscoe as orchestrator of the Bakin multi-agent system.
 
-1. **Every task gets logged before work begins.** Use \`bakin tasks create\` before spawning any subagent or producing any deliverable. No exceptions.
+1. **Every task gets logged before work begins.** Call \`bakin_exec_tasks_create\` via MCP before spawning any subagent or producing any deliverable. No exceptions.
+
+    A task is anything that spawns a subagent, produces a deliverable (image, code, document, post), requires research, or gets handed off. NOT a task: quick questions, reactions, casual banter, acknowledgements. If it involves a verb (generate, build, research, write, fix, create), it's a task — log it first, then do it.
 
 2. **Never do subagent work inline.** Roscoe delegates — Roscoe does not generate images, write long-form copy, or produce video. That's what the team is for.
 
@@ -397,31 +411,46 @@ These rules govern Roscoe as orchestrator of the Bakin multi-agent system.
 
 9. **Workflow tasks are hands-off.** If a task has a \`workflowId\`, the workflow engine manages step progression. Do not manually move workflow tasks between columns, do not produce step output yourself, and do not interfere with gates outside the Bakin UI.
 
-10. **Every task requires a workflow decision.** When creating a task, you MUST either specify a workflow or explain why none applies:
-    - With workflow: \`bakin tasks create "<title>" <agent> --workflow=<id>\`
-    - Without workflow: \`bakin tasks create "<title>" <agent> --no-workflow="<reason>"\`
-    If you forget, Bakin will warn you and suggest a matching workflow if one exists. Use \`bakin workflows list\` to see available workflows. The available workflows are:
+10. **Every task requires a workflow decision.** When calling \`bakin_exec_tasks_create\`, you MUST either specify a \`workflowId\` or explain why none applies via \`skipWorkflowReason\`:
+    - With workflow: \`{ title, assignee, workflowId: "<id>" }\`
+    - Without workflow: \`{ title, assignee, skipWorkflowReason: "<reason>" }\`
+    If you forget, Bakin will warn you and suggest a matching workflow if one exists. Call \`bakin_exec_workflows_list\` to see available workflows. The available workflows are:
 WORKFLOW_CATALOG_PLACEHOLDER
 
 The skip reason is logged to the audit trail for debugging. Always check workflows first — most content tasks have one.
 
 11. **Gate approvals go through the UI.** When a workflow gate is reached, a notification is sent and the task card shows "Awaiting Approval" in the Bakin UI. Tell Mark a gate is waiting — do NOT approve or reject gates yourself. Mark handles gates in the task drawer.
 
-### Workflow API Reference (Roscoe only)
+12. **MCP tools only. No REST. No CLI. Ever.** All orchestration happens through the \`bakin_exec_*\` MCP tools. OpenClaw has no native MCP client, so you reach them by shelling out to **mcporter** — a CLI shim that relays your call to Bakin's MCP server. Your server is \`bakin-AGENT_ID_PLACEHOLDER\`.
 
-These are the ONLY valid workflow endpoints. Do NOT guess at other paths.
+    **Invocation pattern (positional args):**
+    \`\`\`
+    mcporter call bakin-AGENT_ID_PLACEHOLDER.<tool_name> key=value key=value
+    \`\`\`
 
-| Action | Method | Path |
-|--------|--------|------|
-| List templates | GET | \`/api/plugins/workflows/definitions\` |
-| Get definition | GET | \`/api/plugins/workflows/definitions/:name\` |
-| Start workflow | POST | \`/api/plugins/workflows/instances/start\` — body: \`{"taskId":"...","workflowId":"..."}\` |
-| List instances | GET | \`/api/plugins/workflows/instances?status=<optional>\` |
-| Get instance | GET | \`/api/plugins/workflows/instances/:taskId\` |
-| Pending gates | GET | \`/api/plugins/workflows/gates/pending\` |
-| Gate status | GET | \`/api/plugins/workflows/gates/status?taskIds=id1,id2\` |
+    **Invocation pattern (JSON args, for nested/complex inputs):**
+    \`\`\`
+    mcporter call bakin-AGENT_ID_PLACEHOLDER.<tool_name> --args '{"key":"value","nested":{"k":"v"}}'
+    \`\`\`
 
-Do NOT use \`/api/tasks\`, \`/api/tasks/list\`, \`/api/plugins/workflows/runs\`, or \`/api/plugins/workflows/run\` — these do not exist. All task operations are via MCP exec tools (bakin_exec_tasks_*).`
+    **Discovery:** \`mcporter list bakin-AGENT_ID_PLACEHOLDER --schema\` prints every available tool with its input schema. Run it when you're not sure what's available. Do NOT guess tool names.
+
+    The REST API at \`/api/plugins/*\` and the \`bakin\` CLI both exist for humans, the web UI, and scripting — NOT for you. If a capability appears to be missing from MCP, STOP and tell Mark so we can add the tool. Do not curl, do not fetch, do not shell out to \`bakin tasks ...\`, do not write scripts that hit \`/api/...\`. Every REST call from an agent surfaces on the Health dashboard as a bad-habit signal.
+
+    **Core orchestration tools** (non-exhaustive — run discovery for the full list):
+    - Tasks: \`bakin_exec_tasks_create\`, \`bakin_exec_tasks_get\`, \`bakin_exec_tasks_move\`, \`bakin_exec_tasks_log_progress\`, \`bakin_exec_tasks_complete\`, \`bakin_exec_tasks_block\`
+    - Workflows: \`bakin_exec_workflows_list\`, \`bakin_exec_workflows_get_definition\`, \`bakin_exec_workflows_start\`, \`bakin_exec_workflows_get_instance\`, \`bakin_exec_workflows_get_step\`, \`bakin_exec_workflows_complete_step\`
+    - Team: \`bakin_exec_team_list\`, \`bakin_exec_team_status\`, \`bakin_exec_team_message\`
+    - Health: \`bakin_exec_health_status\`, \`bakin_exec_health_doctor\`
+
+    **Example — create a task for Pixel:**
+    \`\`\`
+    mcporter call bakin-AGENT_ID_PLACEHOLDER.bakin_exec_tasks_create --args '{"title":"Create a stylized image of a horse","assignee":"pixel","skipWorkflowReason":"one-off request, no workflow matches"}'
+    \`\`\`
+
+13. **Never impersonate other agents.** You are Roscoe. You do not speak as Basil, Pixel, Flint, Nori, or any other team member. You do not write their task updates, fabricate their progress logs, or mark their tasks done on their behalf. If an agent is silent or stuck, create a follow-up task or tell Mark — do not ventriloquize.
+
+14. **The channel doesn't change the rules.** These rules apply whether Mark is talking to you in the Bakin UI, a group chat, the terminal, or any other surface. There is no "informal mode" where CLI, REST, or inline subagent work becomes acceptable.`
 
 /** Build the workflow catalog from available definitions for embedding in rules */
 async function buildWorkflowCatalog(): Promise<string> {
@@ -439,9 +468,12 @@ async function buildWorkflowCatalog(): Promise<string> {
   }
 }
 
-/** Resolve the orchestrator rules template with the current workflow catalog */
-async function resolveOrchestratorRules(): Promise<string> {
-  return ORCHESTRATOR_RULES_CONTENT.replace('WORKFLOW_CATALOG_PLACEHOLDER', await buildWorkflowCatalog())
+/** Resolve the orchestrator rules template with the current workflow catalog and main agent id */
+export async function resolveOrchestratorRules(): Promise<string> {
+  const agentId = getMainAgentId()
+  return ORCHESTRATOR_RULES_CONTENT
+    .replace('WORKFLOW_CATALOG_PLACEHOLDER', await buildWorkflowCatalog())
+    .replaceAll('AGENT_ID_PLACEHOLDER', agentId)
 }
 
 async function checkOrchestratorRules(autoFix: boolean): Promise<DiagnosticResult[]> {

--- a/src/core/request-log.ts
+++ b/src/core/request-log.ts
@@ -77,6 +77,86 @@ export function getRecentStatsForPathPrefix(
 }
 
 /**
+ * Bucketed REST stats by plugin id, derived from the ring buffer. Used by
+ * the Health page to surface per-plugin REST traffic alongside the MCP
+ * tile, so we can see which plugins agents are hitting via REST instead
+ * of MCP tools.
+ *
+ * Only counts paths under `/api/plugins/{pluginId}/...`. Anything else
+ * (top-level /api routes, /mcp, static assets) is ignored.
+ */
+export interface RestPluginStats {
+  pluginId: string
+  total: number
+  errors: number
+  successRate: number
+  perMethod: Record<string, number>
+  lastCalled: string | null
+}
+
+export function getRestStatsByPlugin(windowMs: number): {
+  windowSec: number
+  total: number
+  errors: number
+  successRate: number
+  byPlugin: RestPluginStats[]
+} {
+  const cutoff = Date.now() - windowMs
+  const buckets = new Map<string, RestPluginStats>()
+  let total = 0
+  let errors = 0
+
+  for (const entry of recent) {
+    const ts = Date.parse(entry.ts)
+    if (isNaN(ts) || ts < cutoff) continue
+    if (!entry.path.startsWith('/api/plugins/')) continue
+
+    // Extract plugin id: /api/plugins/{pluginId}/...
+    const rest = entry.path.slice('/api/plugins/'.length)
+    const slash = rest.indexOf('/')
+    const pluginId = slash === -1 ? rest : rest.slice(0, slash)
+    if (!pluginId) continue
+
+    total++
+    const isError = entry.status >= 500
+    if (isError) errors++
+
+    let bucket = buckets.get(pluginId)
+    if (!bucket) {
+      bucket = {
+        pluginId,
+        total: 0,
+        errors: 0,
+        successRate: 1,
+        perMethod: {},
+        lastCalled: null,
+      }
+      buckets.set(pluginId, bucket)
+    }
+    bucket.total++
+    if (isError) bucket.errors++
+    bucket.perMethod[entry.method] = (bucket.perMethod[entry.method] ?? 0) + 1
+    if (!bucket.lastCalled || entry.ts > bucket.lastCalled) {
+      bucket.lastCalled = entry.ts
+    }
+  }
+
+  for (const bucket of buckets.values()) {
+    bucket.successRate = bucket.total > 0
+      ? (bucket.total - bucket.errors) / bucket.total
+      : 1
+  }
+
+  return {
+    windowSec: Math.round(windowMs / 1000),
+    total,
+    errors,
+    successRate: total > 0 ? (total - errors) / total : 1,
+    byPlugin: Array.from(buckets.values()).sort((a, b) => b.total - a.total),
+  }
+}
+
+/**
  * Get current stats snapshot.
  */
 export function getRequestStats() {

--- a/src/core/search-reconcile.ts
+++ b/src/core/search-reconcile.ts
@@ -294,16 +294,22 @@ export async function performStartupReconcile(
 
   // Orphans: indexed keys that no longer exist on disk
   for (const indexedKey of indexedMtimes.keys()) {
+    // Zombie row guard: an empty/nullish key came out of the index. This
+    // shouldn't happen in normal writes, but a pre-existing bad row in the
+    // underlying store (e.g. a legacy doc with a blank _key) would cause
+    // `deps.remove('')` to throw "nonempty key required" on every startup.
+    // Skip with a warning so operators know a zombie exists without failing
+    // the reconcile.
+    if (!indexedKey) {
+      log.warn('Reconcile skipped zombie index row with empty key', { table: tableName })
+      continue
+    }
     if (fsByKey.has(indexedKey)) continue
     try {
-      if (def.onUnlink) {
-        // Escape-hatch unlink can't reverse-derive a file path from a key,
-        // so we delegate via the helper's standard remove path. The plugin
-        // can still observe the removal through its own bookkeeping.
-        await deps.remove(indexedKey)
-      } else {
-        await deps.remove(indexedKey)
-      }
+      // Escape-hatch and default paths both delegate to deps.remove. The
+      // plugin can observe the removal through its own bookkeeping if it
+      // registered an onUnlink hook.
+      await deps.remove(indexedKey)
       result.removed++
     } catch (err) {
       log.warn('Reconcile remove failed', err, { table: tableName, key: indexedKey })

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -200,6 +200,21 @@ export async function createTaskWithEffects(opts: {
   const suggested = !opts.workflowId ? (await hooks().invoke<string | null>('workflows.matchWorkflow', { title: opts.title, description: opts.description }) || undefined) : undefined
   const effectiveWorkflowId = opts.workflowId || undefined
 
+  // Validate that the workflow actually exists BEFORE writing any task row.
+  // Without this, agents (or buggy callers) can create tasks pointing at
+  // bogus workflowIds, which then poison the dispatch loop forever.
+  if (effectiveWorkflowId) {
+    const def = await hooks().invoke<Record<string, unknown> | null>('workflows.loadDefinition', { name: effectiveWorkflowId })
+    if (!def) {
+      const available = await hooks().invoke<Array<{ name: string }>>('workflows.listDefinitions', {}) ?? []
+      const names = available.map(d => d.name).sort().join(', ') || '(none)'
+      throw new Error(
+        `Unknown workflow: "${effectiveWorkflowId}". Available workflows: ${names}. ` +
+        `Use bakin_exec_workflows_list to see all options.`
+      )
+    }
+  }
+
   const task = await hooks().invoke<{ id: string }>('tasks.createTask', {
     id: opts.id,
     title: opts.title,

--- a/src/core/watchdog.ts
+++ b/src/core/watchdog.ts
@@ -18,6 +18,7 @@ const hooks = () => getHookRegistry()
 
 let watchdogTimer: NodeJS.Timeout | null = null
 let lastMcpAlertAt = 0
+let lastRestAlertAt = 0
 
 // Bypass detection patterns — agents trying to work around errors instead of blocking
 const BYPASS_PATTERNS = [
@@ -227,6 +228,52 @@ export function start(contentDir: string, port: number): void {
         }
       } catch (err) {
         log.error('MCP 5xx alert check failed', err)
+      }
+
+      // ─── REST 5xx error-rate alert ───────────────────────────────────
+      // Parallel to the MCP block above. Agents SHOULD be using MCP exec
+      // tools, but the UI, CLI, and any misbehaving agent still route
+      // through /api/plugins/*. Alert when that surface starts flapping.
+      try {
+        const wd = settings.watchdog
+        const restStats = getRecentStatsForPathPrefix('/api/plugins', wd.restWindowMs)
+        if (restStats.total >= wd.restMinSamples) {
+          const errorRate = restStats.errors / restStats.total
+          if (errorRate >= wd.restErrorThreshold) {
+            const sinceLast = now - lastRestAlertAt
+            if (sinceLast >= wd.restAlertCooldownMs) {
+              lastRestAlertAt = now
+              const pct = Math.round(errorRate * 100)
+              const windowSec = Math.round(wd.restWindowMs / 1000)
+              const alertMsg = `REST API returning ${pct}% 5xx (${restStats.errors}/${restStats.total} requests in last ${windowSec}s)`
+
+              broadcast({ type: 'alert', title: 'REST API unhealthy', message: alertMsg })
+              appendAudit(contentDir, 'rest.5xx_alert', 'watchdog', {
+                errors: restStats.errors,
+                total: restStats.total,
+                errorRate,
+                windowMs: wd.restWindowMs,
+              })
+              log.error('REST 5xx alert', undefined, {
+                errors: restStats.errors,
+                total: restStats.total,
+                errorRate,
+              })
+
+              if (settings.notifications.channel !== 'none') {
+                openclaw.sendChannelMessage(
+                  settings.notifications.channel,
+                  settings.notifications.target || `channel:${wd.alertChannelId}`,
+                  `⚠️ **REST API unhealthy** — ${alertMsg}. Check \`~/.bakin/logs/server.log\` and \`/health\`.`,
+                ).catch(err => {
+                  log.error('REST 5xx Discord alert failed', err)
+                })
+              }
+            }
+          }
+        }
+      } catch (err) {
+        log.error('REST 5xx alert check failed', err)
       }
 
       // ─── Workflow step timeout detection ─────────────────────────────

--- a/tests/core/main-agent.test.ts
+++ b/tests/core/main-agent.test.ts
@@ -40,26 +40,26 @@ describe('main-agent', () => {
     expect(getMainAgentId()).toBe('roscoe') // lowercased
   })
 
-  it('returns "main" as final fallback', () => {
+  it('falls back to "roscoe" via OPENCLAW_ID_TO_BAKIN_NAME when no other source resolves', () => {
     vi.mocked(getSettings).mockReturnValue({} as any)
     vi.mocked(readFileSync).mockImplementation(() => { throw new Error('ENOENT') })
-    expect(getMainAgentId()).toBe('main')
+    expect(getMainAgentId()).toBe('roscoe')
   })
 
-  it('returns "main" when OpenClaw has no main agent entry', () => {
+  it('falls back to "roscoe" when OpenClaw has no main agent entry', () => {
     vi.mocked(getSettings).mockReturnValue({} as any)
     vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
       agents: { list: [{ id: 'pixel' }] },
     }))
-    expect(getMainAgentId()).toBe('main')
+    expect(getMainAgentId()).toBe('roscoe')
   })
 
-  it('returns "main" when OpenClaw main agent has no identity.name', () => {
+  it('falls back to "roscoe" when OpenClaw main agent has no identity.name', () => {
     vi.mocked(getSettings).mockReturnValue({} as any)
     vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
       agents: { list: [{ id: 'main' }] },
     }))
-    expect(getMainAgentId()).toBe('main')
+    expect(getMainAgentId()).toBe('roscoe')
   })
 
   it('prefers settings over OpenClaw', () => {

--- a/tests/core/search-reconcile.test.ts
+++ b/tests/core/search-reconcile.test.ts
@@ -329,6 +329,28 @@ describe('search-reconcile', () => {
     expect(indexed).toEqual([])
   })
 
+  it('skips zombie index rows with empty keys instead of calling remove', async () => {
+    // A legacy / corrupted row with an empty _key in the underlying store
+    // must not cause the reconcile to blow up with "nonempty key required".
+    mkdirSync(join(tempDir, 'projects'), { recursive: true })
+    writeFileSync(join(tempDir, 'projects', 'alpha.md'), 'alpha body')
+
+    const removed: string[] = []
+    const result = await performStartupReconcile(makeDef(), tempDir, {
+      index: async () => {},
+      remove: async (key) => { removed.push(key) },
+      scanIndex: async function* () {
+        yield { key: '', mtimeMs: 0 }
+        yield { key: 'real-orphan', mtimeMs: 1000 }
+      },
+    })
+
+    // Real orphan still removed; empty key is skipped cleanly.
+    expect(removed).toEqual(['real-orphan'])
+    expect(result.removed).toBe(1)
+    expect(result.errors).toBe(0)
+  })
+
   it('handles mixed drift in a single pass', async () => {
     mkdirSync(join(tempDir, 'projects'), { recursive: true })
     writeFileSync(join(tempDir, 'projects', 'fresh.md'), 'new content')

--- a/tests/core/task-service.test.ts
+++ b/tests/core/task-service.test.ts
@@ -65,6 +65,12 @@ vi.mock('@bakin/workflows/lib/matcher', () => ({
   matchWorkflow: vi.fn(() => null),
 }))
 
+const mockLoadDefinition = vi.fn((_data: any): Record<string, unknown> | null => ({ name: 'image-social-post', steps: [] }))
+const mockListDefinitions = vi.fn((): Array<{ name: string }> => [
+  { name: 'image-social-post' },
+  { name: 'video-storyboard' },
+])
+
 // Mock the hook registry so that hooks().invoke() routes to the right mock functions
 const hookHandlers: Record<string, (...args: unknown[]) => unknown> = {
   'tasks.readTaskboard': () => mockReadTaskboard(),
@@ -77,6 +83,8 @@ const hookHandlers: Record<string, (...args: unknown[]) => unknown> = {
   'workflows.loadInstance': (data: any) => mockLoadInstance(data),
   'workflows.createInstance': (data: any) => mockCreateInstance(data),
   'workflows.matchWorkflow': () => null,
+  'workflows.loadDefinition': (data: any) => mockLoadDefinition(data),
+  'workflows.listDefinitions': () => mockListDefinitions(),
   'projects.autoCheckLinkedItem': () => Promise.resolve(),
 }
 
@@ -241,6 +249,51 @@ describe('task-service', () => {
         expect.objectContaining({ title: 'Test' }),
         undefined,
       )
+    })
+
+    it('rejects a workflowId that does not match a known workflow', async () => {
+      mockLoadDefinition.mockReturnValueOnce(null)
+
+      await expect(
+        service.createTaskWithEffects({
+          title: 'Bogus',
+          workflowId: 'instagram-post',
+          createdBy: 'roscoe',
+        })
+      ).rejects.toThrow(/Unknown workflow: "instagram-post"/)
+
+      // The task row must NOT be written when the workflow is invalid.
+      expect(mockCreateTask).not.toHaveBeenCalled()
+    })
+
+    it('lists available workflows in the rejection message', async () => {
+      mockLoadDefinition.mockReturnValueOnce(null)
+
+      await expect(
+        service.createTaskWithEffects({
+          title: 'Bogus',
+          workflowId: 'made-up',
+          createdBy: 'roscoe',
+        })
+      ).rejects.toThrow(/image-social-post/)
+    })
+
+    it('accepts a workflowId that matches a known workflow', async () => {
+      mockLoadDefinition.mockReturnValueOnce({ name: 'image-social-post', steps: [] })
+
+      const result = await service.createTaskWithEffects({
+        title: 'Real one',
+        workflowId: 'image-social-post',
+        createdBy: 'roscoe',
+      })
+
+      expect(result.workflowId).toBe('image-social-post')
+      expect(mockCreateTask).toHaveBeenCalled()
+    })
+
+    it('does not call workflows.loadDefinition when no workflowId provided', async () => {
+      await service.createTaskWithEffects({ title: 'Plain task', createdBy: 'cli' })
+      expect(mockLoadDefinition).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -48,6 +48,13 @@ const mockRequestStats = {
 vi.mock('../../../src/core/request-log', () => ({
   getRequestStats: () => mockRequestStats,
   getRecentStatsForPathPrefix: () => ({ total: 0, errors: 0 }),
+  getRestStatsByPlugin: () => ({
+    windowSec: 0,
+    total: 0,
+    errors: 0,
+    successRate: 1,
+    byPlugin: [],
+  }),
 }))
 
 const mockDoctorResults = [

--- a/tests/plugins/tasks/flow-store.test.ts
+++ b/tests/plugins/tasks/flow-store.test.ts
@@ -455,6 +455,20 @@ describe('updateTask', () => {
     const found = getTask(task.id)
     expect(found!.description).toBeUndefined()
   })
+
+  it('clears workflowId when caller passes explicit undefined', async () => {
+    // Regression: createTaskWithEffects' workflow-failure cleanup path passes
+    // `{ workflowId: undefined }` to roll back the workflow attachment. The
+    // old `!== undefined` guard silently no-op'd this, leaving bogus
+    // workflowIds attached forever.
+    const task = await createTask('With workflow', 'todo', undefined, undefined, 'wf-original')
+    expect(task.workflowId).toBe('wf-original')
+
+    await updateTask(task.id, { workflowId: undefined })
+
+    const found = getTask(task.id)
+    expect(found!.workflowId).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three related fixes so Main Operator (orchestrator) stops bypassing Bakin infrastructure, plus an incidental search-reconcile hardening.

**Workflow validation at task-create time** — `src/core/task-service.ts` now rejects unknown workflow ids before writing the task row, returning the available catalog in the error. `plugins/tasks/lib/flow-store.ts` `updateTask` switches from `!== undefined` to `'key' in updates` so the `createTaskWithEffects` cleanup path can actually clear a bogus `workflowId` via explicit `undefined`.

**REST observability in Health** — `src/core/request-log.ts` gains `getRestStatsByPlugin()`; the catch-all plugin route audits write/error traffic and records the `X-Bakin-Agent` actor; `watchdog.ts` adds a parallel 5xx REST alert with its own threshold/cooldown (`settings.watchdog.rest*`); `plugins/health` surfaces a **REST Health** tile and a per-plugin traffic card so we can see which plugins agents are hitting via REST instead of MCP.

**Orchestrator rules + MCP wiring** — the auto-managed block in `src/core/doctor.ts` now:
- Teaches **mcporter** invocation (positional + JSON args, discovery command, core tool list, worked example) — agents can't call MCP natively through OpenClaw, so this is the bridge.
- Substitutes `AGENT_ID_PLACEHOLDER` via a new `getMainAgentId()` fallback mapping (`main` → `main-operator`).
- Reframes rule #10 as a numbered **preflight sequence** with explicit STOP lines, verbatim example phrasing, enumerated valid skip exceptions, and a "trust the live `bakin_exec_workflows_list` output over this file" defense-in-depth note. This closes the loophole Main Operator used to bypass `image-generation` for an "obvious" one-off image request.
- Adds rules **#13** (never impersonate other agents) and **#14** (the channel doesn't change the rules).

`cli/bakin.ts` drops its duplicate template and imports `AGENT_RULES_BLOCK_START` / `AGENT_RULES_BLOCK_END` / `resolveOrchestratorRules` from doctor so there's one source of truth. `skill/SKILL.md` mirrors the preflight sequence for subagent-created subtasks.

**Incidental:** `src/core/search-reconcile.ts` now skips zombie index rows with empty keys instead of calling `deps.remove('')` and crashing startup with "nonempty key required."

## Test plan

- [x] `npx vitest run tests/core/task-service.test.ts tests/plugins/tasks/flow-store.test.ts tests/plugins/health/routes.test.ts tests/core/search-reconcile.test.ts` — 130 passing
- [x] `npx tsc --noEmit` — clean except for pre-existing `tests/core/antfly-reranker.test.ts` errors unrelated to this PR
- [ ] Restart Bakin, hit `/api/plugins/health/doctor?fresh=true`, confirm the regenerated AGENTS.md block contains: `bakin-main-operator` server name, populated 7-workflow catalog, numbered preflight sequence, mcporter invocation example, rules #13/#14
- [ ] Visit `/health` and confirm the REST Health tile + per-plugin traffic card render
- [ ] Manual: ask Main Operator for a "quick image of a horse" and confirm it pauses to ask about `image-generation` instead of calling `skipWorkflowReason` on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)