### PR TITLE
Add dispatch-facing assets open tool

### DIFF
--- a/.claude/knowledge/assets-plugin.md
+++ b/.claude/knowledge/assets-plugin.md
@@ -265,6 +265,7 @@ src/hooks/use-assets.ts       — Data fetching + SSE live updates
 |------|-------------|
 | `bakin_exec_assets_list` | List assets with optional filters (type, agent, taskId, tag) |
 | `bakin_exec_assets_get` | Read sidecar metadata by filename |
+| `bakin_exec_assets_open` | Dispatch-facing reader: sidecar metadata plus extracted text when available |
 | `bakin_exec_assets_save` | Save agent-created file with canonical naming + sidecar |
 | `bakin_exec_assets_delete` | Soft-delete to trash |
 | `bakin_exec_assets_link` | Edit sidecar `taskId` (metadata-only; no move) |
@@ -280,7 +281,19 @@ All tools accept **filenames**, never paths. Agents should treat filenames as st
 
 ### Dispatch hint — `bakin_exec_assets_open`
 
-`src/core/dispatch.ts` points agents at a `bakin_exec_assets_open` tool that is **not yet registered**. The spec defines it as a sidecar-plus-extracted-content reader, but the handler has not landed. Agents currently calling it will get "tool not found". Either register the tool (mirror `assets_get` + `content-extractor`) or rewrite the dispatch hint to call `assets_get` + `file` REST. Tracked as follow-up.
+`src/core/dispatch.ts` points agents at `bakin_exec_assets_open` for attached
+task assets. The tool accepts a canonical filename and returns:
+
+- `asset.filename` and `asset.path` resolved by filename-as-identity.
+- `asset.sidecar` metadata, or `null` when the file exists without a sidecar.
+- `asset.content.mode = "text"` with extracted `text` for text-like assets
+  (`.md`, `.txt`, `.json`, `.csv`, `.yaml`, `.xml`, `.pdf`, etc.).
+- `asset.content.mode = "metadata-only"` for binary assets with a note that the
+  asset has no extractable text content.
+
+Use `bakin_exec_assets_get` when metadata alone is enough. Use
+`bakin_exec_assets_open` when an agent needs to inspect attached task context
+without guessing which asset types are text-readable.
 
 ## Editable Asset Types
 

--- a/plugins/assets/bakin-plugin.json
+++ b/plugins/assets/bakin-plugin.json
@@ -98,6 +98,11 @@
         "description": "Retrieve a single asset's sidecar metadata by canonical filename."
       },
       {
+        "name": "bakin_exec_assets_open",
+        "summary": "Open an attached asset by canonical filename",
+        "description": "Open an attached asset by canonical filename. Returns sidecar metadata plus extracted text for text-like assets; non-extractable assets return metadata-only status."
+      },
+      {
         "name": "bakin_exec_assets_link",
         "summary": "Link an asset to a different task, or unlink it (set taskId to null)",
         "description": "Link an asset to a different task, or unlink it (set taskId to null). Sidecar-only edit — no file move."

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -30,7 +30,7 @@ import { ingestInboxFile, ingestInboxDir } from './lib/ingest-inbox'
 import { getContentDir } from '../../src/core/content-dir'
 import { createLogger } from '../../src/core/logger'
 import { buildAssetFileUrl } from './lib/asset-url'
-import { extractAssetContent } from './lib/content-extractor'
+import { canExtractAssetContent, extractAssetContent } from './lib/content-extractor'
 import { checkAssets } from './lib/health-checks'
 
 /** Filename is the canonical identity under the filename-as-identity model. */
@@ -551,7 +551,7 @@ const assetsPlugin: BakinPlugin = {
         filename: z.string().describe('Canonical asset filename (e.g. "20260401-hero-a1b2c3d4.png")'),
       },
       handler: async (params: Record<string, unknown>) => {
-        const filename = params.filename as string
+        const filename = typeof params.filename === 'string' ? params.filename : ''
         if (!isSafeCanonicalFilename(filename)) return { ok: false, error: 'Invalid filename' }
         const assetPath = pathForFilename(filename)
         if (!assetPath) return { ok: false, error: 'Invalid filename' }
@@ -569,6 +569,67 @@ const assetsPlugin: BakinPlugin = {
           return { ok: true, asset: { filename, path: assetPath, ...sidecar } }
         } catch (err) {
           return { ok: false, error: `Failed to read sidecar: ${(err as Error).message}` }
+        }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_assets_open',
+      label: 'Opened an asset',
+      description: 'Open an attached asset by canonical filename. Returns sidecar metadata plus extracted text for text-like assets; non-extractable assets return metadata-only status.',
+      parameters: {
+        filename: z.string().describe('Canonical asset filename (e.g. "20260401-hero-a1b2c3d4.png")'),
+      },
+      handler: async (params: Record<string, unknown>) => {
+        const filename = typeof params.filename === 'string' ? params.filename : ''
+        if (!isSafeCanonicalFilename(filename)) return { ok: false, error: 'Invalid filename' }
+        const assetPath = pathForFilename(filename)
+        if (!assetPath) return { ok: false, error: 'Invalid filename' }
+
+        const contentDir = getContentDir()
+        const fullPath = join(contentDir, assetPath)
+        if (!existsSync(fullPath)) return { ok: false, error: 'Asset not found' }
+
+        const sidecarPath = getSidecarPath(fullPath)
+        let sidecar: Record<string, unknown> | null = null
+        if (existsSync(sidecarPath)) {
+          try {
+            sidecar = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
+          } catch (err) {
+            return { ok: false, error: `Failed to read sidecar: ${(err as Error).message}` }
+          }
+        }
+
+        if (!canExtractAssetContent(filename)) {
+          return {
+            ok: true,
+            asset: {
+              filename,
+              path: assetPath,
+              sidecar,
+              content: {
+                mode: 'metadata-only',
+                available: false,
+                text: '',
+                note: 'This asset type has no extractable text content; use the metadata or asset preview UI for binary inspection.',
+              },
+            },
+          }
+        }
+
+        const text = await extractAssetContent(fullPath, filename)
+        return {
+          ok: true,
+          asset: {
+            filename,
+            path: assetPath,
+            sidecar,
+            content: {
+              mode: 'text',
+              available: text.length > 0,
+              text,
+            },
+          },
         }
       },
     })

--- a/plugins/assets/lib/content-extractor.ts
+++ b/plugins/assets/lib/content-extractor.ts
@@ -39,6 +39,11 @@ const PLAIN_TEXT_EXTS = new Set([
   '.yaml', '.yml',
 ])
 
+export function canExtractAssetContent(filename: string): boolean {
+  const ext = (filename.toLowerCase().match(/\.[^.]+$/) ?? [''])[0]
+  return PLAIN_TEXT_EXTS.has(ext) || ext === '.pdf'
+}
+
 /**
  * Extract searchable text content from an asset file. Returns an empty
  * string for unsupported types and for any extraction that fails —

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -1,6 +1,6 @@
 /**
  * Comprehensive tests for the assets plugin routes and exec tools.
- * Tests all 7 API routes and 9 MCP exec tools registered by the plugin.
+ * Tests all API routes and MCP exec tools registered by the plugin.
  */
 import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test'
 import { mkdirSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync, renameSync } from 'fs'
@@ -195,13 +195,14 @@ describe('route registration', () => {
 // ===========================================================================
 
 describe('exec tool registration', () => {
-  it('registers all 12 exec tools', () => {
-    expect(plugin.execTools.length).toBe(12)
+  it('registers all 13 exec tools', () => {
+    expect(plugin.execTools.length).toBe(13)
   })
 
   it.each([
     'bakin_exec_assets_list',
     'bakin_exec_assets_get',
+    'bakin_exec_assets_open',
     'bakin_exec_assets_save',
     'bakin_exec_assets_delete',
     'bakin_exec_assets_link',
@@ -742,6 +743,93 @@ describe('exec tool: bakin_exec_assets_list', () => {
     for (const a of assets) {
       expect(a.type).toBe('data')
     }
+  })
+})
+
+// ===========================================================================
+// Exec tool: bakin_exec_assets_open
+// ===========================================================================
+
+describe('exec tool: bakin_exec_assets_open', () => {
+  it('returns sidecar metadata plus extracted content for text-like assets', async () => {
+    const filename = '20260325-tool-open-abcd1234.md'
+    createAssetFixture(filename, '# Open Me\n\nReadable content.', {
+      agent: 'scribe',
+      taskId: 'task-tool-open',
+      created: '2026-03-25T00:00:00Z',
+      type: 'text',
+      description: 'Open tool markdown fixture',
+    })
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_open')!
+    const result = await callTool(tool, { filename }, 'scribe')
+    const asset = result.asset as {
+      filename: string
+      path: string
+      sidecar: { taskId: string; description: string }
+      content: { mode: string; text: string; available: boolean }
+    }
+
+    expect(result.ok).toBe(true)
+    expect(asset.filename).toBe(filename)
+    expect(asset.path).toBe(relPathFor(filename))
+    expect(asset.sidecar.taskId).toBe('task-tool-open')
+    expect(asset.sidecar.description).toBe('Open tool markdown fixture')
+    expect(asset.content.mode).toBe('text')
+    expect(asset.content.available).toBe(true)
+    expect(asset.content.text).toContain('Readable content.')
+  })
+
+  it('returns metadata-only content status for binary assets', async () => {
+    const filename = '20260325-tool-open-image-abcd1234.png'
+    createAssetFixture(filename, 'png-bytes', {
+      agent: 'pixel',
+      taskId: 'task-tool-open-image',
+      created: '2026-03-25T00:00:00Z',
+      type: 'images',
+    })
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_open')!
+    const result = await callTool(tool, { filename }, 'pixel')
+    const asset = result.asset as {
+      sidecar: { taskId: string }
+      content: { mode: string; text: string; available: boolean; note: string }
+    }
+
+    expect(result.ok).toBe(true)
+    expect(asset.sidecar.taskId).toBe('task-tool-open-image')
+    expect(asset.content.mode).toBe('metadata-only')
+    expect(asset.content.available).toBe(false)
+    expect(asset.content.text).toBe('')
+    expect(asset.content.note).toContain('no extractable text')
+  })
+
+  it('returns not found for a missing asset', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_open')!
+    const result = await callTool(tool, {
+      filename: '20260325-missing-abcd1234.md',
+    }, 'scribe')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/asset not found/i)
+  })
+
+  it('rejects missing filename input', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_open')!
+    const result = await callTool(tool, {}, 'scribe')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/invalid filename/i)
+  })
+
+  it('rejects path-shaped filenames', async () => {
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_open')!
+    const result = await callTool(tool, {
+      filename: 'assets/store/2026-03/20260325-tool-open-abcd1234.md',
+    }, 'scribe')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/invalid filename/i)
   })
 })
 


### PR DESCRIPTION
Closes #222
Refs #221

## Summary
- Register `bakin_exec_assets_open` as the dispatch-facing asset reader promised by `src/core/dispatch.ts`.
- Return filename/path, sidecar metadata, and extracted text for text-like assets; return explicit metadata-only status for non-extractable assets.
- Harden filename handling for direct exec-tool calls and update plugin metadata/docs for the final contract.

## Verification
- `bun test tests/plugins/assets/routes.test.ts tests/core/dispatch-assets.test.ts --isolate`
- `bun test tests/plugins/assets tests/core/dispatch-assets.test.ts --isolate`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- `bun test --isolate` (3387 pass, 0 fail)

## Review Notes
- Existing agent package allowlists use `bakin_exec_assets_*`, so this new tool is included under the MCP policy enforcement added in #224.
- Existing React `act(...)` warnings still appear in unrelated team UI tests; no failures.