### PR TITLE
fix(assets): debug overlay shows real multimodal scores

### DIFF
--- a/plugins/assets/components/asset-card.tsx
+++ b/plugins/assets/components/asset-card.tsx
@@ -102,18 +102,27 @@ export function AssetCard({ asset, onClick, onDelete, scoreInfo }: AssetCardProp
           {formatSize(asset.size)}
         </span>
 
-        {/* Antfly relevance score debug overlay */}
+        {/* Antfly relevance score debug overlay.
+            bakin_assets is a multimodal table: Bleve BM25 + assets_text (BGE
+            text embeddings) + assets_visual (CLIP on image pixels). The Bleve
+            key is an absolute index path containing "bleve", so detect it by
+            substring. Previously this hardcoded `semKey = 'embeddings'` which
+            matched neither semantic index, so SEM always read 0.0000 and BM25
+            could land on assets_text instead of Bleve. */}
         {scoreInfo && (
           <div className="absolute top-1.5 left-1.5 flex flex-col gap-0.5 text-[9px] font-mono bg-black/80 px-1.5 py-1 rounded">
             <span className="text-amber-400">RRF {scoreInfo.score.toFixed(4)}</span>
             {(() => {
               const scores = scoreInfo.indexScores ?? {}
-              const semKey = 'embeddings'
-              const bm25Key = Object.keys(scores).find(k => k !== semKey)
+              const bm25Key = Object.keys(scores).find(k => /bleve|full_text/.test(k))
+              const bm25 = bm25Key ? (scores[bm25Key] as number) ?? 0 : 0
+              const txt = (scores['assets_text'] as number) ?? 0
+              const vis = (scores['assets_visual'] as number) ?? 0
               return (
                 <>
-                  <span className="text-cyan-400">BM25 {(bm25Key ? scores[bm25Key] as number : 0).toFixed(4)}</span>
-                  <span className="text-purple-400">SEM {((scores[semKey] as number) ?? 0).toFixed(4)}</span>
+                  <span className="text-cyan-400">BM25 {bm25.toFixed(4)}</span>
+                  <span className="text-purple-400">TXT {txt.toFixed(4)}</span>
+                  <span className="text-pink-400">VIS {vis.toFixed(4)}</span>
                 </>
               )
             })()}


### PR DESCRIPTION
## Summary

- The RRF/BM25/SEM debug overlay on asset cards hardcoded `semKey = 'embeddings'`, which doesn't exist on the multimodal `bakin_assets` table. SEM always read 0.0000 and BM25 could land on a semantic index instead of Bleve, making semantic search look broken in debug mode even though the search backend was returning correct results.
- `bakin_assets` has three indexes: Bleve BM25, `assets_text` (BGE text embeddings), `assets_visual` (CLIP on image pixels). Antfly returns the Bleve key as an absolute index path, so detect it by substring (`/bleve|full_text/`).
- Overlay now renders `RRF / BM25 / TXT / VIS` so you can see which modality fired on a hit.

## Test plan

- [x] `npx vitest run tests/plugins/assets/` — 215/215 passing
- [ ] In debug mode on /assets, search `cowboy` and confirm the cowboy spurs + horse results show non-zero TXT and/or VIS values (previously all SEM badges rendered 0.0000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)