### PR TITLE
fix(scripts): back exec tool registry with globalThis

### DIFF
--- a/scripts/lib/registry.ts
+++ b/scripts/lib/registry.ts
@@ -9,12 +9,19 @@ import type { ExecToolDefinition, ExecToolResult, PluginToolContext, StorageAdap
 
 // ---------------------------------------------------------------------------
 // Registry state
+//
+// Backed by globalThis so the custom Node server context and the Next.js
+// webpack-bundled context share one registry instance. Without this, plugins
+// activated at boot (Node context) are invisible to code running in API route
+// handlers (bundled context), including the doctor's skill-sync check.
 // ---------------------------------------------------------------------------
 
-const execTools = new Map<string, ExecToolDefinition>()
+const execTools: Map<string, ExecToolDefinition> =
+  (globalThis as any).__bakinExecTools ??= new Map<string, ExecToolDefinition>()
 
 /** Per-tool call stats for health dashboard */
-const toolStats = new Map<string, { calls: number; errors: number; lastUsed: string | null; lastError: string | null }>()
+const toolStats: Map<string, { calls: number; errors: number; lastUsed: string | null; lastError: string | null }> =
+  (globalThis as any).__bakinExecToolStats ??= new Map<string, { calls: number; errors: number; lastUsed: string | null; lastError: string | null }>()
 
 // ---------------------------------------------------------------------------
 // Registration


### PR DESCRIPTION
## Summary
- The exec-tool registry `Map` in `scripts/lib/registry.ts` lived at module scope, so the custom Node server and the Next.js webpack bundle each got a separate empty instance. Plugins activated at boot registered into the Node Map only.
- Symptom (surfaced by #93's refactored doctor skill check): fresh doctor runs triggered from `/api/plugins/health/doctor?fresh=true` rendered the skill exec-tools block from the empty bundled registry — the new safety guard then (correctly) refused to overwrite the full-fat installed file, leaving a persistent warning on the health dashboard.
- Fix: same pattern already used by `hookRegistry` and `__bakinBroadcast` — park the Map on `globalThis.__bakinExecTools` so both bundler contexts share one instance.

## Test plan
- [x] `pnpm vitest run tests/scripts/registry.test.ts tests/core/doctor.test.ts` — 14/14 passing
- [x] Restart server, hit `GET /api/plugins/health/doctor?fresh=true` — zero non-ok results, skill check reports `ok — Bakin skill is up to date`
- [x] `~/.openclaw/workspace/skills/bakin/SKILL.md` still contains all 93 `bakin_exec_*` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)