### PR TITLE
Move doctor infrastructure into core

### DIFF
--- a/.claude/knowledge/doctor-and-health-checks.md
+++ b/.claude/knowledge/doctor-and-health-checks.md
@@ -24,7 +24,7 @@ src/core/doctor.ts
   ├─ getLastResults()           cached lightweight reads (health page polls this)
   └─ notifyUnfixableIssues()    escalates warn/error+!autoFixable to main agent
 
-plugins/health/lib/health-check-registry.ts
+src/core/health-check-registry.ts
   ├─ registerHealthCheck(def)   appends; throws on duplicate id
   ├─ listHealthChecks()         the orchestrator's source of truth
   └─ unregisterPluginHealthChecks(pluginId)   plugin teardown sweep
@@ -58,9 +58,13 @@ The orchestrator is intentionally trivial — it has no opinion about what's bei
 | `plugins/health/lib/system-checks/orchestrator-rules.ts` | `orchestrator-rules` |
 | `plugins/health/lib/system-checks/sync-skill.ts` | `skill` |
 | `plugins/health/lib/system-checks/plugin-assets.ts` | `plugin-assets` |
-| `plugins/health/lib/managed-blocks.ts` | `managed-blocks` |
+| `src/core/agent-rules/managed-blocks.ts` | `managed-blocks` |
 
 Health plugin is the natural home for system-level checks because it already orchestrates the doctor UI (`/api/plugins/health/doctor` route + `bakin_exec_health_doctor` MCP tool) and imports `runDiagnostics` / `getLastResults`. The inversion is complete: health plugin both produces and consumes the doctor results.
+
+The registry and managed-block mechanics are core-owned. The health plugin
+registers/runs the checks, but CLI and plugin-host teardown import those shared
+surfaces from `src/core/*`, not from `plugins/health/*`.
 
 ### Namespacing
 
@@ -103,14 +107,14 @@ Same pattern, lives at `plugins/health/lib/system-checks/{your-check}.ts`. Regis
 
 ## Managed-block infrastructure
 
-`plugins/health/lib/managed-blocks.ts` holds:
+`src/core/agent-rules/managed-blocks.ts` holds:
 - `MANAGED_BLOCKS` — the 7 block definitions (mission-control, hard-rules, dependency-pattern, media-delegation, workflow-rules, scheduling-rules, asset-rules)
 - `applyAllManagedBlocks(autoFix)` — iterates all blocks, calls `checkManagedBlock` per (block × non-main-agent), returns the union of result rows
 - `AGENT_RULES_BLOCK_START/END` + `ORCHESTRATOR_RULES_CONTENT` + `resolveOrchestratorRules` — the orchestrator-rules block (lives separately because it targets the **main** agent, not subagents)
 
 The marker primitives (`extractBlock`, `getBlockState`, `injectBlock`) live in `packages/core/src/agent-packages/managed-blocks.ts` and are shared with the agent-package installer/projector. Don't reimplement them.
 
-The CLI's `bakin agent-rules --apply / --apply-all / --check / --check-all` imports directly from `plugins/health/lib/managed-blocks.ts` (not via HTTP — works when the server is down).
+The CLI's `bakin agent-rules --apply / --apply-all / --check / --check-all` imports directly from `src/core/agent-rules/managed-blocks.ts` (not via HTTP — works when the server is down).
 
 **Marker text in user files is bit-identical to pre-migration**: `<!-- bakin:{blockId}:start/end -->` strings live in `~/.openclaw/workspaces/{agentId}/AGENTS.md` and `~/.openclaw/workspace/AGENTS.md`. Renaming them would orphan existing user state. Don't touch.
 
@@ -163,7 +167,8 @@ The orchestrator (`runPluginHealthChecks` in `src/core/doctor.ts`) wraps each `d
 ## Migration history
 
 - **#137 (PR #138)**: First 3 checks moved out — workflow definitions, stale instances, skills. Established the registry + ctx.registerHealthCheck precedent.
-- **#139 (this work)**: Migrated the remaining 15 checks across 9 commits, collapsed `DiagnosticResult` → `HealthCheckResult` (one canonical type), relocated managed-block infrastructure to `plugins/health/lib/managed-blocks.ts`, swung CLI imports.
+- **#139**: Migrated the remaining 15 checks across 9 commits, collapsed `DiagnosticResult` → `HealthCheckResult` (one canonical type), relocated managed-block infrastructure out of the doctor monolith, swung CLI imports.
+- **#174**: Moved health-check registry and managed-block infrastructure into `src/core/*`; health plugin now contributes checks without owning core doctor/CLI primitives.
 
 ## Follow-ups
 

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -568,7 +568,7 @@ async function cmdDoctor(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 // Orchestrator rules block constants and template are owned by
-// plugins/health/lib/managed-blocks.ts. Imported lazily inside
+// src/core/agent-rules/managed-blocks.ts. Imported lazily inside
 // cmdAgentRules so the CLI stays a pure entry point.
 
 async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyAll?: boolean; checkAll?: boolean } = {}): Promise<void> {
@@ -576,7 +576,7 @@ async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyA
     AGENT_RULES_BLOCK_START,
     AGENT_RULES_BLOCK_END,
     resolveOrchestratorRules,
-  } = await import('../plugins/health/lib/managed-blocks')
+  } = await import('../src/core/agent-rules/managed-blocks')
   const { createAppServices, maybeGetAppServices } = await import('../src/core/app-services')
   const { selectRuntimeMainAgent } = await import('@bakin/core/adapters/runtime')
 
@@ -631,7 +631,7 @@ async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyA
 
   // Handle --apply-all and --check-all for all agents
   if (options.applyAll || options.checkAll) {
-    const { applyAllManagedBlocks } = await import('../plugins/health/lib/managed-blocks')
+    const { applyAllManagedBlocks } = await import('../src/core/agent-rules/managed-blocks')
     const results = await applyAllManagedBlocks(!!options.applyAll)
     const errors = results.filter(r => r.status === 'error')
     const warnings = results.filter(r => r.status === 'warn')

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -15,7 +15,7 @@ import {
   listHealthChecks,
   getHealthCheck,
   type HealthCheckDef,
-} from './lib/health-check-registry'
+} from '../../src/core/health-check-registry'
 import { checkContentDir } from './lib/system-checks/content-dir'
 import { checkService } from './lib/system-checks/service'
 import { checkMcporter } from './lib/system-checks/mcporter'
@@ -25,7 +25,7 @@ import { checkSearchAdapter } from './lib/system-checks/search'
 import { checkOrchestratorRules } from './lib/system-checks/orchestrator-rules'
 import { checkAndSyncSkill } from './lib/system-checks/sync-skill'
 import { checkPluginAssets } from './lib/system-checks/plugin-assets'
-import { applyAllManagedBlocksForRuntime } from './lib/managed-blocks'
+import { applyAllManagedBlocksForRuntime } from '../../src/core/agent-rules/managed-blocks'
 // Registry accessors live on globalThis because Next.js API routes get
 // separate webpack-compiled module instances with empty Maps. The custom
 // server (server.ts) registers the real accessors after plugin init.

--- a/plugins/health/lib/system-checks/orchestrator-rules.ts
+++ b/plugins/health/lib/system-checks/orchestrator-rules.ts
@@ -8,7 +8,7 @@ import { getSettings } from '../../../../src/core/settings'
 import type { AgentRuntimeAdapter, RuntimeAgent } from '../../../../packages/core/src/adapters/runtime'
 import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
 
-import { AGENT_RULES_BLOCK_END, AGENT_RULES_BLOCK_START, resolveOrchestratorRulesForAgent } from '../managed-blocks'
+import { AGENT_RULES_BLOCK_END, AGENT_RULES_BLOCK_START, resolveOrchestratorRulesForAgent } from '../../../../src/core/agent-rules/managed-blocks'
 
 function ok(message: string): HealthCheckResult {
   return { check: 'orchestrator-rules', status: 'ok', message, autoFixable: false }

--- a/src/core/agent-rules/managed-blocks.ts
+++ b/src/core/agent-rules/managed-blocks.ts
@@ -9,10 +9,9 @@
  * packages/core/src/agent-packages/managed-blocks.ts and are shared
  * with the agent-package installer/projector.
  *
- * The orchestrator-rules block targets the main agent's
- * workspace `AGENTS.md` and is owned by plugins/health/lib/system-checks/orchestrator-rules.ts
- * (which imports
- * AGENT_RULES_BLOCK_START/END + resolveOrchestratorRules from here).
+ * The orchestrator-rules block targets the main agent's workspace
+ * `AGENTS.md`. The health plugin verifies it, but the block contract is
+ * core-owned so the CLI can apply/check it without importing plugins.
  *
  * Migrated from src/core/doctor.ts in #139 C8 (orchestrator-rules
  * constants + template) and #139 C9 (MANAGED_BLOCKS + check helper +
@@ -24,8 +23,6 @@ import {
   getBlockState,
   injectBlock,
 } from '../../../packages/core/src/agent-packages/managed-blocks'
-import { createAppServices, maybeGetAppServices } from '../../../src/core/app-services'
-import { getHookRegistry } from '../../../src/lib/plugin-registry'
 import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
 import type { AgentRuntimeAdapter, RuntimeAgent } from '../../../packages/core/src/adapters/runtime'
 
@@ -132,6 +129,7 @@ The skip reason is logged to the audit trail for debugging. Always verify agains
 /** Build the workflow catalog from available definitions for embedding in rules */
 async function buildWorkflowCatalog(): Promise<string> {
   try {
+    const { getHookRegistry } = await import('../../lib/plugin-registry')
     const hooks = getHookRegistry()
     const defs = await hooks.invoke<Array<{ definition: Record<string, unknown>; name: string }>>('workflows.definitions.list', {}) ?? []
     if (defs.length === 0) return '   (no workflows defined yet)'
@@ -240,6 +238,7 @@ async function checkManagedBlockRuntime(
 }
 
 async function getRuntimeForManagedBlocks(): Promise<AgentRuntimeAdapter> {
+  const { createAppServices, maybeGetAppServices } = await import('../app-services')
   const existing = maybeGetAppServices()?.runtime
   if (existing) return existing
   return (await createAppServices()).runtime

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -15,7 +15,7 @@ import { appendAudit } from './audit'
 import { getAppServices } from './app-services'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { isOnboarded } from './onboarding/state'
-import { listHealthChecks } from '../../plugins/health/lib/health-check-registry'
+import { listHealthChecks } from './health-check-registry'
 import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
 
 const log = createLogger('doctor')

--- a/src/core/health-check-registry.ts
+++ b/src/core/health-check-registry.ts
@@ -14,7 +14,7 @@
 import type {
   HealthCheckDef,
   PluginHealthCheckInput,
-} from '../../../packages/core/src/plugin-types'
+} from '../../packages/core/src/plugin-types'
 
 export type { HealthCheckDef, PluginHealthCheckInput }
 

--- a/src/core/plugin-host/reload-pipeline.ts
+++ b/src/core/plugin-host/reload-pipeline.ts
@@ -39,7 +39,7 @@ import { pluginRegistry, getHookRegistry, removePluginSkillsByPlugin } from '@/l
 import { removeExecToolsByPlugin } from '../../../scripts/lib/registry'
 import { unregisterPluginNodeTypes } from '../../../plugins/workflows/lib/node-type-registry'
 import { unregisterPluginNotificationChannels } from '../../../plugins/workflows/lib/notification-channel-registry'
-import { unregisterPluginHealthChecks } from '../../../plugins/health/lib/health-check-registry'
+import { unregisterPluginHealthChecks } from '../health-check-registry'
 import { ensurePluginSearchReady, unregisterContentTypesByPlugin } from '@/core/search-registry'
 import {
   bumpVersion,

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -29,7 +29,7 @@ import {
 import {
   registerPluginHealthCheck,
   unregisterPluginHealthChecks,
-} from '../../plugins/health/lib/health-check-registry'
+} from '../core/health-check-registry'
 import type {
   PluginNotificationChannelInput,
   PluginHealthCheckInput,

--- a/tests/core/agent-rules-import.test.ts
+++ b/tests/core/agent-rules-import.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+describe('agent-rules managed-block module import', () => {
+  let tempDir: string | null = null
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true })
+    tempDir = null
+  })
+
+  it('can be imported by CLI code without initializing user state', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bakin-agent-rules-import-'))
+    const bakinHome = join(tempDir, 'bakin-home')
+    const openclawHome = join(tempDir, 'openclaw-home')
+    const home = join(tempDir, 'home')
+
+    const proc = Bun.spawn(
+      [
+        process.execPath,
+        '-e',
+        [
+          "const mod = await import('./src/core/agent-rules/managed-blocks.ts')",
+          "if (!mod.AGENT_RULES_BLOCK_START || !mod.AGENT_RULES_BLOCK_END) throw new Error('missing exports')",
+        ].join('; '),
+      ],
+      {
+        cwd: join(import.meta.dir, '../..'),
+        env: {
+          ...process.env,
+          BAKIN_HOME: bakinHome,
+          OPENCLAW_HOME: openclawHome,
+          HOME: home,
+          NODE_ENV: 'test',
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
+
+    expect(stdout).toBe('')
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+    expect(existsSync(bakinHome)).toBe(false)
+    expect(existsSync(openclawHome)).toBe(false)
+    expect(existsSync(home)).toBe(false)
+  })
+})

--- a/tests/core/agent-rules-managed-blocks.test.ts
+++ b/tests/core/agent-rules-managed-blocks.test.ts
@@ -1,10 +1,10 @@
 /**
- * Regression test for plugins/health/lib/managed-blocks.ts.
+ * Regression test for src/core/agent-rules/managed-blocks.ts.
  *
  * Migrated from tests/core/doctor-managed-blocks.test.ts in #139 C9.
  * Pins the existing managed-block flow byte-equal so the registered
- * health.managed-blocks check can be lifted in without changing
- * observed behavior. Cases:
+ * health.managed-blocks check can call core-owned infrastructure without
+ * changing observed behavior. Cases:
  *
  *   - Block missing + autoFix=true → block appended with one blank line
  *     of separation; trailing newline; rest of file untouched
@@ -60,12 +60,12 @@ mock.module('@bakin/core/content-dir', () => ({
   getBakinPaths: () => ({}),
   isUsingBakinHome: () => true,
 }))
-mock.module('../../../src/core/app-services', () => ({
+mock.module('../../src/core/app-services', () => ({
   maybeGetAppServices: () => ({ runtime: appRuntime }),
   createAppServices: async () => ({ runtime: appRuntime }),
 }))
 
-import { applyAllManagedBlocks, applyAllManagedBlocksForRuntime } from '../../../plugins/health/lib/managed-blocks'
+import { applyAllManagedBlocks, applyAllManagedBlocksForRuntime } from '../../src/core/agent-rules/managed-blocks'
 import { createMockRuntimeAdapter } from '@bakin/core/adapters/runtime/testing'
 
 afterAll(() => {

--- a/tests/core/doctor-plugin-checks.test.ts
+++ b/tests/core/doctor-plugin-checks.test.ts
@@ -44,7 +44,7 @@ mock.module('@/core/task-store', () => ({
 import {
   registerPluginHealthCheck,
   unregisterPluginHealthChecks,
-} from '../../plugins/health/lib/health-check-registry'
+} from '../../src/core/health-check-registry'
 import { runPluginHealthChecks } from '../../src/core/doctor'
 
 beforeEach(() => {

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -169,7 +169,7 @@ describe('doctor', () => {
     // Sanity check: when plugins ARE registered, runDiagnostics surfaces
     // their rows. Catches the regression "runPluginHealthChecks isn't being
     // awaited" — a class of bug invisible to the gate-only assertions below.
-    const registry = await import('../../plugins/health/lib/health-check-registry')
+    const registry = await import('../../src/core/health-check-registry')
     registry.registerHealthCheck({
       runtime: 'plugin',
       pluginId: 'doctor-test',
@@ -193,7 +193,7 @@ describe('doctor', () => {
   })
 
   it('notifies the runtime main agent about unfixable plugin issues', async () => {
-    const registry = await import('../../plugins/health/lib/health-check-registry')
+    const registry = await import('../../src/core/health-check-registry')
     registry.registerHealthCheck({
       runtime: 'plugin',
       pluginId: 'doctor-test',

--- a/tests/core/health-check-registry.test.ts
+++ b/tests/core/health-check-registry.test.ts
@@ -17,15 +17,15 @@ mock.module('@bakin/core/main-agent', () => ({
   getMainAgentName: () => 'Main',
 }))
 
-mock.module('../../../src/core/content-dir', () => ({
+mock.module('../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ root: testDir }),
 }))
-mock.module('../../../packages/core/src/content-dir', () => ({
+mock.module('../../packages/core/src/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ root: testDir }),
 }))
-mock.module('../../../src/core/logger', () => ({
+mock.module('../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
 }))
 mock.module('@/core/task-store', () => ({
@@ -41,7 +41,7 @@ import {
   unregisterHealthCheck,
   registerPluginHealthCheck,
   unregisterPluginHealthChecks,
-} from '../../../plugins/health/lib/health-check-registry'
+} from '../../src/core/health-check-registry'
 
 // Track ids we add per-test so we can clean up between tests.
 const added: string[] = []

--- a/tests/plugins/health/checks-route.test.ts
+++ b/tests/plugins/health/checks-route.test.ts
@@ -66,7 +66,7 @@ const healthPlugin = require('../../../plugins/health/index').default as typeof 
 import {
   registerPluginHealthCheck,
   unregisterPluginHealthChecks,
-} from '../../../plugins/health/lib/health-check-registry'
+} from '../../../src/core/health-check-registry'
 import { activatePlugin, findRoute, callRoute } from '../test-helpers'
 import type { ActivatedPlugin } from '../test-helpers'
 

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -82,8 +82,8 @@ mock.module('../../../src/core/search-registry', () => ({
   })),
   getContentTypes: mock(() => []),
   purgeContentType: mock(async () => {}),
-  // plugin-registry.ts (transitively imported by health/managed-blocks via
-  // getHookRegistry) re-imports buildSearchAPI; provide a no-op stub.
+  // plugin-registry.ts can be reached by core agent-rules when rendering
+  // workflow catalog snapshots; provide a no-op search API stub.
   buildSearchAPI: () => ({
     registerContentType: mock(),
     registerFileBackedContentType: mock(),


### PR DESCRIPTION
## Summary
- Move the health-check registry from the health plugin into core ownership
- Move agent-rules managed-block infrastructure into core ownership and keep plugin checks as contributors
- Lazy-load app/plugin registry dependencies from agent-rules so CLI import stays hermetic
- Move ownership-aligned tests under tests/core and add a subprocess import regression
- Update doctor/health knowledge docs for the new boundary

Closes #174

## Validation
- bun run lint
- bun run typecheck
- bun run test (3330 pass, 0 fail)
- focused health/core slice (91 pass, 0 fail)
- git diff --check