### PR TITLE
Include official plugin sources in host CSS scan

### DIFF
--- a/packages/host/src/globals.css
+++ b/packages/host/src/globals.css
@@ -13,6 +13,7 @@
 @source "../../sdk/src/**/*.{ts,tsx}";
 @source "../../../src/**/*.{ts,tsx}";
 @source "../../../plugins/**/*.{ts,tsx}";
+@source "../../../../bakin-bits-official/plugins/**/*.{ts,tsx}";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
## Summary
- add the local bakin-bits-official plugin tree to the host Tailwind source scan
- keeps locally linked official plugin UI classes available during development

## Tests
- bun run lint
- git diff --check