### PR TITLE
feat(team): surgical agent-packages UI (#158, partial)

### DIFF
--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -126,8 +126,71 @@ The REST routes and MCP tools share the same adapter layer underneath. UI uses R
 
 - `useAgent(id)`, `useAgentList()`, `useAgentIds()`, `useAgentColor(id)`
 - `useMainAgentId()` — reads the `mainAgentId` field the roster route returns (server-side `getMainAgentId()`). Used by `TeamGrid` to pass the canonical root into `buildGraph`.
+- `usePackageState(id)` — reads the per-agent agent-package row sourced from `/api/agent-packages` (see "Agent-Package Surfaces" below).
 
 Components never compute "who is the main agent" themselves — always read it from the store.
+
+## Agent-Package Surfaces (#158)
+
+The Teams UI exposes three contextual agent-package surfaces. Cross-agent operations (install, browse, curated) are intentionally CLI-only in this iteration; a future Workshop page will bring those into the UI.
+
+### Data Plumbing
+
+`useAgentStore.load()` issues `/api/plugins/team/` and `/api/agent-packages` in parallel and merges the package response into a `packageStates: Record<agentId, PackageStateRow>` map. A failed `/api/agent-packages` is non-fatal — the agent grid keeps working with no badges. The store also exposes `refreshPackageStates()` for post-Adopt invalidation; consumers call it after a write so the UI updates without a page reload.
+
+`PackageStateRow.state` is typed as the badge component's 6-state union (`absent | unmanaged | adopted | managed | drifted | update-available`) for forward-compat. The server today emits only the 4-state subset; `drifted` and `update-available` code paths are wired but unreachable until the API starts returning them.
+
+### Surface 1 — Badge on AgentCardNode (`team-grid.tsx`)
+
+The compact `<PackageStateBadge state={...} compact />` renders inline next to the agent name, but **only when state is "attention-worthy"**: `unmanaged`, `drifted`, or `update-available`. Healthy states (`managed`, `adopted`) and missing data leave the card visually unchanged. Convention: *no badge means OK.*
+
+The compact pill is purely visual — no text label, tooltip + aria-label preserved. Click on the agent card opens the detail page where the full Package card lives.
+
+### Surface 2 — Package Card on Profile Tab (`agent-detail.tsx`)
+
+A read-only `<PackageCard>` sits at the top of the Profile tab and adapts content per state:
+
+| State | Render |
+|---|---|
+| `managed` / `adopted` | Full state badge + dl-style fields: source, ref, commit (sliced to 7 chars), installed-at, dependencies. No CLI hint. |
+| `unmanaged` (default when no row exists) | State badge + Adopt button → opens `<AdoptDialog>`. |
+| `drifted` | State badge + CLI hint: `bakin install agent-assets` with copy button. |
+| `update-available` | State badge + CLI hint: `bakin agents update <id>` with copy button. |
+
+Convention: **CLI hints render only when there is no UI affordance for the action.** Adopt is wired in-UI, so `unmanaged` shows no hint. Update / Reinstall / Remove / Reset workspace are all CLI-only and show hints in their respective state branches.
+
+### Surface 3 — Knowledge Tab (`agent-detail.tsx`)
+
+The "Knowledge" tab sits between Skills and Memory in the tab order — both are package-rooted concepts. Always visible, content adapts:
+
+- **`managed` / `adopted`:** renders `<KnowledgeToggleList agentId={...}>` (existing component, optimistic UI, REST round-trip on toggle).
+- **Anything else:** "Coming soon" placeholder pointing the user back at the Package card on the Profile tab to adopt first. Future work replaces this with adoption-value + knowledge-explainer copy.
+
+### Adopt Round-Trip
+
+```
+PackageCard (unmanaged) → click "Adopt"
+  → <AdoptDialog open={true} agentId={agentId}>
+    → user enters source → submit
+      → POST /api/agent-packages/install { source, adopt: agentId }
+        → onAdopted callback
+          → refreshPackageStates() invalidates the store slice
+            → PackageCard re-renders with the new state (managed/adopted)
+              → Badge on AgentCardNode disappears (state no longer attention-worthy)
+```
+
+No page reload, no manual refetch from the consumer side.
+
+### What's Deferred (future Workshop ticket)
+
+- Curated browser (`<CuratedBrowser>` exists, unwired)
+- Generic install dialog (`<InstallDialog>` exists, unwired) — for installing fresh agents and non-agent kinds
+- Per-package detail drawer for skill-pack / workflow-pack / knowledge-pack
+- Update / Reinstall / Remove / Reset workspace as UI buttons
+- `.userEdited` lock surfacing
+- Drift-count widget in Health plugin
+
+These all stay CLI-only until the Workshop page lands.
 
 ## Test Coverage Map
 

--- a/.claude/specs/team-agent-packages-ui-plan.md
+++ b/.claude/specs/team-agent-packages-ui-plan.md
@@ -1,0 +1,392 @@
+# Execution Plan — Surgical Agent-Packages UI in Teams (#158)
+
+Companion to `.claude/specs/team-agent-packages-ui.md`. Read the spec first for the *what* and *why*; this document is the *how* — exact files, line numbers, dependency graph, per-checkpoint verification, and the rollback story.
+
+## Refresher (locked decisions live in the spec)
+
+Three Teams surfaces wired in this issue, two components stay on the shelf, no Workshop. The 6-commit strategy carries us from data-plumbing to docs in independently-revertable slices.
+
+## One Deviation From Spec Wording
+
+The spec described "a new `usePackageStates()` hook" as the data-plumbing pattern. The plan uses the **existing Zustand `useAgentStore`** instead — extending its `load()` to fetch `/api/agent-packages` in parallel with the existing roster fetch and exposing a `packageStates` field + a `refreshPackageStates()` action.
+
+Why the deviation:
+- `AgentThemeProvider` (`packages/host/src/providers/AgentThemeProvider.tsx:13-15`) already calls `useAgentStore.load()` once at app mount, so the store is populated before any consumer renders. A standalone hook would duplicate that bootstrap fetch in two places (team-grid + agent-detail).
+- Single source of truth is more aligned with CLAUDE.md's "no parallel stat-tracking systems" principle.
+- The existing `reload` action pattern (used by `team-grid:176`, `agent-detail:43`, `team-manager:21`) already gives us cache-invalidation precedent for free.
+
+The spec's intent — *parallel client fetch, no Teams server changes* — is preserved exactly. Only the implementation shape changes.
+
+## Critical Files
+
+| # | Path | Role | Rough edit surface |
+|---|---|---|---|
+| 1 | `plugins/team/hooks/use-agent-store.ts` | Add `packageStates: Record<agentId, PackageStateRow>` field, fetch in parallel inside `load()`, expose `refreshPackageStates()` action. New selector `usePackageState(agentId)`. | Extend `AgentStore` interface (12-34), add parallel fetch in `load()` (46-77), add `refreshPackageStates` action, add `usePackageState` selector after `useAgentColor` (108). New `PackageStateRow` type imported from a shared location or inlined. |
+| 2 | `plugins/team/types.ts` | Add `PackageStateRow` type (mirrors `/api/agent-packages` response row shape) for use by the store and consumers. | Append type at end of file. |
+| 3 | `plugins/team/components/package-state-badge.tsx` | Add `compact` prop for the cramped node context. Compact = no text label, just the colored pill (12px, no padding). | Add `compact?: boolean` to `PackageStateBadgeProps` (25-31). Adjust render branch (66-78) to skip label + tooltip-only mode when compact. |
+| 4 | `plugins/team/components/team-grid.tsx` | Wire `<PackageStateBadge compact>` into `AgentCardNode` with attention-only conditional rendering. | Modify `AgentCardNode` (86-140). Add `usePackageState(agent.id)` call near top. Render badge in bottom row (124-136) only when `state ∈ {unmanaged, drifted, update-available}`. Position to be settled visually during build (likely between status badge and model name on line 127-135). |
+| 5 | `plugins/team/components/agent-detail.tsx` | Add Knowledge tab to TABS list and render `<KnowledgeToggleList>` (or "Coming soon" empty state). Add Package card section to ProfileTab. Lift agent state for refetch after Adopt. | (a) Extend `Tab` union (25) and `TABS` (27-35). (b) Pass `packageState` prop into `ProfileTab` (272). (c) Insert new `<PackageCard>` component above existing sections in `ProfileTab` (330-363). (d) Add `{activeTab === 'knowledge' && <KnowledgeTab agentId={agentId} packageState={...} />}` row after line 277. (e) Define `<PackageCard>` and `<KnowledgeTab>` helper components after `ProfileTab` (363+) — `<PackageCard>` renders state badge, fields, Adopt button on unmanaged; `<KnowledgeTab>` renders `<KnowledgeToggleList>` for managed/adopted, "Coming soon" otherwise. (f) Adopt button mounts `<AdoptDialog>` and on `onAdopted` calls `refreshPackageStates()`. |
+| 6 | `tests/plugins/team/use-package-states.test.ts` | **New.** Unit tests for the store extension. | Asserts: load() fetches both endpoints in parallel; merge by agentId; refreshPackageStates() invalidates and re-fetches; failed `/api/agent-packages` doesn't break agent loading. ~120 lines. |
+| 7 | `tests/plugins/team/agent-card-package-badge.test.tsx` | **New.** Component-level test for AgentCardNode badge wiring. | Renders AgentCardNode within a minimal store wrapper for each PackageState; asserts badge presence/absence per attention rules; asserts compact prop applied. ~80 lines. |
+| 8 | `tests/plugins/team/agent-detail-package-card.test.tsx` | **New.** Renders Package card per state. | Asserts visible fields per state; CLI hint visibility (drifted, update-available) and absence (managed, adopted, unmanaged); Adopt button visibility (unmanaged only). ~120 lines. |
+| 9 | `tests/plugins/team/agent-detail-adopt.test.tsx` | **New.** Adopt button wiring. | Click Adopt → dialog opens with correct `agentId`; mock POST to `/api/agent-packages/install` with `{source, adopt: agentId}`; on success → `refreshPackageStates` called. ~100 lines. |
+| 10 | `tests/plugins/team/agent-detail-knowledge-tab.test.tsx` | **New.** Knowledge tab. | Tab visible in tab bar; renders `<KnowledgeToggleList>` for managed/adopted; renders "Coming soon" for unmanaged; clicking tab updates `?tab=knowledge` URL state. ~80 lines. |
+| 11 | `.claude/knowledge/team-plugin-ui.md` | **New.** Documents the wiring patterns for future agents. | Sections: agent-card structure, package badge convention (attention-only rule), agent-detail tab order, package state fetching pattern (store extension), Adopt flow round-trip. ~150 lines. |
+| 12 | `docs/agent-packages-authoring.md` | Add "From the UI" section. | Short paragraph: what's surfaced today (badge, Package card, Knowledge tab) and what's CLI-only (install, browse, update, remove, reset, drift repair). ~30 lines. |
+
+**No changes to:**
+
+- `plugins/team/index.ts` — Teams server code unchanged. `/api/plugins/team/` continues returning the same shape.
+- `packages/host/src/api/agent-packages/*` — REST endpoints already exist and match.
+- `plugins/team/components/install-dialog.tsx`, `curated-browser.tsx` — stay built-but-unwired (Workshop ticket).
+- `plugins/team/lib/build-graph.ts` — keep `buildGraph` pure; AgentCardNode reads package state via hook, not via prop drilling.
+- `plugins/team/components/knowledge-toggle-list.tsx` — already correct, no changes.
+- `plugins/team/components/adopt-dialog.tsx` — already correct, no changes.
+- `plugins/health/*` — drift widget deferred to Workshop ticket.
+- `CLAUDE.md` — plugin count unchanged; existing patterns adequate.
+- `README.md` — no user-facing surface change.
+
+## Dependency Graph
+
+```
+C1 (store extension) ──┬──▶ C2 (badge) ──────────┐
+                       │                          │
+                       ├──▶ C3 (Package card) ───▶ C4 (Adopt wiring) ──┐
+                       │                                                │
+                       └──▶ C5 (Knowledge tab) ─────────────────────────┘
+                                                                        │
+                                                                        ▼
+                                                            C6 (docs — independent, ships last)
+```
+
+- **C1 must land before C2, C3, C5** because all three read `packageStates` from the store.
+- **C3 must land before C4** because the Adopt button lives inside the Package card.
+- **C2, C3, C5 can be developed in parallel** if multiple branches/agents are at play (not the case here, but useful for understanding the slice independence).
+- **C6 (docs) is independent** — could land at any point. We put it last so the knowledge file reflects the *landed* state, not the planned state.
+
+## Per-Commit Plan
+
+### C1 — `feat(team): fetch package state in agent store`
+
+**Files:** `plugins/team/hooks/use-agent-store.ts`, `plugins/team/types.ts`, `tests/plugins/team/use-package-states.test.ts`
+
+**Changes:**
+
+1. Add `PackageStateRow` type to `plugins/team/types.ts` mirroring the row shape from `/api/agent-packages`:
+   ```ts
+   export interface PackageStateRow {
+     agentId: string
+     state: PackageState  // imported from package-state-badge
+     packageId?: string
+     source?: string
+     ref?: string
+     commitSha?: string
+     installedAt?: string
+     dependencies?: string[]
+   }
+   ```
+   Reference the actual response shape in `packages/host/src/api/agent-packages/list.ts` to confirm field names; correct any drift before committing.
+
+2. Extend `AgentStore` interface (`use-agent-store.ts:12-34`) with:
+   ```ts
+   packageStates: Record<string, PackageStateRow>
+   refreshPackageStates: () => Promise<void>
+   ```
+
+3. Modify `load()` (lines 46-77) to use `Promise.all` for the two endpoints:
+   ```ts
+   const [rosterRes, pkgRes] = await Promise.all([
+     fetch('/api/plugins/team/'),
+     fetch('/api/agent-packages'),
+   ])
+   ```
+   - Process roster as today
+   - Process pkgRes into `packageStates: Record<string, PackageStateRow>`
+   - **Failed `/api/agent-packages` is non-fatal** — log + set `packageStates: {}` so the rest of the UI keeps working
+   - `set({...existing, packageStates})`
+
+4. Implement `refreshPackageStates()` — re-fetches just `/api/agent-packages` and updates the slice without touching `agents`.
+
+5. Add `usePackageState(agentId)` selector after `useAgentColor` (line 108):
+   ```ts
+   export function usePackageState(agentId: string): PackageStateRow | undefined {
+     return useAgentStore((s) => s.packageStates[agentId])
+   }
+   ```
+
+**Tests (`use-package-states.test.ts`):**
+- `load()` calls both endpoints in parallel (assert via call order/timing)
+- Merge: store has correct `packageStates` map after load
+- `refreshPackageStates()` re-fetches only the package endpoint
+- Failed `/api/agent-packages` → `packageStates: {}`, agents still load
+- All required mocks per CLAUDE.md (content-dir x2, openclaw-home, logger, watcher, openclaw-client) — even though this is client-side, transitive imports may pull server modules.
+
+**Verification:**
+```bash
+bun test --isolate tests/plugins/team/use-package-states.test.ts
+bun test --isolate tests/plugins/team   # ensure no existing test regressions
+bun run dev:mock                         # store loads without error; check Network tab for parallel fetches
+```
+
+**Acceptance:** New test passes. No UI change visible. Network tab shows both `/api/plugins/team/` and `/api/agent-packages` firing on app mount.
+
+---
+
+### C2 — `feat(team): show package state badge on agent cards`
+
+**Files:** `plugins/team/components/package-state-badge.tsx`, `plugins/team/components/team-grid.tsx`, `tests/plugins/team/agent-card-package-badge.test.tsx`
+
+**Changes:**
+
+1. Add `compact` prop to `<PackageStateBadge>` (`package-state-badge.tsx:25-31`):
+   ```ts
+   compact?: boolean
+   ```
+   Render branch (66-78) — when `compact`, output a smaller pill: no label text (just the colored dot/pill), tooltip retained, narrower padding (`text-[10px] px-1 py-0` or similar). Keep the existing default render unchanged for non-compact callers.
+
+2. Wire `<PackageStateBadge compact>` into `AgentCardNode` (`team-grid.tsx:86-140`):
+   - Add `usePackageState(agent.id)` call near top of component (line 87-88 vicinity)
+   - Within bottom row (124-136), after the status `<Badge>` (133) and before the model `<span>` (134) — render conditionally:
+     ```tsx
+     {pkgState && ['unmanaged', 'drifted', 'update-available'].includes(pkgState.state) && (
+       <PackageStateBadge state={pkgState.state} compact />
+     )}
+     ```
+   - If the bottom row gets cramped, expand `CARD_W` in `build-graph.ts:31` from 152 → 168 (or similar). Settle visually during build.
+
+**Tests (`agent-card-package-badge.test.tsx`):**
+- Render `AgentCardNode` inside a wrapper that primes the store with each of: `managed`, `adopted`, `unmanaged`, `drifted`, `update-available`, `absent`, undefined (no entry)
+- Assert badge presence: only `unmanaged`, `drifted`, `update-available` show a badge
+- Assert badge absence: `managed`, `adopted`, `absent`, undefined show no badge
+- Assert `compact` prop is passed (badge has no visible label text)
+
+**Verification:**
+```bash
+bun test --isolate tests/plugins/team/agent-card-package-badge.test.tsx
+bun run dev:mock
+# Visual: open /team. Verify:
+#   - Healthy agents (managed/adopted) → no badge (clean cards as today)
+#   - Imitation Crab seeds at least one unmanaged agent → amber/yellow badge visible
+#   - Tooltip on the badge shows the state-specific copy
+```
+
+**Acceptance:** New test passes. Visual verification matches attention-only rule. Existing team-grid tests still green.
+
+---
+
+### C3 — `feat(team): add Package card to agent detail Profile tab`
+
+**Files:** `plugins/team/components/agent-detail.tsx`, `tests/plugins/team/agent-detail-package-card.test.tsx`
+
+**Changes:**
+
+1. Define new `<PackageCard>` helper component below `ProfileTab` (after line 363). Inputs: `packageState: PackageStateRow | undefined`. Output:
+   - Section wrapper (matches `ProfileSection` pattern at line 313-319) — label "Package"
+   - State badge (full, non-compact) at top
+   - **If state is managed/adopted:** dl-style list of fields — Source, Ref, Commit SHA (short, 7 chars), Installed at (formatted date), Dependencies (chip list)
+   - **If state is drifted:** state badge + CLI hint copy box: ``bakin install agent-assets`` with copy-to-clipboard button
+   - **If state is update-available:** state badge + CLI hint copy box: ``bakin agents update <agentId>`` with copy-to-clipboard
+   - **If state is unmanaged or undefined:** state badge + Adopt button (disabled in C3, wired in C4 — for now placeholder onClick)
+
+2. Modify `ProfileTab` signature (`agent-detail.tsx:330`) to accept `packageState`:
+   ```tsx
+   function ProfileTab({ profile, packageState }: { profile: AgentProfile; packageState: PackageStateRow | undefined })
+   ```
+
+3. Insert `<PackageCard packageState={packageState} />` at the top of `ProfileTab` body (line 332, before the existing Identity section) — appears first so package state is the primary metadata.
+
+4. Update the `<ProfileTab>` callsite (line 272):
+   ```tsx
+   {activeTab === 'profile' && <ProfileTab profile={profile} packageState={pkgState} />}
+   ```
+   And `pkgState = usePackageState(agentId)` near the top of `AgentDetail` (around line 39-54).
+
+**Tests (`agent-detail-package-card.test.tsx`):**
+- Render Package card with each state value
+- Assert displayed fields per state (Source/Ref/Commit/Installed/Deps shown for managed+adopted; CLI hint shown for drifted+update-available; Adopt button shown for unmanaged)
+- Assert clipboard button present on CLI hints (don't test actual clipboard write — too fragile)
+- Assert Adopt button **disabled** in this commit (becomes enabled in C4)
+
+**Verification:**
+```bash
+bun test --isolate tests/plugins/team/agent-detail-package-card.test.tsx
+bun run dev:mock
+# Visual: click into any agent → Profile tab → Package card visible at top.
+# Switch between agents in different states (Imitation Crab seeds them) → card adapts correctly.
+```
+
+**Acceptance:** New test passes. Visual verification across all 5 states. Adopt button visible but inert.
+
+---
+
+### C4 — `feat(team): wire AdoptDialog into Package card`
+
+**Files:** `plugins/team/components/agent-detail.tsx`, `tests/plugins/team/agent-detail-adopt.test.tsx`
+
+**Changes:**
+
+1. Inside `<PackageCard>`:
+   - Local state: `const [adoptOpen, setAdoptOpen] = useState(false)`
+   - Replace placeholder Adopt button onClick with `() => setAdoptOpen(true)`
+   - Render `<AdoptDialog open={adoptOpen} onOpenChange={setAdoptOpen} agentId={agentId} onAdopted={...} />` at the bottom of the card. Note `agentId` needs to be prop-drilled into `<PackageCard>` from `<ProfileTab>` (or read from a context — prop-drilling is fine here, single hop).
+   - `onAdopted` handler: calls `refreshPackageStates()` from the store (new selector), then closes the dialog. Dialog already closes itself on success but we explicitly invalidate state.
+
+2. Pull in `refreshPackageStates`:
+   ```tsx
+   const refresh = useAgentStore((s) => s.refreshPackageStates)
+   ```
+
+**Tests (`agent-detail-adopt.test.tsx`):**
+- Render Package card in `unmanaged` state, click Adopt → assert `<AdoptDialog>` is in the DOM with `open=true`
+- Mock `fetch('/api/agent-packages/install')` with success
+- Submit dialog with valid source → assert POST body matches `{source, adopt: agentId}` shape
+- Assert `refreshPackageStates` is called after success
+- Assert dialog closes after success (button enabled state, etc.)
+
+**Verification:**
+```bash
+bun test --isolate tests/plugins/team/agent-detail-adopt.test.tsx
+bun run dev:mock
+# Visual: pick an unmanaged agent → Profile → Package card → Adopt
+#   → enter `github:bakin-examples/pixel` (or any seeded curated source) → submit
+#   → verify card transitions to managed/adopted without page reload
+#   → verify badge on the agent card in the grid disappears (was attention-only)
+```
+
+**Acceptance:** New test passes. End-to-end Adopt flow works from the UI without reload.
+
+---
+
+### C5 — `feat(team): add Knowledge tab to agent-detail`
+
+**Files:** `plugins/team/components/agent-detail.tsx`, `tests/plugins/team/agent-detail-knowledge-tab.test.tsx`
+
+**Changes:**
+
+1. Extend `Tab` union (`agent-detail.tsx:25`):
+   ```ts
+   type Tab = 'profile' | 'soul' | 'rules' | 'tools' | 'skills' | 'memory' | 'stats' | 'knowledge'
+   ```
+
+2. Add to `TABS` array (27-35) — insert after `'memory'` (or wherever fits the visual order; suggest: **after `'skills'` and before `'memory'`** since both Skills and Knowledge are package-rooted concepts):
+   ```ts
+   { id: 'knowledge', label: 'Knowledge' },
+   ```
+
+3. Add render branch in tab content (after line 277):
+   ```tsx
+   {activeTab === 'knowledge' && <KnowledgeTab agentId={agentId} packageState={pkgState} />}
+   ```
+
+4. Define `<KnowledgeTab>` helper after `<PackageCard>`:
+   - **If state is managed or adopted:** render `<KnowledgeToggleList agentId={agentId} />` (existing component, no changes)
+   - **Else:** render an empty state — centered "Coming soon" with a brief explainer line ("Knowledge management requires an agent-package. Adopt this agent in the Package card to unlock."). Use the existing pattern for empty states (find one in `tasks/skills/memory` tabs to match).
+
+**Tests (`agent-detail-knowledge-tab.test.tsx`):**
+- Tab "Knowledge" appears in the tab bar
+- Click Knowledge tab → URL updates to `?tab=knowledge`
+- For state=managed: renders `<KnowledgeToggleList>` (assert presence by querying for the component's identifying markup, e.g., the loader or a test-id)
+- For state=adopted: same as managed
+- For state=unmanaged: renders "Coming soon" placeholder
+- For state=undefined (no package data): also renders "Coming soon"
+
+**Verification:**
+```bash
+bun test --isolate tests/plugins/team/agent-detail-knowledge-tab.test.tsx
+bun run dev:mock
+# Visual: pick a managed agent → Knowledge tab → toggles visible, can flip them
+# Pick an unmanaged agent → Knowledge tab → "Coming soon"
+# Reload preserves ?tab=knowledge URL state
+```
+
+**Acceptance:** New test passes. Knowledge tab works end-to-end for both states.
+
+---
+
+### C6 — `docs: document Teams agent-package UI surfaces`
+
+**Files:** `.claude/knowledge/team-plugin-ui.md` (new), `docs/agent-packages-authoring.md` (extend)
+
+**Changes:**
+
+1. Create `.claude/knowledge/team-plugin-ui.md` with sections:
+   - **AgentCardNode structure** — 152px-wide ReactFlow node, status dot top-right, name+role+bottom-row layout, badge insertion point
+   - **Package badge convention** — attention-only render rule, compact variant, color mapping per state
+   - **agent-detail tab order** — current 8-tab list (Profile, Soul, Rules, Tools, Skills, Knowledge, Memory, Stats), URL-state via `useQueryState('tab')`
+   - **Package card placement** — top of Profile tab, render variants per state, CLI hint conventions
+   - **Package state fetching** — extension of `useAgentStore.load()` with parallel `/api/agent-packages` fetch, `usePackageState(agentId)` selector, `refreshPackageStates()` invalidation pattern
+   - **Adopt flow round-trip** — button → dialog → POST install → onAdopted → refresh → UI auto-updates
+
+2. Extend `docs/agent-packages-authoring.md` with a new "From the UI" section near the end:
+   - One paragraph naming the three Teams UI surfaces (badge, Package card, Knowledge tab)
+   - One paragraph naming what's CLI-only today (install, browse, curated, update, remove, reset workspace, `.userEdited` lock-release, drift repair)
+   - One sentence pointing at the future Workshop ticket
+
+**Tests:** None.
+
+**Verification:**
+```bash
+# Read the new knowledge file end-to-end. Verify it reflects what landed in C1-C5.
+# Read the updated agent-packages-authoring.md section. Verify it matches reality.
+```
+
+**Acceptance:** Both files committed; no inaccuracies vs the landed code.
+
+---
+
+## Verification Across All Commits
+
+After each commit:
+```bash
+bun test --isolate tests/plugins/team   # focused
+bun test --isolate                       # full suite, no regressions
+```
+
+Before opening the PR:
+```bash
+bun run typecheck     # confirm exact name in package.json
+bun run build:plugins # or scripts/build-plugins.ts — full plugin build clean
+bun run dev:mock      # last visual sweep across all 5 acceptance criteria
+```
+
+PR checklist (mirrors spec's "Definition of Done"):
+- [ ] All 6 commits on `feat/team-agent-packages-ui`
+- [ ] Full test suite passes
+- [ ] Visual verification of all 5 happy-path criteria + 1 CLI-hint criterion
+- [ ] PR body says "Closes #158 partially. Follow-up: <Workshop issue link>"
+- [ ] Workshop follow-up issue filed before merge
+
+## Rollback Story
+
+Every commit is independently revertable; the codebase remains functional after any subset is reverted.
+
+| Revert | Result |
+|---|---|
+| Just C6 | Code identical; only the new knowledge file + docs section disappear. No user-visible change. |
+| Just C5 | Knowledge tab vanishes from `agent-detail`; URL `?tab=knowledge` falls back to default `profile`. Other surfaces unchanged. |
+| Just C4 | Adopt button on Package card becomes inert (placeholder onClick) — visible but does nothing. CLI hint not added either; user is told via copy to use CLI. Or revert C4 + C3 together for cleaner removal. |
+| Just C3 | Package card disappears from Profile tab. Knowledge tab and badge still work. |
+| Just C2 | Badges vanish from `AgentCardNode`. Package card + Knowledge tab still functional. |
+| Just C1 | All consumers fail to read package state — `usePackageState` returns undefined → badge never renders, Package card defaults to "no package data" (which renders as the unmanaged variant). **C2/C3/C4/C5 must be reverted alongside C1** for full cleanliness, but the partial-revert state is non-broken (just shows "no package data" everywhere). |
+| Full revert (C1-C6) | Codebase identical to pre-#158 state. The 5 components in `plugins/team/components/` are still present (they were already there before this issue), still untested at the isolation level (also unchanged). |
+
+**Recovery:** Each commit ships with its own test additions, so `git revert <sha>` cleanly removes both feature and test in one operation. No orphaned tests, no broken imports.
+
+**No destructive operations** in any commit:
+- No file deletions
+- No schema migrations
+- No env var requirements
+- No build-pipeline changes
+- No new dependencies (every component used is already in the tree; existing primitives in `@bakin/sdk/ui`)
+
+## Open Questions (resolve during build, not blockers)
+
+These are intentionally left open — they're micro-decisions the spec doesn't constrain and that benefit from being settled visually rather than on paper:
+
+1. **Badge placement within the bottom row of `AgentCardNode`** — left-of-status-badge vs right-of-model-text vs replacing the model text. To be settled by eyeballing the rendered card.
+2. **Card width adjustment** — keep 152px or grow to ~168px to accommodate the badge. Tied to (1).
+3. **Adopt button styling** — primary CTA vs subtle secondary. Probably primary since it's the only action on an unmanaged Package card.
+4. **CLI hint copy box style** — fully-rendered `<code>` block with copy button vs inline backtick mention. Probably the former for clipboard ergonomics.
+5. **Knowledge tab order** — between Skills and Memory (suggested) or end of list. Tied to mental model of "package-rooted concepts together."
+
+None of these block C1 from starting; all can be settled during their respective commits.

--- a/.claude/specs/team-agent-packages-ui.md
+++ b/.claude/specs/team-agent-packages-ui.md
@@ -1,0 +1,213 @@
+# Spec — Surgical Agent-Packages UI in Teams Plugin (#158)
+
+Closes part of [#158](https://github.com/madeinwyo/bakin/issues/158) as a partial. Opens follow-up for Workshop install/browse UX.
+
+## Problem
+
+The agent-packages refactor shipped 5 self-contained React components in `plugins/team/components/` but **wired none of them into the live Teams UI**. Today:
+
+- Managed / adopted / unmanaged / drifted state is invisible in the browser
+- Adopting an existing OpenClaw agent requires CLI
+- Per-agent knowledge lessons can't be toggled from the UI
+- Package metadata (source, ref, commit, installed-at, deps) is invisible
+
+Components on the shelf, no UI consuming them.
+
+## Why surgical, not comprehensive
+
+The full issue #158 imagines a complete UI parity flow including curated browse, install dialogs, lifecycle (update / remove / reinstall / reset workspace), bulk operations, and a per-package detail drawer for non-agent kinds. That is a different beast — *install/browse/manage* — and naturally belongs in a future top-level "Workshop" page (native, sibling of `/settings`), not the Teams plugin.
+
+This spec covers only what's *contextual to an existing agent*:
+
+1. Visual signal of package state (badge on the agent node)
+2. Read-only package metadata + adopt CTA (in agent-detail Profile tab)
+3. Interactive knowledge toggling (new tab in agent-detail)
+
+The 2 deferred components stay built-but-unwired in `plugins/team/components/`, awaiting the Workshop ticket.
+
+## Locked Decisions
+
+1. **No Workshop in this issue.** Install / browse / curated UX deferred to a follow-up ticket. `<InstallDialog>` and `<CuratedBrowser>` remain on the shelf, untouched.
+2. **3 of 5 components wired:** `<PackageStateBadge>`, `<AdoptDialog>`, `<KnowledgeToggleList>`.
+3. **Three Teams surfaces:**
+   - Conditional attention-only badge on `AgentCardNode` (only renders when `state ∈ {unmanaged, drifted, update-available}`)
+   - Read-only Package card added to Profile tab in `agent-detail`
+   - Knowledge tab added to `agent-detail`, always visible (with empty state for unmanaged)
+4. **Adopt button lives in the Package card**, not on the node itself. The node badge does the visual signaling; click → agent-detail → Adopt button in Package card.
+5. **Package state via parallel client fetch.** New `usePackageStates()` hook calls `/api/agent-packages` in parallel with the existing team list fetch; merge by `agentId` client-side. **Zero changes to Teams server code.**
+6. **CLI hints only when no UI alternative.** Unmanaged → Adopt button (no hint). Drifted → `bakin install agent-assets` hint. Update-available → `bakin agents update <id>` hint. Managed/adopted → no hint.
+7. **Knowledge tab empty state for unmanaged is "Coming soon"** placeholder — replaced in a follow-up with adoption-value + knowledge-explainer copy.
+8. **Issue #158 closes as a partial.** Opens follow-up issue: "Workshop: install/browse/curated UX (the deferred 2 components)."
+9. **Branch:** `feat/team-agent-packages-ui`. Single PR.
+
+## Acceptance Criteria
+
+A user opening Teams in the browser can:
+
+- ✅ See at a glance which agents need attention (unmanaged, drifted, or update-available render a colored badge on the agent card; managed/adopted are visually unchanged from today)
+- ✅ Open any agent's detail page and see a Package card showing current state and (when present) source / ref / commit SHA / installed-at / dependencies
+- ✅ Click "Adopt" on the Package card of any unmanaged agent, complete the flow, and see the agent transition to `managed` state without page refresh
+- ✅ Open the Knowledge tab on a managed/adopted agent and toggle individual lessons on/off; toggles persist across reload
+- ✅ Open the Knowledge tab on an unmanaged agent and see a "Coming soon" placeholder
+- ✅ See a CLI hint with copy-to-clipboard for drifted and update-available states, since those flows are deferred
+
+Not in this issue (CLI remains canonical):
+
+- ❌ Curated browser
+- ❌ Install dialog (generic install entry)
+- ❌ Update / Reinstall / Remove buttons in agent-detail
+- ❌ Reset workspace flow
+- ❌ `.userEdited` lock surfacing
+- ❌ Drift report widget in Health plugin
+- ❌ Bulk update-all
+- ❌ Per-package detail drawer for non-agent kinds (skill-pack / workflow-pack / knowledge-pack)
+- ❌ Sort / filter team-grid by package state (graph viz makes this awkward; punt to Workshop's installed-list)
+
+## In Scope (Files Touched)
+
+| Path | Change |
+|---|---|
+| `plugins/team/components/team-grid.tsx` | Wire `<PackageStateBadge>` (compact variant, attention-only) into `AgentCardNode` (lines 86–140). Pass package state to nodes via `data.packageState`. |
+| `plugins/team/components/agent-detail.tsx` | Add Package card section to Profile tab (around lines 327–365). Add new "Knowledge" tab to the tab list (lines 27–35) and panel. |
+| `plugins/team/components/package-state-badge.tsx` | Add `compact` prop or `size="sm"` variant for the cramped node context. |
+| `plugins/team/hooks/use-package-states.ts` | **New.** Hook fetching `/api/agent-packages`, returning a `Record<agentId, PackageStateRow>` map. Re-fetches on focus + on demand (after Adopt success). |
+| `plugins/team/hooks/use-agent-store.ts` | Wire `usePackageStates()` alongside existing agent fetch; merge by `agentId` so node `data.packageState` is populated. |
+| `tests/plugins/team/use-package-states.test.tsx` | **New.** Coverage for the hook (fetch shape, merge logic, refetch trigger). |
+| `tests/plugins/team/agent-card-package-badge.test.tsx` | **New.** Renders `AgentCardNode` with each state value; asserts badge visibility per attention rules. |
+| `tests/plugins/team/agent-detail-package-card.test.tsx` | **New.** Renders Package card per state; asserts CLI hint visibility, Adopt button visibility. |
+| `tests/plugins/team/agent-detail-adopt.test.tsx` | **New.** Click Adopt → assert `<AdoptDialog>` opens with correct `agentId`; on success assert refetch is triggered. |
+| `tests/plugins/team/agent-detail-knowledge-tab.test.tsx` | **New.** Tab renders for managed (lessons + toggles), unmanaged (Coming soon), adopted (lessons). |
+| `.claude/knowledge/team-plugin-ui.md` | **New** (or extension to existing `team-plugin.md` if focused). Documents the agent-card structure, package badge convention, agent-detail tabs, package state fetching pattern. |
+| `docs/agent-packages-authoring.md` | Add "From the UI" section: short paragraph on what's surfaced in the Teams UI today (badge, Package card, Knowledge tab) and what's CLI-only. |
+
+**Not touched:**
+
+- `plugins/team/index.ts` — Teams server code unchanged. Package state comes from `/api/agent-packages`, which already exists.
+- `packages/host/src/api/agent-packages/*` — REST endpoints already exist and match the shapes we need.
+- `plugins/team/components/install-dialog.tsx`, `curated-browser.tsx` — stay on the shelf.
+- `plugins/health/*` — no drift widget in this issue.
+- `CLAUDE.md` — no plugin count changes; pattern coverage already adequate.
+- `README.md` — no user-facing CLI or workflow surface changes.
+
+## Commands (Verification Surfaces)
+
+```bash
+# Tests during dev (every commit must keep these green)
+bun test --watch --isolate tests/plugins/team
+
+# Full suite (pre-merge)
+bun test --isolate
+
+# Type check
+bun run typecheck   # or whatever the project's tsc invocation is — check package.json
+
+# Build verification (catches plugin-build regressions)
+bun run build:plugins   # or scripts/build-plugins.ts
+
+# Visual verification (this is UI work — required)
+bun run dev:mock
+# Open http://localhost:3737/team and visually verify:
+#   - Badges only on attention agents (Imitation Crab seeds at least one of each state)
+#   - Click into an agent → Profile tab → Package card visible
+#   - Adopt button on unmanaged agents → opens dialog → completes
+#   - Knowledge tab visible → renders toggles for managed agents → "Coming soon" for unmanaged
+```
+
+## Code Style
+
+Inherits from `CLAUDE.md`:
+
+- TypeScript strict, no `any` across module boundaries
+- Functional preference, hooks over class components
+- `kebab-case.tsx` for files, `PascalCase` for components
+- Imports follow the standard order (Node → external → SDK → internal → plugin → relative)
+- `const` over `let`, never `var`
+- No empty catch blocks
+- No unsolicited refactors of adjacent code (scope discipline)
+
+UI specifics:
+
+- Use existing `@bakin/sdk/components` primitives where they exist (`Badge`, `Button`, `Card`, `Tabs` triggers/content, etc. — survey their actual location during build)
+- Mirror existing `agent-detail` tab structure for the Knowledge tab (don't invent a new tab pattern)
+- Follow the conditional rendering convention from the existing `<Badge variant=...>` lookups in `team-grid.tsx`
+
+## Testing Strategy
+
+**Mandatory mock setup** (project rule, non-negotiable — see CLAUDE.md "Testing Rules — CRITICAL"):
+
+Every test file must mock both `getContentDir` resolvers (the shim in `src/core/content-dir.ts` AND the canonical `packages/core/src/content-dir.ts`), the OpenClaw home resolver, the logger, the watcher, and the openclaw-client. Test data goes to `tmpdir()`, never to `~/.bakin/` or `~/.openclaw/`. Cleanup with `afterAll(() => rmSync(testDir, ...))`.
+
+For the new tests in this spec, since we're testing UI components and a thin client-side hook (no server-side filesystem reads), most of those mocks are precautionary — but the rule applies anyway because component imports may transitively pull in modules that read content-dir at module-load.
+
+**Per-commit test focus:**
+
+| Commit | Test additions |
+|---|---|
+| C1 (hook) | `use-package-states.test.tsx` — fetch shape, merge logic, refetch trigger. Use `mock.module` to stub `/api/agent-packages` response. |
+| C2 (badge) | `agent-card-package-badge.test.tsx` — render `AgentCardNode` with each state; assert visibility per attention rules. Snapshot-style assertions on which Badge variant renders. |
+| C3 (Package card read-only) | `agent-detail-package-card.test.tsx` — render Package card variants (managed / adopted / unmanaged / drifted / update-available); assert displayed fields + CLI hint visibility. |
+| C4 (Adopt wiring) | `agent-detail-adopt.test.tsx` — click Adopt → dialog opens with correct `agentId`; on dialog success → refetch hook called. |
+| C5 (Knowledge tab) | `agent-detail-knowledge-tab.test.tsx` — tab renders for managed (delegates to `<KnowledgeToggleList>`); empty state "Coming soon" for unmanaged. |
+| C6 (docs) | No test additions. |
+
+**No new isolation tests for `<PackageStateBadge>`, `<AdoptDialog>`, `<KnowledgeToggleList>` themselves** — they exist as components today (the issue body claims "passing isolation tests" but none were found in `tests/plugins/team/`; we're not adding speculative coverage to components that already work, only to the wiring that consumes them). If a wired flow fails because of a component bug, *then* we add isolation tests for the failing component.
+
+**Bun test runner:** `bun test --isolate tests/plugins/team` for the focused suite during dev.
+
+## Boundaries
+
+**Always do:**
+
+- Maintain CLAUDE.md test isolation rules (mock content-dir + openclaw-home → tmpdir, mock logger, mock watcher, mock openclaw-client) — corruption of `~/.bakin/` from a leaked test has happened multiple times
+- Use existing `@bakin/sdk/components` primitives instead of duplicating them inside Teams
+- Refetch package state on `<AdoptDialog>` success so the UI updates without page reload
+- Pass package state through to `AgentCardNode` via `data.packageState` (the React Flow data prop), not via context or external state
+- Keep `plugins/team/index.ts` untouched — server-side Teams code does not need to know about packages
+- Use TanStack Router's existing `team.$id.tsx` route shape; don't add new routes
+
+**Ask first about:**
+
+- Any change to `<PackageStateBadge>` beyond adding a `compact`/`size="sm"` variant — the component is shared with the (deferred) Workshop ticket; breaking changes propagate
+- Any change to the `/api/agent-packages` REST shape — backend is out of scope for this issue
+- Reordering Profile tab cards (Identity, Soul, Rules, Tools, Heartbeat exist today; Package card insertion point matters for muscle memory)
+- Adding any UI surface for the deferred lifecycle ops (Update / Reinstall / Remove / Reset) — these were explicitly punted to CLI
+
+**Never do:**
+
+- Wire `<InstallDialog>` or `<CuratedBrowser>` in this issue (Workshop ticket)
+- Add UI buttons for Update / Reinstall / Remove / Reset (CLI-only for V1)
+- Hardcode `~/.bakin/` or `~/.openclaw/` anywhere — use `getContentDir()` / `getOpenClawPath()`
+- Add a parallel package-state cache or fetch system — `usePackageStates()` is the single client source of truth, mirroring the "no parallel stat-tracking systems" rule from CLAUDE.md
+- Modify Teams server code (`plugins/team/index.ts`) to enrich `/api/plugins/team/` with package state — keeps the two endpoints decoupled and avoids cross-plugin server-side coupling
+- Bypass the badge attention-only rule by showing badges for `managed`/`adopted` — clean cards on healthy teams is the explicit design choice
+- Skip tests because "the components already work" — wiring is what we're testing here
+- Add backwards-compatibility shims for the unwired components (single-user app, no v1→v2 migration)
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Adopt flow doesn't refresh state cleanly → user sees stale "unmanaged" until reload | Adopt dialog `onAdopted` callback explicitly invalidates `usePackageStates` query. Test C4 covers this. |
+| Knowledge toggle race during in-flight enable/disable | Existing `<KnowledgeToggleList>` already has optimistic UI + revert-on-error (verified in survey). No new logic needed. |
+| Badge visual overload on a fresh install where every agent is unmanaged | Acceptable — that's the point. Once user adopts via CLI/UI, badges disappear. |
+| Cross-fetch latency makes the team-grid render briefly without badges | Acceptable — both fetches start in parallel on mount. Worst case is ~50ms of badge-less grid. Don't add a loading skeleton just for this. |
+| `.userEdited` lock surfacing was an issue ask — skipping it could leave user stuck | Documented in `docs/agent-packages-authoring.md` as CLI-managed for V1: `rm <file>.userEdited` (or future Workshop affordance). Not a blocker. |
+| Drift detection produces false positives | Out of scope — drift logic lives server-side in `/api/agent-packages`. We're a display-only consumer. |
+
+## Out of Scope (Tracked in Follow-Up Issues)
+
+To open after this lands:
+
+- **"Workshop: install/browse/curated UX"** — wires `<InstallDialog>` + `<CuratedBrowser>`, adds native `/workshop` page, includes Packages tab for non-agent kinds, drift filter, Health plugin drift count widget.
+- **"Knowledge tab adoption-value copy"** — replaces "Coming soon" placeholder with marketing/explainer content.
+- **"Lifecycle ops in agent-detail UI"** — Update / Reinstall / Remove / Reset workspace buttons (after Workshop lands and the patterns are settled).
+
+## Definition of Done
+
+- All 6 commits land on `feat/team-agent-packages-ui`
+- `bun test --isolate` passes (no regressions in existing suites; new tests pass)
+- `bun run dev:mock` visual verification for all 5 acceptance criteria
+- PR opened against `main` referencing #158 with "Closes #158 partially. Follow-up: <Workshop issue link>"
+- Knowledge file `.claude/knowledge/team-plugin-ui.md` (new or appended) documents the wiring patterns for future agents
+- `docs/agent-packages-authoring.md` "From the UI" section landed
+- Follow-up Workshop issue filed before merge

--- a/docs/agent-packages-authoring.md
+++ b/docs/agent-packages-authoring.md
@@ -612,6 +612,31 @@ To get your package into the curated catalog, send a PR to
 `trust` is display-only in V1 (`official | verified | community`). A
 hosted registry + signed-package trust enforcement is future work.
 
+## From the UI
+
+The Teams plugin surfaces a small but useful slice of the agent-package model in the browser. Everything else is CLI today.
+
+**Surfaced in the UI:**
+
+- **Package state badge** on every agent card in the team grid — only renders for `unmanaged`, `drifted`, or `update-available` (healthy states stay clean). Color-coded.
+- **Package card** at the top of the agent-detail Profile tab — read-only display of state, source, ref, commit (short SHA), installed-at, and dependencies for managed/adopted agents.
+- **Adopt button** in the Package card on unmanaged agents — opens a dialog, asks for the package source, and `POST`s `/api/agent-packages/install` with `{ source, adopt: agentId }`. The Teams page updates without a reload.
+- **Knowledge tab** on agent-detail — for managed/adopted agents, renders per-lesson on/off toggles backed by `/api/agent-packages/:id/knowledge`. Optimistic UI, revert on error.
+
+**Still CLI-only:**
+
+- **Install fresh agent** → `bakin agents install <source>`
+- **Browse curated catalog** → `bakin agents install` from the curated list (no in-app browser yet)
+- **Install non-agent kinds** (skill-pack / workflow-pack / knowledge-pack) → `bakin packages install <source>`
+- **List installed packages** of any kind → `bakin packages list`
+- **Update a package** → `bakin agents update <id>` or `bakin packages update <id>`
+- **Remove a package** → `bakin agents remove <id>` or `bakin packages remove <id>`
+- **Reset workspace** (re-template from package source) → `bakin agents update <id> --refresh-template`
+- **Release a `.userEdited` lock** → `rm <file>.userEdited`
+- **Drift repair** → `bakin install agent-assets` (CLI hint surfaced inside the Package card on `drifted` state)
+
+A future "Workshop" page will bring install / browse / curated / non-agent management into the UI. Until then the CLI remains the canonical surface for those flows; the UI is sugar on top.
+
 ## Future work (not yet supported)
 
 - **Per-skill rename via `installAs`.** V1 aliases the lockfile key only;

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -32,6 +32,7 @@ export {
   useAgentDisplayName,
   useAgentIds,
   useMainAgentId,
+  usePackageState,
   hexToMuted,
 } from '@bakin/team/hooks/use-agent-store'
 

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -20,6 +20,7 @@ import type { AvailableModel } from "@bakin/sdk/types"
 import { useAgentStore, useAgentColor, useMainAgentId, usePackageState } from '@bakin/sdk/hooks'
 import { useQueryState } from "@bakin/sdk/hooks"
 import { PackageStateBadge } from './package-state-badge'
+import { AdoptDialog } from './adopt-dialog'
 import type { AgentProfile, SkillSummary, PackageStateRow } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
 
@@ -446,13 +447,15 @@ function PackageCard({ agentId, packageState }: { agentId: string; packageState:
   // most common reason is the agent exists in OpenClaw but has never been
   // adopted, which is the same thing as state=unmanaged.
   const state = packageState?.state ?? 'unmanaged'
+  const refreshPackageStates = useAgentStore((s) => s.refreshPackageStates)
+  const [adoptOpen, setAdoptOpen] = useState(false)
   return (
     <ProfileSection label="Package">
       <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-3">
         <div className="flex items-center justify-between gap-2">
           <PackageStateBadge state={state} packageId={packageState?.packageId} />
           {state === 'unmanaged' && (
-            <Button size="sm" disabled title="Adopt flow lands in C4">
+            <Button size="sm" onClick={() => setAdoptOpen(true)}>
               Adopt
             </Button>
           )}
@@ -477,6 +480,12 @@ function PackageCard({ agentId, packageState }: { agentId: string; packageState:
           </div>
         )}
       </div>
+      <AdoptDialog
+        open={adoptOpen}
+        onOpenChange={setAdoptOpen}
+        agentId={agentId}
+        onAdopted={() => { refreshPackageStates() }}
+      />
     </ProfileSection>
   )
 }

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useRouter } from '@bakin/sdk/hooks'
-import { ArrowLeft, Save, Loader2, Camera, Trash2 } from 'lucide-react'
+import { ArrowLeft, Save, Loader2, Camera, Trash2, Copy } from 'lucide-react'
 import { Badge } from "@bakin/sdk/ui"
 import { Button } from "@bakin/sdk/ui"
 import {
@@ -17,9 +17,10 @@ import { MarkdownContent } from "@bakin/sdk/components"
 import { ModelSelect } from "@bakin/sdk/components"
 import { useGatewayStatus } from "@bakin/sdk/hooks"
 import type { AvailableModel } from "@bakin/sdk/types"
-import { useAgentStore, useAgentColor, useMainAgentId } from '@bakin/sdk/hooks'
+import { useAgentStore, useAgentColor, useMainAgentId, usePackageState } from '@bakin/sdk/hooks'
 import { useQueryState } from "@bakin/sdk/hooks"
-import type { AgentProfile, SkillSummary } from '../types'
+import { PackageStateBadge } from './package-state-badge'
+import type { AgentProfile, SkillSummary, PackageStateRow } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
 
 type Tab = 'profile' | 'soul' | 'rules' | 'tools' | 'skills' | 'memory' | 'stats'
@@ -41,6 +42,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
   const teams = useAgentStore((s) => s.teams)
   const displaySettings = useAgentStore((s) => s.displaySettings)
   const reload = useAgentStore((s) => s.load)
+  const packageState = usePackageState(agentId)
   const currentTeamId = displaySettings[agentId]?.teamId ?? ''
   const [profile, setProfile] = useState<AgentProfile | null>(null)
   const [tabParam, setTabParam] = useQueryState('tab', 'profile')
@@ -269,7 +271,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
 
       {/* Tab Content */}
       <div className="min-h-[400px]">
-        {activeTab === 'profile' && <ProfileTab profile={profile} />}
+        {activeTab === 'profile' && <ProfileTab profile={profile} agentId={agentId} packageState={packageState} />}
         {activeTab === 'soul' && <FileEditorTab agentId={agentId} filename="SOUL.md" content={profile.soul} />}
         {activeTab === 'rules' && <FileEditorTab agentId={agentId} filename="AGENTS.md" content={profile.rules} />}
         {activeTab === 'tools' && <FileEditorTab agentId={agentId} filename="TOOLS.md" content={profile.tools} />}
@@ -327,9 +329,18 @@ function ProfileMarkdown({ content }: { content: string }) {
   )
 }
 
-function ProfileTab({ profile }: { profile: AgentProfile }) {
+function ProfileTab({
+  profile,
+  agentId,
+  packageState,
+}: {
+  profile: AgentProfile
+  agentId: string
+  packageState: PackageStateRow | undefined
+}) {
   return (
     <div className="space-y-5 max-w-2xl">
+      <PackageCard agentId={agentId} packageState={packageState} />
       {profile.identity && (
         <ProfileSection label="Identity">
           <ProfileMarkdown content={profile.identity} />
@@ -359,6 +370,114 @@ function ProfileTab({ profile }: { profile: AgentProfile }) {
         <code className="text-[11px] text-muted-foreground font-mono">{profile.workspacePath}</code>
       </ProfileSection>
     </div>
+  )
+}
+
+// ─── Package Card (lives inside Profile Tab) ─────────────────────────────────
+
+function CliHint({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // clipboard api unavailable — fail quietly, the command is visible
+    }
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs">
+      <code className="flex-1 font-mono text-foreground">{command}</code>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={handleCopy}
+        title={copied ? 'Copied' : 'Copy'}
+        aria-label="Copy command"
+      >
+        <Copy className="size-3.5" />
+      </Button>
+    </div>
+  )
+}
+
+function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageStateRow['entry']>; packageId?: string }) {
+  return (
+    <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">
+      {packageId && (
+        <>
+          <dt className="text-muted-foreground">Package</dt>
+          <dd className="font-mono text-foreground break-all">{packageId}</dd>
+        </>
+      )}
+      <dt className="text-muted-foreground">Source</dt>
+      <dd className="font-mono text-foreground break-all">{entry.source}</dd>
+      {entry.ref && (
+        <>
+          <dt className="text-muted-foreground">Ref</dt>
+          <dd className="font-mono text-foreground">{entry.ref}</dd>
+        </>
+      )}
+      {entry.commitSha && (
+        <>
+          <dt className="text-muted-foreground">Commit</dt>
+          <dd className="font-mono text-foreground">{entry.commitSha.slice(0, 7)}</dd>
+        </>
+      )}
+      <dt className="text-muted-foreground">Installed</dt>
+      <dd className="text-foreground">{entry.installedAt}</dd>
+      {entry.dependencies && entry.dependencies.length > 0 && (
+        <>
+          <dt className="text-muted-foreground">Depends on</dt>
+          <dd className="flex flex-wrap gap-1">
+            {entry.dependencies.map((d) => (
+              <Badge key={d} variant="outline" className="text-[10px] font-mono">{d}</Badge>
+            ))}
+          </dd>
+        </>
+      )}
+    </dl>
+  )
+}
+
+function PackageCard({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
+  // Default to "unmanaged" when the API hasn't reported a row at all — the
+  // most common reason is the agent exists in OpenClaw but has never been
+  // adopted, which is the same thing as state=unmanaged.
+  const state = packageState?.state ?? 'unmanaged'
+  return (
+    <ProfileSection label="Package">
+      <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-3">
+        <div className="flex items-center justify-between gap-2">
+          <PackageStateBadge state={state} packageId={packageState?.packageId} />
+          {state === 'unmanaged' && (
+            <Button size="sm" disabled title="Adopt flow lands in C4">
+              Adopt
+            </Button>
+          )}
+        </div>
+        {packageState?.entry && (state === 'managed' || state === 'adopted') && (
+          <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
+        )}
+        {state === 'drifted' && (
+          <div className="space-y-1.5">
+            <p className="text-xs text-muted-foreground">
+              Projection sha mismatch detected. Repair from the CLI:
+            </p>
+            <CliHint command="bakin install agent-assets" />
+          </div>
+        )}
+        {state === 'update-available' && (
+          <div className="space-y-1.5">
+            <p className="text-xs text-muted-foreground">
+              A newer version of the source package is available. Update from the CLI:
+            </p>
+            <CliHint command={`bakin agents update ${agentId}`} />
+          </div>
+        )}
+      </div>
+    </ProfileSection>
   )
 }
 

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -21,10 +21,11 @@ import { useAgentStore, useAgentColor, useMainAgentId, usePackageState } from '@
 import { useQueryState } from "@bakin/sdk/hooks"
 import { PackageStateBadge } from './package-state-badge'
 import { AdoptDialog } from './adopt-dialog'
+import { KnowledgeToggleList } from './knowledge-toggle-list'
 import type { AgentProfile, SkillSummary, PackageStateRow } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
 
-type Tab = 'profile' | 'soul' | 'rules' | 'tools' | 'skills' | 'memory' | 'stats'
+type Tab = 'profile' | 'soul' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'memory' | 'stats'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'profile', label: 'Profile' },
@@ -32,6 +33,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'rules', label: 'Rules' },
   { id: 'tools', label: 'Tools' },
   { id: 'skills', label: 'Skills' },
+  { id: 'knowledge', label: 'Knowledge' },
   { id: 'memory', label: 'Memory' },
   { id: 'stats', label: 'Stats' },
 ]
@@ -277,6 +279,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
         {activeTab === 'rules' && <FileEditorTab agentId={agentId} filename="AGENTS.md" content={profile.rules} />}
         {activeTab === 'tools' && <FileEditorTab agentId={agentId} filename="TOOLS.md" content={profile.tools} />}
         {activeTab === 'skills' && <SkillsTab agentId={agentId} />}
+        {activeTab === 'knowledge' && <KnowledgeTab agentId={agentId} packageState={packageState} />}
         {activeTab === 'memory' && <MemoryTab agentId={agentId} />}
         {activeTab === 'stats' && <StatsTab agentId={agentId} />}
       </div>
@@ -487,6 +490,27 @@ function PackageCard({ agentId, packageState }: { agentId: string; packageState:
         onAdopted={() => { refreshPackageStates() }}
       />
     </ProfileSection>
+  )
+}
+
+// ─── Knowledge Tab ───────────────────────────────────────────────────────────
+
+function KnowledgeTab({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
+  const state = packageState?.state ?? 'unmanaged'
+  if (state === 'managed' || state === 'adopted') {
+    return (
+      <div className="max-w-2xl">
+        <KnowledgeToggleList agentId={agentId} />
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+      <div className="text-base font-medium text-foreground mb-1">Coming soon</div>
+      <p className="text-sm max-w-md">
+        Knowledge management requires a managed agent-package. Adopt this agent in the Package card on the Profile tab to unlock per-lesson toggles.
+      </p>
+    </div>
   )
 }
 

--- a/plugins/team/components/package-state-badge.tsx
+++ b/plugins/team/components/package-state-badge.tsx
@@ -28,6 +28,12 @@ export interface PackageStateBadgeProps {
   packageId?: string
   /** Hover tooltip override; defaults to a state-specific explainer */
   title?: string
+  /**
+   * Compact mode — drops the text label, renders a small colored pill.
+   * For cramped contexts like the agent grid card. Tooltip is preserved
+   * so the user can still read the state on hover.
+   */
+  compact?: boolean
 }
 
 const STATE_STYLES: Record<PackageState, { label: string; cls: string; tip: string }> = {
@@ -63,8 +69,18 @@ const STATE_STYLES: Record<PackageState, { label: string; cls: string; tip: stri
   },
 }
 
-export function PackageStateBadge({ state, packageId, title }: PackageStateBadgeProps) {
+export function PackageStateBadge({ state, packageId, title, compact }: PackageStateBadgeProps) {
   const style = STATE_STYLES[state]
+  if (compact) {
+    return (
+      <span
+        title={title ?? `${style.label} — ${style.tip}`}
+        aria-label={`Package state: ${style.label}`}
+        data-state={state}
+        className={`inline-block size-2 rounded-full ${style.cls}`}
+      />
+    )
+  }
   return (
     <span title={title ?? style.tip} className="inline-flex items-center gap-2">
       <Badge className={style.cls} variant="secondary">

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -25,11 +25,19 @@ import {
 } from "@bakin/sdk/ui"
 import { BakinDrawer } from "@bakin/sdk/components"
 import { useGatewayStatus } from "@bakin/sdk/hooks"
-import { useAgentStore, useAgentColor, useMainAgentId } from '@bakin/sdk/hooks'
+import { useAgentStore, useAgentColor, useMainAgentId, usePackageState } from '@bakin/sdk/hooks'
 import { buildGraph } from '../lib/build-graph'
 import { AgentForm, type AgentFormData } from './agent-form'
 import { TeamManager } from './team-manager'
+import { PackageStateBadge, type PackageState } from './package-state-badge'
 import type { AgentWithStatus } from '../types'
+
+/**
+ * Render a compact package badge on an agent card only when the state is
+ * attention-worthy. Healthy states (managed/adopted/absent/undefined) leave
+ * the card uncluttered — the convention is "no badge means OK."
+ */
+const ATTENTION_STATES: PackageState[] = ['unmanaged', 'drifted', 'update-available']
 
 /** Strip default ReactFlow node chrome + animated edges + hover glow */
 const RESET_STYLES = `
@@ -83,9 +91,11 @@ interface AgentNodeData extends Record<string, unknown> {
   agent: AgentWithStatus
 }
 
-function AgentCardNode({ data }: NodeProps) {
+export function AgentCardNode({ data }: NodeProps) {
   const { agent } = data as AgentNodeData
   const accentColor = useAgentColor(agent.id)
+  const pkgState = usePackageState(agent.id)
+  const showBadge = pkgState && ATTENTION_STATES.includes(pkgState.state)
 
   const dotColor =
     agent.status === 'online' ? 'bg-green-400' :
@@ -122,7 +132,12 @@ function AgentCardNode({ data }: NodeProps) {
         <div className={`absolute top-2 right-2 size-2.5 rounded-full border-2 border-zinc-900 ${dotColor}`} />
       </div>
       <div className="p-2.5 flex flex-col gap-0.5">
-        <div className="text-sm font-semibold text-zinc-100 leading-tight">{agent.name}</div>
+        <div className="flex items-center gap-1.5 leading-tight">
+          <span className="text-sm font-semibold text-zinc-100 truncate">{agent.name}</span>
+          {showBadge && pkgState && (
+            <PackageStateBadge state={pkgState.state} compact />
+          )}
+        </div>
         <div className="text-xs text-zinc-500 leading-tight truncate">{agent.role}</div>
         <div className="flex items-center gap-1.5 mt-1.5">
           <Badge

--- a/plugins/team/hooks/use-agent-store.ts
+++ b/plugins/team/hooks/use-agent-store.ts
@@ -156,7 +156,7 @@ export function useAgentColor(agentId: string): string {
 
 /** Get an agent's package state row. Undefined when the API hasn't reported one. */
 export function usePackageState(agentId: string): PackageStateRow | undefined {
-  return useAgentStore((s) => s.packageStates[agentId])
+  return useAgentStore((s) => s.packageStates?.[agentId])
 }
 
 /** Get an agent's display name override, if any. */

--- a/plugins/team/hooks/use-agent-store.ts
+++ b/plugins/team/hooks/use-agent-store.ts
@@ -7,7 +7,7 @@
  * All components that need agent info import from here instead of static constants.
  */
 import { create } from 'zustand'
-import type { AgentMeta, AgentDisplaySettings, AgentDisplaySettingsMap, AgentWithStatus, OrgTeam } from '../types'
+import type { AgentMeta, AgentDisplaySettings, AgentDisplaySettingsMap, AgentWithStatus, OrgTeam, PackageStateRow } from '../types'
 
 interface AgentStore {
   /** Lightweight agent list (for dropdowns, badges, avatars) */
@@ -22,15 +22,46 @@ interface AgentStore {
   displaySettings: AgentDisplaySettingsMap
   /** Organizational teams */
   teams: OrgTeam[]
+  /**
+   * Agent-package state per agent id, sourced from `/api/agent-packages`.
+   * Fetched in parallel with the roster on `load()`. Empty map when the
+   * endpoint fails — agent-packages is optional context, not load-blocking.
+   */
+  packageStates: Record<string, PackageStateRow>
   /** Canonical main/orchestrator agent id (resolved server-side from settings → OpenClaw) */
   mainAgentId: string | null
   /** Whether initial load has completed */
   loaded: boolean
 
-  /** Fetch agents + display settings from team plugin API */
+  /** Fetch agents + display settings + package states from the API */
   load: () => Promise<void>
+  /** Re-fetch only `/api/agent-packages` — used after Adopt to invalidate staleness */
+  refreshPackageStates: () => Promise<void>
   /** Update display settings for a single agent */
   updateDisplay: (agentId: string, patch: Partial<AgentDisplaySettings>) => Promise<void>
+}
+
+/**
+ * Normalize a `/api/agent-packages` response into a Record keyed by agentId.
+ * Handles both the success shape and any failure (non-ok response, network
+ * error, malformed payload) by returning an empty map — the agent-package
+ * surface is supplementary context, not load-blocking.
+ */
+async function parsePackageStatesResponse(
+  res: Response | null,
+): Promise<Record<string, PackageStateRow>> {
+  if (!res || !res.ok) return {}
+  try {
+    const body = await res.json() as { ok?: boolean; agents?: PackageStateRow[] }
+    if (!body.ok || !Array.isArray(body.agents)) return {}
+    const map: Record<string, PackageStateRow> = {}
+    for (const row of body.agents) {
+      map[row.agentId] = row
+    }
+    return map
+  } catch {
+    return {}
+  }
 }
 
 export const useAgentStore = create<AgentStore>((set, get) => ({
@@ -40,17 +71,21 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
   agentsWithStatus: [],
   displaySettings: {},
   teams: [],
+  packageStates: {},
   mainAgentId: null,
   loaded: false,
 
   load: async () => {
     try {
-      const res = await fetch('/api/plugins/team/')
-      if (!res.ok) {
+      const [rosterRes, pkgRes] = await Promise.all([
+        fetch('/api/plugins/team/'),
+        fetch('/api/agent-packages').catch(() => null),
+      ])
+      if (!rosterRes.ok) {
         set({ loaded: true })
         return
       }
-      const data = await res.json() as {
+      const data = await rosterRes.json() as {
         agents: AgentWithStatus[]
         displaySettings: AgentDisplaySettingsMap
         teams: OrgTeam[]
@@ -61,6 +96,7 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
       for (const a of agents) {
         agentMap[a.id] = a
       }
+      const packageStates = await parsePackageStatesResponse(pkgRes)
       set({
         agents,
         agentIds: agents.map((a) => a.id),
@@ -68,12 +104,19 @@ export const useAgentStore = create<AgentStore>((set, get) => ({
         agentsWithStatus: data.agents,
         displaySettings: data.displaySettings,
         teams: data.teams ?? [],
+        packageStates,
         mainAgentId: data.mainAgentId ?? null,
         loaded: true,
       })
     } catch {
       set({ loaded: true })
     }
+  },
+
+  refreshPackageStates: async () => {
+    const res = await fetch('/api/agent-packages').catch(() => null)
+    const packageStates = await parsePackageStatesResponse(res)
+    set({ packageStates })
   },
 
   updateDisplay: async (agentId, patch) => {
@@ -109,6 +152,11 @@ export function useAgentColor(agentId: string): string {
   return useAgentStore(
     (s) => s.displaySettings[agentId]?.accentColor ?? '#a1a1aa'
   )
+}
+
+/** Get an agent's package state row. Undefined when the API hasn't reported one. */
+export function usePackageState(agentId: string): PackageStateRow | undefined {
+  return useAgentStore((s) => s.packageStates[agentId])
 }
 
 /** Get an agent's display name override, if any. */

--- a/plugins/team/types.ts
+++ b/plugins/team/types.ts
@@ -69,3 +69,26 @@ export interface SkillSummary {
   name: string
   hasSkillMd: boolean
 }
+
+/**
+ * Per-agent agent-package state, sourced from `/api/agent-packages`. Mirrors
+ * the server-side `AgentStateInfo` shape but stays self-contained so the
+ * client doesn't reach across the package boundary for types.
+ *
+ * The server today returns 4 states (`absent | unmanaged | adopted | managed`).
+ * `drifted` and `update-available` are declared on the badge component for
+ * forward-compat — wiring handles them but the API doesn't yet emit them.
+ */
+export interface PackageStateRow {
+  agentId: string
+  state: 'absent' | 'unmanaged' | 'adopted' | 'managed' | 'drifted' | 'update-available'
+  packageId?: string
+  entry?: {
+    source: string
+    ref: string
+    commitSha: string
+    installedAt: string
+    version?: string
+    dependencies?: string[]
+  }
+}

--- a/tests/plugins/team/agent-card-package-badge.test.tsx
+++ b/tests/plugins/team/agent-card-package-badge.test.tsx
@@ -78,7 +78,10 @@ describe('AgentCardNode — package state badge wiring', () => {
 
   function renderCard() {
     // NodeProps minimal stub — AgentCardNode only reads `data.agent`.
-    const props = { data: { agent: AGENT }, id: AGENT.id, type: 'agentCard' } as never
+    // Cast to `any` (not `never`) so JSX spread is allowed; the runtime
+    // surface AgentCardNode actually reads is just `data.agent`.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const props: any = { data: { agent: AGENT }, id: AGENT.id, type: 'agentCard' }
     return render(<AgentCardNode {...props} />)
   }
 

--- a/tests/plugins/team/agent-card-package-badge.test.tsx
+++ b/tests/plugins/team/agent-card-package-badge.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+/**
+ * AgentCardNode badge wiring contract.
+ *
+ * The team grid renders a compact PackageStateBadge on agent cards only when
+ * the package state is "attention-worthy" — unmanaged, drifted, or
+ * update-available. Healthy states (managed, adopted) and missing data
+ * leave the card unchanged.
+ *
+ * This test primes the Zustand store with a single agent and varies its
+ * package state, asserting the badge presence/absence per the rule. We
+ * render AgentCardNode directly (not the full ReactFlow grid) — the badge
+ * logic lives entirely inside the node component.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-agent-card-badge-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+
+// ReactFlow's <Handle> requires being inside a ReactFlowProvider when used
+// from a component. We replace it with a stub so the node renders standalone.
+mock.module('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Top: 'top', Bottom: 'bottom' },
+}))
+
+import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+import { AgentCardNode } from '../../../plugins/team/components/team-grid'
+import type { AgentWithStatus, PackageStateRow } from '../../../plugins/team/types'
+
+const AGENT: AgentWithStatus = {
+  id: 'pixel',
+  name: 'Pixel',
+  emoji: '🎨',
+  role: 'designer',
+  headshot: 'data:image/png;base64,iVBORw0KGgo=', // 1x1 placeholder to silence empty-src warnings
+  status: 'online',
+  model: 'claude-opus-4-7',
+  heartbeat: null,
+  heartbeatAge: null,
+}
+
+function primeState(packageStates: Record<string, PackageStateRow> = {}) {
+  useAgentStore.setState({
+    agents: [], agentIds: [], agentMap: {}, agentsWithStatus: [],
+    displaySettings: {}, teams: [], packageStates,
+    mainAgentId: null, loaded: true,
+  })
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('AgentCardNode — package state badge wiring', () => {
+  beforeEach(() => primeState())
+
+  function renderCard() {
+    // NodeProps minimal stub — AgentCardNode only reads `data.agent`.
+    const props = { data: { agent: AGENT }, id: AGENT.id, type: 'agentCard' } as never
+    return render(<AgentCardNode {...props} />)
+  }
+
+  it('shows the agent name', () => {
+    renderCard()
+    expect(screen.getByText('Pixel')).toBeDefined()
+  })
+
+  it('renders no package badge when state is undefined', () => {
+    renderCard()
+    expect(screen.queryByLabelText(/Package state:/)).toBeNull()
+  })
+
+  it('renders no badge for healthy state: managed', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'managed' } })
+    renderCard()
+    expect(screen.queryByLabelText(/Package state:/)).toBeNull()
+  })
+
+  it('renders no badge for healthy state: adopted', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'adopted' } })
+    renderCard()
+    expect(screen.queryByLabelText(/Package state:/)).toBeNull()
+  })
+
+  it('renders no badge for state: absent', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'absent' } })
+    renderCard()
+    expect(screen.queryByLabelText(/Package state:/)).toBeNull()
+  })
+
+  it('renders attention badge for state: unmanaged', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'unmanaged' } })
+    renderCard()
+    const badge = screen.getByLabelText(/Package state: unmanaged/)
+    expect(badge).toBeDefined()
+    expect(badge.getAttribute('data-state')).toBe('unmanaged')
+  })
+
+  it('renders attention badge for state: drifted', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'drifted' } })
+    renderCard()
+    expect(screen.getByLabelText(/Package state: drifted/)).toBeDefined()
+  })
+
+  it('renders attention badge for state: update-available', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'update-available' } })
+    renderCard()
+    expect(screen.getByLabelText(/Package state: update available/)).toBeDefined()
+  })
+
+  it('compact badge has no visible text label (compact mode dropped the label)', () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'unmanaged' } })
+    renderCard()
+    const badge = screen.getByLabelText(/Package state: unmanaged/)
+    // The compact pill has no text content; the label is in aria-label only
+    expect(badge.textContent).toBe('')
+  })
+})

--- a/tests/plugins/team/agent-detail-adopt.test.tsx
+++ b/tests/plugins/team/agent-detail-adopt.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+/**
+ * Adopt-flow wiring contract for the Package card.
+ *
+ * Click on the Adopt button must:
+ *   - mount AdoptDialog with the current agentId baked in
+ *   - submit POST /api/agent-packages/install with { source, adopt: agentId }
+ *   - on success, fire refreshPackageStates() so the card reflects the new
+ *     state without a page reload
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-adopt-wiring-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+
+mock.module('@/hooks/use-query-state', () => ({
+  useQueryState: (_key: string, _default: string) => ['profile', mock(), mock()],
+}))
+mock.module('@/hooks/use-gateway-status', () => ({
+  useGatewayStatus: () => ({ restartNeeded: false, restart: mock(), restarting: false, markDirty: mock() }),
+}))
+mock.module('@/components/agent-avatar', () => ({ AgentAvatar: () => <div /> }))
+mock.module('@/components/markdown-content', () => ({ MarkdownContent: () => <div /> }))
+mock.module('@/components/model-select', () => ({ ModelSelect: () => <div /> }))
+
+import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+import { AgentDetail } from '../../../plugins/team/components/agent-detail'
+
+const PROFILE = {
+  id: 'pixel',
+  name: 'Pixel',
+  emoji: '🎨',
+  role: 'designer',
+  headshot: 'data:image/png;base64,iVBORw0KGgo=',
+  model: 'claude-opus-4-7',
+  workspacePath: '/tmp/pixel',
+  identity: null, soul: null, rules: null, tools: null, heartbeatMd: null, subagentPerms: null,
+}
+
+const installCalls: Array<{ url: string; init?: RequestInit }> = []
+let installResponseOk = true
+
+function setupFetch() {
+  installCalls.length = 0
+  installResponseOk = true
+  global.fetch = mock((url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url)
+    if (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(PROFILE) } as Response)
+    }
+    if (u.startsWith('/api/plugins/models/available')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ models: [] }) } as Response)
+    }
+    if (u === '/api/agent-packages' && init?.method !== 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true, agents: [{ agentId: 'pixel', state: 'managed', packageId: 'examples/pixel' }] }),
+      } as Response)
+    }
+    if (u === '/api/agent-packages/install' && init?.method === 'POST') {
+      installCalls.push({ url: u, init })
+      return Promise.resolve({
+        ok: installResponseOk,
+        json: () => Promise.resolve(installResponseOk ? { ok: true } : { ok: false, error: 'fail' }),
+      } as Response)
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
+  }) as unknown as typeof global.fetch
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  setupFetch()
+  // Prime store with no row so the Package card renders unmanaged + Adopt button.
+  useAgentStore.setState({
+    agents: [], agentIds: [], agentMap: {}, agentsWithStatus: [],
+    displaySettings: {}, teams: [], packageStates: {},
+    mainAgentId: 'main', loaded: true,
+  })
+})
+
+async function openDetail() {
+  render(<AgentDetail agentId="pixel" />)
+  await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+}
+
+describe('PackageCard — Adopt flow', () => {
+  it('opens AdoptDialog with the agentId baked in when Adopt is clicked', async () => {
+    await openDetail()
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+    // Dialog title bakes in the agentId
+    await waitFor(() => expect(screen.getByText(/Adopt pixel into a package/)).toBeDefined())
+  })
+
+  it('POSTs /api/agent-packages/install with { source, adopt: agentId } on submit', async () => {
+    await openDetail()
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+    await waitFor(() => screen.getByLabelText('Package source'))
+    fireEvent.change(screen.getByLabelText('Package source'), {
+      target: { value: 'github:examples/pixel@v0.1.0' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+
+    await waitFor(() => expect(installCalls.length).toBe(1))
+    const call = installCalls[0]
+    expect(call.init?.method).toBe('POST')
+    const body = JSON.parse((call.init?.body as string) ?? '{}')
+    expect(body).toEqual({ source: 'github:examples/pixel@v0.1.0', adopt: 'pixel' })
+  })
+
+  it('refreshes package state on successful adopt', async () => {
+    await openDetail()
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+    await waitFor(() => screen.getByLabelText('Package source'))
+    fireEvent.change(screen.getByLabelText('Package source'), {
+      target: { value: 'github:examples/pixel' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+
+    // After successful adopt the store should pick up the new state
+    // from /api/agent-packages (which our mock returns as managed).
+    await waitFor(() => expect(useAgentStore.getState().packageStates['pixel']?.state).toBe('managed'))
+  })
+})

--- a/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
+++ b/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+/**
+ * Knowledge tab contract for agent-detail.
+ *
+ * - Tab is always visible in the tab bar (regardless of package state)
+ * - For managed/adopted agents the tab renders KnowledgeToggleList
+ *   (which fetches from /api/agent-packages/:id/knowledge)
+ * - For unmanaged/absent/undefined the tab renders a "Coming soon"
+ *   placeholder with a hint pointing back at the Package card
+ * - Tab click writes ?tab=knowledge to the URL via useQueryState
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-knowledge-tab-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+mock.module('@/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+
+const queryState: { tab: string } = { tab: 'profile' }
+const setTabSpy = mock((v: string) => { queryState.tab = v })
+
+mock.module('@/hooks/use-query-state', () => ({
+  useQueryState: (_key: string, defaultValue: string) => [queryState.tab || defaultValue, setTabSpy, mock()],
+}))
+mock.module('@/hooks/use-gateway-status', () => ({
+  useGatewayStatus: () => ({ restartNeeded: false, restart: mock(), restarting: false, markDirty: mock() }),
+}))
+mock.module('@/components/agent-avatar', () => ({ AgentAvatar: () => <div /> }))
+mock.module('@/components/markdown-content', () => ({ MarkdownContent: () => <div /> }))
+mock.module('@/components/model-select', () => ({ ModelSelect: () => <div /> }))
+
+import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+import { AgentDetail } from '../../../plugins/team/components/agent-detail'
+import type { PackageStateRow } from '../../../plugins/team/types'
+
+const PROFILE = {
+  id: 'pixel', name: 'Pixel', emoji: '🎨', role: 'designer',
+  headshot: 'data:image/png;base64,iVBORw0KGgo=',
+  model: 'claude-opus-4-7', workspacePath: '/tmp/pixel',
+  identity: null, soul: null, rules: null, tools: null, heartbeatMd: null, subagentPerms: null,
+}
+
+function setupFetch() {
+  global.fetch = mock((url: RequestInfo | URL) => {
+    const u = String(url)
+    if (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(PROFILE) } as Response)
+    }
+    if (u.startsWith('/api/plugins/models/available')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ models: [] }) } as Response)
+    }
+    if (u.includes('/api/agent-packages/pixel/knowledge')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          ok: true,
+          packageId: 'examples/pixel@0.1.0',
+          lessons: [
+            { lessonId: 'l1', title: 'Lesson One', tags: [], defaultEnabled: true, enabled: true },
+            { lessonId: 'l2', title: 'Lesson Two', tags: [], defaultEnabled: false, enabled: false },
+          ],
+        }),
+      } as Response)
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
+  }) as unknown as typeof global.fetch
+}
+
+function primeState(packageStates: Record<string, PackageStateRow> = {}) {
+  useAgentStore.setState({
+    agents: [], agentIds: [], agentMap: {}, agentsWithStatus: [],
+    displaySettings: {}, teams: [], packageStates,
+    mainAgentId: 'main', loaded: true,
+  })
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+  queryState.tab = 'profile'
+  setTabSpy.mockClear()
+})
+
+beforeEach(() => {
+  setupFetch()
+})
+
+async function openDetail() {
+  render(<AgentDetail agentId="pixel" />)
+  await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+}
+
+describe('AgentDetail — Knowledge tab', () => {
+  it('shows the Knowledge tab in the tab bar', async () => {
+    primeState()
+    await openDetail()
+    expect(screen.getByRole('button', { name: 'Knowledge' })).toBeDefined()
+  })
+
+  it('clicking Knowledge writes tab=knowledge to the URL', async () => {
+    primeState()
+    await openDetail()
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+    expect(setTabSpy).toHaveBeenCalledWith('knowledge')
+  })
+
+  it('renders KnowledgeToggleList for state=managed', async () => {
+    primeState({
+      pixel: { agentId: 'pixel', state: 'managed', packageId: 'examples/pixel@0.1.0' },
+    })
+    queryState.tab = 'knowledge'
+    await openDetail()
+    await waitFor(() => expect(screen.getByText('Lesson One')).toBeDefined())
+    expect(screen.getByText('Lesson Two')).toBeDefined()
+    expect(screen.queryByText('Coming soon')).toBeNull()
+  })
+
+  it('renders KnowledgeToggleList for state=adopted', async () => {
+    primeState({
+      pixel: { agentId: 'pixel', state: 'adopted', packageId: 'examples/pixel@0.1.0' },
+    })
+    queryState.tab = 'knowledge'
+    await openDetail()
+    await waitFor(() => expect(screen.getByText('Lesson One')).toBeDefined())
+  })
+
+  it('renders "Coming soon" empty state for state=unmanaged', async () => {
+    primeState({ pixel: { agentId: 'pixel', state: 'unmanaged' } })
+    queryState.tab = 'knowledge'
+    await openDetail()
+    await waitFor(() => expect(screen.getByText('Coming soon')).toBeDefined())
+    expect(screen.queryByText('Lesson One')).toBeNull()
+  })
+
+  it('renders "Coming soon" when no package state row exists', async () => {
+    primeState()
+    queryState.tab = 'knowledge'
+    await openDetail()
+    await waitFor(() => expect(screen.getByText('Coming soon')).toBeDefined())
+  })
+})

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+/**
+ * PackageCard rendering contract — covers the read-only display surface
+ * inside the agent-detail Profile tab. C3 only asserts what's *visible*
+ * per state; the Adopt button is intentionally inert in this commit and
+ * gets fully wired in C4.
+ *
+ * Strategy: PackageCard is not exported. We render the AgentDetail
+ * component end-to-end with a minimal profile payload so we can poke at
+ * the Profile tab through the real tab bar. The package-state row comes
+ * from the Zustand store, which we prime per test.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-package-card-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+
+mock.module('@/hooks/use-query-state', () => ({
+  useQueryState: (_key: string, defaultValue: string) => ['profile', mock(), mock()],
+}))
+mock.module('@/hooks/use-gateway-status', () => ({
+  useGatewayStatus: () => ({ restartNeeded: false, restart: mock(), restarting: false, markDirty: mock() }),
+}))
+mock.module('@/components/agent-avatar', () => ({ AgentAvatar: () => <div /> }))
+mock.module('@/components/markdown-content', () => ({ MarkdownContent: () => <div /> }))
+mock.module('@/components/model-select', () => ({ ModelSelect: () => <div /> }))
+
+import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+import { AgentDetail } from '../../../plugins/team/components/agent-detail'
+import type { PackageStateRow } from '../../../plugins/team/types'
+
+const PROFILE = {
+  id: 'pixel',
+  name: 'Pixel',
+  emoji: '🎨',
+  role: 'designer',
+  headshot: 'data:image/png;base64,iVBORw0KGgo=',
+  model: 'claude-opus-4-7',
+  workspacePath: '/tmp/pixel',
+  identity: null,
+  soul: null,
+  rules: null,
+  tools: null,
+  heartbeatMd: null,
+  subagentPerms: null,
+}
+
+function primeState(packageStates: Record<string, PackageStateRow> = {}) {
+  useAgentStore.setState({
+    agents: [], agentIds: [], agentMap: {}, agentsWithStatus: [],
+    displaySettings: {}, teams: [], packageStates,
+    mainAgentId: 'main', loaded: true,
+  })
+}
+
+function mockProfileFetch() {
+  global.fetch = mock((url: RequestInfo | URL) => {
+    const u = String(url)
+    if (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(PROFILE) } as Response)
+    }
+    if (u.startsWith('/api/plugins/models/available')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ models: [] }) } as Response)
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
+  }) as unknown as typeof global.fetch
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  mockProfileFetch()
+})
+
+async function renderDetail() {
+  render(<AgentDetail agentId="pixel" />)
+  await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+}
+
+describe('PackageCard — read-only display per state', () => {
+  it('renders an unmanaged badge + Adopt button (disabled in C3) when no row exists', async () => {
+    primeState()
+    await renderDetail()
+    expect(screen.getByText('unmanaged')).toBeDefined()
+    const adopt = screen.getByRole('button', { name: 'Adopt' })
+    expect(adopt).toBeDefined()
+    expect((adopt as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('renders a managed badge + entry fields when state=managed', async () => {
+    primeState({
+      pixel: {
+        agentId: 'pixel',
+        state: 'managed',
+        packageId: 'examples/pixel@0.1.0',
+        entry: {
+          source: 'github:examples/pixel',
+          ref: 'v0.1.0',
+          commitSha: 'abc1234567',
+          installedAt: '2026-04-25T00:00:00Z',
+          dependencies: ['examples/shared@0.1.0'],
+        },
+      },
+    })
+    await renderDetail()
+    expect(screen.getByText('managed')).toBeDefined()
+    expect(screen.getByText('github:examples/pixel')).toBeDefined()
+    expect(screen.getByText('v0.1.0')).toBeDefined()
+    // commitSha gets sliced to 7 chars
+    expect(screen.getByText('abc1234')).toBeDefined()
+    expect(screen.getByText('examples/shared@0.1.0')).toBeDefined()
+    // No Adopt button on managed state
+    expect(screen.queryByRole('button', { name: 'Adopt' })).toBeNull()
+  })
+
+  it('renders an adopted badge + entry fields when state=adopted', async () => {
+    primeState({
+      pixel: {
+        agentId: 'pixel',
+        state: 'adopted',
+        packageId: 'examples/pixel@0.1.0',
+        entry: {
+          source: 'github:examples/pixel',
+          ref: 'main',
+          commitSha: 'feedface',
+          installedAt: '2026-04-20T00:00:00Z',
+        },
+      },
+    })
+    await renderDetail()
+    expect(screen.getByText('adopted')).toBeDefined()
+    expect(screen.getByText('github:examples/pixel')).toBeDefined()
+    expect(screen.queryByRole('button', { name: 'Adopt' })).toBeNull()
+  })
+
+  it('renders a CLI hint with Copy button for state=drifted', async () => {
+    primeState({
+      pixel: { agentId: 'pixel', state: 'drifted', packageId: 'examples/pixel@0.1.0' },
+    })
+    await renderDetail()
+    expect(screen.getByText('drifted')).toBeDefined()
+    expect(screen.getByText('bakin install agent-assets')).toBeDefined()
+    expect(screen.getByLabelText('Copy command')).toBeDefined()
+    expect(screen.queryByRole('button', { name: 'Adopt' })).toBeNull()
+  })
+
+  it('renders a CLI hint with the agent id baked in for state=update-available', async () => {
+    primeState({
+      pixel: { agentId: 'pixel', state: 'update-available', packageId: 'examples/pixel@0.1.0' },
+    })
+    await renderDetail()
+    expect(screen.getByText('update available')).toBeDefined()
+    expect(screen.getByText('bakin agents update pixel')).toBeDefined()
+    expect(screen.getByLabelText('Copy command')).toBeDefined()
+  })
+})

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -106,13 +106,13 @@ async function renderDetail() {
 }
 
 describe('PackageCard — read-only display per state', () => {
-  it('renders an unmanaged badge + Adopt button (disabled in C3) when no row exists', async () => {
+  it('renders an unmanaged badge + Adopt button when no row exists', async () => {
     primeState()
     await renderDetail()
     expect(screen.getByText('unmanaged')).toBeDefined()
     const adopt = screen.getByRole('button', { name: 'Adopt' })
     expect(adopt).toBeDefined()
-    expect((adopt as HTMLButtonElement).disabled).toBe(true)
+    expect((adopt as HTMLButtonElement).disabled).toBe(false)
   })
 
   it('renders a managed badge + entry fields when state=managed', async () => {

--- a/tests/plugins/team/use-package-states.test.ts
+++ b/tests/plugins/team/use-package-states.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Store-extension tests for `useAgentStore` package-state plumbing.
+ *
+ * Covers:
+ *   - load() fetches /api/plugins/team/ and /api/agent-packages in parallel
+ *   - merge: packageStates becomes a map keyed by agentId
+ *   - failed /api/agent-packages → packageStates: {}, agents still load
+ *   - refreshPackageStates() re-fetches only the package endpoint
+ *   - usePackageState(id) selector returns the right row (or undefined)
+ *
+ * No DOM, no React Testing Library — Zustand stores are usable from plain
+ * code. We exercise the store's actions directly via getState().
+ */
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-use-package-states-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+
+import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+const ROSTER_OK = {
+  agents: [
+    { id: 'pixel', name: 'Pixel', emoji: '🎨', role: 'designer', headshot: '', status: 'online', model: 'claude-opus-4-7', heartbeat: null, heartbeatAge: null },
+    { id: 'orca', name: 'Orca', emoji: '🐋', role: 'planner', headshot: '', status: 'offline', model: 'claude-sonnet-4-6', heartbeat: null, heartbeatAge: null },
+  ],
+  displaySettings: {},
+  teams: [],
+  mainAgentId: 'main',
+}
+
+const PKG_OK = {
+  ok: true,
+  agents: [
+    {
+      agentId: 'pixel',
+      state: 'managed' as const,
+      packageId: 'examples/pixel@0.1.0',
+      entry: { source: 'github:examples/pixel', ref: 'v0.1.0', commitSha: 'abc1234', installedAt: '2026-04-25T00:00:00Z' },
+    },
+    { agentId: 'orca', state: 'unmanaged' as const },
+  ],
+}
+
+function makeFetchSpy(opts: {
+  rosterStatus?: number
+  rosterBody?: unknown
+  pkgStatus?: number
+  pkgBody?: unknown
+  pkgRejects?: boolean
+  onCall?: (url: string, ts: number) => void
+}) {
+  return mock((url: RequestInfo | URL) => {
+    const u = String(url)
+    const ts = performance.now()
+    opts.onCall?.(u, ts)
+    if (u === '/api/plugins/team/') {
+      return Promise.resolve({
+        ok: (opts.rosterStatus ?? 200) < 400,
+        json: () => Promise.resolve(opts.rosterBody ?? ROSTER_OK),
+      } as Response)
+    }
+    if (u === '/api/agent-packages') {
+      if (opts.pkgRejects) return Promise.reject(new Error('network down'))
+      return Promise.resolve({
+        ok: (opts.pkgStatus ?? 200) < 400,
+        json: () => Promise.resolve(opts.pkgBody ?? PKG_OK),
+      } as Response)
+    }
+    return Promise.reject(new Error(`unexpected fetch: ${u}`))
+  })
+}
+
+beforeEach(() => {
+  // Reset store between tests so cross-test state doesn't leak.
+  useAgentStore.setState({
+    agents: [], agentIds: [], agentMap: {}, agentsWithStatus: [],
+    displaySettings: {}, teams: [], packageStates: {},
+    mainAgentId: null, loaded: false,
+  })
+})
+
+describe('useAgentStore — package state plumbing', () => {
+  it('fires both fetches in parallel during load()', async () => {
+    const calls: Array<{ url: string; ts: number }> = []
+    global.fetch = makeFetchSpy({
+      onCall: (url, ts) => calls.push({ url, ts }),
+    }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+
+    expect(calls.map((c) => c.url).sort()).toEqual(
+      ['/api/agent-packages', '/api/plugins/team/'],
+    )
+    // Parallel == both calls landed before either resolved. Timestamps will
+    // be within microseconds of each other; we assert <5ms which is generous.
+    const span = Math.abs(calls[0].ts - calls[1].ts)
+    expect(span).toBeLessThan(5)
+  })
+
+  it('merges package state into a map keyed by agentId', async () => {
+    global.fetch = makeFetchSpy({}) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+
+    const { packageStates } = useAgentStore.getState()
+    expect(packageStates['pixel']).toMatchObject({
+      agentId: 'pixel',
+      state: 'managed',
+      packageId: 'examples/pixel@0.1.0',
+    })
+    expect(packageStates['orca']).toMatchObject({ agentId: 'orca', state: 'unmanaged' })
+    expect(packageStates['nonexistent']).toBeUndefined()
+  })
+
+  it('survives a failed /api/agent-packages — agents still load, packageStates empty', async () => {
+    global.fetch = makeFetchSpy({ pkgRejects: true }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+
+    const state = useAgentStore.getState()
+    expect(state.loaded).toBe(true)
+    expect(state.agents).toHaveLength(2)
+    expect(state.packageStates).toEqual({})
+  })
+
+  it('survives a non-ok /api/agent-packages response (500) — packageStates empty', async () => {
+    global.fetch = makeFetchSpy({ pkgStatus: 500, pkgBody: { ok: false, error: 'boom' } }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+
+    expect(useAgentStore.getState().agents).toHaveLength(2)
+    expect(useAgentStore.getState().packageStates).toEqual({})
+  })
+
+  it('survives a malformed /api/agent-packages payload — packageStates empty', async () => {
+    global.fetch = makeFetchSpy({ pkgBody: { ok: true, agents: 'not-an-array' } }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+
+    expect(useAgentStore.getState().packageStates).toEqual({})
+  })
+
+  it('refreshPackageStates() re-fetches only the package endpoint', async () => {
+    const calls: string[] = []
+    global.fetch = makeFetchSpy({ onCall: (url) => calls.push(url) }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+    calls.length = 0
+
+    await useAgentStore.getState().refreshPackageStates()
+
+    expect(calls).toEqual(['/api/agent-packages'])
+  })
+
+  it('refreshPackageStates() picks up a new state value', async () => {
+    let pkgVariant = PKG_OK
+    global.fetch = mock((url: RequestInfo | URL) => {
+      const u = String(url)
+      if (u === '/api/plugins/team/') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(ROSTER_OK) } as Response)
+      }
+      if (u === '/api/agent-packages') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(pkgVariant) } as Response)
+      }
+      return Promise.reject(new Error('unexpected'))
+    }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+    expect(useAgentStore.getState().packageStates['orca']?.state).toBe('unmanaged')
+
+    pkgVariant = {
+      ok: true,
+      agents: [
+        { agentId: 'pixel', state: 'managed' as const, packageId: 'examples/pixel@0.1.0', entry: PKG_OK.agents[0].entry },
+        { agentId: 'orca', state: 'adopted' as const, packageId: 'examples/orca@0.1.0' },
+      ],
+    }
+    await useAgentStore.getState().refreshPackageStates()
+
+    expect(useAgentStore.getState().packageStates['orca']?.state).toBe('adopted')
+  })
+
+  it('roster fetch failure short-circuits before package merge', async () => {
+    global.fetch = makeFetchSpy({ rosterStatus: 500 }) as unknown as typeof global.fetch
+
+    await useAgentStore.getState().load()
+
+    const state = useAgentStore.getState()
+    expect(state.loaded).toBe(true)
+    expect(state.agents).toHaveLength(0)
+    // packageStates stays at its previous value ({}) since we never call set on it
+    expect(state.packageStates).toEqual({})
+  })
+})

--- a/tests/plugins/team/use-package-states.test.ts
+++ b/tests/plugins/team/use-package-states.test.ts
@@ -32,6 +32,13 @@ mock.module('../../../packages/core/src/content-dir', () => ({
 }))
 
 import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+import type { PackageStateRow } from '../../../plugins/team/types'
+
+interface PkgResponse {
+  ok: boolean
+  agents?: PackageStateRow[]
+  error?: string
+}
 
 afterAll(() => {
   try { rmSync(testDir, { recursive: true, force: true }) } catch {}
@@ -47,16 +54,16 @@ const ROSTER_OK = {
   mainAgentId: 'main',
 }
 
-const PKG_OK = {
+const PKG_OK: PkgResponse = {
   ok: true,
   agents: [
     {
       agentId: 'pixel',
-      state: 'managed' as const,
+      state: 'managed',
       packageId: 'examples/pixel@0.1.0',
       entry: { source: 'github:examples/pixel', ref: 'v0.1.0', commitSha: 'abc1234', installedAt: '2026-04-25T00:00:00Z' },
     },
-    { agentId: 'orca', state: 'unmanaged' as const },
+    { agentId: 'orca', state: 'unmanaged' },
   ],
 }
 
@@ -172,7 +179,7 @@ describe('useAgentStore — package state plumbing', () => {
   })
 
   it('refreshPackageStates() picks up a new state value', async () => {
-    let pkgVariant = PKG_OK
+    let pkgVariant: PkgResponse = PKG_OK
     global.fetch = mock((url: RequestInfo | URL) => {
       const u = String(url)
       if (u === '/api/plugins/team/') {
@@ -190,8 +197,8 @@ describe('useAgentStore — package state plumbing', () => {
     pkgVariant = {
       ok: true,
       agents: [
-        { agentId: 'pixel', state: 'managed' as const, packageId: 'examples/pixel@0.1.0', entry: PKG_OK.agents[0].entry },
-        { agentId: 'orca', state: 'adopted' as const, packageId: 'examples/orca@0.1.0' },
+        { agentId: 'pixel', state: 'managed', packageId: 'examples/pixel@0.1.0', entry: PKG_OK.agents?.[0].entry },
+        { agentId: 'orca', state: 'adopted', packageId: 'examples/orca@0.1.0' },
       ],
     }
     await useAgentStore.getState().refreshPackageStates()


### PR DESCRIPTION
## Summary

Wires 3 of 5 prebuilt agent-package components into the Teams plugin per the surgical scope agreed in `.claude/specs/team-agent-packages-ui.md`. Closes part of #158; install/browse/curated UX deferred to a follow-up Workshop ticket.

**What ships in this PR:**

- `<PackageStateBadge>` (compact variant) on each `AgentCardNode` — attention-only conditional rendering (`unmanaged` / `drifted` / `update-available` only)
- Read-only Package card on the Profile tab — adapts content per state, includes Adopt button on unmanaged + CLI hints on drifted/update-available
- Knowledge tab between Skills and Memory — wires existing `<KnowledgeToggleList>` for managed/adopted, "Coming soon" placeholder otherwise
- `useAgentStore.load()` extended with parallel `/api/agent-packages` fetch + `refreshPackageStates()` action for post-Adopt invalidation
- Doc updates in `.claude/knowledge/team-plugin.md` and `docs/agent-packages-authoring.md` ("From the UI" section)

**What stays CLI-only (deferred to Workshop ticket):**

- Curated browser, generic install dialog, non-agent kinds inventory, Update / Reinstall / Remove / Reset workspace, drift repair UI, Health drift widget

## Acceptance criteria from #158

| Criterion | Status |
|---|---|
| See package-managed at a glance | ✅ via badge |
| Install a curated agent | ❌ CLI (deferred) |
| Adopt an existing OpenClaw agent | ✅ via Adopt button on Package card |
| Toggle knowledge lessons | ✅ via Knowledge tab |
| Update + remove a package | ❌ CLI (deferred) |

3/5 criteria met via UI; 2/5 explicitly punted to the Workshop follow-up.

## Test plan

- [x] `bun test --isolate tests/plugins/team` — 142/142 pass (was 119; added 23 new tests across 4 new files)
- [x] `bun test --isolate` — full repo suite, 3482/3482 pass
- [ ] Visual smoke test: `bun run dev:mock`, walk through all 5 acceptance criteria

## Commit log

7 commits — 1 spec/plan + 6 implementation slices, each independently revertable per the rollback story in the plan.

## Follow-ups to file before merge

- New issue: "Workshop: install/browse/curated UX (the deferred 2 components)"
- New issue: "Knowledge tab adoption-value copy" — replaces the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)