### PR TITLE
Expose runtime cron tool allowlists in Schedule

### DIFF
--- a/.claude/knowledge/adapter-architecture.md
+++ b/.claude/knowledge/adapter-architecture.md
@@ -135,6 +135,14 @@ Channel operations go through `runtime.channels.*`. Cron operations go through
 `runtime.cron.*`. Plugin notification channel definitions still belong to the
 Bakin workflow/channel registry; provider delivery is adapter-backed.
 
+Cron adapter policy fields should be normalized at the runtime boundary. For
+OpenClaw, native isolated agent-turn cron tool allowlists live on
+`payload.toolsAllow`; the adapter exposes that as `CronJob.toolsAllow`. Schedule
+can display or audit that policy, but Bakin-owned schedules still use runtime
+cron as a timer and create Bakin tasks through the schedule reconciler. Hard
+scoping of `bakin_exec_*` MCP tools is a separate MCP routing-layer concern, not
+a runtime cron concern.
+
 ## Boundary Enforcement
 
 Run:

--- a/docs/src/content/docs/using/schedule.md
+++ b/docs/src/content/docs/using/schedule.md
@@ -39,6 +39,14 @@ Same menu lives in the detail drawer for jobs you've already opened.
 
 The detail drawer's `History` tab lists past fires with timestamps, success/failure, and the task that resulted. Useful when scheduled work looks stale or duplicated.
 
+### Cron tool allowlists
+
+Runtime-native cron jobs may also show a `Cron tools` field. That comes from the runtime adapter's cron allowlist, such as OpenClaw's `--tools` / `payload.toolsAllow` policy for isolated agent-turn cron jobs.
+
+If a runtime-native or legacy cron job has no allowlist, Schedule flags it as missing cron tools. Treat that as an audit prompt, not an automatic fix: choose the smallest tool set the native job needs before changing the runtime cron.
+
+Bakin-owned schedules are different. They use runtime cron as a timer, then create Bakin tasks. The eventual agent task's MCP permissions are not controlled by cron `toolsAllow`; that belongs to Bakin MCP tool scoping.
+
 ## How it works
 
 Schedule splits ownership: the runtime owns the cron, Bakin owns everything around it.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -9,12 +9,14 @@ import type {
   ChannelInfo,
   CronJob,
   CronRun,
+  CreateCronJobInput,
   CreateRuntimeAgentInput,
   RuntimeAgent,
   RuntimeAvailableModel,
   RuntimeMetadata,
   RuntimeMemorySearchResult,
   RuntimeSkill,
+  UpdateCronJobInput,
   WorkspaceFile,
 } from '@bakin/core/adapters/runtime'
 import type { AdapterHealthCheckDefinition, AdapterInitOpts, AdapterLogger } from '@bakin/core/adapters/shared'
@@ -104,7 +106,7 @@ interface OpenClawCronStoreJob {
   sessionTarget?: string
   wakeMode?: string
   delivery?: { mode?: string; url?: string; to?: string; token?: string; channel?: string; threadId?: string; accountId?: string; bestEffort?: boolean; failureDestination?: unknown }
-  payload?: { kind?: string; message?: string; text?: string } & Record<string, unknown>
+  payload?: { kind?: string; message?: string; text?: string; toolsAllow?: string[] } & Record<string, unknown>
   failureAlert?: unknown
   state?: Record<string, unknown>
   createdAt?: string
@@ -734,7 +736,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       const job = readCronJobs().find((entry) => entry.id === id)
       return job ? cronStoreJobToRuntime(job) : null
     },
-    create: async (input: { id?: string; name: string; schedule: string; command: string; enabled?: boolean; metadata?: RuntimeMetadata }): Promise<CronJob> => {
+    create: async (input: CreateCronJobInput): Promise<CronJob> => {
       const store = readCronStore()
       const jobs = store.jobs ?? []
       const id = input.id ?? uniqueCronId(input.name, jobs)
@@ -742,6 +744,9 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       const nowMs = Date.now()
       const now = new Date(nowMs).toISOString()
       const bakinSchedule = isBakinScheduleMetadata(input.metadata)
+      const payload = bakinSchedule
+        ? { kind: 'systemEvent', text: input.command }
+        : withCronToolsAllow({ kind: 'agentTurn', message: input.command }, input.toolsAllow)
       const job: OpenClawCronStoreJob = {
         id,
         name: input.name,
@@ -750,9 +755,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
         sessionTarget: bakinSchedule ? 'main' : 'isolated',
         wakeMode: 'now',
         delivery: cronDeliveryFromMetadata(input.metadata) ?? { mode: 'none' },
-        payload: bakinSchedule
-          ? { kind: 'systemEvent', text: input.command }
-          : { kind: 'agentTurn', message: input.command },
+        payload,
         createdAt: now,
         updatedAt: now,
         createdAtMs: nowMs,
@@ -763,7 +766,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       writeCronStore({ ...store, jobs: [...jobs, job] })
       return cronStoreJobToRuntime(job)
     },
-    update: async (id: string, patch: { name?: string; schedule?: string; command?: string; enabled?: boolean; metadata?: RuntimeMetadata }): Promise<CronJob> => {
+    update: async (id: string, patch: UpdateCronJobInput): Promise<CronJob> => {
       const store = readCronStore()
       const jobs = store.jobs ?? []
       const index = jobs.findIndex((job) => job.id === id)
@@ -773,6 +776,9 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       const bakinSchedule = isBakinScheduleMetadata(metadata)
       const command = patch.command ?? cronStoreJobToRuntime(current).command
       const nowMs = Date.now()
+      const payload = bakinSchedule || patch.command !== undefined || patch.toolsAllow !== undefined
+        ? withCronToolsAllow(cronPayloadForCommand(command, current.payload, bakinSchedule), patch.toolsAllow)
+        : current.payload
       const next: OpenClawCronStoreJob = {
         ...current,
         name: patch.name ?? current.name,
@@ -783,9 +789,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
         delivery: bakinSchedule
           ? { mode: 'none' }
           : patch.metadata ? cronDeliveryFromMetadata(patch.metadata) ?? current.delivery ?? { mode: 'none' } : current.delivery,
-        payload: bakinSchedule || patch.command !== undefined
-          ? cronPayloadForCommand(command, current.payload, bakinSchedule)
-          : current.payload,
+        payload,
         metadata,
         updatedAt: new Date(nowMs).toISOString(),
         updatedAtMs: nowMs,
@@ -1212,6 +1216,7 @@ function cronStoreJobToRuntime(job: OpenClawCronStoreJob): CronJob {
         ? job.payload.text
         : '',
     enabled: job.enabled ?? true,
+    toolsAllow: normalizeCronToolsAllow(job.payload?.toolsAllow),
     metadata: job.metadata,
   }
 }
@@ -1234,6 +1239,32 @@ function cronPayloadForCommand(
     return { kind: 'systemEvent', text: command }
   }
   return { ...(current ?? {}), kind: 'agentTurn', message: command }
+}
+
+function withCronToolsAllow(
+  payload: OpenClawCronStoreJob['payload'],
+  toolsAllow: string[] | null | undefined,
+): OpenClawCronStoreJob['payload'] {
+  if (payload?.kind !== 'agentTurn' || toolsAllow === undefined) return payload
+  const next = { ...payload }
+  const normalized = normalizeCronToolsAllow(toolsAllow)
+  if (normalized) next.toolsAllow = normalized
+  else delete next.toolsAllow
+  return next
+}
+
+function normalizeCronToolsAllow(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const seen = new Set<string>()
+  const tools: string[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue
+    const tool = entry.trim()
+    if (!tool || seen.has(tool)) continue
+    seen.add(tool)
+    tools.push(tool)
+  }
+  return tools.length > 0 ? tools : undefined
 }
 
 function cronScheduleToString(schedule: OpenClawCronStoreJob['schedule']): string {

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -339,6 +339,7 @@ export interface CronJob {
   schedule: string
   command: string
   enabled: boolean
+  toolsAllow?: string[]
   metadata?: RuntimeMetadata
 }
 
@@ -358,10 +359,13 @@ export interface CreateCronJobInput {
   schedule: string
   command: string
   enabled?: boolean
+  toolsAllow?: string[]
   metadata?: RuntimeMetadata
 }
 
-export type UpdateCronJobInput = Partial<Omit<CreateCronJobInput, 'id'>>
+export type UpdateCronJobInput = Partial<Omit<CreateCronJobInput, 'id' | 'toolsAllow'>> & {
+  toolsAllow?: string[] | null
+}
 
 export interface RawCronSnapshot {
   provider: string

--- a/packages/core/src/adapters/runtime/testing.ts
+++ b/packages/core/src/adapters/runtime/testing.ts
@@ -135,6 +135,7 @@ export function createMockRuntimeAdapter(
         schedule: input.schedule,
         command: input.command,
         enabled: input.enabled ?? true,
+        toolsAllow: input.toolsAllow,
         metadata: input.metadata,
       }),
       update: async (id, patch) => ({
@@ -143,6 +144,7 @@ export function createMockRuntimeAdapter(
         schedule: patch.schedule ?? '* * * * *',
         command: patch.command ?? '',
         enabled: patch.enabled ?? true,
+        toolsAllow: patch.toolsAllow === null ? undefined : patch.toolsAllow,
         metadata: patch.metadata,
       }),
       remove: async () => {},
@@ -166,6 +168,7 @@ export function createMockRuntimeAdapter(
           schedule: string | { expr?: string; value?: string }
           command: string
           payload: { message?: string; text?: string }
+          toolsAllow: string[]
           enabled: boolean
           metadata: Record<string, unknown>
         }> : {}
@@ -178,6 +181,7 @@ export function createMockRuntimeAdapter(
           schedule,
           command: raw.command ?? raw.payload?.message ?? raw.payload?.text ?? '',
           enabled: raw.enabled ?? true,
+          toolsAllow: raw.toolsAllow,
           metadata: raw.metadata,
         }
       },

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -334,6 +334,7 @@ export interface CronJob {
   schedule: string
   command: string
   enabled: boolean
+  toolsAllow?: string[]
   metadata?: Record<string, unknown>
 }
 
@@ -386,8 +387,8 @@ export interface AgentRuntimeAdapter {
   cron: {
     list(): Promise<CronJob[]>
     get(id: string): Promise<CronJob | null>
-    create(input: { id?: string; name: string; schedule: string; command: string; enabled?: boolean; metadata?: Record<string, unknown> }): Promise<CronJob>
-    update(id: string, patch: Partial<Omit<CronJob, 'id'>>): Promise<CronJob>
+    create(input: { id?: string; name: string; schedule: string; command: string; enabled?: boolean; toolsAllow?: string[]; metadata?: Record<string, unknown> }): Promise<CronJob>
+    update(id: string, patch: Partial<Omit<CronJob, 'id' | 'toolsAllow'>> & { toolsAllow?: string[] | null }): Promise<CronJob>
     remove(id: string): Promise<void>
     runNow(id: string): Promise<CronRun>
     listRuns(jobId: string): Promise<CronRun[]>

--- a/plugins/schedule/README.md
+++ b/plugins/schedule/README.md
@@ -50,6 +50,7 @@ The UI always works with "merged jobs" — a combination of runtime cron data an
 | Source | Fields |
 |--------|--------|
 | Runtime cron | `id`, `name`, `schedule` (type/value/tz), `enabled` |
+| Runtime cron policy | `toolsAllow`, `toolsAllowMissing` |
 | Sidecar | `source`, `agentId`, `owner`, `taskPrompt`, `taskTitle`, `workflowId`, `paused`, `pauseUntil`, `pauseReason`, `allowOverlap`, `maxFailures`, `consecutiveFailures`, `processedRunIds`, `originalRuntimeCron`, `createdAt` |
 | Computed | `humanSchedule`, `nextRun`, `lastRun` |
 
@@ -80,6 +81,8 @@ Calendar views respect each job's `createdAt` date — jobs don't render on days
 
 - **Job detail** (`job-drawer.tsx`): Shows job config, run history, pause controls. Actions menu (duplicate, delete) via `BakinDrawer` actions prop.
 - **Job form** (`job-form.tsx`): Create/edit/duplicate form with schedule input, agent select, advanced options (workflow, title template, overlap, max failures).
+
+Native or legacy runtime cron jobs can carry a runtime tool allowlist. When the runtime adapter reports `toolsAllow`, Schedule shows it in the detail drawer. When a non-Bakin runtime timer has no allowlist, Schedule marks it with a missing cron-tools warning so the operator can decide whether to repair the native cron policy.
 
 ### Schedule Input
 
@@ -145,6 +148,20 @@ When the reconciler or bridge processes a successful runtime run, the shared tas
 6. **Overlap?** — If `allowOverlap: false`, skip if the previous task is still active (todo/inProgress/review/blocked)
 7. **Track outcomes** — Check if last task succeeded (done/archived) or failed (blocked) to update failure counter
 8. **Create task** — Title from template, assign agent (unless `requireTriage`), attach workflow
+
+## Runtime Cron Tool Allowlists
+
+OpenClaw supports per-cron tool policy on native isolated agent-turn jobs through `payload.toolsAllow` (`openclaw cron add/edit --tools`). The OpenClaw runtime adapter maps that field to `CronJob.toolsAllow` so Schedule can display and audit it without shelling out to the provider CLI.
+
+Bakin-owned schedules are different: runtime cron acts as a timer and Bakin creates tasks after successful runs are reconciled. Those jobs do not rely on cron `toolsAllow` for the eventual task's MCP permissions. Hard scoping of `bakin_exec_*` MCP tools is a separate Bakin routing-layer concern tracked outside this plugin.
+
+Common native cron examples:
+
+| Job shape | Typical allowlist |
+|-----------|-------------------|
+| Posting-only reminder | `message` |
+| Script runner | `exec` |
+| Content/image job | `message,image_generate` when both are required |
 
 ## Settings
 

--- a/plugins/schedule/components/job-drawer.tsx
+++ b/plugins/schedule/components/job-drawer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Play, Pencil, Copy, Trash2, SkipForward, MoreHorizontal, Clock, Timer, Workflow, Terminal, CirclePlus, Undo2, Power } from 'lucide-react'
+import { Play, Pencil, Copy, Trash2, SkipForward, MoreHorizontal, Clock, Timer, Workflow, Terminal, CirclePlus, Undo2, Power, ShieldAlert, ShieldCheck } from 'lucide-react'
 import { BakinDrawer } from "@bakin/sdk/components"
 import { AgentAvatar } from "@bakin/sdk/components"
 import { Badge } from "@bakin/sdk/ui"
@@ -220,6 +220,17 @@ export function JobDrawer({
             <div className="rounded-lg bg-surface p-3 space-y-1">
               <div className="text-[11px] text-muted-foreground uppercase tracking-wider">Last Task</div>
               <div className="text-sm font-medium font-mono">{job.lastTaskId.slice(0, 8)}</div>
+            </div>
+          )}
+          {(job.toolsAllow?.length || job.toolsAllowMissing) && (
+            <div className="rounded-lg bg-surface p-3 space-y-1 col-span-2">
+              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground uppercase tracking-wider">
+                {job.toolsAllowMissing ? <ShieldAlert className="size-3 text-amber-400" /> : <ShieldCheck className="size-3 text-emerald-400" />}
+                Cron tools
+              </div>
+              <div className={job.toolsAllowMissing ? 'text-sm font-medium text-amber-400' : 'text-sm font-medium font-mono'}>
+                {job.toolsAllow?.length ? job.toolsAllow.join(', ') : 'Missing allowlist'}
+              </div>
             </div>
           )}
           <div className="rounded-lg bg-surface p-3 space-y-1 col-span-2">

--- a/plugins/schedule/components/job-row.tsx
+++ b/plugins/schedule/components/job-row.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { MoreHorizontal, Play, Pause, RotateCcw, Trash2, Pencil, Copy, SkipForward, CirclePlus, Undo2 } from 'lucide-react'
+import { MoreHorizontal, Play, Pause, RotateCcw, Trash2, Pencil, Copy, SkipForward, CirclePlus, Undo2, ShieldAlert } from 'lucide-react'
 import { TableRow, TableCell } from "@bakin/sdk/ui"
 import { Badge } from "@bakin/sdk/ui"
 import {
@@ -78,6 +78,12 @@ export function JobRow({
           <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
             {job.source === 'adopted' ? 'Adopted' : job.isBakinJob ? 'Bakin schedule' : 'Runtime cron'}
           </span>
+          {job.toolsAllowMissing && (
+            <span className="inline-flex items-center gap-1 text-[10px] text-amber-400">
+              <ShieldAlert className="size-3" />
+              Missing cron tools
+            </span>
+          )}
           {scoreInfo && (
             <span className="flex items-center gap-2 font-mono text-[10px] mt-0.5">
               <span className="text-amber-400">RRF {scoreInfo.score.toFixed(3)}</span>

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -857,6 +857,8 @@ const schedulePlugin: BakinPlugin = {
             paused: j.paused,
             isBakinJob: j.isBakinJob,
             lastTaskId: j.lastTaskId,
+            ...(j.toolsAllow?.length ? { toolsAllow: j.toolsAllow } : {}),
+            ...(j.toolsAllowMissing ? { toolsAllowMissing: true } : {}),
           })),
         }
       },

--- a/plugins/schedule/lib/jobs-reader.ts
+++ b/plugins/schedule/lib/jobs-reader.ts
@@ -15,6 +15,7 @@ type RuntimeCronReader = Pick<AgentRuntimeAdapter['cron'], 'list'>
 export function runtimeCronToScheduleJob(job: CronJob): RuntimeCronJobSnapshot {
   const tz = metadataString(job.metadata, 'tz')
   const scheduleType = metadataScheduleType(job.metadata)
+  const toolsAllow = normalizeToolsAllow(job.toolsAllow)
   return {
     id: job.id,
     name: job.name,
@@ -30,6 +31,8 @@ export function runtimeCronToScheduleJob(job: CronJob): RuntimeCronJobSnapshot {
       ? { mode: 'webhook', url: metadataString(job.metadata, 'webhookUrl') }
       : undefined,
     payload: { message: job.command },
+    toolsAllow,
+    toolsAllowMissing: !toolsAllow && !isBakinScheduleMetadata(job.metadata),
     createdAt: metadataString(job.metadata, 'createdAt'),
     updatedAt: metadataString(job.metadata, 'updatedAt'),
   }
@@ -89,6 +92,8 @@ export function mergeJob(
     workflowId: meta?.workflowId,
     taskPrompt: meta?.taskPrompt ?? orphanContext.prompt,
     taskTitle: meta?.taskTitle,
+    toolsAllow: job.toolsAllow,
+    toolsAllowMissing: job.toolsAllowMissing ?? false,
     paused: meta?.paused ?? false,
     pauseUntil: meta?.pauseUntil,
     pauseReason: meta?.pauseReason,
@@ -141,7 +146,28 @@ function metadataString(metadata: RuntimeMetadata | undefined, key: string): str
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
+function metadataBoolean(metadata: RuntimeMetadata | undefined, key: string): boolean {
+  return metadata?.[key] === true
+}
+
+function isBakinScheduleMetadata(metadata: RuntimeMetadata | undefined): boolean {
+  return metadataBoolean(metadata, 'bakinSchedule') || metadataBoolean(metadata, 'bakin.schedule')
+}
+
 function metadataScheduleType(metadata: RuntimeMetadata | undefined): RuntimeCronJobSnapshot['schedule']['type'] {
   const value = metadataString(metadata, 'scheduleType')
   return value === 'every' || value === 'at' ? value : 'cron'
+}
+
+function normalizeToolsAllow(value: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const seen = new Set<string>()
+  const tools = value
+    .map(tool => tool.trim())
+    .filter(tool => {
+      if (!tool || seen.has(tool)) return false
+      seen.add(tool)
+      return true
+    })
+  return tools.length > 0 ? tools : undefined
 }

--- a/plugins/schedule/types.ts
+++ b/plugins/schedule/types.ts
@@ -66,6 +66,8 @@ export interface RuntimeCronJobSnapshot {
     channel?: string
   }
   payload?: Record<string, unknown>
+  toolsAllow?: string[]
+  toolsAllowMissing?: boolean
   createdAt?: string
   updatedAt?: string
   createdAtMs?: number
@@ -102,6 +104,8 @@ export interface MergedJob {
   workflowId?: string
   taskPrompt?: string
   taskTitle?: string
+  toolsAllow?: string[]
+  toolsAllowMissing?: boolean
   paused: boolean
   pauseUntil?: string
   pauseReason?: string

--- a/src/hooks/use-schedule.ts
+++ b/src/hooks/use-schedule.ts
@@ -27,6 +27,8 @@ export interface ScheduleJob {
   workflowId?: string
   taskPrompt?: string
   taskTitle?: string
+  toolsAllow?: string[]
+  toolsAllowMissing?: boolean
   tz?: string
   lastTaskId?: string
   nextRun?: string

--- a/tests/adapter-openclaw/runtime-cron.test.ts
+++ b/tests/adapter-openclaw/runtime-cron.test.ts
@@ -44,6 +44,105 @@ describe('OpenClaw runtime cron adapter', () => {
     expect(typeof store.jobs[0].createdAtMs).toBe('number')
   })
 
+  it('persists toolsAllow on native isolated cron jobs and returns it from list/get', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await runtime.cron.create({
+      id: 'native-tools',
+      name: 'Native Tools',
+      schedule: '0 7 * * *',
+      command: 'Post the daily recipe',
+      toolsAllow: ['message', 'image_generate'],
+    })
+
+    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(store.jobs[0].payload).toEqual(expect.objectContaining({
+      kind: 'agentTurn',
+      message: 'Post the daily recipe',
+      toolsAllow: ['message', 'image_generate'],
+    }))
+
+    await expect(runtime.cron.get('native-tools')).resolves.toEqual(expect.objectContaining({
+      id: 'native-tools',
+      toolsAllow: ['message', 'image_generate'],
+    }))
+    await expect(runtime.cron.list()).resolves.toEqual([
+      expect.objectContaining({ id: 'native-tools', toolsAllow: ['message', 'image_generate'] }),
+    ])
+  })
+
+  it('updates and clears toolsAllow without dropping native cron payload fields', async () => {
+    mkdirSync(join(testDir, 'cron'), { recursive: true })
+    writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({
+      version: 1,
+      jobs: [{
+        id: 'native-update-tools',
+        name: 'Native Update Tools',
+        enabled: true,
+        schedule: { kind: 'cron', expr: '0 8 * * *' },
+        sessionTarget: 'isolated',
+        payload: {
+          kind: 'agentTurn',
+          message: 'Original native command',
+          model: 'openai/gpt-5.4',
+          toolsAllow: ['message'],
+        },
+        delivery: { mode: 'none' },
+      }],
+    }), 'utf-8')
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await runtime.cron.update('native-update-tools', { toolsAllow: ['message', 'exec'] })
+
+    const updatedStore = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(updatedStore.jobs[0].payload).toEqual(expect.objectContaining({
+      kind: 'agentTurn',
+      message: 'Original native command',
+      model: 'openai/gpt-5.4',
+      toolsAllow: ['message', 'exec'],
+    }))
+
+    await expect(runtime.cron.get('native-update-tools')).resolves.toEqual(expect.objectContaining({
+      toolsAllow: ['message', 'exec'],
+    }))
+
+    await runtime.cron.update('native-update-tools', { toolsAllow: null })
+
+    const clearedStore = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(clearedStore.jobs[0].payload).toEqual(expect.objectContaining({
+      kind: 'agentTurn',
+      message: 'Original native command',
+      model: 'openai/gpt-5.4',
+    }))
+    expect(clearedStore.jobs[0].payload.toolsAllow).toBeUndefined()
+    await expect(runtime.cron.get('native-update-tools')).resolves.toEqual(expect.objectContaining({
+      toolsAllow: undefined,
+    }))
+  })
+
+  it('does not attach toolsAllow to Bakin schedule system-event cron jobs', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await runtime.cron.create({
+      id: 'schedule-tools',
+      name: 'Schedule Tools',
+      schedule: '0 9 * * *',
+      command: 'bakin:schedule:schedule-tools',
+      metadata: { bakinSchedule: true },
+      toolsAllow: ['message'],
+    })
+
+    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
+    expect(store.jobs[0].payload).toEqual({ kind: 'systemEvent', text: 'bakin:schedule:schedule-tools' })
+    await expect(runtime.cron.get('schedule-tools')).resolves.toEqual(expect.objectContaining({
+      toolsAllow: undefined,
+    }))
+  })
+
   it('captures and restores raw cron snapshots without dropping provider-specific fields', async () => {
     mkdirSync(join(testDir, 'cron'), { recursive: true })
     writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({

--- a/tests/plugins/schedule/jobs-reader.test.ts
+++ b/tests/plugins/schedule/jobs-reader.test.ts
@@ -95,6 +95,7 @@ describe('schedule/jobs-reader', () => {
   describe('runtimeCronToScheduleJob', () => {
     it('normalizes runtime cron jobs for schedule merging', () => {
       const job = runtimeCronToScheduleJob(makeCronJob({
+        toolsAllow: ['message'],
         metadata: {
           tz: 'America/Denver',
           webhookUrl: 'http://localhost:3737/api/plugins/schedule/bridge',
@@ -110,12 +111,30 @@ describe('schedule/jobs-reader', () => {
       expect(job.payload?.message).toBe('Post a daily recipe')
       expect(job.delivery?.mode).toBe('webhook')
       expect(job.createdAt).toBe('2026-03-27T00:00:00Z')
+      expect(job.toolsAllow).toEqual(['message'])
+      expect(job.toolsAllowMissing).toBe(false)
+    })
+
+    it('flags non-Bakin runtime cron jobs that are missing a toolsAllow policy', () => {
+      const job = runtimeCronToScheduleJob(makeCronJob())
+
+      expect(job.toolsAllow).toBeUndefined()
+      expect(job.toolsAllowMissing).toBe(true)
+    })
+
+    it('does not flag Bakin schedule timer cron jobs without toolsAllow', () => {
+      const job = runtimeCronToScheduleJob(makeCronJob({
+        command: 'bakin:schedule:j1',
+        metadata: { bakinSchedule: true },
+      }))
+
+      expect(job.toolsAllowMissing).toBe(false)
     })
   })
 
   describe('mergeJob', () => {
     it('merges runtime job without sidecar entry', () => {
-      const job = makeRuntimeJob({ id: 'j1', name: 'Raw Job' })
+      const job = makeRuntimeJob({ id: 'j1', name: 'Raw Job', toolsAllowMissing: true })
       const merged = mergeJob(job, undefined, 'boss')
 
       expect(merged.id).toBe('j1')
@@ -125,6 +144,20 @@ describe('schedule/jobs-reader', () => {
       expect(merged.owner).toBe('boss')
       expect(merged.paused).toBe(false)
       expect(merged.humanSchedule).toBe('Daily at 9am')
+      expect(merged.toolsAllowMissing).toBe(true)
+    })
+
+    it('carries runtime cron toolsAllow into the merged job', () => {
+      const job = makeRuntimeJob({
+        id: 'j1',
+        name: 'Raw Job',
+        toolsAllow: ['message', 'exec'],
+        toolsAllowMissing: false,
+      })
+      const merged = mergeJob(job, undefined, defaultOwner)
+
+      expect(merged.toolsAllow).toEqual(['message', 'exec'])
+      expect(merged.toolsAllowMissing).toBe(false)
     })
 
     it('merges runtime job with sidecar entry', () => {

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -84,6 +84,7 @@ function mergedJobToCronJob(job: MergedJob): CronJob {
     schedule: job.schedule.value,
     command: job.taskPrompt || job.taskTitle || `bakin:schedule:${job.displayName || job.name || job.id}`,
     enabled: job.enabled,
+    toolsAllow: job.toolsAllow,
     metadata: { tz: job.tz, createdAt: job.createdAt },
   }
 }
@@ -148,7 +149,11 @@ const mockCronUpdate = mock(async (id: string, patch: UpdateCronJobInput): Promi
   const current = index === -1
     ? { id, name: id, schedule: '* * * * *', command: '', enabled: true }
     : mockRuntimeCronJobs[index]
-  const next = { ...current, ...patch }
+  const next = {
+    ...current,
+    ...patch,
+    toolsAllow: patch.toolsAllow === null ? undefined : patch.toolsAllow ?? current.toolsAllow,
+  }
   if (index === -1) mockRuntimeCronJobs.push(next)
   else mockRuntimeCronJobs[index] = next
   return next
@@ -178,6 +183,7 @@ const mockCronRestoreRaw = mock(async (id: string, snapshot: unknown): Promise<C
     schedule: raw.schedule ?? '* * * * *',
     command: raw.command ?? '',
     enabled: raw.enabled ?? true,
+    toolsAllow: raw.toolsAllow,
     metadata: raw.metadata,
   }
   const index = mockRuntimeCronJobs.findIndex(job => job.id === id)
@@ -370,6 +376,30 @@ describe('schedule routes', () => {
       expect(jobs).toHaveLength(2)
       expect(jobs[0].cron).toBe('0 9 * * *')
       expect(jobs[1].cron).toBeUndefined() // 'every' type has no cron field
+    })
+
+    it('returns cron tool allowlist audit fields for runtime jobs', async () => {
+      mockMergedJobs.push(makeMergedJob({
+        id: 'native-tools',
+        isBakinJob: false,
+        source: 'runtime',
+        toolsAllow: ['message'],
+        toolsAllowMissing: false,
+      }), makeMergedJob({
+        id: 'native-missing-tools',
+        isBakinJob: false,
+        source: 'runtime',
+        toolsAllowMissing: true,
+      }))
+
+      const route = findRoute(plugin.routes, 'GET', '/')!
+      const { status, body } = await callRoute(route, plugin.ctx)
+
+      expect(status).toBe(200)
+      const jobs = body.jobs as Array<Record<string, unknown>>
+      expect(jobs.find(job => job.id === 'native-tools')?.toolsAllow).toEqual(['message'])
+      expect(jobs.find(job => job.id === 'native-tools')?.toolsAllowMissing).toBe(false)
+      expect(jobs.find(job => job.id === 'native-missing-tools')?.toolsAllowMissing).toBe(true)
     })
   })
 
@@ -1116,6 +1146,27 @@ describe('schedule exec tools', () => {
         isBakinJob: true,
         lastTaskId: 'task-99',
       })
+    })
+
+    it('includes cron tool allowlist audit fields when present', async () => {
+      mockMergedJobs.push(makeMergedJob({
+        id: 'native-tools',
+        displayName: 'Native Tools',
+        isBakinJob: false,
+        toolsAllow: ['message'],
+      }), makeMergedJob({
+        id: 'native-missing-tools',
+        displayName: 'Native Missing Tools',
+        isBakinJob: false,
+        toolsAllowMissing: true,
+      }))
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_schedule_list')!
+      const result = await callTool(tool, {})
+
+      const jobs = result.jobs as Array<Record<string, unknown>>
+      expect(jobs.find(job => job.id === 'native-tools')?.toolsAllow).toEqual(['message'])
+      expect(jobs.find(job => job.id === 'native-missing-tools')?.toolsAllowMissing).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary
- Adds toolsAllow to the runtime cron contract and maps OpenClaw native agent-turn payload.toolsAllow through CronJob.toolsAllow.
- Surfaces Schedule audit fields and UI warnings for runtime cron jobs missing allowlists.
- Documents that cron toolsAllow is separate from Bakin MCP hard scoping, which is tracked in #218.

## Tests
- bun test --isolate tests/adapter-openclaw/runtime-cron.test.ts tests/plugins/schedule/jobs-reader.test.ts tests/plugins/schedule/routes.test.ts
- bun run typecheck
- bun run lint
- git diff --check
- bun test --isolate (3369 pass, 0 fail)

Refs #31.