### PR TITLE
Harden package lesson integrity

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -43,6 +43,8 @@ atomically.
 
 ID rule: `/^[a-z0-9][a-z0-9-_]{0,39}$/i` — same as plugin install. Source rule: `github:user/repo[@ref][#subpath]` or local path (`./` `../` `/` `~/`); bare names refuse with a clear error. GitHub `#subpath` installs stage only the package directory and reject empty, absolute, traversal, dot-segment, multi-`#`, and whitespace subpaths.
 
+Lesson integrity rule: install/update preflights agent and lesson-pack lesson contributions before writing lockfile or projections. Lesson contributions must be real, non-empty Markdown files at `lessons/<lesson-id>.md`, with unique basename-derived ids. Agent `install.enableLessons[]` and update-preserved `lessonsEnabled[]` must reference contributed lesson ids.
+
 ## Lockfile
 
 `~/.bakin/packages/lock.json`. zod-validated, atomic IO (`tmp + rename`). Schema in `packages/core/src/agent-packages/lockfile.ts`:

--- a/docs/src/content/docs/extending/agents/lessons.md
+++ b/docs/src/content/docs/extending/agents/lessons.md
@@ -21,7 +21,7 @@ Do not use lesson files for secrets, ephemeral task notes, live credentials, per
 
 ## File Shape
 
-Lesson files are Markdown. Keep headings direct and avoid clever structure. Agents should be able to scan the file and extract instructions without guessing.
+Lesson files are Markdown under `lessons/<lesson-id>.md`. Install and update fail if a contributed lesson file is missing, empty, outside that path shape, or duplicates another lesson ID. Keep headings direct and avoid clever structure. Agents should be able to scan the file and extract instructions without guessing.
 
 ```md
 # Voice

--- a/docs/src/content/docs/extending/agents/packages.md
+++ b/docs/src/content/docs/extending/agents/packages.md
@@ -138,6 +138,8 @@ Agent packages can contribute:
 
 `skill-pack` packages must contribute at least one skill. `workflow-pack` packages must contribute at least one workflow or workflow skill. `lesson-pack` packages must contribute at least one lesson file.
 
+Lesson contributions are preflighted during install and update. Each lesson must be a real, non-empty Markdown file at `lessons/<lesson-id>.md`; the basename is the lesson ID. `enableLessons` can only name lessons contributed by the package.
+
 ## Install Commands
 
 Install from a local path:

--- a/src/core/agent-packages/installer.ts
+++ b/src/core/agent-packages/installer.ts
@@ -68,6 +68,7 @@ import {
 import { getAppServices } from '../app-services'
 import { readFileSync } from 'fs'
 import { join } from 'path'
+import { validatePackageLessonIntegrity } from './lesson-integrity'
 
 const log = createLogger('agent-pkg:install')
 
@@ -293,6 +294,10 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
     }
 
     const resolvedTopId = options.installAs ?? manifest.id
+    validatePackageLessonIntegrity({
+      manifest,
+      stagingDir: topFetched.stagingDir,
+    })
 
     // ─── 3. Compute install mode for kind:"agent" ──────────────────────────
     const lock = readLockfile()
@@ -348,6 +353,12 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
     // ─── 4. Resolve dependencies ───────────────────────────────────────────
     const resolved = resolveDependencies(manifest)
     for (const r of resolved) depFetched.push(r.fetched)
+    for (const r of resolved) {
+      validatePackageLessonIntegrity({
+        manifest: r.manifest,
+        stagingDir: r.fetched.stagingDir,
+      })
+    }
 
     // ─── 5. Pre-flight collision check ─────────────────────────────────────
     const collisions = preflightCollisions(lock, resolvedTopId, resolved)

--- a/src/core/agent-packages/lesson-integrity.ts
+++ b/src/core/agent-packages/lesson-integrity.ts
@@ -1,0 +1,114 @@
+import { existsSync, readFileSync, statSync } from 'fs'
+import { basename, isAbsolute, normalize, relative, resolve } from 'path'
+import type { Manifest } from '../../../packages/core/src/agent-packages/manifest'
+
+const LESSON_ID_PATTERN = /^[a-z0-9][a-z0-9-_]{0,39}$/i
+const LESSON_PATH_PATTERN = /^lessons\/[^/]+\.md$/i
+
+export interface LessonIntegrityOptions {
+  manifest: Manifest
+  stagingDir: string
+  /**
+   * Explicit enabled lesson ids. Update passes lockfile state here so a
+   * package update cannot silently orphan an enabled lesson.
+   */
+  enabledLessons?: string[]
+}
+
+export function validatePackageLessonIntegrity(options: LessonIntegrityOptions): void {
+  const rels = contributedLessonRels(options.manifest)
+  const ids = new Map<string, string>()
+
+  for (const rel of rels) {
+    const normalizedRel = normalizePackageRel(rel)
+    validateLessonRel(options.manifest.id, rel, normalizedRel)
+
+    const abs = resolve(options.stagingDir, normalizedRel)
+    if (!isPathInside(options.stagingDir, abs)) {
+      throw new Error(`Lesson source path escapes the package root: ${rel}`)
+    }
+    if (!existsSync(abs)) {
+      throw new Error(`Lesson source file is missing: ${rel}`)
+    }
+    if (!statSync(abs).isFile()) {
+      throw new Error(`Lesson source path is not a file: ${rel}`)
+    }
+
+    const lessonId = lessonIdFromRel(normalizedRel)
+    const existingRel = ids.get(lessonId)
+    if (existingRel) {
+      throw new Error(
+        `Duplicate lesson id "${lessonId}" in package "${options.manifest.id}": ` +
+          `${existingRel} and ${rel}`,
+      )
+    }
+    ids.set(lessonId, normalizedRel)
+
+    const body = extractLessonBody(readFileSync(abs, 'utf-8'))
+    if (!body.trim()) {
+      throw new Error(`Lesson source file is empty: ${rel}`)
+    }
+  }
+
+  if (options.manifest.kind !== 'agent') return
+
+  const enabledLessons = options.enabledLessons ?? options.manifest.install.enableLessons ?? []
+  const seenEnabled = new Set<string>()
+  for (const lessonId of enabledLessons) {
+    if (seenEnabled.has(lessonId)) {
+      throw new Error(`Enabled lesson "${lessonId}" is listed more than once in package "${options.manifest.id}".`)
+    }
+    seenEnabled.add(lessonId)
+    if (!ids.has(lessonId)) {
+      const available = Array.from(ids.keys()).sort().join(', ') || '<none>'
+      throw new Error(
+        `Enabled lesson "${lessonId}" is not contributed by package "${options.manifest.id}". ` +
+          `Available: ${available}`,
+      )
+    }
+  }
+}
+
+function contributedLessonRels(manifest: Manifest): string[] {
+  if (manifest.kind === 'agent') return manifest.contributions.lessons ?? []
+  if (manifest.kind === 'lesson-pack') return manifest.contributions.lessons
+  return []
+}
+
+function normalizePackageRel(rel: string): string {
+  return normalize(rel).replaceAll('\\', '/')
+}
+
+function validateLessonRel(packageId: string, originalRel: string, normalizedRel: string): void {
+  if (isAbsolute(originalRel) || normalizedRel === '..' || normalizedRel.startsWith('../')) {
+    throw new Error(`Lesson source path escapes the package root: ${originalRel}`)
+  }
+  if (!LESSON_PATH_PATTERN.test(normalizedRel)) {
+    throw new Error(
+      `Lesson contribution "${originalRel}" in package "${packageId}" must use lessons/<lesson-id>.md ` +
+        `so search indexing and dispatch retrieval can find it.`,
+    )
+  }
+
+  const lessonId = lessonIdFromRel(normalizedRel)
+  if (!LESSON_ID_PATTERN.test(lessonId)) {
+    throw new Error(
+      `Lesson id "${lessonId}" from ${originalRel} must match /^[a-z0-9][a-z0-9-_]{0,39}$/i.`,
+    )
+  }
+}
+
+function lessonIdFromRel(rel: string): string {
+  return basename(rel).replace(/\.md$/i, '')
+}
+
+function isPathInside(root: string, target: string): boolean {
+  const rel = relative(resolve(root), target)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+function extractLessonBody(raw: string): string {
+  const normalized = raw.replace(/\r\n/g, '\n')
+  const match = normalized.match(/^---\n[\s\S]*?\n---\n?([\s\S]*)$/)
+  return match ? match[1].trim() : normalized.trim()
+}

--- a/src/core/agent-packages/projector.ts
+++ b/src/core/agent-packages/projector.ts
@@ -53,6 +53,7 @@ import {
   injectBlock,
   removeBlock,
 } from '../../../packages/core/src/agent-packages/managed-blocks'
+import { validatePackageLessonIntegrity } from './lesson-integrity'
 
 const log = createLogger('agent-pkg:project')
 
@@ -623,6 +624,12 @@ async function projectLessonMarkers(
  * re-throwing so the install state matches what was on disk before.
  */
 export async function projectPackage(options: ProjectorOptions): Promise<ProjectorResult> {
+  validatePackageLessonIntegrity({
+    manifest: options.manifest,
+    stagingDir: options.stagingDir,
+    enabledLessons: options.enabledLessons,
+  })
+
   const result: ProjectorResult = { projections: [], skipped: [] }
   const writeLog = new WriteLog()
 

--- a/src/core/agent-packages/updater.ts
+++ b/src/core/agent-packages/updater.ts
@@ -33,6 +33,7 @@ import {
   acquireInstallLock,
   releaseInstallLock,
 } from './install-lock'
+import { validatePackageLessonIntegrity } from './lesson-integrity'
 
 const log = createLogger('agent-pkg:update')
 
@@ -107,6 +108,12 @@ export async function updatePackageById(options: UpdateOptions): Promise<UpdateR
           `Run \`bakin agents remove ${options.packageId}\` then install the new id fresh.`,
       )
     }
+
+    validatePackageLessonIntegrity({
+      manifest,
+      stagingDir: fetched.stagingDir,
+      enabledLessons: entry.kind === 'agent' ? entry.lessonsEnabled ?? [] : undefined,
+    })
 
     // Roll back the old projections so the new ones land on a clean slate.
     // Two carve-outs:

--- a/tests/agent-packages/installer.test.ts
+++ b/tests/agent-packages/installer.test.ts
@@ -450,6 +450,77 @@ describe('installPackage — refuse paths', () => {
     expect(adapterCalls.addAgent).toHaveLength(0)
     expect(isInstallLockHeld()).toBe(false)
   })
+
+  it('refuses an agent package when a contributed lesson file is missing', async () => {
+    const src = seedAgentPackage()
+    rmSync(join(src, 'lessons', 'style.md'), { force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/lesson source file is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
+  it('refuses an agent package when install.enableLessons references an undeclared lesson', async () => {
+    const src = seedAgentPackage()
+    const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))
+    manifest.install.enableLessons = ['missing']
+    writeFileSync(join(src, 'bakin-package.json'), JSON.stringify(manifest, null, 2))
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/enabled lesson "missing" is not contributed/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
+  it('refuses agent lessons outside the indexed lessons/<id>.md layout', async () => {
+    const src = seedAgentPackage()
+    mkdirSync(join(src, 'docs'), { recursive: true })
+    writeFileSync(join(src, 'docs', 'style.md'), readFileSync(join(src, 'lessons', 'style.md'), 'utf-8'))
+    rmSync(join(src, 'lessons', 'style.md'), { force: true })
+    const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))
+    manifest.contributions.lessons = ['docs/style.md']
+    writeFileSync(join(src, 'bakin-package.json'), JSON.stringify(manifest, null, 2))
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/lessons\/<lesson-id>\.md/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+  })
+
+  it('refuses duplicate contributed lesson ids', async () => {
+    const src = seedAgentPackage()
+    const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))
+    manifest.contributions.lessons = ['lessons/style.md', 'lessons/style.md']
+    writeFileSync(join(src, 'bakin-package.json'), JSON.stringify(manifest, null, 2))
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/duplicate lesson id "style"/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
+  it('refuses a contributed lesson with no body content', async () => {
+    const src = seedAgentPackage()
+    writeFileSync(
+      join(src, 'lessons', 'style.md'),
+      `---\ntitle: Style\ndefaultEnabled: true\n---\n\n`,
+    )
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/lesson source file is empty/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
 })
 
 // ─── Composition (single-level deps) ─────────────────────────────────────────

--- a/tests/agent-packages/standalone-packs.test.ts
+++ b/tests/agent-packages/standalone-packs.test.ts
@@ -278,6 +278,33 @@ describe('installPackage — kind:"lesson-pack"', () => {
     const entry = readLockfile().packages['shared-lessons@1.0.0']
     expect(entry?.projections ?? []).toEqual([])
   })
+
+  it('refuses a lesson-pack when a contributed lesson file is missing', async () => {
+    const src = seedLessonPack('shared-lessons')
+    rmSync(join(src, 'lessons', 'lesson-two.md'), { force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/lesson source file is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(existsSync(join(testDir, 'packages', 'lesson-packs', 'shared-lessons@1.0.0'))).toBe(false)
+  })
+
+  it('refuses a lesson-pack when a contributed lesson has no body content', async () => {
+    const src = seedLessonPack('shared-lessons')
+    writeFileSync(
+      join(src, 'lessons', 'lesson-two.md'),
+      `---\ntitle: Lesson Two\ndefaultEnabled: false\n---\n\n`,
+    )
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/lesson source file is empty/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(existsSync(join(testDir, 'packages', 'lesson-packs', 'shared-lessons@1.0.0'))).toBe(false)
+  })
 })
 
 // ─── refCount lifecycle (orphan handling) ────────────────────────────────────

--- a/tests/agent-packages/updater.test.ts
+++ b/tests/agent-packages/updater.test.ts
@@ -302,4 +302,34 @@ describe('updatePackageById — refuse paths', () => {
       await updatePackageById({ packageId: 'pixel' })
     }).toThrow(/does not match installed id/)
   })
+
+  it('refuses an update that removes a currently enabled lesson', async () => {
+    const src = seedAgentPackage({ id: 'pixel', version: '0.1.0' })
+    await installPackage({ source: src })
+
+    const soulPath = join(openClawDir, 'workspaces', 'pixel', 'SOUL.md')
+    const beforeSoul = readFileSync(soulPath, 'utf-8')
+    expect(beforeSoul).toContain('v0.1.0 body.')
+
+    const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))
+    manifest.version = '0.2.0'
+    manifest.contributions.lessons = ['lessons/new-style.md']
+    writeFileSync(join(src, 'bakin-package.json'), JSON.stringify(manifest, null, 2))
+    rmSync(join(src, 'lessons', 'style.md'), { force: true })
+    writeFileSync(
+      join(src, 'lessons', 'new-style.md'),
+      `---\ntitle: New Style\ndefaultEnabled: false\n---\n\nv0.2.0 body.`,
+    )
+
+    expect(async () => {
+      await updatePackageById({ packageId: 'pixel' })
+    }).toThrow(/enabled lesson "style" is not contributed/i)
+
+    const lockAfter = readLockfile()
+    expect(lockAfter.packages.pixel.version).toBe('0.1.0')
+    expect(lockAfter.packages.pixel.lessonsEnabled).toEqual(['style'])
+    const afterSoul = readFileSync(soulPath, 'utf-8')
+    expect(afterSoul).toBe(beforeSoul)
+    expect(afterSoul).not.toContain('v0.2.0 body.')
+  })
 })


### PR DESCRIPTION
## Summary

This closes the next deep-audit gap around agent package lessons: package install/update could previously accept lesson metadata that the runtime could not safely retrieve later. Missing files were logged and skipped, while `lessonsEnabled` could still persist IDs that no longer mapped to a real installed lesson.

Changes:

- Added shared lesson integrity validation for agent packages and lesson-packs.
- Install/update now fail before projection or lockfile writes when lesson state is invalid.
- Projector also validates as a defense-in-depth boundary for direct internal calls.
- Agent updates now reject updated package sources that remove a currently enabled lesson.
- Public docs and `.claude/knowledge/agent-packages.md` now document the hard lesson contract.

## Integrity Rules Added

Lesson contributions must now:

- exist on disk in the staged package source
- be real files, not directories
- live at `lessons/<lesson-id>.md`
- derive a valid unique lesson id from the basename
- contain non-empty body content after optional frontmatter

Agent enabled lesson state must now:

- avoid duplicate IDs
- reference only lessons contributed by the package
- remain valid across update when preserving lockfile `lessonsEnabled`

## Why

This prevents context drift and bloat in the agent-kit layer. An install or update can no longer leave durable state saying a lesson is enabled when the source file is missing, empty, outside the indexed retrieval layout, or no longer contributed by the package.

## Verification

- `bun test tests/agent-packages/installer.test.ts tests/agent-packages/updater.test.ts tests/agent-packages/standalone-packs.test.ts`
- `bun test tests/agent-packages/projector.test.ts tests/agent-packages/lesson-retrieval.test.ts tests/agent-packages/lesson-toggle.test.ts`
- `bun run typecheck`
- `bunx eslint src/core/agent-packages/lesson-integrity.ts src/core/agent-packages/installer.ts src/core/agent-packages/projector.ts src/core/agent-packages/updater.ts tests/agent-packages/installer.test.ts tests/agent-packages/updater.test.ts tests/agent-packages/standalone-packs.test.ts`
- `git diff --check`
- `bun run docs:validate`
- `bun run test` -> 3534 pass, 10 skip, 0 fail
