### PR TITLE
Harden restart recovery for in-flight tasks

### DIFF
--- a/.claude/knowledge/agent-system.md
+++ b/.claude/knowledge/agent-system.md
@@ -202,6 +202,26 @@ Monitors agent and MCP server health:
 - Alert delivery via `settings.notifications.channel` (runtime channel ID; blank means in-app only) — configurable in the **System & Alerts** settings tab
 - Re-reads settings every cycle, so channel/threshold changes apply without a restart
 
+## Restart Recovery (`src/core/restart-recovery.ts`)
+
+Runs once after server boot, after plugins are active and the HTTP server is
+listening, before the normal dispatch/watchdog loops start. It repairs
+`inProgress` tasks whose active agent heartbeat is missing/stale after a crash
+or restart:
+
+- Plain tasks use the card assignee heartbeat.
+- Workflow tasks use `workflows.getActiveAgents` so the current workflow step
+  owner is authoritative.
+- Workflow gates waiting on approval are skipped.
+- Partial parallel heartbeat loss and workflow states with no active agents
+  are surfaced through the health plugin's `restart-recovery` doctor check
+  instead of being mutated automatically.
+- Recovered tasks move back to `todo` through `src/core/task-store.ts`; Bakin
+  starts the normal loops and immediately triggers a dispatch cycle so the
+  normal dispatcher reassigns them.
+- The retry cap is shared with watchdog recovery via
+  `settings.watchdog.maxAutoRecoveries`; exhausted tasks move to `blocked`.
+
 ## Key Files
 
 | File | Purpose |
@@ -214,6 +234,7 @@ Monitors agent and MCP server health:
 | `plugins/team/hooks/use-agent-store.ts` | Client-side Zustand store for agent data |
 | `src/core/agents.ts` | Agent status resolution and communication |
 | `src/core/dispatch.ts` | Task dispatch engine. Roster from `getAppServices().runtime.agents` |
+| `src/core/restart-recovery.ts` | One-shot boot repair for orphaned `inProgress` tasks |
 | `src/core/mcp-server.ts` | MCP tool server |
 | `packages/adapter-openclaw/src/runtime.ts` | OpenClaw runtime adapter implementation |
 | `src/core/task-service.ts` | Task mutations with side effects |

--- a/.claude/knowledge/dispatch.md
+++ b/.claude/knowledge/dispatch.md
@@ -38,9 +38,33 @@ Both classes share the `count` field. `settings.dispatch.maxRetries` (default 5)
 
 Legacy plain-number entries are migrated to `{ kind: 'structural' }` by `getFailureRecord()` on read — no separate migration step needed.
 
+## Restart recovery
+
+Startup orphan repair lives in `src/core/restart-recovery.ts`, not in the
+dispatch loop. After plugins are active and the HTTP server is listening,
+`server.ts` runs one recovery pass over Bakin's task store before starting the
+normal dispatch/watchdog loops:
+
+- Plain `inProgress` tasks recover when their assigned agent heartbeat is
+  missing or stale.
+- Workflow-backed tasks ask the workflow plugin for `workflows.loadInstance`
+  and `workflows.getActiveAgents`; recovery uses active workflow agents, not
+  the card assignee.
+- `pending_approval`, `complete`, and `cancelled` workflow instances are left
+  alone.
+- Partial parallel staleness and workflow states with no active agents are
+  reported for manual attention instead of redispatching live work.
+- Recovery loops share `settings.watchdog.maxAutoRecoveries`; exhausted tasks
+  move to `blocked`.
+
+When recovery returns tasks to `todo`, `server.ts` starts the loops and then
+immediately triggers one dispatch cycle so recovered work does not wait for the
+next interval.
+
 ## Where to look
 
 - `src/core/app-services.ts` — boot-created runtime/search/task service object
 - `packages/adapter-openclaw/src/runtime.ts` — OpenClaw adapter transport
 - `src/core/dispatch.ts` — `classifyDispatchError`, cooldown selection, blocked escalation
+- `src/core/restart-recovery.ts` — post-boot recovery of orphaned `inProgress` tasks
 - `.claude/knowledge/adapter-architecture.md` — adapter boundaries and task/runtime ownership

--- a/docs/.generated/coverage.json
+++ b/docs/.generated/coverage.json
@@ -44,7 +44,7 @@
     },
     "settings": {
       "status": "active",
-      "count": 49,
+      "count": 50,
       "source": "packages/core/src/settings.ts"
     },
     "sdkSubpaths": {

--- a/docs/public/llms/settings.md
+++ b/docs/public/llms/settings.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 49. Operators can override settings in settings.json under the resolved Bakin home directory.
+The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 50. Operators can override settings in settings.json under the resolved Bakin home directory.

--- a/docs/src/content/docs/reference/generated/api.md
+++ b/docs/src/content/docs/reference/generated/api.md
@@ -925,6 +925,16 @@ Approve a human gate step
 Reject a gate step, rewinds workflow
 
 
+### `GET /api/plugins/workflows/gates/:taskId/decision`
+
+Render a durable Bakin gate approval fallback page
+
+
+### `POST /api/plugins/workflows/gates/:taskId/decision`
+
+Approve or reject a gate through the durable Bakin approval fallback page
+
+
 ### `GET /api/plugins/workflows/gates/pending`
 
 List all gates awaiting approval

--- a/docs/src/content/docs/reference/generated/coverage.md
+++ b/docs/src/content/docs/reference/generated/coverage.md
@@ -12,7 +12,7 @@ description: Coverage report for generated Bakin documentation surfaces.
 | Slots | SDK slot contract plus source scan | Documented: 6 public slot names, 1 audited registrations |
 | Exec/MCP tools | Source scan for `registerExecTool(...)` | Audited: 106 tools |
 | Core plugins | `plugins/*/bakin-plugin.json` | Active: 8 plugin manifests |
-| Settings | `packages/core/src/settings.ts` | Active: 49 flattened settings |
+| Settings | `packages/core/src/settings.ts` | Active: 50 flattened settings |
 | Runtime paths | `packages/core/src/content-dir.ts` | Active: documented path contract |
 | SDK exports | `packages/sdk/package.json` and barrel files | Audited: 8 subpaths |
 | Agent package kinds | `packages/core/src/agent-packages/manifest.ts` | Active: agent, skill-pack, workflow-pack, knowledge-pack |

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -91,6 +91,20 @@ description: Generated reference for Bakin core settings defaults.
   </tbody>
 </table>
 
+## Restart Recovery
+
+<table class="settings-defaults-table">
+  <thead>
+    <tr><th>Key</th><th>Default</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>restartRecovery.enabled</code></td>
+      <td><code>true</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## Runtime
 
 <table class="settings-defaults-table">

--- a/docs/src/content/docs/using/health.md
+++ b/docs/src/content/docs/using/health.md
@@ -56,7 +56,7 @@ Three tabs sit below the cost cards, all feeding from the same in-memory recorde
 
 ## Doctor
 
-A green-light scan of every moving part in the stack. Agent roster, runtime adapter, search adapter, taskboard, assets, channel approvals, the works. Red means broken, yellow means drifting, and most rows have a one-click auto-fix so you don't have to know what went wrong to fix it.
+A green-light scan of every moving part in the stack. Agent roster, runtime adapter, search adapter, taskboard, assets, channel approvals, restart-recovery candidates, the works. Red means broken, yellow means drifting, and most rows have a one-click auto-fix so you don't have to know what went wrong to fix it.
 
 Run it before you start the day or any time something feels off. Results cache so the dashboard reads fast; the refresh button (or `bakin doctor` from the CLI) forces a fresh sweep.
 

--- a/docs/src/content/docs/using/settings.md
+++ b/docs/src/content/docs/using/settings.md
@@ -19,6 +19,7 @@ The built-in tab covers the runtime knobs that don't belong to any single plugin
 | --- | --- |
 | **Dispatch** | How often the dispatch loop fires, retry counts, cooldowns after structural and transient failures, the max number of in-flight dispatches. |
 | **Watchdog** | Stuck-task thresholds, auto-recovery toggle, MCP and REST error-rate alerts (window, threshold, sample size, alert cooldown). |
+| **Restart recovery** | Whether Bakin repairs stale `inProgress` tasks on server startup before kicking a dispatch cycle. |
 | **Models** | Global allowlist and blocklist. Models on the blocklist never get assigned, even by alias or profile. |
 | **Doctor** | Diagnostic interval, auto-fix toggle for skill drift, require-onboard guard so doctor stays quiet on fresh installs. |
 | **Notifications** | Default notification channel and gate-alert toggle. |
@@ -37,7 +38,7 @@ Every plugin can declare its own settings. When it does, a tab shows up here wit
 
 ## On disk
 
-Prefer a text editor? Go straight to the JSON. System settings live at `~/.bakin/settings.json`; per-plugin values at `~/.bakin/plugin-settings/<id>.json`. Same rules: the watchdog picks up changes within one cycle, no restart needed.
+Prefer a text editor? Go straight to the JSON. System settings live at `~/.bakin/settings.json`; per-plugin values at `~/.bakin/plugin-settings/<id>.json`. Same rules: live services pick up settings on their next cycle; startup-only settings apply on the next server boot.
 
 ## Related
 

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -102,6 +102,14 @@ export interface BakinSettings {
     restMinSamples: number
     restAlertCooldownMs: number
   }
+  restartRecovery: {
+    /**
+     * One-shot startup repair for in-progress tasks whose active agent
+     * heartbeat is missing/stale after a server restart. Uses the same
+     * maxAutoRecoveries cap as the watchdog.
+     */
+    enabled: boolean
+  }
   sse: {
     maxClients: number
     keepAliveMs: number
@@ -203,6 +211,9 @@ export const DEFAULT_SETTINGS: BakinSettings = {
     restErrorThreshold: 0.5,
     restMinSamples: 3,
     restAlertCooldownMs: 5 * 60 * 1000,
+  },
+  restartRecovery: {
+    enabled: true,
   },
   sse: {
     maxClients: 50,

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -21,6 +21,7 @@ import { checkService } from './lib/system-checks/service'
 import { checkMcporter } from './lib/system-checks/mcporter'
 import { checkRuntime } from './lib/system-checks/runtime'
 import { checkChannelApprovals } from './lib/system-checks/channel-approvals'
+import { checkRestartRecovery } from './lib/system-checks/restart-recovery'
 import { checkSearchAdapter } from './lib/system-checks/search'
 import { checkAndSyncSkill } from './lib/system-checks/sync-skill'
 import { checkPluginAssets } from './lib/system-checks/plugin-assets'
@@ -311,6 +312,11 @@ const healthPlugin: BakinPlugin = {
       id: 'channel-approvals',
       name: 'Runtime channel approval responses',
       run: () => checkChannelApprovals(ctx.runtime),
+    })
+    ctx.registerHealthCheck({
+      id: 'restart-recovery',
+      name: 'Restart recovery candidates',
+      run: () => checkRestartRecovery(),
     })
     ctx.registerHealthCheck({
       id: 'search',

--- a/plugins/health/lib/system-checks/restart-recovery.ts
+++ b/plugins/health/lib/system-checks/restart-recovery.ts
@@ -1,0 +1,41 @@
+/**
+ * System check — restart recovery candidates.
+ *
+ * Reports in-progress tasks that appear recoverable on next startup recovery
+ * pass, plus workflow states that need manual attention because Bakin cannot
+ * safely infer the right active agent.
+ */
+import { findRestartRecoveryCandidates } from '../../../../src/core/restart-recovery'
+import { getContentDir } from '../../../../src/core/content-dir'
+import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+
+function ok(message: string): HealthCheckResult {
+  return { check: 'restart-recovery', status: 'ok', message, autoFixable: false }
+}
+
+function warn(message: string): HealthCheckResult {
+  return { check: 'restart-recovery', status: 'warn', message, autoFixable: false }
+}
+
+export async function checkRestartRecovery(): Promise<HealthCheckResult[]> {
+  try {
+    const candidates = await findRestartRecoveryCandidates(getContentDir())
+    if (candidates.length === 0) {
+      return [ok('No stale in-progress task recovery candidates found.')]
+    }
+
+    const recoverable = candidates.filter((candidate) => candidate.action === 'recover').length
+    const exhausted = candidates.filter((candidate) => candidate.action === 'block').length
+    const manual = candidates.filter((candidate) => candidate.action === 'manual').length
+    const examples = candidates.slice(0, 3).map((candidate) => {
+      const agents = candidate.effectiveAgents.length > 0 ? ` agents=${candidate.effectiveAgents.join(',')}` : ''
+      return `${candidate.title} (${candidate.reason}${agents})`
+    }).join('; ')
+
+    return [warn(
+      `${candidates.length} in-progress task(s) need restart recovery attention: ${recoverable} recoverable, ${exhausted} exhausted, ${manual} manual. ${examples}`,
+    )]
+  } catch (err) {
+    return [warn(`Restart recovery check failed: ${err instanceof Error ? err.message : String(err)}`)]
+  }
+}

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1232,7 +1232,7 @@ function renderSettingsReference(): string {
     '',
   ]
 
-  const settingGroupTitles: Record<string, string> = { sse: 'SSE' }
+  const settingGroupTitles: Record<string, string> = { restartRecovery: 'Restart Recovery', sse: 'SSE' }
 
   for (const namespace of [...grouped.keys()].sort((a, b) => a.localeCompare(b))) {
     const title = settingGroupTitles[namespace] ?? (namespace === 'other' ? 'Other' : `${namespace[0].toUpperCase()}${namespace.slice(1)}`)

--- a/server.ts
+++ b/server.ts
@@ -36,6 +36,7 @@ import { writeCrossPluginSearchResponse } from './src/core/api-search-handler'
 import * as watcher from './src/core/watcher'
 import * as dispatch from './src/core/dispatch'
 import * as watchdog from './src/core/watchdog'
+import { runRestartRecovery } from './src/core/restart-recovery'
 import { registerShutdownHandlers } from './src/core/lifecycle'
 import { checkAndContinueDependents } from './src/core/continuation'
 import { getAllRoutes, generateDocs } from './src/core/api-docs'
@@ -625,12 +626,9 @@ const eventBus = new BakinEventBus(broadcast)
     log.warn('mcporter setup failed — agents can still use REST/CLI', err)
   }
 
-  // Start all subsystems
+  // Start file watching before the server loops. Dispatch/watchdog wait until
+  // restart recovery has taken the first look at stale in-progress tasks.
   watcher.start({ contentDir: CONTENT_DIR, eventBus, onInboxFile: handleInboxFile })
-  dispatch.start(CONTENT_DIR, port)
-  dispatch.reconcileOnStartup(CONTENT_DIR)
-  watchdog.start(CONTENT_DIR)
-  doctor.start(CONTENT_DIR, process.cwd())
 
   // Notify all plugins that every plugin is now active
   await pluginRegistry.onAllReady()
@@ -645,6 +643,29 @@ const eventBus = new BakinEventBus(broadcast)
   server.listen(port, '0.0.0.0', () => {
     log.info(`Bakin ready on http://localhost:${port}`)
     log.info(`Listening on 0.0.0.0:${port} (Tailscale: http://100.91.112.69:${port})`)
+
+    void (async () => {
+      let recovered = 0
+      try {
+        const result = await runRestartRecovery(CONTENT_DIR)
+        recovered = result.recovered
+      } catch (err) {
+        log.error('Restart recovery failed', err)
+      } finally {
+        dispatch.start(CONTENT_DIR, port)
+        watchdog.start(CONTENT_DIR)
+      }
+
+      try {
+        if (recovered > 0) {
+          await dispatch.dispatchTasks(CONTENT_DIR, port)
+        }
+      } catch (err) {
+        log.error('Post-recovery dispatch failed', err)
+      } finally {
+        doctor.start(CONTENT_DIR, process.cwd())
+      }
+    })()
   })
 
   // Hot-reload coordinator (Phase 2 P2.C8). Enabled by `bakin dev`

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -10,12 +10,10 @@ import { appendAudit } from './audit'
 import { recordUsage } from './usage'
 import { getAppServices } from './app-services'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
-import { isStale } from '../lib/format'
 import { getHookRegistry } from '../lib/plugin-registry'
 import {
   addTaskLog as appendTaskLog,
   blockTask as blockStoredTask,
-  moveTask as moveStoredTask,
   readTaskboard,
   updateTask as updateStoredTask,
 } from './task-store'
@@ -95,10 +93,6 @@ async function addTaskLog(taskId: string, author: string, message: string): Prom
 
 async function moveTaskToInProgress(taskId: string, agent: string): Promise<void> {
   await updateStoredTask(taskId, { column: 'inProgress', agent })
-}
-
-async function moveTask(taskId: string, to: string, from?: string): Promise<void> {
-  await moveStoredTask(taskId, to, from)
 }
 
 const TRANSIENT_CODES = new Set([
@@ -904,58 +898,6 @@ function buildWorkflowDispatchMessage(
   lines.push('- Move the task to Done (the workflow engine handles this)')
 
   return lines.join('\n')
-}
-
-/**
- * Run once on server startup to recover orphaned in-progress tasks.
- * If an agent's heartbeat is stale and the task has no recent logs, move back to todo.
- */
-export async function reconcileOnStartup(contentDir: string): Promise<void> {
-  const settings = getSettings()
-  try {
-    const { columns } = readTaskboard() as unknown as { columns: Record<string, Array<{ id: string; title: string; agent?: string; workflowId?: string; description?: string; projectId?: string; log?: Array<{ timestamp: string }> }>> }
-    let recovered = 0
-
-    for (const task of [...columns.inProgress]) {
-      const agentStale = isAgentHeartbeatStale(contentDir, task.agent)
-      const hasRecentLog = task.log?.some(e => {
-        const ts = new Date(e.timestamp).getTime()
-        return !isNaN(ts) && (Date.now() - ts) < settings.watchdog.stuckThresholdMs
-      })
-
-      if (agentStale && !hasRecentLog) {
-        try {
-          await addTaskLog(task.id, 'system', 'Recovered on server restart: agent heartbeat stale and no recent task logs.')
-          await moveTask(task.id, 'todo', 'inProgress')
-          appendAudit(contentDir, 'task.startup_recovered', 'system', { id: task.id, title: task.title, agent: task.agent })
-          recovered++
-          log.info('Startup recovery: task moved to todo', { id: task.id, title: task.title })
-        } catch (err) {
-          log.error('Startup recovery failed for task', err, { id: task.id })
-        }
-      }
-    }
-
-    if (recovered > 0) {
-      log.info('Startup reconciliation complete', { recovered })
-    }
-  } catch (err) {
-    log.error('Startup reconciliation failed', err)
-  }
-}
-
-function isAgentHeartbeatStale(contentDir: string, agent: string | undefined): boolean {
-  if (!agent) return true
-  const heartbeatPath = join(contentDir, 'heartbeats', `${agent}.json`)
-  try {
-    if (!existsSync(heartbeatPath)) return true
-    const data = JSON.parse(readFileSync(heartbeatPath, 'utf-8'))
-    const ts = data.timestamp || data.ts
-    if (!ts) return true
-    return isStale(ts, 15 * 60 * 1000)
-  } catch {
-    return true
-  }
 }
 
 export function getDispatchInfo(contentDir: string): Record<string, unknown> {

--- a/src/core/restart-recovery.ts
+++ b/src/core/restart-recovery.ts
@@ -1,0 +1,317 @@
+/**
+ * Restart recovery — one-shot boot repair for orphaned in-progress tasks.
+ *
+ * The runtime adapter owns live execution. Bakin owns task state. On server
+ * restart, any task still marked inProgress but whose active agent heartbeat is
+ * missing/stale can be returned to todo so normal dispatch can pick it up.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { createLogger } from './logger'
+import { getSettings } from './settings'
+import { appendAudit } from './audit'
+import { isStale } from '../lib/format'
+import { getHookRegistry } from '../lib/plugin-registry'
+import {
+  addTaskLog,
+  blockTask,
+  moveTask,
+  readTaskboard,
+} from './task-store'
+
+const log = createLogger('restart-recovery')
+const hooks = () => getHookRegistry()
+
+const HEARTBEAT_STALE_MS = 15 * 60 * 1000
+const RESTART_RECOVERY_PREFIX = 'Restart recovery:'
+const WATCHDOG_RECOVERY_PREFIX = 'Auto-recovered:'
+
+type RecoveryAction = 'recover' | 'block' | 'manual'
+
+type RecoveryReason =
+  | 'plain-agent-stale'
+  | 'workflow-agent-stale'
+  | 'workflow-instance-missing'
+  | 'workflow-no-active-agents'
+  | 'workflow-partial-agent-stale'
+  | 'workflow-not-running'
+
+type RecoveryTask = {
+  id: string
+  title: string
+  agent?: string
+  workflowId?: string
+  log?: Array<{ message?: string; timestamp?: string }>
+}
+
+type WorkflowInstanceLike = {
+  status?: string
+}
+
+type WorkflowAgent = {
+  agent: string
+  stepId?: string
+  effectiveTaskId?: string
+}
+
+export interface RestartRecoveryCandidate {
+  id: string
+  title: string
+  agent?: string
+  workflowId?: string
+  effectiveAgents: string[]
+  staleAgents: string[]
+  recoveryCount: number
+  reason: RecoveryReason
+  action: RecoveryAction
+}
+
+export interface RestartRecoveryResult {
+  recovered: number
+  blocked: number
+  skipped: number
+  candidates: RestartRecoveryCandidate[]
+}
+
+function isAgentHeartbeatStale(contentDir: string, agent: string | undefined): boolean {
+  if (!agent) return true
+
+  const heartbeatPath = join(contentDir, 'heartbeats', `${agent}.json`)
+  try {
+    if (!existsSync(heartbeatPath)) return true
+    const data = JSON.parse(readFileSync(heartbeatPath, 'utf-8'))
+    const ts = data.timestamp || data.ts
+    if (!ts) return true
+    return isStale(ts, HEARTBEAT_STALE_MS)
+  } catch {
+    return true
+  }
+}
+
+function countRecoveries(task: RecoveryTask): number {
+  return (task.log ?? []).filter((entry) => {
+    const message = entry.message ?? ''
+    return message.startsWith(RESTART_RECOVERY_PREFIX) || message.startsWith(WATCHDOG_RECOVERY_PREFIX)
+  }).length
+}
+
+function uniq(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => !!value))]
+}
+
+function withActionForRecoveryLimit(
+  task: RecoveryTask,
+  candidate: Omit<RestartRecoveryCandidate, 'id' | 'title' | 'agent' | 'workflowId' | 'recoveryCount' | 'action'>,
+): RestartRecoveryCandidate {
+  const settings = getSettings()
+  const recoveryCount = countRecoveries(task)
+  return {
+    id: task.id,
+    title: task.title,
+    agent: task.agent,
+    workflowId: task.workflowId,
+    recoveryCount,
+    ...candidate,
+    action: recoveryCount >= settings.watchdog.maxAutoRecoveries ? 'block' : 'recover',
+  }
+}
+
+async function assessWorkflowTask(
+  task: RecoveryTask,
+  contentDir: string,
+): Promise<RestartRecoveryCandidate | null> {
+  const recoveryCount = countRecoveries(task)
+  const instance = await hooks().invoke<WorkflowInstanceLike | null>('workflows.loadInstance', {
+    taskId: task.id,
+    contentDir,
+  })
+
+  if (!instance) {
+    return withActionForRecoveryLimit(task, {
+      effectiveAgents: uniq([task.agent]),
+      staleAgents: uniq([task.agent]),
+      reason: 'workflow-instance-missing',
+    })
+  }
+
+  if (instance.status === 'pending_approval' || instance.status === 'complete' || instance.status === 'cancelled') {
+    return null
+  }
+
+  if (instance.status !== 'in_progress') {
+    return {
+      id: task.id,
+      title: task.title,
+      agent: task.agent,
+      workflowId: task.workflowId,
+      effectiveAgents: [],
+      staleAgents: [],
+      recoveryCount,
+      reason: 'workflow-not-running',
+      action: 'manual',
+    }
+  }
+
+  const activeAgents = await hooks().invoke<WorkflowAgent[]>('workflows.getActiveAgents', {
+    taskId: task.id,
+    contentDir,
+  }) ?? []
+  const effectiveAgents = uniq(activeAgents.map((entry) => entry.agent))
+
+  if (effectiveAgents.length === 0) {
+    return {
+      id: task.id,
+      title: task.title,
+      agent: task.agent,
+      workflowId: task.workflowId,
+      effectiveAgents: [],
+      staleAgents: [],
+      recoveryCount,
+      reason: 'workflow-no-active-agents',
+      action: 'manual',
+    }
+  }
+
+  const staleAgents = effectiveAgents.filter((agent) => isAgentHeartbeatStale(contentDir, agent))
+  if (staleAgents.length === 0) return null
+
+  if (staleAgents.length !== effectiveAgents.length) {
+    return {
+      id: task.id,
+      title: task.title,
+      agent: task.agent,
+      workflowId: task.workflowId,
+      effectiveAgents,
+      staleAgents,
+      recoveryCount,
+      reason: 'workflow-partial-agent-stale',
+      action: 'manual',
+    }
+  }
+
+  return withActionForRecoveryLimit(task, {
+    effectiveAgents,
+    staleAgents,
+    reason: 'workflow-agent-stale',
+  })
+}
+
+async function assessTask(task: RecoveryTask, contentDir: string): Promise<RestartRecoveryCandidate | null> {
+  if (task.workflowId) {
+    return assessWorkflowTask(task, contentDir)
+  }
+
+  if (!isAgentHeartbeatStale(contentDir, task.agent)) return null
+
+  return withActionForRecoveryLimit(task, {
+    effectiveAgents: uniq([task.agent]),
+    staleAgents: uniq([task.agent]),
+    reason: 'plain-agent-stale',
+  })
+}
+
+export async function findRestartRecoveryCandidates(contentDir: string): Promise<RestartRecoveryCandidate[]> {
+  const board = readTaskboard() as unknown as { columns?: { inProgress?: RecoveryTask[] } }
+  const tasks = board.columns?.inProgress ?? []
+  const candidates: RestartRecoveryCandidate[] = []
+
+  for (const task of tasks) {
+    try {
+      const candidate = await assessTask(task, contentDir)
+      if (candidate) candidates.push(candidate)
+    } catch (err) {
+      log.warn('Failed to assess restart recovery candidate', err, { id: task.id })
+    }
+  }
+
+  return candidates
+}
+
+export async function runRestartRecovery(contentDir: string): Promise<RestartRecoveryResult> {
+  const settings = getSettings()
+  const candidates = await findRestartRecoveryCandidates(contentDir)
+  const result: RestartRecoveryResult = {
+    recovered: 0,
+    blocked: 0,
+    skipped: 0,
+    candidates,
+  }
+
+  if (settings.restartRecovery?.enabled === false) {
+    if (candidates.length > 0) {
+      log.warn('Restart recovery disabled; leaving candidates untouched', { count: candidates.length })
+    }
+    result.skipped = candidates.length
+    return result
+  }
+
+  for (const candidate of candidates) {
+    if (candidate.action === 'manual') {
+      result.skipped++
+      continue
+    }
+
+    try {
+      if (candidate.action === 'block') {
+        await blockTask(
+          candidate.id,
+          `Restart recovery limit reached (${candidate.recoveryCount} attempts). Active agent heartbeat is missing or stale.`,
+        )
+        await addTaskLog(
+          candidate.id,
+          'system',
+          `${RESTART_RECOVERY_PREFIX} recovery limit reached after ${candidate.recoveryCount} attempts; task moved to blocked for manual review.`,
+        )
+        appendAudit(contentDir, 'task.restart_recovery_exhausted', 'system', {
+          id: candidate.id,
+          title: candidate.title,
+          agent: candidate.agent,
+          workflowId: candidate.workflowId,
+          recoveryCount: candidate.recoveryCount,
+          reason: candidate.reason,
+        })
+        result.blocked++
+        log.warn('Restart recovery blocked exhausted task', {
+          id: candidate.id,
+          title: candidate.title,
+          recoveryCount: candidate.recoveryCount,
+        })
+        continue
+      }
+
+      await addTaskLog(
+        candidate.id,
+        'system',
+        `${RESTART_RECOVERY_PREFIX} inactive agent heartbeat after server restart; returned to Todo for re-dispatch.`,
+      )
+      await moveTask(candidate.id, 'todo', 'inProgress')
+      appendAudit(contentDir, 'task.restart_recovered', 'system', {
+        id: candidate.id,
+        title: candidate.title,
+        agent: candidate.agent,
+        workflowId: candidate.workflowId,
+        effectiveAgents: candidate.effectiveAgents,
+        reason: candidate.reason,
+      })
+      result.recovered++
+      log.info('Restart recovery moved task to todo', {
+        id: candidate.id,
+        title: candidate.title,
+        reason: candidate.reason,
+      })
+    } catch (err) {
+      result.skipped++
+      log.error('Restart recovery failed for task', err, { id: candidate.id })
+    }
+  }
+
+  if (result.recovered > 0 || result.blocked > 0 || result.skipped > 0) {
+    log.info('Restart recovery complete', {
+      recovered: result.recovered,
+      blocked: result.blocked,
+      skipped: result.skipped,
+    })
+  }
+
+  return result
+}

--- a/tests/core/restart-recovery.test.ts
+++ b/tests/core/restart-recovery.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const contentDirMockPath = join(tmpdir(), `bakin-restart-recovery-test-${Date.now()}`)
+
+mock.module('../../src/core/content-dir', () => ({
+  getContentDir: () => contentDirMockPath,
+  getBakinPaths: () => ({ root: contentDirMockPath }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => contentDirMockPath,
+  getBakinPaths: () => ({ root: contentDirMockPath }),
+}))
+
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+const mockGetSettings = mock(() => ({
+  watchdog: {
+    maxAutoRecoveries: 3,
+  },
+  restartRecovery: {
+    enabled: true,
+  },
+}))
+
+mock.module('../../src/core/settings', () => ({
+  getSettings: mockGetSettings,
+}))
+
+const mockAppendAudit = mock((..._args: unknown[]) => undefined)
+mock.module('../../src/core/audit', () => ({
+  appendAudit: (...args: unknown[]) => mockAppendAudit(...args),
+}))
+
+type RecoveryTask = {
+  id: string
+  title: string
+  agent?: string
+  workflowId?: string
+  log?: Array<{ message: string; timestamp: string }>
+}
+
+type RecoveryColumns = {
+  backlog: RecoveryTask[]
+  todo: RecoveryTask[]
+  inProgress: RecoveryTask[]
+  review: RecoveryTask[]
+  done: RecoveryTask[]
+  archived: RecoveryTask[]
+  blocked: RecoveryTask[]
+}
+
+function emptyColumns(): RecoveryColumns {
+  return { backlog: [], todo: [], inProgress: [], review: [], done: [], archived: [], blocked: [] }
+}
+
+let currentColumns = emptyColumns()
+function setColumns(columns: Partial<RecoveryColumns>): void {
+  currentColumns = { ...emptyColumns(), ...columns }
+}
+
+const mockAddTaskLog = mock(async (..._args: unknown[]) => undefined)
+const mockBlockTask = mock(async (..._args: unknown[]) => undefined)
+const mockMoveTask = mock(async (..._args: unknown[]) => undefined)
+
+mock.module('../../src/core/task-store', () => ({
+  readTaskboard: mock(() => ({ columns: currentColumns })),
+  addTaskLog: (...args: unknown[]) => mockAddTaskLog(...args),
+  blockTask: (...args: unknown[]) => mockBlockTask(...args),
+  moveTask: (...args: unknown[]) => mockMoveTask(...args),
+}))
+
+const mockHookInvoke = mock(async (..._args: unknown[]): Promise<unknown> => undefined)
+mock.module('../../src/lib/plugin-registry', () => ({
+  getHookRegistry: mock(() => ({
+    invoke: (...args: unknown[]) => mockHookInvoke(...args),
+  })),
+}))
+
+import {
+  findRestartRecoveryCandidates,
+  runRestartRecovery,
+} from '../../src/core/restart-recovery'
+import { checkRestartRecovery } from '../../plugins/health/lib/system-checks/restart-recovery'
+
+describe('restart recovery', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'bakin-restart-recovery-'))
+    mock.clearAllMocks()
+    setColumns({})
+    mockGetSettings.mockReturnValue({
+      watchdog: {
+        maxAutoRecoveries: 3,
+      },
+      restartRecovery: {
+        enabled: true,
+      },
+    })
+    mockHookInvoke.mockImplementation(async () => undefined)
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+    mock.restore()
+  })
+
+  it('recovers a plain in-progress task with a missing heartbeat even when logs are recent', async () => {
+    setColumns({
+      inProgress: [{
+        id: 'task-1',
+        title: 'Needs recovery',
+        agent: 'pixel',
+        log: [{ message: 'Still working', timestamp: new Date().toISOString() }],
+      }],
+    })
+
+    const result = await runRestartRecovery(tempDir)
+
+    expect(result.recovered).toBe(1)
+    expect(mockAddTaskLog).toHaveBeenCalledWith(
+      'task-1',
+      'system',
+      expect.stringContaining('Restart recovery: inactive agent heartbeat'),
+    )
+    expect(mockMoveTask).toHaveBeenCalledWith('task-1', 'todo', 'inProgress')
+    expect(mockAppendAudit).toHaveBeenCalledWith(
+      tempDir,
+      'task.restart_recovered',
+      'system',
+      expect.objectContaining({ id: 'task-1', reason: 'plain-agent-stale' }),
+    )
+  })
+
+  it('skips plain in-progress tasks when the assigned agent heartbeat is fresh', async () => {
+    mkdirSync(join(tempDir, 'heartbeats'), { recursive: true })
+    writeFileSync(
+      join(tempDir, 'heartbeats', 'pixel.json'),
+      JSON.stringify({ timestamp: new Date().toISOString() }),
+    )
+    setColumns({
+      inProgress: [{ id: 'task-2', title: 'Still active', agent: 'pixel' }],
+    })
+
+    const candidates = await findRestartRecoveryCandidates(tempDir)
+
+    expect(candidates).toHaveLength(0)
+    expect(mockMoveTask).not.toHaveBeenCalled()
+  })
+
+  it('skips workflow tasks that are legitimately waiting on approval', async () => {
+    setColumns({
+      inProgress: [{ id: 'task-3', title: 'Gate wait', agent: 'pixel', workflowId: 'publish' }],
+    })
+    mockHookInvoke.mockImplementation(async (hook: unknown) => {
+      if (hook === 'workflows.loadInstance') return { status: 'pending_approval' }
+      return undefined
+    })
+
+    const result = await runRestartRecovery(tempDir)
+
+    expect(result.recovered).toBe(0)
+    expect(result.blocked).toBe(0)
+    expect(mockMoveTask).not.toHaveBeenCalled()
+  })
+
+  it('uses workflow active agents instead of the card assignee', async () => {
+    setColumns({
+      inProgress: [{ id: 'task-4', title: 'Workflow task', agent: 'nemo', workflowId: 'video' }],
+    })
+    mockHookInvoke.mockImplementation(async (hook: unknown) => {
+      if (hook === 'workflows.loadInstance') return { status: 'in_progress' }
+      if (hook === 'workflows.getActiveAgents') return [{ agent: 'pixel', stepId: 'clip' }]
+      return undefined
+    })
+
+    const result = await runRestartRecovery(tempDir)
+
+    expect(result.recovered).toBe(1)
+    expect(mockMoveTask).toHaveBeenCalledWith('task-4', 'todo', 'inProgress')
+    expect(mockAppendAudit).toHaveBeenCalledWith(
+      tempDir,
+      'task.restart_recovered',
+      'system',
+      expect.objectContaining({ id: 'task-4', effectiveAgents: ['pixel'], reason: 'workflow-agent-stale' }),
+    )
+  })
+
+  it('reports partial workflow heartbeat loss as manual instead of redispatching live agents', async () => {
+    mkdirSync(join(tempDir, 'heartbeats'), { recursive: true })
+    writeFileSync(
+      join(tempDir, 'heartbeats', 'pixel.json'),
+      JSON.stringify({ timestamp: new Date().toISOString() }),
+    )
+    setColumns({
+      inProgress: [{ id: 'task-5', title: 'Partial workflow', workflowId: 'parallel' }],
+    })
+    mockHookInvoke.mockImplementation(async (hook: unknown) => {
+      if (hook === 'workflows.loadInstance') return { status: 'in_progress' }
+      if (hook === 'workflows.getActiveAgents') {
+        return [
+          { agent: 'pixel', stepId: 'design' },
+          { agent: 'rolo', stepId: 'copy' },
+        ]
+      }
+      return undefined
+    })
+
+    const candidates = await findRestartRecoveryCandidates(tempDir)
+    const result = await runRestartRecovery(tempDir)
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        id: 'task-5',
+        action: 'manual',
+        reason: 'workflow-partial-agent-stale',
+        effectiveAgents: ['pixel', 'rolo'],
+        staleAgents: ['rolo'],
+      }),
+    ])
+    expect(result.skipped).toBe(1)
+    expect(mockMoveTask).not.toHaveBeenCalled()
+  })
+
+  it('escalates exhausted restart recovery loops to blocked', async () => {
+    setColumns({
+      inProgress: [{
+        id: 'task-6',
+        title: 'Exhausted',
+        agent: 'pixel',
+        log: [
+          { message: 'Auto-recovered: attempt 1', timestamp: '2020-01-01T00:00:00Z' },
+          { message: 'Restart recovery: attempt 2', timestamp: '2020-01-01T01:00:00Z' },
+          { message: 'Restart recovery: attempt 3', timestamp: '2020-01-01T02:00:00Z' },
+        ],
+      }],
+    })
+
+    const result = await runRestartRecovery(tempDir)
+
+    expect(result.blocked).toBe(1)
+    expect(mockBlockTask).toHaveBeenCalledWith('task-6', expect.stringContaining('Restart recovery limit reached'))
+    expect(mockMoveTask).not.toHaveBeenCalled()
+    expect(mockAppendAudit).toHaveBeenCalledWith(
+      tempDir,
+      'task.restart_recovery_exhausted',
+      'system',
+      expect.objectContaining({ id: 'task-6', recoveryCount: 3 }),
+    )
+  })
+
+  it('does not mutate candidates when restart recovery is disabled', async () => {
+    mockGetSettings.mockReturnValue({
+      watchdog: {
+        maxAutoRecoveries: 3,
+      },
+      restartRecovery: {
+        enabled: false,
+      },
+    })
+    setColumns({
+      inProgress: [{ id: 'task-7', title: 'Disabled recovery', agent: 'pixel' }],
+    })
+
+    const result = await runRestartRecovery(tempDir)
+
+    expect(result.skipped).toBe(1)
+    expect(mockMoveTask).not.toHaveBeenCalled()
+    expect(mockBlockTask).not.toHaveBeenCalled()
+  })
+
+  it('surfaces restart recovery candidates through the health check', async () => {
+    setColumns({
+      inProgress: [{ id: 'task-8', title: 'Health candidate', agent: 'pixel' }],
+    })
+
+    const rows = await checkRestartRecovery()
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        check: 'restart-recovery',
+        status: 'warn',
+        message: expect.stringContaining('Health candidate'),
+      }),
+    ])
+  })
+})

--- a/tests/plugins/health/checks-route.test.ts
+++ b/tests/plugins/health/checks-route.test.ts
@@ -55,11 +55,16 @@ mock.module('../../../src/core/watcher', () => ({
   start: mock(),
   stop: mock(),
 }))
-mock.module('@/core/task-store', () => ({
+const taskStoreMock = {
   readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getTask: () => null,
-}))
+  addTaskLog: mock(async () => {}),
+  blockTask: mock(async () => {}),
+  moveTask: mock(async () => {}),
+}
+mock.module('@/core/task-store', () => taskStoreMock)
+mock.module('../../../src/core/task-store', () => taskStoreMock)
 ;(globalThis as any).__bakinBroadcast = mock()
 
 const healthPlugin = require('../../../plugins/health/index').default as typeof import('../../../plugins/health/index').default

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -94,10 +94,19 @@ mock.module('../../../src/core/search-registry', () => ({
   }),
 }))
 
+const taskStoreMock = {
+  readTaskboard: () => ({ columns: { inProgress: [] } }),
+  getAllTasks: () => ({ columns: { inProgress: [] } }),
+  getTask: () => null,
+  addTaskLog: mock(async () => {}),
+  blockTask: mock(async () => {}),
+  moveTask: mock(async () => {}),
+}
 // Defensive stub — the test isolation hook scans for plugin refs in text
 // and flags any mention of plugins/tasks even though we never import the
 // module. Usage-feed assertions contain /api/plugins/tasks/* strings.
-mock.module('@/core/task-store', () => ({}))
+mock.module('@/core/task-store', () => taskStoreMock)
+mock.module('../../../src/core/task-store', () => taskStoreMock)
 
 // Registry snapshot accessor (plugins list only — exec tool stats are gone).
 ;(globalThis as unknown as { __bakinGetRegistrySnapshot: () => unknown[] }).__bakinGetRegistrySnapshot = () => [

--- a/tests/plugins/health/system-checks.test.ts
+++ b/tests/plugins/health/system-checks.test.ts
@@ -525,7 +525,7 @@ describe('checkPluginAssets', () => {
 // ─── Registration smoke test ──────────────────────────────────────────────
 
 describe('plugin registration', () => {
-  it('registers all 10 system + managed-blocks health checks on activate', async () => {
+  it('registers all 11 system + managed-blocks health checks on activate', async () => {
     const healthPlugin = (await import('../../../plugins/health')).default
     const registeredIds: string[] = []
     const noop = mock()
@@ -552,12 +552,13 @@ describe('plugin registration', () => {
     }
     await healthPlugin.activate(ctx as unknown as Parameters<typeof healthPlugin.activate>[0])
 
-    // 10 health checks: 8 health-owned checks plus the 2 core managed-block scopes.
+    // 11 health checks: 9 health-owned checks plus the 2 core managed-block scopes.
     expect(registeredIds).toContain('content-dir')
     expect(registeredIds).toContain('service')
     expect(registeredIds).toContain('mcporter')
     expect(registeredIds).toContain('runtime')
     expect(registeredIds).toContain('channel-approvals')
+    expect(registeredIds).toContain('restart-recovery')
     expect(registeredIds).toContain('search')
     expect(registeredIds).toContain('orchestrator-rules')
     expect(registeredIds).toContain('skill')


### PR DESCRIPTION
## Summary
- replace the old dispatch startup reconciliation with a dedicated restart-recovery pass over Bakin task state
- recover stale plain tasks, use workflow active-agent hooks for workflow tasks, skip approval waits, and surface partial/manual cases through Health
- start dispatch/watchdog after restart recovery, add a restartRecovery setting, and update docs/knowledge/generated references

## Verification
- bun run typecheck
- bun run lint
- bun run docs:validate
- bun test --isolate tests/core/restart-recovery.test.ts tests/plugins/health/routes.test.ts tests/plugins/health/checks-route.test.ts tests/plugins/health/system-checks.test.ts
- bun test --isolate

Closes #113