### PR TITLE
Fix boot log noise and plugin contract warnings

### DIFF
--- a/packages/adapter-antfly/src/server.ts
+++ b/packages/adapter-antfly/src/server.ts
@@ -50,6 +50,15 @@ const TRANSIENT_RECONCILER_MESSAGES = new Set([
   'Failed to add index',
   'Failed to update schema',
 ])
+const OPTIONAL_TERMITE_MODEL_DIRECTORY_MESSAGES = new Set([
+  'Chunker models directory does not exist',
+  'Generator models directory does not exist',
+  'NER models directory does not exist',
+  'Seq2Seq models directory does not exist',
+  'Classifier models directory does not exist',
+  'Reader models directory does not exist',
+  'Transcriber models directory does not exist',
+])
 const ANTFLY_WARNING_DETAIL_KEYS = [
   'tableName',
   'table',
@@ -77,6 +86,17 @@ function isTransientReconcilerWarning(message: string, fields: Record<string, st
   return TRANSIENT_RECONCILER_MESSAGES.has(message) && fields.error === SHARD_INITIALIZING_ERROR
 }
 
+function isOptionalTermiteModelDirectoryWarning(message: string, fields: Record<string, string>): boolean {
+  return OPTIONAL_TERMITE_MODEL_DIRECTORY_MESSAGES.has(message)
+    && fields.caller?.startsWith('termite/') === true
+    && typeof fields.dir === 'string'
+}
+
+function isExpectedStartupDebug(message: string, fields: Record<string, string>): boolean {
+  return isTransientReconcilerWarning(message, fields)
+    || isOptionalTermiteModelDirectoryWarning(message, fields)
+}
+
 function transientReconcilerMessage(message: string, fields: Record<string, string>): string {
   if (message === 'Failed to add index') {
     return `Antfly reconciler deferred index update until shard initialization completes${
@@ -88,6 +108,13 @@ function transientReconcilerMessage(message: string, fields: Record<string, stri
   }`
 }
 
+function optionalTermiteModelDirectoryMessage(message: string, fields: Record<string, string>): string {
+  const registry = message.replace(' models directory does not exist', '').toLowerCase()
+  return `Antfly skipped optional Termite ${registry} registry with no local models${
+    summarizeAntflyFields(fields, ['dir'])
+  }`
+}
+
 function formatAntflyLogMessage(
   message: string,
   level: AntflyLogLevel,
@@ -95,6 +122,9 @@ function formatAntflyLogMessage(
 ): string {
   if (isTransientReconcilerWarning(message, fields)) {
     return transientReconcilerMessage(message, fields)
+  }
+  if (isOptionalTermiteModelDirectoryWarning(message, fields)) {
+    return optionalTermiteModelDirectoryMessage(message, fields)
   }
   if (level !== 'warn' && level !== 'error') return message
   return `${message}${summarizeAntflyFields(fields, ANTFLY_WARNING_DETAIL_KEYS)}`
@@ -110,7 +140,7 @@ export function parseAntflyLogLine(line: string, streamLevel: AntflyLogLevel): P
     ? parsedLevel
     : streamLevel
   const rawMessage = fields.msg || line
-  const level = isTransientReconcilerWarning(rawMessage, fields) ? 'debug' : rawLevel
+  const level = isExpectedStartupDebug(rawMessage, fields) ? 'debug' : rawLevel
 
   const data: Record<string, unknown> = { source: 'antfly', raw: line }
   for (const [key, value] of Object.entries(fields)) {

--- a/packages/adapter-antfly/src/server.ts
+++ b/packages/adapter-antfly/src/server.ts
@@ -45,15 +45,72 @@ function parseAntflyFields(line: string): Record<string, string> {
   return fields
 }
 
+const SHARD_INITIALIZING_ERROR = 'shard is still initializing'
+const TRANSIENT_RECONCILER_MESSAGES = new Set([
+  'Failed to add index',
+  'Failed to update schema',
+])
+const ANTFLY_WARNING_DETAIL_KEYS = [
+  'tableName',
+  'table',
+  'indexName',
+  'name',
+  'shardID',
+  'error',
+] as const
+
+function compactAntflyValue(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function summarizeAntflyFields(fields: Record<string, string>, keys: readonly string[]): string {
+  const parts: string[] = []
+  for (const key of keys) {
+    const value = fields[key]
+    if (!value) continue
+    parts.push(`${key}=${compactAntflyValue(value)}`)
+  }
+  return parts.length > 0 ? ` (${parts.join(', ')})` : ''
+}
+
+function isTransientReconcilerWarning(message: string, fields: Record<string, string>): boolean {
+  return TRANSIENT_RECONCILER_MESSAGES.has(message) && fields.error === SHARD_INITIALIZING_ERROR
+}
+
+function transientReconcilerMessage(message: string, fields: Record<string, string>): string {
+  if (message === 'Failed to add index') {
+    return `Antfly reconciler deferred index update until shard initialization completes${
+      summarizeAntflyFields(fields, ['indexName', 'shardID'])
+    }`
+  }
+  return `Antfly reconciler deferred schema update until shard initialization completes${
+    summarizeAntflyFields(fields, ['shardID'])
+  }`
+}
+
+function formatAntflyLogMessage(
+  message: string,
+  level: AntflyLogLevel,
+  fields: Record<string, string>,
+): string {
+  if (isTransientReconcilerWarning(message, fields)) {
+    return transientReconcilerMessage(message, fields)
+  }
+  if (level !== 'warn' && level !== 'error') return message
+  return `${message}${summarizeAntflyFields(fields, ANTFLY_WARNING_DETAIL_KEYS)}`
+}
+
 export function parseAntflyLogLine(line: string, streamLevel: AntflyLogLevel): ParsedAntflyLogLine {
   const fields = parseAntflyFields(line)
   const parsedLevel = fields.lvl
-  const level: AntflyLogLevel = parsedLevel === 'debug'
+  const rawLevel: AntflyLogLevel = parsedLevel === 'debug'
     || parsedLevel === 'info'
     || parsedLevel === 'warn'
     || parsedLevel === 'error'
     ? parsedLevel
     : streamLevel
+  const rawMessage = fields.msg || line
+  const level = isTransientReconcilerWarning(rawMessage, fields) ? 'debug' : rawLevel
 
   const data: Record<string, unknown> = { source: 'antfly', raw: line }
   for (const [key, value] of Object.entries(fields)) {
@@ -63,7 +120,7 @@ export function parseAntflyLogLine(line: string, streamLevel: AntflyLogLevel): P
 
   return {
     level,
-    message: fields.msg || line,
+    message: formatAntflyLogMessage(rawMessage, rawLevel, fields),
     data,
   }
 }

--- a/plugins/schedule/bakin-plugin.json
+++ b/plugins/schedule/bakin-plugin.json
@@ -26,6 +26,7 @@
     "storage.write",
     "events.emit",
     "runtime.read",
+    "runtime.agents",
     "runtime.cron",
     "search.read",
     "search.write"

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -13,6 +13,7 @@ import type { ApprovalActor, BakinPlugin, PluginContext } from '@bakin/core/plug
 import { defineRoute, definePlugin } from '@bakin/core/routing'
 import type { PluginContextLite } from '@bakin/core/routing'
 import { listDefinitions, loadDefinition, validateDefinition } from './lib/parser'
+import { workflowDefinitionNameFromHookInput } from './lib/hook-input'
 import { loadDefaultWorkflows } from './lib/load-defaults'
 import { workflowDefinitionSchema, listNodeTypes } from './lib/node-type-registry'
 import {
@@ -1495,7 +1496,10 @@ const workflowsPlugin: BakinPlugin = definePlugin({
     ctx.hooks.register('workflows.completeStep', (d: Record<string, unknown>) => completeStep(d.taskId as string, d.stepId as string, d.output as Record<string, unknown>, d.callerAgentId as string | undefined, d.contentDir as string | undefined), { label: 'Complete workflow step.', summary: 'Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.matchWorkflow', (d: Record<string, unknown>) => matchWorkflow(d.title as string, d.description as string | undefined), { label: 'Match workflow.', summary: 'Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.definitions.list', (d: Record<string, unknown>) => listDefinitions(d.contentDir as string | undefined), { label: 'List workflow definitions.', summary: 'Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.loadDefinition', (d: Record<string, unknown>) => loadDefinition(d.name as string, d.contentDir as string | undefined), { label: 'Load workflow definition.', summary: 'Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.', hookKind: 'rpc' })
+    ctx.hooks.register('workflows.loadDefinition', (d: Record<string, unknown>) => {
+      const name = workflowDefinitionNameFromHookInput(d)
+      return name ? loadDefinition(name, d.contentDir as string | undefined) : null
+    }, { label: 'Load workflow definition.', summary: 'Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.getActiveAgents', (d: Record<string, unknown>) => getActiveAgents(d.taskId as string, d.contentDir as string | undefined), { label: 'List active workflow agents.', summary: 'Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.authorizeToolUse', (d: Record<string, unknown>) => authorizeWorkflowToolUse(d.taskId as string, d.agent as string, d.action as WorkflowToolUseAction, d.contentDir as string | undefined), { label: 'Authorize workflow tool use.', summary: 'Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.isGateNotified', (d: Record<string, unknown>) => isGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Check gate notification.', summary: 'Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.', hookKind: 'rpc' })

--- a/plugins/workflows/lib/hook-input.ts
+++ b/plugins/workflows/lib/hook-input.ts
@@ -1,0 +1,5 @@
+export function workflowDefinitionNameFromHookInput(input: Record<string, unknown>): string | undefined {
+  if (typeof input.name === 'string' && input.name.length > 0) return input.name
+  if (typeof input.workflowId === 'string' && input.workflowId.length > 0) return input.workflowId
+  return undefined
+}

--- a/scripts/dev-log-classifier.ts
+++ b/scripts/dev-log-classifier.ts
@@ -1,0 +1,9 @@
+export function isBenignTailwindLine(line: string): boolean {
+  const trimmed = line.trim()
+  return !trimmed
+    || trimmed.startsWith('≈ tailwindcss')
+    || trimmed.startsWith('Done in ')
+    || trimmed === 'Resolving dependencies'
+    || /^Resolved, downloaded and extracted \[\d+\]$/.test(trimmed)
+    || trimmed === 'Saved lockfile'
+}

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -59,6 +59,7 @@ import chokidar from 'chokidar'
 
 import { broadcastDev, type DevEvent, type DevScope } from '../packages/host/src/api/dev/events'
 import { buildOnePlugin } from './dev-build-one-plugin'
+import { isBenignTailwindLine } from './dev-log-classifier'
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const PLUGINS_DIR = join(REPO_ROOT, 'plugins')
@@ -214,13 +215,6 @@ async function buildDevClient(): Promise<void> {
 // ---------- Tailwind child process --------------------------------------
 
 let tailwindChild: ChildProcess | null = null
-
-function isBenignTailwindLine(line: string): boolean {
-  return !line
-    || line.startsWith('≈ tailwindcss')
-    || line.startsWith('Done in ')
-    || line === 'Saved lockfile'
-}
 
 function startTailwindWatch(): void {
   devLog('build', 'tailwind', 'starting --watch=always...')

--- a/tests/adapter-antfly/server.test.ts
+++ b/tests/adapter-antfly/server.test.ts
@@ -65,4 +65,21 @@ describe('Antfly server log parsing', () => {
       'Failed to add index (indexName=embeddings, shardID=b009cb75eee1aa90, error=invalid vector dimension)',
     )
   })
+
+  it('demotes optional Termite model registry directory warnings', () => {
+    const parsed = parseAntflyLogLine(
+      'ts=19:54:17 lvl=warn caller=termite/chunker_registry.go:178 msg="Chunker models directory does not exist" dir=/Users/roscoe/.termite/models/chunkers',
+      'warn',
+    )
+
+    expect(parsed.level).toBe('debug')
+    expect(parsed.message).toBe(
+      'Antfly skipped optional Termite chunker registry with no local models (dir=/Users/roscoe/.termite/models/chunkers)',
+    )
+    expect(parsed.data).toMatchObject({
+      source: 'antfly',
+      caller: 'termite/chunker_registry.go:178',
+      dir: '/Users/roscoe/.termite/models/chunkers',
+    })
+  })
 })

--- a/tests/adapter-antfly/server.test.ts
+++ b/tests/adapter-antfly/server.test.ts
@@ -16,4 +16,53 @@ describe('Antfly server log parsing', () => {
       address: '0.0.0.0:8080',
     })
   })
+
+  it('demotes transient index reconciliation while a shard is initializing', () => {
+    const parsed = parseAntflyLogLine(
+      'ts=19:44:56 lvl=warn caller=reconciler/executor.go:300 msg="Failed to add index" shardID=b009cb75eee1aa90 indexName=embeddings error="shard is still initializing"',
+      'warn',
+    )
+
+    expect(parsed.level).toBe('debug')
+    expect(parsed.message).toBe(
+      'Antfly reconciler deferred index update until shard initialization completes (indexName=embeddings, shardID=b009cb75eee1aa90)',
+    )
+    expect(parsed.data).toMatchObject({
+      source: 'antfly',
+      caller: 'reconciler/executor.go:300',
+      shardID: 'b009cb75eee1aa90',
+      indexName: 'embeddings',
+      error: 'shard is still initializing',
+    })
+  })
+
+  it('demotes transient schema reconciliation while a shard is initializing', () => {
+    const parsed = parseAntflyLogLine(
+      'ts=19:44:57 lvl=warn caller=reconciler/executor.go:326 msg="Failed to update schema" shardID=b009cb75eee1aa90 error="shard is still initializing"',
+      'warn',
+    )
+
+    expect(parsed.level).toBe('debug')
+    expect(parsed.message).toBe(
+      'Antfly reconciler deferred schema update until shard initialization completes (shardID=b009cb75eee1aa90)',
+    )
+    expect(parsed.data).toMatchObject({
+      source: 'antfly',
+      caller: 'reconciler/executor.go:326',
+      shardID: 'b009cb75eee1aa90',
+      error: 'shard is still initializing',
+    })
+  })
+
+  it('keeps non-transient warnings visible with useful Antfly fields', () => {
+    const parsed = parseAntflyLogLine(
+      'ts=19:44:56 lvl=warn caller=reconciler/executor.go:300 msg="Failed to add index" shardID=b009cb75eee1aa90 indexName=embeddings error="invalid vector dimension"',
+      'warn',
+    )
+
+    expect(parsed.level).toBe('warn')
+    expect(parsed.message).toBe(
+      'Failed to add index (indexName=embeddings, shardID=b009cb75eee1aa90, error=invalid vector dimension)',
+    )
+  })
 })

--- a/tests/plugins/lifecycle/permissions-smoke.test.ts
+++ b/tests/plugins/lifecycle/permissions-smoke.test.ts
@@ -5,7 +5,7 @@
  * suggestion, newPermissions diff. Full coverage in C10.
  */
 import { describe, it, expect, afterAll, mock } from 'bun:test'
-import { rmSync } from 'fs'
+import { readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { randomUUID } from 'crypto'
@@ -124,5 +124,15 @@ describe('suggestPermission', () => {
   it('returns null when no known permission is close enough', () => {
     expect(suggestPermission('network.fetch')).toBe(null)
     expect(suggestPermission('completely.different.thing')).toBe(null)
+  })
+})
+
+describe('core plugin manifests', () => {
+  it('schedule declares runtime agent access used for owner defaults', () => {
+    const manifest = JSON.parse(
+      readFileSync(join(import.meta.dir, '../../../plugins/schedule/bakin-plugin.json'), 'utf-8'),
+    ) as { permissions?: string[] }
+
+    expect(manifest.permissions).toContain('runtime.agents')
   })
 })

--- a/tests/plugins/workflows/hook-input.test.ts
+++ b/tests/plugins/workflows/hook-input.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+import { workflowDefinitionNameFromHookInput } from '../../../plugins/workflows/lib/hook-input'
+
+describe('workflow hook input helpers', () => {
+  it('accepts workflowId as an alias for definition name', () => {
+    expect(workflowDefinitionNameFromHookInput({ workflowId: 'messaging-image-post-prep' }))
+      .toBe('messaging-image-post-prep')
+  })
+
+  it('prefers explicit name over workflowId', () => {
+    expect(workflowDefinitionNameFromHookInput({ name: 'canonical', workflowId: 'legacy' }))
+      .toBe('canonical')
+  })
+})

--- a/tests/scripts/dev-log-classifier.test.ts
+++ b/tests/scripts/dev-log-classifier.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test'
+import { isBenignTailwindLine } from '../../scripts/dev-log-classifier'
+
+describe('dev log classifier', () => {
+  it('suppresses normal Tailwind and bunx dependency progress lines', () => {
+    expect(isBenignTailwindLine('≈ tailwindcss v4.1.7')).toBe(true)
+    expect(isBenignTailwindLine('Done in 120ms')).toBe(true)
+    expect(isBenignTailwindLine('Resolving dependencies')).toBe(true)
+    expect(isBenignTailwindLine('Resolved, downloaded and extracted [2]')).toBe(true)
+    expect(isBenignTailwindLine('Saved lockfile')).toBe(true)
+  })
+
+  it('keeps real Tailwind stderr lines visible', () => {
+    expect(isBenignTailwindLine('Cannot apply unknown utility class: text-brand')).toBe(false)
+  })
+})


### PR DESCRIPTION
Summary: Demotes expected Antfly startup reconciliation and optional Termite registry messages to debug while preserving details for real Antfly warnings. Suppresses benign Tailwind and bunx dependency progress from dev watcher warnings. Declares schedule runtime agent permission and lets workflows.loadDefinition accept workflowId as a compatibility alias. Review note: Messaging ready-time workflow validation depends on the workflowId alias in this PR. Tests: bun test tests/plugins/lifecycle/permissions-smoke.test.ts tests/plugins/workflows/hook-input.test.ts tests/adapter-antfly/server.test.ts tests/scripts/dev-log-classifier.test.ts, bun run typecheck, bun run lint, git diff --check.