### PR TITLE
Add durable brainstorm session helpers

### DIFF
--- a/.claude/knowledge/messaging-plugin.md
+++ b/.claude/knowledge/messaging-plugin.md
@@ -8,4 +8,6 @@ Core Bakin keeps only the stable host surface for installed plugins:
 - runtime-discovered CLI commands from the plugin manifest
 - scoped storage under `plugin-data/messaging/`
 
+Planning sessions are plugin-owned durable records. The plugin stores visible user, assistant, and `activity` timeline entries under `messaging/sessions/<id>.json`, plus proposals. Runtime conversation continuity is adapter-owned: session message routes and exec tools pass a stable SDK-built `threadId` (`messaging:${sessionId}:${agentId}`) through `ctx.runtime.messaging`, rather than replaying prior stored messages into every prompt. Search indexes user/assistant planning text and proposal summaries; tool activity stays available in the UI timeline but is excluded from `message_body`.
+
 Do not restore `plugins/messaging/`, `tests/plugins/messaging/`, `src/core/messaging-cron.ts`, `~/.bakin/messaging.json`, or a top-level `~/.bakin/messaging/` data path in this repo.

--- a/.claude/knowledge/shared-ui-patterns.md
+++ b/.claude/knowledge/shared-ui-patterns.md
@@ -332,7 +332,7 @@ Set `disabled` while a search is active so the upstream relevance order (e.g. An
 
 - You need a chat with a single agent.
 - Responses stream from an SSE-shaped backend (OpenAI-style `choices[].delta.content` chunks work, as does any transport you wrap yourself).
-- You want consistent chrome: avatar-tinted assistant bubbles, markdown rendering, `json`-block transform hook, thinking indicator, Esc-to-abort, culinary-verb personality, collapse chrome, empty state.
+- You want consistent chrome: avatar-tinted assistant bubbles, normalized tool/activity rows, markdown rendering, `json`-block transform hook, thinking indicator, Esc-to-abort, culinary-verb personality, collapse chrome, empty state.
 
 Not for: one-shot prompts without history (use `sendMessage` + a button), multi-agent threads, or anything that needs a chat list / session list above it — render those separately in the page, not in this component.
 
@@ -349,17 +349,17 @@ Not for: one-shot prompts without history (use `sendMessage` + a button), multi-
 | `emptyState` | no | Replace default "Brainstorm with {agent}" welcome. |
 | `collapsible` | no | Default `true`. `false` shows a static header. |
 | `defaultOpen` | no | Default `true`. |
-| `fitParent` | no | `true` → panel fills parent height (no inline `height`, no top border, no drag handle, no auto-expand). Use for full-pane surfaces (messaging session chat). Default `false` (bottom-sheet mode). |
+| `fitParent` | no | `true` → panel fills parent height (no inline `height`, no top border, no drag handle). Use for full-pane surfaces (messaging session chat). Default `false` (bottom-sheet mode). |
 | `showHeader` | no | Default `true`. Set `false` when the parent page already has its own title chrome. |
 | `readOnly` | no | Swaps the input row for `readOnlyNotice` (defaults to "Chat is read-only."). History stays scrollable. Used by messaging for completed sessions. |
 | `transformAssistantMessage` | no | `(raw) => { text, extras? }`. Strip inline `json` blocks before rendering; surface the extracted count as a badge. Applied to streaming AND finalized content. |
-| `conversationStartHeight` / `minHeight` / `maxHeight` | no | Outer panel sizing. Default 400 / 100 / 720 (bottom-sheet mode only). |
+| `defaultHeight` / `minHeight` / `maxHeight` | no | Outer panel sizing. Default 480 / 260 / 720 (bottom-sheet mode only). `minHeight` is the lower drag bound, not the initial height. |
 | `maxInputHeight` | no | Textarea auto-grow cap. Default 200px. Textarea has no drag grip — content-driven height only. |
 | `storageKey` | no | When set, outer-panel drag height persists in `localStorage['bakin-vresize:{key}']`. Ignored when `fitParent` is on. |
 
 ### Two call-site shapes
 
-1. **Bottom sheet** (projects) — panel is pinned below other content, auto-expands to 400px on first send, drag handle to resize.
+1. **Bottom sheet** (projects) — panel is pinned below other content, opens at 480px by default, and has a drag handle to resize.
    ```tsx
    <IntegratedBrainstorm
      messages={m} onMessagesChange={setM}
@@ -394,46 +394,28 @@ Not for: one-shot prompts without history (use `sendMessage` + a button), multi-
 
 ### Transport layer
 
-`IntegratedBrainstorm` doesn't own the transport — the plugin writes a small `onSend` adapter around its backend. For OpenAI-shaped SSE, the pattern is identical to what's in `plugins/projects/components/project-detail.tsx` and `plugins/messaging/components/session-chat.tsx`:
+`IntegratedBrainstorm` doesn't own the transport — the plugin writes a small `onSend` adapter around its backend. Use `readBrainstormSseResponse` from `@bakin/sdk/components` on the client side for the common token/activity/done/error loop:
 
 ```ts
 const onSend: BrainstormOnSend = async (prompt, history, { signal, onToken, onCustom }) => {
   const res = await fetch(endpoint, { method: 'POST', signal, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ prompt, history }) })
-  const reader = res.body!.getReader()
-  const decoder = new TextDecoder()
-  let buffer = '', currentEvent = '', accumulated = '', finalContent = ''
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split('\n'); buffer = lines.pop() || ''
-    for (const line of lines) {
-      if (line.startsWith('event: ')) currentEvent = line.slice(7).trim()
-      else if (line.startsWith('data: ') && currentEvent) {
-        const data = JSON.parse(line.slice(6))
-        if (currentEvent === 'token') { accumulated += data.text; onToken(data.text) }
-        else if (currentEvent === 'done') finalContent = data.content ?? accumulated
-        else if (currentEvent === 'proposal') onCustom?.('proposal', data.proposal)
-        currentEvent = ''
-      }
-    }
-  }
-  return { content: finalContent || accumulated }
+  return readBrainstormSseResponse(res, { signal, onToken, onCustom })
 }
 ```
 
-Server-side agent calls go through the active runtime adapter (`ctx.runtime` in plugins, `getAppServices().runtime` in core). Project and messaging brainstorm routes write SSE events themselves while using `runtime.messaging.send()` for non-streaming provider calls.
+Server-side agent calls go through the active runtime adapter (`ctx.runtime` in plugins, `getAppServices().runtime` in core). Routes should map runtime chunks with `runtimeChunkToBrainstormActivity` from `@bakin/sdk/utils` and emit `event: activity` frames, rather than modeling provider-specific tool payloads in each plugin.
 
 ### Architecture notes
 
 - State lives in `use-brainstorm-state.ts` — a small `idle → sending → streaming → idle` machine. Optimistic user-message append, concurrent-send guard via ref (not state), culinary thinking verb stable per request, error-bubble rendering.
+- Activity helpers live in `activity.ts` and are also exported from `@bakin/sdk/utils` for server-side route code. Tool call/result messages with the same `callId` are grouped in `message-list.tsx` and shown with readable details sections instead of raw JSON.
 - Auto-growing textarea uses `use-auto-grow.ts` — `scrollHeight` measurement on every input change, capped at `maxInputHeight`, overflow-y auto past the cap. No native `resize-y` grip (removed — it conflicted with the outer panel drag).
-- Outer panel drag handle is wired via `useVerticalResize` from `@bakin/sdk/hooks` — same hook as messaging input panel and the prior brainstorm. Auto-expand to `conversationStartHeight` is one-shot on first send; subsequent height is user-owned (drag) and optionally persisted via `storageKey`.
+- Outer panel drag handle is wired via `useVerticalResize` from `@bakin/sdk/hooks` — same hook as messaging input panel and the prior brainstorm. `defaultHeight` is the initial open size; subsequent height is user-owned (drag) and optionally persisted via `storageKey`.
 - Send button is embedded inside the textarea's bottom-right (claude.ai pattern) — hidden when input is empty, visible with spinner during send, disabled when not ready.
 
 ### Test coverage
 
-`tests/components/integrated-brainstorm/` — ~95 unit cases across 10 files: collapse, empty state, message rendering, send state machine, streaming, keyboard + IME + abort, textarea auto-grow, outer panel resize, read-only, transform, onCustom pass-through, focus, scroll, agent picker, accessibility, edge cases, fit-parent, aborted-notice. Plugin-level integration at `tests/plugins/projects/routes.test.ts` (SSE `/ask` route) and `tests/plugins/messaging/session-chat-proposals.test.tsx` (proposal forwarding end-to-end).
+`tests/components/integrated-brainstorm/` — 100+ unit cases across 11 files: collapse, empty state, message/activity rendering, send state machine, streaming, keyboard + IME + abort, textarea auto-grow, outer panel resize, read-only, transform, onCustom pass-through, focus, scroll, agent picker, accessibility, edge cases, fit-parent, aborted-notice, and reusable activity/SSE helpers. Plugin-level integration at `tests/plugins/projects/routes.test.ts` (SSE `/ask` route) and `tests/plugins/messaging/session-chat-proposals.test.tsx` (proposal forwarding end-to-end).
 
 ## Key Files
 

--- a/.claude/specs/adapter-layer.md
+++ b/.claude/specs/adapter-layer.md
@@ -632,6 +632,8 @@ interface NotificationArgs {
 interface MessageArgs {
   channels: string[]
   text: string
+  // Adapter-neutral durable conversation key. Runtime adapters should map the
+  // same agentId + threadId pair to the same provider/runtime session.
   threadId?: string
   mentionAgentId?: string
   assets?: Asset[]

--- a/.claude/specs/integrated-brainstorm.md
+++ b/.claude/specs/integrated-brainstorm.md
@@ -228,6 +228,7 @@ packages/sdk/src/components/integrated-brainstorm/
   use-auto-grow.ts         — textarea scrollHeight → height effect
   use-brainstorm-state.ts  — send/abort/streaming state machine
   activity.ts              — runtime chunk → brainstorm activity helpers
+  session.ts               — durable thread id + activity storage helpers
   sse.ts                   — reusable SSE reader for brainstorm transports
   types.ts                 — BrainstormMessage, prop types
 ```
@@ -245,11 +246,21 @@ Pure helpers are also exported from `@bakin/sdk/utils` for server-side plugin ro
 
 ```ts
 export {
+  brainstormThreadId,
+  normalizeBrainstormActivityForStorage,
+  normalizeBrainstormActivityMessageForStorage,
   runtimeChunkToBrainstormActivity,
   readBrainstormSseResponse,
   toBrainstormTimeline,
 } from '@bakin/sdk/utils'
 ```
+
+Durable session rules:
+
+- Use `brainstormThreadId(scope, entityId, agentId)` for adapter-neutral runtime continuity. The same `agentId + threadId` pair must map to the same provider/runtime session.
+- Store plugin-owned messages for UI hydration and auditability, not as prompt replay. Replaying every prior turn into every request grows tokens and bypasses the runtime adapter's session model.
+- Normalize activity with `normalizeBrainstormActivityForStorage()` before persistence. It trims/limits summaries and preview payloads so tool transparency does not turn session files into unbounded logs.
+- Persist streamed `activity` events when the plugin owns a durable session. One-shot brainstorm endpoints may stream activity without storing it.
 
 ### State machine
 
@@ -276,9 +287,10 @@ Reuses existing `src/hooks/use-vertical-resize.ts` (exported through `@bakin/sdk
 1. Open the SSE stream (fetch + `body.getReader()` — messaging already does this; projects gets a new handler).
 2. Parse `event: token` / `event: done` / `event: error` / custom events.
 3. Forward text chunks via `onToken(text)`.
-4. Forward domain events (e.g. `proposal`, `proposals`) via `onCustom(name, data)`.
-5. Honor `signal.aborted` — close the reader, abandon the fetch.
-6. Resolve with `{ content }` on `done`, reject with an `Error` on server error or transport failure.
+4. Forward `event: activity` via `onCustom('activity', data)`; SDK helpers render it as assistant-style tool/status rows.
+5. Forward domain events (e.g. `proposal`, `proposals`) via `onCustom(name, data)`.
+6. Honor `signal.aborted` — close the reader, abandon the fetch.
+7. Resolve with `{ content }` on `done`, reject with an `Error` on server error or transport failure.
 
 `readBrainstormSseResponse(response, ctx, options)` is the reusable SDK parser for common brainstorm SSE streams. Plugin clients should use it instead of duplicating the token/activity/done/error loop. The component itself still never opens fetch or EventSource — callers own transport and pass an `onSend`.
 

--- a/.claude/specs/integrated-brainstorm.md
+++ b/.claude/specs/integrated-brainstorm.md
@@ -153,7 +153,7 @@ interface BrainstormMessage {
 
 - **User**: right-aligned bubble, accent-tinted background.
 - **Assistant**: left-aligned with `<AgentAvatar size="sm">` + left border tinted with agent color from `useAgentColor`. Body rendered via `<MarkdownContent>`. Consecutive assistant messages grouped with negative top margin (`-mt-2`); avatar shown only on the first of a run.
-- **Activity**: runtime/tool events render as assistant-style rows with the same avatar + tinted left border. Tool call/result pairs with the same `callId` collapse into one row; the compact row shows tool name, status, duration, summary, and expandable `Input` / `Output` / `Metadata` sections.
+- **Activity**: runtime/tool events render as assistant-style rows with the same avatar + tinted left border. Tool call/result pairs with the same `callId` collapse into one row; the compact row shows tool name, status, duration, and a human-readable `summary` when the runtime provides one. Raw commands and payloads stay in expandable `Input` / `Output` / `Metadata` sections.
 - **Streaming**: partial text renders in the same bubble shape; the message's `id` is provisional (`streaming-<ts>`) and gets replaced with the server-final id when `onSend` resolves.
 - **Empty state**: default is `<AgentAvatar size="xl">` above `Brainstorm with ${agentName}` + a one-line hint. `emptyState` prop overrides.
 

--- a/.claude/specs/integrated-brainstorm.md
+++ b/.claude/specs/integrated-brainstorm.md
@@ -6,7 +6,7 @@ A unified, protocol-agnostic agent-chat component in `@bakin/sdk/components`, re
 
 Bakin has two separate brainstorm chat implementations today, neither of which share code:
 
-- `plugins/projects/components/project-detail.tsx` (bottom panel, lines 646+) — synchronous JSON reply, collapsible, auto-expand-on-first-message, markdown-rendered, textarea with broken native `resize-y` grip.
+- `plugins/projects/components/project-detail.tsx` (bottom panel, lines 646+) — synchronous JSON reply, collapsible, markdown-rendered, textarea with broken native `resize-y` grip.
 - `plugins/messaging/components/session-chat.tsx` — full-pane split layout, SSE token stream with inline `json` proposal blocks, plain-text rendering, `<AgentAvatar>` + agent-colored border, manual input-pane drag handle.
 
 Plus `plugins/messaging/components/brainstorm-panel.tsx` is dead code (not imported anywhere).
@@ -95,9 +95,9 @@ interface IntegratedBrainstormProps {
   collapsible?: boolean
   /** Default open state when collapsible. Default: true. */
   defaultOpen?: boolean
-  /** Height the panel auto-expands to on first send. Default: 400. */
-  conversationStartHeight?: number
-  /** Min panel height (collapsed-ish state, before first send). Default: 100. */
+  /** Default open panel height. Default: 480. */
+  defaultHeight?: number
+  /** Min panel height the user can drag down to. Default: 260. */
   minHeight?: number
   /** Max panel height the user can drag to. Default: 720. */
   maxHeight?: number
@@ -127,10 +127,14 @@ interface IntegratedBrainstormProps {
 ```ts
 interface BrainstormMessage {
   id: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'activity'
   content: string
   /** Agent attribution for assistant messages (defaults to current agentId). */
   agentId?: string
+  /** Activity kind for non-chat runtime events such as tool calls. */
+  kind?: 'runtime_status' | 'tool_call' | 'error' | string
+  /** Normalized runtime activity payload or plugin-specific event data. */
+  data?: unknown
   timestamp?: string
 }
 ```
@@ -139,7 +143,7 @@ interface BrainstormMessage {
 
 ### Visual shape
 
-- **Outer panel**: border-top, auto-expand on first send to `conversationStartHeight`, vertical drag handle at top edge (uses existing `useVerticalResize`). User-adjustable from `minHeight` to `maxHeight`.
+- **Outer panel**: border-top, opens at `defaultHeight` (480px by default), vertical drag handle at top edge (uses existing `useVerticalResize`). User-adjustable from `minHeight` to `maxHeight`.
 - **Collapsed**: shows only the centered header — `<icon> <label> (N replies) ▼`. Clicking anywhere on the header toggles open.
 - **Open**: two stacked regions.
   - **History** (flex-grow, `overflow-y-auto`, always scrolls to bottom on new message/token).
@@ -149,6 +153,7 @@ interface BrainstormMessage {
 
 - **User**: right-aligned bubble, accent-tinted background.
 - **Assistant**: left-aligned with `<AgentAvatar size="sm">` + left border tinted with agent color from `useAgentColor`. Body rendered via `<MarkdownContent>`. Consecutive assistant messages grouped with negative top margin (`-mt-2`); avatar shown only on the first of a run.
+- **Activity**: runtime/tool events render as assistant-style rows with the same avatar + tinted left border. Tool call/result pairs with the same `callId` collapse into one row; the compact row shows tool name, status, duration, summary, and expandable `Input` / `Output` / `Metadata` sections.
 - **Streaming**: partial text renders in the same bubble shape; the message's `id` is provisional (`streaming-<ts>`) and gets replaced with the server-final id when `onSend` resolves.
 - **Empty state**: default is `<AgentAvatar size="xl">` above `Brainstorm with ${agentName}` + a one-line hint. `emptyState` prop overrides.
 
@@ -165,9 +170,9 @@ crisping, churning, seasoning, scorching, folding, charring, toasting
 
 Once the first token arrives, the thinking indicator is replaced by the streaming message bubble.
 
-### Auto-expand
+### Panel sizing
 
-On the first `onSend` call after mount, the panel's height is set to `conversationStartHeight`. After that, the user's drag wins — no further automatic expansion. Guarded by an internal ref so toggling collapsed/open doesn't re-fire.
+Open bottom-sheet mode starts at `defaultHeight` (480px by default) so the empty state and recent history are visible immediately. Sending a message does not change the panel height. After a manual drag, the user's height wins and can persist through `storageKey`.
 
 ### Textarea
 
@@ -222,6 +227,8 @@ packages/sdk/src/components/integrated-brainstorm/
   thinking-indicator.tsx   — verb picker + spinner
   use-auto-grow.ts         — textarea scrollHeight → height effect
   use-brainstorm-state.ts  — send/abort/streaming state machine
+  activity.ts              — runtime chunk → brainstorm activity helpers
+  sse.ts                   — reusable SSE reader for brainstorm transports
   types.ts                 — BrainstormMessage, prop types
 ```
 
@@ -233,6 +240,16 @@ export type { BrainstormMessage, IntegratedBrainstormProps } from '@/components/
 ```
 
 Component name registered in vendor bundle externalization: no change needed — it's inside `@bakin/sdk/components` which is already externalized.
+
+Pure helpers are also exported from `@bakin/sdk/utils` for server-side plugin route code:
+
+```ts
+export {
+  runtimeChunkToBrainstormActivity,
+  readBrainstormSseResponse,
+  toBrainstormTimeline,
+} from '@bakin/sdk/utils'
+```
 
 ### State machine
 
@@ -250,7 +267,7 @@ idle ─▶ sending ─▶ streaming ─▶ idle
 
 ### Outer panel resize
 
-Reuses existing `src/hooks/use-vertical-resize.ts` (exported through `@bakin/sdk/hooks`). Auto-expand-on-first-send is layered on top via a one-shot effect guarded by a ref.
+Reuses existing `src/hooks/use-vertical-resize.ts` (exported through `@bakin/sdk/hooks`). `defaultHeight` controls the initial open height; `minHeight` is only the lower drag bound.
 
 ### Streaming shape
 
@@ -263,7 +280,7 @@ Reuses existing `src/hooks/use-vertical-resize.ts` (exported through `@bakin/sdk
 5. Honor `signal.aborted` — close the reader, abandon the fetch.
 6. Resolve with `{ content }` on `done`, reject with an `Error` on server error or transport failure.
 
-The component itself never touches fetch, headers, or SSE parsing — it's purely UI.
+`readBrainstormSseResponse(response, ctx, options)` is the reusable SDK parser for common brainstorm SSE streams. Plugin clients should use it instead of duplicating the token/activity/done/error loop. The component itself still never opens fetch or EventSource — callers own transport and pass an `onSend`.
 
 ## Migration plan
 
@@ -328,7 +345,7 @@ Per `CLAUDE.md` testing rules: content-dir mocking is mandatory for anything tou
 
 ### Location & runner
 
-- Tests co-located: `packages/sdk/src/components/integrated-brainstorm/__tests__/`.
+- Tests live under `tests/components/integrated-brainstorm/`.
 - Runner: `bun test --isolate` (jsdom via `happy-dom` or Bun's built-in DOM shim — choose whichever other SDK component tests use; if none exist, go with Bun's built-in).
 - Helpers: one shared `fake-on-send.ts` that returns a controllable mock — exposes `onSend`, `emitToken`, `emitCustom`, `resolve`, `reject` — so tests drive the streaming state machine deterministically without real timers or fetch.
 
@@ -361,9 +378,9 @@ Every exported prop must have at least one test that exercises it at a non-defau
 - 2.6 Custom `icon` and `label` props rendered in place of defaults.
 - 2.7 Default icon = lucide `Sparkles`, default label = `Brainstorm`.
 
-**3. Auto-expand & resize**
-- 3.1 First `onSend` sets panel height to `conversationStartHeight`.
-- 3.2 Second `onSend` does NOT re-fire auto-expand (ref guard).
+**3. Default sizing & resize**
+- 3.1 Open bottom-sheet mode starts at `defaultHeight` (480px by default).
+- 3.2 First `onSend` does not change panel height.
 - 3.3 Manual drag updates height inside `[minHeight, maxHeight]`.
 - 3.4 Drag below `minHeight` clamps to `minHeight`.
 - 3.5 Drag above `maxHeight` clamps to `maxHeight`.
@@ -475,7 +492,7 @@ Every exported prop must have at least one test that exercises it at a non-defau
 
 Against `bun run dev`:
 
-- [ ] Projects: new project → open it → expand Brainstorm → ask question → tokens stream → reply arrives → panel auto-expanded to 400px on first send.
+- [ ] Projects: new project → open it → Brainstorm opens around 480px tall → ask question → tokens stream → reply arrives → panel height remains user-controlled.
 - [ ] Projects: drag outer handle up → more history visible; drag down → clamps at min.
 - [ ] Projects: mid-stream press Esc → stream stops, partial reply preserved, can send again immediately.
 - [ ] Projects: collapse chevron → panel collapses to header; chevron flips; click again → expands, textarea focused.
@@ -538,7 +555,7 @@ A PR merges only when all of these are true:
 bun install                                          # install deps
 bun run build                                        # type-check + compile the world
 bun test --isolate                                   # full test suite
-bun test packages/sdk/src/components/integrated-brainstorm/__tests__ --isolate   # component tests only
+bun test --isolate tests/components/integrated-brainstorm   # component tests only
 bun run dev                                          # watch-mode for manual verification
 ```
 

--- a/docs/.generated/coverage.json
+++ b/docs/.generated/coverage.json
@@ -34,7 +34,7 @@
     },
     "execTools": {
       "status": "audited",
-      "count": 111,
+      "count": 112,
       "source": "source scan"
     },
     "corePlugins": {

--- a/docs/public/llms/exec-tools.md
+++ b/docs/public/llms/exec-tools.md
@@ -972,11 +972,9 @@ mcporter call bakin-<agent>.bakin_exec_post_channel --args '{
 }'
 ```
 
-## Project
+## Projects
 
-Project tools let agents create, update, read, and maintain project specs and linked checklist items.
-
-### bakin_exec_project_add_item
+### bakin_exec_projects_add_item
 
 Label: Added project item
 Purpose: Add a new checklist item to a project.
@@ -989,13 +987,44 @@ Purpose: Add a new checklist item to a project.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_add_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_add_item --args '{
   "projectId": "value",
   "title": "value"
 }'
 ```
 
-### bakin_exec_project_ask
+### bakin_exec_projects_apply_plan
+
+Label: Applied a project plan
+Purpose: Apply a confirmed project plan update in one operation. Use this after the user confirms exact body/checklist changes so agents do not need shell scripts or multiple low-level calls.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `projectId` | string | yes | Project ID |
+| `title` | string | no | Optional new project title |
+| `status` | choice | no | Optional new status |
+| `body` | string | no | Replacement markdown body for the project plan |
+| `appendBody` | string | no | Markdown to append to the existing project body; cannot be combined with body |
+| `owner` | string | no | Optional new owner |
+| `checklistItems` | array | no | New unchecked checklist item titles to append |
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_projects_apply_plan --args '{
+  "projectId": "value",
+  "title": "value",
+  "status": "value",
+  "body": "value",
+  "appendBody": "value",
+  "owner": "value",
+  "checklistItems": [
+    "value"
+  ]
+}'
+```
+
+### bakin_exec_projects_ask
 
 Label: Asked project question
 Purpose: Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming.
@@ -1009,17 +1038,17 @@ Purpose: Ask an agent a question about a project. Sends the project context (spe
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_ask --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_ask --args '{
   "projectId": "value",
   "message": "value",
   "agent": "value"
 }'
 ```
 
-### bakin_exec_project_attach_asset
+### bakin_exec_projects_attach_asset
 
 Label: Attached asset to project
-Purpose: Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed.
+Purpose: Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in projects_get — use asset tools to read full content when needed.
 
 | Argument | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -1030,14 +1059,14 @@ Purpose: Attach an existing asset to a project by filename. Assets provide addit
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_attach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_attach_asset --args '{
   "projectId": "value",
   "filename": "value",
   "label": "value"
 }'
 ```
 
-### bakin_exec_project_create
+### bakin_exec_projects_create
 
 Label: Created a project
 Purpose: Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs.
@@ -1052,7 +1081,7 @@ Purpose: Create a new project with title, markdown body, and optional initial ch
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_create --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_create --args '{
   "title": "value",
   "body": "value",
   "owner": "value",
@@ -1062,7 +1091,7 @@ mcporter call bakin-<agent>.bakin_exec_project_create --args '{
 }'
 ```
 
-### bakin_exec_project_delete
+### bakin_exec_projects_delete
 
 Label: Deleted a project
 Purpose: Delete a project by ID.
@@ -1074,12 +1103,12 @@ Purpose: Delete a project by ID.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_delete --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_delete --args '{
   "projectId": "value"
 }'
 ```
 
-### bakin_exec_project_detach_asset
+### bakin_exec_projects_detach_asset
 
 Label: Detached asset from project
 Purpose: Remove an asset reference from a project by filename. Does not delete the asset itself.
@@ -1092,13 +1121,13 @@ Purpose: Remove an asset reference from a project by filename. Does not delete t
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_detach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_detach_asset --args '{
   "projectId": "value",
   "filename": "value"
 }'
 ```
 
-### bakin_exec_project_get
+### bakin_exec_projects_get
 
 Label: Read project details
 Purpose: Get a project by ID including full spec, checklist, progress, and linked board task statuses.
@@ -1110,12 +1139,12 @@ Purpose: Get a project by ID including full spec, checklist, progress, and linke
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_get --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_get --args '{
   "projectId": "value"
 }'
 ```
 
-### bakin_exec_project_link_item
+### bakin_exec_projects_link_item
 
 Label: Linked project item
 Purpose: Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project.
@@ -1129,14 +1158,14 @@ Purpose: Link an existing board task to a project checklist item. Use this when 
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_link_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_link_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "taskId": "value"
 }'
 ```
 
-### bakin_exec_project_list
+### bakin_exec_projects_list
 
 Label: Listed projects
 Purpose: List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount.
@@ -1148,12 +1177,12 @@ Purpose: List all projects with optional status filter. Returns summaries with i
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_list --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_list --args '{
   "status": "value"
 }'
 ```
 
-### bakin_exec_project_mark_item
+### bakin_exec_projects_mark_item
 
 Label: Marked project item
 Purpose: Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage.
@@ -1167,14 +1196,14 @@ Purpose: Mark a checklist item as checked (done) or unchecked. Returns updated p
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_mark_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_mark_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "checked": true
 }'
 ```
 
-### bakin_exec_project_promote_item
+### bakin_exec_projects_promote_item
 
 Label: Promoted project item
 Purpose: Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set.
@@ -1188,14 +1217,14 @@ Purpose: Create a NEW board task from a project checklist item and automatically
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_promote_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_promote_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "assignee": "value"
 }'
 ```
 
-### bakin_exec_project_remove_item
+### bakin_exec_projects_remove_item
 
 Label: Removed project item
 Purpose: Remove a checklist item from a project.
@@ -1208,13 +1237,13 @@ Purpose: Remove a checklist item from a project.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_remove_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_remove_item --args '{
   "projectId": "value",
   "taskItemId": "value"
 }'
 ```
 
-### bakin_exec_project_toggle_item
+### bakin_exec_projects_toggle_item
 
 Label: Toggled project item
 Purpose: Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage.
@@ -1228,14 +1257,14 @@ Purpose: Toggle a checklist item checked/unchecked by item ID. Returns updated p
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_toggle_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_toggle_item --args '{
   "projectId": "value",
   "itemId": "value",
   "checked": true
 }'
 ```
 
-### bakin_exec_project_update
+### bakin_exec_projects_update
 
 Label: Updated a project
 Purpose: Update a project's title, status, body, or owner. Cannot set status to "completed" if unchecked items remain.
@@ -1251,7 +1280,7 @@ Purpose: Update a project's title, status, body, or owner. Cannot set status to 
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_update --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_update --args '{
   "projectId": "value",
   "title": "value",
   "status": "value",
@@ -1260,7 +1289,7 @@ mcporter call bakin-<agent>.bakin_exec_project_update --args '{
 }'
 ```
 
-### bakin_exec_project_update_item
+### bakin_exec_projects_update_item
 
 Label: Updated project item
 Purpose: Update a checklist item's title and/or description.
@@ -1275,7 +1304,7 @@ Purpose: Update a checklist item's title and/or description.
 Example:
 
 ```sh
-mcporter call bakin-<agent>.bakin_exec_project_update_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_update_item --args '{
   "projectId": "value",
   "itemId": "value",
   "title": "value",

--- a/docs/public/llms/hooks.md
+++ b/docs/public/llms/hooks.md
@@ -334,7 +334,7 @@ Task hooks let plugins enrich task details and react to task lifecycle changes.
 Label: Add project task context.
 Purpose: Adds project title, status, progress, and excerpt data to task detail payloads. Use it when a task surface wants project context without depending on project storage.
 Kind: waterfall
-Source: bakin-bits-official/plugins/projects/index.ts:160
+Source: bakin-bits-official/plugins/projects/index.ts:222
 
 Example:
 
@@ -355,7 +355,7 @@ const next = await ctx.hooks.call(
 Label: Sync project task state.
 Purpose: Updates linked project checklist items when a task moves into a completed state. Use it to keep project progress in sync with task lifecycle events.
 Kind: event
-Source: bakin-bits-official/plugins/projects/index.ts:149
+Source: bakin-bits-official/plugins/projects/index.ts:211
 
 Example:
 

--- a/docs/src/content/docs/extending/sdk/overview.md
+++ b/docs/src/content/docs/extending/sdk/overview.md
@@ -68,6 +68,34 @@ import { PluginHeader } from '@makinbakin/sdk/components'
 
 Avoid copying host component files into a plugin. If a component is broadly useful, promote it to the SDK instead.
 
+## Brainstorm Components
+
+Use `IntegratedBrainstorm` for plugin-owned back-and-forth agent work. The component owns the chat UI, streaming state, keyboard behavior, tool/activity rendering, abort behavior, and resize persistence. The plugin still owns transport, storage, and domain side effects.
+
+```tsx
+import {
+  IntegratedBrainstorm,
+  readBrainstormSseResponse,
+} from '@makinbakin/sdk/components'
+```
+
+Server routes and exec tools should use the matching utilities from `@makinbakin/sdk/utils`:
+
+```ts
+import {
+  brainstormThreadId,
+  normalizeBrainstormActivityForStorage,
+  runtimeChunkToBrainstormActivity,
+} from '@makinbakin/sdk/utils'
+```
+
+- `brainstormThreadId(scope, entityId, agentId)` builds a stable adapter-neutral runtime thread key. Use it for durable sessions, for example `projects:${projectId}:${agentId}` or `messaging:${sessionId}:${agentId}`.
+- `runtimeChunkToBrainstormActivity(chunk)` maps runtime stream chunks such as status and tool events into UI activity records.
+- `normalizeBrainstormActivityForStorage(activity)` bounds and normalizes activity before a plugin persists it.
+- `readBrainstormSseResponse(response, ctx, options)` parses `token`, `activity`, `done`, and `error` events for client-side `onSend` handlers.
+
+Do not replay an entire plugin-stored transcript into every prompt when a durable runtime thread is available. Store chat messages and activity for UI hydration and search, but let the active runtime adapter map repeated `agentId + threadId` calls to the same provider session.
+
 ## Metadata Helpers
 
 `@makinbakin/sdk/metadata` re-exports docs-aware contract types and helper functions. New HTTP APIs should use `defineRoute()` from `@makinbakin/sdk` or `@makinbakin/sdk/routing`; older metadata helpers remain for compatibility with existing contracts.

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -1482,5 +1482,5 @@ curl -sS \
 </OpenApiReference>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/cli.mdx
+++ b/docs/src/content/docs/reference/generated/cli.mdx
@@ -340,10 +340,17 @@ bakin restart
 bakin status
 ```
 </CliCommandCard>
-<CliCommandCard id="dev" name="dev" summary="Run the source-tree development loop." description="Runs Bakin in watch-mode development from a source checkout. The compiled binary refuses this command outside a repo clone.">
+<CliCommandCard id="dev" name="dev" summary="Run the source-tree development loop." description="Runs Bakin in watch-mode development from a source checkout. By default output is compact; use --verbose for raw child-process output and debug logs.">
 ```sh frame="terminal"
-bakin dev
+bakin dev [--verbose] [--no-color]
 ```
+  <table class="cli-command__args">
+    <thead><tr><th>Part</th><th>Type</th><th>Required</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td><code>[--verbose]</code></td><td>option</td><td>no</td><td>Optional flag.</td></tr>
+      <tr><td><code>[--no-color]</code></td><td>option</td><td>no</td><td>Optional flag.</td></tr>
+    </tbody>
+  </table>
 </CliCommandCard>
 <CliCommandCard id="version" name="version" summary="Print the Bakin version." description="Prints the version embedded in the running CLI/binary.">
 ```sh frame="terminal"
@@ -746,5 +753,5 @@ bakin workflows submit <taskId> <stepId> <json>
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/core-plugins.md
+++ b/docs/src/content/docs/reference/generated/core-plugins.md
@@ -93,5 +93,5 @@ description: Generated catalog of official plugins supported by Bakin.
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/exec-tools.mdx
+++ b/docs/src/content/docs/reference/generated/exec-tools.mdx
@@ -306,14 +306,14 @@ mcporter call bakin-<agent>.bakin_exec_memory_status
 <p class="mcp-section-description">Messaging tools let agents create, update, approve, reject, and inspect human-facing messages and sessions.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="messaging-approve" name="bakin_exec_messaging_approve" label="Approved a message" description="Approve a messaging item (draft → scheduled, review → published)" source="bakin-bits-official/plugins/messaging/index.ts:1072" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"}]}>
+<McpToolCard id="messaging-approve" name="bakin_exec_messaging_approve" label="Approved a message" description="Approve a messaging item (draft → scheduled, review → published)" source="bakin-bits-official/plugins/messaging/index.ts:1045" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_approve --args '{
   "itemId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-create" name="bakin_exec_messaging_create" label="Created a message" description="Create a new messaging item" source="bakin-bits-official/plugins/messaging/index.ts:1011" parameters={[{"name":"title","type":"string","required":true,"description":"Item title (required)"},{"name":"agent","type":"string","required":true,"description":"Assigned agent (required)"},{"name":"scheduledAt","type":"string","required":true,"description":"ISO datetime for scheduling (required)"},{"name":"channels","type":"array","required":false,"description":"Runtime channel IDs (default: [\"general\"])"},{"name":"contentType","type":"string","required":false,"description":"Content type id from the messaging contentTypes setting (e.g. post, article, video)"},{"name":"tone","type":"string","required":false,"description":"Content tone (energetic, calm, educational, etc.)"},{"name":"brief","type":"string","required":false,"description":"Content brief"},{"name":"status","type":"string","required":false,"description":"Initial status (default: draft)"}]}>
+<McpToolCard id="messaging-create" name="bakin_exec_messaging_create" label="Created a message" description="Create a new messaging item" source="bakin-bits-official/plugins/messaging/index.ts:984" parameters={[{"name":"title","type":"string","required":true,"description":"Item title (required)"},{"name":"agent","type":"string","required":true,"description":"Assigned agent (required)"},{"name":"scheduledAt","type":"string","required":true,"description":"ISO datetime for scheduling (required)"},{"name":"channels","type":"array","required":false,"description":"Runtime channel IDs (default: [\"general\"])"},{"name":"contentType","type":"string","required":false,"description":"Content type id from the messaging contentTypes setting (e.g. post, article, video)"},{"name":"tone","type":"string","required":false,"description":"Content tone (energetic, calm, educational, etc.)"},{"name":"brief","type":"string","required":false,"description":"Content brief"},{"name":"status","type":"string","required":false,"description":"Initial status (default: draft)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_create --args '{
   "title": "value",
@@ -329,21 +329,21 @@ mcporter call bakin-<agent>.bakin_exec_messaging_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-delete" name="bakin_exec_messaging_delete" label="Deleted a message" description="Delete a messaging item" source="bakin-bits-official/plugins/messaging/index.ts:1113" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"}]}>
+<McpToolCard id="messaging-delete" name="bakin_exec_messaging_delete" label="Deleted a message" description="Delete a messaging item" source="bakin-bits-official/plugins/messaging/index.ts:1086" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_delete --args '{
   "itemId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-get" name="bakin_exec_messaging_get" label="Read message details" description="Get details for a single messaging item" source="bakin-bits-official/plugins/messaging/index.ts:996" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"}]}>
+<McpToolCard id="messaging-get" name="bakin_exec_messaging_get" label="Read message details" description="Get details for a single messaging item" source="bakin-bits-official/plugins/messaging/index.ts:969" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_get --args '{
   "itemId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-list" name="bakin_exec_messaging_list" label="Listed messages" description="List messaging items with optional filters" source="bakin-bits-official/plugins/messaging/index.ts:960" parameters={[{"name":"month","type":"string","required":false,"description":"Filter by month (YYYY-MM)"},{"name":"status","type":"string","required":false,"description":"Filter by status (draft, scheduled, review, published, etc.)"},{"name":"agent","type":"string","required":false,"description":"Filter by assigned agent"},{"name":"channel","type":"string","required":false,"description":"Filter by runtime channel ID (e.g. general, announcements)"}]}>
+<McpToolCard id="messaging-list" name="bakin_exec_messaging_list" label="Listed messages" description="List messaging items with optional filters" source="bakin-bits-official/plugins/messaging/index.ts:933" parameters={[{"name":"month","type":"string","required":false,"description":"Filter by month (YYYY-MM)"},{"name":"status","type":"string","required":false,"description":"Filter by status (draft, scheduled, review, published, etc.)"},{"name":"agent","type":"string","required":false,"description":"Filter by assigned agent"},{"name":"channel","type":"string","required":false,"description":"Filter by runtime channel ID (e.g. general, announcements)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_list --args '{
   "month": "value",
@@ -353,7 +353,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_list --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-proposal-update" name="bakin_exec_messaging_proposal_update" label="Updated brainstorm proposal" description="Update a proposal status or fields (approve, reject, edit)" source="bakin-bits-official/plugins/messaging/index.ts:1294" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"proposalId","type":"string","required":true,"description":"Proposal ID (required)"},{"name":"status","type":"string","required":false,"description":"New status (proposed, approved, rejected, revised)"},{"name":"title","type":"string","required":false,"description":"Updated title"},{"name":"brief","type":"string","required":false,"description":"Updated brief"},{"name":"tone","type":"string","required":false,"description":"Updated tone"},{"name":"scheduledAt","type":"string","required":false,"description":"Updated schedule datetime"},{"name":"channels","type":"array","required":false,"description":"Updated channels"},{"name":"rejectionNote","type":"string","required":false,"description":"Note explaining rejection"}]}>
+<McpToolCard id="messaging-proposal-update" name="bakin_exec_messaging_proposal_update" label="Updated brainstorm proposal" description="Update a proposal status or fields (approve, reject, edit)" source="bakin-bits-official/plugins/messaging/index.ts:1268" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"proposalId","type":"string","required":true,"description":"Proposal ID (required)"},{"name":"status","type":"string","required":false,"description":"New status (proposed, approved, rejected, revised)"},{"name":"title","type":"string","required":false,"description":"Updated title"},{"name":"brief","type":"string","required":false,"description":"Updated brief"},{"name":"tone","type":"string","required":false,"description":"Updated tone"},{"name":"scheduledAt","type":"string","required":false,"description":"Updated schedule datetime"},{"name":"channels","type":"array","required":false,"description":"Updated channels"},{"name":"rejectionNote","type":"string","required":false,"description":"Note explaining rejection"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_proposal_update --args '{
   "sessionId": "value",
@@ -370,7 +370,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_proposal_update --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-reject" name="bakin_exec_messaging_reject" label="Rejected a message" description="Reject a messaging item back to draft status" source="bakin-bits-official/plugins/messaging/index.ts:1090" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"},{"name":"note","type":"string","required":false,"description":"Rejection note / feedback"}]}>
+<McpToolCard id="messaging-reject" name="bakin_exec_messaging_reject" label="Rejected a message" description="Reject a messaging item back to draft status" source="bakin-bits-official/plugins/messaging/index.ts:1063" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"},{"name":"note","type":"string","required":false,"description":"Rejection note / feedback"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_reject --args '{
   "itemId": "value",
@@ -378,7 +378,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_reject --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-confirm" name="bakin_exec_messaging_session_confirm" label="Confirmed brainstorm proposal" description="Confirm a planning session — creates messaging items from approved proposals" source="bakin-bits-official/plugins/messaging/index.ts:1328" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"autoApprove","type":"boolean","required":false,"description":"Auto-approve: create items in scheduled status instead of draft"}]}>
+<McpToolCard id="messaging-session-confirm" name="bakin_exec_messaging_session_confirm" label="Confirmed brainstorm proposal" description="Confirm a planning session — creates messaging items from approved proposals" source="bakin-bits-official/plugins/messaging/index.ts:1302" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"autoApprove","type":"boolean","required":false,"description":"Auto-approve: create items in scheduled status instead of draft"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_confirm --args '{
   "sessionId": "value",
@@ -386,7 +386,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_session_confirm --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-create" name="bakin_exec_messaging_session_create" label="Created brainstorm session" description="Create a new planning session for an agent" source="bakin-bits-official/plugins/messaging/index.ts:1165" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID (required)"},{"name":"title","type":"string","required":false,"description":"Session title"}]}>
+<McpToolCard id="messaging-session-create" name="bakin_exec_messaging_session_create" label="Created brainstorm session" description="Create a new planning session for an agent" source="bakin-bits-official/plugins/messaging/index.ts:1138" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID (required)"},{"name":"title","type":"string","required":false,"description":"Session title"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_create --args '{
   "agentId": "value",
@@ -394,21 +394,21 @@ mcporter call bakin-<agent>.bakin_exec_messaging_session_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-delete" name="bakin_exec_messaging_session_delete" label="Deleted brainstorm session" description="Delete a planning session" source="bakin-bits-official/plugins/messaging/index.ts:1208" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"}]}>
+<McpToolCard id="messaging-session-delete" name="bakin_exec_messaging_session_delete" label="Deleted brainstorm session" description="Delete a planning session" source="bakin-bits-official/plugins/messaging/index.ts:1181" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_delete --args '{
   "sessionId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-get" name="bakin_exec_messaging_session_get" label="Read brainstorm session" description="Get a planning session with full message history and proposals" source="bakin-bits-official/plugins/messaging/index.ts:1150" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"}]}>
+<McpToolCard id="messaging-session-get" name="bakin_exec_messaging_session_get" label="Read brainstorm session" description="Get a planning session with full message history and proposals" source="bakin-bits-official/plugins/messaging/index.ts:1123" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_get --args '{
   "sessionId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-list" name="bakin_exec_messaging_session_list" label="Listed brainstorm sessions" description="List planning sessions with optional filters" source="bakin-bits-official/plugins/messaging/index.ts:1133" parameters={[{"name":"status","type":"string","required":false,"description":"Filter by status (active, completed)"},{"name":"agentId","type":"string","required":false,"description":"Filter by agent ID"}]}>
+<McpToolCard id="messaging-session-list" name="bakin_exec_messaging_session_list" label="Listed brainstorm sessions" description="List planning sessions with optional filters" source="bakin-bits-official/plugins/messaging/index.ts:1106" parameters={[{"name":"status","type":"string","required":false,"description":"Filter by status (active, completed)"},{"name":"agentId","type":"string","required":false,"description":"Filter by agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_list --args '{
   "status": "value",
@@ -416,7 +416,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_session_list --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-message" name="bakin_exec_messaging_session_message" label="Sent brainstorm message" description="Send a message in a planning session (non-streaming, returns full response)" source="bakin-bits-official/plugins/messaging/index.ts:1228" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"message","type":"string","required":true,"description":"User message content (required)"}]}>
+<McpToolCard id="messaging-session-message" name="bakin_exec_messaging_session_message" label="Sent brainstorm message" description="Send a message in a planning session (non-streaming, returns full response)" source="bakin-bits-official/plugins/messaging/index.ts:1201" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"message","type":"string","required":true,"description":"User message content (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_message --args '{
   "sessionId": "value",
@@ -424,7 +424,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_session_message --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-session-update" name="bakin_exec_messaging_session_update" label="Updated brainstorm session" description="Update a planning session title or status" source="bakin-bits-official/plugins/messaging/index.ts:1185" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"string","required":false,"description":"New status (active, completed)"}]}>
+<McpToolCard id="messaging-session-update" name="bakin_exec_messaging_session_update" label="Updated brainstorm session" description="Update a planning session title or status" source="bakin-bits-official/plugins/messaging/index.ts:1158" parameters={[{"name":"sessionId","type":"string","required":true,"description":"Session ID (required)"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"string","required":false,"description":"New status (active, completed)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_session_update --args '{
   "sessionId": "value",
@@ -433,7 +433,7 @@ mcporter call bakin-<agent>.bakin_exec_messaging_session_update --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="messaging-update" name="bakin_exec_messaging_update" label="Updated a message" description="Update a messaging item" source="bakin-bits-official/plugins/messaging/index.ts:1046" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"scheduledAt","type":"string","required":false,"description":"New schedule datetime"},{"name":"status","type":"string","required":false,"description":"New status"},{"name":"brief","type":"string","required":false,"description":"Updated brief"},{"name":"tone","type":"string","required":false,"description":"Updated tone"}]}>
+<McpToolCard id="messaging-update" name="bakin_exec_messaging_update" label="Updated a message" description="Update a messaging item" source="bakin-bits-official/plugins/messaging/index.ts:1019" parameters={[{"name":"itemId","type":"string","required":true,"description":"Item ID (required)"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"scheduledAt","type":"string","required":false,"description":"New schedule datetime"},{"name":"status","type":"string","required":false,"description":"New status"},{"name":"brief","type":"string","required":false,"description":"Updated brief"},{"name":"tone","type":"string","required":false,"description":"Updated tone"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_messaging_update --args '{
   "itemId": "value",
@@ -489,40 +489,55 @@ mcporter call bakin-<agent>.bakin_exec_post_channel --args '{
 </McpToolCard>
 </div>
 
-## Project
+## Projects
 
-<p class="mcp-section-description">Project tools let agents create, update, read, and maintain project specs and linked checklist items.</p>
+<p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="project-add-item" name="bakin_exec_project_add_item" label="Added project item" description="Add a new checklist item to a project." source="bakin-bits-official/plugins/projects/index.ts:614" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":true,"description":"Checklist item title"}]}>
+<McpToolCard id="projects-add-item" name="bakin_exec_projects_add_item" label="Added project item" description="Add a new checklist item to a project." source="bakin-bits-official/plugins/projects/index.ts:740" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":true,"description":"Checklist item title"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_add_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_add_item --args '{
   "projectId": "value",
   "title": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-ask" name="bakin_exec_project_ask" label="Asked project question" description="Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming." source="bakin-bits-official/plugins/projects/index.ts:804" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"message","type":"string","required":true,"description":"Question or prompt for the agent"},{"name":"agent","type":"string","required":false,"description":"Agent ID to ask (defaults to main)"}]}>
+<McpToolCard id="projects-apply-plan" name="bakin_exec_projects_apply_plan" label="Applied a project plan" description="Apply a confirmed project plan update in one operation. Use this after the user confirms exact body/checklist changes so agents do not need shell scripts or multiple low-level calls." source="bakin-bits-official/plugins/projects/index.ts:691" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"Optional new project title"},{"name":"status","type":"choice","required":false,"description":"Optional new status"},{"name":"body","type":"string","required":false,"description":"Replacement markdown body for the project plan"},{"name":"appendBody","type":"string","required":false,"description":"Markdown to append to the existing project body; cannot be combined with body"},{"name":"owner","type":"string","required":false,"description":"Optional new owner"},{"name":"checklistItems","type":"array","required":false,"description":"New unchecked checklist item titles to append"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_ask --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_apply_plan --args '{
+  "projectId": "value",
+  "title": "value",
+  "status": "value",
+  "body": "value",
+  "appendBody": "value",
+  "owner": "value",
+  "checklistItems": [
+    "value"
+  ]
+}'
+```
+</McpToolCard>
+<McpToolCard id="projects-ask" name="bakin_exec_projects_ask" label="Asked project question" description="Ask an agent a question about a project. Sends the project context (spec, checklist, assets) along with the message to the agent for brainstorming." source="bakin-bits-official/plugins/projects/index.ts:930" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"message","type":"string","required":true,"description":"Question or prompt for the agent"},{"name":"agent","type":"string","required":false,"description":"Agent ID to ask (defaults to main)"}]}>
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_projects_ask --args '{
   "projectId": "value",
   "message": "value",
   "agent": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-attach-asset" name="bakin_exec_project_attach_asset" label="Attached asset to project" description="Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in project_get — use asset tools to read full content when needed." source="bakin-bits-official/plugins/projects/index.ts:716" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename (e.g., \"20260327-hero-a1b2c3d4.png\") — globally unique, stable across retype/relink"},{"name":"label","type":"string","required":false,"description":"Human-readable label or summary of what this asset contains"}]}>
+<McpToolCard id="projects-attach-asset" name="bakin_exec_projects_attach_asset" label="Attached asset to project" description="Attach an existing asset to a project by filename. Assets provide additional context (specs, designs, docs) that agents can reference. Only summaries are included in projects_get — use asset tools to read full content when needed." source="bakin-bits-official/plugins/projects/index.ts:842" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename (e.g., \"20260327-hero-a1b2c3d4.png\") — globally unique, stable across retype/relink"},{"name":"label","type":"string","required":false,"description":"Human-readable label or summary of what this asset contains"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_attach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_attach_asset --args '{
   "projectId": "value",
   "filename": "value",
   "label": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-create" name="bakin_exec_project_create" label="Created a project" description="Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs." source="bakin-bits-official/plugins/projects/index.ts:547" parameters={[{"name":"title","type":"string","required":true,"description":"Project title"},{"name":"body","type":"string","required":false,"description":"Markdown body (spec/plan)"},{"name":"owner","type":"string","required":false,"description":"Project owner"},{"name":"tasks","type":"array","required":false,"description":"Initial checklist item titles"}]}>
+<McpToolCard id="projects-create" name="bakin_exec_projects_create" label="Created a project" description="Create a new project with title, markdown body, and optional initial checklist items. Returns project ID and generated task item IDs." source="bakin-bits-official/plugins/projects/index.ts:642" parameters={[{"name":"title","type":"string","required":true,"description":"Project title"},{"name":"body","type":"string","required":false,"description":"Markdown body (spec/plan)"},{"name":"owner","type":"string","required":false,"description":"Project owner"},{"name":"tasks","type":"array","required":false,"description":"Initial checklist item titles"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_create --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_create --args '{
   "title": "value",
   "body": "value",
   "owner": "value",
@@ -532,82 +547,82 @@ mcporter call bakin-<agent>.bakin_exec_project_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-delete" name="bakin_exec_project_delete" label="Deleted a project" description="Delete a project by ID." source="bakin-bits-official/plugins/projects/index.ts:596" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
+<McpToolCard id="projects-delete" name="bakin_exec_projects_delete" label="Deleted a project" description="Delete a project by ID." source="bakin-bits-official/plugins/projects/index.ts:722" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_delete --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_delete --args '{
   "projectId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-detach-asset" name="bakin_exec_project_detach_asset" label="Detached asset from project" description="Remove an asset reference from a project by filename. Does not delete the asset itself." source="bakin-bits-official/plugins/projects/index.ts:736" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename to detach"}]}>
+<McpToolCard id="projects-detach-asset" name="bakin_exec_projects_detach_asset" label="Detached asset from project" description="Remove an asset reference from a project by filename. Does not delete the asset itself." source="bakin-bits-official/plugins/projects/index.ts:862" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"filename","type":"string","required":true,"description":"Asset filename to detach"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_detach_asset --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_detach_asset --args '{
   "projectId": "value",
   "filename": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-get" name="bakin_exec_project_get" label="Read project details" description="Get a project by ID including full spec, checklist, progress, and linked board task statuses." source="bakin-bits-official/plugins/projects/index.ts:533" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
+<McpToolCard id="projects-get" name="bakin_exec_projects_get" label="Read project details" description="Get a project by ID including full spec, checklist, progress, and linked board task statuses." source="bakin-bits-official/plugins/projects/index.ts:628" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_get --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_get --args '{
   "projectId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-link-item" name="bakin_exec_project_link_item" label="Linked project item" description="Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project." source="bakin-bits-official/plugins/projects/index.ts:668" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID"},{"name":"taskId","type":"string","required":true,"description":"Board task ID to link"}]}>
+<McpToolCard id="projects-link-item" name="bakin_exec_projects_link_item" label="Linked project item" description="Link an existing board task to a project checklist item. Use this when a task was created separately and should be associated with a project." source="bakin-bits-official/plugins/projects/index.ts:794" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID"},{"name":"taskId","type":"string","required":true,"description":"Board task ID to link"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_link_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_link_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-list" name="bakin_exec_project_list" label="Listed projects" description="List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount." source="bakin-bits-official/plugins/projects/index.ts:517" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by status"}]}>
+<McpToolCard id="projects-list" name="bakin_exec_projects_list" label="Listed projects" description="List all projects with optional status filter. Returns summaries with id, title, status, progress, taskCount." source="bakin-bits-official/plugins/projects/index.ts:612" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by status"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_list --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_list --args '{
   "status": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-mark-item" name="bakin_exec_project_mark_item" label="Marked project item" description="Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:629" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
+<McpToolCard id="projects-mark-item" name="bakin_exec_projects_mark_item" label="Marked project item" description="Mark a checklist item as checked (done) or unchecked. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:755" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_mark_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_mark_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "checked": true
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-promote-item" name="bakin_exec_project_promote_item" label="Promoted project item" description="Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set." source="bakin-bits-official/plugins/projects/index.ts:692" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to promote to a board task"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign the task to"}]}>
+<McpToolCard id="projects-promote-item" name="bakin_exec_projects_promote_item" label="Promoted project item" description="Create a NEW board task from a project checklist item and automatically link it. The task appears on the task board with the item title and projectId set." source="bakin-bits-official/plugins/projects/index.ts:818" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to promote to a board task"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign the task to"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_promote_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_promote_item --args '{
   "projectId": "value",
   "taskItemId": "value",
   "assignee": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-remove-item" name="bakin_exec_project_remove_item" label="Removed project item" description="Remove a checklist item from a project." source="bakin-bits-official/plugins/projects/index.ts:649" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to remove"}]}>
+<McpToolCard id="projects-remove-item" name="bakin_exec_projects_remove_item" label="Removed project item" description="Remove a checklist item from a project." source="bakin-bits-official/plugins/projects/index.ts:775" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"taskItemId","type":"string","required":true,"description":"Checklist item ID to remove"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_remove_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_remove_item --args '{
   "projectId": "value",
   "taskItemId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-toggle-item" name="bakin_exec_project_toggle_item" label="Toggled project item" description="Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:755" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
+<McpToolCard id="projects-toggle-item" name="bakin_exec_projects_toggle_item" label="Toggled project item" description="Toggle a checklist item checked/unchecked by item ID. Returns updated progress percentage." source="bakin-bits-official/plugins/projects/index.ts:881" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"checked","type":"boolean","required":true,"description":"true to mark as done, false to uncheck"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_toggle_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_toggle_item --args '{
   "projectId": "value",
   "itemId": "value",
   "checked": true
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-update" name="bakin_exec_project_update" label="Updated a project" description="Update a project's title, status, body, or owner. Cannot set status to &quot;completed&quot; if unchecked items remain." source="bakin-bits-official/plugins/projects/index.ts:569" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"choice","required":false,"description":"New status"},{"name":"body","type":"string","required":false,"description":"New markdown body"},{"name":"owner","type":"string","required":false,"description":"New owner"}]}>
+<McpToolCard id="projects-update" name="bakin_exec_projects_update" label="Updated a project" description="Update a project's title, status, body, or owner. Cannot set status to &quot;completed&quot; if unchecked items remain." source="bakin-bits-official/plugins/projects/index.ts:664" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"title","type":"string","required":false,"description":"New title"},{"name":"status","type":"choice","required":false,"description":"New status"},{"name":"body","type":"string","required":false,"description":"New markdown body"},{"name":"owner","type":"string","required":false,"description":"New owner"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_update --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_update --args '{
   "projectId": "value",
   "title": "value",
   "status": "value",
@@ -616,9 +631,9 @@ mcporter call bakin-<agent>.bakin_exec_project_update --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="project-update-item" name="bakin_exec_project_update_item" label="Updated project item" description="Update a checklist item's title and/or description." source="bakin-bits-official/plugins/projects/index.ts:776" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"title","type":"string","required":false,"description":"New title for the checklist item"},{"name":"description","type":"string","required":false,"description":"New description for the checklist item"}]}>
+<McpToolCard id="projects-update-item" name="bakin_exec_projects_update_item" label="Updated project item" description="Update a checklist item's title and/or description." source="bakin-bits-official/plugins/projects/index.ts:902" parameters={[{"name":"projectId","type":"string","required":true,"description":"Project ID"},{"name":"itemId","type":"string","required":true,"description":"Checklist item ID (e.g., t001)"},{"name":"title","type":"string","required":false,"description":"New title for the checklist item"},{"name":"description","type":"string","required":false,"description":"New description for the checklist item"}]}>
 ```sh frame="terminal"
-mcporter call bakin-<agent>.bakin_exec_project_update_item --args '{
+mcporter call bakin-<agent>.bakin_exec_projects_update_item --args '{
   "projectId": "value",
   "itemId": "value",
   "title": "value",
@@ -1075,5 +1090,5 @@ mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -199,7 +199,7 @@ await ctx.hooks.callAll(
 <p class="hook-section-description">Task hooks let plugins enrich task details and react to task lifecycle changes.</p>
 
 <div class="hook-card-list">
-<HookCard id="tasks-enrichdetails" name="tasks.enrichDetails" label="Add project task context." summary="Adds project title, status, progress, and excerpt data to task detail payloads. Use it when a task surface wants project context without depending on project storage." source="bakin-bits-official/plugins/projects/index.ts:160" badges={["waterfall"]}>
+<HookCard id="tasks-enrichdetails" name="tasks.enrichDetails" label="Add project task context." summary="Adds project title, status, progress, and excerpt data to task detail payloads. Use it when a task surface wants project context without depending on project storage." source="bakin-bits-official/plugins/projects/index.ts:222" badges={["waterfall"]}>
 ```ts frame="terminal"
 const next = await ctx.hooks.call(
   'tasks.enrichDetails',
@@ -212,7 +212,7 @@ const next = await ctx.hooks.call(
 )
 ```
 </HookCard>
-<HookCard id="tasks-statuschanged" name="tasks.statusChanged" label="Sync project task state." summary="Updates linked project checklist items when a task moves into a completed state. Use it to keep project progress in sync with task lifecycle events." source="bakin-bits-official/plugins/projects/index.ts:149" badges={["event"]}>
+<HookCard id="tasks-statuschanged" name="tasks.statusChanged" label="Sync project task state." summary="Updates linked project checklist items when a task moves into a completed state. Use it to keep project progress in sync with task lifecycle events." source="bakin-bits-official/plugins/projects/index.ts:211" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'tasks.statusChanged',
@@ -487,5 +487,5 @@ const result = await ctx.hooks.invoke(
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/runtime-paths.md
+++ b/docs/src/content/docs/reference/generated/runtime-paths.md
@@ -100,5 +100,5 @@ description: Reference for Bakin runtime files under the resolved Bakin home dir
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -90,6 +90,7 @@ Source: `packages/sdk/src/components/index.ts`
 | `export type { FacetOption } from '@/components/facet-filter'` |
 | `export { IntegratedBrainstorm } from '@/components/integrated-brainstorm'` |
 | `export type {` |
+| `export {` |
 | `export { MarkdownContent } from '@/components/markdown-content'` |
 | `export { MarkdownEditor } from '@/components/markdown-editor'` |
 | `export { ModelSelect } from '@/components/model-select'` |
@@ -146,6 +147,7 @@ Source: `packages/sdk/src/types/index.ts`
 | `export interface StorageAdapter {` |
 | `export interface EventBus {` |
 | `export interface ActivityAPI {` |
+| `export interface PluginLogger {` |
 | `export interface HookAPI {` |
 | `export interface HookRegistrationMetadata {` |
 | `export type HookKind = 'rpc' \| 'event' \| 'waterfall'` |
@@ -157,6 +159,7 @@ Source: `packages/sdk/src/types/index.ts`
 | `export interface RuntimeChannel {` |
 | `export interface RuntimeMessageArgs {` |
 | `export interface RuntimeMessageResult {` |
+| `export interface RuntimeToolActivity {` |
 | `export interface RuntimeChatChunk {` |
 | `export interface CronJob {` |
 | `export interface CronRun {` |
@@ -231,6 +234,11 @@ Source: `packages/sdk/src/utils/index.ts`
 | --- |
 | `export { cn } from '@/lib/utils'` |
 | `export { formatAge, formatSize, isStale } from '@bakin/core/format'` |
+| `export {` |
+| `export {` |
+| `export type {` |
+| `export type {` |
+| `export { readBrainstormSseResponse } from '@/components/integrated-brainstorm/sse'` |
 
 ## `@makinbakin/sdk/metadata`
 
@@ -251,5 +259,5 @@ Source: `packages/sdk/src/routing/index.ts`
 | `export type {` |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -361,5 +361,5 @@ description: Generated reference for Bakin core settings defaults.
 
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 6, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 9, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/using/messaging.md
+++ b/docs/src/content/docs/using/messaging.md
@@ -70,6 +70,12 @@ Where the work starts. Open the brainstorm view, hit `New Session`, pick an agen
 
 Every calendar item links back to the session it came from. You can always trace a published post to the conversation behind it.
 
+### Session continuity and tool activity
+
+Brainstorm sessions are durable. When you leave a session and come back, Bakin reloads the stored user, assistant, and tool-activity timeline from the session file. New messages also reuse the same adapter-neutral runtime thread key for that session and agent, so the active runtime adapter can continue the same underlying conversation instead of starting over.
+
+Tool calls and runtime status updates stream into the chat while the agent is working. They render in the same assistant-style thread with compact summaries and expandable details. Those activity rows are persisted with the session so the "what happened behind the scenes" trail is still there after reload. Search indexes user/assistant planning text and proposal summaries, not raw tool output.
+
 ### What are proposals?
 
 <figure class="screenshot-frame">
@@ -118,7 +124,7 @@ Each calendar item picks one or more channels from that registry. Channels show 
 ~/.bakin/
   messaging.json                  # flat array of every calendar item
   messaging/
-    sessions/<id>.json            # one file per brainstorm session
+    sessions/<id>.json            # brainstorm messages, activity rows, and proposals
   plugin-settings/
     messaging.json                # content types, default view, etc.
 ```

--- a/docs/src/content/docs/using/projects.md
+++ b/docs/src/content/docs/using/projects.md
@@ -25,6 +25,8 @@ Most of the work happens here. Open the panel, pick an agent, start the conversa
 
 Hammer the plan out here before any real work starts.
 
+Project brainstorm uses a stable runtime thread per project and agent, so a reopened project continues the same adapter-backed conversation instead of replaying the old transcript into every prompt. The project file still stores the visible chat timeline, including streamed tool/status activity, so you can see how the agent reached an answer after navigation or reload.
+
 ### Tasks
 
 <figure class="screenshot-frame">
@@ -70,6 +72,7 @@ Projects index into search (table `bakin_projects`) on `title` and `body`, facet
 | `bakin projects get <projectId>` | Get a project |
 | `bakin projects create <title>` | Create a project |
 | `bakin projects update <projectId>` | Update a project |
+| `bakin projects apply-plan <projectId>` | Apply a confirmed project plan update |
 | `bakin projects delete <projectId>` | Delete a project |
 | `bakin projects add-item <projectId> <title>` | Add a checklist item |
 | `bakin projects toggle-item <projectId> <itemId> <checked>` | Toggle a checklist item |

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1651,6 +1651,10 @@ function summarizeOpenClawToolPurpose(name: string, args: unknown): string | und
     return summarizeShellCommandPurpose(command)
   }
 
+  if (name === 'web_fetch') {
+    return summarizeWebFetchPurpose(args)
+  }
+
   return summarizeToolNamePurpose(name)
 }
 
@@ -1678,6 +1682,7 @@ function summarizeToolNamePurpose(toolName: string): string | undefined {
   if (/^bakin_exec_projects_add_item$/.test(toolName)) return 'Adding a project checklist item'
   if (/^bakin_exec_projects_(list|search)$/.test(toolName)) return 'Inspecting projects'
   if (/^bakin_exec_messaging_/.test(toolName)) return 'Updating messaging content'
+  if (toolName === 'web_fetch') return 'Fetching web content'
   return undefined
 }
 
@@ -1692,7 +1697,32 @@ function summarizeRuntimeToolPurpose(toolName: string, inputPreview: string | un
     const path = typeof parsed?.path === 'string' ? parsed.path : undefined
     if (path) return summarizeOpenClawToolPurpose('read', { path })
   }
+  if (toolName === 'web_fetch' && inputPreview) {
+    return summarizeWebFetchPurpose(parseJsonObject(inputPreview) ?? inputPreview)
+  }
   return summarizeToolNamePurpose(toolName)
+}
+
+function summarizeWebFetchPurpose(args: unknown): string {
+  const url = extractUrlForDisplay(args)
+  return url ? `Fetching ${url}` : 'Fetching web content'
+}
+
+function extractUrlForDisplay(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const parsed = parseJsonObject(value)
+    if (parsed) return extractUrlForDisplay(parsed)
+    const trimmed = value.trim()
+    return /^https?:\/\//i.test(trimmed) ? truncateMiddle(redactSensitiveText(trimmed), 140) : undefined
+  }
+  if (!isPlainObject(value)) return undefined
+  for (const key of ['url', 'uri', 'href']) {
+    const raw = value[key]
+    if (typeof raw === 'string' && raw.trim()) {
+      return truncateMiddle(redactSensitiveText(raw.trim()), 140)
+    }
+  }
+  return undefined
 }
 
 function basenameForDisplay(path: string): string {
@@ -1720,7 +1750,8 @@ function redactSensitiveText(value: string): string {
   return value
     .replace(/(authorization:\s*bearer\s+)[^\s"'`]+/gi, '$1[redacted]')
     .replace(/(x-access-token:)[^\s"'`@]+/gi, '$1[redacted]')
-    .replace(/\b([A-Za-z0-9_]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_]*\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,}]+)/gi, '$1[redacted]')
+    .replace(/([?&][^=\s"'`]*(?:token|password|secret|api[_-]?key)[^=\s"'`]*=)[^&\s"'`]+/gi, '$1[redacted]')
+    .replace(/\b([A-Za-z0-9_]*(?:token|password|secret|api[_-]?key)[A-Za-z0-9_]*\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,"'`}]+)/gi, '$1[redacted]')
 }
 
 function parseStreamFrame(frame: string): ChatChunk | null {
@@ -1900,7 +1931,7 @@ function normalizeRuntimeToolActivity(payload: unknown, fallbackPhase: RuntimeTo
   const inputPreview = firstString(
     payload.inputPreview,
     payload.argumentsPreview,
-    functionArgs,
+    functionArgs !== undefined ? previewUnknown(functionArgs) : undefined,
     payload.arguments !== undefined ? previewUnknown(payload.arguments) : undefined,
   )
   const outputPreview = firstString(

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1571,6 +1571,8 @@ function activityChunksFromAssistantMessage(message: Record<string, unknown>): C
     if (!isPlainObject(part) || part.type !== 'toolCall') continue
     const name = typeof part.name === 'string' && part.name.length > 0 ? part.name : 'tool'
     const args = part.arguments
+    const summary = firstString(part.summary, part.purpose, part.displayLabel)
+      ?? summarizeOpenClawToolPurpose(name, args)
     chunks.push({
       type: 'tool',
       content: summarizeOpenClawToolCall(name, args),
@@ -1579,6 +1581,7 @@ function activityChunksFromAssistantMessage(message: Record<string, unknown>): C
         callId: typeof part.id === 'string' ? part.id : undefined,
         toolName: name,
         status: 'running',
+        ...(summary ? { summary } : {}),
         inputPreview: previewUnknown(args),
       },
     })
@@ -1628,6 +1631,73 @@ function summarizeOpenClawToolCall(name: string, args: unknown): string {
     }
   }
   return name
+}
+
+function summarizeOpenClawToolPurpose(name: string, args: unknown): string | undefined {
+  if (name === 'read' && isPlainObject(args)) {
+    const path = typeof args.path === 'string' ? args.path.trim() : ''
+    if (!path) return undefined
+    if (/\/skills\/[^/]+\/SKILL\.md$/.test(path)) return 'Reading workflow instructions'
+    return `Reading ${basenameForDisplay(path)}`
+  }
+
+  if (name === 'process' && isPlainObject(args)) {
+    const action = typeof args.action === 'string' ? args.action.trim() : ''
+    if (action === 'poll') return 'Waiting for command output'
+  }
+
+  if (name === 'exec' && isPlainObject(args)) {
+    const command = typeof args.command === 'string' ? args.command.trim() : ''
+    return summarizeShellCommandPurpose(command)
+  }
+
+  return summarizeToolNamePurpose(name)
+}
+
+function summarizeShellCommandPurpose(command: string): string | undefined {
+  if (!command) return undefined
+  const first = command.split(/\r?\n/)[0]?.trim() ?? ''
+  if (/\bmcporter\s+call\s+--help\b/.test(first)) return 'Checking Bakin tool call syntax'
+  const mcporterCall = first.match(/\bmcporter\s+call\s+([^\s]+)/)
+  if (mcporterCall) {
+    const tool = mcporterCall[1].split('.').pop() ?? mcporterCall[1]
+    return summarizeToolNamePurpose(tool) ?? 'Calling a Bakin tool'
+  }
+  if (/\bmcporter\s+list\b/.test(first)) return 'Inspecting available Bakin tools'
+  if (/\bgh\s+issue\b/.test(first)) return 'Checking GitHub issues'
+  if (/\bgh\s+pr\b/.test(first)) return 'Checking GitHub pull requests'
+  if (/^python3?\s+-\s*<<|^python3?\s+-c\b/.test(first)) return 'Preparing structured tool arguments'
+  if (/^cat\s+>\s+\/tmp\//.test(first)) return 'Preparing a temporary helper script'
+  return undefined
+}
+
+function summarizeToolNamePurpose(toolName: string): string | undefined {
+  if (/^bakin_exec_projects_get$/.test(toolName)) return 'Reading project details'
+  if (/^bakin_exec_projects_apply_plan$/.test(toolName)) return 'Applying confirmed project plan'
+  if (/^bakin_exec_projects_update$/.test(toolName)) return 'Updating project details'
+  if (/^bakin_exec_projects_add_item$/.test(toolName)) return 'Adding a project checklist item'
+  if (/^bakin_exec_projects_(list|search)$/.test(toolName)) return 'Inspecting projects'
+  if (/^bakin_exec_messaging_/.test(toolName)) return 'Updating messaging content'
+  return undefined
+}
+
+function summarizeRuntimeToolPurpose(toolName: string, inputPreview: string | undefined): string | undefined {
+  if (toolName === 'exec' && inputPreview) {
+    const parsed = parseJsonObject(inputPreview)
+    const command = typeof parsed?.command === 'string' ? parsed.command : inputPreview
+    return summarizeShellCommandPurpose(command)
+  }
+  if (toolName === 'read' && inputPreview) {
+    const parsed = parseJsonObject(inputPreview)
+    const path = typeof parsed?.path === 'string' ? parsed.path : undefined
+    if (path) return summarizeOpenClawToolPurpose('read', { path })
+  }
+  return summarizeToolNamePurpose(toolName)
+}
+
+function basenameForDisplay(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.split('/').pop() || normalized
 }
 
 function firstLine(value: string): string {
@@ -1717,10 +1787,14 @@ function parseActivityChunk(parsed: {
     }
     if (kind === 'tool_call' || kind === 'tool') {
       const toolActivity = normalizeRuntimeToolActivity(parsed.activity.data, 'call')
+      const data = withRuntimeToolSummary(
+        toolActivity ?? fallbackToolActivity(parsed.activity.data, 'call'),
+        parsed.activity.content,
+      )
       return {
         type: 'tool',
         content: parsed.activity.content || describeToolPayload(toolActivity ?? parsed.activity.data),
-        data: toolActivity ?? fallbackToolActivity(parsed.activity.data, 'call'),
+        data,
       }
     }
   }
@@ -1736,10 +1810,14 @@ function parseActivityChunk(parsed: {
   if (frameKind === 'tool' || frameKind === 'tool_call') {
     const payload = parsed.data ?? parsed.tool ?? parsed.tool_call ?? parsed.toolCall
     const toolActivity = normalizeRuntimeToolActivity(payload, 'call')
+    const data = withRuntimeToolSummary(
+      toolActivity ?? fallbackToolActivity(payload, 'call'),
+      parsed.content,
+    )
     return {
       type: 'tool',
       content: parsed.content || describeToolPayload(toolActivity ?? payload),
-      data: toolActivity ?? fallbackToolActivity(payload, 'call'),
+      data,
     }
   }
 
@@ -1772,6 +1850,11 @@ function fallbackToolActivity(payload: unknown, phase: RuntimeToolActivity['phas
     toolName: describeToolPayload(payload),
     status: phase === 'call' ? 'running' : 'completed',
   }
+}
+
+function withRuntimeToolSummary(activity: RuntimeToolActivity, summary: string | undefined): RuntimeToolActivity {
+  if (!summary || activity.summary) return activity
+  return { ...activity, summary }
 }
 
 function metadataFromUnknown(value: unknown): RuntimeMetadata | undefined {
@@ -1825,12 +1908,20 @@ function normalizeRuntimeToolActivity(payload: unknown, fallbackPhase: RuntimeTo
     payload.resultPreview,
     payload.output !== undefined ? previewUnknown(payload.output) : undefined,
   )
+  const summary = firstString(
+    payload.summary,
+    payload.purpose,
+    payload.displayLabel,
+  ) ?? (phase === 'call'
+    ? summarizeRuntimeToolPurpose(toolName, inputPreview)
+    : undefined)
 
   return {
     phase,
     ...(callId ? { callId } : {}),
     toolName,
     status,
+    ...(summary ? { summary } : {}),
     ...(inputPreview ? { inputPreview } : {}),
     ...(outputPreview ? { outputPreview } : {}),
     ...(typeof payload.durationMs === 'number' ? { durationMs: payload.durationMs } : {}),

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1670,9 +1670,22 @@ function summarizeShellCommandPurpose(command: string): string | undefined {
   if (/\bmcporter\s+list\b/.test(first)) return 'Inspecting available Bakin tools'
   if (/\bgh\s+issue\b/.test(first)) return 'Checking GitHub issues'
   if (/\bgh\s+pr\b/.test(first)) return 'Checking GitHub pull requests'
+  const bxContextSummary = summarizeBxContextCommand(first)
+  if (bxContextSummary) return bxContextSummary
+  const fetchedUrl = extractUrlForDisplay(command)
+  if (fetchedUrl) return `Fetching ${fetchedUrl}`
   if (/^python3?\s+-\s*<<|^python3?\s+-c\b/.test(first)) return 'Preparing structured tool arguments'
   if (/^cat\s+>\s+\/tmp\//.test(first)) return 'Preparing a temporary helper script'
   return undefined
+}
+
+function summarizeBxContextCommand(command: string): string | undefined {
+  const match = command.match(/^bx\s+context\s+(.+?)(?:\s+--\S+|$)/)
+  if (!match) return undefined
+  const topic = cleanShellArgumentForDisplay(match[1])
+  const githubReleaseRepo = topic.match(/\bgithub\s+releases?\b.*\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\b/i)
+  if (githubReleaseRepo) return `Checking GitHub releases for ${githubReleaseRepo[1]}`
+  return topic ? `Looking up ${truncateMiddle(topic, 100)}` : 'Looking up context'
 }
 
 function summarizeToolNamePurpose(toolName: string): string | undefined {
@@ -1713,7 +1726,9 @@ function extractUrlForDisplay(value: unknown): string | undefined {
     const parsed = parseJsonObject(value)
     if (parsed) return extractUrlForDisplay(parsed)
     const trimmed = value.trim()
-    return /^https?:\/\//i.test(trimmed) ? truncateMiddle(redactSensitiveText(trimmed), 140) : undefined
+    if (/^https?:\/\//i.test(trimmed)) return truncateMiddle(redactSensitiveText(trimmed), 140)
+    const match = trimmed.match(/https?:\/\/[^\s"'`\\]+/i)
+    return match ? truncateMiddle(redactSensitiveText(match[0]), 140) : undefined
   }
   if (!isPlainObject(value)) return undefined
   for (const key of ['url', 'uri', 'href']) {
@@ -1723,6 +1738,17 @@ function extractUrlForDisplay(value: unknown): string | undefined {
     }
   }
   return undefined
+}
+
+function cleanShellArgumentForDisplay(value: string): string {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
 }
 
 function basenameForDisplay(path: string): string {

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -16,6 +16,7 @@ import type {
   RuntimeMetadata,
   RuntimeMemorySearchResult,
   RuntimeSkill,
+  RuntimeToolActivity,
   UpdateCronJobInput,
   WorkspaceFile,
 } from '@bakin/core/adapters/runtime'
@@ -1575,9 +1576,10 @@ function activityChunksFromAssistantMessage(message: Record<string, unknown>): C
       content: summarizeOpenClawToolCall(name, args),
       data: {
         phase: 'call',
-        id: typeof part.id === 'string' ? part.id : undefined,
-        name,
-        argumentsPreview: previewUnknown(args),
+        callId: typeof part.id === 'string' ? part.id : undefined,
+        toolName: name,
+        status: 'running',
+        inputPreview: previewUnknown(args),
       },
     })
   }
@@ -1591,17 +1593,23 @@ function activityChunkFromToolResultMessage(message: Record<string, unknown>): C
   const label = status ? `${toolName} ${status}` : `${toolName} finished`
   return [{
     type: 'tool',
-    content: label,
-    data: {
-      phase: 'result',
-      toolName,
-      toolCallId: typeof message.toolCallId === 'string' ? message.toolCallId : undefined,
-      status,
-      exitCode: typeof details.exitCode === 'number' ? details.exitCode : undefined,
-      durationMs: typeof details.durationMs === 'number' ? details.durationMs : undefined,
-      outputPreview: previewUnknown(message.content),
-    },
+      content: label,
+      data: {
+        phase: 'result',
+        toolName,
+        callId: typeof message.toolCallId === 'string' ? message.toolCallId : undefined,
+        status: normalizeToolResultStatus(status, typeof details.exitCode === 'number' ? details.exitCode : undefined),
+        exitCode: typeof details.exitCode === 'number' ? details.exitCode : undefined,
+        durationMs: typeof details.durationMs === 'number' ? details.durationMs : undefined,
+        outputPreview: previewUnknown(message.content),
+      },
   }]
+}
+
+function normalizeToolResultStatus(status: string | undefined, exitCode: number | undefined): string {
+  if (status && status.length > 0) return status
+  if (typeof exitCode === 'number') return exitCode === 0 ? 'completed' : 'failed'
+  return 'completed'
 }
 
 function summarizeOpenClawToolCall(name: string, args: unknown): string {
@@ -1708,10 +1716,11 @@ function parseActivityChunk(parsed: {
       }
     }
     if (kind === 'tool_call' || kind === 'tool') {
+      const toolActivity = normalizeRuntimeToolActivity(parsed.activity.data, 'call')
       return {
         type: 'tool',
-        content: parsed.activity.content || describeToolPayload(parsed.activity.data),
-        data: parsed.activity.data,
+        content: parsed.activity.content || describeToolPayload(toolActivity ?? parsed.activity.data),
+        data: toolActivity ?? fallbackToolActivity(parsed.activity.data, 'call'),
       }
     }
   }
@@ -1725,32 +1734,118 @@ function parseActivityChunk(parsed: {
     }
   }
   if (frameKind === 'tool' || frameKind === 'tool_call') {
+    const payload = parsed.data ?? parsed.tool ?? parsed.tool_call ?? parsed.toolCall
+    const toolActivity = normalizeRuntimeToolActivity(payload, 'call')
     return {
       type: 'tool',
-      content: parsed.content || describeToolPayload(parsed.data ?? parsed.tool ?? parsed.tool_call ?? parsed.toolCall),
-      data: parsed.data ?? parsed.tool ?? parsed.tool_call ?? parsed.toolCall,
+      content: parsed.content || describeToolPayload(toolActivity ?? payload),
+      data: toolActivity ?? fallbackToolActivity(payload, 'call'),
     }
   }
 
   const toolCalls = parsed.choices?.[0]?.delta?.tool_calls ?? parsed.choices?.[0]?.message?.tool_calls
   if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    const toolActivity = normalizeRuntimeToolActivity({ toolCalls }, 'call')
     return {
       type: 'tool',
       content: describeToolPayload(toolCalls),
-      data: { toolCalls },
+      data: toolActivity ?? fallbackToolActivity(toolCalls, 'call'),
     }
   }
 
   const toolPayload = parsed.tool ?? parsed.tool_call ?? parsed.toolCall
   if (toolPayload !== undefined) {
+    const toolActivity = normalizeRuntimeToolActivity(toolPayload, 'call')
     return {
       type: 'tool',
       content: parsed.content || describeToolPayload(toolPayload),
-      data: toolPayload,
+      data: toolActivity ?? fallbackToolActivity(toolPayload, 'call'),
     }
   }
 
   return null
+}
+
+function fallbackToolActivity(payload: unknown, phase: RuntimeToolActivity['phase']): RuntimeToolActivity {
+  return {
+    phase,
+    toolName: describeToolPayload(payload),
+    status: phase === 'call' ? 'running' : 'completed',
+  }
+}
+
+function normalizeRuntimeToolActivity(payload: unknown, fallbackPhase: RuntimeToolActivity['phase']): RuntimeToolActivity | null {
+  const toolCallPayload = firstToolCallPayload(payload)
+  if (toolCallPayload) return normalizeRuntimeToolActivity(toolCallPayload, fallbackPhase)
+
+  if (typeof payload === 'string' && payload.trim()) {
+    return {
+      phase: fallbackPhase,
+      toolName: payload.trim(),
+      status: fallbackPhase === 'call' ? 'running' : 'completed',
+    }
+  }
+
+  if (!isPlainObject(payload)) return null
+
+  const functionValue = payload.function
+  const functionName = isPlainObject(functionValue) && typeof functionValue.name === 'string'
+    ? functionValue.name
+    : undefined
+  const functionArgs = isPlainObject(functionValue) && typeof functionValue.arguments === 'string'
+    ? functionValue.arguments
+    : undefined
+  const phase = payload.phase === 'result' ? 'result' : payload.phase === 'call' ? 'call' : fallbackPhase
+  const toolName = firstString(
+    payload.toolName,
+    payload.name,
+    payload.tool,
+    functionName,
+    payload.id,
+  ) ?? 'tool'
+  const callId = firstString(payload.callId, payload.toolCallId, payload.id)
+  const status = typeof payload.status === 'string'
+    ? payload.status
+    : phase === 'call'
+      ? 'running'
+      : normalizeToolResultStatus(undefined, typeof payload.exitCode === 'number' ? payload.exitCode : undefined)
+  const inputPreview = firstString(
+    payload.inputPreview,
+    payload.argumentsPreview,
+    functionArgs,
+    payload.arguments !== undefined ? previewUnknown(payload.arguments) : undefined,
+  )
+  const outputPreview = firstString(
+    payload.outputPreview,
+    payload.resultPreview,
+    payload.output !== undefined ? previewUnknown(payload.output) : undefined,
+  )
+
+  return {
+    phase,
+    ...(callId ? { callId } : {}),
+    toolName,
+    status,
+    ...(inputPreview ? { inputPreview } : {}),
+    ...(outputPreview ? { outputPreview } : {}),
+    ...(typeof payload.durationMs === 'number' ? { durationMs: payload.durationMs } : {}),
+    ...(typeof payload.exitCode === 'number' ? { exitCode: payload.exitCode } : {}),
+  }
+}
+
+function firstToolCallPayload(payload: unknown): unknown | null {
+  if (Array.isArray(payload)) return payload.find(isPlainObject) ?? null
+  if (!isPlainObject(payload)) return null
+  const toolCalls = payload.toolCalls
+  if (Array.isArray(toolCalls)) return toolCalls.find(isPlainObject) ?? null
+  return null
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
 }
 
 function describeToolPayload(payload: unknown): string {

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1712,7 +1712,7 @@ function parseActivityChunk(parsed: {
       return {
         type: 'status',
         content: parsed.activity.content || 'Agent status update',
-        data: parsed.activity.data,
+        data: metadataFromUnknown(parsed.activity.data),
       }
     }
     if (kind === 'tool_call' || kind === 'tool') {
@@ -1730,7 +1730,7 @@ function parseActivityChunk(parsed: {
     return {
       type: 'status',
       content: parsed.content || 'Agent status update',
-      data: parsed.data,
+      data: metadataFromUnknown(parsed.data),
     }
   }
   if (frameKind === 'tool' || frameKind === 'tool_call') {
@@ -1772,6 +1772,11 @@ function fallbackToolActivity(payload: unknown, phase: RuntimeToolActivity['phas
     toolName: describeToolPayload(payload),
     status: phase === 'call' ? 'running' : 'completed',
   }
+}
+
+function metadataFromUnknown(value: unknown): RuntimeMetadata | undefined {
+  if (value === undefined) return undefined
+  return isPlainObject(value) ? value : { value }
 }
 
 function normalizeRuntimeToolActivity(payload: unknown, fallbackPhase: RuntimeToolActivity['phase']): RuntimeToolActivity | null {

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -64,6 +64,7 @@ export interface RuntimeToolActivity {
   callId?: string
   toolName: string
   status?: 'running' | 'completed' | 'failed' | string
+  summary?: string
   inputPreview?: string
   outputPreview?: string
   durationMs?: number

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -59,10 +59,22 @@ export interface MessageResult {
   metadata?: RuntimeMetadata
 }
 
+export interface RuntimeToolActivity {
+  phase: 'call' | 'result'
+  callId?: string
+  toolName: string
+  status?: 'running' | 'completed' | 'failed' | string
+  inputPreview?: string
+  outputPreview?: string
+  durationMs?: number
+  exitCode?: number
+  metadata?: RuntimeMetadata
+}
+
 export interface ChatChunk {
   type: 'text' | 'tool' | 'status' | 'done' | 'error'
   content?: string
-  data?: unknown
+  data?: RuntimeMetadata | RuntimeToolActivity
 }
 
 export interface ToolDefinition {

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -49,6 +49,10 @@ export interface WorkspaceFile {
 export interface MessageArgs {
   agentId: string
   content: string
+  /**
+   * Adapter-neutral durable conversation key. Runtime adapters should map the
+   * same agentId + threadId pair to the same provider/runtime session.
+   */
   threadId?: string
   metadata?: RuntimeMetadata
 }

--- a/packages/core/src/adapters/runtime/index.ts
+++ b/packages/core/src/adapters/runtime/index.ts
@@ -46,6 +46,7 @@ export type {
   ResolveApprovalArgs,
   RuntimeAgent,
   RuntimeAllowlistPatch,
+  RuntimeToolActivity,
   RuntimeAvailableModel,
   RuntimeConfigAccess,
   RuntimeMemoryEntry,

--- a/packages/sdk/src/components/index.ts
+++ b/packages/sdk/src/components/index.ts
@@ -25,11 +25,16 @@ export type {
   SendContext,
   AssistantTransformed,
   BrainstormActivityInput,
+  BrainstormActivityStorageInput,
+  BrainstormActivityStorageRecord,
   BrainstormTimelineActivityInput,
   BrainstormTimelineMessageInput,
 } from '@/components/integrated-brainstorm'
 export {
   brainstormActivityMessageFromCustom,
+  brainstormThreadId,
+  normalizeBrainstormActivityForStorage,
+  normalizeBrainstormActivityMessageForStorage,
   readBrainstormSseResponse,
   runtimeChunkToBrainstormActivity,
   toBrainstormTimeline,

--- a/packages/sdk/src/components/index.ts
+++ b/packages/sdk/src/components/index.ts
@@ -24,6 +24,15 @@ export type {
   BrainstormOnSend,
   SendContext,
   AssistantTransformed,
+  BrainstormActivityInput,
+  BrainstormTimelineActivityInput,
+  BrainstormTimelineMessageInput,
+} from '@/components/integrated-brainstorm'
+export {
+  brainstormActivityMessageFromCustom,
+  readBrainstormSseResponse,
+  runtimeChunkToBrainstormActivity,
+  toBrainstormTimeline,
 } from '@/components/integrated-brainstorm'
 export { MarkdownContent } from '@/components/markdown-content'
 export { MarkdownEditor } from '@/components/markdown-editor'

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -349,6 +349,7 @@ export interface RuntimeToolActivity {
   callId?: string
   toolName: string
   status?: 'running' | 'completed' | 'failed' | string
+  summary?: string
   inputPreview?: string
   outputPreview?: string
   durationMs?: number

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -344,10 +344,22 @@ export interface RuntimeMessageResult {
   metadata?: Record<string, unknown>
 }
 
+export interface RuntimeToolActivity {
+  phase: 'call' | 'result'
+  callId?: string
+  toolName: string
+  status?: 'running' | 'completed' | 'failed' | string
+  inputPreview?: string
+  outputPreview?: string
+  durationMs?: number
+  exitCode?: number
+  metadata?: Record<string, unknown>
+}
+
 export interface RuntimeChatChunk {
   type: 'text' | 'tool' | 'status' | 'done' | 'error'
   content?: string
-  data?: unknown
+  data?: Record<string, unknown> | RuntimeToolActivity
 }
 
 export interface CronJob {

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -334,6 +334,10 @@ export interface RuntimeChannel {
 export interface RuntimeMessageArgs {
   agentId: string
   content: string
+  /**
+   * Adapter-neutral durable conversation key. Runtime adapters should map the
+   * same agentId + threadId pair to the same provider/runtime session.
+   */
   threadId?: string
   metadata?: Record<string, unknown>
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -7,3 +7,14 @@
  */
 export { cn } from '@/lib/utils'
 export { formatAge, formatSize, isStale } from '@bakin/core/format'
+export {
+  brainstormActivityMessageFromCustom,
+  runtimeChunkToBrainstormActivity,
+  toBrainstormTimeline,
+} from '@/components/integrated-brainstorm/activity'
+export type {
+  BrainstormActivityInput,
+  BrainstormTimelineActivityInput,
+  BrainstormTimelineMessageInput,
+} from '@/components/integrated-brainstorm/activity'
+export { readBrainstormSseResponse } from '@/components/integrated-brainstorm/sse'

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -12,9 +12,18 @@ export {
   runtimeChunkToBrainstormActivity,
   toBrainstormTimeline,
 } from '@/components/integrated-brainstorm/activity'
+export {
+  brainstormThreadId,
+  normalizeBrainstormActivityForStorage,
+  normalizeBrainstormActivityMessageForStorage,
+} from '@/components/integrated-brainstorm/session'
 export type {
   BrainstormActivityInput,
   BrainstormTimelineActivityInput,
   BrainstormTimelineMessageInput,
 } from '@/components/integrated-brainstorm/activity'
+export type {
+  BrainstormActivityStorageInput,
+  BrainstormActivityStorageRecord,
+} from '@/components/integrated-brainstorm/session'
 export { readBrainstormSseResponse } from '@/components/integrated-brainstorm/sse'

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -17,6 +17,25 @@ The live MCP server is authoritative. If a tool name or argument is uncertain, r
 mcporter list bakin-<agent> --schema
 ```
 
+Runtime shells are intentionally minimal. Do not assume `rg`, `jq`, GNU-only flags, or stdin JSON helpers exist. If you need to filter schema output, use portable tools such as `grep`, `sed`, `awk`, and `head`:
+
+```bash
+mcporter list bakin-main --schema | grep -n -E 'bakin_exec_projects_apply_plan|bakin_exec_projects_get'
+```
+
+Call tools with valid `mcporter` argument syntax. Use `--args '<json object>'` as one shell argument, or simple `key=value` arguments when the schema is obvious. Do not use `--args @-`, heredocs, process substitution, or stdin-fed JSON with `mcporter call`; this mcporter version does not parse them.
+
+```bash
+mcporter call bakin-main.bakin_exec_projects_get --args '{"projectId":"proj_123"}'
+```
+
+For larger or multiline payloads, generate compact JSON first and pass it as a quoted variable:
+
+```bash
+ARGS=$(node -e 'process.stdout.write(JSON.stringify({projectId:"proj_123",body:"Updated plan\n\nNext step"}))')
+mcporter call bakin-main.bakin_exec_projects_apply_plan --args "$ARGS"
+```
+
 Do not rely on old non-exec tool names such as `bakin_create_task`, `bakin_report_complete`, `bakin_get_task`, or `bakin_post_discord`. Current task-board and plugin tools use the `bakin_exec_*` namespace.
 
 <!-- bakin:exec-tools:start -->

--- a/src/components/integrated-brainstorm/activity.ts
+++ b/src/components/integrated-brainstorm/activity.ts
@@ -1,5 +1,6 @@
 import type { RuntimeChatChunk } from '@bakin/sdk/types'
 import type { BrainstormMessage } from './types'
+import { normalizeBrainstormActivityForStorage } from './session'
 
 export interface BrainstormActivityInput {
   kind: string
@@ -57,12 +58,18 @@ export function brainstormActivityMessageFromCustom(name: string, data: unknown)
   const activity = payload as Record<string, unknown>
   const content = typeof activity.content === 'string' ? activity.content : ''
   if (!content) return null
-  return {
-    id: typeof activity.id === 'string' ? activity.id : newActivityId(),
-    role: 'activity',
+  const normalized = normalizeBrainstormActivityForStorage({
     kind: typeof activity.kind === 'string' ? activity.kind : 'runtime_status',
     content,
     data: activity.data,
+  })
+  if (!normalized) return null
+  return {
+    id: typeof activity.id === 'string' ? activity.id : newActivityId(),
+    role: 'activity',
+    kind: normalized.kind,
+    content: normalized.content,
+    ...(normalized.data !== undefined ? { data: normalized.data } : {}),
     timestamp: typeof activity.timestamp === 'string' ? activity.timestamp : new Date().toISOString(),
   }
 }

--- a/src/components/integrated-brainstorm/activity.ts
+++ b/src/components/integrated-brainstorm/activity.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type { RuntimeChatChunk } from '@bakin/sdk/types'
 import type { BrainstormMessage } from './types'
 

--- a/src/components/integrated-brainstorm/activity.ts
+++ b/src/components/integrated-brainstorm/activity.ts
@@ -1,0 +1,100 @@
+'use client'
+
+import type { RuntimeChatChunk } from '@bakin/sdk/types'
+import type { BrainstormMessage } from './types'
+
+export interface BrainstormActivityInput {
+  kind: string
+  content: string
+  data?: unknown
+}
+
+export interface BrainstormTimelineMessageInput {
+  id: string
+  role: 'user' | 'assistant' | 'agent'
+  content: string
+  timestamp?: string
+}
+
+export interface BrainstormTimelineActivityInput extends BrainstormActivityInput {
+  id: string
+  timestamp?: string
+}
+
+function newActivityId(): string {
+  return `act-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function runtimeChunkToBrainstormActivity(chunk: RuntimeChatChunk): BrainstormActivityInput | null {
+  if (chunk.type === 'status') {
+    return {
+      kind: 'runtime_status',
+      content: chunk.content || 'Agent status update',
+      data: chunk.data,
+    }
+  }
+  if (chunk.type === 'tool') {
+    return {
+      kind: 'tool_call',
+      content: chunk.content || 'Tool call',
+      data: chunk.data,
+    }
+  }
+  if (chunk.type === 'error') {
+    return {
+      kind: 'error',
+      content: chunk.content || 'Runtime stream error',
+      data: chunk.data,
+    }
+  }
+  return null
+}
+
+export function brainstormActivityMessageFromCustom(name: string, data: unknown): BrainstormMessage | null {
+  if (name !== 'activity') return null
+  const payload = data && typeof data === 'object' && 'activity' in data
+    ? (data as { activity?: unknown }).activity
+    : data
+  if (!payload || typeof payload !== 'object') return null
+  const activity = payload as Record<string, unknown>
+  const content = typeof activity.content === 'string' ? activity.content : ''
+  if (!content) return null
+  return {
+    id: typeof activity.id === 'string' ? activity.id : newActivityId(),
+    role: 'activity',
+    kind: typeof activity.kind === 'string' ? activity.kind : 'runtime_status',
+    content,
+    data: activity.data,
+    timestamp: typeof activity.timestamp === 'string' ? activity.timestamp : new Date().toISOString(),
+  }
+}
+
+export function toBrainstormTimeline(
+  agentId: string,
+  input: {
+    messages: BrainstormTimelineMessageInput[]
+    activities?: BrainstormTimelineActivityInput[]
+  },
+): BrainstormMessage[] {
+  return [
+    ...input.messages.map((message): BrainstormMessage => ({
+      id: message.id,
+      role: message.role === 'user' ? 'user' : 'assistant',
+      content: message.content,
+      agentId: message.role === 'user' ? undefined : agentId,
+      timestamp: message.timestamp,
+    })),
+    ...(input.activities ?? []).map((activity): BrainstormMessage => ({
+      id: activity.id,
+      role: 'activity',
+      kind: activity.kind,
+      content: activity.content,
+      data: activity.data,
+      timestamp: activity.timestamp,
+    })),
+  ].sort((a, b) => {
+    const aTime = a.timestamp ? Date.parse(a.timestamp) : 0
+    const bTime = b.timestamp ? Date.parse(b.timestamp) : 0
+    return aTime - bTime
+  })
+}

--- a/src/components/integrated-brainstorm/index.tsx
+++ b/src/components/integrated-brainstorm/index.tsx
@@ -41,8 +41,8 @@ export function IntegratedBrainstorm({
   emptyState,
   collapsible = true,
   defaultOpen = true,
-  conversationStartHeight = 400,
-  minHeight = 100,
+  defaultHeight = 480,
+  minHeight = 260,
   maxHeight = 720,
   maxInputHeight = 200,
   storageKey,
@@ -61,13 +61,12 @@ export function IntegratedBrainstorm({
   const agent = useAgent(agentId)
   const agentName = agent?.name ?? agentId
 
-  const { height, setHeight, handleProps } = useVerticalResize({
-    defaultHeight: minHeight,
+  const { height, handleProps } = useVerticalResize({
+    defaultHeight,
     minHeight,
     maxHeight,
     storageKey: fitParent ? undefined : storageKey,
   })
-  const didAutoExpandRef = useRef(fitParent || height > minHeight + 10 || messages.length > 0)
 
   const { status, streamingContent, thinkingVerb, errorMessage, wasAborted, send, abort } = useBrainstormState({
     messages,
@@ -78,13 +77,9 @@ export function IntegratedBrainstorm({
 
   const handleSend = useCallback(
     (prompt: string) => {
-      if (!didAutoExpandRef.current) {
-        didAutoExpandRef.current = true
-        setHeight(conversationStartHeight)
-      }
       return send(prompt)
     },
-    [send, setHeight, conversationStartHeight],
+    [send],
   )
 
   const replyCount = messages.filter((m) => m.role === 'assistant').length

--- a/src/components/integrated-brainstorm/index.tsx
+++ b/src/components/integrated-brainstorm/index.tsx
@@ -22,11 +22,20 @@ export {
   runtimeChunkToBrainstormActivity,
   toBrainstormTimeline,
 } from './activity'
+export {
+  brainstormThreadId,
+  normalizeBrainstormActivityForStorage,
+  normalizeBrainstormActivityMessageForStorage,
+} from './session'
 export type {
   BrainstormActivityInput,
   BrainstormTimelineActivityInput,
   BrainstormTimelineMessageInput,
 } from './activity'
+export type {
+  BrainstormActivityStorageInput,
+  BrainstormActivityStorageRecord,
+} from './session'
 export { readBrainstormSseResponse } from './sse'
 
 export function IntegratedBrainstorm({

--- a/src/components/integrated-brainstorm/index.tsx
+++ b/src/components/integrated-brainstorm/index.tsx
@@ -17,6 +17,17 @@ export type {
   SendContext,
   AssistantTransformed,
 } from './types'
+export {
+  brainstormActivityMessageFromCustom,
+  runtimeChunkToBrainstormActivity,
+  toBrainstormTimeline,
+} from './activity'
+export type {
+  BrainstormActivityInput,
+  BrainstormTimelineActivityInput,
+  BrainstormTimelineMessageInput,
+} from './activity'
+export { readBrainstormSseResponse } from './sse'
 
 export function IntegratedBrainstorm({
   messages,

--- a/src/components/integrated-brainstorm/message-list.tsx
+++ b/src/components/integrated-brainstorm/message-list.tsx
@@ -87,6 +87,9 @@ const TOOL_DATA_KEYS = new Set([
   'name',
   'tool',
   'status',
+  'summary',
+  'purpose',
+  'displayLabel',
   'inputPreview',
   'argumentsPreview',
   'outputPreview',
@@ -174,7 +177,7 @@ function ToolActivityContent({ view, icon }: { view: ToolActivityView; icon: Rea
         )}
       </div>
       {view.summary && (
-        <div className="mt-1 break-words text-xs leading-5 text-zinc-400">
+        <div data-testid="tool-activity-summary" className="mt-1 break-words text-xs leading-5 text-zinc-400">
           {view.summary}
         </div>
       )}
@@ -262,7 +265,7 @@ function toolActivityView(message: BrainstormMessage): ToolActivityView | null {
     callId: stringField(data.callId) ?? stringField(data.toolCallId) ?? stringField(data.id),
     toolName,
     status,
-    summary: message.content,
+    summary: stringField(data.summary) ?? stringField(data.purpose) ?? stringField(data.displayLabel) ?? message.content,
     inputPreview: stringField(data.inputPreview) ?? stringField(data.argumentsPreview),
     outputPreview: stringField(data.outputPreview) ?? stringField(data.resultPreview),
     durationMs: numberField(data.durationMs),

--- a/src/components/integrated-brainstorm/message-list.tsx
+++ b/src/components/integrated-brainstorm/message-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertTriangle, CheckCircle2, CircleDot, Clock3, Wrench, XCircle } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, ChevronRight, CircleDot, Clock3, Wrench, XCircle } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { AgentAvatar, MarkdownContent } from '@bakin/sdk/components'
 import { useAgentColor } from '@bakin/sdk/hooks'
@@ -160,8 +160,9 @@ function ActivityBubble({ group, agentId }: { group: MessageItem; agentId: strin
 
 function ToolActivityContent({ view, icon }: { view: ToolActivityView; icon: ReactNode }) {
   const details = toolDetailSections(view)
+  const hasDetails = details.length > 0
   return (
-    <div className="min-w-0">
+    <div className={hasDetails ? 'relative min-w-0 pr-20' : 'min-w-0'}>
       <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
         <span className={isFailedTool(view) ? 'text-red-400' : 'text-zinc-500'}>{icon}</span>
         <span className="font-medium uppercase tracking-wide text-zinc-500">Tool</span>
@@ -181,39 +182,49 @@ function ToolActivityContent({ view, icon }: { view: ToolActivityView; icon: Rea
           {view.summary}
         </div>
       )}
-      {details.length > 0 && (
-        <details className="mt-2">
-          <summary className="cursor-pointer select-none text-[11px] text-zinc-500 hover:text-zinc-300">
-            Details
-          </summary>
-          <div className="mt-2 space-y-2">
-            {details.map((section) => (
-              <ActivityDetailSection key={section.label} label={section.label} value={section.value} />
-            ))}
-          </div>
-        </details>
+      {hasDetails && (
+        <InlineActivityDetails>
+          {details.map((section) => (
+            <ActivityDetailSection key={section.label} label={section.label} value={section.value} />
+          ))}
+        </InlineActivityDetails>
       )}
     </div>
   )
 }
 
 function GenericActivityContent({ view, icon }: { view: GenericActivityView; icon: ReactNode }) {
+  const hasDetails = view.data !== undefined
   return (
-    <div className="min-w-0">
+    <div className={hasDetails ? 'relative min-w-0 pr-20' : 'min-w-0'}>
       <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
         <span className={view.kind === 'error' ? 'text-red-400' : 'text-zinc-500'}>{icon}</span>
         <span className="font-medium uppercase tracking-wide text-zinc-500">{view.label}</span>
         <span className="break-words text-zinc-400">{view.summary}</span>
       </div>
-      {view.data !== undefined && (
-        <details className="mt-2">
-          <summary className="cursor-pointer select-none text-[11px] text-zinc-500 hover:text-zinc-300">
-            Details
-          </summary>
+      {hasDetails && (
+        <InlineActivityDetails>
           <ActivityDetailSection label="Data" value={view.data} />
-        </details>
+        </InlineActivityDetails>
       )}
     </div>
+  )
+}
+
+function InlineActivityDetails({ children }: { children: ReactNode }) {
+  return (
+    <details className="group">
+      <summary
+        data-testid="activity-details-toggle"
+        className="absolute right-0 top-0 inline-flex min-w-[4.5rem] cursor-pointer list-none items-center justify-end gap-1 rounded-sm text-[11px] leading-5 text-zinc-500 hover:text-zinc-300 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-blue-400 [&::-webkit-details-marker]:hidden"
+      >
+        <ChevronRight className="size-3 transition-transform group-open:rotate-90" aria-hidden="true" />
+        <span>Details</span>
+      </summary>
+      <div className="mt-2 space-y-2">
+        {children}
+      </div>
+    </details>
   )
 }
 

--- a/src/components/integrated-brainstorm/message-list.tsx
+++ b/src/components/integrated-brainstorm/message-list.tsx
@@ -145,7 +145,7 @@ function ActivityBubble({ group, agentId }: { group: MessageItem; agentId: strin
     >
       <AgentAvatar agentId={agentId} size="sm" className="mt-0.5 shrink-0 opacity-85" />
       <div
-        className="max-w-[90%] rounded-lg border-l-2 bg-[rgba(255,255,255,0.03)] px-3 py-2 text-sm"
+        className="min-w-[50%] max-w-[90%] rounded-lg border-l-2 bg-[rgba(255,255,255,0.03)] px-3 py-2 text-sm"
         style={{ borderLeftColor: isError ? 'rgba(248, 113, 113, 0.8)' : `${color}80` }}
       >
         {view.kind === 'tool' ? (

--- a/src/components/integrated-brainstorm/message-list.tsx
+++ b/src/components/integrated-brainstorm/message-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { AlertTriangle, CircleDot, Wrench } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, CircleDot, Clock3, Wrench, XCircle } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { AgentAvatar, MarkdownContent } from '@bakin/sdk/components'
 import { useAgentColor } from '@bakin/sdk/hooks'
@@ -13,19 +13,27 @@ interface MessageListProps {
 }
 
 export function MessageList({ messages, defaultAgentId, transform }: MessageListProps) {
+  const items = groupActivityMessages(messages)
   return (
     <div
       data-testid="brainstorm-message-list"
       className="space-y-2"
     >
-      {messages.map((msg, idx) => {
+      {items.map((item, idx) => {
+        const msg = item.message
         if (msg.role === 'user') {
           return <UserBubble key={msg.id} content={msg.content} />
         }
         if (msg.role === 'activity') {
-          return <ActivityBubble key={msg.id} message={msg} />
+          return (
+            <ActivityBubble
+              key={item.key}
+              group={item}
+              agentId={defaultAgentId}
+            />
+          )
         }
-        const prev = idx > 0 ? messages[idx - 1] : null
+        const prev = idx > 0 ? items[idx - 1]?.message : null
         const isConsecutive = prev?.role === 'assistant'
         const transformed = transform ? transform(msg.content) : { text: msg.content }
         return (
@@ -42,45 +50,297 @@ export function MessageList({ messages, defaultAgentId, transform }: MessageList
   )
 }
 
-function formatActivityData(data: unknown): string | null {
-  if (data === undefined || data === null) return null
-  try {
-    return JSON.stringify(data, null, 2)
-  } catch {
-    return String(data)
-  }
+interface MessageItem {
+  key: string
+  message: BrainstormMessage
+  result?: BrainstormMessage
 }
 
-function ActivityBubble({ message }: { message: BrainstormMessage }) {
-  const data = formatActivityData(message.data)
-  const kind = message.kind ?? 'runtime_status'
-  const Icon = kind === 'tool_call' ? Wrench : kind === 'error' ? AlertTriangle : CircleDot
-  const label = kind === 'tool_call' ? 'Tool' : kind === 'error' ? 'Error' : 'Status'
+interface ToolActivityView {
+  kind: 'tool'
+  toolName: string
+  status: string
+  phase: 'call' | 'result'
+  callId?: string
+  summary: string
+  inputPreview?: string
+  outputPreview?: string
+  durationMs?: number
+  exitCode?: number
+  metadata: Record<string, unknown>
+}
+
+interface GenericActivityView {
+  kind: 'status' | 'error'
+  label: string
+  summary: string
+  data?: unknown
+}
+
+type ActivityView = ToolActivityView | GenericActivityView
+
+const TOOL_DATA_KEYS = new Set([
+  'phase',
+  'callId',
+  'toolCallId',
+  'toolName',
+  'name',
+  'tool',
+  'status',
+  'inputPreview',
+  'argumentsPreview',
+  'outputPreview',
+  'resultPreview',
+  'durationMs',
+  'exitCode',
+])
+
+function groupActivityMessages(messages: BrainstormMessage[]): MessageItem[] {
+  const items: MessageItem[] = []
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    if (message.role === 'activity') {
+      const next = messages[i + 1]
+      if (next?.role === 'activity' && shouldGroupToolActivities(message, next)) {
+        items.push({ key: `${message.id}:${next.id}`, message, result: next })
+        i++
+        continue
+      }
+    }
+    items.push({ key: message.id, message })
+  }
+  return items
+}
+
+function shouldGroupToolActivities(call: BrainstormMessage, result: BrainstormMessage): boolean {
+  const callView = toolActivityView(call)
+  const resultView = toolActivityView(result)
+  return Boolean(
+    callView &&
+      resultView &&
+      callView.phase === 'call' &&
+      resultView.phase === 'result' &&
+      callView.callId &&
+      callView.callId === resultView.callId,
+  )
+}
+
+function ActivityBubble({ group, agentId }: { group: MessageItem; agentId: string }) {
+  const color = useAgentColor(agentId)
+  const view = activityView(group)
+  const isError = view.kind === 'error' || (view.kind === 'tool' && isFailedTool(view))
+  const Icon = view.kind === 'tool'
+    ? isFailedTool(view) ? XCircle : view.phase === 'result' ? CheckCircle2 : Wrench
+    : view.kind === 'error'
+      ? AlertTriangle
+      : CircleDot
 
   return (
     <div
       data-testid="activity-bubble"
-      className="ml-8 flex items-start gap-2 text-[11px] leading-5 text-zinc-500"
+      className="flex items-start gap-2"
     >
-      <Icon className="mt-0.5 size-3 shrink-0 text-zinc-600" aria-hidden="true" />
-      <div className="min-w-0">
-        <div className="flex min-w-0 flex-wrap items-baseline gap-x-2">
-          <span className="font-medium uppercase tracking-wide text-zinc-600">{label}</span>
-          <span className="break-words text-zinc-400">{message.content}</span>
-        </div>
-        {data && (
-          <details className="mt-1">
-            <summary className="cursor-pointer select-none text-zinc-600 hover:text-zinc-400">
-              Details
-            </summary>
-            <pre className="mt-1 max-h-40 overflow-auto rounded border border-[rgba(255,255,255,0.06)] bg-zinc-950/60 p-2 text-[10px] leading-4 text-zinc-500">
-              {data}
-            </pre>
-          </details>
+      <AgentAvatar agentId={agentId} size="sm" className="mt-0.5 shrink-0 opacity-85" />
+      <div
+        className="max-w-[90%] rounded-lg border-l-2 bg-[rgba(255,255,255,0.03)] px-3 py-2 text-sm"
+        style={{ borderLeftColor: isError ? 'rgba(248, 113, 113, 0.8)' : `${color}80` }}
+      >
+        {view.kind === 'tool' ? (
+          <ToolActivityContent view={view} icon={<Icon className="size-3.5 shrink-0" aria-hidden="true" />} />
+        ) : (
+          <GenericActivityContent view={view} icon={<Icon className="size-3.5 shrink-0" aria-hidden="true" />} />
         )}
       </div>
     </div>
   )
+}
+
+function ToolActivityContent({ view, icon }: { view: ToolActivityView; icon: ReactNode }) {
+  const details = toolDetailSections(view)
+  return (
+    <div className="min-w-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+        <span className={isFailedTool(view) ? 'text-red-400' : 'text-zinc-500'}>{icon}</span>
+        <span className="font-medium uppercase tracking-wide text-zinc-500">Tool</span>
+        <span className="font-medium text-zinc-300">{view.toolName}</span>
+        <span className={statusClassName(view)}>
+          {statusLabel(view)}
+        </span>
+        {view.durationMs !== undefined && (
+          <span className="inline-flex items-center gap-1 text-[11px] text-zinc-500">
+            <Clock3 className="size-3" aria-hidden="true" />
+            {formatDuration(view.durationMs)}
+          </span>
+        )}
+      </div>
+      {view.summary && (
+        <div className="mt-1 break-words text-xs leading-5 text-zinc-400">
+          {view.summary}
+        </div>
+      )}
+      {details.length > 0 && (
+        <details className="mt-2">
+          <summary className="cursor-pointer select-none text-[11px] text-zinc-500 hover:text-zinc-300">
+            Details
+          </summary>
+          <div className="mt-2 space-y-2">
+            {details.map((section) => (
+              <ActivityDetailSection key={section.label} label={section.label} value={section.value} />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function GenericActivityContent({ view, icon }: { view: GenericActivityView; icon: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+        <span className={view.kind === 'error' ? 'text-red-400' : 'text-zinc-500'}>{icon}</span>
+        <span className="font-medium uppercase tracking-wide text-zinc-500">{view.label}</span>
+        <span className="break-words text-zinc-400">{view.summary}</span>
+      </div>
+      {view.data !== undefined && (
+        <details className="mt-2">
+          <summary className="cursor-pointer select-none text-[11px] text-zinc-500 hover:text-zinc-300">
+            Details
+          </summary>
+          <ActivityDetailSection label="Data" value={view.data} />
+        </details>
+      )}
+    </div>
+  )
+}
+
+function ActivityDetailSection({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div>
+      <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-zinc-500">
+        {label}
+      </div>
+      <pre className="max-h-44 overflow-auto whitespace-pre-wrap break-words rounded border border-[rgba(255,255,255,0.06)] bg-zinc-950/60 p-2 text-[10px] leading-4 text-zinc-400">
+        {formatDetailValue(value)}
+      </pre>
+    </div>
+  )
+}
+
+function activityView(group: MessageItem): ActivityView {
+  const resultTool = group.result ? toolActivityView(group.result) : null
+  const callTool = toolActivityView(group.message)
+  if (resultTool || callTool) {
+    const active = resultTool ?? callTool!
+    return {
+      ...active,
+      summary: callTool?.summary || active.summary,
+      inputPreview: callTool?.inputPreview ?? active.inputPreview,
+      metadata: { ...(callTool?.metadata ?? {}), ...active.metadata },
+    }
+  }
+
+  const kind = group.message.kind === 'error' ? 'error' : 'status'
+  return {
+    kind,
+    label: kind === 'error' ? 'Error' : 'Status',
+    summary: group.message.content,
+    data: group.message.data,
+  }
+}
+
+function toolActivityView(message: BrainstormMessage): ToolActivityView | null {
+  if (message.kind !== 'tool_call' && !looksLikeToolData(message.data)) return null
+  const data = isRecord(message.data) ? message.data : {}
+  const phase = data.phase === 'result' ? 'result' : 'call'
+  const toolName = stringField(data.toolName) ?? stringField(data.name) ?? stringField(data.tool) ?? inferToolName(message.content)
+  if (!toolName) return null
+  const status = stringField(data.status) ?? (phase === 'call' ? 'running' : 'completed')
+  return {
+    kind: 'tool',
+    phase,
+    callId: stringField(data.callId) ?? stringField(data.toolCallId) ?? stringField(data.id),
+    toolName,
+    status,
+    summary: message.content,
+    inputPreview: stringField(data.inputPreview) ?? stringField(data.argumentsPreview),
+    outputPreview: stringField(data.outputPreview) ?? stringField(data.resultPreview),
+    durationMs: numberField(data.durationMs),
+    exitCode: numberField(data.exitCode),
+    metadata: activityMetadata(data),
+  }
+}
+
+function looksLikeToolData(data: unknown): boolean {
+  if (!isRecord(data)) return false
+  return Boolean(data.toolName || data.name || data.tool || data.phase === 'call' || data.phase === 'result')
+}
+
+function activityMetadata(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (!TOOL_DATA_KEYS.has(key)) out[key] = value
+  }
+  if (typeof data.exitCode === 'number') out.exitCode = data.exitCode
+  if (typeof data.callId === 'string') out.callId = data.callId
+  if (typeof data.toolCallId === 'string') out.callId = data.toolCallId
+  return out
+}
+
+function toolDetailSections(view: ToolActivityView): Array<{ label: string; value: unknown }> {
+  const sections: Array<{ label: string; value: unknown }> = []
+  if (view.inputPreview) sections.push({ label: 'Input', value: view.inputPreview })
+  if (view.outputPreview) sections.push({ label: 'Output', value: view.outputPreview })
+  if (Object.keys(view.metadata).length > 0) sections.push({ label: 'Metadata', value: view.metadata })
+  return sections
+}
+
+function statusLabel(view: ToolActivityView): string {
+  if (isFailedTool(view)) return 'failed'
+  return view.status || (view.phase === 'call' ? 'running' : 'completed')
+}
+
+function statusClassName(view: ToolActivityView): string {
+  const base = 'rounded-full px-1.5 py-0.5 text-[10px] font-medium'
+  if (isFailedTool(view)) return `${base} bg-red-500/10 text-red-300`
+  if (view.phase === 'call') return `${base} bg-yellow-400/10 text-yellow-300`
+  return `${base} bg-emerald-500/10 text-emerald-300`
+}
+
+function isFailedTool(view: ToolActivityView): boolean {
+  const status = view.status.toLowerCase()
+  return status.includes('fail') || status.includes('error') || (view.exitCode !== undefined && view.exitCode !== 0)
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${durationMs}ms`
+  return `${(durationMs / 1000).toFixed(1)}s`
+}
+
+function formatDetailValue(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function inferToolName(content: string): string | undefined {
+  const match = content.match(/^([a-zA-Z0-9_.-]+)(?::|\s)/)
+  return match?.[1]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function UserBubble({ content }: { content: string }) {

--- a/src/components/integrated-brainstorm/session.ts
+++ b/src/components/integrated-brainstorm/session.ts
@@ -1,0 +1,106 @@
+import type { BrainstormMessage } from './types'
+
+const ACTIVITY_CONTENT_MAX_CHARS = 500
+const ACTIVITY_PREVIEW_MAX_CHARS = 2000
+const ACTIVITY_METADATA_MAX_CHARS = 4000
+const ACTIVITY_DATA_MAX_KEYS = 24
+
+export interface BrainstormActivityStorageInput {
+  id?: string
+  kind?: string
+  content?: string
+  data?: unknown
+  timestamp?: string
+}
+
+export interface BrainstormActivityStorageRecord {
+  kind: string
+  content: string
+  data?: unknown
+}
+
+export function brainstormThreadId(scope: string, entityId: string, agentId: string): string {
+  return [scope, entityId, agentId].map(threadIdPart).join(':')
+}
+
+export function normalizeBrainstormActivityForStorage(
+  activity: BrainstormActivityStorageInput,
+): BrainstormActivityStorageRecord | null {
+  const content = typeof activity.content === 'string' ? truncate(activity.content.trim(), ACTIVITY_CONTENT_MAX_CHARS) : ''
+  if (!content) return null
+  const data = normalizeActivityData(activity.data)
+  return {
+    kind: typeof activity.kind === 'string' && activity.kind ? activity.kind : 'runtime_status',
+    content,
+    ...(data !== undefined ? { data } : {}),
+  }
+}
+
+export function normalizeBrainstormActivityMessageForStorage(
+  activity: BrainstormActivityStorageInput,
+): Pick<BrainstormMessage, 'role' | 'kind' | 'content' | 'data'> | null {
+  const normalized = normalizeBrainstormActivityForStorage(activity)
+  if (!normalized) return null
+  return {
+    role: 'activity',
+    kind: normalized.kind,
+    content: normalized.content,
+    ...(normalized.data !== undefined ? { data: normalized.data } : {}),
+  }
+}
+
+function threadIdPart(value: string): string {
+  const trimmed = value.trim()
+  return encodeURIComponent(trimmed || 'default')
+}
+
+function normalizeActivityData(data: unknown): unknown {
+  if (data === undefined) return undefined
+  if (!isRecord(data)) return normalizeActivityValue(data, 'value')
+
+  const out: Record<string, unknown> = {}
+  let count = 0
+  for (const [key, value] of Object.entries(data)) {
+    if (count >= ACTIVITY_DATA_MAX_KEYS) {
+      out.truncatedKeys = Object.keys(data).length - count
+      break
+    }
+    out[key] = normalizeActivityValue(value, key)
+    count += 1
+  }
+  return out
+}
+
+function normalizeActivityValue(value: unknown, key: string): unknown {
+  if (typeof value === 'string') {
+    const max = isPreviewKey(key) ? ACTIVITY_PREVIEW_MAX_CHARS : ACTIVITY_METADATA_MAX_CHARS
+    return truncate(value, max)
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) return value
+  if (value === undefined) return undefined
+  return truncate(stringify(value), ACTIVITY_METADATA_MAX_CHARS)
+}
+
+function isPreviewKey(key: string): boolean {
+  return key === 'inputPreview' ||
+    key === 'argumentsPreview' ||
+    key === 'outputPreview' ||
+    key === 'resultPreview'
+}
+
+function stringify(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  return `${value.slice(0, Math.max(0, maxChars - 3))}...`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}

--- a/src/components/integrated-brainstorm/sse.ts
+++ b/src/components/integrated-brainstorm/sse.ts
@@ -1,9 +1,7 @@
-'use client'
-
 import type { SendContext } from './types'
 
 interface BrainstormSseReadOptions {
-  onCustomEvent?: (event: string, data: unknown) => void
+  onCustomEvent?: (event: string, data: unknown) => boolean | void
 }
 
 interface SseFrame {
@@ -50,7 +48,7 @@ export async function readBrainstormSseResponse(
     if (frame.event === 'error') {
       throw new Error(textField(frame.data, 'message') || 'Unknown error')
     }
-    options.onCustomEvent?.(frame.event, frame.data)
+    if (options.onCustomEvent?.(frame.event, frame.data) === true) return
     ctx.onCustom?.(frame.event, frame.data)
   }
 

--- a/src/components/integrated-brainstorm/sse.ts
+++ b/src/components/integrated-brainstorm/sse.ts
@@ -1,0 +1,124 @@
+'use client'
+
+import type { SendContext } from './types'
+
+interface BrainstormSseReadOptions {
+  onCustomEvent?: (event: string, data: unknown) => void
+}
+
+interface SseFrame {
+  event: string
+  data: unknown
+}
+
+export async function readBrainstormSseResponse(
+  response: Response,
+  ctx: SendContext,
+  options: BrainstormSseReadOptions = {},
+): Promise<{ content: string }> {
+  if (!response.ok || !response.body) {
+    const text = await response.text().catch(() => '')
+    throw new Error(text || `Server returned ${response.status}`)
+  }
+
+  const reader = response.body.getReader()
+  const abort = () => {
+    void reader.cancel().catch(() => {})
+  }
+  ctx.signal.addEventListener('abort', abort, { once: true })
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let accumulated = ''
+  let finalContent = ''
+
+  const dispatch = (frame: SseFrame) => {
+    if (frame.event === 'token') {
+      const text = textField(frame.data, 'text')
+      accumulated += text
+      ctx.onToken(text)
+      return
+    }
+    if (frame.event === 'activity') {
+      ctx.onCustom?.('activity', frame.data)
+      return
+    }
+    if (frame.event === 'done') {
+      finalContent = textField(frame.data, 'content') || accumulated
+      return
+    }
+    if (frame.event === 'error') {
+      throw new Error(textField(frame.data, 'message') || 'Unknown error')
+    }
+    options.onCustomEvent?.(frame.event, frame.data)
+    ctx.onCustom?.(frame.event, frame.data)
+  }
+
+  try {
+    while (true) {
+      if (ctx.signal.aborted) throw abortError()
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const parsed = drainSseFrames(buffer)
+      buffer = parsed.remainder
+      for (const frame of parsed.frames) dispatch(frame)
+    }
+
+    buffer += decoder.decode()
+    const parsed = drainSseFrames(buffer, true)
+    for (const frame of parsed.frames) dispatch(frame)
+  } finally {
+    ctx.signal.removeEventListener('abort', abort)
+    reader.releaseLock()
+  }
+
+  return { content: finalContent || accumulated }
+}
+
+function drainSseFrames(input: string, flush = false): { frames: SseFrame[]; remainder: string } {
+  const parts = input.split(/\r?\n\r?\n/)
+  const remainder = flush ? '' : parts.pop() ?? ''
+  const frames = parts
+    .map(parseSseFrame)
+    .filter((frame): frame is SseFrame => frame !== null)
+  if (flush && parts.length === 0 && input.trim()) {
+    const frame = parseSseFrame(input)
+    if (frame) frames.push(frame)
+  }
+  return { frames, remainder }
+}
+
+function parseSseFrame(frame: string): SseFrame | null {
+  let event = 'message'
+  const dataLines: string[] = []
+  for (const rawLine of frame.split(/\r?\n/)) {
+    const line = rawLine.trimEnd()
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trim()
+    } else if (line.startsWith('data:')) {
+      dataLines.push(line.slice('data:'.length).trimStart())
+    }
+  }
+  if (dataLines.length === 0) return null
+  const rawData = dataLines.join('\n')
+  let data: unknown = rawData
+  try {
+    data = JSON.parse(rawData)
+  } catch {
+    // Plain text SSE data is valid; callers can decide what to do with it.
+  }
+  return { event, data }
+}
+
+function textField(data: unknown, key: string): string {
+  if (!data || typeof data !== 'object') return ''
+  const value = (data as Record<string, unknown>)[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function abortError(): Error {
+  const err = new Error('Aborted')
+  err.name = 'AbortError'
+  return err
+}

--- a/src/components/integrated-brainstorm/types.ts
+++ b/src/components/integrated-brainstorm/types.ts
@@ -49,16 +49,16 @@ export interface IntegratedBrainstormProps {
   position?: 'bottom'
   collapsible?: boolean
   defaultOpen?: boolean
-  conversationStartHeight?: number
+  defaultHeight?: number
   minHeight?: number
   maxHeight?: number
   maxInputHeight?: number
   storageKey?: string
   /**
    * Fill parent height via flex-1/h-full instead of a fixed pixel height.
-   * Drops the drag handle (nothing to drag against) and disables auto-expand
-   * (already full-size). Use when the panel IS the pane — e.g. a dedicated
-   * chat route — rather than a bottom sheet above other content.
+   * Drops the drag handle because there is nothing fixed to drag against. Use
+   * when the panel IS the pane — e.g. a dedicated chat route — rather than a
+   * bottom sheet above other content.
    */
   fitParent?: boolean
   /**

--- a/src/components/integrated-brainstorm/use-brainstorm-state.ts
+++ b/src/components/integrated-brainstorm/use-brainstorm-state.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useRef, useState } from 'react'
+import { brainstormActivityMessageFromCustom } from './activity'
 import { THINKING_VERBS } from './thinking-indicator'
 import type { BrainstormMessage, BrainstormOnSend } from './types'
 
@@ -12,25 +13,6 @@ function pickVerb(): string {
 
 function newId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-}
-
-function activityMessageFromCustom(name: string, data: unknown): BrainstormMessage | null {
-  if (name !== 'activity') return null
-  const payload = data && typeof data === 'object' && 'activity' in data
-    ? (data as { activity?: unknown }).activity
-    : data
-  if (!payload || typeof payload !== 'object') return null
-  const activity = payload as Record<string, unknown>
-  const content = typeof activity.content === 'string' ? activity.content : ''
-  if (!content) return null
-  return {
-    id: typeof activity.id === 'string' ? activity.id : newId('act'),
-    role: 'activity',
-    kind: typeof activity.kind === 'string' ? activity.kind : 'runtime_status',
-    content,
-    data: activity.data,
-    timestamp: typeof activity.timestamp === 'string' ? activity.timestamp : new Date().toISOString(),
-  }
 }
 
 interface UseBrainstormStateOpts {
@@ -108,7 +90,7 @@ export function useBrainstormState({
             setStatus('streaming')
           },
           onCustom: (name: string, data: unknown) => {
-            const activityMessage = activityMessageFromCustom(name, data)
+            const activityMessage = brainstormActivityMessageFromCustom(name, data)
             if (activityMessage) {
               customMessages.push(activityMessage)
               onMessagesChange([...historyWithUser, ...customMessages])

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -184,6 +184,82 @@ describe('OpenClaw runtime stream parsing', () => {
     })
   })
 
+  it('summarizes exec-based context lookups without changing the real tool name', async () => {
+    globalThis.fetch = mock(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              id: 'call-context',
+              type: 'function',
+              function: {
+                name: 'exec',
+                arguments: JSON.stringify({
+                  command: 'bx context "OpenClaw GitHub releases latest openclaw/openclaw" --max-tokens 4096',
+                }),
+              },
+            }],
+          },
+        }],
+      },
+    ])) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks[0]).toMatchObject({
+      type: 'tool',
+      data: {
+        toolName: 'exec',
+        summary: 'Checking GitHub releases for openclaw/openclaw',
+      },
+    })
+  })
+
+  it('summarizes exec-based web fetches when commands contain URLs', async () => {
+    globalThis.fetch = mock(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              id: 'call-python-fetch',
+              type: 'function',
+              function: {
+                name: 'exec',
+                arguments: JSON.stringify({
+                  command: "python3 - <<'PY'\nurl='https://api.github.com/repos/openclaw/openclaw/releases?per_page=3'\nPY",
+                }),
+              },
+            }],
+          },
+        }],
+      },
+    ])) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks[0]).toMatchObject({
+      type: 'tool',
+      data: {
+        toolName: 'exec',
+        summary: 'Fetching https://api.github.com/repos/openclaw/openclaw/releases?per_page=3',
+      },
+    })
+  })
+
   it('includes the URL in web_fetch tool summaries', async () => {
     globalThis.fetch = mock(async () => sseResponse([
       {

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -69,7 +69,15 @@ describe('OpenClaw runtime stream parsing', () => {
   it('preserves OpenClaw status and tool frames as chat chunks', async () => {
     globalThis.fetch = mock(async () => sseResponse([
       { type: 'status', content: 'Checking project notes' },
-      { type: 'tool', content: 'Read project file', data: { tool: 'bakin_exec_projects_get' } },
+      {
+        type: 'tool',
+        content: 'Read project file',
+        data: {
+          phase: 'call',
+          toolName: 'bakin_exec_projects_get',
+          status: 'running',
+        },
+      },
       { choices: [{ delta: { content: 'Done.' } }] },
     ])) as unknown as typeof fetch
 
@@ -84,7 +92,15 @@ describe('OpenClaw runtime stream parsing', () => {
 
     expect(chunks).toEqual([
       { type: 'status', content: 'Checking project notes', data: undefined },
-      { type: 'tool', content: 'Read project file', data: { tool: 'bakin_exec_projects_get' } },
+      {
+        type: 'tool',
+        content: 'Read project file',
+        data: {
+          phase: 'call',
+          toolName: 'bakin_exec_projects_get',
+          status: 'running',
+        },
+      },
       { type: 'text', content: 'Done.' },
       { type: 'done' },
     ])
@@ -118,11 +134,11 @@ describe('OpenClaw runtime stream parsing', () => {
       type: 'tool',
       content: 'bakin_exec_projects_get',
       data: {
-        toolCalls: [{
-          id: 'call-1',
-          type: 'function',
-          function: { name: 'bakin_exec_projects_get', arguments: '{"projectId":"p1"}' },
-        }],
+        phase: 'call',
+        callId: 'call-1',
+        toolName: 'bakin_exec_projects_get',
+        status: 'running',
+        inputPreview: '{"projectId":"p1"}',
       },
     })
   })
@@ -185,9 +201,10 @@ describe('OpenClaw runtime stream parsing', () => {
         content: 'exec: gh issue list --repo markhayden/bakin --search messaging',
         data: {
           phase: 'call',
-          id: 'call-1',
-          name: 'exec',
-          argumentsPreview: '{"command":"gh issue list --repo markhayden/bakin --search messaging"}',
+          callId: 'call-1',
+          toolName: 'exec',
+          status: 'running',
+          inputPreview: '{"command":"gh issue list --repo markhayden/bakin --search messaging"}',
         },
       },
       {
@@ -196,7 +213,7 @@ describe('OpenClaw runtime stream parsing', () => {
         data: {
           phase: 'result',
           toolName: 'exec',
-          toolCallId: 'call-1',
+          callId: 'call-1',
           status: 'completed',
           exitCode: 0,
           durationMs: 12,
@@ -273,9 +290,10 @@ describe('OpenClaw runtime stream parsing', () => {
         content: 'read: /tmp/project.md',
         data: {
           phase: 'call',
-          id: 'call-2',
-          name: 'read',
-          argumentsPreview: '{"path":"/tmp/project.md"}',
+          callId: 'call-2',
+          toolName: 'read',
+          status: 'running',
+          inputPreview: '{"path":"/tmp/project.md"}',
         },
       })
     }

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -76,6 +76,7 @@ describe('OpenClaw runtime stream parsing', () => {
           phase: 'call',
           toolName: 'bakin_exec_projects_get',
           status: 'running',
+          summary: 'Read project file',
         },
       },
       { choices: [{ delta: { content: 'Done.' } }] },
@@ -99,6 +100,7 @@ describe('OpenClaw runtime stream parsing', () => {
           phase: 'call',
           toolName: 'bakin_exec_projects_get',
           status: 'running',
+          summary: 'Read project file',
         },
       },
       { type: 'text', content: 'Done.' },
@@ -138,7 +140,46 @@ describe('OpenClaw runtime stream parsing', () => {
         callId: 'call-1',
         toolName: 'bakin_exec_projects_get',
         status: 'running',
+        summary: 'Reading project details',
         inputPreview: '{"projectId":"p1"}',
+      },
+    })
+  })
+
+  it('adds fallback summaries for reliable shell command patterns', async () => {
+    globalThis.fetch = mock(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              id: 'call-help',
+              type: 'function',
+              function: { name: 'exec', arguments: '{"command":"mcporter call --help | sed -n \\"1,120p\\""}' },
+            }],
+          },
+        }],
+      },
+    ])) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks[0]).toEqual({
+      type: 'tool',
+      content: 'exec',
+      data: {
+        phase: 'call',
+        callId: 'call-help',
+        toolName: 'exec',
+        status: 'running',
+        summary: 'Checking Bakin tool call syntax',
+        inputPreview: '{"command":"mcporter call --help | sed -n \\"1,120p\\""}',
       },
     })
   })
@@ -204,6 +245,7 @@ describe('OpenClaw runtime stream parsing', () => {
           callId: 'call-1',
           toolName: 'exec',
           status: 'running',
+          summary: 'Checking GitHub issues',
           inputPreview: '{"command":"gh issue list --repo markhayden/bakin --search messaging"}',
         },
       },
@@ -293,6 +335,7 @@ describe('OpenClaw runtime stream parsing', () => {
           callId: 'call-2',
           toolName: 'read',
           status: 'running',
+          summary: 'Reading project.md',
           inputPreview: '{"path":"/tmp/project.md"}',
         },
       })

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -184,6 +184,44 @@ describe('OpenClaw runtime stream parsing', () => {
     })
   })
 
+  it('includes the URL in web_fetch tool summaries', async () => {
+    globalThis.fetch = mock(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              id: 'call-web',
+              type: 'function',
+              function: { name: 'web_fetch', arguments: '{"url":"https://example.com/docs?token=secret"}' },
+            }],
+          },
+        }],
+      },
+    ])) as unknown as typeof fetch
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    const chunks = await collect(runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: 'thread-1',
+    }))
+
+    expect(chunks[0]).toEqual({
+      type: 'tool',
+      content: 'web_fetch',
+      data: {
+        phase: 'call',
+        callId: 'call-web',
+        toolName: 'web_fetch',
+        status: 'running',
+        summary: 'Fetching https://example.com/docs?token=[redacted]',
+        inputPreview: '{"url":"https://example.com/docs?token=[redacted]"}',
+      },
+    })
+  })
+
   it('emits OpenClaw transcript tool activity while the chat stream is pending', async () => {
     const sessionsDir = join(testDir, 'agents', 'main', 'sessions')
     mkdirSync(sessionsDir, { recursive: true })

--- a/tests/components/integrated-brainstorm/activity-helpers.test.ts
+++ b/tests/components/integrated-brainstorm/activity-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   toBrainstormTimeline,
 } from '@/components/integrated-brainstorm'
 import type { BrainstormMessage } from '@/components/integrated-brainstorm'
+import { runtimeChunkToBrainstormActivity as runtimeChunkToBrainstormActivityFromUtils } from '@bakin/sdk/utils'
 import type { RuntimeChatChunk } from '@bakin/sdk/types'
 
 function sseResponse(events: Array<{ event: string; data: unknown }>): Response {
@@ -37,6 +38,11 @@ describe('brainstorm activity helpers', () => {
     }
 
     expect(runtimeChunkToBrainstormActivity(chunk)).toEqual({
+      kind: 'tool_call',
+      content: 'exec: gh issue list',
+      data: chunk.data,
+    })
+    expect(runtimeChunkToBrainstormActivityFromUtils(chunk)).toEqual({
       kind: 'tool_call',
       content: 'exec: gh issue list',
       data: chunk.data,
@@ -140,7 +146,9 @@ describe('readBrainstormSseResponse', () => {
         onCustom: (event, data) => custom.push({ event, data }),
       },
       {
-        onCustomEvent: (event, data) => sideEffects.push({ event, data }),
+        onCustomEvent: (event, data) => {
+          sideEffects.push({ event, data })
+        },
       },
     )
 
@@ -161,5 +169,28 @@ describe('readBrainstormSseResponse', () => {
         onToken: () => {},
       },
     )).rejects.toThrow('runtime rejected')
+  })
+
+  it('lets callers own custom event handling when needed', async () => {
+    const custom: Array<{ event: string; data: unknown }> = []
+    const sideEffects: Array<{ event: string; data: unknown }> = []
+
+    await readBrainstormSseResponse(
+      sseResponse([{ event: 'proposals', data: { proposals: [{ id: 'p1' }] } }]),
+      {
+        signal: new AbortController().signal,
+        onToken: () => {},
+        onCustom: (event, data) => custom.push({ event, data }),
+      },
+      {
+        onCustomEvent: (event, data) => {
+          sideEffects.push({ event, data })
+          return true
+        },
+      },
+    )
+
+    expect(sideEffects).toEqual([{ event: 'proposals', data: { proposals: [{ id: 'p1' }] } }])
+    expect(custom).toEqual([])
   })
 })

--- a/tests/components/integrated-brainstorm/activity-helpers.test.ts
+++ b/tests/components/integrated-brainstorm/activity-helpers.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  brainstormActivityMessageFromCustom,
+  readBrainstormSseResponse,
+  runtimeChunkToBrainstormActivity,
+  toBrainstormTimeline,
+} from '@/components/integrated-brainstorm'
+import type { BrainstormMessage } from '@/components/integrated-brainstorm'
+import type { RuntimeChatChunk } from '@bakin/sdk/types'
+
+function sseResponse(events: Array<{ event: string; data: unknown }>): Response {
+  const encoder = new TextEncoder()
+  return new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const item of events) {
+        controller.enqueue(encoder.encode(`event: ${item.event}\ndata: ${JSON.stringify(item.data)}\n\n`))
+      }
+      controller.close()
+    },
+  }), {
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+}
+
+describe('brainstorm activity helpers', () => {
+  it('maps normalized runtime tool chunks to brainstorm activity records', () => {
+    const chunk: RuntimeChatChunk = {
+      type: 'tool',
+      content: 'exec: gh issue list',
+      data: {
+        phase: 'call',
+        callId: 'call-1',
+        toolName: 'exec',
+        status: 'running',
+        inputPreview: '{"command":"gh issue list"}',
+      },
+    }
+
+    expect(runtimeChunkToBrainstormActivity(chunk)).toEqual({
+      kind: 'tool_call',
+      content: 'exec: gh issue list',
+      data: chunk.data,
+    })
+  })
+
+  it('maps status and error chunks to brainstorm activity records', () => {
+    expect(runtimeChunkToBrainstormActivity({
+      type: 'status',
+      content: 'Reading context',
+      data: { step: 'context' },
+    })).toEqual({
+      kind: 'runtime_status',
+      content: 'Reading context',
+      data: { step: 'context' },
+    })
+
+    expect(runtimeChunkToBrainstormActivity({
+      type: 'error',
+      content: 'runtime rejected',
+    })).toEqual({
+      kind: 'error',
+      content: 'runtime rejected',
+    })
+  })
+
+  it('creates activity messages from custom SSE payloads', () => {
+    expect(brainstormActivityMessageFromCustom('activity', {
+      activity: {
+        id: 'act-1',
+        kind: 'tool_call',
+        content: 'read: plan.md',
+        data: { phase: 'call', toolName: 'read' },
+        timestamp: '2026-05-09T10:00:00.000Z',
+      },
+    })).toEqual({
+      id: 'act-1',
+      role: 'activity',
+      kind: 'tool_call',
+      content: 'read: plan.md',
+      data: { phase: 'call', toolName: 'read' },
+      timestamp: '2026-05-09T10:00:00.000Z',
+    })
+  })
+
+  it('builds a chronological brainstorm timeline from durable plugin records', () => {
+    const timeline = toBrainstormTimeline('main', {
+      messages: [
+        { id: 'm2', role: 'assistant', content: 'Done', timestamp: '2026-05-09T10:00:03.000Z' },
+        { id: 'm1', role: 'user', content: 'Look this up', timestamp: '2026-05-09T10:00:00.000Z' },
+      ],
+      activities: [
+        {
+          id: 'a1',
+          kind: 'tool_call',
+          content: 'exec: gh issue list',
+          timestamp: '2026-05-09T10:00:01.000Z',
+          data: { phase: 'call', callId: 'call-1', toolName: 'exec' },
+        },
+      ],
+    })
+
+    expect(timeline).toEqual([
+      { id: 'm1', role: 'user', content: 'Look this up', timestamp: '2026-05-09T10:00:00.000Z' },
+      {
+        id: 'a1',
+        role: 'activity',
+        kind: 'tool_call',
+        content: 'exec: gh issue list',
+        timestamp: '2026-05-09T10:00:01.000Z',
+        data: { phase: 'call', callId: 'call-1', toolName: 'exec' },
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: 'Done',
+        agentId: 'main',
+        timestamp: '2026-05-09T10:00:03.000Z',
+      },
+    ] satisfies BrainstormMessage[])
+  })
+})
+
+describe('readBrainstormSseResponse', () => {
+  it('streams tokens, forwards activity/custom events, and returns final content', async () => {
+    const tokens: string[] = []
+    const custom: Array<{ event: string; data: unknown }> = []
+    const sideEffects: Array<{ event: string; data: unknown }> = []
+
+    const result = await readBrainstormSseResponse(
+      sseResponse([
+        { event: 'token', data: { text: 'Hel' } },
+        { event: 'activity', data: { activity: { id: 'a1', kind: 'tool_call', content: 'exec: ls' } } },
+        { event: 'proposal', data: { id: 'p1' } },
+        { event: 'token', data: { text: 'lo' } },
+        { event: 'done', data: { content: 'Hello final' } },
+      ]),
+      {
+        signal: new AbortController().signal,
+        onToken: (text) => tokens.push(text),
+        onCustom: (event, data) => custom.push({ event, data }),
+      },
+      {
+        onCustomEvent: (event, data) => sideEffects.push({ event, data }),
+      },
+    )
+
+    expect(tokens).toEqual(['Hel', 'lo'])
+    expect(custom).toEqual([
+      { event: 'activity', data: { activity: { id: 'a1', kind: 'tool_call', content: 'exec: ls' } } },
+      { event: 'proposal', data: { id: 'p1' } },
+    ])
+    expect(sideEffects).toEqual([{ event: 'proposal', data: { id: 'p1' } }])
+    expect(result).toEqual({ content: 'Hello final' })
+  })
+
+  it('throws a useful error for SSE error events', async () => {
+    await expect(readBrainstormSseResponse(
+      sseResponse([{ event: 'error', data: { message: 'runtime rejected' } }]),
+      {
+        signal: new AbortController().signal,
+        onToken: () => {},
+      },
+    )).rejects.toThrow('runtime rejected')
+  })
+})

--- a/tests/components/integrated-brainstorm/activity-helpers.test.ts
+++ b/tests/components/integrated-brainstorm/activity-helpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test'
 import {
   brainstormActivityMessageFromCustom,
+  brainstormThreadId,
+  normalizeBrainstormActivityForStorage,
   readBrainstormSseResponse,
   runtimeChunkToBrainstormActivity,
   toBrainstormTimeline,
@@ -85,6 +87,36 @@ describe('brainstorm activity helpers', () => {
       content: 'read: plan.md',
       data: { phase: 'call', toolName: 'read' },
       timestamp: '2026-05-09T10:00:00.000Z',
+    })
+  })
+
+  it('builds stable URL-safe brainstorm thread ids', () => {
+    expect(brainstormThreadId('projects', 'proj/one', 'main agent')).toBe('projects:proj%2Fone:main%20agent')
+    expect(brainstormThreadId('projects', 'proj/one', 'main agent')).toBe('projects:proj%2Fone:main%20agent')
+  })
+
+  it('normalizes activity payloads before durable storage', () => {
+    const huge = 'x'.repeat(2500)
+    const normalized = normalizeBrainstormActivityForStorage({
+      kind: 'tool_call',
+      content: '  Reading project details  ',
+      data: {
+        phase: 'call',
+        toolName: 'exec',
+        inputPreview: huge,
+        nested: { value: huge },
+      },
+    })
+
+    expect(normalized).toEqual({
+      kind: 'tool_call',
+      content: 'Reading project details',
+      data: {
+        phase: 'call',
+        toolName: 'exec',
+        inputPreview: `${'x'.repeat(1997)}...`,
+        nested: expect.stringContaining('"value"'),
+      },
     })
   })
 

--- a/tests/components/integrated-brainstorm/fit-parent.test.tsx
+++ b/tests/components/integrated-brainstorm/fit-parent.test.tsx
@@ -59,11 +59,11 @@ function Harness(props: {
 }
 
 describe('IntegratedBrainstorm — fitParent', () => {
-  it('default mode has inline height style and a drag handle', () => {
+  it('default mode has readable inline height style and a drag handle', () => {
     const fake = createFakeOnSend()
     render(<Harness fake={fake} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
-    expect(panel.style.height).toBe('100px')
+    expect(panel.style.height).toBe('480px')
     expect(screen.getByTestId('resize-handle')).toBeDefined()
     expect(panel.className).toContain('shrink-0')
     expect(panel.className).not.toMatch(/\bh-full\b/)
@@ -80,7 +80,7 @@ describe('IntegratedBrainstorm — fitParent', () => {
     expect(panel.className).not.toMatch(/\bshrink-0\b/)
   })
 
-  it('fitParent=true disables auto-expand on first send (no inline height appears)', async () => {
+  it('fitParent=true keeps parent-owned height on first send', async () => {
     const fake = createFakeOnSend()
     render(<Harness fake={fake} fitParent />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement

--- a/tests/components/integrated-brainstorm/messages.test.tsx
+++ b/tests/components/integrated-brainstorm/messages.test.tsx
@@ -155,6 +155,10 @@ describe('IntegratedBrainstorm — message list rendering', () => {
     expect(activity!.textContent).toContain('exec: set -e')
     expect(activity!.querySelector('div[style*="border-left-color"]')).toBeTruthy()
     expect(activity!.querySelector('details')?.open).toBe(false)
+    const detailsToggle = activity!.querySelector('[data-testid="activity-details-toggle"]') as HTMLElement
+    expect(detailsToggle).toBeTruthy()
+    expect(detailsToggle.className).toContain('absolute')
+    expect(detailsToggle.className).toContain('right-0')
   })
 
   it('prefers runtime tool summaries for visible activity text', () => {

--- a/tests/components/integrated-brainstorm/messages.test.tsx
+++ b/tests/components/integrated-brainstorm/messages.test.tsx
@@ -128,15 +128,21 @@ describe('IntegratedBrainstorm — message list rendering', () => {
     expect(bubble.style.borderLeftColor.toLowerCase()).toMatch(/10b981|rgba?\(16,\s*185,\s*129/)
   })
 
-  it('renders activity messages as collapsed timeline rows', () => {
+  it('renders tool activity in the assistant-style bubble frame', () => {
     const messages: BrainstormMessage[] = [
       { id: 'u1', role: 'user', content: 'check this' },
       {
         id: 'act1',
         role: 'activity',
         kind: 'tool_call',
-        content: 'Read project file',
-        data: { tool: 'bakin_exec_projects_get' },
+        content: 'exec: set -e',
+        data: {
+          phase: 'call',
+          callId: 'call-1',
+          toolName: 'exec',
+          status: 'running',
+          inputPreview: '{"command":"set -e"}',
+        },
       },
       { id: 'a1', role: 'assistant', content: 'done' },
     ]
@@ -144,8 +150,83 @@ describe('IntegratedBrainstorm — message list rendering', () => {
     const activity = container.querySelector('[data-testid="activity-bubble"]')
     expect(activity).toBeTruthy()
     expect(activity!.textContent).toContain('Tool')
-    expect(activity!.textContent).toContain('Read project file')
+    expect(activity!.textContent).toContain('exec')
+    expect(activity!.textContent).toContain('running')
+    expect(activity!.textContent).toContain('exec: set -e')
+    expect(activity!.querySelector('div[style*="border-left-color"]')).toBeTruthy()
     expect(activity!.querySelector('details')?.open).toBe(false)
+  })
+
+  it('groups matching tool call and result activity into one completed row', () => {
+    const messages: BrainstormMessage[] = [
+      {
+        id: 'act-call',
+        role: 'activity',
+        kind: 'tool_call',
+        content: 'exec: gh issue list',
+        data: {
+          phase: 'call',
+          callId: 'call-1',
+          toolName: 'exec',
+          status: 'running',
+          inputPreview: '{"command":"gh issue list"}',
+        },
+      },
+      {
+        id: 'act-result',
+        role: 'activity',
+        kind: 'tool_call',
+        content: 'exec completed',
+        data: {
+          phase: 'result',
+          callId: 'call-1',
+          toolName: 'exec',
+          status: 'completed',
+          durationMs: 6605,
+          exitCode: 0,
+          outputPreview: '[{"type":"text","text":"Found #190"}]',
+        },
+      },
+    ]
+    const { container } = render(<IntegratedBrainstorm {...baseProps} messages={messages} />)
+    const activities = container.querySelectorAll('[data-testid="activity-bubble"]')
+    expect(activities.length).toBe(1)
+    expect(activities[0].textContent).toContain('Tool')
+    expect(activities[0].textContent).toContain('exec')
+    expect(activities[0].textContent).toContain('completed')
+    expect(activities[0].textContent).toContain('6.6s')
+    expect(activities[0].textContent).toContain('exec: gh issue list')
+    expect(activities[0].textContent).toContain('Details')
+  })
+
+  it('formats expanded activity details into readable sections', () => {
+    const messages: BrainstormMessage[] = [
+      {
+        id: 'act1',
+        role: 'activity',
+        kind: 'tool_call',
+        content: 'read: plan.md',
+        data: {
+          phase: 'result',
+          callId: 'call-1',
+          toolName: 'read',
+          status: 'failed',
+          exitCode: 1,
+          inputPreview: '{"path":"plan.md"}',
+          outputPreview: 'No such file',
+        },
+      },
+    ]
+    const { container } = render(<IntegratedBrainstorm {...baseProps} messages={messages} />)
+    const activity = container.querySelector('[data-testid="activity-bubble"]')!
+    expect(activity.textContent).toContain('failed')
+    expect(activity.textContent).toContain('Details')
+    expect(activity.textContent).toContain('Input')
+    expect(activity.textContent).toContain('{"path":"plan.md"}')
+    expect(activity.textContent).toContain('Output')
+    expect(activity.textContent).toContain('No such file')
+    expect(activity.textContent).toContain('Metadata')
+    expect(activity.textContent).toContain('exitCode')
   })
 
   it('hides the message list when collapsed', () => {

--- a/tests/components/integrated-brainstorm/messages.test.tsx
+++ b/tests/components/integrated-brainstorm/messages.test.tsx
@@ -153,6 +153,7 @@ describe('IntegratedBrainstorm — message list rendering', () => {
     expect(activity!.textContent).toContain('exec')
     expect(activity!.textContent).toContain('running')
     expect(activity!.textContent).toContain('exec: set -e')
+    expect(activity!.querySelector('div[style*="border-left-color"]')?.className).toContain('min-w-[50%]')
     expect(activity!.querySelector('div[style*="border-left-color"]')).toBeTruthy()
     expect(activity!.querySelector('details')?.open).toBe(false)
     const detailsToggle = activity!.querySelector('[data-testid="activity-details-toggle"]') as HTMLElement

--- a/tests/components/integrated-brainstorm/messages.test.tsx
+++ b/tests/components/integrated-brainstorm/messages.test.tsx
@@ -157,6 +157,32 @@ describe('IntegratedBrainstorm — message list rendering', () => {
     expect(activity!.querySelector('details')?.open).toBe(false)
   })
 
+  it('prefers runtime tool summaries for visible activity text', () => {
+    const messages: BrainstormMessage[] = [
+      {
+        id: 'act1',
+        role: 'activity',
+        kind: 'tool_call',
+        content: "exec: mcporter call --help | sed -n '1,120p'",
+        data: {
+          phase: 'call',
+          callId: 'call-1',
+          toolName: 'exec',
+          status: 'running',
+          summary: 'Checking Bakin tool call syntax',
+          inputPreview: '{"command":"mcporter call --help | sed -n \'1,120p\'"}',
+        },
+      },
+    ]
+    const { container } = render(<IntegratedBrainstorm {...baseProps} messages={messages} />)
+    const activity = container.querySelector('[data-testid="activity-bubble"]')
+    const summary = container.querySelector('[data-testid="tool-activity-summary"]')
+    expect(activity).toBeTruthy()
+    expect(summary?.textContent).toBe('Checking Bakin tool call syntax')
+    expect(summary?.textContent).not.toContain('mcporter call --help')
+    expect(activity!.textContent).toContain('Input')
+  })
+
   it('groups matching tool call and result activity into one completed row', () => {
     const messages: BrainstormMessage[] = [
       {

--- a/tests/components/integrated-brainstorm/resize.test.tsx
+++ b/tests/components/integrated-brainstorm/resize.test.tsx
@@ -42,7 +42,7 @@ import { createFakeOnSend } from './fake-on-send'
 
 function Harness(props: {
   fake: ReturnType<typeof createFakeOnSend>
-  conversationStartHeight?: number
+  defaultHeight?: number
   minHeight?: number
   maxHeight?: number
   storageKey?: string
@@ -55,7 +55,7 @@ function Harness(props: {
       onMessagesChange={setMessages}
       onSend={props.fake.onSend}
       agentId="pixel"
-      conversationStartHeight={props.conversationStartHeight}
+      defaultHeight={props.defaultHeight}
       minHeight={props.minHeight}
       maxHeight={props.maxHeight}
       storageKey={props.storageKey}
@@ -69,54 +69,63 @@ beforeEach(() => {
   } catch {}
 })
 
-describe('IntegratedBrainstorm — auto-expand', () => {
-  it('sets panel height to conversationStartHeight on first send', async () => {
+describe('IntegratedBrainstorm — default sizing', () => {
+  it('opens at the readable default height before any message is sent', () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} conversationStartHeight={400} />)
+    render(<Harness fake={fake} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
-    expect(panel.style.height).toBe('100px')
+    expect(panel.style.height).toBe('480px')
+  })
+
+  it('honors an explicit defaultHeight without changing min drag height', () => {
+    const fake = createFakeOnSend()
+    render(<Harness fake={fake} defaultHeight={500} minHeight={260} />)
+    const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
+    expect(panel.style.height).toBe('500px')
+    const handle = screen.getByTestId('resize-handle')
+    act(() => {
+      fireEvent.mouseDown(handle, { clientY: 100 })
+      fireEvent.mouseMove(document, { clientY: 5000 })
+      fireEvent.mouseUp(document)
+    })
+    expect(panel.style.height).toBe('260px')
+  })
+
+  it('does not resize the panel on first send', async () => {
+    const fake = createFakeOnSend()
+    render(<Harness fake={fake} defaultHeight={480} />)
+    const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
     const ta = screen.getByLabelText(/Ask Pixel/) as HTMLTextAreaElement
     act(() => {
       fireEvent.change(ta, { target: { value: 'hi' } })
       fireEvent.keyDown(ta, { key: 'Enter' })
     })
-    await waitFor(() => expect(panel.style.height).toBe('400px'))
+    await waitFor(() => expect(fake.isPending()).toBe(true))
+    expect(panel.style.height).toBe('480px')
   })
 
-  it('does NOT re-fire auto-expand on subsequent sends', async () => {
+  it('preserves a manual resize across subsequent sends', async () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} conversationStartHeight={400} />)
+    render(<Harness fake={fake} defaultHeight={480} minHeight={260} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
     const ta = screen.getByLabelText(/Ask Pixel/) as HTMLTextAreaElement
-    // First send
+    const handle = screen.getByTestId('resize-handle')
+    act(() => {
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      fireEvent.mouseMove(document, { clientY: 700 })
+      fireEvent.mouseUp(document)
+    })
+    const shrunk = panel.style.height
+    expect(shrunk).toBe('280px')
     act(() => {
       fireEvent.change(ta, { target: { value: 'one' } })
       fireEvent.keyDown(ta, { key: 'Enter' })
     })
-    await waitFor(() => expect(panel.style.height).toBe('400px'))
-    act(() => {
-      fake.resolve('reply one')
-    })
-    await waitFor(() => fake.isPending() === false)
-    // Manually shrink
-    const handle = screen.getByTestId('resize-handle')
-    act(() => {
-      fireEvent.mouseDown(handle, { clientY: 0 })
-      fireEvent.mouseMove(document, { clientY: 200 })
-      fireEvent.mouseUp(document)
-    })
-    const shrunk = panel.style.height
-    expect(shrunk).not.toBe('400px')
-    // Second send should NOT reset to 400
-    act(() => {
-      fireEvent.change(ta, { target: { value: 'two' } })
-      fireEvent.keyDown(ta, { key: 'Enter' })
-    })
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => expect(fake.isPending()).toBe(true))
     expect(panel.style.height).toBe(shrunk)
   })
 
-  it('skips auto-expand when seeded with existing messages', async () => {
+  it('keeps default height when seeded with existing messages', async () => {
     const fake = createFakeOnSend()
     const seed: BrainstormMessage[] = [
       { id: 's1', role: 'user', content: 'seed' },
@@ -126,42 +135,41 @@ describe('IntegratedBrainstorm — auto-expand', () => {
       <Harness
         fake={fake}
         initialMessages={seed}
-        conversationStartHeight={400}
-        minHeight={100}
+        defaultHeight={480}
+        minHeight={260}
       />,
     )
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
-    expect(panel.style.height).toBe('100px')
+    expect(panel.style.height).toBe('480px')
     const ta = screen.getByLabelText(/Ask Pixel/) as HTMLTextAreaElement
     act(() => {
       fireEvent.change(ta, { target: { value: 'new send' } })
       fireEvent.keyDown(ta, { key: 'Enter' })
     })
-    await new Promise((r) => setTimeout(r, 20))
-    // Height did not change
-    expect(panel.style.height).toBe('100px')
+    await waitFor(() => expect(fake.isPending()).toBe(true))
+    expect(panel.style.height).toBe('480px')
   })
 })
 
 describe('IntegratedBrainstorm — drag resize', () => {
   it('mouse drag updates panel height', () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} minHeight={100} maxHeight={720} />)
+    render(<Harness fake={fake} defaultHeight={480} minHeight={260} maxHeight={720} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
-    expect(panel.style.height).toBe('100px')
+    expect(panel.style.height).toBe('480px')
     const handle = screen.getByTestId('resize-handle')
     act(() => {
       fireEvent.mouseDown(handle, { clientY: 500 })
       fireEvent.mouseMove(document, { clientY: 300 })
       fireEvent.mouseUp(document)
     })
-    // Drag upward by 200px grew panel by 200 → 300
-    expect(panel.style.height).toBe('300px')
+    // Drag upward by 200px grew panel by 200 → 680
+    expect(panel.style.height).toBe('680px')
   })
 
   it('clamps to minHeight on downward over-drag', () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} minHeight={100} maxHeight={720} />)
+    render(<Harness fake={fake} defaultHeight={480} minHeight={260} maxHeight={720} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
     const handle = screen.getByTestId('resize-handle')
     act(() => {
@@ -169,12 +177,12 @@ describe('IntegratedBrainstorm — drag resize', () => {
       fireEvent.mouseMove(document, { clientY: 5000 })
       fireEvent.mouseUp(document)
     })
-    expect(panel.style.height).toBe('100px')
+    expect(panel.style.height).toBe('260px')
   })
 
   it('clamps to maxHeight on upward over-drag', () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} minHeight={100} maxHeight={720} />)
+    render(<Harness fake={fake} defaultHeight={480} minHeight={260} maxHeight={720} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
     const handle = screen.getByTestId('resize-handle')
     act(() => {
@@ -196,7 +204,7 @@ describe('IntegratedBrainstorm — drag resize', () => {
 
   it('touch drag updates panel height', () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} minHeight={100} maxHeight={720} />)
+    render(<Harness fake={fake} defaultHeight={480} minHeight={260} maxHeight={720} />)
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
     const handle = screen.getByTestId('resize-handle')
     act(() => {
@@ -204,14 +212,14 @@ describe('IntegratedBrainstorm — drag resize', () => {
       fireEvent.touchMove(document, { touches: [{ clientY: 300 }] })
       fireEvent.touchEnd(document)
     })
-    expect(panel.style.height).toBe('300px')
+    expect(panel.style.height).toBe('680px')
   })
 })
 
 describe('IntegratedBrainstorm — height persistence', () => {
   it('persists drag-applied height to localStorage under the storageKey', () => {
     const fake = createFakeOnSend()
-    render(<Harness fake={fake} storageKey="resize-test-a" minHeight={100} maxHeight={720} />)
+    render(<Harness fake={fake} storageKey="resize-test-a" defaultHeight={480} minHeight={260} maxHeight={720} />)
     const handle = screen.getByTestId('resize-handle')
     act(() => {
       fireEvent.mouseDown(handle, { clientY: 500 })
@@ -219,7 +227,7 @@ describe('IntegratedBrainstorm — height persistence', () => {
       fireEvent.mouseUp(document)
     })
     const stored = window.localStorage.getItem('bakin-vresize:resize-test-a')
-    expect(stored).toBe('400')
+    expect(stored).toBe('720')
   })
 
   it('reads persisted height on mount', () => {
@@ -230,11 +238,11 @@ describe('IntegratedBrainstorm — height persistence', () => {
     expect(panel.style.height).toBe('555px')
   })
 
-  it('skips auto-expand when persisted height is already above min', async () => {
+  it('uses persisted height and does not resize on submit', async () => {
     window.localStorage.setItem('bakin-vresize:resize-test-c', '555')
     const fake = createFakeOnSend()
     render(
-      <Harness fake={fake} storageKey="resize-test-c" conversationStartHeight={400} minHeight={100} />,
+      <Harness fake={fake} storageKey="resize-test-c" defaultHeight={480} minHeight={260} />,
     )
     const panel = screen.getByTestId('integrated-brainstorm') as HTMLDivElement
     expect(panel.style.height).toBe('555px')
@@ -243,7 +251,7 @@ describe('IntegratedBrainstorm — height persistence', () => {
       fireEvent.change(ta, { target: { value: 'hi' } })
       fireEvent.keyDown(ta, { key: 'Enter' })
     })
-    await new Promise((r) => setTimeout(r, 20))
+    await waitFor(() => expect(fake.isPending()).toBe(true))
     // Height unchanged — user's persisted preference wins.
     expect(panel.style.height).toBe('555px')
   })

--- a/tests/skill/bakin-skill.test.ts
+++ b/tests/skill/bakin-skill.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('Bakin runtime skill', () => {
+  it('documents portable mcporter command patterns', () => {
+    const skill = readFileSync(join(process.cwd(), 'skill', 'SKILL.md'), 'utf-8')
+
+    expect(skill).toContain('grep -n -E')
+    expect(skill).toContain('Do not use `--args @-`, heredocs, process substitution, or stdin-fed JSON')
+    expect(skill).toContain('mcporter call bakin-main.bakin_exec_projects_get --args')
+    expect(skill).toContain('ARGS=$(node -e')
+    expect(skill).toContain('mcporter call bakin-main.bakin_exec_projects_apply_plan --args "$ARGS"')
+  })
+})


### PR DESCRIPTION
## Summary
- add SDK helpers for stable brainstorm runtime thread IDs and bounded activity storage
- export brainstorm session/activity helpers through SDK components and utils barrels
- document the durable brainstorm contract in public docs and internal specs
- regenerate generated docs/reference artifacts

## Verification
- bun run typecheck
- bun run lint
- bun run test
- bun run docs:check

Related plugin PR should consume these SDK helpers in `bakin-bits-official`.