### PR TITLE
fix(team): canonical main-agent ids, dedupe roster, straighten org chart (#90)

### DIFF
--- a/.claude/knowledge/agent-system.md
+++ b/.claude/knowledge/agent-system.md
@@ -47,7 +47,22 @@ Agent models are changed via the models plugin API, not direct OpenClaw writes:
 - The models plugin writes to `{OPENCLAW_HOME}/openclaw.json` and fires the `models.configChanged` hook when agent effective model changes
 
 ### Agent IDs
-Bakin uses OpenClaw's canonical agent ids verbatim — no translation layer. The orchestrator is `main`; subagents keep whatever ids OpenClaw assigns. Display names (e.g. "Roscoe", "Crab") come from `identity.name` in `openclaw.json` at render time and never leak into storage keys. Resolution helpers: `getMainAgentId()` and `getMainAgentName()` in `packages/core/src/main-agent.ts`.
+Bakin uses OpenClaw's canonical agent ids verbatim — no translation layer. The orchestrator id is the literal string `"main"` on **every** install; there is no detection heuristic, no settings override, no fallback. Subagents keep whatever ids OpenClaw assigns. Display names (e.g. "Roscoe", "Crab") come from `identity.name` in `openclaw.json` at render time and never leak into storage keys.
+
+Resolution helpers in `packages/core/src/main-agent.ts`:
+- `getMainAgentId(): string` — returns `"main"` if the entry exists, throws otherwise (with a pointer to `bakin check openclaw`)
+- `tryGetMainAgentId(): string | null` — non-throwing variant for UI/degraded paths
+- `getMainAgentName(): string` — reads `identity.name` on the `main` entry, falls back to `"Main"`
+
+All three call through `packages/core/src/openclaw-config.ts`, the single mtime-cached reader for `openclaw.json`. Live edits (e.g. renaming `identity.name`) are picked up on the next read without a restart. Callers that need the raw roster use `getAgentIds()` or `findAgentById(id)` from the same module — **never** `BakinSettings.agents` (that field no longer exists).
+
+### Roster validation and dedupe
+`plugins/team/lib/openclaw-adapter.ts` validates the roster on every read:
+- If no entry has `id: "main"`, `listAgents()` returns `[]` and logs an error. The UI then renders an empty team rather than a partial/broken pyramid.
+- Duplicate ids → first-wins, error logged with the discarded entry.
+- Duplicate **resolved** workspaces (explicit `workspace` field, falling back to `defaults.workspace`) → first-wins, error logged.
+
+The adapter is **read-only** — it never writes back to `openclaw.json` to "fix" violations. Repairs are the user's job; `bakin check openclaw` reports the exact violations (see `src/core/onboarding/openclaw.ts`).
 
 ## Agent Communication
 
@@ -183,16 +198,20 @@ Monitors agent and MCP server health:
 
 | File | Purpose |
 |------|---------|
-| `plugins/team/lib/openclaw-adapter.ts` | Reads/writes OpenClaw filesystem for agent data |
+| `packages/core/src/openclaw-config.ts` | Single mtime-cached reader for `openclaw.json`. Exports `readOpenClawConfig`, `getAgentList`, `getAgentIds`, `findAgentById`, `resetOpenClawConfigCache` |
+| `packages/core/src/main-agent.ts` | Canonical `"main"` resolver: `getMainAgentId`, `tryGetMainAgentId`, `getMainAgentName` |
+| `plugins/team/lib/openclaw-adapter.ts` | Read-only adapter over OpenClaw: validation, dedupe, merges Bakin-owned display data |
+| `plugins/team/lib/build-graph.ts` | Pure pyramid-graph builder — root derived from `mainAgentId`, `reportsTo ?? mainAgentId` resolution, unknown-id fallback |
 | `plugins/team/hooks/use-agent-store.ts` | Client-side Zustand store for agent data |
-| `plugins/team/index.ts` | Team plugin server: routes, hooks, exec tools |
+| `plugins/team/index.ts` | Team plugin server: routes, hooks, exec tools. Normalizes `reportsTo === mainAgentId → null` on write; degrades unknown `reportsTo` → null on read |
 | `src/core/agents.ts` | Agent status resolution and communication |
-| `src/core/dispatch.ts` | Task dispatch engine |
+| `src/core/dispatch.ts` | Task dispatch engine. Roster from `getAgentIds()` in openclaw-config |
 | `src/core/mcp-server.ts` | MCP tool server |
 | `src/core/openclaw-client.ts` | OpenClaw HTTP gateway client |
 | `src/core/task-service.ts` | Task mutations with side effects |
 | `src/core/audit.ts` | Audit logging |
 | `src/core/sse.ts` | SSE client management |
 | `src/core/watchdog.ts` | Agent health monitoring |
-| `src/core/settings.ts` | BakinSettings (agents list, dispatch config, etc.) |
+| `src/core/onboarding/openclaw.ts` | Doctor check — validates missing `main`, duplicate ids, duplicate workspaces. Reports only, never auto-fixes |
+| `src/core/settings.ts` | BakinSettings (dispatch/watchdog/antfly/etc. config). **Does not** contain the agent roster |
 | `scripts/lib/log-progress.ts` | Structured activity logging exec tool |

--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -1,0 +1,108 @@
+# Team Plugin — Deep Reference
+
+## Purpose
+
+The team plugin is Bakin's adapter layer over OpenClaw's agent roster. It derives the entire team page — every agent card, every edge, the full pyramid — from whatever `openclaw.json` reports at runtime, decorated with Bakin-owned UI data (avatars, display overrides, heartbeats). Bakin **never** copies OpenClaw state; identity, rules, tools, soul, and workspace files all stay in `{OPENCLAW_HOME}/`.
+
+## Canonical Main Agent Contract
+
+The orchestrator id is always the literal string `"main"` on every OpenClaw install. Display names come from `identity.name` on that entry. No detection heuristic, no settings override, no rename logic.
+
+- `packages/core/src/main-agent.ts` — `getMainAgentId()`, `tryGetMainAgentId()`, `getMainAgentName()`
+- `packages/core/src/openclaw-config.ts` — single mtime-cached reader for `openclaw.json`. All three helpers above call through here. Live edits are picked up on the next call.
+- `src/core/onboarding/openclaw.ts` — doctor check that flags missing `main`, duplicate ids, duplicate workspaces. Reports only, never auto-fixes. Run via `bakin check openclaw`.
+
+`BakinSettings.agents` and `BakinSettings.mainAgentId` **do not exist**. If you find a reference to them in tests or production code, it's a bug — use `getAgentIds()` / `getMainAgentId()` instead.
+
+## Read Path: openclaw-adapter → listAgents
+
+`plugins/team/lib/openclaw-adapter.ts#listAgents()` is the single read entry point for "the full roster as Bakin wants to render it." It:
+
+1. Reads `openclaw.json` via `readOpenClawConfig()` (mtime-cached).
+2. **Validates:**
+   - If no entry has `id: "main"` → returns `[]` and logs an error. The UI shows an empty team rather than a broken pyramid.
+   - Duplicate ids → first-wins, logs an error with the discarded entry.
+   - Duplicate **resolved workspaces** (explicit `workspace` field, falling back to `defaults.workspace`) → first-wins, logs an error.
+3. Merges Bakin-owned display data (`~/.bakin/plugin-settings/team.json` → accent colors, display name overrides, teamId assignments).
+4. Merges heartbeats from `~/.bakin/heartbeats/{id}.json`.
+5. Returns `AgentWithStatus[]`.
+
+The adapter is **read-only**. It never writes back to `openclaw.json`. User-initiated agent CRUD goes through the separate `addAgent`/`removeAgent` paths which write via the OpenClaw gateway, not the filesystem.
+
+## Pyramid Builder: build-graph.ts
+
+`plugins/team/lib/build-graph.ts#buildGraph()` is a pure function — identical inputs produce identical outputs, no React, no side effects. The team-grid component is a thin xyflow wrapper that calls it.
+
+### Row layout
+
+| Row | Contents |
+|-----|----------|
+| 0 | Founder card ("Mark") |
+| 1 | Main agent card (row 1 derived from `mainAgentId`, not from `topAgentIds`) |
+| 2 | Non-main team leaders (sub-orgs whose `reportsTo` points at a non-main agent) |
+| 3+ | Team section headers + member cards, grouped per reporter |
+| +1 | Unassigned bucket (agents never placed) |
+
+### reportsTo resolution
+
+`resolveReporter()` treats all of these as "reports to main":
+
+- `reportsTo === null`
+- `reportsTo === undefined`
+- `reportsTo === ""` (empty string)
+- `reportsTo === someUnknownAgentId` (graceful degradation — don't orphan, don't crash)
+
+This runs at render time. Stored `team.json` values are never rewritten on read.
+
+### Broken roster degraded state
+
+If `listAgents()` returned `[]` (missing `main`), the builder renders founder only. No orphan subagents, no synthesized sections. This is the intentional signal that OpenClaw state is broken — the UI stays quiet and points the user at `bakin check openclaw`.
+
+### Synthetic "All agents" section
+
+When `teams.length === 0` and the main agent has subagents, the builder synthesizes a single "All agents" section under main. Fresh installs get a visible pyramid shape without requiring the user to define any teams.
+
+## Write Path: POST/PUT /teams normalization
+
+`plugins/team/index.ts` owns the `teams` route. Both create (POST) and update (PUT) call `normalizeReportsTo()` before persisting:
+
+```
+normalizeReportsTo(input):
+  if input === undefined || null || ""       → null
+  if input === getMainAgentId() (try/catch)  → null
+  else                                       → input
+```
+
+`null` is the canonical on-disk representation for "reports to main". This keeps stored team.json tidy and avoids the "display name drift" bug where renaming the main agent orphans every team that stored the old name.
+
+Read path degrades too: in the GET / handler, `degradeUnknownReportsTo()` rewrites any `reportsTo` string that isn't in the current roster to `null` with a warning log. Read-side degradation is non-mutating — the stored file is never rewritten on read.
+
+`OrgTeam.reportsTo` in `plugins/team/types.ts` is typed `string | null` to match.
+
+## Client Store
+
+`plugins/team/hooks/use-agent-store.ts` — single Zustand store loaded on app init. Exposes:
+
+- `useAgent(id)`, `useAgentList()`, `useAgentIds()`, `useAgentColor(id)`
+- `useMainAgentId()` — reads the `mainAgentId` field the roster route returns (server-side `getMainAgentId()`). Used by `TeamGrid` to pass the canonical root into `buildGraph`.
+
+Components never compute "who is the main agent" themselves — always read it from the store.
+
+## Test Coverage Map
+
+| Concern | Test file |
+|---------|-----------|
+| mtime-cached reader + helpers | `tests/core/openclaw-config.test.ts` |
+| main-agent canonical resolver | `tests/core/main-agent.test.ts` |
+| Adapter validation + dedupe | `tests/plugins/team/openclaw-adapter.test.ts` |
+| Pyramid graph builder | `tests/plugins/team/build-graph.test.ts` |
+| Write normalization + read degradation | `tests/plugins/team/routes.test.ts` |
+| Doctor integrity check | `tests/core/onboarding/openclaw.test.ts` |
+
+## Common Pitfalls
+
+- **Don't add settings.agents back.** The field was deleted for a reason — having two sources of truth caused the original "duplicate roscoe + main" bug on production.
+- **Don't cache openclaw.json in a new spot.** `openclaw-config.ts` is the single reader. Add helpers there; don't re-stat from another module.
+- **Don't write to openclaw.json from validation code.** The adapter is read-only. Integrity problems are the user's job to fix — surface them via the doctor, don't auto-heal.
+- **Don't hard-code the main agent's display name** (e.g. "Roscoe"). It varies per install. Always resolve via `getMainAgentName()` server-side or `useMainAgentId()` + `useAgent(id)` client-side.
+- **Don't skip the test mocks.** `tests/plugins/team/*` must mock `@bakin/core/openclaw-config`, `@bakin/core/openclaw-home`, and `src/core/content-dir` — leaking into `~/.openclaw/` has caused real incidents.

--- a/.claude/specs/issue-90-team-main-agent-canonical.md
+++ b/.claude/specs/issue-90-team-main-agent-canonical.md
@@ -1,0 +1,215 @@
+---
+name: team-plugin-main-agent-canonical
+issue: https://github.com/madeinwyo/bakin/issues/90
+status: draft
+author: claude (opus-4-6) / roscoe
+date: 2026-04-15
+---
+
+# Spec — Team plugin derives entire roster from OpenClaw's canonical ids
+
+## 1. Objective
+
+The Bakin team page today shows two cards for the same logical agent: "Roscoe" at the pyramid top and "main" as an unassigned orphan at the bottom. This is the visible symptom of a deeper problem — Bakin still has code and stored state that treats display names and canonical ids as interchangeable, even though the adapter principle says only OpenClaw owns agent identity.
+
+This spec defines the changes needed to guarantee that **the Bakin team page, on any OpenClaw install (fresh or existing), renders exactly the agents OpenClaw reports — keyed by OpenClaw's canonical id, labeled by `identity.name` at render time — with the orchestrator (`id: "main"`) at the top of the pyramid and no duplicate cards ever, regardless of what the user chose to name their main agent.**
+
+No Bakin code or data file may hold a hardcoded agent id string like `"roscoe"`, `"main"`, or `"bob"`. The only hardcoded literal allowed is the canonical orchestrator id `"main"` itself, because that is an OpenClaw-defined contract (documented in `.claude/knowledge/agent-system.md:50` and reflected in the imitation-crab fixture at `dev/imitation-crab/fixtures/openclaw.json:9`).
+
+### Target user
+Single-user, single-machine (this Mac mini). No backwards-compat shims. Reduce tech debt aggressively — any code that only exists because of the old `roscoe`-as-id assumption gets deleted, not deprecated.
+
+## 2. OpenClaw contract (restated — this is the invariant everything depends on)
+
+- Every OpenClaw install has exactly one agent whose id is the literal string `"main"`. That agent is the orchestrator. This is OpenClaw's convention, not Bakin's.
+- The human-facing name of the main agent ("Roscoe", "Crab", "Bob", etc.) lives in `agents.list[].identity.name`. It is arbitrary per install.
+- Subagents have whatever ids OpenClaw assigns them (`pixel`, `patch`, `basil`, …). Those ids are also canonical — Bakin never renames them.
+- `agents.defaults.workspace` is the main agent's workspace. Subagents each have their own workspace under `workspaces/{id}/`.
+- Anything Bakin needs to display as a human label must be resolved at render time from `identity.name` (or fall back to the id). Display names are never stored as keys.
+
+## 3. Core features & acceptance criteria
+
+### F1 — `getMainAgentId()` always returns `"main"`
+**Change:** Strip the detection heuristic in `packages/core/src/main-agent.ts`. The function becomes: read `openclaw.json`, confirm an entry with `id === "main"` exists, return `"main"`. If missing, throw with a message telling the user to add a `main` entry to their `openclaw.json` (the adapter principle says Bakin won't do it for them).
+
+**Accept:**
+- `tryGetMainAgentId()` returns `"main"` when an entry exists, `null` otherwise.
+- `getMainAgentId()` returns `"main"` or throws with a clear message.
+- `getMainAgentName()` returns `identity.name` from the `main` entry, falling back to `"Main"` if unset.
+- `settings.mainAgentId` override is **deleted** from `BakinSettings`. It was a hack for the pre-rename world. (Tech debt reduction.)
+- No code path exists that can cause `getMainAgentId()` to return anything other than `"main"`. Grep proof in the PR description.
+
+### F2 — Team plugin dedupes and validates OpenClaw's agent list
+**Change:** In `plugins/team/lib/openclaw-adapter.ts`'s `listAgents()`, add a validation pass:
+- Reject duplicate ids (log an error, skip the second).
+- Reject two agents whose resolved workspace path is identical (log an error, skip the second — that's the `main` + `roscoe` bug we're fixing).
+- Require the `main` entry to exist; if missing, return an empty list and log a critical error so the UI shows an empty state instead of silently omitting the orchestrator.
+
+**Accept:**
+- Given a broken `openclaw.json` with both `{ id: "main" }` and `{ id: "roscoe", workspace: <default> }`, `listAgents()` returns one agent (`main`), logs one error, and the UI shows a single pyramid root.
+- Given a clean `openclaw.json`, `listAgents()` is a pure passthrough (no extra allocations, same shape as today).
+- The adapter never mutates `openclaw.json`.
+
+### F3 — Pyramid root is always the `main` agent; `reportsTo` defaults resolve at render time
+**Change:** In `plugins/team/components/team-grid.tsx` and whatever computes the team grouping:
+- The pyramid root is the agent with `id === "main"`. Always. Not derived from team membership, not from `topAgentIds`.
+- Every other agent reports to `main` by default. A `team` entry in `team.json` whose `reportsTo` is null/undefined is resolved at render time to `getMainAgentId()`.
+- Teams in `team.json` may set `reportsTo` to a non-`"main"` agent id for sub-org structures (e.g. Creators reports to Basil instead of main). That override is respected.
+- The "Unassigned" bucket is only rendered if there are genuinely agents that have no team assignment AND no implicit-main parent. In the default flat configuration (no teams yet), all subagents render as a single row directly under main, with no "Unassigned" label.
+
+**Accept:**
+- Fresh install (no `team.json`): pyramid shows founder → main agent → all subagents in one row. No "Unassigned" bucket.
+- User's current install after fix: pyramid shows founder → Roscoe (main) → Creators team + Builders team, each with their members. No stray `main` card.
+- User edits `team.json` to add `reportsTo: "basil"` on Creators team: Creators team appears under Basil instead of main.
+- Deleting `team.json` entirely (fresh-install simulation) still renders a valid pyramid.
+
+### F4 — `team.json` schema strips stored `reportsTo` strings that equal the current main id
+**Change:** When Bakin writes `team.json`, any `reportsTo` value that equals `getMainAgentId()` is stored as `null` (or omitted). When Bakin reads it, `null`/missing → `main` at render time. This means `team.json` on disk never contains the literal string `"main"` or `"roscoe"` as a `reportsTo` value — the default-pyramid-root is implicit.
+
+This prevents the same class of bug from recurring if someone ever renames the canonical id, and it makes `team.json` portable between installs that might have different `identity.name` values.
+
+**Accept:**
+- After this fix ships, `~/.bakin/plugin-settings/team.json` contains no `"reportsTo": "main"` strings anywhere. `reportsTo` is either null/omitted or a non-main agent id.
+- Reading a team.json written by the old code (with `"reportsTo": "roscoe"`) works: the `"roscoe"` string resolves to nothing and falls back to main. We don't need a migration shim because the first write under the new code cleans it up. (This is *not* a backwards-compat shim — it's graceful handling of a string that happens to be invalid.)
+
+### F5 — Delete the stale `agents: [...]` array in `settings.json`
+**Change:** Grep for whoever writes `agents: [...]` into `~/.bakin/settings.json`. That field is not in the `BakinSettings` type and is duplicating OpenClaw data. Delete:
+- The writer code.
+- The field from the user's actual `settings.json` (one-time edit).
+- Any reader code (if any exists).
+
+**Accept:**
+- No code in `packages/core/src/settings.ts` (or anywhere else) writes an `agents` field to `settings.json`.
+- `~/.bakin/settings.json` on this machine no longer has the field.
+- Grep for `settings.agents` / `\.agents.*=.*\[` returns only tests/fixtures that can be deleted.
+
+### F6 — Doctor / health check: detect broken openclaw.json
+**Change:** Add a check (in `src/core/onboarding/openclaw.ts` or a new doctor check) that validates:
+- Exactly one agent has `id === "main"`.
+- No two agents share the same `workspace` path (after resolution — relative paths, `~` expansion, `agents.defaults.workspace` inheritance).
+- Every agent has a unique `id`.
+
+On failure, the check prints a specific, actionable error (e.g. "openclaw.json has two agents sharing workspace `/Users/.../workspace`: `main` and `roscoe`. Remove one.") and exits non-zero. It does not auto-fix.
+
+**Accept:**
+- `bakin check openclaw` (or equivalent) catches the current broken state on a machine that still has the duplicate.
+- A clean openclaw.json passes silently.
+- The check is wired into `bakin onboard` / `bakin doctor` so fresh installs hit it automatically.
+- No test fixture contains a broken openclaw.json outside of the negative-test cases for this check.
+
+### F7 — Manual cleanup on this machine (post-fix)
+Not part of the Bakin code, but part of the task: after F1–F6 ship and pass tests, perform these one-shot fixes on this Mac mini to match the new contract:
+1. Edit `~/.openclaw/openclaw.json`: delete the `roscoe` entry, move its `identity: { name: "Roscoe", emoji: "🐾" }` and `workspace` / `agentDir` fields into the `main` entry. Keep the same subagents list.
+2. Move `~/.bakin/agents/roscoe/avatar.jpg` and `avatar-full.png` → `~/.bakin/agents/main/`.
+3. Delete `~/.bakin/agents/roscoe/` (should be empty after the move, or just has a stale `AGENTS.md` that came from the old rename — delete that too unless `agents/main/AGENTS.md` is stale in which case overwrite).
+4. Delete `~/.bakin/heartbeats/roscoe.json`.
+5. Open `~/.bakin/plugin-settings/team.json` and change `"reportsTo": "roscoe"` → remove the field entirely (null/omitted means main). The next write from the new code would do this anyway, but we do it by hand so the transition is observable.
+6. Open `~/.bakin/settings.json`, delete the top-level `agents: [...]` array.
+7. Restart Bakin. Team page should show a single Roscoe at the pyramid top with Creators + Builders under it. No orphan "main" card.
+
+## 4. Out of scope
+
+- Changing OpenClaw's internal id scheme. `main` is a contract Bakin accepts, not invents.
+- **Auto-mutating `openclaw.json`** from doctor checks, migration helpers, or onboarding code. User-initiated agent CRUD through the existing `addAgent` / `removeAgent` adapter functions (`plugins/team/lib/openclaw-adapter.ts:279,333`) remains the legitimate write path — that's what CLAUDE.md's "Bakin writes to OpenClaw" clause refers to. What we're ruling out is code that *silently* edits the file as a side effect of a check or migration.
+- A generic "agent id migration" tool. This is a single install; the manual steps in F7 are fine and documented.
+- The `bakin-roscoe` → `bakin-main` mcporter rename, which per the audit is already in place (`tests/core/mcporter.test.ts` confirms).
+- Multi-user or multi-install scenarios. Single user, single machine.
+- UI to edit teams / reportsTo. The existing team.json edit UI already exists; we're just changing what it stores.
+
+## 5. Tech stack / constraints
+
+- TypeScript strict mode, no `any` across module boundaries.
+- Zod validation at new boundaries (the validated `openclaw.json` shape in F2/F6 should flow through a Zod schema).
+- All OpenClaw paths via `getOpenClawPath()` in `packages/core/src/openclaw-home.ts`. No `~/.openclaw/` string literals.
+- All Bakin paths via `getContentDir()` / `getBakinPaths()`. No `~/.bakin/` string literals.
+- Logger: `createLogger('main-agent')` / `createLogger('team:adapter')` / etc. No `console.log`.
+- **No backwards-compat shims.** If old code exists only to support a pre-rename layout, delete it in the same PR.
+
+## 6. Testing strategy
+
+Every test file touching storage must mock `src/core/content-dir` per `CLAUDE.md`'s test isolation rules. See `tests/plugins/test-helpers.ts` for the established pattern.
+
+### Unit tests
+- `tests/core/main-agent.test.ts` — add cases:
+  - Returns `"main"` when openclaw.json has an agent with `id: "main"`.
+  - Throws when missing.
+  - `getMainAgentName()` returns `identity.name` when set, falls back to `"Main"` when missing.
+  - Old `settings.mainAgentId` override field no longer exists / has no effect (grep-level check + a test that asserts the field isn't in `BakinSettings`).
+- `tests/plugins/team/openclaw-adapter.test.ts` — add cases:
+  - Duplicate id → second is skipped, error logged.
+  - Two agents sharing workspace → second is skipped, error logged.
+  - Missing `main` entry → returns empty list, critical error logged.
+  - Clean config → one-to-one passthrough.
+
+### Integration tests
+- `tests/plugins/team/routes.test.ts` — extend:
+  - `GET /api/plugins/team` returns a roster where every entry's id appears in `openclaw.json` and nothing else.
+  - On a broken openclaw.json with both `main` and `roscoe`, the route returns only the `main` entry.
+- `tests/plugins/team/team-grid.test.tsx` (new or existing) — render the grid with a `team.json` that has no `reportsTo` and confirm the pyramid root is the `main` agent.
+
+### Doctor check
+- `tests/core/doctor.test.ts` — extend:
+  - Valid openclaw.json passes.
+  - Missing `main` → fails with actionable message.
+  - Duplicate workspace → fails with actionable message naming both ids.
+  - Duplicate id → fails.
+
+### Manual / e2e
+- Start Bakin with the imitation-crab fixture (which has `id: "main"`, `identity.name: "Crab"`). Team page shows Crab at the pyramid top. No duplicate.
+- After manual cleanup (F7) on the real machine: team page shows Roscoe at the pyramid top, Creators + Builders under. No orphan main card.
+
+### Test isolation reminder
+All tests use the `tests/plugins/test-helpers.ts` `activatePlugin` / `callRoute` helpers, which mock `getContentDir`, `logger`, `watcher`, `openclaw-client`. Any new test fixtures that need an openclaw.json go under `tests/fixtures/openclaw/` and are loaded via a mocked `getOpenClawPath()`.
+
+## 7. Boundaries
+
+**Always:**
+- Treat `"main"` as the canonical orchestrator id. Never hardcode any other agent id.
+- Resolve display names from `identity.name` at render time.
+- Read agent data from OpenClaw. Write UI-only augmentations to `~/.bakin/`.
+- Use `getOpenClawPath()` / `getContentDir()` for all path resolution.
+- Log with `createLogger()`.
+
+**Ask first about:**
+- Adding any new stored field that holds an agent id as a string (we should prefer "resolved at render time" wherever possible).
+- Changing the `BakinSettings` schema (other unrelated fields exist; don't accidentally drop them).
+- Touching the imitation-crab fixture (we rely on it as the "fresh install" reference).
+
+**Never:**
+- Auto-mutate `openclaw.json` from a doctor check, migration helper, or onboarding step. (User-initiated CRUD through the existing `addAgent`/`removeAgent` adapter functions is fine — those are the legitimate write path.)
+- Store an agent display name (`"Roscoe"`, `"Crab"`) as a key in any data structure or filesystem path.
+- Add a backwards-compat shim for the old `roscoe`-as-id layout. Delete the old code paths; the single manual cleanup in F7 is the entire migration.
+- Use `settings.mainAgentId` as a source of truth. It's gone after F1.
+- Re-introduce `OPENCLAW_TO_BAKIN` / `OPENCLAW_ID_TO_BAKIN_NAME` maps or any equivalent.
+
+## 8. Commit strategy (rollback checkpoints)
+
+The work decomposes into six independent commits, each testable on its own. Any one can be reverted without breaking the others.
+
+1. **`refactor(core): getMainAgentId always returns "main"`** — F1. Strips the detection heuristic and `settings.mainAgentId` override. Updates `main-agent.ts` and `tests/core/main-agent.test.ts`. Self-contained; rolls back to current heuristic cleanly.
+
+2. **`refactor(core): remove stale agents[] field from BakinSettings`** — F5. Deletes the writer, removes the field from `settings.json` on disk, updates tests. Independent of F1.
+
+3. **`feat(team): dedupe and validate openclaw agent list`** — F2. Adds the validation pass to `listAgents()`, logs duplicates, keeps the adapter read-only. Includes `tests/plugins/team/openclaw-adapter.test.ts` cases.
+
+4. **`feat(team): pyramid root is always the main agent`** — F3 + F4. Changes `team-grid.tsx` to derive the root from `getMainAgentId()`, drops the `topAgentIds` heuristic for the root, makes `reportsTo: null` resolve to main at render time. Writes team.json normalized (no stored `"main"` string).
+
+5. **`feat(onboarding): doctor check for openclaw.json integrity`** — F6. Adds the validation check, wires it into `bakin onboard` / `bakin doctor`, new `tests/core/doctor.test.ts` cases.
+
+6. **`chore: cleanup stale roscoe artifacts on this machine`** — F7 as a tiny documentation-only commit to `.claude/knowledge/` (or an internal migration note), capturing what was done by hand. The actual filesystem edits are not in the repo but are listed so future-me can trace them.
+
+**Merge order:** 1 → 2 → 3 → 4 → 5 → 6. Each commit must pass `npm run test` and `npm run typecheck` before the next lands. If any commit breaks something unexpected, revert only that commit; the earlier commits remain valid.
+
+**Rollback:** because `main-agent.ts` underpins everything, commit 1 is the highest-risk. If its test suite passes but runtime behavior is off, `git revert <commit-1>` restores the heuristic without affecting commits 2+. Commits 3 and 4 are tightly coupled — if 4 needs to revert, 3 can stay in place (it just means the adapter still validates but the UI hasn't taken advantage of it yet).
+
+## 9. Knowledge / doc updates
+
+After the fix ships, update:
+- `.claude/knowledge/agent-system.md` — confirm the existing statement on line 50 is still accurate (it should be, after the fix it's literally true instead of aspirational); add a note that `getMainAgentId()` is now a trivial constant-return and that the detection heuristic is gone.
+- `.claude/knowledge/team-plugin.md` (if exists; otherwise check if one should be created) — document the pyramid rendering rules and `reportsTo` resolution.
+- `CLAUDE.md` — the "OpenClaw Adapter Principle" section already captures the spirit; no changes needed unless the `main-agent.ts` description in the Directory Map is stale.
+- `README.md` — no impact (README doesn't talk about agent ids).
+
+## 10. Open questions
+
+None remaining — decisions #1–#4 from the clarifying round are locked in above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ dev/imitation-crab/         — Imitation Crab: OpenClaw mock for dev without re
 Created by `bakin init`. Per-installation state, NOT in the repo.
 ```
 ~/.bakin/
-  settings.json            — Runtime config (mainAgentId, bridge settings)
+  settings.json            — Runtime config (dispatch/watchdog/antfly/bridge settings — NOT the agent roster)
   plugin-settings/         — Per-plugin configuration
   plugins/                 — Addon plugins (installed via bakin install)
   agents/                  — Per-agent data ({id}/avatar.jpg, avatar-full.png)

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -3,6 +3,7 @@
  * Bakin CLI — command-line interface for Bakin orchestration platform.
  * All commands are thin wrappers around the Bakin HTTP API.
  */
+import { getAgentIds } from '@bakin/core/openclaw-config'
 import { getMainAgentId } from '@bakin/core/main-agent'
 import { getOpenClawPath } from '@bakin/core/openclaw-home'
 import {
@@ -77,14 +78,13 @@ function printTable(rows: Record<string, unknown>[], columns?: string[]): void {
 // ---------------------------------------------------------------------------
 async function cmdStatus(): Promise<void> {
   const dispatch = await apiGet('/api/dispatch') as Record<string, unknown>
-  const settings = await apiGet('/api/settings') as Record<string, unknown>
 
   console.log('=== Bakin Status ===')
   console.log(`Dispatch interval: ${dispatch.intervalMin}min`)
   console.log(`Last run: ${dispatch.lastRun || 'never'}`)
   console.log(`Next run: ${dispatch.nextRun} (${dispatch.secondsUntilNext}s)`)
   console.log(`Tasks dispatched: ${dispatch.dispatchedCount}`)
-  console.log(`Agents: ${(settings.agents as string[]).join(', ')}`)
+  console.log(`Agents: ${getAgentIds().join(', ')}`)
 }
 
 async function cmdDispatch(): Promise<void> {
@@ -878,9 +878,8 @@ async function cmdStart(): Promise<void> {
         console.log(`[OK] Bakin is up (${data.version})`)
         console.log('')
         console.log('MCP endpoints:')
-        const settings = await (await fetch(`${BASE_URL}/api/settings`)).json() as { agents?: string[] }
-        const agents = (settings as Record<string, unknown>).agents as string[] || []
-        for (const agent of agents as string[]) {
+        const agents = getAgentIds()
+        for (const agent of agents) {
           console.log(`  ${agent}: mcporter call bakin-${agent}.<tool> ...`)
         }
         console.log('')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "./main-agent": "./src/main-agent.ts",
     "./vault": "./src/vault.ts",
     "./openclaw-home": "./src/openclaw-home.ts",
+    "./openclaw-config": "./src/openclaw-config.ts",
     "./plugin-types": "./src/plugin-types.ts",
     "./constants": "./src/constants.ts",
     "./storage": "./src/storage/markdown-adapter.ts",

--- a/packages/core/src/main-agent.ts
+++ b/packages/core/src/main-agent.ts
@@ -1,32 +1,26 @@
 /**
  * Main agent (orchestrator) resolution for Bakin.
  *
- * The orchestrator id is NOT hardcoded. It resolves dynamically per install:
- *   1. `settings.mainAgentId` from ~/.bakin/settings.json — explicit override,
- *      never auto-written. Set it by hand only if auto-detection picks the
- *      wrong agent (e.g. two orchestrators in the same openclaw.json).
- *   2. Auto-detect from OpenClaw: the agent whose `workspace` equals
- *      `agents.defaults.workspace` (subagents override with per-agent paths).
- *   3. Fallback: the first agent in `agents.list` with a populated
- *      `subagents.allowAgents` listing (covers configs where the orchestrator
- *      inherits the default workspace instead of setting it explicitly).
+ * OpenClaw's canonical orchestrator id is the literal string `"main"` on every
+ * install. There is no detection heuristic, no settings override, no fallback:
+ * if `openclaw.json` has an agent with `id: "main"` we return that id; if it
+ * doesn't, we throw and point the caller at `bakin check openclaw`.
  *
- * If nothing resolves, throws — the caller should run onboarding or set
- * `mainAgentId` in settings.json. Display names come from `identity.name`.
+ * Display name comes from `identity.name` on that entry, with a static `"Main"`
+ * fallback when the name is missing.
  *
- * Reads are mtime-cached: every call stats `openclaw.json` (cheap), re-parses
- * only when the file changes. Rename the orchestrator in openclaw.json and the
- * next call picks it up without a restart.
+ * Reads go through `openclaw-config`, which owns the mtime-keyed cache — a
+ * live edit to `openclaw.json` (e.g. renaming via `identity.name`) is picked
+ * up on the next call without a restart.
  */
-import { getSettings } from './settings'
-import { readOpenClawConfig, findAgentById } from './openclaw-config'
+import { findAgentById } from './openclaw-config'
 
 export function getMainAgentId(): string {
-  const id = tryGetMainAgentId()
-  if (id) return id
+  const entry = findAgentById('main')
+  if (entry) return 'main'
   throw new Error(
-    'Cannot resolve main agent id. Set `mainAgentId` in ~/.bakin/settings.json ' +
-    'or run `bakin onboard` to detect it from OpenClaw.'
+    "openclaw.json has no agent with id 'main'. OpenClaw's orchestrator id is always 'main'; " +
+    'add that entry or run `bakin check openclaw`.'
   )
 }
 
@@ -35,35 +29,12 @@ export function getMainAgentId(): string {
  * (e.g. sort order, optional UI defaults, diagnostic logging).
  */
 export function tryGetMainAgentId(): string | null {
-  const settings = getSettings()
-  const fromSettings = settings.mainAgentId
-  if (typeof fromSettings === 'string' && fromSettings) return fromSettings
-
-  return detectOrchestratorFromOpenClaw()
+  return findAgentById('main') ? 'main' : null
 }
 
 export function getMainAgentName(): string {
-  const id = getMainAgentId()
-  const entry = findAgentById(id)
+  const entry = findAgentById('main')
   const name = entry?.identity?.name
   if (typeof name === 'string' && name.trim().length > 0) return name
-  return id.charAt(0).toUpperCase() + id.slice(1)
-}
-
-function detectOrchestratorFromOpenClaw(): string | null {
-  const config = readOpenClawConfig()
-  if (!config) return null
-  const list = config.agents?.list
-  if (!Array.isArray(list) || list.length === 0) return null
-
-  const defaultWorkspace = config.agents?.defaults?.workspace
-  if (typeof defaultWorkspace === 'string' && defaultWorkspace) {
-    const workspaceMatch = list.find((a) => a.workspace === defaultWorkspace)
-    if (workspaceMatch) return workspaceMatch.id
-  }
-
-  const withSubagents = list.find(
-    (a) => Array.isArray(a.subagents?.allowAgents) && (a.subagents?.allowAgents?.length ?? 0) > 0
-  )
-  return withSubagents?.id ?? null
+  return 'Main'
 }

--- a/packages/core/src/main-agent.ts
+++ b/packages/core/src/main-agent.ts
@@ -18,24 +18,8 @@
  * only when the file changes. Rename the orchestrator in openclaw.json and the
  * next call picks it up without a restart.
  */
-import { readFileSync, statSync } from 'fs'
-
 import { getSettings } from './settings'
-import { getOpenClawPath } from './openclaw-home'
-
-interface OpenClawAgentEntry {
-  id: string
-  workspace?: string
-  identity?: { name?: string; emoji?: string }
-  subagents?: { allowAgents?: string[] }
-}
-
-interface OpenClawConfig {
-  agents?: {
-    defaults?: { workspace?: string }
-    list?: OpenClawAgentEntry[]
-  }
-}
+import { readOpenClawConfig, findAgentById } from './openclaw-config'
 
 export function getMainAgentId(): string {
   const id = tryGetMainAgentId()
@@ -60,7 +44,7 @@ export function tryGetMainAgentId(): string | null {
 
 export function getMainAgentName(): string {
   const id = getMainAgentId()
-  const entry = findOpenClawAgentById(id)
+  const entry = findAgentById(id)
   const name = entry?.identity?.name
   if (typeof name === 'string' && name.trim().length > 0) return name
   return id.charAt(0).toUpperCase() + id.slice(1)
@@ -82,33 +66,4 @@ function detectOrchestratorFromOpenClaw(): string | null {
     (a) => Array.isArray(a.subagents?.allowAgents) && (a.subagents?.allowAgents?.length ?? 0) > 0
   )
   return withSubagents?.id ?? null
-}
-
-function findOpenClawAgentById(id: string): OpenClawAgentEntry | null {
-  const config = readOpenClawConfig()
-  const list = config?.agents?.list
-  if (!Array.isArray(list)) return null
-  return list.find((a) => a.id === id) ?? null
-}
-
-let cachedConfig: { mtimeMs: number; config: OpenClawConfig | null } | null = null
-
-function readOpenClawConfig(): OpenClawConfig | null {
-  const path = getOpenClawPath('openclaw.json')
-  let mtimeMs: number
-  try {
-    mtimeMs = statSync(path).mtimeMs
-  } catch {
-    cachedConfig = null
-    return null
-  }
-  if (cachedConfig && cachedConfig.mtimeMs === mtimeMs) return cachedConfig.config
-  let config: OpenClawConfig | null
-  try {
-    config = JSON.parse(readFileSync(path, 'utf-8')) as OpenClawConfig
-  } catch {
-    config = null
-  }
-  cachedConfig = { mtimeMs, config }
-  return config
 }

--- a/packages/core/src/openclaw-config.ts
+++ b/packages/core/src/openclaw-config.ts
@@ -1,0 +1,109 @@
+/**
+ * Centralized reader for `~/.openclaw/openclaw.json`.
+ *
+ * Before this module existed, three separate call sites (main-agent,
+ * team/openclaw-adapter, settings) each maintained their own mtime-cached
+ * parse of openclaw.json. They drifted, each caught errors differently, and
+ * any regression had to be fixed in triplicate. This module is the single
+ * place that stats + parses the file; every other Bakin module imports from
+ * here.
+ *
+ * Contract:
+ *   - Pure read path. Never mutates openclaw.json.
+ *     The legitimate write path lives in `plugins/team/lib/openclaw-adapter`
+ *     (`addAgent` / `removeAgent`) and calls `resetOpenClawConfigCache()`
+ *     after writing to force a re-read on the next call.
+ *   - Mtime-cached: every call stats the file (cheap), re-parses only when
+ *     the mtime changes. Renaming an agent in openclaw.json is picked up on
+ *     the next call without a restart.
+ *   - Non-throwing: any stat, read, parse, or path-resolution failure
+ *     returns `null` (from `readOpenClawConfig`) or `[]` (from the agent
+ *     helpers). The test-env guard in `openclaw-home.ts` can throw when
+ *     resolving paths; we swallow that here so tests that don't mock us
+ *     still observe a clean "no config" state.
+ */
+import { readFileSync, statSync } from 'fs'
+
+import { getOpenClawPath } from './openclaw-home'
+
+export interface OpenClawAgent {
+  id: string
+  name?: string
+  workspace?: string
+  agentDir?: string
+  model?: { primary?: string }
+  identity?: { name?: string; emoji?: string }
+  subagents?: { allowAgents?: string[]; model?: string }
+}
+
+export interface OpenClawConfig {
+  agents?: {
+    defaults?: {
+      model?: { primary?: string }
+      workspace?: string
+    }
+    list?: OpenClawAgent[]
+  }
+}
+
+let cachedConfig: { mtimeMs: number; config: OpenClawConfig | null } | null = null
+
+/**
+ * Read openclaw.json through an mtime-keyed cache. Returns the parsed config
+ * or `null` if the file is missing, unreadable, malformed, or if the path
+ * itself cannot be resolved (e.g. the test-env safety guard fires).
+ */
+export function readOpenClawConfig(): OpenClawConfig | null {
+  let path: string
+  try {
+    path = getOpenClawPath('openclaw.json')
+  } catch {
+    cachedConfig = null
+    return null
+  }
+
+  let mtimeMs: number
+  try {
+    mtimeMs = statSync(path).mtimeMs
+  } catch {
+    cachedConfig = null
+    return null
+  }
+
+  if (cachedConfig && cachedConfig.mtimeMs === mtimeMs) return cachedConfig.config
+
+  let config: OpenClawConfig | null
+  try {
+    config = JSON.parse(readFileSync(path, 'utf-8')) as OpenClawConfig
+  } catch {
+    config = null
+  }
+  cachedConfig = { mtimeMs, config }
+  return config
+}
+
+/** Returns the agents list or an empty array. Safe on missing/malformed config. */
+export function getAgentList(): OpenClawAgent[] {
+  const list = readOpenClawConfig()?.agents?.list
+  return Array.isArray(list) ? list : []
+}
+
+/** Returns just the agent ids, in list order. Empty array on missing config. */
+export function getAgentIds(): string[] {
+  return getAgentList().map((a) => a.id)
+}
+
+/** Look up a single agent by id, or `null` when missing. */
+export function findAgentById(id: string): OpenClawAgent | null {
+  return getAgentList().find((a) => a.id === id) ?? null
+}
+
+/**
+ * Drop the mtime cache. Called by the openclaw-adapter write path after
+ * `addAgent` / `removeAgent` mutate the file so the next read observes the
+ * fresh contents even if the filesystem mtime granularity is coarser than
+ * the caller's write-read gap.
+ */
+export function resetOpenClawConfigCache(): void {
+  cachedConfig = null
+}

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -6,7 +6,6 @@ import fs from 'fs'
 import path from 'path'
 import { createLogger } from './logger'
 import { getContentDir } from './content-dir'
-import { getAgentIds as getOpenClawAgentIds } from './openclaw-config'
 
 const log = createLogger('settings')
 
@@ -53,13 +52,6 @@ export interface BakinSettings {
     allowlist?: string[]
     blocklist?: string[]
   }
-  agents: string[]
-  /**
-   * Canonical id of the main/orchestrator agent. Overrides the OpenClaw
-   * config lookup performed by `getMainAgentId()`. Usually unset — the
-   * OpenClaw config is the source of truth.
-   */
-  mainAgentId?: string
   antfly: {
     enabled: boolean
     url: string
@@ -179,7 +171,6 @@ const DEFAULTS: BakinSettings = {
     gatewayPort: 18789,
   },
   models: {},
-  agents: [], // populated dynamically from OpenClaw at load time
   antfly: {
     enabled: true,
     url: 'http://localhost:8080/api/v1',
@@ -272,60 +263,41 @@ function deepMerge(defaults: Record<string, unknown>, overrides: Record<string, 
 }
 
 export function getSettings(): BakinSettings {
-  let settings = getCachedSettings()
+  const cached = getCachedSettings()
+  if (cached) return cached
+
+  const settingsPath = getSettingsPath()
   let overrides: Record<string, unknown> = {}
 
-  if (!settings) {
-    const settingsPath = getSettingsPath()
-
-    try {
-      if (fs.existsSync(settingsPath)) {
-        overrides = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
-        log.info('Settings loaded', { path: settingsPath })
-      }
-    } catch (err) {
-      log.warn('Failed to read settings, using defaults', err)
+  try {
+    if (fs.existsSync(settingsPath)) {
+      overrides = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
+      log.info('Settings loaded', { path: settingsPath })
     }
-
-    settings = deepMerge(
-      DEFAULTS as unknown as Record<string, unknown>,
-      overrides
-    ) as unknown as BakinSettings
-
-    // Legacy embedder field — migrate to embedders.default if the user
-    // set it directly without also setting embedders.default. This is
-    // detected by inspecting the raw overrides, not the merged settings,
-    // since defaults alone never populate the legacy field.
-    const overrideAntfly = (overrides as { antfly?: Record<string, unknown> }).antfly
-    const legacyEmbedder = overrideAntfly && (overrideAntfly as { embedder?: { provider: string; model: string } }).embedder
-    const hasEmbedders = overrideAntfly && 'embedders' in overrideAntfly
-    if (legacyEmbedder && !hasEmbedders) {
-      settings.antfly.embedders.default = { provider: legacyEmbedder.provider, model: legacyEmbedder.model }
-      log.warn('settings.antfly.embedder is deprecated — migrate to settings.antfly.embedders.default')
-    } else if (legacyEmbedder && hasEmbedders) {
-      log.warn('settings.antfly.embedder is deprecated and ignored — using settings.antfly.embedders instead')
-    }
-
-    setCachedSettings(settings)
-  } else {
-    const settingsPath = getSettingsPath()
-    try {
-      if (fs.existsSync(settingsPath)) {
-        overrides = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'))
-      }
-    } catch {
-      // keep cached settings, treat as no explicit overrides
-    }
+  } catch (err) {
+    log.warn('Failed to read settings, using defaults', err)
   }
 
-  const hasExplicitAgentsOverride = Array.isArray(overrides.agents)
+  const settings = deepMerge(
+    DEFAULTS as unknown as Record<string, unknown>,
+    overrides
+  ) as unknown as BakinSettings
 
-  // If the user did not explicitly set an agent roster, mirror OpenClaw.
-  // If they did, respect it and do not overwrite it based on openclaw.json mtime.
-  if (!hasExplicitAgentsOverride) {
-    settings.agents = getOpenClawAgentIds()
+  // Legacy embedder field — migrate to embedders.default if the user
+  // set it directly without also setting embedders.default. This is
+  // detected by inspecting the raw overrides, not the merged settings,
+  // since defaults alone never populate the legacy field.
+  const overrideAntfly = (overrides as { antfly?: Record<string, unknown> }).antfly
+  const legacyEmbedder = overrideAntfly && (overrideAntfly as { embedder?: { provider: string; model: string } }).embedder
+  const hasEmbedders = overrideAntfly && 'embedders' in overrideAntfly
+  if (legacyEmbedder && !hasEmbedders) {
+    settings.antfly.embedders.default = { provider: legacyEmbedder.provider, model: legacyEmbedder.model }
+    log.warn('settings.antfly.embedder is deprecated — migrate to settings.antfly.embedders.default')
+  } else if (legacyEmbedder && hasEmbedders) {
+    log.warn('settings.antfly.embedder is deprecated and ignored — using settings.antfly.embedders instead')
   }
 
+  setCachedSettings(settings)
   return settings
 }
 

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -6,7 +6,7 @@ import fs from 'fs'
 import path from 'path'
 import { createLogger } from './logger'
 import { getContentDir } from './content-dir'
-import { getOpenClawPath } from './openclaw-home'
+import { getAgentIds as getOpenClawAgentIds } from './openclaw-config'
 
 const log = createLogger('settings')
 
@@ -241,36 +241,9 @@ const DEFAULTS: BakinSettings = {
 // bust the cache seen by the custom server's /api/settings handler.
 const _g = globalThis as typeof globalThis & {
   __bakinSettingsCache?: BakinSettings | null
-  __bakinOpenClawMtime?: number
-  __bakinOpenClawAgents?: string[]
 }
 function getCachedSettings(): BakinSettings | null { return _g.__bakinSettingsCache ?? null }
 function setCachedSettings(v: BakinSettings | null) { _g.__bakinSettingsCache = v }
-
-/**
- * Read agent IDs from ~/.openclaw/openclaw.json with mtime-based caching.
- * Re-reads when the file changes on disk — picks up agents added via OpenClaw
- * without needing a Bakin restart or explicit cache bust. Ids flow through
- * unchanged; display names are resolved separately at render time.
- */
-function readAgentIdsFromOpenClaw(): string[] {
-  try {
-    const openclawJsonPath = getOpenClawPath('openclaw.json')
-    const stat = fs.statSync(openclawJsonPath)
-    if (_g.__bakinOpenClawMtime === stat.mtimeMs && _g.__bakinOpenClawAgents) {
-      return _g.__bakinOpenClawAgents
-    }
-    const config = JSON.parse(fs.readFileSync(openclawJsonPath, 'utf-8'))
-    const list = config?.agents?.list as Array<{ id: string }> | undefined
-    if (!Array.isArray(list)) return []
-    const agents = list.map((a) => a.id)
-    _g.__bakinOpenClawMtime = stat.mtimeMs
-    _g.__bakinOpenClawAgents = agents
-    return agents
-  } catch {
-    return []
-  }
-}
 
 function getSettingsPath(): string {
   return path.join(getContentDir(), 'settings.json')
@@ -350,7 +323,7 @@ export function getSettings(): BakinSettings {
   // If the user did not explicitly set an agent roster, mirror OpenClaw.
   // If they did, respect it and do not overwrite it based on openclaw.json mtime.
   if (!hasExplicitAgentsOverride) {
-    settings.agents = readAgentIdsFromOpenClaw()
+    settings.agents = getOpenClawAgentIds()
   }
 
   return settings

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -67,8 +67,8 @@ interface FounderNodeData extends Record<string, unknown> {
 function FounderNode({ data }: NodeProps) {
   const { label, subtitle } = data as FounderNodeData
   return (
-    <div className="rounded-xl border border-zinc-700 bg-zinc-900 px-5 py-3 flex items-center gap-3 shadow-md">
-      <div className="size-9 rounded-full bg-zinc-800 flex items-center justify-center text-base">👤</div>
+    <div className="rounded-xl border border-zinc-700 bg-zinc-900 px-5 py-3 flex items-center justify-center gap-3 shadow-md w-[152px]">
+      <div className="size-9 rounded-full bg-zinc-800 flex items-center justify-center text-base shrink-0">👤</div>
       <div>
         <div className="text-sm font-semibold text-zinc-100">{label}</div>
         <div className="text-xs text-zinc-400">{subtitle}</div>

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -8,7 +8,6 @@ import {
   Background,
   BackgroundVariant,
   type Node,
-  type Edge,
   type NodeTypes,
   Position,
   Handle,
@@ -25,10 +24,11 @@ import {
 } from '@/components/ui/dialog'
 import { BakinDrawer } from '@/components/bakin-drawer'
 import { useGatewayStatus } from '@/hooks/use-gateway-status'
-import { useAgentStore, useAgentColor } from '../hooks/use-agent-store'
+import { useAgentStore, useAgentColor, useMainAgentId } from '../hooks/use-agent-store'
+import { buildGraph } from '../lib/build-graph'
 import { AgentForm, type AgentFormData } from './agent-form'
 import { TeamManager } from './team-manager'
-import type { AgentWithStatus, OrgTeam, AgentDisplaySettingsMap } from '../types'
+import type { AgentWithStatus } from '../types'
 
 /** Strip default ReactFlow node chrome + animated edges + hover glow */
 const RESET_STYLES = `
@@ -163,216 +163,6 @@ const nodeTypes: NodeTypes = {
   section: SectionNode,
 }
 
-// ─── Layout ──────────────────────────────────────────────────────────────────
-
-const CARD_W = 152
-const CARD_H = 240
-const X_GAP = 24
-const Y_GAP = 50
-
-const EDGE_STYLE: Record<string, unknown> = { stroke: '#525252', strokeWidth: 2 }
-const EDGE_DASHED: Record<string, unknown> = { ...EDGE_STYLE }
-
-function placeRow(
-  agents: AgentWithStatus[],
-  y: number,
-  nodes: Node[],
-) {
-  const totalW = agents.length * CARD_W + (agents.length - 1) * X_GAP
-  const startX = -totalW / 2
-  agents.forEach((agent, i) => {
-    nodes.push({
-      id: agent.id,
-      type: 'agentCard',
-      position: { x: startX + i * (CARD_W + X_GAP), y },
-      data: { agent },
-    })
-  })
-}
-
-interface GraphInput {
-  agents: AgentWithStatus[]
-  teams: OrgTeam[]
-  displaySettings: AgentDisplaySettingsMap
-}
-
-function buildGraph({ agents, teams, displaySettings }: GraphInput) {
-  const nodes: Node[] = []
-  const edges: Edge[] = []
-  const agentMap = new Map(agents.map((a) => [a.id, a]))
-
-  // Sort teams by order
-  const sortedTeams = [...teams].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-
-  // Build team membership from display settings
-  const teamMembers = new Map<string, AgentWithStatus[]>()
-  const assignedIds = new Set<string>()
-
-  for (const team of sortedTeams) {
-    teamMembers.set(team.id, [])
-  }
-  for (const agent of agents) {
-    const teamId = displaySettings[agent.id]?.teamId
-    if (teamId && teamMembers.has(teamId)) {
-      teamMembers.get(teamId)!.push(agent)
-      assignedIds.add(agent.id)
-    }
-  }
-
-  // Group teams by who they report to
-  const teamsByReporter = new Map<string, OrgTeam[]>()
-  for (const team of sortedTeams) {
-    const list = teamsByReporter.get(team.reportsTo) ?? []
-    list.push(team)
-    teamsByReporter.set(team.reportsTo, list)
-  }
-
-  // Find top-level agents: agents that have teams reporting to them
-  // or agents with no team assignment that aren't in any team
-  const topAgentIds = new Set<string>()
-  for (const team of sortedTeams) {
-    topAgentIds.add(team.reportsTo)
-  }
-
-  // Unassigned agents (not in any team, not a team leader)
-  const unassigned = agents.filter((a) => !assignedIds.has(a.id) && !topAgentIds.has(a.id))
-
-  let y = 0
-
-  // Row 0: Founder (Mark)
-  const founderW = 160
-  nodes.push({
-    id: 'mark',
-    type: 'founder',
-    position: { x: -founderW / 2, y },
-    data: { label: 'Mark', subtitle: 'Founder' },
-  })
-
-  y += 80 + Y_GAP
-
-  // Row 1: Top-level agents (those with teams reporting to them)
-  // Typically just the main agent, but could be multiple
-  const topAgents = agents.filter((a) => topAgentIds.has(a.id))
-  if (topAgents.length > 0) {
-    placeRow(topAgents, y, nodes)
-    for (const agent of topAgents) {
-      assignedIds.add(agent.id)
-      edges.push({
-        id: `mark->${agent.id}`,
-        source: 'mark',
-        target: agent.id,
-        type: 'smoothstep',
-        style: EDGE_STYLE,
-      })
-    }
-    y += CARD_H + Y_GAP
-  }
-
-  // Render each team: section header → member cards
-  // Collect all teams that need rendering, grouped side-by-side when they share a reporter
-  const renderedTeams = new Set<string>()
-
-  for (const topAgent of topAgents) {
-    const teamsForAgent = teamsByReporter.get(topAgent.id) ?? []
-    if (teamsForAgent.length === 0) continue
-
-    // Calculate total width of all teams side by side
-    const teamWidths: number[] = []
-    const teamMembersList: AgentWithStatus[][] = []
-    for (const team of teamsForAgent) {
-      const members = teamMembers.get(team.id) ?? []
-      teamMembersList.push(members)
-      const w = Math.max(1, members.length) * CARD_W + Math.max(0, members.length - 1) * X_GAP
-      teamWidths.push(w)
-      renderedTeams.add(team.id)
-    }
-
-    const TEAM_GAP = 80
-    const totalTeamWidth = teamWidths.reduce((a, b) => a + b, 0) + (teamsForAgent.length - 1) * TEAM_GAP
-    let teamX = -totalTeamWidth / 2
-
-    // Section headers
-    const sectionY = y
-    for (let t = 0; t < teamsForAgent.length; t++) {
-      const team = teamsForAgent[t]
-      const sectionW = 200
-      const centerX = teamX + teamWidths[t] / 2
-      nodes.push({
-        id: `section-${team.id}`,
-        type: 'section',
-        position: { x: centerX - sectionW / 2, y: sectionY },
-        data: { label: team.label },
-      })
-      edges.push({
-        id: `${topAgent.id}->section-${team.id}`,
-        source: topAgent.id,
-        target: `section-${team.id}`,
-        type: 'smoothstep',
-        style: EDGE_STYLE,
-      })
-      teamX += teamWidths[t] + TEAM_GAP
-    }
-
-    y += 30 + Y_GAP
-
-    // Member cards
-    teamX = -totalTeamWidth / 2
-    for (let t = 0; t < teamsForAgent.length; t++) {
-      const team = teamsForAgent[t]
-      const members = teamMembersList[t]
-      const memberStartX = teamX
-
-      members.forEach((agent, i) => {
-        const x = memberStartX + i * (CARD_W + X_GAP)
-        nodes.push({
-          id: agent.id,
-          type: 'agentCard',
-          position: { x, y },
-          data: { agent },
-        })
-        edges.push({
-          id: `section-${team.id}->${agent.id}`,
-          source: `section-${team.id}`,
-          target: agent.id,
-          type: 'smoothstep',
-          style: EDGE_DASHED,
-        })
-      })
-
-      teamX += teamWidths[t] + TEAM_GAP
-    }
-
-    if (teamsForAgent.some((_, t) => teamMembersList[t].length > 0)) {
-      y += CARD_H + Y_GAP
-    }
-  }
-
-  // Unassigned agents
-  if (unassigned.length > 0) {
-    const sectionW = 200
-    nodes.push({
-      id: 'section-unassigned',
-      type: 'section',
-      position: { x: -sectionW / 2, y },
-      data: { label: 'Unassigned' },
-    })
-    y += 30 + Y_GAP
-
-    placeRow(unassigned, y, nodes)
-    for (const agent of unassigned) {
-      edges.push({
-        id: `unassigned->${agent.id}`,
-        source: 'section-unassigned',
-        target: agent.id,
-        type: 'smoothstep',
-        style: EDGE_DASHED,
-      })
-    }
-  }
-
-  return { nodes, edges: edges.map((e) => ({ ...e, animated: true })) }
-}
-
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function TeamGrid() {
@@ -380,6 +170,7 @@ export function TeamGrid() {
   const agentsWithStatus = useAgentStore((s) => s.agentsWithStatus)
   const teams = useAgentStore((s) => s.teams)
   const displaySettings = useAgentStore((s) => s.displaySettings)
+  const mainAgentId = useMainAgentId()
   const loaded = useAgentStore((s) => s.loaded)
   const reload = useAgentStore((s) => s.load)
   const [showCreate, setShowCreate] = useState(false)
@@ -397,8 +188,10 @@ export function TeamGrid() {
   )
 
   const { nodes, edges } = useMemo(
-    () => loaded ? buildGraph({ agents: agentsWithStatus, teams, displaySettings }) : { nodes: [], edges: [] },
-    [agentsWithStatus, teams, displaySettings, loaded],
+    () => loaded
+      ? buildGraph({ agents: agentsWithStatus, teams, displaySettings, mainAgentId })
+      : { nodes: [], edges: [] },
+    [agentsWithStatus, teams, displaySettings, mainAgentId, loaded],
   )
 
   // Step 1: form submits → stash data and show confirmation dialog

--- a/plugins/team/components/team-manager.tsx
+++ b/plugins/team/components/team-manager.tsx
@@ -110,7 +110,7 @@ export function TeamManager() {
                   <div className="text-xs text-muted-foreground">
                     Reports to{' '}
                     <select
-                      value={team.reportsTo}
+                      value={team.reportsTo ?? ''}
                       onChange={(e) => handleUpdate(team.id, { reportsTo: e.target.value })}
                       className="inline-flex h-5 rounded border border-border bg-transparent px-1 text-[10px] text-foreground focus:outline-none"
                     >

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -87,6 +87,51 @@ function writeTeams(teams: OrgTeam[]): void {
   writePluginSettings({ ...current, teams })
 }
 
+/**
+ * Normalize a `reportsTo` value for persistence in team.json.
+ *
+ * Stores `null` when the incoming value is undefined/null or equals the
+ * current main agent id. This decouples team.json from the specific
+ * orchestrator name so installs sharing the file don't get pinned to
+ * "main" (or whatever id the local main agent happens to use).
+ *
+ * If `getMainAgentId()` itself fails (e.g. a malformed roster), we fall
+ * back to returning the value as-is rather than crashing the write path.
+ */
+function normalizeReportsTo(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') return null
+  try {
+    if (value === getMainAgentId()) return null
+  } catch (err) {
+    log.warn('normalizeReportsTo: getMainAgentId() threw — preserving value as-is', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  return value
+}
+
+/**
+ * Degrade teams whose `reportsTo` points at an agent that no longer
+ * exists in the roster. The render-time resolver treats `null` as
+ * "report to main", so this keeps legacy team.json files rendering
+ * cleanly after a rename or removal. Read-only — never rewrites the
+ * file from the read path.
+ */
+function degradeUnknownReportsTo(teams: OrgTeam[], knownIds: Set<string>): OrgTeam[] {
+  return teams.map((team) => {
+    const reportsTo = team.reportsTo
+    if (typeof reportsTo === 'string' && !knownIds.has(reportsTo)) {
+      log.warn('team.json has a team reporting to unknown agent id — treating as null', {
+        teamId: team.id,
+        reportsTo,
+      })
+      return { ...team, reportsTo: null }
+    }
+    return team
+  })
+}
+
 function mergeDisplayDefaults(overrides: AgentDisplaySettingsMap): AgentDisplaySettingsMap {
   const result: AgentDisplaySettingsMap = {}
   const ids = adapter.getAgentIds()
@@ -380,7 +425,8 @@ const teamPlugin: BakinPlugin = {
             ]).catch(() => {})
           }
 
-          const teams = readTeams()
+          const knownIds = new Set(agents.map((a) => a.id))
+          const teams = degradeUnknownReportsTo(readTeams(), knownIds)
           return Response.json({ agents: result, displaySettings, teams, mainAgentId: getMainAgentId() })
         } catch (err) {
           log.error('Failed to list agents', err)
@@ -792,7 +838,6 @@ const teamPlugin: BakinPlugin = {
         const id = (body.id as string || '').toLowerCase().replace(/[^a-z0-9-]/g, '')
         if (!id) return Response.json({ error: 'id required' }, { status: 400 })
         if (!body.label) return Response.json({ error: 'label required' }, { status: 400 })
-        if (!body.reportsTo) return Response.json({ error: 'reportsTo required' }, { status: 400 })
 
         const teams = readTeams()
         if (teams.some((t) => t.id === id)) {
@@ -802,7 +847,7 @@ const teamPlugin: BakinPlugin = {
         const team: OrgTeam = {
           id,
           label: body.label as string,
-          reportsTo: body.reportsTo as string,
+          reportsTo: normalizeReportsTo(body.reportsTo),
           color: body.color as string | undefined,
           order: typeof body.order === 'number' ? body.order : teams.length,
         }
@@ -830,7 +875,7 @@ const teamPlugin: BakinPlugin = {
 
         const body = await req.json() as Record<string, unknown>
         if (body.label !== undefined) teams[idx].label = body.label as string
-        if (body.reportsTo !== undefined) teams[idx].reportsTo = body.reportsTo as string
+        if (body.reportsTo !== undefined) teams[idx].reportsTo = normalizeReportsTo(body.reportsTo)
         if (body.color !== undefined) teams[idx].color = body.color as string
         if (body.order !== undefined) teams[idx].order = body.order as number
 

--- a/plugins/team/lib/build-graph.ts
+++ b/plugins/team/lib/build-graph.ts
@@ -1,0 +1,339 @@
+/**
+ * Pyramid layout for the team grid — pure function, no React.
+ *
+ * Root is always the main agent (resolved from `mainAgentId` in the store,
+ * which comes from the team plugin roster route, which itself calls
+ * `getMainAgentId()` server-side). Teams in `team.json` whose `reportsTo`
+ * is null/undefined are resolved at render time to `mainAgentId`. Teams
+ * whose `reportsTo` points at an unknown agent fall back to main as well
+ * — we don't crash and we don't orphan them.
+ *
+ * Row shape:
+ *   0  Founder (Mark)
+ *   1  Main agent card (if resolvable, otherwise empty)
+ *   2  Team section headers + non-main team-leader cards
+ *   3  Team member cards
+ *   +  Unassigned bucket for agents that don't belong to any rendered team
+ */
+import type { Node, Edge } from '@xyflow/react'
+import type { AgentWithStatus, AgentDisplaySettingsMap, OrgTeam } from '../types'
+
+// ─── Layout constants ───────────────────────────────────────────────────────
+
+export const CARD_W = 152
+export const CARD_H = 240
+export const X_GAP = 24
+export const Y_GAP = 50
+const TEAM_GAP = 80
+const SECTION_W = 200
+const FOUNDER_W = 160
+const FOUNDER_ROW_H = 80
+const SECTION_ROW_H = 30
+
+const EDGE_STYLE: Record<string, unknown> = { stroke: '#525252', strokeWidth: 2 }
+const EDGE_DASHED: Record<string, unknown> = { ...EDGE_STYLE }
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface BuildGraphInput {
+  agents: AgentWithStatus[]
+  teams: OrgTeam[]
+  displaySettings: AgentDisplaySettingsMap
+  /** Canonical main/orchestrator agent id. Null when the roster is broken. */
+  mainAgentId: string | null
+}
+
+export interface BuildGraphResult {
+  nodes: Node[]
+  edges: Edge[]
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function placeRow(agents: AgentWithStatus[], y: number, nodes: Node[]): void {
+  const totalW = agents.length * CARD_W + Math.max(0, agents.length - 1) * X_GAP
+  const startX = -totalW / 2
+  agents.forEach((agent, i) => {
+    nodes.push({
+      id: agent.id,
+      type: 'agentCard',
+      position: { x: startX + i * (CARD_W + X_GAP), y },
+      data: { agent },
+    })
+  })
+}
+
+/**
+ * Resolve a team's effective reporter — treat null/undefined/empty/unknown as
+ * "reports to main". The OrgTeam.reportsTo field is typed string, but legacy
+ * team.json files may contain null, missing fields, or stale agent ids.
+ */
+function resolveReporter(
+  team: OrgTeam,
+  agentIds: Set<string>,
+  mainAgentId: string | null,
+): string | null {
+  const raw = (team as { reportsTo?: string | null }).reportsTo
+  if (!raw) return mainAgentId
+  if (!agentIds.has(raw)) return mainAgentId
+  return raw
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build the pyramid graph. Deterministic and pure — call with identical
+ * inputs and you'll get identical output.
+ */
+export function buildGraph(input: BuildGraphInput): BuildGraphResult {
+  const { agents, teams, displaySettings, mainAgentId } = input
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+  const agentMap = new Map(agents.map((a) => [a.id, a]))
+  const agentIds = new Set(agentMap.keys())
+
+  // Sort teams by order for stable rendering
+  const sortedTeams = [...teams].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+
+  // Map teamId → member agents (from displaySettings)
+  const teamMembers = new Map<string, AgentWithStatus[]>()
+  for (const team of sortedTeams) teamMembers.set(team.id, [])
+  const assignedIds = new Set<string>()
+  for (const agent of agents) {
+    const teamId = displaySettings[agent.id]?.teamId
+    if (teamId && teamMembers.has(teamId)) {
+      teamMembers.get(teamId)!.push(agent)
+      assignedIds.add(agent.id)
+    }
+  }
+
+  // Resolve each team's reporter (reportsTo ?? mainAgentId), then group
+  // teams by their effective reporter.
+  const teamsByReporter = new Map<string, OrgTeam[]>()
+  for (const team of sortedTeams) {
+    const reporter = resolveReporter(team, agentIds, mainAgentId)
+    if (!reporter) continue // no main agent and no valid reporter — skip
+    const list = teamsByReporter.get(reporter) ?? []
+    list.push(team)
+    teamsByReporter.set(reporter, list)
+  }
+
+  // ─── Row 0: Founder ──────────────────────────────────────────────────────
+  let y = 0
+  nodes.push({
+    id: 'mark',
+    type: 'founder',
+    position: { x: -FOUNDER_W / 2, y },
+    data: { label: 'Mark', subtitle: 'Founder' },
+  })
+  y += FOUNDER_ROW_H + Y_GAP
+
+  // ─── Row 1: Main agent ───────────────────────────────────────────────────
+  const mainAgent =
+    mainAgentId && agentMap.has(mainAgentId) ? agentMap.get(mainAgentId)! : null
+
+  if (mainAgent) {
+    placeRow([mainAgent], y, nodes)
+    assignedIds.add(mainAgent.id)
+    edges.push({
+      id: `mark->${mainAgent.id}`,
+      source: 'mark',
+      target: mainAgent.id,
+      type: 'smoothstep',
+      style: EDGE_STYLE,
+    })
+    y += CARD_H + Y_GAP
+  }
+
+  // ─── Row 2: Non-main team leaders (sub-orgs) ─────────────────────────────
+  // An agent is a "non-main team leader" when a team's reportsTo points at
+  // them AND they're not the main agent. In the default flat config there
+  // are none — all teams resolve to main.
+  const nonMainLeaderIds: string[] = []
+  for (const reporter of teamsByReporter.keys()) {
+    if (reporter === mainAgentId) continue
+    if (!agentMap.has(reporter)) continue
+    nonMainLeaderIds.push(reporter)
+  }
+
+  if (nonMainLeaderIds.length > 0) {
+    const leaders = nonMainLeaderIds.map((id) => agentMap.get(id)!)
+    placeRow(leaders, y, nodes)
+    for (const leader of leaders) {
+      assignedIds.add(leader.id)
+      // Wire them back up to main (if main exists), so the org stays connected
+      if (mainAgent) {
+        edges.push({
+          id: `${mainAgent.id}->${leader.id}`,
+          source: mainAgent.id,
+          target: leader.id,
+          type: 'smoothstep',
+          style: EDGE_STYLE,
+        })
+      }
+    }
+    y += CARD_H + Y_GAP
+  }
+
+  // ─── Rows 3+: team sections and members, grouped by reporter ─────────────
+  // Render each reporter's teams in one horizontal strip. Order: main first,
+  // then non-main leaders in insertion order.
+  const reporterOrder: string[] = []
+  if (mainAgentId && teamsByReporter.has(mainAgentId)) reporterOrder.push(mainAgentId)
+  for (const id of nonMainLeaderIds) {
+    if (teamsByReporter.has(id)) reporterOrder.push(id)
+  }
+
+  // Synthesize a default "All Agents" section when there are no teams at all
+  // and we have a main agent with subagents. This gives fresh installs a
+  // visible pyramid shape without requiring the user to define any teams.
+  const needsSynthetic =
+    sortedTeams.length === 0 &&
+    mainAgent !== null &&
+    agents.some((a) => a.id !== mainAgent!.id)
+
+  for (const reporterId of reporterOrder) {
+    const teamsForReporter = teamsByReporter.get(reporterId) ?? []
+    if (teamsForReporter.length === 0) continue
+
+    const teamWidths: number[] = []
+    const teamMembersList: AgentWithStatus[][] = []
+    for (const team of teamsForReporter) {
+      const members = teamMembers.get(team.id) ?? []
+      teamMembersList.push(members)
+      const w = Math.max(1, members.length) * CARD_W + Math.max(0, members.length - 1) * X_GAP
+      teamWidths.push(w)
+    }
+
+    const totalTeamWidth =
+      teamWidths.reduce((a, b) => a + b, 0) + Math.max(0, teamsForReporter.length - 1) * TEAM_GAP
+    let teamX = -totalTeamWidth / 2
+
+    // Section headers
+    const sectionY = y
+    for (let t = 0; t < teamsForReporter.length; t++) {
+      const team = teamsForReporter[t]
+      const centerX = teamX + teamWidths[t] / 2
+      nodes.push({
+        id: `section-${team.id}`,
+        type: 'section',
+        position: { x: centerX - SECTION_W / 2, y: sectionY },
+        data: { label: team.label },
+      })
+      edges.push({
+        id: `${reporterId}->section-${team.id}`,
+        source: reporterId,
+        target: `section-${team.id}`,
+        type: 'smoothstep',
+        style: EDGE_STYLE,
+      })
+      teamX += teamWidths[t] + TEAM_GAP
+    }
+
+    y += SECTION_ROW_H + Y_GAP
+
+    // Member cards
+    teamX = -totalTeamWidth / 2
+    for (let t = 0; t < teamsForReporter.length; t++) {
+      const team = teamsForReporter[t]
+      const members = teamMembersList[t]
+      const memberStartX = teamX
+
+      members.forEach((agent, i) => {
+        const x = memberStartX + i * (CARD_W + X_GAP)
+        nodes.push({
+          id: agent.id,
+          type: 'agentCard',
+          position: { x, y },
+          data: { agent },
+        })
+        edges.push({
+          id: `section-${team.id}->${agent.id}`,
+          source: `section-${team.id}`,
+          target: agent.id,
+          type: 'smoothstep',
+          style: EDGE_DASHED,
+        })
+      })
+
+      teamX += teamWidths[t] + TEAM_GAP
+    }
+
+    if (teamMembersList.some((m) => m.length > 0)) {
+      y += CARD_H + Y_GAP
+    }
+  }
+
+  // Synthesized default section: fresh installs only.
+  if (needsSynthetic && mainAgent) {
+    const subagents = agents.filter((a) => a.id !== mainAgent.id)
+    const totalW = subagents.length * CARD_W + Math.max(0, subagents.length - 1) * X_GAP
+
+    nodes.push({
+      id: 'section-all',
+      type: 'section',
+      position: { x: -SECTION_W / 2, y },
+      data: { label: 'All agents' },
+    })
+    edges.push({
+      id: `${mainAgent.id}->section-all`,
+      source: mainAgent.id,
+      target: 'section-all',
+      type: 'smoothstep',
+      style: EDGE_STYLE,
+    })
+    y += SECTION_ROW_H + Y_GAP
+
+    const startX = -totalW / 2
+    subagents.forEach((agent, i) => {
+      nodes.push({
+        id: agent.id,
+        type: 'agentCard',
+        position: { x: startX + i * (CARD_W + X_GAP), y },
+        data: { agent },
+      })
+      edges.push({
+        id: `section-all->${agent.id}`,
+        source: 'section-all',
+        target: agent.id,
+        type: 'smoothstep',
+        style: EDGE_DASHED,
+      })
+      assignedIds.add(agent.id)
+    })
+    if (subagents.length > 0) y += CARD_H + Y_GAP
+  }
+
+  // ─── Unassigned bucket ──────────────────────────────────────────────────
+  // Agents that never got placed: not main, not a team leader, not a team
+  // member. In the default flat config (no teams defined) the synthetic
+  // section picks everyone up and this bucket stays empty.
+  //
+  // If the main agent is missing (broken roster), we bail out here and show
+  // founder only — per T5 spec, an empty pyramid is the correct degraded
+  // state. Rendering orphan subagents when the orchestrator is gone would
+  // misrepresent the org.
+  const unassigned = mainAgent ? agents.filter((a) => !assignedIds.has(a.id)) : []
+  if (unassigned.length > 0) {
+    nodes.push({
+      id: 'section-unassigned',
+      type: 'section',
+      position: { x: -SECTION_W / 2, y },
+      data: { label: 'Unassigned' },
+    })
+    y += SECTION_ROW_H + Y_GAP
+
+    placeRow(unassigned, y, nodes)
+    for (const agent of unassigned) {
+      edges.push({
+        id: `unassigned->${agent.id}`,
+        source: 'section-unassigned',
+        target: agent.id,
+        type: 'smoothstep',
+        style: EDGE_DASHED,
+      })
+    }
+  }
+
+  return { nodes, edges: edges.map((e) => ({ ...e, animated: true })) }
+}

--- a/plugins/team/lib/build-graph.ts
+++ b/plugins/team/lib/build-graph.ts
@@ -26,7 +26,7 @@ export const X_GAP = 24
 export const Y_GAP = 50
 const TEAM_GAP = 80
 const SECTION_W = 200
-const FOUNDER_W = 160
+const FOUNDER_W = CARD_W
 const FOUNDER_ROW_H = 80
 const SECTION_ROW_H = 30
 

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -17,6 +17,12 @@ import { join } from 'path'
 import { createLogger } from '../../../src/core/logger'
 import { getOpenClawHome, getOpenClawPath } from '@bakin/core/openclaw-home'
 import { tryGetMainAgentId } from '@bakin/core/main-agent'
+import {
+  readOpenClawConfig,
+  resetOpenClawConfigCache,
+  type OpenClawAgent,
+  type OpenClawConfig,
+} from '@bakin/core/openclaw-config'
 import type { AgentMeta, AgentProfile, SkillSummary } from '../types'
 
 const log = createLogger('team:openclaw')
@@ -28,42 +34,13 @@ const OPENCLAW_JSON = getOpenClawPath('openclaw.json')
 
 // ─── Config Reading ──────────────────────────────────────────────────────────
 
-interface OpenClawAgent {
-  id: string
-  name?: string
-  workspace?: string
-  agentDir?: string
-  model?: { primary?: string }
-  identity?: { name?: string; emoji?: string }
-  subagents?: { allowAgents?: string[]; model?: string }
-}
-
-interface OpenClawConfig {
-  agents?: {
-    defaults?: {
-      model?: { primary?: string }
-      workspace?: string
-    }
-    list?: OpenClawAgent[]
-  }
-}
-
-let configCache: { data: OpenClawConfig; mtime: number } | null = null
-
-/** Read and cache openclaw.json. Re-reads when file changes. */
+/**
+ * Read openclaw.json. Thin adapter over the centralized reader in
+ * `@bakin/core/openclaw-config` — returns `{}` on failure for historical
+ * compatibility with call sites that expect a non-null object.
+ */
 export function getOpenClawConfig(): OpenClawConfig {
-  try {
-    const stat = statSync(OPENCLAW_JSON)
-    if (configCache && configCache.mtime === stat.mtimeMs) {
-      return configCache.data
-    }
-    const data = JSON.parse(readFileSync(OPENCLAW_JSON, 'utf-8')) as OpenClawConfig
-    configCache = { data, mtime: stat.mtimeMs }
-    return data
-  } catch (err) {
-    log.warn('Failed to read openclaw.json', { error: err instanceof Error ? err.message : String(err) })
-    return {}
-  }
+  return readOpenClawConfig() ?? {}
 }
 
 // ─── Agent List ──────────────────────────────────────────────────────────────
@@ -301,7 +278,7 @@ export function addAgent(input: NewAgentInput): void {
 
   // Write updated config
   writeFileSync(OPENCLAW_JSON, JSON.stringify(config, null, 2), 'utf-8')
-  configCache = null // bust cache
+  resetOpenClawConfigCache() // bust cache
   log.info('Added agent to openclaw.json', { id: input.id, name: input.name })
 
   // Create workspace directory with initial files
@@ -339,7 +316,7 @@ export function removeAgent(agentId: string): boolean {
   if (config.agents.list.length === before) return false
 
   writeFileSync(OPENCLAW_JSON, JSON.stringify(config, null, 2), 'utf-8')
-  configCache = null
+  resetOpenClawConfigCache()
   log.info('Removed agent from openclaw.json', { id: agentId })
 
   // Move workspace to trash

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -45,23 +45,69 @@ export function getOpenClawConfig(): OpenClawConfig {
 
 // ─── Agent List ──────────────────────────────────────────────────────────────
 
-/** List all agents as lightweight AgentMeta (for dropdowns, badges, etc.) */
+/**
+ * List all agents as lightweight AgentMeta (for dropdowns, badges, etc.).
+ *
+ * This is a validation pass over `openclaw.json`, not a passthrough:
+ *   - Rejects duplicate agent ids (first occurrence wins).
+ *   - Rejects duplicate resolved workspaces — an agent's explicit
+ *     `workspace` or the inherited `agents.defaults.workspace`. When two
+ *     entries land on the same directory we keep the first and drop the
+ *     rest so the UI doesn't render ghost cards pointing at shared files.
+ *   - Requires a canonical `main` agent. If the roster has no `id: "main"`
+ *     we return an empty list so the UI surfaces the broken config instead
+ *     of silently hiding the orchestrator.
+ *
+ * All three violations log at `error` level — these are config bugs.
+ */
 export function listAgents(): AgentMeta[] {
   const config = getOpenClawConfig()
-  const agents = config.agents?.list ?? []
+  const raw = config.agents?.list ?? []
+  const defaultWorkspace = config.agents?.defaults?.workspace ?? null
 
-  return agents.map((a) => {
-    const name = a.identity?.name ?? a.name ?? a.id
-    const emoji = a.identity?.emoji ?? ''
-    const role = resolveRole(a.id)
-    return {
-      id: a.id,
+  const seenIds = new Set<string>()
+  const workspaceToFirstId = new Map<string, string>()
+  const accepted: AgentMeta[] = []
+
+  for (const agent of raw) {
+    if (seenIds.has(agent.id)) {
+      log.error(`openclaw.json contains duplicate agent id "${agent.id}" — dropping the later entry. See \`bakin check openclaw\`.`)
+      continue
+    }
+
+    const resolvedWorkspace = agent.workspace ?? defaultWorkspace
+    if (resolvedWorkspace !== null) {
+      const owner = workspaceToFirstId.get(resolvedWorkspace)
+      if (owner !== undefined) {
+        log.error(`openclaw.json agent "${agent.id}" resolves to workspace "${resolvedWorkspace}" already claimed by "${owner}" — dropping "${agent.id}". See \`bakin check openclaw\`.`)
+        continue
+      }
+    }
+
+    seenIds.add(agent.id)
+    if (resolvedWorkspace !== null) {
+      workspaceToFirstId.set(resolvedWorkspace, agent.id)
+    }
+
+    const name = agent.identity?.name ?? agent.name ?? agent.id
+    const emoji = agent.identity?.emoji ?? ''
+    const role = resolveRole(agent.id)
+    accepted.push({
+      id: agent.id,
       name,
       emoji,
       role,
-      headshot: `/api/plugins/team/${a.id}/avatar`,
-    }
-  })
+      headshot: `/api/plugins/team/${agent.id}/avatar`,
+    })
+  }
+
+  if (!seenIds.has('main')) {
+    const seen = Array.from(seenIds)
+    log.error(`openclaw.json must contain an agent with id "main" — got ids: [${seen.join(', ')}]. See \`bakin check openclaw\`.`)
+    return []
+  }
+
+  return accepted
 }
 
 /** Get IDs of all configured agents */

--- a/plugins/team/types.ts
+++ b/plugins/team/types.ts
@@ -46,7 +46,13 @@ export type AgentDisplaySettingsMap = Record<string, AgentDisplaySettings>
 export interface OrgTeam {
   id: string
   label: string
-  reportsTo: string   // agent ID this team reports to (e.g. "main")
+  /**
+   * Agent ID this team reports to, or `null` to indicate "reports to the
+   * main orchestrator". Stored as `null` whenever the incoming value
+   * matches the current main agent id so team.json stays decoupled from
+   * the specific orchestrator name.
+   */
+  reportsTo: string | null
   color?: string
   order?: number
 }

--- a/src/core/agents.ts
+++ b/src/core/agents.ts
@@ -5,7 +5,7 @@
 import { readFileSync, existsSync, readdirSync } from 'fs'
 import { join } from 'path'
 import { createLogger } from './logger'
-import { getSettings } from './settings'
+import { getAgentIds } from '@bakin/core/openclaw-config'
 import * as openclaw from './openclaw-client'
 import { readTaskboard } from '../lib/taskboard'
 
@@ -30,8 +30,7 @@ interface AgentTask {
  * Get status for a specific agent — their current tasks and last activity.
  */
 export async function getAgentStatus(agentId: string, contentDir: string): Promise<AgentStatus> {
-  const settings = getSettings()
-  const agents = settings.agents
+  const agents = getAgentIds()
 
   // Resolve name (agents list uses short names)
   const name = agents.includes(agentId) ? agentId : agentId
@@ -106,10 +105,9 @@ export async function sendMessageToAgent(
  * List all configured agents with their current status.
  */
 export async function listAgents(contentDir: string): Promise<AgentStatus[]> {
-  const settings = getSettings()
   const statuses: AgentStatus[] = []
 
-  for (const agentId of settings.agents) {
+  for (const agentId of getAgentIds()) {
     statuses.push(await getAgentStatus(agentId, contentDir))
   }
 

--- a/src/core/antfly-server.ts
+++ b/src/core/antfly-server.ts
@@ -13,6 +13,7 @@ const log = createLogger('antfly-server')
 
 let antflyProcess: ChildProcess | null = null
 let isRunning = false
+let recheckTimer: NodeJS.Timeout | null = null
 
 /**
  * Find the antfly binary on the system. Exported for reuse by the
@@ -61,6 +62,28 @@ async function waitForReady(url: string, timeoutMs = 15000): Promise<boolean> {
   return false
 }
 
+function clearRecheckTimer(): void {
+  if (recheckTimer) {
+    clearTimeout(recheckTimer)
+    recheckTimer = null
+  }
+}
+
+function scheduleExternalRecheck(url: string): void {
+  clearRecheckTimer()
+  recheckTimer = setTimeout(async () => {
+    recheckTimer = null
+
+    if (antflyProcess) return
+
+    const stillRunning = await isAlreadyRunning(url)
+    if (stillRunning) return
+
+    log.warn('Antfly disappeared after startup check, attempting takeover restart', { url })
+    await start()
+  }, 3000)
+}
+
 /**
  * Start the Antfly server if enabled and not already running.
  * Returns true if Antfly is available (either started or already running).
@@ -79,6 +102,7 @@ export async function start(): Promise<boolean> {
   if (await isAlreadyRunning(url)) {
     log.info('Antfly already running', { url })
     isRunning = true
+    scheduleExternalRecheck(url)
     return true
   }
 
@@ -119,6 +143,7 @@ export async function start(): Promise<boolean> {
     antflyProcess.on('exit', (code, signal) => {
       isRunning = false
       antflyProcess = null
+      clearRecheckTimer()
       if (code !== null && code !== 0) {
         log.error('Antfly exited unexpectedly', { code, signal })
       } else {
@@ -152,6 +177,8 @@ export async function start(): Promise<boolean> {
  * Stop the Antfly server if we started it.
  */
 export function stop(): void {
+  clearRecheckTimer()
+
   if (!antflyProcess) return
 
   log.info('Stopping Antfly server...')

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -12,6 +12,7 @@ import * as openclaw from './openclaw-client'
 import { isStale } from '../lib/format'
 import { getHookRegistry } from '../lib/plugin-registry'
 import { getMainAgentId } from '@bakin/core/main-agent'
+import { getAgentIds } from '@bakin/core/openclaw-config'
 
 const log = createLogger('dispatch')
 const hooks = () => getHookRegistry()
@@ -172,7 +173,7 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
         if (Date.now() - failure.lastAttempt < settings.dispatch.failureCooldownMs) continue
       }
 
-      if (task.agent && !settings.agents.includes(task.agent)) continue
+      if (task.agent && !getAgentIds().includes(task.agent)) continue
 
       // Workflow-aware dispatch path
       const taskWithWorkflow = task as typeof task & { workflowId?: string }
@@ -250,7 +251,7 @@ export async function dispatchSingleTask(
       return
     }
 
-    if (task.agent && !settings.agents.includes(task.agent)) {
+    if (task.agent && !getAgentIds().includes(task.agent)) {
       log.warn('dispatchSingleTask: agent not in allowed list', { taskId, agent: task.agent })
       return
     }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 
 import { join, dirname } from 'path'
 import { createLogger } from './logger'
 import { getSettings } from './settings'
+import { getAgentIds } from '@bakin/core/openclaw-config'
 import { getOpenClawPath } from '@bakin/core/openclaw-home'
 import { appendAudit } from './audit'
 import { isUsingBakinHome, getContentDir } from './content-dir'
@@ -65,7 +66,6 @@ function fixed(check: string, message: string): DiagnosticResult {
  */
 function checkAgentRoster(contentDir: string): DiagnosticResult[] {
   const results: DiagnosticResult[] = []
-  const settings = getSettings()
   const openclawConfigPath = getOpenClawPath('openclaw.json')
 
   if (!existsSync(openclawConfigPath)) {
@@ -76,7 +76,7 @@ function checkAgentRoster(contentDir: string): DiagnosticResult[] {
   try {
     const config = JSON.parse(readFileSync(openclawConfigPath, 'utf-8'))
     const openclawAgents = (config.agents?.list || []).map((a: { id: string }) => a.id)
-    const bakinAgents = settings.agents
+    const bakinAgents = getAgentIds()
 
     for (const agent of bakinAgents) {
       if (!openclawAgents.includes(agent)) {
@@ -106,7 +106,7 @@ function checkAgentRoster(contentDir: string): DiagnosticResult[] {
  */
 function checkPersonas(contentDir: string, autoFix: boolean): DiagnosticResult[] {
   const results: DiagnosticResult[] = []
-  const settings = getSettings()
+  const agentIds = getAgentIds()
   const personasDir = join(contentDir, 'team', 'personas')
 
   if (!existsSync(personasDir)) {
@@ -126,7 +126,7 @@ function checkPersonas(contentDir: string, autoFix: boolean): DiagnosticResult[]
   )
 
   let created = 0
-  for (const agent of settings.agents) {
+  for (const agent of agentIds) {
     if (!existing.has(agent)) {
       if (autoFix) {
         const stub = `# ${agent.charAt(0).toUpperCase() + agent.slice(1)}\n\n_Persona not yet configured. Update this file with the agent's personality, background, and communication style._\n`
@@ -143,7 +143,7 @@ function checkPersonas(contentDir: string, autoFix: boolean): DiagnosticResult[]
   }
 
   if (results.filter(r => r.check === 'personas').length === 0) {
-    results.push(ok('personas', `All ${settings.agents.length} agents have persona files`))
+    results.push(ok('personas', `All ${agentIds.length} agents have persona files`))
   }
 
   return results
@@ -738,7 +738,6 @@ function checkService(projectRoot: string): DiagnosticResult[] {
  */
 async function checkTaskConsistency(contentDir: string, autoFix: boolean): Promise<DiagnosticResult[]> {
   const results: DiagnosticResult[] = []
-  const settings = getSettings()
   const hooks = getHookRegistry()
 
   try {
@@ -748,8 +747,8 @@ async function checkTaskConsistency(contentDir: string, autoFix: boolean): Promi
     const { columns } = board
     const now = Date.now()
 
-    // Known agents from settings
-    const knownAgents = new Set(settings.agents)
+    // Known agents from openclaw.json
+    const knownAgents = new Set(getAgentIds())
 
     // Count tasks per agent
     const agentTaskCount: Record<string, number> = {}
@@ -861,7 +860,6 @@ interface ManagedBlockDef {
  *   <!-- bakin:{blockId}:end -->
  */
 function checkManagedBlock(def: ManagedBlockDef, autoFix: boolean): DiagnosticResult[] {
-  const settings = getSettings()
   const results: DiagnosticResult[] = []
   const openclawBase = getOpenClawPath()
   const startMarker = `<!-- bakin:${def.blockId}:start -->`
@@ -869,7 +867,7 @@ function checkManagedBlock(def: ManagedBlockDef, autoFix: boolean): DiagnosticRe
   const checkName = `agent-${def.blockId}`
 
   const mainId = getMainAgentId()
-  for (const agentId of settings.agents) {
+  for (const agentId of getAgentIds()) {
     if (agentId === mainId) continue
     if (def.agentFilter && !def.agentFilter(agentId)) continue
 

--- a/src/core/mcporter.ts
+++ b/src/core/mcporter.ts
@@ -12,7 +12,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { execSync } from 'child_process'
 import { createLogger } from './logger'
-import { getSettings } from './settings'
+import { getAgentIds } from '@bakin/core/openclaw-config'
 
 const log = createLogger('mcporter')
 
@@ -103,8 +103,7 @@ export function mcpUrl(agent: string, port: number): string {
  * Returns list of changes made.
  */
 export function syncConfig(port: number): string[] {
-  const settings = getSettings()
-  const agents = settings.agents
+  const agents = getAgentIds()
   const config = readConfig()
   const changes: string[] = []
 
@@ -152,8 +151,7 @@ export function verifyConfig(port: number): {
   agentEntries: Array<{ agent: string; name: string; url: string; correct: boolean }>
   staleEntries: string[]
 } {
-  const settings = getSettings()
-  const agents = settings.agents
+  const agents = getAgentIds()
   const config = readConfig()
   const servers = config.mcpServers || {}
 

--- a/src/core/onboarding/openclaw.ts
+++ b/src/core/onboarding/openclaw.ts
@@ -24,6 +24,8 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { createLogger } from '../logger'
 import { getOpenClawHome, getOpenClawPath } from '@bakin/core/openclaw-home'
+import { readOpenClawConfig, resetOpenClawConfigCache } from '@bakin/core/openclaw-config'
+import type { OpenClawConfig } from '@bakin/core/openclaw-config'
 import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
 
 const log = createLogger('onboarding:openclaw')
@@ -51,6 +53,81 @@ function findBinary(): string | null {
     if (existsSync(candidate)) return candidate
   }
   return null
+}
+
+/**
+ * Reports-only integrity validator for a parsed openclaw.json.
+ *
+ * After issue #90, we rely on the invariant that OpenClaw's orchestrator
+ * lives at `id: "main"` in every install, that agent ids are unique, and
+ * that no two agents resolve to the same workspace (otherwise Bakin's
+ * adapter cannot distinguish them). This scan collects *every* violation
+ * so the user sees the whole picture on one run of `bakin check openclaw`
+ * instead of playing whack-a-mole.
+ *
+ * **Never mutates openclaw.json.** Section 7 of the issue-90 spec is
+ * explicit: doctor and migration code must never auto-write OpenClaw's
+ * config. The user owns that file and decides how to fix it.
+ */
+export function validateOpenClawIntegrity(config: OpenClawConfig | null): string[] {
+  const issues: string[] = []
+  if (!config) return issues
+
+  const list = Array.isArray(config.agents?.list) ? config.agents!.list! : []
+
+  // 1. Missing main — OpenClaw's orchestrator id is always "main" on every
+  //    install; Bakin's main-agent resolver depends on that invariant.
+  const hasMain = list.some((a) => a?.id === 'main')
+  if (!hasMain) {
+    issues.push(
+      `openclaw.json has no agent with id 'main'. Add an entry like ` +
+        `{ "id": "main", "identity": { "name": "<your-agent-name>" } }. ` +
+        `OpenClaw's orchestrator id is always 'main' on every install.`
+    )
+  }
+
+  // 2. Duplicate ids — collect each colliding id exactly once in
+  //    encounter order so the report is stable across runs.
+  const seen = new Set<string>()
+  const reportedDupes = new Set<string>()
+  for (const agent of list) {
+    const id = agent?.id
+    if (typeof id !== 'string' || id.length === 0) continue
+    if (seen.has(id)) {
+      if (!reportedDupes.has(id)) {
+        issues.push(
+          `openclaw.json has duplicate agent id '${id}'. Keep one entry; remove the other.`
+        )
+        reportedDupes.add(id)
+      }
+    } else {
+      seen.add(id)
+    }
+  }
+
+  // 3. Duplicate resolved workspaces — resolve via `agent.workspace ??
+  //    defaults.workspace`. Agents with no resolved workspace are skipped
+  //    because there's nothing for them to collide with.
+  const defaultWorkspace = config.agents?.defaults?.workspace ?? null
+  const firstOwner = new Map<string, string>()
+  for (const agent of list) {
+    const id = agent?.id
+    if (typeof id !== 'string' || id.length === 0) continue
+    const resolved = agent?.workspace ?? defaultWorkspace
+    if (!resolved) continue
+    const existing = firstOwner.get(resolved)
+    if (existing && existing !== id) {
+      issues.push(
+        `openclaw.json has two agents sharing workspace '${resolved}': ` +
+          `'${existing}' and '${id}'. Bakin's adapter cannot distinguish ` +
+          `them — rename the workspace of one, or remove the duplicate entry.`
+      )
+    } else if (!existing) {
+      firstOwner.set(resolved, id)
+    }
+  }
+
+  return issues
 }
 
 async function check(): Promise<CheckResult> {
@@ -104,6 +181,22 @@ async function check(): Promise<CheckResult> {
       message: `openclaw.json at ${configPath} is not valid JSON`,
       remediation: 'Fix or regenerate the file via OpenClaw, then rerun onboarding.',
       details: { binary, configPath, parseError: String(err) },
+    }
+  }
+
+  // Integrity scan — reports-only. Never mutates openclaw.json. We drop
+  // the mtime cache first so successive `bakin check openclaw` runs after
+  // a manual edit observe the fresh file even on coarse-mtime filesystems.
+  resetOpenClawConfigCache()
+  const config = readOpenClawConfig()
+  const integrityIssues = validateOpenClawIntegrity(config)
+  if (integrityIssues.length > 0) {
+    return {
+      name: 'openclaw',
+      status: 'broken',
+      message: `openclaw.json has ${integrityIssues.length} integrity issue${integrityIssues.length === 1 ? '' : 's'}:\n  - ${integrityIssues.join('\n  - ')}`,
+      remediation: 'Edit openclaw.json to resolve the listed issues, then rerun `bakin check openclaw`. Bakin will not modify openclaw.json for you.',
+      details: { binary, configPath, integrityIssues },
     }
   }
 

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,390 +1,431 @@
-# Plan: Health Plugin Overhaul
+# Plan: Team plugin canonical main-agent ids
 
-**Spec:** `.claude/specs/health-plugin-overhaul.md`
-**Branch:** `fix/health-plugin-overhaul`
-**Created:** 2026-04-14
-
----
-
-## Ground truth (verified from source, not assumed)
-
-Before planning I verified the key code paths. The spec assumptions were mostly right but one audit claim was wrong — correcting it here:
-
-1. **`server.ts:147-166` middleware DOES catch plugin catch-all REST traffic.** It wraps `res.end()` at the Node HTTP layer, so every response — including ones Next.js produces for `/api/plugins/*` — flows through `recordRequest()`. The audit that claimed GET requests silently bypass tracking was wrong at the architectural level. GET tracking is real; it's just in-memory only and uses a *different* agent-attribution path than the catch-all.
-
-2. **Agent attribution is currently split in two:**
-   - `server.ts:162` reads `url.searchParams.get('agent')` — for clients that pass `?agent=` as a query param.
-   - `src/app/api/plugins/[pluginId]/[[...path]]/route.ts:249` reads `req.headers.get('x-bakin-agent')` — for agents that set a header.
-   Neither path reads the other. Unified recorder must check header first, then query param, then `'unknown'`.
-
-3. **The catch-all does its own audit + duration tracking** in parallel with the middleware. This is redundant — the middleware already records duration. The catch-all's audit behavior (writes + errors only, skips successful GETs) stays, but its duration/stat tracking is dead work once we unify.
-
-4. **Consumers of `request-log.ts` outside health**: `src/core/watchdog.ts` uses `getRecentStatsForPathPrefix` for MCP 5xx alerting. Must be retargeted to `getUsageStats({kind: 'mcp'})` before we can delete the module.
-
-5. **Existing test at `tests/core/request-log.test.ts`** will be deleted in Phase 5 alongside the module.
-
-6. **`scripts/lib/registry.ts:22-24, 56-93`** holds a parallel in-memory stats map (`toolStats`). Delete in Phase 5.
-
-7. **`setInterval` cleanup in `mcp-server.ts:88`** for stale sessions is unrelated and stays untouched.
+**Spec:** `.claude/specs/issue-90-team-main-agent-canonical.md`
+**Issue:** https://github.com/madeinwyo/bakin/issues/90
+**Branch:** `fix/issue-90-team-main-agent`
+**Created:** 2026-04-15
+**Author:** claude (opus-4-6) / roscoe
 
 ---
 
-## Strategy: vertical slices with feature-flag-free safe rollback
+## Spec correction (apply before starting work)
 
-The central design constraint: each commit must leave the app **in a working, deployable state**, so any one commit can be reverted independently. That rules out "delete the old system, then build the new one in 6 commits" because the middle commits would be broken.
+The spec as written says Bakin "never writes to openclaw.json, ever." That's wrong — `plugins/team/lib/openclaw-adapter.ts:279` (`addAgent`) and `:333` (`removeAgent`) already write to it as part of normal user-initiated agent CRUD, and the CLAUDE.md adapter principle explicitly permits it ("Bakin reads from OpenClaw. Bakin writes to OpenClaw. Bakin never *copies* OpenClaw").
 
-Strategy: **build the new system alongside the old, switch the consumers, then delete the old**. Five phases with commit-sized rollback points between each.
+The correct rule is: **doctor checks, migration helpers, and onboarding code never auto-mutate openclaw.json.** User-initiated CRUD through the existing adapter functions is fine.
 
-```
-Phase 1    Recorder exists in isolation            ← rollback here is free
-Phase 2    Producers feed BOTH old & new           ← rollback safely, UI still works
-Phase 3    New API route alongside old             ← rollback, UI unaffected
-Phase 4    UI switches to new API                  ← rollback reverts the UI only
-Phase 5    Old code deleted                        ← final — rollback from here
-                                                     goes back to phase 4 state
-```
-
-Between every phase, `pnpm lint && pnpm test && pnpm typecheck` must be green.
+**Pre-flight task:** update section 4 ("Out of scope") and section 7 ("Never") of the spec to reflect this. Do this in the same PR, at the top of commit 1.
 
 ---
 
 ## Dependency graph
 
 ```
-┌─────────────────────────────────────────────────┐
-│ Phase 1: Recorder                               │
-│   T1.1  src/core/usage.ts  + unit tests         │
-└─────────────────────────┬───────────────────────┘
-                          │
-       ┌──────────────────┼──────────────────┐
-       │                  │                  │
-┌──────▼─────┐   ┌────────▼────────┐  ┌──────▼──────────┐
-│ Phase 2a   │   │ Phase 2b        │  │ Phase 2c        │
-│ T2.1  MCP  │   │ T2.2  REST      │  │ T2.3  Agent     │
-│ producer   │   │ producers       │  │ producers       │
-│            │   │ (server.ts +    │  │ (dispatch +     │
-│            │   │  catch-all)     │  │  heartbeat +    │
-│            │   │                 │  │  task-service)  │
-└──────┬─────┘   └────────┬────────┘  └──────┬──────────┘
-       │                  │                  │
-       └──────────────────┼──────────────────┘
-                          │
-┌─────────────────────────▼───────────────────────┐
-│ Phase 3: API route                              │
-│   T3.1  /usage-feed + trim /summary             │
-└─────────────────────────┬───────────────────────┘
-                          │
-       ┌──────────────────┼──────────────────┐
-       │                  │                  │
-┌──────▼──────┐   ┌───────▼────────┐  ┌──────▼────────┐
-│ T4.1        │   │ T4.2           │  │ T4.3          │
-│ Top row     │   │ Tabs shell     │  │ Tab contents  │
-│ rebuild     │   │ + window       │  │ (Tool/Endpt/  │
-│             │   │ filter         │  │  Agent)       │
-└──────┬──────┘   └───────┬────────┘  └──────┬────────┘
-       │                  │                  │
-       └──────────────────┼──────────────────┘
-                          │
-┌─────────────────────────▼───────────────────────┐
-│ Phase 5: Cleanup                                │
-│   T5.1  Delete old code + retarget watchdog     │
-│   T5.2  Rewrite routes.test.ts with real wiring │
-│   T5.3  Docs: CLAUDE.md + .claude/knowledge     │
-└─────────────────────────────────────────────────┘
+Phase 1 (solo):
+  T3 — create openclaw-config.ts, migrate the three duplicate readers
+       (pure refactor, no behavior change)
+              │
+              ▼
+Phase 2 (6-way parallel, all file-disjoint after T3):
+  ┌──── T1 — main-agent.ts: strip detection heuristic
+  │
+  ├──── T2 — settings.ts: delete `agents` + `mainAgentId` fields,
+  │          migrate cli/bakin.ts consumers
+  │
+  ├──── T4 — openclaw-adapter.ts: listAgents validation + dedupe
+  │
+  ├──── T5 — team-grid.tsx: pyramid root = main agent,
+  │          reportsTo?.mainAgentId resolution
+  │
+  ├──── T6 — team/index.ts: writer normalization (reportsTo===main → null)
+  │
+  └──── T7 — onboarding/openclaw.ts: doctor integrity check
+              │
+              ▼
+Phase 3 (solo):
+  T8 — docs (describes the final shipped state)
+              │
+              ▼
+Phase 4 (runbook, no commit):
+  T9 — manual cleanup on this machine
 ```
 
----
+**Why this shape:** after the T3 refactor lands, each of T1/T2/T4/T5/T6/T7 touches a single file that no other task touches. Zero merge conflicts, zero ordering dependencies. They can execute as 6 parallel sub-agents (6× wall-time speedup on Phase 2) or serially by a single agent — either way the commit graph is the same.
 
-## Tasks
+**Key micro-reshuffle from v1 of this plan:** the `settings.mainAgentId` field deletion moved from T1 into T2, so T1 is now `main-agent.ts`-only and T2 is `settings.ts` + `cli/bakin.ts`-only. That removes the false conflict between T1 and T2 that made them appear sequential.
 
-### Phase 1 — Recorder foundation
-
-#### T1.1  Create `src/core/usage.ts` + unit tests
-- **Files:** `src/core/usage.ts` (new), `tests/core/usage.test.ts` (new)
-- **What:** Module exports `recordUsage`, `getUsageFeed`, `getUsageStats`, `getErrorCount`, `getCurrentAgentActivity`, `clearUsage` (test-only), and the `UsageEntry` type. State is a `globalThis.__bakinUsage`-backed array with FIFO eviction at `MAX_ENTRIES = 10_000`. Window constants: `WINDOW_MS = { '5m': 300_000, '1h': 3_600_000, '24h': 86_400_000 }`.
-- **API surface:**
-  ```ts
-  type UsageKind = 'mcp' | 'rest' | 'agent'
-  interface UsageEntry {
-    ts: string
-    kind: UsageKind
-    name: string
-    agent: string | null
-    durationMs: number | null
-    status: 'ok' | 'error'
-    meta?: Record<string, unknown>
-  }
-  interface UsageQuery {
-    kind?: UsageKind
-    window: '5m' | '1h' | '24h'
-    agent?: string
-  }
-  interface UsageFeed {
-    totals: { count: number; errors: number; errorRate: number }
-    topByName: Array<{ name: string; count: number; errors: number; medianDurationMs: number | null }>
-    recent: UsageEntry[]  // last 50 matching the filter, newest first
-    byAgent: Array<{ agent: string; count: number; errors: number; lastActivity: UsageEntry | null }>
-  }
-  ```
-- **Acceptance:**
-  - [ ] `recordUsage` inserts an entry; `getUsageFeed` returns it.
-  - [ ] Window filter excludes entries older than window.
-  - [ ] Kind filter narrows to one kind.
-  - [ ] Agent filter narrows to one agent.
-  - [ ] Ring buffer evicts oldest on overflow; entry count never exceeds `MAX_ENTRIES`.
-  - [ ] `getCurrentAgentActivity` returns `{ agent, latest, idleSec }` per agent. `idleSec >= 30` means idle.
-  - [ ] `getErrorCount(windowMs)` returns `{ total, byKind: { mcp, rest, agent } }`.
-  - [ ] `topByName` is sorted by count desc, top 10.
-  - [ ] Median duration computed correctly for entries with non-null `durationMs`; returns `null` when no entries have durations.
-  - [ ] `globalThis.__bakinUsage` is used — not a module-level array (per `feedback_globalthis_sse.md`).
-- **Verify:** `pnpm vitest tests/core/usage.test.ts` green.
-- **Commit:** `feat(core): add unified usage recorder`
-
-**Checkpoint 1** — recorder lives alongside nothing else; can be deleted without affecting any other module. ✅
+**Commit landing order** (for rollback sanity) follows the graph: T3 first, then any order of T1/T2/T4/T5/T6/T7, then T8. T9 is a runbook, not a commit.
 
 ---
 
-### Phase 2 — Wire producers (parallel after Phase 1)
+## Phase 1 — Refactor prelude (solo, 1 commit)
 
-All three tasks can be worked in parallel. Each writes to the new recorder **in addition to** the existing systems. The old systems keep working; the new recorder just gets populated too. Every task includes a *real-wiring* integration test — no mocks on the recorder.
+### T3. Centralize the `openclaw.json` reader
 
-#### T2.1  MCP producer
-- **Files:** `src/core/mcp-server.ts` (lines 80-84, 120-151), `tests/integration/usage-wiring-mcp.test.ts` (new)
-- **What:** Inside the `registerTools` callback, after `recordToolCall` / `recordExecToolCall`, call `recordUsage({ kind: 'mcp', name: tool.name, agent, durationMs, status, meta: { taskId } })`. Measure duration around the `tool.handler(...)` call. Status `'error'` on `!result.ok` or thrown exception. Leave `recordToolCall` / `recordExecToolCall` calls in place — Phase 5 removes them.
-- **Integration test:** Import `registerTools` and `recordUsage`, register a dummy exec tool that returns `{ ok: true }`, invoke the MCP server's JSON-RPC handler directly with a `tools/call` payload, assert `getUsageFeed({ kind: 'mcp', window: '5m' })` contains the tool name with status ok and a non-null duration. Also test an error case where the handler throws. Mock `getContentDir` + `logger` per project rules.
-- **Acceptance:**
-  - [ ] Success path writes `status: 'ok'` entry.
-  - [ ] Thrown error writes `status: 'error'` entry with `meta.error`.
-  - [ ] Handler-returned `{ ok: false }` writes `status: 'error'` entry.
-  - [ ] `durationMs` is > 0 and < 1000 for a no-op handler.
-  - [ ] Integration test fails if you comment out the `recordUsage` call.
-- **Verify:** `pnpm vitest tests/integration/usage-wiring-mcp.test.ts` green.
-- **Commit:** `feat(mcp): record tool calls to unified usage store`
+**Files:**
+- `packages/core/src/openclaw-config.ts` — **new file**
+- `packages/core/src/main-agent.ts` — migrate to use the new module (keep existing heuristic for now; T1 strips it)
+- `plugins/team/lib/openclaw-adapter.ts` — migrate `getOpenClawConfig` to use the new module
+- `packages/core/src/settings.ts` — migrate `readAgentIdsFromOpenClaw` to use the new module (keep the field for now; T2 deletes it)
+- `tests/core/openclaw-config.test.ts` — **new** unit tests for the reader
 
-#### T2.2  REST producers (server.ts middleware + catch-all)
-- **Files:** `server.ts` (lines 147-166), `src/app/api/plugins/[pluginId]/[[...path]]/route.ts` (lines 245-303), `tests/integration/usage-wiring-rest.test.ts` (new)
-- **What (server.ts):** In the `res.end` override, after `recordRequest(...)`, also call `recordUsage({ kind: 'rest', name: normalizedPath, agent, durationMs, status, meta: { method, status } })`. Normalize path: strip query string, keep `/api/plugins/{pluginId}/{...}` verbatim, replace UUID-shaped segments elsewhere with `:id`. Status = `'ok'` if `< 400`, else `'error'`. Agent = header `x-bakin-agent` if present (need to peek from `req.headers['x-bakin-agent']`), else query param `agent`, else `null`.
-- **What (catch-all route.ts):** Remove the now-redundant `appendAudit` block at lines 276-289 only if it's fully replaced by middleware recording — **no, keep `appendAudit` calls**, they feed the audit log/SSE which is a separate system. Just ensure the middleware is the sole source of usage tracking. No new code here unless the integration test reveals a gap.
-- **Integration test:**
-  - Extract the middleware logic from `server.ts` into a tiny helper if necessary to make it testable without booting a full Next server. OR: spin up a minimal `http.createServer` in the test that runs the exact middleware closure, fire a real `http.request`, assert the recorder got the entry.
-  - Test three cases: (a) `/api/plugins/tasks/list` with `x-bakin-agent: roscoe` header → entry has `agent: 'roscoe'`; (b) `/api/plugins/tasks/list?agent=pixel` without header → entry has `agent: 'pixel'`; (c) `/api/version` 200 response → entry with `kind: 'rest'`, status `'ok'`.
-  - Test path normalization: `/api/some/resource/550e8400-e29b-41d4-a716-446655440000/edit` → `/api/some/resource/:id/edit`.
-- **Acceptance:**
-  - [ ] Every `/api/*` and `/mcp*` request writes one usage entry.
-  - [ ] Agent attribution precedence: header → query param → null.
-  - [ ] Path normalization preserves plugin IDs, replaces UUIDs elsewhere.
-  - [ ] Integration test fires a real HTTP request and observes it in the recorder.
-- **Verify:** `pnpm vitest tests/integration/usage-wiring-rest.test.ts` green.
-- **Commit:** `feat(server): record REST requests to unified usage store`
+**Changes:**
+- **Create `packages/core/src/openclaw-config.ts`** — owns the single mtime-cached reader for `openclaw.json`. Exports:
+  - `readOpenClawConfig(): OpenClawConfig | null`
+  - `getAgentList(): OpenClawAgent[]`
+  - `getAgentIds(): string[]`
+  - `findAgentById(id: string): OpenClawAgent | null`
+  - Shared `OpenClawConfig` / `OpenClawAgent` Zod schemas (types defined here and re-exported).
+- **Delete the three duplicate readers:**
+  - `packages/core/src/main-agent.ts` — `readOpenClawConfig` + `cachedConfig` (lines ~94–114)
+  - `plugins/team/lib/openclaw-adapter.ts` — `getOpenClawConfig` + `configCache` (lines ~51–67)
+  - `packages/core/src/settings.ts` — `readAgentIdsFromOpenClaw` + its `__bakinOpenClawMtime` / `__bakinOpenClawAgents` globals (lines ~256–273)
+- **Replace with imports** from `@bakin/core/openclaw-config`.
+- **No behavior change.** `getMainAgentId()` still runs its heuristic. `BakinSettings.agents` is still populated. All existing tests still pass unchanged.
+- Pure plumbing refactor. The sole purpose of this commit is to collapse three readers into one so Phase 2 can fan out cleanly.
 
-#### T2.3  Agent producers (dispatch + heartbeat + task-service)
-- **Files:** `src/core/dispatch.ts` (around `dispatchSingleTask` line 236), `scripts/lib/heartbeat.ts` (inside the handler around line 36), `src/core/task-service.ts` (wherever task status transitions happen), `tests/integration/usage-wiring-agent.test.ts` (new)
-- **What:**
-  - **dispatch.ts:** In `dispatchSingleTask`, record `{ kind: 'agent', name: 'dispatch', agent: <task.agent>, durationMs: <measured>, status: <ok|error>, meta: { taskId, title } }` when dispatch completes.
-  - **heartbeat.ts:** After writing the heartbeat file, record `{ kind: 'agent', name: 'heartbeat', agent, durationMs: null, status: 'ok', meta: { status: params.status, currentTask: params.currentTask } }`.
-  - **task-service.ts:** On task status change (claim/start/complete/fail), record `{ kind: 'agent', name: 'task.<status>', agent, ..., meta: { taskId } }`.
-- **Integration test:**
-  - Call `dispatchSingleTask` against a real fixture task with a stubbed OpenClaw client, assert recorder entry.
-  - Call `heartbeat` handler directly as the MCP server would, assert recorder entry with `name: 'heartbeat'`.
-  - Call task-service lifecycle transition, assert recorder entry.
-- **Acceptance:**
-  - [ ] Dispatch emits an entry with `name: 'dispatch'` and the task's assigned agent.
-  - [ ] Heartbeat emits an entry with `name: 'heartbeat'` and the agent that called it.
-  - [ ] Task status transitions emit entries with `name: 'task.<status>'`.
-  - [ ] Integration test fails if any of the three `recordUsage` calls is commented out.
-- **Verify:** `pnpm vitest tests/integration/usage-wiring-agent.test.ts` green.
-- **Commit:** `feat(agents): record agent lifecycle events to unified usage store`
+**Acceptance:**
+- `packages/core/src/openclaw-config.ts` exists with the exports above.
+- Net LOC reduction across the three touched files: ~30–50 lines.
+- No behavior observable from outside: all pre-existing tests pass without modification.
+- `grep -rn "statSync.*openclaw.json" packages src plugins` returns exactly one hit (the new module).
 
-**Checkpoint 2** — all three producers feed the recorder. Old systems still populated in parallel. Old health UI still works. ✅
+**Verification:**
+- `npm run test` passes in full.
+- `npm run typecheck` passes.
+- `bakin check openclaw` still works.
+- Team page renders identically to before.
+
+**Commit:** `refactor(core): centralize openclaw.json reader into openclaw-config module`
 
 ---
 
-### Phase 3 — API route
+## ✅ Phase 1 checkpoint
 
-#### T3.1  Add `/api/plugins/health/usage-feed` + trim `/summary`
-- **Files:** `plugins/health/index.ts`, `tests/plugins/health/routes.test.ts` (update existing)
-- **What:**
-  - Register `GET /usage-feed` that accepts `?kind=mcp|rest|agent&window=5m|1h|24h&agent=<id>`, parsed via Zod. Returns `UsageFeed` from `getUsageFeed(...)`.
-  - Add `errors1h` field to `/summary` response: `{ total, byKind: { mcp, rest, agent } }` sourced from `getErrorCount(WINDOW_MS['1h'])`.
-  - **Do NOT remove `/requests`, `/registry.execTools`, `mcp`, `restHealth`, `requests` fields yet.** Phase 5 does the deletion. This keeps the old UI working.
-- **Tests:**
-  - Seed recorder via `recordUsage`, fire `GET /usage-feed?kind=mcp&window=1h`, assert response shape.
-  - Test that window filter narrows results.
-  - Test Zod validation rejects bad params (400 response).
-  - Test `errors1h` field populated in `/summary` from real recorder state.
-- **Acceptance:**
-  - [ ] New route returns valid `UsageFeed` for all three kinds.
-  - [ ] Zod rejects unknown kinds and windows.
-  - [ ] Existing `/summary`, `/requests`, `/registry`, `/usage`, `/doctor` routes still pass their original tests.
-- **Verify:** `pnpm vitest tests/plugins/health/routes.test.ts` green.
-- **Commit:** `feat(health): add usage-feed route backed by unified recorder`
+- `npm run typecheck` green
+- `npm run test` green (full suite, no modifications)
+- Manual: start dev server, team page and `/api/settings` both unchanged from Phase 0
 
-**Checkpoint 3** — new API exists alongside old. Frontend still uses old fields. Safe to deploy. ✅
+If this fails, `git revert` the T3 commit — everything is back to pre-refactor state with zero side effects.
 
 ---
 
-### Phase 4 — UI rebuild
+## Phase 2 — Parallel fan-out (6 commits, independently landable)
 
-These three tasks touch the same file (`plugins/health/components/health-page.tsx`) and must be sequential. But each is small and produces a visually verifiable state.
+**All six tasks below touch disjoint files and can execute in parallel.** Either as six concurrent sub-agents (fastest), or serially by one agent in any order. Each lands as its own commit for granular rollback.
 
-#### T4.1  Top row rebuild
-- **Files:** `plugins/health/components/health-page.tsx` (lines 453-575)
-- **What:** Replace the 6-card grid with a 4-card grid: `Uptime`, `Active Sessions`, `Memory`, `Errors (1h)`. Errors card reads `data.errors1h` (added in T3.1). Card shows total count big; subtext `mcp: N · rest: N · agent: N`; color red if total > 0, emerald if 0.
-- **Acceptance:**
-  - [ ] API Requests, MCP Health, REST Health cards gone.
-  - [ ] Errors card renders with breakdown.
-  - [ ] Grid is 4 columns on desktop, 2 on mobile.
-- **Verify:** Start dev server, load `/health`, visually confirm.
-- **Commit:** `feat(health): rebuild top row — drop redundant cards, add errors tile`
+### T1. Strip the detection heuristic from `getMainAgentId()`
 
-#### T4.2  Usage tabs shell + window filter
-- **Files:** `plugins/health/components/health-page.tsx`, reuse `src/components/ui/tabs.tsx`
-- **What:** Replace the 4-up usage grid with a single `Card` containing `<Tabs value={activeTab}>` with three `TabsTrigger` (Tool Usage / Endpoint Usage / Agent Usage). Shared window state via `useQueryState('usage_window', '1h')` per CLAUDE.md URL-state rule. A small segmented control renders `5m | 1h | 24h`. Active tab state via `useQueryState('usage_tab', 'tools')`. Content panels render placeholder text; T4.3 fills them.
-- **Acceptance:**
-  - [ ] Tab state is in URL, bookmarkable.
-  - [ ] Window state is in URL.
-  - [ ] Switching tabs/windows triggers a re-fetch of `/usage-feed`.
-  - [ ] Context Usage and Cost Breakdown still render below, unchanged.
-- **Verify:** Visually confirm; reload page with `?usage_tab=endpoints&usage_window=24h` and state is restored.
-- **Commit:** `feat(health): tabbed usage section with window filter`
+**Files:**
+- `packages/core/src/main-agent.ts` — rewrite
+- `tests/core/main-agent.test.ts` — update + add cases
 
-#### T4.3  Tab contents — Tool / Endpoint / Agent
-- **Files:** `plugins/health/components/health-page.tsx`
-- **What:** Populate each `TabsContent`:
-  - **Tool Usage:** `HorizontalBars` of `topByName` with count badge; small line underneath each showing `{errors} err · {median}ms`; footer row showing `recent[0]` as "firing right now: {name} · {agent} · Xs ago".
-  - **Endpoint Usage:** Same pattern on REST data. Below bars, a compact per-plugin rollup derived client-side from `topByName` (group by plugin id extracted from path).
-  - **Agent Usage:** One row per entry in `byAgent`. Left column agent id. Middle column "current activity" string derived from `lastActivity` (the latest entry): format `calling {name} · {age}s ago` (mcp), `handling {method} {path} · {age}s ago` (rest), or `{name} · {age}s ago` (agent). If age > 30s, show `idle {age}s`. Right column total calls in window and error count.
-- **Acceptance:**
-  - [ ] Each tab populates with real data once the dev server has seen traffic.
-  - [ ] "Firing right now" row updates as new data arrives on refresh.
-  - [ ] Idle agents labelled correctly.
-  - [ ] Empty state ("no data in this window") renders cleanly.
-- **Verify:** Dev server. Trigger some MCP tool calls via the mock, click through all three tabs and all three windows, confirm data flows.
-- **Commit:** `feat(health): populate tool/endpoint/agent usage tabs`
+**Changes:**
+- `getMainAgentId()` reads from `openclaw-config.findAgentById("main")`. If present, returns `"main"`. If missing, throws: *"openclaw.json has no agent with id 'main'. OpenClaw's orchestrator id is always 'main'; add that entry or run `bakin check openclaw`."*
+- `tryGetMainAgentId()` returns `"main"` if the entry exists, `null` otherwise. No detection, no fallback.
+- `getMainAgentName()` returns `identity.name` from the `main` entry, falling back to the string `"Main"` when unset.
+- Delete `detectOrchestratorFromOpenClaw()`. (This function becomes dead code after the heuristic is stripped.)
+- **Does NOT touch `settings.ts`.** The `mainAgentId` override deletion is T2's responsibility.
 
-**Checkpoint 4** — new UI live, reads new API. Old API endpoints still present but the frontend no longer reads their deprecated fields. ✅
+**Acceptance:**
+- `getMainAgentId()` with a valid openclaw.json returns `"main"`.
+- With `agents.list[0] = { id: "main" }` only, returns `"main"`.
+- With `{ id: "bob" }` only (no `main`), throws.
+- With an empty list, throws.
+- `tryGetMainAgentId()` returns `null` in the empty / missing cases.
+- `getMainAgentName()` returns `"Roscoe"` when the main entry has `identity.name: "Roscoe"`, returns `"Main"` when identity is absent.
+
+**Verification:**
+- `npm run test -- tests/core/main-agent.test.ts` passes.
+- `npm run typecheck` passes.
+- `grep -rn "detectOrchestratorFromOpenClaw\|OPENCLAW_TO_BAKIN\|OPENCLAW_ID_TO_BAKIN_NAME"` returns zero hits.
+
+**Commit:** `refactor(core): getMainAgentId always returns "main"`
 
 ---
 
-### Phase 5 — Cleanup
+### T2. Delete `BakinSettings.agents` + `settings.mainAgentId`, migrate consumers
 
-#### T5.1  Delete old code + retarget watchdog
-- **Files:** delete `src/core/request-log.ts`, delete `tests/core/request-log.test.ts`, edit `scripts/lib/registry.ts` (drop `toolStats`, `recordExecToolCall`, `recordExecToolError`, `getExecToolStats`, `ExecToolStat`), edit `src/core/mcp-server.ts` (drop `recordToolCall`, `stats` object), edit `src/core/watchdog.ts` (retarget `getRecentStatsForPathPrefix` → `getUsageStats({kind:'mcp', window:...})` with matching semantics), edit `plugins/health/index.ts` (drop `/requests` route, drop `execTools` from `/registry`, drop `mcp`/`restHealth`/`requests` from `/summary`), edit `server.ts` (drop `recordRequest` call — middleware now writes only to recorder).
-- **What:** Clean slate. No shims, no aliases.
-- **Acceptance:**
-  - [ ] Grep for `request-log`, `toolStats`, `recordToolCall`, `recordExecToolCall`, `getRestStatsByPlugin`, `getRecentStatsForPathPrefix`, `getExecToolStats` returns zero matches in `src/`, `plugins/`, `scripts/`, `server.ts`.
-  - [ ] Watchdog MCP 5xx alerting still triggers — verified by unit test.
-  - [ ] `pnpm typecheck` green.
-  - [ ] `pnpm test` green.
-- **Verify:** Full test suite + manual watchdog trigger.
-- **Commit:** `refactor(health): remove legacy request-log and toolStats systems`
+**Files:**
+- `packages/core/src/settings.ts` — delete the two fields and related code
+- `cli/bakin.ts` — migrate consumers to `openclaw-config.getAgentIds()`
+- `tests/core/settings.test.ts` (if exists) — drop assertions on the deleted fields
 
-#### T5.2  Rewrite `routes.test.ts` with real wiring
-- **Files:** `tests/plugins/health/routes.test.ts`
-- **What:** Remove mocks of usage sources. Tests now call `recordUsage` directly to seed recorder state, then hit the route handlers. Only `agent-usage.ts` (OpenClaw session files) and `doctor` remain mocked. Add a test that intentionally verifies the route is wired to the real `getUsageFeed` — if someone swaps it for a mock, the test fails.
-- **Acceptance:**
-  - [ ] No mock for `src/core/usage.ts` anywhere in the test file.
-  - [ ] Every route test passes with real recorder backing.
-  - [ ] Removing a `recordUsage` call from any producer would still fail at least one integration test (from Phase 2) — verified by deliberately breaking one producer momentarily.
-- **Verify:** `pnpm vitest tests/plugins/health/routes.test.ts` green.
-- **Commit:** `test(health): replace mocked stat sources with real recorder`
+**Changes:**
+- Delete `agents: string[]` from `BakinSettings` (line 56).
+- Delete `mainAgentId?: string` from `BakinSettings` (line 62) and its comment block.
+- Delete `agents: []` from `DEFAULTS` (line 182).
+- Delete `readAgentIdsFromOpenClaw()` and its globals (already thin after T3's centralization; just remove the wrapper).
+- Delete the `hasExplicitAgentsOverride` branch (lines 348–354).
+- Migrate `cli/bakin.ts` consumers:
+  - `cli/bakin.ts:87` — replace `settings.agents.join(', ')` with `getAgentIds().join(', ')`
+  - `cli/bakin.ts:882` — delete the `(settings as Record...).agents as string[]` cast hack; replace with `getAgentIds()`
+  - `cli/bakin.ts:147` — verify this is reading an API response's `result.agents` (not settings); leave alone if so
+- **Does NOT touch `main-agent.ts`.** T1 handles that.
 
-#### T5.3  Docs
-- **Files:** `CLAUDE.md` (Key Patterns section), audit `.claude/knowledge/*` for health references
-- **What:**
-  - Add "Usage Recording" subsection to `CLAUDE.md` Key Patterns: describe `recordUsage()`, the three kinds, the globalThis pattern, and the rule that new producers must add a wiring integration test.
-  - Grep `.claude/knowledge/` for `request-log`, `toolStats`, `/api/plugins/health/requests`, `mcpHealth`, `restHealth` and fix any stale refs.
-  - Update `README.md` only if it mentions the health page features being removed.
-- **Acceptance:**
-  - [ ] CLAUDE.md has a "Usage Recording" subsection.
-  - [ ] `.claude/knowledge/` has no stale references to deleted APIs.
-  - [ ] Memory updated: add a `project_health_overhaul.md` pointing to this spec + plan.
-- **Verify:** Read the subsection; skim the knowledge docs.
-- **Commit:** `docs: document unified usage recorder pattern`
+**Acceptance:**
+- `BakinSettings` type has no `agents` or `mainAgentId` fields.
+- `getSettings()` returns a settings object that is identical to before for all other fields.
+- No code path in `settings.ts` touches `openclaw.json`.
+- `grep -rn "settings\\.agents\|settings\\.mainAgentId" packages src plugins cli` returns no hits.
 
-**Checkpoint 5 (final)** — overhaul complete. Every checkpoint between 1–4 is a valid rollback target. ✅
+**Verification:**
+- `npm run typecheck` passes.
+- `npm run test` passes.
+- `bakin` commands that listed agents render identical output.
+
+**Commit:** `refactor(core): drop stale settings.agents + mainAgentId fields`
 
 ---
 
-## Commit strategy summary
+### T4. `listAgents()` dedupes and validates OpenClaw's agent list
 
-10 commits total, each a valid deployable state. Conventional-commit format with scope.
+### T4. `listAgents()` dedupes and validates OpenClaw's agent list
 
-| # | Phase | Commit message | Rollback safety |
-|---|-------|----------------|-----------------|
-| 1 | 1 | `feat(core): add unified usage recorder` | Full — new code only |
-| 2 | 2a | `feat(mcp): record tool calls to unified usage store` | Old system still runs |
-| 3 | 2b | `feat(server): record REST requests to unified usage store` | Old system still runs |
-| 4 | 2c | `feat(agents): record agent lifecycle events to unified usage store` | Old system still runs |
-| 5 | 3 | `feat(health): add usage-feed route backed by unified recorder` | Old routes still work |
-| 6 | 4a | `feat(health): rebuild top row — drop redundant cards, add errors tile` | Usage grid unchanged |
-| 7 | 4b | `feat(health): tabbed usage section with window filter` | Content is placeholder |
-| 8 | 4c | `feat(health): populate tool/endpoint/agent usage tabs` | New UI complete |
-| 9 | 5a | `refactor(health): remove legacy request-log and toolStats systems` | Point of no return for old code |
-| 10 | 5b | `test(health): replace mocked stat sources with real recorder` | — |
-| 11 | 5c | `docs: document unified usage recorder pattern` | — |
+**Files:**
+- `plugins/team/lib/openclaw-adapter.ts` — `listAgents()` rewrite
+- `tests/plugins/team/openclaw-adapter.test.ts` — new or extended
+- `tests/fixtures/openclaw/` — add negative fixtures (broken configs)
 
-**Rollback drill**: if commit 9 breaks something in production, `git revert` it; commits 1–8 leave us in a working state with the new UI and new recorder, minus the code deletion. Re-attempt commit 9 after fixing.
+**Changes:**
+- After T3, `listAgents()` pulls its raw list from `openclaw-config.getAgentList()`. Validation pass:
+  1. Track seen ids; on duplicate id, log error and skip the second occurrence.
+  2. Resolve each agent's effective workspace (explicit `workspace` field OR `defaults.workspace` when the agent has no override). Track seen resolved workspaces; on collision, log an error naming both ids and skip the second.
+  3. Confirm an entry with `id === "main"` exists. If missing, log a critical error and return an empty list so the UI surfaces an unmistakable empty state instead of silently hiding the orchestrator.
+- Log level: use `log.error` for dupes, `log.error` + empty-return for missing main. Never `log.warn` — these are bugs in the config, not curiosities.
+- Do NOT mutate `openclaw.json`. Read-only path.
 
----
+**Acceptance:**
+- Given a fixture with `[{id:"main"},{id:"roscoe",workspace:<default>}]`, `listAgents()` returns 1 entry (`main`) and logs one error mentioning both ids and the shared workspace.
+- Given a fixture with `[{id:"main"},{id:"main"}]`, returns 1 entry, logs one error mentioning duplicate id.
+- Given a fixture with `[{id:"bob"}]` (no main), returns `[]` and logs a critical error.
+- Given a clean fixture, returns the full list unchanged.
 
-## Parallelization opportunities
+**Verification:**
+- `npm run test -- tests/plugins/team/openclaw-adapter.test.ts` passes.
+- `npm run typecheck` passes.
 
-The user asked to fan out work. Here's what can actually go in parallel without stepping on itself:
-
-- **After Phase 1 lands**, Phase 2 tasks T2.1, T2.2, T2.3 are fully independent — three different agents, three different files, three different integration tests. Spawn all three simultaneously.
-- **Phase 4 tasks are sequential** — same file (`health-page.tsx`) and each builds on the previous visual state. Don't parallelize.
-- **Phase 5 tasks T5.1 and T5.2 can overlap** only if T5.2 is drafted but not committed until T5.1 lands, because the test rewrite depends on deletions. Cleaner to do them sequentially.
-- **T5.3 docs** can be drafted in parallel with any other Phase 5 task.
-
-Recommended execution:
-- **Serial:** T1.1
-- **Parallel fan-out (3 agents):** T2.1 + T2.2 + T2.3
-- **Serial:** T3.1
-- **Serial:** T4.1 → T4.2 → T4.3
-- **Serial:** T5.1 → T5.2
-- **Parallel with T5.1:** T5.3
+**Commit:** `feat(team): validate and dedupe openclaw agent list`
 
 ---
 
-## Verification gates between phases
+### T5. Pyramid root is always `main`; `reportsTo` defaults to main at render time
 
-Before committing each phase's final task:
+**Files:**
+- `plugins/team/components/team-grid.tsx` — rewrite `buildGraph()` grouping logic
+- `plugins/team/hooks/use-agent-store.ts` — ensure a selector for the main agent id is available (route response already returns `mainAgentId`)
+- `plugins/team/index.ts` — the `GET /` route already returns `mainAgentId`; verify the store consumes it
+- `tests/plugins/team/team-grid.test.tsx` — new or extended (or write assertions against `buildGraph` as a pure function if component-level tests aren't set up)
 
-1. `pnpm lint` — no new warnings
-2. `pnpm typecheck` — no new errors
-3. `pnpm test` — full suite green (not just the new tests)
-4. Dev server loads `/health` without console errors
-5. The integration tests from Phase 2 still pass — this is the regression safety net
+**Changes in `team-grid.tsx:buildGraph()`:**
+- Accept `mainAgentId: string` as a new input field in `GraphInput`. Pass it from the store.
+- Pyramid root = the agent whose `id === mainAgentId`. Always. Not derived from `topAgentIds`.
+- `teamsByReporter` key resolution: `team.reportsTo ?? mainAgentId`. This means a null/undefined `reportsTo` renders under the main agent automatically.
+- Delete the `topAgentIds` heuristic; replace with `new Set([mainAgentId])` plus any additional ids that appear as non-null `reportsTo` values. (An agent who is a team leader for a non-default reporter also gets a "top-of-subtree" row.)
+- Unassigned bucket: only include agents that (a) are not in any team's `teamMembers`, (b) are not the `mainAgentId`, (c) are not a team leader. In the default flat config, subagents all go under main via the default `reportsTo` fallback, so unassigned is empty.
+- Row 1 now always has exactly the main agent (if present); teams for main render in row 2 (section headers) and row 3 (members). Matches current visual hierarchy for the "one orchestrator with teams under it" case.
+- If `mainAgentId` is not in the roster (e.g. `listAgents()` returned empty per T4's missing-main path), render only the founder + an empty state message.
 
-If any of these fail, stop and fix before committing. No skipping gates.
+**Acceptance:**
+- Fresh install simulation: `team.json` absent, openclaw.json has `main` + 7 subagents. Pyramid renders founder → main → single row of 7 subagents. No "Unassigned" bucket.
+- Current user state during transition: openclaw.json still has both `main` and `roscoe` — T4 dedupes to just `main`, T5 puts `main` at the root, Creators + Builders teams with `reportsTo: "roscoe"` (unresolvable) fall back to main per T6.
+- Roster override: team.json has a team with `reportsTo: "basil"`. That team renders under basil, not main.
+- Empty roster: only the founder node renders.
+- No duplicate card for the main agent anywhere in the grid.
+
+**Verification:**
+- `npm run test -- tests/plugins/team/team-grid.test.tsx` passes (or whichever harness we use).
+- Manual: start dev server on imitation-crab fixture, visually confirm the pyramid shape.
+
+**Commit:** `feat(team): pyramid root is always the main agent`
 
 ---
 
-## Known risks & mitigations
+### T6. Normalize `team.json` writes: null/omit `reportsTo` when it equals main
 
-1. **Risk:** T2.2 test (REST wiring) is hard to write without booting a real HTTP server.
-   **Mitigation:** Extract the middleware body into a pure `trackResponse(req, res, start)` helper exported from `server.ts` or a new `src/core/rest-tracking.ts`. Test the helper directly. The server.ts `res.end` override becomes a one-liner that calls the helper.
+**Files:**
+- `plugins/team/index.ts` — the team.json writer route (POST/PUT for teams)
+- `plugins/team/lib/team-settings.ts` (if exists) or wherever `writePluginSettings` lives
+- `tests/plugins/team/routes.test.ts` — add normalization assertion
 
-2. **Risk:** `globalThis.__bakinUsage` gets duplicated by webpack re-evaluation.
-   **Mitigation:** This is exactly the case the `feedback_globalthis_sse.md` memory warns about. Use the `(globalThis as any).__bakinUsage ??= []` idiom, not a module-level `const`.
+**Changes:**
+- On write: for each team in the incoming payload, if `reportsTo === getMainAgentId()` or `reportsTo === undefined`, set it to `null`. (Null over omission for schema stability.)
+- On read: in `buildGraph`, a `null`/missing `reportsTo` resolves to `mainAgentId` at render time (already covered by T5).
+- Reading a team.json written by old code that has `"reportsTo": "roscoe"` (an unknown id): **graceful degradation** — treat any `reportsTo` that isn't in the roster as null, and log a warning telling the user to re-save. This way, the user's current messy team.json starts rendering correctly as soon as T5+T6 land.
 
-3. **Risk:** `watchdog.ts` MCP alerting semantics drift when retargeted.
-   **Mitigation:** T5.1 includes a unit test that asserts watchdog fires on the same thresholds it used to fire on, using seeded recorder state. Match the semantics (5xx counts in window) exactly — `status === 'error' && kind === 'mcp'` in the new model.
+**Acceptance:**
+- POST `/api/plugins/team/teams` with `reportsTo: "main"` → written file has `reportsTo: null`.
+- POST with `reportsTo: "basil"` → written file has `reportsTo: "basil"`.
+- Reading a file with `reportsTo: "roscoe"` (unknown id) logs a warning and treats the team as reporting to main.
+- Reading a file with `reportsTo: null` resolves to main at render time.
 
-4. **Risk:** Heartbeats dominate Agent Usage counts because they're frequent.
-   **Mitigation:** T4.3 filters `name === 'heartbeat'` out of the activity-count column (shows separately) but includes them in `lastActivity` so "current state" is accurate.
+**Verification:**
+- `npm run test -- tests/plugins/team/routes.test.ts` passes.
+- `npm run test -- tests/plugins/team/team-grid.test.tsx` still passes.
+- Manual: edit team.json by hand with `reportsTo: "roscoe"`, reload, confirm the team renders under main.
 
-5. **Risk:** Spec assumed the Next.js catch-all bypassed tracking; it doesn't. One of the motivating bullets (fix the GET bypass) may not be a real bug.
-   **Mitigation:** T2.2 integration test will reveal the truth. If the middleware is capturing everything, the fix becomes "unify agent attribution paths" instead of "fix the bypass". Either way the test is the proof, not the spec bullet.
+**Commit:** `feat(team): normalize team.json writes to drop implicit main reportsTo`
 
 ---
 
-## Done definition
+### T7. Doctor check for openclaw.json integrity
 
-- All 11 commits merged.
-- `pnpm test` fully green.
-- Mark can open `/health`, see 4 top cards, switch tabs + windows, and see live data.
-- `request-log.ts` gone from the repo.
-- CLAUDE.md documents the pattern.
-- Breaking any producer's `recordUsage` call fails at least one Phase 2 integration test.
+**Files:**
+- `src/core/onboarding/openclaw.ts` — extend the existing `check()` function OR add a new sub-check
+- `tests/core/doctor.test.ts` (or `tests/core/onboarding/openclaw.test.ts`) — new cases
+- `cli/bakin.ts` — if a `bakin check openclaw` subcommand exists, ensure it hits the new validation
+
+**Changes:**
+- Add a validator that, on `bakin check openclaw` / `bakin doctor`, reports:
+  1. Does an agent with `id === "main"` exist? If not, error with actionable text.
+  2. Are there duplicate ids in `agents.list`? If so, error naming the dupes.
+  3. Are there two agents whose effective workspace (explicit + defaults fallback) resolves to the same path? If so, error naming both ids and the shared path.
+- Reports-only. Does not auto-fix. Non-zero exit on error.
+- Wire into `bakin onboard` and the doctor loop so fresh installs catch broken configs immediately.
+
+**Acceptance:**
+- Clean openclaw.json: check passes silently.
+- Missing main: clear error *"openclaw.json has no agent with id 'main'. Add an entry: `{ \"id\": \"main\", \"identity\": { \"name\": \"<your-agent-name>\" } }`"*.
+- Duplicate id: clear error naming the id.
+- Two agents sharing workspace `/Users/.../workspace`: clear error naming both ids and the shared path.
+- Non-zero exit code when any of the above fire.
+
+**Verification:**
+- `npm run test -- tests/core/doctor.test.ts` passes.
+- Manual: break openclaw.json intentionally (add a duplicate id), run `bakin check openclaw`, confirm the error.
+- Manual: run on a known-good imitation-crab fixture, confirm silence.
+
+**Commit:** `feat(onboarding): doctor validates openclaw.json integrity`
+
+---
+
+## ✅ Phase 2 checkpoint
+
+After T1, T2, T4, T5, T6, T7 have all landed (in any order):
+- `npm run typecheck` green
+- `npm run test` green (full suite)
+- Manual: start dev server on imitation-crab fixture — team page shows founder → Crab → 7 subagents. No duplicate cards.
+- Manual: edit team.json on imitation-crab to add a Creators team with `reportsTo: null`. Reload. Confirm Creators renders under Crab.
+- Manual: run `bakin check openclaw` against a deliberately-broken fixture. Confirm it flags the expected error and exits non-zero.
+
+Commits so far: 7 on the branch (T3 + T1 + T2 + T4 + T5 + T6 + T7). Revert granularity: any single commit is independently reversible because all six parallel tasks touch disjoint files.
+
+---
+
+## Phase 3 — Docs (solo, 1 commit)
+
+### T8. Doc updates
+
+**Files:**
+- `.claude/knowledge/agent-system.md` — confirm line 50 statement is now literally true (after fix, not aspirational); add a subsection on `getMainAgentId()` being trivial and the `openclaw-config.ts` centralized reader
+- `.claude/knowledge/team-plugin.md` — create if missing, or append: document the pyramid rendering rules (root = main, reportsTo resolution, unassigned bucket semantics) and the team.json schema
+- `CLAUDE.md` — check the "OpenClaw Adapter Principle" section and the Directory Map's `main-agent.ts` description; update if stale. The principle statement is still correct — leave it alone unless the specific file descriptions are wrong.
+- `README.md` — no changes needed (README doesn't discuss agent identity)
+
+**Acceptance:**
+- `.claude/knowledge/agent-system.md` mentions the centralized `openclaw-config.ts` reader and notes that `getMainAgentId()` is constant-return.
+- `.claude/knowledge/team-plugin.md` exists and documents the pyramid rules.
+- Running `grep -rn "roscoe\|OPENCLAW_TO_BAKIN" .claude/knowledge CLAUDE.md README.md` returns only intentional references (e.g. historical context).
+
+**Verification:**
+- Read each touched doc; confirm the statements match the shipped code.
+
+**Commit:** `docs: update agent-system and team-plugin knowledge notes`
+
+---
+
+### T9. Manual cleanup on this machine (documented, not code)
+
+**Not a commit — a runbook for roscoe to execute after T1–T8 merge.**
+
+```bash
+# 1. Back everything up first
+cp ~/.openclaw/openclaw.json ~/.openclaw/openclaw.json.pre-issue-90
+cp -r ~/.bakin ~/.bakin.pre-issue-90
+
+# 2. Stop Bakin
+bakin stop
+
+# 3. Edit ~/.openclaw/openclaw.json by hand:
+#    - In the agents.list[0] "main" entry, add identity.name = "Roscoe" and identity.emoji = "🐾"
+#    - Delete the agents.list[] entry with id: "roscoe"
+#    (Do not leave a stale workspace field — inherit from agents.defaults.workspace)
+
+# 4. Move avatars
+mv ~/.bakin/agents/roscoe/avatar.jpg ~/.bakin/agents/main/
+mv ~/.bakin/agents/roscoe/avatar-full.png ~/.bakin/agents/main/
+rm ~/.bakin/agents/roscoe/AGENTS.md    # stale — owned by openclaw now
+rmdir ~/.bakin/agents/roscoe
+
+# 5. Delete stale heartbeat
+rm ~/.bakin/heartbeats/roscoe.json
+
+# 6. Edit ~/.bakin/plugin-settings/team.json by hand:
+#    - Remove "reportsTo": "roscoe" from both team entries
+#    (null/omitted means main at render time — T5/T6)
+
+# 7. Edit ~/.bakin/settings.json by hand:
+#    - Delete the top-level "agents": [...] array
+#    (T2 deleted the field from the type — it's no longer read)
+
+# 8. Run the new doctor check
+bakin check openclaw
+# Should print nothing (clean)
+
+# 9. Start Bakin
+bakin start
+
+# 10. Open team page in browser. Expected:
+#     - Founder (Mark) at top
+#     - Roscoe as single card below
+#     - Creators + Builders sections under Roscoe
+#     - No orphan "main" card anywhere
+```
+
+**Acceptance:**
+- Team page renders one Roscoe card at the pyramid top, with Creators + Builders underneath. No duplicate.
+- `bakin check openclaw` passes.
+- No files in `~/.bakin/agents/roscoe/` or `~/.bakin/heartbeats/roscoe.json`.
+- `~/.bakin/settings.json` has no `agents` field.
+- `~/.bakin/plugin-settings/team.json` has `reportsTo: null` (or omitted) on both teams.
+
+**Commit:** (no code commit — this is a runbook the user executes.)
+
+---
+
+## ✅ Phase 3 checkpoint (final)
+
+- All tests green.
+- Team page visually correct on this machine.
+- Issue #90 closable with a summary comment linking the commits.
+
+---
+
+## Commit sequence summary
+
+| # | Task | Commit | Phase | Parallel? | Reversible? |
+|---|------|--------|-------|-----------|-------------|
+| 1 | T3 | `refactor(core): centralize openclaw.json reader into openclaw-config module` | 1 (solo) | No — must land first | Yes (pure refactor) |
+| 2 | T1 | `refactor(core): getMainAgentId always returns "main"` | 2 | ✅ Parallel | Yes |
+| 3 | T2 | `refactor(core): drop stale settings.agents + mainAgentId fields` | 2 | ✅ Parallel | Yes |
+| 4 | T4 | `feat(team): validate and dedupe openclaw agent list` | 2 | ✅ Parallel | Yes |
+| 5 | T5 | `feat(team): pyramid root is always the main agent` | 2 | ✅ Parallel | Yes |
+| 6 | T6 | `feat(team): normalize team.json writes to drop implicit main reportsTo` | 2 | ✅ Parallel | Yes |
+| 7 | T7 | `feat(onboarding): doctor validates openclaw.json integrity` | 2 | ✅ Parallel | Yes |
+| 8 | T8 | `docs: update agent-system and team-plugin knowledge notes` | 3 (solo) | No — must land last | Yes |
+
+**8 commits. 3 phases. 3 checkpoints (after Phase 1, Phase 2, Phase 3).**
+
+The Phase 2 fan-out (commits 2–7) is truly parallel: each task touches a disjoint set of files, so they can execute as six concurrent sub-agents or serially in any order. The commit landing order within Phase 2 doesn't matter for correctness — only for reviewability.
+
+Any single commit can be reverted with `git revert <sha>` without corrupting the ones before it. The only ordering constraint is: commit 1 must land before any Phase 2 commit, and commit 8 must land after.
+
+---
+
+## Risks and open edges
+
+1. **T3 scope creep.** Centralizing the openclaw.json reader touches main-agent.ts, settings.ts, openclaw-adapter.ts, and possibly cli/bakin.ts. If the refactor touches more than ~150 lines, split it into "create openclaw-config.ts" and "migrate consumers" as two commits.
+2. **team-grid.tsx tests may not exist yet.** The current test file structure is unclear — if no test harness exists for rendering React components in this repo, we'll write assertions against `buildGraph()` as a pure function rather than the full component. That's fine for verifying the pyramid shape.
+3. **T6 unresolved-id fallback.** Graceful degradation means team.json with `reportsTo: "roscoe"` "just works" after Phase 2 — which is good for the user but means the T9 manual edit of team.json is optional, not strictly required. Keep it in the runbook so on-disk state matches code expectations.
+4. **Imitation Crab fixture.** `dev/imitation-crab/fixtures/openclaw.json:9` already has `id: "main"`. Good — this is the "fresh install" reference for F2/F6 tests. Don't touch it.
+5. **`~/.bakin/agents/{id}/AGENTS.md`** — origin unclear. The plan treats it as a stale artifact on this machine. If something still writes it and the spec's implication is wrong, that's a follow-up to investigate, not a blocker for this PR.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -26,8 +26,8 @@
 
 ## Phase 3 — Docs (solo)
 
-- [ ] **T8** — update `.claude/knowledge/agent-system.md`, create/append `.claude/knowledge/team-plugin.md`, verify `CLAUDE.md` is still accurate. _(commit: `docs: update agent-system and team-plugin knowledge notes`)_
-- [ ] ✅ **Phase 3 checkpoint:** all tests green, docs match shipped code.
+- [x] **T8** — updated `.claude/knowledge/agent-system.md`, created `.claude/knowledge/team-plugin.md`, tidied `CLAUDE.md` (mainAgentId no longer under ~/.bakin/settings.json). _(commit: `docs: update agent-system and team-plugin knowledge notes` — da2a6c4)_
+- [x] ✅ **Phase 3 checkpoint:** 141 files / 2108 passing / 1 skipped. Docs match shipped code.
 
 ## Phase 4 — Manual cleanup (runbook, no commit)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,142 +1,38 @@
-# TODO: Health Plugin Overhaul
+# TODO: Team plugin canonical main-agent ids
 
-**Spec:** `.claude/specs/health-plugin-overhaul.md`
+**Spec:** `.claude/specs/issue-90-team-main-agent-canonical.md`
 **Plan:** `tasks/plan.md`
-**Branch:** `fix/health-plugin-overhaul`
+**Issue:** https://github.com/madeinwyo/bakin/issues/90
+**Branch:** `fix/issue-90-team-main-agent`
 
----
+## Phase 1 — Refactor prelude (solo)
 
-## Phase 1 — Recorder foundation
+- [ ] **Spec patch** — update spec section 4 & 7: doctor/migration code cannot auto-mutate openclaw.json, but user-initiated CRUD (existing `addAgent`/`removeAgent`) is allowed per CLAUDE.md's adapter principle.
+- [ ] **T3** — create `packages/core/src/openclaw-config.ts`; migrate the three duplicate mtime-cached readers from `main-agent.ts` / `openclaw-adapter.ts` / `settings.ts` to import from it. Pure refactor, no behavior change. _(commit: `refactor(core): centralize openclaw.json reader into openclaw-config module`)_
+- [ ] ✅ **Phase 1 checkpoint:** `typecheck` + full `test` pass. Team page and `/api/settings` are unchanged from pre-refactor.
 
-- [ ] **T1.1** Create `src/core/usage.ts` + `tests/core/usage.test.ts`
-  - API: `recordUsage`, `getUsageFeed`, `getUsageStats`, `getErrorCount`, `getCurrentAgentActivity`, `clearUsage` (test-only)
-  - `UsageEntry` type + `UsageKind` union + `UsageFeed` shape
-  - `globalThis.__bakinUsage` backing, 10k ring buffer, FIFO eviction
-  - `WINDOW_MS = { '5m': 300_000, '1h': 3_600_000, '24h': 86_400_000 }`
-  - Unit tests cover: insert, window/kind/agent filter, eviction, idle detection, error count, median duration
-  - **Commit:** `feat(core): add unified usage recorder`
+## Phase 2 — Parallel fan-out (6 commits, any order)
 
-**▶ CHECKPOINT 1** — recorder exists in isolation, safe to roll back.
+**All six tasks below touch disjoint files.** Execute as six concurrent sub-agents or serially in any order. Each lands as its own commit.
 
----
+- [ ] **T1** — `packages/core/src/main-agent.ts` only. `getMainAgentId()` always returns `"main"`; delete detection heuristic and the old `mainAgentId` setting reference. _(commit: `refactor(core): getMainAgentId always returns "main"`)_
+- [ ] **T2** — `packages/core/src/settings.ts` + `cli/bakin.ts` only. Delete `BakinSettings.agents` and `BakinSettings.mainAgentId` fields; migrate cli consumers to `openclaw-config.getAgentIds()`. _(commit: `refactor(core): drop stale settings.agents + mainAgentId fields`)_
+- [ ] **T4** — `plugins/team/lib/openclaw-adapter.ts` only. `listAgents()` validates + dedupes (reject duplicate ids, duplicate workspaces, missing `main`). Read-only, never mutates openclaw.json. _(commit: `feat(team): validate and dedupe openclaw agent list`)_
+- [ ] **T5** — `plugins/team/components/team-grid.tsx` only. `buildGraph()` roots the pyramid at the main agent; `reportsTo ?? mainAgentId` resolution; drop `topAgentIds` heuristic for the root. _(commit: `feat(team): pyramid root is always the main agent`)_
+- [ ] **T6** — `plugins/team/index.ts` (writer route) only. Normalize `reportsTo === mainAgentId` → null on write; reader treats unknown `reportsTo` strings as null with a warning log. _(commit: `feat(team): normalize team.json writes to drop implicit main reportsTo`)_
+- [ ] **T7** — `src/core/onboarding/openclaw.ts` only. Doctor check validates missing `main`, duplicate ids, duplicate workspaces. Reports only, non-zero exit on failure, never auto-fixes. _(commit: `feat(onboarding): doctor validates openclaw.json integrity`)_
+- [ ] ✅ **Phase 2 checkpoint:** `typecheck` + full `test` pass. Team page on imitation-crab fixture shows founder → Crab → 7 subagents (no dupes). Null-reportsTo Creators team renders under Crab. `bakin check openclaw` flags a deliberately-broken fixture.
 
-## Phase 2 — Wire producers (parallel fan-out, 3 agents)
+## Phase 3 — Docs (solo)
 
-- [ ] **T2.1** MCP producer
-  - Edit `src/core/mcp-server.ts:120-151` — add `recordUsage({ kind: 'mcp', ... })` around `tool.handler`
-  - Measure duration, capture status, record errors on throw or `!result.ok`
-  - New test: `tests/integration/usage-wiring-mcp.test.ts` — real tool invocation via MCP JSON-RPC
-  - Leave `recordToolCall` / `recordExecToolCall` in place (deleted in Phase 5)
-  - **Commit:** `feat(mcp): record tool calls to unified usage store`
+- [ ] **T8** — update `.claude/knowledge/agent-system.md`, create/append `.claude/knowledge/team-plugin.md`, verify `CLAUDE.md` is still accurate. _(commit: `docs: update agent-system and team-plugin knowledge notes`)_
+- [ ] ✅ **Phase 3 checkpoint:** all tests green, docs match shipped code.
 
-- [ ] **T2.2** REST producers
-  - Extract middleware body from `server.ts:147-166` into `trackResponse()` helper for testability
-  - Helper calls both `recordRequest` (legacy) and `recordUsage({ kind: 'rest', ... })`
-  - Agent attribution: header `x-bakin-agent` → query `?agent=` → `null`
-  - Path normalization: keep `/api/plugins/{id}/...` verbatim, UUID → `:id` elsewhere
-  - New test: `tests/integration/usage-wiring-rest.test.ts` — real HTTP request through middleware
-  - Tests cover: header attribution, query attribution, normalization, error status
-  - **Commit:** `feat(server): record REST requests to unified usage store`
+## Phase 4 — Manual cleanup (runbook, no commit)
 
-- [ ] **T2.3** Agent producers
-  - `src/core/dispatch.ts:236` (`dispatchSingleTask`) — record `name: 'dispatch'`
-  - `scripts/lib/heartbeat.ts:36` — record `name: 'heartbeat'`
-  - `src/core/task-service.ts` — record `name: 'task.<status>'` on lifecycle transitions
-  - New test: `tests/integration/usage-wiring-agent.test.ts`
-  - Tests cover: each of the three producers emits correct entry
-  - **Commit:** `feat(agents): record agent lifecycle events to unified usage store`
+- [ ] **T9** — runbook execution on this machine per `tasks/plan.md` Phase 4. Backup → edit openclaw.json (merge roscoe into main) → move avatars → delete heartbeats → edit team.json → edit settings.json → `bakin check openclaw` → restart → visually verify one Roscoe card at the pyramid top with Creators + Builders under it.
 
-**▶ CHECKPOINT 2** — all producers feeding recorder; old systems still running in parallel; old UI still works.
+## Post-merge
 
----
-
-## Phase 3 — API route
-
-- [ ] **T3.1** Add `/api/plugins/health/usage-feed` + add `errors1h` to `/summary`
-  - Register route in `plugins/health/index.ts`
-  - Zod parse `?kind=&window=&agent=`
-  - Returns `UsageFeed` shape from `getUsageFeed(...)`
-  - Add `errors1h: { total, byKind }` to `/summary` response from `getErrorCount`
-  - **Do not** drop `/requests`, `execTools`, `mcp`, `restHealth`, `requests` yet
-  - Update existing `tests/plugins/health/routes.test.ts` — add usage-feed tests seeding via `recordUsage`
-  - **Commit:** `feat(health): add usage-feed route backed by unified recorder`
-
-**▶ CHECKPOINT 3** — new API alongside old; deployable.
-
----
-
-## Phase 4 — UI rebuild (sequential, same file)
-
-- [ ] **T4.1** Top row rebuild
-  - Replace 6-card grid at `plugins/health/components/health-page.tsx:453-575`
-  - New grid: `Uptime | Active Sessions | Memory | Errors (1h)` (4 cols desktop, 2 mobile)
-  - Errors card: big count, subtext `mcp: N · rest: N · agent: N`, red if >0 else emerald
-  - Drop references to `data.mcpHealth`, `data.restHealth`, `requests.totalRequests` in top row
-  - Visual verify in dev server
-  - **Commit:** `feat(health): rebuild top row — drop redundant cards, add errors tile`
-
-- [ ] **T4.2** Usage tabs shell + window filter
-  - Replace 4-up usage grid with `<Card>` containing `<Tabs>` (Tool / Endpoint / Agent)
-  - URL state: `useQueryState('usage_tab', 'tools')`, `useQueryState('usage_window', '1h')`
-  - Segmented window control `5m | 1h | 24h`
-  - Wire fetch to `/api/plugins/health/usage-feed?kind=...&window=...`
-  - Placeholder content in each `TabsContent`
-  - Context Usage + Cost Breakdown cards stay below, unchanged
-  - Wrap page content in `<Suspense>` per URL-state rule
-  - **Commit:** `feat(health): tabbed usage section with window filter`
-
-- [ ] **T4.3** Tab contents
-  - **Tool Usage:** `HorizontalBars` of `topByName`, per-bar `err/median`, "firing right now" footer
-  - **Endpoint Usage:** Same pattern for REST; per-plugin rollup strip below
-  - **Agent Usage:** Row per agent — id | current activity string | count · errors
-  - Activity string formats: `calling {name} · Xs ago` (mcp), `handling {method} {path} · Xs ago` (rest), `{name} · Xs ago` (agent), `idle Ys` (>30s)
-  - Filter `name === 'heartbeat'` out of activity count column
-  - Empty states rendered cleanly
-  - Click through all 3 tabs × 3 windows in dev server
-  - **Commit:** `feat(health): populate tool/endpoint/agent usage tabs`
-
-**▶ CHECKPOINT 4** — new UI live; old API endpoints still present but unused.
-
----
-
-## Phase 5 — Cleanup
-
-- [ ] **T5.1** Delete old code + retarget watchdog
-  - Delete `src/core/request-log.ts`
-  - Delete `tests/core/request-log.test.ts`
-  - `scripts/lib/registry.ts`: drop `toolStats`, `recordExecToolCall`, `recordExecToolError`, `getExecToolStats`, `ExecToolStat`
-  - `src/core/mcp-server.ts`: drop `recordToolCall`, `stats` object, references to removed registry exports
-  - `src/core/watchdog.ts`: retarget `getRecentStatsForPathPrefix` → `getUsageStats({ kind: 'mcp', ... })` with matching semantics
-  - `plugins/health/index.ts`: drop `/requests` route, drop `execTools` from `/registry`, drop `mcp`/`restHealth`/`requests` from `/summary`
-  - `server.ts`: drop legacy `recordRequest` call from middleware (now only calls `recordUsage`)
-  - Grep verify: zero matches for `request-log|toolStats|recordToolCall|recordExecToolCall|getRestStatsByPlugin|getRecentStatsForPathPrefix|getExecToolStats` in `src/ plugins/ scripts/ server.ts`
-  - `pnpm lint && pnpm typecheck && pnpm test` all green
-  - **Commit:** `refactor(health): remove legacy request-log and toolStats systems`
-
-- [ ] **T5.2** Rewrite `tests/plugins/health/routes.test.ts`
-  - Remove all mocks of the deleted modules
-  - Seed recorder state via real `recordUsage` calls
-  - Only `agent-usage.ts` (OpenClaw) + `doctor` remain mocked
-  - Briefly break one Phase 2 producer; confirm an integration test fails; restore
-  - **Commit:** `test(health): replace mocked stat sources with real recorder`
-
-- [ ] **T5.3** Docs (parallel with T5.1/T5.2)
-  - Add "Usage Recording" subsection to `CLAUDE.md` Key Patterns
-  - Grep `.claude/knowledge/` for stale refs, update where needed
-  - Check `README.md` for references to removed features
-  - Save memory: `project_health_overhaul.md`
-  - **Commit:** `docs: document unified usage recorder pattern`
-
-**▶ CHECKPOINT 5** — overhaul complete.
-
----
-
-## Verification gates (between every commit)
-
-1. `pnpm lint`
-2. `pnpm typecheck`
-3. `pnpm test` (full suite, not just new tests)
-4. `/health` page loads with no console errors
-5. All Phase 2 integration tests still pass
-
-No skipping.
+- [ ] Close issue #90 with a comment linking the PR and summarizing: "canonical id is `main`, display name from `identity.name`, team page derives roster from OpenClaw with dedupe + validation, doctor catches future regressions."
+- [ ] Archive `tasks/plan.md` and `tasks/todo.md` to match the convention used for the Health Plugin Overhaul work.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -31,7 +31,8 @@
 
 ## Phase 4 — Manual cleanup (runbook, no commit)
 
-- [ ] **T9** — runbook execution on this machine per `tasks/plan.md` Phase 4. Backup → edit openclaw.json (merge roscoe into main) → move avatars → delete heartbeats → edit team.json → edit settings.json → `bakin check openclaw` → restart → visually verify one Roscoe card at the pyramid top with Creators + Builders under it.
+- [x] **T9** — runbook executed on this machine. Backed up `~/.openclaw/openclaw.json` → `.pre-issue-90` and `~/.bakin` → `~/.bakin.pre-issue-90` (122 MB). Stopped bakin, merged `roscoe` identity into the `main` entry in openclaw.json (emoji changed from 🐾 to 🐷), deleted the `roscoe` entry, moved `avatar.jpg` + `avatar-full.png` into `~/.bakin/agents/main/`, removed `~/.bakin/agents/roscoe/`, removed `~/.bakin/heartbeats/roscoe.json`, normalized both team `reportsTo` values to null in `plugin-settings/team.json`, deleted the stale top-level `agents` array from `settings.json`. `bakin check openclaw` clean (T7 integrity validator returned ok). Restarted — mcporter auto-pruned `bakin-roscoe`, roster API returned `mainAgentId: main → Roscoe 🐷` with 8 agents and no duplicates. Team page visually verified: Mark at top, one Roscoe card under him, Creators + Builders branching off correctly.
+- [x] **Bonus fix** — founder node edge jog. Founder card had no explicit width so xyflow drew a slightly kinked smoothstep edge between off-center handles; fixed by forcing `w-[152px]` on the founder and aligning `FOUNDER_W` to `CARD_W`. _(commit: `fix(team): align founder node width with agent cards to eliminate edge jog` — 4acc9b3)_
 
 ## Post-merge
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,20 +8,21 @@
 ## Phase 1 — Refactor prelude (solo)
 
 - [ ] **Spec patch** — update spec section 4 & 7: doctor/migration code cannot auto-mutate openclaw.json, but user-initiated CRUD (existing `addAgent`/`removeAgent`) is allowed per CLAUDE.md's adapter principle.
-- [ ] **T3** — create `packages/core/src/openclaw-config.ts`; migrate the three duplicate mtime-cached readers from `main-agent.ts` / `openclaw-adapter.ts` / `settings.ts` to import from it. Pure refactor, no behavior change. _(commit: `refactor(core): centralize openclaw.json reader into openclaw-config module`)_
-- [ ] ✅ **Phase 1 checkpoint:** `typecheck` + full `test` pass. Team page and `/api/settings` are unchanged from pre-refactor.
+- [x] **T3** — create `packages/core/src/openclaw-config.ts`; migrate the three duplicate mtime-cached readers from `main-agent.ts` / `openclaw-adapter.ts` / `settings.ts` to import from it. Pure refactor, no behavior change. _(commit: `refactor(core): centralize openclaw.json reader into openclaw-config module` — 773ed59)_
+- [x] ✅ **Phase 1 checkpoint:** `typecheck` (no new errors) + full `test` (139 files, 2076 passing) pass. Team page and `/api/settings` are unchanged from pre-refactor.
 
 ## Phase 2 — Parallel fan-out (6 commits, any order)
 
 **All six tasks below touch disjoint files.** Execute as six concurrent sub-agents or serially in any order. Each lands as its own commit.
 
-- [ ] **T1** — `packages/core/src/main-agent.ts` only. `getMainAgentId()` always returns `"main"`; delete detection heuristic and the old `mainAgentId` setting reference. _(commit: `refactor(core): getMainAgentId always returns "main"`)_
-- [ ] **T2** — `packages/core/src/settings.ts` + `cli/bakin.ts` only. Delete `BakinSettings.agents` and `BakinSettings.mainAgentId` fields; migrate cli consumers to `openclaw-config.getAgentIds()`. _(commit: `refactor(core): drop stale settings.agents + mainAgentId fields`)_
-- [ ] **T4** — `plugins/team/lib/openclaw-adapter.ts` only. `listAgents()` validates + dedupes (reject duplicate ids, duplicate workspaces, missing `main`). Read-only, never mutates openclaw.json. _(commit: `feat(team): validate and dedupe openclaw agent list`)_
-- [ ] **T5** — `plugins/team/components/team-grid.tsx` only. `buildGraph()` roots the pyramid at the main agent; `reportsTo ?? mainAgentId` resolution; drop `topAgentIds` heuristic for the root. _(commit: `feat(team): pyramid root is always the main agent`)_
-- [ ] **T6** — `plugins/team/index.ts` (writer route) only. Normalize `reportsTo === mainAgentId` → null on write; reader treats unknown `reportsTo` strings as null with a warning log. _(commit: `feat(team): normalize team.json writes to drop implicit main reportsTo`)_
-- [ ] **T7** — `src/core/onboarding/openclaw.ts` only. Doctor check validates missing `main`, duplicate ids, duplicate workspaces. Reports only, non-zero exit on failure, never auto-fixes. _(commit: `feat(onboarding): doctor validates openclaw.json integrity`)_
-- [ ] ✅ **Phase 2 checkpoint:** `typecheck` + full `test` pass. Team page on imitation-crab fixture shows founder → Crab → 7 subagents (no dupes). Null-reportsTo Creators team renders under Crab. `bakin check openclaw` flags a deliberately-broken fixture.
+- [x] **T1** — `packages/core/src/main-agent.ts`. `getMainAgentId()` always returns `"main"`; deleted detection heuristic and old `mainAgentId` setting reference. _(commit: `refactor(core): getMainAgentId always returns "main"` — cb62901)_
+- [x] **T2** — `packages/core/src/settings.ts` + cli/dispatch/doctor/mcporter/agents consumers. Deleted `BakinSettings.agents` and `BakinSettings.mainAgentId` fields; migrated all consumers to `openclaw-config.getAgentIds()`. _(commit: `refactor(core): drop stale settings.agents + mainAgentId fields` — 704d37b)_
+- [x] **T4** — `plugins/team/lib/openclaw-adapter.ts`. `listAgents()` validates + dedupes (rejects duplicate ids, duplicate resolved workspaces, returns empty roster when `main` missing). Read-only, never mutates openclaw.json. _(commit: `feat(team): validate and dedupe openclaw agent list` — 7202c41)_
+- [x] **T5** — `plugins/team/components/team-grid.tsx` + extracted `plugins/team/lib/build-graph.ts`. `buildGraph()` roots the pyramid at the main agent; `reportsTo ?? mainAgentId` resolution with unknown-id fallback; dropped `topAgentIds` heuristic. _(commit: `feat(team): pyramid root is always the main agent` — aaf2aba)_
+- [x] **T6** — `plugins/team/index.ts` (writer route) + types.ts + team-manager.tsx + routes.test.ts. Normalizes `reportsTo === mainAgentId` → null on write; reader degrades unknown `reportsTo` strings to null with warning log. _(commit: `feat(team): normalize team.json writes to drop implicit main reportsTo` — 7765585)_
+- [x] **T7** — `src/core/onboarding/openclaw.ts`. Doctor check validates missing `main`, duplicate ids, duplicate workspaces. Reports only, never auto-fixes, collects all violations in one pass. _(commit: `feat(onboarding): doctor validates openclaw.json integrity` — 8abffa6)_
+- [x] **Test mock migration** — doctor/mcporter/usage-wiring tests were still mocking `BakinSettings.agents`; migrated to `@bakin/core/openclaw-config.getAgentIds` and added openclaw-home pins. _(commit: `test(core): migrate stale settings.agents mocks to openclaw-config` — 84d1b94)_
+- [x] ✅ **Phase 2 checkpoint:** typecheck clean on Phase 2 surface (pre-existing errors in antfly-reranker/search-auto-registration/search-tools-mcp/brainstorm/project-grid are unrelated). Full test suite: 141 files, 2108 passing, 1 skipped.
 
 ## Phase 3 — Docs (solo)
 

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -46,12 +46,24 @@ vi.mock('@/core/content-dir', () => ({
 // Mock settings
 vi.mock('@/core/settings', () => ({
   getSettings: vi.fn(() => ({
-    agents: ['main', 'patch', 'pixel'],
     antfly: { enabled: false },
     doctor: { intervalMs: 1800000, autoFixSkill: false },
     openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },
     service: { enabled: false },
   })),
+}))
+
+// Mock openclaw-config — owns the authoritative agent roster after T2
+vi.mock('@bakin/core/openclaw-config', () => ({
+  getAgentIds: vi.fn(() => ['main', 'patch', 'pixel']),
+  findAgentById: vi.fn((id: string) => (['main', 'patch', 'pixel'].includes(id) ? { id } : null)),
+  readOpenClawConfig: vi.fn(() => ({ agents: [{ id: 'main' }, { id: 'patch' }, { id: 'pixel' }] })),
+  resetOpenClawConfigCache: vi.fn(),
+}))
+
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => '/tmp/doctor-test-openclaw',
+  getOpenClawPath: (...parts: string[]) => ['/tmp/doctor-test-openclaw', ...parts].join('/'),
 }))
 
 // Mock openclaw-client
@@ -238,7 +250,6 @@ describe('doctor', () => {
       const { getSettings } = await import('@/core/settings')
       const settings = (getSettings as unknown as ReturnType<typeof vi.fn>)
       settings.mockReturnValueOnce({
-        agents: [],
         antfly: { enabled: false },
         doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: true },
         openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },
@@ -258,7 +269,6 @@ describe('doctor', () => {
       const { getSettings } = await import('@/core/settings')
       const settings = (getSettings as unknown as ReturnType<typeof vi.fn>)
       settings.mockReturnValueOnce({
-        agents: ['main'],
         antfly: { enabled: false },
         doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: true },
         openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },
@@ -277,7 +287,6 @@ describe('doctor', () => {
       const { getSettings } = await import('@/core/settings')
       const settings = (getSettings as unknown as ReturnType<typeof vi.fn>)
       settings.mockReturnValueOnce({
-        agents: ['main'],
         antfly: { enabled: false },
         doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: false },
         openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -179,7 +179,6 @@ describe('doctor', () => {
       // Override settings to enable autoFix
       const { getSettings } = await import('@/core/settings')
       vi.mocked(getSettings).mockReturnValue({
-        agents: ['main', 'patch', 'pixel'],
         antfly: { enabled: false },
         doctor: { intervalMs: 1800000, autoFixSkill: true },
         openclaw: { binaryPath: 'openclaw', gatewayUrl: 'http://127.0.0.1', gatewayPort: 18789 },

--- a/tests/core/main-agent.test.ts
+++ b/tests/core/main-agent.test.ts
@@ -46,31 +46,19 @@ vi.mock('../../src/core/content-dir', () => ({
 vi.unmock('../../packages/core/src/main-agent')
 vi.unmock('@bakin/core/main-agent')
 
-vi.mock('../../packages/core/src/settings', () => ({
-  getSettings: vi.fn().mockReturnValue({}),
-}))
-
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
   return { ...actual, readFileSync: vi.fn(), statSync: vi.fn() }
 })
 
-import { getSettings } from '../../packages/core/src/settings'
 import { readFileSync, statSync } from 'fs'
 
 let getMainAgentId: typeof import('../../packages/core/src/main-agent').getMainAgentId
+let tryGetMainAgentId: typeof import('../../packages/core/src/main-agent').tryGetMainAgentId
 let getMainAgentName: typeof import('../../packages/core/src/main-agent').getMainAgentName
 
-const WS = '/tmp/openclaw/workspace'
-
-function openclawConfig(overrides: Record<string, unknown> = {}): string {
-  return JSON.stringify({
-    agents: {
-      defaults: { workspace: WS },
-      list: [],
-      ...overrides,
-    },
-  })
+function openclawConfig(list: Array<Record<string, unknown>>): string {
+  return JSON.stringify({ agents: { list } })
 }
 
 function mockOpenclawFile(mtimeMs: number, content: string): void {
@@ -82,159 +70,113 @@ describe('main-agent', () => {
   beforeEach(async () => {
     vi.resetModules()
     vi.clearAllMocks()
-    vi.mocked(getSettings).mockReturnValue({} as any)
     vi.mocked(readFileSync).mockImplementation(() => { throw new Error('ENOENT') })
     vi.mocked(statSync).mockImplementation(() => { throw new Error('ENOENT') })
 
     const mod = await import('../../packages/core/src/main-agent')
     getMainAgentId = mod.getMainAgentId
+    tryGetMainAgentId = mod.tryGetMainAgentId
     getMainAgentName = mod.getMainAgentName
   })
 
   describe('getMainAgentId', () => {
-    it('returns mainAgentId from settings when set', () => {
-      vi.mocked(getSettings).mockReturnValue({ mainAgentId: 'custom' } as any)
-      expect(getMainAgentId()).toBe('custom')
-    })
-
-    it('detects orchestrator from OpenClaw when its workspace equals agents.defaults.workspace', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [
-          { id: 'pixel', workspace: '/tmp/openclaw/workspaces/pixel' },
-          { id: 'roscoe', workspace: WS, identity: { name: 'Roscoe' } },
-          { id: 'patch', workspace: '/tmp/openclaw/workspaces/patch' },
-        ],
-      }))
-      expect(getMainAgentId()).toBe('roscoe')
-    })
-
-    it('detects orchestrator when openclaw uses `main` as the id', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [
-          { id: 'main', workspace: WS },
-          { id: 'pixel', workspace: '/tmp/openclaw/workspaces/pixel' },
-        ],
-      }))
+    it('returns "main" when openclaw.json has an agent with id "main"', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main', identity: { name: 'Roscoe' } },
+        { id: 'patch', workspace: '/tmp/ws/patch' },
+      ]))
       expect(getMainAgentId()).toBe('main')
     })
 
-    it('falls back to agent with populated subagents allowlist when workspace match is absent', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [
-          { id: 'alpha', subagents: { allowAgents: ['x', 'y', 'z'] } },
-          { id: 'x', workspace: '/tmp/openclaw/workspaces/x' },
-        ],
-      }))
-      expect(getMainAgentId()).toBe('alpha')
+    it('throws a clear error when openclaw.json has no "main" entry', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'pixel', workspace: '/tmp/ws/pixel' },
+        { id: 'patch', workspace: '/tmp/ws/patch' },
+      ]))
+      expect(() => getMainAgentId()).toThrow(/openclaw\.json has no agent with id 'main'/)
+      expect(() => getMainAgentId()).toThrow(/bakin check openclaw/)
     })
 
-    it('throws when settings has no mainAgentId and OpenClaw config is unreadable', () => {
-      vi.mocked(statSync).mockImplementation(() => { throw new Error('ENOENT') })
-      expect(() => getMainAgentId()).toThrow(/main agent/i)
+    it('throws when openclaw.json is missing entirely', () => {
+      expect(() => getMainAgentId()).toThrow(/openclaw\.json has no agent with id 'main'/)
+    })
+  })
+
+  describe('tryGetMainAgentId', () => {
+    it('returns "main" in the happy case', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main', identity: { name: 'Roscoe' } },
+      ]))
+      expect(tryGetMainAgentId()).toBe('main')
     })
 
-    it('throws when OpenClaw config has no matching orchestrator', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [
-          { id: 'pixel', workspace: '/tmp/openclaw/workspaces/pixel' },
-          { id: 'patch', workspace: '/tmp/openclaw/workspaces/patch' },
-        ],
-      }))
-      expect(() => getMainAgentId()).toThrow(/main agent/i)
+    it('returns null when openclaw.json has no "main" entry', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'pixel', workspace: '/tmp/ws/pixel' },
+      ]))
+      expect(tryGetMainAgentId()).toBeNull()
     })
 
-    it('prefers settings.mainAgentId over OpenClaw detection', () => {
-      vi.mocked(getSettings).mockReturnValue({ mainAgentId: 'chief' } as any)
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'roscoe', workspace: WS }],
-      }))
-      expect(getMainAgentId()).toBe('chief')
-    })
-
-    it('ignores empty-string mainAgentId in settings', () => {
-      vi.mocked(getSettings).mockReturnValue({ mainAgentId: '' } as any)
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'roscoe', workspace: WS }],
-      }))
-      expect(getMainAgentId()).toBe('roscoe')
+    it('returns null when openclaw.json is missing', () => {
+      expect(tryGetMainAgentId()).toBeNull()
     })
   })
 
   describe('getMainAgentName', () => {
-    it('returns identity.name when set on the resolved agent', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'roscoe', workspace: WS, identity: { name: 'Roscoe' } }],
-      }))
+    it('returns identity.name when set on the main entry', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main', identity: { name: 'Roscoe' } },
+      ]))
       expect(getMainAgentName()).toBe('Roscoe')
     })
 
-    it('falls back to title-cased id when identity.name is missing', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'boss', workspace: WS }],
-      }))
-      expect(getMainAgentName()).toBe('Boss')
+    it('returns "Main" when identity.name is absent', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main' },
+      ]))
+      expect(getMainAgentName()).toBe('Main')
     })
 
-    it('propagates throw from getMainAgentId when nothing resolves', () => {
-      vi.mocked(statSync).mockImplementation(() => { throw new Error('ENOENT') })
-      expect(() => getMainAgentName()).toThrow(/main agent/i)
+    it('returns "Main" when identity.name is a blank string', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main', identity: { name: '   ' } },
+      ]))
+      expect(getMainAgentName()).toBe('Main')
     })
 
-    it('uses settings.mainAgentId to locate the matching agent entry', () => {
-      vi.mocked(getSettings).mockReturnValue({ mainAgentId: 'orchestrator' } as any)
-      mockOpenclawFile(1000, openclawConfig({
-        list: [
-          { id: 'roscoe', workspace: WS, identity: { name: 'Wrong' } },
-          { id: 'orchestrator', identity: { name: 'Captain' } },
-        ],
-      }))
-      expect(getMainAgentName()).toBe('Captain')
+    it('returns "Main" when openclaw.json has no main entry', () => {
+      // getMainAgentName degrades gracefully rather than throwing — it has no
+      // agent to pull a name from, so the static fallback applies.
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'pixel', workspace: '/tmp/ws/pixel' },
+      ]))
+      expect(getMainAgentName()).toBe('Main')
     })
   })
 
-  describe('mtime-cached config reads', () => {
-    it('reuses parsed config across calls when mtime is unchanged', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'boss', workspace: WS }],
-      }))
-      expect(getMainAgentId()).toBe('boss')
-      expect(getMainAgentId()).toBe('boss')
-      expect(getMainAgentId()).toBe('boss')
-      // One parse, three stats — stat is the only per-call cost.
-      expect(readFileSync).toHaveBeenCalledTimes(1)
-      expect(statSync).toHaveBeenCalledTimes(3)
+  describe('live openclaw.json edits', () => {
+    it('picks up a rename of identity.name without a restart (mtime change)', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main', identity: { name: 'Roscoe' } },
+      ]))
+      expect(getMainAgentName()).toBe('Roscoe')
+
+      mockOpenclawFile(2000, openclawConfig([
+        { id: 'main', identity: { name: 'Captain' } },
+      ]))
+      expect(getMainAgentName()).toBe('Captain')
     })
 
-    it('re-reads when mtime changes (live rename recovery)', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'old-name', workspace: WS }],
-      }))
-      expect(getMainAgentId()).toBe('old-name')
+    it('picks up a removal of the "main" entry (mtime change)', () => {
+      mockOpenclawFile(1000, openclawConfig([
+        { id: 'main', identity: { name: 'Roscoe' } },
+      ]))
+      expect(getMainAgentId()).toBe('main')
 
-      mockOpenclawFile(2000, openclawConfig({
-        list: [{ id: 'new-name', workspace: WS }],
-      }))
-      expect(getMainAgentId()).toBe('new-name')
-      expect(readFileSync).toHaveBeenCalledTimes(2)
-    })
-
-    it('recovers when openclaw.json becomes available after being missing', () => {
-      expect(() => getMainAgentId()).toThrow(/main agent/i)
-
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'boss', workspace: WS }],
-      }))
-      expect(getMainAgentId()).toBe('boss')
-    })
-
-    it('does not cache a stale config across consecutive getMainAgentId + getMainAgentName calls', () => {
-      mockOpenclawFile(1000, openclawConfig({
-        list: [{ id: 'boss', workspace: WS, identity: { name: 'Boss Man' } }],
-      }))
-      expect(getMainAgentId()).toBe('boss')
-      expect(getMainAgentName()).toBe('Boss Man')
-      // Both helpers share the same cache — only one parse total.
-      expect(readFileSync).toHaveBeenCalledTimes(1)
+      mockOpenclawFile(2000, openclawConfig([
+        { id: 'pixel', workspace: '/tmp/ws/pixel' },
+      ]))
+      expect(() => getMainAgentId()).toThrow(/openclaw\.json has no agent with id 'main'/)
     })
   })
 })

--- a/tests/core/mcporter.test.ts
+++ b/tests/core/mcporter.test.ts
@@ -12,10 +12,18 @@ vi.mock('../../src/core/logger', () => ({
   }),
 }))
 
-vi.mock('../../src/core/settings', () => ({
-  getSettings: vi.fn().mockReturnValue({
-    agents: ['main', 'pixel', 'nemo'],
-  }),
+vi.mock('@bakin/core/openclaw-config', () => ({
+  getAgentIds: vi.fn().mockReturnValue(['main', 'pixel', 'nemo']),
+}))
+
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => '/tmp/mcporter-test-openclaw',
+  getOpenClawPath: (...parts: string[]) => ['/tmp/mcporter-test-openclaw', ...parts].join('/'),
+}))
+
+vi.mock('../../src/core/content-dir', () => ({
+  getContentDir: () => '/tmp/mcporter-test-bakin',
+  getBakinPaths: () => ({ root: '/tmp/mcporter-test-bakin' }),
 }))
 
 vi.mock('child_process', () => ({

--- a/tests/core/onboarding/openclaw.test.ts
+++ b/tests/core/onboarding/openclaw.test.ts
@@ -20,6 +20,18 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 let fakeHome: string
+const fakeContentDir = join(tmpdir(), `bakin-test-openclaw-content-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => fakeContentDir,
+  getBakinPaths: () => ({
+    home: fakeContentDir,
+    settings: join(fakeContentDir, 'settings.json'),
+    logs: join(fakeContentDir, 'logs'),
+  }),
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+}))
 
 vi.mock('@bakin/core/openclaw-home', () => ({
   getOpenClawHome: () => fakeHome,
@@ -105,7 +117,12 @@ describe('onboarding openclaw component', () => {
       const binaryPath = join(binaryDir, 'openclaw')
       mkdirSync(binaryDir, { recursive: true })
       writeFileSync(binaryPath, '#!/bin/sh\n', { mode: 0o755 })
-      writeFileSync(join(fakeHome, 'openclaw.json'), JSON.stringify({ channels: {} }))
+      // Minimal valid config: one 'main' agent satisfies the integrity
+      // validator, so this test can focus on binary discovery.
+      writeFileSync(
+        join(fakeHome, 'openclaw.json'),
+        JSON.stringify({ agents: { list: [{ id: 'main' }] } })
+      )
       process.env.OPENCLAW_PATH = binaryPath
       // Re-import to pick up the env var in the candidate builder
       vi.resetModules()
@@ -160,6 +177,166 @@ describe('onboarding openclaw component', () => {
       await openclawComponent.install(opts)
       // Noop → still missing
       expect(realExistsSync(fakeHome)).toBe(false)
+    })
+  })
+
+  /**
+   * Integrity validator. These tests exercise the reports-only scan that
+   * runs after openclaw.json parses successfully. Each test writes a
+   * specific fixture openclaw.json, then re-imports the openclaw component
+   * to pick up the fresh state, then asserts `check()` reports (or does
+   * not report) the expected violations. `vi.resetModules()` is called
+   * between imports so the openclaw-config mtime cache doesn't bleed.
+   */
+  describe('integrity check', () => {
+    async function importCheck() {
+      vi.resetModules()
+      const mod = await import('../../../src/core/onboarding/openclaw')
+      return mod.openclawComponent.check
+    }
+
+    function setupBinary(): void {
+      const binaryDir = join(fakeHome, 'bin')
+      const binaryPath = join(binaryDir, 'openclaw')
+      mkdirSync(binaryDir, { recursive: true })
+      writeFileSync(binaryPath, '#!/bin/sh\n', { mode: 0o755 })
+      process.env.OPENCLAW_PATH = binaryPath
+    }
+
+    function writeConfig(config: unknown): void {
+      writeFileSync(join(fakeHome, 'openclaw.json'), JSON.stringify(config))
+    }
+
+    it('passes a clean config with a main entry and distinct workspaces', async () => {
+      setupBinary()
+      writeConfig({
+        agents: {
+          list: [
+            { id: 'main', workspace: '/tmp/main-ws' },
+            { id: 'alpha', workspace: '/tmp/alpha-ws' },
+            { id: 'beta', workspace: '/tmp/beta-ws' },
+          ],
+        },
+      })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('installed')
+    })
+
+    it("reports an error when no agent has id 'main'", async () => {
+      setupBinary()
+      writeConfig({ agents: { list: [{ id: 'bob', workspace: '/tmp/bob' }] } })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('no agent')
+      expect(result.message).toContain("'main'")
+      const issues = result.details?.integrityIssues as string[] | undefined
+      expect(Array.isArray(issues)).toBe(true)
+      expect(issues?.length).toBe(1)
+    })
+
+    it('reports an error when two agents share the same id', async () => {
+      setupBinary()
+      writeConfig({
+        agents: {
+          list: [
+            { id: 'main', workspace: '/tmp/main-ws' },
+            { id: 'main', workspace: '/tmp/other-ws' },
+          ],
+        },
+      })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('duplicate')
+      expect(result.message).toContain("'main'")
+    })
+
+    it('reports an error when two agents collide on defaults.workspace', async () => {
+      setupBinary()
+      writeConfig({
+        agents: {
+          defaults: { workspace: '/shared' },
+          list: [{ id: 'main' }, { id: 'roscoe' }],
+        },
+      })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain("'main'")
+      expect(result.message).toContain("'roscoe'")
+      expect(result.message).toContain('/shared')
+    })
+
+    it('reports an error when two agents share an explicit workspace path', async () => {
+      setupBinary()
+      writeConfig({
+        agents: {
+          list: [
+            { id: 'a', workspace: '/x' },
+            { id: 'b', workspace: '/x' },
+            { id: 'main', workspace: '/y' },
+          ],
+        },
+      })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain("'a'")
+      expect(result.message).toContain("'b'")
+      expect(result.message).toContain('/x')
+      // main is fine here; the report should be about the a/b collision only
+      const issues = result.details?.integrityIssues as string[] | undefined
+      expect(issues?.length).toBe(1)
+    })
+
+    it('reports multiple violations in a single run', async () => {
+      setupBinary()
+      writeConfig({
+        agents: {
+          list: [
+            // no 'main' entry AND a duplicate id
+            { id: 'alpha', workspace: '/tmp/alpha' },
+            { id: 'alpha', workspace: '/tmp/alpha-two' },
+          ],
+        },
+      })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('broken')
+      const issues = result.details?.integrityIssues as string[] | undefined
+      expect(issues).toBeDefined()
+      expect(issues!.length).toBe(2)
+      expect(issues!.some((i) => i.includes('no agent'))).toBe(true)
+      expect(issues!.some((i) => i.includes('duplicate'))).toBe(true)
+    })
+
+    it('preserves the existing "openclaw.json missing" behavior when the file is absent', async () => {
+      setupBinary()
+      // Intentionally do NOT write openclaw.json
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('broken')
+      expect(result.message).toContain('openclaw.json')
+      expect(result.message).toContain('missing')
+      // No integrity issues emitted — we short-circuited before the validator
+      expect(result.details?.integrityIssues).toBeUndefined()
+    })
+
+    it('skips agents with no resolved workspace instead of reporting a false collision', async () => {
+      setupBinary()
+      writeConfig({
+        agents: {
+          // No defaults.workspace, two entries with no workspace field:
+          // neither resolves to a path, so there's nothing to collide.
+          list: [{ id: 'main' }, { id: 'roscoe' }],
+        },
+      })
+      const check = await importCheck()
+      const result = await check()
+      expect(result.status).toBe('ok')
     })
   })
 })

--- a/tests/core/openclaw-config.test.ts
+++ b/tests/core/openclaw-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { join } from 'path'
+
+const testHome = vi.hoisted(() => {
+  const { mkdtempSync } = require('fs')
+  const { tmpdir } = require('os')
+  const { join } = require('path')
+  const home = mkdtempSync(join(tmpdir(), 'bakin-test-home-'))
+  const openclaw = mkdtempSync(join(tmpdir(), 'bakin-test-openclaw-'))
+  process.env.BAKIN_HOME = home
+  process.env.OPENCLAW_HOME = openclaw
+  return { home, openclaw }
+})
+
+vi.mock('../../src/core/content-dir', () => ({
+  getContentDir: () => testHome.home,
+  getBakinPaths: () => ({
+    home: testHome.home,
+    settings: join(testHome.home, 'settings.json'),
+    logs: join(testHome.home, 'logs'),
+  }),
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return { ...actual, readFileSync: vi.fn(), statSync: vi.fn() }
+})
+
+import { readFileSync, statSync } from 'fs'
+
+let readOpenClawConfig: typeof import('../../packages/core/src/openclaw-config').readOpenClawConfig
+let getAgentList: typeof import('../../packages/core/src/openclaw-config').getAgentList
+let getAgentIds: typeof import('../../packages/core/src/openclaw-config').getAgentIds
+let findAgentById: typeof import('../../packages/core/src/openclaw-config').findAgentById
+let resetOpenClawConfigCache: typeof import('../../packages/core/src/openclaw-config').resetOpenClawConfigCache
+
+function configBody(list: Array<Record<string, unknown>>, defaults: Record<string, unknown> = {}): string {
+  return JSON.stringify({ agents: { defaults, list } })
+}
+
+function mockFile(mtimeMs: number, content: string): void {
+  vi.mocked(statSync).mockReturnValue({ mtimeMs } as any)
+  vi.mocked(readFileSync).mockReturnValue(content)
+}
+
+describe('openclaw-config', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.mocked(readFileSync).mockImplementation(() => { throw new Error('ENOENT') })
+    vi.mocked(statSync).mockImplementation(() => { throw new Error('ENOENT') })
+
+    const mod = await import('../../packages/core/src/openclaw-config')
+    readOpenClawConfig = mod.readOpenClawConfig
+    getAgentList = mod.getAgentList
+    getAgentIds = mod.getAgentIds
+    findAgentById = mod.findAgentById
+    resetOpenClawConfigCache = mod.resetOpenClawConfigCache
+  })
+
+  describe('readOpenClawConfig', () => {
+    it('returns null when openclaw.json is missing', () => {
+      expect(readOpenClawConfig()).toBeNull()
+    })
+
+    it('returns parsed config when file exists and is valid JSON', () => {
+      mockFile(1000, configBody([{ id: 'main', workspace: '/tmp/ws' }]))
+      const config = readOpenClawConfig()
+      expect(config?.agents?.list).toHaveLength(1)
+      expect(config?.agents?.list?.[0].id).toBe('main')
+    })
+
+    it('returns null when file content is malformed JSON', () => {
+      mockFile(1000, '{ not valid json')
+      expect(readOpenClawConfig()).toBeNull()
+    })
+
+    it('caches parsed config across calls with unchanged mtime', () => {
+      mockFile(1000, configBody([{ id: 'boss', workspace: '/tmp/ws' }]))
+      readOpenClawConfig()
+      readOpenClawConfig()
+      readOpenClawConfig()
+      expect(readFileSync).toHaveBeenCalledTimes(1)
+      expect(statSync).toHaveBeenCalledTimes(3)
+    })
+
+    it('re-parses when mtime changes (live edit recovery)', () => {
+      mockFile(1000, configBody([{ id: 'old', workspace: '/tmp/ws' }]))
+      expect(readOpenClawConfig()?.agents?.list?.[0].id).toBe('old')
+
+      mockFile(2000, configBody([{ id: 'new', workspace: '/tmp/ws' }]))
+      expect(readOpenClawConfig()?.agents?.list?.[0].id).toBe('new')
+      expect(readFileSync).toHaveBeenCalledTimes(2)
+    })
+
+    it('recovers when openclaw.json becomes available after being missing', () => {
+      expect(readOpenClawConfig()).toBeNull()
+
+      mockFile(1000, configBody([{ id: 'boss', workspace: '/tmp/ws' }]))
+      expect(readOpenClawConfig()?.agents?.list?.[0].id).toBe('boss')
+    })
+  })
+
+  describe('getAgentList / getAgentIds / findAgentById', () => {
+    it('returns empty list when config is missing', () => {
+      expect(getAgentList()).toEqual([])
+      expect(getAgentIds()).toEqual([])
+      expect(findAgentById('main')).toBeNull()
+    })
+
+    it('extracts agents from a well-formed config', () => {
+      mockFile(1000, configBody([
+        { id: 'main', identity: { name: 'Roscoe' }, workspace: '/tmp/ws' },
+        { id: 'patch', workspace: '/tmp/ws/patch' },
+      ]))
+      expect(getAgentIds()).toEqual(['main', 'patch'])
+      expect(findAgentById('main')?.identity?.name).toBe('Roscoe')
+      expect(findAgentById('ghost')).toBeNull()
+    })
+
+    it('shares a cache across helper calls — only one parse', () => {
+      mockFile(1000, configBody([{ id: 'boss', workspace: '/tmp/ws' }]))
+      getAgentList()
+      getAgentIds()
+      findAgentById('boss')
+      readOpenClawConfig()
+      expect(readFileSync).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('resetOpenClawConfigCache', () => {
+    it('forces a re-parse on the next call even when mtime is unchanged', () => {
+      mockFile(1000, configBody([{ id: 'boss', workspace: '/tmp/ws' }]))
+      readOpenClawConfig()
+      expect(readFileSync).toHaveBeenCalledTimes(1)
+
+      resetOpenClawConfigCache()
+      readOpenClawConfig()
+      expect(readFileSync).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/tests/core/settings.test.ts
+++ b/tests/core/settings.test.ts
@@ -26,8 +26,6 @@ describe('Settings', () => {
     const settings = getSettings()
     expect(settings.dispatch.intervalMs).toBe(300000)
     expect(settings.sse.maxClients).toBe(50)
-    // agents is populated dynamically from OpenClaw; in test env it may be empty
-    expect(Array.isArray(settings.agents)).toBe(true)
     expect(settings.antfly.enabled).toBe(true)
   })
 
@@ -119,13 +117,11 @@ describe('Settings', () => {
     fs.mkdirSync(TEST_CONTENT_DIR, { recursive: true })
     fs.writeFileSync(SETTINGS_FILE, JSON.stringify({
       dispatch: { intervalMs: 60000 },
-      agents: ['main', 'patch'],
     }))
 
     const settings = getSettings()
     expect(settings.dispatch.intervalMs).toBe(60000)
     expect(settings.dispatch.failureCooldownMs).toBe(1800000) // default preserved
-    expect(settings.agents).toEqual(['main', 'patch'])
   })
 
   it('caches settings on subsequent calls', () => {

--- a/tests/integration/usage-wiring-agent.test.ts
+++ b/tests/integration/usage-wiring-agent.test.ts
@@ -70,6 +70,12 @@ vi.mock('../../src/core/main-agent', () => ({
   getMainAgentId: () => 'orchestrator',
 }))
 
+// Pin openclaw home under testDir so nothing reads real ~/.openclaw.
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, '.openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, '.openclaw', ...parts),
+}))
+
 import { clearUsage, getUsageFeed } from '../../src/core/usage'
 import { getHookRegistry } from '../../src/lib/plugin-registry'
 
@@ -133,9 +139,15 @@ describe('T2.3 agent usage wiring', () => {
     // Stub settings before importing dispatch.
     vi.doMock('../../src/core/settings', () => ({
       getSettings: () => ({
-        agents: ['alice'],
         dispatch: { maxRetries: 3, failureCooldownMs: 1000, maxDispatched: 200 },
       }),
+    }))
+    // Dispatch now derives the agent roster from openclaw-config (T2).
+    vi.doMock('@bakin/core/openclaw-config', () => ({
+      getAgentIds: () => ['alice'],
+      findAgentById: (id: string) => (id === 'alice' ? { id: 'alice' } : null),
+      readOpenClawConfig: () => ({ agents: [{ id: 'alice' }] }),
+      resetOpenClawConfigCache: () => {},
     }))
     // Stub taskboard lib used via dynamic import inside dispatch.
     vi.doMock('../../src/lib/taskboard', () => ({

--- a/tests/plugins/team/build-graph.test.ts
+++ b/tests/plugins/team/build-graph.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Pure-function tests for the team-grid pyramid layout.
+ *
+ * Covers the T5 contract: the root of the pyramid is always `mainAgentId`
+ * from the store, and each team's `reportsTo` is resolved to
+ * `reportsTo ?? mainAgentId` at render time. We also check graceful
+ * degradation when the roster is broken.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+// ─── Mandatory test-isolation mocks ────────────────────────────────────────
+// Per CLAUDE.md: every test file must mock content-dir even if the code
+// under test is pure. This is a backstop — buildGraph is pure and never
+// touches the filesystem, but the check keeps that true.
+
+const testDir = join(tmpdir(), `bakin-test-build-graph-${Date.now()}`)
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    agents: join(testDir, 'agents'),
+    heartbeats: join(testDir, 'heartbeats'),
+  }),
+}))
+
+vi.mock('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    agents: join(testDir, 'agents'),
+    heartbeats: join(testDir, 'heartbeats'),
+  }),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('../../../src/core/watcher', () => ({
+  registerSyncHook: vi.fn(),
+  registerUnlinkHook: vi.fn(),
+}))
+
+// ─── Imports under test ────────────────────────────────────────────────────
+
+import { buildGraph } from '../../../plugins/team/lib/build-graph'
+import type { AgentWithStatus, OrgTeam, AgentDisplaySettingsMap } from '../../../plugins/team/types'
+
+// ─── Fixture helpers ───────────────────────────────────────────────────────
+
+function agent(id: string, name: string = id): AgentWithStatus {
+  return {
+    id,
+    name,
+    emoji: '🤖',
+    role: 'Agent',
+    headshot: '',
+    status: 'offline',
+    model: 'claude-opus-4',
+    heartbeat: null,
+    heartbeatAge: null,
+  }
+}
+
+function team(overrides: Partial<OrgTeam> & { id: string }): OrgTeam {
+  return {
+    id: overrides.id,
+    label: overrides.label ?? overrides.id,
+    // Cast through unknown to allow null for legacy / default-main semantics.
+    reportsTo: (overrides.reportsTo ?? (null as unknown as string)),
+    color: overrides.color,
+    order: overrides.order,
+  }
+}
+
+function getNodeIds(nodes: ReadonlyArray<{ id: string }>): string[] {
+  return nodes.map((n) => n.id)
+}
+
+function countAgentCards(nodes: ReadonlyArray<{ type?: string; id: string }>, agentId: string): number {
+  return nodes.filter((n) => n.type === 'agentCard' && n.id === agentId).length
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('buildGraph — founder row', () => {
+  it('always renders the founder node', () => {
+    const { nodes } = buildGraph({
+      agents: [],
+      teams: [],
+      displaySettings: {},
+      mainAgentId: null,
+    })
+    expect(nodes.find((n) => n.id === 'mark')).toBeDefined()
+  })
+})
+
+describe('buildGraph — fresh install (no teams, main + subagents)', () => {
+  it('roots the pyramid at main and puts all subagents under a synthetic section', () => {
+    const agents = [agent('main', 'Crab'), agent('a'), agent('b'), agent('c')]
+    const { nodes, edges } = buildGraph({
+      agents,
+      teams: [],
+      displaySettings: {},
+      mainAgentId: 'main',
+    })
+
+    // Row 1: main card exists, exactly once
+    expect(countAgentCards(nodes, 'main')).toBe(1)
+
+    // Row 2: synthetic "All agents" section
+    const section = nodes.find((n) => n.id === 'section-all')
+    expect(section).toBeDefined()
+
+    // Main wires to the synthetic section
+    expect(edges.find((e) => e.source === 'main' && e.target === 'section-all')).toBeDefined()
+
+    // Subagents wired from the section
+    for (const id of ['a', 'b', 'c']) {
+      expect(countAgentCards(nodes, id)).toBe(1)
+      expect(edges.find((e) => e.source === 'section-all' && e.target === id)).toBeDefined()
+    }
+
+    // No unassigned bucket in the default flat config
+    expect(nodes.find((n) => n.id === 'section-unassigned')).toBeUndefined()
+  })
+})
+
+describe('buildGraph — reportsTo fallback resolution', () => {
+  const agents = [agent('main'), agent('a'), agent('b')]
+  const displaySettings: AgentDisplaySettingsMap = {
+    a: { teamId: 'creators' },
+    b: { teamId: 'creators' },
+  }
+
+  it('renders a team with null reportsTo under main', () => {
+    const { nodes, edges } = buildGraph({
+      agents,
+      teams: [team({ id: 'creators', label: 'Creators', reportsTo: null as unknown as string })],
+      displaySettings,
+      mainAgentId: 'main',
+    })
+
+    expect(nodes.find((n) => n.id === 'section-creators')).toBeDefined()
+    expect(edges.find((e) => e.source === 'main' && e.target === 'section-creators')).toBeDefined()
+  })
+
+  it('renders a team with reportsTo="main" under main (same bucket as null)', () => {
+    const { edges } = buildGraph({
+      agents,
+      teams: [team({ id: 'creators', reportsTo: 'main' })],
+      displaySettings,
+      mainAgentId: 'main',
+    })
+    expect(edges.find((e) => e.source === 'main' && e.target === 'section-creators')).toBeDefined()
+  })
+
+  it('falls back to main when reportsTo points at an unknown agent', () => {
+    const { edges } = buildGraph({
+      agents,
+      teams: [team({ id: 'ghost', reportsTo: 'phantom' })],
+      displaySettings: { a: { teamId: 'ghost' } },
+      mainAgentId: 'main',
+    })
+    // Should still render under main, not crash
+    expect(edges.find((e) => e.source === 'main' && e.target === 'section-ghost')).toBeDefined()
+  })
+})
+
+describe('buildGraph — non-main team leader (sub-org)', () => {
+  it('renders basil as a row 2 leader when a team reports to basil', () => {
+    const agents = [agent('main'), agent('basil'), agent('a')]
+    const displaySettings: AgentDisplaySettingsMap = {
+      a: { teamId: 'crew' },
+    }
+    const teams = [team({ id: 'crew', reportsTo: 'basil' })]
+
+    const { nodes, edges } = buildGraph({
+      agents,
+      teams,
+      displaySettings,
+      mainAgentId: 'main',
+    })
+
+    // Basil appears as an agent card (row 2 leader)
+    expect(countAgentCards(nodes, 'basil')).toBe(1)
+    // Basil connects back up to main
+    expect(edges.find((e) => e.source === 'main' && e.target === 'basil')).toBeDefined()
+    // Crew section is attached to basil
+    expect(edges.find((e) => e.source === 'basil' && e.target === 'section-crew')).toBeDefined()
+    // Member a wired from crew section
+    expect(edges.find((e) => e.source === 'section-crew' && e.target === 'a')).toBeDefined()
+  })
+})
+
+describe('buildGraph — missing main agent', () => {
+  it('renders founder only when mainAgentId is null', () => {
+    const { nodes } = buildGraph({
+      agents: [agent('a'), agent('b')],
+      teams: [],
+      displaySettings: {},
+      mainAgentId: null,
+    })
+    expect(nodes.find((n) => n.id === 'mark')).toBeDefined()
+    // No main card — there is no main agent
+    expect(countAgentCards(nodes, 'a')).toBe(0)
+    expect(countAgentCards(nodes, 'b')).toBe(0)
+  })
+
+  it('renders founder only when mainAgentId refers to an agent not in the roster', () => {
+    const { nodes } = buildGraph({
+      agents: [agent('a')],
+      teams: [],
+      displaySettings: {},
+      mainAgentId: 'ghost',
+    })
+    expect(nodes.find((n) => n.id === 'mark')).toBeDefined()
+    expect(countAgentCards(nodes, 'ghost')).toBe(0)
+    expect(countAgentCards(nodes, 'a')).toBe(0)
+  })
+})
+
+describe('buildGraph — no duplicate main card', () => {
+  it('places main exactly once when roster is [main] only', () => {
+    const { nodes } = buildGraph({
+      agents: [agent('main')],
+      teams: [],
+      displaySettings: {},
+      mainAgentId: 'main',
+    })
+    expect(countAgentCards(nodes, 'main')).toBe(1)
+
+    // No synthetic section, no unassigned bucket
+    expect(nodes.find((n) => n.id === 'section-all')).toBeUndefined()
+    expect(nodes.find((n) => n.id === 'section-unassigned')).toBeUndefined()
+  })
+})
+
+describe('buildGraph — unassigned bucket', () => {
+  it('puts agents not in any team into the unassigned bucket (when teams exist)', () => {
+    const agents = [agent('main'), agent('a'), agent('b')]
+    const teams = [team({ id: 't1', reportsTo: null as unknown as string })]
+    const displaySettings: AgentDisplaySettingsMap = {
+      a: { teamId: 't1' },
+    }
+
+    const { nodes, edges } = buildGraph({
+      agents,
+      teams,
+      displaySettings,
+      mainAgentId: 'main',
+    })
+
+    // t1 renders under main
+    expect(edges.find((e) => e.source === 'main' && e.target === 'section-t1')).toBeDefined()
+    // a is in the team
+    expect(edges.find((e) => e.source === 'section-t1' && e.target === 'a')).toBeDefined()
+    // b is unassigned
+    expect(nodes.find((n) => n.id === 'section-unassigned')).toBeDefined()
+    expect(edges.find((e) => e.source === 'section-unassigned' && e.target === 'b')).toBeDefined()
+    // main is NOT in unassigned
+    expect(edges.find((e) => e.source === 'section-unassigned' && e.target === 'main')).toBeUndefined()
+  })
+
+  it('does not duplicate main into unassigned when teams exist and main is the root', () => {
+    const agents = [agent('main'), agent('a')]
+    const teams = [team({ id: 't1', reportsTo: null as unknown as string })]
+    const displaySettings: AgentDisplaySettingsMap = { a: { teamId: 't1' } }
+
+    const { nodes } = buildGraph({
+      agents,
+      teams,
+      displaySettings,
+      mainAgentId: 'main',
+    })
+    expect(countAgentCards(nodes, 'main')).toBe(1)
+  })
+})
+
+describe('buildGraph — determinism', () => {
+  it('produces identical output for identical input', () => {
+    const input = {
+      agents: [agent('main'), agent('a'), agent('b')],
+      teams: [team({ id: 't1', reportsTo: null as unknown as string, order: 0 })],
+      displaySettings: { a: { teamId: 't1' }, b: { teamId: 't1' } } as AgentDisplaySettingsMap,
+      mainAgentId: 'main' as string | null,
+    }
+    const a = buildGraph(input)
+    const b = buildGraph(input)
+    expect(getNodeIds(a.nodes)).toEqual(getNodeIds(b.nodes))
+    expect(a.edges.map((e) => e.id)).toEqual(b.edges.map((e) => e.id))
+  })
+})

--- a/tests/plugins/team/openclaw-adapter.test.ts
+++ b/tests/plugins/team/openclaw-adapter.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the team plugin's openclaw-adapter validation pass in
+ * `listAgents()`. Verifies the adapter rejects duplicate ids, rejects
+ * duplicate resolved workspaces, and returns an empty list when the
+ * canonical `main` agent is missing.
+ *
+ * The adapter reads from `~/.openclaw/openclaw.json` via
+ * `readOpenClawConfig` in `@bakin/core/openclaw-config`. We mock that
+ * module and the logger so tests can drive config shapes without ever
+ * touching the real filesystem.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { join } from 'path'
+
+// ---------------------------------------------------------------------------
+// Mandatory test-isolation mocks — declared before any plugin import
+// ---------------------------------------------------------------------------
+
+const testDir = vi.hoisted(() => {
+  const { tmpdir } = require('os') as typeof import('os')
+  const { join } = require('path') as typeof import('path')
+  return join(tmpdir(), `bakin-test-team-adapter-${Date.now()}`)
+})
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    agents: join(testDir, 'agents'),
+    heartbeats: join(testDir, 'heartbeats'),
+  }),
+}))
+
+vi.mock('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    agents: join(testDir, 'agents'),
+    heartbeats: join(testDir, 'heartbeats'),
+  }),
+}))
+
+// Shared logger mock — the adapter calls createLogger('team:openclaw') at
+// module init so we capture the singleton and assert on it per test.
+// vi.hoisted is required because vi.mock factories run before the test
+// module body executes.
+const loggerMock = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}))
+
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => loggerMock,
+}))
+
+vi.mock('../../../src/core/watcher', () => ({
+  registerSyncHook: vi.fn(),
+  registerUnlinkHook: vi.fn(),
+}))
+
+// OpenClaw client — adapter doesn't import it directly, but other modules
+// pulled in transitively might. Stub to be safe.
+vi.mock('../../../src/core/openclaw-client', () => ({
+  sendMessage: vi.fn(async () => 'ok'),
+  invokeTool: vi.fn(async () => ({ ok: true })),
+  sendChannelMessage: vi.fn(async () => 'ok'),
+  restartGateway: vi.fn(async () => {}),
+  ping: vi.fn(async () => true),
+  getAgentLastReply: vi.fn(() => null),
+}))
+
+// main-agent — `resolveRole` falls back on tryGetMainAgentId for the
+// orchestrator-role label. Stub to avoid reading settings.
+vi.mock('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+}))
+
+// openclaw-home — adapter touches getOpenClawHome/getOpenClawPath at
+// module init. Point them at a non-existent tmp path so filesystem reads
+// for workspace files (called from resolveRole) return null gracefully.
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+}))
+
+// The module under test — drive config shapes through this mock.
+const readOpenClawConfigMock = vi.hoisted(() => vi.fn(() => null as unknown))
+vi.mock('@bakin/core/openclaw-config', () => ({
+  readOpenClawConfig: () => readOpenClawConfigMock(),
+  resetOpenClawConfigCache: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Import after mocks are declared
+// ---------------------------------------------------------------------------
+
+import { listAgents } from '../../../plugins/team/lib/openclaw-adapter'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setConfig(config: unknown): void {
+  readOpenClawConfigMock.mockReturnValue(config)
+}
+
+describe('team/openclaw-adapter · listAgents', () => {
+  beforeEach(() => {
+    loggerMock.info.mockClear()
+    loggerMock.warn.mockClear()
+    loggerMock.error.mockClear()
+    loggerMock.debug.mockClear()
+    readOpenClawConfigMock.mockReset()
+  })
+
+  it('accepts a clean config with main + another agent', () => {
+    setConfig({
+      agents: {
+        list: [
+          { id: 'main', identity: { name: 'Crab' } },
+          { id: 'patch', workspace: '/ws/patch' },
+        ],
+      },
+    })
+
+    const result = listAgents()
+
+    expect(result).toHaveLength(2)
+    expect(result.map((a) => a.id)).toEqual(['main', 'patch'])
+    expect(result[0].name).toBe('Crab')
+    expect(loggerMock.error).not.toHaveBeenCalled()
+  })
+
+  it('drops a duplicate id and logs one error (first wins)', () => {
+    setConfig({
+      agents: {
+        list: [
+          { id: 'main' },
+          { id: 'main', identity: { name: 'Shadow' } },
+        ],
+      },
+    })
+
+    const result = listAgents()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('main')
+    // Duplicate should NOT have overridden the first entry's name/identity.
+    expect(result[0].name).toBe('main')
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    expect(loggerMock.error.mock.calls[0][0]).toMatch(/duplicate.*main/i)
+  })
+
+  it('returns empty and logs the missing-main error when no main agent exists', () => {
+    setConfig({ agents: { list: [{ id: 'bob' }] } })
+
+    const result = listAgents()
+
+    expect(result).toEqual([])
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    expect(loggerMock.error.mock.calls[0][0]).toMatch(/must contain.*main/i)
+  })
+
+  it('drops an agent colliding on the defaults-inherited workspace', () => {
+    setConfig({
+      agents: {
+        defaults: { workspace: '/shared/ws' },
+        list: [
+          { id: 'main' },
+          { id: 'roscoe' },
+        ],
+      },
+    })
+
+    const result = listAgents()
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('main')
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    const msg = loggerMock.error.mock.calls[0][0] as string
+    expect(msg).toMatch(/workspace.*shared/i)
+    expect(msg).toContain('roscoe')
+    expect(msg).toContain('main')
+  })
+
+  it('drops an explicit workspace collision but keeps other valid agents', () => {
+    setConfig({
+      agents: {
+        list: [
+          { id: 'a', workspace: '/ws/x' },
+          { id: 'b', workspace: '/ws/x' },
+          { id: 'main', workspace: '/ws/y' },
+        ],
+      },
+    })
+
+    const result = listAgents()
+
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.id)).toEqual(['a', 'main'])
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    const msg = loggerMock.error.mock.calls[0][0] as string
+    expect(msg).toContain('b')
+    expect(msg).toContain('a')
+    expect(msg).toContain('/ws/x')
+  })
+
+  it('returns empty for an empty agents list and logs missing-main', () => {
+    setConfig({ agents: { list: [] } })
+
+    const result = listAgents()
+
+    expect(result).toEqual([])
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    expect(loggerMock.error.mock.calls[0][0]).toMatch(/must contain.*main/i)
+  })
+
+  it('returns empty when readOpenClawConfig yields null/empty and logs missing-main', () => {
+    setConfig(null)
+
+    const result = listAgents()
+
+    expect(result).toEqual([])
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    expect(loggerMock.error.mock.calls[0][0]).toMatch(/must contain.*main/i)
+  })
+
+  it('preserves original order of surviving entries when dedupe kicks in', () => {
+    setConfig({
+      agents: {
+        list: [
+          { id: 'main' },
+          { id: 'dup', workspace: '/x' },
+          { id: 'dup' }, // duplicate id — drop
+          { id: 'patch', workspace: '/p' },
+        ],
+      },
+    })
+
+    const result = listAgents()
+
+    expect(result.map((a) => a.id)).toEqual(['main', 'dup', 'patch'])
+    expect(loggerMock.error).toHaveBeenCalledTimes(1)
+    expect(loggerMock.error.mock.calls[0][0]).toMatch(/duplicate.*dup/i)
+  })
+})

--- a/tests/plugins/team/routes.test.ts
+++ b/tests/plugins/team/routes.test.ts
@@ -9,8 +9,8 @@
  * The team plugin is an adapter over OpenClaw; all OpenClaw-touching
  * modules are stubbed so the test never reads from ~/.openclaw/.
  */
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
-import { mkdirSync, rmSync } from 'fs'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest'
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -40,12 +40,19 @@ vi.mock('../../../packages/core/src/content-dir', () => ({
   }),
 }))
 
+const { logWarn, logInfo, logError, logDebug } = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+}))
+
 vi.mock('../../../src/core/logger', () => ({
   createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
+    info: logInfo,
+    warn: logWarn,
+    error: logError,
+    debug: logDebug,
   }),
 }))
 
@@ -100,13 +107,21 @@ vi.mock('../../../src/lib/content', () => ({
   readHeartbeats: vi.fn(() => ({})),
 }))
 
+// Shared mutable roster so individual tests can simulate missing agents
+// without redefining the full adapter mock.
+const { rosterAgents } = vi.hoisted(() => ({
+  rosterAgents: {
+    current: [
+      { id: 'main', name: 'Main', emoji: '🤖', role: 'Orchestrator', headshot: '' },
+      { id: 'basil', name: 'Basil', emoji: '🌿', role: 'Cook', headshot: '' },
+    ] as Array<{ id: string; name: string; emoji: string; role: string; headshot: string }>,
+  },
+}))
+
 // OpenClaw adapter — fully stubbed, never touches ~/.openclaw/
 vi.mock('@bakin/team/lib/openclaw-adapter', () => ({
-  listAgents: vi.fn(() => [
-    { id: 'main', name: 'Main', emoji: '🤖', role: 'Orchestrator', headshot: '' },
-    { id: 'basil', name: 'Basil', emoji: '🌿', role: 'Cook', headshot: '' },
-  ]),
-  getAgentIds: vi.fn(() => ['main', 'basil']),
+  listAgents: vi.fn(() => rosterAgents.current),
+  getAgentIds: vi.fn(() => rosterAgents.current.map((a) => a.id)),
   getAgentModel: vi.fn(() => 'claude-opus-4'),
   getAgentProfile: vi.fn((id: string) => ({
     id,
@@ -139,11 +154,8 @@ vi.mock('@bakin/team/lib/openclaw-adapter', () => ({
 // The team plugin's relative import path inside the plugin uses './lib/openclaw-adapter'.
 // Add a relative-path alias so vi.mock catches both shapes.
 vi.mock('../../../plugins/team/lib/openclaw-adapter', () => ({
-  listAgents: vi.fn(() => [
-    { id: 'main', name: 'Main', emoji: '🤖', role: 'Orchestrator', headshot: '' },
-    { id: 'basil', name: 'Basil', emoji: '🌿', role: 'Cook', headshot: '' },
-  ]),
-  getAgentIds: vi.fn(() => ['main', 'basil']),
+  listAgents: vi.fn(() => rosterAgents.current),
+  getAgentIds: vi.fn(() => rosterAgents.current.map((a) => a.id)),
   getAgentModel: vi.fn(() => 'claude-opus-4'),
   getAgentProfile: vi.fn((id: string) => ({
     id,
@@ -256,5 +268,193 @@ describe('team plugin — non-search routes', () => {
     const route = findRoute(activated.routes, 'GET', '/')
     expect(route).toBeDefined()
     expect(route?.description).toMatch(/agent/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// team.json reportsTo normalization & graceful degradation
+// ---------------------------------------------------------------------------
+
+describe('team plugin — reportsTo normalization on write', () => {
+  const teamJsonPath = join(testDir, 'plugin-settings', 'team.json')
+
+  /**
+   * Write the raw team.json (bypassing the plugin) so tests can seed
+   * legacy values without going through the normalized POST path.
+   */
+  function seedTeamJson(teams: unknown[]): void {
+    mkdirSync(join(testDir, 'plugin-settings'), { recursive: true })
+    writeFileSync(
+      teamJsonPath,
+      JSON.stringify({ displaySettings: {}, teams }, null, 2),
+    )
+  }
+
+  function readTeamJson(): { teams: Array<Record<string, unknown>> } {
+    const raw = JSON.parse(readFileSync(teamJsonPath, 'utf-8')) as {
+      teams: Array<Record<string, unknown>>
+    }
+    return raw
+  }
+
+  beforeEach(() => {
+    if (existsSync(teamJsonPath)) {
+      rmSync(teamJsonPath, { force: true })
+    }
+    logWarn.mockClear()
+    // Reset roster to default for each test
+    rosterAgents.current = [
+      { id: 'main', name: 'Main', emoji: '🤖', role: 'Orchestrator', headshot: '' },
+      { id: 'basil', name: 'Basil', emoji: '🌿', role: 'Cook', headshot: '' },
+    ]
+  })
+
+  it('write with reportsTo="main" stores null in team.json', async () => {
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'POST', '/teams')!
+    const { status } = await callRoute(route, activated.ctx, {
+      body: { id: 'builders', label: 'Builders', reportsTo: 'main' },
+    })
+    expect(status).toBe(200)
+    const file = readTeamJson()
+    const team = file.teams.find((t) => t.id === 'builders')!
+    expect(team.reportsTo).toBeNull()
+  })
+
+  it('write with reportsTo undefined stores null in team.json', async () => {
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'POST', '/teams')!
+    const { status } = await callRoute(route, activated.ctx, {
+      body: { id: 'creators', label: 'Creators' },
+    })
+    expect(status).toBe(200)
+    const file = readTeamJson()
+    const team = file.teams.find((t) => t.id === 'creators')!
+    expect(team.reportsTo).toBeNull()
+  })
+
+  it('write with unknown non-null reportsTo preserves the value (basil not in roster)', async () => {
+    // "basil" is technically in the roster above, but we want to prove the
+    // write path does not validate against the roster — it only normalizes
+    // the "this is the main agent" case. Point at a clearly-unknown id.
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'POST', '/teams')!
+    const { status } = await callRoute(route, activated.ctx, {
+      body: { id: 'scouts', label: 'Scouts', reportsTo: 'ghost' },
+    })
+    expect(status).toBe(200)
+    const file = readTeamJson()
+    const team = file.teams.find((t) => t.id === 'scouts')!
+    expect(team.reportsTo).toBe('ghost')
+  })
+
+  it('write with reportsTo="basil" (known roster member) preserves the value', async () => {
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'POST', '/teams')!
+    const { status } = await callRoute(route, activated.ctx, {
+      body: { id: 'cooks', label: 'Cooks', reportsTo: 'basil' },
+    })
+    expect(status).toBe(200)
+    const file = readTeamJson()
+    const team = file.teams.find((t) => t.id === 'cooks')!
+    expect(team.reportsTo).toBe('basil')
+  })
+})
+
+describe('team plugin — reportsTo graceful degradation on read', () => {
+  const teamJsonPath = join(testDir, 'plugin-settings', 'team.json')
+
+  function seedTeamJson(teams: unknown[]): void {
+    mkdirSync(join(testDir, 'plugin-settings'), { recursive: true })
+    writeFileSync(
+      teamJsonPath,
+      JSON.stringify({ displaySettings: {}, teams }, null, 2),
+    )
+  }
+
+  beforeEach(() => {
+    if (existsSync(teamJsonPath)) {
+      rmSync(teamJsonPath, { force: true })
+    }
+    logWarn.mockClear()
+    // Default roster contains main + basil (not "roscoe")
+    rosterAgents.current = [
+      { id: 'main', name: 'Main', emoji: '🤖', role: 'Orchestrator', headshot: '' },
+      { id: 'basil', name: 'Basil', emoji: '🌿', role: 'Cook', headshot: '' },
+    ]
+  })
+
+  it('degrades reportsTo pointing at a missing agent to null and logs once', async () => {
+    seedTeamJson([
+      { id: 'builders', label: 'Builders', reportsTo: 'roscoe' },
+    ])
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'GET', '/')!
+    const { status, body } = await callRoute(route, activated.ctx)
+    expect(status).toBe(200)
+    const teams = (body as { teams: Array<{ id: string; reportsTo: string | null }> }).teams
+    const builders = teams.find((t) => t.id === 'builders')!
+    expect(builders.reportsTo).toBeNull()
+
+    const warnCalls = logWarn.mock.calls.filter((call) =>
+      String(call[0]).includes('unknown agent id'),
+    )
+    expect(warnCalls.length).toBe(1)
+    expect(warnCalls[0][1]).toMatchObject({ teamId: 'builders', reportsTo: 'roscoe' })
+  })
+
+  it('preserves reportsTo=null in the response', async () => {
+    seedTeamJson([
+      { id: 'builders', label: 'Builders', reportsTo: null },
+    ])
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'GET', '/')!
+    const { status, body } = await callRoute(route, activated.ctx)
+    expect(status).toBe(200)
+    const teams = (body as { teams: Array<{ id: string; reportsTo: string | null }> }).teams
+    expect(teams.find((t) => t.id === 'builders')!.reportsTo).toBeNull()
+
+    const warnCalls = logWarn.mock.calls.filter((call) =>
+      String(call[0]).includes('unknown agent id'),
+    )
+    expect(warnCalls.length).toBe(0)
+  })
+
+  it('preserves reportsTo="basil" when basil is in the roster', async () => {
+    seedTeamJson([
+      { id: 'cooks', label: 'Cooks', reportsTo: 'basil' },
+    ])
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'GET', '/')!
+    const { status, body } = await callRoute(route, activated.ctx)
+    expect(status).toBe(200)
+    const teams = (body as { teams: Array<{ id: string; reportsTo: string | null }> }).teams
+    expect(teams.find((t) => t.id === 'cooks')!.reportsTo).toBe('basil')
+
+    const warnCalls = logWarn.mock.calls.filter((call) =>
+      String(call[0]).includes('unknown agent id'),
+    )
+    expect(warnCalls.length).toBe(0)
+  })
+
+  it('logs once per team when multiple reportsTo are unknown', async () => {
+    seedTeamJson([
+      { id: 'teamA', label: 'Team A', reportsTo: 'ghost1' },
+      { id: 'teamB', label: 'Team B', reportsTo: 'ghost2' },
+    ])
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const route = findRoute(activated.routes, 'GET', '/')!
+    const { status, body } = await callRoute(route, activated.ctx)
+    expect(status).toBe(200)
+    const teams = (body as { teams: Array<{ id: string; reportsTo: string | null }> }).teams
+    expect(teams.find((t) => t.id === 'teamA')!.reportsTo).toBeNull()
+    expect(teams.find((t) => t.id === 'teamB')!.reportsTo).toBeNull()
+
+    const warnCalls = logWarn.mock.calls.filter((call) =>
+      String(call[0]).includes('unknown agent id'),
+    )
+    expect(warnCalls.length).toBe(2)
+    const teamIds = warnCalls.map((c) => (c[1] as { teamId: string }).teamId).sort()
+    expect(teamIds).toEqual(['teamA', 'teamB'])
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src'),
       '@bakin/core/openclaw-home': path.resolve(__dirname, 'packages/core/src/openclaw-home.ts'),
+      '@bakin/core/openclaw-config': path.resolve(__dirname, 'packages/core/src/openclaw-config.ts'),
       '@bakin/core/main-agent': path.resolve(__dirname, 'packages/core/src/main-agent.ts'),
       '@bakin/core/content-dir': path.resolve(__dirname, 'packages/core/src/content-dir.ts'),
       '@bakin/core/settings': path.resolve(__dirname, 'packages/core/src/settings.ts'),


### PR DESCRIPTION
## Summary

Fixes #90 — the team plugin was showing "main-operator" and "main" as two disconnected cards on the org chart. Main Operator *is* main, main *is* main-operator; the split came from duplicate state drifting across `openclaw.json`, `BakinSettings.agents`, and `team.json`'s stale `reportsTo` strings.

This PR enshrines the contract that **OpenClaw's orchestrator id is always the literal string `"main"` on every install**. Display names come from `identity.name` and vary per install ("Main Operator" here, "Crab" on someone else's box). All roster data derives from a single mtime-cached `openclaw.json` reader; nothing Bakin-owned duplicates it.

- **T3** — `packages/core/src/openclaw-config.ts`: single mtime-cached reader, shared by `main-agent.ts`, `openclaw-adapter.ts`, and `settings.ts`
- **T1** — `getMainAgentId()` always returns `"main"`; detection heuristic and `mainAgentId` override deleted
- **T2** — `BakinSettings.agents` and `BakinSettings.mainAgentId` deleted; dispatch/doctor/mcporter/agents/cli all migrated to `getAgentIds()`
- **T4** — `listAgents()` validates + dedupes (first-wins on duplicate ids and duplicate resolved workspaces; returns empty roster when `main` missing, so the UI shows a broken state instead of a partial pyramid)
- **T5** — pyramid root derived from `mainAgentId` in the roster response, not the old `topAgentIds` heuristic. `reportsTo ?? mainAgentId` with unknown-id graceful fallback. Extracted `buildGraph` to `plugins/team/lib/build-graph.ts` as a pure function with its own test file
- **T6** — `POST/PUT /teams` normalize `reportsTo === mainAgentId → null` on write; `GET /` degrades unknown `reportsTo` strings to `null` with a warning log. No side effects on read
- **T7** — `bakin check openclaw` validates missing `main`, duplicate ids, and duplicate workspaces in one pass. Reports only, never auto-fixes
- **T8** — updated `.claude/knowledge/agent-system.md`, added `.claude/knowledge/team-plugin.md`, tidied `CLAUDE.md`
- **Runbook (no code)** — merged the live `main-operator` entry into `main` in `~/.openclaw/openclaw.json`, moved avatars, scrubbed stale heartbeats and `settings.agents`, normalized `team.json`
- **Bonus** — straightened the edge from Mark → main agent by forcing the founder node to `w-[152px]`; its intrinsic width drifted ~14px off-center and produced a kinked smoothstep edge

One Antfly commit (`8f4abf3 Fix Antfly restart handoff race`) landed on this branch mid-work from a parallel session. Unrelated to issue #90 but small enough to leave rather than rebase.

## Test plan

- [x] `npm test` — 141 files, 2108 passing, 1 skipped
- [x] `bakin check openclaw` on the live machine — returns `ok` after runbook
- [x] Team page renders Mark → Main Operator → Creators + Builders with no duplicate cards and no kinked edges
- [x] Roster API (`/api/plugins/team`) returns `mainAgentId: "main"` and 8 agents with no `main-operator` entry
- [x] `typecheck` clean on the Phase 2 surface (pre-existing errors in antfly-reranker/search-auto-registration/search-tools-mcp/brainstorm/project-grid are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)