### PR TITLE
Add Imitation Crab onboarding contracts

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -123,8 +123,10 @@ port is part of what you need to verify.
 
 `tests/dev/mock-runtime-contract.test.ts` is the baseline runtime contract suite
 for the harness. `tests/dev/mock-runtime-failure-contract.test.ts` covers the
-adapter-facing failure contract. Add new runtime-surface expectations there when
-adapter-backed features expand instead of creating one-off mock smoke tests.
+adapter-facing failure contract. `tests/dev/mock-onboarding-contract.test.ts`
+proves seeded and intentionally corrupted fixtures through onboarding runtime
+and credential checks. Add new runtime-surface expectations there when adapter-
+backed features expand instead of creating one-off mock smoke tests.
 
 ## One-React-instance invariant
 

--- a/.claude/plans/platform-integrity-audit.md
+++ b/.claude/plans/platform-integrity-audit.md
@@ -264,6 +264,9 @@ Findings:
 - **fourth slice:** add mock gateway failure controls and a runtime failure
   contract suite proving chat, stream, tool, and channel-send gateway errors
   reject loudly through the OpenClaw adapter when no CLI target fallback applies.
+- **fifth slice:** add onboarding contracts against Imitation Crab and fix the
+  runtime integrity check so OpenClaw `agents.defaults.workspace` is treated as
+  the main workspace default, not as an inherited subagent workspace collision.
 
 Evidence to inspect:
 
@@ -312,6 +315,8 @@ Evidence to inspect:
   - pass (27 tests).
 - `bun test tests/dev/mock-runtime-failure-contract.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-harness.test.ts --isolate`
   - pass (6 tests).
+- `bun test tests/dev/mock-onboarding-contract.test.ts tests/core/onboarding/runtime.test.ts --isolate`
+  - pass (14 tests).
 - `bunx eslint dev/imitation-crab/cli-shim-install.ts dev/imitation-crab/env.ts dev/imitation-crab/gateway.ts dev/imitation-crab/harness.ts dev/imitation-crab/index.ts dev/imitation-crab/safety.ts dev/imitation-crab/seed.ts packages/adapter-openclaw/src/config.ts tests/adapter-openclaw/config-cache.test.ts tests/dev/mock-env.test.ts tests/dev/mock-gateway-streaming.test.ts tests/dev/mock-harness.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-runtime-failure-contract.test.ts tests/dev/mock-seed.test.ts`
   - pass.
 - `bun test tests/cli/bakin.test.ts tests/cli/plugin-install-args.test.ts tests/cli/agents-packages.test.ts tests/cli/install-plugin-assets.test.ts tests/cli/install-agent-assets.test.ts tests/core/onboarding/index.test.ts tests/core/onboarding/runtime.test.ts tests/core/onboarding/plugin-assets.test.ts tests/core/onboarding/models.test.ts --isolate`

--- a/src/core/onboarding/runtime.ts
+++ b/src/core/onboarding/runtime.ts
@@ -102,15 +102,16 @@ export function validateRuntimeIntegrity(config: RuntimeConfigForIntegrity | nul
     }
   }
 
-  // 3. Duplicate resolved workspaces — resolve via `agent.workspace ??
-  //    defaults.workspace`. Agents with no resolved workspace are skipped
-  //    because there's nothing for them to collide with.
+  // 3. Duplicate resolved workspaces. The OpenClaw adapter uses
+  //    `agents.defaults.workspace` only for main; subagents without an explicit
+  //    workspace resolve to adapter-owned per-agent paths, so they are skipped
+  //    here rather than treated as collisions on the main workspace.
   const defaultWorkspace = config.agents?.defaults?.workspace ?? null
   const firstOwner = new Map<string, string>()
   for (const agent of list) {
     const id = agent?.id
     if (typeof id !== 'string' || id.length === 0) continue
-    const resolved = agent?.workspace ?? defaultWorkspace
+    const resolved = agent?.workspace ?? (id === 'main' ? defaultWorkspace : null)
     if (!resolved) continue
     const existing = firstOwner.get(resolved)
     if (existing && existing !== id) {

--- a/tests/core/onboarding/runtime.test.ts
+++ b/tests/core/onboarding/runtime.test.ts
@@ -151,6 +151,25 @@ describe('onboarding runtime component', () => {
       expect(result.message).toContain("'b'")
       expect(result.message).toContain('/x')
     })
+
+    it('does not apply the default workspace to every subagent when agent workspaces are omitted', async () => {
+      runtimeAgents = [
+        { id: 'main', name: 'Main', role: 'Orchestrator', status: 'active' },
+        { id: 'pixel', name: 'Pixel', status: 'active' },
+      ]
+      runtimeConfig = {
+        agents: {
+          defaults: { workspace: '/tmp/main-workspace' },
+          list: [
+            { id: 'main' },
+            { id: 'pixel' },
+          ],
+        },
+      }
+
+      const result = await runtimeComponent.check()
+      expect(result.status).toBe('ok')
+    })
   })
 
   describe('install()', () => {

--- a/tests/dev/mock-onboarding-contract.test.ts
+++ b/tests/dev/mock-onboarding-contract.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import type { AppServices } from '@bakin/core/app-services'
+import { readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { createImitationCrabHarness, type ImitationCrabHarness } from '../../dev/imitation-crab/harness'
+import { resetOpenClawConfigCache } from '../../packages/adapter-openclaw/src/config'
+import { maybeGetAppServices, setAppServices } from '../../src/core/app-services'
+import { llmComponent, channelsComponent } from '../../src/core/onboarding/credentials'
+import { runtimeComponent } from '../../src/core/onboarding/runtime'
+
+type AppServicesGlobal = typeof globalThis & {
+  __bakinAppServices?: AppServices
+}
+
+function restoreAppServices(previous: AppServices | undefined): void {
+  if (previous) {
+    setAppServices(previous)
+  } else {
+    delete (globalThis as AppServicesGlobal).__bakinAppServices
+  }
+}
+
+function readRuntimeConfig(home: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(home, 'openclaw.json'), 'utf-8')) as Record<string, unknown>
+}
+
+function writeRuntimeConfig(home: string, config: Record<string, unknown>): void {
+  writeFileSync(join(home, 'openclaw.json'), `${JSON.stringify(config, null, 2)}\n`, 'utf-8')
+  resetOpenClawConfigCache()
+}
+
+describe('imitation-crab onboarding contract', () => {
+  let harness: ImitationCrabHarness | null = null
+  let previousServices: AppServices | undefined
+
+  afterEach(async () => {
+    await harness?.close()
+    harness = null
+    restoreAppServices(previousServices)
+    previousServices = undefined
+    resetOpenClawConfigCache()
+  })
+
+  async function openHarness(): Promise<ImitationCrabHarness> {
+    previousServices = maybeGetAppServices()
+    harness = await createImitationCrabHarness({ chatMode: 'echo' })
+    setAppServices(harness.services)
+    return harness
+  }
+
+  it('passes runtime, LLM, and channel onboarding checks against seeded fixtures', async () => {
+    await openHarness()
+
+    await expect(runtimeComponent.check()).resolves.toEqual(expect.objectContaining({
+      status: 'ok',
+      details: expect.objectContaining({ runtime: 'openclaw', mainAgentId: 'main' }),
+    }))
+    await expect(llmComponent.check()).resolves.toEqual(expect.objectContaining({
+      status: 'ok',
+      details: expect.objectContaining({ providers: ['anthropic'] }),
+    }))
+    await expect(channelsComponent.check()).resolves.toEqual(expect.objectContaining({
+      status: 'ok',
+      details: expect.objectContaining({ channels: ['discord'] }),
+    }))
+  })
+
+  it('reports a broken runtime check when the seeded roster loses main', async () => {
+    const { env } = await openHarness()
+    const config = readRuntimeConfig(env.home) as {
+      agents?: { list?: Array<{ id?: string }> }
+    }
+    const main = config.agents?.list?.find((agent) => agent.id === 'main')
+    if (!main) throw new Error('Fixture invariant failed: main agent is missing')
+    main.id = 'crab'
+    writeRuntimeConfig(env.home, config as Record<string, unknown>)
+
+    const result = await runtimeComponent.check()
+    expect(result.status).toBe('broken')
+    expect(result.message).toContain("id 'main'")
+  })
+
+  it('warns when the seeded LLM auth profile file becomes malformed', async () => {
+    const { env } = await openHarness()
+    writeFileSync(join(env.home, 'agents', 'main', 'agent', 'auth-profiles.json'), 'not-json {{{', 'utf-8')
+
+    const result = await llmComponent.check()
+    expect(result.status).toBe('warn')
+    expect(result.message).toContain('Could not parse')
+  })
+
+  it('warns when the seeded channel config is removed', async () => {
+    const { env } = await openHarness()
+    const config = readRuntimeConfig(env.home)
+    delete config.channels
+    writeRuntimeConfig(env.home, config)
+
+    const result = await channelsComponent.check()
+    expect(result.status).toBe('warn')
+    expect(result.message).toContain('channels config is missing')
+  })
+})


### PR DESCRIPTION
## Summary

- Add an Imitation Crab onboarding contract suite that runs runtime, LLM, and channel checks against seeded harness services.
- Cover corrupted fixture paths for missing `main`, malformed `auth-profiles.json`, and removed channel config.
- Fix the runtime integrity check so `agents.defaults.workspace` is treated as the main workspace default, not as an inherited workspace for every subagent. The new harness test caught this false positive against seeded Imitation Crab.
- Update the platform audit and dev-loop notes with the new onboarding contract slice.

## Verification

- `bun test tests/dev/mock-onboarding-contract.test.ts tests/dev/mock-runtime-contract.test.ts tests/dev/mock-runtime-failure-contract.test.ts tests/core/onboarding/runtime.test.ts tests/core/onboarding/credentials.test.ts --isolate` - pass, 36 tests
- `bun run typecheck` - pass
- `bunx eslint src/core/onboarding/runtime.ts tests/core/onboarding/runtime.test.ts tests/dev/mock-onboarding-contract.test.ts` - pass
- `git diff --check` - pass
- `bun run lint` - fails on the existing repo-wide unused-var/routing baseline outside this change, including `packages/core/src/routing/*`, plugin route files, and `scripts/docs/generate.ts`.