### PR TITLE
Add git worktree isolation for agent code work

### DIFF
--- a/.claude/knowledge/git-plugin.md
+++ b/.claude/knowledge/git-plugin.md
@@ -1,0 +1,39 @@
+# Git Plugin
+
+## Purpose
+
+The `git` core plugin owns task-scoped worktree isolation for code-producing agents. It exists because a skill-only convention cannot prevent multiple agents from editing the shared checkout at the same time.
+
+## Public Surface
+
+- REST routes:
+  - `GET /api/plugins/git/worktrees`
+  - `POST /api/plugins/git/worktrees/prepare`
+  - `POST /api/plugins/git/worktrees/release`
+- MCP exec tools:
+  - `bakin_exec_git_prepare_worktree`
+  - `bakin_exec_git_status`
+  - `bakin_exec_git_release_worktree`
+- Doctor check:
+  - `git.worktrees`, warning when an active tracked worktree path is missing.
+
+## Settings
+
+- `allowedRepoRoots`: list of `{ path }` records or strings. Defaults to `~/go/src/github.com/madeinwyo`.
+- `worktreeRoot`: path for Bakin-created worktrees. Defaults to `~/.bakin/git-worktrees`.
+
+The plugin resolves real paths for both requested repos and allowed roots. A repo is accepted only when both the requested path and the actual git top-level are within a configured allowed root.
+
+## Agent Contract
+
+Developer agents should call `bakin_exec_git_prepare_worktree` before code edits, work only inside the returned `worktreePath`, call `bakin_exec_git_status` before handoff, and call `bakin_exec_git_release_worktree` only after local cleanup is safe. Release refuses dirty worktrees unless `force=true` is explicitly provided.
+
+Patch is the first package wired to this contract through:
+
+- `agents/patch/bakin-package.json` tool allowlist: `bakin_exec_git_*`
+- `agents/patch/skills/git-isolation/SKILL.md`
+- `agents/patch/workspace/TOOLS.md`
+
+## Deliberate Scope
+
+This first slice does not create PRs, push branches, or auto-prepare worktrees at dispatch time. The agent calls the tool once it knows the repository path for the task. PR creation remains normal `git`/`gh` workflow from inside the prepared worktree.

--- a/agents/patch/README.md
+++ b/agents/patch/README.md
@@ -8,6 +8,8 @@ Reference agent package for Bakin's developer agent. Builds + maintains API inte
 agents/patch/
 ├── bakin-package.json
 ├── workspace/                SOUL/IDENTITY/AGENTS/TOOLS templates
+├── skills/
+│   └── git-isolation/        runtime procedure for Bakin git worktree tools
 ├── knowledge/
 │   └── dev-discipline.md     (default-enabled)
 └── assets/                   avatar.jpg + avatar-full.png
@@ -17,6 +19,7 @@ agents/patch/
 
 - **`agent.defaultModel: "anthropic/claude-opus-4-6"`** — Patch uses Opus 4.6 by default rather than the system default, since dev work benefits from the larger context window for codebase navigation. Set on fresh install only; the user can change it via the Models UI afterward (per the D5 settled-decision in SPEC.md).
 - Single knowledge file: `dev-discipline` — durable principles (build right first time / automate everything / debugging discipline / security first / never deploy without testing / documentation rules / when-to-ask-before-acting checklist).
+- Runtime skill: `git-isolation` — teaches Patch to call Bakin's git worktree tools before editing code, status before handoff, and release only when the worktree is safe to clean up.
 - AGENTS.md inherits Patch's existing operational rules: `~/go/src/github.com/madeinwyo/` for code, browser `profile="user"`, run `date` before any timestamp.
 
 ## Install

--- a/agents/patch/bakin-package.json
+++ b/agents/patch/bakin-package.json
@@ -15,12 +15,13 @@
     "allowedTools": [
       "bakin_exec_tasks_*",
       "bakin_exec_assets_*",
+      "bakin_exec_git_*",
       "bakin_exec_knowledge_search",
       "bakin_exec_get_paths",
       "bakin_exec_log",
       "bakin_exec_heartbeat"
     ],
-    "allowedSkills": []
+    "allowedSkills": ["git-isolation"]
   },
   "install": {
     "createIfMissing": true,
@@ -37,6 +38,7 @@
       "workspace/AGENTS.md",
       "workspace/TOOLS.md"
     ],
+    "skills": ["skills/git-isolation"],
     "knowledge": ["knowledge/dev-discipline.md"],
     "assets": ["assets/avatar.jpg", "assets/avatar-full.png"]
   }

--- a/agents/patch/skills/git-isolation/SKILL.md
+++ b/agents/patch/skills/git-isolation/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: git-isolation
+description: Use before making code changes for a Bakin task so work happens in an isolated git worktree instead of the shared repo checkout.
+---
+
+# Git Isolation
+
+Use this skill whenever you will edit code, run formatters that may rewrite files, or prepare a PR for a Bakin task.
+
+## Procedure
+
+1. Before editing, call `bakin_exec_git_prepare_worktree` with:
+   - `repoPath`: the repository you will change
+   - `taskId`: the Bakin task or issue id
+   - `branch`: optional; use a clear `bakin/<task>-<summary>` branch when you know the branch name
+   - `baseRef`: optional; defaults to `HEAD`
+2. If preparation fails, stop and report the error. Do not edit the shared checkout.
+3. Move into the returned `worktreePath` and do all code reads, writes, tests, commits, pushes, and PR work from there.
+4. Before handoff, call `bakin_exec_git_status` for the task and confirm the worktree state matches what you are about to report.
+5. After the PR is opened or the branch is no longer needed locally, call `bakin_exec_git_release_worktree`.
+
+## Guardrails
+
+- Never continue code edits in the original repo after a worktree has been prepared for the task.
+- Never use `force=true` on release to hide unfinished work. Only force release when the user explicitly asks to discard local changes or when a missing worktree needs to be cleared from the registry.
+- If the worktree is dirty at handoff, explain exactly what is uncommitted and why it remains.
+- If multiple agents are working on nearby code, each agent must have its own prepared worktree and branch.

--- a/agents/patch/workspace/TOOLS.md
+++ b/agents/patch/workspace/TOOLS.md
@@ -1,6 +1,8 @@
 # TOOLS.md - Local Notes
 
 - Code repo root: `~/go/src/github.com/madeinwyo/` — every new project lives under here
+- For code changes on a Bakin task, call `bakin_exec_git_prepare_worktree` first and work only inside the returned `worktreePath`
+- Before handoff, call `bakin_exec_git_status`; after the PR is open or the branch is no longer needed locally, call `bakin_exec_git_release_worktree`
 - Browser profile to use: `profile="user"` + Chrome "Work" profile (per AGENTS.md)
 - API keys / tokens: per-install, stored as env vars or in the agent's `.env` (never in tracked files)
 - Common SDKs you maintain (per-install)

--- a/bakin.config.ts
+++ b/bakin.config.ts
@@ -10,6 +10,7 @@ const config: BakinConfig = {
     { path: 'plugins/assets' },
     { path: 'plugins/schedule' },
     { path: 'plugins/health' },
+    { path: 'plugins/git' },
   ],
   theme: {},
 }

--- a/docs/.generated/coverage.json
+++ b/docs/.generated/coverage.json
@@ -34,17 +34,17 @@
     },
     "execTools": {
       "status": "audited",
-      "count": 107,
+      "count": 111,
       "source": "source scan"
     },
     "corePlugins": {
       "status": "active",
-      "count": 8,
+      "count": 9,
       "source": "plugins/*/bakin-plugin.json"
     },
     "settings": {
       "status": "active",
-      "count": 50,
+      "count": 56,
       "source": "packages/core/src/settings.ts"
     },
     "sdkSubpaths": {

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -217,6 +217,7 @@ document.addEventListener("click", function (event) {
             { label: 'Memory', slug: 'using/memory' },
             { label: 'Team', slug: 'using/team' },
             { label: 'Models', slug: 'using/models' },
+            { label: 'Git', slug: 'using/git' },
             { label: 'Health', slug: 'using/health' },
             { label: 'Settings', slug: 'using/settings' },
           ],

--- a/docs/public/llms/core-plugins.md
+++ b/docs/public/llms/core-plugins.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The official plugin catalog is generated from supported plugin manifests. Current official plugin count: 10. Core plugins ship in this repo; additional official plugins can live in the official plugin repo.
+The official plugin catalog is generated from supported plugin manifests. Current official plugin count: 11. Core plugins ship in this repo; additional official plugins can live in the official plugin repo.

--- a/docs/public/llms/exec-tools.md
+++ b/docs/public/llms/exec-tools.md
@@ -341,6 +341,47 @@ mcporter call bakin-<agent>.bakin_exec_get_step --args '{
 }'
 ```
 
+## Git
+
+### bakin_exec_git_prepare_worktree
+
+Label: Prepared git worktree
+Purpose: Create or reuse an isolated git worktree for a task. Call this before editing code for a Bakin task.
+
+Arguments: none.
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_git_prepare_worktree
+```
+
+### bakin_exec_git_release_worktree
+
+Label: Released git worktree
+Purpose: Release a tracked git worktree. Refuses dirty removal unless force=true.
+
+Arguments: none.
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_git_release_worktree
+```
+
+### bakin_exec_git_status
+
+Label: Checked git worktrees
+Purpose: List Bakin-tracked git worktrees and their dirty state.
+
+Arguments: none.
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_git_status
+```
+
 ## Health
 
 Health tools let agents check whether Bakin is running correctly before or during work.
@@ -397,6 +438,27 @@ mcporter call bakin-<agent>.bakin_exec_heartbeat --args '{
   "status": "value",
   "currentTask": "value",
   "message": "value"
+}'
+```
+
+## Knowledge
+
+### bakin_exec_knowledge_search
+
+Label: Searched package knowledge
+Purpose: Search the enabled agent-package knowledge lessons for the calling agent.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `query` | string | yes | Search query |
+| `limit` | number | no | Max lessons to return (default from settings, max 10) |
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_knowledge_search --args '{
+  "query": "value",
+  "limit": 20
 }'
 ```
 

--- a/docs/public/llms/hooks.md
+++ b/docs/public/llms/hooks.md
@@ -331,15 +331,14 @@ Task hooks let plugins enrich task details and react to task lifecycle changes.
 
 ### tasks.enrichDetails
 
-Label: Add project task context.
-Purpose: Adds project title, status, progress, and excerpt data to task detail payloads. Use it when a task surface wants project context without depending on project storage.
-Kind: waterfall
-Source: bakin-bits-official/plugins/projects/index.ts:160
+Label: tasks.enrichDetails
+Kind: rpc
+Source: bakin-bits-official/plugins/projects/index.ts:156
 
 Example:
 
 ```ts
-const next = await ctx.hooks.call(
+const result = await ctx.hooks.invoke(
   'tasks.enrichDetails',
   {
     task: {
@@ -352,15 +351,14 @@ const next = await ctx.hooks.call(
 
 ### tasks.statusChanged
 
-Label: Sync project task state.
-Purpose: Updates linked project checklist items when a task moves into a completed state. Use it to keep project progress in sync with task lifecycle events.
-Kind: event
+Label: tasks.statusChanged
+Kind: rpc
 Source: bakin-bits-official/plugins/projects/index.ts:149
 
 Example:
 
 ```ts
-await ctx.hooks.callAll(
+const result = await ctx.hooks.invoke(
   'tasks.statusChanged',
   {
     taskId: 'task-123',
@@ -379,7 +377,7 @@ Team hooks expose runtime agent and team metadata for plugins that need agent-aw
 Label: Get an agent.
 Purpose: Returns one runtime agent by id, including team-aware metadata when available. Use it when a plugin already has an agent id and needs the full display record.
 Kind: rpc
-Source: plugins/team/index.ts:1742
+Source: plugins/team/index.ts:1743
 
 Example:
 
@@ -397,7 +395,7 @@ const result = await ctx.hooks.invoke(
 Label: List agent ids.
 Purpose: Returns the ids of agents currently known to the runtime. Use it for lightweight validation, assignment pickers, or loops that do not need full agent metadata.
 Kind: rpc
-Source: plugins/team/index.ts:1747
+Source: plugins/team/index.ts:1748
 
 Example:
 
@@ -413,7 +411,7 @@ const result = await ctx.hooks.invoke(
 Label: Get agent team.
 Purpose: Returns the team currently assigned to an agent, or null when the agent is unassigned. Use it to add team context to task, workflow, or activity views.
 Kind: rpc
-Source: plugins/team/index.ts:1754
+Source: plugins/team/index.ts:1755
 
 Example:
 
@@ -431,7 +429,7 @@ const result = await ctx.hooks.invoke(
 Label: Get org structure.
 Purpose: Returns the current organization structure for teams and agents. Use it when a plugin needs the full hierarchy instead of individual team or agent records.
 Kind: rpc
-Source: plugins/team/index.ts:1760
+Source: plugins/team/index.ts:1761
 
 Example:
 
@@ -447,7 +445,7 @@ const result = await ctx.hooks.invoke(
 Label: List team members.
 Purpose: Returns the agents assigned to one team. Use it for team dashboards, routing rules, or workflow logic that needs team membership.
 Kind: rpc
-Source: plugins/team/index.ts:1751
+Source: plugins/team/index.ts:1752
 
 Example:
 
@@ -465,7 +463,7 @@ const result = await ctx.hooks.invoke(
 Label: List agents.
 Purpose: Returns runtime agents with their display and team metadata attached. Use it when another plugin needs the agent roster as Bakin presents it.
 Kind: rpc
-Source: plugins/team/index.ts:1741
+Source: plugins/team/index.ts:1742
 
 Example:
 
@@ -481,7 +479,7 @@ const result = await ctx.hooks.invoke(
 Label: Resolve agent profile.
 Purpose: Returns the runtime profile for an agent id. Use it when a plugin needs the lower-level profile data behind an agent display record.
 Kind: rpc
-Source: plugins/team/index.ts:1748
+Source: plugins/team/index.ts:1749
 
 Example:
 

--- a/docs/public/llms/settings.md
+++ b/docs/public/llms/settings.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 50. Operators can override settings in settings.json under the resolved Bakin home directory.
+The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 56. Operators can override settings in settings.json under the resolved Bakin home directory.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -16,6 +16,9 @@
       "name": "Assets"
     },
     {
+      "name": "Git"
+    },
+    {
       "name": "Health"
     },
     {
@@ -946,6 +949,323 @@
           }
         ],
         "x-bakin-full-path": "/api/plugins/assets/search"
+      }
+    },
+    "/api/plugins/git/worktrees": {
+      "get": {
+        "operationId": "git.get.worktrees",
+        "summary": "List tracked git worktrees",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Git"
+        ],
+        "parameters": [
+          {
+            "name": "repoPath",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "taskId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "includeReleased",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/git/worktrees"
+      }
+    },
+    "/api/plugins/git/worktrees/prepare": {
+      "post": {
+        "operationId": "git.post.worktrees-prepare",
+        "summary": "Create or reuse an isolated git worktree for a task",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type — body content type does not match the declared content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Git"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "repoPath": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "taskId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "branch": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "baseRef": {
+                    "default": "HEAD",
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "purpose": {
+                    "type": "string",
+                    "maxLength": 200
+                  },
+                  "agent": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "repoPath",
+                  "taskId",
+                  "baseRef"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-bakin-full-path": "/api/plugins/git/worktrees/prepare"
+      }
+    },
+    "/api/plugins/git/worktrees/release": {
+      "post": {
+        "operationId": "git.post.worktrees-release",
+        "summary": "Release a tracked git worktree",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type — body content type does not match the declared content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Git"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "worktreePath": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "repoPath": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "taskId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "force": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "force"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "agent": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "x-bakin-full-path": "/api/plugins/git/worktrees/release"
       }
     },
     "/api/plugins/health/checks": {

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -570,6 +570,37 @@ curl -sS \
 ```
 </OpenApiReference>
 
+## Git
+
+<OpenApiReference tag="Git" summary />
+
+<OpenApiReference operationId="git.get.worktrees">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  'http://localhost:3737/api/plugins/git/worktrees?repoPath=<repoPath>&taskId=<taskId>&includeReleased=<includeReleased>'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="git.post.worktrees-prepare">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/git/worktrees/prepare' \
+  -H 'Content-Type: application/json' \
+  --data '{"repoPath":"value","taskId":"value","branch":"value","baseRef":"value","purpose":"value","agent":"value"}'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="git.post.worktrees-release">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/git/worktrees/release' \
+  -H 'Content-Type: application/json' \
+  --data '"value"'
+```
+</OpenApiReference>
+
 ## Health
 
 <OpenApiReference tag="Health" summary />

--- a/docs/src/content/docs/reference/generated/core-plugins.md
+++ b/docs/src/content/docs/reference/generated/core-plugins.md
@@ -20,6 +20,13 @@ description: Generated catalog of official plugins supported by Bakin.
       <td>none</td>
     </tr>
     <tr>
+      <td>Git<br/><span>Git worktree isolation for agent code work</span></td>
+      <td><code>git</code></td>
+      <td>Core</td>
+      <td><code>1.0.0</code></td>
+      <td>none</td>
+    </tr>
+    <tr>
       <td>Health<br/><span>System health dashboard — MCP stats, diagnostics, and uptime</span></td>
       <td><code>health</code></td>
       <td>Core</td>

--- a/docs/src/content/docs/reference/generated/exec-tools.mdx
+++ b/docs/src/content/docs/reference/generated/exec-tools.mdx
@@ -170,6 +170,28 @@ mcporter call bakin-<agent>.bakin_exec_get_step --args '{
 </McpToolCard>
 </div>
 
+## Git
+
+<p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
+
+<div class="mcp-tool-list">
+<McpToolCard id="git-prepare-worktree" name="bakin_exec_git_prepare_worktree" label="Prepared git worktree" description="Create or reuse an isolated git worktree for a task. Call this before editing code for a Bakin task." source="plugins/git/index.ts:639">
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_git_prepare_worktree
+```
+</McpToolCard>
+<McpToolCard id="git-release-worktree" name="bakin_exec_git_release_worktree" label="Released git worktree" description="Release a tracked git worktree. Refuses dirty removal unless force=true." source="plugins/git/index.ts:654">
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_git_release_worktree
+```
+</McpToolCard>
+<McpToolCard id="git-status" name="bakin_exec_git_status" label="Checked git worktrees" description="List Bakin-tracked git worktrees and their dirty state." source="plugins/git/index.ts:647">
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_git_status
+```
+</McpToolCard>
+</div>
+
 ## Health
 
 <p class="mcp-section-description">Health tools let agents check whether Bakin is running correctly before or during work.</p>
@@ -200,6 +222,21 @@ mcporter call bakin-<agent>.bakin_exec_heartbeat --args '{
   "status": "value",
   "currentTask": "value",
   "message": "value"
+}'
+```
+</McpToolCard>
+</div>
+
+## Knowledge
+
+<p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
+
+<div class="mcp-tool-list">
+<McpToolCard id="knowledge-search" name="bakin_exec_knowledge_search" label="Searched package knowledge" description="Search the enabled agent-package knowledge lessons for the calling agent." source="plugins/team/index.ts:1819" parameters={[{"name":"query","type":"string","required":true,"description":"Search query"},{"name":"limit","type":"number","required":false,"description":"Max lessons to return (default from settings, max 10)"}]}>
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_knowledge_search --args '{
+  "query": "value",
+  "limit": 20
 }'
 ```
 </McpToolCard>
@@ -457,7 +494,7 @@ mcporter call bakin-<agent>.bakin_exec_post_channel --args '{
 <p class="mcp-section-description">Project tools let agents create, update, read, and maintain project specs and linked checklist items.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="project-add-item" name="bakin_exec_project_add_item" label="Added project item" description="Add a new checklist item to a project." source="bakin-bits-official/plugins/projects/index.ts:614" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":true,"description":"Checklist item title"}]}>
+<McpToolCard id="project-add-item" name="bakin_exec_project_add_item" label="Added project item" description="Add a new checklist item to a project." source="bakin-bits-official/plugins/projects/index.ts:606" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":true,"description":"Checklist item title"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_add_item --args '{
   "projectId": "value",
@@ -465,7 +502,7 @@ mcporter call bakin-<agent>.bakin_exec_project_add_item --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-ask" name="bakin_exec_project_ask" label="Asked project question" description="Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming." source="bakin-bits-official/plugins/projects/index.ts:804" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"message","type":"string","required":true,"description":"Question or prompt for the agent"},{"name":"agent","type":"string","required":false,"description":"Agent ID to ask (defaults to main)"}]}>
+<McpToolCard id="project-ask" name="bakin_exec_project_ask" label="Asked project question" description="Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming." source="bakin-bits-official/plugins/projects/index.ts:796" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"message","type":"string","required":true,"description":"Question or prompt for the agent"},{"name":"agent","type":"string","required":false,"description":"Agent ID to ask (defaults to main)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_ask --args '{
   "projectId": "value",
@@ -474,7 +511,7 @@ mcporter call bakin-<agent>.bakin_exec_project_ask --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-attach-asset" name="bakin_exec_project_attach_asset" label="Attached asset to project" description="Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed." source="bakin-bits-official/plugins/projects/index.ts:716" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename (e.g., \"20260327-hero-a1b2c3d4.png\") — globally unique, stable across retype/relink"},{"name":"label","type":"string","required":false,"description":"Human-readable label or summary of what this asset contains"}]}>
+<McpToolCard id="project-attach-asset" name="bakin_exec_project_attach_asset" label="Attached asset to project" description="Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed." source="bakin-bits-official/plugins/projects/index.ts:708" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename (e.g., \"20260327-hero-a1b2c3d4.png\") — globally unique, stable across retype/relink"},{"name":"label","type":"string","required":false,"description":"Human-readable label or summary of what this asset contains"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_attach_asset --args '{
   "projectId": "value",
@@ -483,7 +520,7 @@ mcporter call bakin-<agent>.bakin_exec_project_attach_asset --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-create" name="bakin_exec_project_create" label="Created a project" description="Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs." source="bakin-bits-official/plugins/projects/index.ts:547" parameters={[{"name":"title","type":"string","required":true,"description":"Project title"},{"name":"body","type":"string","required":false,"description":"Markdown body (spec/plan)"},{"name":"owner","type":"string","required":false,"description":"Project owner"},{"name":"tasks","type":"array","required":false,"description":"Initial checklist item titles"}]}>
+<McpToolCard id="project-create" name="bakin_exec_project_create" label="Created a project" description="Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs." source="bakin-bits-official/plugins/projects/index.ts:539" parameters={[{"name":"title","type":"string","required":true,"description":"Project title"},{"name":"body","type":"string","required":false,"description":"Markdown body (spec/plan)"},{"name":"owner","type":"string","required":false,"description":"Project owner"},{"name":"tasks","type":"array","required":false,"description":"Initial checklist item titles"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_create --args '{
   "title": "value",
@@ -495,14 +532,14 @@ mcporter call bakin-<agent>.bakin_exec_project_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-delete" name="bakin_exec_project_delete" label="Deleted a project" description="Delete a project by ID." source="bakin-bits-official/plugins/projects/index.ts:596" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
+<McpToolCard id="project-delete" name="bakin_exec_project_delete" label="Deleted a project" description="Delete a project by ID." source="bakin-bits-official/plugins/projects/index.ts:588" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_delete --args '{
   "projectId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-detach-asset" name="bakin_exec_project_detach_asset" label="Detached asset from project" description="Remove an asset reference from a project by filename. Does not delete the asset itself." source="bakin-bits-official/plugins/projects/index.ts:736" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename to detach"}]}>
+<McpToolCard id="project-detach-asset" name="bakin_exec_project_detach_asset" label="Detached asset from project" description="Remove an asset reference from a project by filename. Does not delete the asset itself." source="bakin-bits-official/plugins/projects/index.ts:728" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename to detach"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_detach_asset --args '{
   "projectId": "value",
@@ -510,14 +547,14 @@ mcporter call bakin-<agent>.bakin_exec_project_detach_asset --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-get" name="bakin_exec_project_get" label="Read project details" description="Get a project by ID including full spec, checklist, progress, and linked board task statuses." source="bakin-bits-official/plugins/projects/index.ts:533" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
+<McpToolCard id="project-get" name="bakin_exec_project_get" label="Read project details" description="Get a project by ID including full spec, checklist, progress, and linked board task statuses." source="bakin-bits-official/plugins/projects/index.ts:525" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_get --args '{
   "projectId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-link-item" name="bakin_exec_project_link_item" label="Linked project item" description="Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project." source="bakin-bits-official/plugins/projects/index.ts:668" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID"},{"name":"taskId","type":"string","required":true,"description":"Board task ID to link"}]}>
+<McpToolCard id="project-link-item" name="bakin_exec_project_link_item" label="Linked project item" description="Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project." source="bakin-bits-official/plugins/projects/index.ts:660" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID"},{"name":"taskId","type":"string","required":true,"description":"Board task ID to link"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_link_item --args '{
   "projectId": "value",
@@ -526,14 +563,14 @@ mcporter call bakin-<agent>.bakin_exec_project_link_item --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-list" name="bakin_exec_project_list" label="Listed projects" description="List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount." source="bakin-bits-official/plugins/projects/index.ts:517" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by status"}]}>
+<McpToolCard id="project-list" name="bakin_exec_project_list" label="Listed projects" description="List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount." source="bakin-bits-official/plugins/projects/index.ts:509" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by status"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_list --args '{
   "status": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-mark-item" name="bakin_exec_project_mark_item" label="Marked project item" description="Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:629" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
+<McpToolCard id="project-mark-item" name="bakin_exec_project_mark_item" label="Marked project item" description="Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:621" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_mark_item --args '{
   "projectId": "value",
@@ -542,7 +579,7 @@ mcporter call bakin-<agent>.bakin_exec_project_mark_item --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-promote-item" name="bakin_exec_project_promote_item" label="Promoted project item" description="Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set." source="bakin-bits-official/plugins/projects/index.ts:692" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to promote to a board task"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign the task to"}]}>
+<McpToolCard id="project-promote-item" name="bakin_exec_project_promote_item" label="Promoted project item" description="Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set." source="bakin-bits-official/plugins/projects/index.ts:684" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to promote to a board task"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign the task to"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_promote_item --args '{
   "projectId": "value",
@@ -551,7 +588,7 @@ mcporter call bakin-<agent>.bakin_exec_project_promote_item --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-remove-item" name="bakin_exec_project_remove_item" label="Removed project item" description="Remove a checklist item from a project." source="bakin-bits-official/plugins/projects/index.ts:649" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to remove"}]}>
+<McpToolCard id="project-remove-item" name="bakin_exec_project_remove_item" label="Removed project item" description="Remove a checklist item from a project." source="bakin-bits-official/plugins/projects/index.ts:641" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to remove"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_remove_item --args '{
   "projectId": "value",
@@ -559,7 +596,7 @@ mcporter call bakin-<agent>.bakin_exec_project_remove_item --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-toggle-item" name="bakin_exec_project_toggle_item" label="Toggled project item" description="Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:755" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
+<McpToolCard id="project-toggle-item" name="bakin_exec_project_toggle_item" label="Toggled project item" description="Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:747" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_toggle_item --args '{
   "projectId": "value",
@@ -568,7 +605,7 @@ mcporter call bakin-<agent>.bakin_exec_project_toggle_item --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-update" name="bakin_exec_project_update" label="Updated a project" description="Update a project's title, status, body, or owner. Cannot set status to &quot;completed&quot; if unchecked items remain." source="bakin-bits-official/plugins/projects/index.ts:569" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"choice","required":false,"description":"New status"},{"name":"body","type":"string","required":false,"description":"New markdown body"},{"name":"owner","type":"string","required":false,"description":"New owner"}]}>
+<McpToolCard id="project-update" name="bakin_exec_project_update" label="Updated a project" description="Update a project's title, status, body, or owner. Cannot set status to &quot;completed&quot; if unchecked items remain." source="bakin-bits-official/plugins/projects/index.ts:561" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"choice","required":false,"description":"New status"},{"name":"body","type":"string","required":false,"description":"New markdown body"},{"name":"owner","type":"string","required":false,"description":"New owner"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_update --args '{
   "projectId": "value",
@@ -579,7 +616,7 @@ mcporter call bakin-<agent>.bakin_exec_project_update --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-update-item" name="bakin_exec_project_update_item" label="Updated project item" description="Update a checklist item's title and/or description." source="bakin-bits-official/plugins/projects/index.ts:776" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"title","type":"string","required":false,"description":"New title for the checklist item"},{"name":"description","type":"string","required":false,"description":"New description for the checklist item"}]}>
+<McpToolCard id="project-update-item" name="bakin_exec_project_update_item" label="Updated project item" description="Update a checklist item's title and/or description." source="bakin-bits-official/plugins/projects/index.ts:768" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"title","type":"string","required":false,"description":"New title for the checklist item"},{"name":"description","type":"string","required":false,"description":"New description for the checklist item"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_project_update_item --args '{
   "projectId": "value",
@@ -871,7 +908,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_update --args '{
 <p class="mcp-section-description">Team tools expose agent roster, identity, status, messaging, and permission operations.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="team-create-agent" name="bakin_exec_team_create_agent" label="Created agent" description="Create a new agent: registers it with the active runtime, writes persona files, configures dispatch permissions, optionally assigns it to a team. Returns next-step instructions." source="plugins/team/index.ts:1902" parameters={[{"name":"id","type":"string","required":false,"description":"Agent ID (lowercase alphanumeric + hyphens). Auto-derived from name if omitted."},{"name":"name","type":"string","required":true,"description":"Display name (e.g. \"Jessica Fetcher\")"},{"name":"emoji","type":"string","required":false,"description":"Single emoji (e.g. \"🔎\")"},{"name":"role","type":"string","required":false,"description":"One-line role description"},{"name":"vibe","type":"string","required":false,"description":"Personality vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"What the agent does"},{"name":"defaultMode","type":"string","required":false,"description":"How the agent operates by default"},{"name":"model","type":"string","required":false,"description":"Full provider/model string. Uses default if omitted."},{"name":"soul","type":"string","required":false,"description":"Raw markdown for SOUL.md"},{"name":"tools","type":"string","required":false,"description":"Raw markdown for TOOLS.md"},{"name":"teamId","type":"string","required":false,"description":"Bakin team to assign the agent to"},{"name":"dispatchable","type":"union","required":false,"description":"Who can dispatch tasks to this agent. Default: \"main\"."}]}>
+<McpToolCard id="team-create-agent" name="bakin_exec_team_create_agent" label="Created agent" description="Create a new agent: registers it with the active runtime, writes persona files, configures dispatch permissions, optionally assigns it to a team. Returns next-step instructions." source="plugins/team/index.ts:1953" parameters={[{"name":"id","type":"string","required":false,"description":"Agent ID (lowercase alphanumeric + hyphens). Auto-derived from name if omitted."},{"name":"name","type":"string","required":true,"description":"Display name (e.g. \"Jessica Fetcher\")"},{"name":"emoji","type":"string","required":false,"description":"Single emoji (e.g. \"🔎\")"},{"name":"role","type":"string","required":false,"description":"One-line role description"},{"name":"vibe","type":"string","required":false,"description":"Personality vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"What the agent does"},{"name":"defaultMode","type":"string","required":false,"description":"How the agent operates by default"},{"name":"model","type":"string","required":false,"description":"Full provider/model string. Uses default if omitted."},{"name":"soul","type":"string","required":false,"description":"Raw markdown for SOUL.md"},{"name":"tools","type":"string","required":false,"description":"Raw markdown for TOOLS.md"},{"name":"teamId","type":"string","required":false,"description":"Bakin team to assign the agent to"},{"name":"dispatchable","type":"union","required":false,"description":"Who can dispatch tasks to this agent. Default: \"main\"."}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_create_agent --args '{
   "id": "value",
@@ -889,7 +926,7 @@ mcporter call bakin-<agent>.bakin_exec_team_create_agent --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-delete-agent" name="bakin_exec_team_delete_agent" label="Deleted agent" description="Remove an agent from the active runtime and clean up Bakin state. Requires confirm=true as a safety guard." source="plugins/team/index.ts:2012" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent to delete"},{"name":"confirm","type":"boolean","required":true,"description":"Must be true — safety guard against accidental deletion"}]}>
+<McpToolCard id="team-delete-agent" name="bakin_exec_team_delete_agent" label="Deleted agent" description="Remove an agent from the active runtime and clean up Bakin state. Requires confirm=true as a safety guard." source="plugins/team/index.ts:2063" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent to delete"},{"name":"confirm","type":"boolean","required":true,"description":"Must be true — safety guard against accidental deletion"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_delete_agent --args '{
   "agentId": "value",
@@ -897,19 +934,19 @@ mcporter call bakin-<agent>.bakin_exec_team_delete_agent --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-list" name="bakin_exec_team_list" label="Listed team" description="List all agents with their current status (online/working/available/offline)." source="plugins/team/index.ts:1769">
+<McpToolCard id="team-list" name="bakin_exec_team_list" label="Listed team" description="List all agents with their current status (online/working/available/offline)." source="plugins/team/index.ts:1770">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_list
 ```
 </McpToolCard>
-<McpToolCard id="team-members" name="bakin_exec_team_members" label="Listed team members" description="Get agents that belong to a specific team (e.g. &quot;builders&quot;, &quot;creators&quot;)." source="plugins/team/index.ts:1857" parameters={[{"name":"teamId","type":"string","required":true,"description":"Team ID (e.g. \"builders\", \"creators\")"}]}>
+<McpToolCard id="team-members" name="bakin_exec_team_members" label="Listed team members" description="Get agents that belong to a specific team (e.g. &quot;builders&quot;, &quot;creators&quot;)." source="plugins/team/index.ts:1908" parameters={[{"name":"teamId","type":"string","required":true,"description":"Team ID (e.g. \"builders\", \"creators\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_members --args '{
   "teamId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-message" name="bakin_exec_team_message" label="Sent a message" description="Send a message to an agent via the active runtime." source="plugins/team/index.ts:1833" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"message","type":"string","required":true,"description":"Message to send"}]}>
+<McpToolCard id="team-message" name="bakin_exec_team_message" label="Sent a message" description="Send a message to an agent via the active runtime." source="plugins/team/index.ts:1884" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"message","type":"string","required":true,"description":"Message to send"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_message --args '{
   "agentId": "value",
@@ -917,26 +954,26 @@ mcporter call bakin-<agent>.bakin_exec_team_message --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-my-team" name="bakin_exec_team_my_team" label="Read own team" description="Get the team that a specific agent belongs to, including all teammates." source="plugins/team/index.ts:1876" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
+<McpToolCard id="team-my-team" name="bakin_exec_team_my_team" label="Read own team" description="Get the team that a specific agent belongs to, including all teammates." source="plugins/team/index.ts:1927" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_my_team --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-org" name="bakin_exec_team_org" label="Read organization" description="Get the full org structure: teams with their members. Use this to understand who is on which team and reporting lines." source="plugins/team/index.ts:1847">
+<McpToolCard id="team-org" name="bakin_exec_team_org" label="Read organization" description="Get the full org structure: teams with their members. Use this to understand who is on which team and reporting lines." source="plugins/team/index.ts:1898">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_org
 ```
 </McpToolCard>
-<McpToolCard id="team-profile" name="bakin_exec_team_profile" label="Read agent profile" description="Get the full profile for an agent including soul, rules, and tools." source="plugins/team/index.ts:1789" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
+<McpToolCard id="team-profile" name="bakin_exec_team_profile" label="Read agent profile" description="Get the full profile for an agent including soul, rules, and tools." source="plugins/team/index.ts:1790" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_profile --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-read-file" name="bakin_exec_team_read_file" label="Read agent file" description="Read a workspace file for an agent (e.g., SOUL.md, AGENTS.md, TOOLS.md)." source="plugins/team/index.ts:1818" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"filename","type":"string","required":true,"description":"File name (e.g., SOUL.md)"}]}>
+<McpToolCard id="team-read-file" name="bakin_exec_team_read_file" label="Read agent file" description="Read a workspace file for an agent (e.g., SOUL.md, AGENTS.md, TOOLS.md)." source="plugins/team/index.ts:1869" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"filename","type":"string","required":true,"description":"File name (e.g., SOUL.md)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_read_file --args '{
   "agentId": "value",
@@ -944,7 +981,7 @@ mcporter call bakin-<agent>.bakin_exec_team_read_file --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-set-permissions" name="bakin_exec_team_set_permissions" label="Updated permissions" description="Update dispatch permissions — which agents a given agent can dispatch tasks to (subagents.allowAgents)." source="plugins/team/index.ts:2057" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent whose allowAgents to modify"},{"name":"allowAgents","type":"array","required":true,"description":"Full replacement list of agent IDs this agent can dispatch to"}]}>
+<McpToolCard id="team-set-permissions" name="bakin_exec_team_set_permissions" label="Updated permissions" description="Update dispatch permissions — which agents a given agent can dispatch tasks to (subagents.allowAgents)." source="plugins/team/index.ts:2108" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent whose allowAgents to modify"},{"name":"allowAgents","type":"array","required":true,"description":"Full replacement list of agent IDs this agent can dispatch to"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_set_permissions --args '{
   "agentId": "value",
@@ -954,14 +991,14 @@ mcporter call bakin-<agent>.bakin_exec_team_set_permissions --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-status" name="bakin_exec_team_status" label="Checked agent status" description="Get the heartbeat and health status for an agent." source="plugins/team/index.ts:1803" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
+<McpToolCard id="team-status" name="bakin_exec_team_status" label="Checked agent status" description="Get the heartbeat and health status for an agent." source="plugins/team/index.ts:1804" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_status --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-update-identity" name="bakin_exec_team_update_identity" label="Updated agent identity" description="Update an existing agent's identity fields (name, emoji, role, vibe, etc.) and/or workspace files (SOUL.md, TOOLS.md)." source="plugins/team/index.ts:1977" parameters={[{"name":"agentId","type":"string","required":true,"description":"Target agent ID"},{"name":"name","type":"string","required":false,"description":"New display name"},{"name":"emoji","type":"string","required":false,"description":"New emoji"},{"name":"role","type":"string","required":false,"description":"Updated role"},{"name":"vibe","type":"string","required":false,"description":"Updated vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"Updated primary function"},{"name":"defaultMode","type":"string","required":false,"description":"Updated default mode"},{"name":"soul","type":"string","required":false,"description":"Replace SOUL.md content"},{"name":"tools","type":"string","required":false,"description":"Replace TOOLS.md content"}]}>
+<McpToolCard id="team-update-identity" name="bakin_exec_team_update_identity" label="Updated agent identity" description="Update an existing agent's identity fields (name, emoji, role, vibe, etc.) and/or workspace files (SOUL.md, TOOLS.md)." source="plugins/team/index.ts:2028" parameters={[{"name":"agentId","type":"string","required":true,"description":"Target agent ID"},{"name":"name","type":"string","required":false,"description":"New display name"},{"name":"emoji","type":"string","required":false,"description":"New emoji"},{"name":"role","type":"string","required":false,"description":"Updated role"},{"name":"vibe","type":"string","required":false,"description":"Updated vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"Updated primary function"},{"name":"defaultMode","type":"string","required":false,"description":"Updated default mode"},{"name":"soul","type":"string","required":false,"description":"Replace SOUL.md content"},{"name":"tools","type":"string","required":false,"description":"Replace TOOLS.md content"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_update_identity --args '{
   "agentId": "value",

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -199,9 +199,9 @@ await ctx.hooks.callAll(
 <p class="hook-section-description">Task hooks let plugins enrich task details and react to task lifecycle changes.</p>
 
 <div class="hook-card-list">
-<HookCard id="tasks-enrichdetails" name="tasks.enrichDetails" label="Add project task context." summary="Adds project title, status, progress, and excerpt data to task detail payloads. Use it when a task surface wants project context without depending on project storage." source="bakin-bits-official/plugins/projects/index.ts:160" badges={["waterfall"]}>
+<HookCard id="tasks-enrichdetails" name="tasks.enrichDetails" label="tasks.enrichDetails" source="bakin-bits-official/plugins/projects/index.ts:156">
 ```ts frame="terminal"
-const next = await ctx.hooks.call(
+const result = await ctx.hooks.invoke(
   'tasks.enrichDetails',
   {
     task: {
@@ -212,9 +212,9 @@ const next = await ctx.hooks.call(
 )
 ```
 </HookCard>
-<HookCard id="tasks-statuschanged" name="tasks.statusChanged" label="Sync project task state." summary="Updates linked project checklist items when a task moves into a completed state. Use it to keep project progress in sync with task lifecycle events." source="bakin-bits-official/plugins/projects/index.ts:149" badges={["event"]}>
+<HookCard id="tasks-statuschanged" name="tasks.statusChanged" label="tasks.statusChanged" source="bakin-bits-official/plugins/projects/index.ts:149">
 ```ts frame="terminal"
-await ctx.hooks.callAll(
+const result = await ctx.hooks.invoke(
   'tasks.statusChanged',
   {
     taskId: 'task-123',
@@ -231,7 +231,7 @@ await ctx.hooks.callAll(
 <p class="hook-section-description">Team hooks expose runtime agent and team metadata for plugins that need agent-aware behavior.</p>
 
 <div class="hook-card-list">
-<HookCard id="team-getagent" name="team.getAgent" label="Get an agent." summary="Returns one runtime agent by id, including team-aware metadata when available. Use it when a plugin already has an agent id and needs the full display record." source="plugins/team/index.ts:1742" badges={["rpc"]}>
+<HookCard id="team-getagent" name="team.getAgent" label="Get an agent." summary="Returns one runtime agent by id, including team-aware metadata when available. Use it when a plugin already has an agent id and needs the full display record." source="plugins/team/index.ts:1743" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getAgent',
@@ -241,7 +241,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getagentids" name="team.getAgentIds" label="List agent ids." summary="Returns the ids of agents currently known to the runtime. Use it for lightweight validation, assignment pickers, or loops that do not need full agent metadata." source="plugins/team/index.ts:1747" badges={["rpc"]}>
+<HookCard id="team-getagentids" name="team.getAgentIds" label="List agent ids." summary="Returns the ids of agents currently known to the runtime. Use it for lightweight validation, assignment pickers, or loops that do not need full agent metadata." source="plugins/team/index.ts:1748" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getAgentIds',
@@ -249,7 +249,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getagentteam" name="team.getAgentTeam" label="Get agent team." summary="Returns the team currently assigned to an agent, or null when the agent is unassigned. Use it to add team context to task, workflow, or activity views." source="plugins/team/index.ts:1754" badges={["rpc"]}>
+<HookCard id="team-getagentteam" name="team.getAgentTeam" label="Get agent team." summary="Returns the team currently assigned to an agent, or null when the agent is unassigned. Use it to add team context to task, workflow, or activity views." source="plugins/team/index.ts:1755" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getAgentTeam',
@@ -259,7 +259,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getorgstructure" name="team.getOrgStructure" label="Get org structure." summary="Returns the current organization structure for teams and agents. Use it when a plugin needs the full hierarchy instead of individual team or agent records." source="plugins/team/index.ts:1760" badges={["rpc"]}>
+<HookCard id="team-getorgstructure" name="team.getOrgStructure" label="Get org structure." summary="Returns the current organization structure for teams and agents. Use it when a plugin needs the full hierarchy instead of individual team or agent records." source="plugins/team/index.ts:1761" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getOrgStructure',
@@ -267,7 +267,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getteammembers" name="team.getTeamMembers" label="List team members." summary="Returns the agents assigned to one team. Use it for team dashboards, routing rules, or workflow logic that needs team membership." source="plugins/team/index.ts:1751" badges={["rpc"]}>
+<HookCard id="team-getteammembers" name="team.getTeamMembers" label="List team members." summary="Returns the agents assigned to one team. Use it for team dashboards, routing rules, or workflow logic that needs team membership." source="plugins/team/index.ts:1752" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getTeamMembers',
@@ -277,7 +277,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-list" name="team.list" label="List agents." summary="Returns runtime agents with their display and team metadata attached. Use it when another plugin needs the agent roster as Bakin presents it." source="plugins/team/index.ts:1741" badges={["rpc"]}>
+<HookCard id="team-list" name="team.list" label="List agents." summary="Returns runtime agents with their display and team metadata attached. Use it when another plugin needs the agent roster as Bakin presents it." source="plugins/team/index.ts:1742" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.list',
@@ -285,7 +285,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-resolveprofile" name="team.resolveProfile" label="Resolve agent profile." summary="Returns the runtime profile for an agent id. Use it when a plugin needs the lower-level profile data behind an agent display record." source="plugins/team/index.ts:1748" badges={["rpc"]}>
+<HookCard id="team-resolveprofile" name="team.resolveProfile" label="Resolve agent profile." summary="Returns the runtime profile for an agent id. Use it when a plugin needs the lower-level profile data behind an agent display record." source="plugins/team/index.ts:1749" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.resolveProfile',

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -7,6 +7,40 @@ description: Generated reference for Bakin core settings defaults.
   <p>Bakin starts with these values, then deep-merges anything you set in <code>settings.json</code>. Use this page when you need the exact key for CLI updates, automation, or troubleshooting.</p>
 </div>
 
+## AgentPackages
+
+<table class="settings-defaults-table">
+  <thead>
+    <tr><th>Key</th><th>Default</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>agentPackages.knowledgeRetrieval.enabled</code></td>
+      <td><code>true</code></td>
+    </tr>
+    <tr>
+      <td><code>agentPackages.knowledgeRetrieval.injectIntoDispatch</code></td>
+      <td><code>true</code></td>
+    </tr>
+    <tr>
+      <td><code>agentPackages.knowledgeRetrieval.maxCharacters</code></td>
+      <td><code>8000</code></td>
+    </tr>
+    <tr>
+      <td><code>agentPackages.knowledgeRetrieval.maxLessons</code></td>
+      <td><code>3</code></td>
+    </tr>
+    <tr>
+      <td><code>agentPackages.knowledgeRetrieval.mcpTool</code></td>
+      <td><code>true</code></td>
+    </tr>
+    <tr>
+      <td><code>agentPackages.knowledgeRetrieval.minScore</code></td>
+      <td><code>0</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## Dispatch
 
 <table class="settings-defaults-table">

--- a/docs/src/content/docs/using/git.md
+++ b/docs/src/content/docs/using/git.md
@@ -1,0 +1,50 @@
+---
+title: Git
+description: "Task-scoped git worktrees for agents doing code work."
+---
+
+Bakin's Git plugin gives agents a controlled way to do code work without sharing the same checkout. An agent asks Bakin for a task worktree, receives a branch and path, works there, then releases the worktree when the PR or handoff is complete.
+
+This is intentionally a small surface. It does not try to replace `git`, `gh`, or your normal review flow. It enforces the part that matters for concurrent agents: every code task gets its own working tree and Bakin keeps track of what is still active.
+
+## How it works
+
+1. The agent calls `bakin_exec_git_prepare_worktree` with a repo path and task id.
+2. Bakin verifies the repo lives under an allowed root.
+3. Bakin creates or reuses a worktree under the configured worktree root.
+4. The agent runs edits, tests, commits, pushes, and PR commands from that returned path.
+5. The agent calls `bakin_exec_git_status` before handoff.
+6. When local cleanup is safe, the agent calls `bakin_exec_git_release_worktree`.
+
+Release refuses to remove a dirty worktree unless `force=true` is supplied. That keeps unfinished local work visible instead of silently deleting it.
+
+## Settings
+
+<!-- docs:settings git -->
+<div class="settings-table">
+
+| Setting | Type | Default | What it does |
+| --- | --- | --- | --- |
+| Allowed repo roots | `list` | `[{ path: DEFAULT_ALLOWED_ROOT` | Directories agents may prepare git worktrees from. |
+| Worktree root | `string` | `~/.bakin/${DEFAULT_WORKTREE_DIR}` | Directory where Bakin-created worktrees are stored. |
+
+</div>
+<!-- /docs:settings -->
+
+## For agents
+
+Patch ships with the `git-isolation` runtime skill and is allowed to call the Git exec tools. Other developer agents should get the same tool allowlist and a similar procedure before they do code work.
+
+<!-- docs:exec-tools git -->
+- `bakin_exec_git_prepare_worktree`: Create or reuse an isolated git worktree for a task. Call this before editing code for a Bakin task.
+- `bakin_exec_git_release_worktree`: Release a tracked git worktree. Refuses dirty removal unless force=true.
+- `bakin_exec_git_status`: List Bakin-tracked git worktrees and their dirty state.
+<!-- /docs:exec-tools -->
+
+HTTP API surface for this plugin: see the [API reference](/docs/reference/generated/api/#git).
+
+## Related
+
+- [Team](/docs/using/team/): install and manage the Patch package.
+- [Package Manifest](/docs/extending/agents/packages/): declare tool allowlists and runtime skills for agent packages.
+- [Health](/docs/using/health/): doctor shows stale tracked worktrees if a path disappears outside Bakin.

--- a/plugins/git/bakin-plugin.json
+++ b/plugins/git/bakin-plugin.json
@@ -1,0 +1,57 @@
+{
+  "id": "git",
+  "name": "Git",
+  "version": "1.0.0",
+  "bakin": ">=1.0.0",
+  "description": "Git worktree isolation for agent code work",
+  "entry": {
+    "server": "index.ts"
+  },
+  "contentFiles": [],
+  "secrets": [],
+  "tests": "tests/",
+  "dependencies": [],
+  "permissions": [
+    "storage.read",
+    "storage.write"
+  ],
+  "contributes": {
+    "apiRoutes": [
+      {
+        "method": "GET",
+        "path": "/worktrees",
+        "summary": "List git worktrees tracked by Bakin"
+      },
+      {
+        "method": "POST",
+        "path": "/worktrees/prepare",
+        "summary": "Create or reuse an isolated git worktree for a task"
+      },
+      {
+        "method": "POST",
+        "path": "/worktrees/release",
+        "summary": "Release a tracked git worktree after task work is complete"
+      }
+    ],
+    "execTools": [
+      {
+        "name": "bakin_exec_git_prepare_worktree",
+        "summary": "Create or reuse an isolated git worktree for a task",
+        "description": "Create or reuse an isolated git worktree for a task. Validates the repo is under an allowed root, creates a task branch, records the worktree, and returns the path to use for code edits."
+      },
+      {
+        "name": "bakin_exec_git_status",
+        "summary": "List tracked git worktrees and their dirty state",
+        "description": "List Bakin-tracked git worktrees, optionally filtered by repoPath or taskId, including branch, path, existence, and git status output."
+      },
+      {
+        "name": "bakin_exec_git_release_worktree",
+        "summary": "Release a tracked git worktree",
+        "description": "Release a tracked git worktree. Refuses to remove dirty worktrees unless force=true is supplied."
+      }
+    ],
+    "docs": {
+      "slug": "using/git"
+    }
+  }
+}

--- a/plugins/git/index.ts
+++ b/plugins/git/index.ts
@@ -1,0 +1,669 @@
+/**
+ * Git plugin — server entry point.
+ * Provides worktree isolation tools for code-producing agents.
+ */
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, realpathSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { promisify } from 'node:util'
+import { z } from 'zod'
+import type {
+  BakinPlugin,
+  ExecToolResult,
+  HealthCheckResult,
+  PluginContext,
+} from '@bakin/core/plugin-types'
+import type { PluginContextLite } from '@bakin/core/routing'
+import { definePlugin, defineRoute } from '@bakin/core/routing'
+import { getContentDir } from '../../packages/core/src/content-dir'
+
+const execFileAsync = promisify(execFile)
+
+const REGISTRY_PATH = 'worktrees.json'
+const DEFAULT_WORKTREE_DIR = 'git-worktrees'
+const DEFAULT_ALLOWED_ROOT = '~/go/src/github.com/madeinwyo'
+
+const okResponse = z.object({ ok: z.boolean() }).passthrough()
+const errorResponse = z.object({ error: z.string() }).passthrough()
+
+const prepareShape = {
+  repoPath: z.string().min(1),
+  taskId: z.string().min(1),
+  branch: z.string().min(1).optional(),
+  baseRef: z.string().min(1).default('HEAD'),
+  purpose: z.string().max(200).optional(),
+}
+const prepareSchema = z.object(prepareShape)
+
+const statusShape = {
+  repoPath: z.string().min(1).optional(),
+  taskId: z.string().min(1).optional(),
+  includeReleased: z.boolean().default(false),
+}
+const statusSchema = z.object(statusShape)
+
+const statusQuerySchema = z.object({
+  repoPath: z.string().min(1).optional(),
+  taskId: z.string().min(1).optional(),
+  includeReleased: z.enum(['true', 'false']).optional(),
+})
+
+const releaseShape = {
+  worktreePath: z.string().min(1).optional(),
+  repoPath: z.string().min(1).optional(),
+  taskId: z.string().min(1).optional(),
+  force: z.boolean().default(false),
+}
+const releaseSchema = z.object(releaseShape).refine(
+  (input) => Boolean(input.worktreePath) || Boolean(input.repoPath && input.taskId),
+  { message: 'Provide worktreePath, or repoPath plus taskId.' },
+)
+
+const routePrepareSchema = prepareSchema.extend({
+  agent: z.string().min(1).optional(),
+})
+
+const routeReleaseSchema = releaseSchema.and(z.object({
+  agent: z.string().min(1).optional(),
+}))
+
+type PrepareInput = z.infer<typeof prepareSchema>
+type ReleaseInput = z.infer<typeof releaseSchema>
+
+interface WorktreeEntry {
+  id: string
+  repoPath: string
+  worktreePath: string
+  branch: string
+  baseRef: string
+  taskId: string
+  agent: string
+  purpose?: string
+  state: 'active' | 'released'
+  createdAt: string
+  updatedAt: string
+  releasedAt?: string
+}
+
+interface Registry {
+  version: 1
+  worktrees: WorktreeEntry[]
+}
+
+interface GitSettings {
+  allowedRepoRoots?: Array<string | { path?: string }>
+  worktreeRoot?: string
+}
+
+interface GitStatus {
+  branch: string | null
+  status: string
+  dirty: boolean
+}
+
+function emptyRegistry(): Registry {
+  return { version: 1, worktrees: [] }
+}
+
+function readRegistry(ctx: PluginContextLite): Registry {
+  const raw = ctx.storage.read(REGISTRY_PATH)
+  if (!raw) return emptyRegistry()
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`Git worktree registry is invalid JSON at ${REGISTRY_PATH}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  if (
+    !parsed
+    || typeof parsed !== 'object'
+    || (parsed as Registry).version !== 1
+    || !Array.isArray((parsed as Registry).worktrees)
+  ) {
+    throw new Error(`Git worktree registry has an unsupported shape at ${REGISTRY_PATH}`)
+  }
+
+  return parsed as Registry
+}
+
+function writeRegistry(ctx: PluginContextLite, registry: Registry): void {
+  ctx.storage.write(REGISTRY_PATH, JSON.stringify(registry, null, 2))
+}
+
+function expandHome(path: string): string {
+  if (path === '~') return homedir()
+  if (path.startsWith('~/')) return join(homedir(), path.slice(2))
+  return path
+}
+
+function resolvePath(path: string): string {
+  return resolve(expandHome(path))
+}
+
+function realpath(path: string): string {
+  return realpathSync(resolvePath(path))
+}
+
+function normalizeAgent(agent: string): string {
+  return slug(agent || 'agent') || 'agent'
+}
+
+function slug(value: string, max = 48): string {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return cleaned.slice(0, max).replace(/-$/, '')
+}
+
+function shortHash(value: string): string {
+  return createHash('sha1').update(value).digest('hex').slice(0, 10)
+}
+
+function isWithin(candidate: string, root: string): boolean {
+  const rel = relative(root, candidate)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+function defaultAllowedRoots(): string[] {
+  return [DEFAULT_ALLOWED_ROOT]
+}
+
+function readSettings(ctx: PluginContextLite): { allowedRepoRoots: string[]; worktreeRoot: string } {
+  const raw = ctx.getSettings<GitSettings>()
+  const settingsRoots = Array.isArray(raw.allowedRepoRoots)
+    ? raw.allowedRepoRoots
+        .map((entry) => typeof entry === 'string' ? entry : entry.path)
+        .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : []
+
+  const allowedRepoRoots = settingsRoots.length > 0 ? settingsRoots : defaultAllowedRoots()
+  return {
+    allowedRepoRoots,
+    worktreeRoot: raw.worktreeRoot && raw.worktreeRoot.trim()
+      ? raw.worktreeRoot
+      : join(getContentDir(), DEFAULT_WORKTREE_DIR),
+  }
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  try {
+    const result = await execFileAsync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+    })
+    return String(result.stdout).trim()
+  } catch (err) {
+    const maybe = err as { stderr?: string | Buffer; stdout?: string | Buffer; message?: string }
+    const stderr = maybe.stderr ? String(maybe.stderr).trim() : ''
+    const stdout = maybe.stdout ? String(maybe.stdout).trim() : ''
+    const message = stderr || stdout || maybe.message || String(err)
+    throw new Error(message)
+  }
+}
+
+async function tryGit(cwd: string, args: string[]): Promise<{ ok: true; stdout: string } | { ok: false; error: string }> {
+  try {
+    return { ok: true, stdout: await runGit(cwd, args) }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function assertSafeRef(value: string, label: string): void {
+  if (value.length > 200) throw new Error(`${label} is too long`)
+  if (value.startsWith('-')) throw new Error(`${label} must not start with "-"`)
+  if (/[\u0000-\u001f\s]/.test(value)) throw new Error(`${label} must not contain whitespace or control characters`)
+  if (value.includes('..') || value.includes('@{')) throw new Error(`${label} contains unsupported git ref syntax`)
+}
+
+async function validateBranch(repoPath: string, branch: string): Promise<void> {
+  assertSafeRef(branch, 'branch')
+  const result = await tryGit(repoPath, ['check-ref-format', '--branch', branch])
+  if (!result.ok) {
+    throw new Error(`Invalid branch "${branch}": ${result.error}`)
+  }
+}
+
+function validateBaseRef(baseRef: string): void {
+  assertSafeRef(baseRef, 'baseRef')
+}
+
+async function resolveRepoRoot(ctx: PluginContextLite, repoPath: string): Promise<string> {
+  let candidate: string
+  try {
+    candidate = realpath(repoPath)
+  } catch {
+    throw new Error(`Repository path does not exist: ${repoPath}`)
+  }
+
+  const settings = readSettings(ctx)
+  const allowedRoots = settings.allowedRepoRoots.map((root) => {
+    try {
+      return realpath(root)
+    } catch {
+      return resolvePath(root)
+    }
+  })
+
+  if (!allowedRoots.some((root) => isWithin(candidate, root))) {
+    throw new Error(`Repository path is outside configured allowed repo roots: ${settings.allowedRepoRoots.join(', ')}`)
+  }
+
+  const topLevel = await runGit(candidate, ['rev-parse', '--show-toplevel'])
+  const repoRoot = realpath(topLevel)
+  if (!allowedRoots.some((root) => isWithin(repoRoot, root))) {
+    throw new Error(`Git repository root is outside configured allowed repo roots: ${settings.allowedRepoRoots.join(', ')}`)
+  }
+  return repoRoot
+}
+
+function buildBranch(input: PrepareInput, agent: string): string {
+  if (input.branch) return input.branch
+  const task = slug(input.taskId) || 'task'
+  return `bakin/${task}-${normalizeAgent(agent)}`
+}
+
+function buildWorktreePath(ctx: PluginContextLite, repoPath: string, input: PrepareInput, agent: string, branch: string): string {
+  const settings = readSettings(ctx)
+  const root = resolvePath(settings.worktreeRoot)
+  const repoPart = `${slug(basename(repoPath)) || 'repo'}-${shortHash(repoPath)}`
+  const taskPart = `${slug(input.taskId) || 'task'}-${normalizeAgent(agent)}-${shortHash(branch)}`
+  return join(root, repoPart, taskPart)
+}
+
+function registryId(repoPath: string, taskId: string, agent: string, branch: string): string {
+  return shortHash([repoPath, taskId, agent, branch].join('\0'))
+}
+
+function findActiveForTask(
+  registry: Registry,
+  repoPath: string,
+  taskId: string,
+  agent: string,
+): WorktreeEntry | undefined {
+  return registry.worktrees.find((entry) =>
+    entry.state === 'active'
+    && entry.repoPath === repoPath
+    && entry.taskId === taskId
+    && entry.agent === agent
+  )
+}
+
+async function branchExists(repoPath: string, branch: string): Promise<boolean> {
+  const result = await tryGit(repoPath, ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`])
+  return result.ok
+}
+
+async function readGitStatus(entry: WorktreeEntry): Promise<GitStatus> {
+  const output = await runGit(entry.worktreePath, ['status', '--short', '--branch'])
+  const lines = output.split('\n').filter(Boolean)
+  const branchLine = lines.find((line) => line.startsWith('## '))
+  return {
+    branch: branchLine ? branchLine.slice(3) : null,
+    status: output,
+    dirty: lines.some((line) => !line.startsWith('## ')),
+  }
+}
+
+function publicEntry(entry: WorktreeEntry, status?: GitStatus | { error: string }): Record<string, unknown> {
+  const statusError = status && 'error' in status ? status.error : undefined
+  const gitStatus = status && !('error' in status) ? status : undefined
+  return {
+    id: entry.id,
+    repoPath: entry.repoPath,
+    worktreePath: entry.worktreePath,
+    branch: entry.branch,
+    baseRef: entry.baseRef,
+    taskId: entry.taskId,
+    agent: entry.agent,
+    purpose: entry.purpose,
+    state: entry.state,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    releasedAt: entry.releasedAt,
+    exists: existsSync(entry.worktreePath),
+    dirty: gitStatus?.dirty ?? false,
+    status: gitStatus?.status ?? '',
+    statusError,
+  }
+}
+
+function parseParams<T>(schema: z.ZodType<T>, params: Record<string, unknown>): T {
+  const result = schema.safeParse(params)
+  if (!result.success) {
+    throw new Error(result.error.issues.map((issue) => issue.message).join('; '))
+  }
+  return result.data
+}
+
+async function prepareWorktree(
+  ctx: PluginContextLite,
+  raw: Record<string, unknown>,
+  agent: string,
+): Promise<ExecToolResult> {
+  try {
+    const input = parseParams(prepareSchema, raw)
+    const repoPath = await resolveRepoRoot(ctx, input.repoPath)
+    const branch = buildBranch(input, agent)
+    validateBaseRef(input.baseRef)
+    await validateBranch(repoPath, branch)
+
+    const registry = readRegistry(ctx)
+    const existing = findActiveForTask(registry, repoPath, input.taskId, agent)
+    if (existing) {
+      if (existing.branch !== branch) {
+        return {
+          ok: false,
+          error: `Task ${input.taskId} already has active worktree ${existing.worktreePath} on branch ${existing.branch}. Release it before creating ${branch}.`,
+        }
+      }
+      if (!existsSync(existing.worktreePath)) {
+        return {
+          ok: false,
+          error: `Tracked worktree is missing from disk: ${existing.worktreePath}. Run release with force=true to clear the stale registry entry.`,
+        }
+      }
+      const status = await readGitStatus(existing).catch((err) => ({ error: err instanceof Error ? err.message : String(err) }))
+      return {
+        ok: true,
+        reused: true,
+        ...publicEntry(existing, status),
+        nextSteps: [`cd ${existing.worktreePath}`],
+      }
+    }
+
+    const worktreePath = buildWorktreePath(ctx, repoPath, input, agent, branch)
+    if (existsSync(worktreePath)) {
+      return {
+        ok: false,
+        error: `Worktree path already exists but is not tracked as active: ${worktreePath}`,
+      }
+    }
+
+    mkdirSync(dirname(worktreePath), { recursive: true })
+    const exists = await branchExists(repoPath, branch)
+    const args = exists
+      ? ['worktree', 'add', worktreePath, branch]
+      : ['worktree', 'add', '-b', branch, worktreePath, input.baseRef]
+    await runGit(repoPath, args)
+
+    const now = new Date().toISOString()
+    const entry: WorktreeEntry = {
+      id: registryId(repoPath, input.taskId, agent, branch),
+      repoPath,
+      worktreePath,
+      branch,
+      baseRef: input.baseRef,
+      taskId: input.taskId,
+      agent,
+      purpose: input.purpose,
+      state: 'active',
+      createdAt: now,
+      updatedAt: now,
+    }
+    registry.worktrees.push(entry)
+    writeRegistry(ctx, registry)
+
+    ctx.activity.log(agent, `Prepared git worktree for task ${input.taskId}`, { taskId: input.taskId, category: 'git' })
+    const status = await readGitStatus(entry).catch((err) => ({ error: err instanceof Error ? err.message : String(err) }))
+    return {
+      ok: true,
+      reused: false,
+      ...publicEntry(entry, status),
+      nextSteps: [`cd ${worktreePath}`],
+    }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function listWorktrees(
+  ctx: PluginContextLite,
+  raw: Record<string, unknown>,
+): Promise<ExecToolResult> {
+  try {
+    const input = parseParams(statusSchema, raw)
+    const repoPath = input.repoPath ? await resolveRepoRoot(ctx, input.repoPath) : undefined
+    const registry = readRegistry(ctx)
+    const entries = registry.worktrees.filter((entry) => {
+      if (!input.includeReleased && entry.state === 'released') return false
+      if (repoPath && entry.repoPath !== repoPath) return false
+      if (input.taskId && entry.taskId !== input.taskId) return false
+      return true
+    })
+
+    const worktrees: Record<string, unknown>[] = []
+    for (const entry of entries) {
+      const status = existsSync(entry.worktreePath)
+        ? await readGitStatus(entry).catch((err) => ({ error: err instanceof Error ? err.message : String(err) }))
+        : { error: 'worktree path is missing from disk' }
+      worktrees.push(publicEntry(entry, status))
+    }
+
+    return { ok: true, worktrees }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function findReleaseTarget(
+  registry: Registry,
+  input: ReleaseInput,
+  repoPath: string | undefined,
+): WorktreeEntry | undefined {
+  if (input.worktreePath) {
+    const target = resolvePath(input.worktreePath)
+    return registry.worktrees.find((entry) => entry.state === 'active' && resolvePath(entry.worktreePath) === target)
+  }
+  return registry.worktrees.find((entry) =>
+    entry.state === 'active'
+    && entry.repoPath === repoPath
+    && entry.taskId === input.taskId
+  )
+}
+
+async function releaseWorktree(
+  ctx: PluginContextLite,
+  raw: Record<string, unknown>,
+  agent: string,
+): Promise<ExecToolResult> {
+  try {
+    const input = parseParams(releaseSchema, raw)
+    const repoPath = input.repoPath ? await resolveRepoRoot(ctx, input.repoPath) : undefined
+    const registry = readRegistry(ctx)
+    const entry = findReleaseTarget(registry, input, repoPath)
+    if (!entry) {
+      return { ok: false, error: 'No active tracked worktree matched the release request.' }
+    }
+
+    if (!existsSync(entry.worktreePath)) {
+      if (!input.force) {
+        return {
+          ok: false,
+          error: `Tracked worktree is missing from disk: ${entry.worktreePath}. Re-run with force=true to mark it released.`,
+        }
+      }
+    } else {
+      const status = await readGitStatus(entry)
+      if (status.dirty && !input.force) {
+        return {
+          ok: false,
+          error: `Worktree is dirty; commit, stash, or re-run with force=true before release. Path: ${entry.worktreePath}`,
+          status: status.status,
+        }
+      }
+      const args = input.force
+        ? ['worktree', 'remove', '--force', entry.worktreePath]
+        : ['worktree', 'remove', entry.worktreePath]
+      await runGit(entry.repoPath, args)
+    }
+
+    const now = new Date().toISOString()
+    entry.state = 'released'
+    entry.updatedAt = now
+    entry.releasedAt = now
+    writeRegistry(ctx, registry)
+    ctx.activity.log(agent, `Released git worktree for task ${entry.taskId}`, { taskId: entry.taskId, category: 'git' })
+    return { ok: true, ...publicEntry(entry) }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function checkWorktrees(ctx: PluginContextLite): Promise<HealthCheckResult[]> {
+  try {
+    const registry = readRegistry(ctx)
+    const active = registry.worktrees.filter((entry) => entry.state === 'active')
+    if (active.length === 0) {
+      return [{
+        check: 'git.worktrees',
+        status: 'ok',
+        message: 'No active git worktrees tracked by Bakin.',
+        autoFixable: false,
+      }]
+    }
+
+    const missing = active.filter((entry) => !existsSync(entry.worktreePath))
+    if (missing.length > 0) {
+      return missing.map((entry) => ({
+        check: `git.worktrees.${entry.id}`,
+        status: 'warn',
+        message: `Tracked worktree for task ${entry.taskId} is missing: ${entry.worktreePath}`,
+        autoFixable: false,
+      }))
+    }
+
+    return [{
+      check: 'git.worktrees',
+      status: 'ok',
+      message: `${active.length} active git worktree${active.length === 1 ? '' : 's'} tracked.`,
+      autoFixable: false,
+    }]
+  } catch (err) {
+    return [{
+      check: 'git.worktrees',
+      status: 'error',
+      message: err instanceof Error ? err.message : String(err),
+      autoFixable: false,
+    }]
+  }
+}
+
+const routes = [
+  defineRoute({
+    path: '/worktrees',
+    method: 'GET',
+    summary: 'List tracked git worktrees',
+    query: statusQuerySchema,
+    responses: { 200: okResponse, 400: errorResponse },
+    handler: async (_req, ctx, { query }) => {
+      const result = await listWorktrees(ctx, {
+        repoPath: query.repoPath,
+        taskId: query.taskId,
+        includeReleased: query.includeReleased === 'true',
+      })
+      return Response.json(result, { status: result.ok ? 200 : 400 })
+    },
+  }),
+  defineRoute({
+    path: '/worktrees/prepare',
+    method: 'POST',
+    summary: 'Create or reuse an isolated git worktree for a task',
+    body: routePrepareSchema,
+    responses: { 200: okResponse, 400: errorResponse },
+    handler: async (_req, ctx, { body }) => {
+      const { agent, ...input } = body
+      const result = await prepareWorktree(ctx, input, agent || 'rest')
+      return Response.json(result, { status: result.ok ? 200 : 400 })
+    },
+  }),
+  defineRoute({
+    path: '/worktrees/release',
+    method: 'POST',
+    summary: 'Release a tracked git worktree',
+    body: routeReleaseSchema,
+    responses: { 200: okResponse, 400: errorResponse },
+    handler: async (_req, ctx, { body }) => {
+      const input = body as z.infer<typeof routeReleaseSchema>
+      const { agent, ...release } = input
+      const result = await releaseWorktree(ctx, release, agent || 'rest')
+      return Response.json(result, { status: result.ok ? 200 : 400 })
+    },
+  }),
+]
+
+const gitPlugin = definePlugin({
+  id: 'git',
+  name: 'Git',
+  version: '1.0.0',
+  routes,
+  settingsSchema: {
+    fields: [
+      {
+        key: 'allowedRepoRoots',
+        label: 'Allowed repo roots',
+        description: 'Directories agents may prepare git worktrees from.',
+        type: 'list',
+        default: [{ path: DEFAULT_ALLOWED_ROOT }],
+        addLabel: 'Add repo root',
+        uniqueField: 'path',
+        itemShape: {
+          path: {
+            key: 'path',
+            label: 'Path',
+            type: 'string',
+            required: true,
+            default: DEFAULT_ALLOWED_ROOT,
+          },
+        },
+      },
+      {
+        key: 'worktreeRoot',
+        label: 'Worktree root',
+        description: 'Directory where Bakin-created worktrees are stored.',
+        type: 'string',
+        default: `~/.bakin/${DEFAULT_WORKTREE_DIR}`,
+      },
+    ],
+  },
+  activate(ctx: PluginContext) {
+    ctx.registerExecTool({
+      name: 'bakin_exec_git_prepare_worktree',
+      description: 'Create or reuse an isolated git worktree for a task. Call this before editing code for a Bakin task.',
+      label: 'Prepared git worktree',
+      activityDuplicate: true,
+      parameters: prepareShape,
+      handler: (params, agent) => prepareWorktree(ctx, params, agent),
+    })
+    ctx.registerExecTool({
+      name: 'bakin_exec_git_status',
+      description: 'List Bakin-tracked git worktrees and their dirty state.',
+      label: 'Checked git worktrees',
+      parameters: statusShape,
+      handler: (params) => listWorktrees(ctx, params),
+    })
+    ctx.registerExecTool({
+      name: 'bakin_exec_git_release_worktree',
+      description: 'Release a tracked git worktree. Refuses dirty removal unless force=true.',
+      label: 'Released git worktree',
+      activityDuplicate: true,
+      parameters: releaseShape,
+      handler: (params, agent) => releaseWorktree(ctx, params, agent),
+    })
+    ctx.registerHealthCheck({
+      id: 'worktrees',
+      name: 'Git worktree registry',
+      run: () => checkWorktrees(ctx),
+    })
+  },
+}) as unknown as BakinPlugin
+
+export default gitPlugin

--- a/scripts/build-plugins.ts
+++ b/scripts/build-plugins.ts
@@ -18,6 +18,7 @@ import { buildOnePlugin } from './dev-build-one-plugin'
 const CORE_PLUGINS = [
   'tasks', 'team', 'workflows', 'assets',
   'schedule', 'memory', 'models', 'health',
+  'git',
 ]
 
 const EXTERNAL = [

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -30,6 +30,7 @@ const DEV_CLIENT_OUTDIR = join(REPO_ROOT, 'packages/host/public/__bakin-dev')
 const CORE_PLUGINS = [
   'tasks', 'team', 'workflows', 'assets',
   'schedule', 'memory', 'models', 'health',
+  'git',
 ]
 
 const EXTERNAL = [

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1692,7 +1692,7 @@ const apiReferenceGroups = new Map<string, Array<{ operationId: string; curl: st
   const { buildOperation, normalizeOpenApiPath } = await import('../../packages/core/src/openapi')
   const { coreRoutes: typedCoreRoutes } = await import('../../packages/host/src/core-routes')
 
-  const inRepoPluginIds = ['assets', 'health', 'memory', 'models', 'schedule', 'tasks', 'team', 'workflows']
+  const inRepoPluginIds = ['assets', 'git', 'health', 'memory', 'models', 'schedule', 'tasks', 'team', 'workflows']
   const sources: Array<{ scope: string; tag: string; fullPath: string; route: any }> = []
   for (const id of inRepoPluginIds) {
     const mod = await import(join(repoRoot, 'plugins', id, 'index.ts')) as { default?: { name?: string; routes?: any[] } }

--- a/src/core/plugins/dependencies.ts
+++ b/src/core/plugins/dependencies.ts
@@ -17,6 +17,7 @@ export const CORE_PLUGIN_IDS = new Set([
   'assets',
   'schedule',
   'health',
+  'git',
 ])
 
 export interface DependencyPlanInput {

--- a/src/lib/plugin-static-imports.ts
+++ b/src/lib/plugin-static-imports.ts
@@ -22,6 +22,7 @@ import workflowsPlugin from '../../plugins/workflows'
 import assetsPlugin from '../../plugins/assets'
 import schedulePlugin from '../../plugins/schedule'
 import healthPlugin from '../../plugins/health'
+import gitPlugin from '../../plugins/git'
 
 import type { BakinPlugin } from '@bakin/core/plugin-types'
 
@@ -34,4 +35,5 @@ export const CORE_PLUGIN_IMPORTS: Readonly<Record<string, BakinPlugin>> = {
   'plugins/assets': assetsPlugin,
   'plugins/schedule': schedulePlugin,
   'plugins/health': healthPlugin,
+  'plugins/git': gitPlugin,
 }

--- a/tests/docs/static-plugin-routes.test.ts
+++ b/tests/docs/static-plugin-routes.test.ts
@@ -95,7 +95,7 @@ mock.module('../../src/core/task-store', () => ({
 
 import { validateRouteContracts } from '../../scripts/docs/route-contract-check-lib'
 
-const IN_REPO_PLUGINS = ['assets', 'health', 'memory', 'models', 'schedule', 'tasks', 'team', 'workflows'] as const
+const IN_REPO_PLUGINS = ['assets', 'git', 'health', 'memory', 'models', 'schedule', 'tasks', 'team', 'workflows'] as const
 
 afterAll(() => {
   rmSync(testDir, { recursive: true, force: true })

--- a/tests/plugins/contract.test.ts
+++ b/tests/plugins/contract.test.ts
@@ -101,6 +101,7 @@ const workflowsPlugin = require('../../plugins/workflows').default as typeof imp
 const assetsPlugin = require('../../plugins/assets').default as typeof import('../../plugins/assets').default
 const schedulePlugin = require('../../plugins/schedule').default as typeof import('../../plugins/schedule').default
 const healthPlugin = require('../../plugins/health').default as typeof import('../../plugins/health').default
+const gitPlugin = require('../../plugins/git').default as typeof import('../../plugins/git').default
 
 const TEST_DIR = hoistedBakinHome
 const TEST_OPENCLAW_HOME = hoistedOpenClawHome
@@ -193,6 +194,7 @@ const ALL_PLUGINS: BakinPlugin[] = [
   assetsPlugin,
   schedulePlugin,
   healthPlugin,
+  gitPlugin,
 ]
 
 describe('Plugin Contract', () => {

--- a/tests/plugins/git/worktrees.test.ts
+++ b/tests/plugins/git/worktrees.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test'
+import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+import { createTestContext, findTool, callTool } from '../test-helpers'
+import { gitAvailable, runGit } from '../../fixtures/plugins/hermetic-git'
+import gitPlugin from '../../../plugins/git'
+
+const rootDir = join(tmpdir(), `bakin-test-git-plugin-${Date.now()}-${randomUUID()}`)
+const bakinHome = join(rootDir, 'bakin-home')
+const reposRoot = join(rootDir, 'repos')
+const worktreeRoot = join(bakinHome, 'git-worktrees')
+
+const maybeIt = gitAvailable() ? it : it.skip
+
+beforeEach(() => {
+  rmSync(rootDir, { recursive: true, force: true })
+  mkdirSync(reposRoot, { recursive: true })
+  mkdirSync(bakinHome, { recursive: true })
+  process.env.BAKIN_HOME = bakinHome
+})
+
+afterAll(() => {
+  rmSync(rootDir, { recursive: true, force: true })
+})
+
+function seedRepo(name = 'app'): string {
+  const repoPath = join(reposRoot, name)
+  mkdirSync(repoPath, { recursive: true })
+  runGit(['init', '-b', 'main'], repoPath)
+  runGit(['config', 'user.email', 'test@bakin.local'], repoPath)
+  runGit(['config', 'user.name', 'Bakin Test'], repoPath)
+  writeFileSync(join(repoPath, 'README.md'), '# Test repo\n', 'utf-8')
+  runGit(['add', '-A'], repoPath)
+  runGit(['commit', '-m', 'initial'], repoPath, {
+    GIT_AUTHOR_NAME: 'Bakin Test',
+    GIT_AUTHOR_EMAIL: 'test@bakin.local',
+    GIT_COMMITTER_NAME: 'Bakin Test',
+    GIT_COMMITTER_EMAIL: 'test@bakin.local',
+  })
+  return repoPath
+}
+
+async function activateGitPlugin() {
+  const activated = createTestContext('git', bakinHome)
+  activated.ctx.getSettings = (<T = Record<string, unknown>>() => ({
+    allowedRepoRoots: [{ path: reposRoot }],
+    worktreeRoot,
+  }) as T) as typeof activated.ctx.getSettings
+  await gitPlugin.activate(activated.ctx)
+  return activated
+}
+
+describe('git plugin worktree tools', () => {
+  maybeIt('creates and reuses an isolated worktree for a task', async () => {
+    const repoPath = seedRepo()
+    const activated = await activateGitPlugin()
+    const prepare = findTool(activated.execTools, 'bakin_exec_git_prepare_worktree')
+    expect(prepare).toBeDefined()
+
+    const first = await callTool(prepare!, {
+      repoPath,
+      taskId: '36',
+      branch: 'bakin/36-test-agent',
+      baseRef: 'HEAD',
+    }, 'patch')
+
+    expect(first.ok).toBe(true)
+    expect(first.repoPath).toBe(realpathSync(repoPath))
+    expect(first.branch).toBe('bakin/36-test-agent')
+    expect(typeof first.worktreePath).toBe('string')
+    expect(String(first.worktreePath).startsWith(worktreeRoot)).toBe(true)
+    expect(existsSync(String(first.worktreePath))).toBe(true)
+    expect(runGit(['rev-parse', '--show-toplevel'], String(first.worktreePath))).toBe(realpathSync(String(first.worktreePath)))
+
+    const second = await callTool(prepare!, {
+      repoPath,
+      taskId: '36',
+      branch: 'bakin/36-test-agent',
+    }, 'patch')
+
+    expect(second.ok).toBe(true)
+    expect(second.reused).toBe(true)
+    expect(second.worktreePath).toBe(first.worktreePath)
+  })
+
+  maybeIt('reports dirty status and refuses release without force', async () => {
+    const repoPath = seedRepo()
+    const activated = await activateGitPlugin()
+    const prepare = findTool(activated.execTools, 'bakin_exec_git_prepare_worktree')!
+    const status = findTool(activated.execTools, 'bakin_exec_git_status')!
+    const release = findTool(activated.execTools, 'bakin_exec_git_release_worktree')!
+
+    const prepared = await callTool(prepare, {
+      repoPath,
+      taskId: '36',
+      branch: 'bakin/36-dirty',
+    }, 'patch')
+    expect(prepared.ok).toBe(true)
+
+    const worktreePath = String(prepared.worktreePath)
+    writeFileSync(join(worktreePath, 'scratch.txt'), 'dirty\n', 'utf-8')
+
+    const current = await callTool(status, { repoPath, taskId: '36' }, 'patch')
+    expect(current.ok).toBe(true)
+    expect(Array.isArray(current.worktrees)).toBe(true)
+    expect((current.worktrees as Array<Record<string, unknown>>)[0].dirty).toBe(true)
+    expect(String((current.worktrees as Array<Record<string, unknown>>)[0].status)).toContain('scratch.txt')
+
+    const refused = await callTool(release, { worktreePath }, 'patch')
+    expect(refused.ok).toBe(false)
+    expect(String(refused.error)).toContain('dirty')
+    expect(existsSync(worktreePath)).toBe(true)
+
+    const forced = await callTool(release, { worktreePath, force: true }, 'patch')
+    expect(forced.ok).toBe(true)
+    expect(existsSync(worktreePath)).toBe(false)
+  })
+
+  maybeIt('rejects repositories outside configured allowed roots', async () => {
+    const outsideRoot = join(rootDir, 'outside')
+    mkdirSync(outsideRoot, { recursive: true })
+    const repoPath = seedRepo('inside')
+    const outsideRepo = join(outsideRoot, 'repo')
+    mkdirSync(outsideRepo, { recursive: true })
+    runGit(['init', '-b', 'main'], outsideRepo)
+
+    const activated = await activateGitPlugin()
+    const prepare = findTool(activated.execTools, 'bakin_exec_git_prepare_worktree')!
+
+    const accepted = await callTool(prepare, { repoPath, taskId: '36' }, 'patch')
+    expect(accepted.ok).toBe(true)
+
+    const rejected = await callTool(prepare, { repoPath: outsideRepo, taskId: '37' }, 'patch')
+    expect(rejected.ok).toBe(false)
+    expect(String(rejected.error)).toContain('allowed repo roots')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a core Git plugin with typed REST routes, MCP exec tools, settings, and a doctor check for Bakin-tracked task worktrees.
- Enforce allowed repo roots, create/reuse task branches in isolated worktrees, report dirty status, and refuse dirty release unless force=true.
- Wire Patch to the new flow with a git-isolation runtime skill, tool allowlist, package docs, and generated API/exec-tool docs.

Closes #36.

## Verification
- bun test --isolate tests/plugins/git/worktrees.test.ts
- bun test --isolate tests/plugins/git/worktrees.test.ts tests/docs/static-plugin-routes.test.ts tests/plugins/contract.test.ts tests/agent-packages/manifest.test.ts tests/agent-packages/projector.test.ts
- bun test --isolate
- bun run typecheck
- bun run build:plugins
- bun run docs:generate
- bun run docs:validate
- bun run docs:validate:routes
- bunx eslint plugins/git/index.ts tests/plugins/git/worktrees.test.ts

## Notes
- Full repo lint still fails on existing unrelated lint debt in routing, assets, memory, tasks, team, workflows, and docs generator files. The new Git plugin and tests pass direct ESLint.