### PR TITLE
Fix schedule cron run reconciliation

### DIFF
--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -94,13 +94,23 @@ interface OpenClawCronStore {
 
 interface OpenClawCronStoreJob {
   id: string
+  agentId?: string
+  sessionKey?: string
   name?: string
+  description?: string
   enabled?: boolean
+  deleteAfterRun?: boolean
   schedule?: string | { kind?: string; type?: string; expr?: string; value?: string; tz?: string }
-  delivery?: { mode?: string; url?: string; token?: string; channel?: string }
-  payload?: { message?: string } & Record<string, unknown>
+  sessionTarget?: string
+  wakeMode?: string
+  delivery?: { mode?: string; url?: string; to?: string; token?: string; channel?: string; threadId?: string; accountId?: string; bestEffort?: boolean; failureDestination?: unknown }
+  payload?: { kind?: string; message?: string; text?: string } & Record<string, unknown>
+  failureAlert?: unknown
+  state?: Record<string, unknown>
   createdAt?: string
   updatedAt?: string
+  createdAtMs?: number
+  updatedAtMs?: number
   metadata?: RuntimeMetadata
 }
 
@@ -729,16 +739,25 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       const jobs = store.jobs ?? []
       const id = input.id ?? uniqueCronId(input.name, jobs)
       if (jobs.some((job) => job.id === id)) throw new Error(`Cron job already exists: ${id}`)
-      const now = new Date().toISOString()
+      const nowMs = Date.now()
+      const now = new Date(nowMs).toISOString()
+      const bakinSchedule = isBakinScheduleMetadata(input.metadata)
       const job: OpenClawCronStoreJob = {
         id,
         name: input.name,
         enabled: input.enabled ?? true,
         schedule: { kind: 'cron', expr: input.schedule },
-        delivery: cronDeliveryFromMetadata(input.metadata),
-        payload: { message: input.command },
+        sessionTarget: bakinSchedule ? 'main' : 'isolated',
+        wakeMode: 'now',
+        delivery: cronDeliveryFromMetadata(input.metadata) ?? { mode: 'none' },
+        payload: bakinSchedule
+          ? { kind: 'systemEvent', text: input.command }
+          : { kind: 'agentTurn', message: input.command },
         createdAt: now,
         updatedAt: now,
+        createdAtMs: nowMs,
+        updatedAtMs: nowMs,
+        state: {},
         metadata: input.metadata,
       }
       writeCronStore({ ...store, jobs: [...jobs, job] })
@@ -750,15 +769,26 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       const index = jobs.findIndex((job) => job.id === id)
       if (index === -1) throw new Error(`Cron job not found: ${id}`)
       const current = jobs[index]
+      const metadata = patch.metadata ?? current.metadata
+      const bakinSchedule = isBakinScheduleMetadata(metadata)
+      const command = patch.command ?? cronStoreJobToRuntime(current).command
+      const nowMs = Date.now()
       const next: OpenClawCronStoreJob = {
         ...current,
         name: patch.name ?? current.name,
         enabled: patch.enabled ?? current.enabled ?? true,
         schedule: patch.schedule ? { kind: 'cron', expr: patch.schedule } : current.schedule,
-        delivery: patch.metadata ? cronDeliveryFromMetadata(patch.metadata) ?? current.delivery : current.delivery,
-        payload: { ...(current.payload ?? {}), ...(patch.command !== undefined ? { message: patch.command } : {}) },
-        metadata: patch.metadata ?? current.metadata,
-        updatedAt: new Date().toISOString(),
+        sessionTarget: bakinSchedule ? 'main' : current.sessionTarget,
+        wakeMode: bakinSchedule ? 'now' : current.wakeMode,
+        delivery: bakinSchedule
+          ? { mode: 'none' }
+          : patch.metadata ? cronDeliveryFromMetadata(patch.metadata) ?? current.delivery ?? { mode: 'none' } : current.delivery,
+        payload: bakinSchedule || patch.command !== undefined
+          ? cronPayloadForCommand(command, current.payload, bakinSchedule)
+          : current.payload,
+        metadata,
+        updatedAt: new Date(nowMs).toISOString(),
+        updatedAtMs: nowMs,
       }
       jobs[index] = next
       writeCronStore({ ...store, jobs })
@@ -778,6 +808,27 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       }
     },
     listRuns: async (jobId: string): Promise<CronRun[]> => readCronRuns(jobId),
+    getRaw: async (id: string, reason: string): Promise<unknown | null> => {
+      if (!reason) throw new Error('cron.getRaw requires a reason')
+      const job = readCronJobs().find((entry) => entry.id === id)
+      return job ? cloneJson(job) : null
+    },
+    restoreRaw: async (id: string, snapshot: unknown, reason: string): Promise<CronJob> => {
+      if (!reason) throw new Error('cron.restoreRaw requires a reason')
+      if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+        throw new Error('cron.restoreRaw requires an object snapshot')
+      }
+      const restored = cloneJson(snapshot) as OpenClawCronStoreJob
+      if (typeof restored.id !== 'string' || restored.id.length === 0) restored.id = id
+      if (restored.id !== id) throw new Error(`Raw cron snapshot id mismatch: expected ${id}, got ${restored.id}`)
+      const store = readCronStore()
+      const jobs = store.jobs ?? []
+      const index = jobs.findIndex((job) => job.id === id)
+      if (index === -1) jobs.push(restored)
+      else jobs[index] = restored
+      writeCronStore({ ...store, jobs })
+      return cronStoreJobToRuntime(restored)
+    },
   }
 
   config = {
@@ -1155,7 +1206,11 @@ function cronStoreJobToRuntime(job: OpenClawCronStoreJob): CronJob {
     id: job.id,
     name: job.name ?? job.id,
     schedule: cronScheduleToString(job.schedule),
-    command: typeof job.payload?.message === 'string' ? job.payload.message : '',
+    command: typeof job.payload?.message === 'string'
+      ? job.payload.message
+      : typeof job.payload?.text === 'string'
+        ? job.payload.text
+        : '',
     enabled: job.enabled ?? true,
     metadata: job.metadata,
   }
@@ -1163,12 +1218,31 @@ function cronStoreJobToRuntime(job: OpenClawCronStoreJob): CronJob {
 
 function cronDeliveryFromMetadata(metadata: RuntimeMetadata | undefined): OpenClawCronStoreJob['delivery'] | undefined {
   const webhookUrl = metadataValue(metadata, 'webhookUrl')
-  return webhookUrl ? { mode: 'webhook', url: webhookUrl } : undefined
+  return webhookUrl ? { mode: 'webhook', to: webhookUrl, url: webhookUrl } : undefined
+}
+
+function isBakinScheduleMetadata(metadata: RuntimeMetadata | undefined): boolean {
+  return metadata?.bakinSchedule === true || metadata?.['bakin.schedule'] === true
+}
+
+function cronPayloadForCommand(
+  command: string,
+  current: OpenClawCronStoreJob['payload'],
+  bakinSchedule: boolean,
+): OpenClawCronStoreJob['payload'] {
+  if (bakinSchedule || current?.kind === 'systemEvent') {
+    return { kind: 'systemEvent', text: command }
+  }
+  return { ...(current ?? {}), kind: 'agentTurn', message: command }
 }
 
 function cronScheduleToString(schedule: OpenClawCronStoreJob['schedule']): string {
   if (typeof schedule === 'string') return schedule
   return schedule?.expr ?? schedule?.value ?? '* * * * *'
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
 }
 
 function uniqueCronId(name: string, jobs: OpenClawCronStoreJob[]): string {

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -363,6 +363,12 @@ export interface CreateCronJobInput {
 
 export type UpdateCronJobInput = Partial<Omit<CreateCronJobInput, 'id'>>
 
+export interface RawCronSnapshot {
+  provider: string
+  capturedAt: string
+  snapshot: unknown
+}
+
 export interface RuntimeConfigAccess {
   get<T = Record<string, unknown>>(): Promise<T>
   update(patch: Record<string, unknown>): Promise<void>
@@ -467,6 +473,8 @@ export interface AgentRuntimeAdapter {
     remove(id: string): Promise<void>
     runNow(id: string): Promise<CronRun>
     listRuns(jobId: string): Promise<CronRun[]>
+    getRaw(id: string, reason: string): Promise<unknown | null>
+    restoreRaw(id: string, snapshot: unknown, reason: string): Promise<CronJob>
   }
 
   config: RuntimeConfigAccess

--- a/packages/core/src/adapters/runtime/index.ts
+++ b/packages/core/src/adapters/runtime/index.ts
@@ -56,6 +56,7 @@ export type {
   RuntimeMemoryTier,
   RuntimeMetadata,
   RuntimePermissionPatch,
+  RawCronSnapshot,
   RuntimeSession,
   RuntimeSkill,
   TaskDispatchArgs,

--- a/packages/core/src/adapters/runtime/testing.ts
+++ b/packages/core/src/adapters/runtime/testing.ts
@@ -154,6 +154,33 @@ export function createMockRuntimeAdapter(
         endedAt: new Date().toISOString(),
       }),
       listRuns: async () => [],
+      getRaw: async (id, reason) => {
+        if (!reason) throw new Error('cron.getRaw requires a reason')
+        return adapter.cron.get(id)
+      },
+      restoreRaw: async (id, snapshot, reason) => {
+        if (!reason) throw new Error('cron.restoreRaw requires a reason')
+        const raw = snapshot && typeof snapshot === 'object' ? snapshot as Partial<{
+          id: string
+          name: string
+          schedule: string | { expr?: string; value?: string }
+          command: string
+          payload: { message?: string; text?: string }
+          enabled: boolean
+          metadata: Record<string, unknown>
+        }> : {}
+        const schedule = typeof raw.schedule === 'string'
+          ? raw.schedule
+          : raw.schedule?.expr ?? raw.schedule?.value ?? '* * * * *'
+        return {
+          id,
+          name: raw.name ?? raw.id ?? id,
+          schedule,
+          command: raw.command ?? raw.payload?.message ?? raw.payload?.text ?? '',
+          enabled: raw.enabled ?? true,
+          metadata: raw.metadata,
+        }
+      },
     },
 
     config: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,7 @@ export type {
   RuntimeMemoryTier,
   RuntimeMetadata,
   RuntimePermissionPatch,
+  RawCronSnapshot,
   RuntimeSession,
   RuntimeSkill,
   TaskDispatchArgs,

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -391,6 +391,8 @@ export interface AgentRuntimeAdapter {
     remove(id: string): Promise<void>
     runNow(id: string): Promise<CronRun>
     listRuns(jobId: string): Promise<CronRun[]>
+    getRaw(id: string, reason: string): Promise<unknown | null>
+    restoreRaw(id: string, snapshot: unknown, reason: string): Promise<CronJob>
   }
   skills?: {
     list(): Promise<RuntimeSkill[]>

--- a/plugins/schedule/README.md
+++ b/plugins/schedule/README.md
@@ -1,22 +1,36 @@
 # Schedule Plugin
 
-Cron job scheduling through the active runtime adapter with automatic task creation. Manages recurring jobs that create tasks on the Bakin task board when they fire.
+Cron job visibility and Bakin task scheduling through the active runtime adapter. The schedule page shows all runtime cron jobs, but only Bakin-owned or explicitly adopted jobs create Bakin tasks when they fire.
 
 ## How It Works
 
 The schedule plugin sits between the **runtime cron adapter** and **Bakin's task board**:
 
-1. **Runtime cron** manages timing and fires webhooks when jobs trigger
-2. **Bakin sidecar** (`~/.bakin/schedule/sidecar.json`) stores metadata that the runtime cron adapter doesn't own — agent assignment, task prompts, pause state, failure tracking
-3. **Bridge endpoint** receives the webhook, checks pause/skip/overlap rules, and creates a task on the board
+1. **Runtime cron** manages timing and records run history.
+2. **Bakin sidecar** (`~/.bakin/schedule/sidecar.json`) stores metadata that the runtime cron adapter doesn't own: ownership, agent assignment, task prompts, pause state, failure tracking, processed run IDs, and reversible native-cron snapshots.
+3. **Run reconciler** watches successful runtime cron runs for Bakin-owned jobs, checks pause/skip/overlap rules, and creates tasks on the board exactly once per run.
 
 ```
-Runtime cron fires   →  POST /api/plugins/schedule/bridge?secret=<hex>
-                         ├── Auth: bridgeEnabled setting + shared-secret gate
-                         ├── Check: paused? skip? overlap? failure limit?
+Runtime cron fires   →  OpenClaw records a cron run
+                         ├── Bakin reconciler reads successful runs
+                         ├── Skip if runtime-only, already processed, paused, skipped, overlapping, or auto-paused
                          ├── Create task on board (via task-service)
-                         └── Update sidecar (lastTaskId, failure count, etc.)
+                         └── Update sidecar (lastTaskId, processedRunIds, failure count, etc.)
 ```
+
+The `/bridge` endpoint remains as a private callback path for future runtimes or explicit webhook callers, but OpenClaw webhook delivery is not the canonical path for task creation.
+
+### Runtime vs Bakin Ownership
+
+Schedule jobs have three user-visible states:
+
+| State | Meaning |
+|-------|---------|
+| Runtime cron | Native runtime cron. Bakin lists it and can run/enable/disable/delete it, but it does not create Bakin tasks. |
+| Bakin schedule | Created by Bakin. Runtime cron is the timer; Bakin creates tasks when successful runs appear. |
+| Adopted | Originally native runtime cron, converted into a Bakin schedule. The original runtime cron snapshot is preserved so it can be restored. |
+
+Adopting a runtime cron is explicit. The UI opens a conversion form, captures the original raw runtime cron, writes Bakin sidecar metadata, and updates future runtime runs to a Bakin sentinel event. Restoring native behavior writes the preserved raw cron snapshot back to the runtime and marks the job as runtime-only again.
 
 ### Bridge Authentication
 
@@ -25,7 +39,7 @@ The `/bridge` endpoint is gated on two things:
 1. **`bridgeEnabled` setting** — set to `false` to kill-switch the bridge without deleting crons. Rejects with `503`.
 2. **Shared secret** — a 32-byte hex token stored in plugin settings as `bridgeSecret`, passed as a `?secret=...` query param. Compared with `timingSafeEqual`. Rejects with `401`.
 
-The secret is auto-generated on first access (`getOrCreateBridgeSecret`) and persisted to `~/.bakin/plugin-settings/schedule.json`. Every cron registered via `bakin_exec_schedule_create` or `POST /api/plugins/schedule/` builds its webhook URL through `buildBridgeWebhookUrl()`, which embeds the current secret — agents and UI code never see or handle it directly. `bridgeSecret` is intentionally absent from `settingsSchema` so the settings UI doesn't expose it.
+The secret is auto-generated on first access (`getOrCreateBridgeSecret`) and persisted to `~/.bakin/plugin-settings/schedule.json`. `bridgeSecret` is intentionally absent from `settingsSchema` so the settings UI doesn't expose it.
 
 ## Data Model
 
@@ -36,12 +50,12 @@ The UI always works with "merged jobs" — a combination of runtime cron data an
 | Source | Fields |
 |--------|--------|
 | Runtime cron | `id`, `name`, `schedule` (type/value/tz), `enabled` |
-| Sidecar | `agentId`, `owner`, `taskPrompt`, `taskTitle`, `workflowId`, `paused`, `pauseUntil`, `pauseReason`, `allowOverlap`, `maxFailures`, `consecutiveFailures`, `createdAt` |
+| Sidecar | `source`, `agentId`, `owner`, `taskPrompt`, `taskTitle`, `workflowId`, `paused`, `pauseUntil`, `pauseReason`, `allowOverlap`, `maxFailures`, `consecutiveFailures`, `processedRunIds`, `originalRuntimeCron`, `createdAt` |
 | Computed | `humanSchedule`, `nextRun`, `lastRun` |
 
 ### Schedule Sidecar
 
-Stored at `~/.bakin/schedule/sidecar.json`. Maps job IDs to `BakinJobMeta` records. Only Bakin-created jobs have `isBakinJob: true` — runtime-only jobs appear in the list but lack Bakin metadata.
+Stored at `~/.bakin/schedule/sidecar.json`. Maps job IDs to `BakinJobMeta` records. Only Bakin-created or adopted jobs have `isBakinJob: true` — runtime-only jobs appear in the list but do not create tasks.
 
 ### Run History
 
@@ -99,12 +113,14 @@ All routes are prefixed with `/api/plugins/schedule/`.
 | POST | `/` | Create a new job |
 | GET | `/:jobId` | Get single job details |
 | PUT | `/:jobId` | Update job fields |
+| POST | `/:jobId/adopt` | Adopt a native runtime cron into Bakin task scheduling |
+| POST | `/:jobId/restore-native` | Restore an adopted job to its original native runtime cron behavior |
 | DELETE | `/:jobId` | Delete a job |
 | POST | `/:jobId/pause` | Pause, resume, or skip runs |
 | POST | `/:jobId/run` | Trigger immediate run |
 | GET | `/:jobId/runs` | Get run history for a job |
 | POST | `/parse` | Parse NL/cron schedule expression |
-| POST | `/bridge?secret=<hex>` | Webhook endpoint (called by runtime cron). Requires `bridgeEnabled=true` and a matching `bridgeSecret`. See [Bridge Authentication](#bridge-authentication). |
+| POST | `/bridge?secret=<hex>` | Private webhook endpoint. Requires `bridgeEnabled=true` and a matching `bridgeSecret`. See [Bridge Authentication](#bridge-authentication). |
 
 ## Exec Tools (Agent-Facing)
 
@@ -119,15 +135,16 @@ All routes are prefixed with `/api/plugins/schedule/`.
 
 ## Bridge Logic
 
-When runtime cron fires a job, the bridge endpoint runs these checks in order:
+When the reconciler or bridge processes a successful runtime run, the shared task-creation path runs these checks in order:
 
 1. **Is Bakin job?** — Skip if not managed by Bakin
-2. **Paused?** — Check manual pause + `pauseUntil` auto-resume
-3. **Skip count?** — Decrement `skipNextN` if active
-4. **Failure limit?** — Auto-pause if `consecutiveFailures >= maxFailures`
-5. **Overlap?** — If `allowOverlap: false`, skip if the previous task is still active (todo/inProgress/review/blocked)
-6. **Track outcomes** — Check if last task succeeded (done/archived) or failed (blocked) to update failure counter
-7. **Create task** — Title from template, assign agent (unless `requireTriage`), attach workflow
+2. **Already processed?** — Skip if this run ID is already recorded in `processedRunIds`
+3. **Paused?** — Check manual pause + `pauseUntil` auto-resume
+4. **Skip count?** — Decrement `skipNextN` if active
+5. **Failure limit?** — Auto-pause if `consecutiveFailures >= maxFailures`
+6. **Overlap?** — If `allowOverlap: false`, skip if the previous task is still active (todo/inProgress/review/blocked)
+7. **Track outcomes** — Check if last task succeeded (done/archived) or failed (blocked) to update failure counter
+8. **Create task** — Title from template, assign agent (unless `requireTriage`), attach workflow
 
 ## Settings
 
@@ -139,10 +156,11 @@ Configurable via `/settings` page:
 | `failureCooldownMs` | number | 300000 | Wait time after failure before retry |
 | `maxFailures` | number | 3 | Consecutive failures before auto-pause |
 | `bridgeEnabled` | boolean | true | Allow bridge to create tasks |
+| `reconcileLookbackHours` | number | 24 | On startup, create missed scheduled tasks only for successful runtime cron runs newer than this many hours. Set to 0 to disable startup backfill. |
 
 ## Dependencies
 
-- Bakin task store — Bridge creates tasks via `task-service` and checks task status via the shared task-store service
+- Bakin task store — Shared schedule run processing creates tasks via `task-service` and checks task status via the shared task-store service
 - **runtime cron adapter** — Provides cron CRUD, immediate runs, and run history
 
 ## File Structure

--- a/plugins/schedule/bakin-plugin.json
+++ b/plugins/schedule/bakin-plugin.json
@@ -55,6 +55,16 @@
       },
       {
         "method": "POST",
+        "path": "/:jobId/adopt",
+        "summary": "Adopt a runtime cron into Bakin"
+      },
+      {
+        "method": "POST",
+        "path": "/:jobId/restore-native",
+        "summary": "Restore an adopted cron to native runtime behavior"
+      },
+      {
+        "method": "POST",
         "path": "/:jobId/pause",
         "summary": "Pause/resume/skip a job"
       },

--- a/plugins/schedule/components/job-drawer.tsx
+++ b/plugins/schedule/components/job-drawer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Play, Pencil, Copy, Trash2, SkipForward, MoreHorizontal, Clock, Timer, Workflow, Terminal } from 'lucide-react'
+import { Play, Pencil, Copy, Trash2, SkipForward, MoreHorizontal, Clock, Timer, Workflow, Terminal, CirclePlus, Undo2, Power } from 'lucide-react'
 import { BakinDrawer } from "@bakin/sdk/components"
 import { AgentAvatar } from "@bakin/sdk/components"
 import { Badge } from "@bakin/sdk/ui"
@@ -30,6 +30,8 @@ export function JobDrawer({
   onRunNow,
   onEdit,
   onDuplicate,
+  onAdopt,
+  onRestoreNative,
   onSkipNext,
 }: {
   job: ScheduleJob | null
@@ -41,6 +43,8 @@ export function JobDrawer({
   onRunNow: (jobId: string) => Promise<boolean>
   onEdit: () => void
   onDuplicate: () => void
+  onAdopt: () => void
+  onRestoreNative: (jobId: string) => Promise<boolean>
   onSkipNext: (jobId: string, n?: number) => Promise<boolean>
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -70,9 +74,9 @@ export function JobDrawer({
       title={
         <span className="flex items-center gap-2">
           {job.displayName || job.id}
-          {job.isBakinJob && (
-            <Badge variant="outline" className="text-[10px] uppercase tracking-wider">Bakin</Badge>
-          )}
+          <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
+            {job.source === 'adopted' ? 'Adopted' : job.isBakinJob ? 'Bakin schedule' : 'Runtime cron'}
+          </Badge>
         </span>
       }
       actions={
@@ -81,10 +85,23 @@ export function JobDrawer({
             <MoreHorizontal className="size-4" />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="min-w-36">
-            <DropdownMenuItem onClick={onDuplicate}>
-              <Copy className="size-3.5 mr-2" />
-              Duplicate
-            </DropdownMenuItem>
+            {job.isBakinJob ? (
+              <DropdownMenuItem onClick={onDuplicate}>
+                <Copy className="size-3.5 mr-2" />
+                Duplicate
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem onClick={onAdopt}>
+                <CirclePlus className="size-3.5 mr-2" />
+                Adopt into Bakin
+              </DropdownMenuItem>
+            )}
+            {job.canRestoreNative && (
+              <DropdownMenuItem onClick={() => onRestoreNative(job.id)}>
+                <Undo2 className="size-3.5 mr-2" />
+                Restore Native
+              </DropdownMenuItem>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={handleDelete}
@@ -118,9 +135,9 @@ export function JobDrawer({
                   ) : (
                     <Badge className="bg-zinc-500/20 text-zinc-400">Disabled</Badge>
                   )}
-                  {job.isBakinJob && (
-                    <Badge variant="outline" className="text-[10px] uppercase tracking-wider">Bakin</Badge>
-                  )}
+                  <Badge variant="outline" className="text-[10px] uppercase tracking-wider">
+                    {job.source === 'adopted' ? 'Adopted' : job.isBakinJob ? 'Bakin schedule' : 'Runtime cron'}
+                  </Badge>
                   {job.nextRun && (
                     <span className="text-xs text-muted-foreground">
                       Next: {new Date(job.nextRun).toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}
@@ -137,12 +154,30 @@ export function JobDrawer({
           <Button variant="outline" size="sm" onClick={() => onRunNow(job.id)}>
             <Play className="size-3.5 mr-1.5" /> Run Now
           </Button>
-          <Button variant="outline" size="sm" onClick={() => onSkipNext(job.id, 1)}>
-            <SkipForward className="size-3.5 mr-1.5" /> Skip Next
-          </Button>
-          <Button variant="outline" size="sm" onClick={onEdit}>
-            <Pencil className="size-3.5 mr-1.5" /> Edit
-          </Button>
+          {job.isBakinJob ? (
+            <>
+              <Button variant="outline" size="sm" onClick={() => onSkipNext(job.id, 1)}>
+                <SkipForward className="size-3.5 mr-1.5" /> Skip Next
+              </Button>
+              <Button variant="outline" size="sm" onClick={onEdit}>
+                <Pencil className="size-3.5 mr-1.5" /> Edit
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={onAdopt}>
+              <CirclePlus className="size-3.5 mr-1.5" /> Adopt into Bakin
+            </Button>
+          )}
+          {job.canRestoreNative && (
+            <Button variant="outline" size="sm" onClick={() => onRestoreNative(job.id)}>
+              <Undo2 className="size-3.5 mr-1.5" /> Restore Native
+            </Button>
+          )}
+          {!job.isBakinJob && (
+            <Button variant="outline" size="sm" onClick={() => job.enabled ? onPause(job.id) : onResume(job.id)}>
+              <Power className="size-3.5 mr-1.5" /> {job.enabled ? 'Disable' : 'Enable'}
+            </Button>
+          )}
         </div>
 
         {/* Metadata grid */}
@@ -219,13 +254,16 @@ export function JobDrawer({
 
         <Separator />
 
-        {/* Pause controls */}
-        <div>
-          <h3 className="text-[11px] text-muted-foreground uppercase tracking-wider mb-3">Pause / Resume</h3>
-          <PauseControls job={job} onPause={onPause} onResume={onResume} />
-        </div>
+        {job.isBakinJob && (
+          <>
+            <div>
+              <h3 className="text-[11px] text-muted-foreground uppercase tracking-wider mb-3">Pause / Resume</h3>
+              <PauseControls job={job} onPause={onPause} onResume={onResume} />
+            </div>
 
-        <Separator />
+            <Separator />
+          </>
+        )}
 
         {/* Run history */}
         <div>

--- a/plugins/schedule/components/job-form.tsx
+++ b/plugins/schedule/components/job-form.tsx
@@ -34,7 +34,7 @@ export function JobForm({
   onCancel: () => void
   submitting: boolean
   initial?: Partial<JobFormData>
-  mode?: 'create' | 'edit' | 'duplicate'
+  mode?: 'create' | 'edit' | 'duplicate' | 'adopt'
 }) {
   const mainAgentId = useMainAgentId()
   const [name, setName] = useState(initial?.name ?? '')
@@ -48,7 +48,7 @@ export function JobForm({
   const [requireTriage, setRequireTriage] = useState(initial?.requireTriage ?? false)
   const [allowOverlap, setAllowOverlap] = useState(initial?.allowOverlap ?? false)
   const [maxFailures, setMaxFailures] = useState(initial?.maxFailures ?? 3)
-  const [parsedOk, setParsedOk] = useState(mode === 'edit') // edit mode: assume current schedule is valid
+  const [parsedOk, setParsedOk] = useState(mode === 'edit' || mode === 'adopt') // existing runtime schedules are already valid
 
   // Reset form when initial changes (e.g. switching between jobs)
   useEffect(() => {
@@ -63,7 +63,7 @@ export function JobForm({
       setRequireTriage(initial.requireTriage ?? false)
       setAllowOverlap(initial.allowOverlap ?? false)
       setMaxFailures(initial.maxFailures ?? 3)
-      setParsedOk(mode === 'edit')
+      setParsedOk(mode === 'edit' || mode === 'adopt')
     }
   }, [initial, mode])
 
@@ -80,6 +80,7 @@ export function JobForm({
     create: { submit: 'Create Job', submitting: 'Creating...' },
     edit: { submit: 'Save Changes', submitting: 'Saving...' },
     duplicate: { submit: 'Create Copy', submitting: 'Creating...' },
+    adopt: { submit: 'Adopt into Bakin', submitting: 'Adopting...' },
   }
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/plugins/schedule/components/job-list.tsx
+++ b/plugins/schedule/components/job-list.tsx
@@ -15,6 +15,8 @@ export function JobList({
   onDelete,
   onEdit,
   onDuplicate,
+  onAdopt,
+  onRestoreNative,
   onSkipNext,
   scoreMap,
   showScores,
@@ -27,6 +29,8 @@ export function JobList({
   onDelete: (jobId: string) => void
   onEdit: (job: ScheduleJob) => void
   onDuplicate: (job: ScheduleJob) => void
+  onAdopt: (job: ScheduleJob) => void
+  onRestoreNative: (jobId: string) => void
   onSkipNext: (jobId: string) => void
   scoreMap?: Map<string, JobScoreInfo>
   showScores?: boolean
@@ -58,6 +62,8 @@ export function JobList({
             onDelete={() => onDelete(job.id)}
             onEdit={() => onEdit(job)}
             onDuplicate={() => onDuplicate(job)}
+            onAdopt={() => onAdopt(job)}
+            onRestoreNative={() => onRestoreNative(job.id)}
             onSkipNext={() => onSkipNext(job.id)}
             scoreInfo={showScores ? scoreMap?.get(job.id) : undefined}
           />

--- a/plugins/schedule/components/job-row.tsx
+++ b/plugins/schedule/components/job-row.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MoreHorizontal, Play, Pause, RotateCcw, Trash2, Pencil, Copy, SkipForward } from 'lucide-react'
+import { MoreHorizontal, Play, Pause, RotateCcw, Trash2, Pencil, Copy, SkipForward, CirclePlus, Undo2 } from 'lucide-react'
 import { TableRow, TableCell } from "@bakin/sdk/ui"
 import { Badge } from "@bakin/sdk/ui"
 import {
@@ -48,6 +48,8 @@ export function JobRow({
   onDelete,
   onEdit,
   onDuplicate,
+  onAdopt,
+  onRestoreNative,
   onSkipNext,
   scoreInfo,
 }: {
@@ -59,6 +61,8 @@ export function JobRow({
   onDelete: () => void
   onEdit: () => void
   onDuplicate: () => void
+  onAdopt: () => void
+  onRestoreNative: () => void
   onSkipNext: () => void
   scoreInfo?: JobScoreInfo
 }) {
@@ -71,9 +75,9 @@ export function JobRow({
       <TableCell>
         <div className="flex flex-col gap-0.5">
           <span className="text-sm font-medium text-foreground">{job.displayName || job.id}</span>
-          {job.isBakinJob && (
-            <span className="text-[10px] text-muted-foreground uppercase tracking-wider">Bakin</span>
-          )}
+          <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
+            {job.source === 'adopted' ? 'Adopted' : job.isBakinJob ? 'Bakin schedule' : 'Runtime cron'}
+          </span>
           {scoreInfo && (
             <span className="flex items-center gap-2 font-mono text-[10px] mt-0.5">
               <span className="text-amber-400">RRF {scoreInfo.score.toFixed(3)}</span>
@@ -111,24 +115,43 @@ export function JobRow({
             <DropdownMenuItem onClick={onRunNow}>
               <Play className="size-3.5 mr-2" /> Run Now
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={onEdit}>
-              <Pencil className="size-3.5 mr-2" /> Edit
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={onDuplicate}>
-              <Copy className="size-3.5 mr-2" /> Duplicate
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={onSkipNext}>
-              <SkipForward className="size-3.5 mr-2" /> Skip Next
-            </DropdownMenuItem>
+            {job.isBakinJob ? (
+              <>
+                <DropdownMenuItem onClick={onEdit}>
+                  <Pencil className="size-3.5 mr-2" /> Edit
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onDuplicate}>
+                  <Copy className="size-3.5 mr-2" /> Duplicate
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onSkipNext}>
+                  <SkipForward className="size-3.5 mr-2" /> Skip Next
+                </DropdownMenuItem>
+              </>
+            ) : (
+              <DropdownMenuItem onClick={onAdopt}>
+                <CirclePlus className="size-3.5 mr-2" /> Adopt into Bakin
+              </DropdownMenuItem>
+            )}
+            {job.canRestoreNative && (
+              <DropdownMenuItem onClick={onRestoreNative}>
+                <Undo2 className="size-3.5 mr-2" /> Restore Native
+              </DropdownMenuItem>
+            )}
             <DropdownMenuSeparator />
             {job.paused ? (
               <DropdownMenuItem onClick={onResume}>
                 <RotateCcw className="size-3.5 mr-2" /> Resume
               </DropdownMenuItem>
             ) : (
-              <DropdownMenuItem onClick={onPause}>
-                <Pause className="size-3.5 mr-2" /> Pause
-              </DropdownMenuItem>
+              job.enabled ? (
+                <DropdownMenuItem onClick={onPause}>
+                  <Pause className="size-3.5 mr-2" /> {job.isBakinJob ? 'Pause' : 'Disable'}
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={onResume}>
+                  <RotateCcw className="size-3.5 mr-2" /> {job.isBakinJob ? 'Resume' : 'Enable'}
+                </DropdownMenuItem>
+              )
             )}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={onDelete} className="text-red-400 focus:text-red-400">

--- a/plugins/schedule/components/schedule-page.tsx
+++ b/plugins/schedule/components/schedule-page.tsx
@@ -46,7 +46,7 @@ export function SchedulePage() {
 
   const {
     jobs, loading, refresh,
-    pauseJob, resumeJob, deleteJob, runNow, updateJob, skipNext,
+    pauseJob, resumeJob, deleteJob, runNow, updateJob, adoptJob, restoreNative, skipNext,
   } = useScheduleJobs({
     agent: agentFilter === 'all' ? undefined : agentFilter,
   })
@@ -88,7 +88,7 @@ export function SchedulePage() {
 
   // Derive drawer/form visibility from URL state
   const selectedJob = jobIdParam ? jobs.find(j => j.id === jobIdParam) ?? null : null
-  const showForm = mode === 'create' || ((mode === 'edit' || mode === 'duplicate') && !!selectedJob)
+  const showForm = mode === 'create' || ((mode === 'edit' || mode === 'duplicate' || mode === 'adopt') && !!selectedJob)
   const showDetail = !!selectedJob && !showForm
 
   // --- Transitions ---
@@ -107,6 +107,7 @@ export function SchedulePage() {
 
   const openEdit = () => pushMode('edit')
   const openDuplicate = () => pushMode('duplicate')
+  const openAdopt = () => pushMode('adopt')
 
   // Atomic: set both jobId and mode in a single push (used from list/row context)
   const openEditFor = (job: ScheduleJob) => {
@@ -130,7 +131,21 @@ export function SchedulePage() {
   const handleFormSubmit = async (data: JobFormData) => {
     setSubmitting(true)
     try {
-      if (mode === 'edit' && selectedJob) {
+      if (mode === 'adopt' && selectedJob) {
+        const ok = await adoptJob(selectedJob.id, {
+          name: data.name,
+          schedule: data.schedule,
+          agentId: data.agentId || null,
+          taskPrompt: data.taskPrompt || null,
+          taskTitle: data.taskTitle || null,
+          workflowId: data.workflowId || null,
+          owner: data.owner || null,
+          requireTriage: data.requireTriage,
+          allowOverlap: data.allowOverlap,
+          maxFailures: data.maxFailures,
+        })
+        if (ok) closeForm()
+      } else if (mode === 'edit' && selectedJob) {
         const ok = await updateJob(selectedJob.id, {
           name: data.name,
           displayName: data.name,
@@ -161,9 +176,9 @@ export function SchedulePage() {
   }
 
   // Derive form initial data from URL state
-  const formInitial = (mode === 'edit' || mode === 'duplicate') && selectedJob ? {
+  const formInitial = (mode === 'edit' || mode === 'duplicate' || mode === 'adopt') && selectedJob ? {
     name: mode === 'duplicate' ? `${selectedJob.displayName} (copy)` : selectedJob.displayName,
-    schedule: selectedJob.humanSchedule,
+    schedule: selectedJob.cron || selectedJob.humanSchedule,
     agentId: selectedJob.agentId,
     taskPrompt: selectedJob.taskPrompt,
     taskTitle: selectedJob.taskTitle,
@@ -178,7 +193,9 @@ export function SchedulePage() {
     ? `Edit: ${selectedJob?.displayName}`
     : mode === 'duplicate'
       ? `Duplicate: ${selectedJob?.displayName}`
-      : 'New Scheduled Job'
+      : mode === 'adopt'
+        ? `Adopt: ${selectedJob?.displayName}`
+        : 'New Scheduled Job'
 
   return (
     <div className="p-6 flex flex-col h-full min-h-0 gap-4">
@@ -237,6 +254,13 @@ export function SchedulePage() {
             onDelete={(id) => deleteJob(id)}
             onEdit={openEditFor}
             onDuplicate={openDuplicateFor}
+            onAdopt={(job) => {
+              const params = new URLSearchParams(searchParams.toString())
+              params.set('jobId', job.id)
+              params.set('mode', 'adopt')
+              router.push(`${pathname}?${params.toString()}`, { scroll: false })
+            }}
+            onRestoreNative={restoreNative}
             onSkipNext={(id) => skipNext(id)}
             scoreMap={scoreMap}
             showScores={debug && !!search.trim()}
@@ -261,6 +285,8 @@ export function SchedulePage() {
         onRunNow={runNow}
         onEdit={openEdit}
         onDuplicate={openDuplicate}
+        onAdopt={openAdopt}
+        onRestoreNative={restoreNative}
         onSkipNext={skipNext}
       />
 
@@ -276,7 +302,7 @@ export function SchedulePage() {
           onCancel={closeForm}
           submitting={submitting}
           initial={formInitial}
-          mode={mode === 'duplicate' ? 'duplicate' : mode === 'edit' ? 'edit' : 'create'}
+          mode={mode === 'duplicate' ? 'duplicate' : mode === 'edit' ? 'edit' : mode === 'adopt' ? 'adopt' : 'create'}
         />
       </BakinDrawer>
     </div>

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -5,9 +5,10 @@
 import { randomBytes, timingSafeEqual } from 'crypto'
 import { z } from 'zod'
 import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
+import type { CronRun } from '@bakin/core/adapters/runtime'
 import { readMergedJobs } from './lib/jobs-reader'
 import { getLastRun, readRuns } from './lib/runs-reader'
-import { upsertJob, removeJob, getJob, isPaused, shouldSkip, recordFailure, recordSuccess, withDefaults } from './lib/sidecar'
+import { upsertJob, removeJob, getJob, isPaused, shouldSkip, recordFailure, recordSuccess, withDefaults, hasProcessedRun, recordProcessedRun } from './lib/sidecar'
 import { parseSchedule } from './lib/cron-parser'
 import { createTaskWithEffects } from '../../src/core/task-service'
 import { getContentDir } from '../../src/core/content-dir'
@@ -55,6 +56,7 @@ function expandTemplate(template: string, vars: Record<string, string>): string 
 interface ScheduleSettings {
   bridgeEnabled?: boolean
   bridgeSecret?: string
+  reconcileLookbackHours?: number
 }
 
 /** Constant-time string comparison. Returns false for any length mismatch. */
@@ -80,14 +82,6 @@ function getOrCreateBridgeSecret(): string | null {
   return fresh
 }
 
-/** Build the webhook URL the runtime cron will POST to, with secret attached. */
-function buildBridgeWebhookUrl(): string {
-  const port = process.env.PORT || '3737'
-  const base = `${process.env.BAKIN_URL || `http://localhost:${port}`}/api/plugins/schedule/bridge`
-  const secret = getOrCreateBridgeSecret()
-  return secret ? `${base}?secret=${secret}` : base
-}
-
 async function getScheduleDefaultOwner(): Promise<string> {
   return pluginCtx?.runtime ? getRuntimeMainAgentId(pluginCtx.runtime) : 'main'
 }
@@ -98,6 +92,10 @@ async function getScheduleDefaultOwner(): Promise<string> {
 
 /** Module-level ctx set during activate(), used by handleBridge */
 let pluginCtx: PluginContext | null = null
+let reconcileTimer: ReturnType<typeof setInterval> | null = null
+let reconcileRunning = false
+
+const RECONCILE_INTERVAL_MS = 60_000
 
 async function handleBridge(req: Request): Promise<Response> {
   // Gate 1: feature flag. The bridge setting defaults to enabled, but admins
@@ -110,8 +108,7 @@ async function handleBridge(req: Request): Promise<Response> {
   }
 
   // Gate 2: shared-secret auth. Runtime cron calls the webhook with ?secret=<hex>
-  // from the URL we registered when the cron was created (see
-  // buildBridgeWebhookUrl). We require a match so a stale cron from a
+  // from the URL used by future direct webhook callers. We require a match so a stale cron from a
   // previous install — or any unauthorized caller — cannot create tasks.
   const expected = getOrCreateBridgeSecret()
   if (!expected) {
@@ -126,11 +123,24 @@ async function handleBridge(req: Request): Promise<Response> {
   }
 
   const payload = await readBody<BridgePayload>(req)
-  const { jobId, runId } = payload
+  const result = await processScheduledRun(payload)
+  return json(result.body, result.status)
+}
 
+interface ProcessRunResult {
+  status: number
+  body: BridgeResult
+}
+
+async function processScheduledRun(payload: BridgePayload): Promise<ProcessRunResult> {
+  const { jobId, runId } = payload
   const meta = getJob(jobId)
   if (!meta || !meta.isBakinJob) {
-    return json({ ok: true, skipped: 'not-bakin' } satisfies BridgeResult)
+    return { status: 200, body: { ok: true, skipped: 'not-bakin' } }
+  }
+
+  if (runId && hasProcessedRun(meta, runId)) {
+    return { status: 200, body: { ok: true, skipped: 'already-processed' } }
   }
 
   const defaults = withDefaults(meta, await getScheduleDefaultOwner())
@@ -138,22 +148,25 @@ async function handleBridge(req: Request): Promise<Response> {
   // Check pause state
   const pauseState = isPaused(meta)
   if (pauseState.paused) {
+    if (runId) recordProcessedRun(meta, runId, payload.timestamp)
     upsertJob(meta) // persist any auto-resume changes
-    return json({ ok: true, skipped: 'paused' } satisfies BridgeResult)
+    return { status: 200, body: { ok: true, skipped: 'paused' } }
   }
 
   // Check skip-next-N
   if (shouldSkip(meta)) {
+    if (runId) recordProcessedRun(meta, runId, payload.timestamp)
     upsertJob(meta)
-    return json({ ok: true, skipped: 'skip-count' } satisfies BridgeResult)
+    return { status: 200, body: { ok: true, skipped: 'skip-count' } }
   }
 
   // Check failure auto-pause
   if ((defaults.consecutiveFailures ?? 0) >= (defaults.maxFailures ?? 3)) {
     meta.paused = true
     meta.pauseReason = 'auto-failures'
+    if (runId) recordProcessedRun(meta, runId, payload.timestamp)
     upsertJob(meta)
-    return json({ ok: true, skipped: 'auto-paused' } satisfies BridgeResult)
+    return { status: 200, body: { ok: true, skipped: 'auto-paused' } }
   }
 
   // Check overlap
@@ -164,7 +177,11 @@ async function handleBridge(req: Request): Promise<Response> {
       for (const col of activeColumns) {
         const tasks = board.columns[col] ?? []
         if (tasks.some(t => t.id === meta.lastTaskId)) {
-          return json({ ok: true, skipped: 'overlap' } satisfies BridgeResult)
+          if (runId) {
+            recordProcessedRun(meta, runId, payload.timestamp)
+            upsertJob(meta)
+          }
+          return { status: 200, body: { ok: true, skipped: 'overlap' } }
         }
       }
     } catch {
@@ -185,8 +202,9 @@ async function handleBridge(req: Request): Promise<Response> {
         if (blocked.some(t => t.id === meta.lastTaskId)) {
           const autoPaused = recordFailure(meta)
           if (autoPaused) {
+            if (runId) recordProcessedRun(meta, runId, payload.timestamp)
             upsertJob(meta)
-            return json({ ok: true, skipped: 'auto-paused' } satisfies BridgeResult)
+            return { status: 200, body: { ok: true, skipped: 'auto-paused' } }
           }
         }
       }
@@ -223,6 +241,7 @@ async function handleBridge(req: Request): Promise<Response> {
     const taskId = result.id
 
     meta.lastTaskId = taskId
+    if (runId) recordProcessedRun(meta, runId, payload.timestamp)
     upsertJob(meta)
 
     // Audit + activity feed
@@ -231,13 +250,83 @@ async function handleBridge(req: Request): Promise<Response> {
       pluginCtx.activity.log('system', `Schedule "${meta.displayName ?? jobId}" created task ${taskId}${meta.agentId ? ` for ${meta.agentId}` : ''}`, { taskId })
     }
 
-    return json({ ok: true, taskId } satisfies BridgeResult)
+    return { status: 200, body: { ok: true, taskId } }
   } catch (err) {
     log.error('Bridge failed to create task', err)
     recordFailure(meta)
     upsertJob(meta)
-    return json({ ok: false, error: (err as Error).message }, 500)
+    return { status: 500, body: { ok: false, error: (err as Error).message } }
   }
+}
+
+function runTimestamp(run: CronRun): string {
+  return run.startedAt ?? run.endedAt ?? new Date().toISOString()
+}
+
+function runTimeMs(run: CronRun): number {
+  const parsed = Date.parse(runTimestamp(run))
+  return Number.isFinite(parsed) ? parsed : Date.now()
+}
+
+function reconcileLookbackMs(startup: boolean): number {
+  if (!startup) return 0
+  const settings = pluginCtx?.getSettings<ScheduleSettings>() ?? {}
+  const rawHours = typeof settings.reconcileLookbackHours === 'number' ? settings.reconcileLookbackHours : 24
+  const hours = Math.max(0, Math.min(rawHours, 168))
+  return hours * 60 * 60 * 1000
+}
+
+async function reconcileScheduleRuns(startup = false): Promise<void> {
+  if (!pluginCtx || reconcileRunning) return
+  reconcileRunning = true
+  try {
+    const cutoffMs = reconcileLookbackMs(startup)
+    const cutoff = startup
+      ? cutoffMs > 0 ? Date.now() - cutoffMs : Number.POSITIVE_INFINITY
+      : 0
+    const jobs = await readMergedJobs(pluginCtx.runtime.cron, await getScheduleDefaultOwner())
+    for (const job of jobs) {
+      if (!job.isBakinJob) continue
+      const meta = getJob(job.id)
+      if (!meta?.isBakinJob) continue
+      const runs = await pluginCtx.runtime.cron.listRuns(job.id).catch((err) => {
+        log.warn('Failed to read schedule run history', { jobId: job.id, error: err instanceof Error ? err.message : String(err) })
+        return [] as CronRun[]
+      })
+      const jobCreatedAtMs = Number.isFinite(Date.parse(meta.createdAt)) ? Date.parse(meta.createdAt) : 0
+      const candidates = runs
+        .filter(run => run.status === 'succeeded')
+        .filter(run => runTimeMs(run) >= jobCreatedAtMs)
+        .filter(run => startup ? runTimeMs(run) >= cutoff : true)
+        .sort((a, b) => runTimeMs(a) - runTimeMs(b))
+      for (const run of candidates) {
+        const latest = getJob(job.id)
+        if (!latest?.isBakinJob || hasProcessedRun(latest, run.id)) continue
+        await processScheduledRun({
+          jobId: job.id,
+          runId: run.id,
+          timestamp: runTimestamp(run),
+        })
+      }
+    }
+  } finally {
+    reconcileRunning = false
+  }
+}
+
+function startReconciler(): void {
+  if (reconcileTimer) clearInterval(reconcileTimer)
+  reconcileScheduleRuns(true).catch(err => log.warn('Startup schedule reconcile failed', err))
+  reconcileTimer = setInterval(() => {
+    reconcileScheduleRuns(false).catch(err => log.warn('Schedule reconcile failed', err))
+  }, RECONCILE_INTERVAL_MS)
+  reconcileTimer.unref?.()
+}
+
+function stopReconciler(): void {
+  if (!reconcileTimer) return
+  clearInterval(reconcileTimer)
+  reconcileTimer = null
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +344,7 @@ const schedulePlugin: BakinPlugin = {
       { key: 'failureCooldownMs', type: 'number', label: 'Failure cooldown (ms)', description: 'Wait time after failure before retrying', default: 300000 },
       { key: 'maxFailures', type: 'number', label: 'Max consecutive failures', description: 'Pause job after this many consecutive failures', default: 3 },
       { key: 'bridgeEnabled', type: 'boolean', label: 'Bridge enabled', description: 'Allow cron jobs to create tasks via the bridge', default: true },
+      { key: 'reconcileLookbackHours', type: 'number', label: 'Startup reconciliation window', description: 'Create missed scheduled tasks only for successful runtime cron runs newer than this many hours. Set to 0 to disable startup backfill.', default: 24 },
     ],
   },
   // bridgeSecret is stored alongside settings but not exposed in the UI —
@@ -371,7 +461,7 @@ const schedulePlugin: BakinPlugin = {
         name: body.name,
         schedule: parsed.cron,
         command: `bakin:schedule:${body.name}`,
-        metadata: { tz, webhookUrl: buildBridgeWebhookUrl() },
+        metadata: { tz, bakinSchedule: true, scheduleType: 'cron' },
       })
       const jobId = created.id
 
@@ -379,6 +469,7 @@ const schedulePlugin: BakinPlugin = {
       const meta: BakinJobMeta = {
         jobId,
         isBakinJob: true,
+        source: 'bakin',
         displayName: body.name,
         agentId: body.agentId,
         owner,
@@ -446,6 +537,147 @@ const schedulePlugin: BakinPlugin = {
       },
     })
     // GET /:jobId — get single job details
+
+    // POST /:jobId/adopt — convert a native runtime cron into a Bakin schedule
+    ctx.registerRoute({
+      path: '/:jobId/adopt',
+      method: 'POST',
+      description: 'Adopt a runtime cron job into Bakin task scheduling',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<{
+          jobId?: string
+          name?: string
+          schedule?: string
+          agentId?: string | null
+          workflowId?: string | null
+          taskPrompt?: string | null
+          taskTitle?: string | null
+          owner?: string | null
+          requireTriage?: boolean
+          allowOverlap?: boolean
+          maxFailures?: number
+          tz?: string
+        }>(req).catch(() => ({} as {
+          jobId?: string
+          name?: string
+          schedule?: string
+          agentId?: string | null
+          workflowId?: string | null
+          taskPrompt?: string | null
+          taskTitle?: string | null
+          owner?: string | null
+          requireTriage?: boolean
+          allowOverlap?: boolean
+          maxFailures?: number
+          tz?: string
+        }))
+        const jobId = url.searchParams.get('jobId') || body.jobId
+        if (!jobId) return json({ error: 'jobId required' }, 400)
+
+        const runtimeJob = await ctx.runtime.cron.get(jobId)
+        if (!runtimeJob) return json({ error: 'Runtime cron job not found' }, 404)
+
+        const existing = getJob(jobId)
+        if (existing?.isBakinJob) return json({ error: 'Job is already managed by Bakin' }, 409)
+
+        const raw = await ctx.runtime.cron.getRaw(jobId, 'schedule adopt: preserve native cron before Bakin takes ownership')
+        if (!raw) return json({ error: 'Runtime cron snapshot not found' }, 404)
+
+        const parsed = body.schedule ? parseSchedule(body.schedule) : { cron: runtimeJob.schedule }
+        if (!parsed) return json({ error: 'Could not parse schedule' }, 400)
+
+        const now = new Date().toISOString()
+        const tz = body.tz || existing?.tz || getSystemTimezone()
+        const displayName = body.name || existing?.displayName || runtimeJob.name
+        const owner = body.owner || existing?.owner || await getRuntimeMainAgentId(ctx.runtime)
+        const taskPrompt = body.taskPrompt || existing?.taskPrompt || runtimeJob.command
+
+        await ctx.runtime.cron.update(jobId, {
+          name: displayName,
+          schedule: parsed.cron,
+          command: `bakin:schedule:${jobId}`,
+          metadata: {
+            ...(runtimeJob.metadata ?? {}),
+            tz,
+            scheduleType: 'cron',
+            bakinSchedule: true,
+            adoptedByBakin: true,
+          },
+        })
+
+        const meta: BakinJobMeta = {
+          ...(existing ?? {}),
+          jobId,
+          isBakinJob: true,
+          source: 'adopted',
+          displayName,
+          agentId: body.agentId === null ? undefined : body.agentId ?? existing?.agentId,
+          owner,
+          requireTriage: body.requireTriage ?? existing?.requireTriage ?? false,
+          workflowId: body.workflowId === null ? undefined : body.workflowId ?? existing?.workflowId,
+          taskPrompt,
+          taskTitle: body.taskTitle === null ? undefined : body.taskTitle ?? existing?.taskTitle,
+          allowOverlap: body.allowOverlap ?? existing?.allowOverlap ?? false,
+          maxFailures: body.maxFailures ?? existing?.maxFailures ?? 3,
+          consecutiveFailures: existing?.consecutiveFailures ?? 0,
+          tz,
+          originalRuntimeCron: {
+            provider: ctx.runtime.name,
+            capturedAt: now,
+            snapshot: raw,
+          },
+          createdAt: existing?.createdAt ?? now,
+          updatedAt: now,
+        }
+        upsertJob(meta)
+        indexJob(jobId)
+
+        ctx.activity.audit('job.adopted', 'system', { jobId })
+        ctx.activity.log('system', `Adopted runtime cron "${displayName}" into Bakin`)
+        return json({ ok: true, jobId })
+      },
+    })
+
+    // POST /:jobId/restore-native — restore the native runtime cron captured during adoption
+    ctx.registerRoute({
+      path: '/:jobId/restore-native',
+      method: 'POST',
+      description: 'Restore an adopted Bakin schedule back to its native runtime cron behavior',
+      handler: async (req: Request) => {
+        const url = new URL(req.url)
+        const body = await readBody<{ jobId?: string }>(req).catch(() => ({} as { jobId?: string }))
+        const jobId = url.searchParams.get('jobId') || body.jobId
+        if (!jobId) return json({ error: 'jobId required' }, 400)
+
+        const meta = getJob(jobId)
+        if (!meta?.originalRuntimeCron) return json({ error: 'No native cron snapshot available' }, 404)
+
+        const restored = await ctx.runtime.cron.restoreRaw(
+          jobId,
+          meta.originalRuntimeCron.snapshot,
+          'schedule restore: return adopted cron to native runtime behavior',
+        )
+        const now = new Date().toISOString()
+        const runtimeMeta: BakinJobMeta = {
+          jobId,
+          isBakinJob: false,
+          source: 'runtime',
+          displayName: restored.name,
+          owner: meta.owner ?? await getRuntimeMainAgentId(ctx.runtime),
+          requireTriage: true,
+          createdAt: meta.createdAt ?? now,
+          updatedAt: now,
+        }
+        upsertJob(runtimeMeta)
+        indexJob(jobId)
+
+        ctx.activity.audit('job.restored_native', 'system', { jobId })
+        ctx.activity.log('system', `Restored schedule "${restored.name}" to native runtime cron behavior`)
+        return json({ ok: true, jobId })
+      },
+    })
+
     ctx.registerRoute({
       path: '/:jobId',
       method: 'GET',
@@ -515,33 +747,45 @@ const schedulePlugin: BakinPlugin = {
       if (!jobId || !body.action) return json({ error: 'jobId and action required' }, 400)
 
       const meta = getJob(jobId)
-        if (!meta) return json({ error: 'Job not found' }, 404)
-
-        switch (body.action) {
-          case 'pause':
-            meta.paused = true
-            meta.pauseReason = 'manual'
-            meta.pauseUntil = body.pauseUntil
-            break
-          case 'resume':
-            meta.paused = false
-            meta.pauseReason = undefined
-            meta.pauseUntil = undefined
-            meta.skipNextN = undefined
-            meta.skippedCount = undefined
-            meta.consecutiveFailures = 0
-            break
-          case 'skip':
-            meta.skipNextN = body.skipN ?? 1
-            meta.skippedCount = 0
-            break
-        }
-        upsertJob(meta)
+      if (!meta) {
+        if (body.action === 'skip') return json({ error: 'Skip is only available for Bakin schedules' }, 400)
+        const runtimeJob = await ctx.runtime.cron.get(jobId)
+        if (!runtimeJob) return json({ error: 'Job not found' }, 404)
+        await ctx.runtime.cron.update(jobId, { enabled: body.action === 'resume' })
         indexJob(jobId)
-
-        ctx.activity.audit(`job.${body.action}`, 'system', { jobId })
-        ctx.activity.log('system', `Schedule "${meta.displayName || jobId}" ${body.action}d`)
+        ctx.activity.audit(`job.${body.action === 'pause' ? 'disabled' : 'enabled'}`, 'system', { jobId })
+        ctx.activity.log('system', `Runtime cron "${jobId}" ${body.action === 'pause' ? 'disabled' : 'enabled'}`)
         return json({ ok: true })
+      }
+
+      switch (body.action) {
+        case 'pause':
+          meta.paused = true
+          meta.pauseReason = 'manual'
+          meta.pauseUntil = body.pauseUntil
+          await ctx.runtime.cron.update(jobId, { enabled: false })
+          break
+        case 'resume':
+          meta.paused = false
+          meta.pauseReason = undefined
+          meta.pauseUntil = undefined
+          meta.skipNextN = undefined
+          meta.skippedCount = undefined
+          meta.consecutiveFailures = 0
+          await ctx.runtime.cron.update(jobId, { enabled: true })
+          break
+        case 'skip':
+          if (!meta.isBakinJob) return json({ error: 'Skip is only available for Bakin schedules' }, 400)
+          meta.skipNextN = body.skipN ?? 1
+          meta.skippedCount = 0
+          break
+      }
+      upsertJob(meta)
+      indexJob(jobId)
+
+      ctx.activity.audit(`job.${body.action}`, 'system', { jobId })
+      ctx.activity.log('system', `Schedule "${meta.displayName || jobId}" ${body.action}d`)
+      return json({ ok: true })
     }
     ctx.registerRoute({ path: '/:jobId/pause', method: 'POST', description: 'Pause/resume/skip a job', handler: pauseHandler })
 
@@ -551,7 +795,12 @@ const schedulePlugin: BakinPlugin = {
       const body = await readBody<{ jobId?: string }>(req).catch(() => ({}))
       const jobId = url.searchParams.get('jobId') || (body as Record<string, unknown>).jobId as string | undefined
       if (!jobId) return json({ error: 'jobId required' }, 400)
-      await ctx.runtime.cron.runNow(jobId)
+      const runtimeJob = await ctx.runtime.cron.get(jobId)
+      if (!runtimeJob) return json({ error: 'Job not found' }, 404)
+      const run = await ctx.runtime.cron.runNow(jobId)
+      if (run.status === 'succeeded') {
+        await processScheduledRun({ jobId, runId: run.id, timestamp: runTimestamp(run) })
+      }
       ctx.activity.audit('job.run_now', 'system', { jobId })
       ctx.activity.log('system', `Triggered immediate run for "${jobId}"`)
       return json({ ok: true })
@@ -638,13 +887,14 @@ const schedulePlugin: BakinPlugin = {
           name: params.name as string,
           schedule: parsed.cron,
           command: `bakin:schedule:${params.name as string}`,
-          metadata: { tz, webhookUrl: buildBridgeWebhookUrl() },
+          metadata: { tz, bakinSchedule: true, scheduleType: 'cron' },
         })
         const jobId = created.id
 
         const meta: BakinJobMeta = {
           jobId,
           isBakinJob: true,
+          source: 'bakin',
           displayName: params.name as string,
           agentId: params.agentId as string | undefined,
           owner: await getRuntimeMainAgentId(ctx.runtime),
@@ -717,13 +967,20 @@ const schedulePlugin: BakinPlugin = {
         if (!params.jobId || !params.action) return { ok: false, error: 'jobId and action required' }
 
         const meta = getJob(params.jobId as string)
-        if (!meta) return { ok: false, error: 'Job not found' }
+        if (!meta) {
+          if (params.action === 'skip') return { ok: false, error: 'Skip is only available for Bakin schedules' }
+          const runtimeJob = await ctx.runtime.cron.get(params.jobId as string)
+          if (!runtimeJob) return { ok: false, error: 'Job not found' }
+          await ctx.runtime.cron.update(params.jobId as string, { enabled: params.action === 'resume' })
+          return { ok: true }
+        }
 
         switch (params.action) {
           case 'pause':
             meta.paused = true
             meta.pauseReason = 'manual'
             if (params.pauseUntil) meta.pauseUntil = params.pauseUntil as string
+            await ctx.runtime.cron.update(params.jobId as string, { enabled: false })
             break
           case 'resume':
             meta.paused = false
@@ -732,8 +989,10 @@ const schedulePlugin: BakinPlugin = {
             meta.skipNextN = undefined
             meta.skippedCount = undefined
             meta.consecutiveFailures = 0
+            await ctx.runtime.cron.update(params.jobId as string, { enabled: true })
             break
           case 'skip':
+            if (!meta.isBakinJob) return { ok: false, error: 'Skip is only available for Bakin schedules' }
             meta.skipNextN = (params.skipN as number) ?? 1
             meta.skippedCount = 0
             break
@@ -808,9 +1067,12 @@ const schedulePlugin: BakinPlugin = {
       },
       handler: async (params: Record<string, unknown>) => {
         if (!params.jobId) return { ok: false, error: 'jobId required' }
-        const meta = getJob(params.jobId as string)
-        if (!meta) return { ok: false, error: 'Job not found' }
-        await ctx.runtime.cron.runNow(params.jobId as string)
+        const runtimeJob = await ctx.runtime.cron.get(params.jobId as string)
+        if (!runtimeJob) return { ok: false, error: 'Job not found' }
+        const run = await ctx.runtime.cron.runNow(params.jobId as string)
+        if (run.status === 'succeeded') {
+          await processScheduledRun({ jobId: params.jobId as string, runId: run.id, timestamp: runTimestamp(run) })
+        }
         ctx.activity.audit('job.run_now', 'system', { jobId: params.jobId })
         return { ok: true, jobId: params.jobId }
       },
@@ -899,6 +1161,7 @@ const schedulePlugin: BakinPlugin = {
     })
 
     log.info('Schedule plugin activated')
+    startReconciler()
   },
 
   async onReady() {
@@ -911,6 +1174,7 @@ const schedulePlugin: BakinPlugin = {
   },
 
   onShutdown() {
+    stopReconciler()
     log.info('Schedule plugin shutting down')
   },
 }

--- a/plugins/schedule/lib/health-checks.ts
+++ b/plugins/schedule/lib/health-checks.ts
@@ -39,7 +39,7 @@ function fixed(check: string, message: string): HealthCheckResult {
 
 /**
  * Detect orphaned runtime cron jobs that aren't tracked in Bakin's
- * `schedule/sidecar.json`. Auto-adopts them when
+ * `schedule/sidecar.json`. Auto-tracks them when
  * settings.doctor.autoFixSkill is true - creates a minimal sidecar
  * entry flagged `requireTriage: true` and explicitly leaves agentId
  * unset (the user must triage rather than have a guessed assignment).
@@ -93,11 +93,13 @@ export async function checkScheduleSync(
 
   for (const orphan of orphans) {
     if (autoFix) {
-      // Auto-adopt: create minimal sidecar entry flagged for manual triage
+      // Auto-track: create minimal sidecar entry flagged for manual triage.
+      // This is not Bakin adoption; it only records runtime visibility state.
       const now = new Date().toISOString()
       const entry = {
         jobId: orphan.id,
         isBakinJob: false,
+        source: 'runtime',
         displayName: orphan.name,
         agentId: undefined, // Don't guess — flag for triage
         owner: defaultOwner,
@@ -106,14 +108,14 @@ export async function checkScheduleSync(
         updatedAt: now,
       }
       sidecar.jobs[orphan.id] = entry
-      results.push(fixed(checkName, `Auto-adopted orphan runtime cron job "${orphan.name}" (id: ${orphan.id})`))
-      log.info('Auto-adopted orphan cron job', { jobId: orphan.id, name: orphan.name })
+      results.push(fixed(checkName, `Tracked orphan runtime cron job "${orphan.name}" (id: ${orphan.id})`))
+      log.info('Tracked orphan cron job', { jobId: orphan.id, name: orphan.name })
     } else {
       results.push(warn(checkName, `Orphan runtime cron job "${orphan.name}" (id: ${orphan.id}) - not tracked in Bakin sidecar`, true))
     }
   }
 
-  // Write updated sidecar if we adopted anything
+  // Write updated sidecar if we tracked anything
   if (autoFix && results.some(r => r.status === 'fixed')) {
     try {
       const sidecarPath = join(contentDir, 'schedule', 'sidecar.json')

--- a/plugins/schedule/lib/jobs-reader.ts
+++ b/plugins/schedule/lib/jobs-reader.ts
@@ -65,6 +65,8 @@ export function mergeJob(
 
   // For orphaned jobs (no sidecar), extract what we can from the payload
   const orphanContext = !meta ? extractOrphanContext(job) : {}
+  const source = meta?.source ?? (meta?.isBakinJob ? 'bakin' : 'runtime')
+  const normalizedSource = source === 'adopted' || meta?.originalRuntimeCron ? 'adopted' : source
 
   return {
     // Runtime cron fields (normalised)
@@ -73,6 +75,9 @@ export function mergeJob(
     schedule: normalised,
     enabled: job.enabled,
     delivery: job.delivery,
+    source: normalizedSource,
+    canAdopt: !meta?.isBakinJob,
+    canRestoreNative: Boolean(meta?.isBakinJob && meta.originalRuntimeCron),
 
     // Bakin sidecar (with defaults)
     isBakinJob: meta?.isBakinJob ?? false,

--- a/plugins/schedule/lib/sidecar.ts
+++ b/plugins/schedule/lib/sidecar.ts
@@ -16,6 +16,8 @@ const DEFAULTS = {
   requireTriage: false,
 } as const
 
+const MAX_PROCESSED_RUN_IDS = 100
+
 function getSidecarPath(): string {
   return `${getContentDir()}/schedule/sidecar.json`
 }
@@ -65,6 +67,16 @@ export function removeJob(jobId: string): boolean {
   delete sidecar.jobs[jobId]
   writeSidecar(sidecar)
   return true
+}
+
+export function hasProcessedRun(meta: BakinJobMeta, runId: string): boolean {
+  return (meta.processedRunIds ?? []).includes(runId)
+}
+
+export function recordProcessedRun(meta: BakinJobMeta, runId: string, processedAt = new Date().toISOString()): void {
+  const ids = meta.processedRunIds ?? []
+  meta.processedRunIds = [...ids.filter(id => id !== runId), runId].slice(-MAX_PROCESSED_RUN_IDS)
+  meta.lastProcessedRunAt = processedAt
 }
 
 /** Apply defaults to a sidecar entry for display. */

--- a/plugins/schedule/types.ts
+++ b/plugins/schedule/types.ts
@@ -14,6 +14,7 @@ export interface ScheduleSidecar {
 export interface BakinJobMeta {
   jobId: string
   isBakinJob: boolean
+  source?: 'bakin' | 'runtime' | 'adopted'
   displayName?: string
   description?: string
   agentId?: string
@@ -34,6 +35,13 @@ export interface BakinJobMeta {
   createdAt: string
   updatedAt: string
   lastTaskId?: string
+  processedRunIds?: string[]
+  lastProcessedRunAt?: string
+  originalRuntimeCron?: {
+    provider: string
+    capturedAt: string
+    snapshot: unknown
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +88,9 @@ export interface MergedJob {
   schedule: { type: 'cron' | 'every' | 'at'; value: string; tz?: string }
   enabled: boolean
   delivery?: RuntimeCronJobSnapshot['delivery']
+  source: 'bakin' | 'runtime' | 'adopted'
+  canAdopt: boolean
+  canRestoreNative: boolean
 
   // From Bakin sidecar (defaults applied)
   isBakinJob: boolean
@@ -151,5 +162,6 @@ export interface BridgePayload {
 export interface BridgeResult {
   ok: boolean
   taskId?: string
-  skipped?: string // reason: 'overlap' | 'paused' | 'auto-paused' | 'skip-count' | 'not-bakin'
+  error?: string
+  skipped?: string // reason: 'overlap' | 'paused' | 'auto-paused' | 'skip-count' | 'not-bakin' | 'already-processed'
 }

--- a/src/hooks/use-schedule.ts
+++ b/src/hooks/use-schedule.ts
@@ -16,6 +16,9 @@ export interface ScheduleJob {
   skippedCount?: number
   enabled: boolean
   isBakinJob: boolean
+  source?: 'bakin' | 'runtime' | 'adopted'
+  canAdopt?: boolean
+  canRestoreNative?: boolean
   allowOverlap: boolean
   maxFailures: number
   consecutiveFailures: number
@@ -155,6 +158,29 @@ export function useScheduleJobs(options: UseScheduleOptions = {}) {
     } catch { return false }
   }, [fetchJobs])
 
+  const adoptJob = useCallback(async (jobId: string, data: Record<string, unknown>) => {
+    try {
+      const res = await fetch(`/api/plugins/schedule/${jobId}/adopt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (res.ok) fetchJobs()
+      return res.ok
+    } catch { return false }
+  }, [fetchJobs])
+
+  const restoreNative = useCallback(async (jobId: string) => {
+    try {
+      const res = await fetch(`/api/plugins/schedule/${jobId}/restore-native`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      if (res.ok) fetchJobs()
+      return res.ok
+    } catch { return false }
+  }, [fetchJobs])
+
   const skipNext = useCallback(async (jobId: string, n = 1) => {
     try {
       const res = await fetch(`/api/plugins/schedule/${jobId}/pause`, {
@@ -196,7 +222,7 @@ export function useScheduleJobs(options: UseScheduleOptions = {}) {
 
   return {
     jobs: filtered, loading, refresh: fetchJobs,
-    pauseJob, resumeJob, deleteJob, runNow, updateJob, skipNext, duplicateJob,
+    pauseJob, resumeJob, deleteJob, runNow, updateJob, adoptJob, restoreNative, skipNext, duplicateJob,
   }
 }
 

--- a/src/lib/plugin-context-services.ts
+++ b/src/lib/plugin-context-services.ts
@@ -294,6 +294,8 @@ export function createPluginRuntimeFacade(runtime: AgentRuntimeAdapter): AgentRu
       remove: runtime.cron.remove.bind(runtime.cron),
       runNow: runtime.cron.runNow.bind(runtime.cron),
       listRuns: runtime.cron.listRuns.bind(runtime.cron),
+      getRaw: runtime.cron.getRaw.bind(runtime.cron),
+      restoreRaw: runtime.cron.restoreRaw.bind(runtime.cron),
     },
     config: {
       get: async () => { throw new Error('Runtime config is not exposed to plugins') },

--- a/src/lib/plugin-permissions.ts
+++ b/src/lib/plugin-permissions.ts
@@ -98,7 +98,7 @@ for (const method of ['initialize', 'shutdown', 'ping', 'restart', 'getHealthChe
 }
 
 for (const [domain, permission] of Object.entries(RUNTIME_DOMAIN_PERMISSIONS)) {
-  for (const method of ['list', 'get', 'create', 'update', 'remove', 'listWorkspaceFiles', 'readWorkspaceFile', 'writeWorkspaceFile', 'removeWorkspaceFile', 'updatePermissions', 'updateAllowlist', 'heartbeat', 'send', 'stream', 'invoke', 'sendNotification', 'sendMessage', 'deliverContent', 'createApproval', 'editApproval', 'cancelApproval', 'resolveApproval', 'subscribeApprovalResponses', 'onMessage', 'onInteraction', 'write', 'listTiers', 'listEntries', 'getEntry', 'statEntry', 'readEntryRange', 'resolvePath', 'watchPaths', 'search', 'listAvailable', 'dispatch', 'getExecutionStatus', 'listExecutions', 'cancelExecution', 'subscribeExecutionUpdates', 'runNow', 'listRuns', 'replace', 'raw']) {
+  for (const method of ['list', 'get', 'create', 'update', 'remove', 'listWorkspaceFiles', 'readWorkspaceFile', 'writeWorkspaceFile', 'removeWorkspaceFile', 'updatePermissions', 'updateAllowlist', 'heartbeat', 'send', 'stream', 'invoke', 'sendNotification', 'sendMessage', 'deliverContent', 'createApproval', 'editApproval', 'cancelApproval', 'resolveApproval', 'subscribeApprovalResponses', 'onMessage', 'onInteraction', 'write', 'listTiers', 'listEntries', 'getEntry', 'statEntry', 'readEntryRange', 'resolvePath', 'watchPaths', 'search', 'listAvailable', 'dispatch', 'getExecutionStatus', 'listExecutions', 'cancelExecution', 'subscribeExecutionUpdates', 'runNow', 'listRuns', 'getRaw', 'restoreRaw', 'replace', 'raw']) {
     METHOD_PERMISSIONS[`runtime.${domain}.${method}`] = permission
   }
 }

--- a/tests/adapter-openclaw/runtime-cron.test.ts
+++ b/tests/adapter-openclaw/runtime-cron.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+describe('OpenClaw runtime cron adapter', () => {
+  let testDir: string
+  let originalOpenClawHome: string | undefined
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'bakin-openclaw-cron-test-'))
+    originalOpenClawHome = process.env.OPENCLAW_HOME
+    process.env.OPENCLAW_HOME = testDir
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (originalOpenClawHome === undefined) delete process.env.OPENCLAW_HOME
+    else process.env.OPENCLAW_HOME = originalOpenClawHome
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('creates Bakin schedule cron jobs as OpenClaw main-session system events', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await runtime.cron.create({
+      id: 'schedule-1',
+      name: 'Schedule One',
+      schedule: '0 9 * * *',
+      command: 'bakin:schedule:schedule-1',
+      metadata: { bakinSchedule: true, tz: 'America/Denver' },
+    })
+
+    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(store.jobs[0]).toEqual(expect.objectContaining({
+      id: 'schedule-1',
+      sessionTarget: 'main',
+      wakeMode: 'now',
+      delivery: { mode: 'none' },
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:schedule-1' },
+      metadata: expect.objectContaining({ bakinSchedule: true }),
+    }))
+    expect(typeof store.jobs[0].createdAtMs).toBe('number')
+  })
+
+  it('captures and restores raw cron snapshots without dropping provider-specific fields', async () => {
+    mkdirSync(join(testDir, 'cron'), { recursive: true })
+    writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({
+      version: 1,
+      jobs: [{
+        id: 'native-1',
+        name: 'Native',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 8 * * *', tz: 'America/Denver', staggerMs: 30000 },
+        sessionTarget: 'isolated',
+        wakeMode: 'now',
+        payload: { kind: 'agentTurn', message: 'Do native work', model: 'openai/gpt-5.4' },
+        delivery: { mode: 'announce', channel: 'last' },
+        failureAlert: { enabled: true, after: 2 },
+        state: { nextRunAtMs: 123 },
+        createdAtMs: 100,
+        updatedAtMs: 100,
+      }],
+    }), 'utf-8')
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const raw = await runtime.cron.getRaw('native-1', 'test capture')
+
+    await runtime.cron.update('native-1', {
+      command: 'bakin:schedule:native-1',
+      metadata: { bakinSchedule: true },
+    })
+    const adoptedStore = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(adoptedStore.jobs[0]).toEqual(expect.objectContaining({
+      sessionTarget: 'main',
+      wakeMode: 'now',
+      delivery: { mode: 'none' },
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:native-1' },
+    }))
+
+    await runtime.cron.restoreRaw('native-1', raw, 'test restore')
+
+    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(store.jobs[0]).toEqual(raw)
+  })
+
+  it('converts metadata-only Bakin updates to system-event payloads', async () => {
+    mkdirSync(join(testDir, 'cron'), { recursive: true })
+    writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({
+      version: 1,
+      jobs: [{
+        id: 'native-2',
+        name: 'Native Two',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 8 * * *' },
+        sessionTarget: 'isolated',
+        payload: { kind: 'agentTurn', message: 'Original native command' },
+        delivery: { mode: 'announce', channel: 'last' },
+      }],
+    }), 'utf-8')
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await runtime.cron.update('native-2', {
+      metadata: { bakinSchedule: true },
+    })
+
+    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(store.jobs[0]).toEqual(expect.objectContaining({
+      sessionTarget: 'main',
+      wakeMode: 'now',
+      delivery: { mode: 'none' },
+      payload: { kind: 'systemEvent', text: 'Original native command' },
+      metadata: { bakinSchedule: true },
+    }))
+  })
+})

--- a/tests/plugins/schedule/health-checks.test.ts
+++ b/tests/plugins/schedule/health-checks.test.ts
@@ -140,8 +140,8 @@ describe('checkScheduleSync - orphan detection', () => {
   })
 })
 
-describe('checkScheduleSync - auto-adopt', () => {
-  it('auto-adopts orphaned runtime cron jobs into the sidecar without guessing the agent', async () => {
+describe('checkScheduleSync - auto-track', () => {
+  it('tracks orphaned runtime cron jobs in the sidecar without guessing the agent', async () => {
     mockAutoFix = true
     runtimeJobs = [makeCronJob({ id: 'orphan-1', name: 'rogue-cron' })]
     writeFileSync(sidecarPath, JSON.stringify({ version: 1, jobs: {} }))
@@ -149,11 +149,12 @@ describe('checkScheduleSync - auto-adopt', () => {
     const results = await checkScheduleSync(testDir, cronReader, 'boss')
     expect(results).toHaveLength(1)
     expect(results[0].status).toBe('fixed')
-    expect(results[0].message).toMatch(/Auto-adopted/)
+    expect(results[0].message).toMatch(/Tracked/)
 
     const updated = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
     expect(updated.jobs['orphan-1']).toBeDefined()
     expect(updated.jobs['orphan-1'].isBakinJob).toBe(false)
+    expect(updated.jobs['orphan-1'].source).toBe('runtime')
     expect(updated.jobs['orphan-1'].requireTriage).toBe(true)
     expect(updated.jobs['orphan-1'].displayName).toBe('rogue-cron')
     expect(updated.jobs['orphan-1'].owner).toBe('boss')

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -94,6 +94,9 @@ function fallbackMergeJob(job: { id: string; name: string; schedule: { value?: s
     name: job.name,
     schedule: { type: 'cron', value: job.schedule.value ?? job.schedule.expr ?? '* * * * *' },
     enabled: job.enabled,
+    source: sidecar?.source ?? (sidecar?.isBakinJob ? 'bakin' : 'runtime'),
+    canAdopt: !sidecar?.isBakinJob,
+    canRestoreNative: Boolean(sidecar?.isBakinJob && sidecar.originalRuntimeCron),
     isBakinJob: sidecar?.isBakinJob ?? false,
     displayName: sidecar?.displayName ?? job.name,
     description: sidecar?.description,
@@ -164,6 +167,24 @@ const mockCronListRuns = mock(async (jobId: string): Promise<CronRun[]> => {
   if (lastRunOverride && lastRunOverride.jobId === jobId) return [runEntryToCronRun(lastRunOverride)]
   return mockRuns.filter(run => run.jobId === jobId).map(runEntryToCronRun)
 })
+const mockCronGetRaw = mock(async (id: string): Promise<unknown | null> => {
+  return mockRuntimeCronJobs.find(job => job.id === id) ?? null
+})
+const mockCronRestoreRaw = mock(async (id: string, snapshot: unknown): Promise<CronJob> => {
+  const raw = snapshot as Partial<CronJob>
+  const restored: CronJob = {
+    id,
+    name: raw.name ?? id,
+    schedule: raw.schedule ?? '* * * * *',
+    command: raw.command ?? '',
+    enabled: raw.enabled ?? true,
+    metadata: raw.metadata,
+  }
+  const index = mockRuntimeCronJobs.findIndex(job => job.id === id)
+  if (index === -1) mockRuntimeCronJobs.push(restored)
+  else mockRuntimeCronJobs[index] = restored
+  return restored
+})
 const mockCronList = mock(async (): Promise<CronJob[]> => {
   const jobs = new Map<string, CronJob>()
   for (const job of mockMergedJobs.map(mergedJobToCronJob)) jobs.set(job.id, job)
@@ -184,6 +205,8 @@ mock.module('@bakin/core/adapters/runtime/testing', () => ({
       remove: mockCronRemove,
       runNow: mockCronRunNow,
       listRuns: mockCronListRuns,
+      getRaw: mockCronGetRaw,
+      restoreRaw: mockCronRestoreRaw,
     },
   }),
 }))
@@ -229,6 +252,7 @@ function makeMeta(overrides: Partial<BakinJobMeta> = {}): BakinJobMeta {
   return {
     jobId: 'job-123',
     isBakinJob: true,
+    source: 'bakin',
     displayName: 'Daily Report',
     agentId: 'basil',
     owner: 'main',
@@ -249,6 +273,9 @@ function makeMergedJob(overrides: Partial<MergedJob> = {}): MergedJob {
     name: 'Daily Report',
     schedule: { type: 'cron', value: '0 9 * * *' },
     enabled: true,
+    source: 'bakin',
+    canAdopt: false,
+    canRestoreNative: false,
     isBakinJob: true,
     displayName: 'Daily Report',
     agentId: 'basil',
@@ -564,6 +591,100 @@ describe('schedule routes', () => {
   })
 
   // -----------------------------------------------------------------------
+  // POST /:jobId/adopt and /:jobId/restore-native
+  // -----------------------------------------------------------------------
+  describe('POST /:jobId/adopt', () => {
+    it('adopts a native runtime cron into a Bakin schedule while preserving the raw snapshot', async () => {
+      mockRuntimeCronJobs.push({
+        id: 'native-1',
+        name: 'Native Cron',
+        schedule: '0 8 * * *',
+        command: 'Do the native thing',
+        enabled: true,
+        metadata: { existing: true },
+      })
+
+      const route = findRoute(plugin.routes, 'POST', '/:jobId/adopt')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'native-1' },
+        body: {
+          name: 'Adopted Cron',
+          schedule: '0 10 * * *',
+          agentId: 'pixel',
+          taskPrompt: 'Create the Bakin task',
+        },
+      })
+
+      expect(status).toBe(200)
+      expect(body.ok).toBe(true)
+      expect(mockCronGetRaw).toHaveBeenCalledWith('native-1', expect.stringContaining('schedule adopt'))
+      expect(mockCronUpdate).toHaveBeenCalledWith('native-1', expect.objectContaining({
+        name: 'Adopted Cron',
+        schedule: '0 10 * * *',
+        command: 'bakin:schedule:native-1',
+        metadata: expect.objectContaining({ bakinSchedule: true, adoptedByBakin: true }),
+      }))
+
+      const meta = getJob('native-1')
+      expect(meta!.isBakinJob).toBe(true)
+      expect(meta!.source).toBe('adopted')
+      expect(meta!.agentId).toBe('pixel')
+      expect(meta!.taskPrompt).toBe('Create the Bakin task')
+      expect(meta!.originalRuntimeCron?.snapshot).toEqual(expect.objectContaining({ id: 'native-1', command: 'Do the native thing' }))
+    })
+
+    it('rejects adopting a job that is already managed by Bakin', async () => {
+      upsertJob(makeMeta({ jobId: 'already-bakin' }))
+      mockRuntimeCronJobs.push({ id: 'already-bakin', name: 'Bakin', schedule: '0 9 * * *', command: 'run', enabled: true })
+
+      const route = findRoute(plugin.routes, 'POST', '/:jobId/adopt')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'already-bakin' },
+        body: {},
+      })
+
+      expect(status).toBe(409)
+      expect(body.error).toContain('already managed')
+    })
+  })
+
+  describe('POST /:jobId/restore-native', () => {
+    it('restores an adopted job back to its original runtime cron snapshot', async () => {
+      upsertJob(makeMeta({
+        jobId: 'native-restore',
+        source: 'adopted',
+        originalRuntimeCron: {
+          provider: 'openclaw',
+          capturedAt: '2026-03-30T00:00:00Z',
+          snapshot: {
+            id: 'native-restore',
+            name: 'Original Cron',
+            schedule: '0 7 * * *',
+            command: 'Original command',
+            enabled: true,
+          },
+        },
+      }))
+
+      const route = findRoute(plugin.routes, 'POST', '/:jobId/restore-native')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'native-restore' },
+        body: {},
+      })
+
+      expect(status).toBe(200)
+      expect(body.ok).toBe(true)
+      expect(mockCronRestoreRaw).toHaveBeenCalledWith('native-restore', expect.objectContaining({ command: 'Original command' }), expect.stringContaining('schedule restore'))
+
+      const meta = getJob('native-restore')
+      expect(meta!.isBakinJob).toBe(false)
+      expect(meta!.source).toBe('runtime')
+      expect(meta!.displayName).toBe('Original Cron')
+      expect(meta!.originalRuntimeCron).toBeUndefined()
+    })
+  })
+
+  // -----------------------------------------------------------------------
   // DELETE /:jobId — delete a job
   // -----------------------------------------------------------------------
   describe('DELETE /:jobId', () => {
@@ -755,6 +876,7 @@ describe('schedule routes', () => {
   // -----------------------------------------------------------------------
   describe('POST /:jobId/run', () => {
     it('triggers an immediate run via runtime cron', async () => {
+      mockRuntimeCronJobs.push({ id: 'job-run', name: 'Run', schedule: '0 9 * * *', command: 'run', enabled: true })
       const route = findRoute(plugin.routes, 'POST', '/:jobId/run')!
       expect(route).toBeDefined()
 
@@ -768,6 +890,24 @@ describe('schedule routes', () => {
       expect(mockCronRunNow).toHaveBeenCalledWith('job-run')
     })
 
+    it('creates a Bakin task for a successful Bakin-owned run-now result once', async () => {
+      upsertJob(makeMeta({ jobId: 'job-run-bakin', displayName: 'Run Bakin', taskPrompt: 'Do it' }))
+      mockRuntimeCronJobs.push({ id: 'job-run-bakin', name: 'Run Bakin', schedule: '0 9 * * *', command: 'run', enabled: true })
+      const route = findRoute(plugin.routes, 'POST', '/:jobId/run')!
+
+      await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'job-run-bakin' },
+        body: {},
+      })
+      await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'job-run-bakin' },
+        body: {},
+      })
+
+      expect(mockCreateTask).toHaveBeenCalledTimes(1)
+      expect(getJob('job-run-bakin')!.processedRunIds).toContain('run-now')
+    })
+
     it('returns 400 when jobId is missing', async () => {
       const route = findRoute(plugin.routes, 'POST', '/:jobId/run')!
       const { status, body } = await callRoute(route, plugin.ctx, {
@@ -778,6 +918,7 @@ describe('schedule routes', () => {
     })
 
     it('reads jobId from body when not in searchParams', async () => {
+      mockRuntimeCronJobs.push({ id: 'job-from-body', name: 'Run', schedule: '0 9 * * *', command: 'run', enabled: true })
       const route = findRoute(plugin.routes, 'POST', '/:jobId/run')!
       const { status } = await callRoute(route, plugin.ctx, {
         body: { jobId: 'job-from-body' },
@@ -787,6 +928,7 @@ describe('schedule routes', () => {
     })
 
     it('audits and logs the run_now action', async () => {
+      mockRuntimeCronJobs.push({ id: 'job-audit-run', name: 'Run', schedule: '0 9 * * *', command: 'run', enabled: true })
       const route = findRoute(plugin.routes, 'POST', '/:jobId/run')!
       await callRoute(route, plugin.ctx, {
         searchParams: { jobId: 'job-audit-run' },
@@ -1286,6 +1428,7 @@ describe('schedule exec tools', () => {
   describe('bakin_exec_schedule_run_now', () => {
     it('triggers runtime cron runNow', async () => {
       upsertJob(makeMeta({ jobId: 'job-rn' }))
+      mockRuntimeCronJobs.push({ id: 'job-rn', name: 'Run', schedule: '0 9 * * *', command: 'run', enabled: true })
 
       const tool = findTool(plugin.execTools, 'bakin_exec_schedule_run_now')!
       expect(tool).toBeDefined()
@@ -1299,6 +1442,7 @@ describe('schedule exec tools', () => {
 
     it('audits and logs the run', async () => {
       upsertJob(makeMeta({ jobId: 'job-rn-audit', displayName: 'Audit Run' }))
+      mockRuntimeCronJobs.push({ id: 'job-rn-audit', name: 'Audit Run', schedule: '0 9 * * *', command: 'run', enabled: true })
 
       const tool = findTool(plugin.execTools, 'bakin_exec_schedule_run_now')!
       await callTool(tool, { jobId: 'job-rn-audit' })


### PR DESCRIPTION
## Summary

Closes #92.

This replaces the dead webhook-caller assumption with Bakin-side runtime cron run reconciliation:

- Bakin-created schedules now register as OpenClaw main-session system events with `delivery: none` and Bakin ownership metadata.
- The schedule plugin polls runtime cron run history and creates Bakin tasks exactly once per successful run.
- Startup backfill is controlled by `reconcileLookbackHours` with a default 24-hour window, 0 to disable, and a 168-hour cap.
- Runtime-only/native cron jobs remain visible and controllable in Schedule, but they do not create Bakin tasks unless explicitly adopted.
- Native crons can be adopted into Bakin and restored back to their preserved raw runtime snapshot.
- The adapter contract now exposes reason-gated raw cron capture/restore for provider-owned cron data.
- Schedule UI now clearly labels `Runtime cron`, `Bakin schedule`, and `Adopted`, with adopt/restore actions.
- Schedule docs and tests cover the new ownership model, idempotency, adoption, restore, and OpenClaw cron shape.

## Verification

- `bun test --isolate tests/plugins/schedule/routes.test.ts tests/plugins/schedule/jobs-reader.test.ts tests/plugins/schedule/health-checks.test.ts tests/plugins/schedule/bridge.test.ts tests/adapter-openclaw/runtime-cron.test.ts`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- `bun test --isolate`