### PR TITLE
Fix audit boundary hardening gaps

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -15692,12 +15692,15 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "path": {
+                  "localPath": {
                     "type": "string"
+                  },
+                  "force": {
+                    "type": "boolean"
                   }
                 },
                 "required": [
-                  "path"
+                  "localPath"
                 ],
                 "additionalProperties": false
               }

--- a/docs/src/content/docs/extending/ingredients.md
+++ b/docs/src/content/docs/extending/ingredients.md
@@ -45,6 +45,8 @@ Use MCP tools when an agent needs to do something, not just read instructions. S
 
 MCP tools belong to plugins. Register them with `ctx.registerExecTool()`, keep parameter schemas strict, return boring result objects, and declare public tools in `bakin-plugin.json` under `contributes.execTools`.
 
+User plugin tool names must stay inside the plugin namespace: `bakin_exec_{pluginId}_{action}`. Bakin rejects undeclared tools, duplicate tool names, and user plugin tools that try to register outside their own prefix.
+
 Start with [Server Contracts](/docs/extending/plugins/server-contracts/) and the [Exec tools reference](/docs/reference/generated/exec-tools/).
 
 ## Settings
@@ -155,7 +157,7 @@ Plugins use `bakin-plugin.json`. The manifest declares identity, entry points, p
   "permissions": ["storage.read", "tasks.write"],
   "contributes": {
     "clientRoutes": [{ "path": "/lead-intel", "summary": "Lead intelligence view" }],
-    "execTools": [{ "name": "lead_intel_score", "summary": "Score a lead" }]
+    "execTools": [{ "name": "bakin_exec_lead-intel_score", "summary": "Score a lead" }]
   }
 }
 ```

--- a/docs/src/content/docs/extending/plugins/manifest.md
+++ b/docs/src/content/docs/extending/plugins/manifest.md
@@ -125,6 +125,8 @@ The signature covers canonical JSON for `bakin-plugin.json` with the top-level `
 
 API route paths are plugin-relative. A route declared as `/hello` is exposed under `/api/plugins/{pluginId}/hello`. Do not declare `/api/...` paths in a plugin manifest.
 
+Exec tool names must use the plugin-owned MCP namespace: `bakin_exec_{pluginId}_{action}`. The manifest declaration and runtime `ctx.registerExecTool()` call must agree. Bakin rejects undeclared tools, duplicate tool names, and user plugin tools that register outside their own plugin prefix.
+
 ## Permissions
 
 Declare permissions before calling the corresponding APIs.

--- a/docs/src/content/docs/extending/plugins/server-contracts.md
+++ b/docs/src/content/docs/extending/plugins/server-contracts.md
@@ -89,7 +89,7 @@ Exec tools are the API agents usually feel first. Keep tool names stable, parame
 
 ```ts
 ctx.registerExecTool({
-  name: 'docs_basic_echo',
+  name: 'bakin_exec_docs-basic_echo',
   description: 'Echo a short message through the docs basic plugin.',
   parameters: {
     message: z.string().min(1).max(500),
@@ -101,7 +101,7 @@ ctx.registerExecTool({
 })
 ```
 
-Use plugin-specific prefixes. Return an actionable `error` string when `ok` is false. If the tool mutates tasks, assets, workflows, or external systems, make that obvious in the name and description.
+Use the enforced `bakin_exec_{pluginId}_{action}` prefix for user plugin tools. The tool must also be declared in `bakin-plugin.json` under `contributes.execTools`; duplicate names and cross-plugin prefixes fail plugin activation. Return an actionable `error` string when `ok` is false. If the tool mutates tasks, assets, workflows, or external systems, make that obvious in the name and description.
 
 ## Hooks
 

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -365,7 +365,7 @@ curl -sS \
   -X POST \
   'http://localhost:3737/api/plugins/link' \
   -H 'Content-Type: application/json' \
-  --data '{"path":"value"}'
+  --data '{"localPath":"value","force":true}'
 ```
 </OpenApiReference>
 

--- a/packages/host/src/api/_adapter.ts
+++ b/packages/host/src/api/_adapter.ts
@@ -12,6 +12,7 @@
  * evaporates — handlers are already in the shape Bun.serve expects.
  */
 import type { IncomingMessage, ServerResponse } from 'http'
+import { isRequestBodyTooLargeError, readRequestBody } from '@/core/request-body'
 
 export type WebHandler = (req: Request, url: URL) => Promise<Response> | Response
 
@@ -35,11 +36,8 @@ export async function dispatchWebHandler(
     // Read request body for non-GET/HEAD requests.
     let body: BodyInit | undefined = undefined
     if (req.method && req.method !== 'GET' && req.method !== 'HEAD') {
-      const chunks: Buffer[] = []
-      for await (const chunk of req) {
-        chunks.push(chunk as Buffer)
-      }
-      if (chunks.length > 0) body = Buffer.concat(chunks)
+      const rawBody = await readRequestBody(req)
+      if (rawBody) body = rawBody
     }
 
     // Normalize headers: Node's object → Web Headers.
@@ -75,7 +73,8 @@ export async function dispatchWebHandler(
     }
   } catch (err) {
     if (!res.headersSent) {
-      res.writeHead(500, { 'Content-Type': 'application/json' })
+      const status = isRequestBodyTooLargeError(err) ? 413 : 500
+      res.writeHead(status, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify({
         error: err instanceof Error ? err.message : String(err),
       }))

--- a/packages/host/src/api/_adapter.ts
+++ b/packages/host/src/api/_adapter.ts
@@ -37,7 +37,7 @@ export async function dispatchWebHandler(
     let body: BodyInit | undefined = undefined
     if (req.method && req.method !== 'GET' && req.method !== 'HEAD') {
       const rawBody = await readRequestBody(req)
-      if (rawBody) body = rawBody
+      if (rawBody) body = new Uint8Array(rawBody)
     }
 
     // Normalize headers: Node's object → Web Headers.

--- a/packages/host/src/api/_adapter.ts
+++ b/packages/host/src/api/_adapter.ts
@@ -12,7 +12,11 @@
  * evaporates — handlers are already in the shape Bun.serve expects.
  */
 import type { IncomingMessage, ServerResponse } from 'http'
-import { isRequestBodyTooLargeError, readRequestBody } from '@/core/request-body'
+import {
+  DEFAULT_MAX_WEB_REQUEST_BODY_BYTES,
+  isRequestBodyTooLargeError,
+  readRequestBody,
+} from '@/core/request-body'
 
 export type WebHandler = (req: Request, url: URL) => Promise<Response> | Response
 
@@ -36,7 +40,7 @@ export async function dispatchWebHandler(
     // Read request body for non-GET/HEAD requests.
     let body: BodyInit | undefined = undefined
     if (req.method && req.method !== 'GET' && req.method !== 'HEAD') {
-      const rawBody = await readRequestBody(req)
+      const rawBody = await readRequestBody(req, { maxBytes: DEFAULT_MAX_WEB_REQUEST_BODY_BYTES })
       if (rawBody) body = new Uint8Array(rawBody)
     }
 

--- a/packages/host/src/api/docs-runtime.ts
+++ b/packages/host/src/api/docs-runtime.ts
@@ -24,16 +24,29 @@ export interface OpenApiDocument {
   }
 }
 
-interface RouteSource {
+export interface OpenApiRouteLike {
+  path: string
+  method: string
+  summary?: string
+  description?: string
+  params?: unknown
+  query?: unknown
+  body?: unknown
+  responses?: unknown
+  visibility?: string
+  stability?: string
+  permissions?: string[]
+  examples?: unknown[]
+  operationId?: string
+  tags?: string[]
+  input?: unknown
+  output?: unknown
+}
+
+export interface RouteSource {
   scope: 'core' | string
   fullPath: string
-  route: {
-    path: string
-    method: string
-    summary?: string
-    description?: string
-    [key: string]: unknown
-  }
+  route: OpenApiRouteLike
   manifestDescription?: string
 }
 

--- a/packages/host/src/api/openapi-sources.ts
+++ b/packages/host/src/api/openapi-sources.ts
@@ -1,0 +1,24 @@
+import { coreRoutes } from '../core-routes'
+import type { buildOpenApiDocument } from './docs-runtime'
+
+type OpenApiSource = Parameters<typeof buildOpenApiDocument>[0][number]
+
+export interface PluginRouteSource {
+  pluginId: string
+  route: OpenApiSource['route']
+}
+
+export function collectOpenApiSources(pluginRoutes: ReadonlyArray<PluginRouteSource>): OpenApiSource[] {
+  return [
+    ...pluginRoutes.map(({ pluginId, route }) => ({
+      scope: pluginId,
+      fullPath: `/api/plugins/${pluginId}${route.path}`,
+      route,
+    })),
+    ...coreRoutes.map(route => ({
+      scope: 'core' as const,
+      fullPath: route.path,
+      route,
+    })),
+  ]
+}

--- a/packages/host/src/api/openapi-sources.ts
+++ b/packages/host/src/api/openapi-sources.ts
@@ -1,7 +1,7 @@
 import { coreRoutes } from '../core-routes'
-import type { buildOpenApiDocument } from './docs-runtime'
+import type { RouteSource } from './docs-runtime'
 
-type OpenApiSource = Parameters<typeof buildOpenApiDocument>[0][number]
+type OpenApiSource = RouteSource
 
 export interface PluginRouteSource {
   pluginId: string

--- a/packages/host/src/api/plugins/[pluginId]/[[...path]].ts
+++ b/packages/host/src/api/plugins/[pluginId]/[[...path]].ts
@@ -14,7 +14,7 @@
  * plugins are activated once at boot, routes are already registered, ctx
  * lookups go through the real globals. ~170 lines of duplication removed.
  */
-import { readFileSync, writeFileSync, appendFileSync, mkdirSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { MarkdownStorageAdapter } from '@/lib/storage/markdown-adapter'
 import { ScopedPluginStorageAdapter } from '@bakin/core/storage/scoped-plugin-storage'
@@ -105,21 +105,7 @@ function buildCtx(pluginId: string): PluginContext {
         }
       },
       audit: (event, agent, data) => {
-        const contentDir = getContentDir()
-        const entry = JSON.stringify({
-          ts: new Date().toISOString(),
-          event: `${pluginId}.${event}`,
-          agent,
-          ...(data || {}),
-        })
-        const auditPath = join(contentDir, 'audit.jsonl')
-        try { appendFileSync(auditPath, entry + '\n') } catch { /* best-effort */ }
-        const broadcastFn = (globalThis as Record<string, unknown>).__bakinBroadcast as
-          | ((data: Record<string, unknown>) => void)
-          | undefined
-        if (broadcastFn) {
-          broadcastFn({ type: 'audit', event: `${pluginId}.${event}`, agent, ...data })
-        }
+        appendAudit(getContentDir(), `${pluginId}.${event}`, agent, data || {}, 'rest')
       },
     },
     search: buildSearchAPI(pluginId, { registerRoute: noopRegisterRoute, skipFileBackedWiring: true }),

--- a/packages/host/src/core-routes/index.ts
+++ b/packages/host/src/core-routes/index.ts
@@ -66,7 +66,7 @@ const dispatchAndPackagesRoutes = [
 // ─── /api/plugins/* + misc (T16) ─────────────────────────────────────────
 const pluginsAndMiscRoutes = [
   defineCoreRoute({ path: '/api/plugins/install', method: 'POST', summary: 'Install plugin', body: z.object({ source: z.string(), type: z.enum(['local', 'github']) }), responses: { 200: passthrough, 400: errorResponse, 500: errorResponse }, handler: stub }),
-  defineCoreRoute({ path: '/api/plugins/link', method: 'POST', summary: 'Link local plugin', body: z.object({ path: z.string() }), responses: { 200: passthrough, 400: errorResponse, 500: errorResponse }, handler: stub }),
+  defineCoreRoute({ path: '/api/plugins/link', method: 'POST', summary: 'Link local plugin', body: z.object({ localPath: z.string(), force: z.boolean().optional() }), responses: { 200: passthrough, 400: errorResponse, 500: errorResponse }, handler: stub }),
   defineCoreRoute({ path: '/api/plugins/manifest', method: 'GET', summary: 'Get plugin manifest bundle', responses: { 200: passthrough }, handler: stub }),
   defineCoreRoute({ path: '/api/plugins/:pluginId/assets/:path', method: 'GET', summary: 'Serve plugin client asset', params: z.object({ pluginId: z.string(), path: z.string() }), responses: { 200: { contentType: 'application/octet-stream' }, 404: errorResponse }, handler: stub }),
   defineCoreRoute({ path: '/api/plugins/memory/audit', method: 'GET', summary: 'List memory audit entries', responses: { 200: passthrough }, handler: stub }),

--- a/scripts/lib/registry.ts
+++ b/scripts/lib/registry.ts
@@ -53,8 +53,10 @@ function getRuntimePluginState(pluginId: string): RuntimePluginState | undefined
 // ---------------------------------------------------------------------------
 
 export function addExecTool(tool: ExecToolDefinition): void {
-  if (execTools.has(tool.name)) {
-    console.warn(`Exec tool "${tool.name}" already registered — overriding`)
+  const existing = execTools.get(tool.name)
+  if (existing) {
+    const owner = existing.source ? ` by ${existing.source}` : ''
+    throw new Error(`Exec tool "${tool.name}" is already registered${owner}`)
   }
   execTools.set(tool.name, tool)
 }
@@ -78,9 +80,10 @@ export function getExecTool(name: string): ExecToolDefinition | undefined {
  */
 export function removeExecToolsByPlugin(pluginId: string): number {
   const prefix = `bakin_exec_${pluginId}_`
+  const pluginSource = `plugin:${pluginId}`
   let removed = 0
-  for (const name of [...execTools.keys()]) {
-    if (name.startsWith(prefix)) {
+  for (const [name, tool] of [...execTools.entries()]) {
+    if (name.startsWith(prefix) || tool.source === pluginSource) {
       execTools.delete(name)
       removed++
     }

--- a/server.ts
+++ b/server.ts
@@ -42,6 +42,7 @@ import { checkAndContinueDependents } from './src/core/continuation'
 import { getAllRoutes, generateDocs } from './src/core/api-docs'
 import { getCachedOrBuild } from './packages/host/src/api/docs-runtime'
 import type { buildOpenApiDocument } from './packages/host/src/api/docs-runtime'
+import { collectOpenApiSources as collectTypedOpenApiSources } from './packages/host/src/api/openapi-sources'
 import { migrateIfNeeded } from './src/core/search-migration'
 import * as agents from './src/core/agents'
 import * as doctor from './src/core/doctor'
@@ -113,25 +114,12 @@ const CONTENT_DIR = getContentDir()
 
 /**
  * Build the source list the OpenAPI runtime builder consumes from the
- * live route registry. Plugin routes come from pluginRegistry; legacy
- * core routes still flow through src/core/api-docs.ts CORE_ROUTES until
- * T14–T16 migrate them onto the declarative shape.
+ * live route registry. Plugin routes come from pluginRegistry; core routes
+ * come from the typed core route declarations so body/query/response schemas
+ * are preserved in live `/api/openapi`.
  */
 function collectOpenApiSources(): Parameters<typeof buildOpenApiDocument>[0] {
-  return [
-    ...pluginRegistry.getAllPluginRoutes().map(({ pluginId, route }) => ({
-      scope: pluginId,
-      fullPath: `/api/plugins/${pluginId}${route.path}`,
-      route: route as unknown as Parameters<typeof buildOpenApiDocument>[0][number]['route'],
-    })),
-    ...getAllRoutes()
-      .filter(r => r.pluginId === 'core')
-      .map(r => ({
-        scope: 'core' as const,
-        fullPath: r.fullPath,
-        route: r as unknown as Parameters<typeof buildOpenApiDocument>[0][number]['route'],
-      })),
-  ]
+  return collectTypedOpenApiSources(pluginRegistry.getAllPluginRoutes())
 }
 
 // Ensure required directories exist

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -74,18 +74,21 @@ const sseSessions = new Map<string, SseSession>()
 
 const startedAt = new Date().toISOString()
 
-// Expose MCP session state to plugin-land without an HTTP hop. The health
-// plugin reads this via globalThis to avoid coupling to mcp-server.ts
-// directly — same pattern as __bakinBroadcast.
-;(globalThis as unknown as { __bakinGetMcpSessions?: () => { activeSessions: Array<{ agent: string; sessions: number; connectedAt: string }>; upSince: string } }).__bakinGetMcpSessions = () => {
+type SessionSummaryInput = Pick<McpSession | SseSession, 'agentId' | 'createdAt'>
+
+export function summarizeMcpSessions(
+  streamable: Iterable<SessionSummaryInput>,
+  sse: Iterable<SessionSummaryInput>,
+  upSince: string = startedAt,
+): { activeSessions: Array<{ agent: string; sessions: number; connectedAt: string }>; upSince: string } {
   const agentMap = new Map<string, { sessions: number; latestAt: number }>()
-  for (const [, s] of sessions) {
-    const existing = agentMap.get(s.agentId)
+  for (const session of [...streamable, ...sse]) {
+    const existing = agentMap.get(session.agentId)
     if (existing) {
       existing.sessions++
-      existing.latestAt = Math.max(existing.latestAt, s.createdAt)
+      existing.latestAt = Math.max(existing.latestAt, session.createdAt)
     } else {
-      agentMap.set(s.agentId, { sessions: 1, latestAt: s.createdAt })
+      agentMap.set(session.agentId, { sessions: 1, latestAt: session.createdAt })
     }
   }
   return {
@@ -94,8 +97,15 @@ const startedAt = new Date().toISOString()
       sessions: info.sessions,
       connectedAt: new Date(info.latestAt).toISOString(),
     })),
-    upSince: startedAt,
+    upSince,
   }
+}
+
+// Expose MCP session state to plugin-land without an HTTP hop. The health
+// plugin reads this via globalThis to avoid coupling to mcp-server.ts
+// directly — same pattern as __bakinBroadcast.
+;(globalThis as unknown as { __bakinGetMcpSessions?: () => { activeSessions: Array<{ agent: string; sessions: number; connectedAt: string }>; upSince: string } }).__bakinGetMcpSessions = () => {
+  return summarizeMcpSessions(sessions.values(), sseSessions.values(), startedAt)
 }
 
 // Clean up stale sessions every 5 minutes.

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -25,6 +25,11 @@ import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { createLogger } from './logger'
 import { getContentDir } from './content-dir'
 import { appendAudit } from './audit'
+import {
+  isInvalidJsonBodyError,
+  isRequestBodyTooLargeError,
+  readJsonBody,
+} from './request-body'
 import { recordUsage } from '@/core/usage'
 import { getAllExecTools, getExecTool, getToolContext } from '../../scripts/lib/registry'
 import {
@@ -367,7 +372,22 @@ export async function handleMcpRequest(
 
   // ─── POST: route to correct transport ──────────────────────────────
   if (method === 'POST') {
-    const body = await parseBody(req)
+    let body: unknown
+    try {
+      body = await parseBody(req)
+    } catch (err) {
+      if (isRequestBodyTooLargeError(err)) {
+        res.writeHead(413, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: err.message }))
+        return
+      }
+      if (isInvalidJsonBodyError(err)) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Invalid JSON body' }))
+        return
+      }
+      throw err
+    }
 
     // Check for Streamable HTTP session (header-based)
     const existingSessionId = req.headers['mcp-session-id'] as string | undefined
@@ -441,19 +461,7 @@ export async function handleMcpRequest(
 // ---------------------------------------------------------------------------
 
 function parseBody(req: IncomingMessage): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
-    req.on('end', () => {
-      try {
-        const raw = Buffer.concat(chunks).toString('utf-8')
-        resolve(raw ? JSON.parse(raw) : undefined)
-      } catch (err) {
-        reject(err)
-      }
-    })
-    req.on('error', reject)
-  })
+  return readJsonBody(req)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -4,6 +4,11 @@
  */
 import type { IncomingMessage, ServerResponse } from 'http'
 import { createLogger } from './logger'
+import {
+  isRequestBodyTooLargeError,
+  readJsonBody,
+  type ReadRequestBodyOptions,
+} from './request-body'
 
 const log = createLogger('middleware')
 
@@ -11,19 +16,17 @@ const log = createLogger('middleware')
  * Parse a JSON body from an IncomingMessage.
  * Returns the parsed object or null if parsing fails.
  */
-export function parseJsonBody(req: IncomingMessage): Promise<Record<string, unknown> | null> {
-  return new Promise((resolve) => {
-    let body = ''
-    req.on('data', (chunk: Buffer) => { body += chunk.toString() })
-    req.on('end', () => {
-      try {
-        resolve(JSON.parse(body))
-      } catch {
-        resolve(null)
-      }
-    })
-    req.on('error', () => resolve(null))
-  })
+export async function parseJsonBody(
+  req: IncomingMessage,
+  options: ReadRequestBodyOptions = {},
+): Promise<Record<string, unknown> | null> {
+  try {
+    const body = await readJsonBody(req, options)
+    return body && typeof body === 'object' ? body as Record<string, unknown> : null
+  } catch (err) {
+    if (isRequestBodyTooLargeError(err)) throw err
+    return null
+  }
 }
 
 /**
@@ -57,11 +60,21 @@ export function jsonResponse(res: ServerResponse, status: number, data: unknown)
 export async function handleJsonPost(
   req: IncomingMessage,
   res: ServerResponse,
-  handler: (body: Record<string, unknown>) => Promise<unknown>
+  handler: (body: Record<string, unknown>) => Promise<unknown>,
+  options: ReadRequestBodyOptions = {},
 ): Promise<void> {
   if (!validateJsonContentType(req, res)) return
 
-  const body = await parseJsonBody(req)
+  let body: Record<string, unknown> | null
+  try {
+    body = await parseJsonBody(req, options)
+  } catch (err) {
+    if (isRequestBodyTooLargeError(err)) {
+      jsonResponse(res, 413, { error: err.message })
+      return
+    }
+    throw err
+  }
   if (!body) {
     jsonResponse(res, 400, { error: 'Invalid JSON body' })
     return

--- a/src/core/request-body.ts
+++ b/src/core/request-body.ts
@@ -1,0 +1,109 @@
+import type { IncomingMessage } from 'http'
+
+export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024
+
+export interface ReadRequestBodyOptions {
+  maxBytes?: number
+}
+
+export class RequestBodyTooLargeError extends Error {
+  readonly code = 'REQUEST_BODY_TOO_LARGE'
+  readonly statusCode = 413
+
+  constructor(readonly maxBytes: number) {
+    super(`Request body too large; maximum is ${maxBytes} bytes`)
+    this.name = 'RequestBodyTooLargeError'
+  }
+}
+
+export class InvalidJsonBodyError extends Error {
+  readonly code = 'INVALID_JSON_BODY'
+  readonly statusCode = 400
+
+  constructor() {
+    super('Invalid JSON body')
+    this.name = 'InvalidJsonBodyError'
+  }
+}
+
+export function isRequestBodyTooLargeError(err: unknown): err is RequestBodyTooLargeError {
+  return err instanceof RequestBodyTooLargeError
+}
+
+export function isInvalidJsonBodyError(err: unknown): err is InvalidJsonBodyError {
+  return err instanceof InvalidJsonBodyError
+}
+
+export function readRequestBody(
+  req: IncomingMessage,
+  options: ReadRequestBodyOptions = {},
+): Promise<Buffer | undefined> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_REQUEST_BODY_BYTES
+  const declaredLength = parseContentLength(req.headers['content-length'])
+
+  if (declaredLength !== undefined && declaredLength > maxBytes) {
+    req.resume?.()
+    return Promise.reject(new RequestBodyTooLargeError(maxBytes))
+  }
+
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let total = 0
+    let settled = false
+
+    const finish = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      req.off?.('data', onData)
+      req.off?.('end', onEnd)
+      req.off?.('error', onError)
+      fn()
+    }
+
+    const onData = (chunk: Buffer | string) => {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      total += buf.length
+      if (total > maxBytes) {
+        req.destroy?.()
+        finish(() => reject(new RequestBodyTooLargeError(maxBytes)))
+        return
+      }
+      chunks.push(buf)
+    }
+
+    const onEnd = () => {
+      finish(() => resolve(chunks.length > 0 ? Buffer.concat(chunks, total) : undefined))
+    }
+
+    const onError = (err: Error) => {
+      finish(() => reject(err))
+    }
+
+    req.on('data', onData)
+    req.on('end', onEnd)
+    req.on('error', onError)
+  })
+}
+
+export async function readJsonBody(
+  req: IncomingMessage,
+  options: ReadRequestBodyOptions = {},
+): Promise<unknown> {
+  const body = await readRequestBody(req, options)
+  if (!body || body.length === 0) return undefined
+
+  try {
+    return JSON.parse(body.toString('utf-8'))
+  } catch {
+    throw new InvalidJsonBodyError()
+  }
+}
+
+function parseContentLength(value: string | string[] | undefined): number | undefined {
+  const raw = Array.isArray(value) ? value[0] : value
+  if (!raw) return undefined
+
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined
+  return parsed
+}

--- a/src/core/request-body.ts
+++ b/src/core/request-body.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from 'http'
 
 export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024
+export const DEFAULT_MAX_WEB_REQUEST_BODY_BYTES = 100 * 1024 * 1024
 
 export interface ReadRequestBodyOptions {
   maxBytes?: number
@@ -64,8 +65,8 @@ export function readRequestBody(
       const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
       total += buf.length
       if (total > maxBytes) {
-        req.destroy?.()
         finish(() => reject(new RequestBodyTooLargeError(maxBytes)))
+        req.destroy?.()
         return
       }
       chunks.push(buf)

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -448,6 +448,13 @@ export function buildSearchAPI(pluginId: string, opts?: BuildSearchAPIOptions): 
   const api: SearchAPI = {
     registerContentType(def: SearchContentTypeDefinition): void {
       const tableName = fullTableName(def.table)
+      const existing = registry.contentTypes.get(tableName)
+      if (existing && existing.pluginId !== pluginId) {
+        throw new Error(
+          `Search content type table "${tableName}" is already registered by plugin "${existing.pluginId}"; ` +
+          `plugin "${pluginId}" cannot take ownership.`,
+        )
+      }
       registry.contentTypes.set(tableName, { ...def, pluginId })
       registry.pluginTables.set(pluginId, tableName)
       log.info(`Content type registered: ${tableName} (plugin: ${pluginId})`)

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -637,6 +637,13 @@ class PluginRegistryImpl {
         `Declare it in bakin-plugin.json contributes.execTools.`,
       )
     }
+    const expectedPrefix = `bakin_exec_${pluginId}_`
+    if (!tool.name.startsWith(expectedPrefix)) {
+      throw new Error(
+        `Plugin "${pluginId}" registered exec tool "${tool.name}" outside its namespace. ` +
+        `User plugin exec tools must start with "${expectedPrefix}".`,
+      )
+    }
   }
 
   private buildContext(

--- a/tests/api/api-docs-runtime.test.ts
+++ b/tests/api/api-docs-runtime.test.ts
@@ -28,6 +28,7 @@ mock.module('../../src/core/task-store', () => ({}))
 
 import { defineRoute } from '../../packages/core/src/routing'
 import { buildOpenApiDocument, invalidateDocsCache } from '../../packages/host/src/api/docs-runtime'
+import { collectOpenApiSources } from '../../packages/host/src/api/openapi-sources'
 
 describe('buildOpenApiDocument', () => {
   it('returns a valid OpenAPI 3.1 envelope when no routes', () => {
@@ -79,5 +80,17 @@ describe('buildOpenApiDocument', () => {
     ])
     const tagNames = doc.tags.map(t => t.name).sort()
     expect(tagNames).toEqual(['Core', 'Tasks'])
+  })
+
+  it('collects typed core route schemas for the live OpenAPI document', () => {
+    invalidateDocsCache()
+    const doc = buildOpenApiDocument(collectOpenApiSources([]))
+
+    const schema = doc.paths['/api/plugins/link'].post.requestBody?.content['application/json'].schema
+
+    expect(schema?.properties).toHaveProperty('localPath')
+    expect(schema?.properties).toHaveProperty('force')
+    expect(schema?.properties).not.toHaveProperty('path')
+    expect(schema?.required).toEqual(['localPath'])
   })
 })

--- a/tests/api/plugin-route-audit.test.ts
+++ b/tests/api/plugin-route-audit.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const tempDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-route-audit-'))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => tempDir,
+  getBakinPaths: () => ({ root: tempDir }),
+}))
+
+mock.module('@/core/app-services', () => ({
+  getAppServices: () => ({
+    runtime: {},
+    tasks: {},
+    search: {},
+  }),
+}))
+
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+mock.module('@/core/search-registry', () => ({
+  buildSearchAPI: () => ({}),
+}))
+
+mock.module('@/lib/storage/markdown-adapter', () => ({
+  MarkdownStorageAdapter: class {},
+}))
+
+mock.module('@bakin/core/storage/scoped-plugin-storage', () => ({
+  ScopedPluginStorageAdapter: class {},
+}))
+
+mock.module('@/lib/events/event-bus', () => ({
+  BakinEventBus: class {
+    constructor(readonly broadcast: unknown) {}
+  },
+}))
+
+mock.module('@/lib/plugin-context-services', () => ({
+  createPluginAssetsAPI: () => ({}),
+  createPluginRuntimeFacade: () => ({}),
+  createPluginTaskService: () => ({}),
+}))
+
+mock.module('@/lib/plugin-permissions', () => ({
+  wrapPluginContextPermissions: (ctx: unknown) => ctx,
+}))
+
+mock.module('@/core/plugin-host/version-stamp', () => ({
+  stampPluginResponse: (_pluginId: string, res: Response) => res,
+}))
+
+mock.module('@/lib/plugin-registry', () => ({
+  pluginRegistry: {
+    getPluginState: () => ({
+      source: 'user',
+      manifest: { permissions: [] },
+      routes: [
+        {
+          path: '/do',
+          method: 'POST',
+          handler: async (_req: Request, ctx: any) => {
+            ctx.activity.audit('route_event', 'route-agent', { custom: 'field' })
+            return Response.json({ ok: true })
+          },
+        },
+      ],
+    }),
+  },
+}))
+
+import { post } from '../../packages/host/src/api/plugins/[pluginId]/[[...path]]'
+
+describe('plugin route audit context', () => {
+  afterEach(() => {
+    delete (globalThis as any).__bakinBroadcast
+    delete (globalThis as any).__bakinBroadcastAudit
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('writes request-time ctx.activity.audit entries with the canonical audit shape', async () => {
+    const broadcastAudit = mock()
+    ;(globalThis as any).__bakinBroadcastAudit = broadcastAudit
+
+    const req = new Request('http://localhost/api/plugins/audit-plugin/do', {
+      method: 'POST',
+      headers: { 'x-bakin-agent': 'patch' },
+    })
+
+    const res = await post(req, new URL(req.url))
+
+    expect(res.status).toBe(200)
+    const entries = readFileSync(join(tempDir, 'audit.jsonl'), 'utf-8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line))
+    const entry = entries.find(item => item.event === 'audit-plugin.route_event')
+
+    expect(entry).toMatchObject({
+      event: 'audit-plugin.route_event',
+      agent: 'route-agent',
+      channel: 'rest',
+      data: { custom: 'field' },
+    })
+    expect(entry.custom).toBeUndefined()
+    expect(broadcastAudit).toHaveBeenCalledWith(expect.objectContaining({
+      event: 'audit-plugin.route_event',
+      data: { custom: 'field' },
+    }))
+  })
+})

--- a/tests/api/plugins-link.test.ts
+++ b/tests/api/plugins-link.test.ts
@@ -103,6 +103,7 @@ describe('POST /api/plugins/link — happy path', () => {
     writeManifest(sourceDir, { id: 'apilinked', name: 'AL', version: '0.1.0', permissions: [] })
     const res = await callLink({ localPath: sourceDir })
     const body = await res.json()
+    if (res.status !== 200) throw new Error(`link failed: ${body.error}`)
     expect(res.status).toBe(200)
     expect(body.ok).toBe(true)
     expect(body.id).toBe('apilinked')
@@ -127,6 +128,8 @@ describe('POST /api/plugins/unlink', () => {
     await callLink({ localPath: sourceDir })
 
     const res = await callUnlink({ pluginId: 'apiunlinked' })
+    const errorBody = await res.clone().json()
+    if (res.status !== 200) throw new Error(`unlink failed: ${errorBody.error}`)
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.ok).toBe(true)

--- a/tests/api/web-adapter.test.ts
+++ b/tests/api/web-adapter.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, mock } from 'bun:test'
 import { PassThrough } from 'stream'
 import type { IncomingMessage, ServerResponse } from 'http'
 import { dispatchWebHandler } from '../../packages/host/src/api/_adapter'
-import { DEFAULT_MAX_REQUEST_BODY_BYTES } from '../../src/core/request-body'
+import {
+  DEFAULT_MAX_REQUEST_BODY_BYTES,
+  DEFAULT_MAX_WEB_REQUEST_BODY_BYTES,
+} from '../../src/core/request-body'
 
 function mockReq(opts: {
   method?: string
@@ -41,9 +44,23 @@ function mockRes() {
 }
 
 describe('dispatchWebHandler', () => {
-  it('returns 413 and does not call the handler for oversize requests', async () => {
+  it('allows Web handler bodies above the JSON parser default limit', async () => {
     const req = mockReq({
       headers: { 'content-length': String(DEFAULT_MAX_REQUEST_BODY_BYTES + 1) },
+      body: 'ok',
+    })
+    const res = mockRes()
+    const handler = mock(() => new Response(JSON.stringify({ ok: true })))
+
+    await dispatchWebHandler(req, res, handler)
+
+    expect(handler).toHaveBeenCalled()
+    expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+  })
+
+  it('returns 413 and does not call the handler for oversize requests', async () => {
+    const req = mockReq({
+      headers: { 'content-length': String(DEFAULT_MAX_WEB_REQUEST_BODY_BYTES + 1) },
     })
     const res = mockRes()
     const handler = mock(() => new Response(JSON.stringify({ ok: true })))

--- a/tests/api/web-adapter.test.ts
+++ b/tests/api/web-adapter.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { PassThrough } from 'stream'
+import type { IncomingMessage, ServerResponse } from 'http'
+import { dispatchWebHandler } from '../../packages/host/src/api/_adapter'
+import { DEFAULT_MAX_REQUEST_BODY_BYTES } from '../../src/core/request-body'
+
+function mockReq(opts: {
+  method?: string
+  url?: string
+  headers?: Record<string, string>
+  body?: string
+} = {}): IncomingMessage {
+  const stream = new PassThrough()
+  stream.end(opts.body ?? '')
+  const req = stream as unknown as IncomingMessage
+  req.method = opts.method ?? 'POST'
+  req.url = opts.url ?? '/api/test'
+  req.headers = {
+    host: 'localhost:3737',
+    ...opts.headers,
+  }
+  return req
+}
+
+function mockRes() {
+  let body = ''
+  const res = {
+    headersSent: false,
+    writeHead: mock(),
+    end: mock((data?: string | Buffer) => {
+      if (data) body = Buffer.isBuffer(data) ? data.toString('utf-8') : data
+    }),
+  } as unknown as ServerResponse & {
+    headersSent: boolean
+    writeHead: ReturnType<typeof mock>
+    end: ReturnType<typeof mock>
+    _body: string
+  }
+  Object.defineProperty(res, '_body', { get: () => body })
+  return res
+}
+
+describe('dispatchWebHandler', () => {
+  it('returns 413 and does not call the handler for oversize requests', async () => {
+    const req = mockReq({
+      headers: { 'content-length': String(DEFAULT_MAX_REQUEST_BODY_BYTES + 1) },
+    })
+    const res = mockRes()
+    const handler = mock(() => new Response(JSON.stringify({ ok: true })))
+
+    await dispatchWebHandler(req, res, handler)
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(res.writeHead).toHaveBeenCalledWith(413, { 'Content-Type': 'application/json' })
+    expect(res._body).toContain('Request body too large')
+  })
+})

--- a/tests/core/mcp-server.test.ts
+++ b/tests/core/mcp-server.test.ts
@@ -68,6 +68,27 @@ describe('MCP Server', () => {
     expect(getActiveSessions()).toEqual([])
   })
 
+  it('should summarize both streamable and SSE sessions for health stats', async () => {
+    const { summarizeMcpSessions } = await import('@/core/mcp-server')
+
+    const summary = summarizeMcpSessions(
+      [
+        { agentId: 'patch', createdAt: 1_000 },
+        { agentId: 'basil', createdAt: 2_000 },
+      ],
+      [
+        { agentId: 'patch', createdAt: 3_000 },
+      ],
+      '2026-05-04T00:00:00.000Z',
+    )
+
+    expect(summary.upSince).toBe('2026-05-04T00:00:00.000Z')
+    expect(summary.activeSessions).toEqual([
+      { agent: 'patch', sessions: 2, connectedAt: '1970-01-01T00:00:03.000Z' },
+      { agent: 'basil', sessions: 1, connectedAt: '1970-01-01T00:00:02.000Z' },
+    ])
+  })
+
   it('should reject requests without agent param and no session ID', async () => {
     const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
 

--- a/tests/core/mcp-server.test.ts
+++ b/tests/core/mcp-server.test.ts
@@ -80,6 +80,33 @@ describe('MCP Server', () => {
     expect(res._body).toContain('agent query parameter required')
   })
 
+  it('should return 400 for malformed JSON bodies', async () => {
+    const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
+
+    const req = createMockRequest('POST', '/mcp?agent=basil', '{ broken')
+    const res = createMockResponse()
+
+    await handleMcpRequest(req, res)
+
+    expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object))
+    expect(res._body).toContain('Invalid JSON body')
+  })
+
+  it('should return 413 when the request body is too large', async () => {
+    const { DEFAULT_MAX_REQUEST_BODY_BYTES } = await import('@/core/request-body')
+    const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
+
+    const req = createMockRequest('POST', '/mcp?agent=basil', null, {
+      'content-length': String(DEFAULT_MAX_REQUEST_BODY_BYTES + 1),
+    })
+    const res = createMockResponse()
+
+    await handleMcpRequest(req, res)
+
+    expect(res.writeHead).toHaveBeenCalledWith(413, expect.any(Object))
+    expect(res._body).toContain('Request body too large')
+  })
+
   it('should return 404 for unknown Streamable HTTP session ID', async () => {
     const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
 
@@ -121,7 +148,8 @@ function createMockRequest(
     },
     on: mock((event: string, cb: (...args: any[]) => void) => {
       if (event === 'data' && body) {
-        cb(Buffer.from(JSON.stringify(body)))
+        const raw = typeof body === 'string' ? body : JSON.stringify(body)
+        cb(Buffer.from(raw))
       }
       if (event === 'end') {
         cb()

--- a/tests/core/mcp-server.test.ts
+++ b/tests/core/mcp-server.test.ts
@@ -19,14 +19,20 @@ mock.module('@/core/task-service', () => ({
 }))
 
 mock.module('@/core/content-dir', () => ({
-  getContentDir: mock(() => '/tmp/test'),
+  getContentDir: mock(() => process.env.BAKIN_HOME || '/tmp/test'),
   getBakinPaths: mock(() => ({
-    home: '/tmp/test',
-    assets: '/tmp/test/assets',
+    root: process.env.BAKIN_HOME || '/tmp/test',
+    home: process.env.BAKIN_HOME || '/tmp/test',
+    assets: `${process.env.BAKIN_HOME || '/tmp/test'}/assets`,
+    settings: `${process.env.BAKIN_HOME || '/tmp/test'}/settings.json`,
+    pluginSettings: `${process.env.BAKIN_HOME || '/tmp/test'}/plugin-settings`,
+    plugins: `${process.env.BAKIN_HOME || '/tmp/test'}/plugins`,
+    audit: `${process.env.BAKIN_HOME || '/tmp/test'}/audit.jsonl`,
+    logs: `${process.env.BAKIN_HOME || '/tmp/test'}/logs`,
+  })),
   isUsingBakinHome: () => true,
   resetContentDir: () => {},
   initBakinHome: () => {},
-})),
 }))
 
 mock.module('@/core/audit', () => ({
@@ -34,6 +40,9 @@ mock.module('@/core/audit', () => ({
 }))
 
 mock.module('@bakin/workflows/lib/runtime', () => ({
+  createInstance: mock(() => ({ taskId: 'task-1', workflowId: 'wf', status: 'in_progress' })),
+  loadInstance: mock(() => null),
+  saveInstance: mock(),
   getCurrentStep: mock(() => ({
     stepId: 'write-copy',
     label: 'Write Copy',
@@ -41,6 +50,14 @@ mock.module('@bakin/workflows/lib/runtime', () => ({
     output_schema: { type: 'object', properties: { text: { type: 'string' } } },
   })),
   completeStep: mock(() => ({ success: true, workflowComplete: false })),
+  approveGate: mock(() => ({ success: true })),
+  rejectGate: mock(() => ({ success: true })),
+  listInstances: mock(() => []),
+  getActiveAgents: mock(() => []),
+  authorizeWorkflowToolUse: mock(() => ({ allowed: true })),
+  isGateNotified: mock(() => false),
+  markGateNotified: mock(),
+  cancelInstance: mock(),
 }))
 
 mock.module('@/core/logger', () => ({

--- a/tests/core/middleware.test.ts
+++ b/tests/core/middleware.test.ts
@@ -23,6 +23,7 @@ function mockReq(opts: {
   body?: string
   method?: string
   contentType?: string
+  contentLength?: string
 } = {}): IncomingMessage {
   const stream = new PassThrough()
   if (opts.body !== undefined) {
@@ -34,6 +35,7 @@ function mockReq(opts: {
   req.method = opts.method || 'GET'
   req.headers = {}
   if (opts.contentType) req.headers['content-type'] = opts.contentType
+  if (opts.contentLength) req.headers['content-length'] = opts.contentLength
   return req
 }
 
@@ -80,6 +82,12 @@ describe('middleware', () => {
       stream.emit('error', new Error('stream broke'))
       const result = await promise
       expect(result).toBeNull()
+    })
+
+    it('throws when body exceeds the configured limit', async () => {
+      const req = mockReq({ body: '{"ok":true}', contentLength: '16' })
+
+      await expect(parseJsonBody(req, { maxBytes: 8 })).rejects.toThrow('Request body too large')
     })
   })
 
@@ -192,6 +200,24 @@ describe('middleware', () => {
       expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object))
       const body = JSON.parse(res.end.mock.calls[0][0])
       expect(body.error).toContain('Invalid JSON')
+    })
+
+    it('returns 413 when body exceeds the configured limit', async () => {
+      const req = mockReq({
+        method: 'POST',
+        contentType: 'application/json',
+        contentLength: '16',
+        body: '{"ok":true}',
+      })
+      const res = mockRes()
+      const handler = mock()
+
+      await handleJsonPost(req, res, handler, { maxBytes: 8 })
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(res.writeHead).toHaveBeenCalledWith(413, expect.any(Object))
+      const body = JSON.parse(res.end.mock.calls[0][0])
+      expect(body.error).toContain('Request body too large')
     })
 
     it('returns 500 when handler throws', async () => {

--- a/tests/core/plugin-registry.test.ts
+++ b/tests/core/plugin-registry.test.ts
@@ -130,9 +130,31 @@ mock.module('@/core/migrations', () => ({
   runMigrations: mock().mockResolvedValue(0),
 }))
 
+const mockedExecTools = new Map<string, any>()
+const mockedAddExecTool = mock((tool: any) => {
+  if (mockedExecTools.has(tool.name)) {
+    throw new Error(`Exec tool "${tool.name}" is already registered`)
+  }
+  mockedExecTools.set(tool.name, tool)
+})
+const mockedRemoveExecToolsByPlugin = mock((pluginId: string) => {
+  const prefix = `bakin_exec_${pluginId}_`
+  const source = `plugin:${pluginId}`
+  let removed = 0
+  for (const [name, tool] of [...mockedExecTools.entries()]) {
+    if (name.startsWith(prefix) || tool.source === source) {
+      mockedExecTools.delete(name)
+      removed++
+    }
+  }
+  return removed
+})
+
 mock.module('../../scripts/lib/registry', () => ({
-  addExecTool: mock(),
-  removeExecToolsByPlugin: mock(() => 0),
+  addExecTool: mockedAddExecTool,
+  getExecTool: (name: string) => mockedExecTools.get(name),
+  getAllExecTools: () => [...mockedExecTools.values()],
+  removeExecToolsByPlugin: mockedRemoveExecToolsByPlugin,
 }))
 
 describe('PluginRegistryImpl', () => {
@@ -144,14 +166,17 @@ describe('PluginRegistryImpl', () => {
   let mockAppendAudit: any
   let mockAddExecTool: any
   let mockRegisterRouteDoc: any
+  let previousBakinHome: string | undefined
 
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-reg-'))
     // Point user plugins to a non-existent dir (no user plugins by default)
+    previousBakinHome = process.env.BAKIN_HOME
     process.env.BAKIN_HOME = join(tempDir, 'bakin-home')
     // Clear globalThis singletons for fresh instances
     delete (globalThis as any).__bakinPluginRegistry
     delete (globalThis as any).__bakinHookRegistry
+    mockedExecTools.clear()
     const runtime = createMockRuntimeAdapter()
     const search = createMockSearchAdapter()
     ;(globalThis as any).__bakinAppServices = {
@@ -190,7 +215,12 @@ describe('PluginRegistryImpl', () => {
   })
 
   afterEach(() => {
-    delete process.env.BAKIN_HOME
+    if (previousBakinHome === undefined) {
+      delete process.env.BAKIN_HOME
+    } else {
+      process.env.BAKIN_HOME = previousBakinHome
+    }
+    mockGetContentDir?.mockImplementation(() => process.env.BAKIN_HOME || '/tmp/test')
     // Clean up any globalThis test vars
     for (const key of Object.keys(globalThis)) {
       if (key.startsWith('__') && key !== '__bakinPluginRegistry' && key !== '__bakinHookRegistry') {

--- a/tests/core/plugin-registry.test.ts
+++ b/tests/core/plugin-registry.test.ts
@@ -649,13 +649,13 @@ describe('PluginRegistryImpl', () => {
               { method: 'GET', path: '/data', summary: 'Read data' },
             ],
             execTools: [
-              { name: 'declared.tool', summary: 'Declared tool' },
+              { name: 'bakin_exec_declared-surfaces_data', summary: 'Declared tool' },
             ],
           },
         },
         activate: `
           ctx.registerRoute({ path: '/data', method: 'GET', handler: function() { return new Response('ok') } })
-          ctx.registerExecTool({ name: 'declared.tool', description: 'test', parameters: {}, handler: async () => ({ ok: true }) })
+          ctx.registerExecTool({ name: 'bakin_exec_declared-surfaces_data', description: 'test', parameters: {}, handler: async () => ({ ok: true }) })
         `,
       })
 
@@ -664,10 +664,36 @@ describe('PluginRegistryImpl', () => {
       expect(pluginRegistry.findRoute('declared-surfaces', '/data', 'GET')).not.toBeNull()
       expect(mockAddExecTool).toHaveBeenCalledWith(expect.objectContaining({
         source: 'plugin:declared-surfaces',
-        name: 'declared.tool',
+        name: 'bakin_exec_declared-surfaces_data',
       }))
       const active = pluginRegistry.getRegistrySnapshot().find((entry: any) => entry.id === 'declared-surfaces')
       expect(active).toMatchObject({ status: 'active' })
+    })
+
+    it('fails user plugins that declare exec tools outside their namespace', async () => {
+      writeUserPlugin('tool-owner', {
+        manifest: {
+          contributes: {
+            execTools: [
+              { name: 'bakin_exec_tasks_create', summary: 'Looks like a core tool' },
+            ],
+          },
+        },
+        activate: `
+          ctx.registerExecTool({ name: 'bakin_exec_tasks_create', description: 'bad', parameters: {}, handler: async () => ({ ok: true }) })
+        `,
+      })
+      mockAddExecTool.mockClear()
+
+      await pluginRegistry.initialize({ plugins: [] }, mockStorage(), mockEvents())
+
+      const failed = pluginRegistry.getRegistrySnapshot().find((entry: any) => entry.id === 'tool-owner')
+      expect(failed).toMatchObject({
+        status: 'failed',
+        errorCode: 'activation_failed',
+      })
+      expect(failed.errorMessage).toContain('must start with "bakin_exec_tool-owner_"')
+      expect(mockAddExecTool).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/core/request-body.test.ts
+++ b/tests/core/request-body.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test'
+import { PassThrough } from 'stream'
+import type { IncomingMessage } from 'http'
+import { readRequestBody } from '../../src/core/request-body'
+
+function streamReq(): IncomingMessage {
+  const stream = new PassThrough()
+  const req = stream as unknown as IncomingMessage
+  req.headers = {}
+  return req
+}
+
+describe('request body reader', () => {
+  it('rejects streamed bodies that exceed the limit without a content-length header', async () => {
+    const req = streamReq()
+    const body = readRequestBody(req, { maxBytes: 4 })
+
+    req.emit('data', Buffer.from('abc'))
+    req.emit('data', Buffer.from('de'))
+
+    await expect(body).rejects.toThrow('Request body too large')
+  })
+})

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -154,6 +154,25 @@ describe('search-registry', () => {
     expect(entry?.pluginId).toBe('my-plugin')
   })
 
+  it('allows the same plugin to re-register its own table', () => {
+    const api = buildSearchAPI('owner')
+    api.registerContentType(makeDef('widgets'))
+    api.registerContentType(makeDef('widgets'))
+
+    const entry = getContentTypes().get('bakin_widgets')
+    expect(entry?.pluginId).toBe('owner')
+  })
+
+  it('rejects another plugin taking over an already-owned table', () => {
+    buildSearchAPI('owner').registerContentType(makeDef('widgets'))
+
+    expect(() => buildSearchAPI('intruder').registerContentType(makeDef('widgets')))
+      .toThrow('already registered by plugin "owner"')
+
+    const entry = getContentTypes().get('bakin_widgets')
+    expect(entry?.pluginId).toBe('owner')
+  })
+
   // ── auto-registration of /search route (C1 — issue #67) ──────────────
 
   it('registerContentType auto-registers a GET /search route when registerRoute opt is provided', () => {

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -25,6 +25,10 @@ mock.module('@/core/content-dir', () => ({
 
 mock.module('@/core/settings', () => ({
   getSettings: mock(() => ({
+    plugins: {
+      requireSignatures: false,
+      trustedSigners: [],
+    },
     search: {
       adapter: 'antfly',
       settings: {

--- a/tests/scripts/registry.test.ts
+++ b/tests/scripts/registry.test.ts
@@ -20,6 +20,7 @@ import {
   addExecTool,
   getAllExecTools,
   getExecTool,
+  removeExecToolsByPlugin,
 } from '../../scripts/lib/registry'
 
 // Per-tool call counting now lives in the unified usage recorder
@@ -28,17 +29,37 @@ import {
 // directly and query getUsageFeed({ kind: 'mcp' }).
 
 describe('exec tool registry', () => {
-  const mockTool = {
-    name: 'bakin_exec_test_tool',
-    description: 'Test tool',
-    source: 'test',
-    parameters: {},
-    handler: async () => ({ ok: true as const }),
+  function mockTool(name: string, source = 'test') {
+    return {
+      name,
+      description: 'Test tool',
+      source,
+      parameters: {},
+      handler: async () => ({ ok: true as const }),
+    }
   }
 
   it('registers and retrieves a tool', () => {
-    addExecTool(mockTool)
-    expect(getExecTool('bakin_exec_test_tool')).toBe(mockTool)
+    const tool = mockTool('bakin_exec_test_tool_registers')
+    addExecTool(tool)
+    expect(getExecTool('bakin_exec_test_tool_registers')).toBe(tool)
+  })
+
+  it('rejects duplicate tool names instead of overriding', () => {
+    addExecTool(mockTool('bakin_exec_test_tool_duplicate'))
+
+    expect(() => addExecTool(mockTool('bakin_exec_test_tool_duplicate'))).toThrow('already registered')
+  })
+
+  it('removes plugin-owned tools by recorded source as well as namespace prefix', () => {
+    addExecTool(mockTool('legacy_tool_name', 'plugin:sample'))
+    addExecTool(mockTool('bakin_exec_sample_namespaced', 'plugin:sample'))
+    addExecTool(mockTool('bakin_exec_other_namespaced', 'plugin:other'))
+
+    expect(removeExecToolsByPlugin('sample')).toBe(2)
+    expect(getExecTool('legacy_tool_name')).toBeUndefined()
+    expect(getExecTool('bakin_exec_sample_namespaced')).toBeUndefined()
+    expect(getExecTool('bakin_exec_other_namespaced')).toBeDefined()
   })
 
   it('returns undefined for unknown tool', () => {
@@ -46,8 +67,9 @@ describe('exec tool registry', () => {
   })
 
   it('getAllExecTools returns registered tools', () => {
-    addExecTool(mockTool)
+    const tool = mockTool('bakin_exec_test_tool_all')
+    addExecTool(tool)
     const all = getAllExecTools()
-    expect(all.find(t => t.name === 'bakin_exec_test_tool')).toBeDefined()
+    expect(all.find(t => t.name === 'bakin_exec_test_tool_all')).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary

Fixes the concrete gaps found in the deep adapter/plugin/agent-management audit (#221):

- Add bounded request-body parsing for JSON/MCP and Web-handler paths, with 413 responses instead of unbounded buffering.
- Enforce plugin ownership boundaries for exec tools and search content tables.
- Preserve typed core-route schemas in live `/api/openapi`, including the corrected `/api/plugins/link` body shape.
- Route plugin REST audit writes through the canonical audit logger so entries keep `channel`, nested `data`, and audit SSE behavior.
- Include legacy SSE MCP sessions in health stats instead of reporting only streamable sessions.
- Fix grouped test mock isolation that was hiding order-dependent failures.
- Document the enforced `bakin_exec_{pluginId}_{action}` tool namespace for plugin authors.

## Verification

- `bun test --isolate` -> 3524 pass, 10 skip, 0 fail
- `bun run typecheck`
- `bun run docs:check`
- `git diff --check main..HEAD`
- `bunx eslint <changed files>` -> 0 errors; Markdown docs are ignored by ESLint config

Repo-wide `bun run lint` still fails on existing unrelated lint debt outside this PR diff, mostly unused symbols in routing/plugin files. The changed files pass targeted ESLint.