### PR TITLE
Add plugin signature policy enforcement

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -132,6 +132,10 @@ commit submits source B):
    each dependency must be a core plugin, an installed user plugin, or
    in the selected recommended-plugin install plan. Missing deps return
    HTTP 400 and the staging dir is removed.
+   If `settings.plugins.requireSignatures === true`, the same pre-copy
+   phase verifies `bakin-plugin.json.signature` against
+   `settings.plugins.trustedSigners`; unsigned, untrusted, or tampered
+   manifests fail with `plugin.install.rejected`.
 3. If permissions are non-empty AND `accepted !== true`, server returns
    `{ awaitingConsent: true, id, version, permissions, consentToken }`
    and tears down staging. The token is HMAC-SHA256 over
@@ -153,6 +157,37 @@ commit submits source B):
 Zero-permission plugins skip the consent gate (no token needed).
 `--yes` short-circuits the prompt for scripted/CI installs but the
 token round-trip still runs for the binding check.
+
+### Signature Policy
+
+Default behavior is trust-on-first-use: unsigned plugin manifests install,
+link, and upgrade normally, and the lockfile records the source plus
+`manifestSha`.
+
+Set `plugins.requireSignatures: true` in `~/.bakin/settings.json` to fail
+closed for install, dev-link, and upgrade. Trusted roots live in
+`plugins.trustedSigners` and may be:
+
+- `sha256:<hex>` — SHA-256 fingerprint of the Ed25519 SPKI DER public key.
+- Raw base64 Ed25519 SPKI public key.
+- `ed25519:<base64-public-key>`.
+
+Manifest shape:
+
+```json
+{
+  "signature": {
+    "algorithm": "ed25519",
+    "signer": "madeinwyo",
+    "publicKey": "base64-spki-public-key",
+    "signature": "base64-signature"
+  }
+}
+```
+
+The signature covers canonical JSON for `bakin-plugin.json` with the
+top-level `signature` block omitted. `signer` is display metadata only;
+trust is bound to the key or fingerprint.
 
 ### Dependency Validation
 
@@ -256,7 +291,11 @@ without creating a second plugin package schema.
 ### Upgrade flow — `bakin plugins upgrade <id> [--yes]`
 
 `src/core/plugins/upgrade.ts`. Refuses core plugins. Reads the
-lockfile entry to determine source type:
+lockfile entry and verifies the currently installed manifest before
+source-specific no-op checks. That means flipping
+`plugins.requireSignatures` to true makes existing unsigned plugins fail
+closed on their next upgrade attempt until they are reinstalled from a
+trusted signed source. Then it determines source type:
 
 - **github**:
   1. `git remote set-url origin -- <lockfile.source>` — pins origin so
@@ -271,10 +310,11 @@ lockfile entry to determine source type:
      declares a different id (anti-impersonation; otherwise a user
      plugin could rename to `tasks` and clobber a core plugin after
      restart).
-  6. Compute permission diff. If widened AND `!opts.yes` → return
+  6. Verify the remote manifest signature when required.
+  7. Compute permission diff. If widened AND `!opts.yes` → return
      `{ awaitingConsent: true, newPermissions }` WITHOUT mutating disk
      or lockfile.
-  7. Force-push detection via `git merge-base --is-ancestor` then
+  8. Force-push detection via `git merge-base --is-ancestor` then
      `git merge --ff-only`. Build. Project the upgraded plugin's
      `defaults/runtime-skills/` assets into the runtime skill store.
      Unexpected asset install errors fail the upgrade; `.userEdited`
@@ -284,9 +324,9 @@ lockfile entry to determine source type:
   Compute deterministic source-tree sha (skip `node_modules`/`dist`/
   `.git`, content + path only — no mtimes). No-op if unchanged.
   Read source manifest directly (no copy yet), assert manifest.id
-  stable, compute permission diff, run consent gate. Only then wipe +
-  cpSync + rebuild + project plugin runtime-skill assets + write
-  lockfile.
+  stable, verify signature when required, compute permission diff, run
+  consent gate. Only then wipe + cpSync + rebuild + project plugin
+  runtime-skill assets + write lockfile.
 
 Permission widening: if the new manifest declares permissions not in
 the lockfile entry AND `--yes` is unset, return
@@ -583,6 +623,12 @@ interface PluginManifest {
   tests?: string
   dependencies?: string[]      // other plugin IDs — drives topological sort
   permissions?: Permission[]   // strict Zod enum — see PermissionSchema. Empty/missing → []
+  signature?: {
+    algorithm: 'ed25519'
+    signer: string             // display metadata only
+    publicKey: string          // base64 Ed25519 SPKI DER key
+    signature: string          // base64 signature over canonical manifest minus this block
+  }
 }
 ```
 

--- a/.claude/plans/platform-integrity-audit.md
+++ b/.claude/plans/platform-integrity-audit.md
@@ -154,9 +154,13 @@ Findings:
 
 - **non-issue / already covered:** install, source-swap, subpath, upgrade,
   remove, registry teardown, and plugin install API tests pass.
-- **later / product-dependent:** #164 signature verification, #165 uninstalled
-  restore/retention, and #178 SDK publish matter for distribution polish, but
-  they do not block the higher-risk MCP/context work.
+- **fixed in follow-up slice:** #164 signature verification now has a
+  fail-closed policy path for install, dev-link, and upgrade when
+  `plugins.requireSignatures` is enabled. Default trust-on-first-use behavior
+  remains unchanged.
+- **later / product-dependent:** #165 uninstalled restore/retention and #178
+  SDK publish matter for distribution polish, but they do not block the
+  higher-risk MCP/context work.
 - **should-fix before broader third-party plugin push:** plugin docs should
   eventually describe how plugin exec tools participate in agent policy once
   #218 lands.

--- a/.claude/specs/plugin-lifecycle.md
+++ b/.claude/specs/plugin-lifecycle.md
@@ -26,7 +26,7 @@ This work introduces the missing primitive (`~/.bakin/plugins/lock.json`, modele
 
 | Cut | Reason | Follow-up |
 |-----|--------|-----------|
-| Signature verification (`bakin-plugin.json.signature`, `settings.plugins.trustedSigners`, `settings.plugins.requireSignatures`) | No current need; trust-on-first-use stays the default. Schema is additive — no migration cost when added later. | New issue: "feat(plugins): signature verification + trusted signers" |
+| Signature verification (`bakin-plugin.json.signature`, `settings.plugins.trustedSigners`, `settings.plugins.requireSignatures`) | Originally cut from the lifecycle bundle. Now addressed as an additive policy: trust-on-first-use remains default, `requireSignatures` fails closed when enabled. | #164 |
 | Hot reload of user plugins after install/upgrade/remove | Touches plugin registry, route dispatcher, MCP tool registry, Bun module cache. Own design tree. Restart cost is ~2s. | New issue: "feat(plugins): hot reload for install/upgrade/remove" |
 | Tarball retention / cleanup / `bakin plugins restore` | `.uninstalled/` tarballs accumulate without expiry in this PR. Punt to its own UX conversation. | New issue: "feat(plugins): .uninstalled tarball retention + restore command" |
 | Permissions layer 3 (runtime capability gating) | Pervasive SDK surface change. Locks plugins out on enforcement bugs. Needs disable-toggle for rollout. | New sub-issue under #142: "feat(plugins): permissions layer 3 — runtime capability gating" |
@@ -495,7 +495,7 @@ Specific to this work:
 
 ## 10. Follow-up Issues to File (at commit #11)
 
-1. **feat(plugins): signature verification + trusted signers** — From #151 cut. Spec: `bakin-plugin.json.signature`, `settings.plugins.trustedSigners`, `settings.plugins.requireSignatures` (default false).
+1. **Shipped after cut:** #164 signature verification + trusted signers. Spec: `bakin-plugin.json.signature`, `settings.plugins.trustedSigners`, `settings.plugins.requireSignatures` (default false).
 2. **feat(plugins): .uninstalled tarball retention + restore command** — From #119 cut. Spec: retention policy (e.g., 90 days or N most recent), `bakin plugins restore <id>` UX, `bakin trash` integration.
 3. **feat(plugins): permissions layer 3 — runtime capability gating** — From #142. Spec: wrap `ctx.*` methods, throw `PermissionDenied` if undeclared. Needs disable-toggle for rollout.
 4. **feat(plugins): pin install ref (tag/branch/commit)** — From #151. Spec: `github:user/repo@v1.2.0` syntax; lockfile `ref` field already supports it; upgrade UX (`--unpin`/`--ref=`).

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ bakin plugins remove my-plugin              # refuses to remove core plugins
 bakin plugins scaffold <name>               # starter plugin at ./<name>/
 ```
 
+Unsigned plugin manifests are accepted by default. To fail closed for third-party plugin installs and upgrades, set `plugins.requireSignatures: true` in `~/.bakin/settings.json` and add Ed25519 public-key fingerprints or public keys under `plugins.trustedSigners`.
+
 ---
 
 ## CLI reference

--- a/docs/.generated/coverage.json
+++ b/docs/.generated/coverage.json
@@ -44,7 +44,7 @@
     },
     "settings": {
       "status": "active",
-      "count": 56,
+      "count": 58,
       "source": "packages/core/src/settings.ts"
     },
     "sdkSubpaths": {

--- a/docs/public/llms/settings.md
+++ b/docs/public/llms/settings.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 56. Operators can override settings in settings.json under the resolved Bakin home directory.
+The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 58. Operators can override settings in settings.json under the resolved Bakin home directory.

--- a/docs/src/content/docs/extending/plugins/manifest.md
+++ b/docs/src/content/docs/extending/plugins/manifest.md
@@ -81,8 +81,30 @@ Source: `docs/snippets/plugin-basic/bakin-plugin.json`
 | `runtimeCapabilities` | Runtime adapter capabilities the plugin needs, such as `tasks`, `search`, `models`, or `channels.message`. |
 | `contributes` | Public API, UI, CLI, settings, exec tool, and docs metadata. |
 | `devWatch` | Extra plugin-local paths to watch during development. |
+| `signature` | Optional Ed25519 manifest signature. Enforced only when `settings.plugins.requireSignatures` is `true`. |
 
 </div>
+
+## Signature Policy
+
+By default, plugin installs use trust-on-first-use: unsigned manifests are accepted, then Bakin records the installed source and manifest hash in the plugin lockfile.
+
+Set `settings.plugins.requireSignatures` to `true` to fail closed for unsigned, untrusted, or tampered manifests during install, dev-link, and upgrade. Trusted roots live in `settings.plugins.trustedSigners` and may be a `sha256:<hex>` public-key fingerprint, a raw base64 Ed25519 SPKI public key, or `ed25519:<base64-public-key>`.
+
+When present, `signature` has this shape:
+
+```json
+{
+  "signature": {
+    "algorithm": "ed25519",
+    "signer": "madeinwyo",
+    "publicKey": "base64-spki-public-key",
+    "signature": "base64-signature"
+  }
+}
+```
+
+The signature covers canonical JSON for `bakin-plugin.json` with the top-level `signature` block omitted. `signer` is display metadata; trust is bound to the public key or fingerprint.
 
 ## Contributions
 

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -140,6 +140,7 @@ Source: `packages/sdk/src/types/index.ts`
 | `export interface SettingsContribution {` |
 | `export interface DocsContribution {` |
 | `export interface PluginContributions {` |
+| `export interface PluginManifestSignature {` |
 | `export interface PluginManifest {` |
 | `export interface StorageStat {` |
 | `export interface StorageAdapter {` |
@@ -250,5 +251,5 @@ Source: `packages/sdk/src/routing/index.ts`
 | `export type {` |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 1, 2026 · Bakin 1.0.0</span>
+  <span>Generated May 3, 2026 · Bakin 1.0.0</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -119,8 +119,16 @@ description: Generated reference for Bakin core settings defaults.
   </thead>
   <tbody>
     <tr>
+      <td><code>plugins.requireSignatures</code></td>
+      <td><code>false</code></td>
+    </tr>
+    <tr>
       <td><code>plugins.runtimeCapabilityMode</code></td>
       <td><code>&quot;warn&quot;</code></td>
+    </tr>
+    <tr>
+      <td><code>plugins.trustedSigners</code></td>
+      <td><code>[]</code></td>
     </tr>
   </tbody>
 </table>
@@ -353,5 +361,5 @@ description: Generated reference for Bakin core settings defaults.
 
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 1, 2026 · Bakin 1.0.0</span>
+  <span>Generated May 3, 2026 · Bakin 1.0.0</span>
 </aside>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "./routing": "./src/routing/index.ts",
     "./openapi": "./src/openapi/index.ts",
     "./plugins/manifest": "./src/plugins/manifest.ts",
+    "./plugins/signatures": "./src/plugins/signatures.ts",
     "./plugins/permissions": "./src/plugins/permissions.ts",
     "./constants": "./src/constants.ts",
     "./storage": "./src/storage/markdown-adapter.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export type {
   PluginContext,
   BakinPlugin,
   PluginManifest,
+  PluginManifestSignature,
   PluginEntry,
   BakinConfig,
 } from './plugin-types'
@@ -37,6 +38,13 @@ export {
   readPluginManifestJson,
 } from './plugins/manifest'
 export type { ParsePluginManifestOptions } from './plugins/manifest'
+export {
+  PluginSignatureError,
+  canonicalizePluginManifestForSignature,
+  pluginSignatureFingerprint,
+  verifyPluginManifestSignature,
+} from './plugins/signatures'
+export type { PluginSignaturePolicy, PluginSignatureVerification } from './plugins/signatures'
 export {
   PermissionDenied,
   PERMISSION_DESCRIPTIONS,

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -946,6 +946,13 @@ export interface BakinPlugin {
 // ---------------------------------------------------------------------------
 // Plugin Manifest (bakin-plugin.json)
 // ---------------------------------------------------------------------------
+export interface PluginManifestSignature {
+  algorithm: 'ed25519'
+  signer: string
+  publicKey: string
+  signature: string
+}
+
 export interface PluginManifest {
   id: string
   name: string
@@ -958,6 +965,7 @@ export interface PluginManifest {
   tests?: string
   dependencies?: string[]
   permissions?: string[]
+  signature?: PluginManifestSignature
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -6,6 +6,7 @@ import type {
   HttpMethod,
   PluginContributions,
   PluginManifest,
+  PluginManifestSignature,
   PluginPermission,
   RuntimeCapability,
   SettingsContribution,
@@ -74,6 +75,14 @@ function stringArrayField(obj: Record<string, unknown>, key: string): string[] |
     if (!out.includes(item)) out.push(item)
   }
   return out
+}
+
+function signatureStringField(obj: Record<string, unknown>, key: string): string {
+  const value = obj[key]
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new PluginManifestError(`bakin-plugin.json field "signature.${key}" must be a non-empty string`)
+  }
+  return value
 }
 
 function recordField(obj: Record<string, unknown>, key: string, label: string): Record<string, unknown> | undefined {
@@ -236,6 +245,23 @@ function parseContributions(input: unknown): PluginContributions | undefined {
   return out
 }
 
+function parseSignature(raw: unknown): PluginManifestSignature | undefined {
+  if (raw === undefined || raw === null) return undefined
+  if (!isRecord(raw)) {
+    throw new PluginManifestError('bakin-plugin.json field "signature" must be an object')
+  }
+  const algorithm = signatureStringField(raw, 'algorithm')
+  if (algorithm !== 'ed25519') {
+    throw new PluginManifestError('bakin-plugin.json field "signature.algorithm" must be "ed25519"')
+  }
+  return {
+    algorithm,
+    signer: signatureStringField(raw, 'signer'),
+    publicKey: signatureStringField(raw, 'publicKey'),
+    signature: signatureStringField(raw, 'signature'),
+  }
+}
+
 export function parsePluginManifest(raw: unknown, options: ParsePluginManifestOptions = {}): PluginManifest {
   if (!isRecord(raw)) {
     throw new PluginManifestError('bakin-plugin.json must contain a JSON object')
@@ -285,6 +311,7 @@ export function parsePluginManifest(raw: unknown, options: ParsePluginManifestOp
     runtimeCapabilities,
     contributes: parseContributions(raw.contributes),
     devWatch: stringArrayField(raw, 'devWatch'),
+    signature: parseSignature(raw.signature),
   }
 }
 

--- a/packages/core/src/plugins/signatures.ts
+++ b/packages/core/src/plugins/signatures.ts
@@ -1,0 +1,176 @@
+import { createHash, createPublicKey, verify as verifyBytes } from 'crypto'
+import type { PluginManifestSignature } from '@bakin/sdk/types'
+
+export interface PluginSignaturePolicy {
+  requireSignatures?: boolean
+  trustedSigners?: string[]
+}
+
+export interface PluginSignatureVerification {
+  required: boolean
+  verified: boolean
+  signer?: string
+  fingerprint?: string
+}
+
+export class PluginSignatureError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PluginSignatureError'
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeForCanonicalJson(value: unknown, topLevel = false): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => normalizeForCanonicalJson(item))
+  }
+
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(value).sort()) {
+      if (topLevel && key === 'signature') continue
+      const normalized = normalizeForCanonicalJson(value[key])
+      if (normalized !== undefined) out[key] = normalized
+    }
+    return out
+  }
+
+  return value
+}
+
+/**
+ * Canonical JSON body signed by plugin manifests. The top-level signature
+ * block is omitted, object keys are sorted recursively, and arrays keep
+ * their declared order.
+ */
+export function canonicalizePluginManifestForSignature(manifest: unknown): string {
+  if (!isRecord(manifest)) {
+    throw new PluginSignatureError('bakin-plugin.json must contain an object before signature verification')
+  }
+  return JSON.stringify(normalizeForCanonicalJson(manifest, true))
+}
+
+function decodeBase64Field(value: string, field: string): Buffer {
+  if (value.trim().length === 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) {
+    throw new PluginSignatureError(`plugin signature ${field} must be base64`)
+  }
+  const normalized = value.replace(/=+$/, '')
+  const decoded = Buffer.from(value, 'base64')
+  if (decoded.length === 0 || decoded.toString('base64').replace(/=+$/, '') !== normalized) {
+    throw new PluginSignatureError(`plugin signature ${field} must be valid base64`)
+  }
+  return decoded
+}
+
+export function pluginSignatureFingerprint(publicKeyBase64: string): string {
+  const publicKey = decodeBase64Field(publicKeyBase64, 'publicKey')
+  return `sha256:${createHash('sha256').update(publicKey).digest('hex')}`
+}
+
+function readSignature(manifest: unknown): PluginManifestSignature | null {
+  if (!isRecord(manifest)) {
+    throw new PluginSignatureError('bakin-plugin.json must contain an object before signature verification')
+  }
+  const raw = manifest.signature
+  if (raw === undefined || raw === null) return null
+  if (!isRecord(raw)) {
+    throw new PluginSignatureError('plugin signature must be an object')
+  }
+  if (raw.algorithm !== 'ed25519') {
+    throw new PluginSignatureError('plugin signature algorithm must be "ed25519"')
+  }
+  for (const key of ['signer', 'publicKey', 'signature'] as const) {
+    if (typeof raw[key] !== 'string' || raw[key].trim().length === 0) {
+      throw new PluginSignatureError(`plugin signature ${key} must be a non-empty string`)
+    }
+  }
+  const signer = raw.signer
+  const publicKey = raw.publicKey
+  const signature = raw.signature
+  if (typeof signer !== 'string' || typeof publicKey !== 'string' || typeof signature !== 'string') {
+    throw new PluginSignatureError('plugin signature fields must be strings')
+  }
+  return {
+    algorithm: 'ed25519',
+    signer,
+    publicKey,
+    signature,
+  }
+}
+
+function trustedRoots(policy: PluginSignaturePolicy): Set<string> {
+  return new Set(
+    (Array.isArray(policy.trustedSigners) ? policy.trustedSigners : [])
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map(value => {
+        const trimmed = value.trim()
+        return trimmed.startsWith('sha256:')
+          ? `sha256:${trimmed.slice('sha256:'.length).toLowerCase()}`
+          : trimmed
+      }),
+  )
+}
+
+function isTrustedPublicKey(publicKeyBase64: string, fingerprint: string, trust: Set<string>): boolean {
+  return (
+    trust.has(fingerprint) ||
+    trust.has(publicKeyBase64) ||
+    trust.has(`ed25519:${publicKeyBase64}`)
+  )
+}
+
+export function verifyPluginManifestSignature(
+  manifest: unknown,
+  policy: PluginSignaturePolicy,
+): PluginSignatureVerification {
+  const required = policy.requireSignatures === true
+  if (!required) {
+    return { required: false, verified: false }
+  }
+
+  const signature = readSignature(manifest)
+  if (!signature) {
+    throw new PluginSignatureError('settings.plugins.requireSignatures requires a signed plugin manifest')
+  }
+
+  const fingerprint = pluginSignatureFingerprint(signature.publicKey)
+  const trust = trustedRoots(policy)
+  if (!isTrustedPublicKey(signature.publicKey, fingerprint, trust)) {
+    throw new PluginSignatureError(
+      `plugin signature signer key is not trusted (${fingerprint})`,
+    )
+  }
+
+  const publicKeyBytes = decodeBase64Field(signature.publicKey, 'publicKey')
+  const signatureBytes = decodeBase64Field(signature.signature, 'signature')
+  let publicKey: ReturnType<typeof createPublicKey>
+  try {
+    publicKey = createPublicKey({ key: publicKeyBytes, format: 'der', type: 'spki' })
+  } catch {
+    throw new PluginSignatureError('plugin signature publicKey is not a valid Ed25519 SPKI key')
+  }
+  if (publicKey.asymmetricKeyType !== 'ed25519') {
+    throw new PluginSignatureError('plugin signature publicKey must be an Ed25519 key')
+  }
+  const body = Buffer.from(canonicalizePluginManifestForSignature(manifest), 'utf-8')
+  let valid = false
+  try {
+    valid = verifyBytes(null, body, publicKey, signatureBytes)
+  } catch {
+    valid = false
+  }
+  if (!valid) {
+    throw new PluginSignatureError('plugin signature is invalid')
+  }
+
+  return {
+    required: true,
+    verified: true,
+    signer: signature.signer,
+    fingerprint,
+  }
+}

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -159,6 +159,14 @@ export interface BakinSettings {
   }
   plugins: {
     runtimeCapabilityMode: 'off' | 'warn' | 'enforce'
+    /** When true, user plugin install/link/upgrade rejects unsigned or untrusted manifests. */
+    requireSignatures: boolean
+    /**
+     * Trusted signer roots for plugin manifests. Entries may be
+     * `sha256:<hex>` fingerprints, raw base64 Ed25519 SPKI public keys, or
+     * `ed25519:<base64-public-key>`.
+     */
+    trustedSigners: string[]
   }
 }
 
@@ -264,7 +272,47 @@ export const DEFAULT_SETTINGS: BakinSettings = {
   },
   plugins: {
     runtimeCapabilityMode: 'warn',
+    requireSignatures: false,
+    trustedSigners: [],
   },
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizePluginSettings(input: unknown): BakinSettings['plugins'] {
+  const raw = isRecord(input) ? input : {}
+  const runtimeCapabilityMode = (
+    raw.runtimeCapabilityMode === 'off' ||
+    raw.runtimeCapabilityMode === 'warn' ||
+    raw.runtimeCapabilityMode === 'enforce'
+  )
+    ? raw.runtimeCapabilityMode
+    : DEFAULT_SETTINGS.plugins.runtimeCapabilityMode
+  const requireSignatures = typeof raw.requireSignatures === 'boolean'
+    ? raw.requireSignatures
+    : DEFAULT_SETTINGS.plugins.requireSignatures
+  const trustedSigners = Array.isArray(raw.trustedSigners)
+    ? Array.from(new Set(
+      raw.trustedSigners
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map(value => value.trim()),
+    ))
+    : DEFAULT_SETTINGS.plugins.trustedSigners
+
+  return {
+    runtimeCapabilityMode,
+    requireSignatures,
+    trustedSigners,
+  }
+}
+
+function normalizeSettings(settings: BakinSettings): BakinSettings {
+  return {
+    ...settings,
+    plugins: normalizePluginSettings(settings.plugins),
+  }
 }
 
 // Use globalThis so the settings cache is shared across every reach into
@@ -318,10 +366,10 @@ export function getSettings(): BakinSettings {
     log.warn('Failed to read settings, using defaults', err)
   }
 
-  const settings = deepMerge(
+  const settings = normalizeSettings(deepMerge(
     DEFAULT_SETTINGS as unknown as Record<string, unknown>,
     overrides
-  ) as unknown as BakinSettings
+  ) as unknown as BakinSettings)
 
   setCachedSettings(settings)
   return settings

--- a/packages/host/src/api/plugins/install.ts
+++ b/packages/host/src/api/plugins/install.ts
@@ -35,8 +35,10 @@ import {
   writePluginLockfile,
   type PluginLockEntry,
 } from '@bakin/core/plugins/lockfile'
+import { getSettings } from '@bakin/core/settings'
 import { parseManifestPermissions } from '@bakin/core/plugins/permissions'
 import { PLUGIN_ID_RE, readPluginManifestJson, PluginManifestError } from '@bakin/core/plugins/manifest'
+import { verifyPluginManifestSignature } from '@bakin/core/plugins/signatures'
 import { parseGithubSource, InvalidGithubSourceError, assertGitRefValid } from '@bakin/core/plugins/source'
 import { computeSourceTreeSha } from '@/core/plugins/upgrade'
 import { checkPluginDependencies } from '@/core/plugins/dependencies'
@@ -512,8 +514,11 @@ export async function post(req: Request, _url: URL): Promise<Response> {
       }
 
       let manifest: Record<string, unknown> & { id: string; version: string }
+      let rawManifest: unknown
       try {
-        manifest = readPluginManifestJson(readFileSync(manifestPath, 'utf-8')) as unknown as Record<string, unknown> & { id: string; version: string }
+        const manifestText = readFileSync(manifestPath, 'utf-8')
+        manifest = readPluginManifestJson(manifestText) as unknown as Record<string, unknown> & { id: string; version: string }
+        rawManifest = JSON.parse(manifestText)
       } catch (err) {
         rmSync(stagingDir, { recursive: true, force: true })
         return Response.json({
@@ -548,6 +553,18 @@ export async function post(req: Request, _url: URL): Promise<Response> {
         return Response.json({
           ok: false,
           error: `Plugin id "${id}" collides with a core plugin. Re-run with overrideCore:true to intentionally replace the built-in (rare).`,
+        }, { status: 400 })
+      }
+
+      try {
+        verifyPluginManifestSignature(rawManifest, getSettings().plugins)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        rmSync(stagingDir, { recursive: true, force: true })
+        auditInstallRejected('signature_verification_failed', body.source, { id, error: message })
+        return Response.json({
+          ok: false,
+          error: `plugin "${id}": ${message}`,
         }, { status: 400 })
       }
 

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -167,6 +167,16 @@ export interface PluginContributions {
   docs?: DocsContribution
 }
 
+export interface PluginManifestSignature {
+  algorithm: 'ed25519'
+  /** Human-readable signer label. Trust is bound to publicKey/fingerprint, not this label. */
+  signer: string
+  /** Base64-encoded Ed25519 SPKI DER public key. */
+  publicKey: string
+  /** Base64-encoded signature over the canonical manifest without this signature block. */
+  signature: string
+}
+
 export interface PluginManifest {
   id: string
   name: string
@@ -182,6 +192,7 @@ export interface PluginManifest {
   runtimeCapabilities?: RuntimeCapability[]
   contributes?: PluginContributions
   devWatch?: string[]
+  signature?: PluginManifestSignature
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/plugins/link.ts
+++ b/src/core/plugins/link.ts
@@ -37,6 +37,7 @@ import { getContentDir } from '@/core/content-dir'
 import { createLogger } from '@/core/logger'
 import { appendAudit } from '@/core/audit'
 import { isCorePlugin } from '@/lib/plugin-registry'
+import { getSettings } from '@bakin/core/settings'
 import {
   addLinkedPlugin,
   isLinked as isLinkedEntry,
@@ -46,6 +47,7 @@ import {
   type PluginLockEntry,
 } from '@bakin/core/plugins/lockfile'
 import { parseManifestPermissions } from '@bakin/core/plugins/permissions'
+import { verifyPluginManifestSignature } from '@bakin/core/plugins/signatures'
 import { buildUserPlugin } from '../../../packages/host/src/plugin-host/user-plugin-builder'
 import { checkPluginDependencies } from './dependencies'
 
@@ -160,6 +162,13 @@ function readManifest(dir: string): {
   if (!PLUGIN_ID_REGEX.test(manifest.id)) {
     throw new LinkRefusedError(
       `invalid plugin id "${manifest.id}" — must match /^[a-z][a-z0-9-]{0,39}$/`,
+    )
+  }
+  try {
+    verifyPluginManifestSignature(parsed, getSettings().plugins)
+  } catch (err) {
+    throw new LinkRefusedError(
+      `${manifest.id}: ${err instanceof Error ? err.message : String(err)}`,
     )
   }
   let permissions: PluginLockEntry['permissions']

--- a/src/core/plugins/upgrade.ts
+++ b/src/core/plugins/upgrade.ts
@@ -21,6 +21,7 @@ import { getContentDir } from '@/core/content-dir'
 import { createLogger } from '@/core/logger'
 import { isCorePlugin } from '@/lib/plugin-registry'
 import { appendAudit } from '@/core/audit'
+import { getSettings } from '@bakin/core/settings'
 import {
   type PluginLockEntry,
   isLinked,
@@ -29,6 +30,7 @@ import {
   writePluginLockfile,
 } from '@bakin/core/plugins/lockfile'
 import { parseManifestPermissions, type Permission } from '@bakin/core/plugins/permissions'
+import { verifyPluginManifestSignature } from '@bakin/core/plugins/signatures'
 import { parseGithubSource } from '@bakin/core/plugins/source'
 import {
   findSkillsForPlugin,
@@ -202,6 +204,16 @@ function assertManifestIdStable(manifest: Record<string, unknown>, id: string): 
     throw new UpgradeRefusedError(
       `${id}: upgraded manifest declares id "${manifestId}" — plugins cannot rename across upgrades. Remove and reinstall as the new id if intentional.`,
     )
+  }
+}
+
+function assertManifestSignaturePolicy(manifest: Record<string, unknown>, id: string): void {
+  try {
+    verifyPluginManifestSignature(manifest, getSettings().plugins)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    auditUpgradeRejected('signature_verification_failed', id, { error: message })
+    throw new UpgradeRefusedError(`${id}: ${message}`)
   }
 }
 
@@ -416,6 +428,9 @@ export async function upgradePlugin(
   }
 
   const before = { version: entry.version, commitSha: entry.commitSha }
+  const { manifest: currentManifest } = readManifest(pluginDir)
+  assertManifestIdStable(currentManifest, id)
+  assertManifestSignaturePolicy(currentManifest, id)
 
   if (entry.type === 'github') {
     // Subpath installs (`github:user/repo#plugins/foo`) leave `pluginDir`
@@ -479,6 +494,7 @@ async function upgradeGithub(
   // runs against this. If the user declines, no disk change happens.
   const { manifest, manifestSha } = readRemoteManifest(pluginDir, entry.ref)
   assertManifestIdStable(manifest, id)
+  assertManifestSignaturePolicy(manifest, id)
   const newVersion = manifestVersion(manifest, entry.version)
   const newPerms = manifestPermissions(manifest, id)
   const widened = diffNewPermissions(entry.permissions, newPerms)
@@ -611,6 +627,7 @@ async function upgradeGithubSubpath(
 
     const { manifest, manifestSha } = readManifest(subpathDir)
     assertManifestIdStable(manifest, id)
+    assertManifestSignaturePolicy(manifest, id)
     const newVersion = manifestVersion(manifest, entry.version)
     const newPerms = manifestPermissions(manifest, id)
     const widened = diffNewPermissions(entry.permissions, newPerms)
@@ -692,6 +709,7 @@ async function upgradeLocal(
   // (and its lockfile entry) stays exactly where it was.
   const { manifest, manifestSha } = readManifest(sourcePath)
   assertManifestIdStable(manifest, id)
+  assertManifestSignaturePolicy(manifest, id)
   const newVersion = manifestVersion(manifest, entry.version)
   const newPerms = manifestPermissions(manifest, id)
   const widened = diffNewPermissions(entry.permissions, newPerms)

--- a/tests/api/plugins-install.test.ts
+++ b/tests/api/plugins-install.test.ts
@@ -46,6 +46,7 @@ mock.module('@/core/plugins/live-lifecycle', () => ({
 
 import { post as installPOST } from '../../packages/host/src/api/plugins/install'
 import { post as removePOST } from '../../packages/host/src/api/plugins/remove'
+import { resetSettingsCache } from '../../src/core/settings'
 
 // Source plugin lives INSIDE the mocked content dir so it's contained by
 // the install handler's path-traversal guard (C12 hardening). The original
@@ -53,6 +54,7 @@ import { post as removePOST } from '../../packages/host/src/api/plugins/remove'
 // root (~/.bakin/ ↔ testDir / $HOME / cwd) — exactly the case the guard
 // rejects.
 const sourcePluginDir = join(testDir, 'source-plugin')
+const settingsFile = join(testDir, 'settings.json')
 
 function makeRequest(body: unknown): Request {
   return new Request('http://localhost/api/plugins/install', {
@@ -70,9 +72,7 @@ async function invoke(
   return handler(req, new URL(req.url))
 }
 
-beforeAll(() => {
-  mkdirSync(testDir, { recursive: true })
-  mkdirSync(sourcePluginDir, { recursive: true })
+function writeSourceManifest(manifest: Record<string, unknown> = {}) {
   writeFileSync(
     join(sourcePluginDir, 'bakin-plugin.json'),
     JSON.stringify({
@@ -83,8 +83,20 @@ beforeAll(() => {
       description: 'Test plugin',
       entry: { server: 'index.ts' },
       permissions: [],
+      ...manifest,
     }, null, 2),
   )
+}
+
+function writeSettings(settings: Record<string, unknown>) {
+  writeFileSync(settingsFile, JSON.stringify(settings, null, 2))
+  resetSettingsCache()
+}
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true })
+  mkdirSync(sourcePluginDir, { recursive: true })
+  writeSourceManifest()
   writeFileSync(join(sourcePluginDir, 'index.ts'), '// stub\n')
 })
 
@@ -97,6 +109,9 @@ beforeEach(() => {
   const installed = join(testDir, 'plugins', 'hello')
   if (existsSync(installed)) rmSync(installed, { recursive: true, force: true })
   rmSync(join(testDir, 'plugins', 'lock.json'), { force: true })
+  rmSync(settingsFile, { force: true })
+  writeSourceManifest()
+  resetSettingsCache()
 })
 
 describe('POST /api/plugins/install', () => {
@@ -158,6 +173,21 @@ describe('POST /api/plugins/install', () => {
     expect(existsSync(join(testDir, 'plugins', 'hello', 'bakin-plugin.json'))).toBe(true)
   })
 
+  it('rejects unsigned plugins when signatures are required', async () => {
+    writeSettings({
+      plugins: {
+        requireSignatures: true,
+        trustedSigners: [],
+      },
+    })
+
+    const res = await invoke(installPOST, makeRequest({ source: sourcePluginDir, type: 'local' }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/signed plugin manifest/)
+    expect(existsSync(join(testDir, 'plugins', 'hello'))).toBe(false)
+  })
+
   it('rejects dev installs from github sources', async () => {
     const res = await invoke(installPOST, makeRequest({
       source: 'github:madeinwyo/bakin-bits-official#plugins/messaging',
@@ -182,6 +212,24 @@ describe('POST /api/plugins/install', () => {
     expect(body.activated).toBe(true)
     expect(body.linkedSource).toBe(realpathSync(sourcePluginDir))
     expect(body.message).toMatch(/Dev-installed/)
+  })
+
+  it('rejects unsigned dev installs when signatures are required', async () => {
+    writeSettings({
+      plugins: {
+        requireSignatures: true,
+        trustedSigners: [],
+      },
+    })
+
+    const res = await invoke(installPOST, makeRequest({
+      source: sourcePluginDir,
+      type: 'local',
+      dev: true,
+    }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/signed plugin manifest/)
   })
 
   it('overwrites an existing install cleanly', async () => {

--- a/tests/core/plugin-manifest.test.ts
+++ b/tests/core/plugin-manifest.test.ts
@@ -113,6 +113,42 @@ describe('plugin manifest schema', () => {
     expect(manifest.bakin).toBe('>=1.0.0')
   })
 
+  it('accepts an optional ed25519 signature block', () => {
+    const manifest = parsePluginManifest({
+      ...baseManifest,
+      signature: {
+        algorithm: 'ed25519',
+        signer: 'madeinwyo',
+        publicKey: 'MCowBQYDK2VwAyEAtest',
+        signature: 'signed-body',
+      },
+    })
+
+    expect(manifest.signature?.algorithm).toBe('ed25519')
+    expect(manifest.signature?.signer).toBe('madeinwyo')
+  })
+
+  it('rejects malformed signature blocks', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      signature: {
+        algorithm: 'rsa',
+        signer: 'madeinwyo',
+        publicKey: 'MCowBQYDK2VwAyEAtest',
+        signature: 'signed-body',
+      },
+    })).toThrow(/signature\.algorithm/)
+
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      signature: {
+        algorithm: 'ed25519',
+        signer: 'madeinwyo',
+        signature: 'signed-body',
+      },
+    })).toThrow(/signature\.publicKey/)
+  })
+
   it('rejects absolute API paths in plugin route declarations', () => {
     expect(() => parsePluginManifest({
       ...baseManifest,

--- a/tests/core/plugin-signatures.test.ts
+++ b/tests/core/plugin-signatures.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test'
+import { generateKeyPairSync, sign as signBytes } from 'crypto'
+import {
+  PluginSignatureError,
+  canonicalizePluginManifestForSignature,
+  pluginSignatureFingerprint,
+  verifyPluginManifestSignature,
+} from '../../packages/core/src/plugins/signatures'
+
+const baseManifest = {
+  id: 'signed-plugin',
+  name: 'Signed Plugin',
+  version: '1.0.0',
+  bakin: '>=1.0.0',
+  description: 'A signed test plugin',
+  entry: { server: 'index.ts' },
+  permissions: [],
+}
+
+function createSigningFixture() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  const publicKeyBase64 = publicKey.export({ format: 'der', type: 'spki' }).toString('base64')
+  return { privateKey, publicKeyBase64 }
+}
+
+function signedManifest(
+  manifest: Record<string, unknown> = baseManifest,
+  fixture = createSigningFixture(),
+) {
+  const body = canonicalizePluginManifestForSignature(manifest)
+  const signature = signBytes(null, Buffer.from(body, 'utf-8'), fixture.privateKey).toString('base64')
+  return {
+    manifest: {
+      ...manifest,
+      signature: {
+        algorithm: 'ed25519',
+        signer: 'unit-test',
+        publicKey: fixture.publicKeyBase64,
+        signature,
+      },
+    },
+    publicKeyBase64: fixture.publicKeyBase64,
+  }
+}
+
+describe('plugin signature verification', () => {
+  it('allows unsigned manifests when requireSignatures is false', () => {
+    const result = verifyPluginManifestSignature(baseManifest, {
+      requireSignatures: false,
+      trustedSigners: [],
+    })
+
+    expect(result.required).toBe(false)
+    expect(result.verified).toBe(false)
+  })
+
+  it('rejects unsigned manifests when requireSignatures is true', () => {
+    expect(() => verifyPluginManifestSignature(baseManifest, {
+      requireSignatures: true,
+      trustedSigners: [],
+    })).toThrow(PluginSignatureError)
+  })
+
+  it('accepts signed manifests when the public-key fingerprint is trusted', () => {
+    const signed = signedManifest()
+    const fingerprint = pluginSignatureFingerprint(signed.publicKeyBase64)
+    const result = verifyPluginManifestSignature(signed.manifest, {
+      requireSignatures: true,
+      trustedSigners: [fingerprint],
+    })
+
+    expect(result.required).toBe(true)
+    expect(result.verified).toBe(true)
+    expect(result.fingerprint).toBe(fingerprint)
+  })
+
+  it('rejects signed manifests when the signer key is not trusted', () => {
+    const signed = signedManifest()
+
+    expect(() => verifyPluginManifestSignature(signed.manifest, {
+      requireSignatures: true,
+      trustedSigners: ['sha256:0000000000000000000000000000000000000000000000000000000000000000'],
+    })).toThrow(/not trusted/)
+  })
+
+  it('rejects signed manifests when the signed body is changed', () => {
+    const signed = signedManifest()
+
+    expect(() => verifyPluginManifestSignature({
+      ...signed.manifest,
+      description: 'tampered after signing',
+    }, {
+      requireSignatures: true,
+      trustedSigners: [pluginSignatureFingerprint(signed.publicKeyBase64)],
+    })).toThrow(/signature is invalid/)
+  })
+})

--- a/tests/core/settings.test.ts
+++ b/tests/core/settings.test.ts
@@ -29,6 +29,8 @@ describe('Settings', () => {
     expect(settings.search.settings.enabled).toBe(true)
     expect(settings.runtime.adapter).toBe('openclaw')
     expect(settings.runtime.settings).toEqual({})
+    expect(settings.plugins.requireSignatures).toBe(false)
+    expect(settings.plugins.trustedSigners).toEqual([])
   })
 
   it('returns doctor defaults including requireOnboard', () => {
@@ -105,6 +107,35 @@ describe('Settings', () => {
     const settings = getSettings()
     expect(settings.runtime.adapter).toBe('openclaw')
     expect(settings.runtime.settings).toEqual({ customPort: 19000 })
+  })
+
+  it('merges plugin signature policy overrides preserving plugin defaults', () => {
+    fs.mkdirSync(TEST_CONTENT_DIR, { recursive: true })
+    fs.writeFileSync(SETTINGS_FILE, JSON.stringify({
+      plugins: {
+        requireSignatures: true,
+        trustedSigners: ['sha256:abc123'],
+      },
+    }))
+
+    const settings = getSettings()
+    expect(settings.plugins.requireSignatures).toBe(true)
+    expect(settings.plugins.trustedSigners).toEqual(['sha256:abc123'])
+    expect(settings.plugins.runtimeCapabilityMode).toBe('warn')
+  })
+
+  it('normalizes malformed plugin signature policy settings to safe defaults', () => {
+    fs.mkdirSync(TEST_CONTENT_DIR, { recursive: true })
+    fs.writeFileSync(SETTINGS_FILE, JSON.stringify({
+      plugins: {
+        requireSignatures: 'true',
+        trustedSigners: ['sha256:abc123', '', 42],
+      },
+    }))
+
+    const settings = getSettings()
+    expect(settings.plugins.requireSignatures).toBe(false)
+    expect(settings.plugins.trustedSigners).toEqual(['sha256:abc123'])
   })
 
   it('caches settings on subsequent calls', () => {

--- a/tests/plugins/lifecycle/upgrade-smoke.test.ts
+++ b/tests/plugins/lifecycle/upgrade-smoke.test.ts
@@ -59,6 +59,7 @@ import {
   writePluginLockfile,
 } from '../../../packages/core/src/plugins/lockfile'
 import { installPluginAssets } from '../../../src/core/onboarding/plugin-assets'
+import { resetSettingsCache } from '../../../src/core/settings'
 import { computeSourceTreeSha, upgradePlugin, UpgradeRefusedError } from '../../../src/core/plugins/upgrade'
 
 afterAll(() => {
@@ -70,6 +71,7 @@ beforeEach(() => {
   mkdirSync(testDir, { recursive: true })
   mkdirSync(openClawDir, { recursive: true })
   installFilesystemRuntimeAppServices({ openClawDir })
+  resetSettingsCache()
 })
 
 const NOW = '2026-04-25T12:00:00Z'
@@ -134,6 +136,11 @@ function localEntry(opts: { id: string; sourcePath: string; version: string; sou
     manifestSha: 'abc',
     sourceTreeSha: opts.sourceTreeSha,
   }
+}
+
+function writeSettings(settings: Record<string, unknown>): void {
+  writeFileSync(join(testDir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf-8')
+  resetSettingsCache()
 }
 
 describe('computeSourceTreeSha', () => {
@@ -216,6 +223,32 @@ describe('upgradePlugin (local)', () => {
     expect(updated?.version).toBe('1.1.0')
     expect(updated?.sourceTreeSha).not.toBe(initialSha)
     expect(updated?.upgradedAt).toBeTruthy()
+  })
+
+  it('rejects unsigned local plugin upgrades when signatures are required', async () => {
+    const sourcePath = join(testDir, 'src-unsigned')
+    const pluginDir = join(testDir, 'plugins', 'unsigned-plugin')
+    writeFixturePlugin(sourcePath, { id: 'unsigned-plugin', version: '1.0.0' })
+    writeFixturePlugin(pluginDir, { id: 'unsigned-plugin', version: '1.0.0' })
+    const initialSha = computeSourceTreeSha(sourcePath)
+    writePluginLockfile(addPlugin(readPluginLockfile(), 'unsigned-plugin', localEntry({
+      id: 'unsigned-plugin',
+      sourcePath,
+      version: '1.0.0',
+      sourceTreeSha: initialSha,
+    })))
+
+    writeFixturePlugin(sourcePath, { id: 'unsigned-plugin', version: '1.1.0' })
+    writeSettings({
+      plugins: {
+        requireSignatures: true,
+        trustedSigners: [],
+      },
+    })
+
+    await expect(upgradePlugin('unsigned-plugin')).rejects.toThrow(/signed plugin manifest/)
+    expect(readPluginLockfile().plugins['unsigned-plugin']?.version).toBe('1.0.0')
+    expect(existsSync(join(pluginDir, 'bakin-plugin.json'))).toBe(true)
   })
 
   it('installs changed and new runtime skills from the upgraded local plugin', async () => {


### PR DESCRIPTION
## Summary

Closes #164.

Adds an optional fail-closed plugin manifest signature policy while keeping default trust-on-first-use behavior unchanged.

- Adds `bakin-plugin.json.signature` parsing/types for Ed25519 manifest signatures.
- Adds `settings.plugins.requireSignatures` and `settings.plugins.trustedSigners` with normalized settings defaults.
- Adds `@bakin/core/plugins/signatures` for canonical manifest signing, public-key fingerprinting, trusted-root matching, and Ed25519 verification.
- Enforces signature policy in plugin install, dev-link install, and upgrade preflight before mutating plugin state.
- Updates plugin docs, generated settings/sdk docs, and the platform audit notes.

## Behavior

When `plugins.requireSignatures` is false, unsigned plugins still install, link, and upgrade as before.

When `plugins.requireSignatures` is true:

- unsigned manifests reject before copy/build/link/upgrade mutation;
- signed manifests reject if the signer key is not trusted;
- signed manifests reject if the signed manifest body has been tampered with;
- trusted roots can be `sha256:<hex>`, raw base64 Ed25519 SPKI public keys, or `ed25519:<base64-public-key>`.

## Verification

- `bun test tests/core/plugin-signatures.test.ts tests/core/plugin-manifest.test.ts tests/core/settings.test.ts tests/api/plugins-install.test.ts tests/plugins/lifecycle/upgrade-smoke.test.ts --isolate`
- `bun test tests/architecture/adapter-boundary.test.ts --isolate`
- `bun test --isolate` -> 3502 pass, 10 skip, 0 fail
- `bun run typecheck`
- `bunx eslint <changed files>`
- `git diff --check`
- `bun run docs:check` partially passed: docs generation, docs validation, and route-contract validation passed; Astro build stopped locally because `@astrojs/react` is not present in local docs `node_modules` despite being declared in `docs/package.json` and `bun.lock`.

Repo-wide `bun run lint` still fails on the existing unrelated routing/core-plugin unused-var and empty-object baseline; changed-file lint is clean.