### PR TITLE
feat: block plugin import-time lifetime side effects

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -160,6 +160,14 @@ coordinator watches the plugin source root, then filters events against
 `devWatch` patterns itself. Supported patterns intentionally cover the
 common plugin shapes: literal files/directories, `*`, `?`, and `**/*.ext`.
 
+Plugin modules must not create lifetime side effects during import. Old
+module instances remain reachable after cache-busted hot reloads, so
+top-level timers, process listeners, file watchers, sockets, EventSources,
+and event-target listeners leak across saves. The
+`bakin/no-plugin-top-level-side-effects` ESLint rule enforces the direct
+cases. Create lifetime resources inside `activate(ctx)` or narrower
+handlers, store the handle/disposer, and clean them in `onShutdown()`.
+
 ### Why the old module doesn't break
 
 - Old module's exports (React components) were rendered into the DOM. After `unregisterPlugin`, the shell re-renders without those components — React unmounts the subtrees. The exports become garbage.

--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -921,6 +921,12 @@ after restart either matches (0 = client default) or detects a
   the new server module before calling `onShutdown` or sweeping old
   registrations. Syntax/top-level import mistakes therefore show a dev
   overlay without disabling the previous working plugin.
+- **Plugin module import must stay free of lifetime side effects.**
+  Timers, process listeners, file watchers, sockets, and event listeners
+  must be created inside `activate(ctx)` or narrower handlers and cleaned
+  in `onShutdown()`. `bakin/no-plugin-top-level-side-effects` enforces the
+  direct import-time cases because old module instances stay alive after a
+  cache-busted hot reload.
 - **Search tables survive hot reload.** The reload path unregisters
   plugin-owned search wiring and pending reconciles, then recreates them
   on activate. Only remove/uninstall purges backing tables.

--- a/docs/src/content/docs/extend/plugins/server-contracts.md
+++ b/docs/src/content/docs/extend/plugins/server-contracts.md
@@ -38,6 +38,8 @@ export default plugin
 
 Use `activate()` for registration, not for long-running background work. Keep side effects obvious and idempotent so plugin reload and test setup are predictable.
 
+Do not create lifetime resources at module import time. Timers, process listeners, file watchers, sockets, EventSources, and event-target listeners belong inside `activate(ctx)` or a narrower handler and need a matching cleanup path. Bakin's plugin lint rule fails direct top-level lifetime side effects because old module instances can survive hot reload.
+
 | API | Use it for |
 | --- | --- |
 | `ctx.registerRoute()` | HTTP routes under the plugin API mount. |
@@ -120,4 +122,4 @@ settingsSchema: {
 
 ## Shutdown
 
-Use `onShutdown()` for graceful cleanup and `onSettingsChange()` for settings-driven updates. Do not make plugin consumers restart Bakin for ordinary configuration changes unless the underlying service truly requires it.
+Use `onShutdown()` for graceful cleanup and `onSettingsChange()` for settings-driven updates. Clear interval/timeout handles, close sockets/EventSources/watchers, and call any unsubscribe functions returned by event buses or external libraries. Do not make plugin consumers restart Bakin for ordinary configuration changes unless the underlying service truly requires it.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import react from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
+import noPluginTopLevelSideEffects from "./scripts/eslint-rules/no-plugin-top-level-side-effects.mjs";
 
 // Bakin runs across Bun server code, browser UI code, CLI scripts, and tests.
 // TypeScript owns undefined checks; this keeps ESLint from misclassifying
@@ -70,6 +71,12 @@ const adapterBoundaryImportRestrictions = {
       message: "Legacy provider internals are behind the adapter layer. Route through the runtime/search adapter contract.",
     },
   ],
+};
+
+const bakinPluginRules = {
+  rules: {
+    "no-plugin-top-level-side-effects": noPluginTopLevelSideEffects,
+  },
 };
 
 const eslintConfig = defineConfig([
@@ -167,8 +174,10 @@ const eslintConfig = defineConfig([
   // established in #141 (SDK + slot system) and enforced through the Bun
   // migration in #147.
   {
-    files: ["plugins/**/*.{ts,tsx}"],
+    files: ["plugins/**/*.{ts,tsx,js,mjs,mts}"],
+    plugins: { bakin: bakinPluginRules },
     rules: {
+      "bakin/no-plugin-top-level-side-effects": "error",
       "no-restricted-imports": ["error", {
         paths: adapterBoundaryImportRestrictions.paths,
         patterns: [

--- a/plugins/memory/index.ts
+++ b/plugins/memory/index.ts
@@ -67,6 +67,14 @@ const DEFAULTS: MemorySettings = {
 // exist.
 let deferredBackfill: (() => Promise<void>) | null = null
 let ready = false
+let eventDisposers: Array<() => void> = []
+
+function clearEventSubscriptions(): void {
+  for (const dispose of eventDisposers) {
+    dispose()
+  }
+  eventDisposers = []
+}
 
 const memoryPlugin: BakinPlugin = {
   id: 'memory',
@@ -127,6 +135,8 @@ const memoryPlugin: BakinPlugin = {
   contentFiles: [],
 
   async activate(ctx: PluginContext) {
+    clearEventSubscriptions()
+
     const settings = { ...DEFAULTS, ...(ctx.getSettings<Partial<MemorySettings>>() ?? {}) }
 
     // ─── Search: unified bakin_memory table ─────────────────────────────────
@@ -209,18 +219,18 @@ const memoryPlugin: BakinPlugin = {
     // provider-owned tiers is owned by the indexer itself.
     // Events that fire before onReady() would hit a missing table, so we
     // gate them behind the same ready flag as the initial backfill.
-    ctx.events.on('file.add', (_event, data) => {
+    eventDisposers.push(ctx.events.on('file.add', (_event, data) => {
       if (!ready) return
       void indexer.handleWatcherEvent(String(data.file ?? ''), 'add')
-    })
-    ctx.events.on('file.change', (_event, data) => {
+    }))
+    eventDisposers.push(ctx.events.on('file.change', (_event, data) => {
       if (!ready) return
       void indexer.handleWatcherEvent(String(data.file ?? ''), 'change')
-    })
-    ctx.events.on('file.unlink', (_event, data) => {
+    }))
+    eventDisposers.push(ctx.events.on('file.unlink', (_event, data) => {
       if (!ready) return
       void indexer.handleWatcherEvent(String(data.file ?? ''), 'unlink')
-    })
+    }))
 
     // Defer the initial backfill until onReady(). activate() runs BEFORE
     // createRegisteredTables() in server.ts, so writes issued here would
@@ -306,6 +316,7 @@ const memoryPlugin: BakinPlugin = {
   async onShutdown() {
     ready = false
     deferredBackfill = null
+    clearEventSubscriptions()
     stopTtlTimer()
   },
 }

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -36,6 +36,14 @@ import type { Task, ColumnId } from './types'
 const log = createLogger('tasks')
 
 const COLUMNS = ['backlog', 'todo', 'inProgress', 'review', 'done', 'blocked', 'archived'] as const
+let maintenanceTimers: Array<ReturnType<typeof setInterval>> = []
+
+function clearMaintenanceTimers(): void {
+  for (const timer of maintenanceTimers) {
+    clearInterval(timer)
+  }
+  maintenanceTimers = []
+}
 
 const tasksPlugin: BakinPlugin = {
   id: 'tasks',
@@ -56,6 +64,8 @@ const tasksPlugin: BakinPlugin = {
   ],
 
   activate(ctx: PluginContext) {
+    clearMaintenanceTimers()
+
     // ─── Search Content Type Registration ─────────────────────────────
 
     ctx.search.registerContentType({
@@ -705,10 +715,10 @@ const tasksPlugin: BakinPlugin = {
     // Auto-archive: move done tasks to archived after 24 hours (runs hourly)
     const autoArchived = autoArchiveDoneTasks()
     if (autoArchived > 0) log.info(`Auto-archived ${autoArchived} done tasks (>24h)`)
-    setInterval(() => {
+    maintenanceTimers.push(setInterval(() => {
       const count = autoArchiveDoneTasks()
       if (count > 0) log.info(`Auto-archive: moved ${count} done tasks to archived`)
-    }, 60 * 60 * 1000)
+    }, 60 * 60 * 1000))
 
     // Hard-delete old completed tasks on startup + every 6 hours
     const taskSettings = ctx.getSettings<{ autoArchiveDays?: number }>()
@@ -716,10 +726,10 @@ const tasksPlugin: BakinPlugin = {
       const days = taskSettings.autoArchiveDays
       const deleted = archiveOldTasks(days)
       if (deleted > 0) log.info(`Deleted ${deleted} old tasks (>${days} days)`)
-      setInterval(() => {
+      maintenanceTimers.push(setInterval(() => {
         const count = archiveOldTasks(days)
         if (count > 0) log.info(`Periodic cleanup: deleted ${count} old tasks`)
-      }, 6 * 60 * 60 * 1000)
+      }, 6 * 60 * 60 * 1000))
     }
 
     // ─── Health checks (migrated out of core/doctor.ts per #139 C2) ─────
@@ -756,6 +766,7 @@ const tasksPlugin: BakinPlugin = {
   },
 
   onShutdown() {
+    clearMaintenanceTimers()
     log.info('Shutting down tasks plugin')
   },
 }

--- a/scripts/eslint-rules/no-plugin-top-level-side-effects.mjs
+++ b/scripts/eslint-rules/no-plugin-top-level-side-effects.mjs
@@ -1,0 +1,304 @@
+const TIMER_NAMES = new Set(['setInterval', 'setTimeout'])
+const EVENT_TARGET_NAMES = new Set(['globalThis', 'window', 'document', 'self'])
+const PROCESS_LISTENER_NAMES = new Set(['on', 'addListener'])
+const FILE_WATCH_NAMES = new Set(['watch', 'watchFile'])
+const EVENT_LISTENER_NAMES = new Set(['on', 'addListener'])
+const SOCKET_NAMES = new Set(['WebSocket', 'EventSource'])
+const FS_MODULES = new Set(['fs', 'node:fs'])
+const CHOKIDAR_MODULES = new Set(['chokidar'])
+const EVENTS_MODULES = new Set(['events', 'node:events'])
+
+function unwrap(node) {
+  let current = node
+  while (
+    current &&
+    (current.type === 'ChainExpression' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSAsExpression' ||
+      current.type === 'TSTypeAssertion')
+  ) {
+    current = current.expression
+  }
+  return current
+}
+
+function getStaticName(node) {
+  const unwrapped = unwrap(node)
+  if (!unwrapped) return null
+  if (unwrapped.type === 'Identifier') return unwrapped.name
+  if (unwrapped.type === 'Literal' && typeof unwrapped.value === 'string') return unwrapped.value
+  return null
+}
+
+function getMemberParts(node) {
+  const unwrapped = unwrap(node)
+  if (!unwrapped || unwrapped.type !== 'MemberExpression') return null
+  return {
+    object: unwrap(unwrapped.object),
+    property: getStaticName(unwrapped.property),
+  }
+}
+
+function isRequireCall(node, modules) {
+  const unwrapped = unwrap(node)
+  return Boolean(
+    unwrapped &&
+    unwrapped.type === 'CallExpression' &&
+    getStaticName(unwrapped.callee) === 'require' &&
+    unwrapped.arguments.length > 0 &&
+    unwrapped.arguments[0].type === 'Literal' &&
+    modules.has(unwrapped.arguments[0].value),
+  )
+}
+
+function isZeroDelay(node) {
+  const unwrapped = unwrap(node)
+  if (!unwrapped) return false
+  if (unwrapped.type === 'Literal') return Number(unwrapped.value) === 0
+  if (unwrapped.type === 'UnaryExpression' && ['+', '-'].includes(unwrapped.operator)) {
+    return isZeroDelay(unwrapped.argument)
+  }
+  return false
+}
+
+function isTimeoutAllowed(node) {
+  if (node.arguments.length < 2) return true
+  return isZeroDelay(node.arguments[1])
+}
+
+function isIifeFunction(node, sourceCode) {
+  const ancestors = sourceCode.getAncestors(node)
+  const parent = ancestors.at(-1)
+  if (!parent || parent.type !== 'CallExpression') return false
+  return unwrap(parent.callee) === node
+}
+
+function createNoPluginTopLevelSideEffectsRule(context) {
+  const sourceCode = context.sourceCode ?? context.getSourceCode()
+  const importTimeStack = [true]
+  const fsNamespaces = new Set()
+  const chokidarNamespaces = new Set()
+  const fsWatchFunctions = new Set()
+  const chokidarWatchFunctions = new Set()
+  const eventNamespaces = new Set()
+  const eventEmitterConstructors = new Set(['EventEmitter'])
+  const eventEmitterVariables = new Set()
+
+  function inImportTimeContext() {
+    return importTimeStack.at(-1) === true
+  }
+
+  function report(node, kind) {
+    context.report({
+      node,
+      messageId: 'topLevelLifetimeSideEffect',
+      data: { kind },
+    })
+  }
+
+  function trackImportDeclaration(node) {
+    const source = node.source.value
+    const isFs = FS_MODULES.has(source)
+    const isChokidar = CHOKIDAR_MODULES.has(source)
+    const isEvents = EVENTS_MODULES.has(source)
+    if (!isFs && !isChokidar && !isEvents) return
+
+    for (const specifier of node.specifiers) {
+      if (specifier.type === 'ImportNamespaceSpecifier' || specifier.type === 'ImportDefaultSpecifier') {
+        if (isFs) fsNamespaces.add(specifier.local.name)
+        if (isChokidar) chokidarNamespaces.add(specifier.local.name)
+        if (isEvents) eventNamespaces.add(specifier.local.name)
+        continue
+      }
+
+      if (specifier.type !== 'ImportSpecifier') continue
+      const imported = getStaticName(specifier.imported)
+      if (isFs && FILE_WATCH_NAMES.has(imported)) fsWatchFunctions.add(specifier.local.name)
+      if (isChokidar && imported === 'watch') chokidarWatchFunctions.add(specifier.local.name)
+      if (isEvents && imported === 'EventEmitter') eventEmitterConstructors.add(specifier.local.name)
+    }
+  }
+
+  function trackRequireDeclaration(node) {
+    if (!inImportTimeContext()) return
+    const id = node.id
+    const init = unwrap(node.init)
+    if (!id || !init) return
+
+    if (id.type === 'Identifier') {
+      if (isRequireCall(init, FS_MODULES)) fsNamespaces.add(id.name)
+      if (isRequireCall(init, CHOKIDAR_MODULES)) chokidarNamespaces.add(id.name)
+      if (isRequireCall(init, EVENTS_MODULES)) eventNamespaces.add(id.name)
+      if (isEventEmitterNew(init)) eventEmitterVariables.add(id.name)
+      return
+    }
+
+    if (id.type !== 'ObjectPattern') return
+    if (!isRequireCall(init, FS_MODULES) && !isRequireCall(init, CHOKIDAR_MODULES) && !isRequireCall(init, EVENTS_MODULES)) return
+
+    for (const property of id.properties) {
+      if (property.type !== 'Property') continue
+      const imported = getStaticName(property.key)
+      const local = property.value?.type === 'Identifier' ? property.value.name : null
+      if (!imported || !local) continue
+      if (isRequireCall(init, FS_MODULES) && FILE_WATCH_NAMES.has(imported)) fsWatchFunctions.add(local)
+      if (isRequireCall(init, CHOKIDAR_MODULES) && imported === 'watch') chokidarWatchFunctions.add(local)
+      if (isRequireCall(init, EVENTS_MODULES) && imported === 'EventEmitter') eventEmitterConstructors.add(local)
+    }
+  }
+
+  function isFsWatchCall(callee) {
+    const name = getStaticName(callee)
+    if (name && fsWatchFunctions.has(name)) return true
+
+    const member = getMemberParts(callee)
+    return Boolean(
+      member &&
+      member.object?.type === 'Identifier' &&
+      fsNamespaces.has(member.object.name) &&
+      FILE_WATCH_NAMES.has(member.property),
+    )
+  }
+
+  function isChokidarWatchCall(callee) {
+    const name = getStaticName(callee)
+    if (name && chokidarWatchFunctions.has(name)) return true
+
+    const member = getMemberParts(callee)
+    return Boolean(
+      member &&
+      member.object?.type === 'Identifier' &&
+      chokidarNamespaces.has(member.object.name) &&
+      member.property === 'watch',
+    )
+  }
+
+  function isEventEmitterNew(node) {
+    const unwrapped = unwrap(node)
+    if (!unwrapped || unwrapped.type !== 'NewExpression') return false
+
+    const calleeName = getStaticName(unwrapped.callee)
+    if (calleeName && eventEmitterConstructors.has(calleeName)) return true
+
+    const member = getMemberParts(unwrapped.callee)
+    return Boolean(
+      member &&
+      member.object?.type === 'Identifier' &&
+      eventNamespaces.has(member.object.name) &&
+      member.property === 'EventEmitter',
+    )
+  }
+
+  function isEventEmitterListenerCall(callee) {
+    const member = getMemberParts(callee)
+    if (!member || !EVENT_LISTENER_NAMES.has(member.property)) return false
+
+    const object = unwrap(member.object)
+    if (isEventEmitterNew(object)) return true
+    return Boolean(object?.type === 'Identifier' && eventEmitterVariables.has(object.name))
+  }
+
+  function checkCallExpression(node) {
+    if (!inImportTimeContext()) return
+
+    const callee = unwrap(node.callee)
+    const name = getStaticName(callee)
+    if (name && TIMER_NAMES.has(name)) {
+      if (name === 'setTimeout' && isTimeoutAllowed(node)) return
+      report(node, 'timer')
+      return
+    }
+
+    if (isFsWatchCall(callee) || isChokidarWatchCall(callee)) {
+      report(node, 'file watcher')
+      return
+    }
+
+    const member = getMemberParts(callee)
+    if (!member) {
+      if (isEventEmitterListenerCall(callee)) report(node, 'event listener')
+      return
+    }
+
+    const objectName = getStaticName(member.object)
+    if (objectName && TIMER_NAMES.has(member.property) && EVENT_TARGET_NAMES.has(objectName)) {
+      if (member.property === 'setTimeout' && isTimeoutAllowed(node)) return
+      report(node, 'timer')
+      return
+    }
+
+    if (objectName === 'process' && PROCESS_LISTENER_NAMES.has(member.property)) {
+      report(node, 'process listener')
+      return
+    }
+
+    if (objectName && EVENT_TARGET_NAMES.has(objectName) && member.property === 'addEventListener') {
+      report(node, 'event listener')
+      return
+    }
+
+    if (isEventEmitterListenerCall(callee)) {
+      report(node, 'event listener')
+    }
+  }
+
+  function checkNewExpression(node) {
+    if (!inImportTimeContext()) return
+
+    const calleeName = getStaticName(node.callee)
+    if (calleeName && SOCKET_NAMES.has(calleeName)) {
+      report(node, 'connection')
+      return
+    }
+
+    const member = getMemberParts(node.callee)
+    const objectName = member ? getStaticName(member.object) : null
+    if (member && objectName && EVENT_TARGET_NAMES.has(objectName) && SOCKET_NAMES.has(member.property)) {
+      report(node, 'connection')
+    }
+  }
+
+  function enterFunction(node) {
+    importTimeStack.push(inImportTimeContext() && isIifeFunction(node, sourceCode))
+  }
+
+  function exitFunction() {
+    importTimeStack.pop()
+  }
+
+  return {
+    ImportDeclaration: trackImportDeclaration,
+    VariableDeclarator: trackRequireDeclaration,
+    FunctionDeclaration: enterFunction,
+    'FunctionDeclaration:exit': exitFunction,
+    FunctionExpression: enterFunction,
+    'FunctionExpression:exit': exitFunction,
+    ArrowFunctionExpression: enterFunction,
+    'ArrowFunctionExpression:exit': exitFunction,
+    CallExpression: checkCallExpression,
+    NewExpression: checkNewExpression,
+    'VariableDeclarator:exit'(node) {
+      if (!inImportTimeContext()) return
+      if (node.id?.type === 'Identifier' && isEventEmitterNew(node.init)) {
+        eventEmitterVariables.add(node.id.name)
+      }
+    },
+  }
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow plugin lifetime side effects during module import',
+    },
+    schema: [],
+    messages: {
+      topLevelLifetimeSideEffect:
+        'Move this top-level {{kind}} into activate(ctx) and pair it with cleanup in onShutdown(ctx). Module-load lifetime side effects leak across plugin hot reloads.',
+    },
+  },
+  create: createNoPluginTopLevelSideEffectsRule,
+}
+
+export default rule

--- a/tests/eslint/no-plugin-top-level-side-effects.test.mjs
+++ b/tests/eslint/no-plugin-top-level-side-effects.test.mjs
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'bun:test'
+import { Linter } from 'eslint'
+import tseslint from 'typescript-eslint'
+import rule from '../../scripts/eslint-rules/no-plugin-top-level-side-effects.mjs'
+
+function lint(code, filename = 'plugins/example/index.ts') {
+  const linter = new Linter({ configType: 'flat' })
+  return linter.verify(
+    code,
+    {
+      files: ['**/*.{ts,tsx,js,mjs,mts}'],
+      languageOptions: {
+        parser: tseslint.parser,
+        ecmaVersion: 2024,
+        sourceType: 'module',
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
+      plugins: {
+        bakin: {
+          rules: {
+            'no-plugin-top-level-side-effects': rule,
+          },
+        },
+      },
+      rules: {
+        'bakin/no-plugin-top-level-side-effects': 'error',
+      },
+    },
+    { filename },
+  )
+}
+
+function expectClean(code, filename) {
+  expect(lint(code, filename)).toEqual([])
+}
+
+function expectOneError(code, expectedText) {
+  const messages = lint(code)
+  expect(messages).toHaveLength(1)
+  expect(messages[0].ruleId).toBe('bakin/no-plugin-top-level-side-effects')
+  expect(messages[0].message).toContain(expectedText)
+}
+
+describe('bakin/no-plugin-top-level-side-effects', () => {
+  it('allows lifetime work inside plugin lifecycle hooks', () => {
+    expectClean(`
+      import type { BakinPlugin } from '@bakin/sdk/types'
+
+      let timer
+      const plugin: BakinPlugin = {
+        id: 'demo',
+        name: 'Demo',
+        version: '1.0.0',
+        activate() {
+          timer = setInterval(() => {}, 1000)
+          process.on('SIGTERM', () => {})
+        },
+        onShutdown() {
+          clearInterval(timer)
+        },
+      }
+
+      export default plugin
+    `)
+  })
+
+  it('allows component and route-local side effects', () => {
+    expectClean(`
+      import { useEffect } from 'react'
+
+      export function Demo() {
+        useEffect(() => {
+          const timer = window.setInterval(() => {}, 1000)
+          const es = new EventSource('/api/events')
+          window.addEventListener('resize', () => {})
+          return () => {
+            clearInterval(timer)
+            es.close()
+          }
+        }, [])
+        return null
+      }
+
+      export const route = {
+        handler() {
+          const ws = new WebSocket('ws://localhost')
+          return new Response('ok')
+        },
+      }
+    `, 'plugins/example/client.tsx')
+  })
+
+  it('allows top-level zero-delay timeout scheduling', () => {
+    expectClean(`
+      setTimeout(() => {})
+      window.setTimeout(() => {}, 0)
+    `)
+  })
+
+  it('flags top-level timers', () => {
+    expectOneError(`
+      setInterval(() => {}, 1000)
+    `, 'timer')
+  })
+
+  it('flags top-level dynamic-delay timeouts', () => {
+    expectOneError(`
+      const delay = Number(process.env.DELAY_MS ?? 1000)
+      globalThis.setTimeout(() => {}, delay)
+    `, 'timer')
+  })
+
+  it('flags timers inside top-level IIFEs', () => {
+    expectOneError(`
+      ;(async () => {
+        setInterval(() => {}, 1000)
+      })()
+    `, 'timer')
+  })
+
+  it('flags process listeners', () => {
+    expectOneError(`
+      process.addListener('SIGINT', () => {})
+    `, 'process listener')
+  })
+
+  it('flags fs watchers from namespace and named imports', () => {
+    const messages = lint(`
+      import fs from 'node:fs'
+      import { watch as watchFile } from 'fs'
+
+      fs.watch('/tmp', () => {})
+      watchFile('/tmp', () => {})
+    `)
+
+    expect(messages).toHaveLength(2)
+    expect(messages.every((message) => message.message.includes('file watcher'))).toBe(true)
+  })
+
+  it('flags chokidar watchers', () => {
+    expectOneError(`
+      import * as chokidar from 'chokidar'
+
+      chokidar.watch('.')
+    `, 'file watcher')
+  })
+
+  it('flags top-level connections', () => {
+    const messages = lint(`
+      new WebSocket('ws://localhost')
+      new window.EventSource('/api/events')
+    `)
+
+    expect(messages).toHaveLength(2)
+    expect(messages.every((message) => message.message.includes('connection'))).toBe(true)
+  })
+
+  it('flags event-target listeners', () => {
+    expectOneError(`
+      document.addEventListener('visibilitychange', () => {})
+    `, 'event listener')
+  })
+
+  it('flags direct EventEmitter listener chains', () => {
+    const messages = lint(`
+      import { EventEmitter } from 'node:events'
+
+      new EventEmitter().on('change', () => {})
+      const emitter = new EventEmitter()
+      emitter.addListener('change', () => {})
+    `)
+
+    expect(messages).toHaveLength(2)
+    expect(messages.every((message) => message.message.includes('event listener'))).toBe(true)
+  })
+})

--- a/tests/plugins/memory/plugin-lifecycle.test.ts
+++ b/tests/plugins/memory/plugin-lifecycle.test.ts
@@ -164,4 +164,31 @@ describe('memory plugin lifecycle — activate vs onReady', () => {
       handleSpy.mockRestore()
     }
   })
+
+  it('onShutdown() unsubscribes watcher event handlers', async () => {
+    await memoryPlugin.onShutdown?.()
+
+    const handleSpy = vi
+      .spyOn(MemoryIndexer.prototype, 'handleWatcherEvent')
+      .mockImplementation(async () => {})
+
+    try {
+      const activated = await activatePlugin(memoryPlugin, testDir)
+      await flush()
+
+      await memoryPlugin.onReady?.()
+      await flush()
+
+      activated.ctx.events.emit('file.change', { file: '/tmp/before-shutdown.jsonl' })
+      await flush()
+      expect(handleSpy).toHaveBeenCalledTimes(1)
+
+      await memoryPlugin.onShutdown?.()
+      activated.ctx.events.emit('file.change', { file: '/tmp/after-shutdown.jsonl' })
+      await flush()
+      expect(handleSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      handleSpy.mockRestore()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- add a local ESLint rule that rejects plugin import-time lifetime side effects
- wire the rule into plugin lint coverage and add focused rule tests
- clean up existing tasks interval and memory event-subscription lifecycle leaks
- document the plugin hot-reload lifetime contract

Closes #175

## Tests
- bun test tests/eslint/no-plugin-top-level-side-effects.test.mjs tests/plugins/memory/plugin-lifecycle.test.ts
- bun run lint
- bun run typecheck