### PR TITLE
Remove legacy source CLI start path

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1076,96 +1076,6 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
   }
 }
 
-// ---------------------------------------------------------------------------
-// Start / Setup mcporter
-// ---------------------------------------------------------------------------
-
-async function cmdStart(): Promise<void> {
-  const { resolve, dirname, join } = await import('path')
-  const { execSync, spawn } = await import('child_process')
-
-  const projectDir = resolve(dirname(new URL(import.meta.url).pathname), '..')
-  const port = Number(process.env.PORT || 3737)
-
-  // Step 1: Setup mcporter
-  console.log('[..] Checking mcporter...')
-  const mcporter = await import('../src/core/mcporter')
-
-  if (!mcporter.isMcporterInstalled()) {
-    console.log('[..] Installing mcporter...')
-    if (!mcporter.installMcporter()) {
-      console.error('[FAIL] Could not install mcporter. Run manually: npm i -g mcporter')
-      process.exit(1)
-    }
-    console.log('[OK] mcporter installed')
-  } else {
-    console.log('[OK] mcporter available')
-  }
-
-  // Step 2: Sync mcporter config
-  console.log('[..] Syncing mcporter config...')
-  const changes = await mcporter.syncConfig(port)
-  if (changes.length > 0) {
-    for (const c of changes) console.log(`  ${c}`)
-    console.log(`[OK] mcporter config updated (${changes.length} changes)`)
-  } else {
-    console.log('[OK] mcporter config up to date')
-  }
-
-  // Step 3: Kill any existing Bakin server
-  console.log('[..] Checking for running Bakin...')
-  try {
-    const pids = execSync("pgrep -f 'tsx.*server\\.ts'", { encoding: 'utf-8' }).trim()
-    if (pids) {
-      for (const pid of pids.split('\n')) {
-        if (pid && pid !== String(process.pid)) {
-          process.kill(Number(pid), 'SIGTERM')
-        }
-      }
-      console.log('[OK] Stopped existing Bakin server')
-      await new Promise(r => setTimeout(r, 2000))
-    }
-  } catch {
-    // No running process
-  }
-
-  // Step 4: Start the server
-  const serverPath = join(projectDir, 'server.ts')
-  console.log('[..] Starting Bakin server...')
-  const child = spawn('npx', ['tsx', serverPath], {
-    cwd: projectDir,
-    detached: true,
-    stdio: ['ignore', 'ignore', 'ignore'],
-    env: { ...process.env },
-  })
-  child.unref()
-  console.log(`[OK] Bakin starting (pid ${child.pid})`)
-
-  // Step 5: Wait for server to come up
-  console.log('[..] Waiting for server...')
-  for (let i = 0; i < 15; i++) {
-    await new Promise(r => setTimeout(r, 1000))
-    try {
-      const res = await fetch(`${BASE_URL}/api/version`, { signal: AbortSignal.timeout(2000) })
-      if (res.ok) {
-        const data = await res.json() as { version: string }
-        console.log(`[OK] Bakin is up (${data.version})`)
-        console.log('')
-        console.log('MCP endpoints:')
-        const roster = await getCliRoster()
-        for (const agent of roster.agentIds) {
-          console.log(`  ${agent}: mcporter call bakin-${agent}.<tool> ...`)
-        }
-        console.log('')
-        console.log(`Stats: curl ${BASE_URL}/mcp/stats`)
-        console.log(`Audit: tail -f ~/.bakin/audit.jsonl | jq '{event,agent,channel}'`)
-        return
-      }
-    } catch { /* not ready yet */ }
-  }
-  console.log('[WARN] Server not responding after 15s — check logs')
-}
-
 async function cmdLogs(filter?: string): Promise<void> {
   const { spawn, execSync } = await import('child_process')
   const { existsSync } = await import('fs')
@@ -1508,7 +1418,8 @@ async function dispatchPluginCliCommand(cmd: string, args: string[]): Promise<bo
   return false
 }
 
-const USAGE = renderCliUsage({ bakinUrl: BASE_URL })
+const BINARY_ONLY_COMMANDS = new Set(['start'])
+const USAGE = renderCliUsage({ bakinUrl: BASE_URL }, { excludeNames: BINARY_ONLY_COMMANDS })
 
 // ---------------------------------------------------------------------------
 // Onboarding CLI handlers
@@ -1891,10 +1802,6 @@ export async function main(): Promise<void> {
         }
         break
 
-      case 'start':
-        await cmdStart()
-        break
-
       case 'stop':
         await cmdStop()
         break
@@ -2067,7 +1974,7 @@ export async function main(): Promise<void> {
         break
 
       default:
-        if (await dispatchPluginCliCommand(cmd, args.slice(1))) {
+        if (!BINARY_ONLY_COMMANDS.has(cmd) && await dispatchPluginCliCommand(cmd, args.slice(1))) {
           break
         }
         console.error(`Unknown command: ${cmd}`)

--- a/src/core/cli/registry.ts
+++ b/src/core/cli/registry.ts
@@ -145,9 +145,10 @@ export const CLI_COMMANDS = [
   cli({ name: 'trash', usage: 'bakin trash [list|restore|empty] ...', group: 'Assets and search', summary: 'Manage trashed assets.', description: 'Lists, restores, or permanently empties soft-deleted assets.', examples: [{ title: 'List trash', code: 'bakin trash list', test: 'illustrative', reason: 'Depends on local asset state.' }] }),
 ] as const satisfies readonly CliDef[]
 
-export function renderCliUsage(env: { bakinUrl?: string } = {}): string {
+export function renderCliUsage(env: { bakinUrl?: string } = {}, opts: { excludeNames?: ReadonlySet<string> } = {}): string {
   const grouped = new Map<string, CliDef[]>()
   for (const command of CLI_COMMANDS) {
+    if (opts.excludeNames?.has(command.name)) continue
     const group = command.group ?? 'Commands'
     if (!grouped.has(group)) grouped.set(group, [])
     grouped.get(group)!.push(command)
@@ -165,6 +166,8 @@ export function renderCliUsage(env: { bakinUrl?: string } = {}): string {
   lines.push('Environment:')
   lines.push(`  BAKIN_URL${' '.repeat(18)}Base URL for the running server (default: ${env.bakinUrl ?? 'http://localhost:3737'})`)
   lines.push(`  BAKIN_HOME${' '.repeat(17)}Override for ~/.bakin`)
-  lines.push(`  PORT${' '.repeat(23)}Port to bind when \`start\` launches (default: 3737)`)
+  if (!opts.excludeNames?.has('start')) {
+    lines.push(`  PORT${' '.repeat(23)}Port to bind when \`start\` launches (default: 3737)`)
+  }
   return lines.join('\n')
 }

--- a/tests/cli/legacy-start.test.ts
+++ b/tests/cli/legacy-start.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+let spawnCalled = false
+
+mock.module('child_process', () => ({
+  spawn: () => {
+    spawnCalled = true
+    throw new Error('legacy start must not spawn')
+  },
+  execSync: () => '',
+}))
+
+describe('legacy CLI start command', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    spawnCalled = false
+  })
+
+  it('does not exist, preventing the old detached npx tsx server path from running', async () => {
+    const err = spyOn(console, 'error').mockImplementation(() => {})
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+    process.argv = ['bun', 'cli/bakin.ts', 'start']
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${code}`)
+    }) as never
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:1')
+
+    expect(spawnCalled).toBe(false)
+    const output = err.mock.calls.map(call => String(call[0])).join('\n')
+    expect(output).toContain('Unknown command: start')
+    const usage = log.mock.calls.map(call => String(call[0])).join('\n')
+    expect(usage).not.toContain('bakin start')
+    log.mockRestore()
+    err.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- delete the old source CLI `start` implementation that spawned detached `npx tsx server.ts`
- mark `start` as binary-only for source CLI usage/help so `bun run cli start` cannot hit the server/plugin fallback
- add a regression test proving the legacy source CLI cannot spawn the old path

## Tests
- `bun test --isolate tests/cli/legacy-start.test.ts tests/cli/start-onboarding-gate.test.ts`
- `bun run typecheck`
- `bun run cli start`