### PR TITLE
Harden Imitation Crab mock configuration

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -92,6 +92,26 @@ Three env-checks ensure `BAKIN_DEV` never leaks into the compiled binary:
 
 The dev-client bundle itself is disk-only — written to `packages/host/public/__bakin-dev/client.js`, gitignored, naturally excluded from `scripts/generate-embedded-assets.ts` (which only descends into explicitly-walked subdirectories under `public/`). It can never ship in a compiled binary.
 
+## Imitation Crab
+
+`bun run dev:mock` starts the OpenClaw-compatible mock under
+`dev/imitation-crab/`. The mock is still a development harness, not a production
+runtime adapter: Bakin talks to it through the OpenClaw adapter by setting
+`OPENCLAW_HOME` and `OPENCLAW_PATH`.
+
+Runtime knobs:
+
+- `IMITATION_CRAB_HOME` / `OPENCLAW_MOCK_HOME` — mock home directory. Default:
+  `~/.imitationcrab`.
+- `IMITATION_CRAB_PORT` / `OPENCLAW_MOCK_PORT` — mock gateway port. Default:
+  `18789`.
+- `OPENCLAW_MOCK_CHAT_MODE` — `canned`, `echo`, or `error`.
+- `OPENCLAW_MOCK_FORCE=1` — bypasses the safety check that refuses to run when
+  a real OpenClaw binary/config/gateway is detected.
+
+`bun run mock:seed --force` removes the configured mock home before copying
+fixtures, so stale fixture files cannot survive a re-seed.
+
 ## One-React-instance invariant
 
 The shell and every plugin share React via the import map:

--- a/.claude/plans/platform-integrity-audit.md
+++ b/.claude/plans/platform-integrity-audit.md
@@ -240,7 +240,7 @@ Evidence to inspect:
 
 ### G. Imitation Crab / Dev Runtime
 
-Status: focused verification passed.
+Status: focused verification passed; first hardening slice in progress.
 
 Findings:
 
@@ -250,6 +250,10 @@ Findings:
   adapter or remains a deterministic dev harness.
 - **recommended direction:** build an adapter-like facade for dev/runtime tests
   only after #218 establishes the policy boundary it must simulate.
+- **first slice:** make the mock environment deterministic and testable before
+  adapterizing it. The seed path now honors a configured mock home, force re-seed
+  removes stale fixture state, the gateway port is configurable, and chat mode
+  validation fails loud.
 
 Evidence to inspect:
 
@@ -292,8 +296,10 @@ Evidence to inspect:
   - pass (130 tests).
 - `bun test tests/plugins/lifecycle/install-dependencies.test.ts tests/plugins/lifecycle/install-source-swap.test.ts tests/plugins/lifecycle/install-subpath.test.ts tests/plugins/lifecycle/upgrade-flow.integration.test.ts tests/plugins/lifecycle/remove-smoke.test.ts tests/plugins/lifecycle/registry-teardown-smoke.test.ts tests/api/plugins-install.test.ts tests/api/user-plugin-lifecycle.test.ts --isolate`
   - pass (52 tests).
-- `bun test tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-safety.test.ts --isolate`
-  - pass (21 tests).
+- `bun test tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-safety.test.ts --isolate`
+  - pass (24 tests).
+- `bunx eslint dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway-streaming.test.ts`
+  - pass.
 - `bun test tests/cli/bakin.test.ts tests/cli/plugin-install-args.test.ts tests/cli/agents-packages.test.ts tests/cli/install-plugin-assets.test.ts tests/cli/install-agent-assets.test.ts tests/core/onboarding/index.test.ts tests/core/onboarding/runtime.test.ts tests/core/onboarding/plugin-assets.test.ts tests/core/onboarding/models.test.ts --isolate`
   - pass (96 tests).
 - `bun run typecheck` - pass.

--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ scripts/                   Build + infrastructure (build-vendors, build-
 cli/                       Thin CLI entry point. Most commands go through
                            src/core/cli.ts inside the compiled binary.
 
-dev/imitation-crab/        OpenClaw-compatible runtime mock — seeds
-                           ~/.imitationcrab/ with fixtures and runs a mock
-                           gateway on :18789 for local dev without a real
-                           OpenClaw install.
+dev/imitation-crab/        OpenClaw-compatible runtime mock — seeds a mock
+                           home (default ~/.imitationcrab/) with fixtures and
+                           runs a mock gateway (default :18789) for local dev
+                           without a real OpenClaw install.
 ```
 
 ### Runtime data (`~/.bakin/`)
@@ -406,6 +406,10 @@ For mock dev without a real OpenClaw:
 bun run dev:mock          # seeds + launches Imitation Crab mock + Bakin
 bun run mock:seed --force # reseed fixtures
 ```
+
+Set `IMITATION_CRAB_HOME` or `IMITATION_CRAB_PORT` to isolate a mock run from
+the defaults. `OPENCLAW_MOCK_HOME` and `OPENCLAW_MOCK_PORT` are also accepted
+for compatibility with older scripts.
 
 ---
 

--- a/dev/imitation-crab/env.ts
+++ b/dev/imitation-crab/env.ts
@@ -1,0 +1,36 @@
+import { homedir } from 'os'
+import { join } from 'path'
+
+export type MockChatMode = 'canned' | 'echo' | 'error'
+
+const DEFAULT_PORT = 18789
+const CHAT_MODES = new Set<MockChatMode>(['canned', 'echo', 'error'])
+
+export function getMockHome(): string {
+  return process.env.IMITATION_CRAB_HOME
+    || process.env.OPENCLAW_MOCK_HOME
+    || join(homedir(), '.imitationcrab')
+}
+
+export function getGatewayPort(): number {
+  const raw = process.env.IMITATION_CRAB_PORT || process.env.OPENCLAW_MOCK_PORT
+  if (!raw) return DEFAULT_PORT
+
+  const port = Number(raw)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid imitation-crab gateway port: ${raw}`)
+  }
+  return port
+}
+
+export function getGatewayUrl(): string {
+  return `http://127.0.0.1:${getGatewayPort()}`
+}
+
+export function getChatMode(): MockChatMode {
+  const mode = process.env.OPENCLAW_MOCK_CHAT_MODE || 'canned'
+  if (!CHAT_MODES.has(mode as MockChatMode)) {
+    throw new Error(`Invalid OPENCLAW_MOCK_CHAT_MODE: ${mode}`)
+  }
+  return mode as MockChatMode
+}

--- a/dev/imitation-crab/gateway.ts
+++ b/dev/imitation-crab/gateway.ts
@@ -6,9 +6,7 @@
  *   POST /tools/invoke
  */
 import { createServer, type IncomingMessage, type ServerResponse } from 'http'
-
-const PORT = 18789
-const CHAT_MODE = process.env.OPENCLAW_MOCK_CHAT_MODE || 'canned'
+import { getChatMode, getGatewayPort } from './env'
 
 // Agent name lookup for canned responses
 const AGENT_NAMES: Record<string, string> = {
@@ -76,7 +74,7 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
     const userMessage = parsed.messages?.[parsed.messages.length - 1]?.content || ''
 
     let reply: string
-    switch (CHAT_MODE) {
+    switch (getChatMode()) {
       case 'echo':
         reply = `[mock:${agentName}] ${userMessage}`
         break
@@ -168,7 +166,9 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   json(res, response.body, response.status)
 }
 
-export function startGateway(): Promise<void> {
+export function startGateway(port = getGatewayPort()): Promise<void> {
+  const chatMode = getChatMode()
+
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
       handleRequest(req, res).catch((err) => {
@@ -179,16 +179,16 @@ export function startGateway(): Promise<void> {
 
     server.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {
-        console.error(`[gateway] Port ${PORT} is already in use`)
+        console.error(`[gateway] Port ${port} is already in use`)
         reject(err)
       } else {
         reject(err)
       }
     })
 
-    server.listen(PORT, '127.0.0.1', () => {
-      console.log(`[gateway] Mock OpenClaw gateway listening on http://127.0.0.1:${PORT}`)
-      console.log(`[gateway] Chat mode: ${CHAT_MODE}`)
+    server.listen(port, '127.0.0.1', () => {
+      console.log(`[gateway] Mock OpenClaw gateway listening on http://127.0.0.1:${port}`)
+      console.log(`[gateway] Chat mode: ${chatMode}`)
       resolve()
     })
 

--- a/dev/imitation-crab/index.ts
+++ b/dev/imitation-crab/index.ts
@@ -5,8 +5,8 @@
  *   npx tsx dev/imitation-crab/index.ts              # Start mock only
  *   npx tsx dev/imitation-crab/index.ts --with-bakin  # Start mock + Bakin dev server
  *
- * Sets OPENCLAW_HOME=~/.imitationcrab and OPENCLAW_PATH to the CLI shim,
- * then starts the mock HTTP gateway on :18789.
+ * Sets OPENCLAW_HOME to the configured mock home and OPENCLAW_PATH to the CLI
+ * shim, then starts the mock HTTP gateway.
  */
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
@@ -16,6 +16,7 @@ import { spawn, type ChildProcess } from 'child_process'
 import { checkSafety, printSafetyError } from './safety'
 import { seed, getMockHome } from './seed'
 import { startGateway } from './gateway'
+import { getGatewayUrl } from './env'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PROJECT_ROOT = join(__dirname, '..', '..')
@@ -92,7 +93,7 @@ async function main(): Promise<void> {
     console.log('')
     console.log('Mock gateway is running. Start Bakin in another terminal with:')
     console.log('')
-    console.log(`  BAKIN_HOME=${mockHome} OPENCLAW_HOME=${mockHome} OPENCLAW_PATH=${shimPath} npm run dev`)
+    console.log(`  BAKIN_HOME=${mockHome} OPENCLAW_HOME=${mockHome} OPENCLAW_PATH=${shimPath} OPENCLAW_BASE_URL=${getGatewayUrl()} npm run dev`)
     console.log('')
   }
 }

--- a/dev/imitation-crab/safety.ts
+++ b/dev/imitation-crab/safety.ts
@@ -5,6 +5,7 @@
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { getGatewayUrl } from './env'
 
 interface SafetyResult {
   safe: boolean
@@ -33,11 +34,12 @@ export async function checkSafety(): Promise<SafetyResult> {
 
   // 3. Check for running gateway
   try {
-    const res = await fetch('http://127.0.0.1:18789/health', {
+    const url = getGatewayUrl()
+    const res = await fetch(`${url}/health`, {
       signal: AbortSignal.timeout(2000),
     })
     if (res.ok) {
-      reasons.push('Gateway responding on :18789')
+      reasons.push(`Gateway responding on ${url}`)
     }
   } catch {
     // Not running — good

--- a/dev/imitation-crab/seed.ts
+++ b/dev/imitation-crab/seed.ts
@@ -1,83 +1,86 @@
 /**
- * Filesystem seeder — creates ~/.imitationcrab/ with all fixture data.
+ * Filesystem seeder — creates the configured mock home with all fixture data.
  * Idempotent: skips if directory already exists (use --force to re-seed).
  */
-import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
-import { homedir } from 'os'
 import { initBakinHome } from '../../packages/core/src/content-dir'
+import { getMockHome } from './env'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const MOCK_HOME = join(homedir(), '.imitationcrab')
 const FIXTURES_DIR = join(__dirname, 'fixtures')
 
-export function getMockHome(): string {
-  return MOCK_HOME
-}
+export { getMockHome }
 
 export function seed(force = false): void {
-  if (existsSync(MOCK_HOME) && !force) {
-    console.log(`[seed] ${MOCK_HOME} already exists — skipping (use --force to re-seed)`)
+  const mockHome = getMockHome()
+
+  if (existsSync(mockHome) && !force) {
+    console.log(`[seed] ${mockHome} already exists — skipping (use --force to re-seed)`)
     return
   }
 
-  console.log(`[seed] Creating ${MOCK_HOME}`)
+  if (force) {
+    rmSync(mockHome, { recursive: true, force: true })
+  }
+
+  console.log(`[seed] Creating ${mockHome}`)
 
   // Create Bakin content structure (assets/, workflows/, settings.json, etc.)
-  initBakinHome(MOCK_HOME)
+  initBakinHome(mockHome)
 
   // Create directory structure
-  mkdirSync(join(MOCK_HOME, 'agents', 'main', 'agent'), { recursive: true })
-  mkdirSync(join(MOCK_HOME, 'cron', 'runs'), { recursive: true })
-  mkdirSync(join(MOCK_HOME, 'workspace'), { recursive: true })
-  mkdirSync(join(MOCK_HOME, 'bin'), { recursive: true })
+  mkdirSync(join(mockHome, 'agents', 'main', 'agent'), { recursive: true })
+  mkdirSync(join(mockHome, 'cron', 'runs'), { recursive: true })
+  mkdirSync(join(mockHome, 'workspace'), { recursive: true })
+  mkdirSync(join(mockHome, 'bin'), { recursive: true })
 
   // Copy fixtures
-  cpSync(join(FIXTURES_DIR, 'openclaw.json'), join(MOCK_HOME, 'openclaw.json'))
-  cpSync(join(FIXTURES_DIR, 'auth-profiles.json'), join(MOCK_HOME, 'agents', 'main', 'agent', 'auth-profiles.json'))
-  cpSync(join(FIXTURES_DIR, 'jobs.json'), join(MOCK_HOME, 'cron', 'jobs.json'))
+  cpSync(join(FIXTURES_DIR, 'openclaw.json'), join(mockHome, 'openclaw.json'))
+  cpSync(join(FIXTURES_DIR, 'auth-profiles.json'), join(mockHome, 'agents', 'main', 'agent', 'auth-profiles.json'))
+  cpSync(join(FIXTURES_DIR, 'jobs.json'), join(mockHome, 'cron', 'jobs.json'))
 
   // Copy run history
-  cpSync(join(FIXTURES_DIR, 'runs'), join(MOCK_HOME, 'cron', 'runs'), { recursive: true })
+  cpSync(join(FIXTURES_DIR, 'runs'), join(mockHome, 'cron', 'runs'), { recursive: true })
 
   // Copy main workspace
-  cpSync(join(FIXTURES_DIR, 'workspace'), join(MOCK_HOME, 'workspace'), { recursive: true })
+  cpSync(join(FIXTURES_DIR, 'workspace'), join(mockHome, 'workspace'), { recursive: true })
 
   // Copy Bakin-specific mock content (workflow defs, instances, assets)
   const bakinFixtures = join(FIXTURES_DIR, 'bakin')
   if (existsSync(bakinFixtures)) {
-    cpSync(bakinFixtures, MOCK_HOME, { recursive: true })
+    cpSync(bakinFixtures, mockHome, { recursive: true })
   }
 
   // Copy subagent workspaces
   const subagents = ['pixel', 'rolo', 'basil', 'scout', 'nemo', 'zen', 'patch']
   for (const agent of subagents) {
     const src = join(FIXTURES_DIR, 'workspaces', agent)
-    const dest = join(MOCK_HOME, 'workspaces', agent)
+    const dest = join(mockHome, 'workspaces', agent)
     if (existsSync(src)) {
       cpSync(src, dest, { recursive: true })
     }
   }
 
   // Seed Bakin-owned task-store data.
-  seedTasks()
+  seedTasks(mockHome)
 
   // Create a sample gateway log for today
   seedGatewayLog()
 
   // Seed audit entries for watchdog recoveries into ~/.bakin/audit.jsonl
-  seedAuditLog()
+  seedAuditLog(mockHome)
 
-  console.log(`[seed] Done — ${MOCK_HOME} ready`)
+  console.log(`[seed] Done — ${mockHome} ready`)
 }
 
-function seedTasks(): void {
+function seedTasks(mockHome: string): void {
   const tasks = JSON.parse(readFileSync(join(FIXTURES_DIR, 'tasks.json'), 'utf-8')) as Array<{
     id: string
     createdAt?: string
   }>
-  const tasksRoot = join(MOCK_HOME, 'tasks')
+  const tasksRoot = join(mockHome, 'tasks')
 
   for (const task of tasks) {
     const shard = (task.createdAt || new Date().toISOString()).slice(0, 7)
@@ -106,9 +109,9 @@ function seedGatewayLog(): void {
   }
 }
 
-function seedAuditLog(): void {
-  const { appendFileSync, writeFileSync } = require('fs')
-  const bakinHome = process.env.BAKIN_HOME || MOCK_HOME
+function seedAuditLog(mockHome: string): void {
+  const { appendFileSync } = require('fs')
+  const bakinHome = process.env.BAKIN_HOME || mockHome
   const auditPath = join(bakinHome, 'audit.jsonl')
 
   // Watchdog recovery audit entries matching the seeded tasks

--- a/tests/dev/mock-env.test.ts
+++ b/tests/dev/mock-env.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { getChatMode, getGatewayPort, getGatewayUrl, getMockHome } from '../../dev/imitation-crab/env'
+
+describe('imitation-crab env', () => {
+  const originalEnv = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('uses explicit mock home and gateway port when configured', () => {
+    const home = join(tmpdir(), 'configured-crab-home')
+    process.env.IMITATION_CRAB_HOME = home
+    process.env.IMITATION_CRAB_PORT = '19001'
+
+    expect(getMockHome()).toBe(home)
+    expect(getGatewayPort()).toBe(19001)
+    expect(getGatewayUrl()).toBe('http://127.0.0.1:19001')
+  })
+
+  it('fails loud on invalid gateway port and chat mode', () => {
+    process.env.IMITATION_CRAB_PORT = 'not-a-port'
+    expect(() => getGatewayPort()).toThrow('Invalid imitation-crab gateway port')
+
+    process.env.OPENCLAW_MOCK_CHAT_MODE = 'surprise'
+    expect(() => getChatMode()).toThrow('Invalid OPENCLAW_MOCK_CHAT_MODE')
+  })
+})

--- a/tests/dev/mock-gateway-streaming.test.ts
+++ b/tests/dev/mock-gateway-streaming.test.ts
@@ -60,31 +60,30 @@ describe('mock gateway streaming', () => {
   })
 
   it('uses last message content for echo mode reply', async () => {
-    // Save and restore env
     const original = process.env.OPENCLAW_MOCK_CHAT_MODE
     process.env.OPENCLAW_MOCK_CHAT_MODE = 'echo'
 
-    // Need to re-import to pick up env change — but CHAT_MODE is read at module load.
-    // Instead, test that the content field is populated with something sensible.
-    const res = await handleGatewayRequest({
-      method: 'POST',
-      url: '/v1/chat/completions',
-      headers: { 'x-openclaw-agent-id': 'scout' },
-      body: JSON.stringify({
-        model: 'openclaw',
-        stream: true,
-        messages: [
-          { role: 'system', content: 'You are Scout' },
-          { role: 'user', content: 'Plan outdoor content' },
-        ],
-      }),
-    })
+    try {
+      const res = await handleGatewayRequest({
+        method: 'POST',
+        url: '/v1/chat/completions',
+        headers: { 'x-openclaw-agent-id': 'scout' },
+        body: JSON.stringify({
+          model: 'openclaw',
+          stream: true,
+          messages: [
+            { role: 'system', content: 'You are Scout' },
+            { role: 'user', content: 'Plan outdoor content' },
+          ],
+        }),
+      })
 
-    expect(res.status).toBe(200)
-    const body = res.body as Record<string, unknown>
-    expect(body.__stream).toBe(true)
-    expect(typeof body.content).toBe('string')
-
-    process.env.OPENCLAW_MOCK_CHAT_MODE = original
+      expect(res.status).toBe(200)
+      const body = res.body as Record<string, unknown>
+      expect(body.__stream).toBe(true)
+      expect(body.content).toBe('[mock:Scout] Plan outdoor content')
+    } finally {
+      process.env.OPENCLAW_MOCK_CHAT_MODE = original
+    }
   })
 })

--- a/tests/dev/mock-seed.test.ts
+++ b/tests/dev/mock-seed.test.ts
@@ -1,39 +1,59 @@
 import { describe, it, expect, afterEach } from 'bun:test'
-import { existsSync, rmSync, readFileSync } from 'fs'
+import { existsSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
-import { mkdtempSync } from 'fs'
 import { tmpdir } from 'os'
+import { getMockHome, seed } from '../../dev/imitation-crab/seed'
 
 describe('mock seed', () => {
   let tempHome: string | undefined
+  const originalEnv = { ...process.env }
 
   afterEach(() => {
     if (tempHome && existsSync(tempHome)) {
       rmSync(tempHome, { recursive: true, force: true })
     }
+    tempHome = undefined
+    process.env = { ...originalEnv }
   })
 
-  it('creates the expected directory structure', async () => {
-    // The seed module uses a hardcoded path (~/.imitationcrab).
-    // For testing, we import the seed function and check that the fixture files exist.
-    // We'll verify the fixtures directory contains the expected files.
-    const fixturesDir = join(import.meta.dirname, '..', '..', 'dev', 'imitation-crab', 'fixtures')
+  function configureTempHome(): string {
+    tempHome = mkdtempSync(join(tmpdir(), 'bakin-imitation-crab-'))
+    process.env.IMITATION_CRAB_HOME = tempHome
+    process.env.BAKIN_HOME = tempHome
+    return tempHome
+  }
 
-    expect(existsSync(join(fixturesDir, 'openclaw.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'auth-profiles.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'jobs.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'tasks.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'workspace', 'SOUL.md'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'workspace', 'IDENTITY.md'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'workspace', 'AGENTS.md'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'workspace', 'TOOLS.md'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'workflows', 'definitions', 'approval-copy.yaml'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'workflows', 'definitions', 'approval-image.yaml'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'workflows', 'definitions', 'approval-bundle.yaml'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'workflows', 'instances', 'task-rv-002.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'workflows', 'instances', 'task-rv-003.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'workflows', 'instances', 'task-rv-004.json'))).toBe(true)
-    expect(existsSync(join(fixturesDir, 'bakin', 'assets', 'images', 'task-rv-003', 'trail-status-concept.svg'))).toBe(true)
+  it('seeds the expected directory structure into the configured mock home', () => {
+    const home = configureTempHome()
+
+    seed(true)
+
+    expect(getMockHome()).toBe(home)
+    expect(existsSync(join(home, 'openclaw.json'))).toBe(true)
+    expect(existsSync(join(home, 'agents', 'main', 'agent', 'auth-profiles.json'))).toBe(true)
+    expect(existsSync(join(home, 'cron', 'jobs.json'))).toBe(true)
+    expect(existsSync(join(home, 'workspace', 'SOUL.md'))).toBe(true)
+    expect(existsSync(join(home, 'workspace', 'IDENTITY.md'))).toBe(true)
+    expect(existsSync(join(home, 'workspace', 'AGENTS.md'))).toBe(true)
+    expect(existsSync(join(home, 'workspace', 'TOOLS.md'))).toBe(true)
+    expect(existsSync(join(home, 'workflows', 'definitions', 'approval-copy.yaml'))).toBe(true)
+    expect(existsSync(join(home, 'workflows', 'definitions', 'approval-image.yaml'))).toBe(true)
+    expect(existsSync(join(home, 'workflows', 'definitions', 'approval-bundle.yaml'))).toBe(true)
+    expect(existsSync(join(home, 'workflows', 'instances', 'task-rv-002.json'))).toBe(true)
+    expect(existsSync(join(home, 'workflows', 'instances', 'task-rv-003.json'))).toBe(true)
+    expect(existsSync(join(home, 'workflows', 'instances', 'task-rv-004.json'))).toBe(true)
+    expect(existsSync(join(home, 'assets', 'images', 'task-rv-003', 'trail-status-concept.svg'))).toBe(true)
+  })
+
+  it('force reseed removes stale files before copying fixtures', () => {
+    const home = configureTempHome()
+    const stalePath = join(home, 'stale.txt')
+    writeFileSync(stalePath, 'stale', 'utf-8')
+
+    seed(true)
+
+    expect(existsSync(stalePath)).toBe(false)
+    expect(existsSync(join(home, 'openclaw.json'))).toBe(true)
   })
 
   it('fixture openclaw.json has valid agent roster', () => {


### PR DESCRIPTION
## Summary

- Add a shared Imitation Crab env helper for mock home, gateway port, URL, and chat mode validation.
- Make mock seeding honor configurable home paths and make --force remove stale fixture state before copying.
- Make gateway port/chat mode configurable and testable, and update dev docs/audit notes with the supported knobs.
- Replace fixture-only seed coverage with temp-home seed coverage and add env validation tests.

## Verification

- bun test tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-safety.test.ts --isolate
- bun run typecheck
- bunx eslint dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway-streaming.test.ts
- git diff --check

Note: full bun run lint currently fails on unrelated existing routing/plugin unused-var errors outside this branch.

Refs #221
Refs #232