### PR TITLE
Improve dev CLI output

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -46,6 +46,9 @@ bun run dev
     ▼
 scripts/dev.ts (process.env.BAKIN_DEV = '1', BAKIN_DEV_HOTRELOAD = '1')
     │
+    ├── Sets BAKIN_CONSOLE_FORMAT=pretty by default
+    │     • `bakin dev --verbose` switches to verbose console logs
+    │     • `bakin dev --no-color` sets NO_COLOR=1
     ├── Initial prestart build (css, vendors, plugins, host-shell)
     ├── Bun.build(dev-client.ts → public/__bakin-dev/client.js)
     ├── Spawn bunx @tailwindcss/cli --watch=always   (child process)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ bun test --isolate
 ```bash
 bun run dev          # watch mode: rebuild on change, hot-swap plugins in the browser
                      # (same as `bakin dev` — either form works)
+bakin dev --verbose  # same dev loop with raw build/service output and debug logs
 bun run start        # one-shot prestart build + boot (production-style preview)
 bun run server       # boot without rebuilding (use when dist/ is fresh)
 bun run build        # full production build (ends with bun build --compile)
@@ -74,7 +75,7 @@ Do not add an `NPM_TOKEN`; npm publishing is OIDC/trusted-publisher based.
 
 ## Development loop
 
-`bun run dev` is what you use daily. It sets `BAKIN_DEV=1`, runs the same prestart build as `bun run start`, then starts a watcher coordinator + the server in the same process.
+`bun run dev` is what you use daily. It sets `BAKIN_DEV=1`, runs the same prestart build as `bun run start`, then starts a watcher coordinator + the server in the same process. The default console output is compact and source-labeled; pass `--verbose` through `bakin dev --verbose` when you need raw child-process logs, commands, debug lines, and structured data payloads.
 
 What it watches, and what happens when you save:
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Most commands hit the local HTTP API (`http://localhost:3737` or `$BAKIN_URL`). 
 bakin start                            # boot the server
 bakin stop                             # graceful shutdown
 bakin restart                          # stop + start
-bakin dev                              # watch-mode dev loop (HMR) — source-tree only
+bakin dev                              # watch-mode dev loop (HMR) - source-tree only
+bakin dev --verbose                    # include raw build/service output
 bakin status                           # dispatch + server + doctor status
 bakin version                          # print version
 bakin update                           # replace binary with latest release
@@ -390,7 +391,7 @@ bun install
 bun run dev       # or `bakin dev` if the CLI is on your PATH
 ```
 
-Both `bun run dev` and `bakin dev` launch the same watch-mode coordinator. Edits flow through a dev SSE channel:
+Both `bun run dev` and `bakin dev` launch the same watch-mode coordinator. Normal output is compact and source-labeled; use `bakin dev --verbose` for raw build commands, child-process output, debug logs, and structured data payloads. Edits flow through a dev SSE channel:
 
 - Edit `packages/host/src/**` → full page reload (~2 s)
 - Edit `plugins/<id>/**` → that plugin remounts without a reload; shell, other plugins, URL, scroll, and SSE connection all survive

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1966,7 +1966,7 @@ export async function main(): Promise<void> {
         // tree detection + spawn logic lives in one place (and the
         // compiled binary's `bakin dev` uses the same code path).
         const { cmdDev } = await import('../src/core/cli')
-        process.exit(await cmdDev())
+        process.exit(await cmdDev(args.slice(1)))
         break  // unreachable, but eslint's no-fallthrough doesn't know that
       }
 

--- a/packages/adapter-antfly/src/server.ts
+++ b/packages/adapter-antfly/src/server.ts
@@ -9,6 +9,14 @@ export interface AntflyServerSettings {
   url: string
 }
 
+type AntflyLogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+export interface ParsedAntflyLogLine {
+  level: AntflyLogLevel
+  message: string
+  data: Record<string, unknown>
+}
+
 const noopLogger: AdapterLogger = {
   debug: () => {},
   info: () => {},
@@ -19,6 +27,74 @@ const noopLogger: AdapterLogger = {
 let antflyProcess: ChildProcess | null = null
 let isRunning = false
 let recheckTimer: NodeJS.Timeout | null = null
+
+function unquoteAntflyValue(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"')
+  }
+  return value
+}
+
+function parseAntflyFields(line: string): Record<string, string> {
+  const fields: Record<string, string> = {}
+  const pattern = /([A-Za-z0-9_.-]+)=("(?:\\.|[^"])*"|[^\s]+)/g
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(line)) !== null) {
+    fields[match[1]] = unquoteAntflyValue(match[2])
+  }
+  return fields
+}
+
+export function parseAntflyLogLine(line: string, streamLevel: AntflyLogLevel): ParsedAntflyLogLine {
+  const fields = parseAntflyFields(line)
+  const parsedLevel = fields.lvl
+  const level: AntflyLogLevel = parsedLevel === 'debug'
+    || parsedLevel === 'info'
+    || parsedLevel === 'warn'
+    || parsedLevel === 'error'
+    ? parsedLevel
+    : streamLevel
+
+  const data: Record<string, unknown> = { source: 'antfly', raw: line }
+  for (const [key, value] of Object.entries(fields)) {
+    if (key === 'ts' || key === 'lvl' || key === 'msg') continue
+    data[key] = value
+  }
+
+  return {
+    level,
+    message: fields.msg || line,
+    data,
+  }
+}
+
+function writeParsedAntflyLog(logger: AdapterLogger, parsed: ParsedAntflyLogLine): void {
+  if (parsed.level === 'debug') logger.debug(parsed.message, parsed.data)
+  else if (parsed.level === 'info') logger.info(parsed.message, parsed.data)
+  else if (parsed.level === 'warn') logger.warn(parsed.message, parsed.data)
+  else logger.error(parsed.message, parsed.data)
+}
+
+function createAntflyLogBuffer(logger: AdapterLogger, streamLevel: AntflyLogLevel) {
+  let pending = ''
+  const flushLine = (line: string) => {
+    const trimmed = line.trim()
+    if (!trimmed) return
+    writeParsedAntflyLog(logger, parseAntflyLogLine(trimmed, streamLevel))
+  }
+  return {
+    push(data: Buffer) {
+      pending += data.toString()
+      const lines = pending.split(/\r?\n/)
+      pending = lines.pop() ?? ''
+      for (const line of lines) flushLine(line)
+    },
+    flush() {
+      flushLine(pending)
+      pending = ''
+    },
+  }
+}
 
 export function findAntflyBinary(): string | null {
   const candidates = [
@@ -83,17 +159,19 @@ export async function startAntflyServer(
       },
     })
 
+    const stdoutLogs = createAntflyLogBuffer(logger, 'info')
+    const stderrLogs = createAntflyLogBuffer(logger, 'warn')
     antflyProcess.stdout?.on('data', (data: Buffer) => {
-      const line = data.toString().trim()
-      if (line) logger.info(`[antfly] ${line}`)
+      stdoutLogs.push(data)
     })
 
     antflyProcess.stderr?.on('data', (data: Buffer) => {
-      const line = data.toString().trim()
-      if (line) logger.warn(`[antfly] ${line}`)
+      stderrLogs.push(data)
     })
 
     antflyProcess.on('exit', (code, signal) => {
+      stdoutLogs.flush()
+      stderrLogs.flush()
       isRunning = false
       antflyProcess = null
       clearRecheckTimer()

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -11,6 +11,7 @@ import { join } from 'path'
 import { getBakinPaths } from './content-dir'
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+type ConsoleFormat = 'plain' | 'pretty' | 'verbose'
 
 interface LogEntry {
   ts: string
@@ -22,6 +23,23 @@ interface LogEntry {
 }
 
 const MAX_LOG_BYTES = 10 * 1024 * 1024 // 10 MB
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+}
+
+const COLOR_RESET = '\x1b[0m'
+const COLORS = {
+  dim: '\x1b[2m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  magenta: '\x1b[35m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+} as const
 
 let fileStream: WriteStream | null = null
 let fileTransportInitialized = false
@@ -82,6 +100,127 @@ function formatEntry(entry: LogEntry): string {
   return parts.join('\n')
 }
 
+function consoleFormat(): ConsoleFormat {
+  const configured = process.env.BAKIN_CONSOLE_FORMAT
+  if (configured === 'pretty' || configured === 'verbose' || configured === 'plain') {
+    return configured
+  }
+  return 'plain'
+}
+
+function consoleMinLevel(format: ConsoleFormat): LogLevel {
+  const configured = process.env.BAKIN_LOG_LEVEL
+  if (configured === 'debug' || configured === 'info' || configured === 'warn' || configured === 'error') {
+    return configured
+  }
+  if (format === 'verbose') return 'debug'
+  if (format === 'pretty') return 'info'
+  return 'debug'
+}
+
+function colorEnabled(format: ConsoleFormat): boolean {
+  if (format === 'plain') return false
+  if (process.env.NO_COLOR || process.env.BAKIN_NO_COLOR === '1') return false
+  return process.stdout.isTTY === true
+}
+
+function colorize(text: string, color: keyof typeof COLORS, enabled: boolean): string {
+  return enabled ? `${COLORS[color]}${text}${COLOR_RESET}` : text
+}
+
+function sourceLabel(entry: LogEntry): string {
+  const data = entry.data
+  const explicitSource = typeof data?.source === 'string' ? data.source : undefined
+  const pluginId = typeof data?.pluginId === 'string' ? data.pluginId : undefined
+
+  if (explicitSource === 'antfly') return 'antfly'
+  if (explicitSource === 'dev') return 'dev'
+  if (explicitSource === 'plugin' && pluginId) return `plugin:${pluginId}`
+  if (entry.module === 'plugin-registry' && pluginId) return `plugin:${pluginId}`
+  if (entry.module.startsWith('api:')) return 'api'
+  return entry.module
+}
+
+function sourceColor(source: string): keyof typeof COLORS {
+  if (source === 'dev') return 'cyan'
+  if (source === 'server') return 'blue'
+  if (source === 'antfly') return 'magenta'
+  if (source.startsWith('plugin:')) return 'green'
+  if (source.includes('search')) return 'cyan'
+  if (source.includes('runtime')) return 'magenta'
+  return 'dim'
+}
+
+function levelColor(level: LogLevel): keyof typeof COLORS {
+  if (level === 'debug') return 'dim'
+  if (level === 'warn') return 'yellow'
+  if (level === 'error') return 'red'
+  return 'blue'
+}
+
+function isImportantAntflyInfo(entry: LogEntry): boolean {
+  return [
+    'Metadata API server is ready',
+    'Store HTTP server is ready',
+    'Swarm mode: all servers are ready',
+    'Termite\'s api server starting',
+  ].some((message) => entry.message.includes(message))
+}
+
+function suppressPrettyInfo(entry: LogEntry): boolean {
+  if (entry.level !== 'info') return false
+  if (entry.data?.source === 'antfly') return !isImportantAntflyInfo(entry)
+  if (entry.module === 'plugin-registry') {
+    return entry.message === 'plugin activated'
+      || entry.message.startsWith('Auto-registered ')
+      || entry.message.startsWith('Plugin activation order:')
+  }
+  return [
+    'search-registry',
+    'search-reconcile',
+    'search-cleanup',
+    'hot-reload-coordinator',
+    'mcporter',
+    'dispatch',
+    'watchdog',
+    'doctor',
+    'lifecycle',
+  ].includes(entry.module)
+}
+
+function shouldWriteConsole(entry: LogEntry, format: ConsoleFormat): boolean {
+  const minLevel = consoleMinLevel(format)
+  if (LEVEL_RANK[entry.level] < LEVEL_RANK[minLevel]) return false
+  if (format === 'pretty' && suppressPrettyInfo(entry)) return false
+  return true
+}
+
+function formatPrettyEntry(entry: LogEntry, format: Exclude<ConsoleFormat, 'plain'>): string {
+  const colors = colorEnabled(format)
+  const time = new Date(entry.ts).toTimeString().slice(0, 8)
+  const level = entry.level.padEnd(5)
+  const source = sourceLabel(entry)
+  const label = source.padEnd(18)
+  const levelPart = colorize(level, levelColor(entry.level), colors)
+  const sourcePart = colorize(label, sourceColor(source), colors)
+  const messagePart = entry.level === 'error'
+    ? colorize(entry.message, 'red', colors)
+    : entry.message
+
+  const parts = [`${colorize(time, 'dim', colors)}  ${levelPart}  ${sourcePart}  ${messagePart}`]
+  if (entry.error) parts[0] += ` - ${entry.error}`
+  if (format === 'verbose' && entry.data) {
+    parts.push(`  data: ${JSON.stringify(entry.data)}`)
+  }
+  return parts.join('\n')
+}
+
+function formatConsoleEntry(entry: LogEntry): string {
+  const format = consoleFormat()
+  if (format === 'plain') return formatEntry(entry)
+  return formatPrettyEntry(entry, format)
+}
+
 function writeToFile(entry: LogEntry): void {
   const stream = ensureFileStream()
   if (!stream) return
@@ -113,13 +252,16 @@ function createLogger(module: string) {
       entry.data = errorOrData as Record<string, unknown>
     }
 
-    const formatted = formatEntry(entry)
-    if (level === 'error') {
-      console.error(formatted)
-    } else if (level === 'warn') {
-      console.warn(formatted)
-    } else {
-      console.log(formatted)
+    const format = consoleFormat()
+    if (shouldWriteConsole(entry, format)) {
+      const formatted = formatConsoleEntry(entry)
+      if (level === 'error') {
+        console.error(formatted)
+      } else if (level === 'warn') {
+        console.warn(formatted)
+      } else {
+        console.log(formatted)
+      }
     }
 
     writeToFile(entry)

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -171,6 +171,13 @@ export interface ActivityAPI {
   audit(event: string, agent: string, data?: Record<string, unknown>): void
 }
 
+export interface PluginLogger {
+  debug(message: string, data?: Record<string, unknown>): void
+  info(message: string, data?: Record<string, unknown>): void
+  warn(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
+  error(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
+}
+
 // ---------------------------------------------------------------------------
 // Plugin Context (provided to activate())
 // ---------------------------------------------------------------------------
@@ -382,6 +389,8 @@ export interface PluginContext {
   updateSettings(patch: Record<string, unknown>): void
   /** Structured activity logging */
   activity: ActivityAPI
+  /** Plugin-scoped server log. Prefer this over console.* for lifecycle logs. */
+  log?: PluginLogger
   /** Cross-plugin hook registration */
   hooks: HookAPI
   /** Adapter-backed search — register content types, index, query */

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -241,6 +241,13 @@ export interface ActivityAPI {
   audit(event: string, agent: string, data?: Record<string, unknown>): void
 }
 
+export interface PluginLogger {
+  debug(message: string, data?: Record<string, unknown>): void
+  info(message: string, data?: Record<string, unknown>): void
+  warn(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
+  error(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
+}
+
 export interface HookAPI {
   register(name: string, handler: (data: unknown) => unknown, metadata?: HookRegistrationMetadata): () => void
   call<T>(name: string, data: T): Promise<T>
@@ -841,6 +848,7 @@ export interface PluginContext {
   getSettings<T = Record<string, unknown>>(): T
   updateSettings(patch: Record<string, unknown>): void
   activity: ActivityAPI
+  log?: PluginLogger
   hooks: HookAPI
   search: SearchAPI
 }

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -14,6 +14,44 @@
 process.env.BAKIN_DEV = '1'
 process.env.BAKIN_DEV_HOTRELOAD = '1'
 
+interface DevOptions {
+  verbose: boolean
+  noColor: boolean
+}
+
+function parseDevOptions(args: string[]): DevOptions {
+  const options: DevOptions = { verbose: false, noColor: false }
+  for (const arg of args) {
+    if (arg === '--verbose') {
+      options.verbose = true
+    } else if (arg === '--no-color') {
+      options.noColor = true
+    } else {
+      console.error(`Unknown dev option: ${arg}`)
+      console.error('Usage: bakin dev [--verbose] [--no-color]')
+      process.exit(1)
+    }
+  }
+  return options
+}
+
+const DEV_OPTIONS = parseDevOptions(process.argv.slice(2))
+// scripts/dev.ts runs server.ts in-process. Consume dev-only flags here so
+// server.ts's CLI dispatcher sees the same argv shape as plain `bakin start`.
+process.argv.splice(2)
+const DEV_VERBOSE = DEV_OPTIONS.verbose
+  || process.env.BAKIN_DEV_VERBOSE === '1'
+  || process.env.BAKIN_CONSOLE_FORMAT === 'verbose'
+if (DEV_OPTIONS.noColor) process.env.NO_COLOR = '1'
+if (DEV_VERBOSE) {
+  process.env.BAKIN_CONSOLE_FORMAT = 'verbose'
+} else if (!process.env.BAKIN_CONSOLE_FORMAT) {
+  process.env.BAKIN_CONSOLE_FORMAT = 'pretty'
+}
+if (DEV_VERBOSE && !process.env.BAKIN_LOG_LEVEL) {
+  process.env.BAKIN_LOG_LEVEL = 'debug'
+}
+
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join, resolve } from 'node:path'
@@ -53,20 +91,109 @@ const DEFAULT_PLUGIN_DEV_WATCH = [
 
 const DEBOUNCE_MS = 50
 
-// ---------- Initial build ------------------------------------------------
+const COLOR_RESET = '\x1b[0m'
+const DEV_COLORS = {
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+} as const
 
-async function runStep(label: string, cmd: string[]): Promise<void> {
-  console.log(`[dev] ${label}...`)
-  const proc = Bun.spawn(cmd, { stdout: 'inherit', stderr: 'inherit', cwd: REPO_ROOT })
-  const code = await proc.exited
-  if (code !== 0) {
-    console.error(`[dev] ${label} failed (exit ${code})`)
-    process.exit(1)
+type DevLevel = 'debug' | 'build' | 'info' | 'ready' | 'warn' | 'error'
+
+function devColorEnabled(): boolean {
+  if (process.env.NO_COLOR || process.env.BAKIN_NO_COLOR === '1') return false
+  return process.stdout.isTTY === true
+}
+
+function devColor(text: string, color: keyof typeof DEV_COLORS): string {
+  return devColorEnabled() ? `${DEV_COLORS[color]}${text}${COLOR_RESET}` : text
+}
+
+function devLevelColor(level: DevLevel): keyof typeof DEV_COLORS {
+  if (level === 'build') return 'cyan'
+  if (level === 'ready') return 'green'
+  if (level === 'warn') return 'yellow'
+  if (level === 'error') return 'red'
+  if (level === 'debug') return 'dim'
+  return 'blue'
+}
+
+function devLog(level: DevLevel, source: string, message: string): void {
+  if (level === 'debug' && !DEV_VERBOSE) return
+  const time = new Date().toTimeString().slice(0, 8)
+  const levelPart = devColor(level.padEnd(5), devLevelColor(level))
+  const sourcePart = devColor(source.padEnd(18), source === 'dev' ? 'cyan' : 'dim')
+  const line = `${devColor(time, 'dim')}  ${levelPart}  ${sourcePart}  ${message}`
+  if (level === 'error') console.error(line)
+  else if (level === 'warn') console.warn(line)
+  else console.log(line)
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function summarizeBuildOutput(output: string): string | null {
+  const summaries = [
+    /(\d+ bundles built)/,
+    /(\d+ plugins built)/,
+    /(wrote \d+ entries)/,
+  ]
+  for (const pattern of summaries) {
+    const match = pattern.exec(output)
+    if (match) return match[1]
+  }
+  return null
+}
+
+async function readSpawnOutput(stream: ReadableStream<Uint8Array> | null | undefined): Promise<string> {
+  if (!stream) return ''
+  return await new Response(stream).text()
+}
+
+function printCapturedOutput(output: string): void {
+  const trimmed = output.trim()
+  if (!trimmed) return
+  for (const line of trimmed.split(/\r?\n/)) {
+    console.error(`  ${line}`)
   }
 }
 
+// ---------- Initial build ------------------------------------------------
+
+async function runStep(label: string, cmd: string[]): Promise<void> {
+  const started = Date.now()
+  devLog('build', 'dev', `${label}...`)
+  if (DEV_VERBOSE) devLog('debug', 'dev', `$ ${cmd.join(' ')}`)
+  const proc = Bun.spawn(cmd, {
+    stdout: DEV_VERBOSE ? 'inherit' : 'pipe',
+    stderr: DEV_VERBOSE ? 'inherit' : 'pipe',
+    cwd: REPO_ROOT,
+  })
+  const stdoutPromise = DEV_VERBOSE ? Promise.resolve('') : readSpawnOutput(proc.stdout)
+  const stderrPromise = DEV_VERBOSE ? Promise.resolve('') : readSpawnOutput(proc.stderr)
+  const code = await proc.exited
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise])
+  if (code !== 0) {
+    devLog('error', 'dev', `${label} failed (exit ${code})`)
+    if (!DEV_VERBOSE) {
+      printCapturedOutput(stdout)
+      printCapturedOutput(stderr)
+    }
+    process.exit(1)
+  }
+  const summary = summarizeBuildOutput(`${stdout}\n${stderr}`)
+  const summaryText = summary ? ` (${summary})` : ''
+  devLog('ready', 'dev', `${label} completed in ${formatDuration(Date.now() - started)}${summaryText}`)
+}
+
 async function buildDevClient(): Promise<void> {
-  console.log('[dev] building dev-client...')
+  const started = Date.now()
+  devLog('build', 'dev', 'building dev-client...')
   const result = await Bun.build({
     entrypoints: [DEV_CLIENT_ENTRY],
     outdir: DEV_CLIENT_OUTDIR,
@@ -77,18 +204,26 @@ async function buildDevClient(): Promise<void> {
     naming: 'client.[ext]',
   })
   if (!result.success) {
-    console.error('[dev] dev-client build failed:')
+    devLog('error', 'dev', 'dev-client build failed')
     for (const log of result.logs) console.error(log)
     process.exit(1)
   }
+  devLog('ready', 'dev', `dev-client completed in ${formatDuration(Date.now() - started)}`)
 }
 
 // ---------- Tailwind child process --------------------------------------
 
 let tailwindChild: ChildProcess | null = null
 
+function isBenignTailwindLine(line: string): boolean {
+  return !line
+    || line.startsWith('≈ tailwindcss')
+    || line.startsWith('Done in ')
+    || line === 'Saved lockfile'
+}
+
 function startTailwindWatch(): void {
-  console.log('[dev] starting tailwind --watch=always...')
+  devLog('build', 'tailwind', 'starting --watch=always...')
   // --watch=always keeps the watcher alive when stdin is closed (we use
   // stdio:'ignore' for stdin). Plain --watch exits on stdin close and
   // silently stops emitting output.
@@ -100,11 +235,27 @@ function startTailwindWatch(): void {
       '-o', './packages/host/public/globals.css',
       '--watch=always',
     ],
-    { stdio: ['ignore', 'inherit', 'inherit'], cwd: REPO_ROOT },
+    { stdio: ['ignore', DEV_VERBOSE ? 'inherit' : 'pipe', DEV_VERBOSE ? 'inherit' : 'pipe'], cwd: REPO_ROOT },
   )
+  if (!DEV_VERBOSE) {
+    tailwindChild.stdout?.on('data', (data: Buffer) => {
+      for (const line of data.toString().split(/\r?\n/)) {
+        const trimmed = line.trim()
+        if (isBenignTailwindLine(trimmed)) continue
+        devLog('info', 'tailwind', trimmed)
+      }
+    })
+    tailwindChild.stderr?.on('data', (data: Buffer) => {
+      for (const line of data.toString().split(/\r?\n/)) {
+        const trimmed = line.trim()
+        if (isBenignTailwindLine(trimmed)) continue
+        devLog('warn', 'tailwind', trimmed)
+      }
+    })
+  }
   tailwindChild.on('exit', (code) => {
     if (code !== 0 && code !== null) {
-      console.warn(`[dev] tailwind --watch exited with code ${code}`)
+      devLog('warn', 'tailwind', `--watch exited with code ${code}`)
     }
   })
 }
@@ -172,11 +323,12 @@ async function rebuildShell(): Promise<void> {
   const code = await proc.exited
   if (code === 0) {
     emitSuccess('shell', { type: 'dev:reload', scope: 'shell' })
-    console.log('[dev] shell rebuilt')
+    devLog('ready', 'dev', 'shell rebuilt')
   } else {
     const stderr = await new Response(proc.stderr).text()
     emitError('shell', 'shell build failed', stderr)
-    console.error('[dev] shell rebuild failed:\n' + stderr)
+    devLog('error', 'dev', 'shell rebuild failed')
+    printCapturedOutput(stderr)
   }
 }
 
@@ -196,10 +348,11 @@ async function rebuildPlugin(id: string): Promise<void> {
       broadcast({ type: 'dev:recover', scope: 'plugin' })
     }
     broadcast({ type: 'dev:hot-swap', scope: 'plugin', id, version })
-    console.log(`[dev] plugin ${id} rebuilt → hot-swap ${version}`)
+    devLog('ready', `plugin:${id}`, `rebuilt, hot-swap ${version}`)
   } else {
     emitError('plugin', `plugin ${id} build failed`, result.stderr)
-    console.error(`[dev] plugin ${id} rebuild failed:\n${result.stderr}`)
+    devLog('error', `plugin:${id}`, 'rebuild failed')
+    printCapturedOutput(result.stderr)
   }
 }
 
@@ -211,11 +364,12 @@ async function rebuildSdk(): Promise<void> {
   const code = await proc.exited
   if (code === 0) {
     emitSuccess('sdk', { type: 'dev:reload', scope: 'sdk' })
-    console.log('[dev] sdk (vendor bundles) rebuilt')
+    devLog('ready', 'sdk', 'vendor bundles rebuilt')
   } else {
     const stderr = await new Response(proc.stderr).text()
     emitError('sdk', 'sdk build failed', stderr)
-    console.error('[dev] sdk rebuild failed:\n' + stderr)
+    devLog('error', 'sdk', 'rebuild failed')
+    printCapturedOutput(stderr)
   }
 }
 
@@ -335,7 +489,7 @@ function startCssWatcher(): void {
     if (m === lastMtime) return
     lastMtime = m
     broadcast({ type: 'dev:css' })
-    console.log('[dev] css updated')
+    devLog('ready', 'css', 'updated')
   })
 }
 
@@ -373,7 +527,7 @@ async function main(): Promise<void> {
   startSdkWatcher()
   startCssWatcher()
 
-  console.log('[dev] watchers ready — starting server...')
+  devLog('ready', 'dev', 'watchers ready - starting server...')
   await import('../server')
 }
 

--- a/server.ts
+++ b/server.ts
@@ -676,6 +676,10 @@ const eventBus = new BakinEventBus(broadcast)
   server.listen(port, '0.0.0.0', () => {
     log.info(`Bakin ready on http://localhost:${port}`)
     log.info(`Listening on 0.0.0.0:${port} (Tailscale: http://100.91.112.69:${port})`)
+    if (process.env.BAKIN_DEV === '1') {
+      const logPath = join(getBakinPaths().logs, 'server.log')
+      log.info(`Full logs: ${logPath}`, { path: logPath })
+    }
 
     void (async () => {
       let recovered = 0

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -644,7 +644,7 @@ async function cmdHelp(): Promise<number> {
  * packages/host/src/ to watch, so it errors out with a clear pointer.
  * Exported so the legacy cli/bakin.ts entry point can delegate here.
  */
-export async function cmdDev(): Promise<number> {
+export async function cmdDev(devArgs: string[] = process.argv.slice(3)): Promise<number> {
   // Source mode: this file resolves from the on-disk repo layout so we can
   // locate the sibling scripts/dev.ts. In the compiled binary the module
   // lives under the `/$bunfs/` virtual filesystem, which doesn't contain
@@ -666,7 +666,7 @@ export async function cmdDev(): Promise<number> {
   }
 
   const { spawn } = await import('node:child_process')
-  const proc = spawn('bun', ['run', devScript], { stdio: 'inherit', cwd: repoRoot })
+  const proc = spawn('bun', ['run', devScript, ...devArgs], { stdio: 'inherit', cwd: repoRoot })
   return await new Promise<number>((resolvePromise) => {
     proc.once('close', (code: number | null) => resolvePromise(code ?? 0))
     proc.once('error', (err) => {
@@ -718,7 +718,7 @@ export async function dispatchCli(argv: string[]): Promise<CliResult> {
         return { startServer: false, exitCode: await cmdUpdate() }
 
       case 'dev':
-        return { startServer: false, exitCode: await cmdDev() }
+        return { startServer: false, exitCode: await cmdDev(args.slice(1)) }
 
       // `restart` falls through to the legacy delegation below so there's
       // a single implementation (cmdReboot in cli/bakin.ts).

--- a/src/core/cli/registry.ts
+++ b/src/core/cli/registry.ts
@@ -47,11 +47,11 @@ export const CLI_COMMANDS = [
   }),
   cli({
     name: 'dev',
-    usage: 'bakin dev',
+    usage: 'bakin dev [--verbose] [--no-color]',
     group: 'Lifecycle',
     summary: 'Run the source-tree development loop.',
-    description: 'Runs Bakin in watch-mode development from a source checkout. The compiled binary refuses this command outside a repo clone.',
-    examples: [{ title: 'Run development server', code: 'bakin dev', test: 'illustrative', reason: 'Starts a long-running development process.' }],
+    description: 'Runs Bakin in watch-mode development from a source checkout. By default output is compact; use --verbose for raw child-process output and debug logs.',
+    examples: [{ title: 'Run development server', code: 'bakin dev --verbose', test: 'illustrative', reason: 'Starts a long-running development process.' }],
   }),
   cli({
     name: 'version',

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -2,8 +2,10 @@
  * Server-side plugin registry singleton.
  * Loads plugins, stores their registrations, and provides lookups.
  */
+import { AsyncLocalStorage } from 'async_hooks'
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
 import { join } from 'path'
+import { inspect } from 'util'
 import type {
   BakinConfig,
   BakinPlugin,
@@ -85,6 +87,125 @@ export function registerCorePlugins(table: Readonly<Record<string, BakinPlugin>>
 }
 
 const log = createLogger('plugin-registry')
+
+type CapturedConsoleLevel = 'debug' | 'error' | 'info' | 'warn'
+type CapturedConsoleMethod = CapturedConsoleLevel | 'log'
+interface CapturedConsoleContext {
+  pluginId: string
+}
+
+const capturedConsoleContext = new AsyncLocalStorage<CapturedConsoleContext | undefined>()
+
+function withoutCapturedPluginConsole<T>(action: () => T): T {
+  return capturedConsoleContext.run(undefined, action)
+}
+
+function stripPluginConsolePrefix(pluginId: string, message: string): string {
+  const escaped = pluginId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return message.replace(new RegExp(`^\\[${escaped}\\]\\s*`), '')
+}
+
+function formatPluginConsoleArgs(pluginId: string, args: unknown[]): string {
+  return stripPluginConsolePrefix(
+    pluginId,
+    args.map((arg) => {
+      if (typeof arg === 'string') return arg
+      return inspect(arg, { breakLength: Infinity, colors: false, compact: true, depth: 5 })
+    }).join(' '),
+  ).trim()
+}
+
+async function withCapturedPluginConsole<T>(pluginId: string, action: () => Promise<T> | T): Promise<T> {
+  const original: Record<CapturedConsoleMethod, (...args: unknown[]) => void> = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+  }
+
+  const restore = () => {
+    console.debug = original.debug as typeof console.debug
+    console.error = original.error as typeof console.error
+    console.info = original.info as typeof console.info
+    console.log = original.log as typeof console.log
+    console.warn = original.warn as typeof console.warn
+  }
+
+  const install = () => {
+    console.debug = ((...args: unknown[]) => emit('debug', 'debug', args)) as typeof console.debug
+    console.error = ((...args: unknown[]) => emit('error', 'error', args)) as typeof console.error
+    console.info = ((...args: unknown[]) => emit('info', 'info', args)) as typeof console.info
+    console.log = ((...args: unknown[]) => emit('info', 'log', args)) as typeof console.log
+    console.warn = ((...args: unknown[]) => emit('warn', 'warn', args)) as typeof console.warn
+  }
+
+  const emit = (level: CapturedConsoleLevel, method: CapturedConsoleMethod, args: unknown[]) => {
+    const context = capturedConsoleContext.getStore()
+    if (!context) {
+      original[method](...args)
+      return
+    }
+
+    const message = formatPluginConsoleArgs(context.pluginId, args)
+    if (!message) return
+
+    // createLogger writes through console.*. Clear the plugin context while
+    // forwarding so the rendered logger line is not captured recursively.
+    withoutCapturedPluginConsole(() => {
+      const data = { source: 'plugin', pluginId: context.pluginId, console: true }
+      if (level === 'debug') log.debug(message, data)
+      else if (level === 'error') log.error(message, data)
+      else if (level === 'warn') log.warn(message, data)
+      else log.info(message, data)
+    })
+  }
+
+  install()
+  try {
+    return await capturedConsoleContext.run({ pluginId }, action)
+  } finally {
+    restore()
+  }
+}
+
+function withPluginLogData(pluginId: string, data?: unknown): Record<string, unknown> {
+  return {
+    ...(data && typeof data === 'object' && !Array.isArray(data) ? data as Record<string, unknown> : {}),
+    source: 'plugin',
+    pluginId,
+  }
+}
+
+function createPluginScopedLogger(pluginId: string) {
+  const pluginLog = createLogger(`plugin:${pluginId}`)
+  return {
+    debug: (message: string, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => pluginLog.debug(message, withPluginLogData(pluginId, data)))
+    },
+    info: (message: string, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => pluginLog.info(message, withPluginLogData(pluginId, data)))
+    },
+    warn: (message: string, errorOrData?: unknown, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => {
+        if (errorOrData instanceof Error || typeof errorOrData === 'string') {
+          pluginLog.warn(message, errorOrData, withPluginLogData(pluginId, data))
+        } else {
+          pluginLog.warn(message, withPluginLogData(pluginId, errorOrData))
+        }
+      })
+    },
+    error: (message: string, errorOrData?: unknown, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => {
+        if (errorOrData instanceof Error || typeof errorOrData === 'string') {
+          pluginLog.error(message, errorOrData, withPluginLogData(pluginId, data))
+        } else {
+          pluginLog.error(message, withPluginLogData(pluginId, errorOrData))
+        }
+      })
+    },
+  }
+}
 
 function resolveAppServices(services?: AppServices): AppServices {
   return services ?? getAppServices()
@@ -788,6 +909,7 @@ class PluginRegistryImpl {
           appendAudit(getContentDir(), `${pluginId}.${event}`, agent, data || {})
         },
       },
+      log: createPluginScopedLogger(pluginId),
       search: buildSearchAPI(pluginId, { registerRoute }),
       hooks: {
         register: (name: string, handler: (data: any) => any, metadata) => {
@@ -897,7 +1019,12 @@ class PluginRegistryImpl {
       // `cat ~/.bakin/audit.jsonl | jq 'select(.event=="plugin.activate")'`
       // shows the full surface the user authorized.
       logPluginActivation({ plugin, source: 'core', manifestPath })
-      console.log(`  ✓ Plugin loaded: ${plugin.name} v${plugin.version}`)
+      log.info(`Plugin loaded: ${plugin.name} v${plugin.version}`, {
+        source: 'plugin',
+        pluginId: plugin.id,
+        version: plugin.version,
+        pluginSource: 'core',
+      })
     } catch (err) {
       log.error(`Failed to load plugin at ${pluginPath}`, err)
       this.markPluginFailed({
@@ -927,7 +1054,11 @@ class PluginRegistryImpl {
     // Tear down the currently active registration set before activating
     // the new module so routes/hooks/tools/search tables don't pile up.
     if (this.plugins.has(pluginId)) {
-      console.log(`  ↻ User plugin reloads: ${pluginId}`)
+      log.info(`User plugin reloads: ${pluginId}`, {
+        source: 'plugin',
+        pluginId,
+        pluginSource: 'user',
+      })
       await this.deactivatePlugin(pluginId, { callShutdown: true, removeState: true })
     }
 
@@ -941,7 +1072,7 @@ class PluginRegistryImpl {
       importTarget = `${importTarget}?v=${Date.now()}-${userPluginImportCounter}`
     }
 
-    const mod = await import(/* webpackIgnore: true */ importTarget)
+    const mod = await withCapturedPluginConsole(pluginId, () => import(/* webpackIgnore: true */ importTarget))
     const plugin: BakinPlugin = mod.default || mod.plugin || mod
 
     if (!plugin.id || !plugin.activate) {
@@ -964,7 +1095,7 @@ class PluginRegistryImpl {
 
     const ctx = this.buildContext(plugin.id, state, storage, events, services)
     this.registerDeclarativeRoutes(plugin, state)
-    await plugin.activate(ctx)
+    await withCapturedPluginConsole(plugin.id, () => plugin.activate(ctx))
     state.ctx = ctx
     // #142 layer 1 — surface user-plugin permissions to the audit log.
     // Source is read from the lockfile (github vs local) by the helper.
@@ -978,7 +1109,12 @@ class PluginRegistryImpl {
     this.plugins.set(plugin.id, state)
     this.failedPlugins.delete(plugin.id)
     corePluginIds.delete(plugin.id)
-    console.log(`  ✓ User plugin loaded: ${plugin.name} v${plugin.version}`)
+    log.info(`User plugin loaded: ${plugin.name} v${plugin.version}`, {
+      source: 'plugin',
+      pluginId: plugin.id,
+      version: plugin.version,
+      pluginSource: 'user',
+    })
     return { id: plugin.id, version: plugin.version }
   }
 
@@ -1196,7 +1332,11 @@ class PluginRegistryImpl {
   async onAllReady(): Promise<void> {
     for (const [id, state] of this.plugins) {
       try {
-        await state.plugin.onReady?.()
+        if (state.source === 'user') {
+          await withCapturedPluginConsole(id, () => state.plugin.onReady?.())
+        } else {
+          await state.plugin.onReady?.()
+        }
       } catch (err) {
         log.error(`onReady failed for plugin "${id}"`, err)
       }

--- a/tests/adapter-antfly/server.test.ts
+++ b/tests/adapter-antfly/server.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test'
+import { parseAntflyLogLine } from '../../packages/adapter-antfly/src/server'
+
+describe('Antfly server log parsing', () => {
+  it('uses the inner Antfly level instead of the child stream level', () => {
+    const parsed = parseAntflyLogLine(
+      'ts=22:16:17 lvl=info caller=cmd/swarm.go:203 msg="Metadata API server is ready" address=0.0.0.0:8080',
+      'warn',
+    )
+
+    expect(parsed.level).toBe('info')
+    expect(parsed.message).toBe('Metadata API server is ready')
+    expect(parsed.data).toMatchObject({
+      source: 'antfly',
+      caller: 'cmd/swarm.go:203',
+      address: '0.0.0.0:8080',
+    })
+  })
+})

--- a/tests/core/logger.test.ts
+++ b/tests/core/logger.test.ts
@@ -2,6 +2,23 @@ import { describe, it, expect, spyOn } from 'bun:test'
 import { createLogger } from '../../src/core/logger'
 
 describe('Logger', () => {
+  function withConsoleEnv(env: Record<string, string | undefined>, run: () => void): void {
+    const previous: Record<string, string | undefined> = {}
+    for (const key of Object.keys(env)) {
+      previous[key] = process.env[key]
+      if (env[key] === undefined) delete process.env[key]
+      else process.env[key] = env[key]
+    }
+    try {
+      run()
+    } finally {
+      for (const key of Object.keys(env)) {
+        if (previous[key] === undefined) delete process.env[key]
+        else process.env[key] = previous[key]
+      }
+    }
+  }
+
   it('creates a logger with the given module name', () => {
     const log = createLogger('test-module')
     expect(log).toHaveProperty('debug')
@@ -47,5 +64,59 @@ describe('Logger', () => {
     log.info('with data', { key: 'value' })
     expect(spy.mock.calls[0][0]).toContain('"key":"value"')
     spy.mockRestore()
+  })
+
+  it('renders pretty console output with compact source labels', () => {
+    withConsoleEnv({
+      BAKIN_CONSOLE_FORMAT: 'pretty',
+      BAKIN_LOG_LEVEL: undefined,
+      NO_COLOR: '1',
+    }, () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      const log = createLogger('plugin-registry')
+      log.info('Plugin loaded', { pluginId: 'tasks', version: '2.1.0' })
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toMatch(/^\d\d:\d\d:\d\d\s+info\s+plugin:tasks\s+Plugin loaded$/)
+      expect(spy.mock.calls[0][0]).not.toContain('"pluginId"')
+      spy.mockRestore()
+    })
+  })
+
+  it('renders verbose console output with debug and data details', () => {
+    withConsoleEnv({
+      BAKIN_CONSOLE_FORMAT: 'verbose',
+      BAKIN_LOG_LEVEL: undefined,
+      NO_COLOR: '1',
+    }, () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      const log = createLogger('dev')
+      log.debug('trace step', { key: 'value' })
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('debug')
+      expect(spy.mock.calls[0][0]).toContain('dev')
+      expect(spy.mock.calls[0][0]).toContain('trace step')
+      expect(spy.mock.calls[0][0]).toContain('"key":"value"')
+      spy.mockRestore()
+    })
+  })
+
+  it('suppresses noisy Antfly info in pretty mode but keeps readiness lines', () => {
+    withConsoleEnv({
+      BAKIN_CONSOLE_FORMAT: 'pretty',
+      BAKIN_LOG_LEVEL: undefined,
+      NO_COLOR: '1',
+    }, () => {
+      const spy = spyOn(console, 'log').mockImplementation(() => {})
+      const log = createLogger('app-services')
+      log.info('Opening index at registration', { source: 'antfly', shardID: 'abc' })
+      log.info('Metadata API server is ready', { source: 'antfly', address: '0.0.0.0:8080' })
+
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy.mock.calls[0][0]).toContain('antfly')
+      expect(spy.mock.calls[0][0]).toContain('Metadata API server is ready')
+      spy.mockRestore()
+    })
   })
 })

--- a/tests/core/plugin-registry.test.ts
+++ b/tests/core/plugin-registry.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, mock, type Mock } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn, type Mock } from 'bun:test'
+import { AsyncResource } from 'async_hooks'
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -101,12 +102,16 @@ describe('HookRegistry', () => {
 
 // These vi.mock calls are hoisted — they use paths relative to THIS file,
 // matching how vitest resolves them (same as the source's imports via aliases).
+const loggerInfo = mock()
+const loggerWarn = mock()
+const loggerError = mock()
+const loggerDebug = mock()
 mock.module('@/core/logger', () => ({
   createLogger: () => ({
-    info: mock(),
-    warn: mock(),
-    error: mock(),
-    debug: mock(),
+    info: loggerInfo,
+    warn: loggerWarn,
+    error: loggerError,
+    debug: loggerDebug,
   }),
 }))
 
@@ -177,6 +182,10 @@ describe('PluginRegistryImpl', () => {
     delete (globalThis as any).__bakinPluginRegistry
     delete (globalThis as any).__bakinHookRegistry
     mockedExecTools.clear()
+    loggerInfo.mockClear()
+    loggerWarn.mockClear()
+    loggerError.mockClear()
+    loggerDebug.mockClear()
     const runtime = createMockRuntimeAdapter()
     const search = createMockSearchAdapter()
     ;(globalThis as any).__bakinAppServices = {
@@ -299,6 +308,7 @@ describe('PluginRegistryImpl', () => {
     opts: {
       deps?: string[]
       activate?: string
+      onReady?: string
       manifest?: Record<string, unknown>
       root?: string
     } = {},
@@ -324,6 +334,7 @@ describe('PluginRegistryImpl', () => {
         name: '${id.charAt(0).toUpperCase() + id.slice(1)}',
         version: '1.0.0',
         activate: function(ctx) { ${opts.activate || ''} },
+        onReady: ${opts.onReady || 'undefined'},
       }
       module.exports = plugin
       module.exports.default = plugin`,
@@ -567,6 +578,88 @@ describe('PluginRegistryImpl', () => {
   })
 
   describe('user plugin failure states', () => {
+    it('captures user plugin console output into plugin-scoped logs', async () => {
+      writeUserPlugin('projects', {
+        activate: `
+          console.log('[projects] Project index rebuilt', { entries: 0 })
+          console.warn('[projects] Index warning', { code: 'stale' })
+          ctx.log.info('ctx logger activated', { count: 2 })
+        `,
+        onReady: `function() { console.log('[projects] Ready projects', { draft: 1 }) }`,
+      })
+      const consoleLog = spyOn(console, 'log').mockImplementation(() => {})
+      const consoleWarn = spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        await pluginRegistry.initialize({ plugins: [] }, mockStorage(), mockEvents())
+        await pluginRegistry.onAllReady()
+      } finally {
+        consoleLog.mockRestore()
+        consoleWarn.mockRestore()
+      }
+
+      expect(consoleLog).not.toHaveBeenCalled()
+      expect(consoleWarn).not.toHaveBeenCalled()
+
+      const infoCalls = loggerInfo.mock.calls as unknown as Array<[string, Record<string, unknown>?]>
+      const warnCalls = loggerWarn.mock.calls as unknown as Array<[string, Record<string, unknown>?]>
+      expect(infoCalls).toContainEqual([
+        'Project index rebuilt { entries: 0 }',
+        { source: 'plugin', pluginId: 'projects', console: true },
+      ])
+      expect(infoCalls).toContainEqual([
+        'Ready projects { draft: 1 }',
+        { source: 'plugin', pluginId: 'projects', console: true },
+      ])
+      expect(infoCalls).toContainEqual([
+        'ctx logger activated',
+        { count: 2, source: 'plugin', pluginId: 'projects' },
+      ])
+      expect(warnCalls).toContainEqual([
+        'Index warning { code: \'stale\' }',
+        { source: 'plugin', pluginId: 'projects', console: true },
+      ])
+    })
+
+    it('does not capture unrelated console output during async user plugin activation', async () => {
+      let markStarted!: () => void
+      const started = new Promise<void>((resolve) => { markStarted = resolve })
+      ;(globalThis as any).__asyncUserMarkStarted = markStarted
+
+      writeUserPlugin('async-user', {
+        activate: `
+          console.log('[async-user] activation started')
+          global.__asyncUserMarkStarted()
+          return new Promise(resolve => { global.__asyncUserRelease = resolve })
+        `,
+      })
+
+      const outsideMessage = 'outside lifecycle'
+      const outsideResource = new AsyncResource('outside-console')
+      const consoleLog = spyOn(console, 'log').mockImplementation(() => {})
+
+      try {
+        const initializePromise = pluginRegistry.initialize({ plugins: [] }, mockStorage(), mockEvents())
+        await started
+        outsideResource.runInAsyncScope(() => console.log(outsideMessage))
+        const release = (globalThis as any).__asyncUserRelease
+        expect(typeof release).toBe('function')
+        release()
+        await initializePromise
+        expect(consoleLog).toHaveBeenCalledWith(outsideMessage)
+      } finally {
+        outsideResource.emitDestroy()
+        consoleLog.mockRestore()
+      }
+
+      const infoCalls = loggerInfo.mock.calls as unknown as Array<[string, Record<string, unknown>?]>
+      expect(infoCalls).toContainEqual([
+        'activation started',
+        { source: 'plugin', pluginId: 'async-user', console: true },
+      ])
+      expect(infoCalls.some(([message]) => message === outsideMessage)).toBe(false)
+    })
+
     it('loads user plugins installed as symlinks', async () => {
       const sourceDir = writeUserPlugin('linked-user', {
         root: join(tempDir, 'dev-sources'),


### PR DESCRIPTION
## Summary
- add pretty and verbose console modes for Bakin logs, with source labels, colors, log-level filtering, and NO_COLOR support
- make `bakin dev --verbose` pass through to the dev coordinator and raw child-process output while default dev startup shows summarized build/watch lines
- parse Antfly child logs line-by-line, map inner `lvl` correctly, suppress noisy info in pretty mode, and keep full JSON file logs
- document the new dev output behavior

## Verification
- `bun test tests/core/logger.test.ts tests/adapter-antfly/server.test.ts`
- `bun run typecheck`
- `bun run lint`