### PR TITLE
Enforce MCP tool policies per agent package

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -252,12 +252,40 @@ These came up during spec/plan and the answers shape the system. From SPEC.md:
 4. **Adoption block scope** — adopting writes only the catalog block + lessons listed in `manifest.install.enableKnowledge`. All other lessons stay opt-in via UI/CLI toggle.
 5. **Update refresh of `defaultModel` / `dispatchableBy`** — only on fresh install. User controls models via the Models UI from then on.
 
+## MCP tool policy
+
+Agent-package `agent.allowedTools` is enforced by Bakin's MCP server, not by the
+runtime provider. `src/core/mcp-tool-policy.ts` reads the lockfile entry,
+loads the installed package's `bakin-package.json`, and resolves policy for the
+session agent:
+
+- No lockfile entry means an unmanaged legacy agent and remains unrestricted.
+- A managed package agent with no readable, non-empty `allowedTools` policy
+  fails closed.
+- An adopted package agent with `allowedTools` is scoped by that list; an adopted
+  package agent without a policy remains unrestricted until configured.
+- Allow entries are MCP tool-name patterns. Exact names and `*` wildcards are
+  supported, e.g. `bakin_exec_assets_get` or `bakin_exec_assets_*`.
+
+The MCP server hides disallowed tools from `tools/list`, denies forged direct
+calls at `tools/call`, records denied usage, and appends
+`exec.<tool>.denied` audit events.
+
+Do not confuse this with:
+
+- `workflow deny_tools`: prompt-level workflow step guidance, not hard routing.
+- OpenClaw cron `toolsAllow`: native runtime cron policy for isolated agent-turn
+  jobs, not Bakin MCP routing.
+- `allowedSkills`: still declarative/documentation-only until skill routing is
+  implemented.
+
 ## V1 explicit non-goals
 
 - **No hosted registry.** Curated catalog is a static JSON file shipped in the binary; bare-name install errors out.
 - **No trust levels enforcement.** The catalog has a `trust: "official"|"verified"|"community"` field but it's display-only.
 - **No dispatch-time knowledge retrieval.** All enabled lessons inject statically. Issue #157 covers V2 dispatch-time retrieval.
-- **No per-agent MCP-tool scoping enforcement.** Manifests declare `allowedTools` / `allowedSkills` but they're documentation-only. Issue #42 covers the routing-layer enforcement.
+- **No skill scoping enforcement.** Manifests declare `allowedSkills`, but the
+  skill-routing layer does not enforce it yet.
 - **No bundles.** `bakin install creative-team` (bundle of pixel + rolo + jessica + shared visual skills) is a future possibility, not V1.
 
 ## File layout
@@ -325,4 +353,3 @@ agents/                      In-repo reference packages (8 backfilled). NOT bund
 ## Companion future work (issues)
 
 - **#157** — V2 dispatch-time knowledge retrieval. Static block injection in V1; dynamic semantic-search-based at dispatch time in V2. Data model unchanged; only the injection path differs.
-- **#42** — Per-agent MCP-tool hard scoping. Agent manifests already declare `agent.allowedTools` / `allowedSkills`; #42's dispatch-routing layer reads them and enforces.

--- a/.claude/knowledge/agent-system.md
+++ b/.claude/knowledge/agent-system.md
@@ -154,6 +154,30 @@ Agents interact with Bakin through MCP tools served by `src/core/mcp-server.ts`:
 ### Agent identity
 MCP sessions bind agent identity via `?agent=basil` query param at connection time. All tool calls carry the agent ID for audit attribution.
 
+### MCP tool policy
+
+`src/core/mcp-tool-policy.ts` resolves the effective tool policy when a Bakin
+MCP session is created:
+
+- Unmanaged runtime agents have legacy unrestricted access.
+- Managed agent-package agents must have a non-empty
+  `agent.allowedTools` policy in their installed `bakin-package.json`; missing
+  or malformed package policy fails closed.
+- Adopted package agents with an explicit `allowedTools` policy are scoped by
+  that policy. Adopted agents without a policy remain unrestricted until
+  configured.
+- Patterns are tool-name based and support exact names plus `*` wildcards, e.g.
+  `bakin_exec_assets_*`.
+
+The MCP server still registers every exec tool internally, but disallowed tools
+are disabled so they do not appear in `tools/list`. Direct calls to a hidden
+but registered tool return an audited denial (`exec.<tool>.denied`) instead of
+running the handler.
+
+This is distinct from workflow `deny_tools`, which is step prompt guidance, and
+from OpenClaw cron `toolsAllow`, which belongs to native isolated runtime cron
+jobs.
+
 ## Activity Logging
 
 ### Live activity feed

--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -782,6 +782,13 @@ shared utility, not a plugin-to-plugin dependency.
 4. `src/core/mcp-server.ts` imports core tool files, then calls
    `getAllExecTools()` to register all tools with the MCP server at
    startup.
+5. `src/core/mcp-tool-policy.ts` scopes each agent session. Disallowed tools
+   are hidden from `tools/list`; direct `tools/call` attempts are denied and
+   audited before the plugin handler can run.
+
+Plugin authors should use stable `bakin_exec_<pluginId>_<action>` names because
+agent-package `allowedTools` policies reference exact MCP tool names or
+wildcard patterns.
 
 ### PluginToolContext
 When the MCP server executes a tool handler, it builds a

--- a/packages/core/src/agent-packages/manifest.ts
+++ b/packages/core/src/agent-packages/manifest.ts
@@ -85,11 +85,11 @@ const AgentStanzaSchema = z.object({
   dispatchableBy: z.array(z.string().min(1)).optional(),
   tags: z.array(z.string().min(1)).optional(),
   /**
-   * Declarative MCP-tool allow-list. V1 documentation-only — issue #42's
-   * dispatch-routing layer reads this and enforces hard scoping.
+   * Declarative MCP-tool allow-list. Bakin's MCP server reads installed
+   * agent-package manifests and enforces this at listing and invocation time.
    */
   allowedTools: z.array(z.string().min(1)).optional(),
-  /** Declarative skill allow-list. Same V1-doc-only treatment as allowedTools. */
+  /** Declarative skill allow-list. Documentation-only until skill routing exists. */
   allowedSkills: z.array(z.string().min(1)).optional(),
 })
 

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -21,11 +21,18 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { createLogger } from './logger'
 import { getContentDir } from './content-dir'
 import { appendAudit } from './audit'
 import { recordUsage } from '@/core/usage'
-import { getAllExecTools, getToolContext } from '../../scripts/lib/registry'
+import { getAllExecTools, getExecTool, getToolContext } from '../../scripts/lib/registry'
+import {
+  describeMcpToolDenial,
+  isToolAllowedByPolicy,
+  resolveMcpToolPolicy,
+  type McpToolPolicy,
+} from './mcp-tool-policy'
 
 // Script execution tools that stay in scripts/lib/ — self-register on import.
 // Must be imported AFTER registry.ts so the Map is initialized.
@@ -115,8 +122,9 @@ setInterval(() => {
 // ---------------------------------------------------------------------------
 
 export function registerTools(server: McpServer, getAgent: () => string): void {
+  const policy = resolveMcpToolPolicy(getAgent())
   for (const tool of getAllExecTools()) {
-    server.tool(
+    const registered = server.tool(
       tool.name,
       tool.description,
       tool.parameters,
@@ -126,6 +134,12 @@ export function registerTools(server: McpServer, getAgent: () => string): void {
         log.info('Exec tool called', { tool: tool.name, agent, taskId })
 
         const start = Date.now()
+        if (!isToolAllowedByPolicy(policy, tool.name)) {
+          const durationMs = Date.now() - start
+          log.warn('Exec tool denied by MCP policy', { tool: tool.name, agent, taskId })
+          return buildDeniedToolResult(tool.name, agent, policy, tool.label, taskId, durationMs)
+        }
+
         try {
           const toolCtx = getToolContext(tool.name)
           const result = await tool.handler(params as Record<string, unknown>, agent, toolCtx)
@@ -172,7 +186,83 @@ export function registerTools(server: McpServer, getAgent: () => string): void {
         }
       },
     )
+    if (!isToolAllowedByPolicy(policy, tool.name)) {
+      registered?.disable?.()
+    }
   }
+  installPolicyCallGuard(server, getAgent, policy)
+}
+
+function buildDeniedToolResult(
+  toolName: string,
+  agent: string,
+  policy: McpToolPolicy,
+  label: string | undefined,
+  taskId: string | undefined,
+  durationMs: number,
+): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+  const reason = describeMcpToolDenial(policy)
+  recordUsage({
+    kind: 'mcp',
+    name: toolName,
+    agent,
+    durationMs,
+    status: 'error',
+    meta: {
+      taskId,
+      label,
+      reason,
+      denied: true,
+    },
+  })
+  appendAudit(
+    getContentDir(),
+    `exec.${toolName}.denied`,
+    agent,
+    { taskId, label, reason, denied: true },
+    'mcp',
+  )
+  return {
+    content: [{
+      type: 'text',
+      text: `ERROR: MCP tool "${toolName}" is denied for agent "${agent}": ${reason}`,
+    }],
+    isError: true,
+  }
+}
+
+type RawMcpRequestHandler = (request: unknown, extra: unknown) => unknown
+type RawMcpServerWithHandlers = {
+  _requestHandlers?: Map<string, RawMcpRequestHandler>
+  setRequestHandler?: (schema: unknown, handler: RawMcpRequestHandler) => void
+}
+
+function installPolicyCallGuard(
+  server: McpServer,
+  getAgent: () => string,
+  policy: McpToolPolicy,
+): void {
+  // The MCP SDK hides disabled tools from tools/list, but its default
+  // tools/call handler returns "disabled" before reaching our tool callback.
+  // Wrap that handler so forged direct calls to hidden Bakin tools are audited.
+  const rawServer = (server.server as unknown as RawMcpServerWithHandlers | undefined)
+  const original = rawServer?._requestHandlers?.get('tools/call')
+  if (!rawServer?.setRequestHandler || !original) return
+
+  rawServer.setRequestHandler(CallToolRequestSchema, async (request: unknown, extra: unknown) => {
+    const params = (request as { params?: { name?: string; arguments?: Record<string, unknown> } }).params
+    const toolName = params?.name
+    if (toolName && !isToolAllowedByPolicy(policy, toolName)) {
+      const tool = getExecTool(toolName)
+      if (tool) {
+        const agent = getAgent()
+        const taskId = params?.arguments?.taskId as string | undefined
+        log.warn('Exec tool denied by MCP policy', { tool: toolName, agent, taskId })
+        return buildDeniedToolResult(toolName, agent, policy, tool.label, taskId, 0)
+      }
+    }
+    return original(request, extra)
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/mcp-tool-policy.ts
+++ b/src/core/mcp-tool-policy.ts
@@ -1,0 +1,148 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { createLogger } from './logger'
+import { getContentDir } from './content-dir'
+import {
+  findAgentPackage,
+  readLockfile,
+  type Lockfile,
+  type PackageEntry,
+} from '../../packages/core/src/agent-packages/lockfile'
+import { getPackageSourceDir } from '../../packages/core/src/agent-packages/package-paths'
+import { parseManifest } from '../../packages/core/src/agent-packages/manifest'
+
+const log = createLogger('mcp-tool-policy')
+
+export type McpToolPolicy =
+  | {
+    kind: 'unrestricted'
+    reason: 'unmanaged-agent' | 'adopted-agent-unconfigured'
+    packageId?: string
+  }
+  | {
+    kind: 'allowlist'
+    packageId: string
+    agentState: NonNullable<PackageEntry['state']>
+    patterns: string[]
+  }
+  | {
+    kind: 'deny-all'
+    reason: string
+    packageId?: string
+  }
+
+export function resolveMcpToolPolicy(agentId: string): McpToolPolicy {
+  const contentDir = getContentDir()
+  let lock: Lockfile
+  try {
+    lock = readLockfile(join(contentDir, 'packages', 'lock.json'))
+  } catch (err) {
+    log.warn('Failed to read agent-package lockfile for MCP policy; denying tools', {
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return {
+      kind: 'deny-all',
+      reason: 'agent package lockfile could not be read',
+    }
+  }
+
+  const found = findAgentPackage(lock, agentId)
+  if (!found) {
+    return { kind: 'unrestricted', reason: 'unmanaged-agent' }
+  }
+
+  const state = found.entry.state
+  if (!state) {
+    return {
+      kind: 'deny-all',
+      packageId: found.id,
+      reason: 'agent package lockfile entry has no state',
+    }
+  }
+
+  const manifestPath = join(
+    getPackageSourceDir(contentDir, found.entry.kind, found.id, found.entry.version),
+    'bakin-package.json',
+  )
+  if (!existsSync(manifestPath)) {
+    return {
+      kind: 'deny-all',
+      packageId: found.id,
+      reason: 'agent package manifest is missing',
+    }
+  }
+
+  try {
+    const manifest = parseManifest(JSON.parse(readFileSync(manifestPath, 'utf-8')))
+    if (manifest.kind !== 'agent') {
+      return {
+        kind: 'deny-all',
+        packageId: found.id,
+        reason: 'agent package manifest is not kind "agent"',
+      }
+    }
+
+    const patterns = normalizeAllowedTools(manifest.agent.allowedTools)
+    if (patterns.length > 0) {
+      return {
+        kind: 'allowlist',
+        packageId: found.id,
+        agentState: state,
+        patterns,
+      }
+    }
+
+    if (state === 'adopted') {
+      return {
+        kind: 'unrestricted',
+        reason: 'adopted-agent-unconfigured',
+        packageId: found.id,
+      }
+    }
+
+    return {
+      kind: 'deny-all',
+      packageId: found.id,
+      reason: 'managed agent package has no allowedTools policy',
+    }
+  } catch (err) {
+    log.warn('Failed to parse agent-package manifest for MCP policy; denying tools', {
+      agentId,
+      packageId: found.id,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return {
+      kind: 'deny-all',
+      packageId: found.id,
+      reason: 'agent package manifest could not be parsed',
+    }
+  }
+}
+
+export function isToolAllowedByPolicy(policy: McpToolPolicy, toolName: string): boolean {
+  if (policy.kind === 'unrestricted') return true
+  if (policy.kind === 'deny-all') return false
+  return policy.patterns.some((pattern) => toolPatternMatches(pattern, toolName))
+}
+
+export function describeMcpToolDenial(policy: McpToolPolicy): string {
+  if (policy.kind === 'deny-all') return policy.reason
+  if (policy.kind === 'allowlist') return 'tool is not in agent package allowedTools policy'
+  return 'tool is allowed'
+}
+
+function normalizeAllowedTools(patterns: string[] | undefined): string[] {
+  return Array.from(new Set((patterns ?? []).map((pattern) => pattern.trim()).filter(Boolean))).sort()
+}
+
+function toolPatternMatches(pattern: string, toolName: string): boolean {
+  if (pattern === '*' || pattern === toolName) return true
+  if (!pattern.includes('*')) return false
+
+  const escaped = pattern
+    .split('*')
+    .map((part) => part.replace(/[|\\{}()[\]^$+?.]/g, '\\$&'))
+    .join('.*')
+  return new RegExp(`^${escaped}$`).test(toolName)
+}

--- a/tests/core/mcp-tool-policy.test.ts
+++ b/tests/core/mcp-tool-policy.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { z } from 'zod'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+
+const TEST_DIR = join(tmpdir(), `bakin-mcp-policy-${process.pid}-${Date.now()}`)
+const ORIGINAL_BAKIN_HOME = process.env.BAKIN_HOME
+const appendAuditMock = mock()
+
+process.env.BAKIN_HOME = TEST_DIR
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+mock.module('../../src/core/audit', () => ({
+  appendAudit: appendAuditMock,
+}))
+
+mock.module('../../src/core/watcher', () => ({
+  watch: mock(),
+  watchFiles: mock(),
+  registerWatchPattern: mock(),
+  start: mock(),
+  stop: mock(),
+  registerSyncHook: mock(() => () => {}),
+  registerUnlinkHook: mock(() => () => {}),
+}))
+
+afterAll(() => {
+  if (ORIGINAL_BAKIN_HOME === undefined) delete process.env.BAKIN_HOME
+  else process.env.BAKIN_HOME = ORIGINAL_BAKIN_HOME
+  try { rmSync(TEST_DIR, { recursive: true, force: true }) } catch {}
+})
+
+beforeEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true })
+  mkdirSync(TEST_DIR, { recursive: true })
+  process.env.BAKIN_HOME = TEST_DIR
+  appendAuditMock.mockClear()
+
+  const { clearUsage } = require('../../src/core/usage') as typeof import('../../src/core/usage')
+  clearUsage()
+})
+
+describe('MCP tool policy', () => {
+  it('lists and invokes only tools allowed by a managed agent package', async () => {
+    const suffix = `managed_${Date.now()}`
+    const allowedTool = `bakin_exec_policy_allowed_${suffix}`
+    const blockedTool = `bakin_exec_policy_blocked_${suffix}`
+    registerDummyTool(allowedTool)
+    registerDummyTool(blockedTool)
+    writeAgentPackage('pixel', 'managed', [allowedTool])
+
+    const { client, close } = await connectPolicyClient('pixel')
+    try {
+      const listed = await client.listTools()
+      const names = listed.tools.map((tool) => tool.name)
+      expect(names).toContain(allowedTool)
+      expect(names).not.toContain(blockedTool)
+
+      const allowed = await client.callTool({ name: allowedTool, arguments: {} })
+      expect(allowed.isError).toBeFalsy()
+
+      const denied = await client.callTool({ name: blockedTool, arguments: {} })
+      expect(denied.isError).toBe(true)
+      const deniedText = toolText(denied)
+      expect(deniedText).toContain(blockedTool)
+      expect(deniedText).toContain('pixel')
+      expect(appendAuditMock).toHaveBeenCalledWith(
+        TEST_DIR,
+        `exec.${blockedTool}.denied`,
+        'pixel',
+        expect.objectContaining({ reason: expect.any(String) }),
+        'mcp',
+      )
+    } finally {
+      await close()
+    }
+  })
+
+  it('supports wildcard package allowlists', async () => {
+    const suffix = `wildcard_${Date.now()}`
+    const allowedTool = `bakin_exec_policy_assets_${suffix}`
+    const blockedTool = `bakin_exec_policy_tasks_${suffix}`
+    registerDummyTool(allowedTool)
+    registerDummyTool(blockedTool)
+    writeAgentPackage('pixel', 'managed', ['bakin_exec_policy_assets_*'])
+
+    const { client, close } = await connectPolicyClient('pixel')
+    try {
+      const listed = await client.listTools()
+      const names = listed.tools.map((tool) => tool.name)
+      expect(names).toContain(allowedTool)
+      expect(names).not.toContain(blockedTool)
+    } finally {
+      await close()
+    }
+  })
+
+  it('scopes adopted agents when their package declares allowedTools', async () => {
+    const suffix = `adopted_${Date.now()}`
+    const allowedTool = `bakin_exec_policy_adopted_allowed_${suffix}`
+    const blockedTool = `bakin_exec_policy_adopted_blocked_${suffix}`
+    registerDummyTool(allowedTool)
+    registerDummyTool(blockedTool)
+    writeAgentPackage('pixel', 'adopted', [allowedTool])
+
+    const { client, close } = await connectPolicyClient('pixel')
+    try {
+      const listed = await client.listTools()
+      const names = listed.tools.map((tool) => tool.name)
+      expect(names).toContain(allowedTool)
+      expect(names).not.toContain(blockedTool)
+
+      const allowed = await client.callTool({ name: allowedTool, arguments: {} })
+      expect(allowed.isError).toBeFalsy()
+
+      const denied = await client.callTool({ name: blockedTool, arguments: {} })
+      expect(denied.isError).toBe(true)
+      expect(toolText(denied)).toContain('allowedTools policy')
+    } finally {
+      await close()
+    }
+  })
+
+  it('keeps adopted agents with no package policy unrestricted until configured', async () => {
+    const toolName = `bakin_exec_policy_adopted_unconfigured_${Date.now()}`
+    registerDummyTool(toolName)
+    writeAgentPackage('pixel', 'adopted', undefined)
+
+    const { client, close } = await connectPolicyClient('pixel')
+    try {
+      const listed = await client.listTools()
+      expect(listed.tools.map((tool) => tool.name)).toContain(toolName)
+
+      const result = await client.callTool({ name: toolName, arguments: {} })
+      expect(result.isError).toBeFalsy()
+    } finally {
+      await close()
+    }
+  })
+
+  it('fails closed for managed agents whose package has no tool policy', async () => {
+    const toolName = `bakin_exec_policy_missing_${Date.now()}`
+    registerDummyTool(toolName)
+    writeAgentPackage('pixel', 'managed', undefined)
+
+    const { client, close } = await connectPolicyClient('pixel')
+    try {
+      const listed = await client.listTools()
+      expect(listed.tools.map((tool) => tool.name)).not.toContain(toolName)
+
+      const denied = await client.callTool({ name: toolName, arguments: {} })
+      expect(denied.isError).toBe(true)
+      expect(toolText(denied)).toContain('no allowedTools policy')
+    } finally {
+      await close()
+    }
+  })
+
+  it('keeps unmanaged legacy agents permissive', async () => {
+    const toolName = `bakin_exec_policy_legacy_${Date.now()}`
+    registerDummyTool(toolName)
+    writeEmptyLockfile()
+
+    const { client, close } = await connectPolicyClient('legacy')
+    try {
+      const listed = await client.listTools()
+      expect(listed.tools.map((tool) => tool.name)).toContain(toolName)
+
+      const result = await client.callTool({ name: toolName, arguments: {} })
+      expect(result.isError).toBeFalsy()
+    } finally {
+      await close()
+    }
+  })
+})
+
+function registerDummyTool(name: string): void {
+  const { addExecTool } = require('../../scripts/lib/registry') as typeof import('../../scripts/lib/registry')
+  addExecTool({
+    name,
+    label: `Dummy ${name}`,
+    description: `Dummy tool ${name}`,
+    parameters: { value: z.string().optional() },
+    handler: async () => ({ ok: true, name }),
+  })
+}
+
+async function connectPolicyClient(agentId: string): Promise<{ client: Client; close: () => Promise<void> }> {
+  const { registerTools } = require('../../src/core/mcp-server') as typeof import('../../src/core/mcp-server')
+  const server = new McpServer({ name: `bakin-policy-${agentId}`, version: '1.0.0' })
+  registerTools(server, () => agentId)
+
+  const client = new Client({ name: `policy-client-${agentId}`, version: '1.0.0' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ])
+
+  return {
+    client,
+    close: async () => {
+      await client.close()
+      await server.close()
+    },
+  }
+}
+
+function writeEmptyLockfile(): void {
+  const { writeLockfile } = require('../../packages/core/src/agent-packages/lockfile') as typeof import('../../packages/core/src/agent-packages/lockfile')
+  writeLockfile({ version: 1, packages: {} })
+}
+
+function writeAgentPackage(
+  agentId: string,
+  state: 'managed' | 'adopted',
+  allowedTools: string[] | undefined,
+): void {
+  const {
+    writeLockfile,
+  } = require('../../packages/core/src/agent-packages/lockfile') as typeof import('../../packages/core/src/agent-packages/lockfile')
+  const {
+    getPackageSourceDir,
+  } = require('../../packages/core/src/agent-packages/package-paths') as typeof import('../../packages/core/src/agent-packages/package-paths')
+
+  writeLockfile({
+    version: 1,
+    packages: {
+      [agentId]: {
+        kind: 'agent',
+        version: '0.1.0',
+        source: `github:madeinwyo/bakin-agent-${agentId}`,
+        ref: 'v0.1.0',
+        commitSha: 'abc123',
+        installedAt: '2026-04-30T00:00:00Z',
+        state,
+        agentId,
+        projections: [],
+        knowledgeEnabled: [],
+      },
+    },
+  })
+
+  const packageDir = getPackageSourceDir(TEST_DIR, 'agent', agentId, '0.1.0')
+  mkdirSync(packageDir, { recursive: true })
+  const agentStanza: Record<string, unknown> = {
+    identity: { name: agentId },
+  }
+  if (allowedTools !== undefined) agentStanza.allowedTools = allowedTools
+  writeFileSync(
+    join(packageDir, 'bakin-package.json'),
+    JSON.stringify({
+      id: agentId,
+      kind: 'agent',
+      name: agentId,
+      version: '0.1.0',
+      agent: agentStanza,
+      install: {},
+      contributions: {},
+    }, null, 2),
+    'utf-8',
+  )
+}
+
+function toolText(result: unknown): string {
+  const content = (result as { content?: Array<{ text?: string }> }).content
+  return content?.map((entry) => entry.text ?? '').join('\n') ?? ''
+}


### PR DESCRIPTION
Closes #218

## Summary
- Add an MCP tool-policy resolver that reads agent-package lockfile state and installed `bakin-package.json` manifests.
- Hide disallowed exec tools from `tools/list`, deny and audit forged direct `tools/call` attempts, and record denied usage.
- Preserve legacy unmanaged-agent access, fail closed for managed agents without `allowedTools`, and keep adopted agents unrestricted until configured unless they declare a policy.
- Update agent-package, agent-system, plugin-system, and manifest docs for the enforced policy boundary.

## Verification
- `bun test tests/core/mcp-tool-policy.test.ts --isolate`
- `bun run typecheck`
- `bun run lint`
- `git diff --cached --check`
- `bun test --isolate` (3381 pass, 0 fail)

## Review Notes
- The direct-call audit guard wraps the MCP SDK `tools/call` request handler because disabled tools are otherwise hidden before the registered callback runs. This is covered by the policy tests but should be revisited if the SDK changes that internal handler surface.