### PR TITLE
fix: apply plugin runtime skills during upgrade

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -275,14 +275,18 @@ lockfile entry to determine source type:
      `{ awaitingConsent: true, newPermissions }` WITHOUT mutating disk
      or lockfile.
   7. Force-push detection via `git merge-base --is-ancestor` then
-     `git merge --ff-only`. Build. Write lockfile.
+     `git merge --ff-only`. Build. Project the upgraded plugin's
+     `defaults/runtime-skills/` assets into the runtime skill store.
+     Unexpected asset install errors fail the upgrade; `.userEdited`
+     skills are skipped and reported. Write lockfile.
 
 - **local**: re-resolve recorded source path; error if missing.
   Compute deterministic source-tree sha (skip `node_modules`/`dist`/
   `.git`, content + path only — no mtimes). No-op if unchanged.
   Read source manifest directly (no copy yet), assert manifest.id
   stable, compute permission diff, run consent gate. Only then wipe +
-  cpSync + rebuild + write lockfile.
+  cpSync + rebuild + project plugin runtime-skill assets + write
+  lockfile.
 
 Permission widening: if the new manifest declares permissions not in
 the lockfile entry AND `--yes` is unset, return
@@ -290,9 +294,13 @@ the lockfile entry AND `--yes` is unset, return
 the lockfile. CLI runs the upgrade prompt; on accept, recursively
 re-invokes with `yes: true` to commit.
 
-Both branches read the manifest BEFORE any disk mutation so a
-declined upgrade leaves the plugin dir + lockfile exactly as they
-were.
+All upgrade branches read the target manifest BEFORE committed disk
+mutation so a declined upgrade leaves the plugin dir + lockfile
+exactly as they were.
+
+Committed upgrades return a `pluginAssets` report with installed,
+unchanged, and `.userEdited`-skipped runtime skills. No-op and
+awaiting-consent responses do not project assets.
 
 ### Upgrade-available detection — `bakin plugins list --check`
 

--- a/.claude/knowledge/workflows-plugin.md
+++ b/.claude/knowledge/workflows-plugin.md
@@ -244,9 +244,12 @@ Drift rules:
 ```bash
 bakin install plugin-assets [--yes]    # apply pending installs
 bakin check plugin-assets              # report drift, never write
+bakin plugins upgrade <id>             # also reapplies that plugin's runtime skills
 ```
 
-Both are wired through `cmdOnboardingInstallSingle` / `cmdOnboardingCheckSingle` in `cli/bakin.ts`. `pluginAssetsComponent` is also part of `COMPONENT_ORDER` in `src/core/onboarding/index.ts`, so `bakin onboard --yes` covers it as a side effect on a fresh machine.
+The install/check commands are wired through `cmdOnboardingInstallSingle` / `cmdOnboardingCheckSingle` in `cli/bakin.ts`. `pluginAssetsComponent` is also part of `COMPONENT_ORDER` in `src/core/onboarding/index.ts`, so `bakin onboard --yes` covers it as a side effect on a fresh machine.
+
+The plugin upgrade flow calls `installPluginAssets([{ id, path }])` after a committed rebuild and before marking the upgrade complete in the lockfile. Unexpected asset install failures fail the upgrade response. `.userEdited` runtime skills remain protected and are reported as skipped.
 
 ### Doctor Surface
 
@@ -295,7 +298,7 @@ Same non-negotiable rules as the rest of the codebase:
 
 Tracked as separate GitHub issues:
 
-- **2C — Plugin distribution**: `bakin plugin install <name>` from a registry/git, signature verification, automatic `plugin-assets install` after upgrade.
+- **2C — Plugin distribution**: `bakin plugin install <name>` from a registry/git and signature verification.
 - **2D — Skill rebase UX**: replace `.userEdited` warn-and-skip with 3-way merge and a UI for resolving conflicts.
 
 Phases 2A (plugin-registered node types) and 2B (visual canvas editor) shipped together — see the Node-Type Registry and Canvas Editor sections above and `.claude/specs/workflows-phase-2-plugin-nodes-and-canvas.md` for the original spec.

--- a/packages/host/src/api/plugins/upgrade.ts
+++ b/packages/host/src/api/plugins/upgrade.ts
@@ -7,7 +7,7 @@
  * Body: { pluginId: string, yes?: boolean }
  *
  * Response shape:
- *   { ok: true, id, before, after, noop, awaitingConsent, newPermissions }
+ *   { ok: true, id, before, after, noop, awaitingConsent, newPermissions, pluginAssets? }
  *   { ok: false, error: string, core?: boolean }    on refusal/4xx
  *
  * The upgraded plugin is activated immediately after a successful rebuild.

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -320,6 +320,11 @@ async function cmdPluginsUpgrade(pluginId: string, opts: { yes: boolean }): Prom
       newPermissions?: string[]
       before?: { version: string; commitSha: string }
       after?: { version: string; commitSha: string }
+      pluginAssets?: {
+        installed?: Array<{ pluginId: string; name: string }>
+        unchanged?: Array<{ pluginId: string; name: string }>
+        skipped?: Array<{ pluginId: string; name: string; reason: string }>
+      }
     }>('/api/plugins/upgrade', {
       method: 'POST',
       body: JSON.stringify({ pluginId, yes: opts.yes }),
@@ -359,6 +364,12 @@ async function cmdPluginsUpgrade(pluginId: string, opts: { yes: boolean }): Prom
     const toSha = (res.after?.commitSha ?? '').slice(0, 8)
     const shaPart = fromSha && toSha ? ` (sha ${fromSha}...${toSha})` : ''
     console.log(`Upgraded ${pluginId} v${fromV} → v${toV}${shaPart} and activated it.`)
+    const installedAssets = res.pluginAssets?.installed?.length ?? 0
+    const skippedAssets = res.pluginAssets?.skipped?.length ?? 0
+    if (installedAssets > 0 || skippedAssets > 0) {
+      const skippedPart = skippedAssets > 0 ? `, ${skippedAssets} user-edited skipped` : ''
+      console.log(`  Runtime skills: ${installedAssets} applied${skippedPart}`)
+    }
     return 0
   } catch (err) {
     console.error(`Upgrade failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/core/plugins/upgrade.ts
+++ b/src/core/plugins/upgrade.ts
@@ -30,7 +30,11 @@ import {
 } from '@bakin/core/plugins/lockfile'
 import { parseManifestPermissions, type Permission } from '@bakin/core/plugins/permissions'
 import { parseGithubSource } from '@bakin/core/plugins/source'
-import { findSkillsForPlugin } from '@/core/onboarding/plugin-assets'
+import {
+  findSkillsForPlugin,
+  installPluginAssets,
+  type InstallReport,
+} from '@/core/onboarding/plugin-assets'
 import { buildUserPlugin } from '../../../packages/host/src/plugin-host/user-plugin-builder'
 
 const log = createLogger('plugin-upgrade')
@@ -55,6 +59,8 @@ export interface UpgradeResult {
    * the user accepts.
    */
   awaitingConsent: boolean
+  /** Runtime skills projected from defaults/runtime-skills during a committed upgrade. */
+  pluginAssets?: InstallReport
 }
 
 /** Tag for refusal errors so the API layer can map them to HTTP 400. */
@@ -211,6 +217,22 @@ function manifestVersion(manifest: Record<string, unknown>, fallback: string): s
 function diffNewPermissions(prev: string[], next: string[]): string[] {
   const prevSet = new Set(prev)
   return next.filter(p => !prevSet.has(p))
+}
+
+async function installUpgradedPluginAssets(
+  id: string,
+  pluginDir: string,
+): Promise<{ installedSkills: string[]; pluginAssets: InstallReport }> {
+  const installedSkills = findSkillsForPlugin({ id, path: pluginDir }).map(s => s.name).sort()
+  if (installedSkills.length === 0) {
+    return {
+      installedSkills,
+      pluginAssets: { installed: [], unchanged: [], skipped: [] },
+    }
+  }
+
+  const pluginAssets = await installPluginAssets([{ id, path: pluginDir }])
+  return { installedSkills, pluginAssets }
 }
 
 // ─── Upgrade-available detection (C5) ────────────────────────────────────────
@@ -498,7 +520,7 @@ async function upgradeGithub(
 
   await buildUserPlugin(pluginDir)
 
-  const installedSkills = findSkillsForPlugin({ id, path: pluginDir }).map(s => s.name)
+  const assets = await installUpgradedPluginAssets(id, pluginDir)
 
   const updated = updatePlugin(readPluginLockfile(), id, {
     upgradedAt: new Date().toISOString(),
@@ -506,7 +528,7 @@ async function upgradeGithub(
     commitSha: remoteSha,
     manifestSha,
     permissions: newPerms,
-    installedSkills,
+    installedSkills: assets.installedSkills,
   })
   writePluginLockfile(updated)
 
@@ -517,6 +539,7 @@ async function upgradeGithub(
     noop: false,
     newPermissions: widened,
     awaitingConsent: false,
+    pluginAssets: assets.pluginAssets,
   }
 }
 
@@ -612,7 +635,7 @@ async function upgradeGithubSubpath(
 
     await buildUserPlugin(pluginDir)
 
-    const installedSkills = findSkillsForPlugin({ id, path: pluginDir }).map(s => s.name)
+    const assets = await installUpgradedPluginAssets(id, pluginDir)
 
     const updated = updatePlugin(readPluginLockfile(), id, {
       upgradedAt: new Date().toISOString(),
@@ -620,7 +643,7 @@ async function upgradeGithubSubpath(
       commitSha: remoteSha,
       manifestSha,
       permissions: newPerms,
-      installedSkills,
+      installedSkills: assets.installedSkills,
     })
     writePluginLockfile(updated)
 
@@ -631,6 +654,7 @@ async function upgradeGithubSubpath(
       noop: false,
       newPermissions: widened,
       awaitingConsent: false,
+      pluginAssets: assets.pluginAssets,
     }
   } finally {
     rmSync(stagingDir, { recursive: true, force: true })
@@ -692,7 +716,7 @@ async function upgradeLocal(
 
   await buildUserPlugin(pluginDir)
 
-  const installedSkills = findSkillsForPlugin({ id, path: pluginDir }).map(s => s.name)
+  const assets = await installUpgradedPluginAssets(id, pluginDir)
 
   const updated = updatePlugin(readPluginLockfile(), id, {
     upgradedAt: new Date().toISOString(),
@@ -700,7 +724,7 @@ async function upgradeLocal(
     manifestSha,
     permissions: newPerms,
     sourceTreeSha: newTreeSha,
-    installedSkills,
+    installedSkills: assets.installedSkills,
   })
   writePluginLockfile(updated)
 
@@ -711,5 +735,6 @@ async function upgradeLocal(
     noop: false,
     newPermissions: widened,
     awaitingConsent: false,
+    pluginAssets: assets.pluginAssets,
   }
 }

--- a/tests/plugins/lifecycle/upgrade-smoke.test.ts
+++ b/tests/plugins/lifecycle/upgrade-smoke.test.ts
@@ -7,14 +7,17 @@
  * with C10's `upgrade-flow.integration.test.ts`.
  */
 import { describe, it, expect, afterAll, beforeEach, mock } from 'bun:test'
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { randomUUID } from 'crypto'
+import { installFilesystemRuntimeAppServices } from '../../helpers/runtime-app-services'
+import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
 
 const testDir = join(tmpdir(), `bakin-test-upgrade-smoke-${Date.now()}-${randomUUID()}`)
+const openClawDir = join(testDir, 'openclaw')
 process.env.BAKIN_HOME = testDir
-process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+process.env.OPENCLAW_HOME = openClawDir
 
 mock.module('@/core/content-dir', () => ({
   getContentDir: () => testDir,
@@ -55,6 +58,7 @@ import {
   readPluginLockfile,
   writePluginLockfile,
 } from '../../../packages/core/src/plugins/lockfile'
+import { installPluginAssets } from '../../../src/core/onboarding/plugin-assets'
 import { computeSourceTreeSha, upgradePlugin, UpgradeRefusedError } from '../../../src/core/plugins/upgrade'
 
 afterAll(() => {
@@ -64,6 +68,8 @@ afterAll(() => {
 beforeEach(() => {
   rmSync(testDir, { recursive: true, force: true })
   mkdirSync(testDir, { recursive: true })
+  mkdirSync(openClawDir, { recursive: true })
+  installFilesystemRuntimeAppServices({ openClawDir })
 })
 
 const NOW = '2026-04-25T12:00:00Z'
@@ -76,6 +82,44 @@ function writeFixturePlugin(rootDir: string, opts: { id: string; version: string
     'utf-8',
   )
   writeFileSync(join(rootDir, 'index.ts'), `export default { id: '${opts.id}', activate() {} }`, 'utf-8')
+}
+
+function writeRuntimeSkill(pluginRoot: string, name: string, body: string): void {
+  const skillDir = join(pluginRoot, 'defaults', 'runtime-skills', name)
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), body, 'utf-8')
+}
+
+function readInstalledSkill(name: string): string {
+  return readFileSync(join(openClawDir, 'skills', name, 'SKILL.md'), 'utf-8')
+}
+
+const SKILL_V1 = `---
+name: upgrade-helper
+description: Upgrade helper v1
+---
+
+Use the original helper.
+`
+
+const SKILL_V2 = `---
+name: upgrade-helper
+description: Upgrade helper v2
+---
+
+Use the upgraded helper.
+`
+
+const FRESH_SKILL = `---
+name: fresh-helper
+description: Fresh helper
+---
+
+Use the newly shipped helper.
+`
+
+type TestGlobal = typeof globalThis & {
+  __bakinAppServices?: { runtime: AgentRuntimeAdapter }
 }
 
 function localEntry(opts: { id: string; sourcePath: string; version: string; sourceTreeSha?: string }): PluginLockEntry {
@@ -172,6 +216,102 @@ describe('upgradePlugin (local)', () => {
     expect(updated?.version).toBe('1.1.0')
     expect(updated?.sourceTreeSha).not.toBe(initialSha)
     expect(updated?.upgradedAt).toBeTruthy()
+  })
+
+  it('installs changed and new runtime skills from the upgraded local plugin', async () => {
+    const sourcePath = join(testDir, 'src-assets')
+    const pluginDir = join(testDir, 'plugins', 'asset-plugin')
+    writeFixturePlugin(sourcePath, { id: 'asset-plugin', version: '1.0.0' })
+    writeRuntimeSkill(sourcePath, 'upgrade-helper', SKILL_V1)
+    writeFixturePlugin(pluginDir, { id: 'asset-plugin', version: '1.0.0' })
+    writeRuntimeSkill(pluginDir, 'upgrade-helper', SKILL_V1)
+
+    const initialSha = computeSourceTreeSha(sourcePath)
+    writePluginLockfile(addPlugin(readPluginLockfile(), 'asset-plugin', localEntry({
+      id: 'asset-plugin',
+      sourcePath,
+      version: '1.0.0',
+      sourceTreeSha: initialSha,
+    })))
+    await installPluginAssets([{ id: 'asset-plugin', path: pluginDir }])
+
+    writeFixturePlugin(sourcePath, { id: 'asset-plugin', version: '1.1.0' })
+    writeRuntimeSkill(sourcePath, 'upgrade-helper', SKILL_V2)
+    writeRuntimeSkill(sourcePath, 'fresh-helper', FRESH_SKILL)
+
+    const result = await upgradePlugin('asset-plugin')
+
+    expect(result.noop).toBe(false)
+    expect(readInstalledSkill('upgrade-helper')).toBe(SKILL_V2)
+    expect(readInstalledSkill('fresh-helper')).toBe(FRESH_SKILL)
+    expect(result.pluginAssets?.installed.map((s) => s.name).sort()).toEqual(['fresh-helper', 'upgrade-helper'])
+    expect(result.pluginAssets?.skipped).toEqual([])
+    expect(readPluginLockfile().plugins['asset-plugin']?.installedSkills?.sort()).toEqual([
+      'fresh-helper',
+      'upgrade-helper',
+    ])
+  })
+
+  it('reports and preserves user-edited runtime skills during local plugin upgrade', async () => {
+    const sourcePath = join(testDir, 'src-user-edited')
+    const pluginDir = join(testDir, 'plugins', 'locked-plugin')
+    writeFixturePlugin(sourcePath, { id: 'locked-plugin', version: '1.0.0' })
+    writeRuntimeSkill(sourcePath, 'upgrade-helper', SKILL_V1)
+    writeFixturePlugin(pluginDir, { id: 'locked-plugin', version: '1.0.0' })
+    writeRuntimeSkill(pluginDir, 'upgrade-helper', SKILL_V1)
+
+    const initialSha = computeSourceTreeSha(sourcePath)
+    writePluginLockfile(addPlugin(readPluginLockfile(), 'locked-plugin', localEntry({
+      id: 'locked-plugin',
+      sourcePath,
+      version: '1.0.0',
+      sourceTreeSha: initialSha,
+    })))
+    await installPluginAssets([{ id: 'locked-plugin', path: pluginDir }])
+    writeFileSync(join(openClawDir, 'skills', 'upgrade-helper', '.userEdited'), '', 'utf-8')
+
+    writeFixturePlugin(sourcePath, { id: 'locked-plugin', version: '1.1.0' })
+    writeRuntimeSkill(sourcePath, 'upgrade-helper', SKILL_V2)
+
+    const result = await upgradePlugin('locked-plugin')
+
+    expect(result.noop).toBe(false)
+    expect(readInstalledSkill('upgrade-helper')).toBe(SKILL_V1)
+    expect(result.pluginAssets?.installed).toEqual([])
+    expect(result.pluginAssets?.skipped).toEqual([
+      { pluginId: 'locked-plugin', name: 'upgrade-helper', reason: 'userEdited' },
+    ])
+  })
+
+  it('fails loud and leaves lockfile upgrade markers unchanged when runtime skill install fails', async () => {
+    const sourcePath = join(testDir, 'src-install-fails')
+    const pluginDir = join(testDir, 'plugins', 'fail-assets')
+    writeFixturePlugin(sourcePath, { id: 'fail-assets', version: '1.0.0' })
+    writeFixturePlugin(pluginDir, { id: 'fail-assets', version: '1.0.0' })
+
+    const initialSha = computeSourceTreeSha(sourcePath)
+    writePluginLockfile(addPlugin(readPluginLockfile(), 'fail-assets', localEntry({
+      id: 'fail-assets',
+      sourcePath,
+      version: '1.0.0',
+      sourceTreeSha: initialSha,
+    })))
+
+    writeFixturePlugin(sourcePath, { id: 'fail-assets', version: '1.1.0' })
+    writeRuntimeSkill(sourcePath, 'upgrade-helper', SKILL_V2)
+
+    const services = (globalThis as TestGlobal).__bakinAppServices
+    if (!services) throw new Error('test app services not installed')
+    services.runtime.skills.write = async () => {
+      throw new Error('runtime store unavailable')
+    }
+
+    await expect(upgradePlugin('fail-assets')).rejects.toThrow(/runtime store unavailable/)
+
+    const lockEntry = readPluginLockfile().plugins['fail-assets']
+    expect(lockEntry?.version).toBe('1.0.0')
+    expect(lockEntry?.sourceTreeSha).toBe(initialSha)
+    expect(lockEntry?.upgradedAt).toBeUndefined()
   })
 
   it('errors when no lockfile entry exists for the id', async () => {


### PR DESCRIPTION
## Summary
- run installPluginAssets for committed GitHub, GitHub-subpath, and local plugin upgrades before upgrade lockfile markers advance
- return pluginAssets in the upgrade result and print a concise CLI runtime-skill summary
- document the lifecycle behavior and add regression coverage for changed/new skills, .userEdited skips, and fail-loud install errors

## Review
- Self-review completed across correctness, readability, architecture, security, and performance.
- Finding addressed before opening: sorted installedSkills for deterministic lockfile output.
- Remaining risk: upgrade still does not remove runtime skills that a newer plugin version stops shipping; that is out of scope for #216 and belongs with lifecycle/Workshop work.

## Tests
- bun test --isolate tests/core/onboarding/plugin-assets.test.ts tests/plugins/lifecycle/upgrade-smoke.test.ts tests/plugins/lifecycle/upgrade-flow.integration.test.ts tests/plugins/lifecycle/upgrade-decline.test.ts
- bun run typecheck
- bun run lint
- git diff --check

Fixes #216