### PR TITLE
Fix React hook lint warnings

### DIFF
--- a/packages/host/src/components/layout/app-sidebar.tsx
+++ b/packages/host/src/components/layout/app-sidebar.tsx
@@ -20,7 +20,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
-import { getAllNavItems, getRegistryVersion, subscribeRegistry } from '@bakin/sdk'
+import { getNavItemsSnapshot, subscribeRegistry } from '@bakin/sdk'
 import { useSidebarContext } from '@/context/sidebar-context'
 import { usePathname } from '../../hooks/use-pathname'
 import {
@@ -59,11 +59,9 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void }) {
   // Subscribe to registry mutations so the sidebar re-renders when a
   // plugin hot-swaps (v2 dev mode) — PluginHost's own subscription only
   // forces PluginHost itself to re-render; consumers below need their own.
-  useSyncExternalStore(subscribeRegistry, getRegistryVersion, getRegistryVersion)
-  // Runtime registry (populated by each plugin's client.mjs via registerPlugin
-  // after the PluginHost dynamic-imports them). Fetched per render so
-  // newly-registered plugins surface on the next re-render cycle.
-  const allNavItems = getAllNavItems()
+  const allNavItems = useSyncExternalStore(subscribeRegistry, getNavItemsSnapshot, getNavItemsSnapshot)
+  // Runtime registry populated by each plugin's client.mjs via registerPlugin
+  // after PluginHost dynamically imports it.
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => {
     // Seed initial state: expand any group whose section is active on load
     const initial = new Set<string>()
@@ -95,7 +93,7 @@ export function AppSidebar({ onNavigate }: { onNavigate?: () => void }) {
       }
       return next
     })
-  }, [pathname])
+  }, [allNavItems, pathname])
 
   const toggleExpand = (id: string) => {
     setExpandedIds(current => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -28,6 +28,7 @@ export {
   getRegistryVersion,
   subscribeRegistry,
   getAllNavItems,
+  getNavItemsSnapshot,
   getPluginNavItems,
   getPluginRoute,
   getPluginRoutes,

--- a/packages/sdk/src/register.ts
+++ b/packages/sdk/src/register.ts
@@ -61,8 +61,17 @@ interface ClientRegistry {
   navByPlugin: Map<string, NavItem[]>
   routesByPlugin: Map<string, ClientRouteEntry[]>
   cleanupByPlugin: Map<string, Array<() => void>>
+  navItemsSnapshot: NavItem[]
   version: number
   listeners: Set<() => void>
+}
+
+function buildNavItemsSnapshot(registry: ClientRegistry): NavItem[] {
+  const items: NavItem[] = []
+  for (const navItems of registry.navByPlugin.values()) {
+    items.push(...navItems)
+  }
+  return items.sort((a, b) => (a.order ?? 100) - (b.order ?? 100))
 }
 
 function getRegistry(): ClientRegistry {
@@ -72,15 +81,21 @@ function getRegistry(): ClientRegistry {
       navByPlugin: new Map<string, NavItem[]>(),
       routesByPlugin: new Map<string, ClientRouteEntry[]>(),
       cleanupByPlugin: new Map<string, Array<() => void>>(),
+      navItemsSnapshot: [],
       version: 0,
       listeners: new Set<() => void>(),
     } as ClientRegistry
   }
-  return g.__bakinClientRegistry as ClientRegistry
+  const registry = g.__bakinClientRegistry as ClientRegistry
+  if (!Array.isArray(registry.navItemsSnapshot)) {
+    registry.navItemsSnapshot = buildNavItemsSnapshot(registry)
+  }
+  return registry
 }
 
 function bumpVersion(): void {
   const registry = getRegistry()
+  registry.navItemsSnapshot = buildNavItemsSnapshot(registry)
   registry.version++
   for (const l of registry.listeners) {
     try { l() } catch (err) { console.error('[bakin] registry listener threw:', err) }
@@ -175,12 +190,15 @@ export function subscribeRegistry(listener: () => void): () => void {
  * The shell's sidebar reads this at render time.
  */
 export function getAllNavItems(): NavItem[] {
-  const registry = getRegistry()
-  const items: NavItem[] = []
-  for (const navItems of registry.navByPlugin.values()) {
-    items.push(...navItems)
-  }
-  return items.sort((a, b) => (a.order ?? 100) - (b.order ?? 100))
+  return [...getRegistry().navItemsSnapshot]
+}
+
+/**
+ * Stable nav snapshot for React's useSyncExternalStore. The returned array
+ * identity only changes when plugin registration changes.
+ */
+export function getNavItemsSnapshot(): readonly NavItem[] {
+  return getRegistry().navItemsSnapshot
 }
 
 /**

--- a/plugins/schedule/components/job-form.tsx
+++ b/plugins/schedule/components/job-form.tsx
@@ -59,7 +59,7 @@ export function JobForm({
       setPrompt(initial.taskPrompt ?? '')
       setWorkflowId(initial.workflowId ?? '')
       setTaskTitle(initial.taskTitle ?? '')
-      setOwner(initial.owner ?? mainAgentId ?? '')
+      setOwner(initial.owner ?? '')
       setRequireTriage(initial.requireTriage ?? false)
       setAllowOverlap(initial.allowOverlap ?? false)
       setMaxFailures(initial.maxFailures ?? 3)
@@ -69,9 +69,10 @@ export function JobForm({
 
   // Sync default owner once main agent id resolves from the team store.
   useEffect(() => {
+    if (initial?.owner) return
     if (!mainAgentId) return
     setOwner((prev) => (prev ? prev : mainAgentId))
-  }, [mainAgentId])
+  }, [initial, mainAgentId])
 
   const canSubmit = name.trim() && schedule.trim() && parsedOk && !submitting
 

--- a/plugins/tasks/components/kanban-board.tsx
+++ b/plugins/tasks/components/kanban-board.tsx
@@ -338,7 +338,7 @@ export function KanbanBoard() {
 
     await refreshTaskboard()
     setOptimistic(null)
-  }, [agentFilter, hasBoardFilters, optimistic, parsed.columns, refreshTaskboard, search])
+  }, [agentFilter, hasBoardFilters, optimistic, refreshTaskboard, search])
 
   const [detailTask, setDetailTask] = useState<{ task: Task; columnId: ColumnId } | null>(null)
   const [editing, setEditing] = useState(false)

--- a/plugins/tasks/components/task-detail-dialog.tsx
+++ b/plugins/tasks/components/task-detail-dialog.tsx
@@ -229,7 +229,7 @@ export function TaskDetailDrawer({ task, columnId, open, editing, onClose, onEdi
       .then(r => r.ok ? r.json() : null)
       .then(d => { if (d?.definition) setWfDefinition(d.definition) })
       .catch(() => {})
-  }, [workflowId])
+  }, [wfDefinition?.name, workflowId])
 
   // Derived workflow state
   const isGatePending = wfInstance?.status === 'pending_approval'

--- a/plugins/workflows/components/workflow-canvas-editor.tsx
+++ b/plugins/workflows/components/workflow-canvas-editor.tsx
@@ -38,7 +38,7 @@ import { Copy, LayoutGrid, Save, Trash2 } from 'lucide-react'
 import { Button } from "@bakin/sdk/ui"
 import { Input } from "@bakin/sdk/ui"
 
-import { getAllNodeRenderers, getNodeRendererVersion, subscribeNodeRenderers } from '../lib/node-renderer-registry'
+import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-renderer-registry'
 import { NodeTypePalette, PALETTE_DRAG_MIME_TYPE } from './node-type-palette'
 import { NodeConfigDrawer } from './node-config-drawer'
 import { canConnect } from '../lib/edge-rules'
@@ -220,8 +220,7 @@ export function WorkflowCanvasEditor({
   const rfInstanceRef = useRef<ReactFlowInstance | null>(null)
 
   // Subscribe to registry mutations — see note in workflow-canvas.tsx.
-  const rendererVersion = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererVersion, getNodeRendererVersion)
-  const nodeTypes = useMemo<NodeTypes>(() => getAllNodeRenderers(), [rendererVersion])
+  const nodeTypes = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererSnapshot, getNodeRendererSnapshot) as NodeTypes
   const nodes = useMemo(() => deriveNodes(state), [state])
   const edges = state.edges
 

--- a/plugins/workflows/components/workflow-canvas.tsx
+++ b/plugins/workflows/components/workflow-canvas.tsx
@@ -26,7 +26,7 @@ const RESET_NODE_STYLES = `
   }
 `
 
-import { getAllNodeRenderers, getNodeRendererVersion, subscribeNodeRenderers } from '../lib/node-renderer-registry'
+import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-renderer-registry'
 import type { WorkflowDefinition, WorkflowStep } from '../types'
 
 const NODE_WIDTH = 280
@@ -287,8 +287,7 @@ export function WorkflowCanvas({ definition, subWorkflows, onNodeClick }: Workfl
   // load, hot install) trigger a re-render — ESM hoisting means a
   // module-scope snapshot would be empty, and a one-shot mount-time memo
   // would miss anything registered after the canvas mounts.
-  const rendererVersion = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererVersion, getNodeRendererVersion)
-  const nodeTypes = useMemo<NodeTypes>(() => getAllNodeRenderers(), [rendererVersion])
+  const nodeTypes = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererSnapshot, getNodeRendererSnapshot) as NodeTypes
   const { nodes: initialNodes, edges } = useMemo(
     () => buildGraph(definition, subWorkflows),
     [definition, subWorkflows],

--- a/plugins/workflows/lib/node-renderer-registry.ts
+++ b/plugins/workflows/lib/node-renderer-registry.ts
@@ -26,8 +26,18 @@ export type NodeRenderer = ComponentType<NodeProps>
 const registry = new Map<string, NodeRenderer>()
 const listeners = new Set<() => void>()
 let version = 0
+let nodeTypesSnapshot: NodeTypes = {}
+
+function rebuildNodeTypesSnapshot(): void {
+  const result: NodeTypes = {}
+  for (const [kind, component] of registry.entries()) {
+    result[kind] = component
+  }
+  nodeTypesSnapshot = result
+}
 
 function notify(): void {
+  rebuildNodeTypesSnapshot()
   version++
   for (const l of listeners) l()
 }
@@ -55,11 +65,15 @@ export function getNodeRenderer(kind: string): NodeRenderer | undefined {
 
 /** Return the full kind→component map in the shape xyflow's nodeTypes prop expects. */
 export function getAllNodeRenderers(): NodeTypes {
-  const result: NodeTypes = {}
-  for (const [kind, component] of registry.entries()) {
-    result[kind] = component
-  }
-  return result
+  return { ...nodeTypesSnapshot }
+}
+
+/**
+ * Stable snapshot for React's useSyncExternalStore. Unlike getAllNodeRenderers,
+ * this returns the same object until the registry mutates.
+ */
+export function getNodeRendererSnapshot(): NodeTypes {
+  return nodeTypesSnapshot
 }
 
 /** List registered kinds — used by the palette to enumerate available node types. */

--- a/tests/plugins/workflows/node-renderer-registry.test.ts
+++ b/tests/plugins/workflows/node-renderer-registry.test.ts
@@ -33,6 +33,7 @@ import {
   unregisterNodeRenderer,
   getNodeRenderer,
   getAllNodeRenderers,
+  getNodeRendererSnapshot,
   listNodeRendererKinds,
 } from '../../../plugins/workflows/lib/node-renderer-registry'
 
@@ -77,6 +78,24 @@ describe('node-renderer-registry', () => {
     registerNodeRenderer('test.delta', StubA)
     const all = getAllNodeRenderers()
     expect(all['test.delta']).toBe(StubA)
+  })
+
+  it('exposes a stable nodeTypes snapshot for useSyncExternalStore', () => {
+    const before = getNodeRendererSnapshot()
+    expect(getNodeRendererSnapshot()).toBe(before)
+
+    registerNodeRenderer('test.snapshot', StubA)
+    const afterRegister = getNodeRendererSnapshot()
+    expect(afterRegister).not.toBe(before)
+    expect(afterRegister['test.snapshot']).toBe(StubA)
+    expect(getNodeRendererSnapshot()).toBe(afterRegister)
+
+    const copy = getAllNodeRenderers()
+    expect(copy).toEqual(afterRegister)
+    expect(copy).not.toBe(afterRegister)
+
+    unregisterNodeRenderer('test.snapshot')
+    expect(getNodeRendererSnapshot()).not.toBe(afterRegister)
   })
 
   it('listNodeRendererKinds returns registered kinds', () => {

--- a/tests/sdk/register.test.ts
+++ b/tests/sdk/register.test.ts
@@ -35,6 +35,7 @@ import {
   getRegistryVersion,
   subscribeRegistry,
   getAllNavItems,
+  getNavItemsSnapshot,
   getPluginNavItems,
   getPluginRoute,
   getPluginRoutes,
@@ -196,5 +197,23 @@ describe('getRegistryVersion + subscribeRegistry', () => {
     unsubscribe()
     registerPlugin({ id: 'x' })
     expect(listener).toHaveBeenCalledTimes(2)  // no further calls after unsubscribe
+  })
+
+  it('exposes a stable nav snapshot for useSyncExternalStore', () => {
+    const before = getNavItemsSnapshot()
+    expect(getNavItemsSnapshot()).toBe(before)
+
+    registerPlugin({ id: 'x', navItems: [{ id: 'x-nav', label: 'X', href: '/x' }] })
+    const afterRegister = getNavItemsSnapshot()
+    expect(afterRegister).not.toBe(before)
+    expect(afterRegister.some((item) => item.id === 'x-nav')).toBe(true)
+    expect(getNavItemsSnapshot()).toBe(afterRegister)
+
+    const copy = getAllNavItems()
+    expect(copy).toEqual([...afterRegister])
+    expect(copy).not.toBe(afterRegister)
+
+    unregisterPlugin('x')
+    expect(getNavItemsSnapshot()).not.toBe(afterRegister)
   })
 })


### PR DESCRIPTION
## Summary
- add stable SDK nav and workflow node-renderer snapshots for useSyncExternalStore
- fix remaining hook dependency warnings in schedule, tasks, and workflows
- add focused tests covering snapshot identity and defensive copy behavior

## Validation
- bun run lint
- bunx tsc --noEmit -p tsconfig.app.json
- bun test --isolate tests/sdk/register.test.ts tests/plugins/workflows/node-renderer-registry.test.ts tests/core/onboarding/index.test.ts tests/plugins/workflows/sync-hook.test.ts tests/plugins/tasks/routes.test.ts tests/plugins/schedule/routes.test.ts
- bun test --isolate
