### PR TITLE
Validate plugin dependencies before install

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -128,6 +128,10 @@ commit submits source B):
    request-body `ref`, rejects conflicts, clones to staging at that ref,
    validates manifest + permissions, parses the manifest version, and
    computes `manifestSha`.
+   Before any target-dir copy/build, it also validates `dependencies`:
+   each dependency must be a core plugin, an installed user plugin, or
+   in the selected recommended-plugin install plan. Missing deps return
+   HTTP 400 and the staging dir is removed.
 3. If permissions are non-empty AND `accepted !== true`, server returns
    `{ awaitingConsent: true, id, version, permissions, consentToken }`
    and tears down staging. The token is HMAC-SHA256 over
@@ -149,6 +153,29 @@ commit submits source B):
 Zero-permission plugins skip the consent gate (no token needed).
 `--yes` short-circuits the prompt for scripted/CI installs but the
 token round-trip still runs for the binding check.
+
+### Dependency Validation
+
+`dependencies` in `bakin-plugin.json` are Bakin plugin IDs, not npm
+packages. npm packages are handled by `buildUserPlugin()` from the
+plugin's `package.json`; plugin dependencies are runtime/load-order
+contracts.
+
+Validation surfaces:
+
+- Generic copied installs (`bakin plugins install <source>`) refuse a
+  plugin before copy/build if any declared dependency is missing.
+- Dev installs (`bakin plugins install --dev <path>`) apply the same
+  dependency check before linking.
+- Recommended onboarding installs use the curated
+  `RECOMMENDED_PLUGINS` list as the official dependency index, validate
+  all selected plugins before installing, and topologically order selected
+  plugins while preserving curated order for independent entries.
+
+There is intentionally no implicit third-party network install from an
+arbitrary manifest dependency. If a dependency is not core, installed, or
+part of the selected official onboarding set, the user gets a clear error
+and can choose what to install.
 
 #### Monorepo `#subpath` syntax (Phase 1)
 

--- a/docs/src/content/docs/extending/plugins/manifest.md
+++ b/docs/src/content/docs/extending/plugins/manifest.md
@@ -47,13 +47,14 @@ Source: `docs/snippets/plugin-basic/bakin-plugin.json`
 | `contentFiles` | Files the plugin contributes to Bakin content. |
 | `secrets` | Secret names the plugin expects. |
 | `tests` | Plugin-local test command. |
-| `dependencies` | Runtime package dependencies. |
+| `dependencies` | Other Bakin plugin IDs that must be available before this plugin loads. |
 | `permissions` | Capability labels used for review and future policy enforcement. |
 
 ## Authoring Rules
 
 - Treat `id` as permanent once users install the plugin.
 - Keep entries relative to the plugin root.
+- Declare plugin dependencies by plugin ID. `bakin plugins install` refuses a plugin when a dependency is neither core nor already installed.
 - Declare permissions before adding new routes, exec tools, or external integrations.
 - Do not rely on undocumented host files. Import supported APIs from `@bakin/sdk` and `@bakin/sdk/*`.
 

--- a/packages/host/src/api/plugins/install.ts
+++ b/packages/host/src/api/plugins/install.ts
@@ -39,6 +39,7 @@ import { parseManifestPermissions } from '@bakin/core/plugins/permissions'
 import { PLUGIN_ID_RE, readPluginManifestJson, PluginManifestError } from '@bakin/core/plugins/manifest'
 import { parseGithubSource, InvalidGithubSourceError, assertGitRefValid } from '@bakin/core/plugins/source'
 import { computeSourceTreeSha } from '@/core/plugins/upgrade'
+import { checkPluginDependencies } from '@/core/plugins/dependencies'
 import { signConsentToken, verifyConsentToken } from '@/core/plugins/consent-token'
 import { findSkillsForPlugin } from '@/core/onboarding/plugin-assets'
 import { appendAudit } from '@/core/audit'
@@ -565,6 +566,27 @@ export async function post(req: Request, _url: URL): Promise<Response> {
         return Response.json({
           ok: false,
           error: `plugin "${id}": ${err instanceof Error ? err.message : String(err)}`,
+        }, { status: 400 })
+      }
+
+      const dependencyCheck = checkPluginDependencies({
+        id,
+        dependencies: Array.isArray(manifest.dependencies)
+          ? manifest.dependencies.filter((dep): dep is string => typeof dep === 'string')
+          : [],
+      })
+      if (!dependencyCheck.ok) {
+        rmSync(stagingDir, { recursive: true, force: true })
+        const missing = dependencyCheck.missing
+        const self = dependencyCheck.selfDependencies
+        auditInstallRejected('missing_dependencies', body.source, { id, missing, self })
+        const problems = [
+          ...(missing.length > 0 ? [`missing dependencies: ${missing.join(', ')}`] : []),
+          ...(self.length > 0 ? ['plugin cannot depend on itself'] : []),
+        ].join('; ')
+        return Response.json({
+          ok: false,
+          error: `Plugin "${id}" dependency check failed: ${problems}. Install dependencies first, then retry.`,
         }, { status: 400 })
       }
 

--- a/src/core/onboarding/recommended-plugins.ts
+++ b/src/core/onboarding/recommended-plugins.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { getContentDir } from '../content-dir'
 import { readPluginLockfile } from '@bakin/core/plugins/lockfile'
+import { getInstalledPluginIds, planPluginDependencyOrder } from '../plugins/dependencies'
 import { askYesNo } from './prompts'
 import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
 
@@ -10,6 +11,7 @@ export interface RecommendedPlugin {
   name: string
   source: string
   description: string
+  dependencies: readonly string[]
   defaultSelected: boolean
 }
 
@@ -19,6 +21,7 @@ export const RECOMMENDED_PLUGINS = [
     name: 'Messaging',
     source: 'github:madeinwyo/bakin-bits-official#plugins/messaging',
     description: 'Content planning, calendar items, brainstorming sessions, approvals, and channel delivery.',
+    dependencies: ['team', 'workflows'],
     defaultSelected: true,
   },
   {
@@ -26,6 +29,7 @@ export const RECOMMENDED_PLUGINS = [
     name: 'Projects',
     source: 'github:madeinwyo/bakin-bits-official#plugins/projects',
     description: 'Project specs, checklists, task links, assets, and project-context agent tools.',
+    dependencies: ['tasks', 'assets', 'team'],
     defaultSelected: true,
   },
 ] as const satisfies readonly RecommendedPlugin[]
@@ -134,7 +138,17 @@ async function install(opts: OnboardingOptions): Promise<InstallResult> {
 
   const failures: string[] = []
   const installed: string[] = []
-  for (const plugin of selected) {
+  const plan = planPluginDependencyOrder(selected, { installedIds: getInstalledPluginIds() })
+  if (!plan.ok) {
+    return {
+      name: 'recommended-plugins',
+      status: 'failed',
+      message: `Recommended plugin dependency check failed: ${plan.error}`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  for (const plugin of plan.ordered) {
     const result = await installSource(plugin.source)
     if (result.ok) installed.push(plugin.id)
     else failures.push(`${plugin.id}: ${result.error}`)

--- a/src/core/plugins/dependencies.ts
+++ b/src/core/plugins/dependencies.ts
@@ -1,0 +1,180 @@
+import { existsSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { getContentDir } from '../content-dir'
+import { readPluginLockfile } from '@bakin/core/plugins/lockfile'
+
+/**
+ * Core plugin ids that ship with the Bakin binary. This mirrors
+ * `bakin.config.ts` but intentionally avoids importing plugin modules or
+ * server-only static imports from install/onboarding paths.
+ */
+export const CORE_PLUGIN_IDS = new Set([
+  'team',
+  'tasks',
+  'memory',
+  'models',
+  'workflows',
+  'assets',
+  'schedule',
+  'health',
+])
+
+export interface DependencyPlanInput {
+  id: string
+  dependencies?: readonly string[]
+}
+
+export interface DependencyContext {
+  coreIds?: ReadonlySet<string>
+  installedIds?: ReadonlySet<string>
+  selectedIds?: ReadonlySet<string>
+}
+
+export interface DependencyCheckResult {
+  ok: boolean
+  missing: string[]
+  selfDependencies: string[]
+}
+
+export type DependencyPlanResult<T extends DependencyPlanInput> = {
+  ok: true
+  ordered: T[]
+} | {
+  ok: false
+  error: string
+  missing?: Array<{ pluginId: string; dependencies: string[] }>
+  cycle?: string[]
+}
+
+function unique(values: readonly string[] | undefined): string[] {
+  const out: string[] = []
+  for (const value of values ?? []) {
+    if (value && !out.includes(value)) out.push(value)
+  }
+  return out
+}
+
+export function getInstalledPluginIds(): Set<string> {
+  const ids = new Set<string>()
+  try {
+    const lock = readPluginLockfile()
+    for (const id of Object.keys(lock.plugins)) ids.add(id)
+  } catch {
+    // fall through to directory scan
+  }
+
+  const pluginsDir = join(getContentDir(), 'plugins')
+  if (!existsSync(pluginsDir)) return ids
+  try {
+    for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const id = String(entry.name)
+      if (id.startsWith('.')) continue
+      if (existsSync(join(pluginsDir, id, 'bakin-plugin.json'))) ids.add(id)
+    }
+  } catch {
+    // best-effort; lockfile ids are still useful
+  }
+  return ids
+}
+
+export function checkPluginDependencies(
+  plugin: DependencyPlanInput,
+  context: DependencyContext = {},
+): DependencyCheckResult {
+  const coreIds = context.coreIds ?? CORE_PLUGIN_IDS
+  const installedIds = context.installedIds ?? getInstalledPluginIds()
+  const selectedIds = context.selectedIds ?? new Set<string>()
+  const missing: string[] = []
+  const selfDependencies: string[] = []
+
+  for (const dep of unique(plugin.dependencies)) {
+    if (dep === plugin.id) {
+      selfDependencies.push(dep)
+      continue
+    }
+    if (coreIds.has(dep) || installedIds.has(dep) || selectedIds.has(dep)) continue
+    missing.push(dep)
+  }
+
+  return {
+    ok: missing.length === 0 && selfDependencies.length === 0,
+    missing,
+    selfDependencies,
+  }
+}
+
+/**
+ * Topologically sort selected plugins by dependencies that are also in
+ * the selected set. Dependencies satisfied by core or installed plugins
+ * are treated as already available. Queue order follows the input order
+ * so the curated list remains the tie-breaker for independent plugins.
+ */
+export function planPluginDependencyOrder<T extends DependencyPlanInput>(
+  plugins: readonly T[],
+  context: DependencyContext = {},
+): DependencyPlanResult<T> {
+  const selectedIds = new Set(plugins.map(plugin => plugin.id))
+  const missing: Array<{ pluginId: string; dependencies: string[] }> = []
+
+  for (const plugin of plugins) {
+    const check = checkPluginDependencies(plugin, { ...context, selectedIds })
+    const unresolved = [...check.selfDependencies, ...check.missing]
+    if (unresolved.length > 0) {
+      missing.push({ pluginId: plugin.id, dependencies: unresolved })
+    }
+  }
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      missing,
+      error: missing
+        .map(item => `${item.pluginId}: ${item.dependencies.join(', ')}`)
+        .join('; '),
+    }
+  }
+
+  const byId = new Map(plugins.map(plugin => [plugin.id, plugin]))
+  const inDegree = new Map<string, number>()
+  const dependents = new Map<string, string[]>()
+  for (const plugin of plugins) {
+    inDegree.set(plugin.id, 0)
+    dependents.set(plugin.id, [])
+  }
+
+  for (const plugin of plugins) {
+    for (const dep of unique(plugin.dependencies)) {
+      if (!selectedIds.has(dep)) continue
+      inDegree.set(plugin.id, (inDegree.get(plugin.id) ?? 0) + 1)
+      dependents.get(dep)!.push(plugin.id)
+    }
+  }
+
+  const queue = plugins
+    .filter(plugin => (inDegree.get(plugin.id) ?? 0) === 0)
+    .map(plugin => plugin.id)
+  const ordered: T[] = []
+
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    ordered.push(byId.get(id)!)
+    for (const dependent of dependents.get(id) ?? []) {
+      const next = (inDegree.get(dependent) ?? 1) - 1
+      inDegree.set(dependent, next)
+      if (next === 0) queue.push(dependent)
+    }
+  }
+
+  if (ordered.length !== plugins.length) {
+    const cycle = plugins
+      .filter(plugin => !ordered.some(done => done.id === plugin.id))
+      .map(plugin => plugin.id)
+    return {
+      ok: false,
+      cycle,
+      error: `Circular plugin dependencies detected: ${cycle.join(' -> ')}`,
+    }
+  }
+
+  return { ok: true, ordered }
+}

--- a/src/core/plugins/link.ts
+++ b/src/core/plugins/link.ts
@@ -47,6 +47,7 @@ import {
 } from '@bakin/core/plugins/lockfile'
 import { parseManifestPermissions } from '@bakin/core/plugins/permissions'
 import { buildUserPlugin } from '../../../packages/host/src/plugin-host/user-plugin-builder'
+import { checkPluginDependencies } from './dependencies'
 
 const log = createLogger('plugin-link')
 
@@ -88,6 +89,7 @@ const PLUGIN_ID_REGEX = /^[a-z][a-z0-9-]{0,39}$/
 const LinkManifestSchema = z.object({
   id: z.string().min(1),
   version: z.string().optional(),
+  dependencies: z.array(z.string().min(1)).optional(),
   permissions: z.unknown().optional(),
 })
 
@@ -128,7 +130,13 @@ function resolveAndContain(localPath: string): string {
   return real
 }
 
-function readManifest(dir: string): { id: string; version: string; manifestSha: string; permissions: PluginLockEntry['permissions'] } {
+function readManifest(dir: string): {
+  id: string
+  version: string
+  manifestSha: string
+  dependencies: string[]
+  permissions: PluginLockEntry['permissions']
+} {
   const manifestPath = join(dir, 'bakin-plugin.json')
   if (!existsSync(manifestPath)) {
     throw new LinkRefusedError(`source dir is missing bakin-plugin.json: ${dir}`)
@@ -167,6 +175,7 @@ function readManifest(dir: string): { id: string; version: string; manifestSha: 
     id: manifest.id,
     version: manifest.version && manifest.version.length > 0 ? manifest.version : '0.0.0',
     manifestSha,
+    dependencies: manifest.dependencies ?? [],
     permissions,
   }
 }
@@ -195,7 +204,7 @@ export async function linkPlugin(
   opts: LinkOptions = {},
 ): Promise<LinkResult> {
   const real = resolveAndContain(localPath)
-  const { id, version, manifestSha, permissions } = readManifest(real)
+  const { id, version, manifestSha, dependencies, permissions } = readManifest(real)
 
   // Refuse collisions with installed user plugins unless force=true.
   // `addLinkedPlugin` would also catch the dup id, but a clear pre-check
@@ -224,6 +233,22 @@ export async function linkPlugin(
     throw new LinkRefusedError(
       `plugin id "${id}" matches a core feature module; pass --force to intentionally shadow it`,
     )
+  }
+
+  const dependencyCheck = checkPluginDependencies({ id, dependencies })
+  if (!dependencyCheck.ok) {
+    auditLinkRejected('missing_dependencies', localPath, {
+      id,
+      missing: dependencyCheck.missing,
+      self: dependencyCheck.selfDependencies,
+    })
+    const problems = [
+      ...(dependencyCheck.missing.length > 0
+        ? [`missing dependencies: ${dependencyCheck.missing.join(', ')}`]
+        : []),
+      ...(dependencyCheck.selfDependencies.length > 0 ? ['plugin cannot depend on itself'] : []),
+    ].join('; ')
+    throw new LinkRefusedError(`plugin "${id}" dependency check failed: ${problems}. Install dependencies first, then retry.`)
   }
 
   const pluginsRoot = join(getContentDir(), 'plugins')

--- a/tests/core/plugins/dependencies.test.ts
+++ b/tests/core/plugins/dependencies.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  CORE_PLUGIN_IDS,
+  checkPluginDependencies,
+  planPluginDependencyOrder,
+} from '../../../src/core/plugins/dependencies'
+
+describe('plugin dependency checks', () => {
+  it('accepts dependencies satisfied by core plugins', () => {
+    const result = checkPluginDependencies({
+      id: 'official',
+      dependencies: ['tasks', 'team'],
+    }, { installedIds: new Set() })
+    expect(result.ok).toBe(true)
+    expect(result.missing).toEqual([])
+  })
+
+  it('accepts dependencies satisfied by installed user plugins', () => {
+    const result = checkPluginDependencies(
+      { id: 'consumer', dependencies: ['shared'] },
+      { installedIds: new Set(['shared']) },
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('reports missing and self dependencies', () => {
+    const result = checkPluginDependencies({
+      id: 'consumer',
+      dependencies: ['consumer', 'missing'],
+    }, { installedIds: new Set() })
+    expect(result.ok).toBe(false)
+    expect(result.selfDependencies).toEqual(['consumer'])
+    expect(result.missing).toEqual(['missing'])
+  })
+})
+
+describe('plugin dependency install planning', () => {
+  it('preserves curated order for independent plugins', () => {
+    const plan = planPluginDependencyOrder([
+      { id: 'first', dependencies: [] },
+      { id: 'second', dependencies: [] },
+    ], { installedIds: new Set() })
+    expect(plan.ok).toBe(true)
+    if (plan.ok) expect(plan.ordered.map(plugin => plugin.id)).toEqual(['first', 'second'])
+  })
+
+  it('orders selected dependencies before dependents', () => {
+    const plan = planPluginDependencyOrder([
+      { id: 'consumer', dependencies: ['shared'] },
+      { id: 'shared', dependencies: [] },
+    ], { installedIds: new Set() })
+    expect(plan.ok).toBe(true)
+    if (plan.ok) expect(plan.ordered.map(plugin => plugin.id)).toEqual(['shared', 'consumer'])
+  })
+
+  it('fails when a dependency is neither core, installed, nor selected', () => {
+    const plan = planPluginDependencyOrder([
+      { id: 'consumer', dependencies: ['missing'] },
+    ], {
+      coreIds: new Set([...CORE_PLUGIN_IDS].filter(id => id !== 'missing')),
+      installedIds: new Set(),
+    })
+    expect(plan.ok).toBe(false)
+    if (!plan.ok) {
+      expect(plan.error).toContain('consumer: missing')
+      expect(plan.missing).toEqual([{ pluginId: 'consumer', dependencies: ['missing'] }])
+    }
+  })
+
+  it('detects cycles among selected plugins', () => {
+    const plan = planPluginDependencyOrder([
+      { id: 'a', dependencies: ['b'] },
+      { id: 'b', dependencies: ['a'] },
+    ], { installedIds: new Set() })
+    expect(plan.ok).toBe(false)
+    if (!plan.ok) {
+      expect(plan.error).toContain('Circular plugin dependencies')
+      expect(plan.cycle).toEqual(['a', 'b'])
+    }
+  })
+})

--- a/tests/plugins/lifecycle/install-dependencies.test.ts
+++ b/tests/plugins/lifecycle/install-dependencies.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Install-time plugin dependency validation. Missing dependencies should
+ * fail before any copied plugin dir is left behind.
+ */
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-install-deps-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+mock.module(
+  '../../../packages/host/src/plugin-host/user-plugin-builder',
+  () => ({ buildUserPlugin: async () => {} }),
+)
+
+import { post as installPOST } from '../../../packages/host/src/api/plugins/install'
+
+function writePluginSource(id: string, dependencies: string[]): string {
+  const dir = join(testDir, 'sources', id)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({
+    id,
+    name: id,
+    version: '1.0.0',
+    bakin: '>=1.0.0',
+    description: `${id} test plugin`,
+    entry: { server: 'index.ts' },
+    dependencies,
+    permissions: [],
+  }, null, 2))
+  writeFileSync(join(dir, 'index.ts'), `export default { id: '${id}', activate() {} }`)
+  return dir
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/plugins/install', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function invoke(body: unknown) {
+  const res = await installPOST(makeRequest(body), new URL('http://localhost/api/plugins/install'))
+  return { res, body: await res.json() }
+}
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(testDir, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('plugin install dependencies', () => {
+  it('rejects missing dependencies before leaving an installed plugin dir', async () => {
+    const source = writePluginSource('needs-shared', ['shared'])
+
+    const { res, body } = await invoke({ source, type: 'local' })
+
+    expect(res.status).toBe(400)
+    expect(body.error).toContain('missing dependencies: shared')
+    expect(existsSync(join(testDir, 'plugins', 'needs-shared'))).toBe(false)
+  })
+
+  it('allows dependencies satisfied by core plugins', async () => {
+    const source = writePluginSource('needs-tasks', ['tasks'])
+
+    const { res, body } = await invoke({ source, type: 'local' })
+
+    expect(res.status).toBe(200)
+    expect(body.ok).toBe(true)
+    expect(existsSync(join(testDir, 'plugins', 'needs-tasks', 'bakin-plugin.json'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add shared plugin dependency validation and install ordering for Bakin plugin IDs declared in `bakin-plugin.json`.
- Reject copied and dev installs before copy/link/build when dependencies are missing or self-referential.
- Teach recommended official plugin onboarding to validate dependencies and install selected plugins in dependency order.
- Document plugin-vs-npm dependency semantics and add focused install/planner tests.

## Validation
- `bun test tests/core/plugins/dependencies.test.ts tests/plugins/lifecycle/install-dependencies.test.ts tests/plugins/lifecycle/link.test.ts`
- `bun run typecheck && bun run lint && bun run docs:validate`
- `bun test --isolate tests/plugins/lifecycle tests/core/plugins/dependencies.test.ts`
- `bun test --isolate`

Closes #188