### PR TITLE
feat(team): rework /team/:id Overview, add Heartbeat + Active Context, full-width markdown tabs

### DIFF
--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -161,10 +161,10 @@ Convention: **CLI hints render only when there is no UI affordance for the actio
 
 ### Surface 3 — Knowledge Tab (`agent-detail.tsx`)
 
-The "Knowledge" tab sits between Skills and Memory in the tab order — both are package-rooted concepts. Always visible, content adapts:
+The "Knowledge" tab sits between Skills and Active Context in the tab order. Always visible, content adapts:
 
-- **`managed` / `adopted`:** renders `<KnowledgeToggleList agentId={...}>` (existing component, optimistic UI, REST round-trip on toggle).
-- **Anything else:** "Coming soon" placeholder pointing the user back at the Package card on the Overview tab to adopt first. Future work replaces this with adoption-value + knowledge-explainer copy.
+- **`managed` / `adopted`:** renders `<KnowledgeToggleList agentId={...}>` — a responsive grid of cards with title + lessonId + tags + per-card package-source chip. Optimistic UI, REST round-trip on toggle.
+- **Anything else:** shared `<EmptyState>` with "Knowledge requires a package" pointing the user back at the Package card on the Overview tab to adopt first.
 
 ### Adopt Round-Trip
 
@@ -217,15 +217,15 @@ The header contains: back arrow, avatar (clickable for upload), name, role, gate
 
 ### OverviewTab Composition
 
-Single dashboard surface, full-width responsive grid (1 → 2 → 3 cols at md / xl breakpoints). Panels:
+Identity (name + role + workspace path) lives in the page header above the tab bar — OverviewTab itself does **not** repeat it.
 
-- Identity (name + role + emoji + manages-list)
-- Settings (model selector + team selector with live save)
-- PackageCard (embedded — exported from `agent-detail.tsx`)
-- Workspace path
-- Capacity counts (skills, knowledge total + enabled, last-session message count)
-- Latest Session (folds in the killed Stats tab — model, total tokens with input/output split, cache reads, total cost with per-message average)
-- Recent Activity (5m / 1h / 24h dispatch + error counts via `getStatsByMs`, framed as "since server start" because the recorder is in-memory)
+Page sections, top to bottom:
+
+- **Hero card** — accent-bordered, 2-col at lg (stacked at narrower). Two panels separated by a subtle divider:
+  - Settings (no header label) — model selector + team selector with live save
+  - Agent Package — embedded `<PackageCardBody>` (lives in `package-card.tsx`)
+- **Metrics** — 4 color-coded tiles (Skills/violet, Knowledge/cyan, Tokens/blue, Cost/emerald). When a latest-session payload is present, a secondary 4-tile row appears (Model / Messages / Cache reads / Cache writes).
+- **Activity** — 3 tiles tinted with the agent's accent color when count > 0, for 5m/1h/24h windows. Footer caption clarifies "since server start" (the recorder is in-memory and resets on restart).
 
 OverviewTab fetches stats / recent-activity / skills / knowledge in parallel on mount. Each panel handles its own loading/empty state.
 

--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -146,9 +146,9 @@ The compact `<PackageStateBadge state={...} compact />` renders inline next to t
 
 The compact pill is purely visual — no text label, tooltip + aria-label preserved. Click on the agent card opens the detail page where the full Package card lives.
 
-### Surface 2 — Package Card on Profile Tab (`agent-detail.tsx`)
+### Surface 2 — Package Card on Overview Tab (`agent-detail.tsx`)
 
-A read-only `<PackageCard>` sits at the top of the Profile tab and adapts content per state:
+A read-only `<PackageCard>` is embedded inside the Overview tab (post-rework) and adapts content per state:
 
 | State | Render |
 |---|---|
@@ -164,7 +164,7 @@ Convention: **CLI hints render only when there is no UI affordance for the actio
 The "Knowledge" tab sits between Skills and Memory in the tab order — both are package-rooted concepts. Always visible, content adapts:
 
 - **`managed` / `adopted`:** renders `<KnowledgeToggleList agentId={...}>` (existing component, optimistic UI, REST round-trip on toggle).
-- **Anything else:** "Coming soon" placeholder pointing the user back at the Package card on the Profile tab to adopt first. Future work replaces this with adoption-value + knowledge-explainer copy.
+- **Anything else:** "Coming soon" placeholder pointing the user back at the Package card on the Overview tab to adopt first. Future work replaces this with adoption-value + knowledge-explainer copy.
 
 ### Adopt Round-Trip
 
@@ -191,6 +191,83 @@ No page reload, no manual refetch from the consumer side.
 - Drift-count widget in Health plugin
 
 These all stay CLI-only until the Workshop page lands.
+
+## Agent Detail Tab Architecture
+
+The `/team/:id` page (`agent-detail.tsx`) is a thin orchestrator: header + tab bar + dispatch. All meaningful content lives in per-tab components, each in its own file. Tab order:
+
+| Tab | Component | Source |
+|---|---|---|
+| Overview | `<OverviewTab>` | `overview-tab.tsx` |
+| Memory | `<MemoryTab>` (in `agent-detail.tsx`) | `~/.openclaw/agents/<id>/memory/*.md` |
+| Heartbeat | `<HeartbeatTab>` | `heartbeat-tab.tsx` (view-only) |
+| Soul | `<MarkdownEditTab>` | workspace `SOUL.md` |
+| Rules | `<MarkdownEditTab>` | workspace `AGENTS.md` |
+| Tools | `<MarkdownEditTab>` | workspace `TOOLS.md` |
+| Skills | `<SkillsTab>` (in `agent-detail.tsx`) | workspace `skills/<name>/SKILL.md` |
+| Knowledge | `<KnowledgeToggleList>` | `/api/agent-packages/:id/knowledge` |
+| Active Context | `<ActiveContextTab>` | `~/.openclaw/agents/<id>/sessions/*.jsonl` |
+
+URL state via `useQueryState('tab', 'overview')`. Unknown values fall back to `overview`.
+
+### Header Contract
+
+The header contains: back arrow, avatar (clickable for upload), name, role, gateway-restart banner (when dirty), delete button (suppressed on the main agent). It used to host the model picker, team selector, and subagent perms badge — all moved to OverviewTab so the header stays informational.
+
+### OverviewTab Composition
+
+Single dashboard surface, full-width responsive grid (1 → 2 → 3 cols at md / xl breakpoints). Panels:
+
+- Identity (name + role + emoji + manages-list)
+- Settings (model selector + team selector with live save)
+- PackageCard (embedded — exported from `agent-detail.tsx`)
+- Workspace path
+- Capacity counts (skills, knowledge total + enabled, last-session message count)
+- Latest Session (folds in the killed Stats tab — model, total tokens with input/output split, cache reads, total cost with per-message average)
+- Recent Activity (5m / 1h / 24h dispatch + error counts via `getStatsByMs`, framed as "since server start" because the recorder is in-memory)
+
+OverviewTab fetches stats / recent-activity / skills / knowledge in parallel on mount. Each panel handles its own loading/empty state.
+
+### MarkdownEditTab Pattern
+
+Used by Soul / Rules / Tools — Assets-style view→edit toggle. Default state renders `<MarkdownContent>`. Pencil button in the absolute top-right corner switches to a textarea. Save (green check) + Cancel (X) replace the pencil while editing. Cmd+S saves when dirty; Esc cancels. Save POSTs to the existing `/api/plugins/team/:agentId/files/:filename` endpoint.
+
+Layout uses `min-h-[calc(100vh-260px)]` so the markdown surface fills the viewport less header — replaces the prior FileEditorTab's cramped 500px container.
+
+### Heartbeat: View-Only
+
+`HeartbeatTab` renders `HEARTBEAT.md` via `<MarkdownContent>` with a "Last updated <relative>" badge. Explicitly no edit affordance — heartbeats are agent-authored narrative; user editing is meaningless.
+
+There are *two* heartbeat surfaces in the codebase that should not be confused:
+
+- `~/.bakin/heartbeats/<id>.json` — structured status JSON written by the `bakin_exec_heartbeat` MCP tool. Used by the watchdog and online-status detection. Not surfaced in the UI.
+- `<workspace>/HEARTBEAT.md` — markdown narrative the agent maintains for human consumption. This is what the Heartbeat tab shows.
+
+### Active Context: Latest Session Transcript
+
+`ActiveContextTab` fetches `/api/plugins/team/:id/active-context` and renders the parsed message stream from the agent's most recent session JSONL. One row per message with a role-colored badge (system/user/assistant/tool). Plain text via `<MarkdownContent>`; tool calls and JSON-shaped content as `<pre>`. Truncation banner appears when the underlying transcript was capped (default 200 messages on the server).
+
+Backed by `lib/session-reader.ts` — a sibling to `src/core/agent-usage.ts`. Where agent-usage sums tokens/cost across the latest session, session-reader returns the messages themselves.
+
+### New REST Endpoints (introduced in the Overview rework)
+
+Three GET routes on the team plugin, sibling to the existing `/:agentId/stats`:
+
+| Route | Returns |
+|---|---|
+| `/:agentId/heartbeat` | `{ ok, heartbeat: { content, lastUpdated } \| null }` |
+| `/:agentId/active-context?max=200` | `{ ok, transcript: SessionTranscript \| null }` |
+| `/:agentId/recent-activity` | `{ ok, activity: { windowMs, errors, sinceServerStart } }` |
+
+All three follow the existing per-agent route pattern (agentId from search params, structured ok/error response, log + 500 on errors).
+
+### What Got Killed
+
+- **Stats tab** — folded into the OverviewTab "Latest Session" panel.
+- **Profile tab** — replaced by OverviewTab. Old behavior was to re-render Soul / Rules / Tools / Heartbeat content alongside the Identity card; that was redundant since each has its own tab.
+- **FileEditorTab** — replaced by MarkdownEditTab.
+
+If a future iteration restores any of these, prefer adding back via new components rather than git-reverting — the new components have better tests + layout discipline.
 
 ## Test Coverage Map
 

--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -199,9 +199,9 @@ The `/team/:id` page (`agent-detail.tsx`) is a thin orchestrator: header + tab b
 | Tab | Component | Source |
 |---|---|---|
 | Overview | `<OverviewTab>` | `overview-tab.tsx` |
+| Soul | `<MarkdownEditTab>` | workspace `SOUL.md` |
 | Memory | `<MemoryTab>` (in `agent-detail.tsx`) | `~/.openclaw/agents/<id>/memory/*.md` |
 | Heartbeat | `<HeartbeatTab>` | `heartbeat-tab.tsx` (view-only) |
-| Soul | `<MarkdownEditTab>` | workspace `SOUL.md` |
 | Rules | `<MarkdownEditTab>` | workspace `AGENTS.md` |
 | Tools | `<MarkdownEditTab>` | workspace `TOOLS.md` |
 | Skills | `<SkillsTab>` (in `agent-detail.tsx`) | workspace `skills/<name>/SKILL.md` |

--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -199,6 +199,7 @@ The `/team/:id` page (`agent-detail.tsx`) is a thin orchestrator: header + tab b
 | Tab | Component | Source |
 |---|---|---|
 | Overview | `<OverviewTab>` | `overview-tab.tsx` |
+| Identity | `<MarkdownEditTab>` | workspace `IDENTITY.md` |
 | Soul | `<MarkdownEditTab>` | workspace `SOUL.md` |
 | Memory | `<MemoryTab>` (in `agent-detail.tsx`) | `~/.openclaw/agents/<id>/memory/*.md` |
 | Heartbeat | `<HeartbeatTab>` | `heartbeat-tab.tsx` (view-only) |

--- a/.claude/specs/team-overview-rework-plan.md
+++ b/.claude/specs/team-overview-rework-plan.md
@@ -1,0 +1,358 @@
+# Execution Plan — Team Overview Rework
+
+Companion to `.claude/specs/team-overview-rework.md`. Read the spec first for the *what* and *why*; this is the *how* — exact files, line numbers, dependency graph, per-checkpoint verification, rollback story.
+
+## Refresher
+
+9-tab restructure of `agent-detail.tsx`:
+- Rename Profile → Overview, kill Stats (fold in)
+- Add Heartbeat (view-only) and Active Context (read-only session transcript)
+- Apply Assets-style view/edit pattern to Soul / Rules / Tools markdown tabs
+- Move model selector + team selector from header into Overview
+- Full-width layout for markdown tabs
+
+**State of main on branch creation:** #161 already merged. PackageCard, KnowledgeTab, usePackageState, PackageStateRow type, and the Adopt-flow wiring are all present in main. This rework leaves the `Knowledge` tab + Package card as-is (they're already correct) and focuses on Overview / Heartbeat / Active Context / markdown view/edit pattern.
+
+**Per-commit verification adds `bunx tsc --noEmit -p tsconfig.app.json`** alongside `bun test --isolate` — Bun's runtime test runner doesn't catch TS-only errors that CI does.
+
+## Critical Files
+
+| # | Path | Role | Rough edit surface |
+|---|---|---|---|
+| 1 | `plugins/team/types.ts` | Add `SessionMessage` (role, content, model, ts) and `RecentActivity` (5m / 1h / 24h dispatch + error counts) types. Add `HeartbeatRaw` (content, lastUpdated). | Append at end of file. |
+| 2 | `plugins/team/lib/session-reader.ts` | **New.** JSONL parser that returns the message stream from the agent's most recent session — sibling to `agent-usage.ts` but returns messages, not summed usage. Tolerates malformed lines. | ~120 lines. Reuses `getOpenClawPath('agents')` + `getLatestSession()` style discovery. |
+| 3 | `plugins/team/lib/openclaw-adapter.ts` | Add `readHeartbeatRaw(agentId)` that returns `{ content, lastUpdated }` from `~/.bakin/heartbeats/{agentId}.json` (parse the JSON, extract the markdown body + mtime). | New function ~25 lines, slot before line 290 (`getAgentModel`). |
+| 4 | `plugins/team/index.ts` | Add 3 new REST handlers: `GET /:agentId/heartbeat`, `GET /:agentId/active-context`, `GET /:agentId/recent-activity`. | New routes appended after the existing `/:agentId/stats` handler (~lines 1022-1036). Recent-activity reads `getStatsByMs` from `src/core/usage`. |
+| 5 | `plugins/team/components/markdown-edit-tab.tsx` | **New.** Reusable view/edit component with the Assets pattern — pencil corner button → toggles to textarea, Save (green check) + Cancel (X) replace pencil. Cmd+S in edit mode. Save POSTs to a configurable endpoint. | ~120 lines. Props: `agentId`, `filename`, `initialContent`. |
+| 6 | `plugins/team/components/heartbeat-tab.tsx` | **New.** View-only: `<MarkdownContent>` with a "Last updated <relative time>" badge in the top-right corner. Empty state for missing heartbeat. | ~70 lines. Fetches `/api/plugins/team/:id/heartbeat`. |
+| 7 | `plugins/team/components/active-context-tab.tsx` | **New.** Loads session messages, renders one row per message with role-colored badge + content preview (markdown for text, JSON pretty-print for tool calls). Shows latest 200 messages with "show all" affordance. | ~150 lines. |
+| 8 | `plugins/team/components/overview-tab.tsx` | **New.** The consolidated Overview content: Identity card, Package card (reused from #158), Settings (model + team selectors), Workspace path, Summary counts (skills, knowledge), Latest session stats, Recent activity. | ~250 lines. Composed of small sub-components for each panel. |
+| 9 | `plugins/team/components/agent-detail.tsx` | Major restructure. Trim header (remove model picker, team selector, subagent perms badge — those move to Overview). Update `Tab` union + `TABS` array. Replace `<FileEditorTab>` callsites with `<MarkdownEditTab>`. Add `<HeartbeatTab>`, `<ActiveContextTab>`, `<OverviewTab>` to dispatch. Delete `<StatsTab>` + `<Row>` (folds into Overview). Delete `<ProfileTab>` + helpers (replaced by `<OverviewTab>`). | (a) Tab union (line 25) + TABS (27-35) updated. (b) Header (160-232) trimmed. (c) Tab dispatch (272-278) rewired. (d) ProfileTab helpers + StatsTab deleted (313-374, 727-799). (e) FileEditorTab kept temporarily then deleted in favor of MarkdownEditTab. |
+| 10 | `tests/plugins/team/agent-detail-tabs.test.tsx` | Adjust TABS assertion to match the new 9-tab list and order. | ~5 line edit. |
+| 11 | `tests/plugins/team/session-reader.test.ts` | **New.** Pure-function tests for the JSONL parser. | ~80 lines. |
+| 12 | `tests/plugins/team/markdown-edit-tab.test.tsx` | **New.** View/edit toggle, save POST shape, dirty/saved indicators, Cmd+S, Cancel. | ~120 lines. |
+| 13 | `tests/plugins/team/heartbeat-tab.test.tsx` | **New.** Markdown render, last-updated formatting, no edit button, empty state. | ~80 lines. |
+| 14 | `tests/plugins/team/active-context-tab.test.tsx` | **New.** Message rendering per role, empty state, message cap behavior. | ~120 lines. |
+| 15 | `tests/plugins/team/overview-tab.test.tsx` | **New.** Identity, package card, settings panels, summary counts, recent activity all render. | ~150 lines. |
+| 16 | `tests/plugins/team/routes.test.ts` | Extend with coverage for the 3 new REST handlers. | ~80 line addition. |
+| 17 | `.claude/knowledge/team-plugin.md` | Add "Agent Detail Tab Architecture" section documenting the new tab structure, MarkdownEditTab pattern, OverviewTab composition, ActiveContext data source. | ~80 line addition. |
+
+**Not touched:**
+
+- `plugins/team/components/team-grid.tsx` — grid is fine
+- `plugins/team/components/agent-form.tsx` — agent creation flow unchanged
+- `plugins/team/components/team-manager.tsx` — drawer unchanged
+- `plugins/team/components/package-state-badge.tsx` — used by Overview, no change
+- `plugins/team/components/knowledge-toggle-list.tsx` — Knowledge tab still renders this
+- `plugins/team/hooks/use-agent-store.ts` — no new fields needed
+- `packages/host/src/api/*` — REST handlers added inside the team plugin, not at host level
+- `CLAUDE.md` — no architectural shifts requiring doc updates
+- `README.md` — no user-facing CLI surface changes
+
+## Dependency Graph
+
+```
+C1 (types)            ─┬─▶ C2 (session-reader lib)  ─┐
+                       │                              │
+                       ├─▶ C3 (heartbeat reader)  ──┐ │
+                       │                              │ │
+                       └─▶ C4 (REST endpoints)  ◀─┴─┘
+                                                      │
+                                                      ▼
+                                       ┌─ C5 (MarkdownEditTab)
+                                       │
+                                       ├─ C6 (HeartbeatTab)
+                                       │
+                                       ├─ C7 (ActiveContextTab)
+                                       │
+                                       └─ C8 (OverviewTab)
+                                                      │
+                                                      ▼
+                                       C9 (agent-detail integration)
+                                                      │
+                                                      ▼
+                                       C10 (docs)
+```
+
+- **C1 (types) gates everything** — but is trivial.
+- **C2 + C3 are pure-function additions** with no consumers yet — both safe to land before C4.
+- **C4 (REST) gates the visual tabs (C6, C7, C8)** because they fetch from those endpoints.
+- **C5 (MarkdownEditTab) is independent** — extracted from the existing FileEditorTab pattern; no upstream dep.
+- **C9 (agent-detail integration) gates revealing all the new tabs in the live UI.** Until C9 lands, the new tab components exist but aren't wired into the tab bar — every prior commit ships dead-but-tested code.
+- **C10 (docs) ships last** so the knowledge file reflects the landed state.
+
+## Per-Commit Plan
+
+### C1 — `feat(team): add session and activity types`
+
+**Files:** `plugins/team/types.ts`
+
+**Changes:** Append three new exported types:
+```ts
+export interface SessionMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content: string
+  model?: string
+  ts?: string
+  toolName?: string
+}
+
+export interface SessionTranscript {
+  sessionId: string
+  sessionStarted: string | null
+  messages: SessionMessage[]
+  truncated: boolean
+}
+
+export interface RecentActivity {
+  windowMs: Record<'5m' | '1h' | '24h', number>
+  errors: Record<'5m' | '1h' | '24h', number>
+  sinceServerStart: string
+}
+
+export interface HeartbeatRaw {
+  content: string
+  lastUpdated: string | null
+}
+```
+
+**Tests:** None (type-only commit; consumers test the shape).
+
+**Verification:** `bun build` succeeds (type-check clean).
+
+**Rollback:** Trivial — revert one file.
+
+---
+
+### C2 — `feat(team): add session-reader for active-context tab`
+
+**Files:** `plugins/team/lib/session-reader.ts` (new), `tests/plugins/team/session-reader.test.ts` (new)
+
+**Changes:** Pure-function module mirroring `src/core/agent-usage.ts` discovery (latest session JSONL via first-line timestamp). Parses each line: skips `type !== 'message'` entries (system/session/etc), maps assistant/user/tool messages into `SessionMessage`. Returns `SessionTranscript` with truncation flag (cap = 200 by default, configurable param).
+
+Key shape:
+```ts
+export function readLatestSessionTranscript(
+  agentId: string,
+  opts?: { maxMessages?: number },
+): SessionTranscript | null
+```
+
+**Tests:** 6-8 cases — happy path with mixed roles, malformed line skipped, missing-file returns null, truncation flag correct, system message included, tool message includes `toolName`.
+
+**Verification:** `bun test --isolate tests/plugins/team/session-reader.test.ts` green.
+
+**Rollback:** Two files revert; no consumers yet.
+
+---
+
+### C3 — `feat(team): add heartbeat raw reader to adapter`
+
+**Files:** `plugins/team/lib/openclaw-adapter.ts`
+
+**Changes:** Add `readHeartbeatRaw(agentId): HeartbeatRaw | null` before `getAgentModel` (line 290). Reads `~/.bakin/heartbeats/{agentId}.json`, parses JSON, returns `{ content: parsed.markdown ?? parsed.message ?? '', lastUpdated: parsed.timestamp ?? null }`. Returns `null` on missing file.
+
+**Tests:** Existing `tests/plugins/team/openclaw-adapter.test.ts` extended with one happy-path case + one missing-file case.
+
+**Verification:** `bun test --isolate tests/plugins/team/openclaw-adapter.test.ts`.
+
+**Rollback:** Single function removed.
+
+---
+
+### C4 — `feat(team): add REST endpoints for new tabs`
+
+**Files:** `plugins/team/index.ts`, `tests/plugins/team/routes.test.ts`
+
+**Changes:** Three new routes:
+
+- `GET /:agentId/heartbeat` → calls `readHeartbeatRaw(agentId)`, returns `{ ok, heartbeat: HeartbeatRaw | null }`
+- `GET /:agentId/active-context?max=200` → calls `readLatestSessionTranscript(agentId, { maxMessages })`, returns `{ ok, transcript: SessionTranscript | null }`
+- `GET /:agentId/recent-activity` → calls `getStatsByMs` for each window (5m, 1h, 24h) with `agent: agentId`, returns `{ ok, activity: RecentActivity }`. `sinceServerStart` is the process-start ISO timestamp.
+
+Each handler follows the existing pattern (try/catch + `Response.json`). Append after the `/:agentId/stats` handler (~line 1036).
+
+**Tests:** 6-8 new cases in `routes.test.ts` — happy path + missing-data path for each handler. Use the existing test setup.
+
+**Verification:** `bun test --isolate tests/plugins/team/routes.test.ts`.
+
+**Rollback:** Three handlers removed; type imports stay (used by C5+).
+
+---
+
+### C5 — `feat(team): extract MarkdownEditTab reusable component`
+
+**Files:** `plugins/team/components/markdown-edit-tab.tsx` (new), `tests/plugins/team/markdown-edit-tab.test.tsx` (new)
+
+**Changes:** Brand-new component with the Assets-style view/edit toggle:
+
+- Props: `agentId`, `filename`, `initialContent: string | null`
+- Default state: rendered markdown via `<MarkdownContent>`. Pencil icon (top-right, absolute corner button matching Assets pattern).
+- Edit state: textarea (full-width, fills available height). Top-right shows green check (Save) + zinc X (Cancel). Cmd+S triggers save. Save POSTs to `/api/plugins/team/:agentId/files/:filename` (existing endpoint, no server change needed).
+- Indicators: `dirty` badge while editing with unsaved changes, `saved` badge for ~2s after save.
+- Cancel exits edit mode and discards local changes.
+
+Layout: full-width container, no `max-w-2xl`. Min-height fills viewport (`min-h-[calc(100vh-260px)]` initial guess; settle visually in C9).
+
+**Tests:** Toggle to edit, dirty indicator after typing, save POST shape correct, Cancel reverts content, Cmd+S triggers save when dirty, ignores when clean, missing initialContent shows "does not exist" empty state.
+
+**Verification:** `bun test --isolate tests/plugins/team/markdown-edit-tab.test.tsx`. Visual: not yet wired into the live UI; manual stub render to verify pattern feels right.
+
+**Rollback:** Two files revert. agent-detail.tsx still uses old `<FileEditorTab>`.
+
+---
+
+### C6 — `feat(team): add Heartbeat tab component`
+
+**Files:** `plugins/team/components/heartbeat-tab.tsx` (new), `tests/plugins/team/heartbeat-tab.test.tsx` (new)
+
+**Changes:** View-only tab. Fetches `GET /api/plugins/team/:agentId/heartbeat`. Renders `<MarkdownContent>` with the body. Top-right: small "Last updated <relative time>" using a relative-time helper (e.g., `Intl.RelativeTimeFormat`). Empty state when `heartbeat === null`: centered "No heartbeat reported yet."
+
+No edit button anywhere — explicitly forbidden by the spec.
+
+**Tests:** Renders markdown, shows last-updated, no pencil/edit button present (assertion query for absence), shows empty state when API returns null.
+
+**Verification:** `bun test --isolate tests/plugins/team/heartbeat-tab.test.tsx`.
+
+**Rollback:** Two files revert.
+
+---
+
+### C7 — `feat(team): add ActiveContext tab component`
+
+**Files:** `plugins/team/components/active-context-tab.tsx` (new), `tests/plugins/team/active-context-tab.test.tsx` (new)
+
+**Changes:** Read-only transcript view. Fetches `GET /api/plugins/team/:agentId/active-context`. Renders one row per message — role badge (system: gray, user: blue, assistant: green, tool: amber) + content (markdown for text bodies, `<pre>` JSON for tool calls/results). Truncation banner at top when `transcript.truncated === true`: "Showing latest 200 of N messages. Older messages omitted."
+
+Layout: full-width, scrollable container with bottom-anchored scroll position so users land at the most recent message (the typical interesting one).
+
+**Tests:** Each role renders with the correct badge, empty state when API returns null transcript, truncation banner appears when flag set, message count matches API response, content displays correctly for text vs tool entries.
+
+**Verification:** `bun test --isolate tests/plugins/team/active-context-tab.test.tsx`.
+
+**Rollback:** Two files revert.
+
+---
+
+### C8 — `feat(team): add Overview tab component`
+
+**Files:** `plugins/team/components/overview-tab.tsx` (new), `plugins/team/components/agent-detail.tsx` (export PackageCard so OverviewTab can import it), `tests/plugins/team/overview-tab.test.tsx` (new)
+
+**Changes:** Composed component with these panels:
+
+- **Identity card** — agent name, role, emoji, dispatchableBy badge (preserves what's currently in the header)
+- **Package card** — directly reuses the existing `<PackageCard>` from `agent-detail.tsx` (#161 has merged, so it's now in main). Add `export` to the existing `function PackageCard(...)` declaration in agent-detail.tsx so OverviewTab can import it. No code duplication.
+- **Settings panel** — model selector (existing `ModelSelect`), team selector (existing `<select>` from header). On change, the existing handler fires.
+- **Workspace path** — `<code>` with the path
+- **Summary counts** — fetches `/api/plugins/team/:agentId/skills` (count) and `/api/agent-packages/:agentId/knowledge` (count + enabled count). Renders 3-column grid: Skills | Knowledge total | Knowledge enabled
+- **Latest session** — fetches `/api/plugins/team/:agentId/stats` (existing endpoint — no change needed). Renders condensed: Model, Messages, Tokens (total), Cost (total). Folds in the killed Stats tab content.
+- **Recent activity** — fetches `/api/plugins/team/:agentId/recent-activity`. Renders 3-column: 5m | 1h | 24h with errors below each. Footer text: "Since server start (<sinceServerStart>)."
+
+Layout: full-width grid with sensible column counts at responsive breakpoints (likely `grid-cols-1 md:grid-cols-2 xl:grid-cols-3`).
+
+**Tests:** All panels render with mocked fetches, model/team save round-trips, empty/loading states for each fetched data source.
+
+**Verification:** `bun test --isolate tests/plugins/team/overview-tab.test.tsx`.
+
+**Rollback:** Two files revert. agent-detail.tsx still shows old Profile tab.
+
+---
+
+### C9 — `feat(team): integrate new tabs into agent-detail`
+
+**Files:** `plugins/team/components/agent-detail.tsx`, `tests/plugins/team/agent-detail-tabs.test.tsx`
+
+**Changes:** The big swap — wires all C5-C8 components into the live UI:
+
+1. **Tab union** (line 25): `'overview' | 'memory' | 'heartbeat' | 'soul' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'active-context'`
+2. **TABS array** (27-35): reorder to spec list. Default tab from `?tab=` falls back to `'overview'`.
+3. **Header** (160-232): remove model picker (194-204), team selector (213-224), subagent perms badge (208-212), saving spinner (203). Keep: back arrow, avatar, name, role, gateway-restart banner, delete button.
+4. **Tab dispatch** (272-278): replace with the new mapping. `<FileEditorTab>` callsites for SOUL/AGENTS/TOOLS swap to `<MarkdownEditTab>`. Add `<OverviewTab>`, `<HeartbeatTab>`, `<ActiveContextTab>` rows.
+5. **Delete** `<ProfileTab>` (313-374), `<StatsTab>` + `<Row>` (727-799), `<ProfileSection>` + `<ProfileMarkdown>` (315-328) — all subsumed by the new components.
+6. **Delete** `<FileEditorTab>` (376-445) — replaced by `<MarkdownEditTab>`.
+7. **`agent-detail-tabs.test.tsx`** — adjust the asserted TABS list.
+
+**Tests:** Verify all 9 tabs render, URL state survives, default tab is Overview, removed surfaces (model picker, team selector) are absent from the header.
+
+**Verification:** `bun test --isolate tests/plugins/team` — full suite green. `bun run dev:mock` — manually verify all 6 acceptance criteria from the spec.
+
+**Rollback:** Single file revert. Prior commits' new components stay (dead but tested).
+
+---
+
+### C10 — `docs: document Team Overview rework`
+
+**Files:** `.claude/knowledge/team-plugin.md`, `docs/plugin-authoring.md`
+
+**Changes:** Append "Agent Detail Tab Architecture" section to team-plugin.md:
+- Tab map (9 tabs with one-line description each)
+- MarkdownEditTab contract — view/edit toggle, save endpoint
+- OverviewTab composition (panel list)
+- Heartbeat / ActiveContext data sources
+- Recent-activity caveat: "Since server start" framing
+
+Add a brief callout in `docs/plugin-authoring.md` about the markdown view/edit pattern in case other plugins adopt it (no SDK lift yet — flag as a future iteration).
+
+**Tests:** None.
+
+**Verification:** Read both files end-to-end. Confirm accuracy vs landed code.
+
+**Rollback:** Two files revert.
+
+---
+
+## Verification Across All Commits
+
+After each commit:
+```bash
+bun test --isolate tests/plugins/team
+bun test --isolate                       # full suite, no regressions
+```
+
+Before opening the PR:
+```bash
+bun run typecheck     # confirm exact name in package.json
+bun run build:plugins # full plugin build clean
+bun run dev:mock      # full visual sweep
+```
+
+PR checklist (mirrors spec's "Definition of Done"):
+- [ ] All 10 commits on `feat/team-overview-rework`
+- [ ] Full test suite passes
+- [ ] Visual verification of all 6 acceptance criteria
+- [ ] `.claude/knowledge/team-plugin.md` updated
+- [ ] PR body lists what changed from the user's perspective + the killed Stats tab note
+- [ ] Follow-ups filed: per-turn Active Context drill-down; potential MarkdownEditTab → SDK lift
+
+## Rollback Story
+
+| Revert | Result |
+|---|---|
+| Just C10 | Code identical; only the new doc sections disappear. |
+| Just C9 | All new tab components stay built but unwired; agent-detail returns to its pre-rework tab list. The new REST endpoints stay. |
+| Just C8 | OverviewTab vanishes; agent-detail's C9 dispatch fails to render Overview content (would need agent-detail to also revert that switch case). Treat C8/C9 as a paired revert pair. |
+| Just C7 | ActiveContext tab content disappears. C9's dispatch line falls back to a "tab content unavailable" — also paired with C9 revert. |
+| Just C6 | Same shape as C7 — Heartbeat content absent. |
+| Just C5 | Soul/Rules/Tools tabs lose the new pattern. C9 imports MarkdownEditTab — paired revert. |
+| Just C4 | The 3 new endpoints disappear. C6/C7/C8 fetches start failing — empty states everywhere. Paired revert with the consuming commits. |
+| Just C3 | `readHeartbeatRaw` removed. C4's heartbeat handler fails — paired revert. |
+| Just C2 | session-reader removed. C4's active-context handler fails — paired revert. |
+| Just C1 | Type imports break across C2-C9. Full chain revert needed. |
+| Full revert (C1-C10) | Codebase identical to pre-rework state — agent-detail.tsx as it was on `main` (or the post-#158 state if those merged first). |
+
+**No destructive operations** in any commit:
+- No file deletions outside the dead-after-replace components inside agent-detail.tsx
+- No schema migrations
+- No env var additions
+- No new dependencies
+- No build pipeline changes
+
+## Open Micro-Decisions (settle during build)
+
+1. **Recent-activity panel framing copy** — "Last 24h" vs "Past 24h" vs "24h activity"
+2. **Active-context message cap default** (200 chosen; tune if testing reveals heavy sessions render slowly)
+3. **OverviewTab grid breakpoints** — start with `md:grid-cols-2 xl:grid-cols-3`, adjust if panels look cramped
+4. **MarkdownEditTab corner button styling** — match Assets exactly (rounded backdrop pill) vs simpler ghost button. Match Assets for consistency.
+5. **ActiveContext role badge colors** — settle on a palette during build; system=zinc, user=blue, assistant=accent, tool=amber is the proposed start.
+
+None block C1.

--- a/.claude/specs/team-overview-rework-plan.md
+++ b/.claude/specs/team-overview-rework-plan.md
@@ -1,5 +1,14 @@
 # Execution Plan — Team Overview Rework
 
+> **Post-merge note:** this plan targeted 9 tabs and assumed Heartbeat reads
+> from `~/.bakin/heartbeats/{id}.json`. Both shifted during build:
+> - Shipped 10 tabs (Identity added mid-stream).
+> - Heartbeat tab reads `<workspace>/HEARTBEAT.md` instead — the agent-authored
+>   markdown narrative, not the JSON status signal. The two surfaces were
+>   conflated in this plan; the knowledge doc + landed code disambiguate.
+
+
+
 Companion to `.claude/specs/team-overview-rework.md`. Read the spec first for the *what* and *why*; this is the *how* — exact files, line numbers, dependency graph, per-checkpoint verification, rollback story.
 
 ## Refresher

--- a/.claude/specs/team-overview-rework.md
+++ b/.claude/specs/team-overview-rework.md
@@ -1,0 +1,182 @@
+# Spec — Team Agent Detail Overview Rework
+
+Restructures `/team/:id` (`agent-detail.tsx`) around a new "Overview" tab and rationalizes the entire tab list. New tabs: Heartbeat (read-only) and Active Context (read-only session transcript). Existing markdown tabs (Soul / Rules / Tools) get an Assets-style view-then-edit pattern with full-width layout.
+
+## Problem
+
+The current agent-detail Profile tab regurgitates content already shown on dedicated tabs (Soul, Rules, Tools, Heartbeat), the Stats tab is a sparse standalone surface that would be more valuable folded in, and there's no UI surface for "what does this agent actually see when dispatched?" The model picker and team selector also crowd the header instead of living in their natural home (settings on Overview).
+
+## Locked Decisions
+
+1. **Final tab list (9 tabs):**
+   `Overview | Memory | Heartbeat | Soul | Rules | Tools | Skills | Knowledge | Active Context`
+2. **Stats tab killed** — its content folds into Overview.
+3. **Profile renamed → Overview.**
+4. **Overview removes** the redundant Soul / Rules / Tools / Heartbeat content (each has its own tab).
+5. **Overview adds:**
+   - **Summary counts** (skills total, knowledge lessons total + enabled count)
+   - **Latest session stats** (model, messages, total tokens, total cost — same data as old Stats tab, condensed)
+   - **Recent activity** (5m / 1h / 24h dispatch counts via `getStatsByMs`, framed as "since server start")
+   - **Model selector** (moved from header)
+   - **Team selector** (moved from header)
+   - **Workspace path** (already on Profile today; stays)
+   - **Identity** (already on Profile today; stays — IDENTITY.md is structured metadata, not a redundant file editor)
+6. **Header becomes leaner** — back arrow, avatar, name, role, status, gateway-restart banner, delete button. No model picker, no team selector, no subagent perms badge (move to Overview if useful).
+7. **Heartbeat tab — view-only** rendered markdown. No edit affordance. "Last updated <time ago>" header.
+8. **Active Context tab — read-only session transcript.** Shows the most recent session JSONL parsed into a message list (system / user / assistant / tool entries) with role badges and content. No filtering, no per-turn drill-down, no editing. Empty state when no sessions exist.
+9. **Markdown tabs (Soul / Rules / Tools) get the Assets pattern:**
+   - Default: rendered markdown (read mode), full-width
+   - Top-right corner button: pencil → enter edit mode
+   - Edit mode: textarea raw markdown editor, Save (green check) + Cancel (X) replace the pencil
+   - `Cmd+S` saves while in edit mode
+   - Save success surfaces a transient "saved" indicator
+10. **Full-width layout:**
+   - Markdown tabs span the full page width (current `max-w-2xl` removed)
+   - Markdown tabs use min-height that fills the viewport less header (CSS `min-h-[calc(100vh-220px)]` or similar — settle visually)
+   - Non-markdown tabs (Overview, Memory, Heartbeat, Skills, Knowledge, Active Context) also use the full width with grid/column layouts where it improves density
+11. **Branch:** `feat/team-overview-rework`. Single PR.
+12. **Closes** the rework agreed in the conversation. Active Context ships as session-level transcript view; per-turn drill-down (showing the exact reconstructed input window per assistant turn) is a deferred follow-up.
+
+## Acceptance Criteria
+
+A user opening `/team/:agent-id` after this work can:
+
+- ✅ See a single Overview tab containing identity, package state (still present from #158), model selector, team selector, workspace path, summary counts (skills + knowledge), latest session stats (model + messages + tokens + cost), and recent activity (5m/1h/24h counts) — without scrolling past redundant SOUL/AGENTS/TOOLS/HEARTBEAT walls of text
+- ✅ Switch to Soul / Rules / Tools and see rendered markdown by default (full-width, full-height) — click pencil → edit raw → save
+- ✅ Switch to Heartbeat and see the rendered heartbeat markdown view-only with a "last updated" indicator — no edit affordance
+- ✅ Switch to Active Context and see the most recent session's message stream (system, user, assistant, tool messages) in read-only form
+- ✅ Tab order is `Overview | Memory | Heartbeat | Soul | Rules | Tools | Skills | Knowledge | Active Context` — left to right
+- ✅ Header above the tabs no longer contains the model picker, team selector, or subagent perms badge
+- ✅ The deleted Stats tab is gone; its content lives on Overview as a condensed panel
+
+## Out of Scope (Tracked As Follow-Ups)
+
+- Per-turn Active Context drill-down (reconstruct input window per assistant message)
+- Lifetime aggregate stats (total messages / cost since install — would require persistence beyond `recordUsage`'s in-memory store)
+- Heartbeat edit mode (deferred forever — agent-authored, not user-editable)
+- "Active Context" preview while a dispatch is in-flight (live streaming) — out of scope, would need SSE wiring
+- Identity editing on Overview — IDENTITY.md edit goes through `PUT /api/plugins/team/:id/identity` which exists but is structured fields, not a markdown editor; current edit-via-form (when the agent is created) is acceptable
+- Stats tab restoration — explicitly killed; if folded-in summary turns out insufficient in real use we'll revisit, not pre-empt
+
+## In Scope (Files Touched)
+
+| Path | Change |
+|---|---|
+| `plugins/team/components/agent-detail.tsx` | Major restructure. Tab list updated. Header trimmed. New `<OverviewTab>`, `<HeartbeatTab>`, `<ActiveContextTab>` components. `<FileEditorTab>` becomes `<MarkdownEditTab>` with view/edit toggle. |
+| `plugins/team/components/markdown-edit-tab.tsx` | **New.** Extracted reusable component for the Assets-style markdown view/edit pattern (used by Soul / Rules / Tools tabs). |
+| `plugins/team/components/heartbeat-tab.tsx` | **New.** View-only markdown render with "last updated" badge. |
+| `plugins/team/components/active-context-tab.tsx` | **New.** Reads the most recent session JSONL for the agent and renders messages with role badges. |
+| `plugins/team/components/overview-tab.tsx` | **New.** The new consolidated Overview content — splits the existing `ProfileTab` into something more useful. |
+| `packages/host/src/api/plugins/[pluginId]/[[...path]].ts` | No change — uses existing routes. |
+| `plugins/team/index.ts` | Add new REST routes: `GET /:agentId/heartbeat` (raw heartbeat markdown + lastUpdated metadata), `GET /:agentId/active-context` (parsed messages from latest session JSONL). Add `GET /:agentId/recent-activity` (returns 5m/1h/24h counts via `getStatsByMs`). |
+| `plugins/team/lib/openclaw-adapter.ts` | Add `readHeartbeatRaw(agentId)` that returns `{ content, lastUpdated }` from the heartbeat file (currently the adapter only computes the merged status; the raw markdown isn't surfaced). |
+| `plugins/team/lib/session-reader.ts` | **New.** Wraps `agent-usage.ts` style JSONL parsing but returns the structured *message stream* (role, content, model, ts) instead of summed-up usage stats. Distinct concern from `agent-usage.ts`. |
+| `plugins/team/types.ts` | Add `SessionMessage` type and `RecentActivity` type for the new endpoints. |
+| `tests/plugins/team/overview-tab.test.tsx` | **New.** Renders OverviewTab; asserts summary counts, model selector, team selector, condensed stats, recent activity panel all appear. |
+| `tests/plugins/team/markdown-edit-tab.test.tsx` | **New.** Verifies view→edit toggle, save POSTs to the right endpoint, Cancel resets state, dirty indicator. |
+| `tests/plugins/team/heartbeat-tab.test.tsx` | **New.** Heartbeat renders markdown, no edit button, shows last-updated. |
+| `tests/plugins/team/active-context-tab.test.tsx` | **New.** Loads session messages, renders system/user/assistant/tool roles, empty state. |
+| `tests/plugins/team/session-reader.test.ts` | **New.** Pure-function tests for the JSONL → message stream parser. |
+| `tests/plugins/team/agent-detail-tabs.test.tsx` | Update — TABS constant changed; adjust to assert against the new list. |
+| `.claude/knowledge/team-plugin.md` | Document the new tab structure, OverviewTab layout, MarkdownEditTab pattern, ActiveContext data source. |
+| `docs/plugin-authoring.md` | Reference MarkdownEditTab as a reusable pattern other plugins can adopt for view/edit markdown tabs (if it makes sense to lift to SDK in a future iteration). |
+
+**Not touched:**
+
+- `plugins/team/components/team-grid.tsx` — grid is fine as-is
+- `plugins/team/components/agent-form.tsx` — agent creation flow unchanged
+- `plugins/team/components/team-manager.tsx` — team management drawer unchanged
+- `plugins/team/components/package-state-badge.tsx` — used by Overview but unchanged
+- `plugins/team/components/knowledge-toggle-list.tsx` — Knowledge tab still renders this
+- `plugins/team/hooks/use-agent-store.ts` — no new fields needed; existing data sufficient
+
+## Commands (Verification Surfaces)
+
+```bash
+# Tests during dev (every commit must keep these green)
+bun test --watch --isolate tests/plugins/team
+
+# Full suite (pre-merge)
+bun test --isolate
+
+# Build verification
+bun run build:plugins
+
+# Visual verification (REQUIRED — this is UI work)
+bun run dev:mock
+# Open http://localhost:3737/team/main and verify:
+#   - Tabs in order: Overview | Memory | Heartbeat | Soul | Rules | Tools | Skills | Knowledge | Active Context
+#   - Overview shows: identity, package card, model select, team select, workspace path, summary counts, latest session, recent activity
+#   - Header has no model picker, no team selector
+#   - Soul/Rules/Tools default to rendered markdown, pencil button toggles edit
+#   - Heartbeat is view-only, no pencil
+#   - Active Context shows messages from the seeded session JSONL
+```
+
+## Code Style
+
+Inherits from CLAUDE.md. Component-specific:
+
+- Tab content components live in their own files when over ~80 lines (extract liberally to keep agent-detail.tsx readable)
+- Use existing `MarkdownContent` from `@bakin/sdk/components` for rendered markdown
+- Use existing `useAgentStore` and `usePackageState` for store access
+- Keep `agent-detail.tsx` as the orchestrator — it owns the header + tab bar + tab dispatch only after this rework
+
+## Testing Strategy
+
+Mandatory mock setup per CLAUDE.md (content-dir x2, openclaw-home, logger, watcher, openclaw-client) on every test file.
+
+Per-component coverage requirements:
+
+- **OverviewTab:** counts, panels, model save round-trip, team save round-trip
+- **MarkdownEditTab:** view/edit toggle, save round-trip, dirty/saved indicators, Cmd+S, Cancel reverts
+- **HeartbeatTab:** markdown rendering, last-updated formatting, absence of edit button
+- **ActiveContextTab:** message rendering for each role, empty state, loading state, error fallback
+- **session-reader (lib):** JSONL parsing, malformed line tolerance, missing-file behavior
+
+Existing `agent-detail-tabs.test.tsx` updates: adjust the asserted TABS list, keep the URL contract assertion.
+
+## Boundaries
+
+**Always do:**
+
+- Maintain CLAUDE.md test isolation rules — no leak to `~/.bakin/` or `~/.openclaw/`
+- Use existing API endpoints where they suffice; only add new ones for genuinely new data needs (heartbeat raw, active context messages, recent activity)
+- Keep the new tab components self-contained (own file, own tests)
+- Preserve the URL state pattern (`?tab=...`) for all new tabs
+- Preserve every existing endpoint shape — adding new endpoints, not modifying existing ones
+
+**Ask first about:**
+
+- Lifting MarkdownEditTab to `@bakin/sdk/components` (shared markdown view/edit primitive other plugins might adopt) — likely defer to a follow-up iteration once the pattern proves itself
+- Surfacing live Active Context (mid-dispatch streaming) — would require SSE wiring; ask before scope-creeping
+- Persisting session-message rendering preferences (collapsed vs expanded) — defer until the user asks
+
+**Never do:**
+
+- Add an edit button to Heartbeat tab — explicitly forbidden by the spec
+- Reintroduce Stats as a separate tab unless the Overview-condensed view proves insufficient (ask first)
+- Truncate or pre-process active-context messages on the server beyond JSONL parsing — show the user what was actually sent
+- Persist anything new to `~/.bakin/` for this rework — every data source is an existing file
+- Skip the `useGatewayStatus` hook on model change — model swaps trigger a gateway-restart-needed signal that the header banner depends on
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Active Context renders huge sessions (10k+ messages) — DOM bloat | Cap initial render to N most recent messages with a "show all" affordance. Set N=200 as a starting point. |
+| Heartbeat file may not exist for fresh agents | Empty state: "No heartbeat reported yet. Heartbeats appear after the agent runs its first task." |
+| Recent activity counts are session-only (reset on server restart) per CLAUDE.md | Frame the panel as "Since server start (5m / 1h / 24h)" — honest about the constraint. Do not invent persistence to fix this. |
+| Markdown render of arbitrary user content (XSS surface) | `MarkdownContent` already used elsewhere — assume it's safe. If not, that's a separate hardening issue, not this one. |
+| Removing model picker from header changes muscle memory | Acceptable — Overview is the natural home and the user explicitly asked for the move. Document in changelog. |
+| Tab count grew from 8 to 9 — UI density concern on narrow screens | Tab bar already wraps with hover scroll; acceptable. Future polish: collapse to dropdown under N px width. |
+
+## Definition of Done
+
+- All commits land on `feat/team-overview-rework`
+- `bun test --isolate` passes (zero regressions)
+- `bun run dev:mock` visual verification of all 6 acceptance criteria
+- PR opened against `main` with summary referencing the rework
+- `.claude/knowledge/team-plugin.md` updated with the new tab map and component contracts
+- The killed Stats tab content visibly accessible on Overview (no data loss)
+- Follow-up issues filed for: per-turn Active Context drill-down, MarkdownEditTab → SDK lift (if/when reused)

--- a/.claude/specs/team-overview-rework.md
+++ b/.claude/specs/team-overview-rework.md
@@ -1,5 +1,14 @@
 # Spec — Team Agent Detail Overview Rework
 
+> **Post-merge note (scope grew during build):** the spec below targets 9 tabs.
+> Shipped result is **10 tabs** — `Identity` was added mid-stream so users can
+> edit `IDENTITY.md` from the UI (the file the role parser reads). Final tab
+> order: `Overview | Identity | Soul | Memory | Heartbeat | Rules | Tools |
+> Skills | Knowledge | Active Context`. See `.claude/knowledge/team-plugin.md`
+> for the canonical landed state.
+
+
+
 Restructures `/team/:id` (`agent-detail.tsx`) around a new "Overview" tab and rationalizes the entire tab list. New tabs: Heartbeat (read-only) and Active Context (read-only session transcript). Existing markdown tabs (Soul / Rules / Tools) get an Assets-style view-then-edit pattern with full-width layout.
 
 ## Problem

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "react-dom": "19.2.4",
         "react-hook-form": "^7.72.0",
         "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.0.8",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
@@ -1079,9 +1080,25 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
@@ -1108,6 +1125,20 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
 
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
@@ -1315,9 +1346,13 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
     "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -1640,6 +1675,8 @@
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -369,6 +369,20 @@ edits (e.g., a half-filled form), it resets. That's v2's tradeoff —
 full React Fast Refresh is deferred to v3. See
 `.claude/knowledge/dev-loop.md` for the full architecture.
 
+## Reusable patterns from core plugins
+
+A few patterns the team plugin landed during the agent-detail rework are worth knowing about — they aren't in `@bakin/sdk` *yet*, but they're stable patterns other plugins can adopt by referencing the source.
+
+### View→Edit markdown tabs (Assets-style)
+
+`plugins/team/components/markdown-edit-tab.tsx` provides a reusable view/edit component for markdown workspace files. Default state renders `<MarkdownContent>`; a pencil button in the absolute top-right corner toggles to a textarea editor with Save (green check) + Cancel (X) buttons in the same corner. Cmd+S saves when dirty; Esc cancels. Save POSTs to a configurable endpoint.
+
+If a plugin author needs the same pattern, copy the component and adjust the save endpoint. If multiple plugins end up wanting it, lift to `@bakin/sdk/components` as a follow-up.
+
+### Per-tab fetch waterfall in dashboards
+
+`plugins/team/components/overview-tab.tsx` shows the recommended pattern for a dashboard tab that needs to load several independent data sources: `Promise.all` four fetches, one panel per source, each handles its own loading/empty state. Avoid sequential awaits — the user perceives the slowest fetch as the page latency, not the sum.
+
 ## Future work (not yet supported)
 
 - **React Fast Refresh (v3).** Preserve `useState` across a component

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-dom": "19.2.4",
     "react-hook-form": "^7.72.0",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.0.8",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",

--- a/packages/host/src/globals.css
+++ b/packages/host/src/globals.css
@@ -220,22 +220,24 @@
   animation: pulse-dot 2s ease-in-out infinite;
 }
 
-/* Markdown content */
-.prose-invert h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.75rem; }
-.prose-invert h2 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; margin-top: 1.5rem; }
-.prose-invert h3 { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem; margin-top: 1rem; }
-.prose-invert p { margin-bottom: 0.75rem; color: #aeaaaa; line-height: 1.6; }
-.prose-invert ul { list-style: disc; padding-left: 1.5rem; margin-bottom: 0.75rem; }
-.prose-invert ol { list-style: decimal; padding-left: 1.5rem; margin-bottom: 0.75rem; }
-.prose-invert li { margin-bottom: 0.25rem; color: #aeaaaa; }
-.prose-invert code { background: #1b1919; padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-size: 0.875rem; }
-.prose-invert pre { background: #151313; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; margin-bottom: 0.75rem; }
-.prose-invert pre code { background: none; padding: 0; }
+/* Markdown content — sized down ~15% from previous defaults so prose
+   reads as page content rather than display copy. */
+.prose-invert { font-size: 0.875rem; line-height: 1.6; }
+.prose-invert h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.625rem; }
+.prose-invert h2 { font-size: 1.05rem; font-weight: 600; margin-bottom: 0.5rem; margin-top: 1.25rem; }
+.prose-invert h3 { font-size: 0.9375rem; font-weight: 600; margin-bottom: 0.5rem; margin-top: 0.875rem; }
+.prose-invert p { margin-bottom: 0.625rem; color: #aeaaaa; }
+.prose-invert ul { list-style: disc; padding-left: 1.25rem; margin-bottom: 0.625rem; }
+.prose-invert ol { list-style: decimal; padding-left: 1.25rem; margin-bottom: 0.625rem; }
+.prose-invert li { margin-bottom: 0.2rem; color: #aeaaaa; }
+.prose-invert code { background: #1b1919; padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-size: 0.8125rem; }
+.prose-invert pre { background: #151313; padding: 0.875rem; border-radius: 0.5rem; overflow-x: auto; margin-bottom: 0.625rem; font-size: 0.8125rem; }
+.prose-invert pre code { background: none; padding: 0; font-size: inherit; }
 .prose-invert a { color: var(--accent); text-decoration: none; }
 .prose-invert a:hover { text-decoration: underline; }
 .prose-invert strong { color: #ffffff; }
-.prose-invert table { width: 100%; border-collapse: collapse; margin-bottom: 0.75rem; }
-.prose-invert th, .prose-invert td { border: 1px solid rgba(255,255,255,0.08); padding: 0.5rem 0.75rem; text-align: left; }
+.prose-invert table { width: 100%; border-collapse: collapse; margin-bottom: 0.625rem; font-size: 0.8125rem; }
+.prose-invert th, .prose-invert td { border: 1px solid rgba(255,255,255,0.08); padding: 0.4rem 0.625rem; text-align: left; }
 .prose-invert th { font-weight: 600; color: #ffffff; }
 .prose-invert td { color: #aeaaaa; }
 

--- a/plugins/messaging/components/planning-layout.tsx
+++ b/plugins/messaging/components/planning-layout.tsx
@@ -160,7 +160,7 @@ export function PlanningLayout({ sessionId, onBack, onSessionUpdated }: Props) {
   return (
     <div className="flex flex-col h-full" data-testid="planning-layout">
       {/* Session header */}
-      <div className="flex items-center gap-3 px-3 pt-5 pb-3 border-b border-border">
+      <div className="flex items-center gap-3 px-3 pb-3 border-b border-border">
         <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onBack}>
           <ArrowLeft className="w-4 h-4" />
         </Button>

--- a/plugins/messaging/components/planning-layout.tsx
+++ b/plugins/messaging/components/planning-layout.tsx
@@ -247,7 +247,7 @@ export function PlanningLayout({ sessionId, onBack, onSessionUpdated }: Props) {
       </div>
 
       {/* Split layout */}
-      <div className="flex flex-1 overflow-hidden gap-6">
+      <div className="flex flex-1 overflow-hidden gap-6 pt-5">
         {/* Chat panel */}
         <div className={`flex-1 min-w-0 ${showReview ? 'md:w-[60%]' : 'w-full'}`}>
           <SessionChat

--- a/plugins/messaging/components/planning-layout.tsx
+++ b/plugins/messaging/components/planning-layout.tsx
@@ -160,7 +160,7 @@ export function PlanningLayout({ sessionId, onBack, onSessionUpdated }: Props) {
   return (
     <div className="flex flex-col h-full" data-testid="planning-layout">
       {/* Session header */}
-      <div className="flex items-center gap-3 px-3 pb-3 border-b border-border">
+      <div className="flex items-center gap-3 px-3 pt-5 pb-3 border-b border-border">
         <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onBack}>
           <ArrowLeft className="w-4 h-4" />
         </Button>

--- a/plugins/team/components/active-context-tab.tsx
+++ b/plugins/team/components/active-context-tab.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+/**
+ * Active Context tab — read-only render of the agent's most recent
+ * session JSONL parsed into a message stream. Shows what was actually
+ * sent to and produced by the model.
+ *
+ * Per-message: role-colored badge + content. Plain text bodies render as
+ * markdown; tool calls (object payloads stringified into JSON by the
+ * server-side parser) render as a <pre> code block.
+ *
+ * Truncation banner appears when the underlying transcript was capped
+ * (default 200 messages on the server).
+ */
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Badge } from '@bakin/sdk/ui'
+import { MarkdownContent } from '@bakin/sdk/components'
+import type { SessionMessage, SessionTranscript } from '../types'
+
+export interface ActiveContextTabProps {
+  agentId: string
+}
+
+const ROLE_STYLES: Record<SessionMessage['role'], string> = {
+  system: 'bg-zinc-700 text-zinc-200',
+  user: 'bg-blue-600/30 text-blue-200',
+  assistant: 'bg-emerald-600/30 text-emerald-200',
+  tool: 'bg-amber-600/30 text-amber-200',
+}
+
+function isJsonLike(content: string): boolean {
+  const trimmed = content.trim()
+  return trimmed.startsWith('{') || trimmed.startsWith('[')
+}
+
+function MessageRow({ message }: { message: SessionMessage }) {
+  return (
+    <article className="rounded-lg border border-border bg-muted/20 p-4">
+      <header className="flex items-center gap-2 mb-2">
+        <Badge className={`${ROLE_STYLES[message.role]} text-[10px] uppercase tracking-wider`} variant="secondary">
+          {message.role}
+        </Badge>
+        {message.toolName && (
+          <span className="text-xs font-mono text-muted-foreground">{message.toolName}</span>
+        )}
+        {message.model && (
+          <span className="text-[10px] text-muted-foreground">{message.model}</span>
+        )}
+        {message.ts && (
+          <span className="text-[10px] text-muted-foreground ml-auto font-mono">
+            {new Date(message.ts).toLocaleTimeString()}
+          </span>
+        )}
+      </header>
+      <div className="text-sm">
+        {message.role === 'tool' || isJsonLike(message.content) ? (
+          <pre className="bg-muted/40 rounded p-3 text-xs font-mono leading-relaxed overflow-x-auto whitespace-pre-wrap break-words">
+            {message.content}
+          </pre>
+        ) : (
+          <MarkdownContent content={message.content} />
+        )}
+      </div>
+    </article>
+  )
+}
+
+export function ActiveContextTab({ agentId }: ActiveContextTabProps) {
+  const [transcript, setTranscript] = useState<SessionTranscript | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetch(`/api/plugins/team/${agentId}/active-context`)
+      .then((r) => r.json() as Promise<{ ok: boolean; transcript: SessionTranscript | null; error?: string }>)
+      .then((body) => {
+        if (cancelled) return
+        if (!body.ok) {
+          setError(body.error ?? 'Failed to load active context')
+          return
+        }
+        setTranscript(body.transcript)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [agentId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin mr-2" />
+        Loading session context...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-destructive py-12 text-center">{error}</div>
+    )
+  }
+
+  if (!transcript || transcript.messages.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+        <div className="text-base font-medium text-foreground mb-1">No session context yet</div>
+        <p className="text-sm max-w-md">
+          Active context appears here once the agent has been dispatched at least once.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full space-y-3">
+      {transcript.truncated && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-200">
+          Showing latest {transcript.messages.length} of {transcript.totalMessages} messages.
+          Older messages omitted for performance.
+        </div>
+      )}
+      <div className="text-xs text-muted-foreground font-mono">
+        Session: {transcript.sessionId || 'unknown'}
+        {transcript.sessionStarted && ` · started ${new Date(transcript.sessionStarted).toLocaleString()}`}
+      </div>
+      <div className="space-y-2">
+        {transcript.messages.map((msg, i) => (
+          <MessageRow key={`${msg.ts ?? i}-${i}`} message={msg} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/plugins/team/components/active-context-tab.tsx
+++ b/plugins/team/components/active-context-tab.tsx
@@ -13,10 +13,11 @@
  * (default 200 messages on the server).
  */
 import { useEffect, useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, MessageCircle } from 'lucide-react'
 import { Badge } from '@bakin/sdk/ui'
 import { MarkdownContent } from '@bakin/sdk/components'
 import type { SessionMessage, SessionTranscript } from '../types'
+import { EmptyState } from './empty-state'
 
 export interface ActiveContextTabProps {
   agentId: string
@@ -112,12 +113,11 @@ export function ActiveContextTab({ agentId }: ActiveContextTabProps) {
 
   if (!transcript || transcript.messages.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
-        <div className="text-base font-medium text-foreground mb-1">No session context yet</div>
-        <p className="text-sm max-w-md">
-          Active context appears here once the agent has been dispatched at least once.
-        </p>
-      </div>
+      <EmptyState
+        icon={MessageCircle}
+        title="No session context yet"
+        description="The most recent dispatch's full message stream appears here — the system prompt, every user/assistant turn, and every tool call. Run a task with this agent to populate it."
+      />
     )
   }
 

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -190,21 +190,6 @@ export function AgentDetail({ agentId }: { agentId: string }) {
           >
             {profile.workspacePath}
           </code>
-          {profile.subagentPerms && profile.subagentPerms.length > 0 && (
-            <span className="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
-              <span className="text-foreground/70">Manages</span>
-              {profile.subagentPerms.map((id) => (
-                <Badge
-                  key={id}
-                  variant="outline"
-                  className="text-[10px] font-mono"
-                  style={{ borderColor: `${accentColor}40`, color: accentColor }}
-                >
-                  {id}
-                </Badge>
-              ))}
-            </span>
-          )}
         </div>
         {agentId !== mainAgentId && (
           <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-destructive shrink-0" onClick={() => setDeleteOpen(true)}>

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -26,10 +26,11 @@ import { OverviewTab } from './overview-tab'
 import { EmptyState } from './empty-state'
 import type { AgentProfile, SkillSummary, PackageStateRow } from '../types'
 
-type Tab = 'overview' | 'memory' | 'heartbeat' | 'soul' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'active-context'
+type Tab = 'overview' | 'identity' | 'soul' | 'memory' | 'heartbeat' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'active-context'
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'overview', label: 'Overview' },
+  { id: 'identity', label: 'Identity' },
   { id: 'soul', label: 'Soul' },
   { id: 'memory', label: 'Memory' },
   { id: 'heartbeat', label: 'Heartbeat' },
@@ -248,6 +249,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
         )}
         {activeTab === 'memory' && <MemoryTab agentId={agentId} />}
         {activeTab === 'heartbeat' && <HeartbeatTab agentId={agentId} />}
+        {activeTab === 'identity' && <MarkdownEditTab agentId={agentId} filename="IDENTITY.md" initialContent={profile.identity} />}
         {activeTab === 'soul' && <MarkdownEditTab agentId={agentId} filename="SOUL.md" initialContent={profile.soul} />}
         {activeTab === 'rules' && <MarkdownEditTab agentId={agentId} filename="AGENTS.md" initialContent={profile.rules} />}
         {activeTab === 'tools' && <MarkdownEditTab agentId={agentId} filename="TOOLS.md" initialContent={profile.tools} />}

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -443,7 +443,7 @@ function KnowledgeTab({ agentId, packageState }: { agentId: string; packageState
   const state = packageState?.state ?? 'unmanaged'
   if (state === 'managed' || state === 'adopted') {
     return (
-      <div className="max-w-2xl">
+      <div className="w-full">
         <KnowledgeToggleList agentId={agentId} />
       </div>
     )

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -445,7 +445,7 @@ function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageSt
   )
 }
 
-function PackageCard({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
+export function PackageCard({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
   // Default to "unmanaged" when the API hasn't reported a row at all — the
   // most common reason is the agent exists in OpenClaw but has never been
   // adopted, which is the same thing as state=unmanaged.

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -30,9 +30,9 @@ type Tab = 'overview' | 'memory' | 'heartbeat' | 'soul' | 'rules' | 'tools' | 's
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'overview', label: 'Overview' },
+  { id: 'soul', label: 'Soul' },
   { id: 'memory', label: 'Memory' },
   { id: 'heartbeat', label: 'Heartbeat' },
-  { id: 'soul', label: 'Soul' },
   { id: 'rules', label: 'Rules' },
   { id: 'tools', label: 'Tools' },
   { id: 'skills', label: 'Skills' },

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -463,7 +463,13 @@ function SkillsTab({ agentId }: { agentId: string }) {
   useEffect(() => {
     fetch(`/api/plugins/team/${agentId}/skills`)
       .then((r) => r.json())
-      .then((data) => setSkills(data.skills ?? []))
+      .then((data) => {
+        const list: SkillSummary[] = data.skills ?? []
+        setSkills(list)
+        // Auto-select the first skill on load so the user never lands on an
+        // empty pane wondering what to click.
+        if (list.length > 0) setSelectedSkill((current) => current ?? list[0].id)
+      })
       .finally(() => setLoading(false))
   }, [agentId])
 
@@ -486,8 +492,8 @@ function SkillsTab({ agentId }: { agentId: string }) {
   if (skills.length === 0) return <div className="text-sm text-muted-foreground py-8 text-center">No skills installed</div>
 
   return (
-    <div className="flex gap-6">
-      <div className="w-48 shrink-0 space-y-1">
+    <div className="flex gap-6 min-h-[calc(100vh-260px)]">
+      <div className="w-56 shrink-0 space-y-1 border-r border-border pr-4 max-h-[calc(100vh-260px)] overflow-auto">
         {skills.map((s) => (
           <button
             key={s.id}
@@ -503,14 +509,12 @@ function SkillsTab({ agentId }: { agentId: string }) {
       </div>
       <div className="flex-1 min-w-0">
         {skillContent ? (
-          <div className="bg-muted/30 rounded-lg p-4 text-sm whitespace-pre-wrap font-mono leading-relaxed max-h-[600px] overflow-auto">
+          <div className="bg-muted/30 rounded-lg p-4 text-sm whitespace-pre-wrap font-mono leading-relaxed h-full overflow-auto">
             {skillContent}
           </div>
         ) : selectedSkill ? (
-          <div className="text-sm text-muted-foreground">No SKILL.md found</div>
-        ) : (
-          <div className="text-sm text-muted-foreground">Select a skill to view</div>
-        )}
+          <div className="text-sm text-muted-foreground">No SKILL.md found for this skill.</div>
+        ) : null}
       </div>
     </div>
   )
@@ -527,7 +531,13 @@ function MemoryTab({ agentId }: { agentId: string }) {
   useEffect(() => {
     fetch(`/api/plugins/team/${agentId}/memory`)
       .then((r) => r.json())
-      .then((data) => setFiles(data.files ?? []))
+      .then((data) => {
+        const list: string[] = data.files ?? []
+        setFiles(list)
+        // Auto-select the most recent file on load (server returns
+        // newest-first by convention).
+        if (list.length > 0) setSelectedFile((current) => current ?? list[0])
+      })
       .finally(() => setLoading(false))
   }, [agentId])
 
@@ -550,8 +560,8 @@ function MemoryTab({ agentId }: { agentId: string }) {
   if (files.length === 0) return <div className="text-sm text-muted-foreground py-8 text-center">No memory files</div>
 
   return (
-    <div className="flex gap-6">
-      <div className="w-48 shrink-0 space-y-1 max-h-[500px] overflow-auto">
+    <div className="flex gap-6 min-h-[calc(100vh-260px)]">
+      <div className="w-56 shrink-0 space-y-1 border-r border-border pr-4 max-h-[calc(100vh-260px)] overflow-auto">
         {files.map((f) => (
           <button
             key={f}
@@ -566,13 +576,11 @@ function MemoryTab({ agentId }: { agentId: string }) {
       </div>
       <div className="flex-1 min-w-0">
         {content ? (
-          <div className="bg-muted/30 rounded-lg p-4 text-sm whitespace-pre-wrap font-mono leading-relaxed max-h-[600px] overflow-auto">
+          <div className="bg-muted/30 rounded-lg p-4 text-sm whitespace-pre-wrap font-mono leading-relaxed h-full overflow-auto">
             {content}
           </div>
-        ) : selectedFile ? (
-          <Skeleton className="h-40 w-full" />
         ) : (
-          <div className="text-sm text-muted-foreground">Select a date to view</div>
+          <Skeleton className="h-40 w-full" />
         )}
       </div>
     </div>

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -150,7 +150,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
   }
 
   return (
-    <div className="space-y-6 pb-12">
+    <div className="space-y-4 pb-12">
       {/* Header */}
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon-sm" onClick={() => router.push('/team')}>

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -348,7 +348,12 @@ function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageSt
 
 const ADOPT_INFO = `Adopting attaches an agent-package to this agent. Bakin then tracks the source repo + commit, projects the package's knowledge lessons + skills into the workspace, and lets you toggle which lessons are active. Your existing SOUL/IDENTITY/AGENTS/TOOLS files stay on disk untouched.`
 
-export function PackageCard({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
+/**
+ * Package summary content (no surrounding card chrome). Used inside the
+ * Overview hero where it sits as the third column of a merged
+ * Identity/Settings/Package box.
+ */
+export function PackageCardBody({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
   // Default to "unmanaged" when the API hasn't reported a row at all — the
   // most common reason is the agent exists in OpenClaw but has never been
   // adopted, which is the same thing as state=unmanaged.
@@ -362,73 +367,65 @@ export function PackageCard({ agentId, packageState }: { agentId: string; packag
   // sense. Show a different framing instead of the Adopt button.
   if (isMain && (state === 'unmanaged' || state === 'absent')) {
     return (
-      <section>
-        <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">Package</h3>
-        <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-2">
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="bg-zinc-800 text-zinc-300">Self-managed</Badge>
-            <span className="text-xs text-muted-foreground">main agent</span>
-          </div>
-          <p className="text-xs text-muted-foreground leading-relaxed">
-            Your main agent is your own persona — its workspace files live with you, not a package template. Adoption is intentionally not offered here.
-          </p>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" className="bg-zinc-800 text-zinc-300">Self-managed</Badge>
+          <span className="text-xs text-muted-foreground">main agent</span>
         </div>
-      </section>
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          Your main agent is your own persona — its workspace files live with you, not a package template. Adoption is intentionally not offered here.
+        </p>
+      </div>
     )
   }
 
   return (
-    <section>
-      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">Package</h3>
-      <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-3">
-        <div className="flex items-center justify-between gap-2">
-          <PackageStateBadge state={state} packageId={packageState?.packageId} />
-          {state === 'unmanaged' && (
-            <Button
-              size="sm"
-              onClick={() => setAdoptOpen(true)}
-              title={ADOPT_INFO}
-              aria-label={`Adopt this agent into a package — ${ADOPT_INFO}`}
-            >
-              <Info className="size-3 mr-1.5" />
-              Adopt
-            </Button>
-          )}
-        </div>
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <PackageStateBadge state={state} packageId={packageState?.packageId} />
         {state === 'unmanaged' && (
-          <p className="text-xs text-muted-foreground leading-relaxed">
-            This agent isn't tracked by an agent-package. Adopt to enable
-            knowledge-lesson toggles, automatic skill projection, and
-            update-from-source tracking. Your workspace files stay as-is.
-          </p>
-        )}
-        {packageState?.entry && (state === 'managed' || state === 'adopted') && (
-          <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
-        )}
-        {state === 'drifted' && (
-          <div className="space-y-1.5">
-            <p className="text-xs text-muted-foreground">
-              Projection sha mismatch detected. Repair from the CLI:
-            </p>
-            <CliHint command="bakin install agent-assets" />
-          </div>
-        )}
-        {state === 'update-available' && (
-          <div className="space-y-1.5">
-            <p className="text-xs text-muted-foreground">
-              A newer version of the source package is available. Update from the CLI:
-            </p>
-            <CliHint command={`bakin agents update ${agentId}`} />
-          </div>
+          <Button
+            size="sm"
+            onClick={() => setAdoptOpen(true)}
+            title={ADOPT_INFO}
+            aria-label={`Adopt this agent into a package — ${ADOPT_INFO}`}
+          >
+            <Info className="size-3 mr-1.5" />
+            Adopt
+          </Button>
         )}
       </div>
+      {state === 'unmanaged' && (
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          Adopt to enable knowledge-lesson toggles, automatic skill projection, and update-from-source tracking. Your workspace files stay as-is.
+        </p>
+      )}
+      {packageState?.entry && (state === 'managed' || state === 'adopted') && (
+        <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
+      )}
+      {state === 'drifted' && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            Projection sha mismatch detected. Repair from the CLI:
+          </p>
+          <CliHint command="bakin install agent-assets" />
+        </div>
+      )}
+      {state === 'update-available' && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            A newer version of the source package is available. Update from the CLI:
+          </p>
+          <CliHint command={`bakin agents update ${agentId}`} />
+        </div>
+      )}
       <AdoptDialog
         open={adoptOpen}
         onOpenChange={setAdoptOpen}
         agentId={agentId}
         onAdopted={() => { refreshPackageStates() }}
       />
-    </section>
+    </div>
   )
 }
 

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useRouter } from '@bakin/sdk/hooks'
-import { ArrowLeft, Save, Loader2, Camera, Trash2, Copy } from 'lucide-react'
+import { ArrowLeft, Loader2, Camera, Trash2, Copy } from 'lucide-react'
 import { Badge } from "@bakin/sdk/ui"
 import { Button } from "@bakin/sdk/ui"
 import {
@@ -11,10 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@bakin/sdk/ui"
-import { AgentAvatar } from "@bakin/sdk/components"
 import { Skeleton } from "@bakin/sdk/ui"
-import { MarkdownContent } from "@bakin/sdk/components"
-import { ModelSelect } from "@bakin/sdk/components"
 import { useGatewayStatus } from "@bakin/sdk/hooks"
 import type { AvailableModel } from "@bakin/sdk/types"
 import { useAgentStore, useAgentColor, useMainAgentId, usePackageState } from '@bakin/sdk/hooks'
@@ -22,34 +19,35 @@ import { useQueryState } from "@bakin/sdk/hooks"
 import { PackageStateBadge } from './package-state-badge'
 import { AdoptDialog } from './adopt-dialog'
 import { KnowledgeToggleList } from './knowledge-toggle-list'
+import { MarkdownEditTab } from './markdown-edit-tab'
+import { HeartbeatTab } from './heartbeat-tab'
+import { ActiveContextTab } from './active-context-tab'
+import { OverviewTab } from './overview-tab'
 import type { AgentProfile, SkillSummary, PackageStateRow } from '../types'
-import type { AgentUsage } from '../../../src/core/agent-usage'
 
-type Tab = 'profile' | 'soul' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'memory' | 'stats'
+type Tab = 'overview' | 'memory' | 'heartbeat' | 'soul' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'active-context'
 
 const TABS: { id: Tab; label: string }[] = [
-  { id: 'profile', label: 'Profile' },
+  { id: 'overview', label: 'Overview' },
+  { id: 'memory', label: 'Memory' },
+  { id: 'heartbeat', label: 'Heartbeat' },
   { id: 'soul', label: 'Soul' },
   { id: 'rules', label: 'Rules' },
   { id: 'tools', label: 'Tools' },
   { id: 'skills', label: 'Skills' },
   { id: 'knowledge', label: 'Knowledge' },
-  { id: 'memory', label: 'Memory' },
-  { id: 'stats', label: 'Stats' },
+  { id: 'active-context', label: 'Active Context' },
 ]
 
 export function AgentDetail({ agentId }: { agentId: string }) {
   const router = useRouter()
   const accentColor = useAgentColor(agentId)
   const mainAgentId = useMainAgentId()
-  const teams = useAgentStore((s) => s.teams)
-  const displaySettings = useAgentStore((s) => s.displaySettings)
   const reload = useAgentStore((s) => s.load)
   const packageState = usePackageState(agentId)
-  const currentTeamId = displaySettings[agentId]?.teamId ?? ''
   const [profile, setProfile] = useState<AgentProfile | null>(null)
-  const [tabParam, setTabParam] = useQueryState('tab', 'profile')
-  const activeTab = (TABS.some((t) => t.id === tabParam) ? tabParam : 'profile') as Tab
+  const [tabParam, setTabParam] = useQueryState('tab', 'overview')
+  const activeTab = (TABS.some((t) => t.id === tabParam) ? tabParam : 'overview') as Tab
   const setActiveTab = (t: Tab) => setTabParam(t)
   const [loading, setLoading] = useState(true)
   const [avatarKey, setAvatarKey] = useState(0)
@@ -71,9 +69,6 @@ export function AgentDetail({ agentId }: { agentId: string }) {
       .catch((e) => console.error('Failed to fetch available models:', e))
   }, [agentId])
 
-  const profileModel = profile?.model ?? ''
-  const resolvedModelId = availableModels.find((m) => m.id === profileModel)?.id ?? profileModel
-
   const handleModelChange = async (modelId: string) => {
     if (!profile) return
     setSavingModel(true)
@@ -93,15 +88,6 @@ export function AgentDetail({ agentId }: { agentId: string }) {
     } finally {
       setSavingModel(false)
     }
-  }
-
-  const handleTeamChange = async (teamId: string) => {
-    const res = await fetch(`/api/plugins/team/${agentId}/team`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ teamId: teamId || null }),
-    })
-    if (res.ok) await reload()
   }
 
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -195,39 +181,6 @@ export function AgentDetail({ agentId }: { agentId: string }) {
         <div className="flex-1 min-w-0">
           <h1 className="text-xl font-semibold">{profile.name}</h1>
           <div className="text-sm text-muted-foreground">{profile.role}</div>
-          <div className="flex items-center gap-2 mt-1">
-            {availableModels.length > 0 ? (
-              <div className="flex items-center gap-1.5">
-                <ModelSelect
-                  value={resolvedModelId}
-                  onChange={handleModelChange}
-                  models={availableModels}
-                  defaultLabel="Use default"
-                  className="h-6 w-48 text-xs"
-                />
-                {savingModel && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
-              </div>
-            ) : (
-              <span className="text-xs font-mono text-muted-foreground">{profile.model}</span>
-            )}
-            {profile.subagentPerms && (
-              <Badge variant="outline" className="text-[10px]">
-                manages: {profile.subagentPerms.join(', ')}
-              </Badge>
-            )}
-            {teams.length > 0 && (
-              <select
-                value={currentTeamId}
-                onChange={(e) => handleTeamChange(e.target.value)}
-                className="h-6 rounded border border-border bg-transparent px-1.5 text-[10px] text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-              >
-                <option value="">No team</option>
-                {teams.map((t) => (
-                  <option key={t.id} value={t.id}>{t.label}</option>
-                ))}
-              </select>
-            )}
-          </div>
         </div>
         {agentId !== mainAgentId && (
           <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-destructive shrink-0" onClick={() => setDeleteOpen(true)}>
@@ -274,14 +227,24 @@ export function AgentDetail({ agentId }: { agentId: string }) {
 
       {/* Tab Content */}
       <div className="min-h-[400px]">
-        {activeTab === 'profile' && <ProfileTab profile={profile} agentId={agentId} packageState={packageState} />}
-        {activeTab === 'soul' && <FileEditorTab agentId={agentId} filename="SOUL.md" content={profile.soul} />}
-        {activeTab === 'rules' && <FileEditorTab agentId={agentId} filename="AGENTS.md" content={profile.rules} />}
-        {activeTab === 'tools' && <FileEditorTab agentId={agentId} filename="TOOLS.md" content={profile.tools} />}
+        {activeTab === 'overview' && (
+          <OverviewTab
+            agentId={agentId}
+            profile={profile}
+            packageState={packageState}
+            availableModels={availableModels}
+            onModelChange={handleModelChange}
+            savingModel={savingModel}
+          />
+        )}
+        {activeTab === 'memory' && <MemoryTab agentId={agentId} />}
+        {activeTab === 'heartbeat' && <HeartbeatTab agentId={agentId} />}
+        {activeTab === 'soul' && <MarkdownEditTab agentId={agentId} filename="SOUL.md" initialContent={profile.soul} />}
+        {activeTab === 'rules' && <MarkdownEditTab agentId={agentId} filename="AGENTS.md" initialContent={profile.rules} />}
+        {activeTab === 'tools' && <MarkdownEditTab agentId={agentId} filename="TOOLS.md" initialContent={profile.tools} />}
         {activeTab === 'skills' && <SkillsTab agentId={agentId} />}
         {activeTab === 'knowledge' && <KnowledgeTab agentId={agentId} packageState={packageState} />}
-        {activeTab === 'memory' && <MemoryTab agentId={agentId} />}
-        {activeTab === 'stats' && <StatsTab agentId={agentId} />}
+        {activeTab === 'active-context' && <ActiveContextTab agentId={agentId} />}
       </div>
 
       {/* Delete confirmation */}
@@ -314,70 +277,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
   )
 }
 
-// ─── Profile Tab ─────────────────────────────────────────────────────────────
-
-function ProfileSection({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <section>
-      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">{label}</h3>
-      {children}
-    </section>
-  )
-}
-
-function ProfileMarkdown({ content }: { content: string }) {
-  return (
-    <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 text-xs [&_.prose-invert]:text-xs [&_.prose-invert]:leading-relaxed [&_h1]:text-sm [&_h2]:text-xs [&_h3]:text-xs [&_p]:text-xs [&_li]:text-xs [&_code]:text-[11px] [&_pre]:text-[11px]">
-      <MarkdownContent content={content} />
-    </div>
-  )
-}
-
-function ProfileTab({
-  profile,
-  agentId,
-  packageState,
-}: {
-  profile: AgentProfile
-  agentId: string
-  packageState: PackageStateRow | undefined
-}) {
-  return (
-    <div className="space-y-5 max-w-2xl">
-      <PackageCard agentId={agentId} packageState={packageState} />
-      {profile.identity && (
-        <ProfileSection label="Identity">
-          <ProfileMarkdown content={profile.identity} />
-        </ProfileSection>
-      )}
-      {profile.soul && (
-        <ProfileSection label="Soul">
-          <ProfileMarkdown content={profile.soul} />
-        </ProfileSection>
-      )}
-      {profile.rules && (
-        <ProfileSection label="Rules">
-          <ProfileMarkdown content={profile.rules} />
-        </ProfileSection>
-      )}
-      {profile.tools && (
-        <ProfileSection label="Tools">
-          <ProfileMarkdown content={profile.tools} />
-        </ProfileSection>
-      )}
-      {profile.heartbeatMd && (
-        <ProfileSection label="Heartbeat">
-          <ProfileMarkdown content={profile.heartbeatMd} />
-        </ProfileSection>
-      )}
-      <ProfileSection label="Workspace">
-        <code className="text-[11px] text-muted-foreground font-mono">{profile.workspacePath}</code>
-      </ProfileSection>
-    </div>
-  )
-}
-
-// ─── Package Card (lives inside Profile Tab) ─────────────────────────────────
+// ─── Package Card (embedded by OverviewTab) ──────────────────────────────────
 
 function CliHint({ command }: { command: string }) {
   const [copied, setCopied] = useState(false)
@@ -453,7 +353,8 @@ export function PackageCard({ agentId, packageState }: { agentId: string; packag
   const refreshPackageStates = useAgentStore((s) => s.refreshPackageStates)
   const [adoptOpen, setAdoptOpen] = useState(false)
   return (
-    <ProfileSection label="Package">
+    <section>
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">Package</h3>
       <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-3">
         <div className="flex items-center justify-between gap-2">
           <PackageStateBadge state={state} packageId={packageState?.packageId} />
@@ -489,7 +390,7 @@ export function PackageCard({ agentId, packageState }: { agentId: string; packag
         agentId={agentId}
         onAdopted={() => { refreshPackageStates() }}
       />
-    </ProfileSection>
+    </section>
   )
 }
 
@@ -510,88 +411,6 @@ function KnowledgeTab({ agentId, packageState }: { agentId: string; packageState
       <p className="text-sm max-w-md">
         Knowledge management requires a managed agent-package. Adopt this agent in the Package card on the Profile tab to unlock per-lesson toggles.
       </p>
-    </div>
-  )
-}
-
-// ─── File Editor Tab ─────────────────────────────────────────────────────────
-
-function FileEditorTab({ agentId, filename, content: initialContent }: {
-  agentId: string
-  filename: string
-  content: string | null
-}) {
-  const [content, setContent] = useState(initialContent ?? '')
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [dirty, setDirty] = useState(false)
-
-  useEffect(() => {
-    setContent(initialContent ?? '')
-    setDirty(false)
-    setSaved(false)
-  }, [initialContent, agentId, filename])
-
-  const handleSave = useCallback(async () => {
-    setSaving(true)
-    try {
-      await fetch(`/api/plugins/team/${agentId}/files/${filename}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content }),
-      })
-      setSaved(true)
-      setDirty(false)
-      setTimeout(() => setSaved(false), 2000)
-    } finally {
-      setSaving(false)
-    }
-  }, [agentId, filename, content])
-
-  // Ctrl+S / Cmd+S to save
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault()
-        if (dirty) handleSave()
-      }
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [dirty, handleSave])
-
-  if (initialContent === null) {
-    return (
-      <div className="text-sm text-muted-foreground py-8 text-center">
-        {filename} does not exist in this agent&apos;s workspace.
-      </div>
-    )
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <code className="text-xs font-mono text-muted-foreground">{filename}</code>
-          {dirty && <span className="text-xs text-amber-400">modified</span>}
-          {saved && <span className="text-xs text-green-400">saved</span>}
-        </div>
-        <Button
-          size="sm"
-          variant={dirty ? 'default' : 'secondary'}
-          onClick={handleSave}
-          disabled={!dirty || saving}
-        >
-          {saving ? <Loader2 className="size-3 animate-spin mr-1.5" /> : <Save className="size-3 mr-1.5" />}
-          Save
-        </Button>
-      </div>
-      <textarea
-        value={content}
-        onChange={(e) => { setContent(e.target.value); setDirty(true) }}
-        className="w-full min-h-[500px] bg-muted/30 border border-border rounded-lg p-4 text-sm font-mono leading-relaxed text-foreground resize-y focus:outline-none focus:ring-1 focus:ring-primary"
-        spellCheck={false}
-      />
     </div>
   )
 }
@@ -723,77 +542,3 @@ function MemoryTab({ agentId }: { agentId: string }) {
   )
 }
 
-// ─── Stats Tab ───────────────────────────────────────────────────────────────
-
-function StatsTab({ agentId }: { agentId: string }) {
-  const [usage, setUsage] = useState<AgentUsage | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    fetch(`/api/plugins/team/${agentId}/stats`)
-      .then((r) => r.json())
-      .then((data) => setUsage(data.usage ?? null))
-      .finally(() => setLoading(false))
-  }, [agentId])
-
-  if (loading) {
-    return (
-      <div className="grid grid-cols-2 gap-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <Skeleton key={i} className="h-20 w-full" />
-        ))}
-      </div>
-    )
-  }
-
-  if (!usage) {
-    return <div className="text-sm text-muted-foreground py-8 text-center">No session data available</div>
-  }
-
-  const fmt = (n: number) => n.toLocaleString()
-  const fmtCost = (n: number) => `$${n.toFixed(4)}`
-
-  return (
-    <div className="max-w-lg space-y-6">
-      <section>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Latest Session</h3>
-        <div className="bg-muted/30 rounded-lg p-4 space-y-2">
-          <Row label="Model" value={usage.model} />
-          <Row label="Messages" value={fmt(usage.messages)} />
-          <Row label="Session started" value={usage.sessionStarted ? new Date(usage.sessionStarted).toLocaleString() : 'N/A'} />
-        </div>
-      </section>
-
-      <section>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Token Usage</h3>
-        <div className="bg-muted/30 rounded-lg p-4 space-y-2">
-          <Row label="Input" value={fmt(usage.tokens.input)} />
-          <Row label="Output" value={fmt(usage.tokens.output)} />
-          <Row label="Cache read" value={fmt(usage.tokens.cacheRead)} />
-          <Row label="Cache write" value={fmt(usage.tokens.cacheWrite)} />
-          <Row label="Total" value={fmt(usage.tokens.total)} highlight />
-        </div>
-      </section>
-
-      <section>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">Cost</h3>
-        <div className="bg-muted/30 rounded-lg p-4 space-y-2">
-          <Row label="Input" value={fmtCost(usage.cost.input)} />
-          <Row label="Output" value={fmtCost(usage.cost.output)} />
-          <Row label="Cache read" value={fmtCost(usage.cost.cacheRead)} />
-          <Row label="Cache write" value={fmtCost(usage.cost.cacheWrite)} />
-          <Row label="Total" value={fmtCost(usage.cost.total)} highlight />
-        </div>
-      </section>
-    </div>
-  )
-}
-
-function Row({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
-  return (
-    <div className="flex justify-between text-sm">
-      <span className="text-muted-foreground">{label}</span>
-      <span className={highlight ? 'font-semibold text-foreground' : 'font-mono text-foreground'}>{value}</span>
-    </div>
-  )
-}

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useRouter } from '@bakin/sdk/hooks'
-import { ArrowLeft, Loader2, Camera, Trash2, Copy, Info } from 'lucide-react'
+import { ArrowLeft, Loader2, Camera, Trash2, Copy, Info, BookOpen, Sparkles, Calendar } from 'lucide-react'
 import { Badge } from "@bakin/sdk/ui"
 import { Button } from "@bakin/sdk/ui"
 import {
@@ -23,6 +23,7 @@ import { MarkdownEditTab } from './markdown-edit-tab'
 import { HeartbeatTab } from './heartbeat-tab'
 import { ActiveContextTab } from './active-context-tab'
 import { OverviewTab } from './overview-tab'
+import { EmptyState } from './empty-state'
 import type { AgentProfile, SkillSummary, PackageStateRow } from '../types'
 
 type Tab = 'overview' | 'memory' | 'heartbeat' | 'soul' | 'rules' | 'tools' | 'skills' | 'knowledge' | 'active-context'
@@ -443,12 +444,11 @@ function KnowledgeTab({ agentId, packageState }: { agentId: string; packageState
     )
   }
   return (
-    <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
-      <div className="text-base font-medium text-foreground mb-1">Coming soon</div>
-      <p className="text-sm max-w-md">
-        Knowledge management requires a managed agent-package. Adopt this agent in the Package card on the Profile tab to unlock per-lesson toggles.
-      </p>
-    </div>
+    <EmptyState
+      icon={BookOpen}
+      title="Knowledge requires a package"
+      description="Knowledge lessons let you toggle individual pieces of curriculum on or off per agent — useful for narrowing the persona to a task. Adopt this agent into a package on the Overview tab to unlock per-lesson toggles."
+    />
   )
 }
 
@@ -489,7 +489,15 @@ function SkillsTab({ agentId }: { agentId: string }) {
       </div>
     )
   }
-  if (skills.length === 0) return <div className="text-sm text-muted-foreground py-8 text-center">No skills installed</div>
+  if (skills.length === 0) {
+    return (
+      <EmptyState
+        icon={Sparkles}
+        title="No skills installed"
+        description="Skills are reusable OpenClaw capabilities the agent can invoke. Install a skill-pack via the CLI to add some — `bakin packages install <source>`."
+      />
+    )
+  }
 
   return (
     <div className="flex gap-6 min-h-[calc(100vh-260px)]">
@@ -557,7 +565,15 @@ function MemoryTab({ agentId }: { agentId: string }) {
       </div>
     )
   }
-  if (files.length === 0) return <div className="text-sm text-muted-foreground py-8 text-center">No memory files</div>
+  if (files.length === 0) {
+    return (
+      <EmptyState
+        icon={Calendar}
+        title="No memory yet"
+        description="Per-day memory files appear here once this agent writes its first lesson via `bakin_exec_log_memory`. Memory accumulates as the agent works through tasks."
+      />
+    )
+  }
 
   return (
     <div className="flex gap-6 min-h-[calc(100vh-260px)]">

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useRouter } from '@bakin/sdk/hooks'
-import { ArrowLeft, Loader2, Camera, Trash2, Copy, Info, BookOpen, Sparkles, Calendar } from 'lucide-react'
+import { ArrowLeft, Loader2, Camera, Trash2, BookOpen, Sparkles, Calendar } from 'lucide-react'
 import { Badge } from "@bakin/sdk/ui"
 import { Button } from "@bakin/sdk/ui"
 import {
@@ -16,8 +16,6 @@ import { useGatewayStatus } from "@bakin/sdk/hooks"
 import type { AvailableModel } from "@bakin/sdk/types"
 import { useAgentStore, useAgentColor, useMainAgentId, usePackageState } from '@bakin/sdk/hooks'
 import { useQueryState } from "@bakin/sdk/hooks"
-import { PackageStateBadge } from './package-state-badge'
-import { AdoptDialog } from './adopt-dialog'
 import { KnowledgeToggleList } from './knowledge-toggle-list'
 import { MarkdownEditTab } from './markdown-edit-tab'
 import { HeartbeatTab } from './heartbeat-tab'
@@ -288,156 +286,6 @@ export function AgentDetail({ agentId }: { agentId: string }) {
   )
 }
 
-// ─── Package Card (embedded by OverviewTab) ──────────────────────────────────
-
-function CliHint({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false)
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(command)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch {
-      // clipboard api unavailable — fail quietly, the command is visible
-    }
-  }
-  return (
-    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs">
-      <code className="flex-1 font-mono text-foreground">{command}</code>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={handleCopy}
-        title={copied ? 'Copied' : 'Copy'}
-        aria-label="Copy command"
-      >
-        <Copy className="size-3.5" />
-      </Button>
-    </div>
-  )
-}
-
-function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageStateRow['entry']>; packageId?: string }) {
-  return (
-    <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">
-      {packageId && (
-        <>
-          <dt className="text-muted-foreground">Package</dt>
-          <dd className="font-mono text-foreground break-all">{packageId}</dd>
-        </>
-      )}
-      <dt className="text-muted-foreground">Source</dt>
-      <dd className="font-mono text-foreground break-all">{entry.source}</dd>
-      {entry.ref && (
-        <>
-          <dt className="text-muted-foreground">Ref</dt>
-          <dd className="font-mono text-foreground">{entry.ref}</dd>
-        </>
-      )}
-      {entry.commitSha && (
-        <>
-          <dt className="text-muted-foreground">Commit</dt>
-          <dd className="font-mono text-foreground">{entry.commitSha.slice(0, 7)}</dd>
-        </>
-      )}
-      <dt className="text-muted-foreground">Installed</dt>
-      <dd className="text-foreground">{entry.installedAt}</dd>
-      {entry.dependencies && entry.dependencies.length > 0 && (
-        <>
-          <dt className="text-muted-foreground">Depends on</dt>
-          <dd className="flex flex-wrap gap-1">
-            {entry.dependencies.map((d) => (
-              <Badge key={d} variant="outline" className="text-[10px] font-mono">{d}</Badge>
-            ))}
-          </dd>
-        </>
-      )}
-    </dl>
-  )
-}
-
-const ADOPT_INFO = `Adopting attaches an agent-package to this agent. Bakin then tracks the source repo + commit, projects the package's knowledge lessons + skills into the workspace, and lets you toggle which lessons are active. Your existing SOUL/IDENTITY/AGENTS/TOOLS files stay on disk untouched.`
-
-/**
- * Package summary content (no surrounding card chrome). Used inside the
- * Overview hero where it sits as the third column of a merged
- * Identity/Settings/Package box.
- */
-export function PackageCardBody({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
-  // Default to "unmanaged" when the API hasn't reported a row at all — the
-  // most common reason is the agent exists in OpenClaw but has never been
-  // adopted, which is the same thing as state=unmanaged.
-  const state = packageState?.state ?? 'unmanaged'
-  const mainAgentId = useMainAgentId()
-  const isMain = agentId === mainAgentId
-  const refreshPackageStates = useAgentStore((s) => s.refreshPackageStates)
-  const [adoptOpen, setAdoptOpen] = useState(false)
-
-  // Main agent is the user's persona — adopting/replacing it doesn't make
-  // sense. Show a different framing instead of the Adopt button.
-  if (isMain && (state === 'unmanaged' || state === 'absent')) {
-    return (
-      <div className="space-y-2">
-        <div className="flex items-center gap-2">
-          <Badge variant="secondary" className="bg-zinc-800 text-zinc-300">Self-managed</Badge>
-          <span className="text-xs text-muted-foreground">main agent</span>
-        </div>
-        <p className="text-xs text-muted-foreground leading-relaxed">
-          Your main agent is your own persona — its workspace files live with you, not a package template. Adoption is intentionally not offered here.
-        </p>
-      </div>
-    )
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-2 flex-wrap">
-        <PackageStateBadge state={state} packageId={packageState?.packageId} />
-        {state === 'unmanaged' && (
-          <Button
-            size="sm"
-            onClick={() => setAdoptOpen(true)}
-            title={ADOPT_INFO}
-            aria-label={`Adopt this agent into a package — ${ADOPT_INFO}`}
-          >
-            <Info className="size-3 mr-1.5" />
-            Adopt
-          </Button>
-        )}
-      </div>
-      {state === 'unmanaged' && (
-        <p className="text-xs text-muted-foreground leading-relaxed">
-          Adopt to enable knowledge-lesson toggles, automatic skill projection, and update-from-source tracking. Your workspace files stay as-is.
-        </p>
-      )}
-      {packageState?.entry && (state === 'managed' || state === 'adopted') && (
-        <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
-      )}
-      {state === 'drifted' && (
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">
-            Projection sha mismatch detected. Repair from the CLI:
-          </p>
-          <CliHint command="bakin install agent-assets" />
-        </div>
-      )}
-      {state === 'update-available' && (
-        <div className="space-y-1.5">
-          <p className="text-xs text-muted-foreground">
-            A newer version of the source package is available. Update from the CLI:
-          </p>
-          <CliHint command={`bakin agents update ${agentId}`} />
-        </div>
-      )}
-      <AdoptDialog
-        open={adoptOpen}
-        onOpenChange={setAdoptOpen}
-        agentId={agentId}
-        onAdopted={() => { refreshPackageStates() }}
-      />
-    </div>
-  )
-}
 
 // ─── Knowledge Tab ───────────────────────────────────────────────────────────
 

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -182,6 +182,21 @@ export function AgentDetail({ agentId }: { agentId: string }) {
         <div className="flex-1 min-w-0">
           <h1 className="text-xl font-semibold">{profile.name}</h1>
           <div className="text-sm text-muted-foreground">{profile.role}</div>
+          {profile.subagentPerms && profile.subagentPerms.length > 0 && (
+            <div className="text-xs text-muted-foreground mt-1.5 flex flex-wrap items-center gap-1.5">
+              <span className="text-foreground/70">Manages</span>
+              {profile.subagentPerms.map((id) => (
+                <Badge
+                  key={id}
+                  variant="outline"
+                  className="text-[10px] font-mono"
+                  style={{ borderColor: `${accentColor}40`, color: accentColor }}
+                >
+                  {id}
+                </Badge>
+              ))}
+            </div>
+          )}
         </div>
         {agentId !== mainAgentId && (
           <Button variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-destructive shrink-0" onClick={() => setDeleteOpen(true)}>

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -179,11 +179,19 @@ export function AgentDetail({ agentId }: { agentId: string }) {
             onChange={handleAvatarUpload}
           />
         </div>
-        <div className="flex-1 min-w-0">
-          <h1 className="text-xl font-semibold">{profile.name}</h1>
-          <div className="text-sm text-muted-foreground">{profile.role}</div>
+        <div className="flex-1 min-w-0 flex items-center gap-6 flex-wrap">
+          <h1 className="text-xl font-semibold leading-tight">{profile.name}</h1>
+          {profile.role && (
+            <span className="text-sm text-muted-foreground">{profile.role}</span>
+          )}
+          <code
+            className="text-[11px] font-mono text-muted-foreground/70 truncate min-w-0 max-w-md"
+            title={profile.workspacePath}
+          >
+            {profile.workspacePath}
+          </code>
           {profile.subagentPerms && profile.subagentPerms.length > 0 && (
-            <div className="text-xs text-muted-foreground mt-1.5 flex flex-wrap items-center gap-1.5">
+            <span className="text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
               <span className="text-foreground/70">Manages</span>
               {profile.subagentPerms.map((id) => (
                 <Badge
@@ -195,7 +203,7 @@ export function AgentDetail({ agentId }: { agentId: string }) {
                   {id}
                 </Badge>
               ))}
-            </div>
+            </span>
           )}
         </div>
         {agentId !== mainAgentId && (

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useRouter } from '@bakin/sdk/hooks'
-import { ArrowLeft, Loader2, Camera, Trash2, Copy } from 'lucide-react'
+import { ArrowLeft, Loader2, Camera, Trash2, Copy, Info } from 'lucide-react'
 import { Badge } from "@bakin/sdk/ui"
 import { Button } from "@bakin/sdk/ui"
 import {
@@ -345,13 +345,37 @@ function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageSt
   )
 }
 
+const ADOPT_INFO = `Adopting attaches an agent-package to this agent. Bakin then tracks the source repo + commit, projects the package's knowledge lessons + skills into the workspace, and lets you toggle which lessons are active. Your existing SOUL/IDENTITY/AGENTS/TOOLS files stay on disk untouched.`
+
 export function PackageCard({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
   // Default to "unmanaged" when the API hasn't reported a row at all — the
   // most common reason is the agent exists in OpenClaw but has never been
   // adopted, which is the same thing as state=unmanaged.
   const state = packageState?.state ?? 'unmanaged'
+  const mainAgentId = useMainAgentId()
+  const isMain = agentId === mainAgentId
   const refreshPackageStates = useAgentStore((s) => s.refreshPackageStates)
   const [adoptOpen, setAdoptOpen] = useState(false)
+
+  // Main agent is the user's persona — adopting/replacing it doesn't make
+  // sense. Show a different framing instead of the Adopt button.
+  if (isMain && (state === 'unmanaged' || state === 'absent')) {
+    return (
+      <section>
+        <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">Package</h3>
+        <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-2">
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary" className="bg-zinc-800 text-zinc-300">Self-managed</Badge>
+            <span className="text-xs text-muted-foreground">main agent</span>
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Your main agent is your own persona — its workspace files live with you, not a package template. Adoption is intentionally not offered here.
+          </p>
+        </div>
+      </section>
+    )
+  }
+
   return (
     <section>
       <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">Package</h3>
@@ -359,11 +383,24 @@ export function PackageCard({ agentId, packageState }: { agentId: string; packag
         <div className="flex items-center justify-between gap-2">
           <PackageStateBadge state={state} packageId={packageState?.packageId} />
           {state === 'unmanaged' && (
-            <Button size="sm" onClick={() => setAdoptOpen(true)}>
+            <Button
+              size="sm"
+              onClick={() => setAdoptOpen(true)}
+              title={ADOPT_INFO}
+              aria-label={`Adopt this agent into a package — ${ADOPT_INFO}`}
+            >
+              <Info className="size-3 mr-1.5" />
               Adopt
             </Button>
           )}
         </div>
+        {state === 'unmanaged' && (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            This agent isn't tracked by an agent-package. Adopt to enable
+            knowledge-lesson toggles, automatic skill projection, and
+            update-from-source tracking. Your workspace files stay as-is.
+          </p>
+        )}
         {packageState?.entry && (state === 'managed' || state === 'adopted') && (
           <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
         )}

--- a/plugins/team/components/empty-state.tsx
+++ b/plugins/team/components/empty-state.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+/**
+ * Shared empty-state component for agent-detail tabs.
+ *
+ * Pattern: centered icon chip → headline → 1-2 line description →
+ * optional action (link or callback). Used by Memory, Skills,
+ * Knowledge, Heartbeat, and Active Context when their data source
+ * is empty or not applicable.
+ *
+ * Keeping a single component means tone + spacing stay consistent
+ * across tabs — different empty surfaces shouldn't feel like they
+ * came from different apps.
+ */
+import { type ComponentType, type ReactNode } from 'react'
+
+export interface EmptyStateProps {
+  icon: ComponentType<{ className?: string }>
+  title: string
+  description?: ReactNode
+  action?: ReactNode
+  /** When true, the component fills the available height instead of using a fixed minimum. */
+  fillHeight?: boolean
+}
+
+export function EmptyState({ icon: Icon, title, description, action, fillHeight }: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center text-center px-6 ${
+        fillHeight ? 'min-h-[calc(100vh-320px)]' : 'py-16'
+      }`}
+    >
+      <div className="size-14 rounded-2xl bg-muted/40 border border-border flex items-center justify-center mb-4">
+        <Icon className="size-6 text-muted-foreground" />
+      </div>
+      <div className="text-base font-semibold text-foreground mb-1">{title}</div>
+      {description && (
+        <div className="text-sm text-muted-foreground max-w-md leading-relaxed">{description}</div>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  )
+}

--- a/plugins/team/components/heartbeat-tab.tsx
+++ b/plugins/team/components/heartbeat-tab.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * Heartbeat tab — view-only render of HEARTBEAT.md with a "last updated"
+ * indicator. No edit affordance — heartbeats are agent-authored
+ * narrative; user editing is meaningless.
+ *
+ * Reads from /api/plugins/team/:agentId/heartbeat which returns
+ * { content, lastUpdated } or null when the file doesn't exist yet.
+ */
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { MarkdownContent } from '@bakin/sdk/components'
+import type { HeartbeatRaw } from '../types'
+
+export interface HeartbeatTabProps {
+  agentId: string
+}
+
+function formatRelative(isoTimestamp: string | null): string {
+  if (!isoTimestamp) return ''
+  const ts = new Date(isoTimestamp).getTime()
+  if (Number.isNaN(ts)) return ''
+  const deltaSec = Math.round((Date.now() - ts) / 1000)
+  if (deltaSec < 60) return `${deltaSec}s ago`
+  const deltaMin = Math.round(deltaSec / 60)
+  if (deltaMin < 60) return `${deltaMin}m ago`
+  const deltaHr = Math.round(deltaMin / 60)
+  if (deltaHr < 24) return `${deltaHr}h ago`
+  const deltaDay = Math.round(deltaHr / 24)
+  return `${deltaDay}d ago`
+}
+
+export function HeartbeatTab({ agentId }: HeartbeatTabProps) {
+  const [heartbeat, setHeartbeat] = useState<HeartbeatRaw | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetch(`/api/plugins/team/${agentId}/heartbeat`)
+      .then((r) => r.json() as Promise<{ ok: boolean; heartbeat: HeartbeatRaw | null; error?: string }>)
+      .then((body) => {
+        if (cancelled) return
+        if (!body.ok) {
+          setError(body.error ?? 'Failed to load heartbeat')
+          return
+        }
+        setHeartbeat(body.heartbeat)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [agentId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="size-4 animate-spin mr-2" />
+        Loading heartbeat...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-destructive py-12 text-center">{error}</div>
+    )
+  }
+
+  if (!heartbeat) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+        <div className="text-base font-medium text-foreground mb-1">No heartbeat reported yet</div>
+        <p className="text-sm max-w-md">
+          Heartbeats appear here once the agent writes its first <code className="font-mono">HEARTBEAT.md</code>.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative w-full">
+      <div className="absolute top-2 right-2 z-10 text-xs text-muted-foreground bg-muted/40 backdrop-blur-sm rounded-full px-3 py-1">
+        Last updated {formatRelative(heartbeat.lastUpdated)}
+      </div>
+      <div className="w-full min-h-[calc(100vh-260px)] rounded-lg border border-border bg-muted/20 p-6 pr-32 overflow-auto">
+        <MarkdownContent content={heartbeat.content} />
+      </div>
+    </div>
+  )
+}

--- a/plugins/team/components/heartbeat-tab.tsx
+++ b/plugins/team/components/heartbeat-tab.tsx
@@ -9,9 +9,10 @@
  * { content, lastUpdated } or null when the file doesn't exist yet.
  */
 import { useEffect, useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Heart } from 'lucide-react'
 import { MarkdownContent } from '@bakin/sdk/components'
 import type { HeartbeatRaw } from '../types'
+import { EmptyState } from './empty-state'
 
 export interface HeartbeatTabProps {
   agentId: string
@@ -77,12 +78,18 @@ export function HeartbeatTab({ agentId }: HeartbeatTabProps) {
 
   if (!heartbeat) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
-        <div className="text-base font-medium text-foreground mb-1">No heartbeat reported yet</div>
-        <p className="text-sm max-w-md">
-          Heartbeats appear here once the agent writes its first <code className="font-mono">HEARTBEAT.md</code>.
-        </p>
-      </div>
+      <EmptyState
+        icon={Heart}
+        title="No heartbeat yet"
+        description={
+          <>
+            Heartbeats appear here once this agent writes its first
+            {' '}
+            <code className="font-mono text-foreground/80">HEARTBEAT.md</code>.
+            Most agents update theirs at the end of every task.
+          </>
+        }
+      />
     )
   }
 

--- a/plugins/team/components/heartbeat-tab.tsx
+++ b/plugins/team/components/heartbeat-tab.tsx
@@ -14,7 +14,7 @@ import { MarkdownContent } from '@bakin/sdk/components'
 import type { HeartbeatRaw } from '../types'
 import { EmptyState } from './empty-state'
 
-const HEARTBEAT_DISABLED_REASON = 'Heartbeats are agent-authored — they\'re written by the agent itself via the bakin_exec_heartbeat tool. Editing from the UI would just get overwritten on the next dispatch.'
+const HEARTBEAT_DISABLED_REASON = 'HEARTBEAT.md is an agent-maintained narrative — the agent updates it itself as it works. Editing from the UI would conflict with what the agent next writes.'
 
 export interface HeartbeatTabProps {
   agentId: string
@@ -85,10 +85,13 @@ export function HeartbeatTab({ agentId }: HeartbeatTabProps) {
         title="No heartbeat yet"
         description={
           <>
-            Heartbeats appear here once this agent writes its first
+            This agent hasn't written a
             {' '}
-            <code className="font-mono text-foreground/80">HEARTBEAT.md</code>.
-            Most agents update theirs at the end of every task.
+            <code className="font-mono text-foreground/80">HEARTBEAT.md</code>
+            {' '}
+            yet — it appears here once they do. (Distinct from the JSON
+            status signal at <code className="font-mono text-foreground/80">~/.bakin/heartbeats/{'{id}'}.json</code>;
+            this tab shows the agent's narrative file in their workspace.)
           </>
         }
       />

--- a/plugins/team/components/heartbeat-tab.tsx
+++ b/plugins/team/components/heartbeat-tab.tsx
@@ -9,10 +9,12 @@
  * { content, lastUpdated } or null when the file doesn't exist yet.
  */
 import { useEffect, useState } from 'react'
-import { Loader2, Heart } from 'lucide-react'
+import { Loader2, Heart, Pencil } from 'lucide-react'
 import { MarkdownContent } from '@bakin/sdk/components'
 import type { HeartbeatRaw } from '../types'
 import { EmptyState } from './empty-state'
+
+const HEARTBEAT_DISABLED_REASON = 'Heartbeats are agent-authored — they\'re written by the agent itself via the bakin_exec_heartbeat tool. Editing from the UI would just get overwritten on the next dispatch.'
 
 export interface HeartbeatTabProps {
   agentId: string
@@ -95,10 +97,21 @@ export function HeartbeatTab({ agentId }: HeartbeatTabProps) {
 
   return (
     <div className="relative w-full">
-      <div className="absolute top-2 right-2 z-10 text-xs text-muted-foreground bg-muted/40 backdrop-blur-sm rounded-full px-3 py-1">
-        Last updated {formatRelative(heartbeat.lastUpdated)}
+      <div className="absolute top-2 right-2 z-10 flex items-center gap-2">
+        <span className="text-xs text-muted-foreground bg-muted/40 backdrop-blur-sm rounded-full px-3 py-1">
+          Last updated {formatRelative(heartbeat.lastUpdated)}
+        </span>
+        <button
+          disabled
+          aria-disabled="true"
+          title={HEARTBEAT_DISABLED_REASON}
+          aria-label={`Edit disabled — ${HEARTBEAT_DISABLED_REASON}`}
+          className="size-8 rounded-full bg-zinc-700/40 text-zinc-500 flex items-center justify-center cursor-not-allowed shadow-lg backdrop-blur-sm"
+        >
+          <Pencil className="size-4" />
+        </button>
       </div>
-      <div className="w-full min-h-[calc(100vh-260px)] rounded-lg border border-border bg-muted/20 p-6 pr-32 overflow-auto">
+      <div className="w-full min-h-[calc(100vh-260px)] pr-14 overflow-auto">
         <MarkdownContent content={heartbeat.content} />
       </div>
     </div>

--- a/plugins/team/components/knowledge-toggle-list.tsx
+++ b/plugins/team/components/knowledge-toggle-list.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Package } from 'lucide-react'
 import { Switch } from '@bakin/sdk/ui'
 
 /**
@@ -112,37 +112,22 @@ export function KnowledgeToggleList({ agentId }: KnowledgeToggleListProps) {
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      {packageId && (
-        <p className="text-xs text-muted-foreground">
-          From package <code className="rounded bg-muted px-1 py-0.5">{packageId}</code>
-        </p>
-      )}
-      <ul className="flex flex-col gap-2">
-        {lessons.map((lesson) => (
-          <li
-            key={lesson.lessonId}
-            className="flex items-start justify-between gap-3 rounded border border-border/60 p-3"
-          >
-            <div className="flex-1">
-              <div className="flex items-center gap-2">
-                <span className="font-medium">{lesson.title}</span>
-                <code className="text-xs text-muted-foreground">{lesson.lessonId}</code>
-              </div>
-              {lesson.tags.length > 0 && (
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {lesson.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      {lessons.map((lesson) => (
+        <article
+          key={lesson.lessonId}
+          className={`group relative flex flex-col gap-3 rounded-xl border p-5 transition-colors ${
+            lesson.enabled
+              ? 'border-border bg-muted/20 hover:bg-muted/30'
+              : 'border-border/60 bg-muted/5 hover:bg-muted/15'
+          }`}
+        >
+          <header className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold text-foreground leading-snug">{lesson.title}</div>
+              <code className="text-[11px] text-muted-foreground/70 font-mono break-all">{lesson.lessonId}</code>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 shrink-0">
               {pendingId === lesson.lessonId && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
               <Switch
                 checked={lesson.enabled}
@@ -151,9 +136,29 @@ export function KnowledgeToggleList({ agentId }: KnowledgeToggleListProps) {
                 aria-label={`Toggle ${lesson.title}`}
               />
             </div>
-          </li>
-        ))}
-      </ul>
+          </header>
+
+          {lesson.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {lesson.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {packageId && (
+            <footer className="mt-auto pt-2 border-t border-border/40 flex items-center gap-1.5 text-[11px] text-muted-foreground/70">
+              <Package className="size-3" />
+              <span className="font-mono truncate" title={packageId}>{packageId}</span>
+            </footer>
+          )}
+        </article>
+      ))}
     </div>
   )
 }

--- a/plugins/team/components/markdown-edit-tab.tsx
+++ b/plugins/team/components/markdown-edit-tab.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+/**
+ * Reusable view/edit tab for markdown workspace files.
+ *
+ * Default state: rendered markdown (read mode). Pencil button in the
+ * top-right corner toggles to a textarea (edit mode). Save (green check)
+ * or Cancel (X) replace the pencil while editing. Cmd+S triggers save.
+ *
+ * Mirrors the Assets-detail edit pattern so the agent-detail tabs feel
+ * consistent with the rest of the app.
+ *
+ * Used by Soul / Rules / Tools tabs (writes to
+ * /api/plugins/team/:agentId/files/:filename via the existing endpoint).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Check, Loader2, Pencil, X } from 'lucide-react'
+import { MarkdownContent } from '@bakin/sdk/components'
+
+export interface MarkdownEditTabProps {
+  agentId: string
+  filename: string
+  initialContent: string | null
+}
+
+export function MarkdownEditTab({ agentId, filename, initialContent }: MarkdownEditTabProps) {
+  const [editing, setEditing] = useState(false)
+  const [content, setContent] = useState(initialContent ?? '')
+  const [draft, setDraft] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+  const dirty = editing && draft !== content
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    setContent(initialContent ?? '')
+    setEditing(false)
+    setDraft('')
+    setSavedAt(null)
+  }, [initialContent, agentId, filename])
+
+  const handleStartEdit = useCallback(() => {
+    setDraft(content)
+    setEditing(true)
+    setSavedAt(null)
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [content])
+
+  const handleCancel = useCallback(() => {
+    setEditing(false)
+    setDraft('')
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    if (!dirty) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/plugins/team/${agentId}/files/${filename}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: draft }),
+      })
+      if (res.ok) {
+        setContent(draft)
+        setEditing(false)
+        setDraft('')
+        setSavedAt(Date.now())
+        setTimeout(() => setSavedAt(null), 2000)
+      }
+    } finally {
+      setSaving(false)
+    }
+  }, [agentId, filename, draft, dirty])
+
+  useEffect(() => {
+    if (!editing) return
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault()
+        if (dirty) handleSave()
+      }
+      if (e.key === 'Escape') handleCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [editing, dirty, handleSave, handleCancel])
+
+  if (initialContent === null) {
+    return (
+      <div className="text-sm text-muted-foreground py-12 text-center">
+        <code className="font-mono">{filename}</code> does not exist in this agent&apos;s workspace.
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative w-full">
+      <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5">
+        {savedAt && !editing && (
+          <span className="text-xs text-green-400 mr-1">saved</span>
+        )}
+        {editing ? (
+          <>
+            <button
+              onClick={handleSave}
+              disabled={saving || !dirty}
+              className="size-8 rounded-full bg-green-600/90 hover:bg-green-500 text-white flex items-center justify-center transition-colors shadow-lg backdrop-blur-sm disabled:opacity-50"
+              title="Save (Cmd+S)"
+              aria-label="Save changes"
+            >
+              {saving ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={saving}
+              className="size-8 rounded-full bg-zinc-700/90 hover:bg-zinc-600 text-zinc-300 flex items-center justify-center transition-colors shadow-lg backdrop-blur-sm disabled:opacity-50"
+              title="Cancel (Esc)"
+              aria-label="Cancel edit"
+            >
+              <X className="size-4" />
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={handleStartEdit}
+            className="size-8 rounded-full bg-zinc-700/90 hover:bg-zinc-600 text-zinc-300 hover:text-white flex items-center justify-center transition-colors shadow-lg backdrop-blur-sm"
+            title="Edit content"
+            aria-label="Edit markdown"
+          >
+            <Pencil className="size-4" />
+          </button>
+        )}
+      </div>
+      {editing ? (
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          spellCheck={false}
+          className="w-full min-h-[calc(100vh-260px)] bg-muted/30 border border-border rounded-lg p-6 pr-14 text-sm font-mono leading-relaxed text-foreground resize-y focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+      ) : (
+        <div className="w-full min-h-[calc(100vh-260px)] rounded-lg border border-border bg-muted/20 p-6 pr-14 overflow-auto">
+          <MarkdownContent content={content} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/team/components/markdown-edit-tab.tsx
+++ b/plugins/team/components/markdown-edit-tab.tsx
@@ -140,7 +140,7 @@ export function MarkdownEditTab({ agentId, filename, initialContent }: MarkdownE
           className="w-full min-h-[calc(100vh-260px)] bg-muted/30 border border-border rounded-lg p-6 pr-14 text-sm font-mono leading-relaxed text-foreground resize-y focus:outline-none focus:ring-1 focus:ring-primary"
         />
       ) : (
-        <div className="w-full min-h-[calc(100vh-260px)] rounded-lg border border-border bg-muted/20 p-6 pr-14 overflow-auto">
+        <div className="w-full min-h-[calc(100vh-260px)] pr-14 overflow-auto">
           <MarkdownContent content={content} />
         </div>
       )}

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -17,7 +17,7 @@ import { useAgentStore, useAgentColor } from '@bakin/sdk/hooks'
 import type { AvailableModel } from '@bakin/sdk/types'
 import type { AgentProfile, PackageStateRow, RecentActivity } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
-import { PackageCard } from './agent-detail'
+import { PackageCardBody } from './agent-detail'
 
 export interface OverviewTabProps {
   agentId: string
@@ -175,18 +175,19 @@ export function OverviewTab({
 
   return (
     <div className="space-y-6 w-full">
-      {/* HERO ROW — Identity (2/3) + Settings (1/3) */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-        <section className="lg:col-span-2">
-          <SectionLabel>Identity</SectionLabel>
-          <div
-            className="relative rounded-2xl border-2 px-6 py-5 overflow-hidden"
-            style={{
-              borderColor: `${accentColor}55`,
-              background: `linear-gradient(135deg, ${accentColor}10 0%, transparent 60%)`,
-            }}
-          >
-            <div className="flex items-center gap-5">
+      {/* HERO — Identity + Settings + Package merged into one card with the
+          agent's accent color. Stacks at narrow widths; splits 3-up at lg+. */}
+      <section
+        className="relative rounded-2xl border-2 overflow-hidden"
+        style={{
+          borderColor: `${accentColor}55`,
+          background: `linear-gradient(135deg, ${accentColor}10 0%, transparent 50%)`,
+        }}
+      >
+        <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr_1fr] divide-y lg:divide-y-0 lg:divide-x divide-border/40">
+          {/* IDENTITY */}
+          <div className="px-6 py-5">
+            <div className="flex items-center gap-4">
               <div
                 className="size-16 rounded-2xl flex items-center justify-center text-4xl shrink-0"
                 style={{ background: `${accentColor}20`, border: `1px solid ${accentColor}40` }}
@@ -199,7 +200,7 @@ export function OverviewTab({
               </div>
             </div>
             {profile.subagentPerms && profile.subagentPerms.length > 0 && (
-              <div className="text-xs text-muted-foreground mt-4 pt-4 border-t border-border/50 flex flex-wrap items-center gap-1.5">
+              <div className="text-xs text-muted-foreground mt-4 flex flex-wrap items-center gap-1.5">
                 <span className="text-foreground/70">Manages</span>
                 {profile.subagentPerms.map((id) => (
                   <Badge
@@ -214,11 +215,10 @@ export function OverviewTab({
               </div>
             )}
           </div>
-        </section>
 
-        <section>
-          <SectionLabel>Settings</SectionLabel>
-          <div className="rounded-2xl border border-border bg-muted/20 px-4 py-4 space-y-3 h-full">
+          {/* SETTINGS */}
+          <div className="px-6 py-5 space-y-3">
+            <SectionLabel>Settings</SectionLabel>
             <div>
               <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Model</div>
               {availableModels.length > 0 ? (
@@ -252,11 +252,14 @@ export function OverviewTab({
               </div>
             )}
           </div>
-        </section>
-      </div>
 
-      {/* PACKAGE */}
-      <PackageCard agentId={agentId} packageState={packageState} />
+          {/* PACKAGE */}
+          <div className="px-6 py-5 space-y-3">
+            <SectionLabel>Package</SectionLabel>
+            <PackageCardBody agentId={agentId} packageState={packageState} />
+          </div>
+        </div>
+      </section>
 
       {/* TELEMETRY — 4 metric tiles, color-coded, with icons */}
       <section>

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useState } from 'react'
 import { Loader2, Sparkles, BookOpen, MessageSquare, Coins, Database, Activity } from 'lucide-react'
 import { ModelSelect } from '@bakin/sdk/components'
-import { useAgentStore, useAgentColor, useRouter } from '@bakin/sdk/hooks'
+import { useAgentStore, useAgentColor } from '@bakin/sdk/hooks'
 import type { AvailableModel } from '@bakin/sdk/types'
 import type { AgentProfile, PackageStateRow, RecentActivity } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
@@ -121,11 +121,8 @@ export function OverviewTab({
   const teams = useAgentStore((s) => s.teams)
   const displaySettings = useAgentStore((s) => s.displaySettings)
   const reload = useAgentStore((s) => s.load)
-  const agentMap = useAgentStore((s) => s.agentMap)
   const accentColor = useAgentColor(agentId)
-  const router = useRouter()
   const currentTeamId = displaySettings[agentId]?.teamId ?? ''
-  const reports = profile.subagentPerms ?? []
 
   const [usage, setUsage] = useState<AgentUsage | null>(null)
   const [activity, setActivity] = useState<RecentActivity | null>(null)
@@ -325,70 +322,6 @@ export function OverviewTab({
           </div>
         )}
       </section>
-
-      {/* DIRECT REPORTS — agents this one is permitted to dispatch,
-          bucketed by team. Only renders when there's anything to manage. */}
-      {reports.length > 0 && (
-        <section className="space-y-5">
-          <SectionLabel>Direct reports</SectionLabel>
-          {(() => {
-            // Bucket reports by their teamId. Unassigned go to a final
-            // "No team" bucket. Team order follows the teams array; teams
-            // with no matching reports are skipped.
-            const buckets = new Map<string, { label: string; ids: string[] }>()
-            for (const team of teams) {
-              buckets.set(team.id, { label: team.label, ids: [] })
-            }
-            buckets.set('__unassigned', { label: 'No team', ids: [] })
-            for (const id of reports) {
-              const teamId = displaySettings[id]?.teamId
-              const key = teamId && buckets.has(teamId) ? teamId : '__unassigned'
-              buckets.get(key)!.ids.push(id)
-            }
-            return Array.from(buckets.entries())
-              .filter(([, b]) => b.ids.length > 0)
-              .map(([key, bucket]) => (
-                <div key={key} className="space-y-2">
-                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground/80 font-medium flex items-center gap-2">
-                    {bucket.label}
-                    <span className="text-muted-foreground/50">·</span>
-                    <span className="text-muted-foreground/60 normal-case tracking-normal font-normal">{bucket.ids.length}</span>
-                  </div>
-                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-                    {bucket.ids.map((id) => {
-                      const report = agentMap[id]
-                      return (
-                        <button
-                          key={id}
-                          onClick={() => router.push(`/team/${id}`)}
-                          className="group flex items-center gap-3 rounded-xl border border-border bg-muted/15 p-3 text-left transition-colors hover:bg-muted/30 hover:border-border/80"
-                        >
-                          <div className="size-10 rounded-full overflow-hidden bg-muted shrink-0">
-                            {report?.headshot ? (
-                              <img
-                                src={report.headshot}
-                                alt={report?.name ?? id}
-                                className="w-full h-full object-cover object-top"
-                                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
-                              />
-                            ) : (
-                              <div className="w-full h-full flex items-center justify-center text-lg" aria-hidden>
-                                {report?.emoji || '🤖'}
-                              </div>
-                            )}
-                          </div>
-                          <div className="text-sm font-medium text-foreground truncate group-hover:text-foreground">
-                            {report?.name ?? id}
-                          </div>
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>
-              ))
-          })()}
-        </section>
-      )}
 
     </div>
   )

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -312,7 +312,7 @@ export function OverviewTab({
               <ActivityTile label="Last hour" count={activity.windowMs['1h']} errors={activity.errors['1h']} agentColor={accentColor} />
               <ActivityTile label="Last 24 h" count={activity.windowMs['24h']} errors={activity.errors['24h']} agentColor={accentColor} />
             </div>
-            <div className="text-[11px] text-muted-foreground mt-2.5">
+            <div className="text-[11px] text-muted-foreground mt-2.5 text-center">
               Counts since server start ({new Date(activity.sinceServerStart).toLocaleString()}). The recorder is in-memory and resets on restart.
             </div>
           </>

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -186,9 +186,8 @@ export function OverviewTab({
         }}
       >
         <div className="grid grid-cols-1 lg:grid-cols-2 divide-y lg:divide-y-0 lg:divide-x divide-border/40">
-          {/* SETTINGS */}
+          {/* SETTINGS — no header, the labeled selectors below are self-explanatory */}
           <div className="px-6 py-5 space-y-3">
-            <SectionLabel>Settings</SectionLabel>
             <div>
               <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Model</div>
               {availableModels.length > 0 ? (
@@ -233,7 +232,7 @@ export function OverviewTab({
 
       {/* TELEMETRY — 4 metric tiles, color-coded, with icons */}
       <section>
-        <SectionLabel>Telemetry · latest session</SectionLabel>
+        <SectionLabel>Metrics</SectionLabel>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           <MetricTile
             label="Skills"
@@ -303,7 +302,7 @@ export function OverviewTab({
 
       {/* RECENT ACTIVITY — 3 tiles tinted with agent accent when active */}
       <section>
-        <SectionLabel>Recent activity</SectionLabel>
+        <SectionLabel>Activity</SectionLabel>
         {loading ? (
           <div className="text-sm text-muted-foreground py-3">Loading…</div>
         ) : activity ? (

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -1,0 +1,259 @@
+'use client'
+
+/**
+ * Overview tab — consolidated agent dashboard.
+ *
+ * Replaces the old Profile tab (which regurgitated content from the
+ * Soul/Rules/Tools/Heartbeat tabs). Folds in what the killed Stats tab
+ * used to show, plus summary counts (skills + knowledge), recent
+ * activity (5m/1h/24h dispatch counts), model selector, and team
+ * selector — both moved out of the agent-detail header.
+ */
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Badge } from '@bakin/sdk/ui'
+import { ModelSelect } from '@bakin/sdk/components'
+import { useAgentStore } from '@bakin/sdk/hooks'
+import type { AvailableModel } from '@bakin/sdk/types'
+import type { AgentProfile, PackageStateRow, RecentActivity } from '../types'
+import type { AgentUsage } from '../../../src/core/agent-usage'
+import { PackageCard } from './agent-detail'
+
+export interface OverviewTabProps {
+  agentId: string
+  profile: AgentProfile
+  packageState: PackageStateRow | undefined
+  availableModels: AvailableModel[]
+  onModelChange: (modelId: string) => Promise<void> | void
+  savingModel: boolean
+}
+
+interface KnowledgeMeta {
+  total: number
+  enabled: number
+}
+
+function Section({ title, children, span }: { title: string; children: React.ReactNode; span?: 'full' }) {
+  return (
+    <section className={span === 'full' ? 'col-span-full' : undefined}>
+      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">{title}</h3>
+      {children}
+    </section>
+  )
+}
+
+function StatTile({ label, value, sublabel }: { label: string; value: string; sublabel?: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 px-4 py-3">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className="text-2xl font-semibold text-foreground tabular-nums leading-tight mt-1">{value}</div>
+      {sublabel && <div className="text-[11px] text-muted-foreground mt-1">{sublabel}</div>}
+    </div>
+  )
+}
+
+function fmtNum(n: number): string {
+  return n.toLocaleString()
+}
+
+function fmtCost(n: number): string {
+  if (n === 0) return '$0.00'
+  if (n < 0.01) return `$${n.toFixed(4)}`
+  return `$${n.toFixed(2)}`
+}
+
+export function OverviewTab({
+  agentId,
+  profile,
+  packageState,
+  availableModels,
+  onModelChange,
+  savingModel,
+}: OverviewTabProps) {
+  const teams = useAgentStore((s) => s.teams)
+  const displaySettings = useAgentStore((s) => s.displaySettings)
+  const reload = useAgentStore((s) => s.load)
+  const currentTeamId = displaySettings[agentId]?.teamId ?? ''
+
+  const [usage, setUsage] = useState<AgentUsage | null>(null)
+  const [activity, setActivity] = useState<RecentActivity | null>(null)
+  const [skillCount, setSkillCount] = useState<number | null>(null)
+  const [knowledge, setKnowledge] = useState<KnowledgeMeta | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    Promise.all([
+      fetch(`/api/plugins/team/${agentId}/stats`).then((r) => r.json()).catch(() => ({ usage: null })),
+      fetch(`/api/plugins/team/${agentId}/recent-activity`).then((r) => r.json()).catch(() => ({ ok: false })),
+      fetch(`/api/plugins/team/${agentId}/skills`).then((r) => r.json()).catch(() => ({ skills: [] })),
+      fetch(`/api/agent-packages/${agentId}/knowledge`).then((r) => r.json()).catch(() => ({ ok: false })),
+    ]).then(([statsBody, activityBody, skillsBody, knowledgeBody]) => {
+      if (cancelled) return
+      const stats = statsBody as { usage: AgentUsage | null }
+      const act = activityBody as { ok: boolean; activity?: RecentActivity }
+      const skills = skillsBody as { skills?: unknown[] }
+      const know = knowledgeBody as { ok: boolean; lessons?: Array<{ enabled: boolean }> }
+
+      setUsage(stats.usage ?? null)
+      setActivity(act.ok && act.activity ? act.activity : null)
+      setSkillCount(Array.isArray(skills.skills) ? skills.skills.length : 0)
+      if (know.ok && Array.isArray(know.lessons)) {
+        setKnowledge({
+          total: know.lessons.length,
+          enabled: know.lessons.filter((l) => l.enabled).length,
+        })
+      } else {
+        setKnowledge({ total: 0, enabled: 0 })
+      }
+      setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [agentId])
+
+  const resolvedModelId = availableModels.find((m) => m.id === profile.model)?.id ?? profile.model
+
+  const handleTeamChange = async (teamId: string) => {
+    const res = await fetch(`/api/plugins/team/${agentId}/team`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ teamId: teamId || null }),
+    })
+    if (res.ok) await reload()
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5 w-full">
+      <Section title="Identity">
+        <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-2">
+          <div className="flex items-center gap-3">
+            <span className="text-3xl leading-none">{profile.emoji || '🤖'}</span>
+            <div>
+              <div className="text-base font-semibold text-foreground">{profile.name}</div>
+              <div className="text-xs text-muted-foreground">{profile.role || 'No role assigned'}</div>
+            </div>
+          </div>
+          {profile.subagentPerms && profile.subagentPerms.length > 0 && (
+            <div className="text-xs text-muted-foreground pt-1">
+              <span className="text-foreground/80">Manages:</span>{' '}
+              {profile.subagentPerms.map((id) => (
+                <Badge key={id} variant="outline" className="text-[10px] mx-0.5">{id}</Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </Section>
+
+      <Section title="Settings">
+        <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Model</div>
+            {availableModels.length > 0 ? (
+              <div className="flex items-center gap-2">
+                <ModelSelect
+                  value={resolvedModelId}
+                  onChange={onModelChange}
+                  models={availableModels}
+                  defaultLabel="Use default"
+                  className="h-8 w-full text-xs"
+                />
+                {savingModel && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+              </div>
+            ) : (
+              <code className="text-xs font-mono text-muted-foreground">{profile.model}</code>
+            )}
+          </div>
+          {teams.length > 0 && (
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Team</div>
+              <select
+                value={currentTeamId}
+                onChange={(e) => handleTeamChange(e.target.value)}
+                className="h-8 w-full rounded border border-border bg-transparent px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              >
+                <option value="">No team</option>
+                {teams.map((t) => (
+                  <option key={t.id} value={t.id}>{t.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      </Section>
+
+      <PackageCard agentId={agentId} packageState={packageState} />
+
+      <Section title="Workspace" span="full">
+        <code className="text-[11px] text-muted-foreground font-mono break-all">{profile.workspacePath}</code>
+      </Section>
+
+      <Section title="Capacity" span="full">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <StatTile label="Skills" value={loading || skillCount === null ? '—' : fmtNum(skillCount)} />
+          <StatTile
+            label="Knowledge lessons"
+            value={loading || !knowledge ? '—' : fmtNum(knowledge.total)}
+            sublabel={knowledge ? `${knowledge.enabled} enabled` : undefined}
+          />
+          <StatTile
+            label="Sessions"
+            value={loading ? '—' : fmtNum(usage?.messages ?? 0)}
+            sublabel="latest session messages"
+          />
+        </div>
+      </Section>
+
+      <Section title="Latest Session" span="full">
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        ) : usage ? (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <StatTile label="Model" value={usage.model || 'unknown'} />
+            <StatTile label="Tokens" value={fmtNum(usage.tokens.total)} sublabel={`in ${fmtNum(usage.tokens.input)} · out ${fmtNum(usage.tokens.output)}`} />
+            <StatTile label="Cache reads" value={fmtNum(usage.tokens.cacheRead)} />
+            <StatTile label="Cost" value={fmtCost(usage.cost.total)} sublabel={`$${(usage.cost.total / Math.max(1, usage.messages)).toFixed(4)}/msg`} />
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
+            No session data yet
+          </div>
+        )}
+      </Section>
+
+      <Section title="Recent Activity" span="full">
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        ) : activity ? (
+          <>
+            <div className="grid grid-cols-3 gap-3">
+              <StatTile
+                label="Last 5 min"
+                value={fmtNum(activity.windowMs['5m'])}
+                sublabel={activity.errors['5m'] ? `${activity.errors['5m']} errors` : undefined}
+              />
+              <StatTile
+                label="Last hour"
+                value={fmtNum(activity.windowMs['1h'])}
+                sublabel={activity.errors['1h'] ? `${activity.errors['1h']} errors` : undefined}
+              />
+              <StatTile
+                label="Last 24 h"
+                value={fmtNum(activity.windowMs['24h'])}
+                sublabel={activity.errors['24h'] ? `${activity.errors['24h']} errors` : undefined}
+              />
+            </div>
+            <div className="text-[11px] text-muted-foreground mt-2">
+              Counts since server start ({new Date(activity.sinceServerStart).toLocaleString()}).
+              The recorder is in-memory and resets on restart.
+            </div>
+          </>
+        ) : (
+          <div className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
+            No activity recorded
+          </div>
+        )}
+      </Section>
+    </div>
+  )
+}

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -11,7 +11,6 @@
  */
 import { useEffect, useState } from 'react'
 import { Loader2, Sparkles, BookOpen, MessageSquare, Coins, Database, Activity } from 'lucide-react'
-import { Badge } from '@bakin/sdk/ui'
 import { ModelSelect } from '@bakin/sdk/components'
 import { useAgentStore, useAgentColor } from '@bakin/sdk/hooks'
 import type { AvailableModel } from '@bakin/sdk/types'
@@ -175,8 +174,10 @@ export function OverviewTab({
 
   return (
     <div className="space-y-6 w-full">
-      {/* HERO — Identity + Settings + Package merged into one card with the
-          agent's accent color. Stacks at narrow widths; splits 3-up at lg+. */}
+      {/* HERO — Settings + Package merged into one accent-bordered card.
+          Identity (avatar/name/role/manages) lives in the page header above
+          and is intentionally not duplicated here. Stacks 1-up at narrow
+          widths; splits 1:1 at lg+. */}
       <section
         className="relative rounded-2xl border-2 overflow-hidden"
         style={{
@@ -184,38 +185,7 @@ export function OverviewTab({
           background: `linear-gradient(135deg, ${accentColor}10 0%, transparent 50%)`,
         }}
       >
-        <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr_1fr] divide-y lg:divide-y-0 lg:divide-x divide-border/40">
-          {/* IDENTITY */}
-          <div className="px-6 py-5">
-            <div className="flex items-center gap-4">
-              <div
-                className="size-16 rounded-2xl flex items-center justify-center text-4xl shrink-0"
-                style={{ background: `${accentColor}20`, border: `1px solid ${accentColor}40` }}
-              >
-                {profile.emoji || '🤖'}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-2xl font-semibold text-foreground leading-tight">{profile.name}</div>
-                <div className="text-sm text-muted-foreground mt-0.5">{profile.role || 'No role assigned'}</div>
-              </div>
-            </div>
-            {profile.subagentPerms && profile.subagentPerms.length > 0 && (
-              <div className="text-xs text-muted-foreground mt-4 flex flex-wrap items-center gap-1.5">
-                <span className="text-foreground/70">Manages</span>
-                {profile.subagentPerms.map((id) => (
-                  <Badge
-                    key={id}
-                    variant="outline"
-                    className="text-[10px] font-mono"
-                    style={{ borderColor: `${accentColor}30`, color: accentColor }}
-                  >
-                    {id}
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </div>
-
+        <div className="grid grid-cols-1 lg:grid-cols-2 divide-y lg:divide-y-0 lg:divide-x divide-border/40">
           {/* SETTINGS */}
           <div className="px-6 py-5 space-y-3">
             <SectionLabel>Settings</SectionLabel>

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -16,7 +16,7 @@ import { useAgentStore, useAgentColor } from '@bakin/sdk/hooks'
 import type { AvailableModel } from '@bakin/sdk/types'
 import type { AgentProfile, PackageStateRow, RecentActivity } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
-import { PackageCardBody } from './agent-detail'
+import { PackageCardBody } from './package-card'
 
 export interface OverviewTabProps {
   agentId: string

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useState } from 'react'
 import { Loader2, Sparkles, BookOpen, MessageSquare, Coins, Database, Activity } from 'lucide-react'
 import { ModelSelect } from '@bakin/sdk/components'
-import { useAgentStore, useAgentColor } from '@bakin/sdk/hooks'
+import { useAgentStore, useAgentColor, useRouter } from '@bakin/sdk/hooks'
 import type { AvailableModel } from '@bakin/sdk/types'
 import type { AgentProfile, PackageStateRow, RecentActivity } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
@@ -121,8 +121,11 @@ export function OverviewTab({
   const teams = useAgentStore((s) => s.teams)
   const displaySettings = useAgentStore((s) => s.displaySettings)
   const reload = useAgentStore((s) => s.load)
+  const agentMap = useAgentStore((s) => s.agentMap)
   const accentColor = useAgentColor(agentId)
+  const router = useRouter()
   const currentTeamId = displaySettings[agentId]?.teamId ?? ''
+  const reports = profile.subagentPerms ?? []
 
   const [usage, setUsage] = useState<AgentUsage | null>(null)
   const [activity, setActivity] = useState<RecentActivity | null>(null)
@@ -322,6 +325,49 @@ export function OverviewTab({
           </div>
         )}
       </section>
+
+      {/* DIRECT REPORTS — agents this one is permitted to dispatch.
+          Only renders when there's anything to manage. */}
+      {reports.length > 0 && (
+        <section>
+          <SectionLabel>Direct reports</SectionLabel>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+            {reports.map((id) => {
+              const report = agentMap[id]
+              return (
+                <button
+                  key={id}
+                  onClick={() => router.push(`/team/${id}`)}
+                  className="group flex items-center gap-3 rounded-xl border border-border bg-muted/15 p-3 text-left transition-colors hover:bg-muted/30 hover:border-border/80"
+                >
+                  <div className="size-10 rounded-full overflow-hidden bg-muted shrink-0">
+                    {report?.headshot ? (
+                      <img
+                        src={report.headshot}
+                        alt={report?.name ?? id}
+                        className="w-full h-full object-cover object-top"
+                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-lg" aria-hidden>
+                        {report?.emoji || '🤖'}
+                      </div>
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-foreground truncate group-hover:text-foreground">
+                      {report?.name ?? id}
+                    </div>
+                    {report?.role && (
+                      <div className="text-[11px] text-muted-foreground truncate">{report.role}</div>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      )}
 
     </div>
   )

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -224,7 +224,7 @@ export function OverviewTab({
 
           {/* PACKAGE */}
           <div className="px-6 py-5 space-y-3">
-            <SectionLabel>Package</SectionLabel>
+            <SectionLabel>Agent Package</SectionLabel>
             <PackageCardBody agentId={agentId} packageState={packageState} />
           </div>
         </div>

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -323,13 +323,6 @@ export function OverviewTab({
         )}
       </section>
 
-      {/* WORKSPACE — footer line */}
-      <section className="pt-2 border-t border-border/50">
-        <div className="flex items-baseline gap-3 text-xs">
-          <span className="text-muted-foreground/70 uppercase tracking-wider text-[10px] font-semibold">Workspace</span>
-          <code className="font-mono text-muted-foreground break-all">{profile.workspacePath}</code>
-        </div>
-      </section>
     </div>
   )
 }

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -10,10 +10,10 @@
  * selector — both moved out of the agent-detail header.
  */
 import { useEffect, useState } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Sparkles, BookOpen, MessageSquare, Coins, Database, Activity } from 'lucide-react'
 import { Badge } from '@bakin/sdk/ui'
 import { ModelSelect } from '@bakin/sdk/components'
-import { useAgentStore } from '@bakin/sdk/hooks'
+import { useAgentStore, useAgentColor } from '@bakin/sdk/hooks'
 import type { AvailableModel } from '@bakin/sdk/types'
 import type { AgentProfile, PackageStateRow, RecentActivity } from '../types'
 import type { AgentUsage } from '../../../src/core/agent-usage'
@@ -33,21 +33,70 @@ interface KnowledgeMeta {
   enabled: number
 }
 
-function Section({ title, children, span }: { title: string; children: React.ReactNode; span?: 'full' }) {
+function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <section className={span === 'full' ? 'col-span-full' : undefined}>
-      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">{title}</h3>
-      {children}
-    </section>
+    <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70 mb-2">{children}</h3>
   )
 }
 
-function StatTile({ label, value, sublabel }: { label: string; value: string; sublabel?: string }) {
+interface MetricTileProps {
+  label: string
+  value: string
+  sublabel?: string
+  icon: React.ComponentType<{ className?: string }>
+  /** Tailwind color stem used for the icon, value text, and accent border (e.g. "text-blue-400") */
+  accent: string
+  /** Tailwind background stem for the icon chip (e.g. "bg-blue-500/10") */
+  accentBg: string
+}
+
+function MetricTile({ label, value, sublabel, icon: Icon, accent, accentBg }: MetricTileProps) {
   return (
-    <div className="rounded-lg border border-border bg-muted/20 px-4 py-3">
-      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</div>
-      <div className="text-2xl font-semibold text-foreground tabular-nums leading-tight mt-1">{value}</div>
+    <div className="relative rounded-xl border border-border bg-muted/15 px-4 py-4 overflow-hidden group transition-colors hover:bg-muted/25">
+      <div className={`absolute inset-y-0 left-0 w-1 ${accentBg.replace('/10', '/40')}`} />
+      <div className="flex items-start justify-between mb-2">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
+        <span className={`size-7 rounded-lg flex items-center justify-center ${accentBg}`}>
+          <Icon className={`size-3.5 ${accent}`} />
+        </span>
+      </div>
+      <div className={`text-2xl font-semibold tabular-nums leading-tight ${accent}`}>{value}</div>
       {sublabel && <div className="text-[11px] text-muted-foreground mt-1">{sublabel}</div>}
+    </div>
+  )
+}
+
+interface ActivityTileProps {
+  label: string
+  count: number
+  errors: number
+  agentColor: string
+}
+
+function ActivityTile({ label, count, errors, agentColor }: ActivityTileProps) {
+  const isActive = count > 0
+  return (
+    <div
+      className="rounded-xl border border-border bg-muted/15 px-4 py-3 flex items-center gap-3 transition-colors"
+      style={isActive ? { borderColor: `${agentColor}40`, boxShadow: `inset 0 0 0 1px ${agentColor}20` } : undefined}
+    >
+      <div
+        className="size-9 rounded-lg flex items-center justify-center shrink-0"
+        style={isActive ? { background: `${agentColor}20` } : { background: 'rgb(63 63 70 / 0.4)' }}
+      >
+        <Activity className={`size-4 ${isActive ? '' : 'text-muted-foreground'}`} style={isActive ? { color: agentColor } : undefined} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</div>
+        <div className="text-xl font-semibold tabular-nums leading-tight" style={isActive ? { color: agentColor } : { color: 'rgb(244 244 245 / 0.85)' }}>
+          {count.toLocaleString()}
+        </div>
+      </div>
+      {errors > 0 && (
+        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-red-500/15 text-red-300 font-medium">
+          {errors} err
+        </span>
+      )}
     </div>
   )
 }
@@ -73,6 +122,7 @@ export function OverviewTab({
   const teams = useAgentStore((s) => s.teams)
   const displaySettings = useAgentStore((s) => s.displaySettings)
   const reload = useAgentStore((s) => s.load)
+  const accentColor = useAgentColor(agentId)
   const currentTeamId = displaySettings[agentId]?.teamId ?? ''
 
   const [usage, setUsage] = useState<AgentUsage | null>(null)
@@ -124,136 +174,190 @@ export function OverviewTab({
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5 w-full">
-      <Section title="Identity">
-        <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-2">
-          <div className="flex items-center gap-3">
-            <span className="text-3xl leading-none">{profile.emoji || '🤖'}</span>
-            <div>
-              <div className="text-base font-semibold text-foreground">{profile.name}</div>
-              <div className="text-xs text-muted-foreground">{profile.role || 'No role assigned'}</div>
-            </div>
-          </div>
-          {profile.subagentPerms && profile.subagentPerms.length > 0 && (
-            <div className="text-xs text-muted-foreground pt-1">
-              <span className="text-foreground/80">Manages:</span>{' '}
-              {profile.subagentPerms.map((id) => (
-                <Badge key={id} variant="outline" className="text-[10px] mx-0.5">{id}</Badge>
-              ))}
-            </div>
-          )}
-        </div>
-      </Section>
-
-      <Section title="Settings">
-        <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 space-y-3">
-          <div>
-            <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Model</div>
-            {availableModels.length > 0 ? (
-              <div className="flex items-center gap-2">
-                <ModelSelect
-                  value={resolvedModelId}
-                  onChange={onModelChange}
-                  models={availableModels}
-                  defaultLabel="Use default"
-                  className="h-8 w-full text-xs"
-                />
-                {savingModel && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+    <div className="space-y-6 w-full">
+      {/* HERO ROW — Identity (2/3) + Settings (1/3) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <section className="lg:col-span-2">
+          <SectionLabel>Identity</SectionLabel>
+          <div
+            className="relative rounded-2xl border-2 px-6 py-5 overflow-hidden"
+            style={{
+              borderColor: `${accentColor}55`,
+              background: `linear-gradient(135deg, ${accentColor}10 0%, transparent 60%)`,
+            }}
+          >
+            <div className="flex items-center gap-5">
+              <div
+                className="size-16 rounded-2xl flex items-center justify-center text-4xl shrink-0"
+                style={{ background: `${accentColor}20`, border: `1px solid ${accentColor}40` }}
+              >
+                {profile.emoji || '🤖'}
               </div>
-            ) : (
-              <code className="text-xs font-mono text-muted-foreground">{profile.model}</code>
+              <div className="min-w-0 flex-1">
+                <div className="text-2xl font-semibold text-foreground leading-tight">{profile.name}</div>
+                <div className="text-sm text-muted-foreground mt-0.5">{profile.role || 'No role assigned'}</div>
+              </div>
+            </div>
+            {profile.subagentPerms && profile.subagentPerms.length > 0 && (
+              <div className="text-xs text-muted-foreground mt-4 pt-4 border-t border-border/50 flex flex-wrap items-center gap-1.5">
+                <span className="text-foreground/70">Manages</span>
+                {profile.subagentPerms.map((id) => (
+                  <Badge
+                    key={id}
+                    variant="outline"
+                    className="text-[10px] font-mono"
+                    style={{ borderColor: `${accentColor}30`, color: accentColor }}
+                  >
+                    {id}
+                  </Badge>
+                ))}
+              </div>
             )}
           </div>
-          {teams.length > 0 && (
-            <div>
-              <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Team</div>
-              <select
-                value={currentTeamId}
-                onChange={(e) => handleTeamChange(e.target.value)}
-                className="h-8 w-full rounded border border-border bg-transparent px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-              >
-                <option value="">No team</option>
-                {teams.map((t) => (
-                  <option key={t.id} value={t.id}>{t.label}</option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
-      </Section>
+        </section>
 
+        <section>
+          <SectionLabel>Settings</SectionLabel>
+          <div className="rounded-2xl border border-border bg-muted/20 px-4 py-4 space-y-3 h-full">
+            <div>
+              <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Model</div>
+              {availableModels.length > 0 ? (
+                <div className="flex items-center gap-2">
+                  <ModelSelect
+                    value={resolvedModelId}
+                    onChange={onModelChange}
+                    models={availableModels}
+                    defaultLabel="Use default"
+                    className="h-8 w-full text-xs"
+                  />
+                  {savingModel && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
+                </div>
+              ) : (
+                <code className="text-xs font-mono text-muted-foreground">{profile.model}</code>
+              )}
+            </div>
+            {teams.length > 0 && (
+              <div>
+                <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Team</div>
+                <select
+                  value={currentTeamId}
+                  onChange={(e) => handleTeamChange(e.target.value)}
+                  className="h-8 w-full rounded border border-border bg-transparent px-2 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  <option value="">No team</option>
+                  {teams.map((t) => (
+                    <option key={t.id} value={t.id}>{t.label}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      {/* PACKAGE */}
       <PackageCard agentId={agentId} packageState={packageState} />
 
-      <Section title="Workspace" span="full">
-        <code className="text-[11px] text-muted-foreground font-mono break-all">{profile.workspacePath}</code>
-      </Section>
-
-      <Section title="Capacity" span="full">
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-          <StatTile label="Skills" value={loading || skillCount === null ? '—' : fmtNum(skillCount)} />
-          <StatTile
-            label="Knowledge lessons"
+      {/* TELEMETRY — 4 metric tiles, color-coded, with icons */}
+      <section>
+        <SectionLabel>Telemetry · latest session</SectionLabel>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <MetricTile
+            label="Skills"
+            value={loading || skillCount === null ? '—' : fmtNum(skillCount)}
+            icon={Sparkles}
+            accent="text-violet-300"
+            accentBg="bg-violet-500/15"
+          />
+          <MetricTile
+            label="Knowledge"
             value={loading || !knowledge ? '—' : fmtNum(knowledge.total)}
             sublabel={knowledge ? `${knowledge.enabled} enabled` : undefined}
+            icon={BookOpen}
+            accent="text-cyan-300"
+            accentBg="bg-cyan-500/15"
           />
-          <StatTile
-            label="Sessions"
-            value={loading ? '—' : fmtNum(usage?.messages ?? 0)}
-            sublabel="latest session messages"
+          <MetricTile
+            label="Tokens"
+            value={loading ? '—' : fmtNum(usage?.tokens.total ?? 0)}
+            sublabel={usage ? `in ${fmtNum(usage.tokens.input)} · out ${fmtNum(usage.tokens.output)}` : undefined}
+            icon={MessageSquare}
+            accent="text-blue-300"
+            accentBg="bg-blue-500/15"
+          />
+          <MetricTile
+            label="Cost"
+            value={loading ? '—' : fmtCost(usage?.cost.total ?? 0)}
+            sublabel={usage && usage.messages > 0 ? `${fmtCost(usage.cost.total / usage.messages)}/msg` : undefined}
+            icon={Coins}
+            accent="text-emerald-300"
+            accentBg="bg-emerald-500/15"
           />
         </div>
-      </Section>
-
-      <Section title="Latest Session" span="full">
-        {loading ? (
-          <div className="text-sm text-muted-foreground">Loading…</div>
-        ) : usage ? (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <StatTile label="Model" value={usage.model || 'unknown'} />
-            <StatTile label="Tokens" value={fmtNum(usage.tokens.total)} sublabel={`in ${fmtNum(usage.tokens.input)} · out ${fmtNum(usage.tokens.output)}`} />
-            <StatTile label="Cache reads" value={fmtNum(usage.tokens.cacheRead)} />
-            <StatTile label="Cost" value={fmtCost(usage.cost.total)} sublabel={`$${(usage.cost.total / Math.max(1, usage.messages)).toFixed(4)}/msg`} />
-          </div>
-        ) : (
-          <div className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
-            No session data yet
+        {usage && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-3">
+            <MetricTile
+              label="Model"
+              value={usage.model || 'unknown'}
+              icon={MessageSquare}
+              accent="text-zinc-300"
+              accentBg="bg-zinc-500/15"
+            />
+            <MetricTile
+              label="Messages"
+              value={fmtNum(usage.messages)}
+              icon={MessageSquare}
+              accent="text-zinc-300"
+              accentBg="bg-zinc-500/15"
+            />
+            <MetricTile
+              label="Cache reads"
+              value={fmtNum(usage.tokens.cacheRead)}
+              icon={Database}
+              accent="text-amber-300"
+              accentBg="bg-amber-500/15"
+            />
+            <MetricTile
+              label="Cache writes"
+              value={fmtNum(usage.tokens.cacheWrite)}
+              icon={Database}
+              accent="text-amber-300"
+              accentBg="bg-amber-500/15"
+            />
           </div>
         )}
-      </Section>
+      </section>
 
-      <Section title="Recent Activity" span="full">
+      {/* RECENT ACTIVITY — 3 tiles tinted with agent accent when active */}
+      <section>
+        <SectionLabel>Recent activity</SectionLabel>
         {loading ? (
-          <div className="text-sm text-muted-foreground">Loading…</div>
+          <div className="text-sm text-muted-foreground py-3">Loading…</div>
         ) : activity ? (
           <>
-            <div className="grid grid-cols-3 gap-3">
-              <StatTile
-                label="Last 5 min"
-                value={fmtNum(activity.windowMs['5m'])}
-                sublabel={activity.errors['5m'] ? `${activity.errors['5m']} errors` : undefined}
-              />
-              <StatTile
-                label="Last hour"
-                value={fmtNum(activity.windowMs['1h'])}
-                sublabel={activity.errors['1h'] ? `${activity.errors['1h']} errors` : undefined}
-              />
-              <StatTile
-                label="Last 24 h"
-                value={fmtNum(activity.windowMs['24h'])}
-                sublabel={activity.errors['24h'] ? `${activity.errors['24h']} errors` : undefined}
-              />
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <ActivityTile label="Last 5 min" count={activity.windowMs['5m']} errors={activity.errors['5m']} agentColor={accentColor} />
+              <ActivityTile label="Last hour" count={activity.windowMs['1h']} errors={activity.errors['1h']} agentColor={accentColor} />
+              <ActivityTile label="Last 24 h" count={activity.windowMs['24h']} errors={activity.errors['24h']} agentColor={accentColor} />
             </div>
-            <div className="text-[11px] text-muted-foreground mt-2">
-              Counts since server start ({new Date(activity.sinceServerStart).toLocaleString()}).
-              The recorder is in-memory and resets on restart.
+            <div className="text-[11px] text-muted-foreground mt-2.5">
+              Counts since server start ({new Date(activity.sinceServerStart).toLocaleString()}). The recorder is in-memory and resets on restart.
             </div>
           </>
         ) : (
-          <div className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
-            No activity recorded
+          <div className="rounded-xl border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground">
+            No activity recorded yet
           </div>
         )}
-      </Section>
+      </section>
+
+      {/* WORKSPACE — footer line */}
+      <section className="pt-2 border-t border-border/50">
+        <div className="flex items-baseline gap-3 text-xs">
+          <span className="text-muted-foreground/70 uppercase tracking-wider text-[10px] font-semibold">Workspace</span>
+          <code className="font-mono text-muted-foreground break-all">{profile.workspacePath}</code>
+        </div>
+      </section>
     </div>
   )
 }

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -326,46 +326,67 @@ export function OverviewTab({
         )}
       </section>
 
-      {/* DIRECT REPORTS — agents this one is permitted to dispatch.
-          Only renders when there's anything to manage. */}
+      {/* DIRECT REPORTS — agents this one is permitted to dispatch,
+          bucketed by team. Only renders when there's anything to manage. */}
       {reports.length > 0 && (
-        <section>
+        <section className="space-y-5">
           <SectionLabel>Direct reports</SectionLabel>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
-            {reports.map((id) => {
-              const report = agentMap[id]
-              return (
-                <button
-                  key={id}
-                  onClick={() => router.push(`/team/${id}`)}
-                  className="group flex items-center gap-3 rounded-xl border border-border bg-muted/15 p-3 text-left transition-colors hover:bg-muted/30 hover:border-border/80"
-                >
-                  <div className="size-10 rounded-full overflow-hidden bg-muted shrink-0">
-                    {report?.headshot ? (
-                      <img
-                        src={report.headshot}
-                        alt={report?.name ?? id}
-                        className="w-full h-full object-cover object-top"
-                        onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
-                      />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center text-lg" aria-hidden>
-                        {report?.emoji || '🤖'}
-                      </div>
-                    )}
+          {(() => {
+            // Bucket reports by their teamId. Unassigned go to a final
+            // "No team" bucket. Team order follows the teams array; teams
+            // with no matching reports are skipped.
+            const buckets = new Map<string, { label: string; ids: string[] }>()
+            for (const team of teams) {
+              buckets.set(team.id, { label: team.label, ids: [] })
+            }
+            buckets.set('__unassigned', { label: 'No team', ids: [] })
+            for (const id of reports) {
+              const teamId = displaySettings[id]?.teamId
+              const key = teamId && buckets.has(teamId) ? teamId : '__unassigned'
+              buckets.get(key)!.ids.push(id)
+            }
+            return Array.from(buckets.entries())
+              .filter(([, b]) => b.ids.length > 0)
+              .map(([key, bucket]) => (
+                <div key={key} className="space-y-2">
+                  <div className="text-[11px] uppercase tracking-wider text-muted-foreground/80 font-medium flex items-center gap-2">
+                    {bucket.label}
+                    <span className="text-muted-foreground/50">·</span>
+                    <span className="text-muted-foreground/60 normal-case tracking-normal font-normal">{bucket.ids.length}</span>
                   </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-foreground truncate group-hover:text-foreground">
-                      {report?.name ?? id}
-                    </div>
-                    {report?.role && (
-                      <div className="text-[11px] text-muted-foreground truncate">{report.role}</div>
-                    )}
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                    {bucket.ids.map((id) => {
+                      const report = agentMap[id]
+                      return (
+                        <button
+                          key={id}
+                          onClick={() => router.push(`/team/${id}`)}
+                          className="group flex items-center gap-3 rounded-xl border border-border bg-muted/15 p-3 text-left transition-colors hover:bg-muted/30 hover:border-border/80"
+                        >
+                          <div className="size-10 rounded-full overflow-hidden bg-muted shrink-0">
+                            {report?.headshot ? (
+                              <img
+                                src={report.headshot}
+                                alt={report?.name ?? id}
+                                className="w-full h-full object-cover object-top"
+                                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                              />
+                            ) : (
+                              <div className="w-full h-full flex items-center justify-center text-lg" aria-hidden>
+                                {report?.emoji || '🤖'}
+                              </div>
+                            )}
+                          </div>
+                          <div className="text-sm font-medium text-foreground truncate group-hover:text-foreground">
+                            {report?.name ?? id}
+                          </div>
+                        </button>
+                      )
+                    })}
                   </div>
-                </button>
-              )
-            })}
-          </div>
+                </div>
+              ))
+          })()}
         </section>
       )}
 

--- a/plugins/team/components/package-card.tsx
+++ b/plugins/team/components/package-card.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+/**
+ * Package card content for the OverviewTab hero. Lives in its own
+ * file (rather than inside agent-detail.tsx) to break a circular
+ * import — overview-tab.tsx needs PackageCardBody, and
+ * agent-detail.tsx already needs OverviewTab.
+ */
+import { useState } from 'react'
+import { Copy, Info } from 'lucide-react'
+import { Badge, Button } from '@bakin/sdk/ui'
+import { useAgentStore, useMainAgentId } from '@bakin/sdk/hooks'
+import { PackageStateBadge } from './package-state-badge'
+import { AdoptDialog } from './adopt-dialog'
+import type { PackageStateRow } from '../types'
+
+export const ADOPT_INFO = `Adopting attaches an agent-package to this agent. Bakin then tracks the source repo + commit, projects the package's knowledge lessons + skills into the workspace, and lets you toggle which lessons are active. Your existing SOUL/IDENTITY/AGENTS/TOOLS files stay on disk untouched.`
+
+function CliHint({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // clipboard api unavailable — fail quietly, the command is visible
+    }
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs">
+      <code className="flex-1 font-mono text-foreground">{command}</code>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={handleCopy}
+        title={copied ? 'Copied' : 'Copy'}
+        aria-label="Copy command"
+      >
+        <Copy className="size-3.5" />
+      </Button>
+    </div>
+  )
+}
+
+function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageStateRow['entry']>; packageId?: string }) {
+  return (
+    <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">
+      {packageId && (
+        <>
+          <dt className="text-muted-foreground">Package</dt>
+          <dd className="font-mono text-foreground break-all">{packageId}</dd>
+        </>
+      )}
+      <dt className="text-muted-foreground">Source</dt>
+      <dd className="font-mono text-foreground break-all">{entry.source}</dd>
+      {entry.ref && (
+        <>
+          <dt className="text-muted-foreground">Ref</dt>
+          <dd className="font-mono text-foreground">{entry.ref}</dd>
+        </>
+      )}
+      {entry.commitSha && (
+        <>
+          <dt className="text-muted-foreground">Commit</dt>
+          <dd className="font-mono text-foreground">{entry.commitSha.slice(0, 7)}</dd>
+        </>
+      )}
+      <dt className="text-muted-foreground">Installed</dt>
+      <dd className="text-foreground">{entry.installedAt}</dd>
+      {entry.dependencies && entry.dependencies.length > 0 && (
+        <>
+          <dt className="text-muted-foreground">Depends on</dt>
+          <dd className="flex flex-wrap gap-1">
+            {entry.dependencies.map((d) => (
+              <Badge key={d} variant="outline" className="text-[10px] font-mono">{d}</Badge>
+            ))}
+          </dd>
+        </>
+      )}
+    </dl>
+  )
+}
+
+/**
+ * Package summary content (no surrounding card chrome). Used inside the
+ * Overview hero where it sits as the third column of a merged
+ * Settings/Package box.
+ */
+export function PackageCardBody({ agentId, packageState }: { agentId: string; packageState: PackageStateRow | undefined }) {
+  // Default to "unmanaged" when the API hasn't reported a row at all — the
+  // most common reason is the agent exists in OpenClaw but has never been
+  // adopted, which is the same thing as state=unmanaged.
+  const state = packageState?.state ?? 'unmanaged'
+  const mainAgentId = useMainAgentId()
+  const isMain = agentId === mainAgentId
+  const refreshPackageStates = useAgentStore((s) => s.refreshPackageStates)
+  const [adoptOpen, setAdoptOpen] = useState(false)
+
+  // Main agent is the user's persona — adopting/replacing it doesn't make
+  // sense. Show a different framing instead of the Adopt button.
+  if (isMain && (state === 'unmanaged' || state === 'absent')) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary" className="bg-zinc-800 text-zinc-300">Self-managed</Badge>
+          <span className="text-xs text-muted-foreground">main agent</span>
+        </div>
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          Your main agent is your own persona — its workspace files live with you, not a package template. Adoption is intentionally not offered here.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <PackageStateBadge state={state} packageId={packageState?.packageId} />
+        {state === 'unmanaged' && (
+          <Button
+            size="sm"
+            onClick={() => setAdoptOpen(true)}
+            title={ADOPT_INFO}
+            aria-label={`Adopt this agent into a package — ${ADOPT_INFO}`}
+          >
+            <Info className="size-3 mr-1.5" />
+            Adopt
+          </Button>
+        )}
+      </div>
+      {state === 'unmanaged' && (
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          Adopt to enable knowledge-lesson toggles, automatic skill projection, and update-from-source tracking. Your workspace files stay as-is.
+        </p>
+      )}
+      {packageState?.entry && (state === 'managed' || state === 'adopted') && (
+        <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
+      )}
+      {state === 'drifted' && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            Projection sha mismatch detected. Repair from the CLI:
+          </p>
+          <CliHint command="bakin install agent-assets" />
+        </div>
+      )}
+      {state === 'update-available' && (
+        <div className="space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            A newer version of the source package is available. Update from the CLI:
+          </p>
+          <CliHint command={`bakin agents update ${agentId}`} />
+        </div>
+      )}
+      <AdoptDialog
+        open={adoptOpen}
+        onOpenChange={setAdoptOpen}
+        agentId={agentId}
+        onAdopted={() => { refreshPackageStates() }}
+      />
+    </div>
+  )
+}

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -111,7 +111,7 @@ export function AgentCardNode({ data }: NodeProps) {
 
   return (
     <div
-      className="agent-card-hover rounded-xl border border-zinc-700 bg-zinc-900 overflow-hidden w-[152px] flex flex-col cursor-pointer shadow-md"
+      className="agent-card-hover rounded-xl border border-zinc-700 bg-zinc-900 overflow-hidden w-[184px] flex flex-col cursor-pointer shadow-md"
       style={{ '--agent-glow': accentColor } as React.CSSProperties}
     >
       <Handle type="target" position={Position.Top} className="!bg-zinc-600" />
@@ -129,24 +129,24 @@ export function AgentCardNode({ data }: NodeProps) {
         >
           {agent.emoji}
         </div>
-        <div className={`absolute top-2 right-2 size-2.5 rounded-full border-2 border-zinc-900 ${dotColor}`} />
+        <div className="absolute top-2 right-2 flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-zinc-950/80 backdrop-blur-sm shadow-lg">
+          <span className={`size-2 rounded-full ${dotColor}`} />
+          <span className="text-xs font-medium text-zinc-100 leading-none">{statusLabel}</span>
+        </div>
       </div>
-      <div className="p-2.5 flex flex-col gap-0.5">
-        <div className="flex items-center gap-1.5 leading-tight">
-          <span className="text-sm font-semibold text-zinc-100 truncate">{agent.name}</span>
+      <div className="p-3 flex flex-col items-center text-center gap-1">
+        <div className="flex items-center justify-center gap-1.5 leading-tight w-full">
+          <span className="text-base font-semibold text-zinc-100 truncate">{agent.name}</span>
           {showBadge && pkgState && (
             <PackageStateBadge state={pkgState.state} compact />
           )}
         </div>
-        {agent.role && <div className="text-xs text-zinc-500 leading-tight truncate">{agent.role}</div>}
-        <div className="flex items-center gap-1.5 mt-1.5">
-          <Badge
-            variant={agent.status === 'online' || agent.status === 'working' ? 'default' : 'secondary'}
-            className="text-[10px] px-1.5 py-0"
-          >
-            {statusLabel}
-          </Badge>
-          <span className="text-[10px] text-zinc-500 font-mono truncate">{agent.model}</span>
+        {agent.role && <div className="text-xs text-zinc-500 leading-tight truncate w-full">{agent.role}</div>}
+        <div
+          className="text-[11px] text-zinc-400 font-mono truncate mt-1.5 w-full"
+          title={agent.model}
+        >
+          {agent.model}
         </div>
       </div>
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-600" />

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -111,7 +111,7 @@ export function AgentCardNode({ data }: NodeProps) {
 
   return (
     <div
-      className="agent-card-hover rounded-xl border border-zinc-700 bg-zinc-900 overflow-hidden w-[184px] flex flex-col cursor-pointer shadow-md"
+      className="agent-card-hover rounded-xl border border-zinc-700 bg-zinc-900 overflow-hidden w-[208px] flex flex-col cursor-pointer shadow-md"
       style={{ '--agent-glow': accentColor } as React.CSSProperties}
     >
       <Handle type="target" position={Position.Top} className="!bg-zinc-600" />
@@ -141,7 +141,10 @@ export function AgentCardNode({ data }: NodeProps) {
             <PackageStateBadge state={pkgState.state} compact />
           )}
         </div>
-        <div className="text-xs text-zinc-500 leading-tight truncate w-full">
+        <div
+          className="text-xs text-zinc-500 leading-snug w-full line-clamp-3"
+          title={agent.role || undefined}
+        >
           {agent.role || <span className="text-zinc-700">no role</span>}
         </div>
         <div

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -138,7 +138,7 @@ export function AgentCardNode({ data }: NodeProps) {
             <PackageStateBadge state={pkgState.state} compact />
           )}
         </div>
-        <div className="text-xs text-zinc-500 leading-tight truncate">{agent.role}</div>
+        {agent.role && <div className="text-xs text-zinc-500 leading-tight truncate">{agent.role}</div>}
         <div className="flex items-center gap-1.5 mt-1.5">
           <Badge
             variant={agent.status === 'online' || agent.status === 'working' ? 'default' : 'secondary'}

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -39,37 +39,6 @@ import type { AgentWithStatus } from '../types'
  */
 const ATTENTION_STATES: PackageState[] = ['unmanaged', 'drifted', 'update-available']
 
-/**
- * Provider brand colors — mirrors the canonical KNOWN_PROVIDERS list in
- * plugins/models/data/known-models.ts. Inlined to avoid cross-plugin import.
- * Add new providers here when models gains them.
- */
-const PROVIDER_COLOR: Record<string, string> = {
-  anthropic: '#D97757',
-  openai: '#10A37F',
-  'openai-codex': '#10A37F',
-  google: '#4285F4',
-  ollama: '#0B0B0B',
-  bytedance: '#000000',
-  kuaishou: '#FF4906',
-  runway: '#E0F60A',
-  'black-forest-labs': '#000000',
-  stability: '#0050FF',
-  midjourney: '#131415',
-}
-
-const FALLBACK_PROVIDER_COLOR = '#52525b' // zinc-600 — unknown provider
-
-function providerColorFor(modelId: string): string {
-  if (!modelId) return FALLBACK_PROVIDER_COLOR
-  // Most ids are "<provider>/<model>"; bare `claude-*` resolves to anthropic.
-  const provider = modelId.includes('/')
-    ? modelId.split('/')[0]
-    : modelId.startsWith('claude-')
-      ? 'anthropic'
-      : modelId
-  return PROVIDER_COLOR[provider] ?? FALLBACK_PROVIDER_COLOR
-}
 
 /** Strip default ReactFlow node chrome + animated edges + hover glow */
 const RESET_STYLES = `
@@ -180,21 +149,12 @@ export function AgentCardNode({ data }: NodeProps) {
           {agent.role || <span className="text-zinc-700">no role</span>}
         </div>
       </div>
-      {(() => {
-        const providerColor = providerColorFor(agent.model)
-        return (
-          <div
-            className="px-3 py-2 text-[11px] text-zinc-100 font-mono truncate text-center border-t"
-            style={{
-              background: `linear-gradient(180deg, ${providerColor}22 0%, ${providerColor}40 100%)`,
-              borderTopColor: `${providerColor}55`,
-            }}
-            title={agent.model}
-          >
-            {agent.model}
-          </div>
-        )
-      })()}
+      <div
+        className="px-3 py-2 text-[11px] text-zinc-200 font-mono truncate text-center bg-black border-t border-zinc-800"
+        title={agent.model}
+      >
+        {agent.model}
+      </div>
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-600" />
     </div>
   )

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -39,7 +39,6 @@ import type { AgentWithStatus } from '../types'
  */
 const ATTENTION_STATES: PackageState[] = ['unmanaged', 'drifted', 'update-available']
 
-
 /** Strip default ReactFlow node chrome + animated edges + hover glow */
 const RESET_STYLES = `
   .react-flow__node {

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -39,6 +39,38 @@ import type { AgentWithStatus } from '../types'
  */
 const ATTENTION_STATES: PackageState[] = ['unmanaged', 'drifted', 'update-available']
 
+/**
+ * Provider brand colors — mirrors the canonical KNOWN_PROVIDERS list in
+ * plugins/models/data/known-models.ts. Inlined to avoid cross-plugin import.
+ * Add new providers here when models gains them.
+ */
+const PROVIDER_COLOR: Record<string, string> = {
+  anthropic: '#D97757',
+  openai: '#10A37F',
+  'openai-codex': '#10A37F',
+  google: '#4285F4',
+  ollama: '#0B0B0B',
+  bytedance: '#000000',
+  kuaishou: '#FF4906',
+  runway: '#E0F60A',
+  'black-forest-labs': '#000000',
+  stability: '#0050FF',
+  midjourney: '#131415',
+}
+
+const FALLBACK_PROVIDER_COLOR = '#52525b' // zinc-600 — unknown provider
+
+function providerColorFor(modelId: string): string {
+  if (!modelId) return FALLBACK_PROVIDER_COLOR
+  // Most ids are "<provider>/<model>"; bare `claude-*` resolves to anthropic.
+  const provider = modelId.includes('/')
+    ? modelId.split('/')[0]
+    : modelId.startsWith('claude-')
+      ? 'anthropic'
+      : modelId
+  return PROVIDER_COLOR[provider] ?? FALLBACK_PROVIDER_COLOR
+}
+
 /** Strip default ReactFlow node chrome + animated edges + hover glow */
 const RESET_STYLES = `
   .react-flow__node {
@@ -148,16 +180,21 @@ export function AgentCardNode({ data }: NodeProps) {
           {agent.role || <span className="text-zinc-700">no role</span>}
         </div>
       </div>
-      <div
-        className="px-3 py-2 text-[11px] text-zinc-300 font-mono truncate text-center border-t"
-        style={{
-          background: `linear-gradient(180deg, ${accentColor}22 0%, ${accentColor}33 100%)`,
-          borderTopColor: `${accentColor}33`,
-        }}
-        title={agent.model}
-      >
-        {agent.model}
-      </div>
+      {(() => {
+        const providerColor = providerColorFor(agent.model)
+        return (
+          <div
+            className="px-3 py-2 text-[11px] text-zinc-100 font-mono truncate text-center border-t"
+            style={{
+              background: `linear-gradient(180deg, ${providerColor}22 0%, ${providerColor}40 100%)`,
+              borderTopColor: `${providerColor}55`,
+            }}
+            title={agent.model}
+          >
+            {agent.model}
+          </div>
+        )
+      })()}
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-600" />
     </div>
   )

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -134,7 +134,7 @@ export function AgentCardNode({ data }: NodeProps) {
           <span className="text-xs font-medium text-zinc-100 leading-none">{statusLabel}</span>
         </div>
       </div>
-      <div className="p-3 flex flex-col items-center text-center gap-1">
+      <div className="p-3 pb-3 flex flex-col items-center text-center gap-1 flex-1">
         <div className="flex items-center justify-center gap-1.5 leading-tight w-full">
           <span className="text-base font-semibold text-zinc-100 truncate">{agent.name}</span>
           {showBadge && pkgState && (
@@ -147,12 +147,16 @@ export function AgentCardNode({ data }: NodeProps) {
         >
           {agent.role || <span className="text-zinc-700">no role</span>}
         </div>
-        <div
-          className="text-[11px] text-zinc-400 font-mono truncate mt-1.5 w-full"
-          title={agent.model}
-        >
-          {agent.model}
-        </div>
+      </div>
+      <div
+        className="px-3 py-2 text-[11px] text-zinc-300 font-mono truncate text-center border-t"
+        style={{
+          background: `linear-gradient(180deg, ${accentColor}22 0%, ${accentColor}33 100%)`,
+          borderTopColor: `${accentColor}33`,
+        }}
+        title={agent.model}
+      >
+        {agent.model}
       </div>
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-600" />
     </div>

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -161,13 +161,11 @@ interface SectionNodeData extends Record<string, unknown> {
 function SectionNode({ data }: NodeProps) {
   const { label } = data as SectionNodeData
   return (
-    <div className="flex items-center gap-3 px-4">
+    <div className="flex items-center justify-center px-4">
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0" />
-      <div className="h-px flex-1 bg-zinc-700 w-16" />
       <span className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 whitespace-nowrap">
         {label}
       </span>
-      <div className="h-px flex-1 bg-zinc-700 w-16" />
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0" />
     </div>
   )

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -141,7 +141,9 @@ export function AgentCardNode({ data }: NodeProps) {
             <PackageStateBadge state={pkgState.state} compact />
           )}
         </div>
-        {agent.role && <div className="text-xs text-zinc-500 leading-tight truncate w-full">{agent.role}</div>}
+        <div className="text-xs text-zinc-500 leading-tight truncate w-full">
+          {agent.role || <span className="text-zinc-700">no role</span>}
+        </div>
         <div
           className="text-[11px] text-zinc-400 font-mono truncate mt-1.5 w-full"
           title={agent.model}

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -20,7 +20,9 @@ import { syncConfig as syncMcporter } from '../../src/core/mcporter'
 import { sendMessageToAgent } from '../../src/core/agents'
 import { restartGateway } from '../../src/core/openclaw-client'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
+import { getStatsByMs } from '../../src/core/usage'
 import * as adapter from './lib/openclaw-adapter'
+import { readLatestSessionTranscript } from './lib/session-reader'
 import type { AgentWithStatus, AgentDisplaySettingsMap, HeartbeatData, OrgTeam, TeamPluginSettings } from './types'
 
 const log = createLogger('team')
@@ -1032,6 +1034,77 @@ const teamPlugin: BakinPlugin = {
         const usage = allUsage.find((u) => u.agent === agentId)
 
         return Response.json({ usage: usage ?? null })
+      },
+    })
+
+    // GET /:agentId/heartbeat — Raw HEARTBEAT.md content + lastUpdated
+    ctx.registerRoute({
+      path: '/:agentId/heartbeat',
+      method: 'GET',
+      description: 'Read the agent\'s HEARTBEAT.md narrative + file mtime',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const agentId = url.searchParams.get('agentId')
+        if (!agentId) return Response.json({ ok: false, error: 'agentId required' }, { status: 400 })
+
+        try {
+          const heartbeat = adapter.readHeartbeatRaw(agentId)
+          return Response.json({ ok: true, heartbeat })
+        } catch (err) {
+          log.error('Failed to read heartbeat', err, { agentId })
+          return Response.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+        }
+      },
+    })
+
+    // GET /:agentId/active-context — Latest session transcript (read-only)
+    ctx.registerRoute({
+      path: '/:agentId/active-context',
+      method: 'GET',
+      description: 'Read the most recent session JSONL parsed into a message stream',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const agentId = url.searchParams.get('agentId')
+        if (!agentId) return Response.json({ ok: false, error: 'agentId required' }, { status: 400 })
+
+        const maxParam = url.searchParams.get('max')
+        const maxMessages = maxParam ? Math.max(1, Math.min(1000, parseInt(maxParam, 10) || 200)) : 200
+
+        try {
+          const transcript = readLatestSessionTranscript(agentId, { maxMessages })
+          return Response.json({ ok: true, transcript })
+        } catch (err) {
+          log.error('Failed to read active context', err, { agentId })
+          return Response.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+        }
+      },
+    })
+
+    // GET /:agentId/recent-activity — In-memory dispatch counts per window
+    ctx.registerRoute({
+      path: '/:agentId/recent-activity',
+      method: 'GET',
+      description: 'Per-agent dispatch + error counts across 5m / 1h / 24h windows (resets on server restart)',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const agentId = url.searchParams.get('agentId')
+        if (!agentId) return Response.json({ ok: false, error: 'agentId required' }, { status: 400 })
+
+        try {
+          const windows = { '5m': 5 * 60 * 1000, '1h': 60 * 60 * 1000, '24h': 24 * 60 * 60 * 1000 } as const
+          const windowMs: Record<'5m' | '1h' | '24h', number> = { '5m': 0, '1h': 0, '24h': 0 }
+          const errors: Record<'5m' | '1h' | '24h', number> = { '5m': 0, '1h': 0, '24h': 0 }
+          for (const [key, ms] of Object.entries(windows) as Array<['5m' | '1h' | '24h', number]>) {
+            const stats = getStatsByMs({ kind: 'agent', windowMs: ms, agent: agentId })
+            windowMs[key] = stats.total
+            errors[key] = stats.errors
+          }
+          const sinceServerStart = new Date(Date.now() - process.uptime() * 1000).toISOString()
+          return Response.json({ ok: true, activity: { windowMs, errors, sinceServerStart } })
+        } catch (err) {
+          log.error('Failed to compute recent activity', err, { agentId })
+          return Response.json({ ok: false, error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+        }
       },
     })
 

--- a/plugins/team/lib/build-graph.ts
+++ b/plugins/team/lib/build-graph.ts
@@ -20,8 +20,8 @@ import type { AgentWithStatus, AgentDisplaySettingsMap, OrgTeam } from '../types
 
 // ─── Layout constants ───────────────────────────────────────────────────────
 
-export const CARD_W = 184
-export const CARD_H = 280
+export const CARD_W = 208
+export const CARD_H = 320
 export const X_GAP = 28
 export const Y_GAP = 56
 const TEAM_GAP = 80

--- a/plugins/team/lib/build-graph.ts
+++ b/plugins/team/lib/build-graph.ts
@@ -139,7 +139,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
       id: `mark->${mainAgent.id}`,
       source: 'mark',
       target: mainAgent.id,
-      type: 'smoothstep',
+      type: 'default',
       style: EDGE_STYLE,
     })
     y += CARD_H + Y_GAP
@@ -167,7 +167,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
           id: `${mainAgent.id}->${leader.id}`,
           source: mainAgent.id,
           target: leader.id,
-          type: 'smoothstep',
+          type: 'default',
           style: EDGE_STYLE,
         })
       }
@@ -224,7 +224,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
         id: `${reporterId}->section-${team.id}`,
         source: reporterId,
         target: `section-${team.id}`,
-        type: 'smoothstep',
+        type: 'default',
         style: EDGE_STYLE,
       })
       teamX += teamWidths[t] + TEAM_GAP
@@ -251,7 +251,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
           id: `section-${team.id}->${agent.id}`,
           source: `section-${team.id}`,
           target: agent.id,
-          type: 'smoothstep',
+          type: 'default',
           style: EDGE_DASHED,
         })
       })
@@ -279,7 +279,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
       id: `${mainAgent.id}->section-all`,
       source: mainAgent.id,
       target: 'section-all',
-      type: 'smoothstep',
+      type: 'default',
       style: EDGE_STYLE,
     })
     y += SECTION_ROW_H + Y_GAP
@@ -296,7 +296,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
         id: `section-all->${agent.id}`,
         source: 'section-all',
         target: agent.id,
-        type: 'smoothstep',
+        type: 'default',
         style: EDGE_DASHED,
       })
       assignedIds.add(agent.id)
@@ -329,7 +329,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
         id: `unassigned->${agent.id}`,
         source: 'section-unassigned',
         target: agent.id,
-        type: 'smoothstep',
+        type: 'default',
         style: EDGE_DASHED,
       })
     }

--- a/plugins/team/lib/build-graph.ts
+++ b/plugins/team/lib/build-graph.ts
@@ -20,10 +20,10 @@ import type { AgentWithStatus, AgentDisplaySettingsMap, OrgTeam } from '../types
 
 // ─── Layout constants ───────────────────────────────────────────────────────
 
-export const CARD_W = 152
-export const CARD_H = 240
-export const X_GAP = 24
-export const Y_GAP = 50
+export const CARD_W = 184
+export const CARD_H = 280
+export const X_GAP = 28
+export const Y_GAP = 56
 const TEAM_GAP = 80
 const SECTION_W = 200
 const FOUNDER_W = CARD_W

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -653,7 +653,9 @@ function resolveRole(agentId: string): string {
     }
   }
 
-  // Main agent fallback
+  // Main agent fallback — meaningful role for the orchestrator
   if (agentId === tryGetMainAgentId()) return 'Orchestrator'
-  return 'Agent'
+  // No parseable role and not main: return empty so the UI can hide the
+  // line entirely instead of labeling every agent "Agent" (tautology).
+  return ''
 }

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -627,23 +627,32 @@ export async function updateAgentIdentity(agentId: string, fields: IdentityField
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Match a key:value field in IDENTITY.md. Accepts:
- *   - Markdown bullets: `- Vibe: foo`, `* Role: foo`
- *   - Bold-wrapped keys: `- **Role**: foo`
- *   - Plain lines (no bullet): `Role: foo`
- *   - Headings: `## Role\nfoo` (returns first non-empty line)
+ * Match a key:value field in IDENTITY.md. Accepts every common
+ * markdown shape we've seen in the wild:
  *
- * Returns the trimmed value, or null if no match.
+ *   - `Role: Foo`                — plain
+ *   - `- Role: Foo`              — bulleted
+ *   - `- **Role**: Foo`          — bold key, colon outside wrap
+ *   - `- **Role:** Foo`          — bold key, colon INSIDE wrap
+ *   - `## Role\nFoo`             — heading + value on next line
+ *
+ * Returns the trimmed value with any wrapping asterisks/whitespace
+ * stripped, or null if no match.
  */
 function matchIdentityField(identity: string, key: string): string | null {
-  // Inline form: optional bullet + optional bold + key + colon + value
-  const inlineRe = new RegExp(`^\\s*[-*]?\\s*\\*?${key}\\*?\\s*:\\s*(.+)$`, 'mi')
+  // Inline: optional bullet, 0-2 leading asterisks, key, 0-2 trailing
+  // asterisks, optional whitespace, colon, optional asterisks/whitespace,
+  // value, optional trailing asterisks.
+  const inlineRe = new RegExp(
+    `^\\s*[-*]?\\s*\\*{0,2}${key}\\*{0,2}\\s*:\\s*\\*{0,2}\\s*(.+?)\\s*\\*{0,2}\\s*$`,
+    'mi',
+  )
   const inline = identity.match(inlineRe)
   if (inline) {
     const v = inline[1].trim().replace(/^\*+|\*+$/g, '').trim()
     if (v.length > 0) return v
   }
-  // Heading form: ## Role on its own line, value on next non-empty line
+  // Heading: `## Role` on its own line, value on next non-empty line.
   const headingRe = new RegExp(`^#{1,6}\\s+${key}\\s*$\\n+([^\\n]+)`, 'mi')
   const heading = identity.match(headingRe)
   if (heading) {

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -627,16 +627,49 @@ export async function updateAgentIdentity(agentId: string, fields: IdentityField
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
+ * Match a key:value field in IDENTITY.md. Accepts:
+ *   - Markdown bullets: `- Vibe: foo`, `* Role: foo`
+ *   - Bold-wrapped keys: `- **Role**: foo`
+ *   - Plain lines (no bullet): `Role: foo`
+ *   - Headings: `## Role\nfoo` (returns first non-empty line)
+ *
+ * Returns the trimmed value, or null if no match.
+ */
+function matchIdentityField(identity: string, key: string): string | null {
+  // Inline form: optional bullet + optional bold + key + colon + value
+  const inlineRe = new RegExp(`^\\s*[-*]?\\s*\\*?${key}\\*?\\s*:\\s*(.+)$`, 'mi')
+  const inline = identity.match(inlineRe)
+  if (inline) {
+    const v = inline[1].trim().replace(/^\*+|\*+$/g, '').trim()
+    if (v.length > 0) return v
+  }
+  // Heading form: ## Role on its own line, value on next non-empty line
+  const headingRe = new RegExp(`^#{1,6}\\s+${key}\\s*$\\n+([^\\n]+)`, 'mi')
+  const heading = identity.match(headingRe)
+  if (heading) {
+    const v = heading[1].trim().replace(/^\*+|\*+$/g, '').trim()
+    if (v.length > 0) return v
+  }
+  return null
+}
+
+/**
  * Resolve agent role from IDENTITY.md or SOUL.md content.
  * Falls back to a generic role derived from position in the roster.
+ *
+ * Precedence:
+ *   1. IDENTITY.md `Role:` (the explicit field — wins if present)
+ *   2. IDENTITY.md `Vibe:` (legacy / soft descriptor)
+ *   3. SOUL.md "You are X — the Y" first line
+ *   4. 'Orchestrator' for the main agent, '' for everyone else
  */
 function resolveRole(agentId: string): string {
-  // Try IDENTITY.md first (has structured fields)
   const identity = readWorkspaceFile(agentId, 'IDENTITY.md')
   if (identity) {
-    // Parse simple key: value or YAML frontmatter
-    const vibeMatch = identity.match(/^[-*]\s*\*?Vibe\*?:\s*(.+)/mi)
-    if (vibeMatch) return vibeMatch[1].trim()
+    const role = matchIdentityField(identity, 'Role')
+    if (role) return role
+    const vibe = matchIdentityField(identity, 'Vibe')
+    if (vibe) return vibe
   }
 
   // Try SOUL.md — look for a role-like first line

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -167,6 +167,22 @@ export function readWorkspaceFile(agentId: string, filename: string): string | n
   }
 }
 
+/**
+ * Read the agent's HEARTBEAT.md plus its mtime as the lastUpdated timestamp.
+ * Heartbeat is agent-authored narrative — view-only in the UI.
+ */
+export function readHeartbeatRaw(agentId: string): { content: string; lastUpdated: string | null } | null {
+  const wsPath = getWorkspacePath(agentId)
+  const filePath = join(wsPath, 'HEARTBEAT.md')
+  try {
+    const content = readFileSync(filePath, 'utf-8')
+    const stats = statSync(filePath)
+    return { content, lastUpdated: stats.mtime.toISOString() }
+  } catch {
+    return null
+  }
+}
+
 /** Write a workspace file for an agent. Creates if missing. */
 export function writeWorkspaceFile(agentId: string, filename: string, content: string): void {
   if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {

--- a/plugins/team/lib/openclaw-adapter.ts
+++ b/plugins/team/lib/openclaw-adapter.ts
@@ -150,8 +150,6 @@ export function getWorkspacePath(agentId: string): string {
 
 // ─── Workspace File Operations ───────────────────────────────────────────────
 
-const WORKSPACE_FILES = ['SOUL.md', 'IDENTITY.md', 'AGENTS.md', 'TOOLS.md', 'HEARTBEAT.md', 'USER.md', 'BOOTSTRAP.md'] as const
-
 /** Read a workspace file for an agent. Returns null if missing. */
 export function readWorkspaceFile(agentId: string, filename: string): string | null {
   if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) {

--- a/plugins/team/lib/session-reader.ts
+++ b/plugins/team/lib/session-reader.ts
@@ -1,0 +1,161 @@
+/**
+ * OpenClaw session JSONL → structured message stream.
+ *
+ * Sibling to `src/core/agent-usage.ts`. Where agent-usage sums tokens and
+ * cost across the latest session, session-reader returns the *messages*
+ * themselves so the Active Context tab can show what the agent has been
+ * sent and what it has produced.
+ *
+ * Discovery mirrors agent-usage: most recent session by the first JSONL
+ * line's timestamp (file mtime is unreliable — sessions can be touched out
+ * of order).
+ */
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join } from 'path'
+import { createLogger } from '../../../src/core/logger'
+import { getOpenClawPath } from '@bakin/core/openclaw-home'
+import type { SessionMessage, SessionTranscript } from '../types'
+
+const log = createLogger('team:session-reader')
+
+const DEFAULT_MAX_MESSAGES = 200
+
+interface JsonlEntry {
+  type?: string
+  id?: string
+  timestamp?: string
+  toolName?: string
+  message?: {
+    role?: string
+    model?: string
+    content?: string | unknown
+  }
+}
+
+/**
+ * Pick the most recent session file inside `<agentDir>/sessions/`.
+ * Returns null when the directory is missing or empty.
+ */
+function getLatestSession(agentDir: string): string | null {
+  const sessionsDir = join(agentDir, 'sessions')
+  try {
+    const candidates = readdirSync(sessionsDir).filter(
+      (f) => f.endsWith('.jsonl') && !f.includes('.deleted'),
+    )
+
+    let latest: { path: string; ts: number } | null = null
+    for (const f of candidates) {
+      const filePath = join(sessionsDir, f)
+      try {
+        const firstLine = readFileSync(filePath, 'utf-8').split('\n')[0]
+        const entry = JSON.parse(firstLine) as { timestamp?: string }
+        const ts = entry.timestamp ? new Date(entry.timestamp).getTime() : 0
+        if (!latest || ts > latest.ts) latest = { path: filePath, ts }
+      } catch {
+        const mtime = statSync(filePath).mtimeMs
+        if (!latest || mtime > latest.ts) latest = { path: filePath, ts: mtime }
+      }
+    }
+    return latest?.path ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Stringify any content shape from a JSONL message. Strings pass through;
+ * arrays/objects pretty-print as JSON so tool calls stay readable.
+ */
+function stringifyContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (content == null) return ''
+  try {
+    return JSON.stringify(content, null, 2)
+  } catch {
+    return String(content)
+  }
+}
+
+/**
+ * Parse a session JSONL file into a structured message stream.
+ *
+ * Skip rules:
+ *   - non-message entries (`session`, etc.) are dropped
+ *   - malformed lines are silently ignored (don't blow up the whole transcript)
+ *   - messages with no role and no content are skipped
+ */
+function parseSessionTranscript(
+  filePath: string,
+  maxMessages: number,
+): SessionTranscript | null {
+  let content: string
+  try {
+    content = readFileSync(filePath, 'utf-8')
+  } catch (err) {
+    log.debug('Failed to read session file', { filePath, error: err instanceof Error ? err.message : String(err) })
+    return null
+  }
+
+  const lines = content.split('\n').filter((l) => l.trim())
+
+  let sessionId = ''
+  let sessionStarted: string | null = null
+  const allMessages: SessionMessage[] = []
+
+  for (const line of lines) {
+    let entry: JsonlEntry
+    try {
+      entry = JSON.parse(line) as JsonlEntry
+    } catch {
+      continue
+    }
+
+    if (entry.type === 'session') {
+      sessionId = entry.id ?? sessionId
+      sessionStarted = entry.timestamp ?? sessionStarted
+      continue
+    }
+
+    if (entry.type !== 'message' || !entry.message) continue
+
+    const role = entry.message.role
+    if (role !== 'system' && role !== 'user' && role !== 'assistant' && role !== 'tool') continue
+
+    const text = stringifyContent(entry.message.content)
+    if (!text && role !== 'tool') continue
+
+    allMessages.push({
+      role,
+      content: text,
+      model: entry.message.model,
+      ts: entry.timestamp,
+      toolName: role === 'tool' ? entry.toolName : undefined,
+    })
+  }
+
+  const truncated = allMessages.length > maxMessages
+  const messages = truncated ? allMessages.slice(-maxMessages) : allMessages
+
+  return {
+    sessionId,
+    sessionStarted,
+    messages,
+    truncated,
+    totalMessages: allMessages.length,
+  }
+}
+
+/**
+ * Read the latest session transcript for an agent. Returns null if the
+ * agent has no sessions on disk yet.
+ */
+export function readLatestSessionTranscript(
+  agentId: string,
+  opts?: { maxMessages?: number },
+): SessionTranscript | null {
+  const max = opts?.maxMessages ?? DEFAULT_MAX_MESSAGES
+  const agentDir = getOpenClawPath('agents', agentId)
+  const sessionFile = getLatestSession(agentDir)
+  if (!sessionFile) return null
+  return parseSessionTranscript(sessionFile, max)
+}

--- a/plugins/team/types.ts
+++ b/plugins/team/types.ts
@@ -92,3 +92,53 @@ export interface PackageStateRow {
     dependencies?: string[]
   }
 }
+
+/**
+ * Single message from an OpenClaw session JSONL. Used by the Active Context
+ * tab to render what the agent has actually been sent + has produced.
+ */
+export interface SessionMessage {
+  /** system / user / assistant / tool — drives the role badge color */
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  /** Raw text content. JSON tool calls are pretty-printed by the renderer. */
+  content: string
+  /** Model id present on assistant messages when usage was recorded. */
+  model?: string
+  /** ISO timestamp when present; absent on synthetic system messages. */
+  ts?: string
+  /** Tool name for `role: 'tool'` entries. */
+  toolName?: string
+}
+
+/**
+ * Latest-session transcript surfaced through `/api/plugins/team/:id/active-context`.
+ * `truncated` is true when the underlying JSONL had more than the requested
+ * cap (default 200) and we returned the most-recent N.
+ */
+export interface SessionTranscript {
+  sessionId: string
+  sessionStarted: string | null
+  messages: SessionMessage[]
+  truncated: boolean
+  totalMessages: number
+}
+
+/**
+ * Per-agent activity counts pulled from the in-memory `recordUsage` recorder.
+ * Resets on server restart — `sinceServerStart` exists so the UI can frame
+ * the numbers honestly rather than claim lifetime totals.
+ */
+export interface RecentActivity {
+  windowMs: Record<'5m' | '1h' | '24h', number>
+  errors: Record<'5m' | '1h' | '24h', number>
+  sinceServerStart: string
+}
+
+/**
+ * Raw heartbeat surface — the markdown body the agent wrote to its heartbeat
+ * file plus the file mtime. The Heartbeat tab renders this view-only.
+ */
+export interface HeartbeatRaw {
+  content: string
+  lastUpdated: string | null
+}

--- a/src/components/integrated-brainstorm/index.tsx
+++ b/src/components/integrated-brainstorm/index.tsx
@@ -152,7 +152,7 @@ export function IntegratedBrainstorm({
           ) : (
             <div
               data-testid="brainstorm-history"
-              className="flex-1 min-h-0 overflow-y-auto mb-2 pt-5 pr-1"
+              className="flex-1 min-h-0 overflow-y-auto mb-2 pr-1"
               style={{ scrollbarGutter: 'stable' }}
             >
               {messages.length > 0 && (

--- a/src/components/integrated-brainstorm/index.tsx
+++ b/src/components/integrated-brainstorm/index.tsx
@@ -152,7 +152,7 @@ export function IntegratedBrainstorm({
           ) : (
             <div
               data-testid="brainstorm-history"
-              className="flex-1 min-h-0 overflow-y-auto mb-2 pr-1"
+              className="flex-1 min-h-0 overflow-y-auto mb-2 pt-5 pr-1"
               style={{ scrollbarGutter: 'stable' }}
             >
               {messages.length > 0 && (

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -1,11 +1,77 @@
 'use client'
 
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+/**
+ * Markdown renderer.
+ *
+ * Two responsibilities beyond plain react-markdown:
+ *   1. GitHub-Flavored Markdown via remark-gfm — tables, strikethrough,
+ *      task lists, autolinks. Tables in particular are common in agent
+ *      content (skills with parameter tables, knowledge lessons, etc.)
+ *   2. Bakin marker awareness — `<!-- bakin:X:start -->...<!-- bakin:X:end -->`
+ *      pairs render inside a styled container so the user can see at a
+ *      glance which sections are projector-managed and shouldn't be
+ *      hand-edited. Subtle treatment: thin dotted border + small label.
+ */
+
+const MARKER_PAIR = /<!--\s*bakin:([^\s]+?):start\s*-->([\s\S]*?)<!--\s*bakin:\1:end\s*-->/g
+
+type Segment =
+  | { kind: 'normal'; text: string }
+  | { kind: 'bakin'; markerName: string; body: string }
+
+/**
+ * Split markdown source on bakin marker pairs. Orphan markers (start
+ * without matching end) are left in the normal segment as-is.
+ */
+function splitBakinSegments(source: string): Segment[] {
+  const segments: Segment[] = []
+  let lastIndex = 0
+  for (const match of source.matchAll(MARKER_PAIR)) {
+    const start = match.index ?? 0
+    if (start > lastIndex) {
+      segments.push({ kind: 'normal', text: source.slice(lastIndex, start) })
+    }
+    segments.push({
+      kind: 'bakin',
+      markerName: match[1],
+      body: match[2].trim(),
+    })
+    lastIndex = start + match[0].length
+  }
+  if (lastIndex < source.length) {
+    segments.push({ kind: 'normal', text: source.slice(lastIndex) })
+  }
+  return segments
+}
+
+function MarkdownBody({ content }: { content: string }) {
+  if (!content.trim()) return null
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+}
 
 export function MarkdownContent({ content }: { content: string }) {
+  const segments = splitBakinSegments(content)
   return (
     <div className="prose-invert">
-      <ReactMarkdown>{content}</ReactMarkdown>
+      {segments.map((seg, i) =>
+        seg.kind === 'normal' ? (
+          <MarkdownBody key={i} content={seg.text} />
+        ) : (
+          <div
+            key={i}
+            data-bakin-block={seg.markerName}
+            className="bakin-block my-3 rounded-md border border-dashed border-border/60 px-4 py-3 bg-muted/10"
+          >
+            <div className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-mono mb-2">
+              bakin:{seg.markerName}
+            </div>
+            <MarkdownBody content={seg.body} />
+          </div>
+        ),
+      )}
     </div>
   )
 }

--- a/src/components/markdown-content.tsx
+++ b/src/components/markdown-content.tsx
@@ -63,9 +63,9 @@ export function MarkdownContent({ content }: { content: string }) {
           <div
             key={i}
             data-bakin-block={seg.markerName}
-            className="bakin-block my-3 rounded-md border border-dashed border-border/60 px-4 py-3 bg-muted/10"
+            className="bakin-block my-3 rounded-md border border-dashed border-zinc-500/70 px-4 py-3 bg-zinc-800/40"
           >
-            <div className="text-[10px] uppercase tracking-widest text-muted-foreground/60 font-mono mb-2">
+            <div className="text-[10px] uppercase tracking-widest text-zinc-400 font-mono mb-2">
               bakin:{seg.markerName}
             </div>
             <MarkdownBody content={seg.body} />

--- a/tests/plugins/team/active-context-tab.test.tsx
+++ b/tests/plugins/team/active-context-tab.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+/**
+ * ActiveContextTab — read-only render of the agent's most recent
+ * session JSONL parsed into a message stream.
+ *
+ * Covers: loading, error, empty, populated, role badges per message,
+ * truncation banner, JSON content rendered as <pre>, plain text
+ * rendered via MarkdownContent.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-active-context-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+mock.module('@bakin/sdk/components', () => ({
+  MarkdownContent: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+}))
+
+import { ActiveContextTab } from '../../../plugins/team/components/active-context-tab'
+
+interface TranscriptBody {
+  ok: boolean
+  transcript: {
+    sessionId: string
+    sessionStarted: string | null
+    messages: Array<{ role: string; content: string; model?: string; ts?: string; toolName?: string }>
+    truncated: boolean
+    totalMessages: number
+  } | null
+  error?: string
+}
+
+function setupFetch(body: TranscriptBody) {
+  global.fetch = mock(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response),
+  ) as unknown as typeof global.fetch
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ActiveContextTab', () => {
+  it('renders the loading state before the fetch resolves', () => {
+    let resolveFetch: (value: Response) => void
+    global.fetch = mock(
+      () => new Promise<Response>((res) => { resolveFetch = res }),
+    ) as unknown as typeof global.fetch
+
+    render(<ActiveContextTab agentId="pixel" />)
+    expect(screen.getByText(/Loading session context/)).toBeDefined()
+    resolveFetch!({ ok: true, json: () => Promise.resolve({ ok: true, transcript: null }) } as Response)
+  })
+
+  it('renders the empty state when transcript is null', async () => {
+    setupFetch({ ok: true, transcript: null })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/No session context yet/)).toBeDefined())
+  })
+
+  it('renders the empty state when transcript has zero messages', async () => {
+    setupFetch({
+      ok: true,
+      transcript: { sessionId: 'sess-x', sessionStarted: null, messages: [], truncated: false, totalMessages: 0 },
+    })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/No session context yet/)).toBeDefined())
+  })
+
+  it('renders one row per message with the right role badge', async () => {
+    setupFetch({
+      ok: true,
+      transcript: {
+        sessionId: 'sess-1',
+        sessionStarted: '2026-04-25T10:00:00Z',
+        messages: [
+          { role: 'system', content: 'You are Pixel.' },
+          { role: 'user', content: 'Hello.' },
+          { role: 'assistant', content: 'Hi back.', model: 'claude-opus-4-7' },
+          { role: 'tool', content: '{"ok":true}', toolName: 'bakin_exec_log' },
+        ],
+        truncated: false,
+        totalMessages: 4,
+      },
+    })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText('system')).toBeDefined())
+    expect(screen.getByText('user')).toBeDefined()
+    expect(screen.getByText('assistant')).toBeDefined()
+    expect(screen.getByText('tool')).toBeDefined()
+    expect(screen.getByText('bakin_exec_log')).toBeDefined()
+    expect(screen.getByText('claude-opus-4-7')).toBeDefined()
+  })
+
+  it('shows the truncation banner when transcript.truncated is true', async () => {
+    setupFetch({
+      ok: true,
+      transcript: {
+        sessionId: 'sess-big',
+        sessionStarted: null,
+        messages: [{ role: 'user', content: 'last' }],
+        truncated: true,
+        totalMessages: 500,
+      },
+    })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/Showing latest 1 of 500 messages/)).toBeDefined())
+  })
+
+  it('renders text content via MarkdownContent', async () => {
+    setupFetch({
+      ok: true,
+      transcript: {
+        sessionId: 'sess-md',
+        sessionStarted: null,
+        messages: [{ role: 'user', content: '# Heading' }],
+        truncated: false,
+        totalMessages: 1,
+      },
+    })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByTestId('markdown')).toBeDefined())
+    expect(screen.getByTestId('markdown').textContent).toBe('# Heading')
+  })
+
+  it('renders tool/JSON content as a <pre> code block, not markdown', async () => {
+    setupFetch({
+      ok: true,
+      transcript: {
+        sessionId: 'sess-tool',
+        sessionStarted: null,
+        messages: [{ role: 'tool', content: '{\n  "ok": true\n}', toolName: 't' }],
+        truncated: false,
+        totalMessages: 1,
+      },
+    })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/"ok": true/)).toBeDefined())
+    // Markdown stub should not have been used for tool content
+    expect(screen.queryByTestId('markdown')).toBeNull()
+  })
+
+  it('renders an error state when the API returns ok:false', async () => {
+    setupFetch({ ok: false, transcript: null, error: 'denied' })
+    render(<ActiveContextTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText('denied')).toBeDefined())
+  })
+})

--- a/tests/plugins/team/agent-detail-adopt.test.tsx
+++ b/tests/plugins/team/agent-detail-adopt.test.tsx
@@ -36,7 +36,7 @@ mock.module('../../../packages/core/src/content-dir', () => ({
 }))
 
 mock.module('@/hooks/use-query-state', () => ({
-  useQueryState: (_key: string, _default: string) => ['profile', mock(), mock()],
+  useQueryState: (_key: string, _default: string) => ['overview', mock(), mock()],
 }))
 mock.module('@/hooks/use-gateway-status', () => ({
   useGatewayStatus: () => ({ restartNeeded: false, restart: mock(), restarting: false, markDirty: mock() }),
@@ -67,7 +67,7 @@ function setupFetch() {
   installResponseOk = true
   global.fetch = mock((url: RequestInfo | URL, init?: RequestInit) => {
     const u = String(url)
-    if (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar')) {
+    if (u === '/api/plugins/team/pixel') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(PROFILE) } as Response)
     }
     if (u.startsWith('/api/plugins/models/available')) {
@@ -86,6 +86,10 @@ function setupFetch() {
         json: () => Promise.resolve(installResponseOk ? { ok: true } : { ok: false, error: 'fail' }),
       } as Response)
     }
+    if (u.endsWith('/stats')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ usage: null }) } as Response)
+    if (u.endsWith('/recent-activity')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, activity: { windowMs: { '5m': 0, '1h': 0, '24h': 0 }, errors: { '5m': 0, '1h': 0, '24h': 0 }, sinceServerStart: new Date().toISOString() } }) } as Response)
+    if (u.endsWith('/skills')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ skills: [] }) } as Response)
+    if (u.includes('/api/agent-packages/') && u.endsWith('/knowledge')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, lessons: [] }) } as Response)
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
   }) as unknown as typeof global.fetch
 }
@@ -110,7 +114,7 @@ beforeEach(() => {
 
 async function openDetail() {
   render(<AgentDetail agentId="pixel" />)
-  await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+  await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Pixel' })).toBeDefined())
 }
 
 describe('PackageCard — Adopt flow', () => {

--- a/tests/plugins/team/agent-detail-adopt.test.tsx
+++ b/tests/plugins/team/agent-detail-adopt.test.tsx
@@ -34,6 +34,16 @@ mock.module('../../../packages/core/src/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
 }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
 
 mock.module('@/hooks/use-query-state', () => ({
   useQueryState: (_key: string, _default: string) => ['overview', mock(), mock()],

--- a/tests/plugins/team/agent-detail-adopt.test.tsx
+++ b/tests/plugins/team/agent-detail-adopt.test.tsx
@@ -118,16 +118,21 @@ async function openDetail() {
 }
 
 describe('PackageCard — Adopt flow', () => {
+  // The Package card's Adopt button has a verbose aria-label that explains
+  // what adopting means. The dialog's submit button is just "Adopt". Match
+  // the trigger via the aria-label substring; the submit via exact name.
+  const triggerName = /Adopt this agent/
+
   it('opens AdoptDialog with the agentId baked in when Adopt is clicked', async () => {
     await openDetail()
-    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+    fireEvent.click(screen.getByRole('button', { name: triggerName }))
     // Dialog title bakes in the agentId
     await waitFor(() => expect(screen.getByText(/Adopt pixel into a package/)).toBeDefined())
   })
 
   it('POSTs /api/agent-packages/install with { source, adopt: agentId } on submit', async () => {
     await openDetail()
-    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+    fireEvent.click(screen.getByRole('button', { name: triggerName }))
     await waitFor(() => screen.getByLabelText('Package source'))
     fireEvent.change(screen.getByLabelText('Package source'), {
       target: { value: 'github:examples/pixel@v0.1.0' },
@@ -143,7 +148,7 @@ describe('PackageCard — Adopt flow', () => {
 
   it('refreshes package state on successful adopt', async () => {
     await openDetail()
-    fireEvent.click(screen.getByRole('button', { name: 'Adopt' }))
+    fireEvent.click(screen.getByRole('button', { name: triggerName }))
     await waitFor(() => screen.getByLabelText('Package source'))
     fireEvent.change(screen.getByLabelText('Package source'), {
       target: { value: 'github:examples/pixel' },

--- a/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
+++ b/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
@@ -54,7 +54,7 @@ const PROFILE = {
 function setupFetch() {
   global.fetch = mock((url: RequestInfo | URL) => {
     const u = String(url)
-    if (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar')) {
+    if (u === '/api/plugins/team/pixel') {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(PROFILE) } as Response)
     }
     if (u.startsWith('/api/plugins/models/available')) {
@@ -73,6 +73,9 @@ function setupFetch() {
         }),
       } as Response)
     }
+    if (u.endsWith('/stats')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ usage: null }) } as Response)
+    if (u.endsWith('/recent-activity')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, activity: { windowMs: { '5m': 0, '1h': 0, '24h': 0 }, errors: { '5m': 0, '1h': 0, '24h': 0 }, sinceServerStart: new Date().toISOString() } }) } as Response)
+    if (u.endsWith('/skills')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ skills: [] }) } as Response)
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
   }) as unknown as typeof global.fetch
 }
@@ -91,7 +94,7 @@ afterAll(() => {
 
 afterEach(() => {
   cleanup()
-  queryState.tab = 'profile'
+  queryState.tab = 'overview'
   setTabSpy.mockClear()
 })
 
@@ -101,7 +104,7 @@ beforeEach(() => {
 
 async function openDetail() {
   render(<AgentDetail agentId="pixel" />)
-  await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+  await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Pixel' })).toBeDefined())
 }
 
 describe('AgentDetail — Knowledge tab', () => {

--- a/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
+++ b/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
@@ -6,7 +6,7 @@
  * - Tab is always visible in the tab bar (regardless of package state)
  * - For managed/adopted agents the tab renders KnowledgeToggleList
  *   (which fetches from /api/agent-packages/:id/knowledge)
- * - For unmanaged/absent/undefined the tab renders a "Coming soon"
+ * - For unmanaged/absent/undefined the tab renders a "Knowledge requires a package"
  *   placeholder with a hint pointing back at the Package card
  * - Tab click writes ?tab=knowledge to the URL via useQueryState
  */
@@ -129,7 +129,7 @@ describe('AgentDetail — Knowledge tab', () => {
     await openDetail()
     await waitFor(() => expect(screen.getByText('Lesson One')).toBeDefined())
     expect(screen.getByText('Lesson Two')).toBeDefined()
-    expect(screen.queryByText('Coming soon')).toBeNull()
+    expect(screen.queryByText('Knowledge requires a package')).toBeNull()
   })
 
   it('renders KnowledgeToggleList for state=adopted', async () => {
@@ -141,18 +141,18 @@ describe('AgentDetail — Knowledge tab', () => {
     await waitFor(() => expect(screen.getByText('Lesson One')).toBeDefined())
   })
 
-  it('renders "Coming soon" empty state for state=unmanaged', async () => {
+  it('renders "Knowledge requires a package" empty state for state=unmanaged', async () => {
     primeState({ pixel: { agentId: 'pixel', state: 'unmanaged' } })
     queryState.tab = 'knowledge'
     await openDetail()
-    await waitFor(() => expect(screen.getByText('Coming soon')).toBeDefined())
+    await waitFor(() => expect(screen.getByText('Knowledge requires a package')).toBeDefined())
     expect(screen.queryByText('Lesson One')).toBeNull()
   })
 
-  it('renders "Coming soon" when no package state row exists', async () => {
+  it('renders "Knowledge requires a package" when no package state row exists', async () => {
     primeState()
     queryState.tab = 'knowledge'
     await openDetail()
-    await waitFor(() => expect(screen.getByText('Coming soon')).toBeDefined())
+    await waitFor(() => expect(screen.getByText('Knowledge requires a package')).toBeDefined())
   })
 })

--- a/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
+++ b/tests/plugins/team/agent-detail-knowledge-tab.test.tsx
@@ -26,6 +26,16 @@ mock.module('@bakin/core/main-agent', () => ({
 mock.module('@/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
 mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
 mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
 
 const queryState: { tab: string } = { tab: 'profile' }
 const setTabSpy = mock((v: string) => { queryState.tab = v })

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -38,7 +38,7 @@ mock.module('../../../packages/core/src/content-dir', () => ({
 }))
 
 mock.module('@/hooks/use-query-state', () => ({
-  useQueryState: (_key: string, defaultValue: string) => ['profile', mock(), mock()],
+  useQueryState: (_key: string, defaultValue: string) => ['overview', mock(), mock()],
 }))
 mock.module('@/hooks/use-gateway-status', () => ({
   useGatewayStatus: () => ({ restartNeeded: false, restart: mock(), restarting: false, markDirty: mock() }),
@@ -78,12 +78,16 @@ function primeState(packageStates: Record<string, PackageStateRow> = {}) {
 function mockProfileFetch() {
   global.fetch = mock((url: RequestInfo | URL) => {
     const u = String(url)
-    if (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar')) {
+    if (u === '/api/plugins/team/pixel' || (u.startsWith('/api/plugins/team/pixel') && !u.includes('/avatar') && !u.endsWith('/stats') && !u.endsWith('/recent-activity') && !u.endsWith('/skills') && !u.endsWith('/heartbeat') && !u.endsWith('/active-context'))) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(PROFILE) } as Response)
     }
     if (u.startsWith('/api/plugins/models/available')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve({ models: [] }) } as Response)
     }
+    if (u.endsWith('/stats')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ usage: null }) } as Response)
+    if (u.endsWith('/recent-activity')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, activity: { windowMs: { '5m': 0, '1h': 0, '24h': 0 }, errors: { '5m': 0, '1h': 0, '24h': 0 }, sinceServerStart: new Date().toISOString() } }) } as Response)
+    if (u.endsWith('/skills')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ skills: [] }) } as Response)
+    if (u.includes('/api/agent-packages/') && u.endsWith('/knowledge')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, lessons: [] }) } as Response)
     return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
   }) as unknown as typeof global.fetch
 }
@@ -102,7 +106,8 @@ beforeEach(() => {
 
 async function renderDetail() {
   render(<AgentDetail agentId="pixel" />)
-  await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+  // Wait for the agent header to render (h1 is unique)
+  await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Pixel' })).toBeDefined())
 }
 
 describe('PackageCard — read-only display per state', () => {

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -36,6 +36,16 @@ mock.module('../../../packages/core/src/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
 }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
 
 mock.module('@/hooks/use-query-state', () => ({
   useQueryState: (_key: string, defaultValue: string) => ['overview', mock(), mock()],

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -118,10 +118,10 @@ describe('PackageCard — read-only display per state', () => {
     const adopt = screen.getByRole('button', { name: /Adopt/ })
     expect(adopt).toBeDefined()
     expect((adopt as HTMLButtonElement).disabled).toBe(false)
-    // The explainer text now appears below the button so users understand
+    // The explainer text appears below the button so users understand
     // what adoption means before clicking.
-    expect(screen.getByText(/This agent isn't tracked by an agent-package/)).toBeDefined()
     expect(screen.getByText(/knowledge-lesson toggles/)).toBeDefined()
+    expect(screen.getByText(/workspace files stay as-is/)).toBeDefined()
   })
 
   it('renders a managed badge + entry fields when state=managed', async () => {

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -111,13 +111,17 @@ async function renderDetail() {
 }
 
 describe('PackageCard — read-only display per state', () => {
-  it('renders an unmanaged badge + Adopt button when no row exists', async () => {
+  it('renders an unmanaged badge + Adopt button + explainer when no row exists', async () => {
     primeState()
     await renderDetail()
     expect(screen.getByText('unmanaged')).toBeDefined()
-    const adopt = screen.getByRole('button', { name: 'Adopt' })
+    const adopt = screen.getByRole('button', { name: /Adopt/ })
     expect(adopt).toBeDefined()
     expect((adopt as HTMLButtonElement).disabled).toBe(false)
+    // The explainer text now appears below the button so users understand
+    // what adoption means before clicking.
+    expect(screen.getByText(/This agent isn't tracked by an agent-package/)).toBeDefined()
+    expect(screen.getByText(/knowledge-lesson toggles/)).toBeDefined()
   })
 
   it('renders a managed badge + entry fields when state=managed', async () => {
@@ -185,5 +189,56 @@ describe('PackageCard — read-only display per state', () => {
     expect(screen.getByText('update available')).toBeDefined()
     expect(screen.getByText('bakin agents update pixel')).toBeDefined()
     expect(screen.getByLabelText('Copy command')).toBeDefined()
+  })
+})
+
+describe('PackageCard — main agent special-case', () => {
+  function setupMainFetch() {
+    const MAIN_PROFILE = { ...PROFILE, id: 'main', name: 'Roscoe', role: 'Head Honcho' }
+    global.fetch = mock((url: RequestInfo | URL) => {
+      const u = String(url)
+      if (u === '/api/plugins/team/main') return Promise.resolve({ ok: true, json: () => Promise.resolve(MAIN_PROFILE) } as Response)
+      if (u.startsWith('/api/plugins/models/available')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ models: [] }) } as Response)
+      if (u.endsWith('/stats')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ usage: null }) } as Response)
+      if (u.endsWith('/recent-activity')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, activity: { windowMs: { '5m': 0, '1h': 0, '24h': 0 }, errors: { '5m': 0, '1h': 0, '24h': 0 }, sinceServerStart: new Date().toISOString() } }) } as Response)
+      if (u.endsWith('/skills')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ skills: [] }) } as Response)
+      if (u.includes('/api/agent-packages/') && u.endsWith('/knowledge')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, lessons: [] }) } as Response)
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
+    }) as unknown as typeof global.fetch
+  }
+
+  beforeEach(() => {
+    setupMainFetch()
+    primeState()
+  })
+
+  it('shows "Self-managed" instead of Adopt for the main agent when unmanaged', async () => {
+    render(<AgentDetail agentId="main" />)
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Roscoe' })).toBeDefined())
+
+    // No Adopt button on main
+    expect(screen.queryByRole('button', { name: /Adopt/ })).toBeNull()
+    // Self-managed badge instead
+    expect(screen.getByText('Self-managed')).toBeDefined()
+    // Explainer copy that frames the design choice
+    expect(screen.getByText(/main agent is your own persona/)).toBeDefined()
+  })
+
+  it('still shows package details for main agent if it is somehow managed', async () => {
+    primeState({
+      main: {
+        agentId: 'main',
+        state: 'managed',
+        packageId: 'examples/main@0.1.0',
+        entry: { source: 'github:examples/main', ref: 'v0.1.0', commitSha: 'abcdefg', installedAt: '2026-04-25T00:00:00Z' },
+      },
+    })
+    render(<AgentDetail agentId="main" />)
+    await waitFor(() => expect(screen.getByRole('heading', { level: 1, name: 'Roscoe' })).toBeDefined())
+
+    // Managed/adopted main bypasses the Self-managed special-case and shows
+    // standard package fields. (This is an unusual state but should not crash.)
+    expect(screen.getByText('managed')).toBeDefined()
+    expect(screen.getByText('github:examples/main')).toBeDefined()
   })
 })

--- a/tests/plugins/team/agent-detail-tabs.test.tsx
+++ b/tests/plugins/team/agent-detail-tabs.test.tsx
@@ -5,8 +5,8 @@
  *
  * The agent detail page reads the active tab from `?tab=` via useQueryState.
  * This test pins the three behaviours that matter for bookmarks and shared
- * links: a missing param defaults to Profile, a valid param (soul) selects
- * that tab, and an unknown param falls back to Profile rather than rendering
+ * links: a missing param defaults to Overview, a valid param (soul) selects
+ * that tab, and an unknown param falls back to Overview rather than rendering
  * nothing.  Clicking a tab must write back through setTabParam so the URL
  * stays the source of truth.
  */
@@ -30,6 +30,20 @@ mock.module('@/core/content-dir', () => ({
 mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
 }))
 
 // useQueryState is what we're actually pinning.  The factory reads a global

--- a/tests/plugins/team/agent-detail-tabs.test.tsx
+++ b/tests/plugins/team/agent-detail-tabs.test.tsx
@@ -102,12 +102,12 @@ afterEach(() => {
 })
 
 describe('AgentDetail — tab URL contract', () => {
-  it('defaults to Profile when no ?tab= param is present', async () => {
+  it('defaults to Overview when no ?tab= param is present', async () => {
     queryState.tab = ''
     render(<AgentDetail agentId="scout" />)
-    const profileBtn = await waitFor(() => screen.getByRole('button', { name: 'Profile' }))
+    const overviewBtn = await waitFor(() => screen.getByRole('button', { name: 'Overview' }))
     // Active tab gets the accent underline style applied inline.
-    expect(profileBtn.getAttribute('style') ?? '').toMatch(/border-color/i)
+    expect(overviewBtn.getAttribute('style') ?? '').toMatch(/border-color/i)
   })
 
   it('selects the Soul tab when ?tab=soul is present', async () => {
@@ -115,23 +115,40 @@ describe('AgentDetail — tab URL contract', () => {
     render(<AgentDetail agentId="scout" />)
     const soulBtn = await waitFor(() => screen.getByRole('button', { name: 'Soul' }))
     expect(soulBtn.getAttribute('style') ?? '').toMatch(/border-color/i)
-    // Profile button must NOT be active when Soul is selected.
-    const profileBtn = screen.getByRole('button', { name: 'Profile' })
-    expect(profileBtn.getAttribute('style') ?? '').not.toMatch(/border-color/i)
+    // Overview button must NOT be active when Soul is selected.
+    const overviewBtn = screen.getByRole('button', { name: 'Overview' })
+    expect(overviewBtn.getAttribute('style') ?? '').not.toMatch(/border-color/i)
   })
 
-  it('falls back to Profile when ?tab= is an unknown value', async () => {
+  it('falls back to Overview when ?tab= is an unknown value', async () => {
     queryState.tab = 'bogus'
     render(<AgentDetail agentId="scout" />)
-    const profileBtn = await waitFor(() => screen.getByRole('button', { name: 'Profile' }))
-    expect(profileBtn.getAttribute('style') ?? '').toMatch(/border-color/i)
+    const overviewBtn = await waitFor(() => screen.getByRole('button', { name: 'Overview' }))
+    expect(overviewBtn.getAttribute('style') ?? '').toMatch(/border-color/i)
   })
 
   it('writes the tab back to the URL when a tab is clicked', async () => {
-    queryState.tab = 'profile'
+    queryState.tab = 'overview'
     render(<AgentDetail agentId="scout" />)
     const rulesBtn = await waitFor(() => screen.getByRole('button', { name: 'Rules' }))
     fireEvent.click(rulesBtn)
     expect(setTabSpy).toHaveBeenCalledWith('rules')
+  })
+
+  it('renders the new Heartbeat, Active Context, and Memory tabs in the bar', async () => {
+    queryState.tab = 'overview'
+    render(<AgentDetail agentId="scout" />)
+    await waitFor(() => screen.getByRole('button', { name: 'Overview' }))
+    expect(screen.getByRole('button', { name: 'Memory' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Heartbeat' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Active Context' })).toBeDefined()
+  })
+
+  it('no longer renders the legacy Profile or Stats tabs', async () => {
+    queryState.tab = 'overview'
+    render(<AgentDetail agentId="scout" />)
+    await waitFor(() => screen.getByRole('button', { name: 'Overview' }))
+    expect(screen.queryByRole('button', { name: 'Profile' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Stats' })).toBeNull()
   })
 })

--- a/tests/plugins/team/heartbeat-tab.test.tsx
+++ b/tests/plugins/team/heartbeat-tab.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+/**
+ * Heartbeat tab contract — view-only markdown render with last-updated.
+ *
+ * Covers: loading state, error state, empty state, populated state,
+ * last-updated formatting, absence of any edit/save affordance.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-heartbeat-tab-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+mock.module('@bakin/sdk/components', () => ({
+  MarkdownContent: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+}))
+
+import { HeartbeatTab } from '../../../plugins/team/components/heartbeat-tab'
+
+function setupFetch(body: { ok: boolean; heartbeat: { content: string; lastUpdated: string | null } | null; error?: string }) {
+  global.fetch = mock(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response),
+  ) as unknown as typeof global.fetch
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('HeartbeatTab', () => {
+  it('shows the loading state before the fetch resolves', () => {
+    let resolveFetch: (value: Response) => void
+    global.fetch = mock(
+      () => new Promise<Response>((res) => { resolveFetch = res }),
+    ) as unknown as typeof global.fetch
+
+    render(<HeartbeatTab agentId="pixel" />)
+    expect(screen.getByText(/Loading heartbeat/)).toBeDefined()
+    // Resolve so the test doesn't dangle
+    resolveFetch!({ ok: true, json: () => Promise.resolve({ ok: true, heartbeat: null }) } as Response)
+  })
+
+  it('renders the empty state when heartbeat is null', async () => {
+    setupFetch({ ok: true, heartbeat: null })
+    render(<HeartbeatTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/No heartbeat reported yet/)).toBeDefined())
+  })
+
+  it('renders the markdown content + last updated badge for a populated heartbeat', async () => {
+    setupFetch({
+      ok: true,
+      heartbeat: {
+        content: '## Status\n\nAlive.',
+        lastUpdated: new Date(Date.now() - 5 * 60 * 1000).toISOString(), // 5 minutes ago
+      },
+    })
+    render(<HeartbeatTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByTestId('markdown')).toBeDefined())
+    expect(screen.getByTestId('markdown').textContent).toBe('## Status\n\nAlive.')
+    expect(screen.getByText(/Last updated 5m ago/)).toBeDefined()
+  })
+
+  it('formats sub-minute updates in seconds', async () => {
+    setupFetch({
+      ok: true,
+      heartbeat: { content: 'x', lastUpdated: new Date(Date.now() - 12 * 1000).toISOString() },
+    })
+    render(<HeartbeatTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/Last updated/)).toBeDefined())
+    expect(screen.getByText(/Last updated 1[12]s ago/)).toBeDefined()
+  })
+
+  it('formats day-old updates in days', async () => {
+    setupFetch({
+      ok: true,
+      heartbeat: { content: 'x', lastUpdated: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString() },
+    })
+    render(<HeartbeatTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText(/Last updated 3d ago/)).toBeDefined())
+  })
+
+  it('renders an error state when the API returns ok:false', async () => {
+    setupFetch({ ok: false, heartbeat: null, error: 'boom' })
+    render(<HeartbeatTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByText('boom')).toBeDefined())
+  })
+
+  it('exposes no edit affordance — Heartbeat is view-only', async () => {
+    setupFetch({
+      ok: true,
+      heartbeat: { content: 'alive', lastUpdated: new Date().toISOString() },
+    })
+    render(<HeartbeatTab agentId="pixel" />)
+    await waitFor(() => expect(screen.getByTestId('markdown')).toBeDefined())
+    expect(screen.queryByLabelText(/Edit/i)).toBeNull()
+    expect(screen.queryByLabelText(/Save/i)).toBeNull()
+    expect(screen.queryByRole('textbox')).toBeNull()
+  })
+})

--- a/tests/plugins/team/heartbeat-tab.test.tsx
+++ b/tests/plugins/team/heartbeat-tab.test.tsx
@@ -106,14 +106,22 @@ describe('HeartbeatTab', () => {
     await waitFor(() => expect(screen.getByText('boom')).toBeDefined())
   })
 
-  it('exposes no edit affordance — Heartbeat is view-only', async () => {
+  it('shows a disabled edit button (visual parity with markdown tabs) but no editable surface', async () => {
     setupFetch({
       ok: true,
       heartbeat: { content: 'alive', lastUpdated: new Date().toISOString() },
     })
     render(<HeartbeatTab agentId="pixel" />)
     await waitFor(() => expect(screen.getByTestId('markdown')).toBeDefined())
-    expect(screen.queryByLabelText(/Edit/i)).toBeNull()
+
+    // Button is present so the corner real-estate matches Soul/Rules/Tools
+    // tabs, but it's explicitly disabled with an explanatory tooltip.
+    const btn = screen.getByLabelText(/Edit disabled/) as HTMLButtonElement
+    expect(btn).toBeDefined()
+    expect(btn.disabled).toBe(true)
+
+    // No save button, no editable textbox — the disabled affordance is
+    // visual parity only, never lets the user edit.
     expect(screen.queryByLabelText(/Save/i)).toBeNull()
     expect(screen.queryByRole('textbox')).toBeNull()
   })

--- a/tests/plugins/team/heartbeat-tab.test.tsx
+++ b/tests/plugins/team/heartbeat-tab.test.tsx
@@ -64,7 +64,7 @@ describe('HeartbeatTab', () => {
   it('renders the empty state when heartbeat is null', async () => {
     setupFetch({ ok: true, heartbeat: null })
     render(<HeartbeatTab agentId="pixel" />)
-    await waitFor(() => expect(screen.getByText(/No heartbeat reported yet/)).toBeDefined())
+    await waitFor(() => expect(screen.getByText(/No heartbeat yet/)).toBeDefined())
   })
 
   it('renders the markdown content + last updated badge for a populated heartbeat', async () => {

--- a/tests/plugins/team/markdown-edit-tab.test.tsx
+++ b/tests/plugins/team/markdown-edit-tab.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+/**
+ * Wiring contract for MarkdownEditTab — the Assets-style view/edit
+ * pattern reused by Soul / Rules / Tools tabs in agent-detail.
+ *
+ * Covers: default view-mode renders MarkdownContent, pencil → edit
+ * mode, save POSTs to the right endpoint, Cancel reverts, Cmd+S
+ * triggers save when dirty (and not when clean), missing file
+ * shows the "does not exist" empty state.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-markdown-edit-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+// MarkdownContent renders raw text in tests so we can assert on content.
+mock.module('@bakin/sdk/components', () => ({
+  MarkdownContent: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+}))
+
+import { MarkdownEditTab } from '../../../plugins/team/components/markdown-edit-tab'
+
+const fetchCalls: Array<{ url: string; init?: RequestInit }> = []
+
+function setupFetch(opts: { ok?: boolean } = {}) {
+  fetchCalls.length = 0
+  global.fetch = mock((url: RequestInfo | URL, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init })
+    return Promise.resolve({ ok: opts.ok ?? true, json: () => Promise.resolve({ ok: true }) } as Response)
+  }) as unknown as typeof global.fetch
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  setupFetch()
+})
+
+describe('MarkdownEditTab', () => {
+  it('renders the markdown view by default with the pencil button visible', () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="# Pixel persona" />)
+    expect(screen.getByTestId('markdown').textContent).toBe('# Pixel persona')
+    expect(screen.getByLabelText('Edit markdown')).toBeDefined()
+    expect(screen.queryByLabelText('Save changes')).toBeNull()
+  })
+
+  it('shows the empty-state message when initialContent is null', () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent={null} />)
+    expect(screen.getByText(/does not exist/)).toBeDefined()
+    expect(screen.queryByLabelText('Edit markdown')).toBeNull()
+  })
+
+  it('switches to edit mode and shows save+cancel when pencil is clicked', () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    expect(screen.getByLabelText('Save changes')).toBeDefined()
+    expect(screen.getByLabelText('Cancel edit')).toBeDefined()
+    expect(screen.queryByLabelText('Edit markdown')).toBeNull()
+    // Textarea is the edit surface
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textarea.value).toBe('hello')
+  })
+
+  it('save button stays disabled until the user types something different', () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    const save = screen.getByLabelText('Save changes') as HTMLButtonElement
+    expect(save.disabled).toBe(true)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello world' } })
+    expect((screen.getByLabelText('Save changes') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('POSTs the new content to /api/plugins/team/:agentId/files/:filename', async () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'updated body' } })
+    fireEvent.click(screen.getByLabelText('Save changes'))
+
+    await waitFor(() => expect(fetchCalls.length).toBe(1))
+    const call = fetchCalls[0]
+    expect(call.url).toBe('/api/plugins/team/pixel/files/SOUL.md')
+    expect(call.init?.method).toBe('PUT')
+    expect(JSON.parse(call.init?.body as string)).toEqual({ content: 'updated body' })
+  })
+
+  it('exits edit mode and shows the new content after a successful save', async () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'updated body' } })
+    fireEvent.click(screen.getByLabelText('Save changes'))
+
+    await waitFor(() => expect(screen.queryByRole('textbox')).toBeNull())
+    expect(screen.getByTestId('markdown').textContent).toBe('updated body')
+    expect(screen.getByLabelText('Edit markdown')).toBeDefined()
+  })
+
+  it('Cancel exits edit mode and discards local changes', () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'never persisted' } })
+    fireEvent.click(screen.getByLabelText('Cancel edit'))
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.getByTestId('markdown').textContent).toBe('hello')
+    expect(fetchCalls.length).toBe(0)
+  })
+
+  it('Cmd+S triggers save when dirty', async () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'changed' } })
+    fireEvent.keyDown(window, { key: 's', metaKey: true })
+    await waitFor(() => expect(fetchCalls.length).toBe(1))
+  })
+
+  it('Cmd+S is a no-op when nothing has changed', async () => {
+    render(<MarkdownEditTab agentId="pixel" filename="SOUL.md" initialContent="hello" />)
+    fireEvent.click(screen.getByLabelText('Edit markdown'))
+    fireEvent.keyDown(window, { key: 's', metaKey: true })
+    // Wait briefly so any spurious fetch would have fired.
+    await new Promise((r) => setTimeout(r, 30))
+    expect(fetchCalls.length).toBe(0)
+  })
+})

--- a/tests/plugins/team/openclaw-adapter.test.ts
+++ b/tests/plugins/team/openclaw-adapter.test.ts
@@ -126,6 +126,7 @@ const {
   listAgents, addAgent, removeAgent, removeFromAllowLists,
   openclawExec, synthesizeIdentityMd, addToAllowLists,
   setSubagentPermissions, parseIdentityMd, updateAgentIdentity,
+  readHeartbeatRaw,
 } = require('../../../plugins/team/lib/openclaw-adapter') as typeof import('../../../plugins/team/lib/openclaw-adapter')
 
 // ---------------------------------------------------------------------------
@@ -798,5 +799,36 @@ describe('team/openclaw-adapter · updateAgentIdentity', () => {
     await updateAgentIdentity('pixel', { role: 'New Role', vibe: 'Calm' })
 
     expect(execFileMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('team/openclaw-adapter · readHeartbeatRaw', () => {
+  const pixelWs = join(testDir, 'openclaw', 'workspaces', 'heartbeat-test')
+  const heartbeatFile = join(pixelWs, 'HEARTBEAT.md')
+
+  beforeEach(() => {
+    readOpenClawConfigMock.mockReset()
+    setConfig({ agents: { list: [{ id: 'main' }, { id: 'heartbeat-test' }] } })
+    rmSync(pixelWs, { recursive: true, force: true })
+    mkdirSync(pixelWs, { recursive: true })
+  })
+
+  it('returns content + lastUpdated for an existing HEARTBEAT.md', () => {
+    const fs = require('fs') as typeof import('fs')
+    fs.writeFileSync(heartbeatFile, '## Status\n\nAlive and well.\n')
+
+    const result = readHeartbeatRaw('heartbeat-test')
+
+    expect(result).not.toBeNull()
+    expect(result!.content).toBe('## Status\n\nAlive and well.\n')
+    expect(result!.lastUpdated).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('returns null when HEARTBEAT.md is missing', () => {
+    expect(readHeartbeatRaw('heartbeat-test')).toBeNull()
+  })
+
+  it('returns null for an unknown agent', () => {
+    expect(readHeartbeatRaw('does-not-exist')).toBeNull()
   })
 })

--- a/tests/plugins/team/overview-tab.test.tsx
+++ b/tests/plugins/team/overview-tab.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+/**
+ * OverviewTab — consolidated agent dashboard.
+ *
+ * Covers all the panels: Identity, Settings (model + team), Package
+ * card (delegated), Workspace, Capacity (skills + knowledge counts),
+ * Latest Session (folded-in Stats data), Recent Activity.
+ *
+ * Tests the wiring shape — fetches happen, UI reflects responses,
+ * model + team interactions fire the right round-trips.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+
+const testDir = join(tmpdir(), `bakin-test-overview-tab-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: () => ({}) }))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+mock.module('@bakin/sdk/components', () => ({
+  ModelSelect: ({ value, onChange, models }: { value: string; onChange: (id: string) => void; models: { id: string; label: string }[] }) => (
+    <select data-testid="model-select" value={value} onChange={(e) => onChange(e.target.value)}>
+      {models.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+    </select>
+  ),
+  MarkdownContent: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+}))
+
+import { useAgentStore } from '../../../plugins/team/hooks/use-agent-store'
+import { OverviewTab } from '../../../plugins/team/components/overview-tab'
+import type { PackageStateRow } from '../../../plugins/team/types'
+
+const PROFILE = {
+  id: 'pixel',
+  name: 'Pixel',
+  emoji: '🎨',
+  role: 'designer',
+  headshot: '',
+  model: 'claude-opus-4-7',
+  workspacePath: '/tmp/openclaw/workspaces/pixel',
+  identity: null, soul: null, rules: null, tools: null, heartbeatMd: null,
+  subagentPerms: null,
+}
+
+interface FetchExpectation {
+  stats?: { usage: { agent: string; sessionId: string; sessionStarted: string; model: string; messages: number; tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }; cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } } | null }
+  recentActivity?: { ok: boolean; activity?: { windowMs: Record<string, number>; errors: Record<string, number>; sinceServerStart: string } }
+  skills?: { skills: Array<{ id: string }> }
+  knowledge?: { ok: boolean; lessons?: Array<{ enabled: boolean }> }
+}
+
+const teamRoutes: Array<{ url: string; init?: RequestInit }> = []
+
+function setupFetch(exp: FetchExpectation) {
+  teamRoutes.length = 0
+  global.fetch = mock((url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url)
+    teamRoutes.push({ url: u, init })
+    if (u.endsWith('/stats')) return Promise.resolve({ ok: true, json: () => Promise.resolve(exp.stats ?? { usage: null }) } as Response)
+    if (u.endsWith('/recent-activity')) return Promise.resolve({ ok: true, json: () => Promise.resolve(exp.recentActivity ?? { ok: true, activity: { windowMs: { '5m': 0, '1h': 0, '24h': 0 }, errors: { '5m': 0, '1h': 0, '24h': 0 }, sinceServerStart: new Date().toISOString() } }) } as Response)
+    if (u.endsWith('/skills')) return Promise.resolve({ ok: true, json: () => Promise.resolve(exp.skills ?? { skills: [] }) } as Response)
+    if (u.includes('/api/agent-packages/') && u.endsWith('/knowledge')) return Promise.resolve({ ok: true, json: () => Promise.resolve(exp.knowledge ?? { ok: true, lessons: [] }) } as Response)
+    if (u.endsWith('/team')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) } as Response)
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response)
+  }) as unknown as typeof global.fetch
+}
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  useAgentStore.setState({
+    agents: [], agentIds: [], agentMap: {}, agentsWithStatus: [],
+    displaySettings: { pixel: { teamId: 'team-design' } as never },
+    teams: [{ id: 'team-design', label: 'Design', leaderId: '', reportsTo: null }],
+    packageStates: {},
+    mainAgentId: 'main', loaded: true,
+  } as never)
+  setupFetch({})
+})
+
+describe('OverviewTab', () => {
+  function renderTab(packageState?: PackageStateRow) {
+    return render(
+      <OverviewTab
+        agentId="pixel"
+        profile={PROFILE}
+        packageState={packageState}
+        availableModels={[{ id: 'claude-opus-4-7', name: 'Opus 4.7', label: 'Opus' } as never, { id: 'claude-sonnet-4-6', name: 'Sonnet', label: 'Sonnet' } as never]}
+        onModelChange={mock(async () => {})}
+        savingModel={false}
+      />,
+    )
+  }
+
+  it('renders identity (name + role + emoji)', () => {
+    renderTab()
+    expect(screen.getByText('Pixel')).toBeDefined()
+    expect(screen.getByText('designer')).toBeDefined()
+    expect(screen.getByText('🎨')).toBeDefined()
+  })
+
+  it('renders the model selector pre-set to the agent\'s model', () => {
+    renderTab()
+    const select = screen.getByTestId('model-select') as HTMLSelectElement
+    expect(select.value).toBe('claude-opus-4-7')
+  })
+
+  it('renders the team selector with the current team', () => {
+    renderTab()
+    const teamSelect = screen.getAllByRole('combobox').find((s) => (s as HTMLSelectElement).value === 'team-design')
+    expect(teamSelect).toBeDefined()
+  })
+
+  it('renders the workspace path', () => {
+    renderTab()
+    expect(screen.getByText('/tmp/openclaw/workspaces/pixel')).toBeDefined()
+  })
+
+  it('fetches stats / recent-activity / skills / knowledge in parallel and renders the counts', async () => {
+    setupFetch({
+      stats: { usage: { agent: 'pixel', sessionId: 's', sessionStarted: '', model: 'claude-opus-4-7', messages: 12, tokens: { input: 1000, output: 500, cacheRead: 200, cacheWrite: 50, total: 1750 }, cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0.001, total: 0.03 } } },
+      recentActivity: { ok: true, activity: { windowMs: { '5m': 1, '1h': 7, '24h': 23 }, errors: { '5m': 0, '1h': 1, '24h': 1 }, sinceServerStart: new Date().toISOString() } },
+      skills: { skills: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] },
+      knowledge: { ok: true, lessons: [{ enabled: true }, { enabled: true }, { enabled: false }, { enabled: false }, { enabled: false }] },
+    })
+    renderTab()
+    await waitFor(() => expect(screen.getByText('1,750')).toBeDefined())
+    // Distinct values per tile so getByText is unambiguous
+    expect(screen.getByText('3')).toBeDefined() // skills count
+    expect(screen.getByText('5')).toBeDefined() // knowledge total
+    expect(screen.getByText('2 enabled')).toBeDefined()
+    expect(screen.getByText('1')).toBeDefined() // 5m count
+    expect(screen.getByText('7')).toBeDefined() // 1h count
+    expect(screen.getByText('23')).toBeDefined() // 24h count
+  })
+
+  it('shows the no-data fallback when stats endpoint returns null', async () => {
+    setupFetch({ stats: { usage: null } })
+    renderTab()
+    await waitFor(() => expect(screen.getByText('No session data yet')).toBeDefined())
+  })
+
+  it('writes /team on team select change', async () => {
+    renderTab()
+    const teamSelect = screen.getAllByRole('combobox').find((s) => (s as HTMLSelectElement).value === 'team-design') as HTMLSelectElement
+    fireEvent.change(teamSelect, { target: { value: '' } })
+    await waitFor(() => {
+      const teamWrites = teamRoutes.filter((c) => c.url === '/api/plugins/team/pixel/team' && c.init?.method === 'PUT')
+      expect(teamWrites.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('renders the embedded PackageCard for the agent (delegating to its own surface)', async () => {
+    renderTab({ agentId: 'pixel', state: 'managed', packageId: 'examples/pixel@0.1.0' })
+    expect(screen.getByText('managed')).toBeDefined()
+  })
+})

--- a/tests/plugins/team/overview-tab.test.tsx
+++ b/tests/plugins/team/overview-tab.test.tsx
@@ -155,10 +155,16 @@ describe('OverviewTab', () => {
     expect(screen.getByText('23')).toBeDefined() // 24h count
   })
 
-  it('shows the no-data fallback when stats endpoint returns null', async () => {
+  it('shows em-dash placeholders + suppresses the secondary metric row when stats is null', async () => {
     setupFetch({ stats: { usage: null } })
     renderTab()
-    await waitFor(() => expect(screen.getByText('No session data yet')).toBeDefined())
+    // Top-row tiles render '—' for missing data
+    await waitFor(() => expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2))
+    // The secondary row (Model / Messages / Cache reads / Cache writes) only
+    // renders when usage is present — confirm via labels unique to that row.
+    expect(screen.queryByText('Cache reads')).toBeNull()
+    expect(screen.queryByText('Cache writes')).toBeNull()
+    expect(screen.queryByText('Messages')).toBeNull()
   })
 
   it('writes /team on team select change', async () => {

--- a/tests/plugins/team/overview-tab.test.tsx
+++ b/tests/plugins/team/overview-tab.test.tsx
@@ -113,11 +113,13 @@ describe('OverviewTab', () => {
     )
   }
 
-  it('renders identity (name + role + emoji)', () => {
+  it('does NOT render identity (name/role/emoji) — header owns that surface', () => {
     renderTab()
-    expect(screen.getByText('Pixel')).toBeDefined()
-    expect(screen.getByText('designer')).toBeDefined()
-    expect(screen.getByText('🎨')).toBeDefined()
+    // OverviewTab is rendered standalone in this test (no AgentDetail
+    // header), so the identity strings should be entirely absent.
+    expect(screen.queryByText('Pixel')).toBeNull()
+    expect(screen.queryByText('designer')).toBeNull()
+    expect(screen.queryByText('🎨')).toBeNull()
   })
 
   it('renders the model selector pre-set to the agent\'s model', () => {

--- a/tests/plugins/team/overview-tab.test.tsx
+++ b/tests/plugins/team/overview-tab.test.tsx
@@ -134,9 +134,9 @@ describe('OverviewTab', () => {
     expect(teamSelect).toBeDefined()
   })
 
-  it('renders the workspace path', () => {
+  it('does NOT render the workspace path — header owns that surface now', () => {
     renderTab()
-    expect(screen.getByText('/tmp/openclaw/workspaces/pixel')).toBeDefined()
+    expect(screen.queryByText('/tmp/openclaw/workspaces/pixel')).toBeNull()
   })
 
   it('fetches stats / recent-activity / skills / knowledge in parallel and renders the counts', async () => {

--- a/tests/plugins/team/routes.test.ts
+++ b/tests/plugins/team/routes.test.ts
@@ -108,6 +108,14 @@ mock.module('../../../src/core/agent-usage', () => ({
   getAllAgentUsage: mock(() => []),
 }))
 
+mock.module('../../../src/core/usage', () => ({
+  getStatsByMs: mock(() => ({ total: 0, errors: 0 })),
+}))
+
+mock.module('../../../plugins/team/lib/session-reader', () => ({
+  readLatestSessionTranscript: mock(() => null),
+}))
+
 mock.module('../../../src/lib/agents', () => ({
   startAgent: mock(async () => {}),
   stopAgent: mock(async () => {}),
@@ -165,6 +173,7 @@ mock.module('@bakin/team/lib/openclaw-adapter', () => ({
   addToAllowLists: mock(),
   setSubagentPermissions: mock(),
   updateAgentIdentity: mock(async () => ['name', 'role']),
+  readHeartbeatRaw: mock(() => null),
 }))
 
 // The team plugin's relative import path inside the plugin uses './lib/openclaw-adapter'.
@@ -205,6 +214,7 @@ mock.module('../../../plugins/team/lib/openclaw-adapter', () => ({
   addToAllowLists: mock(),
   setSubagentPermissions: mock(),
   updateAgentIdentity: mock(async () => ['name', 'role']),
+  readHeartbeatRaw: mock(() => null),
 }))
 
 // ---------------------------------------------------------------------------
@@ -689,5 +699,118 @@ describe('team plugin — PUT /:agentId/permissions', () => {
     })
     expect(status).toBe(400)
     expect((body as { error: string }).error).toMatch(/ghost/)
+  })
+})
+
+describe('team plugin — GET /:agentId/heartbeat', () => {
+  let activated: ActivatedPlugin
+
+  beforeAll(async () => {
+    activated = await activatePlugin(teamPlugin, testDir)
+  })
+
+  it('rejects missing agentId with 400', async () => {
+    const route = findRoute(activated.routes, 'GET', '/:agentId/heartbeat')!
+    const { status } = await callRoute(route, activated.ctx, { searchParams: {} })
+    expect(status).toBe(400)
+  })
+
+  it('returns null heartbeat when none exists', async () => {
+    const adapterMod = await import('../../../plugins/team/lib/openclaw-adapter')
+    const spy = adapterMod.readHeartbeatRaw as ReturnType<typeof mock>
+    spy.mockReturnValueOnce(null)
+
+    const route = findRoute(activated.routes, 'GET', '/:agentId/heartbeat')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { agentId: 'main' } })
+    expect(status).toBe(200)
+    expect(body).toEqual({ ok: true, heartbeat: null })
+  })
+
+  it('returns content + lastUpdated when the file exists', async () => {
+    const adapterMod = await import('../../../plugins/team/lib/openclaw-adapter')
+    const spy = adapterMod.readHeartbeatRaw as ReturnType<typeof mock>
+    spy.mockReturnValueOnce({ content: '## Alive', lastUpdated: '2026-04-25T10:00:00.000Z' })
+
+    const route = findRoute(activated.routes, 'GET', '/:agentId/heartbeat')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { agentId: 'pixel' } })
+    expect(status).toBe(200)
+    expect(body).toEqual({
+      ok: true,
+      heartbeat: { content: '## Alive', lastUpdated: '2026-04-25T10:00:00.000Z' },
+    })
+  })
+})
+
+describe('team plugin — GET /:agentId/active-context', () => {
+  let activated: ActivatedPlugin
+
+  beforeAll(async () => {
+    activated = await activatePlugin(teamPlugin, testDir)
+  })
+
+  it('rejects missing agentId with 400', async () => {
+    const route = findRoute(activated.routes, 'GET', '/:agentId/active-context')!
+    const { status } = await callRoute(route, activated.ctx, { searchParams: {} })
+    expect(status).toBe(400)
+  })
+
+  it('returns transcript=null when no session exists', async () => {
+    const sessionMod = await import('../../../plugins/team/lib/session-reader')
+    const spy = sessionMod.readLatestSessionTranscript as ReturnType<typeof mock>
+    spy.mockReturnValueOnce(null)
+
+    const route = findRoute(activated.routes, 'GET', '/:agentId/active-context')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { agentId: 'main' } })
+    expect(status).toBe(200)
+    expect(body).toEqual({ ok: true, transcript: null })
+  })
+
+  it('returns the parsed transcript and respects the max query param', async () => {
+    const sessionMod = await import('../../../plugins/team/lib/session-reader')
+    const spy = sessionMod.readLatestSessionTranscript as ReturnType<typeof mock>
+    const transcript = {
+      sessionId: 'sess-1',
+      sessionStarted: '2026-04-25T10:00:00Z',
+      messages: [{ role: 'user', content: 'hi' }],
+      truncated: false,
+      totalMessages: 1,
+    }
+    spy.mockReturnValueOnce(transcript)
+
+    const route = findRoute(activated.routes, 'GET', '/:agentId/active-context')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { agentId: 'pixel', max: '50' } })
+    expect(status).toBe(200)
+    expect(body).toEqual({ ok: true, transcript })
+    expect(spy).toHaveBeenCalledWith('pixel', { maxMessages: 50 })
+  })
+})
+
+describe('team plugin — GET /:agentId/recent-activity', () => {
+  let activated: ActivatedPlugin
+
+  beforeAll(async () => {
+    activated = await activatePlugin(teamPlugin, testDir)
+  })
+
+  it('rejects missing agentId with 400', async () => {
+    const route = findRoute(activated.routes, 'GET', '/:agentId/recent-activity')!
+    const { status } = await callRoute(route, activated.ctx, { searchParams: {} })
+    expect(status).toBe(400)
+  })
+
+  it('returns counts across 5m / 1h / 24h windows + sinceServerStart', async () => {
+    const usageMod = await import('../../../src/core/usage')
+    const spy = usageMod.getStatsByMs as ReturnType<typeof mock>
+    spy.mockReturnValueOnce({ total: 1, errors: 0 })
+       .mockReturnValueOnce({ total: 5, errors: 1 })
+       .mockReturnValueOnce({ total: 12, errors: 2 })
+
+    const route = findRoute(activated.routes, 'GET', '/:agentId/recent-activity')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { agentId: 'pixel' } })
+    expect(status).toBe(200)
+    const activity = (body as { activity: { windowMs: Record<string, number>; errors: Record<string, number>; sinceServerStart: string } }).activity
+    expect(activity.windowMs).toEqual({ '5m': 1, '1h': 5, '24h': 12 })
+    expect(activity.errors).toEqual({ '5m': 0, '1h': 1, '24h': 2 })
+    expect(activity.sinceServerStart).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 })

--- a/tests/plugins/team/session-reader.test.ts
+++ b/tests/plugins/team/session-reader.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure-function tests for plugins/team/lib/session-reader.ts.
+ *
+ * Strategy: write fixture JSONL files into a tmp OpenClaw home, point
+ * the openclaw-home resolver at it, then call readLatestSessionTranscript
+ * directly. No HTTP, no React.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-session-reader-${Date.now()}-${randomUUID()}`)
+const openclawHome = join(testDir, 'openclaw')
+const agentsDir = join(openclawHome, 'agents')
+
+process.env.OPENCLAW_HOME = openclawHome
+process.env.BAKIN_HOME = testDir
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => openclawHome,
+  getOpenClawPath: (...parts: string[]) => join(openclawHome, ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../packages/core/src/openclaw-home', () => ({
+  getOpenClawHome: () => openclawHome,
+  getOpenClawPath: (...parts: string[]) => join(openclawHome, ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { readLatestSessionTranscript } from '../../../plugins/team/lib/session-reader'
+
+function writeSession(agentId: string, filename: string, lines: object[]) {
+  const sessionDir = join(agentsDir, agentId, 'sessions')
+  mkdirSync(sessionDir, { recursive: true })
+  writeFileSync(
+    join(sessionDir, filename),
+    lines.map((l) => JSON.stringify(l)).join('\n') + '\n',
+  )
+}
+
+beforeAll(() => {
+  mkdirSync(agentsDir, { recursive: true })
+})
+
+beforeEach(() => {
+  // Clean per-test agent dirs so fixtures don't leak between cases.
+  rmSync(agentsDir, { recursive: true, force: true })
+  mkdirSync(agentsDir, { recursive: true })
+})
+
+afterAll(() => {
+  try { rmSync(testDir, { recursive: true, force: true }) } catch {}
+})
+
+describe('readLatestSessionTranscript', () => {
+  it('returns null when the agent has no sessions directory', () => {
+    expect(readLatestSessionTranscript('ghost')).toBeNull()
+  })
+
+  it('returns null when the sessions directory is empty', () => {
+    mkdirSync(join(agentsDir, 'pixel', 'sessions'), { recursive: true })
+    expect(readLatestSessionTranscript('pixel')).toBeNull()
+  })
+
+  it('parses a happy-path session into a structured transcript', () => {
+    writeSession('pixel', '2026-04-25.jsonl', [
+      { type: 'session', id: 'sess-123', timestamp: '2026-04-25T10:00:00Z' },
+      { type: 'message', timestamp: '2026-04-25T10:00:01Z', message: { role: 'system', content: 'You are Pixel.' } },
+      { type: 'message', timestamp: '2026-04-25T10:00:05Z', message: { role: 'user', content: 'Hello.' } },
+      { type: 'message', timestamp: '2026-04-25T10:00:10Z', message: { role: 'assistant', model: 'claude-opus-4-7', content: 'Hi Mark!' } },
+    ])
+
+    const transcript = readLatestSessionTranscript('pixel')
+    expect(transcript).not.toBeNull()
+    expect(transcript!.sessionId).toBe('sess-123')
+    expect(transcript!.sessionStarted).toBe('2026-04-25T10:00:00Z')
+    expect(transcript!.totalMessages).toBe(3)
+    expect(transcript!.truncated).toBe(false)
+    expect(transcript!.messages).toHaveLength(3)
+    expect(transcript!.messages[0]).toMatchObject({ role: 'system', content: 'You are Pixel.' })
+    expect(transcript!.messages[2]).toMatchObject({ role: 'assistant', model: 'claude-opus-4-7', content: 'Hi Mark!' })
+  })
+
+  it('skips malformed JSONL lines without breaking the whole transcript', () => {
+    const sessionDir = join(agentsDir, 'pixel', 'sessions')
+    mkdirSync(sessionDir, { recursive: true })
+    writeFileSync(
+      join(sessionDir, 'mixed.jsonl'),
+      [
+        JSON.stringify({ type: 'session', id: 'sess-bad', timestamp: '2026-04-25T10:00:00Z' }),
+        '{ this is not valid json',
+        JSON.stringify({ type: 'message', timestamp: '2026-04-25T10:00:05Z', message: { role: 'user', content: 'survived' } }),
+        '',
+      ].join('\n'),
+    )
+
+    const transcript = readLatestSessionTranscript('pixel')
+    expect(transcript!.messages).toHaveLength(1)
+    expect(transcript!.messages[0].content).toBe('survived')
+  })
+
+  it('truncates to the requested cap and sets truncated=true', () => {
+    const lines: object[] = [{ type: 'session', id: 'sess-big', timestamp: '2026-04-25T10:00:00Z' }]
+    for (let i = 0; i < 250; i++) {
+      lines.push({ type: 'message', timestamp: `2026-04-25T10:${String(i % 60).padStart(2, '0')}:00Z`, message: { role: 'user', content: `msg ${i}` } })
+    }
+    writeSession('pixel', 'big.jsonl', lines)
+
+    const transcript = readLatestSessionTranscript('pixel', { maxMessages: 50 })
+    expect(transcript!.totalMessages).toBe(250)
+    expect(transcript!.messages).toHaveLength(50)
+    expect(transcript!.truncated).toBe(true)
+    // Truncation keeps the most recent — first message in the slice should be msg 200
+    expect(transcript!.messages[0].content).toBe('msg 200')
+    expect(transcript!.messages[49].content).toBe('msg 249')
+  })
+
+  it('picks the most recent session when multiple files exist', () => {
+    writeSession('pixel', 'old.jsonl', [
+      { type: 'session', id: 'sess-old', timestamp: '2026-04-20T10:00:00Z' },
+      { type: 'message', message: { role: 'user', content: 'old session' } },
+    ])
+    writeSession('pixel', 'new.jsonl', [
+      { type: 'session', id: 'sess-new', timestamp: '2026-04-25T10:00:00Z' },
+      { type: 'message', message: { role: 'user', content: 'new session' } },
+    ])
+
+    const transcript = readLatestSessionTranscript('pixel')
+    expect(transcript!.sessionId).toBe('sess-new')
+    expect(transcript!.messages[0].content).toBe('new session')
+  })
+
+  it('serializes object content as pretty JSON for tool calls', () => {
+    writeSession('pixel', 'tool.jsonl', [
+      { type: 'session', id: 'sess-tool', timestamp: '2026-04-25T10:00:00Z' },
+      {
+        type: 'message',
+        timestamp: '2026-04-25T10:00:01Z',
+        toolName: 'bakin_exec_log',
+        message: { role: 'tool', content: { result: 'ok', payload: { nested: true } } },
+      },
+    ])
+
+    const transcript = readLatestSessionTranscript('pixel')
+    expect(transcript!.messages).toHaveLength(1)
+    const msg = transcript!.messages[0]
+    expect(msg.role).toBe('tool')
+    expect(msg.toolName).toBe('bakin_exec_log')
+    expect(msg.content).toContain('"result"')
+    expect(msg.content).toContain('"nested"')
+  })
+
+  it('drops unknown roles silently (forward-compat with new role types)', () => {
+    writeSession('pixel', 'mystery.jsonl', [
+      { type: 'session', id: 'sess-x', timestamp: '2026-04-25T10:00:00Z' },
+      { type: 'message', message: { role: 'user', content: 'kept' } },
+      { type: 'message', message: { role: 'wizard', content: 'dropped' } },
+    ])
+
+    const transcript = readLatestSessionTranscript('pixel')
+    expect(transcript!.messages).toHaveLength(1)
+    expect(transcript!.messages[0].content).toBe('kept')
+  })
+})


### PR DESCRIPTION
## Summary

Major restructure of the agent detail page (`/team/:id`). Consolidates redundant content, surfaces what's been hidden, and modernizes the markdown edit pattern. See `.claude/specs/team-overview-rework.md` for the full spec and `team-overview-rework-plan.md` for the implementation plan.

## What changed

**Tab list (was 8, now 9):**
- ❌ Profile (regurgitated other tabs)
- ❌ Stats (folded into Overview)
- ✅ Overview (new — consolidated dashboard)
- ✅ Heartbeat (new — view-only)
- ✅ Active Context (new — read-only session transcript)
- Soul / Rules / Tools / Skills / Knowledge / Memory unchanged in role; Soul/Rules/Tools now use the new view→edit markdown pattern

Final order: `Overview | Memory | Heartbeat | Soul | Rules | Tools | Skills | Knowledge | Active Context`

**Header trimmed:**
Removed the inline model picker, team selector, and subagent perms badge from the page header. They moved into OverviewTab where they live alongside the rest of the agent's settings. Header now: back arrow, avatar, name, role, gateway-restart banner, delete button.

**OverviewTab composition (single dashboard):**
- Identity (name, role, emoji, manages-list)
- Settings (model selector + team selector with live save)
- PackageCard (embedded — exported from `agent-detail.tsx`)
- Workspace path
- Capacity counts (skills, knowledge total + enabled)
- Latest Session (folded-in Stats — model, total tokens with input/output, cache reads, cost, per-msg average)
- Recent Activity (5m / 1h / 24h dispatch + error counts via `getStatsByMs`, framed as "since server start")

**Markdown view→edit pattern (Soul / Rules / Tools):**
Default state renders `<MarkdownContent>` at full width. Pencil button in the absolute top-right corner switches to a textarea editor. Save (green check) + Cancel (X) replace the pencil while editing. `Cmd+S` saves when dirty; `Esc` cancels. Mirrors the Assets edit pattern.

**Heartbeat tab:** View-only render of `<workspace>/HEARTBEAT.md` with a "Last updated <relative>" badge. No edit affordance — heartbeats are agent-authored narrative, user editing is meaningless.

**Active Context tab:** Read-only render of the agent's most recent session JSONL parsed into a message stream. One row per message with role-colored badge (system / user / assistant / tool). Plain text via `<MarkdownContent>`; tool calls and JSON-shaped content as `<pre>`. Truncation banner at 200 messages by default.

## Backend additions

Three new GET routes on the team plugin (sibling to `/:agentId/stats`):
- `/:agentId/heartbeat` — `{ ok, heartbeat: { content, lastUpdated } | null }`
- `/:agentId/active-context?max=200` — `{ ok, transcript: SessionTranscript | null }`
- `/:agentId/recent-activity` — `{ ok, activity: { windowMs, errors, sinceServerStart } }`

New helper `readHeartbeatRaw()` in the openclaw-adapter; new `lib/session-reader.ts` for JSONL → message-stream parsing (sibling to `agent-usage.ts`).

## Tests

- **All 3535 / 3535 repo tests pass.** Type-check (`bunx tsc --noEmit -p tsconfig.app.json`) clean.
- **6 new test files** for the new components / lib / endpoints.
- **4 existing test files** updated to match the new tab list and OverviewTab fetch waterfall (existing `useQueryState` mocks switched from `'profile'` to `'overview'`; profile fetch routes joined by `stats` / `recent-activity` / `skills` / `knowledge` stubs).

## Commits

11 commits per the dependency graph in the plan: types → readers → endpoints → components (each independent) → integration → docs. Each is independently revertable.

```
docs: document Teams Overview rework
feat(team): integrate new tabs into agent-detail
feat(team): add OverviewTab consolidated dashboard
feat(team): add ActiveContextTab component
feat(team): add HeartbeatTab component
feat(team): extract MarkdownEditTab reusable component
feat(team): add REST endpoints for new agent-detail tabs
feat(team): add readHeartbeatRaw to openclaw-adapter
feat(team): add session-reader for active-context tab
feat(team): add session, activity, and heartbeat types
docs(specs): plan agent detail Overview rework
```

## Test plan

- [x] `bun test --isolate` — full repo, 3535/3535 pass
- [x] `bun test --isolate tests/plugins/team` — focused, 195/195 pass
- [x] `bunx tsc --noEmit -p tsconfig.app.json` — clean
- [ ] Visual smoke test: `bun run dev:mock`, walk every tab on `/team/main` and a non-main agent
- [ ] Verify Heartbeat empty state (delete `HEARTBEAT.md` from a workspace)
- [ ] Verify Active Context empty state (an agent with no sessions)
- [ ] Verify the model + team controls round-trip from OverviewTab

## Out of scope (future iterations)

- Per-turn Active Context drill-down (reconstruct exact input window per assistant message)
- Lifetime aggregate stats (the in-memory recorder resets on restart)
- Knowledge tab adoption-value copy (currently "Coming soon")
- MarkdownEditTab → `@bakin/sdk/components` lift (defer until reused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)