### PR TITLE
Align docs SEO and analytics with website

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,8 +3,6 @@ import starlight from '@astrojs/starlight'
 import react from '@astrojs/react'
 import rehypeExternalLinks from 'rehype-external-links'
 
-const gtmId = process.env.PUBLIC_GTM_ID ?? 'GTM-KZQK989V'
-
 export default defineConfig({
   site: 'https://makinbakin.com',
   base: '/docs',
@@ -32,6 +30,8 @@ export default defineConfig({
       },
       customCss: ['./src/styles/docs.css'],
       components: {
+        Head: './src/components/Head.astro',
+        SkipLink: './src/components/SkipLink.astro',
         Header: './src/components/Header.astro',
         PageTitle: './src/components/PageTitle.astro',
         PageSidebar: './src/components/PageSidebar.astro',
@@ -68,118 +68,6 @@ export default defineConfig({
 })();
           `,
         },
-        ...(gtmId
-          ? [
-              {
-                tag: 'script',
-                content: `
-window.dataLayer = window.dataLayer || [];
-window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
-(function () {
-  var COOKIE_NAME = "bakin_consent";
-  var SCHEMA_VERSION = 1;
-  function readStoredConsent() {
-    var match = document.cookie.split("; ").find(function (row) {
-      return row.indexOf(COOKIE_NAME + "=") === 0;
-    });
-    if (!match) return null;
-    try {
-      var raw = decodeURIComponent(match.slice(COOKIE_NAME.length + 1));
-      var parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== "object") return null;
-      if (parsed.v !== SCHEMA_VERSION) return null;
-      if (parsed.a !== "g" && parsed.a !== "d") return null;
-      if (parsed.d !== "g" && parsed.d !== "d") return null;
-      return {
-        analytics_storage: parsed.a === "g" ? "granted" : "denied",
-        ad_storage: parsed.d === "g" ? "granted" : "denied"
-      };
-    } catch (e) {
-      return null;
-    }
-  }
-  window.gtag("consent", "default", {
-    analytics_storage: "granted",
-    ad_storage: "granted",
-    ad_user_data: "granted",
-    ad_personalization: "granted",
-    wait_for_update: 500
-  });
-  var stored = readStoredConsent();
-  if (stored) {
-    window.gtag("consent", "update", {
-      analytics_storage: stored.analytics_storage,
-      ad_storage: stored.ad_storage,
-      ad_user_data: stored.ad_storage,
-      ad_personalization: stored.ad_storage
-    });
-    window.dataLayer.push({
-      event: "consent_update",
-      analytics_storage: stored.analytics_storage,
-      ad_storage: stored.ad_storage,
-      source: "restore"
-    });
-  } else {
-    window.dataLayer.push({
-      event: "consent_update",
-      analytics_storage: "granted",
-      ad_storage: "granted",
-      source: "default"
-    });
-  }
-})();
-`,
-            },
-            {
-              tag: 'script',
-              attrs: {
-                async: true,
-                src: `https://www.googletagmanager.com/gtm.js?id=${gtmId}`,
-              },
-            },
-            {
-              tag: 'script',
-              content: `
-window.dataLayer = window.dataLayer || [];
-window.dataLayer.push({
-  event: "gtm_boot",
-  page_path: window.location.pathname,
-  page_title: document.title
-});
-window.dataLayer.push({
-  event: "page_view_custom",
-  page_path: window.location.pathname,
-  page_title: document.title,
-  page_location: window.location.href
-});
-document.addEventListener("click", function (event) {
-  var target = event.target instanceof Element ? event.target.closest("[data-cta], a[href]") : null;
-  if (!target) return;
-  var cta = target.getAttribute("data-cta");
-  var href = target instanceof HTMLAnchorElement ? target.href : target.getAttribute("href");
-  var label = target.textContent ? target.textContent.trim() : "";
-  var outbound = href ? /^https?:\\/\\//.test(href) && href.indexOf(window.location.host) === -1 : false;
-  if (cta) {
-    window.dataLayer.push({
-      event: "cta_click",
-      cta_name: cta,
-      cta_label: label,
-      page_path: window.location.pathname
-    });
-  }
-  if (outbound) {
-    window.dataLayer.push({
-      event: "outbound_click",
-      outbound_url: href,
-      link_label: label,
-      page_path: window.location.pathname
-    });
-  }
-});
-`,
-              },
-            ]
-          : []),
       ],
       defaultLocale: 'root',
       editLink: {

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -15,16 +15,19 @@ Primary docs:
 - Daily Operation: https://makinbakin.com/docs/start/operation/
   Use this for lifecycle commands, health checks, updates, and runtime operation.
 
-- Core workflows: https://makinbakin.com/docs/core/tasks/
-  Use this for built-in Bakin areas such as tasks, workflows, assets, schedule, memory, models, team, and health. Official add-on plugins such as Messaging and Projects are installed separately but documented in the same site.
+- Essentials: https://makinbakin.com/docs/using/essentials/
+  Use this for the core Bakin areas and the quickest map of day-to-day product concepts.
 
-- Plugin authoring: https://makinbakin.com/docs/extend/plugins/overview/
+- Tasks: https://makinbakin.com/docs/using/tasks/
+  Use this for the task model, task lifecycle, approvals, output, and agent execution flow.
+
+- Plugin authoring: https://makinbakin.com/docs/extending/plugins/overview/
   Use this when building Bakin plugins with @makinbakin/sdk.
 
-- Agent authoring: https://makinbakin.com/docs/extend/agents/overview/
+- Agent authoring: https://makinbakin.com/docs/extending/agents/overview/
   Use this when creating agent packages or writing instructions for coding agents working with Bakin.
 
-- SDK docs: https://makinbakin.com/docs/extend/sdk/overview/
+- SDK docs: https://makinbakin.com/docs/extending/sdk/overview/
   Use this for @makinbakin/sdk imports, UI components, hooks, slots, and public extension contracts.
 
 LLM bundles:

--- a/docs/public/llms/exec-tools.md
+++ b/docs/public/llms/exec-tools.md
@@ -972,9 +972,11 @@ mcporter call bakin-<agent>.bakin_exec_post_channel --args '{
 }'
 ```
 
-## Projects
+## Project
 
-### bakin_exec_projects_add_item
+Project tools let agents create, update, read, and maintain project specs and linked checklist items.
+
+### bakin_exec_project_add_item
 
 Label: Added project item
 Purpose: Add a new checklist item to a project.
@@ -987,13 +989,13 @@ Purpose: Add a new checklist item to a project.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_add_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_add_item --args '{
   "projectId": "value",
   "title": "value"
 }'
 ```
 
-### bakin_exec_projects_ask
+### bakin_exec_project_ask
 
 Label: Asked project question
 Purpose: Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming.
@@ -1007,14 +1009,14 @@ Purpose: Ask an agent a question about a project. Sends the project context (spe
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_ask --args '{
+mcporter call bakin-<agent>.bakin_exec_project_ask --args '{
   "projectId": "value",
   "message": "value",
   "agent": "value"
 }'
 ```
 
-### bakin_exec_projects_attach_asset
+### bakin_exec_project_attach_asset
 
 Label: Attached asset to project
 Purpose: Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed.
@@ -1028,14 +1030,14 @@ Purpose: Attach an existing asset to a project by filename. Assets provide addit
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_attach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_project_attach_asset --args '{
   "projectId": "value",
   "filename": "value",
   "label": "value"
 }'
 ```
 
-### bakin_exec_projects_create
+### bakin_exec_project_create
 
 Label: Created a project
 Purpose: Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs.
@@ -1050,7 +1052,7 @@ Purpose: Create a new project with title, markdown body, and optional initial ch
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_create --args '{
+mcporter call bakin-<agent>.bakin_exec_project_create --args '{
   "title": "value",
   "body": "value",
   "owner": "value",
@@ -1060,7 +1062,7 @@ mcporter call bakin-<agent>.bakin_exec_projects_create --args '{
 }'
 ```
 
-### bakin_exec_projects_delete
+### bakin_exec_project_delete
 
 Label: Deleted a project
 Purpose: Delete a project by ID.
@@ -1072,12 +1074,12 @@ Purpose: Delete a project by ID.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_delete --args '{
+mcporter call bakin-<agent>.bakin_exec_project_delete --args '{
   "projectId": "value"
 }'
 ```
 
-### bakin_exec_projects_detach_asset
+### bakin_exec_project_detach_asset
 
 Label: Detached asset from project
 Purpose: Remove an asset reference from a project by filename. Does not delete the asset itself.
@@ -1090,13 +1092,13 @@ Purpose: Remove an asset reference from a project by filename. Does not delete t
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_detach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_project_detach_asset --args '{
   "projectId": "value",
   "filename": "value"
 }'
 ```
 
-### bakin_exec_projects_get
+### bakin_exec_project_get
 
 Label: Read project details
 Purpose: Get a project by ID including full spec, checklist, progress, and linked board task statuses.
@@ -1108,12 +1110,12 @@ Purpose: Get a project by ID including full spec, checklist, progress, and linke
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_get --args '{
+mcporter call bakin-<agent>.bakin_exec_project_get --args '{
   "projectId": "value"
 }'
 ```
 
-### bakin_exec_projects_link_item
+### bakin_exec_project_link_item
 
 Label: Linked project item
 Purpose: Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project.
@@ -1127,14 +1129,14 @@ Purpose: Link an existing board task to a project checklist item. Use this when 
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_link_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_link_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "taskId": "value"
 }'
 ```
 
-### bakin_exec_projects_list
+### bakin_exec_project_list
 
 Label: Listed projects
 Purpose: List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount.
@@ -1146,12 +1148,12 @@ Purpose: List all projects with optional status filter. Returns summaries with i
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_list --args '{
+mcporter call bakin-<agent>.bakin_exec_project_list --args '{
   "status": "value"
 }'
 ```
 
-### bakin_exec_projects_mark_item
+### bakin_exec_project_mark_item
 
 Label: Marked project item
 Purpose: Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage.
@@ -1165,14 +1167,14 @@ Purpose: Mark a checklist item as checked (done) or unchecked. Returns updated p
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_mark_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_mark_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "checked": true
 }'
 ```
 
-### bakin_exec_projects_promote_item
+### bakin_exec_project_promote_item
 
 Label: Promoted project item
 Purpose: Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set.
@@ -1186,14 +1188,14 @@ Purpose: Create a NEW board task from a project checklist item and automatically
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_promote_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_promote_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "assignee": "value"
 }'
 ```
 
-### bakin_exec_projects_remove_item
+### bakin_exec_project_remove_item
 
 Label: Removed project item
 Purpose: Remove a checklist item from a project.
@@ -1206,13 +1208,13 @@ Purpose: Remove a checklist item from a project.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_remove_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_remove_item --args '{
   "projectId": "value",
   "taskItemId": "value"
 }'
 ```
 
-### bakin_exec_projects_toggle_item
+### bakin_exec_project_toggle_item
 
 Label: Toggled project item
 Purpose: Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage.
@@ -1226,14 +1228,14 @@ Purpose: Toggle a checklist item checked/unchecked by item ID. Returns updated p
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_toggle_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_toggle_item --args '{
   "projectId": "value",
   "itemId": "value",
   "checked": true
 }'
 ```
 
-### bakin_exec_projects_update
+### bakin_exec_project_update
 
 Label: Updated a project
 Purpose: Update a project's title, status, body, or owner. Cannot set status to "completed" if unchecked items remain.
@@ -1249,7 +1251,7 @@ Purpose: Update a project's title, status, body, or owner. Cannot set status to 
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_update --args '{
+mcporter call bakin-<agent>.bakin_exec_project_update --args '{
   "projectId": "value",
   "title": "value",
   "status": "value",
@@ -1258,7 +1260,7 @@ mcporter call bakin-<agent>.bakin_exec_projects_update --args '{
 }'
 ```
 
-### bakin_exec_projects_update_item
+### bakin_exec_project_update_item
 
 Label: Updated project item
 Purpose: Update a checklist item's title and/or description.
@@ -1273,7 +1275,7 @@ Purpose: Update a checklist item's title and/or description.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_projects_update_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_update_item --args '{
   "projectId": "value",
   "itemId": "value",
   "title": "value",

--- a/docs/src/components/Analytics.astro
+++ b/docs/src/components/Analytics.astro
@@ -1,0 +1,154 @@
+---
+const gtmId = import.meta.env.PUBLIC_GTM_ID;
+---
+
+{
+  gtmId && (
+    <>
+      <noscript>
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+          height="0"
+          width="0"
+          style="display:none;visibility:hidden"
+          title="Google Tag Manager"
+        />
+      </noscript>
+      {/* Consent default must precede the GTM bootstrap so GA tags honor the signaled state from the first page view. Do not reorder. Default is granted (opt-out model); a stored reject flips it via consent update. */}
+      <script is:inline>
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+
+        (function () {
+          var COOKIE_NAME = "bakin_consent";
+          var SCHEMA_VERSION = 1;
+
+          function readStoredConsent() {
+            var match = document.cookie.split("; ").find(function (row) {
+              return row.indexOf(COOKIE_NAME + "=") === 0;
+            });
+            if (!match) return null;
+            try {
+              var raw = decodeURIComponent(match.slice(COOKIE_NAME.length + 1));
+              var parsed = JSON.parse(raw);
+              if (!parsed || typeof parsed !== "object") return null;
+              if (parsed.v !== SCHEMA_VERSION) return null;
+              if (parsed.a !== "g" && parsed.a !== "d") return null;
+              if (parsed.d !== "g" && parsed.d !== "d") return null;
+              return {
+                analytics_storage: parsed.a === "g" ? "granted" : "denied",
+                ad_storage: parsed.d === "g" ? "granted" : "denied"
+              };
+            } catch (e) {
+              return null;
+            }
+          }
+
+          window.gtag("consent", "default", {
+            analytics_storage: "granted",
+            ad_storage: "granted",
+            ad_user_data: "granted",
+            ad_personalization: "granted",
+            wait_for_update: 500
+          });
+
+          var stored = readStoredConsent();
+          if (stored) {
+            window.gtag("consent", "update", {
+              analytics_storage: stored.analytics_storage,
+              ad_storage: stored.ad_storage,
+              ad_user_data: stored.ad_storage,
+              ad_personalization: stored.ad_storage
+            });
+            window.dataLayer.push({
+              event: "consent_update",
+              analytics_storage: stored.analytics_storage,
+              ad_storage: stored.ad_storage,
+              source: "restore"
+            });
+          } else {
+            window.dataLayer.push({
+              event: "consent_update",
+              analytics_storage: "granted",
+              ad_storage: "granted",
+              source: "default"
+            });
+          }
+        })();
+      </script>
+      <script is:inline define:vars={{ gtmId }}>
+        window.dataLayer.push({
+          event: "gtm_boot",
+          page_path: window.location.pathname,
+          page_title: document.title
+        });
+        (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!=="dataLayer"?"&l="+l:"";j.async=true;j.src="https://www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer",gtmId);
+      </script>
+      <script is:inline>
+        (function () {
+          var pushedScrollDepths = new Set();
+
+          var pushEvent = function (payload) {
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push(payload);
+          };
+
+          pushEvent({
+            event: "page_view_custom",
+            page_path: window.location.pathname,
+            page_title: document.title,
+            page_location: window.location.href
+          });
+
+          var trackClick = function (event) {
+            var target = event.target instanceof Element ? event.target.closest("[data-cta], a[href]") : null;
+            if (!target) return;
+
+            var cta = target.getAttribute("data-cta");
+            var href = target instanceof HTMLAnchorElement ? target.href : target.getAttribute("href");
+            var label = target.textContent ? target.textContent.trim() : "";
+            var isOutbound = href ? /^https?:\/\//.test(href) && href.indexOf(window.location.host) === -1 : false;
+
+            if (cta) {
+              pushEvent({
+                event: "cta_click",
+                cta_name: cta,
+                cta_label: label,
+                page_path: window.location.pathname
+              });
+            }
+
+            if (isOutbound) {
+              pushEvent({
+                event: "outbound_click",
+                outbound_url: href,
+                link_label: label,
+                page_path: window.location.pathname
+              });
+            }
+          };
+
+          var trackScrollDepth = function () {
+            var doc = document.documentElement;
+            var scrollable = doc.scrollHeight - window.innerHeight;
+            if (scrollable <= 0) return;
+            var percent = Math.round((window.scrollY / scrollable) * 100);
+            [25, 50, 75, 100].forEach(function (depth) {
+              if (percent >= depth && !pushedScrollDepths.has(depth)) {
+                pushedScrollDepths.add(depth);
+                pushEvent({
+                  event: "scroll_depth",
+                  scroll_depth: depth,
+                  page_path: window.location.pathname
+                });
+              }
+            });
+          };
+
+          document.addEventListener("click", trackClick, { passive: true });
+          window.addEventListener("scroll", trackScrollDepth, { passive: true });
+        })();
+      </script>
+    </>
+  )
+}

--- a/docs/src/components/ConsentBanner.astro
+++ b/docs/src/components/ConsentBanner.astro
@@ -2,90 +2,45 @@
 ---
 
 <div
-  class="docs-consent"
+  class="consent-banner"
   data-consent-banner
   role="dialog"
   aria-modal="false"
-  aria-labelledby="docs-consent-title"
-  aria-describedby="docs-consent-copy"
+  aria-labelledby="consent-banner-title"
+  aria-describedby="consent-banner-copy"
   hidden
 >
-  <p id="docs-consent-title" class="docs-consent__title">Cookies &amp; such</p>
-  <p id="docs-consent-copy" class="docs-consent__copy">
+  <p id="consent-banner-title" class="consent-banner__title">Cookies &amp; such</p>
+  <p id="consent-banner-copy" class="consent-banner__copy">
     We use analytics to see what's landing. No ads, no cross-site tracking. Your call.
   </p>
-  <div class="docs-consent__actions">
-    <button type="button" class="docs-consent__button docs-consent__button--primary" data-consent-action="accept" data-cta="consent_accept">
+  <div class="consent-banner__actions">
+    <button
+      type="button"
+      class="consent-banner__button consent-banner__button--primary"
+      data-consent-action="accept"
+      data-cta="consent_accept"
+    >
       Accept
     </button>
-    <button type="button" class="docs-consent__button docs-consent__button--ghost" data-consent-action="reject" data-cta="consent_reject">
+    <button
+      type="button"
+      class="consent-banner__button consent-banner__button--ghost"
+      data-consent-action="reject"
+      data-cta="consent_reject"
+    >
       Reject
     </button>
   </div>
 </div>
 
 <script>
-  const COOKIE_NAME = "bakin_consent";
-  const MAX_AGE_SECONDS = 15552000;
-  const SCHEMA_VERSION = 1;
-
-  const readConsent = () => {
-    const match = document.cookie.split("; ").find((row) => row.startsWith(`${COOKIE_NAME}=`));
-    if (!match) return null;
-    try {
-      const parsed = JSON.parse(decodeURIComponent(match.slice(COOKIE_NAME.length + 1)));
-      if (!parsed || typeof parsed !== "object") return null;
-      if (parsed.v !== SCHEMA_VERSION) return null;
-      if (parsed.a !== "g" && parsed.a !== "d") return null;
-      if (parsed.d !== "g" && parsed.d !== "d") return null;
-      return parsed;
-    } catch {
-      return null;
-    }
-  };
-
-  const writeConsent = (analytics, ads) => {
-    const payload = encodeURIComponent(JSON.stringify({
-      a: analytics === "granted" ? "g" : "d",
-      d: ads === "granted" ? "g" : "d",
-      v: SCHEMA_VERSION,
-      t: Math.floor(Date.now() / 1000),
-    }));
-    const attrs = [
-      `${COOKIE_NAME}=${payload}`,
-      `Max-Age=${MAX_AGE_SECONDS}`,
-      "Path=/",
-      "SameSite=Lax",
-    ];
-    if (window.location.hostname === "makinbakin.com" || window.location.hostname.endsWith(".makinbakin.com")) {
-      attrs.push("Domain=.makinbakin.com");
-    }
-    if (window.location.protocol === "https:") attrs.push("Secure");
-    document.cookie = attrs.join("; ");
-  };
-
-  const applyConsent = (analytics, ads, source) => {
-    writeConsent(analytics, ads);
-    if (typeof window.gtag === "function") {
-      window.gtag("consent", "update", {
-        analytics_storage: analytics,
-        ad_storage: ads,
-        ad_user_data: ads,
-        ad_personalization: ads,
-      });
-    }
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push({
-      event: "consent_update",
-      analytics_storage: analytics,
-      ad_storage: ads,
-      source,
-    });
-  };
+  import { applyConsent, readConsent } from "../lib/consent";
 
   const bindConsentBanner = () => {
-    const banner = document.querySelector("[data-consent-banner]");
+    const banner = document.querySelector<HTMLDivElement>("[data-consent-banner]");
     if (!banner || banner.dataset.bound === "true") return;
+
     if (readConsent()) {
       banner.remove();
       return;
@@ -94,31 +49,43 @@
     banner.dataset.bound = "true";
     banner.hidden = false;
 
-    const previouslyFocused = document.activeElement;
-    const buttons = Array.from(banner.querySelectorAll("[data-consent-action]"));
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const buttons = banner.querySelectorAll<HTMLButtonElement>("[data-consent-action]");
     const firstButton = buttons[0];
-    if (firstButton instanceof HTMLElement) window.requestAnimationFrame(() => firstButton.focus());
+    if (firstButton) {
+      window.requestAnimationFrame(() => firstButton.focus());
+    }
 
     const close = () => {
       banner.remove();
-      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+      if (previouslyFocused && typeof previouslyFocused.focus === "function") {
+        previouslyFocused.focus();
+      }
       document.removeEventListener("keydown", handleKeydown);
     };
 
-    const handleKeydown = (event) => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      // ESC is implicit dismiss - persist the current granted default so the banner stops returning.
       if (event.key === "Escape") {
         event.preventDefault();
-        applyConsent("granted", "granted", "dismiss");
+        applyConsent({ analytics_storage: "granted", ad_storage: "granted" }, "dismiss");
         close();
       }
     };
 
-    for (const button of buttons) {
+    for (const button of Array.from(buttons)) {
       button.addEventListener("click", () => {
-        if (button.dataset.consentAction === "accept") {
-          applyConsent("granted", "granted", "accept");
-        } else {
-          applyConsent("denied", "denied", "reject");
+        const action = button.dataset.consentAction;
+        if (action === "accept") {
+          applyConsent(
+            { analytics_storage: "granted", ad_storage: "granted" },
+            "accept"
+          );
+        } else if (action === "reject") {
+          applyConsent(
+            { analytics_storage: "denied", ad_storage: "denied" },
+            "reject"
+          );
         }
         close();
       });
@@ -132,63 +99,108 @@
 </script>
 
 <style>
-  .docs-consent {
+  .consent-banner {
     position: fixed;
-    left: 1rem;
-    bottom: 1rem;
-    z-index: 100;
-    max-width: min(24rem, calc(100vw - 2rem));
-    padding: 1rem;
-    border: 1px solid color-mix(in srgb, var(--sl-color-accent-high), transparent 45%);
-    border-radius: 0.5rem;
-    background: color-mix(in srgb, var(--sl-color-bg), #000 15%);
-    box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.45);
+    left: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 60;
+    max-width: 22.5rem;
+    padding: 1.1rem 1.2rem 1.2rem;
+    border: 1px solid rgba(74, 71, 71, 0.5);
+    border-radius: 1rem;
+    background: rgba(27, 25, 25, 0.85);
+    backdrop-filter: blur(20px);
+    box-shadow: 0 18px 60px rgba(0, 0, 0, 0.45);
     color: var(--sl-color-white);
+    font-family: var(--font-body);
+    animation: consent-banner-in 220ms ease;
   }
 
-  .docs-consent[hidden] {
+  .consent-banner[hidden] {
     display: none;
   }
 
-  .docs-consent__title {
-    margin: 0 0 0.35rem;
-    font-size: var(--sl-text-sm);
-    font-weight: 700;
+  .consent-banner__title {
+    margin: 0 0 0.45rem;
+    color: var(--bakin-brand-pink);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
   }
 
-  .docs-consent__copy {
-    margin: 0;
-    color: var(--sl-color-gray-2);
-    font-size: var(--sl-text-sm);
-    line-height: 1.45;
+  .consent-banner__copy {
+    margin: 0 0 0.9rem;
+    color: var(--sl-color-gray-3);
+    font-size: 0.875rem;
+    line-height: 1.55;
   }
 
-  .docs-consent__actions {
+  .consent-banner__actions {
     display: flex;
     gap: 0.6rem;
-    flex-wrap: wrap;
-    margin-top: 0.85rem;
   }
 
-  .docs-consent__button {
-    min-height: 2.25rem;
-    padding: 0 0.85rem;
-    border: 1px solid var(--sl-color-gray-5);
-    border-radius: 0.4rem;
-    background: transparent;
-    color: var(--sl-color-white);
-    font: inherit;
-    cursor: pointer;
-  }
-
-  .docs-consent__button--primary {
-    border-color: var(--sl-color-accent-high);
-    background: var(--sl-color-accent-high);
-    color: #160b11;
+  .consent-banner__button {
+    flex: 1 1 0;
+    min-height: 2.5rem;
+    padding: 0.55rem 0.9rem;
+    border-radius: 0.75rem;
+    font-family: var(--font-body);
+    font-size: 0.7rem;
     font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all 160ms ease;
   }
 
-  .docs-consent__button--ghost:hover {
-    border-color: var(--sl-color-accent-high);
+  .consent-banner__button--primary {
+    border: 1px solid transparent;
+    background: var(--bakin-brand-pink);
+    color: #2b1019;
+  }
+
+  .consent-banner__button--primary:hover {
+    filter: brightness(1.08);
+    box-shadow: 0 0 25px rgba(255, 112, 158, 0.25);
+  }
+
+  .consent-banner__button--ghost {
+    border: 1px solid rgba(174, 170, 170, 0.25);
+    background: transparent;
+    color: var(--sl-color-gray-3);
+  }
+
+  .consent-banner__button--ghost:hover {
+    background: rgba(39, 37, 37, 0.7);
+    color: var(--sl-color-white);
+  }
+
+  @media (max-width: 480px) {
+    .consent-banner {
+      left: 0.9rem;
+      right: 0.9rem;
+      bottom: 0.9rem;
+      max-width: none;
+    }
+  }
+
+  @keyframes consent-banner-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .consent-banner {
+      animation: none;
+    }
   }
 </style>

--- a/docs/src/components/DocsFooter.astro
+++ b/docs/src/components/DocsFooter.astro
@@ -1,12 +1,10 @@
 ---
 import Pagination from '@astrojs/starlight/components/Pagination.astro'
-import ConsentBanner from './ConsentBanner.astro'
 ---
 
 <footer class="docs-footer">
   <Pagination />
 </footer>
-<ConsentBanner />
 
 <style>
   .docs-footer {

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,123 @@
+---
+const { entry, head, lang, lastUpdated } = Astro.locals.starlightRoute;
+
+const siteOrigin = Astro.site?.origin ?? "https://makinbakin.com";
+const defaultDescription =
+  "Bakin' extends the power of OpenClaw with full visibility, real collaboration, and AI agents that feel like a team.";
+const pageTitle = entry.data.title;
+const description = entry.data.description || defaultDescription;
+const fullTitle =
+  pageTitle === "Bakin'"
+    ? "Bakin' — Automate Anything, Understand Everything"
+    : `${pageTitle} | Bakin'`;
+const canonicalFromHead = head.find(
+  ({ tag, attrs }) => tag === "link" && attrs?.rel === "canonical"
+)?.attrs?.href;
+const canonicalURL = canonicalFromHead
+  ? String(canonicalFromHead)
+  : new URL(Astro.url.pathname, siteOrigin).href;
+const ogImageURL = `${siteOrigin}/og-image-v2.jpg`;
+
+const organization = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Bakin'",
+  url: "https://makinbakin.com",
+  logo: "https://makinbakin.com/favicon.svg",
+  description: defaultDescription,
+  founder: {
+    "@type": "Person",
+    name: "Mark Hayden",
+    url: "https://github.com/markhayden",
+  },
+  sameAs: [
+    "https://github.com/markhayden",
+    "https://www.linkedin.com/in/markjhayden/",
+  ],
+};
+
+const website = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Bakin'",
+  url: "https://makinbakin.com",
+  description: defaultDescription,
+};
+
+const techArticle = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: pageTitle,
+  description,
+  url: canonicalURL,
+  dateModified: lastUpdated?.toISOString(),
+  inLanguage: lang,
+  isPartOf: {
+    "@type": "WebSite",
+    name: "Bakin'",
+    url: "https://makinbakin.com",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "Bakin'",
+    url: "https://makinbakin.com",
+    logo: "https://makinbakin.com/favicon.svg",
+  },
+};
+
+const shouldReplaceHeadEntry = ({ tag, attrs }: (typeof head)[number]) => {
+  if (tag === "title") return true;
+  if (tag === "link") {
+    return attrs?.rel === "canonical" || attrs?.rel === "shortcut icon" || attrs?.rel === "icon";
+  }
+  if (tag !== "meta") return false;
+  return (
+    attrs?.name === "description" ||
+    attrs?.name === "twitter:card" ||
+    attrs?.name === "twitter:title" ||
+    attrs?.name === "twitter:description" ||
+    attrs?.name === "twitter:image" ||
+    attrs?.property === "og:title" ||
+    attrs?.property === "og:type" ||
+    attrs?.property === "og:url" ||
+    attrs?.property === "og:description" ||
+    attrs?.property === "og:image" ||
+    attrs?.property === "og:site_name"
+  );
+};
+
+const preservedHead = head.filter((entry) => !shouldReplaceHeadEntry(entry));
+---
+
+{
+  preservedHead.map(({ tag: Tag, attrs, content }) => (
+    <Tag {...attrs} set:html={content} />
+  ))
+}
+
+<title>{fullTitle}</title>
+<meta name="description" content={description} />
+<link rel="canonical" href={canonicalURL} />
+
+<!-- Favicon -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="apple-touch-icon" href="/apple-touch-icon.jpg" />
+
+<!-- Open Graph -->
+<meta property="og:type" content="website" />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:title" content={fullTitle} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={ogImageURL} />
+<meta property="og:site_name" content="Bakin'" />
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={fullTitle} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={ogImageURL} />
+
+<!-- Structured Data -->
+<script type="application/ld+json" set:html={JSON.stringify(organization)} />
+<script type="application/ld+json" set:html={JSON.stringify(website)} />
+<script type="application/ld+json" set:html={JSON.stringify(techArticle)} />

--- a/docs/src/components/SkipLink.astro
+++ b/docs/src/components/SkipLink.astro
@@ -1,0 +1,9 @@
+---
+import DefaultSkipLink from '@astrojs/starlight/components/SkipLink.astro'
+import Analytics from './Analytics.astro'
+import ConsentBanner from './ConsentBanner.astro'
+---
+
+<Analytics />
+<ConsentBanner />
+<DefaultSkipLink />

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -1482,5 +1482,5 @@ curl -sS \
 </OpenApiReference>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/cli.mdx
+++ b/docs/src/content/docs/reference/generated/cli.mdx
@@ -746,5 +746,5 @@ bakin workflows submit <taskId> <stepId> <json>
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/core-plugins.md
+++ b/docs/src/content/docs/reference/generated/core-plugins.md
@@ -93,5 +93,5 @@ description: Generated catalog of official plugins supported by Bakin.
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/exec-tools.mdx
+++ b/docs/src/content/docs/reference/generated/exec-tools.mdx
@@ -489,40 +489,40 @@ mcporter call bakin-<agent>.bakin_exec_post_channel --args '{
 </McpToolCard>
 </div>
 
-## Projects
+## Project
 
-<p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
+<p class="mcp-section-description">Project tools let agents create, update, read, and maintain project specs and linked checklist items.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="projects-add-item" name="bakin_exec_projects_add_item" label="Added project item" description="Add a new checklist item to a project." source="bakin-bits-official/plugins/projects/index.ts:614" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":true,"description":"Checklist item title"}]}>
+<McpToolCard id="project-add-item" name="bakin_exec_project_add_item" label="Added project item" description="Add a new checklist item to a project." source="bakin-bits-official/plugins/projects/index.ts:614" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":true,"description":"Checklist item title"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_add_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_add_item --args '{
   "projectId": "value",
   "title": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-ask" name="bakin_exec_projects_ask" label="Asked project question" description="Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming." source="bakin-bits-official/plugins/projects/index.ts:804" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"message","type":"string","required":true,"description":"Question or prompt for the agent"},{"name":"agent","type":"string","required":false,"description":"Agent ID to ask (defaults to main)"}]}>
+<McpToolCard id="project-ask" name="bakin_exec_project_ask" label="Asked project question" description="Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming." source="bakin-bits-official/plugins/projects/index.ts:804" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"message","type":"string","required":true,"description":"Question or prompt for the agent"},{"name":"agent","type":"string","required":false,"description":"Agent ID to ask (defaults to main)"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_ask --args '{
+mcporter call bakin-<agent>.bakin_exec_project_ask --args '{
   "projectId": "value",
   "message": "value",
   "agent": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-attach-asset" name="bakin_exec_projects_attach_asset" label="Attached asset to project" description="Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed." source="bakin-bits-official/plugins/projects/index.ts:716" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename (e.g., \"20260327-hero-a1b2c3d4.png\") — globally unique, stable across retype/relink"},{"name":"label","type":"string","required":false,"description":"Human-readable label or summary of what this asset contains"}]}>
+<McpToolCard id="project-attach-asset" name="bakin_exec_project_attach_asset" label="Attached asset to project" description="Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed." source="bakin-bits-official/plugins/projects/index.ts:716" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename (e.g., \"20260327-hero-a1b2c3d4.png\") — globally unique, stable across retype/relink"},{"name":"label","type":"string","required":false,"description":"Human-readable label or summary of what this asset contains"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_attach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_project_attach_asset --args '{
   "projectId": "value",
   "filename": "value",
   "label": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-create" name="bakin_exec_projects_create" label="Created a project" description="Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs." source="bakin-bits-official/plugins/projects/index.ts:547" parameters={[{"name":"title","type":"string","required":true,"description":"Project title"},{"name":"body","type":"string","required":false,"description":"Markdown body (spec/plan)"},{"name":"owner","type":"string","required":false,"description":"Project owner"},{"name":"tasks","type":"array","required":false,"description":"Initial checklist item titles"}]}>
+<McpToolCard id="project-create" name="bakin_exec_project_create" label="Created a project" description="Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs." source="bakin-bits-official/plugins/projects/index.ts:547" parameters={[{"name":"title","type":"string","required":true,"description":"Project title"},{"name":"body","type":"string","required":false,"description":"Markdown body (spec/plan)"},{"name":"owner","type":"string","required":false,"description":"Project owner"},{"name":"tasks","type":"array","required":false,"description":"Initial checklist item titles"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_create --args '{
+mcporter call bakin-<agent>.bakin_exec_project_create --args '{
   "title": "value",
   "body": "value",
   "owner": "value",
@@ -532,82 +532,82 @@ mcporter call bakin-<agent>.bakin_exec_projects_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-delete" name="bakin_exec_projects_delete" label="Deleted a project" description="Delete a project by ID." source="bakin-bits-official/plugins/projects/index.ts:596" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
+<McpToolCard id="project-delete" name="bakin_exec_project_delete" label="Deleted a project" description="Delete a project by ID." source="bakin-bits-official/plugins/projects/index.ts:596" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_delete --args '{
+mcporter call bakin-<agent>.bakin_exec_project_delete --args '{
   "projectId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-detach-asset" name="bakin_exec_projects_detach_asset" label="Detached asset from project" description="Remove an asset reference from a project by filename. Does not delete the asset itself." source="bakin-bits-official/plugins/projects/index.ts:736" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename to detach"}]}>
+<McpToolCard id="project-detach-asset" name="bakin_exec_project_detach_asset" label="Detached asset from project" description="Remove an asset reference from a project by filename. Does not delete the asset itself." source="bakin-bits-official/plugins/projects/index.ts:736" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename to detach"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_detach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_project_detach_asset --args '{
   "projectId": "value",
   "filename": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-get" name="bakin_exec_projects_get" label="Read project details" description="Get a project by ID including full spec, checklist, progress, and linked board task statuses." source="bakin-bits-official/plugins/projects/index.ts:533" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
+<McpToolCard id="project-get" name="bakin_exec_project_get" label="Read project details" description="Get a project by ID including full spec, checklist, progress, and linked board task statuses." source="bakin-bits-official/plugins/projects/index.ts:533" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_get --args '{
+mcporter call bakin-<agent>.bakin_exec_project_get --args '{
   "projectId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-link-item" name="bakin_exec_projects_link_item" label="Linked project item" description="Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project." source="bakin-bits-official/plugins/projects/index.ts:668" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID"},{"name":"taskId","type":"string","required":true,"description":"Board task ID to link"}]}>
+<McpToolCard id="project-link-item" name="bakin_exec_project_link_item" label="Linked project item" description="Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project." source="bakin-bits-official/plugins/projects/index.ts:668" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID"},{"name":"taskId","type":"string","required":true,"description":"Board task ID to link"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_link_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_link_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-list" name="bakin_exec_projects_list" label="Listed projects" description="List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount." source="bakin-bits-official/plugins/projects/index.ts:517" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by status"}]}>
+<McpToolCard id="project-list" name="bakin_exec_project_list" label="Listed projects" description="List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount." source="bakin-bits-official/plugins/projects/index.ts:517" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by status"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_list --args '{
+mcporter call bakin-<agent>.bakin_exec_project_list --args '{
   "status": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-mark-item" name="bakin_exec_projects_mark_item" label="Marked project item" description="Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:629" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
+<McpToolCard id="project-mark-item" name="bakin_exec_project_mark_item" label="Marked project item" description="Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:629" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_mark_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_mark_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "checked": true
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-promote-item" name="bakin_exec_projects_promote_item" label="Promoted project item" description="Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set." source="bakin-bits-official/plugins/projects/index.ts:692" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to promote to a board task"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign the task to"}]}>
+<McpToolCard id="project-promote-item" name="bakin_exec_project_promote_item" label="Promoted project item" description="Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set." source="bakin-bits-official/plugins/projects/index.ts:692" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to promote to a board task"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign the task to"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_promote_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_promote_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "assignee": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-remove-item" name="bakin_exec_projects_remove_item" label="Removed project item" description="Remove a checklist item from a project." source="bakin-bits-official/plugins/projects/index.ts:649" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to remove"}]}>
+<McpToolCard id="project-remove-item" name="bakin_exec_project_remove_item" label="Removed project item" description="Remove a checklist item from a project." source="bakin-bits-official/plugins/projects/index.ts:649" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to remove"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_remove_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_remove_item --args '{
   "projectId": "value",
   "taskItemId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-toggle-item" name="bakin_exec_projects_toggle_item" label="Toggled project item" description="Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:755" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
+<McpToolCard id="project-toggle-item" name="bakin_exec_project_toggle_item" label="Toggled project item" description="Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:755" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_toggle_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_toggle_item --args '{
   "projectId": "value",
   "itemId": "value",
   "checked": true
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-update" name="bakin_exec_projects_update" label="Updated a project" description="Update a project's title, status, body, or owner. Cannot set status to &quot;completed&quot; if unchecked items remain." source="bakin-bits-official/plugins/projects/index.ts:569" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"choice","required":false,"description":"New status"},{"name":"body","type":"string","required":false,"description":"New markdown body"},{"name":"owner","type":"string","required":false,"description":"New owner"}]}>
+<McpToolCard id="project-update" name="bakin_exec_project_update" label="Updated a project" description="Update a project's title, status, body, or owner. Cannot set status to &quot;completed&quot; if unchecked items remain." source="bakin-bits-official/plugins/projects/index.ts:569" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"choice","required":false,"description":"New status"},{"name":"body","type":"string","required":false,"description":"New markdown body"},{"name":"owner","type":"string","required":false,"description":"New owner"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_update --args '{
+mcporter call bakin-<agent>.bakin_exec_project_update --args '{
   "projectId": "value",
   "title": "value",
   "status": "value",
@@ -616,9 +616,9 @@ mcporter call bakin-<agent>.bakin_exec_projects_update --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="projects-update-item" name="bakin_exec_projects_update_item" label="Updated project item" description="Update a checklist item's title and/or description." source="bakin-bits-official/plugins/projects/index.ts:776" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"title","type":"string","required":false,"description":"New title for the checklist item"},{"name":"description","type":"string","required":false,"description":"New description for the checklist item"}]}>
+<McpToolCard id="project-update-item" name="bakin_exec_project_update_item" label="Updated project item" description="Update a checklist item's title and/or description." source="bakin-bits-official/plugins/projects/index.ts:776" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"title","type":"string","required":false,"description":"New title for the checklist item"},{"name":"description","type":"string","required":false,"description":"New description for the checklist item"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_projects_update_item --args '{
+mcporter call bakin-<agent>.bakin_exec_project_update_item --args '{
   "projectId": "value",
   "itemId": "value",
   "title": "value",
@@ -1075,5 +1075,5 @@ mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -487,5 +487,5 @@ const result = await ctx.hooks.invoke(
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/runtime-paths.md
+++ b/docs/src/content/docs/reference/generated/runtime-paths.md
@@ -100,5 +100,5 @@ description: Reference for Bakin runtime files under the resolved Bakin home dir
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -251,5 +251,5 @@ Source: `packages/sdk/src/routing/index.ts`
 | `export type {` |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -361,5 +361,5 @@ description: Generated reference for Bakin core settings defaults.
 
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 5, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/lib/analytics.ts
+++ b/docs/src/lib/analytics.ts
@@ -1,0 +1,51 @@
+export type AnalyticsEvent =
+  | {
+      event: "page_view_custom";
+      page_path: string;
+      page_title: string;
+      page_location: string;
+    }
+  | {
+      event: "cta_click";
+      cta_name: string;
+      cta_label: string;
+      page_path: string;
+      page_section?: string;
+    }
+  | {
+      event: "outbound_click";
+      outbound_url: string;
+      link_label: string;
+      page_path: string;
+    }
+  | {
+      event: "scroll_depth";
+      scroll_depth: 25 | 50 | 75 | 100;
+      page_path: string;
+    }
+  | {
+      event: "ui_modal_open";
+      modal_source: string;
+    }
+  | {
+      event: "form_submit";
+      form_name: "contact";
+      page_path?: string;
+    }
+  | {
+      event: "content_tab_select";
+      tab_group: string;
+      tab_id: string;
+    }
+  | {
+      event: "consent_update";
+      analytics_storage: "granted" | "denied";
+      ad_storage: "granted" | "denied";
+      source: "default" | "accept" | "reject" | "restore" | "dismiss";
+    };
+
+export const track = (payload: AnalyticsEvent): void => {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(payload);
+};

--- a/docs/src/lib/consent.ts
+++ b/docs/src/lib/consent.ts
@@ -1,0 +1,99 @@
+import { track } from "./analytics";
+
+export type ConsentValue = "granted" | "denied";
+
+export interface ConsentState {
+  analytics_storage: ConsentValue;
+  ad_storage: ConsentValue;
+}
+
+export type ConsentSource = "default" | "accept" | "reject" | "restore" | "dismiss";
+
+export const CONSENT_COOKIE_NAME = "bakin_consent";
+export const CONSENT_COOKIE_MAX_AGE_SECONDS = 15_552_000;
+export const CONSENT_SCHEMA_VERSION = 1;
+
+interface StoredConsent {
+  a: "g" | "d";
+  d: "g" | "d";
+  v: number;
+  t: number;
+}
+
+const toShort = (value: ConsentValue): "g" | "d" => (value === "granted" ? "g" : "d");
+const fromShort = (value: "g" | "d"): ConsentValue => (value === "g" ? "granted" : "denied");
+
+const isStoredConsent = (raw: unknown): raw is StoredConsent => {
+  if (!raw || typeof raw !== "object") return false;
+  const obj = raw as Record<string, unknown>;
+  return (
+    (obj.a === "g" || obj.a === "d") &&
+    (obj.d === "g" || obj.d === "d") &&
+    typeof obj.v === "number" &&
+    typeof obj.t === "number"
+  );
+};
+
+export const readConsent = (): ConsentState | null => {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${CONSENT_COOKIE_NAME}=`));
+  if (!match) return null;
+
+  const rawValue = match.slice(CONSENT_COOKIE_NAME.length + 1);
+  try {
+    const decoded = decodeURIComponent(rawValue);
+    const parsed: unknown = JSON.parse(decoded);
+    if (!isStoredConsent(parsed)) return null;
+    if (parsed.v !== CONSENT_SCHEMA_VERSION) return null;
+    return {
+      analytics_storage: fromShort(parsed.a),
+      ad_storage: fromShort(parsed.d),
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const writeConsent = (state: ConsentState): void => {
+  if (typeof document === "undefined") return;
+  const payload: StoredConsent = {
+    a: toShort(state.analytics_storage),
+    d: toShort(state.ad_storage),
+    v: CONSENT_SCHEMA_VERSION,
+    t: Math.floor(Date.now() / 1000),
+  };
+  const value = encodeURIComponent(JSON.stringify(payload));
+  const attrs = [
+    `${CONSENT_COOKIE_NAME}=${value}`,
+    `Max-Age=${CONSENT_COOKIE_MAX_AGE_SECONDS}`,
+    "Path=/",
+    "SameSite=Lax",
+  ];
+  if (window.location.protocol === "https:") {
+    attrs.push("Secure");
+  }
+  document.cookie = attrs.join("; ");
+};
+
+export const applyConsent = (state: ConsentState, source: ConsentSource): void => {
+  if (typeof window === "undefined") return;
+  if (source === "accept" || source === "reject" || source === "dismiss") {
+    writeConsent(state);
+  }
+  if (typeof window.gtag === "function") {
+    window.gtag("consent", "update", {
+      analytics_storage: state.analytics_storage,
+      ad_storage: state.ad_storage,
+      ad_user_data: state.ad_storage,
+      ad_personalization: state.ad_storage,
+    });
+  }
+  track({
+    event: "consent_update",
+    analytics_storage: state.analytics_storage,
+    ad_storage: state.ad_storage,
+    source,
+  });
+};

--- a/docs/src/types/gtm.d.ts
+++ b/docs/src/types/gtm.d.ts
@@ -1,0 +1,12 @@
+interface ImportMetaEnv {
+  readonly PUBLIC_GTM_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
+interface Window {
+  dataLayer: Array<Record<string, unknown>>;
+  gtag: (...args: unknown[]) => void;
+}

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1825,16 +1825,19 @@ Primary docs:
 - Daily Operation: ${docsUrl}/start/operation/
   Use this for lifecycle commands, health checks, updates, and runtime operation.
 
-- Core workflows: ${docsUrl}/core/tasks/
-  Use this for built-in Bakin areas such as tasks, workflows, assets, schedule, memory, models, team, and health. Official add-on plugins such as Messaging and Projects are installed separately but documented in the same site.
+- Essentials: ${docsUrl}/using/essentials/
+  Use this for the core Bakin areas and the quickest map of day-to-day product concepts.
 
-- Plugin authoring: ${docsUrl}/extend/plugins/overview/
+- Tasks: ${docsUrl}/using/tasks/
+  Use this for the task model, task lifecycle, approvals, output, and agent execution flow.
+
+- Plugin authoring: ${docsUrl}/extending/plugins/overview/
   Use this when building Bakin plugins with @makinbakin/sdk.
 
-- Agent authoring: ${docsUrl}/extend/agents/overview/
+- Agent authoring: ${docsUrl}/extending/agents/overview/
   Use this when creating agent packages or writing instructions for coding agents working with Bakin.
 
-- SDK docs: ${docsUrl}/extend/sdk/overview/
+- SDK docs: ${docsUrl}/extending/sdk/overview/
   Use this for @makinbakin/sdk imports, UI components, hooks, slots, and public extension contracts.
 
 LLM bundles:


### PR DESCRIPTION
## Summary
- replace Starlight default docs head with Bakin SEO metadata, shared favicon paths, OG/Twitter image tags, and structured data
- move docs GTM/consent tracking into website-parity components and wire them at body start
- refresh generated docs/AEO artifacts including canonical llms.txt paths

## Validation
- PUBLIC_GTM_ID=GTM-KZQK989V bun run docs:check
- inspected generated docs HTML for root favicon, OG/Twitter image tags, JSON-LD, GTM noscript, gtm_boot, and scroll_depth