### PR TITLE
Surface OpenClaw tool activity in brainstorm streams

### DIFF
--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1366,16 +1366,115 @@ function parseStreamFrame(frame: string): ChatChunk | null {
   if (data === '[DONE]') return { type: 'done' }
   try {
     const parsed = JSON.parse(data) as {
-      choices?: Array<{ delta?: { content?: string }; message?: { content?: string } }>
-      error?: { message?: string }
+      type?: string
+      event?: string
+      content?: string
+      data?: unknown
+      activity?: { kind?: string; content?: string; data?: unknown }
+      tool?: unknown
+      tool_call?: unknown
+      toolCall?: unknown
+      choices?: Array<{
+        delta?: { content?: string; tool_calls?: unknown[] }
+        message?: { content?: string; tool_calls?: unknown[] }
+      }>
+      error?: { message?: string } | string
     }
-    const error = parsed.error?.message
+    const error = typeof parsed.error === 'string' ? parsed.error : parsed.error?.message
     if (error) return { type: 'error', content: error }
+    const activity = parseActivityChunk(parsed)
+    if (activity) return activity
     const content = parsed.choices?.[0]?.delta?.content ?? parsed.choices?.[0]?.message?.content
     return content ? { type: 'text', content } : null
   } catch {
     return data ? { type: 'text', content: data } : null
   }
+}
+
+function parseActivityChunk(parsed: {
+  type?: string
+  event?: string
+  content?: string
+  data?: unknown
+  activity?: { kind?: string; content?: string; data?: unknown }
+  tool?: unknown
+  tool_call?: unknown
+  toolCall?: unknown
+  choices?: Array<{
+    delta?: { tool_calls?: unknown[] }
+    message?: { tool_calls?: unknown[] }
+  }>
+}): ChatChunk | null {
+  if (parsed.activity) {
+    const kind = parsed.activity.kind
+    if (kind === 'runtime_status' || kind === 'status') {
+      return {
+        type: 'status',
+        content: parsed.activity.content || 'Agent status update',
+        data: parsed.activity.data,
+      }
+    }
+    if (kind === 'tool_call' || kind === 'tool') {
+      return {
+        type: 'tool',
+        content: parsed.activity.content || describeToolPayload(parsed.activity.data),
+        data: parsed.activity.data,
+      }
+    }
+  }
+
+  const frameKind = parsed.type ?? parsed.event
+  if (frameKind === 'status' || frameKind === 'runtime_status') {
+    return {
+      type: 'status',
+      content: parsed.content || 'Agent status update',
+      data: parsed.data,
+    }
+  }
+  if (frameKind === 'tool' || frameKind === 'tool_call') {
+    return {
+      type: 'tool',
+      content: parsed.content || describeToolPayload(parsed.data ?? parsed.tool ?? parsed.tool_call ?? parsed.toolCall),
+      data: parsed.data ?? parsed.tool ?? parsed.tool_call ?? parsed.toolCall,
+    }
+  }
+
+  const toolCalls = parsed.choices?.[0]?.delta?.tool_calls ?? parsed.choices?.[0]?.message?.tool_calls
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    return {
+      type: 'tool',
+      content: describeToolPayload(toolCalls),
+      data: { toolCalls },
+    }
+  }
+
+  const toolPayload = parsed.tool ?? parsed.tool_call ?? parsed.toolCall
+  if (toolPayload !== undefined) {
+    return {
+      type: 'tool',
+      content: parsed.content || describeToolPayload(toolPayload),
+      data: toolPayload,
+    }
+  }
+
+  return null
+}
+
+function describeToolPayload(payload: unknown): string {
+  if (Array.isArray(payload)) {
+    const first = payload[0]
+    const label = describeToolPayload(first)
+    return payload.length > 1 ? `${label} + ${payload.length - 1} more` : label
+  }
+  if (isPlainObject(payload)) {
+    const functionValue = payload.function
+    if (isPlainObject(functionValue) && typeof functionValue.name === 'string') return functionValue.name
+    for (const key of ['name', 'tool', 'toolName', 'id']) {
+      const value = payload[key]
+      if (typeof value === 'string' && value.length > 0) return value
+    }
+  }
+  return 'Tool call'
 }
 
 function parseJsonObject(raw: string): Record<string, unknown> | null {

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs'
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
@@ -71,6 +71,8 @@ const TRANSIENT_FETCH_CODES = new Set([
 ])
 
 const SEND_MESSAGE_RETRY_BACKOFF_MS = [1000, 2000]
+const OPENCLAW_SESSION_ACTIVITY_POLL_MS = 200
+const OPENCLAW_ACTIVITY_PREVIEW_CHARS = 500
 const OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS = 600000
 const OPENCLAW_PLUGIN_APPROVAL_REF_PREFIX = 'openclaw-plugin-approval:'
 const OPENCLAW_PLUGIN_ID = 'bakin'
@@ -140,6 +142,17 @@ interface OpenClawModelListJson {
     tags?: string[]
     missing?: boolean
   }>
+}
+
+interface OpenClawSessionStoreEntry {
+  sessionId?: string
+  sessionFile?: string
+}
+
+interface OpenClawSessionActivityCursor {
+  sessionFile?: string
+  offset: number
+  partial: string
 }
 
 export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
@@ -879,7 +892,21 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   }
 
   private async *streamChat(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): AsyncIterable<ChatChunk> {
+    const activityAbort = new AbortController()
+    const activityCursor = opts.sessionKey
+      ? createOpenClawSessionActivityCursor(opts.agentId, opts.sessionKey)
+      : null
     const response = await this.fetchChat(opts, true)
+    const primary = this.readChatCompletionStream(response)
+    if (!activityCursor || !opts.sessionKey) {
+      yield* primary
+      return
+    }
+    const activity = watchOpenClawSessionActivity(opts.agentId, opts.sessionKey, activityCursor, activityAbort.signal)
+    yield* mergeChatStreams(primary, activity, () => activityAbort.abort())
+  }
+
+  private async *readChatCompletionStream(response: Response): AsyncIterable<ChatChunk> {
     const reader = response.body?.getReader()
     if (!reader) return
     const decoder = new TextDecoder()
@@ -1350,6 +1377,262 @@ function readPath(source: Record<string, unknown>, key: string): unknown {
     current = current[part]
   }
   return current
+}
+
+async function* mergeChatStreams(
+  primary: AsyncIterable<ChatChunk>,
+  secondary: AsyncIterable<ChatChunk>,
+  stopSecondary: () => void,
+): AsyncIterable<ChatChunk> {
+  type QueueItem =
+    | { source: 'primary' | 'secondary'; chunk: ChatChunk }
+    | { source: 'primary' | 'secondary'; done: true }
+    | { source: 'primary' | 'secondary'; error: unknown }
+
+  const queue: QueueItem[] = []
+  let notify: (() => void) | null = null
+  const push = (item: QueueItem): void => {
+    queue.push(item)
+    notify?.()
+    notify = null
+  }
+
+  const pump = async (source: 'primary' | 'secondary', iterable: AsyncIterable<ChatChunk>): Promise<void> => {
+    try {
+      for await (const chunk of iterable) {
+        if (source === 'primary' && chunk.type === 'done') {
+          push({ source, done: true })
+          return
+        }
+        push({ source, chunk })
+      }
+      push({ source, done: true })
+    } catch (error) {
+      push({ source, error })
+    }
+  }
+
+  void pump('primary', primary)
+  void pump('secondary', secondary)
+
+  let primaryDone = false
+  let secondaryDone = false
+  while (!primaryDone || !secondaryDone) {
+    if (queue.length === 0) {
+      await new Promise<void>((resolve) => { notify = resolve })
+    }
+    const item = queue.shift()
+    if (!item) continue
+    if ('error' in item) {
+      if (item.source === 'primary') stopSecondary()
+      throw item.error
+    }
+    if ('done' in item) {
+      if (item.source === 'primary') {
+        primaryDone = true
+        stopSecondary()
+      } else {
+        secondaryDone = true
+      }
+      continue
+    }
+    yield item.chunk
+  }
+
+  yield { type: 'done' }
+}
+
+async function* watchOpenClawSessionActivity(
+  agentId: string,
+  sessionKey: string,
+  cursor: OpenClawSessionActivityCursor,
+  signal: AbortSignal,
+): AsyncIterable<ChatChunk> {
+  while (true) {
+    for (const chunk of readOpenClawSessionActivity(agentId, sessionKey, cursor)) {
+      yield chunk
+    }
+    if (signal.aborted) break
+    await sleep(OPENCLAW_SESSION_ACTIVITY_POLL_MS)
+  }
+
+  for (const chunk of readOpenClawSessionActivity(agentId, sessionKey, cursor)) {
+    yield chunk
+  }
+}
+
+function createOpenClawSessionActivityCursor(agentId: string, sessionKey: string): OpenClawSessionActivityCursor {
+  const sessionFile = resolveOpenClawSessionFile(agentId, sessionKey)
+  return {
+    sessionFile,
+    offset: sessionFile ? safeFileSize(sessionFile) : 0,
+    partial: '',
+  }
+}
+
+function readOpenClawSessionActivity(
+  agentId: string,
+  sessionKey: string,
+  cursor: OpenClawSessionActivityCursor,
+): ChatChunk[] {
+  if (!cursor.sessionFile) {
+    cursor.sessionFile = resolveOpenClawSessionFile(agentId, sessionKey)
+    cursor.offset = 0
+    cursor.partial = ''
+  }
+  if (!cursor.sessionFile) return []
+
+  const next = readFileTail(cursor.sessionFile, cursor.offset)
+  if (!next) return []
+  cursor.offset = next.offset
+
+  const text = cursor.partial + next.text
+  const lines = text.split('\n')
+  cursor.partial = lines.pop() ?? ''
+
+  const chunks: ChatChunk[] = []
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const parsed = parseJsonObject(trimmed)
+    if (parsed) chunks.push(...activityChunksFromOpenClawTranscriptRecord(parsed))
+  }
+  return chunks
+}
+
+function resolveOpenClawSessionFile(agentId: string, sessionKey: string): string | undefined {
+  const storePath = join(getOpenClawHome(), 'agents', agentId, 'sessions', 'sessions.json')
+  const store = readJsonFile<Record<string, OpenClawSessionStoreEntry>>(storePath)
+  const entry = store?.[sessionKey]
+  if (!entry) return undefined
+  if (typeof entry.sessionFile === 'string' && entry.sessionFile.length > 0) return entry.sessionFile
+  if (typeof entry.sessionId === 'string' && entry.sessionId.length > 0) {
+    return join(getOpenClawHome(), 'agents', agentId, 'sessions', `${entry.sessionId}.jsonl`)
+  }
+  return undefined
+}
+
+function safeFileSize(path: string): number {
+  try {
+    return statSync(path).size
+  } catch {
+    return 0
+  }
+}
+
+function readFileTail(path: string, offset: number): { text: string; offset: number } | null {
+  let size: number
+  try {
+    size = statSync(path).size
+  } catch {
+    return null
+  }
+  if (size < offset) offset = 0
+  if (size === offset) return null
+  const length = size - offset
+  const buffer = Buffer.alloc(length)
+  let fd: number | undefined
+  try {
+    fd = openSync(path, 'r')
+    const bytesRead = readSync(fd, buffer, 0, length, offset)
+    return { text: buffer.subarray(0, bytesRead).toString('utf-8'), offset: offset + bytesRead }
+  } catch {
+    return null
+  } finally {
+    if (fd !== undefined) closeSync(fd)
+  }
+}
+
+function activityChunksFromOpenClawTranscriptRecord(record: Record<string, unknown>): ChatChunk[] {
+  if (record.type !== 'message') return []
+  const message = record.message
+  if (!isPlainObject(message)) return []
+  const role = message.role
+  if (role === 'assistant') return activityChunksFromAssistantMessage(message)
+  if (role === 'toolResult') return activityChunkFromToolResultMessage(message)
+  return []
+}
+
+function activityChunksFromAssistantMessage(message: Record<string, unknown>): ChatChunk[] {
+  const content = Array.isArray(message.content) ? message.content : []
+  const chunks: ChatChunk[] = []
+  for (const part of content) {
+    if (!isPlainObject(part) || part.type !== 'toolCall') continue
+    const name = typeof part.name === 'string' && part.name.length > 0 ? part.name : 'tool'
+    const args = part.arguments
+    chunks.push({
+      type: 'tool',
+      content: summarizeOpenClawToolCall(name, args),
+      data: {
+        phase: 'call',
+        id: typeof part.id === 'string' ? part.id : undefined,
+        name,
+        argumentsPreview: previewUnknown(args),
+      },
+    })
+  }
+  return chunks
+}
+
+function activityChunkFromToolResultMessage(message: Record<string, unknown>): ChatChunk[] {
+  const toolName = typeof message.toolName === 'string' && message.toolName.length > 0 ? message.toolName : 'tool'
+  const details = isPlainObject(message.details) ? message.details : {}
+  const status = typeof details.status === 'string' ? details.status : undefined
+  const label = status ? `${toolName} ${status}` : `${toolName} finished`
+  return [{
+    type: 'tool',
+    content: label,
+    data: {
+      phase: 'result',
+      toolName,
+      toolCallId: typeof message.toolCallId === 'string' ? message.toolCallId : undefined,
+      status,
+      exitCode: typeof details.exitCode === 'number' ? details.exitCode : undefined,
+      durationMs: typeof details.durationMs === 'number' ? details.durationMs : undefined,
+      outputPreview: previewUnknown(message.content),
+    },
+  }]
+}
+
+function summarizeOpenClawToolCall(name: string, args: unknown): string {
+  if (isPlainObject(args)) {
+    const command = args.command
+    if (name === 'exec' && typeof command === 'string' && command.trim()) {
+      return `exec: ${firstLine(command)}`
+    }
+    const path = args.path
+    if (name === 'read' && typeof path === 'string' && path.trim()) {
+      return `read: ${truncateMiddle(path.trim(), 140)}`
+    }
+    const action = args.action
+    if (name === 'process' && typeof action === 'string' && action.trim()) {
+      return `process: ${action.trim()}`
+    }
+  }
+  return name
+}
+
+function firstLine(value: string): string {
+  return truncateMiddle(redactSensitiveText(value.trim().split(/\r?\n/)[0] ?? ''), 160)
+}
+
+function previewUnknown(value: unknown): string {
+  const raw = typeof value === 'string' ? value : JSON.stringify(value)
+  return truncateMiddle(redactSensitiveText(raw ?? ''), OPENCLAW_ACTIVITY_PREVIEW_CHARS)
+}
+
+function truncateMiddle(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  const head = Math.max(1, Math.floor((maxChars - 3) * 0.65))
+  const tail = Math.max(1, maxChars - 3 - head)
+  return `${value.slice(0, head)}...${value.slice(-tail)}`
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/(authorization:\s*bearer\s+)[^\s"'`]+/gi, '$1[redacted]')
+    .replace(/(x-access-token:)[^\s"'`@]+/gi, '$1[redacted]')
+    .replace(/\b([A-Za-z0-9_]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_]*\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,}]+)/gi, '$1[redacted]')
 }
 
 function parseStreamFrame(frame: string): ChatChunk | null {

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -892,18 +892,28 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   }
 
   private async *streamChat(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): AsyncIterable<ChatChunk> {
-    const activityAbort = new AbortController()
-    const activityCursor = opts.sessionKey
-      ? createOpenClawSessionActivityCursor(opts.agentId, opts.sessionKey)
-      : null
-    const response = await this.fetchChat(opts, true)
-    const primary = this.readChatCompletionStream(response)
-    if (!activityCursor || !opts.sessionKey) {
+    const primary = this.fetchAndReadChatCompletionStream(opts)
+    if (!opts.sessionKey) {
       yield* primary
       return
     }
+
+    const activityCursor = opts.sessionKey
+      ? createOpenClawSessionActivityCursor(opts.agentId, opts.sessionKey)
+      : null
+    if (!activityCursor) {
+      yield* primary
+      return
+    }
+
+    const activityAbort = new AbortController()
     const activity = watchOpenClawSessionActivity(opts.agentId, opts.sessionKey, activityCursor, activityAbort.signal)
     yield* mergeChatStreams(primary, activity, () => activityAbort.abort())
+  }
+
+  private async *fetchAndReadChatCompletionStream(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): AsyncIterable<ChatChunk> {
+    const response = await this.fetchChat(opts, true)
+    yield* this.readChatCompletionStream(response)
   }
 
   private async *readChatCompletionStream(response: Response): AsyncIterable<ChatChunk> {

--- a/packages/host/src/api/_adapter.ts
+++ b/packages/host/src/api/_adapter.ts
@@ -68,10 +68,10 @@ export async function dispatchWebHandler(
       nodeHeaders[key] = value
     })
     res.writeHead(webRes.status, nodeHeaders)
+    res.flushHeaders?.()
 
     if (webRes.body) {
-      const buf = Buffer.from(await webRes.arrayBuffer())
-      res.end(buf)
+      await writeWebResponseBody(res, webRes.body)
     } else {
       res.end()
     }
@@ -83,5 +83,26 @@ export async function dispatchWebHandler(
         error: err instanceof Error ? err.message : String(err),
       }))
     }
+  }
+}
+
+async function writeWebResponseBody(
+  res: ServerResponse,
+  body: ReadableStream<Uint8Array>,
+): Promise<void> {
+  const reader = body.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!value || value.byteLength === 0) continue
+      const canContinue = res.write(Buffer.from(value))
+      if (!canContinue) {
+        await new Promise<void>((resolve) => res.once('drain', resolve))
+      }
+    }
+    res.end()
+  } finally {
+    reader.releaseLock()
   }
 }

--- a/src/components/integrated-brainstorm/message-list.tsx
+++ b/src/components/integrated-brainstorm/message-list.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { AlertTriangle, CircleDot, Wrench } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { AgentAvatar, MarkdownContent } from '@bakin/sdk/components'
 import { useAgentColor } from '@bakin/sdk/hooks'
@@ -21,6 +22,9 @@ export function MessageList({ messages, defaultAgentId, transform }: MessageList
         if (msg.role === 'user') {
           return <UserBubble key={msg.id} content={msg.content} />
         }
+        if (msg.role === 'activity') {
+          return <ActivityBubble key={msg.id} message={msg} />
+        }
         const prev = idx > 0 ? messages[idx - 1] : null
         const isConsecutive = prev?.role === 'assistant'
         const transformed = transform ? transform(msg.content) : { text: msg.content }
@@ -34,6 +38,47 @@ export function MessageList({ messages, defaultAgentId, transform }: MessageList
           />
         )
       })}
+    </div>
+  )
+}
+
+function formatActivityData(data: unknown): string | null {
+  if (data === undefined || data === null) return null
+  try {
+    return JSON.stringify(data, null, 2)
+  } catch {
+    return String(data)
+  }
+}
+
+function ActivityBubble({ message }: { message: BrainstormMessage }) {
+  const data = formatActivityData(message.data)
+  const kind = message.kind ?? 'runtime_status'
+  const Icon = kind === 'tool_call' ? Wrench : kind === 'error' ? AlertTriangle : CircleDot
+  const label = kind === 'tool_call' ? 'Tool' : kind === 'error' ? 'Error' : 'Status'
+
+  return (
+    <div
+      data-testid="activity-bubble"
+      className="ml-8 flex items-start gap-2 text-[11px] leading-5 text-zinc-500"
+    >
+      <Icon className="mt-0.5 size-3 shrink-0 text-zinc-600" aria-hidden="true" />
+      <div className="min-w-0">
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
+          <span className="font-medium uppercase tracking-wide text-zinc-600">{label}</span>
+          <span className="break-words text-zinc-400">{message.content}</span>
+        </div>
+        {data && (
+          <details className="mt-1">
+            <summary className="cursor-pointer select-none text-zinc-600 hover:text-zinc-400">
+              Details
+            </summary>
+            <pre className="mt-1 max-h-40 overflow-auto rounded border border-[rgba(255,255,255,0.06)] bg-zinc-950/60 p-2 text-[10px] leading-4 text-zinc-500">
+              {data}
+            </pre>
+          </details>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/integrated-brainstorm/types.ts
+++ b/src/components/integrated-brainstorm/types.ts
@@ -3,9 +3,11 @@ import type { ReactNode } from 'react'
 
 export interface BrainstormMessage {
   id: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'activity'
   content: string
   agentId?: string
+  kind?: 'runtime_status' | 'tool_call' | 'error' | string
+  data?: unknown
   timestamp?: string
 }
 

--- a/src/components/integrated-brainstorm/use-brainstorm-state.ts
+++ b/src/components/integrated-brainstorm/use-brainstorm-state.ts
@@ -14,6 +14,25 @@ function newId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
+function activityMessageFromCustom(name: string, data: unknown): BrainstormMessage | null {
+  if (name !== 'activity') return null
+  const payload = data && typeof data === 'object' && 'activity' in data
+    ? (data as { activity?: unknown }).activity
+    : data
+  if (!payload || typeof payload !== 'object') return null
+  const activity = payload as Record<string, unknown>
+  const content = typeof activity.content === 'string' ? activity.content : ''
+  if (!content) return null
+  return {
+    id: typeof activity.id === 'string' ? activity.id : newId('act'),
+    role: 'activity',
+    kind: typeof activity.kind === 'string' ? activity.kind : 'runtime_status',
+    content,
+    data: activity.data,
+    timestamp: typeof activity.timestamp === 'string' ? activity.timestamp : new Date().toISOString(),
+  }
+}
+
 interface UseBrainstormStateOpts {
   messages: BrainstormMessage[]
   onMessagesChange: (next: BrainstormMessage[]) => void
@@ -79,6 +98,7 @@ export function useBrainstormState({
       abortRef.current = controller
 
       let accumulated = ''
+      const customMessages: BrainstormMessage[] = []
       try {
         const result = await onSend(trimmed, messages, {
           signal: controller.signal,
@@ -87,7 +107,14 @@ export function useBrainstormState({
             setStreamingContent(accumulated)
             setStatus('streaming')
           },
-          onCustom: options?.onCustom,
+          onCustom: (name: string, data: unknown) => {
+            const activityMessage = activityMessageFromCustom(name, data)
+            if (activityMessage) {
+              customMessages.push(activityMessage)
+              onMessagesChange([...historyWithUser, ...customMessages])
+            }
+            options?.onCustom?.(name, data)
+          },
         })
         const resolvedContent = result?.content?.trim() ?? ''
         const finalContent = resolvedContent.length > 0 ? resolvedContent : accumulated.trim()
@@ -99,7 +126,7 @@ export function useBrainstormState({
             agentId: defaultAgentId,
             timestamp: new Date().toISOString(),
           }
-          onMessagesChange([...historyWithUser, assistantMsg])
+          onMessagesChange([...historyWithUser, ...customMessages, assistantMsg])
         }
       } catch (err) {
         if (controller.signal.aborted) {
@@ -113,7 +140,7 @@ export function useBrainstormState({
               agentId: defaultAgentId,
               timestamp: new Date().toISOString(),
             }
-            onMessagesChange([...historyWithUser, assistantMsg])
+            onMessagesChange([...historyWithUser, ...customMessages, assistantMsg])
           }
         } else {
           setErrorMessage(err instanceof Error ? err.message : String(err))

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const item of iterable) out.push(item)
+  return out
+}
+
+function sseResponse(frames: unknown[]): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream({
+    start(controller) {
+      for (const frame of frames) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`))
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+describe('OpenClaw runtime stream parsing', () => {
+  let testDir: string
+  let originalOpenClawHome: string | undefined
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'bakin-openclaw-stream-test-'))
+    originalOpenClawHome = process.env.OPENCLAW_HOME
+    originalFetch = globalThis.fetch
+    process.env.OPENCLAW_HOME = testDir
+    mkdirSync(testDir, { recursive: true })
+    writeFileSync(join(testDir, 'openclaw.json'), JSON.stringify({
+      gateway: { auth: { token: 'test-token' } },
+    }), 'utf-8')
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalOpenClawHome === undefined) delete process.env.OPENCLAW_HOME
+    else process.env.OPENCLAW_HOME = originalOpenClawHome
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('preserves OpenClaw status and tool frames as chat chunks', async () => {
+    globalThis.fetch = mock(async () => sseResponse([
+      { type: 'status', content: 'Checking project notes' },
+      { type: 'tool', content: 'Read project file', data: { tool: 'bakin_exec_projects_get' } },
+      { choices: [{ delta: { content: 'Done.' } }] },
+    ])) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks).toEqual([
+      { type: 'status', content: 'Checking project notes', data: undefined },
+      { type: 'tool', content: 'Read project file', data: { tool: 'bakin_exec_projects_get' } },
+      { type: 'text', content: 'Done.' },
+      { type: 'done' },
+    ])
+  })
+
+  it('maps OpenAI tool_calls deltas to tool chunks', async () => {
+    globalThis.fetch = mock(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              id: 'call-1',
+              type: 'function',
+              function: { name: 'bakin_exec_projects_get', arguments: '{"projectId":"p1"}' },
+            }],
+          },
+        }],
+      },
+    ])) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks[0]).toEqual({
+      type: 'tool',
+      content: 'bakin_exec_projects_get',
+      data: {
+        toolCalls: [{
+          id: 'call-1',
+          type: 'function',
+          function: { name: 'bakin_exec_projects_get', arguments: '{"projectId":"p1"}' },
+        }],
+      },
+    })
+  })
+})

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -207,4 +207,84 @@ describe('OpenClaw runtime stream parsing', () => {
       { type: 'done' },
     ])
   })
+
+  it('emits transcript activity before OpenClaw chat response headers arrive', async () => {
+    const sessionsDir = join(testDir, 'agents', 'main', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const sessionFile = join(sessionsDir, 'session-2.jsonl')
+    writeFileSync(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'session-2' }),
+      '',
+    ].join('\n'), 'utf-8')
+    writeFileSync(join(sessionsDir, 'sessions.json'), JSON.stringify({
+      'thread-2': { sessionId: 'session-2', sessionFile },
+    }), 'utf-8')
+
+    let fetchResolved = false
+    const encoder = new TextEncoder()
+    globalThis.fetch = mock(async () => {
+      setTimeout(() => {
+        appendFileSync(sessionFile, `${JSON.stringify({
+          type: 'message',
+          message: {
+            role: 'assistant',
+            content: [{
+              type: 'toolCall',
+              id: 'call-2',
+              name: 'read',
+              arguments: { path: '/tmp/project.md' },
+            }],
+          },
+        })}\n`)
+      }, 20)
+
+      await wait(800)
+      fetchResolved = true
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: 'After tools.' } }] })}\n\n`))
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+          controller.close()
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    }) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const iterator = runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-2',
+    })[Symbol.asyncIterator]()
+
+    const first = await Promise.race([
+      iterator.next(),
+      wait(500).then(() => 'timeout' as const),
+    ])
+
+    expect(first).not.toBe('timeout')
+    expect(fetchResolved).toBe(false)
+    if (first !== 'timeout') {
+      expect(first.value).toEqual({
+        type: 'tool',
+        content: 'read: /tmp/project.md',
+        data: {
+          phase: 'call',
+          id: 'call-2',
+          name: 'read',
+          argumentsPreview: '{"path":"/tmp/project.md"}',
+        },
+      })
+    }
+
+    const remaining: unknown[] = []
+    for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
+      remaining.push(chunk)
+    }
+    expect(remaining).toContainEqual({ type: 'text', content: 'After tools.' })
+    expect(remaining).toContainEqual({ type: 'done' })
+  })
 })

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { appendFileSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -24,6 +24,23 @@ function sseResponse(frames: unknown[]): Response {
     status: 200,
     headers: { 'Content-Type': 'text/event-stream' },
   })
+}
+
+function delayedSseResponse(run: (controller: ReadableStreamDefaultController<Uint8Array>) => Promise<void>): Response {
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      await run(controller)
+      controller.close()
+    },
+  })
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 describe('OpenClaw runtime stream parsing', () => {
@@ -108,5 +125,86 @@ describe('OpenClaw runtime stream parsing', () => {
         }],
       },
     })
+  })
+
+  it('emits OpenClaw transcript tool activity while the chat stream is pending', async () => {
+    const sessionsDir = join(testDir, 'agents', 'main', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const sessionFile = join(sessionsDir, 'session-1.jsonl')
+    writeFileSync(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'session-1' }),
+      JSON.stringify({ type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'before' }] } }),
+      '',
+    ].join('\n'), 'utf-8')
+    writeFileSync(join(sessionsDir, 'sessions.json'), JSON.stringify({
+      'thread-1': { sessionId: 'session-1', sessionFile },
+    }), 'utf-8')
+
+    const encoder = new TextEncoder()
+    globalThis.fetch = mock(async () => delayedSseResponse(async (controller) => {
+      await wait(20)
+      appendFileSync(sessionFile, `${JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{
+            type: 'toolCall',
+            id: 'call-1',
+            name: 'exec',
+            arguments: { command: 'gh issue list --repo markhayden/bakin --search messaging' },
+          }],
+        },
+      })}\n`)
+      appendFileSync(sessionFile, `${JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolName: 'exec',
+          toolCallId: 'call-1',
+          content: [{ type: 'text', text: 'Found #190' }],
+          details: { status: 'completed', exitCode: 0, durationMs: 12 },
+        },
+      })}\n`)
+      await wait(260)
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ choices: [{ delta: { content: 'Done.' } }] })}\n\n`))
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+    })) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks).toEqual([
+      {
+        type: 'tool',
+        content: 'exec: gh issue list --repo markhayden/bakin --search messaging',
+        data: {
+          phase: 'call',
+          id: 'call-1',
+          name: 'exec',
+          argumentsPreview: '{"command":"gh issue list --repo markhayden/bakin --search messaging"}',
+        },
+      },
+      {
+        type: 'tool',
+        content: 'exec completed',
+        data: {
+          phase: 'result',
+          toolName: 'exec',
+          toolCallId: 'call-1',
+          status: 'completed',
+          exitCode: 0,
+          durationMs: 12,
+          outputPreview: '[{"type":"text","text":"Found #190"}]',
+        },
+      },
+      { type: 'text', content: 'Done.' },
+      { type: 'done' },
+    ])
   })
 })

--- a/tests/api/web-adapter.test.ts
+++ b/tests/api/web-adapter.test.ts
@@ -27,19 +27,52 @@ function mockReq(opts: {
 
 function mockRes() {
   let body = ''
+  const chunks: string[] = []
+  const waiters: Array<() => void> = []
+  const notify = () => {
+    const pending = waiters.splice(0)
+    for (const resolve of pending) resolve()
+  }
   const res = {
     headersSent: false,
-    writeHead: mock(),
+    writeHead: mock(() => {
+      res.headersSent = true
+    }),
+    flushHeaders: mock(),
+    write: mock((data?: string | Buffer) => {
+      if (data) {
+        const text = Buffer.isBuffer(data) ? data.toString('utf-8') : data
+        chunks.push(text)
+        body += text
+      }
+      notify()
+      return true
+    }),
     end: mock((data?: string | Buffer) => {
-      if (data) body = Buffer.isBuffer(data) ? data.toString('utf-8') : data
+      if (data) {
+        const text = Buffer.isBuffer(data) ? data.toString('utf-8') : data
+        chunks.push(text)
+        body += text
+      }
+      notify()
     }),
   } as unknown as ServerResponse & {
     headersSent: boolean
     writeHead: ReturnType<typeof mock>
+    flushHeaders: ReturnType<typeof mock>
+    write: ReturnType<typeof mock>
     end: ReturnType<typeof mock>
+    _chunks: string[]
     _body: string
+    _waitForChunkCount: (count: number) => Promise<void>
   }
   Object.defineProperty(res, '_body', { get: () => body })
+  Object.defineProperty(res, '_chunks', { get: () => chunks })
+  res._waitForChunkCount = async (count: number) => {
+    while (chunks.length < count) {
+      await new Promise<void>((resolve) => waiters.push(resolve))
+    }
+  }
   return res
 }
 
@@ -70,5 +103,37 @@ describe('dispatchWebHandler', () => {
     expect(handler).not.toHaveBeenCalled()
     expect(res.writeHead).toHaveBeenCalledWith(413, { 'Content-Type': 'application/json' })
     expect(res._body).toContain('Request body too large')
+  })
+
+  it('streams Web response body chunks before the handler completes', async () => {
+    const encoder = new TextEncoder()
+    let controller!: ReadableStreamDefaultController<Uint8Array>
+    const req = mockReq({ method: 'GET' })
+    const res = mockRes()
+    const handler = mock(() => new Response(new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c
+        c.enqueue(encoder.encode('event: activity\ndata: {"content":"first"}\n\n'))
+      },
+    }), {
+      headers: { 'Content-Type': 'text/event-stream' },
+    }))
+
+    const pending = dispatchWebHandler(req, res, handler)
+    await res._waitForChunkCount(1)
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({
+      'Content-Type': 'text/event-stream',
+    }))
+    expect(res.flushHeaders).toHaveBeenCalled()
+    expect(res._chunks[0]).toContain('first')
+    expect(res.end).not.toHaveBeenCalled()
+
+    controller.enqueue(encoder.encode('event: done\ndata: {"content":"ok"}\n\n'))
+    controller.close()
+    await pending
+
+    expect(res._body).toContain('event: done')
+    expect(res.end).toHaveBeenCalled()
   })
 })

--- a/tests/components/integrated-brainstorm/messages.test.tsx
+++ b/tests/components/integrated-brainstorm/messages.test.tsx
@@ -128,6 +128,26 @@ describe('IntegratedBrainstorm — message list rendering', () => {
     expect(bubble.style.borderLeftColor.toLowerCase()).toMatch(/10b981|rgba?\(16,\s*185,\s*129/)
   })
 
+  it('renders activity messages as collapsed timeline rows', () => {
+    const messages: BrainstormMessage[] = [
+      { id: 'u1', role: 'user', content: 'check this' },
+      {
+        id: 'act1',
+        role: 'activity',
+        kind: 'tool_call',
+        content: 'Read project file',
+        data: { tool: 'bakin_exec_projects_get' },
+      },
+      { id: 'a1', role: 'assistant', content: 'done' },
+    ]
+    const { container } = render(<IntegratedBrainstorm {...baseProps} messages={messages} />)
+    const activity = container.querySelector('[data-testid="activity-bubble"]')
+    expect(activity).toBeTruthy()
+    expect(activity!.textContent).toContain('Tool')
+    expect(activity!.textContent).toContain('Read project file')
+    expect(activity!.querySelector('details')?.open).toBe(false)
+  })
+
   it('hides the message list when collapsed', () => {
     const messages: BrainstormMessage[] = [{ id: 'u1', role: 'user', content: 'hey' }]
     const { container } = render(

--- a/tests/components/integrated-brainstorm/send-streaming.test.tsx
+++ b/tests/components/integrated-brainstorm/send-streaming.test.tsx
@@ -154,6 +154,37 @@ describe('IntegratedBrainstorm — send state machine & streaming', () => {
     })
   })
 
+  it('renders custom activity events during send and preserves them after final reply', async () => {
+    const fake = createFakeOnSend()
+    render(<Harness fake={fake} />)
+    const textarea = screen.getByLabelText(/Ask Pixel/) as HTMLTextAreaElement
+    act(() => {
+      type(textarea, 'inspect')
+      pressEnter(textarea)
+    })
+    await waitFor(() => fake.isPending())
+    act(() => {
+      fake.emitCustom('activity', {
+        activity: {
+          id: 'act1',
+          kind: 'tool_call',
+          content: 'Read project file',
+          data: { tool: 'bakin_exec_projects_get' },
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('activity-bubble').textContent).toContain('Read project file')
+    })
+    act(() => {
+      fake.resolve('All set')
+    })
+    await waitFor(() => {
+      expect(screen.getByText('All set')).toBeDefined()
+      expect(screen.getByTestId('activity-bubble').textContent).toContain('Read project file')
+    })
+  })
+
   it('falls back to accumulated content when resolve content is empty', async () => {
     const fake = createFakeOnSend()
     render(<Harness fake={fake} />)


### PR DESCRIPTION
## Summary
- surface OpenClaw session transcript tool calls/results as runtime tool chunks from the adapter
- keep Projects/Messaging on the existing runtime chunk contract
- add adapter stream coverage for live transcript activity

## Tests
- bun test --isolate tests/adapter-openclaw/runtime-stream.test.ts
- bun run typecheck
- bun run lint