### PR TITLE
Add Imitation Crab AppServices harness

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -112,6 +112,14 @@ Runtime knobs:
 `bun run mock:seed --force` removes the configured mock home before copying
 fixtures, so stale fixture files cannot survive a re-seed.
 
+Tests that need the mock as a contract harness should use
+`createImitationCrabHarness()` from `dev/imitation-crab/harness.ts`. It creates
+an isolated mock home, seeds fixtures, installs the CLI shim, wires an OpenClaw
+runtime adapter with mock settings, pairs it with `createMockSearchAdapter()`,
+and intercepts fetches to the mock gateway in-process. Use
+`startGateway: true` only for manual/server smoke tests where binding a local
+port is part of what you need to verify.
+
 ## One-React-instance invariant
 
 The shell and every plugin share React via the import map:

--- a/.claude/plans/platform-integrity-audit.md
+++ b/.claude/plans/platform-integrity-audit.md
@@ -240,7 +240,7 @@ Evidence to inspect:
 
 ### G. Imitation Crab / Dev Runtime
 
-Status: focused verification passed; first hardening slice in progress.
+Status: focused verification passed; contract-harness slices in progress.
 
 Findings:
 
@@ -254,6 +254,10 @@ Findings:
   adapterizing it. The seed path now honors a configured mock home, force re-seed
   removes stale fixture state, the gateway port is configurable, and chat mode
   validation fails loud.
+- **second slice:** add an Imitation Crab AppServices harness backed by the
+  OpenClaw runtime adapter plus mock search, normalize the seeded main workspace
+  into the mock home, and fix the OpenClaw config cache so swapping
+  `OPENCLAW_HOME` cannot reuse a same-mtime config from another path.
 
 Evidence to inspect:
 
@@ -298,7 +302,9 @@ Evidence to inspect:
   - pass (52 tests).
 - `bun test tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-safety.test.ts --isolate`
   - pass (24 tests).
-- `bunx eslint dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway-streaming.test.ts`
+- `bun test tests/dev/mock-harness.test.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-safety.test.ts --isolate`
+  - pass (27 tests).
+- `bunx eslint dev/imitation-crab/cli-shim-install.ts dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/harness.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts packages/adapter-openclaw/src/config.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-harness.test.ts tests/dev/mock-seed.test.ts`
   - pass.
 - `bun test tests/cli/bakin.test.ts tests/cli/plugin-install-args.test.ts tests/cli/agents-packages.test.ts tests/cli/install-plugin-assets.test.ts tests/cli/install-agent-assets.test.ts tests/core/onboarding/index.test.ts tests/core/onboarding/runtime.test.ts tests/core/onboarding/plugin-assets.test.ts tests/core/onboarding/models.test.ts --isolate`
   - pass (96 tests).

--- a/README.md
+++ b/README.md
@@ -411,6 +411,11 @@ Set `IMITATION_CRAB_HOME` or `IMITATION_CRAB_PORT` to isolate a mock run from
 the defaults. `OPENCLAW_MOCK_HOME` and `OPENCLAW_MOCK_PORT` are also accepted
 for compatibility with older scripts.
 
+Tests that need seeded runtime state can use `createImitationCrabHarness()` from
+`dev/imitation-crab/harness.ts`. It prepares an isolated mock home, installs the
+CLI shim, and returns AppServices backed by the OpenClaw adapter plus a mock
+search adapter.
+
 ---
 
 ## License

--- a/dev/imitation-crab/cli-shim-install.ts
+++ b/dev/imitation-crab/cli-shim-install.ts
@@ -1,0 +1,18 @@
+import { chmodSync, copyFileSync, mkdirSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { getMockHome } from './env'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export function installCliShim(mockHome = getMockHome()): string {
+  const binDir = join(mockHome, 'bin')
+  mkdirSync(binDir, { recursive: true })
+
+  const shimSrc = join(__dirname, 'cli-shim.sh')
+  const shimDest = join(binDir, 'openclaw')
+  copyFileSync(shimSrc, shimDest)
+  chmodSync(shimDest, 0o755)
+
+  return shimDest
+}

--- a/dev/imitation-crab/gateway.ts
+++ b/dev/imitation-crab/gateway.ts
@@ -8,6 +8,16 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'http'
 import { getChatMode, getGatewayPort } from './env'
 
+export interface ImitationCrabGateway {
+  port: number
+  url: string
+  close(): Promise<void>
+}
+
+export interface StartGatewayOptions {
+  registerSignals?: boolean
+}
+
 // Agent name lookup for canned responses
 const AGENT_NAMES: Record<string, string> = {
   main: 'Crab',
@@ -166,8 +176,9 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
   json(res, response.body, response.status)
 }
 
-export function startGateway(port = getGatewayPort()): Promise<void> {
+export function startGateway(port = getGatewayPort(), options: StartGatewayOptions = {}): Promise<ImitationCrabGateway> {
   const chatMode = getChatMode()
+  const registerSignals = options.registerSignals ?? true
 
   return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
@@ -186,18 +197,34 @@ export function startGateway(port = getGatewayPort()): Promise<void> {
       }
     })
 
-    server.listen(port, '127.0.0.1', () => {
-      console.log(`[gateway] Mock OpenClaw gateway listening on http://127.0.0.1:${port}`)
-      console.log(`[gateway] Chat mode: ${chatMode}`)
-      resolve()
-    })
+    const close = async (): Promise<void> => {
+      process.off('SIGINT', shutdown)
+      process.off('SIGTERM', shutdown)
+      if (!server.listening) return
+      await new Promise<void>((closeResolve, closeReject) => {
+        server.close((err) => {
+          if (err) closeReject(err)
+          else closeResolve()
+        })
+      })
+    }
 
-    // Graceful shutdown
     const shutdown = () => {
       console.log('\n[gateway] Shutting down...')
-      server.close()
+      close().catch((err) => {
+        console.error('[gateway] Shutdown failed:', err)
+      })
     }
-    process.on('SIGINT', shutdown)
-    process.on('SIGTERM', shutdown)
+
+    server.listen(port, '127.0.0.1', () => {
+      const url = `http://127.0.0.1:${port}`
+      console.log(`[gateway] Mock OpenClaw gateway listening on ${url}`)
+      console.log(`[gateway] Chat mode: ${chatMode}`)
+      if (registerSignals) {
+        process.on('SIGINT', shutdown)
+        process.on('SIGTERM', shutdown)
+      }
+      resolve({ port, url, close })
+    })
   })
 }

--- a/dev/imitation-crab/harness.ts
+++ b/dev/imitation-crab/harness.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { AppServices } from '@bakin/core/app-services'
+import { createHealthService } from '@bakin/core/app-services'
+import { createMockSearchAdapter } from '@bakin/core/adapters/search/testing'
+import { createFileBakinTaskStore } from '@bakin/core/tasks/store'
+import { createOpenClawRuntimeAdapter } from '@bakin/adapter-openclaw'
+import { getGatewayPort, getMockHome, type MockChatMode } from './env'
+import { installCliShim } from './cli-shim-install'
+import { handleGatewayRequest, startGateway, type ImitationCrabGateway } from './gateway'
+import { seed } from './seed'
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+export interface ImitationCrabEnvironmentOptions {
+  home?: string
+  port?: number
+  chatMode?: MockChatMode
+  forceSeed?: boolean
+  cleanupHome?: boolean
+}
+
+export interface ImitationCrabEnvironment {
+  home: string
+  port: number
+  gatewayUrl: string
+  shimPath: string
+  cleanup(): void
+  restoreEnv(): void
+}
+
+export interface ImitationCrabHarnessOptions extends ImitationCrabEnvironmentOptions {
+  startGateway?: boolean
+  interceptFetch?: boolean
+}
+
+export interface ImitationCrabHarness {
+  env: ImitationCrabEnvironment
+  gateway: ImitationCrabGateway | null
+  services: AppServices
+  close(): Promise<void>
+}
+
+function restoreProcessEnv(original: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in original)) delete process.env[key]
+  }
+  Object.assign(process.env, original)
+}
+
+function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  const result: Record<string, string> = {}
+  if (!headers) return result
+  if (headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      result[key] = value
+    })
+    return result
+  }
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) result[key.toLowerCase()] = value
+    return result
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    result[key.toLowerCase()] = String(value)
+  }
+  return result
+}
+
+function requestBodyToString(body: BodyInit | null | undefined): string {
+  if (!body) return ''
+  if (typeof body === 'string') return body
+  if (body instanceof URLSearchParams) return body.toString()
+  return String(body)
+}
+
+function streamResponse(content: string): Response {
+  const encoder = new TextEncoder()
+  const words = content.split(/(\s+)/)
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const word of words) {
+        if (!word) continue
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: word } }] })}\n\n`))
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+function installGatewayFetchInterceptor(gatewayUrl: string): () => void {
+  const originalFetch = globalThis.fetch
+  const interceptedFetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL ? input.toString() : input.url
+    if (!url.startsWith(gatewayUrl)) {
+      return originalFetch(input, init)
+    }
+
+    const parsedUrl = new URL(url)
+    const response = await handleGatewayRequest({
+      method: init?.method ?? (input instanceof Request ? input.method : 'GET'),
+      url: `${parsedUrl.pathname}${parsedUrl.search}`,
+      headers: normalizeHeaders(init?.headers ?? (input instanceof Request ? input.headers : undefined)),
+      body: requestBodyToString(init?.body),
+    })
+    const body = response.body as Record<string, unknown>
+    if (body?.__stream === true) {
+      return streamResponse(String(body.content ?? ''))
+    }
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as typeof fetch
+  interceptedFetch.preconnect = typeof originalFetch.preconnect === 'function'
+    ? originalFetch.preconnect.bind(originalFetch)
+    : (() => {})
+  globalThis.fetch = interceptedFetch
+  return () => {
+    globalThis.fetch = originalFetch
+  }
+}
+
+export function prepareImitationCrabEnvironment(options: ImitationCrabEnvironmentOptions = {}): ImitationCrabEnvironment {
+  const originalEnv = { ...process.env }
+  const home = options.home ?? mkdtempSync(join(tmpdir(), 'bakin-imitation-crab-'))
+  const cleanupHome = options.cleanupHome ?? options.home === undefined
+
+  process.env.IMITATION_CRAB_HOME = home
+  process.env.OPENCLAW_MOCK_HOME = home
+  process.env.BAKIN_HOME = home
+  process.env.OPENCLAW_HOME = home
+  if (options.port !== undefined) process.env.IMITATION_CRAB_PORT = String(options.port)
+  if (options.chatMode) process.env.OPENCLAW_MOCK_CHAT_MODE = options.chatMode
+
+  const port = getGatewayPort()
+  const gatewayUrl = `http://127.0.0.1:${port}`
+  seed(options.forceSeed ?? true)
+  const shimPath = installCliShim(getMockHome())
+
+  process.env.OPENCLAW_PATH = shimPath
+  process.env.OPENCLAW_BASE_URL = gatewayUrl
+
+  return {
+    home,
+    port,
+    gatewayUrl,
+    shimPath,
+    cleanup: () => {
+      if (cleanupHome) rmSync(home, { recursive: true, force: true })
+    },
+    restoreEnv: () => restoreProcessEnv(originalEnv),
+  }
+}
+
+export async function createImitationCrabHarness(options: ImitationCrabHarnessOptions = {}): Promise<ImitationCrabHarness> {
+  const env = prepareImitationCrabEnvironment(options)
+  const gateway = options.startGateway
+    ? await startGateway(env.port, { registerSignals: false })
+    : null
+  const restoreFetch = options.interceptFetch === false
+    ? () => {}
+    : installGatewayFetchInterceptor(env.gatewayUrl)
+
+  const runtime = createOpenClawRuntimeAdapter({
+    settings: {
+      binaryPath: env.shimPath,
+      gatewayUrl: 'http://127.0.0.1',
+      gatewayPort: env.port,
+    },
+  })
+  const search = createMockSearchAdapter()
+  const tasks = createFileBakinTaskStore(join(env.home, 'tasks'))
+
+  await runtime.initialize({ contentDir: env.home, logger })
+  await search.initialize({ contentDir: env.home, logger })
+
+  const services: AppServices = {
+    runtime,
+    search,
+    tasks,
+    health: createHealthService([runtime, search]),
+  }
+
+  return {
+    env,
+    gateway,
+    services,
+    close: async () => {
+      await runtime.shutdown()
+      await search.shutdown()
+      await gateway?.close()
+      restoreFetch()
+      env.cleanup()
+      env.restoreEnv()
+    },
+  }
+}

--- a/dev/imitation-crab/index.ts
+++ b/dev/imitation-crab/index.ts
@@ -10,13 +10,13 @@
  */
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
-import { chmodSync, copyFileSync, mkdirSync } from 'fs'
 import { spawn, type ChildProcess } from 'child_process'
 
 import { checkSafety, printSafetyError } from './safety'
 import { seed, getMockHome } from './seed'
 import { startGateway } from './gateway'
 import { getGatewayUrl } from './env'
+import { installCliShim } from './cli-shim-install'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PROJECT_ROOT = join(__dirname, '..', '..')
@@ -24,19 +24,6 @@ const withBakin = process.argv.includes('--with-bakin')
 const forceSeed = process.argv.includes('--force')
 
 let bakinProcess: ChildProcess | null = null
-
-function installCliShim(): string {
-  const mockHome = getMockHome()
-  const binDir = join(mockHome, 'bin')
-  mkdirSync(binDir, { recursive: true })
-
-  const shimSrc = join(__dirname, 'cli-shim.sh')
-  const shimDest = join(binDir, 'openclaw')
-  copyFileSync(shimSrc, shimDest)
-  chmodSync(shimDest, 0o755)
-
-  return shimDest
-}
 
 async function main(): Promise<void> {
   console.log('')

--- a/dev/imitation-crab/seed.ts
+++ b/dev/imitation-crab/seed.ts
@@ -37,7 +37,7 @@ export function seed(force = false): void {
   mkdirSync(join(mockHome, 'bin'), { recursive: true })
 
   // Copy fixtures
-  cpSync(join(FIXTURES_DIR, 'openclaw.json'), join(mockHome, 'openclaw.json'))
+  seedOpenClawConfig(mockHome)
   cpSync(join(FIXTURES_DIR, 'auth-profiles.json'), join(mockHome, 'agents', 'main', 'agent', 'auth-profiles.json'))
   cpSync(join(FIXTURES_DIR, 'jobs.json'), join(mockHome, 'cron', 'jobs.json'))
 
@@ -73,6 +73,16 @@ export function seed(force = false): void {
   seedAuditLog(mockHome)
 
   console.log(`[seed] Done — ${mockHome} ready`)
+}
+
+function seedOpenClawConfig(mockHome: string): void {
+  const config = JSON.parse(readFileSync(join(FIXTURES_DIR, 'openclaw.json'), 'utf-8')) as {
+    agents?: { defaults?: { workspace?: string } }
+  }
+  config.agents ??= {}
+  config.agents.defaults ??= {}
+  config.agents.defaults.workspace = join(mockHome, 'workspace')
+  writeFileSync(join(mockHome, 'openclaw.json'), JSON.stringify(config, null, 2) + '\n', 'utf-8')
 }
 
 function seedTasks(mockHome: string): void {

--- a/packages/adapter-openclaw/src/config.ts
+++ b/packages/adapter-openclaw/src/config.ts
@@ -33,7 +33,7 @@ export interface OpenClawConfig {
   skills?: Record<string, unknown>
 }
 
-let cachedConfig: { mtimeMs: number; config: OpenClawConfig | null } | null = null
+let cachedConfig: { path: string; mtimeMs: number; config: OpenClawConfig | null } | null = null
 
 export function readOpenClawConfig(): OpenClawConfig | null {
   let path: string
@@ -52,7 +52,7 @@ export function readOpenClawConfig(): OpenClawConfig | null {
     return null
   }
 
-  if (cachedConfig && cachedConfig.mtimeMs === mtimeMs) return cachedConfig.config
+  if (cachedConfig && cachedConfig.path === path && cachedConfig.mtimeMs === mtimeMs) return cachedConfig.config
 
   let config: OpenClawConfig | null
   try {
@@ -60,7 +60,7 @@ export function readOpenClawConfig(): OpenClawConfig | null {
   } catch {
     config = null
   }
-  cachedConfig = { mtimeMs, config }
+  cachedConfig = { path, mtimeMs, config }
   return config
 }
 

--- a/tests/adapter-openclaw/config-cache.test.ts
+++ b/tests/adapter-openclaw/config-cache.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { readOpenClawConfig, resetOpenClawConfigCache } from '../../packages/adapter-openclaw/src/config'
+
+describe('OpenClaw config cache', () => {
+  const originalOpenClawHome = process.env.OPENCLAW_HOME
+  const homes: string[] = []
+
+  afterEach(() => {
+    if (originalOpenClawHome === undefined) delete process.env.OPENCLAW_HOME
+    else process.env.OPENCLAW_HOME = originalOpenClawHome
+    resetOpenClawConfigCache()
+    for (const home of homes.splice(0)) {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  function writeConfig(name: string, mtime: Date): string {
+    const home = mkdtempSync(join(tmpdir(), 'bakin-openclaw-cache-'))
+    homes.push(home)
+    mkdirSync(home, { recursive: true })
+    const path = join(home, 'openclaw.json')
+    writeFileSync(path, JSON.stringify({
+      agents: { list: [{ id: 'main', identity: { name } }] },
+    }), 'utf-8')
+    utimesSync(path, mtime, mtime)
+    return home
+  }
+
+  it('does not reuse cached config when OPENCLAW_HOME changes to a same-mtime file', () => {
+    const mtime = new Date('2026-01-01T00:00:00.000Z')
+    const first = writeConfig('First', mtime)
+    const second = writeConfig('Second', mtime)
+
+    process.env.OPENCLAW_HOME = first
+    expect(readOpenClawConfig()?.agents?.list?.[0]?.identity?.name).toBe('First')
+
+    process.env.OPENCLAW_HOME = second
+    expect(readOpenClawConfig()?.agents?.list?.[0]?.identity?.name).toBe('Second')
+  })
+})

--- a/tests/dev/mock-harness.test.ts
+++ b/tests/dev/mock-harness.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { existsSync, readFileSync } from 'fs'
+import { createImitationCrabHarness, prepareImitationCrabEnvironment, type ImitationCrabHarness } from '../../dev/imitation-crab/harness'
+
+describe('imitation-crab harness', () => {
+  let harness: ImitationCrabHarness | null = null
+
+  afterEach(async () => {
+    await harness?.close()
+    harness = null
+  })
+
+  it('prepares an isolated mock home, CLI shim, and normalized main workspace', () => {
+    const env = prepareImitationCrabEnvironment()
+    try {
+      expect(process.env.BAKIN_HOME).toBe(env.home)
+      expect(process.env.OPENCLAW_HOME).toBe(env.home)
+      expect(process.env.OPENCLAW_PATH).toBe(env.shimPath)
+      expect(existsSync(env.shimPath)).toBe(true)
+
+      const config = JSON.parse(readFileSync(`${env.home}/openclaw.json`, 'utf-8'))
+      expect(config.agents.defaults.workspace).toBe(`${env.home}/workspace`)
+    } finally {
+      env.cleanup()
+      env.restoreEnv()
+    }
+  })
+
+  it('creates AppServices backed by seeded Imitation Crab runtime fixtures', async () => {
+    harness = await createImitationCrabHarness({ chatMode: 'echo' })
+
+    const { runtime, tasks } = harness.services
+
+    await expect(runtime.ping()).resolves.toBe(true)
+    await expect(runtime.messaging.send({
+      agentId: 'pixel',
+      content: 'Check the harness',
+    })).resolves.toEqual(expect.objectContaining({
+      content: '[mock:Pixel] Check the harness',
+    }))
+
+    const agents = await runtime.agents.list()
+    expect(agents.map((agent) => agent.id)).toEqual(expect.arrayContaining(['main', 'pixel', 'patch']))
+    expect(agents.find((agent) => agent.id === 'main')?.metadata?.workspacePath).toBe(`${harness.env.home}/workspace`)
+
+    const mainSoul = await runtime.agents.readWorkspaceFile('main', 'SOUL.md')
+    expect(mainSoul?.content).toContain('Crab')
+
+    const patchSoul = await runtime.agents.readWorkspaceFile('patch', 'SOUL.md')
+    expect(patchSoul?.content).toContain('Patch')
+
+    const jobs = await runtime.cron.list()
+    expect(jobs.map((job) => job.id)).toEqual(expect.arrayContaining(['daily-brief', 'weekly-review']))
+
+    const taskList = await tasks.list()
+    expect(taskList.length).toBeGreaterThan(10)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a reusable Imitation Crab harness that prepares an isolated mock home, installs the OpenClaw CLI shim, wires the OpenClaw runtime adapter, mock search adapter, task store, and health service into AppServices.
- Intercept mock-gateway fetches in-process for tests, with optional real gateway startup for manual/server smoke cases.
- Normalize seeded OpenClaw main workspace paths into the mock home so runtime workspace reads hit seeded fixtures.
- Fix the OpenClaw config cache to include the config path, preventing stale config reuse when OPENCLAW_HOME changes to a same-mtime file.
- Document the harness in README, dev-loop knowledge, and the platform audit plan.

## Verification

- bun test tests/dev/mock-harness.test.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-safety.test.ts --isolate
- bun run typecheck
- bunx eslint dev/imitation-crab/cli-shim-install.ts dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/harness.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts packages/adapter-openclaw/src/config.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-harness.test.ts tests/dev/mock-seed.test.ts
- git diff --check

Note: full bun run lint has an existing unrelated baseline failure in routing/plugin unused-var files outside this branch.

Refs #221
Refs #232