### PR TITLE
fix(watchdog): prevent race with dispatch from auto-recovering fresh tasks (#114)

### DIFF
--- a/.claude/knowledge/agent-system.md
+++ b/.claude/knowledge/agent-system.md
@@ -199,7 +199,7 @@ Reconnecting clients get missed events via `Last-Event-ID` header.
 Monitors agent and MCP server health:
 - Checks heartbeat freshness on interval
 - Detects stuck agents (working but no progress > threshold)
-- Auto-recovery: restart agent or move task back to todo
+- Auto-recovery: restart agent or move task back to todo. Suppressed when the task's `updatedAt` is within a 60 s guard window to avoid racing dispatch's move (`AUTO_RECOVERY_GUARD_MS` in `watchdog.ts`, issue #114)
 - Detects MCP 5xx outages via a rolling error-rate check on `/mcp` (configurable window/threshold/min-samples/cooldown in `settings.watchdog.mcp*`) — fires SSE alert + audit + Discord on the configured channel
 - Alert delivery via `settings.notifications.channel/target` (Discord, Slack, or none) — configurable in the **System & Alerts** settings tab
 - Re-reads settings every cycle, so channel/threshold changes apply without a restart

--- a/.claude/specs/issue-114-watchdog-dispatch-race-PLAN.md
+++ b/.claude/specs/issue-114-watchdog-dispatch-race-PLAN.md
@@ -1,0 +1,191 @@
+# Issue #114 — Build Plan (commit-by-commit)
+
+_Created: 2026-04-20 | Status: DRAFT (awaiting build-phase kickoff)_
+_Spec: `.claude/specs/issue-114-watchdog-dispatch-race.md`_
+
+Targeted bug fix. Scope: one constant + one guard clause in `src/core/watchdog.ts`, one new test in `tests/core/watchdog.test.ts`, optionally one line of knowledge-doc copy. Approach is already decided in the spec — this plan is execution only.
+
+---
+
+## Branch
+
+**Name:** `fix/issue-114-watchdog-dispatch-race`
+**Parent:** `main` — branch **off main**, land via PR, no rebase-to-master chains.
+
+Create it in Task 1 before any other work. All subsequent commits land on this branch.
+
+---
+
+## Commit Summary
+
+| # | Commit message | Files touched | Rollback role |
+|---|---|---|---|
+| C1 | `test(watchdog): failing test for dispatch-race auto-recovery (#114)` | `tests/core/watchdog.test.ts` | Reverting reverts only the test — no behavior change. |
+| C2 | `fix(watchdog): skip auto-recovery when task updatedAt is within guard window (#114)` | `src/core/watchdog.ts` | Reverting re-exposes the race; C1 test goes red again. Clean bisect target. |
+| C3 (optional) | `docs(watchdog): note auto-recovery guard window` | `.claude/knowledge/agent-system.md` | Pure doc — trivially revertible. |
+
+Three commits max. If C3 adds nothing beyond what the code comment already says, skip it.
+
+### Conventional commit scope
+
+Project uses `<type>(<scope>): <summary>` per CLAUDE.md and recent git log. Scope for all three is `watchdog` (the subsystem), matching existing commits like `fix(workflows): …` and `test(workflows): …`.
+
+---
+
+## Tasks
+
+### Task 1 — Branch + baseline
+**Goal.** Cut a clean branch off `main` and confirm the existing test suite is green before any edits.
+**Files touched.** None (git only).
+**Steps.**
+1. `git fetch origin && git switch main && git pull --ff-only` — ensure local main matches remote.
+2. `git switch -c fix/issue-114-watchdog-dispatch-race` — branch off main.
+3. Pre-flight smoke: `pnpm exec vitest run tests/core/watchdog.test.ts` — should pass on clean main.
+**Verification.**
+- `git branch --show-current` prints `fix/issue-114-watchdog-dispatch-race`.
+- `git log --oneline -1` matches the tip of `origin/main` (no stray commits).
+- Watchdog test file passes green.
+**Expected outcome.** Fresh branch, baseline green. Any failure here means the environment — not our change — is the problem; stop and fix before proceeding.
+
+### Task 2 — Verify the fix's load-bearing assumption
+**Goal.** Confirm `task.updatedAt` is bumped by the write paths that race with the watchdog, so the guard has a real signal to key off. Flagged as risk (b) in the kickoff brief.
+**Files touched.** None — read-only inspection.
+**Steps.**
+1. Confirm `plugins/tasks/lib/flow-store.ts` writes `updated_at = ?` on `moveTask`, `moveTaskToInProgress`, and the other mutation paths (already grep-verified during planning — re-confirm before edit).
+2. Confirm `flowToTask` surfaces `flow.updated_at` as `task.updatedAt` on reads (plugins/tasks/lib/flow-store.ts:173).
+**Verification.**
+- Both writes + read path confirmed in code.
+**Expected outcome.** Assumption holds; fix is not a no-op. If it turns out a mutation path does NOT bump `updated_at`, STOP and revisit the spec — don't ship a silent no-op.
+
+### Task 3 — Write the failing test (C1)
+**Goal.** Lock the invariant in the test harness before touching behavior.
+**Files touched.** `tests/core/watchdog.test.ts`.
+**Steps.**
+1. Add a new `it(...)` case modeled on the existing tests in the file. Fixture:
+   - Settings: `stuckThresholdMs = 30 * 60 * 1000`, `autoRecover: true`.
+   - One in-progress task: `id: 'race-task'`, `updatedAt = Date.now() - 1000` (1 s), `log: [{ timestamp: <now - 35 min>, message: '...' }]`, `agent: 'someone'`.
+   - `tasks.readTaskboard` hook returns `{ columns: { inProgress: [raceTask], todo: [], … } }`.
+   - `isAgentHeartbeatStale` returns true for the agent (legacy path or leave `getAgentLastReply` at null + no heartbeat file).
+2. Start the watchdog, advance fake timers by one interval, flush microtasks.
+3. Assert:
+   - `hookRegistry.invoke` was NOT called with `'tasks.moveTask'` and `{ identifier: 'race-task', to: 'todo' }`.
+   - `hookRegistry.invoke` was NOT called with `'tasks.blockTask'` for this task.
+   - `appendAudit` was NOT called with event name `'task.auto_recovered'` or `'task.auto_recovery_exhausted'` for this task.
+   - `hookRegistry.invoke` was NOT called with `'tasks.addTaskLog'` carrying a message starting with `'Auto-recovered:'`.
+**Verification.**
+- `pnpm exec vitest run tests/core/watchdog.test.ts -t '<new test name>'` — the new case **fails** against current code (it asserts absence of a call that the current code makes). Failing here is the whole point; do not proceed to Task 4 until this test exists and fails for the right reason (auto-recovery fires).
+**Expected outcome.** New red test. **Commit C1** on the branch.
+
+### Task 4 — Implement the guard (C2)
+**Goal.** Add the constant and the guard clause so the C1 test goes green.
+**Files touched.** `src/core/watchdog.ts`.
+**Steps.**
+1. Add module constant near `BYPASS_PATTERNS` (top of file):
+   ```ts
+   const AUTO_RECOVERY_GUARD_MS = 60 * 1000
+   ```
+2. In the `inProgress` loop, insert the guard **after** the `stuckMs <= settings.watchdog.stuckThresholdMs` early-continue (which runs `checkBypassPatterns` then `continue`) and **before** the `minutesStuck` / `effectiveAgent` / `isAgentHeartbeatStale` block:
+   ```ts
+   if (task.updatedAt && now - task.updatedAt < AUTO_RECOVERY_GUARD_MS) {
+     log.debug('Skipping auto-recovery: updatedAt within guard window', {
+       id: task.id, updatedAtAgeMs: now - task.updatedAt,
+     })
+     continue
+   }
+   ```
+3. Placement check: guard must skip BOTH the move-to-`todo` branch AND the escalate-to-`blocked` branch — a `continue` at this point does that, because both branches live below it inside the same `for` iteration. Confirm by re-reading the block around watchdog.ts:140-164.
+4. Do not touch bypass-pattern handling — it already runs in the non-stuck branch above.
+**Verification.**
+- `pnpm exec vitest run tests/core/watchdog.test.ts` — all watchdog tests pass (new case goes green, existing cases unchanged).
+- `pnpm run typecheck` — clean.
+- `pnpm run lint -- src/core/watchdog.ts tests/core/watchdog.test.ts` — clean.
+**Expected outcome.** Green. **Commit C2** on the branch.
+
+### Task 5 — Full suite verification
+**Goal.** Confirm nothing else depended on the old behavior.
+**Files touched.** None (CI-equivalent check).
+**Steps.**
+1. `pnpm run test` (= `vitest run`) — full suite.
+2. If any existing test fails: DO NOT adjust it to "make green" without understanding. Risk (a) from the kickoff brief: a test may have inadvertently simulated the race by bumping `updatedAt` and expecting auto-recovery. Diagnose — if the test was genuinely wrong, fix it in C2 with a clear commit note; if it was asserting legitimate recovery behavior, the guard window needs to be tightened or the test's fixture needs a timestamp that's genuinely old.
+**Verification.**
+- Full suite green on the branch.
+**Expected outcome.** No regressions detected. If a regression appears, stop and triage against the spec before shipping.
+
+### Task 6 — Docs sweep (optional C3)
+**Goal.** Make sure knowledge docs stay accurate.
+**Files touched.** Potentially `.claude/knowledge/agent-system.md`; no other docs.
+**Steps.**
+1. `agent-system.md:202` reads "Auto-recovery: restart agent or move task back to todo". Append a single line such as:
+   > Auto-recovery is suppressed when the task's `updatedAt` is within a 60 s guard window to prevent a race with dispatch-move (issue #114).
+2. Grep the rest of `.claude/knowledge/` and `README.md` for `watchdog|auto.?recover`. Nothing else documents the auto-recovery behavior at that level of detail — skip.
+3. `README.md` references `watchdog.stuckThresholdMs` and "Detects stuck tasks, alerts via Discord" only; no update needed — the guard is an internal detail, not a user-facing setting.
+**Verification.**
+- `rg 'watchdog|auto.?recover' README.md .claude/knowledge/` — reviewed; only `agent-system.md` merits a line.
+**Expected outcome.** Either C3 commit lands or the task is explicitly declined ("no doc update needed — code comment is sufficient"). Either outcome is acceptable.
+
+### Task 7 — Push branch + open PR
+**Goal.** Land the fix via PR against `main`.
+**Files touched.** None (git/GitHub surface).
+**Steps.**
+1. `git push -u origin fix/issue-114-watchdog-dispatch-race`.
+2. Open PR with:
+   - **Title:** `fix(watchdog): prevent race with dispatch from auto-recovering fresh tasks (#114)`
+   - **Base:** `main`
+   - **Body:**
+     - One-paragraph race summary with the 7 ms audit-trail excerpt from the issue.
+     - Link: `Closes #114`.
+     - The acceptance checklist from the spec, ticked:
+       - [x] New test in `tests/core/watchdog.test.ts` simulates the race and asserts no auto-recovery.
+       - [x] Full watchdog test file still passes.
+       - [x] Full project test suite still passes.
+       - [ ] Manual audit-log check after deploy (captured as a post-merge follow-up).
+**Verification.**
+- `gh pr view --web` opens; CI kicks off.
+**Expected outcome.** PR green, ready for merge. Do not auto-merge — hand off to user.
+
+---
+
+## Test Runner Reference
+
+Project uses **vitest** via pnpm (`package.json` scripts). Canonical commands:
+
+| Intent | Command |
+|---|---|
+| Full suite | `pnpm run test` (= `vitest run`) |
+| Single file | `pnpm exec vitest run tests/core/watchdog.test.ts` |
+| Single case | `pnpm exec vitest run tests/core/watchdog.test.ts -t '<name>'` |
+| Typecheck | `pnpm run typecheck` |
+| Lint (scoped) | `pnpm run lint -- <paths>` |
+
+No `npm test` in this repo; it's pnpm. Sticking to pnpm-scripted commands keeps the build skill aligned with the rest of the monorepo.
+
+---
+
+## Risks & Mitigations (carried from the kickoff brief)
+
+- **(a) Hidden dependency on current auto-recovery behavior in an existing test.** Full-suite run in Task 5 is the detector. Mitigation: diagnose, don't paper over. If a test was implicitly simulating the race, its fixture — not the guard — is wrong.
+- **(b) `task.updatedAt` not bumped by `tasks.moveTask`.** Would make the fix a silent no-op. Mitigated by Task 2's pre-flight; already grep-verified during planning (write paths hit `updated_at = ?` in `plugins/tasks/lib/flow-store.ts`).
+- **(c) Guard value drift.** 60 s is baked as a module constant. Re-evaluate only if watchdog/dispatch intervals drop below ~10× the guard. Out of scope today.
+
+---
+
+## Checkpoints & Rollback Points
+
+| After | Checkpoint | If red, roll back with |
+|---|---|---|
+| Task 1 | Clean branch, green baseline | `git switch main && git branch -D fix/issue-114-watchdog-dispatch-race` |
+| C1 (Task 3) | Failing test committed | `git reset --hard HEAD~1` — unpublished, safe |
+| C2 (Task 4) | Guard implemented, new test green, all watchdog tests green | `git reset --hard HEAD~1` — leaves C1 intact for re-try |
+| Task 5 | Full suite green | If a single test broke, revert just that test fix; keep C2 |
+| C3 (Task 6) | Docs line added | `git reset --hard HEAD~1` — trivial |
+| Task 7 | PR open, CI passing | Close PR; branch survives for iteration |
+
+Each commit is a discrete rollback point; no squashing before merge. Merge strategy is the repo default (see recent `Merge pull request #117 from …` — merge commits, not squash).
+
+---
+
+## Done When
+
+- Branch pushed, PR open against `main`, CI green.
+- Acceptance checklist in the spec fully ticked except the post-deploy audit-log check (tracked as a PR-body follow-up).
+- User has a clear rollback: revert the merge commit on `main`.

--- a/.claude/specs/issue-114-watchdog-dispatch-race.md
+++ b/.claude/specs/issue-114-watchdog-dispatch-race.md
@@ -1,0 +1,113 @@
+# Spec — issue #114: Watchdog/dispatch race auto-recovers a task that was just dispatched
+
+_Created: 2026-04-20 | Issue: https://github.com/madeinwyo/bakin/issues/114_
+
+## Objective
+
+Stop the watchdog from auto-recovering a task that dispatch has just moved to `inProgress`. The race causes the card to flip back to `todo` within milliseconds of dispatch, the next dispatch tick re-sends to an agent already processing the first message, the gateway rejects the concurrent send with `fetch failed`, and dispatch lands in the 30-minute structural cooldown (false positive). The task then sits un-dispatchable while the agent silently finishes or aborts.
+
+Single-user, Mac-mini-hosted install. No backwards-compat burden; tech-debt-reducing fix preferred.
+
+## Bug Summary
+
+`src/core/watchdog.ts` takes a taskboard snapshot once per tick and then loops the `inProgress` column, computing `lastActivity = lastLogTs ?? task.updatedAt ?? now`. If dispatch moves a task `todo → inProgress` mid-tick, the watchdog reads a pre-move snapshot (log still old, `updatedAt` possibly old) and auto-recovers it 7 ms later. Dispatch has already sent the agent message, so the agent processes it, but the UI column is wrong and the next dispatch cycle re-sends.
+
+Audit trail from live reproduction on 2026-04-20 (task `8ba3a224`, agent `jessica-fetcher`):
+
+```
+06:21:00.361Z  task.moved          agent=dispatch    from:todo to:inProgress
+06:21:00.368Z  task.auto_recovered agent=watchdog    minutesStuck=31
+06:21:11.712Z  exec.bakin_exec_tasks_log_progress.ok agent=jessica-fetcher
+06:26:01.879Z  task.dispatch_failed error="fetch failed"
+```
+
+Root-cause lines: `src/core/watchdog.ts:117-120`.
+
+## Chosen Fix
+
+**Option 2 — time-window guard on `task.updatedAt`.**
+
+Before the watchdog auto-recovers a task, require `now - task.updatedAt >= AUTO_RECOVERY_GUARD_MS`. If `updatedAt` is inside the window, skip auto-recovery for this tick; the next tick (5 min later, by default) re-evaluates against fresh state.
+
+**Guard window:** `60 * 1000` ms (60 s), as a module-level constant in `watchdog.ts`.
+
+Why 60 s:
+- Watchdog and dispatch both default to a 5-minute interval. 60 s is ≤ 1% of either loop, so at most one extra tick of delay for a genuinely stuck task.
+- Absorbs clock drift, fs write latency, and hook invocation delay well beyond the observed 7 ms race.
+- Auto-recovery only fires when `stuckMs > stuckThresholdMs` (30 min default). The only way `stuckMs > 30 min` AND `updatedAt` within 60 s can both be true is that something just mutated the task — exactly the race we want to catch. So the guard is strictly orthogonal to the stuck check and cannot mask a real stall.
+
+Hardcoded as a constant rather than a new setting — no operator tuning need has been identified, and an extra knob is tech debt. We promote it later only if needed.
+
+### Why not option 1 or 3
+
+- **Option 1 (re-read the task from the board before `moveTask`)**: costs an extra hook round-trip for every candidate recovery and still has a TOCTOU window. Strict subset of what the `updatedAt` guard catches for this race.
+- **Option 3 (share `withStateLock` between dispatch and watchdog)**: real architectural change — new coupling between two independent loops, new failure modes if the lock is forgotten. Overkill for a race the guard window closes.
+
+We pick **option 2 alone**; options 1 and 3 remain as future hardening if a new race shape surfaces.
+
+## Invariant
+
+> The watchdog never auto-recovers a task whose `updatedAt` is within `AUTO_RECOVERY_GUARD_MS` of the current tick's `now`.
+
+Applies to both the move-back-to-`todo` path and the escalate-to-`blocked` path.
+
+## Scope of Change
+
+### `src/core/watchdog.ts`
+
+- Add `const AUTO_RECOVERY_GUARD_MS = 60 * 1000` near the other module constants (top of file, next to `BYPASS_PATTERNS`).
+- In the `inProgress` loop, after the `stuckMs <= settings.watchdog.stuckThresholdMs` early-continue and before the `isAgentHeartbeatStale` call, add:
+  ```ts
+  if (task.updatedAt && now - task.updatedAt < AUTO_RECOVERY_GUARD_MS) {
+    log.debug('Skipping auto-recovery: updatedAt within guard window', {
+      id: task.id, updatedAtAgeMs: now - task.updatedAt,
+    })
+    continue
+  }
+  ```
+- Guard must apply before the `settings.watchdog.autoRecover && agentStale` branch — the whole recovery decision is deferred, not just the move.
+- Do NOT run bypass-pattern checks in the guard-skip path — those already run in the fresh-activity branch above; the guard covers the "task moved recently by dispatch" case.
+
+### `tests/core/watchdog.test.ts`
+
+- New test `does not auto-recover a task whose updatedAt is within the guard window` (or similar).
+- Fixture: task in `inProgress`, a log entry timestamped 35 min in the past, `updatedAt = Date.now() - 1000` (1 s), agent heartbeat stale. Run one watchdog tick.
+- Assert: `tasks.moveTask` hook NOT invoked for this task; `appendAudit` NOT called with `task.auto_recovered`; `tasks.addTaskLog` NOT called with the "Auto-recovered:" message.
+- Existing tests continue to pass unchanged. Expected: no existing test both sets `updatedAt` within 60 s AND requires auto-recovery to fire, so behavior is preserved. Verified by running the full watchdog test file plus the full project test suite.
+
+## Acceptance Criteria
+
+1. New test in `tests/core/watchdog.test.ts` simulates the race and asserts no auto-recovery fires.
+2. Full watchdog test file still passes (no regressions to existing cases).
+3. Full project test suite (`npm test` / `vitest run`) still passes.
+4. Manual verification in `~/.bakin/audit.jsonl` after deploy: no `task.auto_recovered` within 60 s of a preceding `task.moved` on the same task id. Proof can wait for the first naturally occurring dispatch; no synthetic run required.
+
+## Out of Scope
+
+- The 30-minute structural cooldown behavior in `src/core/dispatch.ts` (`classifyDispatchError`). Separate concern; fixing the race removes the false-positive trigger that currently exercises it.
+- Changes to `dispatch`'s `withStateLock` or any locking refactor.
+- Broader watchdog cleanup, renaming, or behavioral changes.
+- New plugin settings, UI, or CLI surface.
+- Changes to `tests/plugins/test-helpers.ts` or the mocking harness beyond the new test case.
+
+## Risks & Mitigations
+
+- **Delayed legitimate recovery.** If something repeatedly bumps `updatedAt` without writing a log entry, the guard could keep rebasing. Mitigation: every normal task mutation path also adds a log entry (feeds `lastLogTs`, fallback #1), so this scenario isn't realistic in the current codebase. If it ever happens, the non-recovery branch's `ALERT:` path still fires.
+- **Missed race if `updatedAt` is not bumped on move.** Mitigation: `tasks.moveTask` currently bumps `updatedAt` (verified by the existing `task.moved` audit behavior). If a future mutation path forgets to, the race symptom reappears in audit and routes us back here.
+- **Constant drift.** If watchdog/dispatch intervals drop far below 60 s, the guard becomes proportionally larger. Not a current concern — both default to 5 min. Revisit if defaults change.
+
+## Commit Strategy (preview — finalized in the plan skill)
+
+Two commits for natural rollback points:
+
+1. `test(watchdog): failing test for dispatch-race auto-recovery (#114)` — adds the new test; it fails against current code.
+2. `fix(watchdog): skip auto-recovery when task updatedAt is within guard window (#114)` — adds the constant and the guard; test passes.
+
+A tiny optional third commit if any knowledge doc needs the new invariant recorded: `docs(watchdog): note auto-recovery guard window`.
+
+## References
+
+- Issue: https://github.com/madeinwyo/bakin/issues/114
+- File under change: `src/core/watchdog.ts:117-164`
+- Existing watchdog tests: `tests/core/watchdog.test.ts`
+- Related context (not blockers): #112, #113, #115

--- a/src/core/watchdog.ts
+++ b/src/core/watchdog.ts
@@ -21,6 +21,13 @@ let watchdogTimer: NodeJS.Timeout | null = null
 let lastMcpAlertAt = 0
 let lastRestAlertAt = 0
 
+// Suppress auto-recovery when a task was mutated within this window.
+// Closes the watchdog/dispatch race where dispatch moves a task
+// todo → inProgress and the watchdog, reasoning from a pre-move snapshot
+// taken earlier in the same tick, declares it "stuck" and moves it back.
+// See issue #114.
+const AUTO_RECOVERY_GUARD_MS = 60 * 1000
+
 // Bypass detection patterns — agents trying to work around errors instead of blocking
 const BYPASS_PATTERNS = [
   /work(?:ing)?\s+around/i,
@@ -121,6 +128,18 @@ export function start(contentDir: string, port: number): void {
         if (stuckMs <= settings.watchdog.stuckThresholdMs) {
           // Task has recent activity — check for bypass patterns instead
           checkBypassPatterns(task, contentDir, port)
+          continue
+        }
+
+        // Race guard (#114): a fresh updatedAt means something (usually
+        // dispatch's moveTask) just touched this task. Skip this tick and
+        // re-evaluate on the next one; by then any legitimate mutation will
+        // have written a log entry that feeds lastLogTs above.
+        if (task.updatedAt && now - task.updatedAt < AUTO_RECOVERY_GUARD_MS) {
+          log.debug('Skipping auto-recovery: updatedAt within guard window', {
+            id: task.id,
+            updatedAtAgeMs: now - task.updatedAt,
+          })
           continue
         }
 

--- a/tests/core/watchdog.test.ts
+++ b/tests/core/watchdog.test.ts
@@ -3,6 +3,19 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+// Defensive content-dir mock (per CLAUDE.md test isolation rules) — the
+// watchdog receives its contentDir via `start()`, but any transitive import
+// must be prevented from reading/writing ~/.bakin/.
+const contentDirMockPath = join(tmpdir(), `bakin-watchdog-test-${Date.now()}`)
+vi.mock('../../src/core/content-dir', () => ({
+  getContentDir: () => contentDirMockPath,
+  getBakinPaths: () => ({ root: contentDirMockPath }),
+}))
+vi.mock('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => contentDirMockPath,
+  getBakinPaths: () => ({ root: contentDirMockPath }),
+}))
+
 vi.mock('../../src/core/logger', () => ({
   createLogger: () => ({
     info: vi.fn(),
@@ -283,6 +296,66 @@ describe('watchdog', () => {
         'task.auto_recovery_exhausted',
         'watchdog',
         expect.objectContaining({ id: 'task-3', recoveryCount: 3 }),
+      )
+    })
+
+    // Regression guard for issue #114 — dispatch moves a task
+    // todo → inProgress and the watchdog, running in the same tick off a
+    // stale pre-move snapshot, declares the task "30 min stuck" and moves
+    // it back to todo. The task's log timestamps are ancient (the task was
+    // queued long ago) but `updatedAt` was just bumped by dispatch's move,
+    // so we key the guard off that.
+    it('does not auto-recover when task.updatedAt is within the guard window', async () => {
+      const hookRegistry = getHookRegistry()
+      const invokeMock = vi.mocked(hookRegistry.invoke)
+
+      invokeMock.mockImplementation(async (name: string) => {
+        if (name === 'tasks.readTaskboard') {
+          return {
+            columns: {
+              todo: [],
+              inProgress: [
+                {
+                  id: 'race-task',
+                  title: 'Just-dispatched task',
+                  agent: 'pixel',
+                  // Log is ancient — the "stuck" check would normally fire.
+                  log: [{ message: 'Queued', timestamp: '2020-01-01T00:00:00Z' }],
+                  // But updatedAt was bumped by dispatch's moveTask 1s ago.
+                  updatedAt: Date.now() - 1000,
+                },
+              ],
+              done: [],
+            },
+          }
+        }
+        return undefined
+      })
+
+      // Heartbeat stale — so absent the guard this would auto-recover.
+      vi.mocked(isStale).mockReturnValue(true)
+
+      start(tempDir, 3737)
+      await vi.advanceTimersByTimeAsync(1500)
+
+      // Guard must block both branches of the recovery decision.
+      expect(invokeMock).not.toHaveBeenCalledWith('tasks.moveTask', expect.anything())
+      expect(invokeMock).not.toHaveBeenCalledWith('tasks.blockTask', expect.anything())
+      expect(invokeMock).not.toHaveBeenCalledWith(
+        'tasks.addTaskLog',
+        expect.objectContaining({ message: expect.stringContaining('Auto-recovered') }),
+      )
+      expect(vi.mocked(appendAudit)).not.toHaveBeenCalledWith(
+        tempDir,
+        'task.auto_recovered',
+        expect.anything(),
+        expect.anything(),
+      )
+      expect(vi.mocked(appendAudit)).not.toHaveBeenCalledWith(
+        tempDir,
+        'task.auto_recovery_exhausted',
+        expect.anything(),
+        expect.anything(),
       )
     })
   })


### PR DESCRIPTION
## Summary

Closes #114.

The watchdog was auto-recovering tasks that dispatch had **just** moved to `inProgress`. Dispatch and the watchdog both run as timers off the same event loop; each watchdog tick takes a taskboard snapshot and then loops the `inProgress` column deciding whether to auto-recover. If dispatch moved a task `todo → inProgress` mid-tick, the watchdog reasoned from the pre-move snapshot (log timestamps still old) and moved the card back to `todo` 7 ms later — even though the agent had already received and started processing the dispatched message.

Audit trail from the live repro on 2026-04-20 (task `8ba3a224`, agent `jessica-fetcher`):

```
06:21:00.361Z  task.moved          agent=dispatch     from:todo to:inProgress
06:21:00.368Z  task.auto_recovered agent=watchdog     minutesStuck=31
06:21:11.712Z  exec.bakin_exec_tasks_log_progress.ok agent=jessica-fetcher  ← she got the message
...
06:26:01.879Z  task.dispatch_failed error="fetch failed"                     ← re-dispatch hit the gateway with a concurrent send
```

The downstream symptom was a 30-minute structural cooldown (false positive) that locked the task out of dispatch while the agent worked on it silently.

## Fix

- New module constant `AUTO_RECOVERY_GUARD_MS = 60 * 1000` in `src/core/watchdog.ts`.
- In the `inProgress` loop, before either branch of the recovery decision (`move to todo` and `escalate to blocked`), skip the task when `now - task.updatedAt < AUTO_RECOVERY_GUARD_MS`. Dispatch's `moveTask` bumps `updated_at` (`plugins/tasks/lib/flow-store.ts`), so the guard keys off the exact signal that causes the race.
- 60 s chosen as the smallest window that comfortably covers the observed race plus fs/hook latency while staying <1% of the 5-minute watchdog/dispatch interval. The guard is strictly orthogonal to `stuckThresholdMs` (30 min default) — the only way `stuckMs > 30 min` AND `updatedAt` within 60 s can both be true is that something just mutated the task, which is the race we want to catch.
- Chose the guard-window approach (option 2 from the issue) over re-read (option 1 — extra hook round-trip, still has TOCTOU) and shared lock (option 3 — architectural change, overkill).

See `.claude/specs/issue-114-watchdog-dispatch-race.md` and `.claude/specs/issue-114-watchdog-dispatch-race-PLAN.md` for the full spec and rollout plan.

## Commits (rollback-friendly)

- `docs(watchdog)` — spec + plan land first, pure reference.
- `test(watchdog)` — failing regression test (C1).
- `fix(watchdog)` — guard clause that makes the test pass (C2).
- `docs(watchdog)` — one-line note in `.claude/knowledge/agent-system.md` (C3).

## Acceptance (from spec)

- [x] New test in `tests/core/watchdog.test.ts` simulates the race and asserts no auto-recovery fires.
- [x] Full watchdog test file still passes (11/11).
- [x] Full project test suite still passes (2888 passed, 1 skipped, 204 files).
- [ ] Manual verification in `~/.bakin/audit.jsonl` after merge: no `task.auto_recovered` within 60 s of a preceding `task.moved` on the same task id. Captured as a post-merge follow-up.

## Test plan

- [x] `pnpm exec vitest run tests/core/watchdog.test.ts` — 11 passed
- [x] `pnpm run test` — full suite green
- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec eslint src/core/watchdog.ts tests/core/watchdog.test.ts` — no new findings (one pre-existing `port` unused-var warning unchanged)