### PR TITLE
feat(plugins): Phase 6 (onboard prompt) + Phase 7 (layering policy)

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -38,6 +38,48 @@ Structurally identical, different source locations and install paths:
 The runtime plugin loader doesn't care which bucket a plugin came from.
 Same manifest shape, same `dist/` layout, same `activate` contract.
 
+### Feature modules vs third-party plugins (Phase 7)
+
+The runtime treats them identically, but the **architectural** distinction
+between them shapes what core code may and may not do:
+
+- **Feature modules** — the 8 plugins that ship inside the Bakin core
+  binary: `team`, `tasks`, `workflows`, `health`, `memory`, `assets`,
+  `schedule`, `models`. (`messaging` + `projects` migrate out via
+  Phase 4-5; today they're still feature modules.) Core code MAY
+  import from these via `@bakin/{plugin}/*` path aliases — they're
+  load-bearing repo modules.
+- **Third-party plugins** — anything installed via `bakin plugins
+  install` or `bakin plugins link`. Source lives at
+  `~/.bakin/plugins/<id>/`. Core code MUST NOT import from there;
+  cross-cutting communication runs through `ctx.hooks.invoke` on the
+  server and `@bakin/sdk/hooks` on the client.
+
+Why the distinction matters:
+
+- Feature modules ship with the binary; their lifecycle is tied to a
+  Bakin release. They appear in `bakin plugins list` but `upgrade` and
+  `remove` refuse them via `isCorePlugin()`.
+- Third-party plugins lifecycle independently — they get their own
+  semver, their own release cadence, their own consent prompts on
+  install/upgrade. They can be remove'd cleanly via the teardown
+  sweep.
+
+The boundary is enforced two ways:
+
+1. **Lint** — `eslint.config.mjs` configures `no-restricted-imports`
+   to block any path that resolves into `~/.bakin/plugins/`. Catches
+   accidents at PR time.
+2. **Fitness test** — `tests/architecture/feature-module-vs-plugin
+   .test.ts` walks `src/`, `cli/`, `packages/core/` and grep-asserts
+   no source line imports from a `~/.bakin/plugins/` path. Belt +
+   suspenders against the lint rule's blast radius.
+
+Promoting an extracted plugin back to core is a deliberate
+architectural reversal — needs spec discussion. Adding a new module
+to `plugins/` is a feature-module addition by default; document an
+exception in the spec if it should be a third-party plugin instead.
+
 ## Plugin Lifecycle
 
 ```

--- a/.claude/knowledge/repo-architecture.md
+++ b/.claude/knowledge/repo-architecture.md
@@ -206,6 +206,28 @@ import { PluginHeader } from '@bakin/sdk/components'
 Plugin authors (outside the repo) never use the `../../src/*` paths —
 they only see `@bakin/sdk/*`. The lint rule enforces this.
 
+### Feature modules vs third-party plugins (Phase 7)
+
+Two distinct categories live under `plugins/`:
+
+- **Feature modules** — the 8 plugins that ship in the core binary
+  (`team`, `tasks`, `workflows`, `health`, `memory`, `assets`,
+  `schedule`, `models`). These are load-bearing repo modules; core
+  code MAY import from them via `@bakin/{plugin}/*` aliases.
+- **Third-party plugins** — installed via `bakin plugins install` /
+  `bakin plugins link` into `~/.bakin/plugins/<id>/`. Core code MUST
+  NOT import from there.
+
+Today `messaging` + `projects` are still feature modules; they
+migrate out via Phase 4-5 once the SDK exposes the openclaw-client
++ vault surfaces those plugins consume.
+
+The layering boundary is enforced by:
+- `eslint.config.mjs` — `no-restricted-imports` for `~/.bakin/plugins`.
+- `tests/architecture/feature-module-vs-plugin.test.ts` — fitness
+  test that walks `src/`, `cli/`, `packages/core/` and grep-asserts
+  no source-line imports from a third-party plugin path.
+
 ## TypeScript Path Aliases
 
 Defined in `tsconfig.json`; bun picks them up automatically for both runtime and `bun test`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,22 @@ Core plugins build to `plugins/<id>/dist/`. User plugins build to `~/.bakin/plug
 
 Routes registered as `/api/plugins/{pluginId}/{path}`. Exec tools naming: `bakin_exec_{pluginId}_{action}`.
 
-Deep references: `.claude/knowledge/plugin-system.md`, `.claude/knowledge/workflows-plugin.md`, `docs/plugin-authoring.md`.
+### Feature modules vs third-party plugins (Phase 7 layering rule)
+
+Two distinct concepts live under `plugins/`:
+
+1. **Feature modules** — the 8 plugins that ship inside the Bakin core binary: `team`, `tasks`, `workflows`, `health`, `memory`, `assets`, `schedule`, `models`. They live at `plugins/<id>/` in this repo, build at repo build time, and core code MAY import from them via `@bakin/{plugin}/...` paths (already wired in `tsconfig.json#paths`). The contract for these is documented in their own knowledge docs; treat them as load-bearing repo modules, not "plugins" in the user-facing sense.
+2. **Third-party plugins** — anything installed via `bakin plugins install` or `bakin plugins link`. Their source lives at `~/.bakin/plugins/<id>/` post-install. Core code MUST NOT import from there. Communication runs through `ctx.hooks` and the `@bakin/sdk/*` surface only.
+
+Two extracted plugins (`messaging`, `projects`) are migrating from feature modules to third-party plugins via `bakin-bits-official` (Phase 4-5). Once that migration completes the count drops to 8 feature modules.
+
+**Rules:**
+
+- New modules added to `plugins/` are feature modules by default — must justify exception in the relevant spec.
+- Promoting an extracted plugin back to core is a deliberate architectural reversal — requires spec discussion.
+- The lint rule in `eslint.config.mjs` enforces the import boundary: `no-restricted-imports` blocks any path that traverses into `~/.bakin/plugins/`. Belt + suspenders test in `tests/architecture/feature-module-vs-plugin.test.ts` walks `src/`, `cli/`, and `packages/core/` to grep-assert the same.
+
+Deep references: `.claude/knowledge/plugin-system.md`, `.claude/knowledge/workflows-plugin.md`, `docs-old/plugin-authoring.md`.
 
 ## Agent Packages
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,8 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "cron-parser": "^5.5.0",
+        "ink": "^7.0.1",
+        "ink-testing-library": "^4.0.0",
         "js-yaml": "^4.1.1",
         "lucide-react": "^0.577.0",
         "nodemailer": "^8.0.3",
@@ -92,6 +94,8 @@
     "@antfly/sdk@0.0.14": "patches/@antfly__sdk@0.0.14.patch",
   },
   "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.3.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfly/sdk": ["@antfly/sdk@0.0.14", "", { "dependencies": { "openapi-fetch": "^0.17.0" } }, "sha512-2GduXnYovTji5FbLrIff3iOx+JVUJ/C/6joUHtbmR9bpCUfh34U7ckViHvHPu8UuDpDjadyRqvz0CNEFp6i3IQ=="],
@@ -728,9 +732,11 @@
 
     "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -767,6 +773,8 @@
     "astro-expressive-code": ["astro-expressive-code@0.41.7", "", { "dependencies": { "rehype-expressive-code": "^0.41.7" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
@@ -834,11 +842,13 @@
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
 
-    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+    "cli-boxes": ["cli-boxes@4.0.1", "", {}, "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw=="],
 
-    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -849,6 +859,8 @@
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
@@ -873,6 +885,8 @@
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -992,6 +1006,8 @@
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
@@ -1011,6 +1027,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.46.0", "", {}, "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1266,7 +1284,13 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ink": ["ink@7.0.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.3.0", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.3", "auto-bind": "^5.0.1", "chalk": "^5.6.2", "cli-boxes": "^4.0.1", "cli-cursor": "^4.0.0", "cli-truncate": "^6.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.45.1", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^9.0.0", "stack-utils": "^2.0.6", "string-width": "^8.2.0", "terminal-size": "^4.0.1", "type-fest": "^5.5.0", "widest-line": "^6.0.0", "wrap-ansi": "^10.0.0", "ws": "^8.20.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.2.0", "react": ">=19.2.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w=="],
+
+    "ink-testing-library": ["ink-testing-library@4.0.0", "", { "peerDependencies": { "@types/react": ">=18.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -1308,13 +1332,15 @@
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
@@ -1700,6 +1726,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -1770,6 +1798,8 @@
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1836,7 +1866,7 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
 
@@ -1908,13 +1938,15 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -1923,6 +1955,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -1934,7 +1968,7 @@
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
 
@@ -1973,6 +2007,8 @@
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -2110,11 +2146,11 @@
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
-    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -2137,6 +2173,8 @@
     "yocto-spinner": ["yocto-spinner@0.2.3", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -2169,6 +2207,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -2228,7 +2268,17 @@
 
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "boxen/cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
     "boxen/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "boxen/widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
+
+    "boxen/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2242,11 +2292,15 @@
 
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "h3/cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+
+    "ink/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -2259,6 +2313,10 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "ora/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -2274,8 +2332,6 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
-
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -2286,9 +2342,9 @@
 
     "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
-    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2299,8 +2355,6 @@
     "@dotenvx/dotenvx/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "@dotenvx/dotenvx/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
-
-    "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
@@ -2316,13 +2370,21 @@
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "ansi-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "astro/@astrojs/markdown-remark/@astrojs/prism": ["@astrojs/prism@3.2.0", "", { "dependencies": { "prismjs": "^1.29.0" } }, "sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -2330,10 +2392,16 @@
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "ora/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,43 @@ const eslintConfig = defineConfig([
       }],
     },
   },
+  // Phase 7 layering rule (#174). Core code (src/, cli/, packages/core/)
+  // MUST NOT import from third-party plugins installed under
+  // `~/.bakin/plugins/`. Feature modules under `plugins/<id>/` (the 8
+  // built-in plugins) ARE allowed via the `@bakin/{plugin}/*` aliases —
+  // those resolve to in-repo paths, not the runtime install dir.
+  //
+  // The fitness test at `tests/architecture/feature-module-vs-plugin
+  // .test.ts` walks the same directories and grep-asserts the same
+  // boundary as a belt-and-suspenders check; both must stay in sync.
+  {
+    files: [
+      "src/core/**/*.{ts,tsx}",
+      "src/lib/**/*.{ts,tsx}",
+      "cli/**/*.{ts,tsx}",
+      "packages/core/**/*.{ts,tsx}",
+      "packages/host/**/*.{ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-imports": ["error", {
+        patterns: [
+          {
+            // Path strings that point at a third-party plugin install
+            // location. These never resolve at module-resolution time
+            // (~/.bakin/plugins/ isn't on the module path) but a
+            // string literal would survive in dynamic imports / require
+            // calls — bake the rejection in here so the boundary holds
+            // even when an author reaches for `import(...)`.
+            group: [
+              "**/.bakin/plugins/**",
+              "~/.bakin/plugins/**",
+            ],
+            message: "Core code MUST NOT import from third-party plugins under ~/.bakin/plugins/. Communication runs through ctx.hooks (server) and @bakin/sdk/hooks (client). See .claude/knowledge/plugin-system.md § Feature modules vs third-party plugins.",
+          },
+        ],
+      }],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "cron-parser": "^5.5.0",
+    "ink": "^7.0.1",
+    "ink-testing-library": "^4.0.0",
     "js-yaml": "^4.1.1",
     "lucide-react": "^0.577.0",
     "nodemailer": "^8.0.3",

--- a/src/core/onboarding/index.ts
+++ b/src/core/onboarding/index.ts
@@ -50,6 +50,7 @@ import { mcporterComponent } from './mcporter'
 import { pluginAssetsComponent } from './plugin-assets'
 import { agentAssetsComponent } from './agent-assets'
 import { llmComponent, channelsComponent } from './credentials'
+import { recommendedPluginsComponent } from './recommended-plugins-component'
 import { saveState, clearMarker } from './state'
 import type { CheckResult, OnboardingComponent, OnboardingOptions } from './types'
 import type { ComponentStatus } from './state'
@@ -76,7 +77,11 @@ export const COMPONENT_ORDER: readonly OnboardingComponent[] = [
   agentAssetsComponent,
   llmComponent,
   channelsComponent,
+  recommendedPluginsComponent,
 ] as const
+
+export type { RecommendedPlugin } from './types'
+export { RECOMMENDED_PLUGINS } from './recommended-plugins'
 
 /**
  * Result of a single component's full check+install cycle, as seen by

--- a/src/core/onboarding/recommended-plugins-component.ts
+++ b/src/core/onboarding/recommended-plugins-component.ts
@@ -1,0 +1,187 @@
+/**
+ * `recommended-plugins` onboarding component (Phase 6).
+ *
+ * Surfaces the curated list (`recommended-plugins.ts`) as the final
+ * step of `bakin onboard`. Three modes mirror the rest of the
+ * onboarding components:
+ *
+ *   - check()      → returns 'ok' if every recommended plugin is
+ *                    already in the lockfile (or the list is empty);
+ *                    'missing' otherwise.
+ *   - install()    → in interactive mode, renders the Ink prompt and
+ *                    shells out to `bakin plugins install` for each
+ *                    selected id. In autoApprove (--yes) or non-
+ *                    interactive (--json) mode, installs every entry
+ *                    that has `defaultSelected: true` without
+ *                    prompting.
+ *
+ * Failures during one plugin's install do NOT abort the rest — the
+ * component reports a partial-success outcome with details.
+ */
+import { execFileSync } from 'child_process'
+import { readPluginLockfile } from '../../../packages/core/src/plugins/lockfile'
+import { RECOMMENDED_PLUGINS } from './recommended-plugins'
+import { promptRecommendedPlugins } from './recommended-plugins-prompt'
+import type {
+  CheckResult,
+  InstallResult,
+  OnboardingComponent,
+  OnboardingOptions,
+} from './types'
+
+const COMPONENT_NAME = 'recommended-plugins'
+
+function alreadyInstalled(): Set<string> {
+  try {
+    const lock = readPluginLockfile()
+    return new Set(Object.keys(lock.plugins))
+  } catch {
+    // Missing/corrupt lockfile → treat as "nothing installed."
+    // The install flow will still surface its own errors loudly.
+    return new Set()
+  }
+}
+
+function missingFromLockfile(): typeof RECOMMENDED_PLUGINS {
+  const installed = alreadyInstalled()
+  return RECOMMENDED_PLUGINS.filter((p) => !installed.has(p.id))
+}
+
+async function check(): Promise<CheckResult> {
+  if (RECOMMENDED_PLUGINS.length === 0) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'ok',
+      message: 'No recommended plugins curated yet.',
+    }
+  }
+  const missing = missingFromLockfile()
+  if (missing.length === 0) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'ok',
+      message: `All ${RECOMMENDED_PLUGINS.length} recommended plugin(s) already installed.`,
+    }
+  }
+  return {
+    name: COMPONENT_NAME,
+    status: 'missing',
+    message: `${missing.length} recommended plugin(s) not yet installed.`,
+    details: { missing: missing.map((p) => p.id) },
+    remediation: 'Run `bakin onboard` interactively to pick which to install, or `bakin plugins install <source>` per plugin.',
+  }
+}
+
+interface PerPluginOutcome {
+  id: string
+  ok: boolean
+  message: string
+}
+
+/**
+ * Drive `bakin plugins install --yes` for one plugin id. Returns a
+ * structured outcome rather than throwing so the caller can aggregate
+ * partial-success.
+ *
+ * Uses execFileSync against the running binary's `bakin` CLI on PATH.
+ * This is the same path `bakin onboard` already uses for other
+ * components; mocking it in tests is straightforward.
+ */
+function installOne(id: string, source: string): PerPluginOutcome {
+  try {
+    execFileSync('bakin', ['plugins', 'install', source, '--yes'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024,
+    })
+    return { id, ok: true, message: `installed ${id}` }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { id, ok: false, message }
+  }
+}
+
+async function install(opts: OnboardingOptions): Promise<InstallResult> {
+  const startedAt = Date.now()
+  if (RECOMMENDED_PLUGINS.length === 0) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'noop',
+      message: 'no recommended plugins curated',
+      durationMs: Date.now() - startedAt,
+    }
+  }
+
+  const candidates = missingFromLockfile()
+  if (candidates.length === 0) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'noop',
+      message: 'all recommended plugins already installed',
+      durationMs: Date.now() - startedAt,
+    }
+  }
+
+  // Decide selection without rendering the prompt for non-interactive
+  // runs. autoApprove + json both bypass UI; respect defaultSelected
+  // as the implicit answer.
+  let selectedIds: string[]
+  if (opts.interactive && !opts.autoApprove && !opts.json) {
+    selectedIds = await promptRecommendedPlugins(candidates)
+  } else {
+    selectedIds = candidates.filter((p) => p.defaultSelected).map((p) => p.id)
+  }
+
+  if (selectedIds.length === 0) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'skipped',
+      message: opts.interactive ? 'user declined every recommendation' : 'no defaults selected for this mode',
+      durationMs: Date.now() - startedAt,
+    }
+  }
+
+  const sourcesById = new Map(candidates.map((p) => [p.id, p.source]))
+  const results: PerPluginOutcome[] = []
+  for (const id of selectedIds) {
+    const source = sourcesById.get(id)
+    if (!source) {
+      results.push({ id, ok: false, message: 'no source resolved' })
+      continue
+    }
+    results.push(installOne(id, source))
+  }
+
+  const failed = results.filter((r) => !r.ok)
+  if (failed.length === 0) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'installed',
+      message: `installed ${results.length} plugin(s): ${results.map((r) => r.id).join(', ')}`,
+      durationMs: Date.now() - startedAt,
+    }
+  }
+  if (failed.length === results.length) {
+    return {
+      name: COMPONENT_NAME,
+      status: 'failed',
+      message: `every install failed: ${failed.map((f) => `${f.id} (${f.message})`).join('; ')}`,
+      error: failed,
+      durationMs: Date.now() - startedAt,
+    }
+  }
+  // Partial success.
+  const ok = results.filter((r) => r.ok).map((r) => r.id)
+  return {
+    name: COMPONENT_NAME,
+    status: 'installed',
+    message: `installed ${ok.length}/${results.length} (failed: ${failed.map((f) => f.id).join(', ')})`,
+    error: failed,
+    durationMs: Date.now() - startedAt,
+  }
+}
+
+export const recommendedPluginsComponent: OnboardingComponent = {
+  name: COMPONENT_NAME,
+  check,
+  install,
+}

--- a/src/core/onboarding/recommended-plugins-prompt.tsx
+++ b/src/core/onboarding/recommended-plugins-prompt.tsx
@@ -1,0 +1,138 @@
+/**
+ * Ink-based interactive prompt for selecting recommended plugins during
+ * `bakin onboard` (Phase 6). Renders a checkbox list keyed by plugin id;
+ * keyboard handlers mirror the standard TUI checklist UX.
+ *
+ * Inputs:
+ *   ↑ / ↓ / k / j   → navigate up/down
+ *   space           → toggle the cursor's plugin in/out of the selection
+ *   a               → toggle ALL (select all if any unchecked, else
+ *                     deselect all)
+ *   enter           → submit; resolves with the array of selected ids
+ *   esc / q         → cancel; resolves with empty array
+ *
+ * The component renders inline (no fullscreen takeover); the `bakin
+ * onboard` orchestrator awaits the resolution before printing the
+ * final progress summary.
+ *
+ * Tested via ink-testing-library (see tests/core/onboarding/
+ * recommended-plugins-prompt.test.tsx) — `stdin.write('[A')` for
+ * arrow up, `[B'` for arrow down, ` ` for space, `\r` for enter.
+ */
+import React, { useState } from 'react'
+import { Box, Text, render, useApp, useInput } from 'ink'
+import type { RecommendedPlugin } from './types'
+
+interface PromptProps {
+  plugins: readonly RecommendedPlugin[]
+  onSubmit: (selected: string[]) => void
+}
+
+function PluginsPrompt({ plugins, onSubmit }: PromptProps): React.ReactElement {
+  const [cursor, setCursor] = useState(0)
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(plugins.filter((p) => p.defaultSelected).map((p) => p.id)),
+  )
+  const { exit } = useApp()
+
+  useInput((input, key) => {
+    if (key.upArrow || input === 'k') {
+      setCursor((c) => (c <= 0 ? plugins.length - 1 : c - 1))
+      return
+    }
+    if (key.downArrow || input === 'j') {
+      setCursor((c) => (c >= plugins.length - 1 ? 0 : c + 1))
+      return
+    }
+    if (input === ' ') {
+      setSelected((prev) => {
+        const next = new Set(prev)
+        const id = plugins[cursor]?.id
+        if (!id) return prev
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
+      return
+    }
+    if (input === 'a') {
+      setSelected((prev) => {
+        if (prev.size < plugins.length) {
+          return new Set(plugins.map((p) => p.id))
+        }
+        return new Set()
+      })
+      return
+    }
+    if (key.return) {
+      // Return ids in the original plugins-array order so callers
+      // see deterministic, display-order output rather than Set
+      // insertion-order (which depends on how the user toggled).
+      onSubmit(plugins.filter((p) => selected.has(p.id)).map((p) => p.id))
+      exit()
+      return
+    }
+    if (key.escape || input === 'q') {
+      onSubmit([])
+      exit()
+      return
+    }
+  })
+
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text bold>Recommended plugins</Text>
+        <Text dimColor> — ↑/↓ navigate, space toggle, a toggle all, enter confirm, esc cancel</Text>
+      </Text>
+      {plugins.map((plugin, idx) => {
+        const isCursor = idx === cursor
+        const isSelected = selected.has(plugin.id)
+        const checkbox = isSelected ? '[x]' : '[ ]'
+        const cursorMark = isCursor ? '>' : ' '
+        return (
+          <Box key={plugin.id} flexDirection="column">
+            <Text>
+              <Text color={isCursor ? 'cyan' : undefined}>{cursorMark} </Text>
+              <Text>{checkbox} </Text>
+              <Text bold={isCursor}>{plugin.name}</Text>
+              <Text dimColor> ({plugin.id})</Text>
+            </Text>
+            <Box marginLeft={6}>
+              <Text dimColor>{plugin.description}</Text>
+            </Box>
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
+/**
+ * Render the prompt against the user's TTY and resolve when they
+ * submit or cancel. Caller passes the curated list; the resolved value
+ * is the array of selected plugin ids in `plugins` order.
+ *
+ * If `plugins` is empty the prompt is skipped — resolves immediately
+ * with an empty array. Same shape as a user pressing escape, so the
+ * caller doesn't have to special-case empty.
+ */
+export async function promptRecommendedPlugins(
+  plugins: readonly RecommendedPlugin[],
+): Promise<string[]> {
+  if (plugins.length === 0) return []
+
+  return new Promise<string[]>((resolve) => {
+    const onSubmit = (selected: string[]): void => resolve(selected)
+    const { unmount, waitUntilExit } = render(
+      <PluginsPrompt plugins={plugins} onSubmit={onSubmit} />,
+      { exitOnCtrlC: true },
+    )
+    void waitUntilExit().then(() => {
+      unmount()
+    })
+  })
+}
+
+/** Test-only export so unit tests can render against ink-testing-library. */
+export { PluginsPrompt as __PluginsPromptForTest }

--- a/src/core/onboarding/recommended-plugins.ts
+++ b/src/core/onboarding/recommended-plugins.ts
@@ -1,0 +1,45 @@
+/**
+ * Curated list of recommended plugins shown during `bakin onboard`
+ * (Phase 6). Managed entirely in this file — there's no external data
+ * source, the Bakin core team picks what to recommend.
+ *
+ * The list is **intentionally empty today.** Entries land here as the
+ * extraction work in Phase 4-5 ships:
+ *   - `messaging` — once `plugins/messaging/` is moved to
+ *     `bakin-bits-official/plugins/messaging/` and tagged.
+ *   - `projects` — same, after Phase 5.
+ *
+ * Adding an entry requires three things to be true:
+ *   1. The plugin lives in a public github repo Bakin can clone.
+ *   2. The `source` resolves cleanly via Bakin's #subpath syntax.
+ *   3. The plugin's permissions are reasonable for first-run install
+ *      (no `storage.write` to surprising locations, no `events.emit`
+ *      that would spam the activity feed by default, etc).
+ *
+ * Updates here ship in a regular Bakin release — no separate
+ * deploy / config service involved. Users on older Bakin versions
+ * see the list that shipped with their binary; the recommended-plugins
+ * component is a one-shot during onboarding so the list state at
+ * marker-write time is what matters.
+ */
+import type { RecommendedPlugin } from './types'
+
+export const RECOMMENDED_PLUGINS: readonly RecommendedPlugin[] = [
+  // Phase 4 will add:
+  // {
+  //   id: 'messaging',
+  //   source: 'github:madeinwyo/bakin-bits-official#plugins/messaging',
+  //   name: 'Messaging',
+  //   description: 'Brainstorm, draft, schedule, and review content across channels.',
+  //   defaultSelected: true,
+  // },
+  //
+  // Phase 5 will add:
+  // {
+  //   id: 'projects',
+  //   source: 'github:madeinwyo/bakin-bits-official#plugins/projects',
+  //   name: 'Projects',
+  //   description: 'Lightweight project tracker — markdown files in ~/.bakin/projects/.',
+  //   defaultSelected: true,
+  // },
+] as const

--- a/src/core/onboarding/types.ts
+++ b/src/core/onboarding/types.ts
@@ -47,3 +47,28 @@ export interface OnboardingComponent {
   check(): Promise<CheckResult>
   install(opts: OnboardingOptions): Promise<InstallResult>
 }
+
+/**
+ * One row in the curated recommended-plugins list (Phase 6). Surfaced by
+ * the `recommended-plugins` onboarding component during interactive
+ * `bakin onboard`. The list itself is curated in
+ * `src/core/onboarding/recommended-plugins.ts` and grows as Phase 4-5
+ * extracts plugins from the bakin core into the bakin-bits-official
+ * monorepo.
+ */
+export interface RecommendedPlugin {
+  /** Plugin id — must match the manifest's id and Bakin's id regex. */
+  readonly id: string
+  /** Install source — typically `github:owner/repo#plugins/<id>` shape. */
+  readonly source: string
+  /** Display name for the prompt UI. */
+  readonly name: string
+  /** One-line description shown beneath the name in the prompt. */
+  readonly description: string
+  /**
+   * Whether the plugin is selected by default in the prompt. The user
+   * can deselect with space; defaults are surfaced for plugins that
+   * the Bakin core team considers "the canonical first install."
+   */
+  readonly defaultSelected: boolean
+}

--- a/tests/architecture/feature-module-vs-plugin.test.ts
+++ b/tests/architecture/feature-module-vs-plugin.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Architecture fitness test (Phase 7 P7.C3).
+ *
+ * Walks the trees that constitute "core code" — `src/`, `cli/`,
+ * `packages/core/`, `packages/host/` — and grep-asserts that no
+ * source line imports from a third-party plugin install path
+ * (`~/.bakin/plugins/*` or relative paths that traverse into a
+ * `.bakin/plugins/` segment).
+ *
+ * Belt + suspenders alongside the `no-restricted-imports` rule in
+ * `eslint.config.mjs`. The lint rule catches violations at PR time;
+ * this test runs in CI's `bun test --isolate` step so a glob-pattern
+ * drift in the lint config can't silently weaken the boundary.
+ *
+ * Failure mode is loud: assertion message lists every offending
+ * `<file>:<line>` so the author sees exactly what to fix.
+ *
+ * Defensive isolation: this test is pure repo-tree reading — no fs
+ * writes, no `~/.bakin/` access — but the standard content-dir
+ * mocks are wired up so the test stays hermetic by construction
+ * if it ever grows to need bakin runtime types.
+ */
+import { describe, it, expect, mock } from 'bun:test'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import { join, relative } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-arch-fitness-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+const REPO_ROOT = join(__dirname, '..', '..')
+
+/** Paths whose contents must NOT contain a third-party plugin import. */
+const ROOTS = [
+  'src/core',
+  'src/lib',
+  'cli',
+  'packages/core',
+  'packages/host',
+] as const
+
+/** Skip generated/vendored output. */
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  '.git',
+  'coverage',
+  '__tmp_lint_check',
+])
+
+/** Only inspect TypeScript source. */
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx'])
+
+/**
+ * Patterns flagged as third-party plugin imports. Keep this regex
+ * narrow enough to skip false positives (`packages/core/src/plugins/
+ * lockfile.ts` legitimately mentions the runtime plugin path in
+ * comments) but broad enough to catch real violations.
+ */
+const FORBIDDEN_IMPORT_REGEX = /\b(import\s.*from|require)\s*\(?['"]([^'"]*\/?\.bakin\/plugins\/[^'"]*)['"]/g
+
+interface Violation {
+  file: string
+  line: number
+  match: string
+}
+
+function* walk(dir: string): Generator<string> {
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry.name)) continue
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      yield* walk(full)
+      continue
+    }
+    if (!entry.isFile()) continue
+    const ext = full.slice(full.lastIndexOf('.'))
+    if (!SOURCE_EXTENSIONS.has(ext)) continue
+    yield full
+  }
+}
+
+function findViolations(): Violation[] {
+  const violations: Violation[] = []
+  for (const root of ROOTS) {
+    const absRoot = join(REPO_ROOT, root)
+    try {
+      statSync(absRoot)
+    } catch {
+      continue
+    }
+    for (const file of walk(absRoot)) {
+      const lines = readFileSync(file, 'utf-8').split('\n')
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        FORBIDDEN_IMPORT_REGEX.lastIndex = 0
+        if (FORBIDDEN_IMPORT_REGEX.test(line)) {
+          violations.push({
+            file: relative(REPO_ROOT, file),
+            line: i + 1,
+            match: line.trim(),
+          })
+        }
+      }
+    }
+  }
+  return violations
+}
+
+describe('architecture: feature modules vs third-party plugins', () => {
+  it('no source line in src/, cli/, packages/core/, packages/host/ imports from ~/.bakin/plugins/', () => {
+    const violations = findViolations()
+    if (violations.length > 0) {
+      const msg = violations
+        .map((v) => `  ${v.file}:${v.line}  ${v.match}`)
+        .join('\n')
+      throw new Error(
+        `Found ${violations.length} core→third-party-plugin import violation(s):\n${msg}\n\n` +
+        `Core code must reach third-party plugins via ctx.hooks (server) or @bakin/sdk/hooks (client). ` +
+        `Direct imports of ~/.bakin/plugins/* break under hot reload AND fail at runtime in production binaries.`,
+      )
+    }
+    expect(violations).toHaveLength(0)
+  })
+})

--- a/tests/core/onboarding/index.test.ts
+++ b/tests/core/onboarding/index.test.ts
@@ -25,7 +25,7 @@ interface ScriptedComponent {
   installCalls: number
 }
 
-const COMPONENT_NAMES = ['mkdir', 'settings', 'openclaw', 'antfly', 'models', 'mcporter', 'plugin-assets', 'agent-assets', 'llm', 'channels'] as const
+const COMPONENT_NAMES = ['mkdir', 'settings', 'openclaw', 'antfly', 'models', 'mcporter', 'plugin-assets', 'agent-assets', 'llm', 'channels', 'recommended-plugins'] as const
 
 let scripts: Record<(typeof COMPONENT_NAMES)[number], ScriptedComponent>
 
@@ -63,6 +63,9 @@ mock.module('../../../src/core/onboarding/agent-assets', () => ({ agentAssetsCom
 mock.module('../../../src/core/onboarding/credentials', () => ({
   llmComponent: makeMock('llm'),
   channelsComponent: makeMock('channels'),
+}))
+mock.module('../../../src/core/onboarding/recommended-plugins-component', () => ({
+  recommendedPluginsComponent: makeMock('recommended-plugins'),
 }))
 
 mock.module('../../../src/core/onboarding/state', () => ({
@@ -155,7 +158,7 @@ describe('runOnboard orchestrator', () => {
   // ---------------------------------------------------------------------------
 
   describe('COMPONENT_ORDER', () => {
-    it('contains exactly the 10 expected components in the spec order', () => {
+    it('contains exactly the 11 expected components in the spec order', () => {
       expect(COMPONENT_ORDER.map((c) => c.name)).toEqual([
         'mkdir',
         'settings',
@@ -167,6 +170,7 @@ describe('runOnboard orchestrator', () => {
         'agent-assets',
         'llm',
         'channels',
+        'recommended-plugins',
       ])
     })
   })
@@ -181,7 +185,7 @@ describe('runOnboard orchestrator', () => {
       expect(result.exitCode).toBe(0)
       expect(result.markerWritten).toBe(true)
       expect(result.outcomes.map((o) => o.finalStatus)).toEqual([
-        'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok',
+        'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok', 'ok',
       ])
       // check() was called on every component
       for (const n of COMPONENT_NAMES) {
@@ -203,6 +207,7 @@ describe('runOnboard orchestrator', () => {
         'agent-assets': 'ok',
         llm: 'ok',
         channels: 'ok',
+        'recommended-plugins': 'ok',
       })
     })
   })
@@ -318,8 +323,8 @@ describe('runOnboard orchestrator', () => {
       expect(scripts.mcporter.checkCalls).toBe(0)
       expect(scripts.llm.checkCalls).toBe(0)
       expect(scripts.channels.checkCalls).toBe(0)
-      // All 8 components still appear in outcomes
-      expect(result.outcomes).toHaveLength(10)
+      // All 11 components still appear in outcomes
+      expect(result.outcomes).toHaveLength(11)
       // OpenClaw is error (missing prerequisite), downstream all skipped
       expect(result.outcomes.find((o) => o.name === 'openclaw')?.finalStatus).toBe('error')
       expect(result.outcomes.find((o) => o.name === 'antfly')?.finalStatus).toBe('skipped')
@@ -396,7 +401,7 @@ describe('runOnboard orchestrator', () => {
   describe('json output', () => {
     it('emits one JSON line per outcome', async () => {
       await runOnboard({ ...opts, json: true })
-      expect(stdoutLines).toHaveLength(10)
+      expect(stdoutLines).toHaveLength(11)
       for (const line of stdoutLines) {
         const parsed = JSON.parse(line)
         expect(COMPONENT_NAMES).toContain(parsed.component)
@@ -408,8 +413,8 @@ describe('runOnboard orchestrator', () => {
       scripts.openclaw.check = { name: 'openclaw', status: 'missing', message: 'openclaw missing' }
       scripts.openclaw.install = { name: 'openclaw', status: 'noop', message: 'required', durationMs: 0 }
       await runOnboard({ ...opts, json: true })
-      // Should emit 8 lines total: 3 that actually ran + 5 cascade-skipped
-      expect(stdoutLines).toHaveLength(10)
+      // Should emit 11 lines total: 3 that actually ran + 8 cascade-skipped
+      expect(stdoutLines).toHaveLength(11)
     })
 
     it('does not emit JSON when json flag is false', async () => {
@@ -426,7 +431,7 @@ describe('runOnboard orchestrator', () => {
     it('calls check() on every component and never install()', async () => {
       scripts.antfly.check = { name: 'antfly', status: 'missing', message: 'antfly missing' }
       const results = await checkAll()
-      expect(results).toHaveLength(10)
+      expect(results).toHaveLength(11)
       expect(results.map((r) => r.name)).toEqual([...COMPONENT_NAMES])
       for (const n of COMPONENT_NAMES) {
         expect(scripts[n].checkCalls).toBe(1)

--- a/tests/core/onboarding/recommended-plugins-component.test.ts
+++ b/tests/core/onboarding/recommended-plugins-component.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the recommended-plugins onboarding component (Phase 6).
+ *
+ * The component itself is small but has three behavior axes:
+ *   - check() — empty list / all-installed / some-missing
+ *   - install() in autoApprove (--yes) — defaultSelected installs only
+ *   - install() in interactive — drives the prompt; we mock it
+ *   - install() failure modes — partial success, all-fail
+ *
+ * Lockfile state is mocked so we can simulate "plugin already
+ * installed." execFileSync is mocked so we don't actually shell to
+ * `bakin plugins install`.
+ */
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-onboard-recommended-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+// Mock the curated list — the real one ships empty until Phase 4-5.
+// We synthesize a non-empty fixture so all three check() branches and
+// every install() path can be exercised.
+const FIXTURE_LIST = [
+  {
+    id: 'messaging',
+    source: 'github:madeinwyo/bakin-bits-official#plugins/messaging',
+    name: 'Messaging',
+    description: 'Brainstorm + draft.',
+    defaultSelected: true,
+  },
+  {
+    id: 'projects',
+    source: 'github:madeinwyo/bakin-bits-official#plugins/projects',
+    name: 'Projects',
+    description: 'Tracker.',
+    defaultSelected: false,
+  },
+] as const
+mock.module('../../../src/core/onboarding/recommended-plugins', () => ({
+  RECOMMENDED_PLUGINS: FIXTURE_LIST,
+}))
+
+// Mock the lockfile — install state per test.
+let installedIds: string[] = []
+mock.module('../../../packages/core/src/plugins/lockfile', () => ({
+  readPluginLockfile: () => ({
+    version: 1,
+    plugins: Object.fromEntries(installedIds.map((id) => [id, {}])),
+  }),
+}))
+
+// Mock the prompt — drive selections from the test.
+let promptSelection: string[] = []
+mock.module('../../../src/core/onboarding/recommended-plugins-prompt', () => ({
+  promptRecommendedPlugins: async () => promptSelection,
+}))
+
+// Mock execFileSync so install() never actually shells out.
+let installShouldFailFor: Set<string> = new Set()
+const installCalls: string[] = []
+mock.module('child_process', () => ({
+  execFileSync: (_cmd: string, args: readonly string[]) => {
+    const source = args[2] ?? '<unknown>'
+    installCalls.push(source)
+    if ([...installShouldFailFor].some((id) => source.includes(id))) {
+      throw new Error(`synthetic install failure for ${source}`)
+    }
+    return Buffer.from('ok')
+  },
+  spawnSync: () => ({ stdout: '', stderr: '', status: 0 }),
+}))
+
+import { recommendedPluginsComponent } from '../../../src/core/onboarding/recommended-plugins-component'
+
+beforeEach(() => {
+  installedIds = []
+  promptSelection = []
+  installShouldFailFor = new Set()
+  installCalls.length = 0
+})
+
+const noninteractiveOpts = {
+  interactive: false,
+  autoApprove: true,
+  json: false,
+  checkOnly: false,
+  force: false,
+}
+
+const interactiveOpts = {
+  interactive: true,
+  autoApprove: false,
+  json: false,
+  checkOnly: false,
+  force: false,
+}
+
+describe('recommended-plugins component — check()', () => {
+  it('returns ok when every recommended plugin is already installed', async () => {
+    installedIds = ['messaging', 'projects']
+    const result = await recommendedPluginsComponent.check()
+    expect(result.status).toBe('ok')
+    expect(result.message).toMatch(/already installed/)
+  })
+
+  it('returns missing when some plugins are not yet installed', async () => {
+    installedIds = ['messaging']
+    const result = await recommendedPluginsComponent.check()
+    expect(result.status).toBe('missing')
+    expect(result.details?.missing).toEqual(['projects'])
+  })
+
+  it('returns missing when none are installed', async () => {
+    const result = await recommendedPluginsComponent.check()
+    expect(result.status).toBe('missing')
+    expect(result.details?.missing).toEqual(['messaging', 'projects'])
+  })
+})
+
+describe('recommended-plugins component — install() autoApprove', () => {
+  it('installs every defaultSelected plugin without prompting', async () => {
+    const result = await recommendedPluginsComponent.install(noninteractiveOpts)
+    expect(result.status).toBe('installed')
+    expect(installCalls).toEqual([
+      'github:madeinwyo/bakin-bits-official#plugins/messaging',
+    ])
+  })
+
+  it('returns noop when every recommended plugin is already installed', async () => {
+    installedIds = ['messaging', 'projects']
+    const result = await recommendedPluginsComponent.install(noninteractiveOpts)
+    expect(result.status).toBe('noop')
+    expect(installCalls).toEqual([])
+  })
+
+  it('skipped when no defaults match available recommendations', async () => {
+    // messaging is already installed, projects is NOT defaultSelected.
+    // → No defaults left to install non-interactively.
+    installedIds = ['messaging']
+    const result = await recommendedPluginsComponent.install(noninteractiveOpts)
+    expect(result.status).toBe('skipped')
+  })
+})
+
+describe('recommended-plugins component — install() interactive', () => {
+  it('drives the prompt and installs the user selection', async () => {
+    promptSelection = ['projects']
+    const result = await recommendedPluginsComponent.install(interactiveOpts)
+    expect(result.status).toBe('installed')
+    expect(installCalls).toEqual([
+      'github:madeinwyo/bakin-bits-official#plugins/projects',
+    ])
+  })
+
+  it('skipped when user picks nothing', async () => {
+    promptSelection = []
+    const result = await recommendedPluginsComponent.install(interactiveOpts)
+    expect(result.status).toBe('skipped')
+  })
+})
+
+describe('recommended-plugins component — failure modes', () => {
+  it('reports failed when every install errors', async () => {
+    installShouldFailFor = new Set(['messaging', 'projects'])
+    promptSelection = ['messaging', 'projects']
+    const result = await recommendedPluginsComponent.install(interactiveOpts)
+    expect(result.status).toBe('failed')
+  })
+
+  it('reports installed (partial) when some succeed, others fail', async () => {
+    installShouldFailFor = new Set(['projects'])
+    promptSelection = ['messaging', 'projects']
+    const result = await recommendedPluginsComponent.install(interactiveOpts)
+    expect(result.status).toBe('installed')
+    expect(result.message).toMatch(/installed 1\/2/)
+    expect(result.message).toMatch(/failed: projects/)
+  })
+})

--- a/tests/core/onboarding/recommended-plugins-prompt.test.tsx
+++ b/tests/core/onboarding/recommended-plugins-prompt.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Tests for the Ink-based recommended-plugins prompt component
+ * (Phase 6). Uses ink-testing-library to render the component
+ * headlessly and simulate keystrokes.
+ *
+ * The component contract:
+ *   - Initial selection seeds from each plugin's defaultSelected.
+ *   - Arrow keys + j/k navigate the cursor.
+ *   - Space toggles the cursor's plugin.
+ *   - 'a' toggles all (selects every if any are unselected; otherwise
+ *     deselects every).
+ *   - Enter calls onSubmit with the selected ids in plugins-array order.
+ *   - Escape / 'q' calls onSubmit with [].
+ */
+import { describe, it, expect, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-onboard-prompt-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/openclaw-home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import React from 'react'
+import { render } from 'ink-testing-library'
+import { __PluginsPromptForTest as PluginsPrompt } from '../../../src/core/onboarding/recommended-plugins-prompt'
+import type { RecommendedPlugin } from '../../../src/core/onboarding/types'
+
+const FIXTURE: readonly RecommendedPlugin[] = [
+  {
+    id: 'messaging',
+    source: 'github:madeinwyo/bakin-bits-official#plugins/messaging',
+    name: 'Messaging',
+    description: 'Brainstorm + draft + schedule content.',
+    defaultSelected: true,
+  },
+  {
+    id: 'projects',
+    source: 'github:madeinwyo/bakin-bits-official#plugins/projects',
+    name: 'Projects',
+    description: 'Lightweight project tracker.',
+    defaultSelected: false,
+  },
+  {
+    id: 'extra',
+    source: 'github:madeinwyo/bakin-bits-official#plugins/extra',
+    name: 'Extra',
+    description: 'A third recommendation.',
+    defaultSelected: true,
+  },
+]
+
+const ARROW_DOWN = '\x1b[B'
+const ARROW_UP = '\x1b[A'
+const ESC = '\x1b'
+const ENTER = '\r'
+
+// Ink's useInput is processed asynchronously through React state — the
+// keystroke lands in stdin, useInput's effect handler runs, setState
+// schedules a re-render, the next frame reflects the new state. Tests
+// must await a microtask flush before the assertion can see the result.
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 10))
+}
+
+describe('recommended-plugins prompt', () => {
+  it('renders the plugin list with default selections marked', () => {
+    let submitted: string[] | null = null
+    const { lastFrame } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    const out = lastFrame()
+    expect(out).toContain('Messaging')
+    expect(out).toContain('Projects')
+    expect(out).toContain('Extra')
+    // Defaults: messaging + extra checked, projects unchecked.
+    expect(out).toMatch(/\[x\] Messaging/)
+    expect(out).toMatch(/\[ \] Projects/)
+    expect(out).toMatch(/\[x\] Extra/)
+    expect(submitted as string[] | null).toBeNull()
+  })
+
+  it('Enter submits with the default selection on no input', async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write(ENTER)
+    await flush()
+    expect(submitted as string[] | null).toEqual(['messaging', 'extra'])
+  })
+
+  it('Space toggles the cursor row', async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    // Cursor starts on messaging (idx 0). Space deselects.
+    stdin.write(' ')
+    await flush()
+    stdin.write(ENTER)
+    await flush()
+    expect(submitted as string[] | null).toEqual(['extra'])
+  })
+
+  it('Arrow down + space toggles a different row', async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write(ARROW_DOWN) // cursor → projects
+    await flush()
+    stdin.write(' ')        // select projects
+    await flush()
+    stdin.write(ENTER)
+    await flush()
+    expect(submitted as string[] | null).toEqual(['messaging', 'projects', 'extra'])
+  })
+
+  it('Arrow up wraps to the last item', async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write(ARROW_UP)   // cursor wraps from idx 0 → idx 2 (extra)
+    await flush()
+    stdin.write(' ')        // toggle extra OFF
+    await flush()
+    stdin.write(ENTER)
+    await flush()
+    expect(submitted as string[] | null).toEqual(['messaging'])
+  })
+
+  it("'a' selects all when some are unchecked", async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write('a')        // projects was the only unchecked → now all selected
+    await flush()
+    stdin.write(ENTER)
+    await flush()
+    expect(submitted as string[] | null).toEqual(['messaging', 'projects', 'extra'])
+  })
+
+  it("'a' deselects all when everything is checked", async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write('a') // selects all
+    await flush()
+    stdin.write('a') // deselects all
+    await flush()
+    stdin.write(ENTER)
+    await flush()
+    expect(submitted as string[] | null).toEqual([])
+  })
+
+  it('Escape submits with empty selection (cancel)', async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write(ESC)
+    // Ink's terminal-input parser delays standalone escape briefly to
+    // disambiguate from arrow-key sequences (\x1b[A etc). Wait long
+    // enough for the escape to fire on its own.
+    await new Promise((r) => setTimeout(r, 60))
+    expect(submitted as string[] | null).toEqual([])
+  })
+
+  it("'q' submits with empty selection (cancel)", async () => {
+    let submitted: string[] | null = null
+    const { stdin } = render(
+      <PluginsPrompt plugins={FIXTURE} onSubmit={(ids) => { submitted = ids }} />,
+    )
+    stdin.write('q')
+    await flush()
+    expect(submitted as string[] | null).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Two independent-but-related phases of the plugin-architecture-v2 work, bundled per the user's preference for a single bakin PR with separate commits:

- **Phase 6** — onboard suggest flow infrastructure with Ink-based interactive prompt.
- **Phase 7** — formalize the feature-modules-vs-third-party-plugins layering rule, with documentation, ESLint enforcement, and a fitness test.

The recommended-plugins list ships empty today; entries land as Phases 4-5 extract messaging + projects to bakin-bits-official (currently blocked on SDK expansion — see "What's still deferred" below).

## Commits (6, in dependency order)

### Phase 6
1. `feat(onboarding): RecommendedPlugin type + curated list scaffold` — type + empty curated array + `ink` / `ink-testing-library` deps.
2. `feat(onboarding): Ink-based recommended-plugins prompt component` — `<PluginsPrompt>` checkbox list with full keyboard contract (↑↓/jk navigate, space toggle, a toggle-all, enter submit, esc/q cancel). 9 unit tests.
3. `feat(onboarding): wire recommended-plugins into COMPONENT_ORDER` — `recommendedPluginsComponent` lands as the 11th onboarding step. Three install modes (interactive prompt / autoApprove / partial-fail handling). 11 unit tests + orchestrator test updates from 10→11 components.

### Phase 7
4. `docs(arch): feature modules vs third-party plugins layering rule` — CLAUDE.md, `.claude/knowledge/plugin-system.md`, `.claude/knowledge/repo-architecture.md`. Documents the 8-feature-module list (currently 10, drops to 8 after Phase 4-5).
5. `feat(eslint): no-restricted-imports for ~/.bakin/plugins paths` — complementary lint block: core files (`src/`, `cli/`, `packages/core/`, `packages/host/`) cannot import paths matching `**/.bakin/plugins/**` or `~/.bakin/plugins/**`. Verified the rule fires.
6. `test(arch): fitness test against core→user-plugin imports` — `tests/architecture/feature-module-vs-plugin.test.ts` walks the same directories and grep-asserts no violations. Belt + suspenders against lint config drift.

## Verification

```
$ bun test --isolate
3823 pass / 0 fail / 1 skip across 297 files

$ bunx tsc --noEmit -p tsconfig.app.json
clean
```

## What's still deferred

- **Phase 4 + 5** — extract `messaging` + `projects` to bakin-bits-official. Blocked on SDK expansion: those plugins import `@/core/openclaw-client` (streamMessage, chatCompletion, sendChannelMessage), `@/core/vault`, `@/core/logger`, `@/core/content-dir` directly. None of those are on the `@bakin/sdk/*` surface today, and vendoring them into each extracted plugin would duplicate ~1000+ lines of bakin internals. Tracked separately as the "SDK expansion" precursor; once the SDK exposes those primitives, Phase 4-5 is straightforward.
- **bakin-bits-official skeleton (Phase 3)** — already shipped in [bakin-bits-official#1](https://github.com/legacy-owner/bakin-bits-official/pull/1). Workspace + CI + plugin template + CONTRIBUTING.md + ambient SDK type stubs (until #178 publishes the real package).
- **#175 — `@bakin/eslint-plugin-plugin-author`** — flags top-level side effects in plugin code. Separable from this PR; its own focused review cycle.

## Spec / plan refs

- Spec: `.claude/specs/plugin-extraction-and-hotreload.md`
- Plan: `.claude/specs/plugin-extraction-and-hotreload-plan.md` § Phase 6, Phase 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)