### PR TITLE
Wire OpenClaw channel approval responses

### DIFF
--- a/.claude/knowledge/adapter-architecture.md
+++ b/.claude/knowledge/adapter-architecture.md
@@ -125,6 +125,12 @@ Workflow approvals persist as Bakin-owned durable records. Runtime channel
 message ids are delivery refs. A lost provider message must not destroy the
 approval decision history.
 
+Adapters may expose `interactive-approval` only when the provider/runtime can
+return structured approval decisions. Provider decisions are normalized into
+`runtime.channels.subscribeApprovalResponses()` events; provider TTLs and
+message ids never become the source of truth. Durable Bakin approval links stay
+available as the provider-agnostic fallback.
+
 Channel operations go through `runtime.channels.*`. Cron operations go through
 `runtime.cron.*`. Plugin notification channel definitions still belong to the
 Bakin workflow/channel registry; provider delivery is adapter-backed.

--- a/.claude/knowledge/workflow-approvals.md
+++ b/.claude/knowledge/workflow-approvals.md
@@ -49,12 +49,20 @@ and `runtime.channels.sendNotification()` where appropriate. These calls are
 fire-and-forget: channel delivery failures log but never block workflow
 progression. The workflow instance and audit log remain canonical.
 
-Current OpenClaw channel approvals are render-only. `createApproval()` posts a
-provider message, but channel replies/buttons do not feed approve/reject
-decisions back into Bakin yet. The OpenClaw adapter marks this in the rendered
-message and the health plugin warns until a runtime channel reports the
-`interactive-approval` capability. Humans must approve or reject gates in the
-Bakin UI for now.
+OpenClaw channel approvals are interactive only for configured channels that
+advertise `interactive-approval`. The OpenClaw adapter uses native
+`plugin.approval.*` gateway requests for those channels and maps provider
+decisions back to Bakin `approvalId` values. Channels without real runtime
+approval responses stay render-only and include a Bakin approval link.
+Requests that require a reject reason also stay on the Bakin fallback page
+unless the provider can collect a structured reason.
+
+Provider approval buttons are a convenience surface, not Bakin state. OpenClaw
+native approval requests can expire before a workflow gate does, and provider
+events may be missed if Bakin is offline. The durable Bakin approval record and
+the Bakin fallback approval URL remain canonical. Reject responses that require
+a reason must include one; no-reason channel rejects are ignored and the user is
+sent back to the Bakin approval link.
 
 ## Long Prior Outputs
 

--- a/.claude/knowledge/workflows-plugin.md
+++ b/.claude/knowledge/workflows-plugin.md
@@ -174,6 +174,8 @@ Workflow gate channel approvals are Bakin-owned durable records, not provider-ow
 
 The approval record contains the `approvalId`, workflow/run/task/step owner, request body/options/context, delivery refs, response data, and timestamps. Runtime channel message ids are stored only as delivery refs. Channel interaction payloads carry `approvalId`; the workflows plugin loads the durable record and gets task/step identity from Bakin state before approving or rejecting a gate.
 
+Channel approval requests include a Bakin-owned fallback URL in the request context. Provider-native buttons may expire or fail independently of the workflow gate; the fallback page posts back to the workflows plugin and uses the same durable approval record, audit trail, summary notification, and render resolution path as the Bakin UI. Gates that require reject reasons must use the fallback page unless the provider can return a structured reason.
+
 Startup calls `rehydratePendingApprovals()` from `plugins/workflows/lib/approval-rehydration.ts`. It reattaches stored delivery refs to pending workflow instances and retries `runtime.channels.createApproval()` for pending records that were written before rendering completed. Duplicate render windows are tolerated; the durable Bakin approval record remains the source of truth.
 
 ## CRUD Routes

--- a/docs/src/content/docs/using/workflows.md
+++ b/docs/src/content/docs/using/workflows.md
@@ -43,7 +43,7 @@ Agents creating a task pick the workflow that fits, or skip with a reason. Bakin
 
 ### Approve a gate
 
-Gates pause the workflow until you decide. The task's detail panel shows the gate and the prior step's output for context. Approve and the workflow advances; reject and it rewinds. If notifications are configured, they ping you when one's waiting; with Discord gate alerts on, you can also approve or reject straight from the message.
+Gates pause the workflow until you decide. The task's detail panel shows the gate and the prior step's output for context. Approve and the workflow advances; reject and it rewinds. If notifications are configured, they ping you when one's waiting. Runtime channels that support interactive approvals can approve or reject straight from the message when a structured reject reason is not required; every gate alert also includes a Bakin approval link so provider button expiry does not expire the workflow gate.
 
 ### Cancel a workflow
 

--- a/packages/adapter-openclaw/src/approval-gateway.ts
+++ b/packages/adapter-openclaw/src/approval-gateway.ts
@@ -1,0 +1,348 @@
+import { randomUUID } from 'crypto'
+import type { AdapterLogger } from '@bakin/core/adapters/shared'
+
+const GATEWAY_PROTOCOL_VERSION = 3
+const DEFAULT_REQUEST_TIMEOUT_MS = 10000
+const CONNECT_TIMEOUT_MS = 5000
+const RECONNECT_DELAY_MS = 1000
+const WS_OPEN = 1
+
+export type OpenClawPluginApprovalDecision = 'allow-once' | 'allow-always' | 'deny'
+
+export interface OpenClawPluginApprovalRequestParams {
+  pluginId: string
+  title: string
+  description: string
+  severity?: string
+  toolName?: string
+  toolCallId?: string
+  agentId?: string
+  sessionKey?: string
+  turnSourceChannel?: string
+  turnSourceTo?: string
+  turnSourceAccountId?: string
+  turnSourceThreadId?: string | number
+  timeoutMs?: number
+  twoPhase?: boolean
+}
+
+export interface OpenClawPluginApprovalRequestResult {
+  id?: string
+  status?: string
+  decision?: OpenClawPluginApprovalDecision | null
+  createdAtMs?: number
+  expiresAtMs?: number
+}
+
+export interface OpenClawPluginApprovalResolvedPayload {
+  id?: string
+  decision?: string
+  resolvedBy?: string | null
+  ts?: number
+  request?: Record<string, unknown>
+}
+
+interface GatewayEventFrame {
+  type: 'event'
+  event: string
+  payload?: unknown
+  seq?: number
+}
+
+interface GatewayResponseFrame {
+  type: 'res'
+  id: string
+  ok: boolean
+  payload?: unknown
+  error?: { message?: string; code?: string; details?: unknown }
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+interface ConnectState {
+  promise: Promise<void>
+  resolve: () => void
+  reject: (error: Error) => void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+export class OpenClawApprovalGatewayClient {
+  private ws: WebSocket | null = null
+  private pending = new Map<string, PendingRequest>()
+  private resolvedHandlers = new Set<(payload: OpenClawPluginApprovalResolvedPayload) => void>()
+  private connectState: ConnectState | null = null
+  private connected = false
+  private stopped = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private connectSent = false
+
+  constructor(
+    private readonly opts: {
+      url: string
+      token: () => string | null
+      logger: AdapterLogger
+    },
+  ) {}
+
+  async requestPluginApproval(
+    params: OpenClawPluginApprovalRequestParams,
+  ): Promise<OpenClawPluginApprovalRequestResult> {
+    const result = await this.request('plugin.approval.request', params as unknown as Record<string, unknown>)
+    return isRecord(result) ? result as OpenClawPluginApprovalRequestResult : {}
+  }
+
+  async resolvePluginApproval(id: string, decision: OpenClawPluginApprovalDecision): Promise<void> {
+    await this.request('plugin.approval.resolve', { id, decision })
+  }
+
+  subscribeResolved(handler: (payload: OpenClawPluginApprovalResolvedPayload) => void): () => void {
+    this.resolvedHandlers.add(handler)
+    this.ensureConnected().catch((err) => {
+      this.opts.logger.warn('OpenClaw approval gateway subscription failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    })
+    return () => {
+      this.resolvedHandlers.delete(handler)
+      if (this.resolvedHandlers.size === 0) this.close()
+    }
+  }
+
+  close(): void {
+    this.stopped = true
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    this.rejectPending(new Error('OpenClaw approval gateway closed'))
+    if (this.connectState) {
+      clearTimeout(this.connectState.timeout)
+      this.connectState.reject(new Error('OpenClaw approval gateway closed'))
+      this.connectState = null
+    }
+    this.connected = false
+    this.connectSent = false
+    const ws = this.ws
+    this.ws = null
+    try {
+      ws?.close()
+    } catch {
+      // best effort shutdown
+    }
+  }
+
+  private async request(method: string, params: Record<string, unknown>): Promise<unknown> {
+    await this.ensureConnected()
+    return this.sendRequest(method, params, DEFAULT_REQUEST_TIMEOUT_MS)
+  }
+
+  private ensureConnected(): Promise<void> {
+    if (this.connected && this.ws?.readyState === WS_OPEN) return Promise.resolve()
+    if (this.connectState) return this.connectState.promise
+
+    this.stopped = false
+    this.connected = false
+    this.connectSent = false
+
+    const WebSocketCtor = globalThis.WebSocket
+    if (!WebSocketCtor) {
+      return Promise.reject(new Error('WebSocket is not available in this runtime'))
+    }
+
+    let resolveConnect!: () => void
+    let rejectConnect!: (error: Error) => void
+    const timeout = setTimeout(() => {
+      const error = new Error('OpenClaw approval gateway connect timed out')
+      this.failConnect(error)
+      this.ws?.close()
+    }, CONNECT_TIMEOUT_MS)
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveConnect = resolve
+      rejectConnect = reject
+    })
+    this.connectState = { promise, resolve: resolveConnect, reject: rejectConnect, timeout }
+
+    const ws = new WebSocketCtor(this.opts.url)
+    this.ws = ws
+    ws.addEventListener('open', () => {
+      // OpenClaw sends connect.challenge before accepting connect. The
+      // challenge event drives sendConnect().
+    })
+    ws.addEventListener('message', (event) => this.handleMessage(messageDataToString(event.data)))
+    ws.addEventListener('close', () => this.handleClose())
+    ws.addEventListener('error', () => {
+      if (!this.connected) this.failConnect(new Error('OpenClaw approval gateway socket error'))
+    })
+
+    return promise
+  }
+
+  private sendConnect(): void {
+    if (this.connectSent) return
+    this.connectSent = true
+    const token = this.opts.token()
+    this.sendRequest('connect', {
+      minProtocol: GATEWAY_PROTOCOL_VERSION,
+      maxProtocol: GATEWAY_PROTOCOL_VERSION,
+      client: {
+        id: 'gateway-client',
+        displayName: 'Bakin',
+        version: '1.0.0',
+        platform: process.platform,
+        mode: 'backend',
+      },
+      role: 'operator',
+      scopes: ['operator.approvals'],
+      ...(token ? { auth: { token } } : {}),
+    }, CONNECT_TIMEOUT_MS)
+      .then(() => {
+        const state = this.connectState
+        if (!state) return
+        clearTimeout(state.timeout)
+        this.connected = true
+        this.connectState = null
+        state.resolve()
+      })
+      .catch((err) => {
+        this.failConnect(err instanceof Error ? err : new Error(String(err)))
+        this.ws?.close()
+      })
+  }
+
+  private sendRequest(method: string, params: Record<string, unknown>, timeoutMs: number): Promise<unknown> {
+    const ws = this.ws
+    if (!ws || ws.readyState !== WS_OPEN) {
+      return Promise.reject(new Error('OpenClaw approval gateway is not connected'))
+    }
+
+    const id = randomUUID()
+    const frame = { type: 'req', id, method, params }
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`OpenClaw approval gateway request timed out: ${method}`))
+      }, timeoutMs)
+      this.pending.set(id, { resolve, reject, timeout })
+    })
+    ws.send(JSON.stringify(frame))
+    return promise
+  }
+
+  private handleMessage(raw: string): void {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return
+    }
+    if (!isRecord(parsed) || typeof parsed.type !== 'string') return
+
+    if (parsed.type === 'event') {
+      this.handleEvent(parsed as unknown as GatewayEventFrame)
+    } else if (parsed.type === 'res') {
+      this.handleResponse(parsed as unknown as GatewayResponseFrame)
+    }
+  }
+
+  private handleEvent(frame: GatewayEventFrame): void {
+    if (frame.event === 'connect.challenge') {
+      const payload = isRecord(frame.payload) ? frame.payload : {}
+      const nonce = typeof payload.nonce === 'string' ? payload.nonce.trim() : ''
+      if (!nonce) {
+        this.failConnect(new Error('OpenClaw approval gateway connect challenge missing nonce'))
+        this.ws?.close()
+        return
+      }
+      this.sendConnect()
+      return
+    }
+
+    if (frame.event !== 'plugin.approval.resolved') return
+    const payload = normalizeResolvedPayload(frame.payload)
+    if (!payload) return
+    for (const handler of this.resolvedHandlers) {
+      try {
+        handler(payload)
+      } catch (err) {
+        this.opts.logger.warn('OpenClaw approval response handler failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  }
+
+  private handleResponse(frame: GatewayResponseFrame): void {
+    const pending = this.pending.get(frame.id)
+    if (!pending) return
+    this.pending.delete(frame.id)
+    clearTimeout(pending.timeout)
+    if (frame.ok) {
+      pending.resolve(frame.payload)
+      return
+    }
+    pending.reject(new Error(frame.error?.message ?? 'OpenClaw approval gateway request failed'))
+  }
+
+  private handleClose(): void {
+    this.connected = false
+    this.connectSent = false
+    this.rejectPending(new Error('OpenClaw approval gateway disconnected'))
+    if (this.connectState) {
+      clearTimeout(this.connectState.timeout)
+      this.connectState.reject(new Error('OpenClaw approval gateway disconnected'))
+      this.connectState = null
+    }
+    if (this.stopped || this.resolvedHandlers.size === 0) return
+    if (this.reconnectTimer) return
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.ensureConnected().catch((err) => {
+        this.opts.logger.warn('OpenClaw approval gateway reconnect failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+    }, RECONNECT_DELAY_MS)
+  }
+
+  private failConnect(error: Error): void {
+    if (!this.connectState) return
+    clearTimeout(this.connectState.timeout)
+    this.connectState.reject(error)
+    this.connectState = null
+  }
+
+  private rejectPending(error: Error): void {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timeout)
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+}
+
+function normalizeResolvedPayload(payload: unknown): OpenClawPluginApprovalResolvedPayload | null {
+  if (!isRecord(payload)) return null
+  const request = isRecord(payload.request) ? payload.request : undefined
+  return {
+    ...(typeof payload.id === 'string' ? { id: payload.id } : {}),
+    ...(typeof payload.decision === 'string' ? { decision: payload.decision } : {}),
+    ...(typeof payload.resolvedBy === 'string' || payload.resolvedBy === null ? { resolvedBy: payload.resolvedBy } : {}),
+    ...(typeof payload.ts === 'number' ? { ts: payload.ts } : {}),
+    ...(request ? { request } : {}),
+  }
+}
+
+function messageDataToString(data: unknown): string {
+  if (typeof data === 'string') return data
+  if (data instanceof ArrayBuffer) return new TextDecoder().decode(data)
+  if (ArrayBuffer.isView(data)) return new TextDecoder().decode(data)
+  return String(data)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -29,6 +29,11 @@ import { getOpenClawHome, getOpenClawPath } from './home'
 import { tryGetMainAgentId } from './main-agent'
 import type { OpenClawRuntimeAdapterOptions } from './index'
 import {
+  OpenClawApprovalGatewayClient,
+  type OpenClawPluginApprovalDecision,
+  type OpenClawPluginApprovalResolvedPayload,
+} from './approval-gateway'
+import {
   getOpenClawMemoryEntry,
   getOpenClawMemoryWatchPaths,
   listOpenClawMemoryEntries,
@@ -64,10 +69,23 @@ const TRANSIENT_FETCH_CODES = new Set([
 ])
 
 const SEND_MESSAGE_RETRY_BACKOFF_MS = [1000, 2000]
+const OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS = 600000
+const OPENCLAW_PLUGIN_APPROVAL_REF_PREFIX = 'openclaw-plugin-approval:'
+const OPENCLAW_PLUGIN_ID = 'bakin'
+const OPENCLAW_WORKFLOW_GATE_TOOL = 'workflow.gate'
 const RENDER_ONLY_APPROVAL_NOTICE = [
-  'Runtime channel approvals are render-only in the current OpenClaw adapter.',
-  'Approve or reject this gate in the Bakin UI; channel replies and buttons are not wired back yet.',
+  'This channel cannot return approval decisions to Bakin.',
+  'Use the Bakin approval link or approve/reject this gate in the Bakin UI.',
 ].join(' ')
+const REJECT_REASON_APPROVAL_NOTICE = [
+  'This gate requires a reject reason.',
+  'Use the Bakin approval link so reject decisions include the required reason.',
+].join(' ')
+const NATIVE_APPROVAL_NOTICE = [
+  'Channel buttons are a convenience path and may expire before the Bakin gate does.',
+  'The durable Bakin approval record remains canonical.',
+].join(' ')
+const NATIVE_APPROVAL_PROVIDERS = new Set(['discord', 'telegram', 'slack', 'matrix', 'qqbot'])
 
 interface OpenClawCronStore {
   version?: number
@@ -121,6 +139,9 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   private logger: AdapterLogger = noopLogger
   private approvalResponsesWarningLogged = false
   private approvalResolveWarningLogged = false
+  private approvalGatewayClient: OpenClawApprovalGatewayClient | null = null
+  private emittedApprovalResponseKeys: string[] = []
+  private emittedApprovalResponseKeySet = new Set<string>()
 
   constructor(options: OpenClawRuntimeAdapterOptions = {}) {
     this.settings = mergeSettings(options.settings)
@@ -131,7 +152,10 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     this.settings = mergeSettings(opts.settings ?? (this.settings as unknown as Record<string, unknown>))
   }
 
-  async shutdown(): Promise<void> {}
+  async shutdown(): Promise<void> {
+    this.approvalGatewayClient?.close()
+    this.approvalGatewayClient = null
+  }
 
   async ping(): Promise<boolean> {
     for (const path of ['/health', '/healthz']) {
@@ -167,12 +191,18 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       {
         id: 'channel-approval-responses',
         name: 'OpenClaw channel approval responses',
-        run: async () => [{
-          check: 'openclaw.channel-approval-responses',
-          status: 'warn',
-          message: 'OpenClaw channel approval requests are render-only. Approve/reject workflow gates in the Bakin UI until interactive channel responses are implemented.',
-          autoFixable: false,
-        }],
+        run: async () => {
+          const channels = await this.channels.list()
+          const interactive = channels.filter(channel => channel.capabilities.includes('interactive-approval'))
+          return [{
+            check: 'openclaw.channel-approval-responses',
+            status: interactive.length > 0 ? 'ok' : 'warn',
+            message: interactive.length > 0
+              ? `OpenClaw channel approval responses are enabled for ${interactive.map(channel => channel.id).join(', ')}.`
+              : 'OpenClaw channel approval requests are render-only for configured channels. Approve/reject workflow gates in the Bakin UI until a channel advertises interactive-approval support.',
+            autoFixable: false,
+          }]
+        },
       },
     ]
   }
@@ -386,37 +416,173 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       })
     },
     createApproval: async (args: { approvalId: string; channels: string[]; request: { title: string; body: string; options: Array<{ id: string; label: string }>; context?: RuntimeMetadata } }) => {
-      const optionText = args.request.options.map((option) => `- ${option.label} (${option.id})`).join('\n')
-      return this.channels.sendMessage({
-        channels: args.channels,
-        message: {
-          title: args.request.title,
-          body: `${args.request.title}\n\n${args.request.body}\n\n${optionText}\n\n${RENDER_ONLY_APPROVAL_NOTICE}`,
-          metadata: { ...(args.request.context ?? {}), approvalId: args.approvalId },
-        },
-      })
+      const renderedAt = new Date().toISOString()
+      const deliveries = []
+      const context = args.request.context ?? {}
+      for (const channel of args.channels) {
+        if (
+          channelHasInteractiveApproval(channel)
+          && !requiresRejectReason(context)
+          && supportsNativeApprovalOptions(args.request.options)
+        ) {
+          const delivery = await this.tryCreateNativeApproval(channel, args, renderedAt)
+          if (delivery) {
+            deliveries.push(delivery)
+            continue
+          }
+        }
+        const fallback = await this.renderApprovalMessage(channel, args, context)
+        deliveries.push(...fallback.deliveries)
+      }
+      return { deliveries }
     },
     editApproval: async (args: { deliveries: Array<{ channelId: string; ref: string; renderedAt: string }> }) => ({ deliveries: args.deliveries }),
     cancelApproval: async () => {},
-    resolveApproval: async () => {
-      if (!this.approvalResolveWarningLogged) {
+    resolveApproval: async (args: { deliveries: Array<{ channelId: string; ref: string; renderedAt: string }>; response: { selectedOption: string } }) => {
+      let sawNativeDelivery = false
+      let sawRenderOnlyDelivery = false
+      for (const delivery of args.deliveries) {
+        const openClawApprovalId = parseNativeApprovalRef(delivery.ref)
+        if (!openClawApprovalId) {
+          sawRenderOnlyDelivery = true
+          continue
+        }
+        sawNativeDelivery = true
+        const decision = openClawDecisionFromBakinOption(args.response.selectedOption)
+        if (!decision) continue
+        try {
+          await this.approvalGateway().resolvePluginApproval(openClawApprovalId, decision)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          if (isExpectedNativeApprovalResolveMiss(message)) {
+            this.logger.debug('OpenClaw native approval was already resolved or expired', {
+              openClawApprovalId,
+              response: args.response.selectedOption,
+            })
+          } else {
+            this.logger.warn('OpenClaw native approval resolve failed; durable Bakin approval remains canonical', {
+              openClawApprovalId,
+              error: message,
+            })
+          }
+        }
+      }
+
+      if (!sawNativeDelivery && sawRenderOnlyDelivery && !this.approvalResolveWarningLogged) {
         this.logger.warn(
           'OpenClaw approval resolve is render-only; provider approval messages are not edited or resolved. The durable Bakin approval record remains canonical.'
         )
         this.approvalResolveWarningLogged = true
       }
     },
-    subscribeApprovalResponses: (_handler: (event: ApprovalResolveEvent) => void) => {
-      if (!this.approvalResponsesWarningLogged) {
-        this.logger.warn(
-          'OpenClaw channel approval responses are not implemented; approval requests are render-only. Approve/reject workflow gates in the Bakin UI.'
-        )
-        this.approvalResponsesWarningLogged = true
+    subscribeApprovalResponses: (handler: (event: ApprovalResolveEvent) => void) => {
+      if (!hasAnyInteractiveApprovalChannel()) {
+        if (!this.approvalResponsesWarningLogged) {
+          this.logger.warn(
+            'OpenClaw channel approval responses are render-only for configured channels. Approve/reject workflow gates in the Bakin UI.'
+          )
+          this.approvalResponsesWarningLogged = true
+        }
+        return () => {}
       }
-      return () => {}
+      return this.approvalGateway().subscribeResolved((payload) => {
+        const event = approvalEventFromOpenClawPayload(payload)
+        if (!event) return
+        if (!this.markApprovalResponseEmitted(event)) return
+        handler(event)
+      })
     },
     onMessage: () => () => {},
     onInteraction: () => () => {},
+  }
+
+  private async tryCreateNativeApproval(
+    channel: string,
+    args: { approvalId: string; request: { title: string; body: string; context?: RuntimeMetadata } },
+    renderedAt: string,
+  ): Promise<{ channelId: string; ref: string; renderedAt: string } | null> {
+    const ref = splitChannelRef(channel, args.request.context)
+    const approvalUrl = metadataValue(args.request.context, 'approvalUrl')
+      ?? metadataValue(args.request.context, 'approvalDecisionUrl')
+    try {
+      const result = await this.approvalGateway().requestPluginApproval({
+        pluginId: OPENCLAW_PLUGIN_ID,
+        title: truncate(args.request.title, 80),
+        description: renderNativeApprovalDescription(args.request.body, approvalUrl),
+        severity: 'warning',
+        toolName: OPENCLAW_WORKFLOW_GATE_TOOL,
+        toolCallId: args.approvalId,
+        turnSourceChannel: ref.channel,
+        ...(ref.target ? { turnSourceTo: ref.target } : {}),
+        timeoutMs: OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS,
+        twoPhase: true,
+      })
+      if (!result.id || result.decision === null) {
+        this.logger.warn('OpenClaw native approval request had no approval route; falling back to render-only message', {
+          approvalId: args.approvalId,
+          channel,
+        })
+        return null
+      }
+      return {
+        channelId: channel,
+        ref: `${OPENCLAW_PLUGIN_APPROVAL_REF_PREFIX}${result.id}`,
+        renderedAt,
+      }
+    } catch (err) {
+      this.logger.warn('OpenClaw native approval request failed; falling back to render-only message', {
+        approvalId: args.approvalId,
+        channel,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return null
+    }
+  }
+
+  private async renderApprovalMessage(
+    channel: string,
+    args: { approvalId: string; request: { title: string; body: string; options: Array<{ id: string; label: string }>; context?: RuntimeMetadata } },
+    context: RuntimeMetadata,
+  ): Promise<{ deliveries: Array<{ channelId: string; ref: string; renderedAt: string }> }> {
+    const optionText = args.request.options.map((option) => `- ${option.label} (${option.id})`).join('\n')
+    const approvalUrl = metadataValue(context, 'approvalUrl') ?? metadataValue(context, 'approvalDecisionUrl')
+    return this.channels.sendMessage({
+      channels: [channel],
+      message: {
+        title: args.request.title,
+        body: [
+          args.request.title,
+          args.request.body,
+          optionText,
+          approvalUrl ? `Open in Bakin: ${approvalUrl}` : undefined,
+          approvalNoticeForMessage(channel, context),
+        ].filter(Boolean).join('\n\n'),
+        metadata: { ...context, approvalId: args.approvalId },
+      },
+    })
+  }
+
+  private approvalGateway(): OpenClawApprovalGatewayClient {
+    if (!this.approvalGatewayClient) {
+      this.approvalGatewayClient = new OpenClawApprovalGatewayClient({
+        url: gatewayWebSocketUrl(this.settings),
+        token: readGatewayToken,
+        logger: this.logger,
+      })
+    }
+    return this.approvalGatewayClient
+  }
+
+  private markApprovalResponseEmitted(event: ApprovalResolveEvent): boolean {
+    const key = `${event.approvalId}:${event.response.selectedOption}:${event.response.respondedAt}`
+    if (this.emittedApprovalResponseKeySet.has(key)) return false
+    this.emittedApprovalResponseKeySet.add(key)
+    this.emittedApprovalResponseKeys.push(key)
+    while (this.emittedApprovalResponseKeys.length > 1000) {
+      const old = this.emittedApprovalResponseKeys.shift()
+      if (old) this.emittedApprovalResponseKeySet.delete(old)
+    }
+    return true
   }
 
   skills = {
@@ -779,14 +945,154 @@ function readChannelInfos(): ChannelInfo[] {
 
   return Object.entries(channels as Record<string, unknown>).map(([id, raw]): ChannelInfo => {
     const entry = isRecord(raw) ? raw : {}
+    const interactive = channelEntrySupportsInteractiveApproval(id, entry)
+    const capabilities: ChannelInfo['capabilities'] = ['message', 'rich-content']
+    if (interactive) capabilities.push('interactive-approval')
     return {
       id,
       platform: typeof entry.platform === 'string' ? entry.platform : id,
       label: typeof entry.label === 'string' ? entry.label : humanizeChannelId(id),
-      capabilities: ['message', 'rich-content'],
-      metadata: { approvalResponses: 'render-only' },
+      capabilities,
+      metadata: {
+        approvalResponses: interactive ? 'interactive' : 'render-only',
+        approvalMode: interactive ? 'openclaw-plugin-approval' : 'render-only',
+        ...(interactive
+          ? {
+              approvalTimeoutMs: OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS,
+              rejectReason: 'bakin-fallback-link',
+            }
+          : {}),
+      },
     }
   })
+}
+
+function hasAnyInteractiveApprovalChannel(): boolean {
+  return readChannelInfos().some(channel => channel.capabilities.includes('interactive-approval'))
+}
+
+function channelHasInteractiveApproval(channelId: string): boolean {
+  const ref = splitChannelRef(channelId, undefined)
+  return readChannelInfos().some(channel => (
+    channel.id === ref.channel && channel.capabilities.includes('interactive-approval')
+  ))
+}
+
+function channelEntrySupportsInteractiveApproval(id: string, entry: Record<string, unknown>): boolean {
+  if (entry.enabled === false) return false
+  const provider = typeof entry.platform === 'string' ? entry.platform : id
+  if (!NATIVE_APPROVAL_PROVIDERS.has(provider)) return false
+
+  const approvalConfig = isRecord(entry.execApprovals)
+    ? entry.execApprovals
+    : isRecord(entry.approvals)
+      ? entry.approvals
+      : null
+  if (!approvalConfig) return false
+  const enabled = approvalConfig.enabled
+  if (!(enabled === true || enabled === 'auto')) return false
+
+  const eventKinds = approvalConfig.eventKinds
+  if (Array.isArray(eventKinds) && !eventKinds.includes('plugin')) return false
+  return true
+}
+
+function gatewayWebSocketUrl(settings: OpenClawSettings): string {
+  const url = new URL(`${settings.gatewayUrl}:${settings.gatewayPort}`)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  return url.toString().replace(/\/$/, '')
+}
+
+function renderNativeApprovalDescription(body: string, approvalUrl: string | undefined): string {
+  const compactBody = body.replace(/\s+/g, ' ').trim()
+  const footer = [
+    approvalUrl ? `Bakin fallback: ${approvalUrl}` : undefined,
+    NATIVE_APPROVAL_NOTICE,
+  ].filter(Boolean).join('\n\n')
+  if (!footer) return truncate(compactBody, 256)
+  const bodyLimit = 256 - footer.length - 2
+  const bodyPart = bodyLimit > 20 ? truncate(compactBody, bodyLimit) : undefined
+  return [bodyPart, footer].filter(Boolean).join('\n\n').slice(0, 256)
+}
+
+function approvalNoticeForMessage(channelId: string, context: RuntimeMetadata): string {
+  return channelHasInteractiveApproval(channelId) && requiresRejectReason(context)
+    ? REJECT_REASON_APPROVAL_NOTICE
+    : RENDER_ONLY_APPROVAL_NOTICE
+}
+
+function supportsNativeApprovalOptions(options: Array<{ id: string }>): boolean {
+  const ids = new Set(options.map(option => option.id))
+  return ids.size === 2 && ids.has('approve') && ids.has('reject')
+}
+
+function requiresRejectReason(context: RuntimeMetadata | undefined): boolean {
+  return context?.requireRejectReason === true
+}
+
+function approvalEventFromOpenClawPayload(payload: OpenClawPluginApprovalResolvedPayload): ApprovalResolveEvent | null {
+  const request = payload.request
+  if (!request) return null
+  if (request.pluginId !== OPENCLAW_PLUGIN_ID) return null
+  if (request.toolName !== OPENCLAW_WORKFLOW_GATE_TOOL) return null
+  const approvalId = typeof request.toolCallId === 'string' ? request.toolCallId : ''
+  if (!approvalId) return null
+
+  const selectedOption = bakinOptionFromOpenClawDecision(payload.decision)
+  if (!selectedOption) return null
+
+  const actorId = payload.resolvedBy?.trim() || 'openclaw-channel'
+  return {
+    approvalId,
+    channelId: channelIdFromOpenClawRequest(request),
+    response: {
+      selectedOption,
+      respondedAt: typeof payload.ts === 'number' ? new Date(payload.ts).toISOString() : new Date().toISOString(),
+      actor: {
+        type: 'human',
+        id: actorId,
+        displayName: actorId,
+      },
+    },
+  }
+}
+
+function channelIdFromOpenClawRequest(request: Record<string, unknown>): string {
+  const channel = typeof request.turnSourceChannel === 'string' && request.turnSourceChannel.length > 0
+    ? request.turnSourceChannel
+    : 'runtime-channel'
+  const target = typeof request.turnSourceTo === 'string' && request.turnSourceTo.length > 0
+    ? request.turnSourceTo
+    : undefined
+  return target ? `${channel}:${target}` : channel
+}
+
+function openClawDecisionFromBakinOption(option: string): OpenClawPluginApprovalDecision | null {
+  if (option === 'approve') return 'allow-once'
+  if (option === 'reject') return 'deny'
+  return null
+}
+
+function bakinOptionFromOpenClawDecision(decision: string | undefined): 'approve' | 'reject' | null {
+  if (decision === 'allow-once' || decision === 'allow-always') return 'approve'
+  if (decision === 'deny') return 'reject'
+  return null
+}
+
+function parseNativeApprovalRef(ref: string): string | null {
+  return ref.startsWith(OPENCLAW_PLUGIN_APPROVAL_REF_PREFIX)
+    ? ref.slice(OPENCLAW_PLUGIN_APPROVAL_REF_PREFIX.length)
+    : null
+}
+
+function isExpectedNativeApprovalResolveMiss(message: string): boolean {
+  return /expired|not found|unknown/i.test(message)
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  if (maxLength <= 1) return value.slice(0, maxLength)
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/plugins/workflows/bakin-plugin.json
+++ b/plugins/workflows/bakin-plugin.json
@@ -66,6 +66,16 @@
       },
       {
         "method": "GET",
+        "path": "/gates/:taskId/decision",
+        "summary": "Render a durable Bakin gate approval fallback page"
+      },
+      {
+        "method": "POST",
+        "path": "/gates/:taskId/decision",
+        "summary": "Approve or reject a gate through the durable Bakin approval fallback page"
+      },
+      {
+        "method": "GET",
         "path": "/gates/pending",
         "summary": "List all gates awaiting approval"
       },

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -477,7 +477,19 @@ const workflowsPlugin: BakinPlugin = {
           ).catch(() => {})
         }
       } else if (selected === 'reject') {
-        const rejectReason = event.response.comment || 'Rejected via runtime channel'
+        const channelComment = event.response.comment?.trim()
+        const requiresRejectReason = approvalRecord.request.context?.requireRejectReason === true
+        if (requiresRejectReason && !channelComment) {
+          log.warn('Channel reject ignored: this gate requires a reject reason', {
+            approvalId: event.approvalId,
+            taskId,
+            stepId,
+            channelId: event.channelId,
+          })
+          ctx.activity.log('channel', `Gate "${stepId}" reject ignored because a reason is required. Use the Bakin approval link to reject with a reason.`, { taskId })
+          return
+        }
+        const rejectReason = channelComment || 'Rejected via runtime channel'
         const approvalRef = approvalRefFromRecord(approvalRecord)
         const result = rejectGate(taskId, stepId, rejectReason, { approver })
         if (!result.success) {
@@ -1017,6 +1029,148 @@ const workflowsPlugin: BakinPlugin = {
     }
     ctx.registerRoute({ path: '/gates/:taskId/reject', method: 'POST', description: 'Reject a gate step, rewinds workflow', handler: rejectHandler })
 
+    const gateDecisionPageHandler = async (req: Request) => {
+      const url = new URL(req.url)
+      const taskId = url.searchParams.get('taskId')
+      const stepId = url.searchParams.get('stepId')
+      const approvalId = url.searchParams.get('approvalId')
+      if (!taskId || !stepId || !approvalId) {
+        return gateDecisionHtmlResponse('Approval Link Error', '<p>taskId, stepId, and approvalId are required.</p>', 400)
+      }
+
+      const approvalRecord = getApprovalRecord(approvalId)
+      if (!approvalRecord || approvalRecord.owner.taskId !== taskId || approvalRecord.owner.stepId !== stepId) {
+        return gateDecisionHtmlResponse('Approval Not Found', '<p>This approval link no longer matches a pending workflow gate.</p>', 404)
+      }
+
+      const escapedTitle = escapeHtml(approvalRecord.request.title)
+      const escapedBody = escapeHtml(approvalRecord.request.body)
+      const statusText = approvalRecord.status === 'pending'
+        ? ''
+        : `<p class="notice">This approval has already been marked ${escapeHtml(approvalRecord.status)}.</p>`
+      const disabled = approvalRecord.status === 'pending' ? '' : ' disabled'
+      return gateDecisionHtmlResponse(approvalRecord.request.title, `
+        <p class="eyebrow">Workflow Approval</p>
+        <h1>${escapedTitle}</h1>
+        <pre>${escapedBody}</pre>
+        ${statusText}
+        <form method="POST">
+          <input type="hidden" name="approvalId" value="${escapeHtml(approvalId)}" />
+          <input type="hidden" name="taskId" value="${escapeHtml(taskId)}" />
+          <input type="hidden" name="stepId" value="${escapeHtml(stepId)}" />
+          <button name="decision" value="approve"${disabled}>Approve</button>
+        </form>
+        <form method="POST">
+          <input type="hidden" name="approvalId" value="${escapeHtml(approvalId)}" />
+          <input type="hidden" name="taskId" value="${escapeHtml(taskId)}" />
+          <input type="hidden" name="stepId" value="${escapeHtml(stepId)}" />
+          <label for="reason">Reject reason</label>
+          <textarea id="reason" name="reason" rows="4"${disabled}></textarea>
+          <button class="danger" name="decision" value="reject"${disabled}>Reject</button>
+        </form>
+      `)
+    }
+    ctx.registerRoute({ path: '/gates/:taskId/decision', method: 'GET', description: 'Render a durable Bakin gate approval fallback page', handler: gateDecisionPageHandler })
+
+    const gateDecisionActionHandler = async (req: Request) => {
+      const url = new URL(req.url)
+      let form: FormData
+      try {
+        form = await req.formData()
+      } catch {
+        return gateDecisionHtmlResponse('Approval Link Error', '<p>Invalid form submission.</p>', 400)
+      }
+
+      const taskId = url.searchParams.get('taskId') || formValue(form, 'taskId')
+      const stepId = url.searchParams.get('stepId') || formValue(form, 'stepId')
+      const approvalId = url.searchParams.get('approvalId') || formValue(form, 'approvalId')
+      const decision = formValue(form, 'decision')
+      if (!taskId || !stepId || !approvalId || !decision) {
+        return gateDecisionHtmlResponse('Approval Link Error', '<p>taskId, stepId, approvalId, and decision are required.</p>', 400)
+      }
+
+      const approvalRecord = getApprovalRecord(approvalId)
+      if (!approvalRecord || approvalRecord.owner.taskId !== taskId || approvalRecord.owner.stepId !== stepId) {
+        return gateDecisionHtmlResponse('Approval Not Found', '<p>This approval link no longer matches a pending workflow gate.</p>', 404)
+      }
+      if (approvalRecord.status !== 'pending') {
+        return gateDecisionHtmlResponse('Approval Already Decided', `<p>This approval is already ${escapeHtml(approvalRecord.status)}.</p>`)
+      }
+
+      const approvalRef = approvalRefFromRecord(approvalRecord)
+      const approver = webApprover()
+      if (decision === 'approve') {
+        const result = approveGate(taskId, stepId, { approver })
+        if (!result.success) {
+          return gateDecisionHtmlResponse('Approval Failed', `<p>${escapeHtml(result.errors?.[0] || 'Unknown approval failure')}</p>`, 400)
+        }
+
+        ctx.activity.audit('gate.approved', 'web', buildGateAuditPayload(taskId, stepId, result.decision))
+        ctx.activity.log('web', `Gate "${stepId}" approved from approval link`, { taskId })
+        indexInstance(taskId).catch(() => {})
+        triggerDispatch()
+
+        const settings = activeGateSettings()
+        const instance = loadInstance(taskId)
+        if (settings.approvalChannelAlerts && result.decision && instance) {
+          resolveGateApproval(approvalRef, 'approved', approver, result.decision.decidedAt).catch(() => {})
+          sendGateDecisionSummary(
+            instance,
+            stepId,
+            result.decision.gateLabel,
+            getGateDescription(instance.workflowId, stepId),
+            'approved',
+            approver,
+            result.decision.requestedAt,
+            result.decision.decidedAt,
+            undefined,
+            settings,
+          ).catch(() => {})
+        }
+
+        return gateDecisionHtmlResponse('Gate Approved', '<p>The workflow gate was approved. You can close this tab.</p>')
+      }
+
+      if (decision === 'reject') {
+        const reason = formValue(form, 'reason')?.trim()
+        if (!reason) {
+          return gateDecisionHtmlResponse('Reject Reason Required', '<p>A reject reason is required.</p>', 400)
+        }
+
+        const result = rejectGate(taskId, stepId, reason, { approver })
+        if (!result.success) {
+          return gateDecisionHtmlResponse('Reject Failed', `<p>${escapeHtml(result.errors?.[0] || 'Unknown rejection failure')}</p>`, 400)
+        }
+
+        ctx.activity.audit('gate.rejected', 'web', buildGateAuditPayload(taskId, stepId, result.decision, reason))
+        ctx.activity.log('web', `Gate "${stepId}" rejected from approval link: ${reason}`, { taskId })
+        indexInstance(taskId).catch(() => {})
+
+        const settings = activeGateSettings()
+        const instance = loadInstance(taskId)
+        if (settings.approvalChannelAlerts && result.decision && instance) {
+          resolveGateApproval(approvalRef, 'rejected', approver, result.decision.decidedAt, reason).catch(() => {})
+          sendGateDecisionSummary(
+            instance,
+            stepId,
+            result.decision.gateLabel,
+            getGateDescription(instance.workflowId, stepId),
+            'rejected',
+            approver,
+            result.decision.requestedAt,
+            result.decision.decidedAt,
+            reason,
+            settings,
+          ).catch(() => {})
+        }
+
+        return gateDecisionHtmlResponse('Gate Rejected', '<p>The workflow gate was rejected. You can close this tab.</p>')
+      }
+
+      return gateDecisionHtmlResponse('Approval Link Error', '<p>decision must be approve or reject.</p>', 400)
+    }
+    ctx.registerRoute({ path: '/gates/:taskId/decision', method: 'POST', description: 'Approve or reject a gate through the durable Bakin approval fallback page', handler: gateDecisionActionHandler })
+
 
     // GET /instances — list active workflow instances
     ctx.registerRoute({
@@ -1485,6 +1639,51 @@ const workflowsPlugin: BakinPlugin = {
       log.warn(`Shutting down with ${active.length} active workflow instance(s)`)
     }
   },
+}
+
+function formValue(form: FormData, key: string): string | undefined {
+  const value = form.get(key)
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function gateDecisionHtmlResponse(title: string, body: string, status = 200): Response {
+  return new Response(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #0f0f10; color: #f2f2f3; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; }
+    main { width: min(720px, 100%); border: 1px solid #2b2b2f; border-radius: 8px; background: #151517; padding: 24px; }
+    h1 { margin: 0 0 16px; font-size: 24px; line-height: 1.2; }
+    pre { white-space: pre-wrap; word-break: break-word; color: #c6c6cc; background: #101012; border: 1px solid #29292d; border-radius: 6px; padding: 16px; }
+    form { margin-top: 16px; display: grid; gap: 10px; }
+    label, .eyebrow { color: #8f8f98; font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0; }
+    textarea { resize: vertical; border-radius: 6px; border: 1px solid #35353a; background: #101012; color: #f2f2f3; padding: 10px; font: inherit; }
+    button { width: fit-content; border: 0; border-radius: 6px; background: #2f6fed; color: white; padding: 10px 14px; font: inherit; font-weight: 700; cursor: pointer; }
+    button.danger { background: #b42318; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .notice { color: #f6c343; }
+  </style>
+</head>
+<body>
+  <main>${body}</main>
+</body>
+</html>`, {
+    status,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+  })
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }
 
 export default workflowsPlugin

--- a/plugins/workflows/lib/notifications.ts
+++ b/plugins/workflows/lib/notifications.ts
@@ -209,6 +209,7 @@ export async function sendGateApprovalRequest(
       taskId: instance.taskId,
       stepId,
       requireRejectReason: settings.requireRejectReason,
+      approvalUrl: buildGateApprovalUrl(instance.taskId, stepId, approvalId),
     },
   }
 
@@ -240,6 +241,14 @@ export async function sendGateApprovalRequest(
     log.warn('Gate approval alert failed', err)
     return null
   }
+}
+
+function buildGateApprovalUrl(taskId: string, stepId: string, approvalId: string): string {
+  const base = process.env.BAKIN_URL || 'http://localhost:3737'
+  const url = new URL(`/api/plugins/workflows/gates/${encodeURIComponent(taskId)}/decision`, base)
+  url.searchParams.set('stepId', stepId)
+  url.searchParams.set('approvalId', approvalId)
+  return url.toString()
 }
 
 export async function resolveGateApproval(

--- a/tests/adapter-openclaw/runtime-channels.test.ts
+++ b/tests/adapter-openclaw/runtime-channels.test.ts
@@ -7,11 +7,14 @@ describe('OpenClaw runtime channels', () => {
   let testDir: string
   let originalOpenClawHome: string | undefined
   let originalFetch: typeof globalThis.fetch
+  let originalWebSocket: typeof globalThis.WebSocket
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), 'bakin-openclaw-channel-test-'))
     originalOpenClawHome = process.env.OPENCLAW_HOME
     originalFetch = globalThis.fetch
+    originalWebSocket = globalThis.WebSocket
+    FakeWebSocket.instances.length = 0
     process.env.OPENCLAW_HOME = testDir
     mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
@@ -24,6 +27,7 @@ describe('OpenClaw runtime channels', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch
+    globalThis.WebSocket = originalWebSocket
     if (originalOpenClawHome === undefined) delete process.env.OPENCLAW_HOME
     else process.env.OPENCLAW_HOME = originalOpenClawHome
     rmSync(testDir, { recursive: true, force: true })
@@ -37,7 +41,32 @@ describe('OpenClaw runtime channels', () => {
     expect(channels).toEqual([expect.objectContaining({
       id: 'discord',
       capabilities: ['message', 'rich-content'],
-      metadata: { approvalResponses: 'render-only' },
+      metadata: expect.objectContaining({ approvalResponses: 'render-only' }),
+    })])
+  })
+
+  it('advertises interactive approvals only for configured native approval channels', async () => {
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+      channels: {
+        discord: {
+          token: 'discord-token',
+          execApprovals: { enabled: true, approvers: ['202168845362921483'], target: 'both' },
+        },
+      },
+    }), 'utf-8')
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const channels = await runtime.channels.list()
+    expect(channels).toEqual([expect.objectContaining({
+      id: 'discord',
+      capabilities: ['message', 'rich-content', 'interactive-approval'],
+      metadata: expect.objectContaining({
+        approvalResponses: 'interactive',
+        approvalMode: 'openclaw-plugin-approval',
+      }),
     })])
   })
 
@@ -64,8 +93,237 @@ describe('OpenClaw runtime channels', () => {
 
     expect(calls).toHaveLength(1)
     const args = calls[0]!.args as Record<string, unknown>
-    expect(args.message).toContain('Runtime channel approvals are render-only')
-    expect(args.message).toContain('Approve or reject this gate in the Bakin UI')
+    expect(args.message).toContain('This channel cannot return approval decisions to Bakin')
+    expect(args.message).toContain('approve/reject this gate in the Bakin UI')
+  })
+
+  it('creates native OpenClaw plugin approvals for interactive channels', async () => {
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+      channels: {
+        discord: {
+          token: 'discord-token',
+          execApprovals: { enabled: true, approvers: ['202168845362921483'], target: 'both' },
+        },
+      },
+    }), 'utf-8')
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    await runtime.initialize({ contentDir: testDir })
+
+    const result = await runtime.channels.createApproval({
+      approvalId: 'approval-1',
+      channels: ['discord:channel-1'],
+      request: {
+        title: 'Gate: Review',
+        body: 'Review the post.',
+        options: [
+          { id: 'approve', label: 'Approve' },
+          { id: 'reject', label: 'Reject' },
+        ],
+        context: {
+          approvalUrl: 'http://localhost:3737/api/plugins/workflows/gates/task-1/decision',
+        },
+      },
+    })
+
+    expect(result.deliveries).toEqual([expect.objectContaining({
+      channelId: 'discord:channel-1',
+      ref: 'openclaw-plugin-approval:plugin:test-approval',
+    })])
+    const approvalRequest = FakeWebSocket.instances[0]!.sentFrames.find(frame => frame.method === 'plugin.approval.request')
+    const connectRequest = FakeWebSocket.instances[0]!.sentFrames.find(frame => frame.method === 'connect')
+    expect(connectRequest?.params).toEqual(expect.objectContaining({
+      client: expect.objectContaining({
+        id: 'gateway-client',
+        mode: 'backend',
+      }),
+      role: 'operator',
+      scopes: ['operator.approvals'],
+    }))
+    expect(approvalRequest?.params).toEqual(expect.objectContaining({
+      pluginId: 'bakin',
+      toolName: 'workflow.gate',
+      toolCallId: 'approval-1',
+      turnSourceChannel: 'discord',
+      turnSourceTo: 'channel-1',
+      timeoutMs: 600000,
+      twoPhase: true,
+    }))
+    expect(String((approvalRequest?.params as Record<string, unknown>).description)).toContain('Bakin fallback:')
+  })
+
+  it('uses the Bakin fallback link instead of native approvals when reject reasons are required', async () => {
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+      channels: {
+        discord: {
+          token: 'discord-token',
+          execApprovals: { enabled: true, approvers: ['202168845362921483'], target: 'both' },
+        },
+      },
+    }), 'utf-8')
+    const calls: Array<Record<string, unknown>> = []
+    globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+      calls.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as unknown as typeof fetch
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    await runtime.initialize({ contentDir: testDir })
+
+    await runtime.channels.createApproval({
+      approvalId: 'approval-1',
+      channels: ['discord:channel-1'],
+      request: {
+        title: 'Gate: Review',
+        body: 'Review the post.',
+        options: [
+          { id: 'approve', label: 'Approve' },
+          { id: 'reject', label: 'Reject' },
+        ],
+        context: {
+          requireRejectReason: true,
+          approvalUrl: 'http://localhost:3737/api/plugins/workflows/gates/task-1/decision',
+        },
+      },
+    })
+
+    expect(FakeWebSocket.instances).toHaveLength(0)
+    expect(calls).toHaveLength(1)
+    const args = calls[0]!.args as Record<string, unknown>
+    expect(args.message).toContain('This gate requires a reject reason')
+    expect(args.message).toContain('Open in Bakin:')
+  })
+
+  it('falls back to render-only messages when approval options are not approve/reject', async () => {
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+      channels: {
+        discord: {
+          token: 'discord-token',
+          execApprovals: { enabled: true, approvers: ['202168845362921483'], target: 'both' },
+        },
+      },
+    }), 'utf-8')
+    const calls: Array<Record<string, unknown>> = []
+    globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+      calls.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as unknown as typeof fetch
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    await runtime.initialize({ contentDir: testDir })
+
+    await runtime.channels.createApproval({
+      approvalId: 'approval-1',
+      channels: ['discord:channel-1'],
+      request: {
+        title: 'Gate: Review',
+        body: 'Review the post.',
+        options: [
+          { id: 'approve', label: 'Approve' },
+          { id: 'needs_changes', label: 'Needs changes' },
+        ],
+        context: {
+          approvalUrl: 'http://localhost:3737/api/plugins/workflows/gates/task-1/decision',
+        },
+      },
+    })
+
+    expect(FakeWebSocket.instances).toHaveLength(0)
+    expect(calls).toHaveLength(1)
+    const args = calls[0]!.args as Record<string, unknown>
+    expect(args.message).toContain('Needs changes')
+    expect(args.message).toContain('Open in Bakin:')
+  })
+
+  it('maps OpenClaw plugin approval resolved events into Bakin approval events', async () => {
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+      channels: {
+        discord: {
+          token: 'discord-token',
+          execApprovals: { enabled: true, approvers: ['202168845362921483'], target: 'both' },
+        },
+      },
+    }), 'utf-8')
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    await runtime.initialize({ contentDir: testDir })
+    const events: unknown[] = []
+    const unsubscribe = runtime.channels.subscribeApprovalResponses(event => events.push(event))
+    await tick()
+
+    FakeWebSocket.instances[0]!.emitMessage({
+      type: 'event',
+      event: 'plugin.approval.resolved',
+      payload: {
+        id: 'plugin:test-approval',
+        decision: 'allow-once',
+        resolvedBy: 'Roscoe',
+        ts: Date.parse('2026-04-28T12:00:00Z'),
+        request: {
+          pluginId: 'bakin',
+          toolName: 'workflow.gate',
+          toolCallId: 'approval-1',
+          turnSourceChannel: 'discord',
+          turnSourceTo: 'channel-1',
+        },
+      },
+    })
+    unsubscribe()
+
+    expect(events).toEqual([{
+      approvalId: 'approval-1',
+      channelId: 'discord:channel-1',
+      response: {
+        selectedOption: 'approve',
+        respondedAt: '2026-04-28T12:00:00.000Z',
+        actor: { type: 'human', id: 'Roscoe', displayName: 'Roscoe' },
+      },
+    }])
+  })
+
+  it('resolves native approval deliveries through OpenClaw', async () => {
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+      channels: {
+        discord: {
+          token: 'discord-token',
+          execApprovals: { enabled: true, approvers: ['202168845362921483'], target: 'both' },
+        },
+      },
+    }), 'utf-8')
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    await runtime.initialize({ contentDir: testDir })
+
+    await runtime.channels.resolveApproval({
+      approvalId: 'approval-1',
+      deliveries: [{ channelId: 'discord', ref: 'openclaw-plugin-approval:plugin:test-approval', renderedAt: '2026-04-28T12:00:00Z' }],
+      response: {
+        selectedOption: 'reject',
+        respondedAt: '2026-04-28T12:00:00Z',
+        actor: { type: 'human', id: 'roscoe' },
+      },
+    })
+
+    const resolveRequest = FakeWebSocket.instances[0]!.sentFrames.find(frame => frame.method === 'plugin.approval.resolve')
+    expect(resolveRequest?.params).toEqual({
+      id: 'plugin:test-approval',
+      decision: 'deny',
+    })
   })
 
   it('warns instead of silently no-oping approval response hooks', async () => {
@@ -85,7 +343,7 @@ describe('OpenClaw runtime channels', () => {
     const unsubscribe = runtime.channels.subscribeApprovalResponses(() => {})
     await runtime.channels.resolveApproval({
       approvalId: 'approval-1',
-      deliveries: [],
+      deliveries: [{ channelId: 'discord', ref: 'message:1', renderedAt: '2026-04-28T12:00:00Z' }],
       response: {
         selectedOption: 'approve',
         respondedAt: '2026-04-28T12:00:00Z',
@@ -95,7 +353,83 @@ describe('OpenClaw runtime channels', () => {
     unsubscribe()
 
     expect(warn).toHaveBeenCalledTimes(2)
-    expect(warn.mock.calls[0]![0]).toContain('approval responses are not implemented')
+    expect(warn.mock.calls[0]![0]).toContain('approval responses are render-only')
     expect(warn.mock.calls[1]![0]).toContain('approval resolve is render-only')
   })
 })
+
+interface FakeGatewayFrame {
+  type: 'req'
+  id: string
+  method: string
+  params: Record<string, unknown>
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = []
+  readyState = 0
+  sentFrames: FakeGatewayFrame[] = []
+  private listeners = new Map<string, Set<(event: { data?: string }) => void>>()
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this)
+    queueMicrotask(() => {
+      this.readyState = 1
+      this.emit('open', {})
+      this.emitMessage({
+        type: 'event',
+        event: 'connect.challenge',
+        payload: { nonce: 'nonce-1' },
+      })
+    })
+  }
+
+  addEventListener(type: string, listener: (event: { data?: string }) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set()
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(type: string, listener: (event: { data?: string }) => void): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  send(raw: string): void {
+    const frame = JSON.parse(raw) as FakeGatewayFrame
+    this.sentFrames.push(frame)
+    if (frame.method === 'connect') {
+      this.emitMessage({ type: 'res', id: frame.id, ok: true, payload: { auth: { scopes: ['operator.approvals'] } } })
+    } else if (frame.method === 'plugin.approval.request') {
+      this.emitMessage({
+        type: 'res',
+        id: frame.id,
+        ok: true,
+        payload: {
+          status: 'accepted',
+          id: 'plugin:test-approval',
+          createdAtMs: Date.parse('2026-04-28T12:00:00Z'),
+          expiresAtMs: Date.parse('2026-04-28T12:10:00Z'),
+        },
+      })
+    } else if (frame.method === 'plugin.approval.resolve') {
+      this.emitMessage({ type: 'res', id: frame.id, ok: true, payload: { ok: true } })
+    }
+  }
+
+  close(): void {
+    this.readyState = 3
+    this.emit('close', {})
+  }
+
+  emitMessage(frame: Record<string, unknown>): void {
+    this.emit('message', { data: JSON.stringify(frame) })
+  }
+
+  private emit(type: string, event: { data?: string }): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event)
+  }
+}
+
+async function tick(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}

--- a/tests/plugins/workflows/notifications.test.ts
+++ b/tests/plugins/workflows/notifications.test.ts
@@ -122,7 +122,7 @@ describe('runtime gate notifications', () => {
       },
     }))
     expect(createApproval).toHaveBeenCalledTimes(1)
-    const [call] = createApproval.mock.calls[0] as unknown as [Record<string, unknown> & { request: { options: unknown } }]
+    const [call] = createApproval.mock.calls[0] as unknown as [Record<string, unknown> & { request: { options: unknown; context: unknown } }]
     expect(call).toEqual(expect.objectContaining({
       approvalId: expectedApprovalId,
       channels: ['approvals'],
@@ -131,6 +131,9 @@ describe('runtime gate notifications', () => {
       { id: 'approve', label: 'Approve', variant: 'primary' },
       { id: 'reject', label: 'Reject', variant: 'destructive' },
     ])
+    expect(call.request.context).toEqual(expect.objectContaining({
+      approvalUrl: expect.stringContaining('/api/plugins/workflows/gates/task-42/decision'),
+    }))
   })
 
   it('skips approval creation when channel alerts are disabled', async () => {


### PR DESCRIPTION
## Summary
- adds an OpenClaw Gateway approval client for plugin approval requests, resolution, and resolved-event subscription
- advertises `interactive-approval` only for configured native-capable channels and keeps render-only fallback behavior explicit
- adds durable Bakin gate approval fallback links/pages so provider button expiry never owns workflow state
- ignores no-reason channel rejects for gates that require reject reasons
- updates workflow approval docs and adapter knowledge

## Review notes
- Fixed during review: the gateway client now uses OpenClaw's documented unsigned backend identity (`gateway-client` / `backend`) instead of a custom client id.
- Fixed during review: native provider buttons are only used for approve/reject-shaped approval requests; arbitrary option sets fall back to Bakin-rendered approval links.

## Verification
- `bun test tests/adapter-openclaw/runtime-channels.test.ts`
- `bun test tests/plugins/workflows/notifications.test.ts`
- `bun run --filter @bakin/adapter-openclaw typecheck`
- `bun run typecheck`
- `bun run lint`
- `bun run docs:validate`
- `bun test --isolate`

Closes #187