### PR TITLE
Dispatch package knowledge at task runtime

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -173,14 +173,20 @@ Resolution order: **user > agent-package > plugin**. User files always win; agen
 
 Server.ts boot: plugin registry initializes → `loadAgentPackageSources()` runs → user files load. Order matters; the load-sources call sits between plugin init and the Antfly initialization (line ~136 of server.ts).
 
-## Search indexing for knowledge files
+## Search indexing and retrieval for knowledge files
 
 The team plugin (`plugins/team/index.ts`) registers a `agent-knowledge` content type via `ctx.search.registerFileBackedContentType()`:
 - Glob: `packages/agents/*/knowledge/*.md`
 - Schema: `title`, `body`, `package_id`, `agent_id`, `lesson_id`, `tags[]`, `default_enabled`, `updated_at`
 - Searchable: `title` + `body`. Facets: `package_id`, `agent_id`, `tags`. Chunker enabled (250 token target / 30 overlap).
 
-V1 limitation: `enabled` is NOT indexed — the lockfile is the source of truth for per-agent enabled state. Searching hits all available lessons; consumers cross-reference the lockfile to filter.
+Retrieval in `src/core/agent-packages/knowledge-retrieval.ts` is dispatch-time:
+- `retrieveAgentPackageKnowledge()` finds the target agent's package via the lockfile, queries `agent-knowledge`, filters results down to the package's enabled `knowledgeEnabled` lessons, dedupes repeated chunk hits by `lesson_id`, hydrates full lesson bodies from the installed package source, and returns the top configured lessons.
+- `dispatch.ts` injects the formatted top lessons into regular task dispatch and workflow step dispatch. Retrieval failures are audited and do not block dispatch.
+- The team plugin exposes `bakin_exec_knowledge_search`, scoped to the calling agent, for follow-up lookup over the same enabled lesson set.
+- Settings live under `settings.agentPackages.knowledgeRetrieval`: `enabled`, `injectIntoDispatch`, `mcpTool`, `maxLessons`, `maxCharacters`, `minScore`.
+
+Current limitation: `enabled` is NOT indexed — the lockfile remains the source of truth for per-agent enabled state. Searching hits all available lessons; consumers cross-reference the lockfile to filter.
 
 V1 limitation: knowledge-pack lessons aren't indexed (glob targets `packages/agents/*` only). Adding a parallel `knowledge-pack-knowledge` content type or extending the glob is V1.5 work.
 
@@ -283,7 +289,7 @@ Do not confuse this with:
 
 - **No hosted registry.** Curated catalog is a static JSON file shipped in the binary; bare-name install errors out.
 - **No trust levels enforcement.** The catalog has a `trust: "official"|"verified"|"community"` field but it's display-only.
-- **No dispatch-time knowledge retrieval.** All enabled lessons inject statically. Issue #157 covers V2 dispatch-time retrieval.
+- **No knowledge-pack lesson retrieval.** Dispatch-time retrieval covers installed agent-package lessons only. Knowledge-pack lessons are not indexed yet.
 - **No skill scoping enforcement.** Manifests declare `allowedSkills`, but the
   skill-routing layer does not enforce it yet.
 - **No bundles.** `bakin install creative-team` (bundle of pixel + rolo + jessica + shared visual skills) is a future possibility, not V1.
@@ -352,4 +358,4 @@ agents/                      In-repo reference packages (8 backfilled). NOT bund
 
 ## Companion future work (issues)
 
-- **#157** — V2 dispatch-time knowledge retrieval. Static block injection in V1; dynamic semantic-search-based at dispatch time in V2. Data model unchanged; only the injection path differs.
+- **#157** — V2 dispatch-time knowledge retrieval. Implemented for installed agent-package lessons via `agent-knowledge` search + lockfile filtering. Remaining follow-up: doctor/analytics reporting for indexed lessons that are never retrieved.

--- a/agents/basil/bakin-package.json
+++ b/agents/basil/bakin-package.json
@@ -14,6 +14,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/jessica-fetcher/bakin-package.json
+++ b/agents/jessica-fetcher/bakin-package.json
@@ -18,6 +18,7 @@
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
       "bakin_exec_search_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/nemo/bakin-package.json
+++ b/agents/nemo/bakin-package.json
@@ -14,6 +14,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/patch/bakin-package.json
+++ b/agents/patch/bakin-package.json
@@ -15,6 +15,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/pixel/bakin-package.json
+++ b/agents/pixel/bakin-package.json
@@ -17,6 +17,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/rolo/bakin-package.json
+++ b/agents/rolo/bakin-package.json
@@ -17,6 +17,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/scout/bakin-package.json
+++ b/agents/scout/bakin-package.json
@@ -17,6 +17,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/agents/zen/bakin-package.json
+++ b/agents/zen/bakin-package.json
@@ -14,6 +14,7 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"

--- a/docs/snippets/agent-package-basic/bakin-package.json
+++ b/docs/snippets/agent-package-basic/bakin-package.json
@@ -20,6 +20,7 @@
     ],
     "allowedTools": [
       "bakin_exec_tasks_list",
+      "bakin_exec_knowledge_search",
       "bakin_exec_workflows_start"
     ],
     "allowedSkills": [

--- a/docs/src/content/docs/extending/agents/packages.md
+++ b/docs/src/content/docs/extending/agents/packages.md
@@ -33,6 +33,7 @@ Source: `docs/snippets/agent-package-basic/bakin-package.json`
     ],
     "allowedTools": [
       "bakin_exec_tasks_list",
+      "bakin_exec_knowledge_search",
       "bakin_exec_workflows_start"
     ],
     "allowedSkills": [
@@ -182,7 +183,12 @@ Dependency sources may be `github:user/repo`, `./relative/path`, `../relative/pa
 - Keep package IDs stable and short.
 - Pin external refs when sharing packages.
 - Keep `allowedTools` narrow enough for review.
+- Add `bakin_exec_knowledge_search` when the agent should be able to look up its enabled package lessons after dispatch.
 - Put reusable behavior in skills and workflows, not only in prose.
 - Use knowledge files for durable domain context, not one-off task state.
 - Keep secrets out of packages.
 - Test package install against a disposable local runtime before sharing.
+
+## Knowledge Retrieval
+
+Enabled agent-package lessons are selected at dispatch time from the `agent-knowledge` search index and injected into task prompts when relevant. Agents can also call `bakin_exec_knowledge_search` for follow-up lookup; the tool only searches the calling agent's enabled lessons.

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -118,6 +118,19 @@ export interface BakinSettings {
     allowlist?: string[]
     blocklist?: string[]
   }
+  agentPackages: {
+    knowledgeRetrieval: {
+      enabled: boolean
+      /** Inject the top relevant enabled lessons directly into dispatch prompts. */
+      injectIntoDispatch: boolean
+      /** Expose the agent-facing MCP search tool for follow-up knowledge lookup. */
+      mcpTool: boolean
+      maxLessons: number
+      /** Approximate prompt budget for injected lesson bodies. */
+      maxCharacters: number
+      minScore: number
+    }
+  }
   doctor: {
     intervalMs: number
     autoFixSkill: boolean
@@ -220,6 +233,16 @@ export const DEFAULT_SETTINGS: BakinSettings = {
     keepAliveMs: 30000,
   },
   models: {},
+  agentPackages: {
+    knowledgeRetrieval: {
+      enabled: true,
+      injectIntoDispatch: true,
+      mcpTool: true,
+      maxLessons: 3,
+      maxCharacters: 8000,
+      minScore: 0,
+    },
+  },
   doctor: {
     intervalMs: 30 * 60 * 1000, // 30 minutes
     autoFixSkill: true,

--- a/plugins/team/bakin-plugin.json
+++ b/plugins/team/bakin-plugin.json
@@ -186,6 +186,11 @@
         "description": "List all agents with their current status (online/working/available/offline)."
       },
       {
+        "name": "bakin_exec_knowledge_search",
+        "summary": "Search enabled package knowledge for the calling agent",
+        "description": "Search the enabled agent-package knowledge lessons for the calling agent."
+      },
+      {
         "name": "bakin_exec_team_members",
         "summary": "Get agents that belong to a specific team (e",
         "description": "Get agents that belong to a specific team (e.g. \"builders\", \"creators\")."

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -27,11 +27,12 @@ import { createLogger } from '../../src/core/logger'
 import { readHeartbeats } from '../../src/lib/content-files'
 import { getContentDir, getBakinPaths } from '../../packages/core/src/content-dir'
 import { startAgent, stopAgent } from '../../src/lib/agents'
-import { resetSettingsCache } from '../../src/core/settings'
+import { getSettings, resetSettingsCache } from '../../src/core/settings'
 import { syncConfig as syncMcporter } from '../../src/core/mcporter'
 import { sendMessageToAgent } from '../../src/core/agents'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
 import { getStatsByMs } from '../../src/core/usage'
+import { retrieveAgentPackageKnowledge } from '../../src/core/agent-packages/knowledge-retrieval'
 import { getRuntimeMainAgentId, type AgentRuntimeAdapter, type RuntimeAgent } from '@bakin/core/adapters/runtime'
 import { readLatestSessionTranscript } from './lib/session-reader'
 import { checkAgentRoster, checkPersonas, checkAgentAssets } from './lib/health-checks'
@@ -1811,6 +1812,56 @@ const teamPlugin: BakinPlugin = definePlugin({
         const auditActivity = getLastAuditActivity()
         const { status, heartbeat, heartbeatAge } = resolveAgentStatus(params.agentId as string, heartbeats, auditActivity)
         return { ok: true, agentId: params.agentId, status, heartbeat, heartbeatAge }
+      },
+    })
+
+    ctx.registerExecTool({
+      name: 'bakin_exec_knowledge_search',
+      label: 'Searched package knowledge',
+      description: 'Search the enabled agent-package knowledge lessons for the calling agent.',
+      parameters: {
+        query: z.string().describe('Search query'),
+        limit: z.number().int().positive().max(10).optional().describe('Max lessons to return (default from settings, max 10)'),
+      },
+      handler: async (params: Record<string, unknown>, agent: string) => {
+        const query = typeof params.query === 'string' ? params.query.trim() : ''
+        if (!query) return { ok: false, error: 'query required' }
+        if (!agent) return { ok: false, error: 'calling agent required' }
+
+        const baseSettings = getSettings().agentPackages?.knowledgeRetrieval
+        const limit = typeof params.limit === 'number'
+          ? Math.max(1, Math.min(10, Math.floor(params.limit)))
+          : undefined
+        if (baseSettings?.enabled === false || baseSettings?.mcpTool === false) {
+          return { ok: true, total: 0, lessons: [], reason: 'disabled' }
+        }
+
+        try {
+          const result = await retrieveAgentPackageKnowledge({
+            contentDir: getContentDir(),
+            agentId: agent,
+            query,
+            settings: {
+              ...baseSettings,
+              ...(limit === undefined ? {} : { maxLessons: limit }),
+            },
+          })
+          return {
+            ok: true,
+            packageId: result.packageId,
+            total: result.lessons.length,
+            reason: result.reason,
+            lessons: result.lessons.map((lesson) => ({
+              lessonId: lesson.lessonId,
+              title: lesson.title,
+              score: lesson.score,
+              tags: lesson.tags,
+              body: lesson.body,
+            })),
+          }
+        } catch (err) {
+          return { ok: false, error: err instanceof Error ? err.message : String(err) }
+        }
       },
     })
 

--- a/src/core/agent-packages/knowledge-retrieval.ts
+++ b/src/core/agent-packages/knowledge-retrieval.ts
@@ -1,0 +1,265 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import type { SearchResponse } from '../../../packages/core/src/plugin-types'
+import {
+  findAgentPackage,
+  readLockfile,
+  type PackageEntry,
+} from '../../../packages/core/src/agent-packages/lockfile'
+import { getPackageSourceDir } from '../../../packages/core/src/agent-packages/package-paths'
+import { crossTableSearch } from '../search-registry'
+
+export interface AgentPackageKnowledgeRetrievalSettings {
+  enabled: boolean
+  injectIntoDispatch: boolean
+  mcpTool: boolean
+  maxLessons: number
+  maxCharacters: number
+  minScore: number
+}
+
+export const DEFAULT_KNOWLEDGE_RETRIEVAL_SETTINGS: AgentPackageKnowledgeRetrievalSettings = {
+  enabled: true,
+  injectIntoDispatch: true,
+  mcpTool: true,
+  maxLessons: 3,
+  maxCharacters: 8000,
+  minScore: 0,
+}
+
+export interface RetrievedKnowledgeLesson {
+  packageId: string
+  agentId: string
+  lessonId: string
+  title: string
+  body: string
+  tags: string[]
+  score: number
+}
+
+export interface KnowledgeRetrievalResult {
+  lessons: RetrievedKnowledgeLesson[]
+  packageId?: string
+  reason?: 'disabled' | 'dispatch-disabled' | 'no-package' | 'no-enabled-lessons' | 'no-query' | 'search-unavailable'
+}
+
+export type KnowledgeSearchFn = (
+  q: string,
+  opts: {
+    table?: string
+    limit?: number
+    filters?: Record<string, string | boolean | number>
+  },
+) => Promise<SearchResponse>
+
+export function normalizeKnowledgeRetrievalSettings(
+  input?: Partial<AgentPackageKnowledgeRetrievalSettings>,
+): AgentPackageKnowledgeRetrievalSettings {
+  const merged = { ...DEFAULT_KNOWLEDGE_RETRIEVAL_SETTINGS, ...(input ?? {}) }
+  return {
+    enabled: merged.enabled !== false,
+    injectIntoDispatch: merged.injectIntoDispatch !== false,
+    mcpTool: merged.mcpTool !== false,
+    maxLessons: clampInteger(merged.maxLessons, 1, 10, DEFAULT_KNOWLEDGE_RETRIEVAL_SETTINGS.maxLessons),
+    maxCharacters: clampInteger(merged.maxCharacters, 1000, 50000, DEFAULT_KNOWLEDGE_RETRIEVAL_SETTINGS.maxCharacters),
+    minScore: typeof merged.minScore === 'number' && Number.isFinite(merged.minScore)
+      ? Math.max(0, merged.minScore)
+      : DEFAULT_KNOWLEDGE_RETRIEVAL_SETTINGS.minScore,
+  }
+}
+
+export async function retrieveAgentPackageKnowledge(options: {
+  contentDir: string
+  agentId: string
+  query: string
+  settings?: Partial<AgentPackageKnowledgeRetrievalSettings>
+  requireDispatchInjection?: boolean
+  search?: KnowledgeSearchFn
+}): Promise<KnowledgeRetrievalResult> {
+  const settings = normalizeKnowledgeRetrievalSettings(options.settings)
+  if (!settings.enabled) return { lessons: [], reason: 'disabled' }
+  if (options.requireDispatchInjection && !settings.injectIntoDispatch) {
+    return { lessons: [], reason: 'dispatch-disabled' }
+  }
+
+  const query = options.query.trim()
+  if (!query) return { lessons: [], reason: 'no-query' }
+
+  const lock = readLockfile(join(options.contentDir, 'packages', 'lock.json'))
+  const owner = findAgentPackage(lock, options.agentId)
+  if (!owner) return { lessons: [], reason: 'no-package' }
+
+  const enabledLessonIds = new Set(owner.entry.knowledgeEnabled ?? [])
+  if (enabledLessonIds.size === 0) {
+    return { lessons: [], packageId: owner.id, reason: 'no-enabled-lessons' }
+  }
+
+  const search = options.search ?? crossTableSearch
+  const candidateLimit = Math.max(settings.maxLessons * 6, 12)
+  const response = await search(query, {
+    table: 'agent-knowledge',
+    limit: candidateLimit,
+    filters: { package_id: owner.id },
+  })
+
+  if (response.meta.source === 'fallback') {
+    return { lessons: [], packageId: owner.id, reason: 'search-unavailable' }
+  }
+
+  const sorted = [...response.results].sort((a, b) => b.score - a.score)
+  const lessons: RetrievedKnowledgeLesson[] = []
+  const seen = new Set<string>()
+  for (const hit of sorted) {
+    if (lessons.length >= settings.maxLessons) break
+    if (hit.score < settings.minScore) continue
+
+    const fields = hit.fields
+    const packageId = stringField(fields.package_id)
+    const lessonId = stringField(fields.lesson_id)
+    if (packageId !== owner.id) continue
+    if (!lessonId || !enabledLessonIds.has(lessonId)) continue
+    if (seen.has(lessonId)) continue
+
+    const diskLesson = readLessonFromDisk(options.contentDir, owner.id, owner.entry, lessonId)
+    const title = diskLesson?.title || stringField(fields.title) || lessonId
+    const body = diskLesson?.body || stringField(fields.body)
+    if (!body.trim()) continue
+
+    lessons.push({
+      packageId,
+      agentId: options.agentId,
+      lessonId,
+      title,
+      body,
+      tags: diskLesson?.tags ?? arrayStringField(fields.tags),
+      score: hit.score,
+    })
+    seen.add(lessonId)
+  }
+
+  return { lessons, packageId: owner.id }
+}
+
+export function formatKnowledgeLessonsForDispatch(
+  lessons: RetrievedKnowledgeLesson[],
+  maxCharacters?: number,
+): string {
+  if (lessons.length === 0) return ''
+  const budget = clampInteger(
+    maxCharacters,
+    1000,
+    50000,
+    DEFAULT_KNOWLEDGE_RETRIEVAL_SETTINGS.maxCharacters,
+  )
+
+  const lines = [
+    '## Relevant Package Knowledge',
+    '',
+    'Bakin selected these enabled agent-package lessons for this assignment. Use them as context; the task instructions still take priority.',
+    '',
+  ]
+  let used = lines.join('\n').length
+
+  for (const lesson of lessons) {
+    const header = [
+      `### ${lesson.title}`,
+      `- Package: ${lesson.packageId}`,
+      `- Lesson: ${lesson.lessonId}`,
+      `- Relevance: ${formatScore(lesson.score)}`,
+      ...(lesson.tags.length > 0 ? [`- Tags: ${lesson.tags.join(', ')}`] : []),
+      '',
+    ].join('\n')
+
+    const remaining = budget - used - header.length - 2
+    if (remaining <= 120) break
+    const body = truncateText(lesson.body, remaining)
+    lines.push(header)
+    lines.push(body)
+    lines.push('')
+    used += header.length + body.length + 2
+  }
+
+  return lines.join('\n').trimEnd()
+}
+
+export function buildTaskKnowledgeQuery(input: {
+  title: string
+  description?: string
+  instructions?: string
+  context?: string
+}): string {
+  return [
+    input.title,
+    input.description,
+    input.instructions,
+    input.context,
+  ].filter((part): part is string => typeof part === 'string' && part.trim().length > 0).join('\n\n')
+}
+
+function readLessonFromDisk(
+  contentDir: string,
+  packageId: string,
+  entry: PackageEntry,
+  lessonId: string,
+): { title: string; body: string; tags: string[] } | null {
+  const lessonPath = join(
+    getPackageSourceDir(contentDir, entry.kind, packageId, entry.version),
+    'knowledge',
+    `${lessonId}.md`,
+  )
+  if (!existsSync(lessonPath)) return null
+
+  try {
+    return parseKnowledgeMarkdown(readFileSync(lessonPath, 'utf-8'), lessonId)
+  } catch {
+    return null
+  }
+}
+
+function parseKnowledgeMarkdown(raw: string, fallbackTitle: string): { title: string; body: string; tags: string[] } {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)
+  if (!match) return { title: fallbackTitle, body: raw.trim(), tags: [] }
+
+  let title = fallbackTitle
+  let tags: string[] = []
+  for (const line of match[1].split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith('title:')) {
+      title = trimmed.slice('title:'.length).trim().replace(/^['"]|['"]$/g, '') || fallbackTitle
+    } else if (trimmed.startsWith('tags:')) {
+      const rest = trimmed.slice('tags:'.length).trim()
+      if (rest.startsWith('[') && rest.endsWith(']')) {
+        tags = rest
+          .slice(1, -1)
+          .split(',')
+          .map((tag) => tag.trim().replace(/^['"]|['"]$/g, ''))
+          .filter(Boolean)
+      }
+    }
+  }
+  return { title, body: match[2].trim(), tags }
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function arrayStringField(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function clampInteger(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.max(min, Math.min(max, Math.floor(value)))
+}
+
+function truncateText(value: string, maxCharacters: number): string {
+  if (value.length <= maxCharacters) return value
+  return `${value.slice(0, Math.max(0, maxCharacters - 16)).trimEnd()}... [truncated]`
+}
+
+function formatScore(score: number): string {
+  if (!Number.isFinite(score)) return '0.00'
+  return score.toFixed(2)
+}

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -12,6 +12,11 @@ import { getAppServices } from './app-services'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { getHookRegistry } from '../lib/plugin-registry'
 import {
+  buildTaskKnowledgeQuery,
+  formatKnowledgeLessonsForDispatch,
+  retrieveAgentPackageKnowledge,
+} from './agent-packages/knowledge-retrieval'
+import {
   addTaskLog as appendTaskLog,
   blockTask as blockStoredTask,
   readTaskboard,
@@ -33,6 +38,51 @@ const MAX_ERR_LEN = 500
 function formatDispatchError(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err)
   return raw.length > MAX_ERR_LEN ? `${raw.slice(0, MAX_ERR_LEN)}… (truncated)` : raw
+}
+
+async function buildDispatchKnowledgeBlock(input: {
+  contentDir: string
+  taskId: string
+  title: string
+  agentId: string
+  query: string
+}): Promise<string> {
+  try {
+    const settings = getSettings().agentPackages?.knowledgeRetrieval
+    const result = await retrieveAgentPackageKnowledge({
+      contentDir: input.contentDir,
+      agentId: input.agentId,
+      query: input.query,
+      settings,
+      requireDispatchInjection: true,
+    })
+    const block = formatKnowledgeLessonsForDispatch(
+      result.lessons,
+      settings?.maxCharacters,
+    )
+    if (result.lessons.length > 0) {
+      appendAudit(input.contentDir, 'agent_pkg.knowledge_retrieved', input.agentId, {
+        taskId: input.taskId,
+        title: input.title,
+        packageId: result.packageId,
+        lessons: result.lessons.map((lesson) => ({
+          lessonId: lesson.lessonId,
+          title: lesson.title,
+          score: lesson.score,
+        })),
+      })
+    }
+    return block
+  } catch (err) {
+    const error = formatDispatchError(err)
+    log.warn('Dispatch knowledge retrieval failed', { taskId: input.taskId, agentId: input.agentId, error })
+    appendAudit(input.contentDir, 'agent_pkg.knowledge_retrieval_failed', input.agentId, {
+      taskId: input.taskId,
+      title: input.title,
+      error,
+    })
+    return ''
+  }
 }
 
 type DispatchFailureKind = 'transient' | 'structural'
@@ -277,7 +327,14 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
 
       const targetAgent = task.agent ?? mainAgentId
 
-      const message = buildDispatchMessage(task, targetAgent, contentDir, port, mainAgentId)
+      const knowledgeBlock = await buildDispatchKnowledgeBlock({
+        contentDir,
+        taskId: task.id,
+        title: task.title,
+        agentId: targetAgent,
+        query: buildTaskKnowledgeQuery(task),
+      })
+      const message = buildDispatchMessage(task, targetAgent, contentDir, port, mainAgentId, knowledgeBlock)
 
       try {
         // Move to inProgress BEFORE sending message to eliminate race condition
@@ -407,7 +464,14 @@ export async function dispatchSingleTask(
 
     // Regular task dispatch
     const targetAgent = task.agent ?? mainAgentId
-    const message = buildDispatchMessage(task, targetAgent, contentDir, port, mainAgentId)
+    const knowledgeBlock = await buildDispatchKnowledgeBlock({
+      contentDir,
+      taskId: task.id,
+      title: task.title,
+      agentId: targetAgent,
+      query: buildTaskKnowledgeQuery(task),
+    })
+    const message = buildDispatchMessage(task, targetAgent, contentDir, port, mainAgentId, knowledgeBlock)
     const dispatchStart = Date.now()
 
     try {
@@ -466,9 +530,11 @@ export function buildDispatchMessage(
   contentDir: string,
   _port: number,
   mainAgentId = 'main',
+  knowledgeBlock = '',
 ): string {
   void _port
   const detailsBlock = task.description ? `\n\nDetails:\n${task.description}` : ''
+  const knowledgeSection = knowledgeBlock ? `\n\n${knowledgeBlock}` : ''
 
   // List attached assets by filename (stable identity). Agents open them
   // via bakin_exec_assets_open — disk paths are a view, not identity.
@@ -511,14 +577,14 @@ export function buildDispatchMessage(
   const mc = (tool: string, args: string) => `mcporter call ${server}.${tool} ${args}`
 
   if (!task.agent) {
-    return `Triage this task: "${task.title}".${detailsBlock}${assetsBlock}\n\nEither handle it yourself or assign it to the right agent (patch=execution, pixel=design/media, rolo=content/comms, basil=research/strategy) via \`${mc('bakin_exec_tasks_assign', `taskId=${task.id} agent="<agent>"`)}\`. ${contactsRef}\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
+    return `Triage this task: "${task.title}".${detailsBlock}${assetsBlock}${knowledgeSection}\n\nEither handle it yourself or assign it to the right agent (patch=execution, pixel=design/media, rolo=content/comms, basil=research/strategy) via \`${mc('bakin_exec_tasks_assign', `taskId=${task.id} agent="<agent>"`)}\`. ${contactsRef}\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
   }
 
   if (task.agent === mainAgentId) {
-    return `Work on this task: "${task.title}".${detailsBlock}${assetsBlock}\n\n${contactsRef} When done: \`${mc('bakin_exec_tasks_complete', `taskId=${task.id} summary="<what you did>"`)}\`\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
+    return `Work on this task: "${task.title}".${detailsBlock}${assetsBlock}${knowledgeSection}\n\n${contactsRef} When done: \`${mc('bakin_exec_tasks_complete', `taskId=${task.id} summary="<what you did>"`)}\`\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
   }
 
-  return `Work on this task: "${task.title}".${detailsBlock}${assetsBlock}${projectBlock}
+  return `Work on this task: "${task.title}".${detailsBlock}${assetsBlock}${projectBlock}${knowledgeSection}
 
 ## PROGRESS LOGGING — MANDATORY
 
@@ -675,8 +741,20 @@ async function dispatchWorkflowTask(
       stepOutputs?: Record<string, Record<string, unknown>>; deny_tools?: string[]
     }
     const targetAgent = agent
+    const knowledgeBlock = await buildDispatchKnowledgeBlock({
+      contentDir,
+      taskId: task.id,
+      title: task.title,
+      agentId: targetAgent,
+      query: buildTaskKnowledgeQuery({
+        title: task.title,
+        description: task.description,
+        instructions: ctx.instructions,
+        context: ctx.label,
+      }),
+    })
     // Pass contextTaskId so the step/complete API targets the right instance
-    const message = buildWorkflowDispatchMessage({ ...task, id: contextTaskId }, ctx, agent, port)
+    const message = buildWorkflowDispatchMessage({ ...task, id: contextTaskId }, ctx, agent, port, knowledgeBlock)
 
     try {
       await sendDispatchMessage(targetAgent, message)
@@ -728,7 +806,8 @@ function buildWorkflowDispatchMessage(
     deny_tools?: string[]
   },
   agentName: string,
-  _port: number
+  _port: number,
+  knowledgeBlock = '',
 ): string {
   void _port
   const lines: string[] = []
@@ -815,6 +894,11 @@ function buildWorkflowDispatchMessage(
     lines.push('```json')
     lines.push(JSON.stringify(stepContext.priorStepOutput, null, 2))
     lines.push('```')
+    lines.push('')
+  }
+
+  if (knowledgeBlock) {
+    lines.push(knowledgeBlock)
     lines.push('')
   }
 

--- a/tests/agent-packages/knowledge-retrieval.test.ts
+++ b/tests/agent-packages/knowledge-retrieval.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+import type { SearchResponse } from '../../packages/core/src/plugin-types'
+import {
+  formatKnowledgeLessonsForDispatch,
+  retrieveAgentPackageKnowledge,
+  type KnowledgeSearchFn,
+} from '../../src/core/agent-packages/knowledge-retrieval'
+
+const testDir = join(tmpdir(), `bakin-knowledge-retrieval-${Date.now()}-${randomUUID()}`)
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(testDir, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('agent package knowledge retrieval', () => {
+  it('selects top enabled lessons for the target package and hydrates full bodies from disk', async () => {
+    seedAgentPackage('pixel', '0.1.0', ['style', 'craft'])
+    seedLesson('pixel', '0.1.0', 'style', {
+      title: 'Style System',
+      tags: ['visual', 'prompting'],
+      body: 'Full style lesson body from disk.',
+    })
+    seedLesson('pixel', '0.1.0', 'craft', {
+      title: 'Craft Notes',
+      tags: ['quality'],
+      body: 'Full craft lesson body from disk.',
+    })
+    seedLesson('pixel', '0.1.0', 'disabled', {
+      title: 'Disabled',
+      tags: [],
+      body: 'Should not appear.',
+    })
+
+    const calls: Array<{ q: string; opts: Parameters<KnowledgeSearchFn>[1] }> = []
+    const search: KnowledgeSearchFn = async (q, opts) => {
+      calls.push({ q, opts })
+      return response([
+        hit('disabled', 0.99, { package_id: 'pixel', lesson_id: 'disabled', title: 'Disabled', body: 'disabled chunk' }),
+        hit('other', 0.95, { package_id: 'rolo', lesson_id: 'pacing', title: 'Pacing', body: 'wrong package' }),
+        hit('style', 0.86, { package_id: 'pixel', lesson_id: 'style', title: 'Style chunk', body: 'chunk body' }),
+        hit('craft', 0.72, { package_id: 'pixel', lesson_id: 'craft', title: 'Craft chunk', body: 'chunk body' }),
+        hit('style-duplicate', 0.4, { package_id: 'pixel', lesson_id: 'style', title: 'Duplicate', body: 'duplicate chunk' }),
+      ])
+    }
+
+    const result = await retrieveAgentPackageKnowledge({
+      contentDir: testDir,
+      agentId: 'pixel',
+      query: 'make a polished social image',
+      settings: { maxLessons: 2 },
+      search,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].opts.table).toBe('agent-knowledge')
+    expect(calls[0].opts.filters).toEqual({ package_id: 'pixel' })
+    expect(result.packageId).toBe('pixel')
+    expect(result.lessons.map((lesson) => lesson.lessonId)).toEqual(['style', 'craft'])
+    expect(result.lessons[0].title).toBe('Style System')
+    expect(result.lessons[0].body).toBe('Full style lesson body from disk.')
+    expect(result.lessons[0].tags).toEqual(['visual', 'prompting'])
+
+    const block = formatKnowledgeLessonsForDispatch(result.lessons)
+    expect(block).toContain('## Relevant Package Knowledge')
+    expect(block).toContain('Style System')
+    expect(block).toContain('Full craft lesson body from disk.')
+    expect(block).not.toContain('Should not appear')
+  })
+
+  it('does not query search when the agent is not package-managed', async () => {
+    let searched = false
+    const result = await retrieveAgentPackageKnowledge({
+      contentDir: testDir,
+      agentId: 'unmanaged',
+      query: 'anything',
+      search: async () => {
+        searched = true
+        return response([])
+      },
+    })
+
+    expect(searched).toBe(false)
+    expect(result.reason).toBe('no-package')
+    expect(result.lessons).toEqual([])
+  })
+
+  it('respects minScore and injection budget', async () => {
+    seedAgentPackage('patch', '0.1.0', ['dev-discipline'])
+    seedLesson('patch', '0.1.0', 'dev-discipline', {
+      title: 'Dev Discipline',
+      tags: [],
+      body: 'A'.repeat(5000),
+    })
+
+    const result = await retrieveAgentPackageKnowledge({
+      contentDir: testDir,
+      agentId: 'patch',
+      query: 'implementation task',
+      settings: { minScore: 0.5 },
+      search: async () => response([
+        hit('dev-discipline', 0.4, { package_id: 'patch', lesson_id: 'dev-discipline', title: 'Dev Discipline', body: 'chunk' }),
+      ]),
+    })
+    expect(result.lessons).toEqual([])
+
+    const selected = await retrieveAgentPackageKnowledge({
+      contentDir: testDir,
+      agentId: 'patch',
+      query: 'implementation task',
+      search: async () => response([
+        hit('dev-discipline', 0.9, { package_id: 'patch', lesson_id: 'dev-discipline', title: 'Dev Discipline', body: 'chunk' }),
+      ]),
+    })
+    const block = formatKnowledgeLessonsForDispatch(selected.lessons, 1200)
+    expect(block.length).toBeLessThanOrEqual(1300)
+    expect(block).toContain('[truncated]')
+  })
+})
+
+function seedAgentPackage(agentId: string, version: string, knowledgeEnabled: string[]): void {
+  const lockPath = join(testDir, 'packages', 'lock.json')
+  mkdirSync(join(testDir, 'packages'), { recursive: true })
+  writeFileSync(lockPath, JSON.stringify({
+    version: 1,
+    packages: {
+      [agentId]: {
+        kind: 'agent',
+        version,
+        source: `local:${agentId}`,
+        ref: 'main',
+        commitSha: 'test',
+        installedAt: '2026-04-30T00:00:00.000Z',
+        state: 'managed',
+        agentId,
+        knowledgeEnabled,
+      },
+    },
+  }, null, 2))
+}
+
+function seedLesson(packageId: string, version: string, lessonId: string, input: {
+  title: string
+  tags: string[]
+  body: string
+}): void {
+  const dir = join(testDir, 'packages', 'agents', `${packageId}@${version}`, 'knowledge')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, `${lessonId}.md`), [
+    '---',
+    `title: ${input.title}`,
+    `tags: [${input.tags.map((tag) => JSON.stringify(tag)).join(', ')}]`,
+    '---',
+    '',
+    input.body,
+  ].join('\n'))
+}
+
+function response(results: SearchResponse['results']): SearchResponse {
+  return {
+    results,
+    meta: {
+      query: 'test',
+      total: results.length,
+      took_ms: 1,
+      source: 'search',
+    },
+  }
+}
+
+function hit(id: string, score: number, fields: Record<string, unknown>): SearchResponse['results'][number] {
+  return {
+    id,
+    table: 'bakin_agent-knowledge',
+    score,
+    fields,
+  }
+}

--- a/tests/core/dispatch-assets.test.ts
+++ b/tests/core/dispatch-assets.test.ts
@@ -125,4 +125,23 @@ describe('buildDispatchMessage — attached assets', () => {
     const msg = buildDispatchMessage(task, 'main', testDir, 3737)
     expect(msg).toContain('## Attached Assets')
   })
+
+  it('can include retrieved package knowledge in dispatch messages', () => {
+    const task = {
+      id: 'task-knowledge',
+      title: 'Use package knowledge',
+      agent: 'pixel',
+    }
+    const msg = buildDispatchMessage(
+      task,
+      'pixel',
+      testDir,
+      3737,
+      'main',
+      '## Relevant Package Knowledge\n\nSelected lesson body.',
+    )
+    expect(msg).toContain('## Relevant Package Knowledge')
+    expect(msg).toContain('Selected lesson body.')
+    expect(msg).toContain('## PROGRESS LOGGING')
+  })
 })

--- a/tests/plugins/team/agent-knowledge-search.test.ts
+++ b/tests/plugins/team/agent-knowledge-search.test.ts
@@ -68,12 +68,13 @@ describe('team plugin: agent-knowledge content type registration', () => {
 
     // Build a minimal mock context that captures registerFileBackedContentType calls.
     const captured: Array<{ table: string; def: { facets?: string[]; filePatterns?: { pattern: string }[] } }> = []
+    const execTools: string[] = []
     const ctx = {
       pluginId: 'team',
       registerNav: () => {},
       registerRoute: () => {},
       registerSlot: () => {},
-      registerExecTool: () => {},
+      registerExecTool: (tool: { name: string }) => { execTools.push(tool.name) },
       registerSkill: () => {},
       registerWorkflow: () => {},
       registerNodeType: () => {},
@@ -107,6 +108,7 @@ describe('team plugin: agent-knowledge content type registration', () => {
     expect(knowledge!.def.facets).toContain('package_id')
     expect(knowledge!.def.facets).toContain('agent_id')
     expect(knowledge!.def.filePatterns?.[0].pattern).toBe('packages/agents/*/knowledge/*.md')
+    expect(execTools).toContain('bakin_exec_knowledge_search')
   })
 })
 

--- a/tests/plugins/team/use-package-states.test.ts
+++ b/tests/plugins/team/use-package-states.test.ts
@@ -107,20 +107,27 @@ beforeEach(() => {
 
 describe('useAgentStore — package state plumbing', () => {
   it('fires both fetches in parallel during load()', async () => {
-    const calls: Array<{ url: string; ts: number }> = []
-    global.fetch = makeFetchSpy({
-      onCall: (url, ts) => calls.push({ url, ts }),
+    const calls: string[] = []
+    const roster = deferred<Response>()
+    const packages = deferred<Response>()
+    global.fetch = mock((url: RequestInfo | URL) => {
+      const u = String(url)
+      calls.push(u)
+      if (u === '/api/plugins/team/') return roster.promise
+      if (u === '/api/agent-packages') return packages.promise
+      return Promise.reject(new Error(`unexpected fetch: ${u}`))
     }) as unknown as typeof global.fetch
 
-    await useAgentStore.getState().load()
+    const loadPromise = useAgentStore.getState().load()
+    await Promise.resolve()
 
-    expect(calls.map((c) => c.url).sort()).toEqual(
+    expect(calls.sort()).toEqual(
       ['/api/agent-packages', '/api/plugins/team/'],
     )
-    // Parallel == both calls landed before either resolved. Timestamps will
-    // be within microseconds of each other; we assert <5ms which is generous.
-    const span = Math.abs(calls[0].ts - calls[1].ts)
-    expect(span).toBeLessThan(5)
+
+    roster.resolve(response(ROSTER_OK))
+    packages.resolve(response(PKG_OK))
+    await loadPromise
   })
 
   it('merges package state into a map keyed by agentId', async () => {
@@ -218,3 +225,24 @@ describe('useAgentStore — package state plumbing', () => {
     expect(state.packageStates).toEqual({})
   })
 })
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function response(body: unknown, status = 200): Response {
+  return {
+    ok: status < 400,
+    json: () => Promise.resolve(body),
+  } as Response
+}


### PR DESCRIPTION
## Summary
- Add dispatch-time package knowledge retrieval over the existing agent-knowledge search index, filtered by lockfile-enabled lessons.
- Inject selected lessons into regular and workflow dispatch prompts, with audit events and fail-open behavior on retrieval errors.
- Add bakin_exec_knowledge_search for caller-scoped follow-up lookup and allow it in the reference agent manifests.
- Document the new retrieval settings and update package authoring guidance.

Fixes #157

## Verification
- bun test tests/agent-packages/knowledge-retrieval.test.ts tests/core/dispatch-assets.test.ts tests/plugins/team/agent-knowledge-search.test.ts
- bun test tests/core/dispatch.test.ts tests/plugins/team/agent-knowledge-search.test.ts tests/agent-packages/knowledge-retrieval.test.ts
- bun run typecheck
- bun run docs:validate
- bunx eslint src/core/agent-packages/knowledge-retrieval.ts src/core/dispatch.ts tests/agent-packages/knowledge-retrieval.test.ts tests/core/dispatch-assets.test.ts tests/plugins/team/agent-knowledge-search.test.ts packages/core/src/settings.ts

Full bun run lint still fails on existing unrelated route/plugin lint debt (unused route types/ctx args in routing, assets, memory, team, workflows, tasks, docs scripts).