### PR TITLE
Add Imitation Crab failure contracts

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -106,6 +106,7 @@ Runtime knobs:
 - `IMITATION_CRAB_PORT` / `OPENCLAW_MOCK_PORT` — mock gateway port. Default:
   `18789`.
 - `OPENCLAW_MOCK_CHAT_MODE` — `canned`, `echo`, or `error`.
+- `OPENCLAW_MOCK_TOOL_MODE` — `ok` or `error`.
 - `OPENCLAW_MOCK_FORCE=1` — bypasses the safety check that refuses to run when
   a real OpenClaw binary/config/gateway is detected.
 
@@ -121,8 +122,9 @@ and intercepts fetches to the mock gateway in-process. Use
 port is part of what you need to verify.
 
 `tests/dev/mock-runtime-contract.test.ts` is the baseline runtime contract suite
-for the harness. Add new runtime-surface expectations there when adapter-backed
-features expand instead of creating one-off mock smoke tests.
+for the harness. `tests/dev/mock-runtime-failure-contract.test.ts` covers the
+adapter-facing failure contract. Add new runtime-surface expectations there when
+adapter-backed features expand instead of creating one-off mock smoke tests.
 
 ## One-React-instance invariant
 

--- a/.claude/plans/platform-integrity-audit.md
+++ b/.claude/plans/platform-integrity-audit.md
@@ -261,6 +261,9 @@ Findings:
 - **third slice:** add a runtime contract suite against that harness covering
   roster, workspace files, skills, messaging, streaming, tool invocation,
   channels, cron create/update/run/remove, and task execution status.
+- **fourth slice:** add mock gateway failure controls and a runtime failure
+  contract suite proving chat, stream, tool, and channel-send gateway errors
+  reject loudly through the OpenClaw adapter when no CLI target fallback applies.
 
 Evidence to inspect:
 
@@ -307,14 +310,16 @@ Evidence to inspect:
   - pass (24 tests).
 - `bun test tests/dev/mock-harness.test.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-seed.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-safety.test.ts --isolate`
   - pass (27 tests).
-- `bun test tests/dev/mock-runtime-contract.test.ts tests/dev/mock-harness.test.ts --isolate`
-  - pass (4 tests).
-- `bunx eslint dev/imitation-crab/cli-shim-install.ts dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/harness.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts packages/adapter-openclaw/src/config.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-harness.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-seed.test.ts`
+- `bun test tests/dev/mock-runtime-failure-contract.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-harness.test.ts --isolate`
+  - pass (6 tests).
+- `bunx eslint dev/imitation-crab/cli-shim-install.ts dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/harness.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts packages/adapter-openclaw/src/config.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-harness.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-runtime-failure-contract.test.ts tests/dev/mock-seed.test.ts`
   - pass.
 - `bun test tests/cli/bakin.test.ts tests/cli/plugin-install-args.test.ts tests/cli/agents-packages.test.ts tests/cli/install-plugin-assets.test.ts tests/cli/install-agent-assets.test.ts tests/core/onboarding/index.test.ts tests/core/onboarding/runtime.test.ts tests/core/onboarding/plugin-assets.test.ts tests/core/onboarding/models.test.ts --isolate`
   - pass (96 tests).
 - `bun run typecheck` - pass.
-- `bun run lint` - pass.
+- `bun run lint` - current repo-wide lint fails on existing unused-var/routing
+  baseline outside the Imitation Crab change; changed-file eslint command above
+  passes.
 - `git diff --check` - pass.
 
 ## Candidate Execution Order

--- a/README.md
+++ b/README.md
@@ -409,7 +409,8 @@ bun run mock:seed --force # reseed fixtures
 
 Set `IMITATION_CRAB_HOME` or `IMITATION_CRAB_PORT` to isolate a mock run from
 the defaults. `OPENCLAW_MOCK_HOME` and `OPENCLAW_MOCK_PORT` are also accepted
-for compatibility with older scripts.
+for compatibility with older scripts. `OPENCLAW_MOCK_CHAT_MODE` can be
+`canned`, `echo`, or `error`; `OPENCLAW_MOCK_TOOL_MODE` can be `ok` or `error`.
 
 Tests that need seeded runtime state can use `createImitationCrabHarness()` from
 `dev/imitation-crab/harness.ts`. It prepares an isolated mock home, installs the

--- a/dev/imitation-crab/env.ts
+++ b/dev/imitation-crab/env.ts
@@ -2,9 +2,11 @@ import { homedir } from 'os'
 import { join } from 'path'
 
 export type MockChatMode = 'canned' | 'echo' | 'error'
+export type MockToolMode = 'ok' | 'error'
 
 const DEFAULT_PORT = 18789
 const CHAT_MODES = new Set<MockChatMode>(['canned', 'echo', 'error'])
+const TOOL_MODES = new Set<MockToolMode>(['ok', 'error'])
 
 export function getMockHome(): string {
   return process.env.IMITATION_CRAB_HOME
@@ -33,4 +35,12 @@ export function getChatMode(): MockChatMode {
     throw new Error(`Invalid OPENCLAW_MOCK_CHAT_MODE: ${mode}`)
   }
   return mode as MockChatMode
+}
+
+export function getToolMode(): MockToolMode {
+  const mode = process.env.OPENCLAW_MOCK_TOOL_MODE || 'ok'
+  if (!TOOL_MODES.has(mode as MockToolMode)) {
+    throw new Error(`Invalid OPENCLAW_MOCK_TOOL_MODE: ${mode}`)
+  }
+  return mode as MockToolMode
 }

--- a/dev/imitation-crab/gateway.ts
+++ b/dev/imitation-crab/gateway.ts
@@ -6,7 +6,7 @@
  *   POST /tools/invoke
  */
 import { createServer, type IncomingMessage, type ServerResponse } from 'http'
-import { getChatMode, getGatewayPort } from './env'
+import { getChatMode, getGatewayPort, getToolMode } from './env'
 
 export interface ImitationCrabGateway {
   port: number
@@ -126,6 +126,16 @@ export async function handleGatewayRequest(req: GatewayRequest): Promise<Gateway
 
     console.log(`  → tool=${parsed.tool || 'unknown'} args=${JSON.stringify(parsed.args || {}).slice(0, 100)}`)
 
+    if (getToolMode() === 'error') {
+      return {
+        status: 500,
+        body: {
+          error: 'Mock tool error mode',
+          tool: parsed.tool || 'unknown',
+        },
+      }
+    }
+
     return { status: 200, body: { ok: true, mock: true } }
   }
 
@@ -178,6 +188,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
 
 export function startGateway(port = getGatewayPort(), options: StartGatewayOptions = {}): Promise<ImitationCrabGateway> {
   const chatMode = getChatMode()
+  const toolMode = getToolMode()
   const registerSignals = options.registerSignals ?? true
 
   return new Promise((resolve, reject) => {
@@ -220,6 +231,7 @@ export function startGateway(port = getGatewayPort(), options: StartGatewayOptio
       const url = `http://127.0.0.1:${port}`
       console.log(`[gateway] Mock OpenClaw gateway listening on ${url}`)
       console.log(`[gateway] Chat mode: ${chatMode}`)
+      console.log(`[gateway] Tool mode: ${toolMode}`)
       if (registerSignals) {
         process.on('SIGINT', shutdown)
         process.on('SIGTERM', shutdown)

--- a/dev/imitation-crab/harness.ts
+++ b/dev/imitation-crab/harness.ts
@@ -6,7 +6,7 @@ import { createHealthService } from '@bakin/core/app-services'
 import { createMockSearchAdapter } from '@bakin/core/adapters/search/testing'
 import { createFileBakinTaskStore } from '@bakin/core/tasks/store'
 import { createOpenClawRuntimeAdapter } from '@bakin/adapter-openclaw'
-import { getGatewayPort, getMockHome, type MockChatMode } from './env'
+import { getGatewayPort, getMockHome, type MockChatMode, type MockToolMode } from './env'
 import { installCliShim } from './cli-shim-install'
 import { handleGatewayRequest, startGateway, type ImitationCrabGateway } from './gateway'
 import { seed } from './seed'
@@ -22,6 +22,7 @@ export interface ImitationCrabEnvironmentOptions {
   home?: string
   port?: number
   chatMode?: MockChatMode
+  toolMode?: MockToolMode
   forceSeed?: boolean
   cleanupHome?: boolean
 }
@@ -145,6 +146,7 @@ export function prepareImitationCrabEnvironment(options: ImitationCrabEnvironmen
   process.env.OPENCLAW_HOME = home
   if (options.port !== undefined) process.env.IMITATION_CRAB_PORT = String(options.port)
   if (options.chatMode) process.env.OPENCLAW_MOCK_CHAT_MODE = options.chatMode
+  if (options.toolMode) process.env.OPENCLAW_MOCK_TOOL_MODE = options.toolMode
 
   const port = getGatewayPort()
   const gatewayUrl = `http://127.0.0.1:${port}`

--- a/tests/dev/mock-env.test.ts
+++ b/tests/dev/mock-env.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { getChatMode, getGatewayPort, getGatewayUrl, getMockHome } from '../../dev/imitation-crab/env'
+import { getChatMode, getGatewayPort, getGatewayUrl, getMockHome, getToolMode } from '../../dev/imitation-crab/env'
 
 describe('imitation-crab env', () => {
   const originalEnv = { ...process.env }
@@ -20,11 +20,14 @@ describe('imitation-crab env', () => {
     expect(getGatewayUrl()).toBe('http://127.0.0.1:19001')
   })
 
-  it('fails loud on invalid gateway port and chat mode', () => {
+  it('fails loud on invalid gateway port, chat mode, and tool mode', () => {
     process.env.IMITATION_CRAB_PORT = 'not-a-port'
     expect(() => getGatewayPort()).toThrow('Invalid imitation-crab gateway port')
 
     process.env.OPENCLAW_MOCK_CHAT_MODE = 'surprise'
     expect(() => getChatMode()).toThrow('Invalid OPENCLAW_MOCK_CHAT_MODE')
+
+    process.env.OPENCLAW_MOCK_TOOL_MODE = 'surprise'
+    expect(() => getToolMode()).toThrow('Invalid OPENCLAW_MOCK_TOOL_MODE')
   })
 })

--- a/tests/dev/mock-runtime-failure-contract.test.ts
+++ b/tests/dev/mock-runtime-failure-contract.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { createImitationCrabHarness, type ImitationCrabHarness } from '../../dev/imitation-crab/harness'
+
+async function drain(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const _chunk of stream) {
+    // Iteration is the contract: streaming failures surface while consuming.
+  }
+}
+
+describe('imitation-crab runtime failure contract', () => {
+  let harness: ImitationCrabHarness | null = null
+
+  afterEach(async () => {
+    await harness?.close()
+    harness = null
+  })
+
+  it('rejects loudly when the mock chat gateway returns an error', async () => {
+    harness = await createImitationCrabHarness({ chatMode: 'error' })
+    const { runtime } = harness.services
+
+    await expect(runtime.messaging.send({
+      agentId: 'pixel',
+      content: 'This should fail',
+    })).rejects.toThrow('OpenClaw chat failed (500)')
+
+    await expect(drain(runtime.messaging.stream({
+      agentId: 'basil',
+      content: 'This stream should fail',
+    }))).rejects.toThrow('OpenClaw chat failed (500)')
+  })
+
+  it('rejects loudly when the mock tool gateway returns an error', async () => {
+    harness = await createImitationCrabHarness({ toolMode: 'error' })
+    const { runtime } = harness.services
+
+    await expect(runtime.tools.invoke('pixel', 'message_send', { message: 'hello' }))
+      .rejects.toThrow('OpenClaw invokeTool failed (500)')
+
+    await expect(runtime.channels.sendMessage({
+      channels: ['discord'],
+      message: { body: 'This channel message should fail' },
+    })).rejects.toThrow('OpenClaw invokeTool failed (500)')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `OPENCLAW_MOCK_TOOL_MODE` with validation and gateway support so Imitation Crab can simulate tool gateway failures.
- Thread `toolMode` through the Imitation Crab harness and add a runtime failure contract suite covering chat send, chat stream, direct tool invocation, and channel send without CLI target fallback.
- Update README/dev-loop/audit notes so the mock harness documents both happy-path and failure-path runtime contracts.

## Verification

- `bun test tests/dev/mock-env.test.ts tests/dev/mock-gateway.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-harness.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-runtime-failure-contract.test.ts --isolate` - pass, 17 tests
- `bun run typecheck` - pass
- `bunx eslint dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/harness.ts tests/dev/mock-env.test.ts tests/dev/mock-runtime-failure-contract.test.ts` - pass
- `git diff --check` - pass
- `bun run lint` - fails on existing repo-wide unused-var/routing baseline outside this change, including `packages/core/src/routing/*`, several plugin route files, and `scripts/docs/generate.ts`.