### PR TITLE
Fix live messaging tool activity

### DIFF
--- a/.claude/knowledge/adapter-architecture.md
+++ b/.claude/knowledge/adapter-architecture.md
@@ -119,6 +119,18 @@ into runtime provider metadata. The runtime may expose execution status through
 `runtime.tasks.*`, but task title, column, priority, blockers, workflow state,
 and logs belong to the Bakin task store.
 
+## Runtime Messaging Streams
+
+Messaging callers pass stable Bakin `threadId` values such as
+`messaging:<sessionId>:<agentId>` through `runtime.messaging.stream()`. The
+OpenClaw adapter maps those to provider session ids and tails the provider
+transcript while the Gateway request is pending so tool calls/results become
+`ChatChunk { type: 'tool' }` events before final assistant text. OpenClaw may
+store the live transcript entry under `agent:<agentId>:explicit:<uuid>` in
+`sessions.json`; the adapter owns that provider-specific lookup. Plugins and UI
+code must continue to consume normalized runtime chunks instead of reading
+OpenClaw session files directly.
+
 ## Approvals And Channels
 
 Workflow approvals persist as Bakin-owned durable records. Runtime channel

--- a/.claude/specs/messaging-live-tool-activity.md
+++ b/.claude/specs/messaging-live-tool-activity.md
@@ -1,0 +1,141 @@
+# Spec: Messaging Live Tool Activity
+
+## Objective
+
+Restore real-time tool/progress visibility in the Messaging brainstorm chat.
+When a runtime agent calls tools during a brainstorm turn, the UI must show
+activity rows as the calls/results happen, before the final assistant reply.
+
+The exact regression is in the OpenClaw runtime adapter transcript lookup.
+Bakin passes a stable runtime thread id such as `messaging:8f3ee82f:scout`.
+The adapter converts that to a deterministic OpenClaw UUID, but current
+OpenClaw records the live transcript in `sessions.json` under
+`agent:<agentId>:explicit:<uuid>`. Bakin only checks the raw thread id, the
+UUID, and `agent:<agentId>:<uuid>`, so the live transcript watcher never
+attaches for these runs.
+
+## Tech Stack
+
+- TypeScript
+- Bun test runner
+- OpenClaw runtime adapter in `packages/adapter-openclaw`
+- Messaging UI route and SSE bridge in linked official plugin source
+- Integrated brainstorm UI in `src/components/integrated-brainstorm`
+
+## Commands
+
+- Target adapter regression: `bun test tests/adapter-openclaw/runtime-stream.test.ts --timeout 20000`
+- Target messaging bridge: `bun test plugins/messaging/tests/streaming.test.ts --timeout 20000` from `../bakin-bits-official`
+- Target UI activity handling: `bun test tests/components/integrated-brainstorm/send-streaming.test.tsx tests/components/integrated-brainstorm/activity-helpers.test.ts`
+- Broader relevant check: `bun test tests/adapter-openclaw/runtime-stream.test.ts tests/components/integrated-brainstorm/send-streaming.test.tsx tests/components/integrated-brainstorm/activity-helpers.test.ts`
+
+## Project Structure
+
+- `packages/adapter-openclaw/src/runtime.ts` owns runtime streaming and transcript activity parsing.
+- `tests/adapter-openclaw/runtime-stream.test.ts` owns the adapter-level streaming contract.
+- `src/components/integrated-brainstorm/*` owns chat activity rendering and SSE parsing.
+- `.claude/knowledge/messaging-plugin.md` and `.claude/knowledge/adapter-architecture.md` document the durable/session boundary.
+- Official messaging plugin source is linked from `/Users/roscoe/go/src/github.com/markhayden/bakin-bits-official/plugins/messaging`.
+
+## Code Style
+
+Keep the fix direct and adapter-local:
+
+```ts
+return store[sessionKey]
+  ?? store[cliSessionId]
+  ?? store[`agent:${agentId}:explicit:${cliSessionId}`]
+  ?? store[`agent:${agentId}:${cliSessionId}`]
+```
+
+Prefer a small resolver extension over new abstractions. The transcript parser,
+activity mapper, and UI renderer already exist and should stay unchanged unless
+tests prove another break.
+
+## Testing Strategy
+
+- Add a failing adapter regression test that writes `sessions.json` with the
+  current OpenClaw `agent:<agentId>:explicit:<uuid>` key and asserts a tool
+  activity chunk is emitted before the final Gateway response.
+- Keep existing messaging plugin tests as bridge coverage: runtime `tool`
+  chunks must become `event: activity` and persisted `activity` messages.
+- Keep existing integrated brainstorm tests as UI coverage: `activity` SSE
+  events must render during send and remain after the final reply.
+- If the browser surface is touched, verify manually in the running UI after
+  target tests pass.
+
+## Boundaries
+
+- Always: preserve the stable Bakin `threadId` contract; keep tool activity out
+  of searchable `message_body`; run target tests.
+- Ask first: editing the linked `bakin-bits-official` plugin source, changing
+  runtime session id semantics, or changing visible activity UI layout.
+- Never: restore legacy core messaging paths, bypass the runtime adapter, read
+  provider state from the messaging plugin, or add compatibility shims outside
+  the adapter boundary.
+
+## Success Criteria
+
+- A runtime transcript stored under `agent:<agentId>:explicit:<uuid>` is found
+  by the adapter using the Bakin stable thread id.
+- Tool call/result transcript rows stream as `ChatChunk { type: "tool" }`
+  before the final assistant text arrives.
+- Messaging SSE continues to forward those chunks as `event: activity`.
+- The integrated brainstorm UI continues to render activity rows during send.
+- Existing activity, proposal, and final-answer behavior remains unchanged.
+
+## Implementation Plan
+
+### Task 1: Adapter Regression Test
+
+Acceptance:
+- `runtime.messaging.stream()` emits a tool activity chunk when OpenClaw stores
+  the transcript under `agent:<agentId>:explicit:<uuid>`.
+- The first emitted chunk arrives before the Gateway final response.
+
+Verify:
+- `bun test tests/adapter-openclaw/runtime-stream.test.ts --timeout 20000`
+
+Files:
+- `tests/adapter-openclaw/runtime-stream.test.ts`
+
+### Task 2: Resolver Fix
+
+Acceptance:
+- `resolveOpenClawSessionFile()` resolves the explicit session store key.
+- Existing raw/UUID/store-key lookup behavior stays passing.
+
+Verify:
+- `bun test tests/adapter-openclaw/runtime-stream.test.ts --timeout 20000`
+
+Files:
+- `packages/adapter-openclaw/src/runtime.ts`
+
+### Task 3: Bridge/UI Regression Sweep
+
+Acceptance:
+- Messaging bridge still emits activity SSE and persists activity messages.
+- Integrated brainstorm still renders custom activity events.
+
+Verify:
+- `bun test plugins/messaging/tests/streaming.test.ts --timeout 20000` in `../bakin-bits-official`
+- `bun test tests/components/integrated-brainstorm/send-streaming.test.tsx tests/components/integrated-brainstorm/activity-helpers.test.ts`
+
+Files:
+- No expected changes unless tests reveal a second issue.
+
+## Commit Strategy
+
+1. Commit adapter regression test and resolver fix together.
+   - Rollback point: reverts only OpenClaw transcript lookup.
+   - Verification: adapter stream test passes.
+2. Commit docs/spec updates if follow-up documentation changes are needed.
+   - Rollback point: documentation only.
+   - Verification: no code test required beyond prior checkpoint.
+
+## Open Question
+
+Do we keep the fix strictly adapter-local, or also add a same-turn browser
+smoke test for the Messaging page? Recommendation: adapter-local for this
+change because the root cause is resolved before the plugin/UI boundary and the
+existing UI tests already cover `activity` rendering.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1756,6 +1756,7 @@ function findOpenClawSessionStoreEntry(
   const cliSessionId = openClawCliSessionId(agentId, sessionKey)
   return store[sessionKey]
     ?? store[cliSessionId]
+    ?? store[`agent:${agentId}:explicit:${cliSessionId}`]
     ?? store[`agent:${agentId}:${cliSessionId}`]
 }
 

--- a/src/components/integrated-brainstorm/thinking-indicator.tsx
+++ b/src/components/integrated-brainstorm/thinking-indicator.tsx
@@ -23,7 +23,7 @@ export function ThinkingIndicator({ agentId, verb }: ThinkingIndicatorProps) {
   return (
     <div
       data-testid="thinking-indicator"
-      className="flex items-center gap-2.5 text-muted-foreground"
+      className="mt-[5px] flex items-center gap-2.5 text-muted-foreground"
       aria-live="polite"
     >
       <AgentAvatar agentId={agentId} size="sm" className="shrink-0" />

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -353,6 +353,85 @@ describe('OpenClaw runtime Gateway chat', () => {
     expect(remaining).toContainEqual({ type: 'done' })
   })
 
+  it('finds transcript activity stored under OpenClaw explicit session keys', async () => {
+    const sessionKey = 'messaging:session-explicit:main'
+    const sessionsDir = join(testDir, 'agents', 'main', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    let sessionFile = ''
+
+    let gatewayResolved = false
+    FakeWebSocket.onRequest = (frame, ws) => {
+      if (frame.method !== 'agent') return
+      const openClawSessionId = String(frame.params.sessionId)
+      sessionFile = join(sessionsDir, `${openClawSessionId}.jsonl`)
+      writeFileSync(sessionFile, [
+        JSON.stringify({ type: 'session', id: openClawSessionId }),
+        '',
+      ].join('\n'), 'utf-8')
+      writeFileSync(join(sessionsDir, 'sessions.json'), JSON.stringify({
+        [`agent:main:explicit:${openClawSessionId}`]: {
+          sessionId: openClawSessionId,
+          sessionFile,
+        },
+      }), 'utf-8')
+      setTimeout(() => {
+        appendFileSync(sessionFile, `${JSON.stringify({
+          type: 'message',
+          message: {
+            role: 'assistant',
+            content: [{
+              type: 'toolCall',
+              id: 'call-explicit',
+              name: 'exec',
+              arguments: { command: 'mcporter call bakin-main.bakin_exec_messaging_session_get --args {"sessionId":"session-explicit"}' },
+            }],
+          },
+        })}\n`)
+      }, 20)
+      setTimeout(() => {
+        gatewayResolved = true
+        ws.emitMessage({ type: 'res', id: frame.id, ok: true, payload: gatewayAgentPayload('Final reply.') })
+      }, 800)
+    }
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const iterator = runtime.messaging.stream({
+      agentId: 'main',
+      content: 'hello',
+      threadId: sessionKey,
+    })[Symbol.asyncIterator]()
+
+    const first = await Promise.race([
+      iterator.next(),
+      wait(500).then(() => 'timeout' as const),
+    ])
+
+    expect(first).not.toBe('timeout')
+    expect(gatewayResolved).toBe(false)
+    if (first !== 'timeout') {
+      expect(first.value).toEqual({
+        type: 'tool',
+        content: 'exec: mcporter call bakin-main.bakin_exec_messaging_session_get --args {"sessionId":"session-explicit"}',
+        data: {
+          phase: 'call',
+          callId: 'call-explicit',
+          toolName: 'exec',
+          status: 'running',
+          summary: 'Updating messaging content',
+          inputPreview: '{"command":"mcporter call bakin-main.bakin_exec_messaging_session_get --args {\\"sessionId\\":\\"session-explicit\\"}"}',
+        },
+      })
+    }
+
+    const remaining: unknown[] = []
+    for await (const chunk of { [Symbol.asyncIterator]: () => iterator }) {
+      remaining.push(chunk)
+    }
+    expect(remaining).toContainEqual({ type: 'text', content: 'Final reply.' })
+    expect(remaining).toContainEqual({ type: 'done' })
+  })
+
   it('summarizes transcript web fetch tools without leaking query secrets', async () => {
     const sessionsDir = join(testDir, 'agents', 'main', 'sessions')
     mkdirSync(sessionsDir, { recursive: true })


### PR DESCRIPTION
## Summary
- Restore OpenClaw explicit-session transcript lookup so messaging streams emit tool activity before final assistant replies.
- Add adapter regression coverage and document the runtime/plugin boundary.
- Add a small top margin to the transient thinking indicator after activity rows.

## Code Review
- Findings: none blocking. The change is adapter-local, preserves existing lookup fallbacks, and keeps plugin/UI activity handling on normalized runtime chunks.
- Scope note: the pre-existing packages/host/src/api/_embedded-assets-static.ts worktree change is intentionally not included.

## Verification
- bun test tests/adapter-openclaw/runtime-stream.test.ts --timeout 20000
- bun test tests/components/integrated-brainstorm/send-streaming.test.tsx tests/components/integrated-brainstorm/activity-helpers.test.ts
- bun test tests/components/integrated-brainstorm/agent-focus-a11y.test.tsx
- bun test plugins/messaging/tests/streaming.test.ts --timeout 20000 (from ../bakin-bits-official)
- git diff --check