### PR TITLE
fix: handle workflow approval gates for agents

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -37,6 +37,7 @@ import {
   listInstances,
   getActiveAgents,
   authorizeWorkflowToolUse,
+  reconcilePendingApprovalTaskColumns,
   isGateNotified,
   markGateNotified,
   cancelInstance,
@@ -233,6 +234,26 @@ function formatSchema(schema: Record<string, unknown>, indent = 0): string {
 }
 
 function formatStepContext(step: Record<string, unknown>): string {
+  if (step.status === 'pending_approval') {
+    const sections: string[] = []
+    sections.push(`STEP: ${step.stepId ?? '(gate)'}`)
+    sections.push('STATUS: pending_approval')
+    if (step.label) sections.push(`LABEL: ${step.label}`)
+    sections.push('')
+    sections.push('WAITING FOR HUMAN APPROVAL')
+    sections.push('No agent action is required until this gate is approved or rejected.')
+    sections.push('Use bakin_exec_check_gates for the current approval status.')
+    return sections.join('\n')
+  }
+
+  if (step.status === 'complete') {
+    return [
+      'STATUS: complete',
+      'WORKFLOW COMPLETE',
+      'No further workflow step is active for this task.',
+    ].join('\n')
+  }
+
   const sections: string[] = []
   sections.push(`STEP: ${step.stepId}`)
   sections.push(`STATUS: ${step.status}`)
@@ -1655,7 +1676,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
           triggerDispatch()
         }
 
-        return { ok: true, workflowComplete: result.workflowComplete }
+        return { ok: true, workflowComplete: result.workflowComplete, nextStep: result.nextStep }
       },
     })
 
@@ -1726,7 +1747,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
             triggerDispatch()
           }
 
-          return { ok: true, workflowComplete: result.workflowComplete }
+          return { ok: true, workflowComplete: result.workflowComplete, nextStep: result.nextStep }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           if (msg.includes('near-duplicate') || msg.includes('rejection')) {
@@ -1797,6 +1818,23 @@ const workflowsPlugin: BakinPlugin = definePlugin({
     if (active.length > 0) {
       log.info(`Ready — ${active.length} active workflow instance(s)`)
     }
+    reconcilePendingApprovalTaskColumns()
+      .then((result) => {
+        if (result.moved > 0) {
+          log.info(`Reconciled ${result.moved} pending approval workflow task card(s)`, {
+            checked: result.checked,
+            skipped: result.skipped,
+          })
+        }
+        if (result.failed.length > 0) {
+          log.warn('Pending approval workflow task reconciliation had failures', {
+            failed: result.failed,
+          })
+        }
+      })
+      .catch((err) => {
+        log.warn('Pending approval workflow task reconciliation failed', err)
+      })
     const defs = listDefinitions()
     log.info(`Ready — ${defs.length} workflow definition(s) loaded`)
   },

--- a/plugins/workflows/lib/runtime.ts
+++ b/plugins/workflows/lib/runtime.ts
@@ -41,6 +41,7 @@ import {
   addTaskLog,
   createTask,
   getTask,
+  getTaskWithColumn,
   moveTask,
 } from '../../../src/core/task-store'
 
@@ -57,6 +58,74 @@ async function addTaskLogToStore(identifier: string, author: string, message: st
 
 async function moveTaskInStore(identifier: string, to: string, from?: string): Promise<void> {
   await moveTask(identifier, to, from)
+}
+
+interface WorkflowTaskReviewMoveResult {
+  moved: boolean
+  skipped: boolean
+  reason?: string
+}
+
+async function moveWorkflowTaskToReview(identifier: string): Promise<WorkflowTaskReviewMoveResult> {
+  const taskWithColumn = getTaskWithColumn(identifier)
+  const currentColumn = taskWithColumn?.column
+
+  if (currentColumn === 'review') return { moved: false, skipped: false }
+
+  if (currentColumn === 'todo') {
+    await moveTaskInStore(identifier, 'inProgress')
+    await moveTaskInStore(identifier, 'review')
+    return { moved: true, skipped: false }
+  }
+
+  if (currentColumn === 'inProgress') {
+    await moveTaskInStore(identifier, 'review')
+    return { moved: true, skipped: false }
+  }
+
+  if (!currentColumn) {
+    await moveTaskInStore(identifier, 'review')
+    return { moved: true, skipped: false }
+  }
+
+  log.warn('Workflow reached a review gate but task is in a non-reviewable column', {
+    taskId: identifier,
+    column: currentColumn,
+  })
+  return { moved: false, skipped: true, reason: `non-reviewable column: ${currentColumn}` }
+}
+
+export interface PendingApprovalTaskColumnReconcileResult {
+  checked: number
+  moved: number
+  skipped: number
+  failed: Array<{ taskId: string; error: string }>
+}
+
+export async function reconcilePendingApprovalTaskColumns(contentDir?: string): Promise<PendingApprovalTaskColumnReconcileResult> {
+  const dir = contentDir || getContentDir()
+  const result: PendingApprovalTaskColumnReconcileResult = {
+    checked: 0,
+    moved: 0,
+    skipped: 0,
+    failed: [],
+  }
+
+  for (const instance of listInstances('pending_approval', dir)) {
+    result.checked += 1
+    try {
+      const move = await moveWorkflowTaskToReview(instance.taskId)
+      if (move.moved) result.moved += 1
+      if (move.skipped) result.skipped += 1
+    } catch (err) {
+      result.failed.push({
+        taskId: instance.taskId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return result
 }
 
 async function completeTaskViaHooks(instance: WorkflowInstance, from: string): Promise<void> {
@@ -491,7 +560,6 @@ export function getCurrentStep(
 
   // Gate pending approval
   if (step.type === 'gate' && instance.stepStates[currentId]?.status === 'pending_approval') {
-    if (agentId) return null
     return {
       status: 'pending_approval',
       stepId: currentId,
@@ -976,7 +1044,7 @@ function advanceWorkflow(instance: WorkflowInstance, def: WorkflowDefinition, co
     }
 
     // Move the task to the review column while awaiting approval.
-    moveTaskInStore(instance.taskId, 'review').catch((err) => {
+    moveWorkflowTaskToReview(instance.taskId).catch((err) => {
       log.warn('Failed to move workflow task to review', err)
     })
   } else if (isPluginKind(nextStep.type)) {

--- a/tests/plugins/workflows/exec-tools.test.ts
+++ b/tests/plugins/workflows/exec-tools.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { activatePlugin, callTool, findTool, type ActivatedPlugin } from '../test-helpers'
+
+const testDir = join(tmpdir(), `bakin-test-workflows-exec-tools-${Date.now()}`)
+const definitionsDir = join(testDir, 'workflows', 'definitions')
+const originalFetch = globalThis.fetch
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+mock.module('../../../src/core/watcher', () => ({
+  registerSyncHook: mock(),
+  registerUnlinkHook: mock(),
+}))
+
+mock.module('../../../src/core/audit', () => ({
+  appendAudit: mock(),
+}))
+
+type HookTask = { id: string; title: string; column: string; description?: string }
+const hookTasks = new Map<string, HookTask>()
+const taskStoreMock = {
+  createTask: mock((title: string, column?: string, _assignee?: string, description?: string, _workflowId?: string, _createdBy?: string, id?: string) => {
+    const taskId = id ?? `task-${hookTasks.size + 1}`
+    const task = { id: taskId, title, column: column ?? 'todo', description }
+    hookTasks.set(taskId, task)
+    return Promise.resolve(task)
+  }),
+  addTaskLog: mock(() => Promise.resolve()),
+  moveTask: mock((identifier: string, to: string) => {
+    const task = hookTasks.get(identifier)
+    if (task) task.column = to
+    return Promise.resolve()
+  }),
+  readTaskboard: mock(() => ({
+    columns: {
+      backlog: [],
+      inProgress: [...hookTasks.values()].filter(task => task.column === 'inProgress'),
+      todo: [...hookTasks.values()].filter(task => task.column === 'todo'),
+      review: [...hookTasks.values()].filter(task => task.column === 'review'),
+      done: [],
+      archived: [],
+      blocked: [],
+    },
+  })),
+  getTask: mock((id: string) => hookTasks.get(id) ?? null),
+  getTaskWithColumn: mock((id: string) => {
+    const task = hookTasks.get(id)
+    return task ? { task, column: task.column } : null
+  }),
+}
+
+mock.module('../../../src/core/task-store', () => taskStoreMock)
+mock.module('@/core/task-store', () => taskStoreMock)
+
+import workflowsPlugin from '../../../plugins/workflows'
+import { createInstance } from '@bakin/workflows/lib/runtime'
+
+const gateWorkflow = `name: Gate Exec Tool Test
+description: Workflow used by exec tool tests
+version: 1
+steps:
+  - id: draft
+    type: agent
+    label: Draft
+    agent: chef
+    description: Write the draft
+  - id: review
+    type: gate
+    label: Review final post
+    description: Human review
+    approval_required: true
+    on_approve: done
+    on_reject:
+      goto: draft
+      note_to_agent: true
+`
+
+let activated: ActivatedPlugin
+
+beforeAll(async () => {
+  globalThis.fetch = mock(async () => new Response('{}')) as unknown as typeof fetch
+  mkdirSync(definitionsDir, { recursive: true })
+  writeFileSync(join(definitionsDir, 'gate-exec.yaml'), gateWorkflow)
+  activated = await activatePlugin(workflowsPlugin, testDir)
+})
+
+beforeEach(() => {
+  hookTasks.clear()
+  taskStoreMock.createTask.mockClear()
+  taskStoreMock.addTaskLog.mockClear()
+  taskStoreMock.moveTask.mockClear()
+  taskStoreMock.getTask.mockClear()
+  taskStoreMock.getTaskWithColumn.mockClear()
+})
+
+afterAll(() => {
+  globalThis.fetch = originalFetch
+  if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('workflow exec tools', () => {
+  it('returns a waiting gate state instead of failing when an agent asks for the current step', async () => {
+    createInstance('task-gate-tool', 'gate-exec', testDir, 'chef')
+    const submit = findTool(activated.execTools, 'bakin_exec_submit_step')!
+    await callTool(submit, {
+      taskId: 'task-gate-tool',
+      stepId: 'draft',
+      output: { text: 'done' },
+    }, 'chef')
+
+    const getStep = findTool(activated.execTools, 'bakin_exec_get_step')!
+    const result = await callTool(getStep, { taskId: 'task-gate-tool' }, 'chef')
+
+    expect(result.ok).toBe(true)
+    expect(result.raw).toMatchObject({
+      status: 'pending_approval',
+      stepId: 'review',
+    })
+    expect(result.formatted).toContain('WAITING FOR HUMAN APPROVAL')
+    expect(result.formatted).not.toContain('first step')
+  })
+
+  it('returns nextStep when submitting a step reaches a gate', async () => {
+    createInstance('task-submit-next-gate', 'gate-exec', testDir, 'chef')
+    const submit = findTool(activated.execTools, 'bakin_exec_submit_step')!
+
+    const result = await callTool(submit, {
+      taskId: 'task-submit-next-gate',
+      stepId: 'draft',
+      output: { text: 'done' },
+    }, 'chef')
+
+    expect(result.ok).toBe(true)
+    expect(result.nextStep).toMatchObject({
+      status: 'pending_approval',
+      stepId: 'review',
+    })
+  })
+})

--- a/tests/plugins/workflows/notification-channels-route.test.ts
+++ b/tests/plugins/workflows/notification-channels-route.test.ts
@@ -56,6 +56,7 @@ mock.module('@/core/task-store', () => ({
   readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getTask: () => null,
+  getTaskWithColumn: () => null,
   createTask: mock(),
   moveTask: mock(),
   addTaskLog: mock(),

--- a/tests/plugins/workflows/runtime.test.ts
+++ b/tests/plugins/workflows/runtime.test.ts
@@ -76,6 +76,10 @@ const taskStoreMock = {
     id?: string,
   ) => createTaskHook({ id, title, column, description }),
   getTask: (id: string) => hookTasks.get(id) ?? null,
+  getTaskWithColumn: (id: string) => {
+    const task = hookTasks.get(id)
+    return task ? { task, column: task.column } : null
+  },
   moveTask: (identifier: string, to: string, from?: string) => moveTaskHook({ identifier, to, from }),
   readTaskboard: readTaskboardForTest,
 }
@@ -118,6 +122,7 @@ import {
   loadInstance,
   getCurrentStep,
   completeStep,
+  reconcilePendingApprovalTaskColumns,
   approveGate,
   rejectGate,
   reopenFromStep,
@@ -393,6 +398,19 @@ Write a great caption.
       expect((step as Record<string, unknown>).status).toBe('pending_approval')
     })
 
+    it('returns pending approval gate status for agent-scoped lookups', () => {
+      createInstance('task-gate-agent', 'gate', testDir)
+      completeStep('task-gate-agent', 'write-copy', { result: 'done' }, 'chef', testDir)
+
+      const step = getCurrentStep('task-gate-agent', 'chef', testDir)
+
+      expect(step).toMatchObject({
+        status: 'pending_approval',
+        stepId: 'review-gate',
+        label: 'Review',
+      })
+    })
+
     it('returns completion status when workflow is done', () => {
       createInstance('task-done', 'linear', testDir)
       completeStep('task-done', 'step-one', { result: 'a' }, undefined, testDir)
@@ -418,6 +436,71 @@ Write a great caption.
       expect(instance!.currentStepId).toBe('step-two')
       expect(instance!.stepStates['step-one'].status).toBe('complete')
       expect(instance!.stepStates['step-two'].status).toBe('in_progress')
+    })
+
+    it('returns pending approval as the next step when completion reaches a gate', () => {
+      createInstance('task-next-gate', 'gate', testDir)
+
+      const result = completeStep('task-next-gate', 'write-copy', { text: 'hello' }, 'chef', testDir)
+
+      expect(result.success).toBe(true)
+      expect(result.nextStep).toMatchObject({
+        status: 'pending_approval',
+        stepId: 'review-gate',
+      })
+    })
+
+    it('moves a todo workflow task through inProgress before review when a gate is reached', async () => {
+      hookTasks.set('task-review-from-todo', {
+        id: 'task-review-from-todo',
+        title: 'Review from todo',
+        column: 'todo',
+      })
+      createInstance('task-review-from-todo', 'gate', testDir)
+
+      completeStep('task-review-from-todo', 'write-copy', { text: 'hello' }, 'chef', testDir)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(moveTaskHook).toHaveBeenNthCalledWith(1, {
+        identifier: 'task-review-from-todo',
+        to: 'inProgress',
+        from: undefined,
+      })
+      expect(moveTaskHook).toHaveBeenNthCalledWith(2, {
+        identifier: 'task-review-from-todo',
+        to: 'review',
+        from: undefined,
+      })
+      expect(hookTasks.get('task-review-from-todo')?.column).toBe('review')
+    })
+
+    it('repairs pending approval workflow tasks that were left in todo', async () => {
+      hookTasks.set('task-reconcile-review', {
+        id: 'task-reconcile-review',
+        title: 'Reconcile review',
+        column: 'todo',
+      })
+      createInstance('task-reconcile-review', 'gate', testDir)
+      completeStep('task-reconcile-review', 'write-copy', { text: 'hello' }, 'chef', testDir)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      hookTasks.get('task-reconcile-review')!.column = 'todo'
+      moveTaskHook.mockClear()
+
+      const result = await reconcilePendingApprovalTaskColumns(testDir)
+
+      expect(result).toMatchObject({ checked: 1, moved: 1, skipped: 0 })
+      expect(moveTaskHook).toHaveBeenNthCalledWith(1, {
+        identifier: 'task-reconcile-review',
+        to: 'inProgress',
+        from: undefined,
+      })
+      expect(moveTaskHook).toHaveBeenNthCalledWith(2, {
+        identifier: 'task-reconcile-review',
+        to: 'review',
+        from: undefined,
+      })
+      expect(hookTasks.get('task-reconcile-review')?.column).toBe('review')
     })
 
     it('rejects invalid output and does not advance', () => {


### PR DESCRIPTION
## Summary
- Return pending approval gate state from agent-scoped workflow step reads instead of failing.
- Move workflow task cards through legal task-board transitions when a gate is reached.
- Reconcile already-stuck pending approval workflow cards on plugin ready.
- Add runtime and exec-tool coverage for pending approval gates.

## Verification
- `bun test --isolate`
- `bun run typecheck`
- `bun run lint`