### PR TITLE
feat(health): plugin-contributed health checks registry (#137)

### DIFF
--- a/.claude/specs/issue-137-health-checks-registry.md
+++ b/.claude/specs/issue-137-health-checks-registry.md
@@ -1,0 +1,290 @@
+# Health Checks Registry (#137)
+
+**Status:** Draft
+**Tracking issue:** [#137](https://github.com/madeinwyo/bakin/issues/137)
+**Depends on:** PRs #126 (channels registry) and #131 (models UX) for established patterns
+**Unblocks:** `assets.renderers` (final registry); then the adapter layer work
+
+## Problem Statement
+
+`src/core/doctor.ts` (1808 lines) hardcodes 17 diagnostic checks inline. Three of them read workflows-plugin data (`checkWorkflowDefinitions`, `checkStaleWorkflowInstances`, `checkWorkflowSkills`) but live in core because there's no extension point for plugins to contribute doctor checks.
+
+Two concrete pains fall out of this:
+
+1. **Ownership is wrong.** The workflows plugin owns the data these checks interrogate but can't own the check code. Any evolution of the data model requires touching core.
+2. **Third-party plugins can't participate.** A future Mastodon publisher plugin (or any marketplace plugin) has no way to register "Mastodon API reachable?" as a doctor-dashboard check without editing `src/core/doctor.ts`.
+
+Unlike `models.providers` (#128, closed as premature abstraction), this registry has a forcing function baked in: three existing checks want to move out of core right now.
+
+## Goals
+
+- Add a `health.checks` registry extension point — 4th of the five called out in `docs/ideas/plugin-system.md`.
+- `ctx.registerHealthCheck(...)` on `PluginContext`, mirroring the `registerNotificationChannel` precedent exactly: auto-namespaced ids, error-isolated execution, clean teardown on hot reload.
+- Orchestrator integration: `runDiagnostics()` transparently gains plugin-registered checks alongside the builtin sweep.
+- **Proof-of-pattern migration:** move the 3 workflow-owned checks out of `src/core/doctor.ts` into the workflows plugin. Pattern is validated the moment this PR lands — not speculative.
+- Cross-plugin read paths (`health.listChecks` hook + `GET /api/plugins/health/checks`) so admin surfaces can introspect what's registered.
+
+## Non-Goals
+
+- Not migrating all 17 core checks. Only the 3 workflows-owned ones. Future migrations happen when each owner plugin is touched anyway.
+- Not changing the `bakin doctor` CLI surface — it calls `runDiagnostics()` which transparently gains plugin results.
+- Not building admin UI for toggling individual checks on/off.
+- Not merging with the `src/core/onboarding/` `check()/install()` contract — that's first-run bootstrap, different purpose and cadence.
+- No manifest changes — runtime registration only, matching channels + node-types.
+- Not introducing check scheduling, priority ordering, or inter-check dependencies. Plugin checks run in parallel after the builtin sweep.
+- No sub-namespace on ctx (e.g. no `ctx.health.register(...)`) — flat `registerHealthCheck` matches the other register* methods.
+
+## Design
+
+### Types (core)
+
+Add to `packages/core/src/plugin-types.ts` after the notification-channel block:
+
+```ts
+// ---------------------------------------------------------------------------
+// Health check registration
+// ---------------------------------------------------------------------------
+
+export interface HealthCheckResult {
+  check: string
+  status: 'ok' | 'warn' | 'error' | 'fixed'
+  message: string
+  autoFixable: boolean
+}
+
+export interface PluginHealthCheckInput {
+  /** Short id, auto-namespaced as `{pluginId}.{id}`. */
+  id: string
+  /** Human-readable label for admin UIs. */
+  name: string
+  /** Runs the check, returns any number of result rows. Failures (thrown or
+   *  rejected) are caught by the orchestrator and converted to a synthetic
+   *  error result — a single bad handler never crashes the doctor sweep. */
+  run: () => Promise<HealthCheckResult[]>
+  /** Advisory flag for UIs: true if run() may perform auto-fixes internally.
+   *  Pure metadata for v1; the orchestrator calls every registered check
+   *  regardless of this value. */
+  autoFix?: boolean
+}
+
+export interface HealthCheckDef extends PluginHealthCheckInput {
+  runtime: 'plugin'
+  pluginId: string
+}
+```
+
+`HealthCheckResult` is shape-identical to the existing `DiagnosticResult` in `src/core/doctor.ts`. Going forward both types refer to the same thing; `DiagnosticResult` remains a type alias in doctor.ts for now to avoid a noisy rename.
+
+### Registry store
+
+New file `plugins/health/lib/health-check-registry.ts`, mirroring `plugins/workflows/lib/notification-channel-registry.ts`:
+
+```ts
+const registry = new Map<string, HealthCheckDef>()
+
+export function registerHealthCheck(def: HealthCheckDef): void
+export function getHealthCheck(id: string): HealthCheckDef | undefined
+export function listHealthChecks(): HealthCheckDef[]
+export function unregisterHealthCheck(id: string): void
+export function unregisterPluginHealthChecks(pluginId: string): void
+
+/** Plugin wrapper — namespaces id to `{pluginId}.{id}`, returns namespaced id. */
+export function registerPluginHealthCheck(
+  pluginId: string,
+  input: PluginHealthCheckInput,
+): string
+```
+
+**No builtins.** Unlike channels and node-types, the core `src/core/doctor.ts` checks stay as direct calls in `runDiagnostics()` — the registry is purely for plugin contributions. Doctor remains the single place that knows about core checks; the registry adds a second, plugin-scoped layer on top.
+
+### PluginContext surface
+
+`packages/core/src/plugin-types.ts`:
+
+```ts
+/**
+ * Register a health check owned by this plugin. The id is auto-namespaced
+ * to `{pluginId}.{id}`. `run()` is invoked during every `runDiagnostics()`
+ * sweep; throws are isolated — one bad check doesn't crash the doctor.
+ * Returns the namespaced id.
+ */
+registerHealthCheck(def: PluginHealthCheckInput): string
+```
+
+`src/lib/plugin-registry.ts` wires it through the `registerPluginHealthCheck` helper (mirror of `registerNotificationChannel` wiring), adds `healthCheckIds: string[]` to `PluginState`, and calls `unregisterPluginHealthChecks(pluginId)` in the user-plugin-override teardown path at :354.
+
+### Orchestrator integration
+
+`src/core/doctor.ts` `runDiagnostics()` gains a plugin-check pass after the existing builtin sweep:
+
+```ts
+// ... existing builtin checks ...
+results.push(...await Promise.all(/* existing async checks */))
+
+// Plugin-contributed checks — isolated try/catch per check so one bad
+// handler doesn't crash the whole doctor pass.
+const pluginChecks = listHealthChecks()
+const pluginResults = await Promise.all(
+  pluginChecks.map(async (def) => {
+    try {
+      return await def.run()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return [{
+        check: def.id,
+        status: 'error' as const,
+        message: `Plugin health check threw: ${message}`,
+        autoFixable: false,
+      }]
+    }
+  })
+)
+results.push(...pluginResults.flat())
+```
+
+Plugin check results are appended to the same `DiagnosticResult[]` as builtins — no separate section. The health page UI already groups by status, so ordering doesn't matter for display.
+
+### Cross-plugin read surface
+
+`plugins/health/index.ts` — registers two hooks + one REST route during `activate()`:
+
+```ts
+ctx.hooks.register('health.listChecks', () => listHealthChecks().map(d => ({
+  id: d.id,
+  name: d.name,
+  pluginId: d.pluginId,
+  autoFix: !!d.autoFix,
+})))
+
+ctx.hooks.register('health.getCheck', (d: Record<string, unknown>) => {
+  const def = getHealthCheck(d.id as string)
+  return def ? { id: def.id, name: def.name, pluginId: def.pluginId, autoFix: !!def.autoFix } : null
+})
+
+ctx.registerRoute({
+  path: '/checks',
+  method: 'GET',
+  description: 'List registered plugin health checks (does not execute them).',
+  handler: async () => Response.json({
+    checks: listHealthChecks().map(d => ({
+      id: d.id, name: d.name, pluginId: d.pluginId, autoFix: !!d.autoFix,
+    })),
+  }),
+})
+```
+
+Hook returns + REST payload strip the `run` function — handlers can't be serialized and consumers only want metadata.
+
+### Migration — workflows plugin
+
+Three `src/core/doctor.ts` functions move to the workflows plugin:
+
+1. **`checkWorkflowDefinitions`** (`doctor.ts:1139`) — reads `getHookRegistry().invoke('workflows.listDefinitions')`, cross-references skill references against `{contentDir}/workflows/skills/`. Move verbatim into `plugins/workflows/lib/health-checks.ts`; the hook invocation becomes a direct function call since we're already inside the workflows plugin.
+
+2. **`checkStaleWorkflowInstances`** (`doctor.ts:1175`) — reads `{contentDir}/workflows/instances/*.json`, flags anything `in_progress` for >2 hours. The `autoFix` parameter becomes an internal check of `getSettings().doctor.autoFixSkill` since the registry signature doesn't pass parameters to `run()`.
+
+3. **`checkWorkflowSkills`** (`doctor.ts:1102`) — compares bundled `plugins/workflows/defaults/workflow-skills/*.md` against user's `{contentDir}/workflows/skills/`.
+
+In `plugins/workflows/index.ts:activate()`:
+
+```ts
+ctx.registerHealthCheck({
+  id: 'definitions',
+  name: 'Workflow definition integrity',
+  run: () => checkWorkflowDefinitions(getContentDir()),
+})
+ctx.registerHealthCheck({
+  id: 'stale-instances',
+  name: 'Stale workflow instances',
+  autoFix: true,
+  run: () => checkStaleWorkflowInstances(getContentDir()),
+})
+ctx.registerHealthCheck({
+  id: 'skills',
+  name: 'Workflow skills bundled vs installed',
+  run: async () => checkWorkflowSkills(getContentDir()),
+})
+```
+
+Delete the three function definitions from `doctor.ts`. Remove the three `results.push(...)` lines in `runDiagnostics()`. The plugin-registry loop picks them up.
+
+### File inventory
+
+- `packages/core/src/plugin-types.ts` — add types + `registerHealthCheck` method
+- `src/lib/plugin-types.ts` — extend re-export list
+- `src/lib/plugin-registry.ts` — import helpers, add `healthCheckIds` to `PluginState`, wire `registerHealthCheck`, extend teardown
+- `plugins/health/lib/health-check-registry.ts` — new file, Map store + helpers
+- `plugins/health/index.ts` — register `health.listChecks` + `health.getCheck` hooks + `GET /checks` route
+- `src/core/doctor.ts` — append plugin-check loop to `runDiagnostics()`; delete three migrated functions
+- `plugins/workflows/lib/health-checks.ts` — new file housing the three migrated functions
+- `plugins/workflows/index.ts` — three `ctx.registerHealthCheck(...)` calls in `activate()`
+- `tests/plugins/health/health-check-registry.test.ts` — new
+- `tests/plugins/health/checks-route.test.ts` — new (route + hook integration)
+- `tests/plugins/workflows/health-checks.test.ts` — new (migration proof)
+
+All 8 `PluginContext`-literal sites (plugin-registry, route.ts, test-helpers, contract.test, 4 misc test files) need a `registerHealthCheck` stub.
+
+## Resolved Decisions
+
+- **Flat `ctx.registerHealthCheck(...)`, no `ctx.health.*` sub-namespace.** PluginContext's rule of thumb: one-shot register-a-thing methods are flat (registerNav/Route/Slot/ExecTool/Skill/Workflow/NodeType/NotificationChannel — 7 precedents); multi-verb APIs get a namespace (activity.*, hooks.*, search.*). Health checks is one-shot. If we ever add `runCheck(id)` or similar, introducing `ctx.health.*` alongside the existing method is additive and non-breaking.
+- **Registry owned by the health plugin** (`plugins/health/lib/health-check-registry.ts`), not by core. Matches how workflows owns `notification-channel-registry.ts`. Core `doctor.ts` imports from the plugin — same directionality as `src/lib/plugin-registry.ts` importing from `plugins/workflows/` today.
+- **`autoFix` is pure metadata.** No orchestrator behavior hangs off it; every registered check's `run()` is always called. Plugins that do internal auto-fixes gate on `getSettings().doctor.autoFixSkill` themselves. UI + summary log can surface the metadata. Future-widening to "orchestrator skips auto-fix checks when the setting is off" is non-breaking.
+- **Plugin checks run after the builtin sweep, appended to the same result list.** No interleaving, no ordering logic. Health page UI groups by status, so order doesn't matter for display.
+- **Failures in a plugin's `run()` yield a synthetic error result, not a crash.** Doctor sweep always completes. Core checks + other plugin checks are unaffected by one bad handler.
+- **`HealthCheckResult` shape-identical to `DiagnosticResult` — coexist for now, collapse once the last check migrates out of doctor.ts.** Not unbounded tech debt: `DiagnosticResult` stays as the existing export from `doctor.ts`, `HealthCheckResult` is the new canonical export from `packages/core/src/plugin-types.ts`. They point at the same shape. Once all 17 checks have been migrated to owner plugins (this PR does 3; the other 14 migrate when their owners are touched anyway), `doctor.ts` can delete `DiagnosticResult` and every consumer imports `HealthCheckResult` instead. Tracked as follow-up: `chore(core): collapse DiagnosticResult into HealthCheckResult after all checks migrate` (filed when this PR merges).
+- **Hook name stays `health.listChecks` (not `health.list`).** Six existing hooks use the `list{Noun}` pattern (`workflows.listDefinitions`, `team.listAgents`, etc). Switching health alone creates inconsistency. Switching all six together is a coordinated rename affecting every plugin — worth doing as its own focused PR. Tracked as follow-up: `chore: hook-name parity pass — rename all list{Noun} hooks to {namespace}.list` (filed when this PR merges).
+- **REST route response includes `pluginId` per check.** Namespacing is already visible in the id string (`workflows.definitions`) but an explicit `pluginId` field makes client-side grouping cheaper and doesn't cost anything on the wire.
+
+## Open Questions
+
+None remain. All decisions locked; two follow-up issues captured under Resolved Decisions.
+
+## Acceptance Criteria
+
+- [ ] `registerHealthCheck` method exists on `PluginContext`, auto-namespaces plugin ids as `{pluginId}.{id}`
+- [ ] Plugin-registry wiring mirrors `registerNotificationChannel` — imports, `PluginState.healthCheckIds: string[]`, teardown at user-plugin-override site
+- [ ] New `plugins/health/lib/health-check-registry.ts` with register/get/list/unregister + plugin namespacing helper + unregisterPluginHealthChecks
+- [ ] `health.listChecks` + `health.getCheck` hooks registered; `GET /api/plugins/health/checks` route registered
+- [ ] `src/core/doctor.ts` `runDiagnostics()` appends plugin-check results to the same list as builtins, with per-check try/catch isolation
+- [ ] `checkWorkflowDefinitions`, `checkStaleWorkflowInstances`, `checkWorkflowSkills` moved out of `doctor.ts` into `plugins/workflows/lib/health-checks.ts`
+- [ ] Workflows plugin's `activate()` registers the three checks via `ctx.registerHealthCheck`
+- [ ] `runDiagnostics()` no longer calls the three functions directly
+- [ ] Unit tests: registry add/collision/list/get/unregister + plugin namespacing + plugin teardown
+- [ ] Integration test: activate health plugin, call `/checks`, assert empty result before any other plugin registers; then activate workflows, re-call, assert 3 entries
+- [ ] Orchestrator test: mock a plugin check that throws → doctor sweep completes, the failing check yields a synthetic error result, other checks still run
+- [ ] Migration test: workflows health checks produce the same `DiagnosticResult[]` shape they did before the move (fixture-based)
+- [ ] `pnpm tsc --noEmit` + full `pnpm vitest run` clean
+- [ ] Grep: `checkWorkflowDefinitions|checkStaleWorkflowInstances|checkWorkflowSkills` in `src/core/doctor.ts` returns zero hits
+
+## Testing Strategy
+
+Follow CLAUDE.md rules (mock `content-dir`, `logger`, `watcher`, `openclaw-client`, `tasks/flow-store`). Registry tests follow the shape of `tests/plugins/workflows/notification-channel-registry.test.ts`.
+
+- **`tests/plugins/health/health-check-registry.test.ts`** — full surface coverage: register/get/list/unregister, collision throw, plugin namespacing correctness, plugin teardown leaves nothing behind, registry starts empty.
+- **`tests/plugins/health/checks-route.test.ts`** — activate health plugin via `activatePlugin` helper, call `GET /checks` on an empty registry (returns `{ checks: [] }`), register a fake check, call again, assert payload.
+- **`tests/plugins/workflows/health-checks.test.ts`** — fixture directories with valid definitions, stale instances, missing skills. Assert each migrated function returns the same shape / count of `DiagnosticResult` rows as the old inline versions did.
+- **Doctor orchestrator test** — extend `tests/core/` coverage (or create new `tests/core/doctor-plugin-checks.test.ts`): register two plugin checks, one that returns ok and one that throws, run `runDiagnostics()`, assert both appear in the result (synthetic error for the throwing one).
+
+## Sequencing
+
+1. **feat(core): HealthCheckResult types + PluginContext.registerHealthCheck** — core types + stubs at all ctx-literal sites (1 commit)
+2. **feat(health): health-check-registry with plugin namespacing + teardown** — new registry file + unit tests (1 commit)
+3. **feat(core): wire registerHealthCheck through plugin-registry** — imports, `PluginState.healthCheckIds`, teardown mirror (1 commit)
+4. **feat(health): list hooks + REST route** — `health.listChecks` / `health.getCheck` / `GET /checks` (1 commit)
+5. **feat(core): run plugin health checks in runDiagnostics** — orchestrator integration with per-check try/catch (1 commit)
+6. **refactor(workflows): migrate workflow health checks out of core/doctor.ts** — move functions, register in activate(), delete from doctor.ts (1 commit)
+7. **test(health): orchestrator isolation + migration regression** — remaining test coverage (1 commit)
+8. **Ship** — push, PR, smoke, merge
+
+Each commit builds clean and passes tests. Commit 1 adds interface; commits 2-5 wire it up; commit 6 is the forcing-function migration; commit 7 closes gaps.
+
+## Not Doing (and Why)
+
+- **Migrating the other 14 checks out of `doctor.ts`** — out of scope; each gets migrated when its owner plugin is touched for unrelated reasons. Avoids a sprawl PR.
+- **Admin UI for toggling plugin checks** — the health page already groups results by status. Disabling individual checks is a future feature once users ask for it.
+- **Merging with the onboarding `check()/install()` contract** — different purposes: onboarding = first-run bootstrap, doctor = ongoing health. Shared result type would tempt unification that doesn't make sense semantically.
+- **Check scheduling / priority / dependencies** — the doctor sweep is atomic; every check runs every pass. Introducing staged execution is a v2+ concern.
+- **Per-check enable/disable settings** — plugins that want this can read their own settings and early-return from `run()`. Don't need orchestrator-level machinery.
+- **Manifest declaration of contributed checks** — runtime registration only, same as channels + node-types. Manifest work happens in the future plugin-system distribution spec.
+- **Widening `autoFix` into orchestrator skip behavior** — advisory metadata only in v1. Non-breaking to add later.
+- **Collapsing `DiagnosticResult` and `HealthCheckResult` into one canonical type** — follow-up refactor after both names have been around long enough to pick the right survivor.

--- a/.claude/tasks/issue-129-plan.md
+++ b/.claude/tasks/issue-129-plan.md
@@ -1,0 +1,379 @@
+# Plan — Issue #129: Models loading UX + curated catalog
+
+**Spec:** `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
+**Issue:** https://github.com/madeinwyo/bakin/issues/129
+**Branch:** `issue-129-models-loading-ux`
+**Replaces:** closed #128 (plugin-contributed models registry — premature abstraction)
+
+## Goal
+
+Kill `fallbackModels()` (the 15-second cold-start lie) by moving model data to a persistent disk cache, and while we're in there, ship the curated catalog + brand icons + enriched UI that makes the models page actually useful. One PR, two user-visible wins: honest loading states + rich model cards.
+
+## Dependency graph
+
+```
+T0 scaffold (archive #125 tasks, write this plan + todo)
+  │
+  ▼
+T1 disk cache + stale flag ...................... (foundation)
+  │
+  ▼
+T2 /refresh route + gateway-restart invalidation . (depends on T1)
+  │
+  ▼
+T3 delete fallbackModels + MODEL_CATALOG dead code (depends on T1 so nothing still calls fallback)
+  │
+  ▼
+T4 curated catalog data module ................... (independent; new data, no consumers yet)
+  │
+  ▼
+T5 enrich AvailableModel from catalog ............ (depends on T4)
+  │
+  ▼
+T6 BrandIcon component + simple-icons dep ........ (independent; sets up the icon surface T7 uses)
+  │
+  ▼
+T7 enriched models-page cards + Refresh + banner . (needs T5 fields + T6 icons)
+  │
+  ▼
+T8 regression tests (full coverage pass)
+  │
+  ▼
+T9 ship
+```
+
+Solo sequential. Each task = one commit. Intermediate commits must build and pass tests — no broken-main moments.
+
+## Task detail
+
+### T0 — chore(issue-129): spec + plan scaffold
+
+**Already done:**
+- Branch `issue-129-models-loading-ux` created from `main`
+- Issue #128 closed with rationale (plugin-registry for models is premature)
+- `docs/ideas/plugin-system.md` updated to strike `models.providers` from the registry list
+- Spec written at `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
+
+**Still to do (this task):**
+- Archive issue-125 tasks → `.claude/tasks/issue-125-{plan,todo}.md`
+- Write this `tasks/plan.md` + `tasks/todo.md`
+- One commit bundling all scaffolding
+
+**Acceptance:**
+- [ ] `tasks/plan.md` + `tasks/todo.md` present, scoped to #129
+- [ ] `.claude/tasks/issue-125-{plan,todo}.md` present with #125's final state
+- [ ] Commit message: `chore(issue-129): spec + plan scaffold`
+
+---
+
+### T1 — feat(models): disk-backed cache + stale flag
+
+**What:** Move model cache persistence from in-memory-only to in-memory + disk. Response gains `stale: boolean`.
+
+**"Look first":** the existing cache at `plugins/models/index.ts:149-157` uses `globalThis.__bakinModelsCache`. Keep it as the hot-read layer; disk is underneath. Do NOT rip out the globalThis pattern.
+
+**Files:**
+- New: `plugins/models/lib/models-cache.ts` — disk read/write with zod-validated reads
+- Edit: `plugins/models/index.ts` — `fetchAvailableModels()` extended to read disk on cold start, write disk on success, return `stale: boolean` in the response
+- Edit: `plugins/models/types.ts` — `AvailableModelsResponse` gains optional `stale?: boolean` field
+- New test: `tests/plugins/models/models-cache.test.ts`
+
+**Shape:**
+
+```ts
+// plugins/models/lib/models-cache.ts
+interface PersistedCache {
+  models: AvailableModel[]
+  fetchedAt: number
+  source: 'openclaw' | 'empty'
+}
+export function readPersistedCache(): PersistedCache | null   // zod-validated; returns null on miss/corrupt
+export function writePersistedCache(cache: PersistedCache): void  // atomic tmp+rename
+export function clearPersistedCache(): void
+```
+
+Path: `getContentDir()` + `plugin-settings/models/available.json`. Mkdir parent on first write.
+
+Response flow in `/available`:
+1. In-memory cache fresh → return `{ models, cached: true, cachedAt, stale: false }`
+2. In-memory cache empty but disk cache present → hydrate in-memory, return `{ models, cached: true, cachedAt, stale: (Date.now() - cachedAt) > CACHE_TTL }`
+3. Both empty → call `loadConfiguredModelsFromOpenClaw`; write both caches on success, return `{ models, cached: false, cachedAt: now, stale: false }`
+4. OpenClaw fails AND no cache → return `{ models: [], cached: false, cachedAt: null, error: '...' }` — **never** `fallbackModels()`
+
+Note: `fallbackModels()` still exists in the file after T1; T3 deletes it. T1 just stops calling it in the success-empty branch.
+
+**Acceptance:**
+- [ ] `plugins/models/lib/models-cache.ts` exists with 3 exports + zod validation on read
+- [ ] Disk cache path resolves to `~/.bakin/plugin-settings/models/available.json`
+- [ ] First `/available` on a fresh install with no disk file returns an HTTP-200 with `models: []` + error (no fake data) — unless OpenClaw is reachable, in which case fresh fetch + disk write
+- [ ] Response shape includes `stale: boolean`
+- [ ] `fallbackModels()` is no longer referenced in `fetchAvailableModels` (still defined, deleted in T3)
+- [ ] Unit tests cover: round-trip write/read, corrupt JSON returns null, missing file returns null, `clearPersistedCache` deletes the file
+- [ ] `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
+
+**Commit:** `feat(models): disk-backed cache with stale flag`
+
+---
+
+### T2 — feat(models): manual refresh + gateway-restart cache invalidation
+
+**What:** New `POST /api/plugins/models/refresh` endpoint that forces a cache bypass. Extend `POST /gateway/restart` to wipe both caches.
+
+**"Look first":** `getGatewaySync()`/`markGatewayRestarted()` live at `plugins/models/index.ts:23-28` (same file). `POST /gateway/restart` exists at `:647`. Just extend, don't relocate.
+
+**Files:**
+- Edit: `plugins/models/index.ts` — new `/refresh` route; `/gateway/restart` clears in-memory + disk cache after successful restart
+- Edit: existing `tests/plugins/models/routes.test.ts` — add cases for /refresh + cache-clear on restart
+
+**Flow for `/refresh`:**
+- Ignore cache
+- Call `loadConfiguredModelsFromOpenClaw` directly
+- On success: write both in-memory + disk cache
+- On failure + there IS a disk cache: return `{ ok: false, error, models: cachedModels, stale: true }`
+- On failure + no cache: return `{ ok: false, error, models: [] }`
+
+**Acceptance:**
+- [ ] `POST /api/plugins/models/refresh` route registered
+- [ ] `/refresh` bypasses cache and returns fresh data
+- [ ] `/refresh` on OpenClaw failure falls back to last-known-good cache when available
+- [ ] `POST /gateway/restart` clears in-memory AND disk cache on successful restart
+- [ ] `pnpm vitest run` clean
+- [ ] `pnpm tsc --noEmit` clean
+
+**Commit:** `feat(models): manual refresh endpoint + invalidate cache on gateway restart`
+
+---
+
+### T3 — refactor(models): delete fallbackModels + MODEL_CATALOG dead code
+
+**What:** Pure deletion. Both surfaces are now unused.
+
+**Files:**
+- Edit: `plugins/models/index.ts` — remove `fallbackModels()` function (lines 252-259)
+- Edit: `plugins/models/types.ts` — remove `MODEL_CATALOG` + `ModelCatalogEntry` (lines 45-58)
+
+**Grep verifications (all zero hits):**
+- `grep -rn 'fallbackModels' plugins/models/`
+- `grep -rn 'MODEL_CATALOG' plugins/`
+- `grep -rn 'ModelCatalogEntry' plugins/`
+
+**Acceptance:**
+- [ ] All three greps return zero hits
+- [ ] `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] No test regressions — `MODEL_CATALOG` was dead code, nothing depends on it
+
+**Commit:** `refactor(models): remove fallbackModels + MODEL_CATALOG dead code`
+
+---
+
+### T4 — feat(models): curated catalog data module
+
+**What:** New `plugins/models/data/known-models.ts` with the 22-entry seed + lookup helpers.
+
+**Files:**
+- New: `plugins/models/data/known-models.ts` — exports `KnownModel`, `KnownProvider`, `KNOWN_MODELS`, `KNOWN_PROVIDERS`, `getKnownModel`, `getKnownProvider`
+- New test: `tests/plugins/models/known-models.test.ts`
+
+**Seed: 9 LLMs + 5 image + 5 video + providers** (per spec §Seed entries).
+
+**`getKnownModel` normalization:**
+- Exact match first
+- On miss, strip trailing `-\d{8}` date suffix and retry
+- Return `undefined` otherwise
+
+**Providers seed:** at minimum `anthropic`, `openai` (and `openai-codex` alias), `google`, `ollama`, `bytedance`, `kuaishou`, `runway`, `black-forest-labs`, `stability`, `midjourney` with matching `brandIconSlug` + `brandColor` (hex).
+
+**Acceptance:**
+- [ ] 22 model entries across `kind: 'llm' | 'image' | 'video'` (9 + 5 + 5; 3 slots flexibility if a seed model shifts)
+- [ ] Providers cover every model's `providerFromId` output
+- [ ] `getKnownModel('anthropic/claude-sonnet-4-6-20250514')` matches the base `anthropic/claude-sonnet-4-6` entry
+- [ ] `getKnownModel('unknown/model')` returns undefined
+- [ ] Unit tests: exact match, date-suffix-strip match, miss, provider lookup hit + miss
+- [ ] `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
+
+**Commit:** `feat(models): curated catalog of 22 popular models + providers`
+
+---
+
+### T5 — feat(models): enrich AvailableModel from catalog
+
+**What:** `loadConfiguredModelsFromOpenClaw` merges catalog metadata into every returned `AvailableModel`.
+
+**Files:**
+- Edit: `plugins/models/types.ts` — `AvailableModel` gains optional fields: `description`, `bestFor`, `costRange`, `kind`, `brandIconSlug`, `providerLabel`, `providerBrandIconSlug`, `providerBrandColor`
+- Edit: `plugins/models/index.ts` — enrichment in the `.map(...)` block at `:213` (around the existing `AvailableModel` construction)
+- Extend: `tests/plugins/models/routes.test.ts` — fixture OpenClaw response for a known id should produce an `AvailableModel` with the catalog's `description` / `bestFor` / `costRange`; unknown id falls back to `tierFromId`
+
+**Enrichment shape (preserves existing fallbacks):**
+
+```ts
+const known = getKnownModel(id)
+const knownProvider = getKnownProvider(providerFromId(id))
+return {
+  id,
+  name: known?.name ?? model.name ?? id,
+  tier: known?.tier ?? tierFromId(id),
+  provider: providerFromId(id),
+  providerLabel: knownProvider?.label,
+  providerBrandIconSlug: knownProvider?.brandIconSlug,
+  providerBrandColor: knownProvider?.brandColor,
+  description: known?.description,
+  bestFor: known?.bestFor,
+  costRange: known?.costRange,
+  kind: known?.kind,
+  brandIconSlug: known?.brandIconSlug,
+  // ... existing fields untouched
+}
+```
+
+**Acceptance:**
+- [ ] `AvailableModel` type has the 8 new optional fields
+- [ ] Mocked OpenClaw fixture including `anthropic/claude-sonnet-4-6` produces enriched shape with catalog fields
+- [ ] Mocked OpenClaw fixture for an unknown id still constructs a valid `AvailableModel` with `tier` from `tierFromId` heuristic and no enrichment fields
+- [ ] Existing `routes.test.ts` tests still pass (no regression on existing assertions)
+- [ ] `pnpm tsc --noEmit` clean — downstream consumers ignore the new optional fields
+
+**Commit:** `feat(models): enrich AvailableModel with curated catalog metadata`
+
+---
+
+### T6 — feat(models): BrandIcon component + simple-icons dep
+
+**What:** New client component that renders SVG brand logos via `simple-icons`, with first-letter chip fallback.
+
+**"Look first":**
+- Run `pnpm add simple-icons` first; verify the deep-import shape by `cat node_modules/simple-icons/icons/openai.js` (should export `{ title, slug, path, hex, source }`)
+- If tree-shaking concerns appear (bundle swells visibly), switch to deep imports by path: `import siOpenai from 'simple-icons/icons/openai'`. Not a blocker — covered in the spec's Not Doing list (no dynamic imports).
+
+**Files:**
+- `package.json` + `pnpm-lock.yaml` — add `simple-icons` dep
+- New: `plugins/models/components/brand-icon.tsx`
+- New test: `tests/plugins/models/brand-icon.test.tsx`
+
+**Import map: 10 slugs** matching the seed catalog — `anthropic`, `openai`, `google`, `ollama`, `runway`, `stability`, `midjourney`, `bytedance`, `kuaishou`, `blackforestlabs`. Plus `helpcircle`-shaped fallback if any icon happens to be missing in the package.
+
+**Props:**
+
+```ts
+interface BrandIconProps {
+  slug?: string
+  fallbackText?: string       // for first-letter chip
+  fallbackColor?: string      // hex
+  size?: 'sm' | 'md'
+  className?: string
+}
+```
+
+**Fallback rules:**
+- `slug` present and in the map → render the SVG path
+- `slug` missing or not in the map → render first-letter chip with `fallbackColor` bg
+- `fallbackText` missing → render `?`
+
+**Acceptance:**
+- [ ] `simple-icons` installed, lockfile updated
+- [ ] `plugins/models/components/brand-icon.tsx` exports `BrandIcon`
+- [ ] Renders `<svg>` for known slug, `<span>` chip for unknown/missing
+- [ ] `pnpm build` (or `pnpm tsc --noEmit`) clean — no TS errors from the deep imports
+- [ ] Bundle size check: nothing obviously catastrophic. Eyeball only, not a hard gate.
+- [ ] Tests: 4 cases (known slug renders path, unknown slug renders chip, empty text renders '?', bg color applied)
+
+**Commit:** `feat(models): BrandIcon component with simple-icons + first-letter fallback`
+
+---
+
+### T7 — feat(models): enriched models-page cards + Refresh + cache-age + banner
+
+**What:** The visible UI work. All changes scoped to the `tab === 'available'` block in `plugins/models/components/models-page.tsx` (lines ~590-640) plus a tab-header area for the Refresh button.
+
+**"Look first:** models-page.tsx is 808 lines; surgical edits, no full-page refactor. The tab content lives inside an `AnimatePresence`-style conditional block. Refresh button + cache-age indicator probably belong inside the `tab === 'available'` block's header (above the provider sections), not in the top-level page header.
+
+**UI additions:**
+1. **Refresh button + cache-age indicator** at top of `tab === 'available'`:
+   - Button disabled during in-flight request
+   - Spinner replaces icon while refreshing
+   - Text: `Last refreshed: 2m ago` (under 24h → relative; older → absolute date)
+2. **Gateway-out-of-sync banner** — pulled from `GET /gateway/status` on mount (`restartNeeded === true`):
+   - Amber background, inline `Restart gateway` button
+   - Only renders when flag is true
+3. **Provider header** now renders `<BrandIcon slug={providerBrandIconSlug} fallbackText={providerLabel ?? provider} fallbackColor={providerBrandColor} />` + `{providerLabel ?? provider.replace(/[-_]/g, ' ')}`
+4. **Model row** gains (when catalog match exists):
+   - Small `<BrandIcon>` next to name
+   - `description` as muted secondary line
+   - `bestFor` badge next to the tier badge
+   - `contextWindow` as mono-font small text next to name
+   - `costRange` right-aligned at end of row
+5. **Loading state** when fetch in-flight AND no cache yet: spinner + "Querying OpenClaw gateway — this can take up to 30 seconds on first load"
+6. **Error state** when fetch failed AND no cache: error message + Retry button (calls `POST /refresh`)
+
+**Files:**
+- Edit: `plugins/models/components/models-page.tsx` — surgical edits inside `tab === 'available'` block + a mount-time fetch for gateway-status
+- Optional new file: `plugins/models/components/model-card-row.tsx` if the enriched row JSX gets unwieldy inline (judgment call during implementation — prefer inline unless it hurts readability)
+
+**Acceptance:**
+- [ ] Refresh button triggers `POST /api/plugins/models/refresh` + updates UI
+- [ ] Cache-age indicator renders relative time for <24h, absolute date otherwise
+- [ ] Provider headers render `<BrandIcon>` + resolved label
+- [ ] Model rows with catalog match show description + bestFor badge + contextWindow + costRange
+- [ ] Model rows without catalog match show plain (existing) layout — no regression
+- [ ] First-ever load (no cache) shows loading state, not fake data
+- [ ] Fetch failure + no cache shows error + Retry button
+- [ ] Gateway-out-of-sync banner renders when `/gateway/status` reports `restartNeeded: true`
+- [ ] Existing model-selector UIs on other tabs (agents, aliases, profiles) render unchanged
+- [ ] `pnpm tsc --noEmit` clean; `pnpm vitest run` clean
+
+**Commit:** `feat(models): enriched cards + Refresh button + cache-age + gateway-sync banner`
+
+---
+
+### T8 — test(models): regression guards
+
+**What:** Comprehensive test pass for the loading/catalog flow. Existing test coverage at `tests/plugins/models/` is limited to `routes.test.ts`; expand to cover cache + enrichment + UI degradation cases that the earlier commits didn't lock down.
+
+**Files:**
+- Extend: `tests/plugins/models/routes.test.ts` — new cases for `/refresh`, cache stale flag, gateway-restart cache-clear
+- New: `tests/plugins/models/enrichment.test.ts` — mocked OpenClaw fixture → enriched `AvailableModel[]` with catalog fields; unknown ids have no enrichment; date-suffix-stripped match works end-to-end
+- New: `tests/plugins/models/models-page.test.tsx` — component-level regression: renders cache-age indicator, renders Refresh button, triggers refresh, shows loading state with no cache, shows error state on fetch failure, gateway-sync banner renders when flag present
+
+**Mocks required:** content-dir, logger, watcher, openclaw-client, tasks/flow-store (per CLAUDE.md), plus `use-agent-store` and any other cross-plugin hooks the page references.
+
+**Acceptance:**
+- [ ] New regression tests pass
+- [ ] Full `pnpm vitest run` clean (ignore pre-existing `@dagrejs/dagre` failures)
+- [ ] `pnpm tsc --noEmit` clean
+- [ ] Grep verifications (repeat from T3 for the final artifact): `fallbackModels` / `MODEL_CATALOG` / `ModelCatalogEntry` all zero hits
+
+**Commit:** `test(models): regression guards for cache + enrichment + loading UI`
+
+---
+
+### T9 — Ship
+
+- [ ] Manual smoke on maintainer's install:
+  - Delete `~/.bakin/plugin-settings/models/available.json` to force cold start
+  - Load `/models` → loading state appears briefly, then real data lands
+  - Click Refresh → spinner, then updated timestamp
+  - Trigger a gateway config change (edit `openclaw.json`, don't restart) → banner appears
+  - Click the banner's Restart button → banner clears, cache refreshes
+  - Verify enriched cards for `anthropic/claude-sonnet-4-6` show description + bestFor + cost range + logo
+  - Verify a non-catalog model (e.g. an OSS local) renders plain row without errors
+- [ ] `git push -u origin issue-129-models-loading-ux`
+- [ ] Open PR against `main`, reference #129, link spec + plugin-system one-pager
+- [ ] Merge when green
+- [ ] Close #129 with before/after summary
+- [ ] Archive `tasks/plan.md` + `tasks/todo.md` → `.claude/tasks/issue-129-{plan,todo}.md`
+
+## Commit strategy
+
+One PR, 9 implementation commits (T0 scaffold + T1–T8) plus any hotfix commits that show up during testing. Each commit self-contained: tsc clean, tests pass, no broken intermediate state. Intermediate commits must not break the models page — so T1 stops *calling* `fallbackModels()` but keeps the function defined until T3.
+
+## Risks / call-outs
+
+- **T1 disk-cache write contention.** If two server processes write concurrently, atomic tmp+rename prevents corruption but the later write wins. In practice Bakin is single-process per install, so this is theoretical. Flag only if we later support multi-process.
+- **T6 simple-icons bundle size.** If deep-imports don't tree-shake cleanly, client bundle swells by the full icon set (~1.5 MB). Worst case: do static imports for only the 10 brands we need (already planned), confirmed tree-shakable via deep paths. If bundle concern materializes, cut back to first-letter chips only and accept the loss of visual polish.
+- **T7 scope creep into a full models-page redesign.** The spec is crystal clear — surgical edits inside `tab === 'available'`. Don't touch other tabs. Don't reshape the page layout. If a visual tweak elsewhere is tempting, note it as a follow-up issue and move on.
+- **T8 test file sprawl.** Three new test files is a lot; if any feel redundant during writing, consolidate. The point is coverage, not file count.
+- **Pre-existing `@dagrejs/dagre` failures** in the test suite are unrelated and will still fail on this branch. Not a blocker; not introduced by #129.
+
+## Archival
+
+After merge, T9 moves `tasks/plan.md` + `tasks/todo.md` into `.claude/tasks/issue-129-{plan,todo}.md` — matches the `issue-115-`, `issue-118-`, `issue-125-` archival pattern already in that directory.

--- a/.claude/tasks/issue-129-todo.md
+++ b/.claude/tasks/issue-129-todo.md
@@ -1,0 +1,127 @@
+# TODO: Issue #129 — Models loading UX + curated catalog
+
+**Spec:** `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
+**Plan:** `tasks/plan.md`
+**Issue:** https://github.com/madeinwyo/bakin/issues/129
+**Branch:** `issue-129-models-loading-ux`
+
+## T0 — Branch + scaffold commit
+
+- [x] `git checkout -b issue-129-models-loading-ux`
+- [x] Close #128 with rationale
+- [x] Update `docs/ideas/plugin-system.md` to strike `models.providers`
+- [x] Write spec at `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
+- [x] Archive #125 tasks → `.claude/tasks/issue-125-{plan,todo}.md`
+- [x] Commit: `chore(issue-129): spec + plan scaffold`
+
+## T1 — feat(models): disk-backed cache + stale flag
+
+- [x] New file `plugins/models/lib/models-cache.ts` — `readPersistedCache()`, `writePersistedCache()`, `clearPersistedCache()` + zod validation on read
+- [x] Path: `getContentDir() + 'plugin-settings/models/available.json'`; atomic tmp+rename on write
+- [x] Extend `fetchAvailableModels()` in `plugins/models/index.ts`:
+  - In-memory hot read stays
+  - On in-memory miss → check disk → hydrate + return with `stale` flag
+  - On OpenClaw fetch success → write both caches
+  - On OpenClaw failure + no cache → return `{ models: [], cached: false, error }` (NOT `fallbackModels()`)
+- [x] Response shape gains `stale: boolean`; `AvailableModelsResponse` in `plugins/models/types.ts` gains optional field
+- [x] New test `tests/plugins/models/models-cache.test.ts` — round-trip, corrupt JSON returns null, missing file returns null, clear deletes
+- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
+- [x] Commit: `feat(models): disk-backed cache with stale flag`
+
+## T2 — feat(models): /refresh + gateway-restart invalidation
+
+- [x] New route: `POST /api/plugins/models/refresh`
+  - Bypasses cache
+  - Calls `loadConfiguredModelsFromOpenClaw`
+  - On success → write both caches
+  - On failure + disk cache exists → `{ ok: false, error, models: cachedModels, stale: true }`
+  - On failure + no cache → `{ ok: false, error, models: [] }`
+- [x] Extend `POST /gateway/restart` (`plugins/models/index.ts:647`):
+  - After successful restart, call `setModelsCache(null)` + `clearPersistedCache()`
+- [x] Extend `tests/plugins/models/routes.test.ts` — `/refresh` happy + failure paths; cache-clear on gateway restart
+- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [x] Commit: `feat(models): manual refresh endpoint + invalidate cache on gateway restart`
+
+## T3 — refactor(models): delete fallbackModels + MODEL_CATALOG dead code
+
+- [x] Remove `fallbackModels()` from `plugins/models/index.ts:252-259`
+- [x] Remove `MODEL_CATALOG` + `ModelCatalogEntry` from `plugins/models/types.ts:45-58`
+- [x] Verify greps all return zero:
+  - [ ] `grep -rn 'fallbackModels' plugins/models/` → 0 hits
+  - [ ] `grep -rn 'MODEL_CATALOG' plugins/` → 0 hits
+  - [ ] `grep -rn 'ModelCatalogEntry' plugins/` → 0 hits
+- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [x] Commit: `refactor(models): remove fallbackModels + MODEL_CATALOG dead code`
+
+## T4 — feat(models): curated catalog data module
+
+- [x] New file `plugins/models/data/known-models.ts` — interfaces + arrays + helpers
+- [x] `KnownModel` with: id, name, description?, bestFor?, tier?, contextWindow?, costRange?, kind, brandIconSlug?
+- [x] `KnownProvider` with: id, label, brandIconSlug?, brandColor?
+- [x] Seed:
+  - [ ] 4 Anthropic LLMs (haiku 4.5, sonnet 4.5, sonnet 4.6, opus 4.6)
+  - [ ] 3 OpenAI LLMs (gpt-5.4, gpt-5, gpt-4o)
+  - [ ] 2 Google LLMs (gemini 2.5 pro, gemini 2.5 flash)
+  - [ ] 2 Ollama LLMs (llama 3.3, qwen 2.5)
+  - [ ] 5 image: DALL-E 3, Imagen 4, Flux (pro), SDXL, Midjourney v6.1
+  - [ ] 5 video: Seedance, Kling 1.6, Runway Gen-3 Alpha, Sora, Veo 2
+  - [ ] 10 providers covering every model's `providerFromId` output with `brandIconSlug` + `brandColor`
+- [x] `getKnownModel(id)` — exact match, fallback to date-suffix-strip retry (`id.replace(/-\d{8}$/, '')`)
+- [x] `getKnownProvider(id)` — exact match only
+- [x] New test `tests/plugins/models/known-models.test.ts` — 5+ cases
+- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
+- [x] Commit: `feat(models): curated catalog of 22 popular models + providers`
+
+## T5 — feat(models): enrich AvailableModel from catalog
+
+- [x] Extend `AvailableModel` in `plugins/models/types.ts` with optional: description, bestFor, costRange, kind, brandIconSlug, providerLabel, providerBrandIconSlug, providerBrandColor
+- [x] Update `.map(...)` block in `loadConfiguredModelsFromOpenClaw` (around `plugins/models/index.ts:213`) to merge `getKnownModel(id)` + `getKnownProvider(providerFromId(id))`
+- [x] Extend `tests/plugins/models/routes.test.ts` with an enrichment regression — fixture OpenClaw response containing a known id produces enriched shape; unknown id falls back to `tierFromId` with no enrichment fields
+- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [x] Commit: `feat(models): enrich AvailableModel with curated catalog metadata`
+
+## T6 — feat(models): BrandIcon + simple-icons dep
+
+- [x] `pnpm add simple-icons`
+- [x] Verify deep import works: `cat node_modules/simple-icons/icons/openai.js` — should export `{ title, slug, path, hex, source }`
+- [x] New file `plugins/models/components/brand-icon.tsx`
+- [x] Import map of 10 brands: anthropic, openai, google, ollama, runway, stability, midjourney, bytedance, kuaishou, blackforestlabs
+- [x] Props: `slug?`, `fallbackText?`, `fallbackColor?`, `size?`, `className?`
+- [x] Known slug → SVG with `<path d={icon.path}/>` inside a `<svg viewBox="0 0 24 24">`
+- [x] Unknown slug / missing → first-letter chip with `fallbackColor` bg
+- [x] New test `tests/plugins/models/brand-icon.test.tsx` — 4 cases (known, unknown, empty, color-applied)
+- [x] Checkpoint: `pnpm tsc --noEmit` clean; bundle not catastrophically larger (eyeball only)
+- [x] Commit: `feat(models): BrandIcon component with simple-icons + first-letter fallback`
+
+## T7 — feat(models): models-page UI — Refresh, cache-age, banner, enriched cards
+
+- [x] Surgical edits inside `tab === 'available'` block (`plugins/models/components/models-page.tsx:590-640`)
+- [x] Mount-time fetch for `GET /gateway/status`; render amber banner when `restartNeeded: true`
+- [x] Top of tab: Refresh button (calls `POST /refresh`; disables during in-flight) + `Last refreshed: X ago` indicator
+- [x] Provider header: `<BrandIcon slug={providerBrandIconSlug} fallbackText={providerLabel ?? provider} fallbackColor={providerBrandColor} />` + label
+- [x] Model row: enriched layout when catalog fields present (description, bestFor badge, contextWindow, costRange), plain layout otherwise
+- [x] Loading state when fetch in-flight AND no cache yet: spinner + "Querying OpenClaw gateway — this can take up to 30 seconds on first load"
+- [x] Error state when fetch failed AND no cache: error message + Retry button
+- [x] Smoke: load `/models/?tab=available` → enriched cards for Anthropic/OpenAI; plain rows for anything else
+- [x] Other tabs (agents, aliases, profiles) render unchanged
+- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [x] Commit: `feat(models): enriched cards + Refresh button + cache-age + gateway-sync banner`
+
+## T8 — test(models): regression guards
+
+- [x] Extend `tests/plugins/models/routes.test.ts`: `/refresh` path, `/available` stale flag, gateway-restart cache-clear
+- [x] New `tests/plugins/models/enrichment.test.ts`: enriched `AvailableModel[]` for known ids, plain for unknown, date-suffix-strip match end-to-end
+- [x] New `tests/plugins/models/models-page.test.tsx`: cache-age indicator renders, Refresh button triggers `/refresh`, loading state with no cache, error state on fetch fail, gateway-sync banner renders on flag
+- [x] All required mocks per CLAUDE.md (content-dir, logger, watcher, openclaw-client, tasks/flow-store, cross-plugin hooks)
+- [x] Grep verifications repeat (zero hits): fallbackModels, MODEL_CATALOG, ModelCatalogEntry
+- [x] Checkpoint: full `pnpm vitest run` + `pnpm tsc --noEmit` clean (ignore pre-existing dagre failures)
+- [x] Commit: `test(models): regression guards for cache + enrichment + loading UI`
+
+## T9 — Ship
+
+- [x] `git push -u origin issue-129-models-loading-ux`
+- [x] Open PR #131 against `main`, reference #129, link spec + plugin-system one-pager
+- [ ] Manual smoke on the other machine (cache wipe → loading → refresh → banner flow)
+- [ ] Merge when smoke passes
+- [ ] Close #129 with before/after summary
+- [ ] Archive `tasks/plan.md` + `tasks/todo.md` → `.claude/tasks/issue-129-{plan,todo}.md`

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -231,6 +231,52 @@ export interface NotificationChannelDef extends PluginNotificationChannelInput {
   pluginId?: string
 }
 
+// ---------------------------------------------------------------------------
+// Health check registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical result shape for a single doctor check row. Shape-identical to
+ * the existing `DiagnosticResult` in `src/core/doctor.ts` — they will be
+ * collapsed into this one name once all builtin checks migrate out of core
+ * (see follow-up tracked alongside #137).
+ */
+export interface HealthCheckResult {
+  check: string
+  status: 'ok' | 'warn' | 'error' | 'fixed'
+  message: string
+  autoFixable: boolean
+}
+
+/**
+ * Input shape plugins pass to `ctx.registerHealthCheck`. The plugin id is
+ * auto-namespaced as `{pluginId}.{id}`. `run()` returns an array so one
+ * registered check can contribute multiple result rows (mirrors how the
+ * existing `checkPersonas` returns one per agent).
+ */
+export interface PluginHealthCheckInput {
+  id: string
+  name: string
+  /**
+   * Runs the check, returns any number of result rows. Throws/rejects are
+   * caught by the doctor orchestrator and converted to a synthetic error
+   * result — a single bad handler never crashes the sweep.
+   */
+  run: () => Promise<HealthCheckResult[]>
+  /**
+   * Advisory flag for admin UIs: `true` if `run()` may perform safe
+   * auto-fixes internally. Pure metadata in v1 — the orchestrator always
+   * invokes every registered check regardless of this value. Plugins that
+   * do internal auto-fixes gate on `getSettings().doctor.*` themselves.
+   */
+  autoFix?: boolean
+}
+
+export interface HealthCheckDef extends PluginHealthCheckInput {
+  runtime: 'plugin'
+  pluginId: string
+}
+
 export interface PluginContext {
   storage: StorageAdapter
   events: EventBus
@@ -265,6 +311,13 @@ export interface PluginContext {
    * via the registry module's lazy self-seed.
    */
   registerNotificationChannel(def: PluginNotificationChannelInput): string
+  /**
+   * Register a health check owned by this plugin. The id is auto-namespaced
+   * to `{pluginId}.{id}`. `run()` is invoked during every `runDiagnostics()`
+   * sweep — throws are isolated, a single bad check never crashes the
+   * doctor. Returns the namespaced id.
+   */
+  registerHealthCheck(def: PluginHealthCheckInput): string
   watchFiles(patterns: string[]): void
   /** Read this plugin's persisted settings */
   getSettings<T = Record<string, unknown>>(): T

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -12,6 +12,11 @@ import { getSettings } from '../../src/core/settings'
 import { getContentDir } from '../../src/core/content-dir'
 import { getSearchHealth } from '../../src/core/search-registry'
 import { getUsageFeed, getErrorCount, getStatsByMs, WINDOW_MS, type UsageKind, type WindowKey } from '../../src/core/usage'
+import {
+  listHealthChecks,
+  getHealthCheck,
+  type HealthCheckDef,
+} from './lib/health-check-registry'
 // Registry accessors live on globalThis because Next.js API routes get
 // separate webpack-compiled module instances with empty Maps. The custom
 // server (server.ts) registers the real accessors after plugin init.
@@ -55,6 +60,32 @@ const healthPlugin: BakinPlugin = {
   contentFiles: [],
 
   activate(ctx: PluginContext) {
+    // ─── Health-check registry hooks + route ─────────────────────────
+    // `run` is not serializable and isn't useful to consumers that only
+    // want registry metadata. Strip it at the boundary.
+    const stripRun = (def: HealthCheckDef) => ({
+      id: def.id,
+      name: def.name,
+      pluginId: def.pluginId,
+      autoFix: !!def.autoFix,
+    })
+
+    ctx.hooks.register('health.listChecks', () => listHealthChecks().map(stripRun))
+    ctx.hooks.register('health.getCheck', (d: Record<string, unknown>) => {
+      const def = getHealthCheck(d.id as string)
+      return def ? stripRun(def) : null
+    })
+
+    ctx.registerRoute({
+      path: '/checks',
+      method: 'GET',
+      description: 'List registered plugin health checks (metadata only; does not execute them).',
+      handler: async () => new Response(
+        JSON.stringify({ checks: listHealthChecks().map(stripRun) }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    })
+
     // Aggregated health summary
     ctx.registerRoute({
       path: '/summary',

--- a/plugins/health/lib/health-check-registry.ts
+++ b/plugins/health/lib/health-check-registry.ts
@@ -1,0 +1,76 @@
+/**
+ * Health-check registry — plugin-contributed doctor checks.
+ *
+ * Core doctor checks in `src/core/doctor.ts` stay as direct calls inside
+ * `runDiagnostics()`. This registry is purely for plugin contributions —
+ * no builtin self-seeding. Plugins register their checks via
+ * `ctx.registerHealthCheck()` in `activate()`; the orchestrator iterates
+ * this Map at the end of each doctor pass and appends per-plugin results
+ * alongside the builtin sweep.
+ *
+ * Per-check try/catch lives in the orchestrator, not here — this module
+ * is a pure data store.
+ */
+import type {
+  HealthCheckDef,
+  PluginHealthCheckInput,
+} from '../../../packages/core/src/plugin-types'
+
+export type { HealthCheckDef, PluginHealthCheckInput }
+
+// ─── Registry store ─────────────────────────────────────────────────────────
+
+const registry = new Map<string, HealthCheckDef>()
+
+export function registerHealthCheck(def: HealthCheckDef): void {
+  if (registry.has(def.id)) {
+    throw new Error(`Health check "${def.id}" is already registered`)
+  }
+  registry.set(def.id, def)
+}
+
+export function getHealthCheck(id: string): HealthCheckDef | undefined {
+  return registry.get(id)
+}
+
+export function listHealthChecks(): HealthCheckDef[] {
+  return Array.from(registry.values())
+}
+
+/** Remove a single registration. Useful for test cleanup. */
+export function unregisterHealthCheck(id: string): void {
+  registry.delete(id)
+}
+
+/** Remove every check owned by a plugin. Called at plugin teardown / hot reload. */
+export function unregisterPluginHealthChecks(pluginId: string): void {
+  for (const [id, def] of registry.entries()) {
+    if (def.pluginId === pluginId) {
+      registry.delete(id)
+    }
+  }
+}
+
+// ─── Plugin-side registration helper ────────────────────────────────────────
+
+/**
+ * Register a plugin-owned health check. The id is auto-namespaced to
+ * `{pluginId}.{id}` so two plugins can ship the same unprefixed id
+ * without colliding. Returns the namespaced id so callers can reference
+ * it from downstream code and tests.
+ */
+export function registerPluginHealthCheck(
+  pluginId: string,
+  input: PluginHealthCheckInput,
+): string {
+  const namespacedId = `${pluginId}.${input.id}`
+  registerHealthCheck({
+    runtime: 'plugin',
+    pluginId,
+    id: namespacedId,
+    name: input.name,
+    run: input.run,
+    autoFix: input.autoFix,
+  })
+  return namespacedId
+}

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -17,6 +17,11 @@ import {
   getNotificationChannel,
   listNotificationChannels,
 } from './lib/notification-channel-registry'
+import {
+  checkWorkflowDefinitions,
+  checkStaleWorkflowInstances,
+  checkWorkflowSkills,
+} from './lib/health-checks'
 import { isReadOnly, getDefinition as getRegistryDefinition } from './lib/source-registry'
 import {
   createInstance,
@@ -458,6 +463,24 @@ const workflowsPlugin: BakinPlugin = {
         JSON.stringify({ channels: listNotificationChannels() }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
+    })
+
+    // ─── Health checks (migrated out of core/doctor.ts per #137) ─────
+    ctx.registerHealthCheck({
+      id: 'definitions',
+      name: 'Workflow definition integrity',
+      run: () => checkWorkflowDefinitions(getContentDir()),
+    })
+    ctx.registerHealthCheck({
+      id: 'stale-instances',
+      name: 'Stale workflow instances',
+      autoFix: true,
+      run: () => checkStaleWorkflowInstances(getContentDir()),
+    })
+    ctx.registerHealthCheck({
+      id: 'skills',
+      name: 'Workflow skills validation',
+      run: async () => checkWorkflowSkills(getContentDir()),
     })
 
     // ─── Template Routes ──────────────────────────────────────────────

--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -1,0 +1,181 @@
+/**
+ * Workflow-plugin-owned doctor checks.
+ *
+ * Migrated out of src/core/doctor.ts (#137) — these three functions
+ * operate on workflow-plugin data (definitions, instances, skills) so
+ * they belong with the plugin that owns that data model.
+ *
+ * Registered in plugins/workflows/index.ts activate() via
+ * ctx.registerHealthCheck. runDiagnostics() picks them up through the
+ * plugin-check loop in src/core/doctor.ts's runPluginHealthChecks().
+ */
+import { existsSync, readFileSync, readdirSync, unlinkSync } from 'fs'
+import { join } from 'path'
+
+import { getSettings } from '../../../src/core/settings'
+import { getHookRegistry } from '../../../src/lib/plugin-registry'
+import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
+
+import { listDefinitions } from './parser'
+import { listInstances } from './runtime'
+
+// ─── Result constructors (inlined; eventual migration target) ─────────────
+
+function ok(check: string, message: string): HealthCheckResult {
+  return { check, status: 'ok', message, autoFixable: false }
+}
+function warn(check: string, message: string, autoFixable = false): HealthCheckResult {
+  return { check, status: 'warn', message, autoFixable }
+}
+function fixed(check: string, message: string): HealthCheckResult {
+  return { check, status: 'fixed', message, autoFixable: true }
+}
+
+// ─── Workflow skills: YAML + output_schema check ──────────────────────────
+
+/**
+ * Scan `{contentDir}/workflows/skills/*.md` for missing YAML frontmatter or
+ * missing `output_schema`. Warnings-only — no auto-fix.
+ */
+export function checkWorkflowSkills(contentDir: string): HealthCheckResult[] {
+  const results: HealthCheckResult[] = []
+  const skillsDir = join(contentDir, 'workflows', 'skills')
+
+  if (!existsSync(skillsDir)) return results
+
+  try {
+    const files = readdirSync(skillsDir).filter(f => f.endsWith('.md'))
+    for (const file of files) {
+      try {
+        const content = readFileSync(join(skillsDir, file), 'utf-8')
+        const match = content.match(/^---\n([\s\S]*?)\n---/)
+        if (!match) {
+          results.push(warn('workflow-skills', `Skill ${file} has no YAML frontmatter — output will not be validated`))
+          continue
+        }
+        if (!content.includes('output_schema')) {
+          results.push(warn('workflow-skills', `Skill ${file} has no output_schema — step output will not be validated server-side`))
+        }
+      } catch {
+        results.push(warn('workflow-skills', `Could not read skill file: ${file}`))
+      }
+    }
+  } catch {
+    // skills dir exists but can't be read
+  }
+
+  if (results.length === 0) {
+    results.push(ok('workflow-skills', 'All workflow skills have output_schema'))
+  }
+
+  return results
+}
+
+// ─── Workflow definitions: skill reference integrity ──────────────────────
+
+/**
+ * Verify every step `skill:` reference in every workflow definition resolves
+ * to an existing skill file. Walks builtin + parallel children.
+ */
+export async function checkWorkflowDefinitions(contentDir: string): Promise<HealthCheckResult[]> {
+  const results: HealthCheckResult[] = []
+  const skillsDir = join(contentDir, 'workflows', 'skills')
+
+  try {
+    const defs = listDefinitions(contentDir)
+    for (const { name, definition } of defs) {
+      for (const step of definition.steps) {
+        const skillName = (step as { skill?: string }).skill
+        if (skillName && !existsSync(join(skillsDir, `${skillName}.md`))) {
+          results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" references skill "${skillName}" which does not exist`))
+        }
+        // Check parallel children too
+        if ((step as { type?: string }).type === 'parallel' && 'steps' in step) {
+          for (const child of (step as { steps: Array<{ id: string; skill?: string }> }).steps) {
+            if (child.skill && !existsSync(join(skillsDir, `${child.skill}.md`))) {
+              results.push(warn('workflow-definitions', `Workflow "${name}" parallel step "${child.id}" references skill "${child.skill}" which does not exist`))
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // No definitions or parser error — non-fatal
+  }
+
+  if (results.length === 0) {
+    results.push(ok('workflow-definitions', 'All workflow skill references resolve'))
+  }
+
+  return results
+}
+
+// ─── Stale / orphaned workflow instances ──────────────────────────────────
+
+/**
+ * Flag in-progress instances stuck > 2 hours, and orphaned instances whose
+ * tasks no longer exist on the board. `autoFix` is read from settings (no
+ * longer a parameter) — matches the core doctor pattern.
+ *
+ * `tasks.readTaskboard` stays as a cross-plugin hook call (tasks plugin owns
+ * the taskboard; we can't import directly without creating a circular dep).
+ */
+export async function checkStaleWorkflowInstances(contentDir: string): Promise<HealthCheckResult[]> {
+  const results: HealthCheckResult[] = []
+  const autoFix = getSettings().doctor.autoFixSkill
+  const hooks = getHookRegistry()
+
+  try {
+    const allInstances = listInstances(undefined, contentDir)
+
+    interface BoardTask { id: string }
+    const board = await hooks.invoke<{ columns: Record<string, BoardTask[]> }>('tasks.readTaskboard', {})
+    if (!board) return [warn('workflow-instances', 'Taskboard not available')]
+    const { columns } = board
+    const allTaskIds = new Set<string>()
+    for (const col of Object.values(columns)) {
+      for (const task of col) {
+        allTaskIds.add(task.id)
+      }
+    }
+
+    const now = Date.now()
+    const staleThreshold = 2 * 60 * 60 * 1000 // 2 hours
+
+    for (const instance of allInstances) {
+      // Orphaned instance — task deleted from board
+      if (!allTaskIds.has(instance.taskId)) {
+        if (autoFix) {
+          const instancePath = join(contentDir, 'workflows', 'instances', `${instance.taskId}.json`)
+          try {
+            unlinkSync(instancePath)
+            results.push(fixed('workflow-instances', `Removed orphaned workflow instance for deleted task "${instance.taskId}"`))
+          } catch {
+            results.push(warn('workflow-instances', `Orphaned workflow instance for deleted task "${instance.taskId}" — could not remove`))
+          }
+        } else {
+          results.push(warn('workflow-instances', `Orphaned workflow instance for deleted task "${instance.taskId}" — task no longer on board`, true))
+        }
+        continue
+      }
+
+      // Stale in-progress instances
+      if (instance.status !== 'in_progress') continue
+      const updated = new Date(instance.updatedAt).getTime()
+      if (isNaN(updated)) continue
+      const age = now - updated
+      if (age > staleThreshold) {
+        const hours = Math.round(age / (60 * 60 * 1000) * 10) / 10
+        results.push(warn('workflow-instances', `Workflow instance for task "${instance.taskId}" has been in_progress on step "${instance.currentStepId}" for ${hours}h with no updates`))
+      }
+    }
+  } catch {
+    // No instances directory — non-fatal
+  }
+
+  if (results.length === 0) {
+    results.push(ok('workflow-instances', 'No stale workflow instances'))
+  }
+
+  return results
+}

--- a/src/app/api/plugins/[pluginId]/[[...path]]/route.ts
+++ b/src/app/api/plugins/[pluginId]/[[...path]]/route.ts
@@ -158,6 +158,7 @@ function ensureInitialized() {
       registerWorkflow: () => {},
       registerNodeType: (def) => `${plugin.id}.${def.kind}`,
       registerNotificationChannel: (def) => `${plugin.id}.${def.id}`,
+      registerHealthCheck: (def) => `${plugin.id}.${def.id}`,
       watchFiles: () => {},
       ...buildCtxExtras(plugin.id, registerRoute),
     }
@@ -225,6 +226,7 @@ function buildContext(pluginId: string): PluginContext {
     registerWorkflow: () => {},
     registerNodeType: (def) => `${pluginId}.${def.kind}`,
     registerNotificationChannel: (def) => `${pluginId}.${def.id}`,
+    registerHealthCheck: (def) => `${pluginId}.${def.id}`,
     watchFiles: () => {},
     ...buildCtxExtras(pluginId, noopRegisterRoute),
   }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1123,143 +1123,6 @@ export function applyAllManagedBlocks(autoFix: boolean): DiagnosticResult[] {
 // Workflow health checks
 // ---------------------------------------------------------------------------
 
-/**
- * Workflow skills: warn if skills referenced by workflow steps are missing output_schema.
- * Without output_schema, server-side validation is bypassed.
- */
-function checkWorkflowSkills(contentDir: string): DiagnosticResult[] {
-  const results: DiagnosticResult[] = []
-  const skillsDir = join(contentDir, 'workflows', 'skills')
-
-  if (!existsSync(skillsDir)) return results
-
-  try {
-    const files = readdirSync(skillsDir).filter(f => f.endsWith('.md'))
-    for (const file of files) {
-      try {
-        const content = readFileSync(join(skillsDir, file), 'utf-8')
-        const match = content.match(/^---\n([\s\S]*?)\n---/)
-        if (!match) {
-          results.push(warn('workflow-skills', `Skill ${file} has no YAML frontmatter — output will not be validated`))
-          continue
-        }
-        if (!content.includes('output_schema')) {
-          results.push(warn('workflow-skills', `Skill ${file} has no output_schema — step output will not be validated server-side`))
-        }
-      } catch {
-        results.push(warn('workflow-skills', `Could not read skill file: ${file}`))
-      }
-    }
-  } catch {
-    // skills dir exists but can't be read
-  }
-
-  if (results.length === 0) {
-    results.push(ok('workflow-skills', 'All workflow skills have output_schema'))
-  }
-
-  return results
-}
-
-/**
- * Workflow definitions: verify all step skill references resolve to existing skill files.
- */
-async function checkWorkflowDefinitions(contentDir: string): Promise<DiagnosticResult[]> {
-  const results: DiagnosticResult[] = []
-  const skillsDir = join(contentDir, 'workflows', 'skills')
-
-  try {
-    const defs = await getHookRegistry().invoke<Array<{ name: string; definition: { steps: Array<Record<string, unknown>> } }>>('workflows.listDefinitions', {}) ?? []
-    for (const { name, definition } of defs) {
-      for (const step of definition.steps) {
-        const skillName = (step as { skill?: string }).skill
-        if (skillName && !existsSync(join(skillsDir, `${skillName}.md`))) {
-          results.push(warn('workflow-definitions', `Workflow "${name}" step "${step.id}" references skill "${skillName}" which does not exist`))
-        }
-        // Check parallel children too
-        if (step.type === 'parallel' && 'steps' in step) {
-          for (const child of (step as { steps: Array<{ id: string; skill?: string }> }).steps) {
-            if (child.skill && !existsSync(join(skillsDir, `${child.skill}.md`))) {
-              results.push(warn('workflow-definitions', `Workflow "${name}" parallel step "${child.id}" references skill "${child.skill}" which does not exist`))
-            }
-          }
-        }
-      }
-    }
-  } catch {
-    // No definitions or parser error — non-fatal
-  }
-
-  if (results.length === 0) {
-    results.push(ok('workflow-definitions', 'All workflow skill references resolve'))
-  }
-
-  return results
-}
-
-/**
- * Stale workflow instances: flag instances stuck in_progress for > 2 hours.
- */
-async function checkStaleWorkflowInstances(contentDir: string, autoFix: boolean): Promise<DiagnosticResult[]> {
-  const results: DiagnosticResult[] = []
-  const hooks = getHookRegistry()
-
-  try {
-    // Check all instances (not just in_progress) for orphans
-    interface WfInstance { taskId: string; status: string; currentStepId: string; updatedAt: string }
-    const allInstances = await hooks.invoke<WfInstance[]>('workflows.listInstances', {}) ?? []
-    interface BoardTask { id: string }
-    const board = await hooks.invoke<{ columns: Record<string, BoardTask[]> }>('tasks.readTaskboard', {})
-    if (!board) { return [warn('workflow-instances', 'Taskboard not available')] }
-    const { columns } = board
-    const allTaskIds = new Set<string>()
-    for (const col of Object.values(columns)) {
-      for (const task of col) {
-        allTaskIds.add(task.id)
-      }
-    }
-
-    const now = Date.now()
-    const staleThreshold = 2 * 60 * 60 * 1000 // 2 hours
-
-    for (const instance of allInstances) {
-      // Check for orphaned instances — task deleted from board
-      if (!allTaskIds.has(instance.taskId)) {
-        if (autoFix) {
-          const instancePath = join(contentDir, 'workflows', 'instances', `${instance.taskId}.json`)
-          try {
-            const { unlinkSync } = require('fs')
-            unlinkSync(instancePath)
-            results.push(fixed('workflow-instances', `Removed orphaned workflow instance for deleted task "${instance.taskId}"`))
-          } catch {
-            results.push(warn('workflow-instances', `Orphaned workflow instance for deleted task "${instance.taskId}" — could not remove`))
-          }
-        } else {
-          results.push(warn('workflow-instances', `Orphaned workflow instance for deleted task "${instance.taskId}" — task no longer on board`, true))
-        }
-        continue
-      }
-
-      // Check for stale in_progress instances
-      if (instance.status !== 'in_progress') continue
-      const updated = new Date(instance.updatedAt).getTime()
-      if (isNaN(updated)) continue
-      const age = now - updated
-      if (age > staleThreshold) {
-        const hours = Math.round(age / (60 * 60 * 1000) * 10) / 10
-        results.push(warn('workflow-instances', `Workflow instance for task "${instance.taskId}" has been in_progress on step "${instance.currentStepId}" for ${hours}h with no updates`))
-      }
-    }
-  } catch {
-    // No instances directory — non-fatal
-  }
-
-  if (results.length === 0) {
-    results.push(ok('workflow-instances', 'No stale workflow instances'))
-  }
-
-  return results
-}
 
 // ---------------------------------------------------------------------------
 // Assets
@@ -1746,9 +1609,9 @@ export async function runDiagnostics(
   results.push(...checkAndSyncSkill(projectRoot, autoFix))
   results.push(...await checkOrchestratorRules(autoFix))
   results.push(...applyAllManagedBlocks(autoFix))
-  results.push(...checkWorkflowSkills(contentDir))
-  results.push(...await checkWorkflowDefinitions(contentDir))
-  results.push(...await checkStaleWorkflowInstances(contentDir, autoFix))
+  // Workflow checks (definitions / stale-instances / skills) now live in
+  // plugins/workflows/lib/health-checks.ts and are picked up via the
+  // plugin-check loop at the end of this function (#137).
   results.push(...await checkTaskConsistency(contentDir, autoFix))
   results.push(...checkAssets(contentDir, autoFix))
   results.push(...checkScheduleSync(autoFix))

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -24,6 +24,34 @@ import { pluginAssetsComponent } from './onboarding/plugin-assets'
 import { getMainAgentId, getMainAgentName } from './main-agent'
 import { getAllExecTools } from '../../scripts/lib/registry'
 import { getHookRegistry } from '../lib/plugin-registry'
+import { listHealthChecks } from '../../plugins/health/lib/health-check-registry'
+
+/**
+ * Run every plugin-registered health check in parallel. Per-check try/catch
+ * isolates failures — a single bad handler yields one synthetic error result
+ * and never crashes the doctor sweep. Exported separately from runDiagnostics
+ * so the isolation behavior can be tested without mocking every builtin
+ * check's dependency tree.
+ */
+export async function runPluginHealthChecks(): Promise<DiagnosticResult[]> {
+  const defs = listHealthChecks()
+  const arrays = await Promise.all(
+    defs.map(async (def) => {
+      try {
+        return await def.run()
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return [{
+          check: def.id,
+          status: 'error' as const,
+          message: `Plugin health check threw: ${message}`,
+          autoFixable: false,
+        }]
+      }
+    }),
+  )
+  return arrays.flat()
+}
 
 const log = createLogger('doctor')
 
@@ -1736,6 +1764,10 @@ export async function runDiagnostics(
     checkPluginAssets(),
   ])
   results.push(...gatewayResults, ...antflyResults, ...searchTableResults, ...pluginAssetsResults)
+
+  // Plugin-contributed health checks (#137). Results appended to the same
+  // list as builtins; the UI groups by status so ordering doesn't matter.
+  results.push(...await runPluginHealthChecks())
 
   // Summarize
   const errors = results.filter(r => r.status === 'error').length

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -234,6 +234,9 @@ class PluginRegistryImpl {
           return `${pluginId}.${def.id}`
         }
       },
+      // T3 wires this through the real registry. Interim stub keeps the
+      // PluginContext interface satisfied so T1/T2 commits build cleanly.
+      registerHealthCheck: (def) => `${pluginId}.${def.id}`,
       watchFiles: (patterns: string[]) => { state.watchPatterns.push(...patterns) },
       getSettings: <T = Record<string, unknown>>(): T => {
         const settingsPath = join(getContentDir(), 'plugin-settings', `${pluginId}.json`)

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -26,7 +26,14 @@ import {
   registerPluginNotificationChannel,
   unregisterPluginNotificationChannels,
 } from '../../plugins/workflows/lib/notification-channel-registry'
-import type { PluginNotificationChannelInput } from '@bakin/core/plugin-types'
+import {
+  registerPluginHealthCheck,
+  unregisterPluginHealthChecks,
+} from '../../plugins/health/lib/health-check-registry'
+import type {
+  PluginNotificationChannelInput,
+  PluginHealthCheckInput,
+} from '@bakin/core/plugin-types'
 import { registerRouteDoc } from '../core/api-docs'
 import { addExecTool } from '../../scripts/lib/registry'
 import { runMigrations } from '../core/migrations'
@@ -59,6 +66,8 @@ interface PluginState {
   nodeKinds: string[]
   /** Namespaced notification channel ids registered via ctx.registerNotificationChannel. */
   channelIds: string[]
+  /** Namespaced health check ids registered via ctx.registerHealthCheck. */
+  healthCheckIds: string[]
 }
 
 /** Slug a workflow definition `name` into a stable id when no `id` is supplied. */
@@ -234,9 +243,19 @@ class PluginRegistryImpl {
           return `${pluginId}.${def.id}`
         }
       },
-      // T3 wires this through the real registry. Interim stub keeps the
-      // PluginContext interface satisfied so T1/T2 commits build cleanly.
-      registerHealthCheck: (def) => `${pluginId}.${def.id}`,
+      registerHealthCheck: (def: PluginHealthCheckInput): string => {
+        try {
+          const namespacedId = registerPluginHealthCheck(pluginId, def)
+          state.healthCheckIds.push(namespacedId)
+          return namespacedId
+        } catch (err) {
+          log.error(
+            `registerHealthCheck collision in plugin "${pluginId}" for id "${def.id}"`,
+            err as Error,
+          )
+          return `${pluginId}.${def.id}`
+        }
+      },
       watchFiles: (patterns: string[]) => { state.watchPatterns.push(...patterns) },
       getSettings: <T = Record<string, unknown>>(): T => {
         const settingsPath = join(getContentDir(), 'plugin-settings', `${pluginId}.json`)
@@ -329,6 +348,7 @@ class PluginRegistryImpl {
         watchPatterns: [],
         nodeKinds: [],
         channelIds: [],
+        healthCheckIds: [],
       }
 
       const ctx = this.buildContext(plugin.id, state, storage, events)
@@ -374,6 +394,7 @@ class PluginRegistryImpl {
             console.log(`  ↻ User plugin overrides built-in: ${pluginId}`)
             unregisterPluginNodeTypes(pluginId)
             unregisterPluginNotificationChannels(pluginId)
+            unregisterPluginHealthChecks(pluginId)
             this.plugins.delete(pluginId)
           }
 
@@ -397,6 +418,7 @@ class PluginRegistryImpl {
             watchPatterns: [],
             nodeKinds: [],
             channelIds: [],
+            healthCheckIds: [],
           }
 
           const ctx = this.buildContext(plugin.id, state, storage, events)

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -44,4 +44,7 @@ export type {
   PluginNodeTypeInput,
   PluginNotificationChannelInput,
   NotificationChannelDef,
+  HealthCheckResult,
+  PluginHealthCheckInput,
+  HealthCheckDef,
 } from '@bakin/core/plugin-types'

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,379 +1,348 @@
-# Plan — Issue #129: Models loading UX + curated catalog
+# Plan — Issue #137: Health Checks Registry
 
-**Spec:** `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
-**Issue:** https://github.com/madeinwyo/bakin/issues/129
-**Branch:** `issue-129-models-loading-ux`
-**Replaces:** closed #128 (plugin-contributed models registry — premature abstraction)
+**Spec:** `.claude/specs/issue-137-health-checks-registry.md`
+**Issue:** https://github.com/madeinwyo/bakin/issues/137
+**Branch:** `issue-137-health-checks-registry`
+**Precedent to mirror:** `workflows.notificationChannels` (#125 / PR #126) — same registry shape, same wiring, same teardown.
 
 ## Goal
 
-Kill `fallbackModels()` (the 15-second cold-start lie) by moving model data to a persistent disk cache, and while we're in there, ship the curated catalog + brand icons + enriched UI that makes the models page actually useful. One PR, two user-visible wins: honest loading states + rich model cards.
+Land the 4th Registry Extension Point from `docs/ideas/plugin-system.md`: `health.checks`. Core surface + plugin-registry wiring + orchestrator integration, with the workflows-plugin migration as the forcing-function proof. Pattern is validated the moment three existing core checks move into their owning plugin without breaking the doctor dashboard.
 
 ## Dependency graph
 
 ```
-T0 scaffold (archive #125 tasks, write this plan + todo)
+T0 scaffold (archive #129 tasks, commit spec + plan + todo)
   │
   ▼
-T1 disk cache + stale flag ...................... (foundation)
+T1 core types + ctx stubs .................... (foundation for everything)
   │
   ▼
-T2 /refresh route + gateway-restart invalidation . (depends on T1)
+T2 health-check-registry store ................ (depends on T1 types)
   │
   ▼
-T3 delete fallbackModels + MODEL_CATALOG dead code (depends on T1 so nothing still calls fallback)
+T3 plugin-registry wiring + teardown ........... (depends on T2; replaces T1 stub)
+  │                                                       ↓
+  ▼                                              Checkpoint: registry usable
+T4 health plugin hooks + REST route ............ (depends on T2; parallel-safe with T5)
   │
   ▼
-T4 curated catalog data module ................... (independent; new data, no consumers yet)
+T5 orchestrator integration in doctor.ts ....... (depends on T2; can land before or after T4)
+  │                                                       ↓
+  ▼                                              Checkpoint: plugin checks execute
+T6 workflows migration (3 checks) .............. (depends on T3 + T5)
+  │                                                       ↓
+  ▼                                              Checkpoint: migration complete
+T7 regression gap-fill tests
   │
   ▼
-T5 enrich AvailableModel from catalog ............ (depends on T4)
-  │
-  ▼
-T6 BrandIcon component + simple-icons dep ........ (independent; sets up the icon surface T7 uses)
-  │
-  ▼
-T7 enriched models-page cards + Refresh + banner . (needs T5 fields + T6 icons)
-  │
-  ▼
-T8 regression tests (full coverage pass)
-  │
-  ▼
-T9 ship
+T8 ship
 ```
 
-Solo sequential. Each task = one commit. Intermediate commits must build and pass tests — no broken-main moments.
+Solo sequential in practice. Each commit builds and passes tests — interim stubs in T1 exist specifically to keep tsc green across T1–T3.
 
 ## Task detail
 
-### T0 — chore(issue-129): spec + plan scaffold
+### T0 — chore(issue-137): spec + plan scaffold
 
-**Already done:**
-- Branch `issue-129-models-loading-ux` created from `main`
-- Issue #128 closed with rationale (plugin-registry for models is premature)
-- `docs/ideas/plugin-system.md` updated to strike `models.providers` from the registry list
-- Spec written at `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
+**Status:** partial. Branch + spec exist uncommitted. `tasks/*.md` still holds #129 content.
 
-**Still to do (this task):**
-- Archive issue-125 tasks → `.claude/tasks/issue-125-{plan,todo}.md`
-- Write this `tasks/plan.md` + `tasks/todo.md`
-- One commit bundling all scaffolding
+**Steps:**
+- Archive `tasks/plan.md` + `tasks/todo.md` (#129 content) → `.claude/tasks/issue-129-{plan,todo}.md` via `git mv`
+- Commit staged renames + spec + this plan + todo together
 
 **Acceptance:**
-- [ ] `tasks/plan.md` + `tasks/todo.md` present, scoped to #129
-- [ ] `.claude/tasks/issue-125-{plan,todo}.md` present with #125's final state
-- [ ] Commit message: `chore(issue-129): spec + plan scaffold`
+- [ ] `.claude/tasks/issue-129-{plan,todo}.md` present with #129 content
+- [ ] `tasks/plan.md` + `tasks/todo.md` contain this new #137 content
+- [ ] `.claude/specs/issue-137-health-checks-registry.md` committed
+- [ ] `git status` clean after commit
+
+**Commit:** `chore(issue-137): spec + plan scaffold`
 
 ---
 
-### T1 — feat(models): disk-backed cache + stale flag
+### T1 — feat(core): HealthCheckResult types + PluginContext.registerHealthCheck
 
-**What:** Move model cache persistence from in-memory-only to in-memory + disk. Response gains `stale: boolean`.
+**Shape changes:**
+- `packages/core/src/plugin-types.ts` — add `HealthCheckResult`, `PluginHealthCheckInput`, `HealthCheckDef` types (per spec §Design)
+- Add `registerHealthCheck(def: PluginHealthCheckInput): string` method to `PluginContext`
+- `src/lib/plugin-types.ts` — extend re-export list
 
-**"Look first":** the existing cache at `plugins/models/index.ts:149-157` uses `globalThis.__bakinModelsCache`. Keep it as the hot-read layer; disk is underneath. Do NOT rip out the globalThis pattern.
+**Interim stubs** (keep tsc green until T3 wires the real path):
+All 8 `PluginContext`-literal sites get `registerHealthCheck: (def) => \`${pluginId}.${def.id}\`` (or `vi.fn(() => '')` in test files — same shape #125 used for `registerNotificationChannel`):
+- `src/lib/plugin-registry.ts` (insert after `registerNotificationChannel` ~line 220)
+- `src/app/api/plugins/[pluginId]/[[...path]]/route.ts` (two sites)
+- `tests/plugins/test-helpers.ts`
+- `tests/plugins/contract.test.ts`
+- `tests/plugins/projects/sync-hook.test.ts`
+- `tests/plugins/workflows/sync-hook.test.ts`
+- `tests/plugins/assets/unlink-hook.test.ts`
+- `tests/plugins/assets/retype-preserves-search.test.ts`
+- `tests/integration/search-watcher-sync.test.ts`
 
-**Files:**
-- New: `plugins/models/lib/models-cache.ts` — disk read/write with zod-validated reads
-- Edit: `plugins/models/index.ts` — `fetchAvailableModels()` extended to read disk on cold start, write disk on success, return `stale: boolean` in the response
-- Edit: `plugins/models/types.ts` — `AvailableModelsResponse` gains optional `stale?: boolean` field
-- New test: `tests/plugins/models/models-cache.test.ts`
+**Acceptance:**
+- [ ] Types exported from both core + re-export
+- [ ] `PluginContext.registerHealthCheck` signature present
+- [ ] All 8 ctx-literal sites stubbed
+- [ ] `pnpm tsc --noEmit` clean
+- [ ] `pnpm vitest run` green
 
-**Shape:**
+**Commit:** `feat(core): HealthCheckResult types + PluginContext.registerHealthCheck`
+
+---
+
+### T2 — feat(health): health-check-registry store + unit tests
+
+**New file:** `plugins/health/lib/health-check-registry.ts` — mirror `plugins/workflows/lib/notification-channel-registry.ts`:
 
 ```ts
-// plugins/models/lib/models-cache.ts
-interface PersistedCache {
-  models: AvailableModel[]
-  fetchedAt: number
-  source: 'openclaw' | 'empty'
-}
-export function readPersistedCache(): PersistedCache | null   // zod-validated; returns null on miss/corrupt
-export function writePersistedCache(cache: PersistedCache): void  // atomic tmp+rename
-export function clearPersistedCache(): void
+const registry = new Map<string, HealthCheckDef>()
+
+export function registerHealthCheck(def: HealthCheckDef): void     // throws on duplicate id
+export function getHealthCheck(id: string): HealthCheckDef | undefined
+export function listHealthChecks(): HealthCheckDef[]
+export function unregisterHealthCheck(id: string): void
+export function unregisterPluginHealthChecks(pluginId: string): void
+
+export function registerPluginHealthCheck(
+  pluginId: string,
+  input: PluginHealthCheckInput,
+): string  // namespaces id to `{pluginId}.{id}`, returns namespaced id
 ```
 
-Path: `getContentDir()` + `plugin-settings/models/available.json`. Mkdir parent on first write.
+**No builtin self-seeding** — unlike channels/node-types, core doctor checks stay as direct calls. Registry is plugin-contributions-only.
 
-Response flow in `/available`:
-1. In-memory cache fresh → return `{ models, cached: true, cachedAt, stale: false }`
-2. In-memory cache empty but disk cache present → hydrate in-memory, return `{ models, cached: true, cachedAt, stale: (Date.now() - cachedAt) > CACHE_TTL }`
-3. Both empty → call `loadConfiguredModelsFromOpenClaw`; write both caches on success, return `{ models, cached: false, cachedAt: now, stale: false }`
-4. OpenClaw fails AND no cache → return `{ models: [], cached: false, cachedAt: null, error: '...' }` — **never** `fallbackModels()`
-
-Note: `fallbackModels()` still exists in the file after T1; T3 deletes it. T1 just stops calling it in the success-empty branch.
-
-**Acceptance:**
-- [ ] `plugins/models/lib/models-cache.ts` exists with 3 exports + zod validation on read
-- [ ] Disk cache path resolves to `~/.bakin/plugin-settings/models/available.json`
-- [ ] First `/available` on a fresh install with no disk file returns an HTTP-200 with `models: []` + error (no fake data) — unless OpenClaw is reachable, in which case fresh fetch + disk write
-- [ ] Response shape includes `stale: boolean`
-- [ ] `fallbackModels()` is no longer referenced in `fetchAvailableModels` (still defined, deleted in T3)
-- [ ] Unit tests cover: round-trip write/read, corrupt JSON returns null, missing file returns null, `clearPersistedCache` deletes the file
-- [ ] `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
-
-**Commit:** `feat(models): disk-backed cache with stale flag`
-
----
-
-### T2 — feat(models): manual refresh + gateway-restart cache invalidation
-
-**What:** New `POST /api/plugins/models/refresh` endpoint that forces a cache bypass. Extend `POST /gateway/restart` to wipe both caches.
-
-**"Look first":** `getGatewaySync()`/`markGatewayRestarted()` live at `plugins/models/index.ts:23-28` (same file). `POST /gateway/restart` exists at `:647`. Just extend, don't relocate.
-
-**Files:**
-- Edit: `plugins/models/index.ts` — new `/refresh` route; `/gateway/restart` clears in-memory + disk cache after successful restart
-- Edit: existing `tests/plugins/models/routes.test.ts` — add cases for /refresh + cache-clear on restart
-
-**Flow for `/refresh`:**
-- Ignore cache
-- Call `loadConfiguredModelsFromOpenClaw` directly
-- On success: write both in-memory + disk cache
-- On failure + there IS a disk cache: return `{ ok: false, error, models: cachedModels, stale: true }`
-- On failure + no cache: return `{ ok: false, error, models: [] }`
+**New test:** `tests/plugins/health/health-check-registry.test.ts` — mirror `tests/plugins/workflows/notification-channel-registry.test.ts`:
+- register + retrieve + list
+- collision throw
+- `registerPluginHealthCheck` namespaces correctly
+- `unregisterPluginHealthChecks(pluginId)` removes only that plugin's entries
+- registry starts empty (no builtin seeds)
 
 **Acceptance:**
-- [ ] `POST /api/plugins/models/refresh` route registered
-- [ ] `/refresh` bypasses cache and returns fresh data
-- [ ] `/refresh` on OpenClaw failure falls back to last-known-good cache when available
-- [ ] `POST /gateway/restart` clears in-memory AND disk cache on successful restart
-- [ ] `pnpm vitest run` clean
+- [ ] 6 exports on the module matching the precedent
+- [ ] 6+ unit-test assertions pass
 - [ ] `pnpm tsc --noEmit` clean
 
-**Commit:** `feat(models): manual refresh endpoint + invalidate cache on gateway restart`
+**Commit:** `feat(health): health-check-registry with plugin namespacing + teardown`
 
 ---
 
-### T3 — refactor(models): delete fallbackModels + MODEL_CATALOG dead code
+### T3 — feat(core): wire registerHealthCheck through plugin-registry
 
-**What:** Pure deletion. Both surfaces are now unused.
+**Edits to `src/lib/plugin-registry.ts`:**
 
-**Files:**
-- Edit: `plugins/models/index.ts` — remove `fallbackModels()` function (lines 252-259)
-- Edit: `plugins/models/types.ts` — remove `MODEL_CATALOG` + `ModelCatalogEntry` (lines 45-58)
-
-**Grep verifications (all zero hits):**
-- `grep -rn 'fallbackModels' plugins/models/`
-- `grep -rn 'MODEL_CATALOG' plugins/`
-- `grep -rn 'ModelCatalogEntry' plugins/`
+1. Import `registerPluginHealthCheck` + `unregisterPluginHealthChecks` alongside the workflows helpers (around :24)
+2. Add `healthCheckIds: string[]` field to `PluginState`
+3. Initialize `healthCheckIds: []` at both `PluginState` construction sites (search for `nodeKinds: []` — two sites)
+4. Replace T1's interim stub at ~:220 with real impl:
+   ```ts
+   registerHealthCheck: (def: PluginHealthCheckInput): string => {
+     try {
+       const namespacedId = registerPluginHealthCheck(pluginId, def)
+       state.healthCheckIds.push(namespacedId)
+       return namespacedId
+     } catch (err) {
+       log.error(
+         `registerHealthCheck collision in plugin "${pluginId}" for id "${def.id}"`,
+         err as Error,
+       )
+       return `${pluginId}.${def.id}`
+     }
+   }
+   ```
+5. Extend teardown at `:372` (user-plugin-override path — verified single teardown site):
+   ```ts
+   unregisterPluginNodeTypes(pluginId)
+   unregisterPluginNotificationChannels(pluginId)
+   unregisterPluginHealthChecks(pluginId)  // NEW
+   ```
 
 **Acceptance:**
-- [ ] All three greps return zero hits
+- [ ] Real impl replaces T1 stub at production plugin-registry site only
+- [ ] Other 7 stubs stay (tests + per-request context that doesn't need the real registry)
+- [ ] Teardown updated
 - [ ] `pnpm tsc --noEmit` + `pnpm vitest run` clean
-- [ ] No test regressions — `MODEL_CATALOG` was dead code, nothing depends on it
+- [ ] Checkpoint: registry functional end-to-end — a plugin calling `ctx.registerHealthCheck(...)` writes to the real Map
 
-**Commit:** `refactor(models): remove fallbackModels + MODEL_CATALOG dead code`
+**Commit:** `feat(core): wire registerHealthCheck through plugin-registry`
 
 ---
 
-### T4 — feat(models): curated catalog data module
+### T4 — feat(health): list hooks + REST route
 
-**What:** New `plugins/models/data/known-models.ts` with the 22-entry seed + lookup helpers.
+**Edits to `plugins/health/index.ts`** in `activate(ctx)`:
+- `ctx.hooks.register('health.listChecks', () => listHealthChecks().map(stripRun))`
+- `ctx.hooks.register('health.getCheck', (d) => { const def = getHealthCheck(d.id as string); return def ? stripRun(def) : null })`
+- `ctx.registerRoute({ path: '/checks', method: 'GET', handler: async () => json({ checks: listHealthChecks().map(stripRun) }) })`
 
-**Files:**
-- New: `plugins/models/data/known-models.ts` — exports `KnownModel`, `KnownProvider`, `KNOWN_MODELS`, `KNOWN_PROVIDERS`, `getKnownModel`, `getKnownProvider`
-- New test: `tests/plugins/models/known-models.test.ts`
+Where `stripRun(def) = { id, name, pluginId, autoFix }` — omits non-serializable `run`.
 
-**Seed: 9 LLMs + 5 image + 5 video + providers** (per spec §Seed entries).
-
-**`getKnownModel` normalization:**
-- Exact match first
-- On miss, strip trailing `-\d{8}` date suffix and retry
-- Return `undefined` otherwise
-
-**Providers seed:** at minimum `anthropic`, `openai` (and `openai-codex` alias), `google`, `ollama`, `bytedance`, `kuaishou`, `runway`, `black-forest-labs`, `stability`, `midjourney` with matching `brandIconSlug` + `brandColor` (hex).
+**New test:** `tests/plugins/health/checks-route.test.ts` — activate the health plugin via `activatePlugin`, assert:
+- `/checks` returns `{ checks: [] }` on a fresh registry
+- After `registerHealthCheck(...)` via the plugin helper, the route returns that entry with correct shape (no `run` field)
 
 **Acceptance:**
-- [ ] 22 model entries across `kind: 'llm' | 'image' | 'video'` (9 + 5 + 5; 3 slots flexibility if a seed model shifts)
-- [ ] Providers cover every model's `providerFromId` output
-- [ ] `getKnownModel('anthropic/claude-sonnet-4-6-20250514')` matches the base `anthropic/claude-sonnet-4-6` entry
-- [ ] `getKnownModel('unknown/model')` returns undefined
-- [ ] Unit tests: exact match, date-suffix-strip match, miss, provider lookup hit + miss
-- [ ] `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
+- [ ] Hooks registered with documented shape
+- [ ] Route registered at `/checks`
+- [ ] Test asserts empty + populated cases
+- [ ] `pnpm tsc --noEmit` + `pnpm vitest run` clean
 
-**Commit:** `feat(models): curated catalog of 22 popular models + providers`
+**Commit:** `feat(health): expose registered checks via hooks + REST route`
 
 ---
 
-### T5 — feat(models): enrich AvailableModel from catalog
+### T5 — feat(core): run plugin health checks in runDiagnostics
 
-**What:** `loadConfiguredModelsFromOpenClaw` merges catalog metadata into every returned `AvailableModel`.
+**Edits to `src/core/doctor.ts`:**
 
-**Files:**
-- Edit: `plugins/models/types.ts` — `AvailableModel` gains optional fields: `description`, `bestFor`, `costRange`, `kind`, `brandIconSlug`, `providerLabel`, `providerBrandIconSlug`, `providerBrandColor`
-- Edit: `plugins/models/index.ts` — enrichment in the `.map(...)` block at `:213` (around the existing `AvailableModel` construction)
-- Extend: `tests/plugins/models/routes.test.ts` — fixture OpenClaw response for a known id should produce an `AvailableModel` with the catalog's `description` / `bestFor` / `costRange`; unknown id falls back to `tierFromId`
+1. Import `listHealthChecks`:
+   ```ts
+   import { listHealthChecks } from '../../plugins/health/lib/health-check-registry'
+   ```
+2. At the end of `runDiagnostics()` (after the existing `await Promise.all(...)` block around :1732), append:
+   ```ts
+   // Plugin-contributed health checks (#137). Per-check try/catch so one
+   // bad handler never crashes the sweep.
+   const pluginChecks = listHealthChecks()
+   const pluginResultArrays = await Promise.all(
+     pluginChecks.map(async (def) => {
+       try {
+         return await def.run()
+       } catch (err) {
+         const message = err instanceof Error ? err.message : String(err)
+         return [{
+           check: def.id,
+           status: 'error' as const,
+           message: `Plugin health check threw: ${message}`,
+           autoFixable: false,
+         }]
+       }
+     }),
+   )
+   results.push(...pluginResultArrays.flat())
+   ```
 
-**Enrichment shape (preserves existing fallbacks):**
+**New test file:** `tests/core/doctor-plugin-checks.test.ts` — `src/core/doctor.ts` has no dedicated test today; gap-filling is fair game.
 
+Test cases:
+- Register a plugin check that returns `[{ status: 'ok', ... }]` → appears in `runDiagnostics()` results
+- Register a plugin check that throws synchronously → synthetic error result appears, other checks still complete
+- Register a plugin check that rejects async → same synthetic-error behavior
+- Plugin check results appear alongside (not replacing) builtin check results — asserts `results.length` grew by exactly the plugin-check count
+
+Doctor test requires extensive mocks per CLAUDE.md (content-dir, openclaw-client, settings, etc.) — focus on the plugin-check code path; mock the existing builtin checks to a stable baseline.
+
+**No UI verification needed:** `plugins/health/components/health-page.tsx:28` consumes `DiagnosticResult`-shaped rows. Plugin check results are shape-identical, so no UI change is required. Confirmed by inspection.
+
+**Acceptance:**
+- [ ] `runDiagnostics()` ends with the plugin-check Promise.all + results.push
+- [ ] Throws in plugin checks never propagate out of runDiagnostics
+- [ ] 3+ new tests pass
+- [ ] `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] Checkpoint: a plugin check registered via the real pipeline appears in doctor output end-to-end
+
+**Commit:** `feat(core): run plugin health checks in runDiagnostics`
+
+---
+
+### T6 — refactor(workflows): migrate 3 workflow checks out of core
+
+**The forcing function.** Until this commit, `health.checks` is infrastructure nobody uses. This is where it becomes live.
+
+**New file:** `plugins/workflows/lib/health-checks.ts` — move three functions out of `src/core/doctor.ts`:
+- `checkWorkflowDefinitions` from `doctor.ts:1139`
+- `checkStaleWorkflowInstances` from `doctor.ts:1175`
+- `checkWorkflowSkills` from `doctor.ts:1102`
+
+**Internalization during move:**
+- `checkWorkflowDefinitions` currently calls `getHookRegistry().invoke('workflows.listDefinitions', {})`. Replace with direct import from `plugins/workflows/lib/source-registry` (or wherever `listDefinitions` is defined). Verify shape match during build.
+- `checkStaleWorkflowInstances` currently takes `autoFix: boolean`. After move, read `getSettings().doctor.autoFixSkill` inline (reuse the core settings-read pattern). Its `hooks.invoke('workflows.listInstances', {})` becomes a direct `listInstances()` import. Its `hooks.invoke('tasks.readTaskboard', {})` STAYS as a hook — workflows→tasks is legitimate cross-plugin communication.
+- `checkWorkflowSkills` is sync, filesystem-only. No internalization needed.
+
+**Helpers needed:** `ok()`, `warn()`, `fixed()` constructors from `doctor.ts`. Inline them at the top of `plugins/workflows/lib/health-checks.ts` (4 lines each, trivial). Keeps the plugin self-contained for eventual helper migration in a follow-up PR.
+
+**Edits to `plugins/workflows/index.ts`** in `activate(ctx)`:
 ```ts
-const known = getKnownModel(id)
-const knownProvider = getKnownProvider(providerFromId(id))
-return {
-  id,
-  name: known?.name ?? model.name ?? id,
-  tier: known?.tier ?? tierFromId(id),
-  provider: providerFromId(id),
-  providerLabel: knownProvider?.label,
-  providerBrandIconSlug: knownProvider?.brandIconSlug,
-  providerBrandColor: knownProvider?.brandColor,
-  description: known?.description,
-  bestFor: known?.bestFor,
-  costRange: known?.costRange,
-  kind: known?.kind,
-  brandIconSlug: known?.brandIconSlug,
-  // ... existing fields untouched
-}
+ctx.registerHealthCheck({
+  id: 'definitions',
+  name: 'Workflow definition integrity',
+  run: () => checkWorkflowDefinitions(getContentDir()),
+})
+ctx.registerHealthCheck({
+  id: 'stale-instances',
+  name: 'Stale workflow instances',
+  autoFix: true,
+  run: () => checkStaleWorkflowInstances(getContentDir()),
+})
+ctx.registerHealthCheck({
+  id: 'skills',
+  name: 'Workflow skills validation',
+  run: async () => checkWorkflowSkills(getContentDir()),
+})
 ```
 
-**Acceptance:**
-- [ ] `AvailableModel` type has the 8 new optional fields
-- [ ] Mocked OpenClaw fixture including `anthropic/claude-sonnet-4-6` produces enriched shape with catalog fields
-- [ ] Mocked OpenClaw fixture for an unknown id still constructs a valid `AvailableModel` with `tier` from `tierFromId` heuristic and no enrichment fields
-- [ ] Existing `routes.test.ts` tests still pass (no regression on existing assertions)
-- [ ] `pnpm tsc --noEmit` clean — downstream consumers ignore the new optional fields
+**Edits to `src/core/doctor.ts`:**
+- Delete three function definitions: `checkWorkflowDefinitions`, `checkStaleWorkflowInstances`, `checkWorkflowSkills`
+- Delete three `results.push(...)` calls in `runDiagnostics()`
 
-**Commit:** `feat(models): enrich AvailableModel with curated catalog metadata`
+**New test:** `tests/plugins/workflows/health-checks.test.ts` — fixture directories with:
+- Valid + invalid workflow definitions (resolvable vs. broken skill references)
+- Stale + fresh workflow instances
+- Skills with + without `output_schema`
+
+Assert each migrated function produces the same `DiagnosticResult[]` count + shape as before the move. Invoke the run functions directly (not through the registry — that's T7's job).
+
+**Acceptance:**
+- [ ] `plugins/workflows/lib/health-checks.ts` exists with 3 function exports
+- [ ] Workflows plugin `activate()` registers all 3 via `ctx.registerHealthCheck`
+- [ ] `src/core/doctor.ts` no longer defines or calls the 3 functions
+- [ ] Migration regression test passes — output shapes identical
+- [ ] Full `runDiagnostics()` still produces the same check coverage (via the plugin registry)
+- [ ] `grep "checkWorkflowDefinitions\|checkStaleWorkflowInstances\|checkWorkflowSkills" src/core/doctor.ts` → 0 hits
+- [ ] `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] Checkpoint: migration complete, pattern validated end-to-end
+
+**Commit:** `refactor(workflows): migrate workflow health checks out of core/doctor.ts`
 
 ---
 
-### T6 — feat(models): BrandIcon component + simple-icons dep
+### T7 — test(health): orchestrator isolation + migration regression
 
-**What:** New client component that renders SVG brand logos via `simple-icons`, with first-letter chip fallback.
+Gap-fill anything T5 and T6 didn't cover:
 
-**"Look first":**
-- Run `pnpm add simple-icons` first; verify the deep-import shape by `cat node_modules/simple-icons/icons/openai.js` (should export `{ title, slug, path, hex, source }`)
-- If tree-shaking concerns appear (bundle swells visibly), switch to deep imports by path: `import siOpenai from 'simple-icons/icons/openai'`. Not a blocker — covered in the spec's Not Doing list (no dynamic imports).
-
-**Files:**
-- `package.json` + `pnpm-lock.yaml` — add `simple-icons` dep
-- New: `plugins/models/components/brand-icon.tsx`
-- New test: `tests/plugins/models/brand-icon.test.tsx`
-
-**Import map: 10 slugs** matching the seed catalog — `anthropic`, `openai`, `google`, `ollama`, `runway`, `stability`, `midjourney`, `bytedance`, `kuaishou`, `blackforestlabs`. Plus `helpcircle`-shaped fallback if any icon happens to be missing in the package.
-
-**Props:**
-
-```ts
-interface BrandIconProps {
-  slug?: string
-  fallbackText?: string       // for first-letter chip
-  fallbackColor?: string      // hex
-  size?: 'sm' | 'md'
-  className?: string
-}
-```
-
-**Fallback rules:**
-- `slug` present and in the map → render the SVG path
-- `slug` missing or not in the map → render first-letter chip with `fallbackColor` bg
-- `fallbackText` missing → render `?`
+- **Integration test:** activate BOTH workflows + health plugins through `activatePlugin`, call `runDiagnostics()`. Assert the 3 workflow-owned checks appear in the results with correct `{pluginId}.{id}` naming.
+- **Isolation test** (if not already in T5): plugin A throws + plugin B returns results → plugin B still appears.
+- **End-to-end shape regression:** verify the `plugins/health/components/health-page.tsx` consumer path doesn't break with plugin-contributed rows. Manual eyeball if writing the component test feels heavyweight; a lightweight integration assertion is enough.
 
 **Acceptance:**
-- [ ] `simple-icons` installed, lockfile updated
-- [ ] `plugins/models/components/brand-icon.tsx` exports `BrandIcon`
-- [ ] Renders `<svg>` for known slug, `<span>` chip for unknown/missing
-- [ ] `pnpm build` (or `pnpm tsc --noEmit`) clean — no TS errors from the deep imports
-- [ ] Bundle size check: nothing obviously catastrophic. Eyeball only, not a hard gate.
-- [ ] Tests: 4 cases (known slug renders path, unknown slug renders chip, empty text renders '?', bg color applied)
-
-**Commit:** `feat(models): BrandIcon component with simple-icons + first-letter fallback`
-
----
-
-### T7 — feat(models): enriched models-page cards + Refresh + cache-age + banner
-
-**What:** The visible UI work. All changes scoped to the `tab === 'available'` block in `plugins/models/components/models-page.tsx` (lines ~590-640) plus a tab-header area for the Refresh button.
-
-**"Look first:** models-page.tsx is 808 lines; surgical edits, no full-page refactor. The tab content lives inside an `AnimatePresence`-style conditional block. Refresh button + cache-age indicator probably belong inside the `tab === 'available'` block's header (above the provider sections), not in the top-level page header.
-
-**UI additions:**
-1. **Refresh button + cache-age indicator** at top of `tab === 'available'`:
-   - Button disabled during in-flight request
-   - Spinner replaces icon while refreshing
-   - Text: `Last refreshed: 2m ago` (under 24h → relative; older → absolute date)
-2. **Gateway-out-of-sync banner** — pulled from `GET /gateway/status` on mount (`restartNeeded === true`):
-   - Amber background, inline `Restart gateway` button
-   - Only renders when flag is true
-3. **Provider header** now renders `<BrandIcon slug={providerBrandIconSlug} fallbackText={providerLabel ?? provider} fallbackColor={providerBrandColor} />` + `{providerLabel ?? provider.replace(/[-_]/g, ' ')}`
-4. **Model row** gains (when catalog match exists):
-   - Small `<BrandIcon>` next to name
-   - `description` as muted secondary line
-   - `bestFor` badge next to the tier badge
-   - `contextWindow` as mono-font small text next to name
-   - `costRange` right-aligned at end of row
-5. **Loading state** when fetch in-flight AND no cache yet: spinner + "Querying OpenClaw gateway — this can take up to 30 seconds on first load"
-6. **Error state** when fetch failed AND no cache: error message + Retry button (calls `POST /refresh`)
-
-**Files:**
-- Edit: `plugins/models/components/models-page.tsx` — surgical edits inside `tab === 'available'` block + a mount-time fetch for gateway-status
-- Optional new file: `plugins/models/components/model-card-row.tsx` if the enriched row JSX gets unwieldy inline (judgment call during implementation — prefer inline unless it hurts readability)
-
-**Acceptance:**
-- [ ] Refresh button triggers `POST /api/plugins/models/refresh` + updates UI
-- [ ] Cache-age indicator renders relative time for <24h, absolute date otherwise
-- [ ] Provider headers render `<BrandIcon>` + resolved label
-- [ ] Model rows with catalog match show description + bestFor badge + contextWindow + costRange
-- [ ] Model rows without catalog match show plain (existing) layout — no regression
-- [ ] First-ever load (no cache) shows loading state, not fake data
-- [ ] Fetch failure + no cache shows error + Retry button
-- [ ] Gateway-out-of-sync banner renders when `/gateway/status` reports `restartNeeded: true`
-- [ ] Existing model-selector UIs on other tabs (agents, aliases, profiles) render unchanged
-- [ ] `pnpm tsc --noEmit` clean; `pnpm vitest run` clean
-
-**Commit:** `feat(models): enriched cards + Refresh button + cache-age + gateway-sync banner`
-
----
-
-### T8 — test(models): regression guards
-
-**What:** Comprehensive test pass for the loading/catalog flow. Existing test coverage at `tests/plugins/models/` is limited to `routes.test.ts`; expand to cover cache + enrichment + UI degradation cases that the earlier commits didn't lock down.
-
-**Files:**
-- Extend: `tests/plugins/models/routes.test.ts` — new cases for `/refresh`, cache stale flag, gateway-restart cache-clear
-- New: `tests/plugins/models/enrichment.test.ts` — mocked OpenClaw fixture → enriched `AvailableModel[]` with catalog fields; unknown ids have no enrichment; date-suffix-stripped match works end-to-end
-- New: `tests/plugins/models/models-page.test.tsx` — component-level regression: renders cache-age indicator, renders Refresh button, triggers refresh, shows loading state with no cache, shows error state on fetch failure, gateway-sync banner renders when flag present
-
-**Mocks required:** content-dir, logger, watcher, openclaw-client, tasks/flow-store (per CLAUDE.md), plus `use-agent-store` and any other cross-plugin hooks the page references.
-
-**Acceptance:**
-- [ ] New regression tests pass
-- [ ] Full `pnpm vitest run` clean (ignore pre-existing `@dagrejs/dagre` failures)
+- [ ] Any coverage gap identified at T5/T6 closure is filled
+- [ ] Full `pnpm vitest run` clean
 - [ ] `pnpm tsc --noEmit` clean
-- [ ] Grep verifications (repeat from T3 for the final artifact): `fallbackModels` / `MODEL_CATALOG` / `ModelCatalogEntry` all zero hits
 
-**Commit:** `test(models): regression guards for cache + enrichment + loading UI`
+**Commit:** `test(health): regression guards + migration isolation`
 
 ---
 
-### T9 — Ship
+### T8 — Ship
 
-- [ ] Manual smoke on maintainer's install:
-  - Delete `~/.bakin/plugin-settings/models/available.json` to force cold start
-  - Load `/models` → loading state appears briefly, then real data lands
-  - Click Refresh → spinner, then updated timestamp
-  - Trigger a gateway config change (edit `openclaw.json`, don't restart) → banner appears
-  - Click the banner's Restart button → banner clears, cache refreshes
-  - Verify enriched cards for `anthropic/claude-sonnet-4-6` show description + bestFor + cost range + logo
-  - Verify a non-catalog model (e.g. an OSS local) renders plain row without errors
-- [ ] `git push -u origin issue-129-models-loading-ux`
-- [ ] Open PR against `main`, reference #129, link spec + plugin-system one-pager
+- [ ] Push branch: `git push -u origin issue-137-health-checks-registry`
+- [ ] Open PR against `main` — reference #137, link spec, mention the 2 follow-ups to file on merge
+- [ ] Quick manual smoke: `bakin doctor` on the other machine should produce the same check output as before (the 3 workflow checks are now plugin-contributed; user shouldn't notice any difference)
+- [ ] File 2 follow-ups (per spec):
+  - `chore(core): collapse DiagnosticResult into HealthCheckResult after all checks migrate`
+  - `chore: hook-name parity pass — rename all list{Noun} hooks to {namespace}.list`
 - [ ] Merge when green
-- [ ] Close #129 with before/after summary
-- [ ] Archive `tasks/plan.md` + `tasks/todo.md` → `.claude/tasks/issue-129-{plan,todo}.md`
+- [ ] Close #137 with before/after summary
+- [ ] Archive `tasks/plan.md` + `tasks/todo.md` → `.claude/tasks/issue-137-{plan,todo}.md`
 
-## Commit strategy
+## Risks & call-outs
 
-One PR, 9 implementation commits (T0 scaffold + T1–T8) plus any hotfix commits that show up during testing. Each commit self-contained: tsc clean, tests pass, no broken intermediate state. Intermediate commits must not break the models page — so T1 stops *calling* `fallbackModels()` but keeps the function defined until T3.
-
-## Risks / call-outs
-
-- **T1 disk-cache write contention.** If two server processes write concurrently, atomic tmp+rename prevents corruption but the later write wins. In practice Bakin is single-process per install, so this is theoretical. Flag only if we later support multi-process.
-- **T6 simple-icons bundle size.** If deep-imports don't tree-shake cleanly, client bundle swells by the full icon set (~1.5 MB). Worst case: do static imports for only the 10 brands we need (already planned), confirmed tree-shakable via deep paths. If bundle concern materializes, cut back to first-letter chips only and accept the loss of visual polish.
-- **T7 scope creep into a full models-page redesign.** The spec is crystal clear — surgical edits inside `tab === 'available'`. Don't touch other tabs. Don't reshape the page layout. If a visual tweak elsewhere is tempting, note it as a follow-up issue and move on.
-- **T8 test file sprawl.** Three new test files is a lot; if any feel redundant during writing, consolidate. The point is coverage, not file count.
-- **Pre-existing `@dagrejs/dagre` failures** in the test suite are unrelated and will still fail on this branch. Not a blocker; not introduced by #129.
+- **T5 imports plugin code from core.** `src/core/doctor.ts` imports `listHealthChecks` from `plugins/health/lib/`. This reverses the usual core-doesn't-depend-on-plugins direction. Justified — `src/lib/plugin-registry.ts:24` already imports from `plugins/workflows/lib/` for the same reason. The owner plugin's registry module IS the source of truth for that extension point. Document in commit message.
+- **T6 internalization of hook calls.** `checkWorkflowDefinitions` uses a hook to reach `listDefinitions`. Moving into the workflows plugin, we replace that with a direct import. Risk: if the hook handler does any transformation, the direct call might have a different shape. Verify during T6 — may need a small adapter layer.
+- **T5 test setup complexity.** `runDiagnostics()` has 18+ imports and reads many filesystem paths. Mocking everything for a full run is expensive. Prefer testing the plugin-check loop in isolation — register mock plugin checks, mock the builtin-check side to a stable baseline, assert only the plugin-check-path behavior. We're adding a new loop at the end, not regressing existing behavior.
+- **Commit sequencing invariant.** T1 stubs MUST be at all 8 sites before merging — if we land T1 with only 7 stubbed, the 8th file breaks tsc. Grep all 8 paths during T1 before committing.
 
 ## Archival
 
-After merge, T9 moves `tasks/plan.md` + `tasks/todo.md` into `.claude/tasks/issue-129-{plan,todo}.md` — matches the `issue-115-`, `issue-118-`, `issue-125-` archival pattern already in that directory.
+After merge, T8 moves `tasks/plan.md` + `tasks/todo.md` into `.claude/tasks/issue-137-{plan,todo}.md` — matches the `issue-115-`, `issue-118-`, `issue-125-`, `issue-129-` archival pattern.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,127 +1,92 @@
-# TODO: Issue #129 — Models loading UX + curated catalog
+# TODO: Issue #137 — Health Checks Registry
 
-**Spec:** `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
+**Spec:** `.claude/specs/issue-137-health-checks-registry.md`
 **Plan:** `tasks/plan.md`
-**Issue:** https://github.com/madeinwyo/bakin/issues/129
-**Branch:** `issue-129-models-loading-ux`
+**Issue:** https://github.com/madeinwyo/bakin/issues/137
+**Branch:** `issue-137-health-checks-registry`
 
 ## T0 — Branch + scaffold commit
 
-- [x] `git checkout -b issue-129-models-loading-ux`
-- [x] Close #128 with rationale
-- [x] Update `docs/ideas/plugin-system.md` to strike `models.providers`
-- [x] Write spec at `.claude/specs/issue-129-models-loading-ux-and-catalog.md`
-- [x] Archive #125 tasks → `.claude/tasks/issue-125-{plan,todo}.md`
-- [x] Commit: `chore(issue-129): spec + plan scaffold`
+- [x] `git checkout -b issue-137-health-checks-registry` (already done)
+- [x] Write spec at `.claude/specs/issue-137-health-checks-registry.md`
+- [ ] Archive `tasks/plan.md` + `tasks/todo.md` (current content is #129) → `.claude/tasks/issue-129-{plan,todo}.md`
+- [ ] Commit: `chore(issue-137): spec + plan scaffold`
 
-## T1 — feat(models): disk-backed cache + stale flag
+## T1 — feat(core): HealthCheckResult types + PluginContext.registerHealthCheck
 
-- [x] New file `plugins/models/lib/models-cache.ts` — `readPersistedCache()`, `writePersistedCache()`, `clearPersistedCache()` + zod validation on read
-- [x] Path: `getContentDir() + 'plugin-settings/models/available.json'`; atomic tmp+rename on write
-- [x] Extend `fetchAvailableModels()` in `plugins/models/index.ts`:
-  - In-memory hot read stays
-  - On in-memory miss → check disk → hydrate + return with `stale` flag
-  - On OpenClaw fetch success → write both caches
-  - On OpenClaw failure + no cache → return `{ models: [], cached: false, error }` (NOT `fallbackModels()`)
-- [x] Response shape gains `stale: boolean`; `AvailableModelsResponse` in `plugins/models/types.ts` gains optional field
-- [x] New test `tests/plugins/models/models-cache.test.ts` — round-trip, corrupt JSON returns null, missing file returns null, clear deletes
-- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
-- [x] Commit: `feat(models): disk-backed cache with stale flag`
+- [ ] Add `HealthCheckResult`, `PluginHealthCheckInput`, `HealthCheckDef` in `packages/core/src/plugin-types.ts`
+- [ ] Add `registerHealthCheck(def): string` method to `PluginContext`
+- [ ] Extend re-export list in `src/lib/plugin-types.ts`
+- [ ] Interim stubs at all 8 ctx-literal sites (plugin-registry + route.ts:2sites + 6 test files)
+- [ ] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] Commit: `feat(core): HealthCheckResult types + PluginContext.registerHealthCheck`
 
-## T2 — feat(models): /refresh + gateway-restart invalidation
+## T2 — feat(health): health-check-registry store + unit tests
 
-- [x] New route: `POST /api/plugins/models/refresh`
-  - Bypasses cache
-  - Calls `loadConfiguredModelsFromOpenClaw`
-  - On success → write both caches
-  - On failure + disk cache exists → `{ ok: false, error, models: cachedModels, stale: true }`
-  - On failure + no cache → `{ ok: false, error, models: [] }`
-- [x] Extend `POST /gateway/restart` (`plugins/models/index.ts:647`):
-  - After successful restart, call `setModelsCache(null)` + `clearPersistedCache()`
-- [x] Extend `tests/plugins/models/routes.test.ts` — `/refresh` happy + failure paths; cache-clear on gateway restart
-- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
-- [x] Commit: `feat(models): manual refresh endpoint + invalidate cache on gateway restart`
+- [ ] New file `plugins/health/lib/health-check-registry.ts`
+- [ ] Exports: `registerHealthCheck` / `getHealthCheck` / `listHealthChecks` / `unregisterHealthCheck` / `unregisterPluginHealthChecks` / `registerPluginHealthCheck`
+- [ ] No builtin seeding (plugin-contributions-only)
+- [ ] New test `tests/plugins/health/health-check-registry.test.ts` — mirror `notification-channel-registry.test.ts`
+- [ ] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/health/` clean
+- [ ] Commit: `feat(health): health-check-registry with plugin namespacing + teardown`
 
-## T3 — refactor(models): delete fallbackModels + MODEL_CATALOG dead code
+## T3 — feat(core): wire registerHealthCheck through plugin-registry
 
-- [x] Remove `fallbackModels()` from `plugins/models/index.ts:252-259`
-- [x] Remove `MODEL_CATALOG` + `ModelCatalogEntry` from `plugins/models/types.ts:45-58`
-- [x] Verify greps all return zero:
-  - [ ] `grep -rn 'fallbackModels' plugins/models/` → 0 hits
-  - [ ] `grep -rn 'MODEL_CATALOG' plugins/` → 0 hits
-  - [ ] `grep -rn 'ModelCatalogEntry' plugins/` → 0 hits
-- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
-- [x] Commit: `refactor(models): remove fallbackModels + MODEL_CATALOG dead code`
+- [ ] Import `registerPluginHealthCheck` + `unregisterPluginHealthChecks` in `src/lib/plugin-registry.ts`
+- [ ] Add `healthCheckIds: string[]` to `PluginState` + both construction sites
+- [ ] Replace T1 stub at production site with real impl (try/catch + log + push)
+- [ ] Add `unregisterPluginHealthChecks(pluginId)` at teardown site `:372`
+- [ ] Checkpoint: `pnpm tsc --noEmit` + full `pnpm vitest run` clean
+- [ ] Commit: `feat(core): wire registerHealthCheck through plugin-registry`
 
-## T4 — feat(models): curated catalog data module
+## T4 — feat(health): list hooks + REST route
 
-- [x] New file `plugins/models/data/known-models.ts` — interfaces + arrays + helpers
-- [x] `KnownModel` with: id, name, description?, bestFor?, tier?, contextWindow?, costRange?, kind, brandIconSlug?
-- [x] `KnownProvider` with: id, label, brandIconSlug?, brandColor?
-- [x] Seed:
-  - [ ] 4 Anthropic LLMs (haiku 4.5, sonnet 4.5, sonnet 4.6, opus 4.6)
-  - [ ] 3 OpenAI LLMs (gpt-5.4, gpt-5, gpt-4o)
-  - [ ] 2 Google LLMs (gemini 2.5 pro, gemini 2.5 flash)
-  - [ ] 2 Ollama LLMs (llama 3.3, qwen 2.5)
-  - [ ] 5 image: DALL-E 3, Imagen 4, Flux (pro), SDXL, Midjourney v6.1
-  - [ ] 5 video: Seedance, Kling 1.6, Runway Gen-3 Alpha, Sora, Veo 2
-  - [ ] 10 providers covering every model's `providerFromId` output with `brandIconSlug` + `brandColor`
-- [x] `getKnownModel(id)` — exact match, fallback to date-suffix-strip retry (`id.replace(/-\d{8}$/, '')`)
-- [x] `getKnownProvider(id)` — exact match only
-- [x] New test `tests/plugins/models/known-models.test.ts` — 5+ cases
-- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run tests/plugins/models/` clean
-- [x] Commit: `feat(models): curated catalog of 22 popular models + providers`
+- [ ] Register `health.listChecks` + `health.getCheck` hooks in `plugins/health/index.ts:activate()`
+- [ ] Register `GET /checks` route returning `{ checks: [{ id, name, pluginId, autoFix }] }` (strip `run`)
+- [ ] New test `tests/plugins/health/checks-route.test.ts` — empty registry + populated case
+- [ ] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] Commit: `feat(health): expose registered checks via hooks + REST route`
 
-## T5 — feat(models): enrich AvailableModel from catalog
+## T5 — feat(core): run plugin health checks in runDiagnostics
 
-- [x] Extend `AvailableModel` in `plugins/models/types.ts` with optional: description, bestFor, costRange, kind, brandIconSlug, providerLabel, providerBrandIconSlug, providerBrandColor
-- [x] Update `.map(...)` block in `loadConfiguredModelsFromOpenClaw` (around `plugins/models/index.ts:213`) to merge `getKnownModel(id)` + `getKnownProvider(providerFromId(id))`
-- [x] Extend `tests/plugins/models/routes.test.ts` with an enrichment regression — fixture OpenClaw response containing a known id produces enriched shape; unknown id falls back to `tierFromId` with no enrichment fields
-- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
-- [x] Commit: `feat(models): enrich AvailableModel with curated catalog metadata`
+- [ ] Import `listHealthChecks` in `src/core/doctor.ts`
+- [ ] Append plugin-check Promise.all loop to `runDiagnostics()` with per-check try/catch
+- [ ] Synthetic error result on throws, never crashes the sweep
+- [ ] New test file `tests/core/doctor-plugin-checks.test.ts` — happy path, sync throw, async reject, alongside-builtins assertion
+- [ ] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] Commit: `feat(core): run plugin health checks in runDiagnostics`
 
-## T6 — feat(models): BrandIcon + simple-icons dep
+## T6 — refactor(workflows): migrate 3 workflow checks out of core
 
-- [x] `pnpm add simple-icons`
-- [x] Verify deep import works: `cat node_modules/simple-icons/icons/openai.js` — should export `{ title, slug, path, hex, source }`
-- [x] New file `plugins/models/components/brand-icon.tsx`
-- [x] Import map of 10 brands: anthropic, openai, google, ollama, runway, stability, midjourney, bytedance, kuaishou, blackforestlabs
-- [x] Props: `slug?`, `fallbackText?`, `fallbackColor?`, `size?`, `className?`
-- [x] Known slug → SVG with `<path d={icon.path}/>` inside a `<svg viewBox="0 0 24 24">`
-- [x] Unknown slug / missing → first-letter chip with `fallbackColor` bg
-- [x] New test `tests/plugins/models/brand-icon.test.tsx` — 4 cases (known, unknown, empty, color-applied)
-- [x] Checkpoint: `pnpm tsc --noEmit` clean; bundle not catastrophically larger (eyeball only)
-- [x] Commit: `feat(models): BrandIcon component with simple-icons + first-letter fallback`
+- [ ] New file `plugins/workflows/lib/health-checks.ts`
+- [ ] Move `checkWorkflowDefinitions` (doctor.ts:1139) — internalize `listDefinitions` hook call
+- [ ] Move `checkStaleWorkflowInstances` (doctor.ts:1175) — internalize `listInstances` hook; internalize `autoFix` setting read; keep `tasks.readTaskboard` as hook (cross-plugin)
+- [ ] Move `checkWorkflowSkills` (doctor.ts:1102) — sync, no internalization needed
+- [ ] Inline `ok` / `warn` / `fixed` helpers at top of new file
+- [ ] Register all 3 via `ctx.registerHealthCheck` in `plugins/workflows/index.ts:activate()`
+- [ ] Delete 3 function definitions from `src/core/doctor.ts`
+- [ ] Delete 3 `results.push(...)` calls in `runDiagnostics()`
+- [ ] New test `tests/plugins/workflows/health-checks.test.ts` — fixture-based regression, shape-identical to pre-migration
+- [ ] Grep verification: `checkWorkflowDefinitions|checkStaleWorkflowInstances|checkWorkflowSkills` in `src/core/doctor.ts` → 0 hits
+- [ ] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
+- [ ] Commit: `refactor(workflows): migrate workflow health checks out of core/doctor.ts`
 
-## T7 — feat(models): models-page UI — Refresh, cache-age, banner, enriched cards
+## T7 — test(health): orchestrator isolation + migration regression
 
-- [x] Surgical edits inside `tab === 'available'` block (`plugins/models/components/models-page.tsx:590-640`)
-- [x] Mount-time fetch for `GET /gateway/status`; render amber banner when `restartNeeded: true`
-- [x] Top of tab: Refresh button (calls `POST /refresh`; disables during in-flight) + `Last refreshed: X ago` indicator
-- [x] Provider header: `<BrandIcon slug={providerBrandIconSlug} fallbackText={providerLabel ?? provider} fallbackColor={providerBrandColor} />` + label
-- [x] Model row: enriched layout when catalog fields present (description, bestFor badge, contextWindow, costRange), plain layout otherwise
-- [x] Loading state when fetch in-flight AND no cache yet: spinner + "Querying OpenClaw gateway — this can take up to 30 seconds on first load"
-- [x] Error state when fetch failed AND no cache: error message + Retry button
-- [x] Smoke: load `/models/?tab=available` → enriched cards for Anthropic/OpenAI; plain rows for anything else
-- [x] Other tabs (agents, aliases, profiles) render unchanged
-- [x] Checkpoint: `pnpm tsc --noEmit` + `pnpm vitest run` clean
-- [x] Commit: `feat(models): enriched cards + Refresh button + cache-age + gateway-sync banner`
+- [ ] Integration: activate workflows + health together, assert 3 workflow-owned checks appear in `runDiagnostics()` output
+- [ ] Isolation: one plugin throws, another returns results — both contribute to the final list
+- [ ] End-to-end shape regression for the health-page consumer
+- [ ] Checkpoint: full `pnpm vitest run` + `pnpm tsc --noEmit` clean
+- [ ] Commit: `test(health): regression guards + migration isolation`
 
-## T8 — test(models): regression guards
+## T8 — Ship
 
-- [x] Extend `tests/plugins/models/routes.test.ts`: `/refresh` path, `/available` stale flag, gateway-restart cache-clear
-- [x] New `tests/plugins/models/enrichment.test.ts`: enriched `AvailableModel[]` for known ids, plain for unknown, date-suffix-strip match end-to-end
-- [x] New `tests/plugins/models/models-page.test.tsx`: cache-age indicator renders, Refresh button triggers `/refresh`, loading state with no cache, error state on fetch fail, gateway-sync banner renders on flag
-- [x] All required mocks per CLAUDE.md (content-dir, logger, watcher, openclaw-client, tasks/flow-store, cross-plugin hooks)
-- [x] Grep verifications repeat (zero hits): fallbackModels, MODEL_CATALOG, ModelCatalogEntry
-- [x] Checkpoint: full `pnpm vitest run` + `pnpm tsc --noEmit` clean (ignore pre-existing dagre failures)
-- [x] Commit: `test(models): regression guards for cache + enrichment + loading UI`
-
-## T9 — Ship
-
-- [x] `git push -u origin issue-129-models-loading-ux`
-- [x] Open PR #131 against `main`, reference #129, link spec + plugin-system one-pager
-- [ ] Manual smoke on the other machine (cache wipe → loading → refresh → banner flow)
-- [ ] Merge when smoke passes
-- [ ] Close #129 with before/after summary
-- [ ] Archive `tasks/plan.md` + `tasks/todo.md` → `.claude/tasks/issue-129-{plan,todo}.md`
+- [ ] `git push -u origin issue-137-health-checks-registry`
+- [ ] Open PR against `main` — reference #137 + spec + 2 follow-up plans
+- [ ] Quick manual smoke: `bakin doctor` output looks unchanged from pre-migration
+- [ ] File 2 follow-up issues:
+  - `chore(core): collapse DiagnosticResult into HealthCheckResult after all checks migrate`
+  - `chore: hook-name parity pass — rename all list{Noun} hooks to {namespace}.list`
+- [ ] Merge when green
+- [ ] Close #137 with before/after summary
+- [ ] Archive `tasks/plan.md` + `tasks/todo.md` → `.claude/tasks/issue-137-{plan,todo}.md`

--- a/tests/core/doctor-plugin-checks.test.ts
+++ b/tests/core/doctor-plugin-checks.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Doctor orchestrator — plugin health check integration.
+ *
+ * Tests `runPluginHealthChecks()` directly rather than the full
+ * `runDiagnostics()` sweep. The full sweep has ~18 dependencies and
+ * mocking every one of them is fragile. The plugin-check loop is
+ * independently testable as an extracted function, and that's what we
+ * exercise here: per-check try/catch isolation, multi-row support,
+ * cross-plugin results.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-doctor-plugin-checks-${Date.now()}`)
+
+vi.mock('../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => `${testDir}/.openclaw`,
+  getOpenClawPath: (p: string = '') => `${testDir}/.openclaw/${p}`,
+}))
+vi.mock('../../src/core/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('../../plugins/tasks/lib/flow-store', () => ({
+  readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getTask: () => null,
+}))
+
+import {
+  registerPluginHealthCheck,
+  unregisterPluginHealthChecks,
+} from '../../plugins/health/lib/health-check-registry'
+import { runPluginHealthChecks } from '../../src/core/doctor'
+
+beforeEach(() => {
+  // Clean registry before each test
+  unregisterPluginHealthChecks('test-a')
+  unregisterPluginHealthChecks('test-b')
+})
+
+afterEach(() => {
+  unregisterPluginHealthChecks('test-a')
+  unregisterPluginHealthChecks('test-b')
+})
+
+describe('runPluginHealthChecks', () => {
+  it('returns empty array when no plugin checks are registered', async () => {
+    const results = await runPluginHealthChecks()
+    expect(results).toEqual([])
+  })
+
+  it('runs a registered check and returns its results', async () => {
+    registerPluginHealthCheck('test-a', {
+      id: 'my-check',
+      name: 'My test check',
+      run: async () => [{
+        check: 'my-check',
+        status: 'ok',
+        message: 'All good',
+        autoFixable: false,
+      }],
+    })
+
+    const results = await runPluginHealthChecks()
+    expect(results).toHaveLength(1)
+    expect(results[0]).toEqual({
+      check: 'my-check',
+      status: 'ok',
+      message: 'All good',
+      autoFixable: false,
+    })
+  })
+
+  it('isolates a check that throws synchronously — other checks still run', async () => {
+    registerPluginHealthCheck('test-a', {
+      id: 'thrower',
+      name: 'Thrower',
+      run: async () => {
+        throw new Error('Intentional failure')
+      },
+    })
+    registerPluginHealthCheck('test-b', {
+      id: 'healthy',
+      name: 'Healthy',
+      run: async () => [{
+        check: 'healthy',
+        status: 'ok',
+        message: 'B is fine',
+        autoFixable: false,
+      }],
+    })
+
+    const results = await runPluginHealthChecks()
+    expect(results).toHaveLength(2)
+
+    const thrower = results.find(r => r.check === 'test-a.thrower')!
+    expect(thrower).toBeDefined()
+    expect(thrower.status).toBe('error')
+    expect(thrower.message).toMatch(/Intentional failure/)
+
+    const healthy = results.find(r => r.message === 'B is fine')!
+    expect(healthy).toBeDefined()
+    expect(healthy.status).toBe('ok')
+  })
+
+  it('isolates async rejections — synthetic error result', async () => {
+    registerPluginHealthCheck('test-a', {
+      id: 'rejecter',
+      name: 'Rejecter',
+      run: () => Promise.reject(new Error('Async fail')),
+    })
+
+    const results = await runPluginHealthChecks()
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('error')
+    expect(results[0].message).toMatch(/Async fail/)
+    expect(results[0].autoFixable).toBe(false)
+  })
+
+  it('handles non-Error throws with a reasonable string', async () => {
+    registerPluginHealthCheck('test-a', {
+      id: 'string-thrower',
+      name: 'String thrower',
+      run: () => Promise.reject('raw string error'),
+    })
+
+    const results = await runPluginHealthChecks()
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('error')
+    expect(results[0].message).toMatch(/raw string error/)
+  })
+
+  it('one check can contribute multiple result rows', async () => {
+    registerPluginHealthCheck('test-a', {
+      id: 'multi',
+      name: 'Multi-row',
+      run: async () => [
+        { check: 'multi.a', status: 'ok',   message: 'Row A', autoFixable: false },
+        { check: 'multi.b', status: 'warn', message: 'Row B', autoFixable: false },
+        { check: 'multi.c', status: 'ok',   message: 'Row C', autoFixable: false },
+      ],
+    })
+
+    const results = await runPluginHealthChecks()
+    expect(results).toHaveLength(3)
+    expect(results.map(r => r.check)).toEqual(['multi.a', 'multi.b', 'multi.c'])
+  })
+})

--- a/tests/core/mcp-server-registration.test.ts
+++ b/tests/core/mcp-server-registration.test.ts
@@ -118,6 +118,10 @@ describe('MCP server tool registration', () => {
           addExecTool(tool)
         },
         registerSkill: () => {},
+        registerWorkflow: () => {},
+        registerNodeType: (def: { kind: string }) => `${plugin.id}.${def.kind}`,
+        registerNotificationChannel: (def: { id: string }) => `${plugin.id}.${def.id}`,
+        registerHealthCheck: (def: { id: string }) => `${plugin.id}.${def.id}`,
         watchFiles: () => {},
         getSettings: () => ({}),
         updateSettings: () => {},

--- a/tests/integration/search-watcher-sync.test.ts
+++ b/tests/integration/search-watcher-sync.test.ts
@@ -137,6 +137,7 @@ function makeCtx(plugin: BakinPlugin): PluginContext {
     registerWorkflow: vi.fn(),
     registerNodeType: vi.fn(() => ''),
     registerNotificationChannel: vi.fn(() => ''),
+    registerHealthCheck: vi.fn(() => ''),
     watchFiles: vi.fn(),
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: vi.fn(),

--- a/tests/plugins/assets/retype-preserves-search.test.ts
+++ b/tests/plugins/assets/retype-preserves-search.test.ts
@@ -85,6 +85,7 @@ function makeCtx(): Captured {
     registerWorkflow: vi.fn(),
     registerNodeType: vi.fn(() => ''),
     registerNotificationChannel: vi.fn(() => ''),
+    registerHealthCheck: vi.fn(() => ''),
     watchFiles: vi.fn(),
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: vi.fn(),

--- a/tests/plugins/assets/unlink-hook.test.ts
+++ b/tests/plugins/assets/unlink-hook.test.ts
@@ -86,6 +86,7 @@ function makeCtx(): CapturedCtx {
     registerWorkflow: vi.fn(),
     registerNodeType: vi.fn(() => ''),
     registerNotificationChannel: vi.fn(() => ''),
+    registerHealthCheck: vi.fn(() => ''),
     watchFiles: vi.fn(),
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: vi.fn(),

--- a/tests/plugins/contract.test.ts
+++ b/tests/plugins/contract.test.ts
@@ -133,6 +133,7 @@ function createMockContext(pluginId: string): {
     registerWorkflow: () => {},
     registerNodeType: () => '',
     registerNotificationChannel: () => '',
+    registerHealthCheck: () => '',
     watchFiles: () => {},
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: () => {},

--- a/tests/plugins/health/checks-route.test.ts
+++ b/tests/plugins/health/checks-route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Health plugin — /checks route + list/get hooks for the registry.
+ *
+ * Activates the plugin via the test helper, exercises the REST route and
+ * the cross-plugin hooks, and asserts the `run` function is stripped at
+ * the serialization boundary.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest'
+import { mkdirSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-health-checks-route-${Date.now()}`)
+})
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => `${testDir}/.openclaw`,
+  getOpenClawPath: (p: string = '') => `${testDir}/.openclaw/${p}`,
+}))
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('../../../src/core/audit', () => ({ appendAudit: vi.fn() }))
+vi.mock('../../../src/core/openclaw-client', () => ({
+  sendMessage: vi.fn(), sendChannelMessage: vi.fn(),
+}))
+vi.mock('../../../src/core/watcher', () => ({ watchFiles: vi.fn() }))
+vi.mock('../../../plugins/tasks/lib/flow-store', () => ({
+  readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getTask: () => null,
+}))
+;(globalThis as any).__bakinBroadcast = vi.fn()
+
+import healthPlugin from '../../../plugins/health/index'
+import {
+  registerPluginHealthCheck,
+  unregisterPluginHealthChecks,
+} from '../../../plugins/health/lib/health-check-registry'
+import { activatePlugin, findRoute, callRoute } from '../test-helpers'
+import type { ActivatedPlugin } from '../test-helpers'
+
+let plugin: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  plugin = await activatePlugin(healthPlugin, testDir)
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+afterEach(() => {
+  // Clear anything tests registered — keeps the module-level registry clean
+  unregisterPluginHealthChecks('test-plugin')
+  unregisterPluginHealthChecks('other-plugin')
+})
+
+describe('GET /checks', () => {
+  it('is registered', () => {
+    expect(findRoute(plugin.routes, 'GET', '/checks')).toBeDefined()
+  })
+
+  it('returns empty array when no plugin checks are registered', async () => {
+    const route = findRoute(plugin.routes, 'GET', '/checks')!
+    const { status, body } = await callRoute(route, plugin.ctx)
+    expect(status).toBe(200)
+    expect(body.checks).toEqual([])
+  })
+
+  it('returns registered checks with metadata only (run stripped)', async () => {
+    registerPluginHealthCheck('test-plugin', {
+      id: 'my-check',
+      name: 'My check',
+      autoFix: true,
+      run: async () => [],
+    })
+
+    const route = findRoute(plugin.routes, 'GET', '/checks')!
+    const { body } = await callRoute(route, plugin.ctx)
+    const checks = body.checks as Array<Record<string, unknown>>
+    expect(checks).toHaveLength(1)
+    expect(checks[0]).toEqual({
+      id: 'test-plugin.my-check',
+      name: 'My check',
+      pluginId: 'test-plugin',
+      autoFix: true,
+    })
+    // Make sure `run` wasn't serialized
+    expect('run' in checks[0]).toBe(false)
+  })
+
+  it('returns multiple checks across plugins', async () => {
+    registerPluginHealthCheck('test-plugin', {
+      id: 'one', name: 'One', run: async () => [],
+    })
+    registerPluginHealthCheck('other-plugin', {
+      id: 'one', name: 'Other One', run: async () => [],
+    })
+
+    const route = findRoute(plugin.routes, 'GET', '/checks')!
+    const { body } = await callRoute(route, plugin.ctx)
+    const checks = body.checks as Array<Record<string, unknown>>
+    expect(checks).toHaveLength(2)
+    const ids = checks.map(c => c.id).sort()
+    expect(ids).toEqual(['other-plugin.one', 'test-plugin.one'])
+  })
+
+  it('autoFix defaults to false in the response when not set on registration', async () => {
+    registerPluginHealthCheck('test-plugin', {
+      id: 'readonly', name: 'Readonly', run: async () => [],
+    })
+
+    const route = findRoute(plugin.routes, 'GET', '/checks')!
+    const { body } = await callRoute(route, plugin.ctx)
+    const checks = body.checks as Array<Record<string, unknown>>
+    const found = checks.find(c => c.id === 'test-plugin.readonly')!
+    expect(found.autoFix).toBe(false)
+  })
+})

--- a/tests/plugins/health/health-check-registry.test.ts
+++ b/tests/plugins/health/health-check-registry.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Health-check registry — unit tests for the store shape.
+ *
+ * Mirrors tests/plugins/workflows/notification-channel-registry.test.ts
+ * but without any builtin-seeding assertions — this registry is
+ * plugin-contributions-only.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-health-registry-${Date.now()}`)
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('../../../plugins/tasks/lib/flow-store', () => ({
+  readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getTask: () => null,
+}))
+
+import {
+  registerHealthCheck,
+  getHealthCheck,
+  listHealthChecks,
+  unregisterHealthCheck,
+  registerPluginHealthCheck,
+  unregisterPluginHealthChecks,
+} from '../../../plugins/health/lib/health-check-registry'
+
+// Track ids we add per-test so we can clean up between tests.
+const added: string[] = []
+afterEach(() => {
+  for (const id of added) unregisterHealthCheck(id)
+  added.length = 0
+})
+
+describe('health-check-registry — baseline', () => {
+  it('starts empty (no builtin self-seeding)', () => {
+    expect(listHealthChecks()).toHaveLength(0)
+  })
+})
+
+describe('health-check-registry — register / get / list', () => {
+  it('registers and retrieves a check', () => {
+    registerHealthCheck({
+      runtime: 'plugin',
+      pluginId: 'test',
+      id: 'test.foo',
+      name: 'Foo check',
+      run: async () => [],
+    })
+    added.push('test.foo')
+    const def = getHealthCheck('test.foo')
+    expect(def).toBeDefined()
+    expect(def!.name).toBe('Foo check')
+    expect(def!.pluginId).toBe('test')
+  })
+
+  it('throws on duplicate id', () => {
+    registerHealthCheck({
+      runtime: 'plugin', pluginId: 'test', id: 'test.dupe', name: 'Dupe', run: async () => [],
+    })
+    added.push('test.dupe')
+    expect(() =>
+      registerHealthCheck({
+        runtime: 'plugin', pluginId: 'test', id: 'test.dupe', name: 'Again', run: async () => [],
+      }),
+    ).toThrow(/already registered/)
+  })
+
+  it('returns undefined for unknown ids', () => {
+    expect(getHealthCheck('nope')).toBeUndefined()
+  })
+
+  it('list returns all registered entries', () => {
+    registerHealthCheck({
+      runtime: 'plugin', pluginId: 'test', id: 'test.a', name: 'A', run: async () => [],
+    })
+    registerHealthCheck({
+      runtime: 'plugin', pluginId: 'test', id: 'test.b', name: 'B', run: async () => [],
+    })
+    added.push('test.a', 'test.b')
+    expect(listHealthChecks()).toHaveLength(2)
+  })
+})
+
+describe('health-check-registry — plugin helper', () => {
+  it('namespaces ids as {pluginId}.{id}', () => {
+    const result = registerPluginHealthCheck('myplugin', {
+      id: 'reachability',
+      name: 'My reachability check',
+      run: async () => [],
+    })
+    added.push(result)
+    expect(result).toBe('myplugin.reachability')
+    expect(getHealthCheck('myplugin.reachability')?.pluginId).toBe('myplugin')
+  })
+
+  it('preserves autoFix flag', () => {
+    const result = registerPluginHealthCheck('myplugin', {
+      id: 'cleanup',
+      name: 'Cleanup check',
+      autoFix: true,
+      run: async () => [],
+    })
+    added.push(result)
+    expect(getHealthCheck(result)?.autoFix).toBe(true)
+  })
+
+  it('defaults autoFix to undefined when not passed', () => {
+    const result = registerPluginHealthCheck('myplugin', {
+      id: 'readonly',
+      name: 'Readonly check',
+      run: async () => [],
+    })
+    added.push(result)
+    expect(getHealthCheck(result)?.autoFix).toBeUndefined()
+  })
+})
+
+describe('health-check-registry — plugin teardown', () => {
+  it('unregisterPluginHealthChecks removes only the named plugin', () => {
+    registerPluginHealthCheck('plugin-a', { id: 'one', name: 'A-one', run: async () => [] })
+    registerPluginHealthCheck('plugin-a', { id: 'two', name: 'A-two', run: async () => [] })
+    registerPluginHealthCheck('plugin-b', { id: 'one', name: 'B-one', run: async () => [] })
+
+    unregisterPluginHealthChecks('plugin-a')
+
+    expect(getHealthCheck('plugin-a.one')).toBeUndefined()
+    expect(getHealthCheck('plugin-a.two')).toBeUndefined()
+    expect(getHealthCheck('plugin-b.one')).toBeDefined()
+
+    unregisterHealthCheck('plugin-b.one')  // cleanup
+  })
+
+  it('is idempotent — unregistering an unknown plugin is a no-op', () => {
+    expect(() => unregisterPluginHealthChecks('never-registered')).not.toThrow()
+  })
+})

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -113,8 +113,8 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('Health Plugin Routes', () => {
-  it('registers 6 routes', () => {
-    expect(activated.routes.length).toBe(6)
+  it('registers 7 routes', () => {
+    expect(activated.routes.length).toBe(7)
   })
 
   it('registers 2 exec tools', () => {

--- a/tests/plugins/projects/sync-hook.test.ts
+++ b/tests/plugins/projects/sync-hook.test.ts
@@ -78,6 +78,7 @@ function makeCtx(): CapturedCtx {
     registerWorkflow: vi.fn(),
     registerNodeType: vi.fn(() => ''),
     registerNotificationChannel: vi.fn(() => ''),
+    registerHealthCheck: vi.fn(() => ''),
     watchFiles: vi.fn(),
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: vi.fn(),

--- a/tests/plugins/test-helpers.ts
+++ b/tests/plugins/test-helpers.ts
@@ -136,6 +136,7 @@ export function createTestContext(pluginId: string, testDir: string): ActivatedP
         return `${pluginId}.${def.id}`
       }
     },
+    registerHealthCheck: vi.fn((def) => `${pluginId}.${def.id}`),
     watchFiles: vi.fn(),
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: vi.fn(),

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Workflow health checks — migration regression coverage.
+ *
+ * Asserts that the three functions moved out of src/core/doctor.ts
+ * (#137) continue to produce `HealthCheckResult[]` rows with the same
+ * shape and semantics as they did pre-migration. Exercises each check
+ * against fixture workflow data written to a temp directory.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = vi.hoisted(() => {
+  const { join } = require('path')
+  const { tmpdir } = require('os')
+  return join(tmpdir(), `bakin-test-workflow-health-${Date.now()}`)
+})
+
+vi.mock('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+vi.mock('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => `${testDir}/.openclaw`,
+  getOpenClawPath: (p: string = '') => `${testDir}/.openclaw/${p}`,
+}))
+vi.mock('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('../../../src/core/settings', () => ({
+  getSettings: () => ({ doctor: { autoFixSkill: false } }),
+}))
+vi.mock('../../../plugins/tasks/lib/flow-store', () => ({
+  readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
+  getTask: () => null,
+}))
+
+// Hook registry — only readTaskboard is called from the checks
+vi.mock('../../../src/lib/plugin-registry', () => ({
+  getHookRegistry: () => ({
+    invoke: async (name: string) => {
+      if (name === 'tasks.readTaskboard') {
+        return { columns: { todo: [{ id: 'task-exists' }], done: [] } }
+      }
+      return undefined
+    },
+    has: () => false,
+    register: () => () => {},
+  }),
+}))
+
+import {
+  checkWorkflowSkills,
+  checkWorkflowDefinitions,
+  checkStaleWorkflowInstances,
+} from '../../../plugins/workflows/lib/health-checks'
+
+const skillsDir = join(testDir, 'workflows', 'skills')
+const definitionsDir = join(testDir, 'workflows', 'definitions')
+const instancesDir = join(testDir, 'workflows', 'instances')
+
+beforeAll(() => {
+  mkdirSync(skillsDir, { recursive: true })
+  mkdirSync(definitionsDir, { recursive: true })
+  mkdirSync(instancesDir, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  // Clear dirs between tests
+  for (const dir of [skillsDir, definitionsDir, instancesDir]) {
+    rmSync(dir, { recursive: true, force: true })
+    mkdirSync(dir, { recursive: true })
+  }
+})
+
+describe('checkWorkflowSkills', () => {
+  it('returns an ok result when the skills directory is empty', () => {
+    const results = checkWorkflowSkills(testDir)
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('ok')
+  })
+
+  it('flags a skill missing YAML frontmatter', () => {
+    writeFileSync(join(skillsDir, 'bad.md'), 'just some content, no frontmatter')
+    const results = checkWorkflowSkills(testDir)
+    expect(results.some(r => r.status === 'warn' && r.message.includes('no YAML frontmatter'))).toBe(true)
+  })
+
+  it('flags a skill missing output_schema', () => {
+    writeFileSync(
+      join(skillsDir, 'no-schema.md'),
+      '---\nname: no-schema\ndescription: test\n---\nbody',
+    )
+    const results = checkWorkflowSkills(testDir)
+    expect(results.some(r => r.status === 'warn' && r.message.includes('no output_schema'))).toBe(true)
+  })
+
+  it('returns ok when all skills have output_schema', () => {
+    writeFileSync(
+      join(skillsDir, 'good.md'),
+      '---\nname: good\noutput_schema: { foo: string }\n---\nbody',
+    )
+    const results = checkWorkflowSkills(testDir)
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('ok')
+  })
+})
+
+describe('checkWorkflowDefinitions', () => {
+  it('returns ok when no definitions exist', async () => {
+    const results = await checkWorkflowDefinitions(testDir)
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('ok')
+    expect(results[0].message).toMatch(/All workflow skill references resolve/)
+  })
+
+  it('flags a workflow step referencing a missing skill', async () => {
+    // Create the skill referenced by one workflow, not the other
+    writeFileSync(join(skillsDir, 'existing-skill.md'), '---\nname: existing\n---\nbody')
+    writeFileSync(
+      join(definitionsDir, 'broken-flow.yaml'),
+      `name: Broken flow
+description: test
+version: 1
+steps:
+  - id: s1
+    label: Step 1
+    type: agent
+    agent: main
+    skill: missing-skill
+`,
+    )
+    const results = await checkWorkflowDefinitions(testDir)
+    expect(results.some(r => r.status === 'warn' && r.message.includes('missing-skill'))).toBe(true)
+  })
+})
+
+describe('checkStaleWorkflowInstances', () => {
+  it('returns ok when no instances exist', async () => {
+    const results = await checkStaleWorkflowInstances(testDir)
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('ok')
+    expect(results[0].message).toMatch(/No stale workflow instances/)
+  })
+
+  it('flags an orphaned instance (task no longer on board)', async () => {
+    const orphanedId = 'task-deleted'
+    writeFileSync(
+      join(instancesDir, `${orphanedId}.json`),
+      JSON.stringify({
+        instanceId: 'i1',
+        taskId: orphanedId,
+        status: 'in_progress',
+        currentStepId: 's1',
+        updatedAt: new Date().toISOString(),
+      }),
+    )
+    const results = await checkStaleWorkflowInstances(testDir)
+    expect(results.some(r => r.status === 'warn' && r.message.includes(orphanedId))).toBe(true)
+  })
+
+  it('flags a stale in-progress instance (>2h old)', async () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString()
+    writeFileSync(
+      join(instancesDir, 'task-exists.json'),
+      JSON.stringify({
+        instanceId: 'i2',
+        taskId: 'task-exists',
+        status: 'in_progress',
+        currentStepId: 'waiting-step',
+        updatedAt: threeHoursAgo,
+      }),
+    )
+    const results = await checkStaleWorkflowInstances(testDir)
+    expect(results.some(r => r.status === 'warn' && r.message.includes('in_progress'))).toBe(true)
+  })
+})

--- a/tests/plugins/workflows/sync-hook.test.ts
+++ b/tests/plugins/workflows/sync-hook.test.ts
@@ -103,6 +103,7 @@ function makeCtx(): CapturedCtx {
     registerWorkflow: vi.fn(),
     registerNodeType: vi.fn(() => ''),
     registerNotificationChannel: vi.fn(() => ''),
+    registerHealthCheck: vi.fn(() => ''),
     watchFiles: vi.fn(),
     getSettings: (() => ({})) as PluginContext['getSettings'],
     updateSettings: vi.fn(),


### PR DESCRIPTION
Closes #137. Implements \`.claude/specs/issue-137-health-checks-registry.md\`. 4th of the 5 Registry Extension Points from \`docs/ideas/plugin-system.md\` — after this, only \`assets.renderers\` remains before the adapter layer pivot.

## Summary

Third metadata/behavior-shaped registry. Plugins can contribute doctor checks via \`ctx.registerHealthCheck(...)\`; the orchestrator picks them up alongside builtin checks at the end of each \`runDiagnostics()\` sweep. Pattern is identical to the notification-channels registry (#125 / PR #126) — same auto-namespacing, same teardown, same cross-plugin read surface.

**Forcing function built in:** three workflow-plugin-owned checks (\`checkWorkflowDefinitions\`, \`checkStaleWorkflowInstances\`, \`checkWorkflowSkills\`) migrated out of \`src/core/doctor.ts\` into \`plugins/workflows/lib/health-checks.ts\`. Pattern validated end-to-end the moment this PR lands — not speculative like the closed #128.

## Commits (7)

1. \`chore(issue-137)\`: spec + plan scaffold
2. \`feat(core)\`: HealthCheckResult types + PluginContext.registerHealthCheck
3. \`feat(health)\`: health-check-registry with plugin namespacing + teardown
4. \`feat(core)\`: wire registerHealthCheck through plugin-registry
5. \`feat(health)\`: expose registered checks via hooks + REST route
6. \`feat(core)\`: run plugin health checks in runDiagnostics
7. \`refactor(workflows)\`: migrate workflow health checks out of core/doctor.ts

## Key design choices (all in the spec)

- **Flat \`ctx.registerHealthCheck\` — no \`ctx.health.*\` namespace.** Matches 7 other one-shot \`register*\` methods on PluginContext. Future-widening is additive.
- **\`HealthCheckResult\` / \`DiagnosticResult\` coexist as aliases.** Not tech debt — the collapse waits for the other 14 builtin checks to migrate (tracked as follow-up).
- **Per-check try/catch isolation.** One bad handler yields a synthetic error row, never crashes the sweep. Async rejections + sync throws + non-Error throws all handled.
- **\`runPluginHealthChecks()\` exported separately** from \`runDiagnostics()\` so isolation behavior is unit-testable without mocking the 18+ dependencies the full sweep touches.
- **Plugin results append after builtins**, no interleaving — the health page UI groups by status so ordering doesn't matter.
- **Result payload strips \`run\` fn at the REST boundary** (not serializable).

## Follow-ups to file on merge

Per the spec's Resolved Decisions:

1. \`chore(core): collapse DiagnosticResult into HealthCheckResult after all checks migrate\` — fires once the other 14 builtin checks have moved out of \`src/core/doctor.ts\`
2. \`chore: hook-name parity pass — rename all list{Noun} hooks to {namespace}.list\` — coordinated rename across 6+ plugins

## Checks

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm vitest run\` — 2965 passed, 1 skipped (adds 31 new tests across registry / route / orchestrator / migration)
- [x] Grep verification: \`checkWorkflowSkills|checkWorkflowDefinitions|checkStaleWorkflowInstances\` in \`src/core/doctor.ts\` → 0 hits

## Manual smoke

\`bakin doctor\` output should look identical to pre-migration — the 3 workflow checks now come from the plugin registry but their result shapes + messages are unchanged. If anything's different visually, that's a regression to flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)