### PR TITLE
chore: normalize list hook names

### DIFF
--- a/.claude/knowledge/assets-plugin.md
+++ b/.claude/knowledge/assets-plugin.md
@@ -211,7 +211,7 @@ Registered in `plugins/assets/index.ts`:
 - `assets.createStub(filename)` — auto-create metadata
 - `assets.detectVariant(filename)` — check if file is a variant
 - `assets.getAssetTypes()` — return available asset type enum
-- `assets.listTrash()` / `assets.restoreAsset()` / `assets.emptyTrash()`
+- `assets.trash.list()` / `assets.restoreAsset()` / `assets.emptyTrash()`
 - `assets.purgeClipboardForTask(taskId)` — soft-delete clipboard-source assets for a completed task (gated by `purgeClipboardOnComplete` setting)
 
 ## Key Files

--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -629,9 +629,9 @@ Same pattern is used for the plugin registry
 | Plugin | Hooks | Examples |
 |--------|-------|---------|
 | tasks | 0 task-metadata hooks | Task metadata is owned by `src/core/task-store.ts` and is not exposed through plugin hooks |
-| workflows | 13 | `workflows.loadInstance`, `workflows.createInstance`, `workflows.getCurrentStep`, `workflows.completeStep`, `workflows.matchWorkflow`, `workflows.listDefinitions`, `workflows.loadDefinition`, `workflows.getActiveAgents`, `workflows.saveInstance`, etc. |
-| assets | 8 | `assets.validateSidecar`, `assets.getSidecarPath`, `assets.createStub`, `assets.detectVariant`, `assets.getAssetTypes`, `assets.listTrash`, `assets.restoreAsset`, `assets.emptyTrash` |
-| team | 7 | `team.listAgents`, `team.getAgent`, `team.getAgentIds`, `team.resolveProfile`, `team.getTeamMembers`, `team.getAgentTeam`, `team.getOrgStructure` |
+| workflows | 13 | `workflows.loadInstance`, `workflows.createInstance`, `workflows.getCurrentStep`, `workflows.completeStep`, `workflows.matchWorkflow`, `workflows.definitions.list`, `workflows.loadDefinition`, `workflows.getActiveAgents`, `workflows.saveInstance`, etc. |
+| assets | 8 | `assets.validateSidecar`, `assets.getSidecarPath`, `assets.createStub`, `assets.detectVariant`, `assets.getAssetTypes`, `assets.trash.list`, `assets.restoreAsset`, `assets.emptyTrash` |
+| team | 7 | `team.list`, `team.getAgent`, `team.getAgentIds`, `team.resolveProfile`, `team.getTeamMembers`, `team.getAgentTeam`, `team.getOrgStructure` |
 | models | 5 | `models.configChanged`, `models.getEffectiveModel`, `models.getAvailableModels`, `models.markConfigDirty`, `models.markGatewayRestarted` |
 | tasks extensions | 2 | `tasks.statusChanged`, `tasks.enrichDetails` |
 

--- a/.claude/knowledge/workflows-plugin.md
+++ b/.claude/knowledge/workflows-plugin.md
@@ -128,7 +128,7 @@ ctx.registerNotificationChannel({
 Plugin ids are auto-namespaced as `{pluginId}.{id}`; builtins keep their short runtime-channel ids (`general`, `alerts`, etc.). `NotifyChannel.channel` in `plugins/workflows/types.ts` is `string` and the zod schema at `notifyChannelSchema` uses `z.string().min(1)`.
 
 **Cross-plugin read surfaces:**
-- `workflows.listNotificationChannels` — HookRegistry, returns `NotificationChannelDef[]`
+- `workflows.notificationChannels.list` — HookRegistry, returns `NotificationChannelDef[]`
 - `workflows.getNotificationChannel` — HookRegistry, takes `{ id }`, returns `NotificationChannelDef | null`
 - `GET /api/plugins/workflows/notification-channels` — REST, returns `{ channels: NotificationChannelDef[] }`
 

--- a/docs/src/content/docs/reference/generated/hooks.md
+++ b/docs/src/content/docs/reference/generated/hooks.md
@@ -47,14 +47,6 @@ Source: `plugins/assets/index.ts:305`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
-## `assets.listTrash`
-
-Source: `plugins/assets/index.ts:340`
-
-- Visibility: `public` until explicitly marked otherwise
-- Stability: `beta` until a hook contract declares stability
-- Contract status: `audited`
-
 ## `assets.pathForFilename`
 
 Source: `plugins/assets/index.ts:309`
@@ -79,6 +71,14 @@ Source: `plugins/assets/index.ts:341`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
+## `assets.trash.list`
+
+Source: `plugins/assets/index.ts:340`
+
+- Visibility: `public` until explicitly marked otherwise
+- Stability: `beta` until a hook contract declares stability
+- Contract status: `audited`
+
 ## `assets.validateSidecar`
 
 Source: `plugins/assets/index.ts:304`
@@ -95,7 +95,7 @@ Source: `plugins/health/index.ts:83`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
-## `health.listChecks`
+## `health.list`
 
 Source: `plugins/health/index.ts:82`
 
@@ -199,7 +199,7 @@ Source: `plugins/team/index.ts:875`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
-## `team.listAgents`
+## `team.list`
 
 Source: `plugins/team/index.ts:865`
 
@@ -239,6 +239,14 @@ Source: `plugins/workflows/index.ts:443`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
+## `workflows.definitions.list`
+
+Source: `plugins/workflows/index.ts:448`
+
+- Visibility: `public` until explicitly marked otherwise
+- Stability: `beta` until a hook contract declares stability
+- Contract status: `audited`
+
 ## `workflows.getActiveAgents`
 
 Source: `plugins/workflows/index.ts:450`
@@ -263,23 +271,7 @@ Source: `plugins/workflows/index.ts:460`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
-## `workflows.isGateNotified`
-
-Source: `plugins/workflows/index.ts:451`
-
-- Visibility: `public` until explicitly marked otherwise
-- Stability: `beta` until a hook contract declares stability
-- Contract status: `audited`
-
-## `workflows.listDefinitions`
-
-Source: `plugins/workflows/index.ts:448`
-
-- Visibility: `public` until explicitly marked otherwise
-- Stability: `beta` until a hook contract declares stability
-- Contract status: `audited`
-
-## `workflows.listInstances`
+## `workflows.instances.list`
 
 Source: `plugins/workflows/index.ts:444`
 
@@ -287,9 +279,9 @@ Source: `plugins/workflows/index.ts:444`
 - Stability: `beta` until a hook contract declares stability
 - Contract status: `audited`
 
-## `workflows.listNotificationChannels`
+## `workflows.isGateNotified`
 
-Source: `plugins/workflows/index.ts:459`
+Source: `plugins/workflows/index.ts:451`
 
 - Visibility: `public` until explicitly marked otherwise
 - Stability: `beta` until a hook contract declares stability
@@ -322,6 +314,14 @@ Source: `plugins/workflows/index.ts:452`
 ## `workflows.matchWorkflow`
 
 Source: `plugins/workflows/index.ts:447`
+
+- Visibility: `public` until explicitly marked otherwise
+- Stability: `beta` until a hook contract declares stability
+- Contract status: `audited`
+
+## `workflows.notificationChannels.list`
+
+Source: `plugins/workflows/index.ts:459`
 
 - Visibility: `public` until explicitly marked otherwise
 - Stability: `beta` until a hook contract declares stability

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -337,7 +337,7 @@ const assetsPlugin: BakinPlugin = {
       }
       return { purged }
     })
-    ctx.hooks.register('assets.listTrash', (d: Record<string, unknown>) => listTrash(d.assetsRoot as string))
+    ctx.hooks.register('assets.trash.list', (d: Record<string, unknown>) => listTrash(d.assetsRoot as string))
     ctx.hooks.register('assets.restoreAsset', (d: Record<string, unknown>) => restoreAsset(d.trashFilename as string, d.assetsRoot as string))
     ctx.hooks.register('assets.emptyTrash', (d: Record<string, unknown>) => emptyTrash(d.assetsRoot as string))
 

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -79,7 +79,7 @@ const healthPlugin: BakinPlugin = {
       autoFix: !!def.autoFix,
     })
 
-    ctx.hooks.register('health.listChecks', () => listHealthChecks().map(stripRun))
+    ctx.hooks.register('health.list', () => listHealthChecks().map(stripRun))
     ctx.hooks.register('health.getCheck', (d: Record<string, unknown>) => {
       const def = getHealthCheck(d.id as string)
       return def ? stripRun(def) : null

--- a/plugins/health/lib/managed-blocks.ts
+++ b/plugins/health/lib/managed-blocks.ts
@@ -133,7 +133,7 @@ The skip reason is logged to the audit trail for debugging. Always verify agains
 async function buildWorkflowCatalog(): Promise<string> {
   try {
     const hooks = getHookRegistry()
-    const defs = await hooks.invoke<Array<{ definition: Record<string, unknown>; name: string }>>('workflows.listDefinitions', {}) ?? []
+    const defs = await hooks.invoke<Array<{ definition: Record<string, unknown>; name: string }>>('workflows.definitions.list', {}) ?? []
     if (defs.length === 0) return '   (no workflows defined yet)'
     return defs.map(d => {
       const steps = (d.definition.steps || []) as Array<Record<string, unknown>>

--- a/plugins/models/index.ts
+++ b/plugins/models/index.ts
@@ -64,7 +64,7 @@ async function getAgentMeta(ctx: PluginContext): Promise<AgentMeta[]> {
     return agentMetaCache.agents
   }
   try {
-    const agents = await ctx.hooks.invoke<AgentMeta[]>('team.listAgents', {})
+    const agents = await ctx.hooks.invoke<AgentMeta[]>('team.list', {})
     if (agents && Array.isArray(agents)) {
       agentMetaCache = { agents, fetchedAt: Date.now() }
       return agents

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -862,7 +862,7 @@ const teamPlugin: BakinPlugin = {
 
     // ─── Cross-Plugin Hooks ────────────────────────────────────────────
 
-    ctx.hooks.register('team.listAgents', () => listRuntimeAgentMetas(ctx.runtime))
+    ctx.hooks.register('team.list', () => listRuntimeAgentMetas(ctx.runtime))
     ctx.hooks.register('team.getAgent', async (d: Record<string, unknown>) => {
       const id = d.id as string
       const agents = await listRuntimeAgentMetas(ctx.runtime)

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -441,11 +441,11 @@ const workflowsPlugin: BakinPlugin = {
     ctx.hooks.register('workflows.loadInstance', (d: Record<string, unknown>) => loadInstance(d.taskId as string, d.contentDir as string | undefined))
     ctx.hooks.register('workflows.saveInstance', (d: Record<string, unknown>) => saveInstance(d.instance as Parameters<typeof saveInstance>[0], d.contentDir as string | undefined))
     ctx.hooks.register('workflows.createInstance', (d: Record<string, unknown>) => createInstance(d.taskId as string, d.workflowId as string, d.contentDir as string | undefined, d.assignee as string | undefined, d.parentContext as Record<string, unknown> | undefined))
-    ctx.hooks.register('workflows.listInstances', (d: Record<string, unknown>) => listInstances(d.statusFilter as string | undefined, d.contentDir as string | undefined))
+    ctx.hooks.register('workflows.instances.list', (d: Record<string, unknown>) => listInstances(d.statusFilter as string | undefined, d.contentDir as string | undefined))
     ctx.hooks.register('workflows.getCurrentStep', (d: Record<string, unknown>) => getCurrentStep(d.taskId as string, d.agentId as string | undefined, d.contentDir as string | undefined))
     ctx.hooks.register('workflows.completeStep', (d: Record<string, unknown>) => completeStep(d.taskId as string, d.stepId as string, d.output as Record<string, unknown>, d.callerAgentId as string | undefined, d.contentDir as string | undefined))
     ctx.hooks.register('workflows.matchWorkflow', (d: Record<string, unknown>) => matchWorkflow(d.title as string, d.description as string | undefined))
-    ctx.hooks.register('workflows.listDefinitions', (d: Record<string, unknown>) => listDefinitions(d.contentDir as string | undefined))
+    ctx.hooks.register('workflows.definitions.list', (d: Record<string, unknown>) => listDefinitions(d.contentDir as string | undefined))
     ctx.hooks.register('workflows.loadDefinition', (d: Record<string, unknown>) => loadDefinition(d.name as string, d.contentDir as string | undefined))
     ctx.hooks.register('workflows.getActiveAgents', (d: Record<string, unknown>) => getActiveAgents(d.taskId as string, d.contentDir as string | undefined))
     ctx.hooks.register('workflows.isGateNotified', (d: Record<string, unknown>) => isGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined))
@@ -456,7 +456,7 @@ const workflowsPlugin: BakinPlugin = {
     })
 
     // ─── Notification Channel Registry Hooks ─────────────────────────
-    ctx.hooks.register('workflows.listNotificationChannels', () => listNotificationChannels())
+    ctx.hooks.register('workflows.notificationChannels.list', () => listNotificationChannels())
     ctx.hooks.register('workflows.getNotificationChannel', (d: Record<string, unknown>) => {
       return getNotificationChannel(d.id as string) ?? null
     })

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -239,7 +239,7 @@ export async function createTaskWithEffects(opts: {
   if (effectiveWorkflowId) {
     const def = await hooks().invoke<Record<string, unknown> | null>('workflows.loadDefinition', { name: effectiveWorkflowId })
     if (!def) {
-      const available = await hooks().invoke<Array<{ name: string }>>('workflows.listDefinitions', {}) ?? []
+      const available = await hooks().invoke<Array<{ name: string }>>('workflows.definitions.list', {}) ?? []
       const names = available.map(d => d.name).sort().join(', ') || '(none)'
       throw new Error(
         `Unknown workflow: "${effectiveWorkflowId}". Available workflows: ${names}. ` +

--- a/src/core/watchdog.ts
+++ b/src/core/watchdog.ts
@@ -314,7 +314,7 @@ export function start(contentDir: string): void {
       // ─── Workflow step timeout detection ─────────────────────────────
       try {
         const wfSettings = settings.workflow
-        const activeInstances = await hooks().invoke<Array<{ taskId: string; currentStepId: string; workflowId: string; status: string; stepStates: Record<string, { status: string; startedAt?: string; output?: unknown }>; history: Array<{ stepId: string; rejectionReason?: string }> }>>('workflows.listInstances', { statusFilter: 'in_progress' }) ?? []
+        const activeInstances = await hooks().invoke<Array<{ taskId: string; currentStepId: string; workflowId: string; status: string; stepStates: Record<string, { status: string; startedAt?: string; output?: unknown }>; history: Array<{ stepId: string; rejectionReason?: string }> }>>('workflows.instances.list', { statusFilter: 'in_progress' }) ?? []
 
         // Build set of task IDs on the board for orphan detection
         const boardTaskIds = new Set<string>()
@@ -369,7 +369,7 @@ export function start(contentDir: string): void {
       const gateNotificationChannel = getNotificationChannel(settings)
       if (gateNotificationChannel && settings.notifications.gateAlerts !== false) {
         try {
-          const pendingGates = await hooks().invoke<Array<{ taskId: string; currentStepId: string; workflowId: string; stepStates: Record<string, { status: string; output?: unknown }>; history: Array<Record<string, unknown>> }>>('workflows.listInstances', { statusFilter: 'pending_approval' }) ?? []
+          const pendingGates = await hooks().invoke<Array<{ taskId: string; currentStepId: string; workflowId: string; stepStates: Record<string, { status: string; output?: unknown }>; history: Array<Record<string, unknown>> }>>('workflows.instances.list', { statusFilter: 'pending_approval' }) ?? []
 
           for (const instance of pendingGates) {
             const { taskId, currentStepId, workflowId } = instance

--- a/tests/core/task-service.test.ts
+++ b/tests/core/task-service.test.ts
@@ -111,7 +111,7 @@ const hookHandlers: Record<string, (...args: unknown[]) => unknown> = {
   'workflows.createInstance': (data: any) => mockCreateInstance(data),
   'workflows.matchWorkflow': () => null,
   'workflows.loadDefinition': (data: any) => mockLoadDefinition(data),
-  'workflows.listDefinitions': () => mockListDefinitions(),
+  'workflows.definitions.list': () => mockListDefinitions(),
 }
 
 const mockHookRegistry = {


### PR DESCRIPTION
## Summary
- rename verbose list hook IDs to the normalized hook vocabulary
- use nested resource names where a plugin namespace has multiple list surfaces
- update hook callers, generated hook docs, and knowledge docs in lockstep

Renames:
- `team.listAgents` -> `team.list`
- `health.listChecks` -> `health.list`
- `assets.listTrash` -> `assets.trash.list`
- `workflows.listDefinitions` -> `workflows.definitions.list`
- `workflows.listInstances` -> `workflows.instances.list`
- `workflows.listNotificationChannels` -> `workflows.notificationChannels.list`

Closes #140

## Tests
- bun test tests/core/task-service.test.ts tests/plugins/workflows/notification-channel-registry.test.ts
- bun test tests/plugins/health/managed-blocks.test.ts
- bun test tests/plugins/workflows/runtime.test.ts
- bun run lint
- bun run typecheck
- bun run docs:validate
- bun test --isolate