### PR TITLE
Harden package contribution integrity

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -43,7 +43,7 @@ atomically.
 
 ID rule: `/^[a-z0-9][a-z0-9-_]{0,39}$/i` — same as plugin install. Source rule: `github:user/repo[@ref][#subpath]` or local path (`./` `../` `/` `~/`); bare names refuse with a clear error. GitHub `#subpath` installs stage only the package directory and reject empty, absolute, traversal, dot-segment, multi-`#`, and whitespace subpaths.
 
-Lesson integrity rule: install/update preflights agent and lesson-pack lesson contributions before writing lockfile or projections. Lesson contributions must be real, non-empty Markdown files at `lessons/<lesson-id>.md`, with unique basename-derived ids. Agent `install.enableLessons[]` and update-preserved `lessonsEnabled[]` must reference contributed lesson ids.
+Contribution integrity rule: install/update preflights declared contributions before writing the lockfile or projections. Workspace files, assets, workflows, and workflow skills must be real files inside the package. Skills must be directories with a non-empty `SKILL.md`. Workflow files must be YAML definitions that pass workflow validation, and workflow-skill Markdown must have a non-empty instruction body. Lesson contributions must be real, non-empty Markdown files at `lessons/<lesson-id>.md`, with unique basename-derived ids. Agent `install.enableLessons[]` and update-preserved `lessonsEnabled[]` must reference contributed lesson ids.
 
 ## Lockfile
 

--- a/docs/snippets/agent-package-basic/bakin-package.json
+++ b/docs/snippets/agent-package-basic/bakin-package.json
@@ -44,7 +44,7 @@
       "workspace/TOOLS.md"
     ],
     "skills": [
-      "skills/content-brief.md"
+      "skills/content-brief"
     ],
     "workflows": [
       "workflows/draft-review.yaml"

--- a/docs/src/content/docs/extending/agents/overview.md
+++ b/docs/src/content/docs/extending/agents/overview.md
@@ -18,7 +18,7 @@ Use agent kits when you want a teammate or team capability that can be installed
 | `workspace/IDENTITY.md` | Human-facing identity and role context. |
 | `workspace/TOOLS.md` | Tool usage rules and boundaries. |
 | `workspace/AGENTS.md` | Collaboration and handoff notes when the package needs them. |
-| `skills/*.md` | Reusable procedures the runtime can load as skills. |
+| `skills/<name>/SKILL.md` | Reusable procedures the runtime can load as skills. |
 | `workflows/*.yaml` | Repeatable task flows the agent can run or participate in. |
 | `lessons/*.md` | Toggleable domain lessons. |
 

--- a/docs/src/content/docs/extending/agents/packages.md
+++ b/docs/src/content/docs/extending/agents/packages.md
@@ -57,7 +57,7 @@ Source: `docs/snippets/agent-package-basic/bakin-package.json`
       "workspace/TOOLS.md"
     ],
     "skills": [
-      "skills/content-brief.md"
+      "skills/content-brief"
     ],
     "workflows": [
       "workflows/draft-review.yaml"
@@ -138,7 +138,9 @@ Agent packages can contribute:
 
 `skill-pack` packages must contribute at least one skill. `workflow-pack` packages must contribute at least one workflow or workflow skill. `lesson-pack` packages must contribute at least one lesson file.
 
-Lesson contributions are preflighted during install and update. Each lesson must be a real, non-empty Markdown file at `lessons/<lesson-id>.md`; the basename is the lesson ID. `enableLessons` can only name lessons contributed by the package.
+Declared contributions are preflighted during install and update before Bakin writes the lockfile or projects files. Workspace files, assets, workflows, and workflow skills must point at real files inside the package. Skills must point at directories with a non-empty `SKILL.md`. Workflows must be valid YAML workflow definitions, and workflow skills must be Markdown files with a non-empty instruction body.
+
+Lesson files must be real, non-empty Markdown files at `lessons/<lesson-id>.md`; the basename is the lesson ID. `enableLessons` can only name lessons contributed by the package.
 
 ## Install Commands
 

--- a/docs/src/content/docs/extending/ingredients.md
+++ b/docs/src/content/docs/extending/ingredients.md
@@ -87,7 +87,7 @@ Use skills when instructions should be reusable and task-sized. If the same proc
 
 Skills can belong to plugins or agent kits. Put a skill in a plugin when it belongs to a plugin-owned capability. Put it in an agent kit when it travels with a teammate or reusable team package.
 
-Plugin skills are registered with `ctx.registerSkill()`. Agent kit skills live under `contributions.skills` in `bakin-package.json` and can be listed in `agent.allowedSkills`.
+Plugin skills are registered with `ctx.registerSkill()`. Agent kit skills live under `contributions.skills` in `bakin-package.json`, where each contribution points at a skill directory containing `SKILL.md`. They can be listed in `agent.allowedSkills`.
 
 Start with [Server Contracts](/docs/extending/plugins/server-contracts/) or [Package Manifest](/docs/extending/agents/packages/).
 
@@ -174,7 +174,7 @@ Agent kits use `bakin-package.json`. The manifest declares package kind, agent i
   },
   "contributions": {
     "workspaceFiles": ["workspace/SOUL.md", "workspace/TOOLS.md"],
-    "skills": ["skills/launch-review.md"],
+    "skills": ["skills/launch-review"],
     "workflows": ["workflows/launch.yaml"],
     "lessons": ["lessons/voice.md"]
   }

--- a/src/core/agent-packages/installer.ts
+++ b/src/core/agent-packages/installer.ts
@@ -68,7 +68,7 @@ import {
 import { getAppServices } from '../app-services'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { validatePackageLessonIntegrity } from './lesson-integrity'
+import { validatePackageContributionIntegrity } from './package-integrity'
 
 const log = createLogger('agent-pkg:install')
 
@@ -294,7 +294,7 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
     }
 
     const resolvedTopId = options.installAs ?? manifest.id
-    validatePackageLessonIntegrity({
+    validatePackageContributionIntegrity({
       manifest,
       stagingDir: topFetched.stagingDir,
     })
@@ -354,7 +354,7 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
     const resolved = resolveDependencies(manifest)
     for (const r of resolved) depFetched.push(r.fetched)
     for (const r of resolved) {
-      validatePackageLessonIntegrity({
+      validatePackageContributionIntegrity({
         manifest: r.manifest,
         stagingDir: r.fetched.stagingDir,
       })

--- a/src/core/agent-packages/package-integrity.ts
+++ b/src/core/agent-packages/package-integrity.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync, statSync } from 'fs'
+import { basename, isAbsolute, normalize, relative, resolve } from 'path'
+import yaml from 'js-yaml'
+import type { Manifest } from '../../../packages/core/src/agent-packages/manifest'
+import type { WorkflowDefinition } from '../../../plugins/workflows/types'
+import { validateDefinition } from '../../../plugins/workflows/lib/parser'
+import { validatePackageLessonIntegrity } from './lesson-integrity'
+
+export interface PackageIntegrityOptions {
+  manifest: Manifest
+  stagingDir: string
+  enabledLessons?: string[]
+}
+
+export function validatePackageContributionIntegrity(options: PackageIntegrityOptions): void {
+  validatePackageLessonIntegrity(options)
+
+  const { manifest, stagingDir } = options
+  switch (manifest.kind) {
+    case 'agent':
+      validateFiles(stagingDir, manifest.contributions.workspaceFiles ?? [], 'workspace file', 'source')
+      validateSkillDirectories(stagingDir, manifest.contributions.skills ?? [])
+      validateWorkflowFiles(stagingDir, manifest.id, manifest.contributions.workflows ?? [])
+      validateWorkflowSkillFiles(stagingDir, manifest.contributions.workflowSkills ?? [])
+      validateFiles(stagingDir, manifest.contributions.assets ?? [], 'asset')
+      break
+    case 'skill-pack':
+      validateSkillDirectories(stagingDir, manifest.contributions.skills)
+      validateFiles(stagingDir, manifest.contributions.assets ?? [], 'asset')
+      break
+    case 'workflow-pack':
+      validateWorkflowFiles(stagingDir, manifest.id, manifest.contributions.workflows ?? [])
+      validateWorkflowSkillFiles(stagingDir, manifest.contributions.workflowSkills ?? [])
+      validateFiles(stagingDir, manifest.contributions.assets ?? [], 'asset')
+      break
+    case 'lesson-pack':
+      validateFiles(stagingDir, manifest.contributions.assets ?? [], 'asset')
+      break
+  }
+}
+
+function validateFiles(stagingDir: string, rels: string[], label: string, sourceLabel = 'source file'): void {
+  for (const rel of rels) {
+    const abs = resolvePackagePath(stagingDir, rel)
+    if (!existsSync(abs)) {
+      throw new Error(`${label} ${sourceLabel} is missing: ${rel}`)
+    }
+    if (!statSync(abs).isFile()) {
+      throw new Error(`${label} source path is not a file: ${rel}`)
+    }
+  }
+}
+
+function validateSkillDirectories(stagingDir: string, rels: string[]): void {
+  for (const rel of rels) {
+    const abs = resolvePackagePath(stagingDir, rel)
+    if (!existsSync(abs)) {
+      throw new Error(`Skill source directory is missing: ${rel}`)
+    }
+    if (!statSync(abs).isDirectory()) {
+      throw new Error(`Skill source path is not a directory: ${rel}`)
+    }
+
+    const skillPath = resolve(abs, 'SKILL.md')
+    if (!existsSync(skillPath)) {
+      throw new Error(`SKILL.md is missing for skill source directory: ${rel}`)
+    }
+    if (!statSync(skillPath).isFile()) {
+      throw new Error(`SKILL.md is not a file for skill source directory: ${rel}`)
+    }
+    if (!readFileSync(skillPath, 'utf-8').trim()) {
+      throw new Error(`SKILL.md is empty for skill source directory: ${rel}`)
+    }
+  }
+}
+
+function validateWorkflowFiles(stagingDir: string, packageId: string, rels: string[]): void {
+  const parsed: Array<{ id: string; rel: string; definition: WorkflowDefinition }> = []
+  for (const rel of rels) {
+    if (!/\.(yaml|yml)$/i.test(rel)) {
+      throw new Error(`Workflow source file must be YAML: ${rel}`)
+    }
+    const abs = resolvePackagePath(stagingDir, rel)
+    if (!existsSync(abs)) {
+      throw new Error(`Workflow source file is missing: ${rel}`)
+    }
+    if (!statSync(abs).isFile()) {
+      throw new Error(`Workflow source path is not a file: ${rel}`)
+    }
+
+    let definition: WorkflowDefinition
+    try {
+      definition = yaml.load(readFileSync(abs, 'utf-8')) as WorkflowDefinition
+    } catch (err) {
+      throw new Error(
+        `Workflow source file is invalid: ${rel}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+    if (!definition || typeof definition !== 'object') {
+      throw new Error(`Workflow source file is invalid: ${rel}: expected a workflow object`)
+    }
+    parsed.push({
+      id: deriveWorkflowId(definition, basename(rel).replace(/\.(yaml|yml)$/i, '')),
+      rel,
+      definition,
+    })
+  }
+
+  const knownWorkflowIds = new Set(parsed.map((entry) => entry.id))
+  for (const { id, rel, definition } of parsed) {
+    const errors = validateDefinition(definition, {
+      definitionId: id,
+      source: 'agent-package',
+      knownWorkflowIds,
+    })
+    if (errors.length > 0) {
+      throw new Error(`Workflow source file is invalid: ${rel}: ${errors.join('; ')}`)
+    }
+  }
+
+  const seen = new Map<string, string>()
+  for (const { id, rel } of parsed) {
+    const existing = seen.get(id)
+    if (existing) {
+      throw new Error(`Duplicate workflow id "${id}" in package "${packageId}": ${existing} and ${rel}`)
+    }
+    seen.set(id, rel)
+  }
+}
+
+function validateWorkflowSkillFiles(stagingDir: string, rels: string[]): void {
+  for (const rel of rels) {
+    if (!/\.md$/i.test(rel)) {
+      throw new Error(`Workflow-skill source file must be Markdown: ${rel}`)
+    }
+    const abs = resolvePackagePath(stagingDir, rel)
+    if (!existsSync(abs)) {
+      throw new Error(`Workflow-skill source file is missing: ${rel}`)
+    }
+    if (!statSync(abs).isFile()) {
+      throw new Error(`Workflow-skill source path is not a file: ${rel}`)
+    }
+
+    const body = extractMarkdownBody(readFileSync(abs, 'utf-8'))
+    if (!body.trim()) {
+      throw new Error(`Workflow-skill source file is empty: ${rel}`)
+    }
+  }
+}
+
+function resolvePackagePath(stagingDir: string, rel: string): string {
+  const normalizedRel = normalizePackageRel(rel)
+  const abs = resolve(stagingDir, normalizedRel)
+  if (!isPathInside(stagingDir, abs)) {
+    throw new Error(`Contribution source path escapes the package root: ${rel}`)
+  }
+  return abs
+}
+
+function normalizePackageRel(rel: string): string {
+  if (isAbsolute(rel)) {
+    throw new Error(`Contribution source path escapes the package root: ${rel}`)
+  }
+  const normalized = normalize(rel).replaceAll('\\', '/')
+  const segments = normalized.split('/')
+  if (
+    normalized === '.' ||
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    segments.some((segment) => segment === '.' || segment === '..')
+  ) {
+    throw new Error(`Contribution source path escapes the package root: ${rel}`)
+  }
+  return normalized
+}
+
+function isPathInside(root: string, target: string): boolean {
+  const rel = relative(resolve(root), target)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+function extractMarkdownBody(raw: string): string {
+  const normalized = raw.replace(/\r\n/g, '\n')
+  const match = normalized.match(/^---\n[\s\S]*?\n---\n?([\s\S]*)$/)
+  return match ? match[1].trim() : normalized.trim()
+}
+
+function deriveWorkflowId(definition: WorkflowDefinition, fallbackBase: string): string {
+  if (typeof definition.id === 'string' && definition.id.length > 0) return definition.id
+  if (typeof definition.name === 'string' && definition.name.length > 0) {
+    return definition.name
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/[\s_]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 60)
+      .replace(/-$/, '')
+  }
+  return fallbackBase
+}

--- a/src/core/agent-packages/projector.ts
+++ b/src/core/agent-packages/projector.ts
@@ -53,7 +53,7 @@ import {
   injectBlock,
   removeBlock,
 } from '../../../packages/core/src/agent-packages/managed-blocks'
-import { validatePackageLessonIntegrity } from './lesson-integrity'
+import { validatePackageContributionIntegrity } from './package-integrity'
 
 const log = createLogger('agent-pkg:project')
 
@@ -624,7 +624,7 @@ async function projectLessonMarkers(
  * re-throwing so the install state matches what was on disk before.
  */
 export async function projectPackage(options: ProjectorOptions): Promise<ProjectorResult> {
-  validatePackageLessonIntegrity({
+  validatePackageContributionIntegrity({
     manifest: options.manifest,
     stagingDir: options.stagingDir,
     enabledLessons: options.enabledLessons,

--- a/src/core/agent-packages/updater.ts
+++ b/src/core/agent-packages/updater.ts
@@ -33,7 +33,7 @@ import {
   acquireInstallLock,
   releaseInstallLock,
 } from './install-lock'
-import { validatePackageLessonIntegrity } from './lesson-integrity'
+import { validatePackageContributionIntegrity } from './package-integrity'
 
 const log = createLogger('agent-pkg:update')
 
@@ -109,7 +109,7 @@ export async function updatePackageById(options: UpdateOptions): Promise<UpdateR
       )
     }
 
-    validatePackageLessonIntegrity({
+    validatePackageContributionIntegrity({
       manifest,
       stagingDir: fetched.stagingDir,
       enabledLessons: entry.kind === 'agent' ? entry.lessonsEnabled ?? [] : undefined,

--- a/tests/agent-packages/installer.test.ts
+++ b/tests/agent-packages/installer.test.ts
@@ -463,6 +463,56 @@ describe('installPackage — refuse paths', () => {
     expect(adapterCalls.addAgent).toHaveLength(0)
   })
 
+  it('refuses an agent package when a declared workspace file is missing', async () => {
+    const src = seedAgentPackage()
+    rmSync(join(src, 'workspace', 'SOUL.md'), { force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/workspace file source is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
+  it('refuses an agent package when a declared skill directory is missing', async () => {
+    const src = seedAgentPackage()
+    rmSync(join(src, 'skills', 'image-gen'), { recursive: true, force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/skill source directory is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
+  it('refuses an agent package when a declared asset file is missing', async () => {
+    const src = seedAgentPackage()
+    rmSync(join(src, 'assets', 'avatar.jpg'), { force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/asset source file is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
+  it('refuses an agent package when a contribution path escapes the package root', async () => {
+    const src = seedAgentPackage()
+    const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))
+    manifest.contributions.assets = ['../avatar.jpg']
+    writeFileSync(join(src, 'bakin-package.json'), JSON.stringify(manifest, null, 2))
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/escapes the package root/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(adapterCalls.addAgent).toHaveLength(0)
+  })
+
   it('refuses an agent package when install.enableLessons references an undeclared lesson', async () => {
     const src = seedAgentPackage()
     const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))

--- a/tests/agent-packages/standalone-packs.test.ts
+++ b/tests/agent-packages/standalone-packs.test.ts
@@ -140,6 +140,28 @@ describe('installPackage — kind:"skill-pack"', () => {
       await installPackage({ source: src })
     }).toThrow()
   })
+
+  it('refuses a skill-pack when a declared skill directory is missing', async () => {
+    const src = seedSkillPack('visual-skills')
+    rmSync(join(src, 'skills', 'image-gen'), { recursive: true, force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/skill source directory is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+  })
+
+  it('refuses a skill-pack when SKILL.md is missing', async () => {
+    const src = seedSkillPack('visual-skills')
+    rmSync(join(src, 'skills', 'image-gen', 'SKILL.md'), { force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/SKILL\.md is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+  })
 })
 
 // ─── workflow-pack ───────────────────────────────────────────────────────────
@@ -214,6 +236,42 @@ describe('installPackage — kind:"workflow-pack"', () => {
     const def = getDefinition('image-flow')
     expect(def?.source).toBe('agent-package')
     expect(def?.packageId).toBe('creative-flows')
+  })
+
+  it('refuses a workflow-pack when a declared workflow file is missing', async () => {
+    const src = seedWorkflowPack('creative-flows')
+    rmSync(join(src, 'workflows', 'image-flow.yaml'), { force: true })
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/workflow source file is missing/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+  })
+
+  it('refuses a workflow-pack when a declared workflow is invalid', async () => {
+    const src = seedWorkflowPack('creative-flows')
+    writeFileSync(join(src, 'workflows', 'image-flow.yaml'), 'bad: yaml: : :: invalid')
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/workflow source file is invalid/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+  })
+
+  it('refuses a workflow-pack when a declared workflow skill has no body content', async () => {
+    const src = seedWorkflowPack('creative-flows')
+    writeFileSync(
+      join(src, 'workflow-skills', 'critique.md'),
+      `---\nname: Critique\n---\n\n`,
+    )
+
+    expect(async () => {
+      await installPackage({ source: src })
+    }).toThrow(/workflow-skill source file is empty/i)
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
   })
 })
 

--- a/tests/agent-packages/updater.test.ts
+++ b/tests/agent-packages/updater.test.ts
@@ -332,4 +332,25 @@ describe('updatePackageById — refuse paths', () => {
     expect(afterSoul).toBe(beforeSoul)
     expect(afterSoul).not.toContain('v0.2.0 body.')
   })
+
+  it('refuses an update with a missing declared asset before mutating installed state', async () => {
+    const src = seedAgentPackage({ id: 'pixel', version: '0.1.0' })
+    await installPackage({ source: src })
+
+    const soulPath = join(openClawDir, 'workspaces', 'pixel', 'SOUL.md')
+    const beforeSoul = readFileSync(soulPath, 'utf-8')
+
+    const manifest = JSON.parse(readFileSync(join(src, 'bakin-package.json'), 'utf-8'))
+    manifest.version = '0.2.0'
+    manifest.contributions.assets = ['assets/missing-avatar.jpg']
+    writeFileSync(join(src, 'bakin-package.json'), JSON.stringify(manifest, null, 2))
+
+    expect(async () => {
+      await updatePackageById({ packageId: 'pixel' })
+    }).toThrow(/asset source file is missing/i)
+
+    const lockAfter = readLockfile()
+    expect(lockAfter.packages.pixel.version).toBe('0.1.0')
+    expect(readFileSync(soulPath, 'utf-8')).toBe(beforeSoul)
+  })
 })


### PR DESCRIPTION
## Summary

This is the next deep-audit fix for agent-package integrity. It expands the prior lesson-only preflight into a full declared-contribution preflight before install/update/projector writes durable state.

Changes:
- Add `validatePackageContributionIntegrity()` for package contribution checks.
- Run contribution integrity validation from install, dependency install, update, and direct projection.
- Preserve the existing lesson rules and add validation for:
  - workspace file sources
  - skill source directories and non-empty `SKILL.md`
  - workflow YAML source files
  - workflow-skill Markdown bodies
  - asset source files
  - contribution paths escaping the package root
- Validate workflow definitions with the existing workflow parser before package state is written.
- Update package docs and examples so agent-kit skills are documented as directories containing `SKILL.md`, not single Markdown files.

## Why

The audit found that several declared contribution types still had skip-or-warn behavior during projection/loading. That could make an install or update appear successful while a declared package capability was missing.

Boot-time source loading remains tolerant so a damaged local install cannot take down startup. Install/update/projection now fail loud before committing package state.

## Testing

- `bun test tests/agent-packages/installer.test.ts tests/agent-packages/updater.test.ts tests/agent-packages/standalone-packs.test.ts`
- `bun test tests/agent-packages/projector.test.ts tests/agent-packages/load-sources.test.ts`
- `bun run typecheck`
- `bun run docs:validate`
- `bunx eslint src/core/agent-packages/package-integrity.ts src/core/agent-packages/lesson-integrity.ts src/core/agent-packages/installer.ts src/core/agent-packages/projector.ts src/core/agent-packages/updater.ts tests/agent-packages/installer.test.ts tests/agent-packages/updater.test.ts tests/agent-packages/standalone-packs.test.ts`
- `git diff --check`
- `bun run test` — 3544 pass, 10 skip, 0 fail
