### PR TITLE
Add explicit doctor repair workflows

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -211,7 +211,7 @@ fresh runtime agent with the same id, risking the user's existing setup.
 
 `plugins/team/lib/health-checks.ts:checkAgentAssets()` surfaces drift in the
 team-owned health checks. It delegates to
-`src/core/onboarding/agent-assets.ts`; with auto-fix enabled, drift triggers the
+`src/core/onboarding/agent-assets.ts`; explicit doctor repair flows trigger the
 standard install/update projection flow (workspace files stay
 templateOnly-protected; everything else re-projects through runtime adapters).
 

--- a/.claude/knowledge/doctor-and-health-checks.md
+++ b/.claude/knowledge/doctor-and-health-checks.md
@@ -82,12 +82,9 @@ The registry namespaces ids: a plugin with `id: 'team'` registering a check with
    function error(check: string, message: string): HealthCheckResult { ... }
    function fixed(check: string, message: string): HealthCheckResult { ... }
    ```
-2. Write the check function. Read settings inline:
+2. Write the check function. Keep it report-only:
    ```ts
-   import { getSettings } from '../../../src/core/settings'
-
    export function checkMyThing(): HealthCheckResult[] {
-     const autoFix = getSettings().doctor.autoFixSkill
      // ...
    }
    ```
@@ -96,11 +93,12 @@ The registry namespaces ids: a plugin with `id: 'team'` registering a check with
    ctx.registerHealthCheck({
      id: 'my-thing',
      name: 'Friendly description shown in admin UIs',
-     autoFix: true, // metadata only — orchestrator runs every check
      run: () => Promise.resolve(checkMyThing()),
+     repair: myThingRepair(), // optional; only called by explicit repair flows
    })
    ```
-4. Don't catch your own errors — the orchestrator's try/catch handles them. Throw freely.
+4. If the check is repairable, expose a `HealthRepairHandler` with `plan()` and `apply()`. Diagnostics must not mutate state; `bakin doctor --fix` and delegated repair flows are the only callers that apply repairs.
+5. Don't catch your own errors — the orchestrator's try/catch handles them. Throw freely.
 
 ## Authoring a system check (in the health plugin)
 
@@ -128,7 +126,6 @@ Projection shape after #208:
 
 Doctor settings stay in core `~/.bakin/settings.json` under `settings.doctor.*`:
 - `intervalMs` — cron period (default 30 minutes)
-- `autoFixSkill` — global autoFix flag, read inline by every check that supports auto-fix
 - `requireOnboard` — gate that returns a single `onboarded` error result when the machine isn't onboarded yet
 
 These remain core settings (not per-plugin) because the doctor cron itself is core-owned and `requireOnboard` is a global gate.
@@ -155,7 +152,8 @@ export interface PluginHealthCheckInput {
   id: string
   name: string
   run: () => Promise<HealthCheckResult[]>
-  autoFix?: boolean   // metadata-only flag for admin UIs
+  repair?: HealthRepairHandler
+  autoFix?: boolean   // legacy metadata only; don't use for new checks
 }
 ```
 

--- a/.claude/knowledge/team-plugin.md
+++ b/.claude/knowledge/team-plugin.md
@@ -306,8 +306,8 @@ If a future iteration restores any of these, prefer adding back via new componen
 Team registers three checks via `ctx.registerHealthCheck` in `activate()`:
 
 - **`agent-roster`** — diff Bakin's agent ids against the active runtime adapter roster. Not auto-fixable (requires human judgment about which side is "right").
-- **`personas`** — verify each agent has a `team/personas/{agent}.md` file. Auto-fixable: under `settings.doctor.autoFixSkill=true` it stubs missing files.
-- **`agent-assets`** — wraps `agentAssetsComponent.check()` from `src/core/onboarding/agent-assets.ts` to surface drift in projected agent-package files. Auto-fixable: under autoFix, runs the same install flow as `bakin install agent-assets`.
+- **`personas`** — verify each agent has a `team/personas/{agent}.md` file. Repairable through the explicit doctor repair workflow, which stubs missing files.
+- **`agent-assets`** — wraps `agentAssetsComponent.check()` from `src/core/onboarding/agent-assets.ts` to surface drift in projected agent-package files. Repairable through explicit doctor repair flows, which run the same install flow as `bakin install agent-assets`.
 
 All three live at `plugins/team/lib/health-checks.ts`. Migrated out of `src/core/doctor.ts` in #139 C1. Deep reference: `.claude/knowledge/doctor-and-health-checks.md`.
 

--- a/.claude/specs/doctor-repair-workflows-plan.md
+++ b/.claude/specs/doctor-repair-workflows-plan.md
@@ -1,0 +1,543 @@
+# Implementation Plan: Doctor Repair Workflows
+
+Companion spec: `.claude/specs/doctor-repair-workflows.md`.
+
+## Overview
+
+Implement #268 and #269 as one repair architecture with two explicit entry
+points: deterministic local repair via `bakin doctor --fix`, and tracked
+agent-assisted repair via `bakin doctor --delegate`. The first half removes the
+current hidden `settings.doctor.autoFixSkill` mutation path. The second half
+adds durable delegated request tracking and status inspection.
+
+## Architecture Decisions
+
+- Diagnostic checks stay pure: `run()` reports only.
+- Repair is an explicit optional contract on health-check definitions.
+- Repairability is derived from the presence of `repair`, not from the existing
+  metadata-only `autoFix` flag.
+- Deterministic repair applies only `safe` plan items.
+- Delegation is not a deterministic repair claim; message delivery means
+  `sent`, task completion means `completed`, and doctor verification means
+  `verified`.
+- Delegated repair request state is Bakin-owned JSON under
+  `~/.bakin/doctor/repair-requests/`.
+- Delegated repair creates a linked task in `todo` assigned to `main`, then
+  kicks immediate dispatch so the normal dispatcher moves it to `inProgress`
+  when the agent is contacted.
+
+## Dependency Graph
+
+```text
+Repair contracts and detailed check execution
+  -> split existing embedded auto-fixes into repair handlers
+    -> deterministic repair service
+      -> health routes
+        -> CLI --fix and JSON/TTY guards
+          -> docs and generated references
+
+Delegated request store
+  -> repair brief builder
+    -> runtime send + linked task
+      -> CLI --delegate
+        -> repair list/show/verify
+          -> docs and knowledge update
+```
+
+## Phase 0: Baseline And Regression Characterization
+
+### Task 1: Capture Current Mutating Paths
+
+**Description:** Inventory every current `settings.doctor.autoFixSkill` reader
+and add focused failing tests that prove normal diagnostics must not mutate.
+
+**Acceptance criteria:**
+
+- Every current auto-fix reader is listed in the implementation notes.
+- At least one core regression test fails on the current branch if normal doctor
+  mutates.
+- Tests identify the expected future surface: repair is explicit, diagnostics
+  are report-only.
+
+**Verification:**
+
+```bash
+rg -n "autoFixSkill|getSettings\\(\\)\\.doctor" src plugins packages
+bun test --isolate tests/core/doctor.test.ts tests/core/doctor-plugin-checks.test.ts
+```
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `tests/core/doctor.test.ts`
+- `tests/core/doctor-plugin-checks.test.ts`
+
+**Estimated scope:** Small
+
+## Phase 1: Repair Contract Foundation
+
+### Task 2: Add Explicit Repair Types And Detailed Check Execution
+
+**Description:** Add repair plan/apply types to core and SDK, then expose a
+detailed health-check execution helper that preserves which registered
+definition produced each result row.
+
+**Acceptance criteria:**
+
+- `PluginHealthCheckInput` accepts optional `repair`.
+- `runPluginHealthChecks()` keeps its public flattened result behavior.
+- A new internal helper returns `{ def, results }[]` for repair planning.
+- Throw/rejection isolation still works per check.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/doctor-plugin-checks.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 1
+
+**Files likely touched:**
+
+- `packages/core/src/plugin-types.ts`
+- `packages/sdk/src/types/index.ts`
+- `src/core/health-check-registry.ts`
+- `src/core/doctor.ts`
+- `tests/core/doctor-plugin-checks.test.ts`
+
+**Estimated scope:** Medium
+
+### Task 3: Delete `doctor.autoFixSkill` As A Behavior Flag
+
+**Description:** Remove the settings-backed auto-fix switch and update
+diagnostic checks so `run()` never applies repairs.
+
+**Acceptance criteria:**
+
+- No check reads `settings.doctor.autoFixSkill`.
+- Normal doctor runs cannot return `fixed` from migrated checks.
+- Settings defaults and generated settings docs no longer advertise
+  `doctor.autoFixSkill`.
+
+**Verification:**
+
+```bash
+rg -n "autoFixSkill" src plugins packages docs .claude
+bun test --isolate tests/core/doctor.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 2
+
+**Files likely touched:**
+
+- `packages/core/src/settings.ts`
+- `docs/src/content/docs/reference/generated/settings.md`
+- `docs/src/content/docs/using/health.md`
+- `.claude/knowledge/doctor-and-health-checks.md`
+- all plugin health-check files that currently read `autoFixSkill`
+
+**Estimated scope:** Medium
+
+## Phase 2: Check-Owned Deterministic Repair
+
+### Task 4: Convert Existing Safe Auto-Fixes Into Repair Handlers
+
+**Description:** Move each existing safe embedded auto-fix branch into a
+check-owned `repair.plan/apply` handler. Keep ambiguous/destructive work as
+manual remediation only.
+
+**Acceptance criteria:**
+
+- Existing safe repairs are still available through `repair`.
+- Repair plans report exact change targets before mutation.
+- Unsafe or ambiguous cases return no safe plan item.
+- Plugin registration no longer uses metadata-only `autoFix`.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/plugins/health tests/plugins/tasks tests/plugins/team tests/plugins/assets tests/plugins/schedule tests/plugins/workflows
+bun run typecheck
+```
+
+**Dependencies:** Task 3
+
+**Files likely touched:**
+
+- `plugins/health/lib/system-checks/mcporter.ts`
+- `plugins/health/lib/system-checks/sync-skill.ts`
+- `src/core/agent-rules/managed-blocks.ts`
+- `plugins/tasks/lib/health-checks.ts`
+- `plugins/team/lib/health-checks.ts`
+- `plugins/assets/lib/health-checks.ts`
+- `plugins/schedule/lib/health-checks.ts`
+- `plugins/workflows/lib/health-checks.ts`
+- plugin `index.ts` registrations
+
+**Estimated scope:** Large, split by plugin owner if needed
+
+### Task 5: Add Deterministic Repair Service
+
+**Description:** Implement the core service that plans, applies, audits, and
+verifies deterministic repair attempts.
+
+**Acceptance criteria:**
+
+- Planning runs diagnostics and returns safe/manual/destructive categories.
+- Applying requires an explicit accepted/yes input at the service boundary.
+- Handler failures are isolated.
+- Affected checks rerun after apply.
+- Results include changed targets and failed remediation.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/doctor-repair.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 4
+
+**Files likely touched:**
+
+- `src/core/doctor-repair.ts`
+- `src/core/audit.ts` call sites only
+- `tests/core/doctor-repair.test.ts`
+
+**Estimated scope:** Medium
+
+### Checkpoint: Deterministic Core
+
+- Diagnostic doctor is report-only.
+- All existing safe embedded auto-fixes have explicit repair handlers.
+- `doctor-repair` core tests pass.
+- Typecheck passes.
+
+## Phase 3: API And CLI For `doctor --fix`
+
+### Task 6: Add Health Plugin Repair Routes
+
+**Description:** Add server-backed plan/apply routes under the health plugin.
+These routes are called by the CLI; do not add an MCP repair exec tool in the
+first pass.
+
+**Acceptance criteria:**
+
+- A plan route returns diagnostics plus repair plan without mutation.
+- An apply route requires accepted confirmation and applies safe items only.
+- API schemas cover JSON output for plan, apply results, and verification.
+- Route failures are concise and actionable.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/plugins/health/routes.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 5
+
+**Files likely touched:**
+
+- `plugins/health/index.ts`
+- `tests/plugins/health/routes.test.ts`
+
+**Estimated scope:** Medium
+
+### Task 7: Add CLI `bakin doctor --fix`
+
+**Description:** Wire CLI flags, TTY confirmation, non-TTY/JSON `--yes` guards,
+plain output, Ink output, and JSON envelopes for deterministic repair.
+
+**Acceptance criteria:**
+
+- `bakin doctor --fix` shows a plan before mutation in TTY.
+- `bakin doctor --fix --yes` applies without prompting.
+- `bakin doctor --fix --json` never mutates without `--yes`.
+- Non-TTY without `--yes` never mutates.
+- Exit codes distinguish success, warnings, repair failures, and confirmation
+  required.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/cli/doctor-ui.test.tsx tests/cli
+bun run typecheck
+```
+
+**Dependencies:** Task 6
+
+**Files likely touched:**
+
+- `cli/bakin.ts`
+- `src/core/cli/ui/doctor.tsx`
+- `tests/cli/doctor-ui.test.tsx`
+- CLI parser/runner tests
+
+**Estimated scope:** Medium
+
+### Checkpoint: Issue #268
+
+- `bakin doctor` report-only.
+- `bakin doctor --fix` is the only deterministic repair command.
+- JSON and non-TTY mutation guards pass.
+- Focused plugin repair tests pass.
+- Docs/knowledge are updated enough for #268.
+
+## Phase 4: Delegated Repair State And Briefs
+
+### Task 8: Add Doctor Repair Request Store
+
+**Description:** Implement an atomic file-backed store for delegated repair
+requests.
+
+**Acceptance criteria:**
+
+- Requests are written as one JSON file per id under month shards.
+- Store supports create, update, get, list, append event.
+- Malformed files are surfaced as read errors with file paths.
+- Tests use temp BAKIN_HOME and never touch real `~/.bakin`.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/doctor-delegate.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 5
+
+**Files likely touched:**
+
+- `src/core/doctor-repair-store.ts`
+- `tests/core/doctor-delegate.test.ts`
+- `packages/core/src/content-dir.ts` if adding `doctor` to `BakinPaths`
+
+**Estimated scope:** Medium
+
+### Task 9: Build Delegated Repair Briefs
+
+**Description:** Build a structured, deterministic brief from unresolved doctor
+rows and skipped deterministic repair items.
+
+**Acceptance criteria:**
+
+- Brief includes request id, timestamp, selected issues, skipped deterministic
+  repairs, verification instructions, and constraints.
+- Brief does not include raw secrets or provider-owned file paths unless already
+  present in doctor output.
+- Empty delegation candidates return a clear no-op result.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/doctor-delegate.test.ts
+```
+
+**Dependencies:** Task 8
+
+**Files likely touched:**
+
+- `src/core/doctor-delegate.ts`
+- `tests/core/doctor-delegate.test.ts`
+
+**Estimated scope:** Small
+
+### Task 10: Send Delegated Repair Requests
+
+**Description:** Check runtime reachability, resolve the main agent, create the
+linked board task, kick immediate dispatch, and record request status/events.
+
+**Acceptance criteria:**
+
+- Runtime unreachable means no message is sent and the request records failure.
+- Successful `runtime.messaging.send()` marks request `sent`, not `completed`.
+- The linked task is created in `todo`, assigned to the main agent, and includes
+  the repair brief in its description.
+- Immediate dispatch is triggered so the user sees the normal board transition
+  from `todo` to `inProgress` when the agent picks it up.
+- Linked task uses `source.pluginId = "health"` and
+  `source.entityType = "doctor-repair"`.
+- Status can be derived from request + linked task.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/doctor-delegate.test.ts tests/core/task-store.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 9
+
+**Files likely touched:**
+
+- `src/core/doctor-delegate.ts`
+- `src/core/task-service.ts` call sites only
+- `tests/core/doctor-delegate.test.ts`
+
+**Estimated scope:** Medium
+
+## Phase 5: API And CLI For `doctor --delegate`
+
+### Task 11: Add Delegate And Repair History Routes
+
+**Description:** Add health plugin routes for delegation, listing requests,
+showing one request, and verifying one request.
+
+**Acceptance criteria:**
+
+- Delegate route requires explicit accepted confirmation to send.
+- List/show routes expose durable request status.
+- Verify route reruns doctor and updates request verification.
+- Runtime failures return clear JSON errors.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/plugins/health/routes.test.ts tests/core/doctor-delegate.test.ts
+bun run typecheck
+```
+
+**Dependencies:** Task 10
+
+**Files likely touched:**
+
+- `plugins/health/index.ts`
+- `tests/plugins/health/routes.test.ts`
+
+**Estimated scope:** Medium
+
+### Task 12: Add CLI `--delegate` And `doctor repair` Subcommands
+
+**Description:** Wire the delegated repair command and request inspection
+commands into the CLI.
+
+**Acceptance criteria:**
+
+- `bakin doctor --delegate` renders selected issues and asks before sending.
+- `--delegate --json` requires `--yes` before sending.
+- `bakin doctor repair list` shows recent requests.
+- `bakin doctor repair show <id>` shows request, task, and verification status.
+- `bakin doctor repair verify <id>` reruns doctor and persists verification.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/cli tests/cli/doctor-ui.test.tsx
+bun run typecheck
+```
+
+**Dependencies:** Task 11
+
+**Files likely touched:**
+
+- `cli/bakin.ts`
+- `src/core/cli/ui/doctor.tsx`
+- CLI parser/runner tests
+
+**Estimated scope:** Medium
+
+### Checkpoint: Issue #269
+
+- Normal doctor and notify-agent remain report-only.
+- `--delegate` is explicit and tracked.
+- Runtime failures are clear and non-spammy.
+- Fresh/offline installs do not delegate unless runtime is reachable.
+- Repair request list/show/verify works in text and JSON.
+
+## Phase 6: Documentation And Cleanup
+
+### Task 13: Update Docs, Knowledge, And Generated References
+
+**Description:** Update user docs, agent knowledge, generated settings/API/CLI
+references, and remove stale auto-fix language.
+
+**Acceptance criteria:**
+
+- Health docs document `--fix`, `--delegate`, `--yes`, JSON behavior, and
+  repair history commands.
+- `.claude/knowledge/doctor-and-health-checks.md` describes the report-only
+  diagnostic contract and repair/delegation architecture.
+- Generated settings docs no longer list `doctor.autoFixSkill`.
+- Generated API/CLI docs include new routes/commands.
+
+**Verification:**
+
+```bash
+bun run docs:generate
+bun run docs:validate
+bun test --isolate tests/cli tests/plugins/health/routes.test.ts
+```
+
+**Dependencies:** Tasks 7 and 12
+
+**Files likely touched:**
+
+- `docs/src/content/docs/using/health.md`
+- `docs/src/content/docs/reference/generated/*`
+- `.claude/knowledge/doctor-and-health-checks.md`
+- `.claude/knowledge/storage-model.md`
+- `README.md` only if command list needs updating
+
+**Estimated scope:** Medium
+
+## Commit Strategy
+
+1. `test: characterize report-only doctor repair boundaries`
+   - Adds failing/protective tests and inventory notes.
+   - Verification: focused core doctor tests.
+   - Rollback: safe, tests only.
+
+2. `feat: add health repair contracts`
+   - Adds repair types and detailed check execution.
+   - Verification: doctor plugin-check tests, typecheck.
+   - Rollback: safe if no plugin conversions have landed.
+
+3. `refactor: make health checks report-only`
+   - Deletes `doctor.autoFixSkill` behavior and converts embedded auto-fix
+     branches into explicit repair handlers.
+   - Verification: focused plugin health tests, typecheck.
+   - Rollback: revert with commit 2 if contract changes need rework.
+
+4. `feat: implement doctor --fix workflow`
+   - Adds repair service, health routes, CLI flag, confirmation guards.
+   - Verification: doctor-repair, health routes, CLI tests.
+   - Rollback: deterministic repair surface only; diagnostic purity remains.
+
+5. `feat: add doctor repair request store`
+   - Adds durable delegated request storage and brief construction.
+   - Verification: doctor-delegate store/brief tests.
+   - Rollback: no command surface yet.
+
+6. `feat: implement doctor --delegate workflow`
+   - Adds runtime send, linked task behavior, routes, CLI.
+   - Verification: doctor-delegate, health routes, CLI tests.
+   - Rollback: delegated workflow only.
+
+7. `docs: document doctor repair workflows`
+   - Updates docs, generated references, and knowledge files.
+   - Verification: docs generate/validate.
+   - Rollback: docs only.
+
+## Risks And Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Hidden auto-fix behavior remains in one check | High | `rg autoFixSkill` is a required verification gate. |
+| Repair handler mutates during planning | High | Plan handlers get unit tests with fixture state snapshots before/after. |
+| CLI JSON accidentally prompts or mutates | High | Dedicated `--json` without `--yes` tests. |
+| Delegation claims completion too early | Medium | Status model separates `sent`, `completed`, and `verified`. |
+| Runtime unavailable on fresh installs | Medium | Runtime ping/main-agent resolution before send; no retries/spam. |
+| Repair plan grows too large | Medium | Convert handlers by plugin owner and land deterministic workflow before delegation. |
+| Task creation duplicates dispatch | Medium | Create the linked task once, assign it to `main`, and call the existing immediate single-task dispatch path instead of also sending an unrelated direct repair message. |
+
+## Resolved Decision
+
+Delegated repair creates a linked Bakin task by default. The task starts in
+`todo`, is assigned to `main`, and immediate dispatch is kicked so the agent
+picks up the visible board task through the normal dispatcher. Task completion
+then provides the delegated repair completion signal; doctor verification still
+provides the proof that the original issues are resolved.

--- a/.claude/specs/doctor-repair-workflows.md
+++ b/.claude/specs/doctor-repair-workflows.md
@@ -1,0 +1,386 @@
+# Spec: Doctor Repair Workflows
+
+## Status
+
+Draft planning spec for GitHub issues:
+
+- #268: deterministic `bakin doctor --fix`
+- #269: agent-delegated `bakin doctor --delegate`
+
+Companion plan: `.claude/specs/doctor-repair-workflows-plan.md`.
+
+## Assumptions
+
+1. These two issues should be designed together because they share diagnostic
+   selection, confirmation, reporting, audit, and JSON output, even if they land
+   in separate commits.
+2. Normal `bakin doctor`, doctor cron, the health dashboard, and
+   `bakin_exec_health_doctor` remain report-only.
+3. `doctor --fix` is the only deterministic local repair path.
+4. `doctor --delegate` is the only tracked agent-assisted repair path.
+5. Existing embedded `settings.doctor.autoFixSkill` behavior should be removed,
+   not preserved behind compatibility shims.
+6. The first implementation can require server-backed health checks for
+   `--fix` and `--delegate`; offline doctor remains diagnostic-only unless a
+   later design adds offline repair handlers.
+7. Delegated repair creates a linked Bakin task by default. The task starts on
+   the board in `todo`, is assigned to the runtime main agent, and the
+   implementation immediately kicks dispatch so the normal dispatcher moves it
+   to `inProgress` when the agent is contacted.
+
+## Objective
+
+Build two explicit repair workflows for doctor results:
+
+- A deterministic repair workflow that plans safe local mutations, asks for
+  confirmation, applies check-owned repair handlers, reruns affected checks,
+  and reports exactly what changed.
+- A delegated repair workflow that sends a structured repair brief to the
+  runtime main/orchestrator agent only after explicit user action, records a
+  durable request, exposes request status/history, and verifies resolution by
+  rerunning doctor.
+
+Success means `bakin doctor` can be trusted as a pure diagnostic command, while
+the two repair paths are intentional, auditable, and scriptable.
+
+## Non-Goals
+
+- No hidden repair behavior from cron, dashboard refreshes, default CLI runs, or
+  MCP diagnostic tools.
+- No ambiguous or destructive repair handlers in `--fix`.
+- No agent-assisted repair under `--fix`.
+- No deterministic repair claims from `--notify-agent`; it remains a one-off
+  notification/report path.
+- No broad runtime capability redesign before there is a runtime that can report
+  repair lifecycle state natively.
+
+## Command Surface
+
+Diagnostic commands:
+
+```bash
+bakin doctor
+bakin doctor --full
+bakin doctor --json
+bakin doctor --notify-agent
+```
+
+Deterministic repair:
+
+```bash
+bakin doctor --fix
+bakin doctor --fix --yes
+bakin doctor --fix --json --yes
+```
+
+Delegated repair:
+
+```bash
+bakin doctor --delegate
+bakin doctor --delegate --yes
+bakin doctor --delegate --json --yes
+```
+
+Repair inspection:
+
+```bash
+bakin doctor repair list
+bakin doctor repair show <request-id>
+bakin doctor repair verify <request-id>
+```
+
+Confirmation rules:
+
+- Interactive TTY without `--yes`: render a plan and ask before mutating.
+- Non-TTY without `--yes`: render/report the plan and exit without mutating.
+- `--json` without `--yes`: return a JSON plan plus
+  `CONFIRMATION_REQUIRED`, without mutating.
+- `--yes`: apply the plan if every item is safe and deterministic.
+
+## Project Structure
+
+Expected new or heavily edited files:
+
+```text
+packages/core/src/plugin-types.ts          repair contract types
+packages/sdk/src/types/index.ts            SDK repair type exports
+src/core/doctor.ts                         report-only diagnostics and cache
+src/core/doctor-repair.ts                  deterministic repair planning/apply
+src/core/doctor-repair-store.ts            delegated request file store
+src/core/doctor-delegate.ts                delegated brief/send/status logic
+src/core/health-check-registry.ts          detailed run metadata for repair
+plugins/health/index.ts                    repair/delegate HTTP routes
+src/core/cli/ui/doctor.tsx                 plan/results rendering additions
+cli/bakin.ts                               flags and repair subcommands
+
+plugins/*/lib/health-checks.ts             split run() from repair handlers
+src/core/agent-rules/managed-blocks.ts     expose managed-block repair handler
+packages/core/src/settings.ts              remove doctor.autoFixSkill
+docs/src/content/docs/using/health.md      command/docs update
+.claude/knowledge/doctor-and-health-checks.md architecture update
+```
+
+Repair request state should live under Bakin-owned storage:
+
+```text
+~/.bakin/doctor/repair-requests/YYYY-MM/repair-<id>.json
+```
+
+This follows the task-store pattern: durable, inspectable, one mutable JSON
+document per request, written atomically.
+
+## Contracts
+
+`HealthCheckResult` stays diagnostic-only:
+
+```ts
+export interface HealthCheckResult {
+  check: string
+  status: 'ok' | 'warn' | 'error' | 'fixed'
+  message: string
+  autoFixable: boolean
+}
+```
+
+`fixed` remains valid only for repair verification or legacy rows during the
+transition. Normal diagnostic `run()` functions must not return `fixed`.
+
+Add explicit repair contracts:
+
+```ts
+export type HealthRepairSafety = 'safe' | 'manual' | 'destructive'
+
+export interface HealthRepairChange {
+  kind: 'file' | 'setting' | 'service' | 'runtime' | 'task' | 'other'
+  target: string
+  action: 'create' | 'update' | 'delete' | 'install' | 'invoke'
+  description: string
+}
+
+export interface HealthRepairPlanItem {
+  id: string
+  checkId: string
+  title: string
+  reason: string
+  safety: HealthRepairSafety
+  requiresConfirmation: boolean
+  changes: HealthRepairChange[]
+}
+
+export interface HealthRepairApplyResult {
+  id: string
+  checkId: string
+  status: 'applied' | 'skipped' | 'failed'
+  message: string
+  changes: HealthRepairChange[]
+}
+
+export interface HealthRepairHandler {
+  plan(rows: HealthCheckResult[]): Promise<HealthRepairPlanItem[]>
+  apply(items: HealthRepairPlanItem[]): Promise<HealthRepairApplyResult[]>
+}
+```
+
+Extend health-check registration:
+
+```ts
+export interface PluginHealthCheckInput {
+  id: string
+  name: string
+  run: () => Promise<HealthCheckResult[]>
+  repair?: HealthRepairHandler
+}
+```
+
+`autoFix` becomes unnecessary metadata and should be removed from in-repo
+registrations. UI/API consumers can derive repairability from `repair != null`.
+
+## Deterministic Repair Flow
+
+1. Run detailed diagnostics through the health registry, preserving the
+   registered check definition that produced each result row.
+2. Select warn/error rows from checks with a repair handler.
+3. Ask each handler for a plan. Reject any item with `safety !== 'safe'` from
+   automatic application.
+4. Render the plan with exact changes grouped by check.
+5. Apply only after interactive confirmation or `--yes`.
+6. Catch each handler failure independently and continue applying unrelated
+   safe items.
+7. Rerun affected checks after apply.
+8. Emit a structured result containing plan, apply results, verification rows,
+   changed files/settings/services, and failed remediation messages.
+9. Append audit events:
+   - `doctor.fix.planned`
+   - `doctor.fix.applied`
+   - `doctor.fix.failed`
+   - `doctor.fix.verified`
+
+## Delegated Repair Flow
+
+1. Run diagnostics.
+2. Build a deterministic repair plan in memory.
+3. Select unresolved warn/error rows that have no safe deterministic repair
+   plan, plus any deterministic repair failures if delegation follows a failed
+   `--fix` run.
+4. Build a repair request record with status `planned`.
+5. Require explicit confirmation or `--yes`.
+6. Verify runtime reachability and resolve the main agent through the runtime
+   adapter.
+7. Create a linked task after confirmation:
+   - title: `Doctor repair: <summary>`
+   - column: `todo`
+   - assignee: main agent id
+   - createdBy: `system`
+   - source: `{ pluginId: 'health', entityType: 'doctor-repair', entityId: requestId, purpose: 'delegated-repair' }`
+   - description: structured repair brief plus verification instructions
+8. Kick the existing single-task dispatch path so the agent picks up the board
+   task. Dispatch moves the task to `inProgress` before contacting the agent.
+9. Send a structured brief via the dispatch/task message path with thread id
+   `doctor-repair:<request-id>:<agent-id>`.
+10. Mark the request `sent` when message delivery succeeds. Do not claim
+   `accepted` or `completed` unless a runtime/task signal supports it.
+11. Let `doctor repair show` derive live status from the request file, linked
+    task state, and latest verification.
+12. Let `doctor repair verify <id>` rerun doctor and store whether the original
+    issue signatures remain.
+
+Runtime status semantics:
+
+- Successful `runtime.messaging.send()` means `sent`, not repaired.
+- A linked task in `done` can mark the request `completed`.
+- A verification rerun with no matching unresolved rows can mark it `verified`.
+- Future runtime adapters may return `MessageResult.metadata.repairStatus`; the
+  store should persist it, but the initial OpenClaw path should not depend on it.
+
+## Repair Request Shape
+
+```ts
+export interface DoctorRepairRequest {
+  id: string
+  kind: 'delegate'
+  status: 'planned' | 'sent' | 'accepted' | 'running' | 'completed' | 'failed' | 'verified'
+  createdAt: string
+  updatedAt: string
+  agentId: string
+  threadId: string
+  messageId?: string
+  taskId?: string
+  diagnosticsHash: string
+  issues: HealthCheckResult[]
+  skippedDeterministic: HealthRepairPlanItem[]
+  brief: string
+  events: Array<{
+    ts: string
+    type: string
+    message: string
+    data?: Record<string, unknown>
+  }>
+  lastVerification?: {
+    ts: string
+    unresolved: HealthCheckResult[]
+    status: 'unverified' | 'still-failing' | 'verified'
+  }
+}
+```
+
+## Testing Strategy
+
+Core tests:
+
+- `tests/core/doctor.test.ts`
+  - default diagnostics do not notify or mutate
+  - `notifyAgent` remains explicit
+  - cache/audit behavior remains intact
+- `tests/core/doctor-plugin-checks.test.ts`
+  - detailed run preserves per-definition results and throw isolation
+- New `tests/core/doctor-repair.test.ts`
+  - plan/apply/verify workflow
+  - non-safe plan items are skipped
+  - handler failures are isolated
+  - JSON/non-TTY confirmation guard behavior at service level
+- New `tests/core/doctor-delegate.test.ts`
+  - request store atomic read/write/list
+  - brief construction
+  - runtime unreachable failure
+  - task link and message send behavior
+  - verification updates status
+
+Plugin tests:
+
+- Update every health-check test that currently toggles
+  `settings.doctor.autoFixSkill`.
+- Add focused repair handler tests beside each plugin-owned check:
+  - team
+  - tasks
+  - assets
+  - schedule
+  - workflows
+  - health system checks
+  - managed blocks
+
+CLI/API tests:
+
+- `tests/cli/doctor-ui.test.tsx` for plan/result rendering.
+- Add CLI parser/runner tests for `--fix`, `--delegate`, `--yes`, `--json`,
+  and `doctor repair list/show/verify`.
+- Extend `tests/plugins/health/routes.test.ts` for repair/delegate routes.
+
+Verification commands:
+
+```bash
+bun test --isolate tests/core/doctor.test.ts tests/core/doctor-plugin-checks.test.ts
+bun test --isolate tests/core/doctor-repair.test.ts tests/core/doctor-delegate.test.ts
+bun test --isolate tests/plugins/health tests/plugins/tasks tests/plugins/team tests/plugins/assets tests/plugins/schedule tests/plugins/workflows
+bun test --isolate tests/cli/doctor-ui.test.tsx
+bun run typecheck
+bun run docs:generate
+```
+
+## Boundaries
+
+Always:
+
+- Keep diagnostic `run()` report-only.
+- Keep repair handlers owned by the check/plugin that owns the affected state.
+- Require explicit confirmation before mutation.
+- Emit structured JSON for automation.
+- Audit repair and delegation attempts.
+- Rerun affected checks after deterministic repair.
+
+Ask first:
+
+- Whether to expose repair controls in the Health UI in the first PR.
+- Whether any existing `autoFixable` behavior should be considered unsafe and
+  demoted to manual-only.
+
+Never:
+
+- Send agent messages from default doctor.
+- Apply destructive repairs from `--fix`.
+- Claim delegated repair completed just because a message was sent.
+- Read or write provider-owned runtime files directly from doctor repair code.
+- Add compatibility shims for `doctor.autoFixSkill`.
+
+## Success Criteria
+
+- `bakin doctor` is report-only in CLI, cron, dashboard, REST, and MCP.
+- `bakin doctor --fix` is the only deterministic repair path.
+- `bakin doctor --fix` presents a plan before mutation.
+- Non-TTY and JSON repair runs require `--yes`.
+- Safe repair attempts report changed files/settings/services.
+- Failed repair attempts include actionable remediation.
+- Affected checks rerun after repair.
+- `bakin doctor --delegate` records a request and sends only after explicit
+  confirmation.
+- Delegated request history/status is inspectable from CLI and JSON.
+- Runtime messaging failures are clear and non-spammy.
+- Fresh/offline installs do not attempt delegated repair unless runtime is
+  reachable.
+
+## Resolved Decision
+
+`bakin doctor --delegate` creates a linked Bakin task automatically after
+confirmation. The task starts in `todo`, is assigned to the runtime main agent,
+and dispatch is kicked immediately. The user sees a normal board task, the agent
+receives the work through the normal dispatch path, and task completion becomes
+the delegated repair completion signal.

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -771,6 +771,12 @@ type CliDoctorRepairApply = {
   }
 }
 
+type CliDoctorDelegateReport = {
+  status: 'confirmation_required' | 'sent' | 'no_unresolved'
+  request: Record<string, unknown>
+  unresolved: Array<{ check: string; status: string; message: string; autoFixable?: boolean }>
+}
+
 function summarizeDoctorResults(results: CliDoctorResult['results']): CliDoctorResult['summary'] {
   return {
     total: results.length,
@@ -856,6 +862,10 @@ async function runDoctorRepairApply(): Promise<CliDoctorRepairApply> {
   return await apiPost('/api/plugins/health/doctor/repair/apply', { accepted: true }) as CliDoctorRepairApply
 }
 
+async function runDoctorDelegateApply(): Promise<CliDoctorDelegateReport> {
+  return await apiPost('/api/plugins/health/doctor/delegate', { accepted: true }) as CliDoctorDelegateReport
+}
+
 function doctorRepairExitCode(report: CliDoctorRepairApply): 0 | 1 | 2 {
   if (report.summary.failed > 0 || report.summary.verificationErrors > 0 || report.errors.length > 0) return 1
   if (report.summary.verificationWarnings > 0) return 2
@@ -904,12 +914,58 @@ function printDoctorRepairApply(report: CliDoctorRepairApply): void {
   }
 }
 
+function unresolvedDelegateRows(plan: CliDoctorRepairPlan): CliDoctorRepairPlan['diagnostics'] {
+  const safeRepairChecks = new Set(
+    plan.items
+      .filter(item => item.safety === 'safe')
+      .map(item => item.checkId),
+  )
+  return plan.diagnostics.filter(row => (
+    (row.status === 'warn' || row.status === 'error')
+    && !safeRepairChecks.has(row.check)
+  ))
+}
+
+function printDoctorDelegatePreview(plan: CliDoctorRepairPlan, unresolved: CliDoctorRepairPlan['diagnostics']): void {
+  console.log('Doctor delegated repair preview')
+  if (unresolved.length === 0) {
+    console.log('No unresolved findings need delegated repair.')
+    return
+  }
+  for (const row of unresolved) {
+    console.log(`[${row.status.toUpperCase()}] ${row.check}: ${row.message}`)
+  }
+}
+
+function printDoctorDelegateResult(report: CliDoctorDelegateReport): void {
+  if (report.status === 'no_unresolved') {
+    console.log('No unresolved findings need delegated repair.')
+    return
+  }
+  const request = report.request as { id?: string; taskId?: string; agentId?: string }
+  console.log(`Delegated doctor repair ${request.id ?? ''}`)
+  if (request.taskId) console.log(`Task: ${request.taskId}`)
+  if (request.agentId) console.log(`Agent: ${request.agentId}`)
+}
+
 async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> {
   if (plan.summary.safeItems === 0) return false
   const readline = await import('node:readline/promises')
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
   try {
     const answer = await rl.question(`Apply ${plan.summary.safeItems} safe repair item${plan.summary.safeItems === 1 ? '' : 's'}? [y/N] `)
+    return /^(y|yes)$/i.test(answer.trim())
+  } finally {
+    rl.close()
+  }
+}
+
+async function confirmDoctorDelegate(unresolved: CliDoctorRepairPlan['diagnostics']): Promise<boolean> {
+  if (unresolved.length === 0) return false
+  const readline = await import('node:readline/promises')
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = await rl.question(`Create a delegated repair task for ${unresolved.length} finding${unresolved.length === 1 ? '' : 's'}? [y/N] `)
     return /^(y|yes)$/i.test(answer.trim())
   } finally {
     rl.close()
@@ -959,15 +1015,111 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
   if (exitCode !== 0) process.exit(exitCode)
 }
 
+async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: boolean }): Promise<void> {
+  if (!options.yes) {
+    const plan = await runDoctorRepairPlan()
+    const unresolved = unresolvedDelegateRows(plan)
+    if (options.json) {
+      if (unresolved.length === 0) {
+        printDoctorRepairJson({ status: 'no_unresolved', plan, unresolved }, 0)
+        return
+      }
+      printDoctorRepairJson(
+        { status: 'confirmation_required', plan, unresolved },
+        1,
+        { code: 'CONFIRMATION_REQUIRED', message: 'Run `bakin doctor --delegate --yes` to create the delegated repair task.' },
+      )
+      process.exit(1)
+    }
+
+    printDoctorDelegatePreview(plan, unresolved)
+    if (unresolved.length === 0) return
+    if (!options.isTTY) {
+      console.log('\nRun `bakin doctor --delegate --yes` to create the delegated repair task.')
+      process.exit(1)
+    }
+    const accepted = await confirmDoctorDelegate(unresolved)
+    if (!accepted) {
+      console.log('Delegated repair cancelled.')
+      process.exit(1)
+    }
+  }
+
+  const report = await runDoctorDelegateApply()
+  if (options.json) {
+    printDoctorRepairJson(report, 0)
+    return
+  }
+  printDoctorDelegateResult(report)
+}
+
+async function cmdDoctorRepair(args: string[], options: { json: boolean }): Promise<void> {
+  const sub = args[1] ?? 'list'
+  if (sub === 'list') {
+    const result = await apiGet('/api/plugins/health/doctor/repair') as { requests?: Array<Record<string, unknown>> }
+    if (options.json) {
+      printDoctorRepairJson(result, 0)
+      return
+    }
+    const requests = result.requests ?? []
+    if (requests.length === 0) {
+      console.log('No doctor repair requests.')
+      return
+    }
+    for (const request of requests) {
+      console.log(`${request.id ?? '(unknown)'}  ${request.status ?? 'unknown'}  task=${request.taskId ?? '-'}`)
+    }
+    return
+  }
+
+  const requestId = args[2]
+  if (!requestId) {
+    console.error(`Usage: bakin doctor repair ${sub} <request-id>`)
+    process.exit(1)
+  }
+
+  if (sub === 'show') {
+    const result = await apiGet(`/api/plugins/health/doctor/repair/${encodeURIComponent(requestId)}`)
+    if (options.json) {
+      printDoctorRepairJson(result, 0)
+      return
+    }
+    print(result)
+    return
+  }
+
+  if (sub === 'verify') {
+    const result = await apiPost(`/api/plugins/health/doctor/repair/${encodeURIComponent(requestId)}/verify`)
+    if (options.json) {
+      printDoctorRepairJson(result, 0)
+      return
+    }
+    print(result)
+    return
+  }
+
+  console.error(`Unknown doctor repair subcommand: ${sub}`)
+  process.exit(1)
+}
+
 async function cmdDoctor(args: string[] = process.argv.slice(2)): Promise<void> {
   const json = args.includes('--json')
   const full = args.includes('--full')
   const notifyAgent = args.includes('--notify-agent')
   const fix = args.includes('--fix')
+  const delegate = args.includes('--delegate')
   const yes = args.includes('--yes')
   const isTTY = Boolean(process.stdout.isTTY)
+  if (args[0] === 'repair') {
+    await cmdDoctorRepair(args, { json })
+    return
+  }
   if (fix) {
     await cmdDoctorFix({ json, yes, isTTY })
+    return
+  }
+  if (delegate) {
+    await cmdDoctorDelegate({ json, yes, isTTY })
     return
   }
   const result = full ? await runFullDoctor({ notifyAgent }) : await runOfflineDoctor()

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -720,6 +720,57 @@ type CliDoctorResult = {
   mode?: 'offline' | 'full'
 }
 
+type CliDoctorRepairChange = {
+  kind: string
+  target: string
+  action: string
+  description: string
+}
+
+type CliDoctorRepairPlanItem = {
+  id: string
+  checkId: string
+  healthCheckId?: string
+  pluginId?: string
+  checkName?: string
+  title: string
+  reason: string
+  safety: 'safe' | 'manual' | 'destructive'
+  requiresConfirmation: boolean
+  changes: CliDoctorRepairChange[]
+}
+
+type CliDoctorRepairPlan = {
+  diagnostics: Array<{ check: string; status: string; message: string; autoFixable?: boolean }>
+  items: CliDoctorRepairPlanItem[]
+  errors: Array<{ phase: string; healthCheckId: string; message: string }>
+  summary: {
+    diagnostics: number
+    repairableChecks: number
+    totalItems: number
+    safeItems: number
+    blockedItems: number
+    planErrors: number
+  }
+}
+
+type CliDoctorRepairApply = {
+  status: 'confirmation_required' | 'applied'
+  plan: CliDoctorRepairPlan
+  applied: Array<{ id: string; checkId: string; status: string; message: string; changes: CliDoctorRepairChange[] }>
+  skipped: Array<{ id: string; checkId: string; status: string; message: string; changes: CliDoctorRepairChange[] }>
+  errors: Array<{ phase: string; healthCheckId: string; message: string }>
+  verification: Array<{ check: string; status: string; message: string; autoFixable?: boolean }>
+  summary: {
+    planned: number
+    applied: number
+    skipped: number
+    failed: number
+    verificationErrors: number
+    verificationWarnings: number
+  }
+}
+
 function summarizeDoctorResults(results: CliDoctorResult['results']): CliDoctorResult['summary'] {
   return {
     total: results.length,
@@ -797,11 +848,128 @@ async function runFullDoctor(options: { notifyAgent: boolean }): Promise<CliDoct
   return { ...result, mode: 'full' }
 }
 
+async function runDoctorRepairPlan(): Promise<CliDoctorRepairPlan> {
+  return await apiGet('/api/plugins/health/doctor/repair/plan') as CliDoctorRepairPlan
+}
+
+async function runDoctorRepairApply(): Promise<CliDoctorRepairApply> {
+  return await apiPost('/api/plugins/health/doctor/repair/apply', { accepted: true }) as CliDoctorRepairApply
+}
+
+function doctorRepairExitCode(report: CliDoctorRepairApply): 0 | 1 | 2 {
+  if (report.summary.failed > 0 || report.summary.verificationErrors > 0 || report.errors.length > 0) return 1
+  if (report.summary.verificationWarnings > 0) return 2
+  return 0
+}
+
+function printDoctorRepairJson(data: unknown, exitCode: 0 | 1 | 2, error: { code: string; message: string } | null = null): void {
+  console.log(JSON.stringify({
+    ok: error === null && exitCode !== 1,
+    command: 'doctor --fix',
+    exitCode,
+    data,
+    error,
+  }, null, 2))
+}
+
+function printDoctorRepairPlan(plan: CliDoctorRepairPlan): void {
+  console.log('Doctor repair plan')
+  console.log(`${plan.summary.safeItems} safe, ${plan.summary.blockedItems} blocked, ${plan.summary.planErrors} plan errors`)
+  if (plan.items.length === 0) {
+    console.log('No deterministic repairs available.')
+    return
+  }
+  for (const item of plan.items) {
+    console.log(`\n[${item.safety.toUpperCase()}] ${item.title}`)
+    console.log(`  id: ${item.id}`)
+    console.log(`  reason: ${item.reason}`)
+    for (const change of item.changes) {
+      console.log(`  - ${change.action} ${change.target}: ${change.description}`)
+    }
+  }
+}
+
+function printDoctorRepairApply(report: CliDoctorRepairApply): void {
+  console.log('Doctor repair results')
+  for (const result of report.applied) {
+    const label = result.status === 'applied' ? 'APPLIED' : result.status.toUpperCase()
+    console.log(`[${label}] ${result.id}: ${result.message}`)
+  }
+  for (const result of report.skipped) {
+    console.log(`[SKIPPED] ${result.id}: ${result.message}`)
+  }
+  console.log(`\n${report.summary.applied} applied, ${report.summary.skipped} skipped, ${report.summary.failed} failed`)
+  if (report.verification.length > 0) {
+    console.log(`${report.summary.verificationErrors} verification errors, ${report.summary.verificationWarnings} verification warnings`)
+  }
+}
+
+async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> {
+  if (plan.summary.safeItems === 0) return false
+  const readline = await import('node:readline/promises')
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    const answer = await rl.question(`Apply ${plan.summary.safeItems} safe repair item${plan.summary.safeItems === 1 ? '' : 's'}? [y/N] `)
+    return /^(y|yes)$/i.test(answer.trim())
+  } finally {
+    rl.close()
+  }
+}
+
+async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boolean }): Promise<void> {
+  if (!options.yes) {
+    const plan = await runDoctorRepairPlan()
+    if (options.json) {
+      if (plan.summary.totalItems === 0) {
+        printDoctorRepairJson({ status: 'planned', plan }, 0)
+        return
+      }
+      printDoctorRepairJson(
+        { status: 'confirmation_required', plan },
+        1,
+        { code: 'CONFIRMATION_REQUIRED', message: 'Run `bakin doctor --fix --yes` to apply safe deterministic repairs.' },
+      )
+      process.exit(1)
+    }
+
+    printDoctorRepairPlan(plan)
+    if (plan.summary.totalItems === 0) return
+
+    if (!options.isTTY) {
+      console.log('\nRun `bakin doctor --fix --yes` to apply safe deterministic repairs.')
+      process.exit(1)
+    }
+    const accepted = await confirmDoctorRepair(plan)
+    if (!accepted) {
+      console.log('Repair cancelled.')
+      process.exit(1)
+    }
+  }
+
+  const report = await runDoctorRepairApply()
+  const exitCode = doctorRepairExitCode(report)
+  if (options.json) {
+    printDoctorRepairJson(report, exitCode, exitCode === 1
+      ? { code: 'DOCTOR_REPAIR_FAILED', message: 'One or more deterministic doctor repairs failed or did not verify.' }
+      : null)
+    if (exitCode !== 0) process.exit(exitCode)
+    return
+  }
+  printDoctorRepairApply(report)
+  if (exitCode !== 0) process.exit(exitCode)
+}
+
 async function cmdDoctor(args: string[] = process.argv.slice(2)): Promise<void> {
   const json = args.includes('--json')
   const full = args.includes('--full')
   const notifyAgent = args.includes('--notify-agent')
+  const fix = args.includes('--fix')
+  const yes = args.includes('--yes')
   const isTTY = Boolean(process.stdout.isTTY)
+  if (fix) {
+    await cmdDoctorFix({ json, yes, isTTY })
+    return
+  }
   const result = full ? await runFullDoctor({ notifyAgent }) : await runOfflineDoctor()
 
   if (json) {

--- a/docs/.generated/coverage.json
+++ b/docs/.generated/coverage.json
@@ -5,7 +5,7 @@
     "cliCommands": {
       "status": "active",
       "count": 61,
-      "examples": 66,
+      "examples": 68,
       "source": "src/core/cli/registry.ts"
     },
     "httpRoutes": {
@@ -44,7 +44,7 @@
     },
     "settings": {
       "status": "active",
-      "count": 58,
+      "count": 57,
       "source": "packages/core/src/settings.ts"
     },
     "sdkSubpaths": {

--- a/docs/public/llms/hooks.md
+++ b/docs/public/llms/hooks.md
@@ -206,7 +206,7 @@ Health hooks expose registered readiness and diagnostic checks so other surfaces
 Label: Get a health check.
 Purpose: Returns metadata for one registered health check by id, without running the check. Use it when a plugin needs the check name, owner, and autofix capability before deciding what to show or run.
 Kind: rpc
-Source: plugins/health/index.ts:301
+Source: plugins/health/index.ts:475
 
 Example:
 
@@ -224,7 +224,7 @@ const result = await ctx.hooks.invoke(
 Label: List health checks.
 Purpose: Returns the health checks registered by core and plugins without executing them. Use it when another surface needs to show the available diagnostics or autofix support.
 Kind: rpc
-Source: plugins/health/index.ts:300
+Source: plugins/health/index.ts:474
 
 Example:
 
@@ -521,7 +521,7 @@ Workflow hooks expose workflow definitions, instances, steps, gates, and notific
 Label: Approve workflow gate.
 Purpose: Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks.
 Kind: rpc
-Source: plugins/workflows/index.ts:1478
+Source: plugins/workflows/index.ts:1479
 
 Example:
 
@@ -537,7 +537,7 @@ const result = await ctx.hooks.invoke(
 Label: Authorize workflow tool use.
 Purpose: Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation.
 Kind: rpc
-Source: plugins/workflows/index.ts:1504
+Source: plugins/workflows/index.ts:1505
 
 Example:
 
@@ -553,7 +553,7 @@ const result = await ctx.hooks.invoke(
 Label: Cancel workflow instance.
 Purpose: Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue.
 Kind: event
-Source: plugins/workflows/index.ts:1508
+Source: plugins/workflows/index.ts:1509
 
 Example:
 
@@ -571,7 +571,7 @@ await ctx.hooks.callAll(
 Label: Complete workflow step.
 Purpose: Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action.
 Kind: rpc
-Source: plugins/workflows/index.ts:1496
+Source: plugins/workflows/index.ts:1497
 
 Example:
 
@@ -593,7 +593,7 @@ const result = await ctx.hooks.invoke(
 Label: Create workflow instance.
 Purpose: Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.
 Kind: rpc
-Source: plugins/workflows/index.ts:1477
+Source: plugins/workflows/index.ts:1478
 
 Example:
 
@@ -613,7 +613,7 @@ const result = await ctx.hooks.invoke(
 Label: List workflow definitions.
 Purpose: Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances.
 Kind: rpc
-Source: plugins/workflows/index.ts:1498
+Source: plugins/workflows/index.ts:1499
 
 Example:
 
@@ -629,7 +629,7 @@ const result = await ctx.hooks.invoke(
 Label: List active workflow agents.
 Purpose: Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants.
 Kind: rpc
-Source: plugins/workflows/index.ts:1503
+Source: plugins/workflows/index.ts:1504
 
 Example:
 
@@ -647,7 +647,7 @@ const result = await ctx.hooks.invoke(
 Label: Get current step.
 Purpose: Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable.
 Kind: rpc
-Source: plugins/workflows/index.ts:1495
+Source: plugins/workflows/index.ts:1496
 
 Example:
 
@@ -666,7 +666,7 @@ const result = await ctx.hooks.invoke(
 Label: Get notification channel.
 Purpose: Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation.
 Kind: rpc
-Source: plugins/workflows/index.ts:1514
+Source: plugins/workflows/index.ts:1515
 
 Example:
 
@@ -684,7 +684,7 @@ const result = await ctx.hooks.invoke(
 Label: List workflow instances.
 Purpose: Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state.
 Kind: rpc
-Source: plugins/workflows/index.ts:1494
+Source: plugins/workflows/index.ts:1495
 
 Example:
 
@@ -702,7 +702,7 @@ const result = await ctx.hooks.invoke(
 Label: Check gate notification.
 Purpose: Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.
 Kind: rpc
-Source: plugins/workflows/index.ts:1505
+Source: plugins/workflows/index.ts:1506
 
 Example:
 
@@ -721,7 +721,7 @@ const result = await ctx.hooks.invoke(
 Label: Load workflow definition.
 Purpose: Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.
 Kind: rpc
-Source: plugins/workflows/index.ts:1499
+Source: plugins/workflows/index.ts:1500
 
 Example:
 
@@ -739,7 +739,7 @@ const result = await ctx.hooks.invoke(
 Label: Load workflow instance.
 Purpose: Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly.
 Kind: rpc
-Source: plugins/workflows/index.ts:1475
+Source: plugins/workflows/index.ts:1476
 
 Example:
 
@@ -757,7 +757,7 @@ const result = await ctx.hooks.invoke(
 Label: Mark gate notified.
 Purpose: Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates.
 Kind: rpc
-Source: plugins/workflows/index.ts:1506
+Source: plugins/workflows/index.ts:1507
 
 Example:
 
@@ -776,7 +776,7 @@ const result = await ctx.hooks.invoke(
 Label: Match workflow.
 Purpose: Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template.
 Kind: rpc
-Source: plugins/workflows/index.ts:1497
+Source: plugins/workflows/index.ts:1498
 
 Example:
 
@@ -795,7 +795,7 @@ const result = await ctx.hooks.invoke(
 Label: List notification channels.
 Purpose: Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts.
 Kind: rpc
-Source: plugins/workflows/index.ts:1513
+Source: plugins/workflows/index.ts:1514
 
 Example:
 
@@ -811,7 +811,7 @@ const result = await ctx.hooks.invoke(
 Label: Reject workflow gate.
 Purpose: Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks.
 Kind: rpc
-Source: plugins/workflows/index.ts:1482
+Source: plugins/workflows/index.ts:1483
 
 Example:
 
@@ -827,7 +827,7 @@ const result = await ctx.hooks.invoke(
 Label: Reopen workflow from step.
 Purpose: Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task.
 Kind: rpc
-Source: plugins/workflows/index.ts:1487
+Source: plugins/workflows/index.ts:1488
 
 Example:
 
@@ -843,7 +843,7 @@ const result = await ctx.hooks.invoke(
 Label: Save workflow instance.
 Purpose: Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer.
 Kind: rpc
-Source: plugins/workflows/index.ts:1476
+Source: plugins/workflows/index.ts:1477
 
 Example:
 
@@ -864,7 +864,7 @@ const result = await ctx.hooks.invoke(
 Label: Validate step output.
 Purpose: Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow.
 Kind: rpc
-Source: plugins/workflows/index.ts:1507
+Source: plugins/workflows/index.ts:1508
 
 Example:
 

--- a/docs/public/llms/settings.md
+++ b/docs/public/llms/settings.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 58. Operators can override settings in settings.json under the resolved Bakin home directory.
+The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 57. Operators can override settings in settings.json under the resolved Bakin home directory.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1727,6 +1727,498 @@
         "x-bakin-full-path": "/api/plugins/health/doctor"
       }
     },
+    "/api/plugins/health/doctor/repair/plan": {
+      "get": {
+        "operationId": "health.get.doctor-repair-plan",
+        "summary": "Plan deterministic doctor repairs",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Runs diagnostics and returns safe/manual repair plan items without mutating state.",
+        "x-bakin-full-path": "/api/plugins/health/doctor/repair/plan"
+      }
+    },
+    "/api/plugins/health/doctor/repair/apply": {
+      "post": {
+        "operationId": "health.post.doctor-repair-apply",
+        "summary": "Apply deterministic doctor repairs",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input — params, query, or body did not match the declared schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type — body content type does not match the declared content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Applies safe repair plan items only after accepted=true, then reruns affected checks for verification.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "accepted": {
+                    "type": "boolean"
+                  },
+                  "itemIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "accepted"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-bakin-full-path": "/api/plugins/health/doctor/repair/apply"
+      }
+    },
+    "/api/plugins/health/doctor/delegate": {
+      "post": {
+        "operationId": "health.post.doctor-delegate",
+        "summary": "Create a delegated doctor repair task",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input — params, query, or body did not match the declared schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type — body content type does not match the declared content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Plans unresolved doctor findings and, after accepted=true, creates a linked task assigned to the runtime main agent and kicks dispatch.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "accepted": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "accepted"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-bakin-full-path": "/api/plugins/health/doctor/delegate"
+      }
+    },
+    "/api/plugins/health/doctor/repair": {
+      "get": {
+        "operationId": "health.get.doctor-repair",
+        "summary": "List doctor repair requests",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Returns durable delegated doctor repair requests.",
+        "x-bakin-full-path": "/api/plugins/health/doctor/repair"
+      }
+    },
+    "/api/plugins/health/doctor/repair/{requestId}": {
+      "get": {
+        "operationId": "health.get.doctor-repair-request-id",
+        "summary": "Show a doctor repair request",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input — params, query, or body did not match the declared schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Returns one durable doctor repair request by id.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/health/doctor/repair/:requestId"
+      }
+    },
+    "/api/plugins/health/doctor/repair/{requestId}/verify": {
+      "post": {
+        "operationId": "health.post.doctor-repair-request-id-verify",
+        "summary": "Verify a doctor repair request",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input — params, query, or body did not match the declared schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Reruns doctor planning and records whether the original delegated findings still reproduce.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/health/doctor/repair/:requestId/verify"
+      }
+    },
     "/api/plugins/memory/audit": {
       "get": {
         "operationId": "core.get.api-plugins-memory-audit",

--- a/docs/src/content/docs/extending/plugins/server-contracts.md
+++ b/docs/src/content/docs/extending/plugins/server-contracts.md
@@ -170,7 +170,6 @@ Doctor checks are plugin-registered. Each `ctx.registerHealthCheck()` call adds 
 ctx.registerHealthCheck({
   id: 'storage',
   name: 'Docs Basic storage',
-  autoFix: false,
   run: async () => [
     {
       check: 'docs-basic.storage',

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -629,6 +629,55 @@ curl -sS \
 ```
 </OpenApiReference>
 
+<OpenApiReference operationId="health.post.doctor-delegate">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/health/doctor/delegate' \
+  -H 'Content-Type: application/json' \
+  --data '{"accepted":true}'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="health.get.doctor-repair">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  'http://localhost:3737/api/plugins/health/doctor/repair'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="health.get.doctor-repair-request-id">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  'http://localhost:3737/api/plugins/health/doctor/repair/<requestId>'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="health.post.doctor-repair-request-id-verify">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/health/doctor/repair/<requestId>/verify'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="health.post.doctor-repair-apply">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/health/doctor/repair/apply' \
+  -H 'Content-Type: application/json' \
+  --data '{"accepted":true,"itemIds":["value"]}'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="health.get.doctor-repair-plan">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  'http://localhost:3737/api/plugins/health/doctor/repair/plan'
+```
+</OpenApiReference>
+
 <OpenApiReference operationId="health.get.registry">
 ```sh frame="terminal" showLineNumbers
 curl -sS \
@@ -1482,5 +1531,5 @@ curl -sS \
 </OpenApiReference>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/cli.mdx
+++ b/docs/src/content/docs/reference/generated/cli.mdx
@@ -218,9 +218,9 @@ bakin trash [list|restore|empty] ...
 <p class="cli-section-description">Diagnostics commands expose the information needed when something is not behaving as expected: logs, resolved paths, health checks, API docs, and generated agent rules.</p>
 
 <div class="cli-command-list">
-<CliCommandCard id="doctor" name="doctor" summary="Run health checks." description="Runs local offline diagnostics by default. Pass --full to include server-backed plugin, task, workflow, search, and runtime checks. Pass --notify-agent with --full to send unfixable issues to the runtime main agent.">
+<CliCommandCard id="doctor" name="doctor" summary="Run health checks." description="Runs local offline diagnostics by default. Pass --full to include server-backed plugin, task, workflow, search, and runtime checks. Pass --notify-agent with --full to send unfixable issues to the runtime main agent. Pass --fix to plan deterministic repairs or --delegate to create a linked repair task for the main agent; add --yes to execute either repair path.">
 ```sh frame="terminal"
-bakin doctor [--json] [--full] [--notify-agent]
+bakin doctor [--json] [--full] [--notify-agent] [--fix|--delegate] [--yes]
 ```
   <table class="cli-command__args">
     <thead><tr><th>Part</th><th>Type</th><th>Required</th><th>Notes</th></tr></thead>
@@ -228,6 +228,9 @@ bakin doctor [--json] [--full] [--notify-agent]
       <tr><td><code>[--json]</code></td><td>option</td><td>no</td><td>Emit machine-readable output.</td></tr>
       <tr><td><code>[--full]</code></td><td>option</td><td>no</td><td>Optional flag.</td></tr>
       <tr><td><code>[--notify-agent]</code></td><td>option</td><td>no</td><td>Optional flag.</td></tr>
+      <tr><td><code>[--fix]</code></td><td>option</td><td>no</td><td>Optional flag.</td></tr>
+      <tr><td><code>[--delegate]</code></td><td>option</td><td>no</td><td>Optional flag.</td></tr>
+      <tr><td><code>[--yes]</code></td><td>option</td><td>no</td><td>Accept all defaults non-interactively.</td></tr>
     </tbody>
   </table>
 </CliCommandCard>
@@ -774,5 +777,5 @@ bakin serve
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/core-plugins.md
+++ b/docs/src/content/docs/reference/generated/core-plugins.md
@@ -93,5 +93,5 @@ description: Generated catalog of official plugins supported by Bakin.
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/exec-tools.mdx
+++ b/docs/src/content/docs/reference/generated/exec-tools.mdx
@@ -121,7 +121,7 @@ mcporter call bakin-<agent>.bakin_exec_assets_update_content --args '{
 <p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="check-gates" name="bakin_exec_check_gates" label="Checked workflow gates" description="Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending." source="plugins/workflows/index.ts:1767" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (or workflow instance ID)"}]}>
+<McpToolCard id="check-gates" name="bakin_exec_check_gates" label="Checked workflow gates" description="Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending." source="plugins/workflows/index.ts:1768" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (or workflow instance ID)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_check_gates --args '{
   "taskId": "value"
@@ -161,7 +161,7 @@ mcporter call bakin-<agent>.bakin_exec_gen_image --args '{
 mcporter call bakin-<agent>.bakin_exec_get_paths
 ```
 </McpToolCard>
-<McpToolCard id="get-step" name="bakin_exec_get_step" label="Read workflow step" description="Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure." source="plugins/workflows/index.ts:1691" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="get-step" name="bakin_exec_get_step" label="Read workflow step" description="Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure." source="plugins/workflows/index.ts:1692" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_get_step --args '{
   "taskId": "value"
@@ -197,14 +197,14 @@ mcporter call bakin-<agent>.bakin_exec_git_status
 <p class="mcp-section-description">Health tools let agents check whether Bakin is running correctly before or during work.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="health-doctor" name="bakin_exec_health_doctor" label="Ran diagnostics" description="Run system diagnostics (agent roster, skill sync, runtime, taskboard, assets, etc.). Returns detailed check results. Use fresh=true to force a full re-check instead of returning cached results." source="plugins/health/index.ts:338" parameters={[{"name":"fresh","type":"boolean","required":false,"description":"Force fresh diagnostics instead of cached results"}]}>
+<McpToolCard id="health-doctor" name="bakin_exec_health_doctor" label="Ran diagnostics" description="Run system diagnostics (agent roster, skill sync, runtime, taskboard, assets, etc.). Returns detailed check results. Use fresh=true to force a full re-check instead of returning cached results." source="plugins/health/index.ts:512" parameters={[{"name":"fresh","type":"boolean","required":false,"description":"Force fresh diagnostics instead of cached results"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_health_doctor --args '{
   "fresh": true
 }'
 ```
 </McpToolCard>
-<McpToolCard id="health-status" name="bakin_exec_health_status" label="Checked system health" description="Get a quick system health summary — uptime, memory, active MCP sessions, and doctor error/warning counts. Useful for checking system state before starting work." source="plugins/health/index.ts:309">
+<McpToolCard id="health-status" name="bakin_exec_health_status" label="Checked system health" description="Get a quick system health summary — uptime, memory, active MCP sessions, and doctor error/warning counts. Useful for checking system state before starting work." source="plugins/health/index.ts:483">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_health_status
 ```
@@ -879,7 +879,7 @@ mcporter call bakin-<agent>.bakin_exec_search_table --args '{
 <p class="mcp-section-description">Workflow submission tools let agents submit step output back to the workflow engine.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="submit-step" name="bakin_exec_submit_step" label="Submitted workflow step" description="Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip." source="plugins/workflows/index.ts:1711" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to submit for"},{"name":"output","type":"record","required":true,"description":"JSON output matching the step schema"}]}>
+<McpToolCard id="submit-step" name="bakin_exec_submit_step" label="Submitted workflow step" description="Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip." source="plugins/workflows/index.ts:1712" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to submit for"},{"name":"output","type":"record","required":true,"description":"JSON output matching the step schema"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_submit_step --args '{
   "taskId": "value",
@@ -897,7 +897,7 @@ mcporter call bakin-<agent>.bakin_exec_submit_step --args '{
 <p class="mcp-section-description">Task tools are the main agent interface for creating, reading, moving, logging, blocking, and completing work.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="tasks-assign" name="bakin_exec_tasks_assign" label="Assigned a task" description="Assign a task to an agent." source="plugins/tasks/index.ts:847" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"agent","type":"string","required":true,"description":"Agent to assign the task to"}]}>
+<McpToolCard id="tasks-assign" name="bakin_exec_tasks_assign" label="Assigned a task" description="Assign a task to an agent." source="plugins/tasks/index.ts:849" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"agent","type":"string","required":true,"description":"Agent to assign the task to"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_assign --args '{
   "taskId": "value",
@@ -905,7 +905,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_assign --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-block" name="bakin_exec_tasks_block" label="Blocked a task" description="Mark a task as blocked with a reason. Use when you cannot proceed." source="plugins/tasks/index.ts:709" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"reason","type":"string","required":true,"description":"Why the task is blocked"}]}>
+<McpToolCard id="tasks-block" name="bakin_exec_tasks_block" label="Blocked a task" description="Mark a task as blocked with a reason. Use when you cannot proceed." source="plugins/tasks/index.ts:711" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"reason","type":"string","required":true,"description":"Why the task is blocked"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_block --args '{
   "taskId": "value",
@@ -913,7 +913,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_block --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-complete" name="bakin_exec_tasks_complete" label="Completed a task" description="Report that your task is complete. Moves the task to Done and notifies the orchestrator." source="plugins/tasks/index.ts:729" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"summary","type":"string","required":true,"description":"Summary of what you accomplished"}]}>
+<McpToolCard id="tasks-complete" name="bakin_exec_tasks_complete" label="Completed a task" description="Report that your task is complete. Moves the task to Done and notifies the orchestrator." source="plugins/tasks/index.ts:731" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"summary","type":"string","required":true,"description":"Summary of what you accomplished"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_complete --args '{
   "taskId": "value",
@@ -921,7 +921,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_complete --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-create" name="bakin_exec_tasks_create" label="Created a task" description="Create a new task on the task board. Workflows are auto-matched by title when workflowId is not provided. Provide workflowId to force a specific workflow, or skipWorkflowReason to explicitly skip." source="plugins/tasks/index.ts:624" parameters={[{"name":"title","type":"string","required":true,"description":"Task title"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign (chef, pixel, rolo, patch, trainer, etc.)"},{"name":"description","type":"string","required":false,"description":"Task description and context"},{"name":"parentId","type":"string","required":false,"description":"Parent task ID if this is a subtask"},{"name":"workflowId","type":"string","required":false,"description":"Workflow to start (e.g. image-social-post, video-script). Use bakin_exec_workflows_list to see options."},{"name":"skipWorkflowReason","type":"string","required":false,"description":"Reason no workflow applies (required if workflowId is not set and this is not a subtask)"},{"name":"projectId","type":"string","required":false,"description":"Project ID to link this task to"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"},{"name":"sourcePluginId","type":"string","required":false,"description":"Plugin that owns the source entity for this task"},{"name":"sourceEntityType","type":"string","required":false,"description":"Source entity type, such as plan or deliverable"},{"name":"sourceEntityId","type":"string","required":false,"description":"Source entity ID"},{"name":"sourcePurpose","type":"string","required":false,"description":"Source purpose, such as kickoff or publish"}]}>
+<McpToolCard id="tasks-create" name="bakin_exec_tasks_create" label="Created a task" description="Create a new task on the task board. Workflows are auto-matched by title when workflowId is not provided. Provide workflowId to force a specific workflow, or skipWorkflowReason to explicitly skip." source="plugins/tasks/index.ts:626" parameters={[{"name":"title","type":"string","required":true,"description":"Task title"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign (chef, pixel, rolo, patch, trainer, etc.)"},{"name":"description","type":"string","required":false,"description":"Task description and context"},{"name":"parentId","type":"string","required":false,"description":"Parent task ID if this is a subtask"},{"name":"workflowId","type":"string","required":false,"description":"Workflow to start (e.g. image-social-post, video-script). Use bakin_exec_workflows_list to see options."},{"name":"skipWorkflowReason","type":"string","required":false,"description":"Reason no workflow applies (required if workflowId is not set and this is not a subtask)"},{"name":"projectId","type":"string","required":false,"description":"Project ID to link this task to"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"},{"name":"sourcePluginId","type":"string","required":false,"description":"Plugin that owns the source entity for this task"},{"name":"sourceEntityType","type":"string","required":false,"description":"Source entity type, such as plan or deliverable"},{"name":"sourceEntityId","type":"string","required":false,"description":"Source entity ID"},{"name":"sourcePurpose","type":"string","required":false,"description":"Source purpose, such as kickoff or publish"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_create --args '{
   "title": "value",
@@ -940,21 +940,21 @@ mcporter call bakin-<agent>.bakin_exec_tasks_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-delete" name="bakin_exec_tasks_delete" label="Deleted a task" description="Delete a task from the board." source="plugins/tasks/index.ts:826" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="tasks-delete" name="bakin_exec_tasks_delete" label="Deleted a task" description="Delete a task from the board." source="plugins/tasks/index.ts:828" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_delete --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-get" name="bakin_exec_tasks_get" label="Read task details" description="Get details about a task — title, description, current column, logs, dependencies, project context." source="plugins/tasks/index.ts:601" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="tasks-get" name="bakin_exec_tasks_get" label="Read task details" description="Get details about a task — title, description, current column, logs, dependencies, project context." source="plugins/tasks/index.ts:603" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_get --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-list" name="bakin_exec_tasks_list" label="Listed tasks" description="List all tasks on the board. Optionally filter by column or agent." source="plugins/tasks/index.ts:571" parameters={[{"name":"column","type":"choice","required":false,"description":"Filter by column"},{"name":"agent","type":"string","required":false,"description":"Filter by assigned agent"}]}>
+<McpToolCard id="tasks-list" name="bakin_exec_tasks_list" label="Listed tasks" description="List all tasks on the board. Optionally filter by column or agent." source="plugins/tasks/index.ts:573" parameters={[{"name":"column","type":"choice","required":false,"description":"Filter by column"},{"name":"agent","type":"string","required":false,"description":"Filter by assigned agent"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_list --args '{
   "column": "value",
@@ -962,7 +962,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_list --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-log-progress" name="bakin_exec_tasks_log_progress" label="Logged progress" description="Log a human-readable progress update to the live activity feed. Call this at every significant step." source="plugins/tasks/index.ts:749" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (e.g. \"fe84ac51\")"},{"name":"message","type":"string","required":true,"description":"Human-readable status update"}]}>
+<McpToolCard id="tasks-log-progress" name="bakin_exec_tasks_log_progress" label="Logged progress" description="Log a human-readable progress update to the live activity feed. Call this at every significant step." source="plugins/tasks/index.ts:751" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (e.g. \"fe84ac51\")"},{"name":"message","type":"string","required":true,"description":"Human-readable status update"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_log_progress --args '{
   "taskId": "value",
@@ -970,7 +970,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_log_progress --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-move" name="bakin_exec_tasks_move" label="Moved a task" description="Move a task to a different column on the task board." source="plugins/tasks/index.ts:684" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"to","type":"choice","required":true,"description":"Target column"},{"name":"reason","type":"string","required":false,"description":"Required when moving to \"blocked\""}]}>
+<McpToolCard id="tasks-move" name="bakin_exec_tasks_move" label="Moved a task" description="Move a task to a different column on the task board." source="plugins/tasks/index.ts:686" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"to","type":"choice","required":true,"description":"Target column"},{"name":"reason","type":"string","required":false,"description":"Required when moving to \"blocked\""}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_move --args '{
   "taskId": "value",
@@ -979,7 +979,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_move --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-set-dependency" name="bakin_exec_tasks_set_dependency" label="Set task dependency" description="Register a dependency between tasks. Your task will be auto-re-dispatched when the dependency completes. After registering, exit — do not wait." source="plugins/tasks/index.ts:768" parameters={[{"name":"taskId","type":"string","required":true,"description":"Your task ID (the one that depends)"},{"name":"dependsOn","type":"string","required":true,"description":"Task ID you depend on"}]}>
+<McpToolCard id="tasks-set-dependency" name="bakin_exec_tasks_set_dependency" label="Set task dependency" description="Register a dependency between tasks. Your task will be auto-re-dispatched when the dependency completes. After registering, exit — do not wait." source="plugins/tasks/index.ts:770" parameters={[{"name":"taskId","type":"string","required":true,"description":"Your task ID (the one that depends)"},{"name":"dependsOn","type":"string","required":true,"description":"Task ID you depend on"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_set_dependency --args '{
   "taskId": "value",
@@ -987,7 +987,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_set_dependency --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-update" name="bakin_exec_tasks_update" label="Updated a task" description="Update a task on the board — change title, description, or assigned agent." source="plugins/tasks/index.ts:787" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"title","type":"string","required":false,"description":"New task title"},{"name":"description","type":"string","required":false,"description":"New task description"},{"name":"agent","type":"string","required":false,"description":"New assigned agent"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"}]}>
+<McpToolCard id="tasks-update" name="bakin_exec_tasks_update" label="Updated a task" description="Update a task on the board — change title, description, or assigned agent." source="plugins/tasks/index.ts:789" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"title","type":"string","required":false,"description":"New task title"},{"name":"description","type":"string","required":false,"description":"New task description"},{"name":"agent","type":"string","required":false,"description":"New assigned agent"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_update --args '{
   "taskId": "value",
@@ -1118,7 +1118,7 @@ mcporter call bakin-<agent>.bakin_exec_team_update_identity --args '{
 <p class="mcp-section-description">Workflow tools expose workflow definitions, active instances, current steps, and step completion.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="workflows-complete-step" name="bakin_exec_workflows_complete_step" label="Completed workflow step" description="Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete." source="plugins/workflows/index.ts:1655" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to complete"},{"name":"output","type":"record","required":true,"description":"Step output object"}]}>
+<McpToolCard id="workflows-complete-step" name="bakin_exec_workflows_complete_step" label="Completed workflow step" description="Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete." source="plugins/workflows/index.ts:1656" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to complete"},{"name":"output","type":"record","required":true,"description":"Step output object"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_complete_step --args '{
   "taskId": "value",
@@ -1129,40 +1129,40 @@ mcporter call bakin-<agent>.bakin_exec_workflows_complete_step --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-definition" name="bakin_exec_workflows_get_definition" label="Read workflow definition" description="Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows." source="plugins/workflows/index.ts:1561" parameters={[{"name":"name","type":"string","required":true,"description":"Workflow definition filename (e.g. \"content-pipeline\")"}]}>
+<McpToolCard id="workflows-get-definition" name="bakin_exec_workflows_get_definition" label="Read workflow definition" description="Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows." source="plugins/workflows/index.ts:1562" parameters={[{"name":"name","type":"string","required":true,"description":"Workflow definition filename (e.g. \"content-pipeline\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_definition --args '{
   "name": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-instance" name="bakin_exec_workflows_get_instance" label="Read workflow instance" description="Get the full state of a workflow instance for a task, including step states and history." source="plugins/workflows/index.ts:1627" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="workflows-get-instance" name="bakin_exec_workflows_get_instance" label="Read workflow instance" description="Get the full state of a workflow instance for a task, including step states and history." source="plugins/workflows/index.ts:1628" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_instance --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-step" name="bakin_exec_workflows_get_step" label="Read workflow step" description="Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next." source="plugins/workflows/index.ts:1641" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="workflows-get-step" name="bakin_exec_workflows_get_step" label="Read workflow step" description="Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next." source="plugins/workflows/index.ts:1642" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_step --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-list" name="bakin_exec_workflows_list" label="Listed workflows" description="List all workflow definitions (templates). Returns name, filename, description, and step count for each." source="plugins/workflows/index.ts:1542">
+<McpToolCard id="workflows-list" name="bakin_exec_workflows_list" label="Listed workflows" description="List all workflow definitions (templates). Returns name, filename, description, and step count for each." source="plugins/workflows/index.ts:1543">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_list
 ```
 </McpToolCard>
-<McpToolCard id="workflows-list-instances" name="bakin_exec_workflows_list_instances" label="Listed workflow runs" description="List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled)." source="plugins/workflows/index.ts:1614" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by instance status"}]}>
+<McpToolCard id="workflows-list-instances" name="bakin_exec_workflows_list_instances" label="Listed workflow runs" description="List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled)." source="plugins/workflows/index.ts:1615" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by instance status"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_list_instances --args '{
   "status": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-start" name="bakin_exec_workflows_start" label="Started a workflow" description="Start a workflow instance for a task. The task must exist on the board. Returns the created instance." source="plugins/workflows/index.ts:1579" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID to start workflow for"},{"name":"workflowId","type":"string","required":true,"description":"Workflow definition filename"}]}>
+<McpToolCard id="workflows-start" name="bakin_exec_workflows_start" label="Started a workflow" description="Start a workflow instance for a task. The task must exist on the board. Returns the created instance." source="plugins/workflows/index.ts:1580" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID to start workflow for"},{"name":"workflowId","type":"string","required":true,"description":"Workflow definition filename"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
   "taskId": "value",
@@ -1173,5 +1173,5 @@ mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -121,7 +121,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Health hooks expose registered readiness and diagnostic checks so other surfaces can list or inspect them.</p>
 
 <div class="hook-card-list">
-<HookCard id="health-getcheck" name="health.getCheck" label="Get a health check." summary="Returns metadata for one registered health check by id, without running the check. Use it when a plugin needs the check name, owner, and autofix capability before deciding what to show or run." source="plugins/health/index.ts:301" badges={["rpc"]}>
+<HookCard id="health-getcheck" name="health.getCheck" label="Get a health check." summary="Returns metadata for one registered health check by id, without running the check. Use it when a plugin needs the check name, owner, and autofix capability before deciding what to show or run." source="plugins/health/index.ts:475" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'health.getCheck',
@@ -131,7 +131,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="health-list" name="health.list" label="List health checks." summary="Returns the health checks registered by core and plugins without executing them. Use it when another surface needs to show the available diagnostics or autofix support." source="plugins/health/index.ts:300" badges={["rpc"]}>
+<HookCard id="health-list" name="health.list" label="List health checks." summary="Returns the health checks registered by core and plugins without executing them. Use it when another surface needs to show the available diagnostics or autofix support." source="plugins/health/index.ts:474" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'health.list',
@@ -317,7 +317,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Workflow hooks expose workflow definitions, instances, steps, gates, and notification helpers for task automation.</p>
 
 <div class="hook-card-list">
-<HookCard id="workflows-approvegate" name="workflows.approveGate" label="Approve workflow gate." summary="Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1478" badges={["rpc"]}>
+<HookCard id="workflows-approvegate" name="workflows.approveGate" label="Approve workflow gate." summary="Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1479" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.approveGate',
@@ -325,7 +325,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-authorizetooluse" name="workflows.authorizeToolUse" label="Authorize workflow tool use." summary="Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation." source="plugins/workflows/index.ts:1504" badges={["rpc"]}>
+<HookCard id="workflows-authorizetooluse" name="workflows.authorizeToolUse" label="Authorize workflow tool use." summary="Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation." source="plugins/workflows/index.ts:1505" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.authorizeToolUse',
@@ -333,7 +333,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-cancelinstance" name="workflows.cancelInstance" label="Cancel workflow instance." summary="Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue." source="plugins/workflows/index.ts:1508" badges={["event"]}>
+<HookCard id="workflows-cancelinstance" name="workflows.cancelInstance" label="Cancel workflow instance." summary="Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue." source="plugins/workflows/index.ts:1509" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'workflows.cancelInstance',
@@ -343,7 +343,7 @@ await ctx.hooks.callAll(
 )
 ```
 </HookCard>
-<HookCard id="workflows-completestep" name="workflows.completeStep" label="Complete workflow step." summary="Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action." source="plugins/workflows/index.ts:1496" badges={["rpc"]}>
+<HookCard id="workflows-completestep" name="workflows.completeStep" label="Complete workflow step." summary="Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action." source="plugins/workflows/index.ts:1497" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.completeStep',
@@ -357,7 +357,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-createinstance" name="workflows.createInstance" label="Create workflow instance." summary="Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow." source="plugins/workflows/index.ts:1477" badges={["rpc"]}>
+<HookCard id="workflows-createinstance" name="workflows.createInstance" label="Create workflow instance." summary="Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow." source="plugins/workflows/index.ts:1478" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.createInstance',
@@ -369,7 +369,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-definitions-list" name="workflows.definitions.list" label="List workflow definitions." summary="Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances." source="plugins/workflows/index.ts:1498" badges={["rpc"]}>
+<HookCard id="workflows-definitions-list" name="workflows.definitions.list" label="List workflow definitions." summary="Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances." source="plugins/workflows/index.ts:1499" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.definitions.list',
@@ -377,7 +377,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getactiveagents" name="workflows.getActiveAgents" label="List active workflow agents." summary="Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants." source="plugins/workflows/index.ts:1503" badges={["rpc"]}>
+<HookCard id="workflows-getactiveagents" name="workflows.getActiveAgents" label="List active workflow agents." summary="Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants." source="plugins/workflows/index.ts:1504" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getActiveAgents',
@@ -387,7 +387,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getcurrentstep" name="workflows.getCurrentStep" label="Get current step." summary="Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable." source="plugins/workflows/index.ts:1495" badges={["rpc"]}>
+<HookCard id="workflows-getcurrentstep" name="workflows.getCurrentStep" label="Get current step." summary="Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable." source="plugins/workflows/index.ts:1496" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getCurrentStep',
@@ -398,7 +398,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getnotificationchannel" name="workflows.getNotificationChannel" label="Get notification channel." summary="Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation." source="plugins/workflows/index.ts:1514" badges={["rpc"]}>
+<HookCard id="workflows-getnotificationchannel" name="workflows.getNotificationChannel" label="Get notification channel." summary="Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation." source="plugins/workflows/index.ts:1515" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getNotificationChannel',
@@ -408,7 +408,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-instances-list" name="workflows.instances.list" label="List workflow instances." summary="Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state." source="plugins/workflows/index.ts:1494" badges={["rpc"]}>
+<HookCard id="workflows-instances-list" name="workflows.instances.list" label="List workflow instances." summary="Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state." source="plugins/workflows/index.ts:1495" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.instances.list',
@@ -418,7 +418,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-isgatenotified" name="workflows.isGateNotified" label="Check gate notification." summary="Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step." source="plugins/workflows/index.ts:1505" badges={["rpc"]}>
+<HookCard id="workflows-isgatenotified" name="workflows.isGateNotified" label="Check gate notification." summary="Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step." source="plugins/workflows/index.ts:1506" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.isGateNotified',
@@ -429,7 +429,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-loaddefinition" name="workflows.loadDefinition" label="Load workflow definition." summary="Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id." source="plugins/workflows/index.ts:1499" badges={["rpc"]}>
+<HookCard id="workflows-loaddefinition" name="workflows.loadDefinition" label="Load workflow definition." summary="Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id." source="plugins/workflows/index.ts:1500" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.loadDefinition',
@@ -439,7 +439,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-loadinstance" name="workflows.loadInstance" label="Load workflow instance." summary="Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly." source="plugins/workflows/index.ts:1475" badges={["rpc"]}>
+<HookCard id="workflows-loadinstance" name="workflows.loadInstance" label="Load workflow instance." summary="Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly." source="plugins/workflows/index.ts:1476" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.loadInstance',
@@ -449,7 +449,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-markgatenotified" name="workflows.markGateNotified" label="Mark gate notified." summary="Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates." source="plugins/workflows/index.ts:1506" badges={["rpc"]}>
+<HookCard id="workflows-markgatenotified" name="workflows.markGateNotified" label="Mark gate notified." summary="Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates." source="plugins/workflows/index.ts:1507" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.markGateNotified',
@@ -460,7 +460,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-matchworkflow" name="workflows.matchWorkflow" label="Match workflow." summary="Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template." source="plugins/workflows/index.ts:1497" badges={["rpc"]}>
+<HookCard id="workflows-matchworkflow" name="workflows.matchWorkflow" label="Match workflow." summary="Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template." source="plugins/workflows/index.ts:1498" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.matchWorkflow',
@@ -471,7 +471,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-notificationchannels-list" name="workflows.notificationChannels.list" label="List notification channels." summary="Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts." source="plugins/workflows/index.ts:1513" badges={["rpc"]}>
+<HookCard id="workflows-notificationchannels-list" name="workflows.notificationChannels.list" label="List notification channels." summary="Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts." source="plugins/workflows/index.ts:1514" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.notificationChannels.list',
@@ -479,7 +479,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-rejectgate" name="workflows.rejectGate" label="Reject workflow gate." summary="Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1482" badges={["rpc"]}>
+<HookCard id="workflows-rejectgate" name="workflows.rejectGate" label="Reject workflow gate." summary="Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1483" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.rejectGate',
@@ -487,7 +487,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-reopenfromstep" name="workflows.reopenFromStep" label="Reopen workflow from step." summary="Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task." source="plugins/workflows/index.ts:1487" badges={["rpc"]}>
+<HookCard id="workflows-reopenfromstep" name="workflows.reopenFromStep" label="Reopen workflow from step." summary="Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task." source="plugins/workflows/index.ts:1488" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.reopenFromStep',
@@ -495,7 +495,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-saveinstance" name="workflows.saveInstance" label="Save workflow instance." summary="Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer." source="plugins/workflows/index.ts:1476" badges={["rpc"]}>
+<HookCard id="workflows-saveinstance" name="workflows.saveInstance" label="Save workflow instance." summary="Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer." source="plugins/workflows/index.ts:1477" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.saveInstance',
@@ -508,7 +508,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-validatestepoutput" name="workflows.validateStepOutput" label="Validate step output." summary="Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow." source="plugins/workflows/index.ts:1507" badges={["rpc"]}>
+<HookCard id="workflows-validatestepoutput" name="workflows.validateStepOutput" label="Validate step output." summary="Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow." source="plugins/workflows/index.ts:1508" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.validateStepOutput',
@@ -526,5 +526,5 @@ const result = await ctx.hooks.invoke(
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/runtime-paths.md
+++ b/docs/src/content/docs/reference/generated/runtime-paths.md
@@ -100,5 +100,5 @@ description: Reference for Bakin runtime files under the resolved Bakin home dir
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -203,6 +203,11 @@ Source: `packages/sdk/src/types/index.ts`
 | `export interface PluginNodeTypeInput<T = unknown> {` |
 | `export interface PluginNotificationChannelInput {` |
 | `export interface HealthCheckResult {` |
+| `export type HealthRepairSafety = 'safe' \| 'manual' \| 'destructive'` |
+| `export interface HealthRepairChange {` |
+| `export interface HealthRepairPlanItem {` |
+| `export interface HealthRepairApplyResult {` |
+| `export interface HealthRepairHandler {` |
 | `export interface PluginHealthCheckInput {` |
 | `export interface StringSettingsField extends BaseSettingsField {` |
 | `export interface NumberSettingsField extends BaseSettingsField {` |
@@ -261,5 +266,5 @@ Source: `packages/sdk/src/routing/index.ts`
 | `export type {` |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -79,10 +79,6 @@ description: Generated reference for Bakin core settings defaults.
   </thead>
   <tbody>
     <tr>
-      <td><code>doctor.autoFixSkill</code></td>
-      <td><code>true</code></td>
-    </tr>
-    <tr>
       <td><code>doctor.intervalMs</code></td>
       <td><code>1800000</code></td>
     </tr>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -357,5 +357,5 @@ description: Generated reference for Bakin core settings defaults.
 
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 15, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/using/assets.md
+++ b/docs/src/content/docs/using/assets.md
@@ -111,7 +111,7 @@ Soft delete first. Files move to `~/.bakin/assets/.trash/` with a `__deleted-{ti
   <figcaption>The trash view with restore and permanent-delete actions.</figcaption>
 </figure>
 
-The default recovery window is 7 days. Past that window, asset health checks can purge expired trash when doctor auto-fix is enabled. You can also empty trash manually at any time. Restore drops the file back at its canonical path, sidecar and all, and re-indexes.
+The default recovery window is 7 days. Past that window, asset health checks can purge expired trash through the explicit doctor repair workflow. You can also empty trash manually at any time. Restore drops the file back at its canonical path, sidecar and all, and re-indexes.
 
 Permanent delete is irreversible. Empty trash wipes everything in one shot.
 

--- a/docs/src/content/docs/using/health.md
+++ b/docs/src/content/docs/using/health.md
@@ -100,7 +100,7 @@ Any plugin can register a health check that surfaces here alongside the built-in
 | Command | Purpose |
 | --- | --- |
 | `bakin status` | Show dispatch and server status. |
-| `bakin doctor [--full] [--notify-agent]` | Run offline or full server-backed health checks. |
+| `bakin doctor [--full] [--notify-agent] [--fix\|--delegate] [--yes]` | Run health checks, apply explicit safe fixes, or create a delegated repair task. |
 <!-- /docs:cli-commands -->
 
 Full surface in the [CLI reference](/docs/reference/generated/cli/).

--- a/docs/src/content/docs/using/health.md
+++ b/docs/src/content/docs/using/health.md
@@ -56,7 +56,7 @@ Three tabs sit below the cost cards, all feeding from the same in-memory recorde
 
 ## Doctor
 
-A green-light scan of every moving part in the stack. Agent roster, runtime adapter, search adapter, taskboard, assets, channel approvals, restart-recovery candidates, the works. Red means broken, yellow means drifting, and most rows have a one-click auto-fix so you don't have to know what went wrong to fix it.
+A green-light scan of every moving part in the stack. Agent roster, runtime adapter, search adapter, taskboard, assets, channel approvals, restart-recovery candidates, the works. Red means broken, yellow means drifting. The scan itself is report-only; repairable rows feed the explicit `bakin doctor --fix` and `bakin doctor --delegate` repair workflows.
 
 Run it before you start the day or any time something feels off. Results cache so the dashboard reads fast; the refresh button (or `bakin doctor` from the CLI) forces a fresh sweep.
 
@@ -79,7 +79,7 @@ Quick sanity check for "did everything actually start up?"
 
 ## Pluggable health checks
 
-Any plugin can register a health check that surfaces here alongside the built-ins. It picks up the same color coding (red / yellow / green) and the same auto-fix scaffolding. If a plugin owns external state worth watching (an API key, a queue, a cache, a daemon), wire a check.
+Any plugin can register a health check that surfaces here alongside the built-ins. It picks up the same color coding (red / yellow / green), and plugins can attach explicit repair handlers for operator-approved fixes. If a plugin owns external state worth watching (an API key, a queue, a cache, a daemon), wire a check.
 
 ## Settings
 

--- a/docs/src/content/docs/using/settings.md
+++ b/docs/src/content/docs/using/settings.md
@@ -21,7 +21,7 @@ The built-in tab covers the runtime knobs that don't belong to any single plugin
 | **Watchdog** | Stuck-task thresholds, auto-recovery toggle, MCP and REST error-rate alerts (window, threshold, sample size, alert cooldown). |
 | **Restart recovery** | Whether Bakin repairs stale `inProgress` tasks on server startup before kicking a dispatch cycle. |
 | **Models** | Global allowlist and blocklist. Models on the blocklist never get assigned, even by alias or profile. |
-| **Doctor** | Diagnostic interval, auto-fix toggle for skill drift, require-onboard guard so doctor stays quiet on fresh installs. |
+| **Doctor** | Diagnostic interval and require-onboard guard so doctor stays quiet on fresh installs. Repairs are explicit through `bakin doctor --fix` or `bakin doctor --delegate`. |
 | **Notifications** | Default notification channel and gate-alert toggle. |
 | **Workflow** | Step timeout, redispatch cap, repeat-rejection threshold, agent-scoping and workflow-guard enforcement. |
 | **Runtime adapter** | Which runtime adapter is active (today: `openclaw`) and any per-adapter settings. |

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -349,12 +349,14 @@ export interface PluginHealthCheckInput {
    */
   run: () => Promise<HealthCheckResult[]>
   /**
-   * Advisory flag for admin UIs: `true` if `run()` may perform safe
-   * auto-fixes internally. Pure metadata in v1 — the orchestrator always
-   * invokes every registered check regardless of this value. Plugins that
-   * do internal auto-fixes gate on `getSettings().doctor.*` themselves.
+   * Legacy advisory flag for older admin surfaces. New code should derive
+   * repairability from `repair`.
    */
   autoFix?: boolean
+  /**
+   * Optional explicit repair contract. Diagnostics call only `run()`; repair
+   * flows call `plan()` first, then `apply()` after explicit confirmation.
+   */
   repair?: HealthRepairHandler
 }
 

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -301,6 +301,38 @@ export interface HealthCheckResult {
   autoFixable: boolean
 }
 
+export type HealthRepairSafety = 'safe' | 'manual' | 'destructive'
+
+export interface HealthRepairChange {
+  kind: 'file' | 'setting' | 'service' | 'runtime' | 'task' | 'other'
+  target: string
+  action: 'create' | 'update' | 'delete' | 'install' | 'invoke'
+  description: string
+}
+
+export interface HealthRepairPlanItem {
+  id: string
+  checkId: string
+  title: string
+  reason: string
+  safety: HealthRepairSafety
+  requiresConfirmation: boolean
+  changes: HealthRepairChange[]
+}
+
+export interface HealthRepairApplyResult {
+  id: string
+  checkId: string
+  status: 'applied' | 'skipped' | 'failed'
+  message: string
+  changes: HealthRepairChange[]
+}
+
+export interface HealthRepairHandler {
+  plan(rows: HealthCheckResult[]): Promise<HealthRepairPlanItem[]>
+  apply(items: HealthRepairPlanItem[]): Promise<HealthRepairApplyResult[]>
+}
+
 /**
  * Input shape plugins pass to `ctx.registerHealthCheck`. The plugin id is
  * auto-namespaced as `{pluginId}.{id}`. `run()` returns an array so one
@@ -323,6 +355,7 @@ export interface PluginHealthCheckInput {
    * do internal auto-fixes gate on `getSettings().doctor.*` themselves.
    */
   autoFix?: boolean
+  repair?: HealthRepairHandler
 }
 
 export interface HealthCheckDef extends PluginHealthCheckInput {

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -133,7 +133,6 @@ export interface BakinSettings {
   }
   doctor: {
     intervalMs: number
-    autoFixSkill: boolean
     /**
      * When true, `runDiagnostics()` refuses to run its normal checks and
      * returns a single `onboarded: error` result until `~/.bakin/.onboarded`
@@ -253,7 +252,6 @@ export const DEFAULT_SETTINGS: BakinSettings = {
   },
   doctor: {
     intervalMs: 30 * 60 * 1000, // 30 minutes
-    autoFixSkill: true,
     requireOnboard: true,
   },
   service: {

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -806,11 +806,44 @@ export interface HealthCheckResult {
   autoFixable: boolean
 }
 
+export type HealthRepairSafety = 'safe' | 'manual' | 'destructive'
+
+export interface HealthRepairChange {
+  kind: 'file' | 'setting' | 'service' | 'runtime' | 'task' | 'other'
+  target: string
+  action: 'create' | 'update' | 'delete' | 'install' | 'invoke'
+  description: string
+}
+
+export interface HealthRepairPlanItem {
+  id: string
+  checkId: string
+  title: string
+  reason: string
+  safety: HealthRepairSafety
+  requiresConfirmation: boolean
+  changes: HealthRepairChange[]
+}
+
+export interface HealthRepairApplyResult {
+  id: string
+  checkId: string
+  status: 'applied' | 'skipped' | 'failed'
+  message: string
+  changes: HealthRepairChange[]
+}
+
+export interface HealthRepairHandler {
+  plan(rows: HealthCheckResult[]): Promise<HealthRepairPlanItem[]>
+  apply(items: HealthRepairPlanItem[]): Promise<HealthRepairApplyResult[]>
+}
+
 export interface PluginHealthCheckInput {
   id: string
   name: string
   run: () => Promise<HealthCheckResult[]>
   autoFix?: boolean
+  repair?: HealthRepairHandler
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -32,7 +32,7 @@ import { getContentDir } from '../../src/core/content-dir'
 import { createLogger } from '../../src/core/logger'
 import { buildAssetFileUrl } from './lib/asset-url'
 import { canExtractAssetContent, extractAssetContent } from './lib/content-extractor'
-import { checkAssets } from './lib/health-checks'
+import { assetRepair, checkAssets } from './lib/health-checks'
 
 /** Filename is the canonical identity under the filename-as-identity model. */
 function filenameFromRel(relPath: string): string {
@@ -1019,8 +1019,8 @@ const assetsPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'assets',
       name: 'Asset directory + sidecar integrity',
-      autoFix: true,
       run: () => Promise.resolve(checkAssets(getContentDir())),
+      repair: assetRepair(getContentDir()),
     })
   },
 

--- a/plugins/assets/lib/health-checks.ts
+++ b/plugins/assets/lib/health-checks.ts
@@ -50,7 +50,7 @@ const SIDECAR_FIELD_ALIASES: Record<string, string> = {
  * Verify directory structure, sidecar pairing, disk usage, and trash
  * retention for the assets tree under {contentDir}/assets/.
  *
- * Auto-fix paths (gated by settings.doctor.autoFixSkill):
+ * Explicit repair paths:
  *   - create missing assets/, store/, inbox/, and .trash/
  *   - write stub sidecars for canonical store assets missing .meta.json
  *   - merge misnamed sidecars into the correctly-named ones (normalizing

--- a/plugins/assets/lib/health-checks.ts
+++ b/plugins/assets/lib/health-checks.ts
@@ -12,8 +12,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, unl
 import { join } from 'path'
 
 import { createLogger } from '../../../src/core/logger'
-import { getSettings } from '../../../src/core/settings'
-import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 
 import { createStub } from './sidecar'
 import { yearMonthFromFilename } from './path-for-filename'
@@ -59,8 +58,11 @@ const SIDECAR_FIELD_ALIASES: Record<string, string> = {
  *   - purge .trash/ items older than 7 days
  */
 export function checkAssets(contentDir: string): HealthCheckResult[] {
+  return checkAssetsInternal(contentDir, false)
+}
+
+function checkAssetsInternal(contentDir: string, autoFix: boolean): HealthCheckResult[] {
   const results: HealthCheckResult[] = []
-  const autoFix = getSettings().doctor.autoFixSkill
   const assetsRoot = join(contentDir, 'assets')
 
   // Check assets/ directory exists with filename-as-identity roots.
@@ -278,6 +280,7 @@ export function checkAssets(contentDir: string): HealthCheckResult[] {
       const trashFiles = readdirSync(trashDir)
       const cutoff = Date.now() - (7 * 24 * 60 * 60 * 1000) // 7 days
       let purged = 0
+      let expired = 0
       for (const file of trashFiles) {
         try {
           const stat = statSync(join(trashDir, file))
@@ -285,12 +288,17 @@ export function checkAssets(contentDir: string): HealthCheckResult[] {
             if (autoFix) {
               rmSync(join(trashDir, file))
               purged++
+            } else {
+              expired++
             }
           }
         } catch { /* skip */ }
       }
       if (purged > 0) {
         results.push(fixed('assets', `Purged ${purged} expired item(s) from .trash/ (>7 days old)`))
+      }
+      if (expired > 0) {
+        results.push(warn('assets', `${expired} expired item(s) in .trash/ older than 7 days`, true))
       }
     }
   } catch { /* skip */ }
@@ -300,4 +308,46 @@ export function checkAssets(contentDir: string): HealthCheckResult[] {
   }
 
   return results
+}
+
+export function assetRepair(contentDir: string): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'assets' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'assets.repair-store',
+        checkId: 'assets',
+        title: 'Repair asset store structure and sidecars',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'file',
+          target: join(contentDir, 'assets'),
+          action: 'update',
+          description: 'Create missing asset directories, create stub sidecars, merge misnamed sidecars, and purge expired trash.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const rows = checkAssetsInternal(contentDir, true)
+      const failures = rows.filter(row => row.status === 'error')
+      return [{
+        id: 'assets.repair-store',
+        checkId: 'assets',
+        status: failures.length > 0 ? 'failed' : 'applied',
+        message: rows.map(row => row.message).join('; '),
+        changes: rows
+          .filter(row => row.status === 'fixed')
+          .map(row => ({
+            kind: 'file' as const,
+            target: join(contentDir, 'assets'),
+            action: 'update' as const,
+            description: row.message,
+          })),
+      }]
+    },
+  }
 }

--- a/plugins/health/bakin-plugin.json
+++ b/plugins/health/bakin-plugin.json
@@ -78,7 +78,7 @@
       {
         "name": "doctor",
         "usage": "bakin doctor [--full] [--notify-agent] [--fix|--delegate] [--yes]",
-        "summary": "Run offline or full server-backed health checks."
+        "summary": "Run health checks, apply explicit safe fixes, or create a delegated repair task."
       }
     ],
     "docs": {

--- a/plugins/health/bakin-plugin.json
+++ b/plugins/health/bakin-plugin.json
@@ -77,7 +77,7 @@
       },
       {
         "name": "doctor",
-        "usage": "bakin doctor [--full] [--notify-agent] [--fix] [--yes]",
+        "usage": "bakin doctor [--full] [--notify-agent] [--fix|--delegate] [--yes]",
         "summary": "Run offline or full server-backed health checks."
       }
     ],

--- a/plugins/health/bakin-plugin.json
+++ b/plugins/health/bakin-plugin.json
@@ -77,7 +77,7 @@
       },
       {
         "name": "doctor",
-        "usage": "bakin doctor [--full] [--notify-agent]",
+        "usage": "bakin doctor [--full] [--notify-agent] [--fix] [--yes]",
         "summary": "Run offline or full server-backed health checks."
       }
     ],

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -4,12 +4,11 @@
  */
 import { totalmem } from 'os'
 import { z } from 'zod'
-import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
+import type { BakinPlugin, HealthRepairHandler, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin, defineRoute } from '@bakin/core/routing'
 import { getLastResults, runDiagnostics } from '../../src/core/doctor'
 import { createLogger } from '../../src/core/logger'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
-import { getSettings } from '../../src/core/settings'
 import { getContentDir } from '../../src/core/content-dir'
 import { getUsageFeed, getErrorCount, getStatsByMs, WINDOW_MS, type UsageKind, type WindowKey } from '../../src/core/usage'
 import {
@@ -19,12 +18,12 @@ import {
 } from '../../src/core/health-check-registry'
 import { checkContentDir } from './lib/system-checks/content-dir'
 import { checkService } from './lib/system-checks/service'
-import { checkMcporter } from './lib/system-checks/mcporter'
+import { checkMcporter, mcporterRepair } from './lib/system-checks/mcporter'
 import { checkRuntime } from './lib/system-checks/runtime'
 import { checkChannelApprovals } from './lib/system-checks/channel-approvals'
 import { checkRestartRecovery } from './lib/system-checks/restart-recovery'
 import { checkSearchAdapter } from './lib/system-checks/search'
-import { checkAndSyncSkill } from './lib/system-checks/sync-skill'
+import { checkAndSyncSkill, syncSkillRepair } from './lib/system-checks/sync-skill'
 import { checkPluginAssets } from './lib/system-checks/plugin-assets'
 import { applyManagedBlocksForRuntime } from '../../src/core/agent-rules/managed-blocks'
 
@@ -47,8 +46,56 @@ const stripRun = (def: HealthCheckDef) => ({
   id: def.id,
   name: def.name,
   pluginId: def.pluginId,
-  autoFix: !!def.autoFix,
+  autoFix: !!def.repair || !!def.autoFix,
 })
+
+function managedBlockRepair(
+  runtime: PluginContext['runtime'],
+  scope: 'orchestrator' | 'subagents',
+  checkId: string,
+): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: `health.${checkId}.managed-blocks`,
+        checkId,
+        title: scope === 'orchestrator'
+          ? 'Repair main agent managed context'
+          : 'Repair subagent managed context',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'runtime',
+          target: scope === 'orchestrator' ? 'main AGENTS.md' : 'subagent AGENTS.md files',
+          action: 'update',
+          description: 'Apply Bakin managed-context blocks through the runtime adapter.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const rows = await applyManagedBlocksForRuntime(runtime, true, { scope })
+      const failures = rows.filter(row => row.status === 'error')
+      return [{
+        id: `health.${checkId}.managed-blocks`,
+        checkId,
+        status: failures.length > 0 ? 'failed' : 'applied',
+        message: rows.map(row => row.message).join('; '),
+        changes: rows
+          .filter(row => row.status === 'fixed')
+          .map(row => ({
+            kind: 'runtime' as const,
+            target: scope === 'orchestrator' ? 'main AGENTS.md' : 'subagent AGENTS.md files',
+            action: 'update' as const,
+            description: row.message,
+          })),
+      }]
+    },
+  }
+}
 
 function buildDoctorResponse(results: Array<{ status: string }> & unknown[]) {
   const errors = results.filter(r => r.status === 'error').length
@@ -378,8 +425,8 @@ const healthPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'mcporter',
       name: 'mcporter install + per-agent config',
-      autoFix: true,
       run: () => checkMcporter(),
+      repair: mcporterRepair(),
     })
     ctx.registerHealthCheck({
       id: 'runtime',
@@ -404,14 +451,14 @@ const healthPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'orchestrator-rules',
       name: 'Main agent AGENTS.md managed context',
-      autoFix: true,
-      run: () => applyManagedBlocksForRuntime(ctx.runtime, getSettings().doctor.autoFixSkill, { scope: 'orchestrator' }),
+      run: () => applyManagedBlocksForRuntime(ctx.runtime, false, { scope: 'orchestrator' }),
+      repair: managedBlockRepair(ctx.runtime, 'orchestrator', 'orchestrator-rules'),
     })
     ctx.registerHealthCheck({
       id: 'skill',
       name: 'Bakin SKILL.md sync to runtime',
-      autoFix: true,
       run: () => checkAndSyncSkill(process.cwd(), ctx.runtime),
+      repair: syncSkillRepair(process.cwd(), ctx.runtime),
     })
     ctx.registerHealthCheck({
       id: 'plugin-assets',
@@ -426,8 +473,8 @@ const healthPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'managed-blocks',
       name: 'Per-agent AGENTS.md managed context',
-      autoFix: true,
-      run: () => applyManagedBlocksForRuntime(ctx.runtime, getSettings().doctor.autoFixSkill, { scope: 'subagents' }),
+      run: () => applyManagedBlocksForRuntime(ctx.runtime, false, { scope: 'subagents' }),
+      repair: managedBlockRepair(ctx.runtime, 'subagents', 'managed-blocks'),
     })
   },
 

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -11,6 +11,8 @@ import { createLogger } from '../../src/core/logger'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
 import { getContentDir } from '../../src/core/content-dir'
 import { applyDoctorRepair, planDoctorRepair } from '../../src/core/doctor-repair'
+import { delegateDoctorRepair, verifyDoctorRepairRequest } from '../../src/core/doctor-delegate'
+import { getDoctorRepairRequest, listDoctorRepairRequests } from '../../src/core/doctor-repair-store'
 import { getUsageFeed, getErrorCount, getStatsByMs, WINDOW_MS, type UsageKind, type WindowKey } from '../../src/core/usage'
 import {
   listHealthChecks,
@@ -182,6 +184,14 @@ const doctorResponse = z.object({
 const doctorRepairApplyBody = z.object({
   accepted: z.boolean(),
   itemIds: z.array(z.string()).optional(),
+})
+
+const acceptedBody = z.object({
+  accepted: z.boolean(),
+})
+
+const repairRequestParams = z.object({
+  requestId: z.string().min(1),
 })
 
 const searchStatusResponse = z.object({
@@ -365,6 +375,74 @@ const routes = [
         })
       } catch (err) {
         return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+      }
+    },
+  }),
+
+  defineRoute({
+    path: '/doctor/delegate',
+    method: 'POST',
+    summary: 'Create a delegated doctor repair task',
+    description: 'Plans unresolved doctor findings and, after accepted=true, creates a linked task assigned to the runtime main agent and kicks dispatch.',
+    body: acceptedBody,
+    responses: { 200: passthrough, 409: passthrough, 500: errorResponse },
+    handler: async (_req, _ctx, { body }) => {
+      try {
+        const report = await delegateDoctorRepair({
+          contentDir: getContentDir(),
+          projectRoot: process.cwd(),
+          accepted: body.accepted,
+        })
+        return Response.json(report, {
+          status: report.status === 'confirmation_required' ? 409 : 200,
+        })
+      } catch (err) {
+        return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+      }
+    },
+  }),
+
+  defineRoute({
+    path: '/doctor/repair',
+    method: 'GET',
+    summary: 'List doctor repair requests',
+    description: 'Returns durable delegated doctor repair requests.',
+    responses: { 200: passthrough },
+    handler: async () => Response.json({ requests: listDoctorRepairRequests(getContentDir()) }),
+  }),
+
+  defineRoute({
+    path: '/doctor/repair/:requestId',
+    method: 'GET',
+    summary: 'Show a doctor repair request',
+    description: 'Returns one durable doctor repair request by id.',
+    params: repairRequestParams,
+    responses: { 200: passthrough, 404: errorResponse },
+    handler: async (_req, _ctx, { params }) => {
+      const request = getDoctorRepairRequest(getContentDir(), params.requestId)
+      if (!request) return Response.json({ error: 'Doctor repair request not found' }, { status: 404 })
+      return Response.json({ request })
+    },
+  }),
+
+  defineRoute({
+    path: '/doctor/repair/:requestId/verify',
+    method: 'POST',
+    summary: 'Verify a doctor repair request',
+    description: 'Reruns doctor planning and records whether the original delegated findings still reproduce.',
+    params: repairRequestParams,
+    responses: { 200: passthrough, 404: errorResponse, 500: errorResponse },
+    handler: async (_req, _ctx, { params }) => {
+      try {
+        return Response.json(await verifyDoctorRepairRequest({
+          contentDir: getContentDir(),
+          projectRoot: process.cwd(),
+          requestId: params.requestId,
+        }))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        const status = message.includes('not found') ? 404 : 500
+        return Response.json({ error: message }, { status })
       }
     },
   }),

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -10,6 +10,7 @@ import { getLastResults, runDiagnostics } from '../../src/core/doctor'
 import { createLogger } from '../../src/core/logger'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
 import { getContentDir } from '../../src/core/content-dir'
+import { applyDoctorRepair, planDoctorRepair } from '../../src/core/doctor-repair'
 import { getUsageFeed, getErrorCount, getStatsByMs, WINDOW_MS, type UsageKind, type WindowKey } from '../../src/core/usage'
 import {
   listHealthChecks,
@@ -178,6 +179,11 @@ const doctorResponse = z.object({
   cachedAt: z.string().optional(),
 })
 
+const doctorRepairApplyBody = z.object({
+  accepted: z.boolean(),
+  itemIds: z.array(z.string()).optional(),
+})
+
 const searchStatusResponse = z.object({
   enabled: z.boolean(),
   tables: z.array(passthrough),
@@ -313,6 +319,49 @@ const routes = [
         return Response.json({
           ...buildDoctorResponse(results),
           cachedAt: new Date().toISOString(),
+        })
+      } catch (err) {
+        return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+      }
+    },
+  }),
+
+  defineRoute({
+    path: '/doctor/repair/plan',
+    method: 'GET',
+    summary: 'Plan deterministic doctor repairs',
+    description: 'Runs diagnostics and returns safe/manual repair plan items without mutating state.',
+    responses: { 200: passthrough, 500: errorResponse },
+    handler: async () => {
+      try {
+        const report = await planDoctorRepair({
+          contentDir: getContentDir(),
+          projectRoot: process.cwd(),
+        })
+        return Response.json(report)
+      } catch (err) {
+        return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+      }
+    },
+  }),
+
+  defineRoute({
+    path: '/doctor/repair/apply',
+    method: 'POST',
+    summary: 'Apply deterministic doctor repairs',
+    description: 'Applies safe repair plan items only after accepted=true, then reruns affected checks for verification.',
+    body: doctorRepairApplyBody,
+    responses: { 200: passthrough, 409: passthrough, 500: errorResponse },
+    handler: async (_req, _ctx, { body }) => {
+      try {
+        const report = await applyDoctorRepair({
+          contentDir: getContentDir(),
+          projectRoot: process.cwd(),
+          accepted: body.accepted,
+          itemIds: body.itemIds,
+        })
+        return Response.json(report, {
+          status: report.status === 'confirmation_required' ? 409 : 200,
         })
       } catch (err) {
         return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })

--- a/plugins/health/lib/system-checks/mcporter.ts
+++ b/plugins/health/lib/system-checks/mcporter.ts
@@ -5,8 +5,7 @@
  * because it only installs a CLI tool and writes config.
  */
 import * as mcporter from '../../../../src/core/mcporter'
-import { getSettings } from '../../../../src/core/settings'
-import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../../packages/core/src/plugin-types'
 
 function ok(message: string): HealthCheckResult {
   return { check: 'mcporter', status: 'ok', message, autoFixable: false }
@@ -22,8 +21,11 @@ function fixed(message: string): HealthCheckResult {
 }
 
 export async function checkMcporter(): Promise<HealthCheckResult[]> {
+  return checkMcporterInternal(false)
+}
+
+async function checkMcporterInternal(autoFix: boolean): Promise<HealthCheckResult[]> {
   const port = Number(process.env.PORT || 3737)
-  const autoFix = getSettings().doctor.autoFixSkill
   const results: HealthCheckResult[] = []
 
   if (!mcporter.isMcporterInstalled()) {
@@ -57,4 +59,46 @@ export async function checkMcporter(): Promise<HealthCheckResult[]> {
   }
 
   return results
+}
+
+export function mcporterRepair(): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'mcporter' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'health.repair-mcporter',
+        checkId: 'mcporter',
+        title: 'Repair mcporter install/config',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'service',
+          target: 'mcporter',
+          action: 'install',
+          description: 'Install mcporter if missing and synchronize Bakin agent server entries.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const rows = await checkMcporterInternal(true)
+      const failures = rows.filter(row => row.status === 'error')
+      return [{
+        id: 'health.repair-mcporter',
+        checkId: 'mcporter',
+        status: failures.length > 0 ? 'failed' : 'applied',
+        message: rows.map(row => row.message).join('; '),
+        changes: rows
+          .filter(row => row.status === 'fixed')
+          .map(row => ({
+            kind: 'service' as const,
+            target: 'mcporter',
+            action: 'install' as const,
+            description: row.message,
+          })),
+      }]
+    },
+  }
 }

--- a/plugins/health/lib/system-checks/sync-skill.ts
+++ b/plugins/health/lib/system-checks/sync-skill.ts
@@ -10,10 +10,9 @@
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 
-import { getSettings } from '../../../../src/core/settings'
 import { getAllExecTools } from '../../../../scripts/lib/registry'
 import type { AgentRuntimeAdapter } from '../../../../packages/core/src/adapters/runtime'
-import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../../packages/core/src/plugin-types'
 
 const EXEC_TOOLS_START = '<!-- bakin:exec-tools:start -->'
 const EXEC_TOOLS_END = '<!-- bakin:exec-tools:end -->'
@@ -81,7 +80,14 @@ function renderSyncedSkill(templateContent: string): string {
 }
 
 export async function checkAndSyncSkill(projectRoot: string, runtime: AgentRuntimeAdapter): Promise<HealthCheckResult[]> {
-  const autoFix = getSettings().doctor.autoFixSkill
+  return checkAndSyncSkillInternal(projectRoot, runtime, false)
+}
+
+async function checkAndSyncSkillInternal(
+  projectRoot: string,
+  runtime: AgentRuntimeAdapter,
+  autoFix: boolean,
+): Promise<HealthCheckResult[]> {
   const sourceSkill = join(projectRoot, 'skill', 'SKILL.md')
   if (!existsSync(sourceSkill)) {
     return [error('Bakin skill source not found at skill/SKILL.md')]
@@ -123,5 +129,47 @@ export async function checkAndSyncSkill(projectRoot: string, runtime: AgentRunti
     return [fixed('Bakin skill updated in runtime')]
   } catch (err) {
     return [error(`Failed to update skill: ${err}`)]
+  }
+}
+
+export function syncSkillRepair(projectRoot: string, runtime: AgentRuntimeAdapter): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'skill' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'health.sync-skill',
+        checkId: 'skill',
+        title: 'Sync Bakin runtime skill',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'runtime',
+          target: 'runtime skill:bakin',
+          action: 'update',
+          description: 'Write the rendered Bakin SKILL.md to the runtime skill store.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const rows = await checkAndSyncSkillInternal(projectRoot, runtime, true)
+      const failures = rows.filter(row => row.status === 'error')
+      return [{
+        id: 'health.sync-skill',
+        checkId: 'skill',
+        status: failures.length > 0 ? 'failed' : 'applied',
+        message: rows.map(row => row.message).join('; '),
+        changes: rows
+          .filter(row => row.status === 'fixed')
+          .map(row => ({
+            kind: 'runtime' as const,
+            target: 'runtime skill:bakin',
+            action: 'update' as const,
+            description: row.message,
+          })),
+      }]
+    },
   }
 }

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -15,7 +15,7 @@ import { createTaskWithEffects } from '../../src/core/task-service'
 import { getContentDir } from '../../src/core/content-dir'
 import { createLogger } from '../../src/core/logger'
 import { readTaskboard } from '../../src/core/task-store'
-import { checkScheduleSync } from './lib/health-checks'
+import { checkScheduleSync, scheduleSyncRepair } from './lib/health-checks'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import type { BakinJobMeta, BridgePayload, BridgeResult, MergedJob } from './types'
 
@@ -1366,8 +1366,8 @@ const schedulePlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'schedule-sync',
       name: 'Runtime cron jobs and Bakin sidecar sync',
-      autoFix: true,
       run: async () => checkScheduleSync(getContentDir(), ctx.runtime.cron, await getRuntimeMainAgentId(ctx.runtime)),
+      repair: scheduleSyncRepair(getContentDir(), ctx.runtime.cron, () => getRuntimeMainAgentId(ctx.runtime)),
     })
 
     log.info('Schedule plugin activated')

--- a/plugins/schedule/lib/health-checks.ts
+++ b/plugins/schedule/lib/health-checks.ts
@@ -13,8 +13,7 @@ import { dirname, join } from 'path'
 import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
 
 import { createLogger } from '../../../src/core/logger'
-import { getSettings } from '../../../src/core/settings'
-import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 
 const log = createLogger('schedule:health')
 
@@ -49,8 +48,16 @@ export async function checkScheduleSync(
   cron: RuntimeCronReader,
   defaultOwner: string,
 ): Promise<HealthCheckResult[]> {
+  return checkScheduleSyncInternal(contentDir, cron, defaultOwner, false)
+}
+
+async function checkScheduleSyncInternal(
+  contentDir: string,
+  cron: RuntimeCronReader,
+  defaultOwner: string,
+  autoFix: boolean,
+): Promise<HealthCheckResult[]> {
   const checkName = 'schedule-sync'
-  const autoFix = getSettings().doctor.autoFixSkill
   const results: HealthCheckResult[] = []
 
   let runtimeJobs: Array<{ id: string; name: string }>
@@ -130,4 +137,51 @@ export async function checkScheduleSync(
   }
 
   return results
+}
+
+export function scheduleSyncRepair(
+  contentDir: string,
+  cron: RuntimeCronReader,
+  resolveDefaultOwner: () => Promise<string>,
+): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'schedule-sync' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'schedule.track-runtime-cron',
+        checkId: 'schedule-sync',
+        title: 'Track orphan runtime cron jobs',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'file',
+          target: join(contentDir, 'schedule', 'sidecar.json'),
+          action: 'update',
+          description: 'Add orphan runtime cron jobs to the schedule sidecar for manual triage.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const defaultOwner = await resolveDefaultOwner()
+      const rows = await checkScheduleSyncInternal(contentDir, cron, defaultOwner, true)
+      const failures = rows.filter(row => row.status === 'error')
+      return [{
+        id: 'schedule.track-runtime-cron',
+        checkId: 'schedule-sync',
+        status: failures.length > 0 ? 'failed' : 'applied',
+        message: rows.map(row => row.message).join('; '),
+        changes: rows
+          .filter(row => row.status === 'fixed')
+          .map(row => ({
+            kind: 'file' as const,
+            target: join(contentDir, 'schedule', 'sidecar.json'),
+            action: 'update' as const,
+            description: row.message,
+          })),
+      }]
+    },
+  }
 }

--- a/plugins/schedule/lib/health-checks.ts
+++ b/plugins/schedule/lib/health-checks.ts
@@ -38,8 +38,7 @@ function fixed(check: string, message: string): HealthCheckResult {
 
 /**
  * Detect orphaned runtime cron jobs that aren't tracked in Bakin's
- * `schedule/sidecar.json`. Auto-tracks them when
- * settings.doctor.autoFixSkill is true - creates a minimal sidecar
+ * `schedule/sidecar.json`. The explicit repair handler creates a minimal sidecar
  * entry flagged `requireTriage: true` and explicitly leaves agentId
  * unset (the user must triage rather than have a guessed assignment).
  */

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -31,6 +31,8 @@ import {
   checkTaskboard,
   checkTaskConsistency,
   checkTaskPositionIntegrity,
+  taskConsistencyRepair,
+  taskOrderRepair,
 } from './lib/health-checks'
 import type { Task, ColumnId } from './types'
 
@@ -895,14 +897,14 @@ const tasksPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'task-consistency',
       name: 'Task consistency (orphans, overload, stale in-progress)',
-      autoFix: true,
       run: () => checkTaskConsistency(getContentDir(), ctx.runtime.agents),
+      repair: taskConsistencyRepair(),
     })
     ctx.registerHealthCheck({
       id: 'order-integrity',
       name: 'Task position / order integrity',
-      autoFix: true,
       run: () => Promise.resolve(checkTaskPositionIntegrity()),
+      repair: taskOrderRepair(),
     })
   },
 

--- a/plugins/tasks/lib/health-checks.ts
+++ b/plugins/tasks/lib/health-checks.ts
@@ -13,8 +13,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { selectRuntimeMainAgent, type AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
 
-import { getSettings } from '../../../src/core/settings'
-import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 import { maybeGetAppServices } from '../../../src/core/app-services'
 import { clearDependency, readTaskboard, reorderTasks } from '../../../src/core/task-store'
 import type { ColumnId, Task } from '../types'
@@ -29,9 +28,6 @@ function warn(check: string, message: string, autoFixable = false): HealthCheckR
 }
 function error(check: string, message: string): HealthCheckResult {
   return { check, status: 'error', message, autoFixable: false }
-}
-function fixed(check: string, message: string): HealthCheckResult {
-  return { check, status: 'fixed', message, autoFixable: true }
 }
 
 type RuntimeAgentReader = Pick<AgentRuntimeAdapter['agents'], 'list'>
@@ -68,16 +64,14 @@ export function checkTaskboard(): HealthCheckResult[] {
 // ─── Task consistency: orphaned, overloaded, or stale in-progress tasks ───
 
 /**
- * Detect orphaned, overloaded, or stale in-progress tasks. Auto-fixes
- * orphaned dependsOn refs on done tasks when settings.doctor.autoFixSkill is
- * true.
+ * Detect orphaned, overloaded, or stale in-progress tasks. Report-only:
+ * orphaned done-task dependencies are repaired by taskConsistencyRepair.
  */
 export async function checkTaskConsistency(
   contentDir: string,
   agentReader?: RuntimeAgentReader,
 ): Promise<HealthCheckResult[]> {
   const results: HealthCheckResult[] = []
-  const autoFix = getSettings().doctor.autoFixSkill
 
   try {
     interface TaskEntry { id: string; title: string; agent?: string; dependsOn?: string; log?: unknown[] }
@@ -122,16 +116,7 @@ export async function checkTaskConsistency(
     // Done tasks with orphaned dependsOn
     for (const task of columns.done) {
       if (task.dependsOn) {
-        if (autoFix) {
-          try {
-            await clearDependency(task.id)
-            results.push(fixed('task-consistency', `Cleared orphaned dependsOn on done task "${task.title}"`))
-          } catch {
-            results.push(warn('task-consistency', `Done task "${task.title}" has orphaned dependsOn="${task.dependsOn}" — failed to clear`))
-          }
-        } else {
-          results.push(warn('task-consistency', `Done task "${task.title}" has orphaned dependsOn="${task.dependsOn}"`, true))
-        }
+        results.push(warn('task-consistency', `Done task "${task.title}" has orphaned dependsOn="${task.dependsOn}"`, true))
       }
     }
 
@@ -145,12 +130,58 @@ export async function checkTaskConsistency(
   return results
 }
 
+export function taskConsistencyRepair(): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row =>
+        row.check === 'task-consistency'
+        && row.autoFixable
+        && row.message.includes('orphaned dependsOn')
+      )
+      if (matching.length === 0) return []
+      return [{
+        id: 'tasks.clear-done-depends-on',
+        checkId: 'task-consistency',
+        title: 'Clear orphaned dependencies from done tasks',
+        reason: `${matching.length} done task(s) still carry dependsOn links.`,
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'task',
+          target: 'done tasks with dependsOn',
+          action: 'update',
+          description: 'Remove dependsOn from done tasks so completed work no longer blocks unrelated tasks.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const board = readTaskboard() as unknown as { columns: { done: Array<{ id: string; title: string; dependsOn?: string }> } }
+      const affected = board.columns.done.filter(task => task.dependsOn)
+      for (const task of affected) {
+        await clearDependency(task.id)
+      }
+      return [{
+        id: 'tasks.clear-done-depends-on',
+        checkId: 'task-consistency',
+        status: 'applied',
+        message: `Cleared orphaned dependsOn from ${affected.length} done task(s).`,
+        changes: affected.map(task => ({
+          kind: 'task' as const,
+          target: task.id,
+          action: 'update' as const,
+          description: `Cleared dependsOn from "${task.title}".`,
+        })),
+      }]
+    },
+  }
+}
+
 // ─── Task position integrity: unique order values per column ───────────────
 
 /**
  * Verify every Bakin task has a unique numeric order value within its
- * column. Auto-fixes by reassigning order zero-indexed by updated_at
- * desc when settings.doctor.autoFixSkill is true.
+ * column. Report-only; taskOrderRepair performs the deterministic reorder.
  *
  * Migration note (#139 C2): emitted check id renamed from
  * `tasks.order_integrity` to `order-integrity`. With plugin-namespacing
@@ -158,7 +189,6 @@ export async function checkTaskConsistency(
  */
 export async function checkTaskPositionIntegrity(): Promise<HealthCheckResult[]> {
   const CHECK = 'order-integrity'
-  const autoFix = getSettings().doctor.autoFixSkill
   try {
     const board = readTaskboard()
     const entries = Object.entries(board.columns) as Array<[ColumnId, Task[]]>
@@ -182,19 +212,56 @@ export async function checkTaskPositionIntegrity(): Promise<HealthCheckResult[]>
     if (missingCount > 0) issues.push(`${missingCount} missing`)
     if (duplicateCount > 0) issues.push(`${duplicateCount} duplicates`)
 
-    if (!autoFix) {
-      return [warn(CHECK, `Order issues: ${issues.join(', ')} across ${total} tasks`, true)]
-    }
-
-    for (const [column, tasks] of entries) {
-      const ordered = [...tasks]
-        .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-        .map((task) => task.id)
-      await reorderTasks(column, ordered)
-    }
-
-    return [fixed(CHECK, `Fixed order issues (${issues.join(', ')}) across ${total} tasks`)]
+    return [warn(CHECK, `Order issues: ${issues.join(', ')} across ${total} tasks`, true)]
   } catch (err) {
     return [error(CHECK, `Order check failed: ${(err as Error).message}`)]
+  }
+}
+
+export function taskOrderRepair(): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'order-integrity' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'tasks.reorder-columns',
+        checkId: 'order-integrity',
+        title: 'Rebuild task order values',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'task',
+          target: 'task columns',
+          action: 'update',
+          description: 'Reassign contiguous order values within each column using updatedAt descending.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const board = readTaskboard()
+      const entries = Object.entries(board.columns) as Array<[ColumnId, Task[]]>
+      const changes = []
+      for (const [column, tasks] of entries) {
+        const ordered = [...tasks]
+          .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+          .map((task) => task.id)
+        await reorderTasks(column, ordered)
+        changes.push({
+          kind: 'task' as const,
+          target: column,
+          action: 'update' as const,
+          description: `Rebuilt order values for ${ordered.length} task(s).`,
+        })
+      }
+      return [{
+        id: 'tasks.reorder-columns',
+        checkId: 'order-integrity',
+        status: 'applied',
+        message: 'Rebuilt task order values.',
+        changes,
+      }]
+    },
   }
 }

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -35,7 +35,7 @@ import { getStatsByMs } from '../../src/core/usage'
 import { retrieveAgentPackageLessons } from '../../src/core/agent-packages/lesson-retrieval'
 import { getRuntimeMainAgentId, type AgentRuntimeAdapter, type RuntimeAgent } from '@bakin/core/adapters/runtime'
 import { readLatestSessionTranscript } from './lib/session-reader'
-import { checkAgentRoster, checkPersonas, checkAgentAssets } from './lib/health-checks'
+import { agentAssetsRepair, checkAgentRoster, checkPersonas, checkAgentAssets, personaRepair } from './lib/health-checks'
 import type {
   AgentMeta,
   AgentProfile,
@@ -2146,14 +2146,14 @@ const teamPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'personas',
       name: 'Persona files',
-      autoFix: true,
       run: () => checkPersonas(getContentDir(), ctx.runtime.agents),
+      repair: personaRepair(getContentDir(), ctx.runtime.agents),
     })
     ctx.registerHealthCheck({
       id: 'agent-assets',
       name: 'Agent-package projection drift',
-      autoFix: true,
       run: () => checkAgentAssets(),
+      repair: agentAssetsRepair(),
     })
   },
 

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -2138,16 +2138,20 @@ const teamPlugin: BakinPlugin = definePlugin({
     })
 
     // ─── Health checks (migrated out of core/doctor.ts per #139) ────────
+    const runtimeAgentReader = {
+      list: () => ctx.runtime.agents.list(),
+    }
+
     ctx.registerHealthCheck({
       id: 'agent-roster',
       name: 'Runtime agent roster',
-      run: () => checkAgentRoster(ctx.runtime.agents),
+      run: () => checkAgentRoster(runtimeAgentReader),
     })
     ctx.registerHealthCheck({
       id: 'personas',
       name: 'Persona files',
-      run: () => checkPersonas(getContentDir(), ctx.runtime.agents),
-      repair: personaRepair(getContentDir(), ctx.runtime.agents),
+      run: () => checkPersonas(getContentDir(), runtimeAgentReader),
+      repair: personaRepair(getContentDir(), runtimeAgentReader),
     })
     ctx.registerHealthCheck({
       id: 'agent-assets',

--- a/plugins/team/lib/health-checks.ts
+++ b/plugins/team/lib/health-checks.ts
@@ -14,9 +14,8 @@ import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
 
-import { getSettings } from '../../../src/core/settings'
 import { agentAssetsComponent } from '../../../src/core/onboarding/agent-assets'
-import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 
 type RuntimeAgentReader = Pick<AgentRuntimeAdapter['agents'], 'list'>
 
@@ -30,9 +29,6 @@ function warn(check: string, message: string, autoFixable = false): HealthCheckR
 }
 function error(check: string, message: string): HealthCheckResult {
   return { check, status: 'error', message, autoFixable: false }
-}
-function fixed(check: string, message: string): HealthCheckResult {
-  return { check, status: 'fixed', message, autoFixable: true }
 }
 
 // ─── Agent roster: runtime agents exposed to Bakin ─────────────────────────
@@ -73,15 +69,14 @@ export async function checkAgentRoster(runtime: RuntimeAgentReader): Promise<Hea
 // ─── Personas: each agent has a persona file under {contentDir}/team/personas
 
 /**
- * Verify each agent has a persona file. Auto-fixable — creates stub
- * files for missing agents when settings.doctor.autoFixSkill is true.
+ * Verify each agent has a persona file. Report-only; personaRepair creates
+ * missing stub files explicitly through the doctor repair workflow.
  */
 export async function checkPersonas(
   contentDir: string,
   runtime: RuntimeAgentReader,
 ): Promise<HealthCheckResult[]> {
   const results: HealthCheckResult[] = []
-  const autoFix = getSettings().doctor.autoFixSkill
   let agentIds: string[]
   try {
     agentIds = (await runtime.list()).map(agent => agent.id).filter(Boolean)
@@ -91,13 +86,8 @@ export async function checkPersonas(
   const personasDir = join(contentDir, 'team', 'personas')
 
   if (!existsSync(personasDir)) {
-    if (autoFix) {
-      mkdirSync(personasDir, { recursive: true })
-      results.push(fixed('personas', 'Created missing personas directory'))
-    } else {
-      results.push(warn('personas', `No personas directory at ${personasDir}`, true))
-      return results
-    }
+    results.push(warn('personas', `No personas directory at ${personasDir}`, true))
+    return results
   }
 
   const existing = new Set(
@@ -106,21 +96,10 @@ export async function checkPersonas(
       .map(f => f.replace('.md', ''))
   )
 
-  let created = 0
   for (const agent of agentIds) {
     if (!existing.has(agent)) {
-      if (autoFix) {
-        const stub = `# ${agent.charAt(0).toUpperCase() + agent.slice(1)}\n\n_Persona not yet configured. Update this file with the agent's personality, background, and communication style._\n`
-        writeFileSync(join(personasDir, `${agent}.md`), stub, 'utf-8')
-        created++
-      } else {
-        results.push(warn('personas', `Missing persona: ${join(personasDir, `${agent}.md`)}`, true))
-      }
+      results.push(warn('personas', `Missing persona: ${join(personasDir, `${agent}.md`)}`, true))
     }
-  }
-
-  if (autoFix && created > 0) {
-    results.push(fixed('personas', `Created ${created} stub persona file(s) — edit them to add real personalities`))
   }
 
   if (results.filter(r => r.check === 'personas').length === 0) {
@@ -130,13 +109,69 @@ export async function checkPersonas(
   return results
 }
 
+function personaStub(agent: string): string {
+  return `# ${agent.charAt(0).toUpperCase() + agent.slice(1)}\n\n_Persona not yet configured. Update this file with the agent's personality, background, and communication style._\n`
+}
+
+export function personaRepair(contentDir: string, runtime: RuntimeAgentReader): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'personas' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'team.create-personas',
+        checkId: 'personas',
+        title: 'Create missing persona files',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'file',
+          target: join(contentDir, 'team', 'personas'),
+          action: 'create',
+          description: 'Create the personas directory and stub markdown files for runtime agents missing personas.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const agentIds = (await runtime.list()).map(agent => agent.id).filter(Boolean)
+      const personasDir = join(contentDir, 'team', 'personas')
+      mkdirSync(personasDir, { recursive: true })
+      const existing = new Set(
+        existsSync(personasDir)
+          ? readdirSync(personasDir).filter(f => f.endsWith('.md')).map(f => f.replace('.md', ''))
+          : [],
+      )
+      const changes = []
+      for (const agent of agentIds) {
+        if (existing.has(agent)) continue
+        const path = join(personasDir, `${agent}.md`)
+        writeFileSync(path, personaStub(agent), 'utf-8')
+        changes.push({
+          kind: 'file' as const,
+          target: path,
+          action: 'create' as const,
+          description: `Created stub persona for ${agent}.`,
+        })
+      }
+      return [{
+        id: 'team.create-personas',
+        checkId: 'personas',
+        status: 'applied',
+        message: `Created ${changes.length} stub persona file(s).`,
+        changes,
+      }]
+    },
+  }
+}
+
 // ─── Agent-package projections: drift / missing / broken-marker findings ──
 
 /**
  * Surface drift / missing / broken-marker findings from the
- * agent-assets onboarding component. With autoFix enabled
- * (settings.doctor.autoFixSkill), runs the same install() flow as
- * `bakin install agent-assets` to repair detected drift in-place.
+ * agent-assets onboarding component. Report-only; agentAssetsRepair runs the
+ * same install() flow as `bakin install agent-assets` explicitly.
  *
  * Doctor sweep companion to the user-facing `bakin doctor` view; the
  * onboarding component (src/core/onboarding/agent-assets.ts) drives
@@ -144,14 +179,41 @@ export async function checkPersonas(
  * the two views never disagree.
  */
 export async function checkAgentAssets(): Promise<HealthCheckResult[]> {
-  const autoFix = getSettings().doctor.autoFixSkill
   try {
     const checkResult = await agentAssetsComponent.check()
     if (checkResult.status === 'ok') {
       return [ok('agent-assets', checkResult.message)]
     }
 
-    if (autoFix) {
+    const reminder = checkResult.remediation ?? 'Run `bakin install agent-assets` to repair.'
+    return [warn('agent-assets', `${checkResult.message} — ${reminder}`, true)]
+  } catch (err) {
+    return [warn('agent-assets', `agent-assets check failed: ${err}`)]
+  }
+}
+
+export function agentAssetsRepair(): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'agent-assets' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'team.install-agent-assets',
+        checkId: 'agent-assets',
+        title: 'Repair agent-package projections',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'runtime',
+          target: 'agent-package projections',
+          action: 'invoke',
+          description: 'Run the agent-assets install flow to repair missing or drifted projected files.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
       const installResult = await agentAssetsComponent.install({
         interactive: false,
         autoApprove: true,
@@ -159,18 +221,18 @@ export async function checkAgentAssets(): Promise<HealthCheckResult[]> {
         checkOnly: false,
         force: false,
       })
-      if (installResult.status === 'installed') {
-        return [fixed('agent-assets', installResult.message)]
-      }
-      if (installResult.status === 'noop') {
-        return [ok('agent-assets', installResult.message)]
-      }
-      return [error('agent-assets', `Repair failed: ${installResult.message}`)]
-    }
-
-    const reminder = checkResult.remediation ?? 'Run `bakin install agent-assets` to repair.'
-    return [warn('agent-assets', `${checkResult.message} — ${reminder}`, true)]
-  } catch (err) {
-    return [warn('agent-assets', `agent-assets check failed: ${err}`)]
+      return [{
+        id: 'team.install-agent-assets',
+        checkId: 'agent-assets',
+        status: installResult.status === 'failed' ? 'failed' : 'applied',
+        message: installResult.message,
+        changes: [{
+          kind: 'runtime',
+          target: 'agent-package projections',
+          action: 'invoke',
+          description: `agent-assets install returned ${installResult.status}.`,
+        }],
+      }]
+    },
   }
 }

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -24,6 +24,7 @@ import {
   checkWorkflowDefinitions,
   checkStaleWorkflowInstances,
   checkWorkflowSkills,
+  staleWorkflowInstancesRepair,
 } from './lib/health-checks'
 import { isReadOnly, getDefinition as getRegistryDefinition } from './lib/source-registry'
 import {
@@ -1526,8 +1527,8 @@ const workflowsPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthCheck({
       id: 'stale-instances',
       name: 'Stale workflow instances',
-      autoFix: true,
       run: () => checkStaleWorkflowInstances(getContentDir()),
+      repair: staleWorkflowInstancesRepair(getContentDir()),
     })
     ctx.registerHealthCheck({
       id: 'skills',

--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -12,9 +12,8 @@
 import { existsSync, readFileSync, readdirSync, unlinkSync } from 'fs'
 import { join } from 'path'
 
-import { getSettings } from '../../../src/core/settings'
 import { readTaskboard } from '../../../src/core/task-store'
-import type { HealthCheckResult } from '../../../packages/core/src/plugin-types'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 
 import { listDefinitions } from './parser'
 import { listInstances } from './runtime'
@@ -121,8 +120,11 @@ export async function checkWorkflowDefinitions(contentDir: string): Promise<Heal
  * hook.
  */
 export async function checkStaleWorkflowInstances(contentDir: string): Promise<HealthCheckResult[]> {
+  return checkStaleWorkflowInstancesInternal(contentDir, false)
+}
+
+async function checkStaleWorkflowInstancesInternal(contentDir: string, autoFix: boolean): Promise<HealthCheckResult[]> {
   const results: HealthCheckResult[] = []
-  const autoFix = getSettings().doctor.autoFixSkill
 
   try {
     const allInstances = listInstances(undefined, contentDir)
@@ -176,4 +178,46 @@ export async function checkStaleWorkflowInstances(contentDir: string): Promise<H
   }
 
   return results
+}
+
+export function staleWorkflowInstancesRepair(contentDir: string): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === 'workflow-instances' && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'workflows.remove-orphan-instances',
+        checkId: 'workflow-instances',
+        title: 'Remove orphaned workflow instances',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'file',
+          target: join(contentDir, 'workflows', 'instances'),
+          action: 'delete',
+          description: 'Delete workflow instance files whose tasks no longer exist on the board.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const rows = await checkStaleWorkflowInstancesInternal(contentDir, true)
+      const failures = rows.filter(row => row.status === 'error')
+      return [{
+        id: 'workflows.remove-orphan-instances',
+        checkId: 'workflow-instances',
+        status: failures.length > 0 ? 'failed' : 'applied',
+        message: rows.map(row => row.message).join('; '),
+        changes: rows
+          .filter(row => row.status === 'fixed')
+          .map(row => ({
+            kind: 'file' as const,
+            target: join(contentDir, 'workflows', 'instances'),
+            action: 'delete' as const,
+            description: row.message,
+          })),
+      }]
+    },
+  }
 }

--- a/src/core/cli/registry.ts
+++ b/src/core/cli/registry.ts
@@ -81,13 +81,14 @@ export const CLI_COMMANDS = [
   }),
   cli({
     name: 'doctor',
-    usage: 'bakin doctor [--json] [--full] [--notify-agent]',
+    usage: 'bakin doctor [--json] [--full] [--notify-agent] [--fix] [--yes]',
     group: 'Lifecycle',
     summary: 'Run health checks.',
-    description: 'Runs local offline diagnostics by default. Pass --full to include server-backed plugin, task, workflow, search, and runtime checks. Pass --notify-agent with --full to send unfixable issues to the runtime main agent.',
+    description: 'Runs local offline diagnostics by default. Pass --full to include server-backed plugin, task, workflow, search, and runtime checks. Pass --notify-agent with --full to send unfixable issues to the runtime main agent. Pass --fix to plan deterministic repairs; add --yes to apply safe repairs.',
     examples: [
       { title: 'Run offline diagnostics', code: 'bakin doctor', test: 'illustrative', reason: 'Depends on local Bakin/runtime state.' },
       { title: 'Run full diagnostics against the server', code: 'bakin doctor --full', test: 'illustrative', reason: 'Requires a running Bakin server.' },
+      { title: 'Apply safe deterministic repairs', code: 'bakin doctor --fix --yes', test: 'illustrative', reason: 'Requires a running Bakin server and may mutate local/runtime state.' },
     ],
   }),
 

--- a/src/core/cli/registry.ts
+++ b/src/core/cli/registry.ts
@@ -81,14 +81,15 @@ export const CLI_COMMANDS = [
   }),
   cli({
     name: 'doctor',
-    usage: 'bakin doctor [--json] [--full] [--notify-agent] [--fix] [--yes]',
+    usage: 'bakin doctor [--json] [--full] [--notify-agent] [--fix|--delegate] [--yes]',
     group: 'Lifecycle',
     summary: 'Run health checks.',
-    description: 'Runs local offline diagnostics by default. Pass --full to include server-backed plugin, task, workflow, search, and runtime checks. Pass --notify-agent with --full to send unfixable issues to the runtime main agent. Pass --fix to plan deterministic repairs; add --yes to apply safe repairs.',
+    description: 'Runs local offline diagnostics by default. Pass --full to include server-backed plugin, task, workflow, search, and runtime checks. Pass --notify-agent with --full to send unfixable issues to the runtime main agent. Pass --fix to plan deterministic repairs or --delegate to create a linked repair task for the main agent; add --yes to execute either repair path.',
     examples: [
       { title: 'Run offline diagnostics', code: 'bakin doctor', test: 'illustrative', reason: 'Depends on local Bakin/runtime state.' },
       { title: 'Run full diagnostics against the server', code: 'bakin doctor --full', test: 'illustrative', reason: 'Requires a running Bakin server.' },
       { title: 'Apply safe deterministic repairs', code: 'bakin doctor --fix --yes', test: 'illustrative', reason: 'Requires a running Bakin server and may mutate local/runtime state.' },
+      { title: 'Create a delegated repair task', code: 'bakin doctor --delegate --yes', test: 'illustrative', reason: 'Requires a running Bakin server and creates a task on the board.' },
     ],
   }),
 

--- a/src/core/doctor-delegate.ts
+++ b/src/core/doctor-delegate.ts
@@ -1,0 +1,168 @@
+import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
+import { getAppServices } from './app-services'
+import { planDoctorRepair, type DoctorRepairPlanReport } from './doctor-repair'
+import {
+  createDoctorRepairRequest,
+  getDoctorRepairRequest,
+  updateDoctorRepairRequest,
+  type DoctorRepairRequest,
+} from './doctor-repair-store'
+import { createTaskWithEffects } from './task-service'
+import { dispatchSingleTask } from './dispatch'
+import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
+
+export interface DoctorDelegateOptions {
+  contentDir: string
+  projectRoot: string
+  accepted: boolean
+}
+
+export interface DoctorDelegateReport {
+  status: 'confirmation_required' | 'sent' | 'no_unresolved'
+  request: DoctorRepairRequest
+  unresolved: HealthCheckResult[]
+}
+
+export interface DoctorDelegateVerificationReport {
+  request: DoctorRepairRequest
+  remaining: HealthCheckResult[]
+  verified: boolean
+}
+
+function unresolvedRows(plan: DoctorRepairPlanReport): HealthCheckResult[] {
+  const safeRepairChecks = new Set(
+    plan.items
+      .filter(item => item.safety === 'safe')
+      .map(item => item.checkId),
+  )
+  return plan.diagnostics.filter(row => (
+    (row.status === 'warn' || row.status === 'error')
+    && !safeRepairChecks.has(row.check)
+  ))
+}
+
+function summarizeUnresolved(rows: HealthCheckResult[]): string {
+  if (rows.length === 0) return 'no unresolved doctor findings'
+  const errors = rows.filter(row => row.status === 'error').length
+  const warnings = rows.filter(row => row.status === 'warn').length
+  return `${errors} error${errors === 1 ? '' : 's'}, ${warnings} warning${warnings === 1 ? '' : 's'}`
+}
+
+function buildRepairBrief(request: DoctorRepairRequest, unresolved: HealthCheckResult[]): string {
+  const lines = [
+    `Doctor repair request: ${request.id}`,
+    '',
+    'Resolve the following Bakin doctor findings. Use normal Bakin tools and update the linked task with progress.',
+    '',
+    ...unresolved.map(row => `- [${row.status.toUpperCase()}] ${row.check}: ${row.message}`),
+    '',
+    'When you believe the issue is fixed, run `bakin doctor --full` and complete this task with a short summary.',
+  ]
+  return lines.join('\n')
+}
+
+function rowSignature(row: HealthCheckResult): string {
+  return `${row.check}:${row.status}:${row.message}`
+}
+
+export async function delegateDoctorRepair(options: DoctorDelegateOptions): Promise<DoctorDelegateReport> {
+  const plan = await planDoctorRepair({
+    contentDir: options.contentDir,
+    projectRoot: options.projectRoot,
+  })
+  const unresolved = unresolvedRows(plan)
+  const request = createDoctorRepairRequest(options.contentDir, { plan, unresolved })
+
+  if (unresolved.length === 0) {
+    return { status: 'no_unresolved', request, unresolved }
+  }
+
+  if (!options.accepted) {
+    return { status: 'confirmation_required', request, unresolved }
+  }
+
+  const runtime = getAppServices().runtime
+  const agentId = await getRuntimeMainAgentId(runtime)
+  const task = await createTaskWithEffects({
+    title: `Doctor repair: ${summarizeUnresolved(unresolved)}`,
+    column: 'todo',
+    assignee: agentId,
+    description: buildRepairBrief(request, unresolved),
+    createdBy: 'system',
+    source: {
+      pluginId: 'health',
+      entityType: 'doctor-repair',
+      entityId: request.id,
+      purpose: 'delegated-repair',
+    },
+    channel: 'system',
+  })
+
+  const withTask = updateDoctorRepairRequest(options.contentDir, request.id, current => ({
+    ...current,
+    status: 'sent',
+    taskId: task.id,
+    agentId,
+    events: [
+      ...current.events,
+      {
+        ts: new Date().toISOString(),
+        type: 'task-created',
+        message: `Created linked repair task ${task.id}.`,
+        data: { taskId: task.id, agentId },
+      },
+    ],
+  }))
+
+  const port = Number(process.env.PORT || 3737)
+  await dispatchSingleTask(task.id, options.contentDir, port, 'kick')
+
+  const sent = updateDoctorRepairRequest(options.contentDir, request.id, current => ({
+    ...current,
+    status: 'sent',
+    events: [
+      ...current.events,
+      {
+        ts: new Date().toISOString(),
+        type: 'dispatch-kicked',
+        message: `Kicked immediate dispatch for linked repair task ${task.id}.`,
+        data: { taskId: task.id, agentId },
+      },
+    ],
+  }))
+
+  return { status: 'sent', request: sent ?? withTask, unresolved }
+}
+
+export async function verifyDoctorRepairRequest(
+  options: Pick<DoctorDelegateOptions, 'contentDir' | 'projectRoot'> & { requestId: string },
+): Promise<DoctorDelegateVerificationReport> {
+  const request = getDoctorRepairRequest(options.contentDir, options.requestId)
+  if (!request) throw new Error(`Doctor repair request not found: ${options.requestId}`)
+
+  const original = new Set(request.unresolved.map(rowSignature))
+  const plan = await planDoctorRepair({
+    contentDir: options.contentDir,
+    projectRoot: options.projectRoot,
+  })
+  const remaining = unresolvedRows(plan).filter(row => original.has(rowSignature(row)))
+  const verified = remaining.length === 0
+
+  const updated = updateDoctorRepairRequest(options.contentDir, request.id, current => ({
+    ...current,
+    status: verified ? 'verified' : current.status,
+    events: [
+      ...current.events,
+      {
+        ts: new Date().toISOString(),
+        type: 'verified',
+        message: verified
+          ? 'Original doctor findings no longer reproduce.'
+          : `${remaining.length} original doctor finding(s) still reproduce.`,
+        data: { remaining: remaining.length },
+      },
+    ],
+  }))
+
+  return { request: updated, remaining, verified }
+}

--- a/src/core/doctor-repair-store.ts
+++ b/src/core/doctor-repair-store.ts
@@ -1,0 +1,135 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
+import type { DoctorRepairPlanReport } from './doctor-repair'
+
+export type DoctorRepairRequestStatus = 'planned' | 'sent' | 'completed' | 'verified' | 'failed'
+
+export interface DoctorRepairRequestEvent {
+  ts: string
+  type: string
+  message: string
+  data?: Record<string, unknown>
+}
+
+export interface DoctorRepairRequest {
+  id: string
+  kind: 'delegate'
+  status: DoctorRepairRequestStatus
+  createdAt: string
+  updatedAt: string
+  plan: DoctorRepairPlanReport
+  unresolved: HealthCheckResult[]
+  taskId?: string
+  agentId?: string
+  events: DoctorRepairRequestEvent[]
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function monthShard(dateIso: string): string {
+  return dateIso.slice(0, 7)
+}
+
+function repairRoot(contentDir: string): string {
+  return join(contentDir, 'doctor', 'repair-requests')
+}
+
+function requestPath(contentDir: string, request: Pick<DoctorRepairRequest, 'id' | 'createdAt'>): string {
+  return join(repairRoot(contentDir), monthShard(request.createdAt), `${request.id}.json`)
+}
+
+function writeJsonAtomic(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`
+  writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`)
+  renameSync(tmp, path)
+}
+
+function readRequestFile(path: string): DoctorRepairRequest {
+  return JSON.parse(readFileSync(path, 'utf-8')) as DoctorRepairRequest
+}
+
+function findRequestPath(contentDir: string, requestId: string): string | null {
+  const root = repairRoot(contentDir)
+  if (!existsSync(root)) return null
+  for (const shard of readdirSync(root)) {
+    const path = join(root, shard, `${requestId}.json`)
+    if (existsSync(path)) return path
+  }
+  return null
+}
+
+export function createDoctorRepairRequest(
+  contentDir: string,
+  input: {
+    plan: DoctorRepairPlanReport
+    unresolved: HealthCheckResult[]
+    events?: DoctorRepairRequestEvent[]
+  },
+): DoctorRepairRequest {
+  const ts = nowIso()
+  const id = `repair-${crypto.randomUUID()}`
+  const request: DoctorRepairRequest = {
+    id,
+    kind: 'delegate',
+    status: 'planned',
+    createdAt: ts,
+    updatedAt: ts,
+    plan: input.plan,
+    unresolved: input.unresolved,
+    events: input.events ?? [{
+      ts,
+      type: 'created',
+      message: 'Delegated doctor repair request planned.',
+    }],
+  }
+  writeJsonAtomic(requestPath(contentDir, request), request)
+  return request
+}
+
+export function getDoctorRepairRequest(contentDir: string, requestId: string): DoctorRepairRequest | null {
+  const path = findRequestPath(contentDir, requestId)
+  return path ? readRequestFile(path) : null
+}
+
+export function updateDoctorRepairRequest(
+  contentDir: string,
+  requestId: string,
+  update: (request: DoctorRepairRequest) => DoctorRepairRequest,
+): DoctorRepairRequest {
+  const path = findRequestPath(contentDir, requestId)
+  if (!path) throw new Error(`Doctor repair request not found: ${requestId}`)
+  const current = readRequestFile(path)
+  const next = { ...update(current), updatedAt: nowIso() }
+  writeJsonAtomic(path, next)
+  return next
+}
+
+export function appendDoctorRepairRequestEvent(
+  contentDir: string,
+  requestId: string,
+  event: Omit<DoctorRepairRequestEvent, 'ts'>,
+): DoctorRepairRequest {
+  return updateDoctorRepairRequest(contentDir, requestId, request => ({
+    ...request,
+    events: [...request.events, { ...event, ts: nowIso() }],
+  }))
+}
+
+export function listDoctorRepairRequests(contentDir: string): DoctorRepairRequest[] {
+  const root = repairRoot(contentDir)
+  if (!existsSync(root)) return []
+  const requests: DoctorRepairRequest[] = []
+  for (const shard of readdirSync(root)) {
+    const dir = join(root, shard)
+    if (!existsSync(dir)) continue
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.json')) continue
+      requests.push(readRequestFile(join(dir, file)))
+    }
+  }
+  return requests.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+}

--- a/src/core/doctor-repair.ts
+++ b/src/core/doctor-repair.ts
@@ -1,0 +1,292 @@
+/**
+ * Explicit doctor repair orchestration.
+ *
+ * Normal diagnostics stay report-only. This module is the deterministic repair
+ * boundary: callers must ask for a plan, then explicitly accept before any
+ * check-owned repair handler can mutate state.
+ */
+import { appendAudit } from './audit'
+import { runDetailedPluginHealthChecks } from './doctor'
+import { getHealthCheck } from './health-check-registry'
+import type {
+  HealthCheckDef,
+  HealthCheckResult,
+  HealthRepairApplyResult,
+  HealthRepairPlanItem,
+} from '../../packages/core/src/plugin-types'
+
+export interface DoctorRepairPlanItem extends HealthRepairPlanItem {
+  healthCheckId: string
+  pluginId: string
+  checkName: string
+}
+
+export interface DoctorRepairError {
+  phase: 'plan' | 'apply' | 'verify'
+  healthCheckId: string
+  pluginId: string
+  checkName: string
+  message: string
+}
+
+export interface DoctorRepairPlanSummary {
+  diagnostics: number
+  repairableChecks: number
+  totalItems: number
+  safeItems: number
+  blockedItems: number
+  planErrors: number
+}
+
+export interface DoctorRepairPlanReport {
+  diagnostics: HealthCheckResult[]
+  items: DoctorRepairPlanItem[]
+  errors: DoctorRepairError[]
+  summary: DoctorRepairPlanSummary
+}
+
+export interface DoctorRepairApplySummary {
+  planned: number
+  applied: number
+  skipped: number
+  failed: number
+  verificationErrors: number
+  verificationWarnings: number
+}
+
+export interface DoctorRepairApplyReport {
+  status: 'confirmation_required' | 'applied'
+  plan: DoctorRepairPlanReport
+  applied: HealthRepairApplyResult[]
+  skipped: HealthRepairApplyResult[]
+  errors: DoctorRepairError[]
+  verification: HealthCheckResult[]
+  summary: DoctorRepairApplySummary
+}
+
+export interface DoctorRepairOptions {
+  contentDir: string
+  projectRoot: string
+}
+
+export interface DoctorRepairApplyOptions extends DoctorRepairOptions {
+  accepted: boolean
+  itemIds?: string[]
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function needsRepair(row: HealthCheckResult): boolean {
+  return row.status === 'warn' || row.status === 'error'
+}
+
+function enrichPlanItem(def: HealthCheckDef, item: HealthRepairPlanItem): DoctorRepairPlanItem {
+  return {
+    ...item,
+    healthCheckId: def.id,
+    pluginId: def.pluginId,
+    checkName: def.name,
+  }
+}
+
+function summarizePlan(
+  diagnostics: HealthCheckResult[],
+  items: DoctorRepairPlanItem[],
+  errors: DoctorRepairError[],
+): DoctorRepairPlanSummary {
+  return {
+    diagnostics: diagnostics.length,
+    repairableChecks: new Set(items.map(item => item.healthCheckId)).size,
+    totalItems: items.length,
+    safeItems: items.filter(item => item.safety === 'safe').length,
+    blockedItems: items.filter(item => item.safety !== 'safe').length,
+    planErrors: errors.length,
+  }
+}
+
+async function verifyHealthCheck(def: HealthCheckDef): Promise<HealthCheckResult[]> {
+  try {
+    const rows = await def.run()
+    if (!Array.isArray(rows)) {
+      return [{
+        check: def.id,
+        status: 'error',
+        message: `Plugin health check returned non-array: ${typeof rows}`,
+        autoFixable: false,
+      }]
+    }
+    return rows
+  } catch (err) {
+    return [{
+      check: def.id,
+      status: 'error',
+      message: `Plugin health check threw: ${errorMessage(err)}`,
+      autoFixable: false,
+    }]
+  }
+}
+
+export async function planDoctorRepair(options: DoctorRepairOptions): Promise<DoctorRepairPlanReport> {
+  void options.projectRoot
+  const groups = await runDetailedPluginHealthChecks()
+  const diagnostics = groups.flatMap(group => group.results)
+  const items: DoctorRepairPlanItem[] = []
+  const errors: DoctorRepairError[] = []
+
+  for (const { def, results } of groups) {
+    if (!def.repair || !results.some(needsRepair)) continue
+    try {
+      const planned = await def.repair.plan(results.filter(needsRepair))
+      items.push(...planned.map(item => enrichPlanItem(def, item)))
+    } catch (err) {
+      errors.push({
+        phase: 'plan',
+        healthCheckId: def.id,
+        pluginId: def.pluginId,
+        checkName: def.name,
+        message: errorMessage(err),
+      })
+    }
+  }
+
+  const report = {
+    diagnostics,
+    items,
+    errors,
+    summary: summarizePlan(diagnostics, items, errors),
+  }
+
+  appendAudit(options.contentDir, 'doctor.fix.planned', 'system', {
+    diagnostics: report.summary.diagnostics,
+    totalItems: report.summary.totalItems,
+    safeItems: report.summary.safeItems,
+    blockedItems: report.summary.blockedItems,
+    planErrors: report.summary.planErrors,
+  })
+
+  return report
+}
+
+export async function applyDoctorRepair(options: DoctorRepairApplyOptions): Promise<DoctorRepairApplyReport> {
+  const plan = await planDoctorRepair(options)
+  const selectedIds = options.itemIds ? new Set(options.itemIds) : null
+  const selectedItems = selectedIds
+    ? plan.items.filter(item => selectedIds.has(item.id))
+    : plan.items
+
+  if (!options.accepted) {
+    return {
+      status: 'confirmation_required',
+      plan,
+      applied: [],
+      skipped: [],
+      errors: [],
+      verification: [],
+      summary: {
+        planned: selectedItems.length,
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        verificationErrors: 0,
+        verificationWarnings: 0,
+      },
+    }
+  }
+
+  const safeItems = selectedItems.filter(item => item.safety === 'safe')
+  const blockedItems = selectedItems.filter(item => item.safety !== 'safe')
+  const skipped: HealthRepairApplyResult[] = blockedItems.map(item => ({
+    id: item.id,
+    checkId: item.checkId,
+    status: 'skipped',
+    message: `Skipped ${item.safety} repair item; deterministic doctor repair only applies safe items.`,
+    changes: item.changes,
+  }))
+
+  const groupsByCheck = new Map<string, DoctorRepairPlanItem[]>()
+  for (const item of safeItems) {
+    const existing = groupsByCheck.get(item.healthCheckId) ?? []
+    existing.push(item)
+    groupsByCheck.set(item.healthCheckId, existing)
+  }
+
+  const applied: HealthRepairApplyResult[] = []
+  const errors: DoctorRepairError[] = [...plan.errors]
+
+  for (const [healthCheckId, items] of groupsByCheck.entries()) {
+    const def = getHealthCheck(healthCheckId)
+    if (!def?.repair) continue
+    try {
+      const results = await def.repair.apply(items)
+      applied.push(...results)
+    } catch (err) {
+      const message = errorMessage(err)
+      errors.push({
+        phase: 'apply',
+        healthCheckId: def.id,
+        pluginId: def.pluginId,
+        checkName: def.name,
+        message,
+      })
+      applied.push({
+        id: `${def.id}.apply-error`,
+        checkId: def.id,
+        status: 'failed',
+        message,
+        changes: items.flatMap(item => item.changes),
+      })
+    }
+  }
+
+  const verification: HealthCheckResult[] = []
+  for (const healthCheckId of groupsByCheck.keys()) {
+    const def = getHealthCheck(healthCheckId)
+    if (!def) continue
+    try {
+      verification.push(...await verifyHealthCheck(def))
+    } catch (err) {
+      errors.push({
+        phase: 'verify',
+        healthCheckId: def.id,
+        pluginId: def.pluginId,
+        checkName: def.name,
+        message: errorMessage(err),
+      })
+    }
+  }
+
+  const failed = applied.filter(result => result.status === 'failed').length
+  const verificationErrors = verification.filter(row => row.status === 'error').length
+  const verificationWarnings = verification.filter(row => row.status === 'warn').length
+
+  appendAudit(options.contentDir, failed > 0 ? 'doctor.fix.failed' : 'doctor.fix.applied', 'system', {
+    planned: selectedItems.length,
+    applied: applied.filter(result => result.status === 'applied').length,
+    skipped: skipped.length,
+    failed,
+  })
+  appendAudit(options.contentDir, 'doctor.fix.verified', 'system', {
+    checks: groupsByCheck.size,
+    errors: verificationErrors,
+    warnings: verificationWarnings,
+  })
+
+  return {
+    status: 'applied',
+    plan,
+    applied,
+    skipped,
+    errors,
+    verification,
+    summary: {
+      planned: selectedItems.length,
+      applied: applied.filter(result => result.status === 'applied').length,
+      skipped: skipped.length,
+      failed,
+      verificationErrors,
+      verificationWarnings,
+    },
+  }
+}

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -16,7 +16,7 @@ import { getAppServices } from './app-services'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { isOnboarded } from './onboarding/state'
 import { listHealthChecks } from './health-check-registry'
-import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
+import type { HealthCheckDef, HealthCheckResult } from '../../packages/core/src/plugin-types'
 
 const log = createLogger('doctor')
 
@@ -27,6 +27,11 @@ let lastResultTime: number = 0
 // Track what we've already notified about to avoid spamming the main agent
 const notifiedIssues = new Set<string>()
 
+export interface DetailedHealthCheckRun {
+  def: HealthCheckDef
+  results: HealthCheckResult[]
+}
+
 /**
  * Run every plugin-registered health check in parallel. Per-check try/catch
  * isolates failures — a single bad handler yields one synthetic error result
@@ -34,33 +39,43 @@ const notifiedIssues = new Set<string>()
  * so the isolation behavior can be tested without mocking every plugin's
  * dependency tree.
  */
-export async function runPluginHealthChecks(): Promise<HealthCheckResult[]> {
+export async function runDetailedPluginHealthChecks(): Promise<DetailedHealthCheckRun[]> {
   const defs = listHealthChecks()
-  const arrays = await Promise.all(
+  return Promise.all(
     defs.map(async (def) => {
       try {
         const rows = await def.run()
         if (!Array.isArray(rows)) {
-          return [{
-            check: def.id,
-            status: 'error' as const,
-            message: `Plugin health check returned non-array: ${typeof rows}`,
-            autoFixable: false,
-          }]
+          return {
+            def,
+            results: [{
+              check: def.id,
+              status: 'error' as const,
+              message: `Plugin health check returned non-array: ${typeof rows}`,
+              autoFixable: false,
+            }],
+          }
         }
-        return rows
+        return { def, results: rows }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        return [{
-          check: def.id,
-          status: 'error' as const,
-          message: `Plugin health check threw: ${message}`,
-          autoFixable: false,
-        }]
+        return {
+          def,
+          results: [{
+            check: def.id,
+            status: 'error' as const,
+            message: `Plugin health check threw: ${message}`,
+            autoFixable: false,
+          }],
+        }
       }
     }),
   )
-  return arrays.flat()
+}
+
+export async function runPluginHealthChecks(): Promise<HealthCheckResult[]> {
+  const groups = await runDetailedPluginHealthChecks()
+  return groups.flatMap(group => group.results)
 }
 
 async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void> {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -5,9 +5,8 @@
  * ctx.registerHealthCheck and contributed through runPluginHealthChecks.
  * Deep reference: .claude/knowledge/doctor-and-health-checks.md.
  *
- * Auto-fix policy is per-check: each plugin reads getSettings().doctor.autoFixSkill
- * inline. Unsafe issues (warn / error with autoFixable=false) are escalated
- * to the runtime main agent so they show up in conversation.
+ * Diagnostics are report-only. Explicit repair flows are built on health-check
+ * repair handlers; notify-agent is only an explicit report notification.
  */
 import { createLogger } from './logger'
 import { getSettings } from './settings'

--- a/src/core/health-check-registry.ts
+++ b/src/core/health-check-registry.ts
@@ -71,6 +71,7 @@ export function registerPluginHealthCheck(
     name: input.name,
     run: input.run,
     autoFix: input.autoFix,
+    repair: input.repair,
   })
   return namespacedId
 }

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const mockPlan = {
+  diagnostics: [{ check: 'taskboard', status: 'warn', message: 'Missing columns', autoFixable: true }],
+  items: [{
+    id: 'repair.taskboard',
+    checkId: 'taskboard',
+    healthCheckId: 'tasks.taskboard',
+    pluginId: 'tasks',
+    checkName: 'Task board',
+    title: 'Repair taskboard',
+    reason: 'Missing columns',
+    safety: 'safe',
+    requiresConfirmation: true,
+    changes: [{ kind: 'file', target: 'tasks/board.json', action: 'update', description: 'Add missing columns' }],
+  }],
+  errors: [],
+  summary: { diagnostics: 1, repairableChecks: 1, totalItems: 1, safeItems: 1, blockedItems: 0, planErrors: 0 },
+}
+
+const mockApply = {
+  status: 'applied',
+  plan: mockPlan,
+  applied: [{
+    id: 'repair.taskboard',
+    checkId: 'taskboard',
+    status: 'applied',
+    message: 'Added missing columns',
+    changes: [{ kind: 'file', target: 'tasks/board.json', action: 'update', description: 'Add missing columns' }],
+  }],
+  skipped: [],
+  errors: [],
+  verification: [{ check: 'taskboard', status: 'ok', message: 'Taskboard healthy', autoFixable: false }],
+  summary: { planned: 1, applied: 1, skipped: 0, failed: 0, verificationErrors: 0, verificationWarnings: 0 },
+}
+
+describe('legacy CLI doctor repair', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+  const originalFetch = globalThis.fetch
+  let log: ReturnType<typeof spyOn>
+  let error: ReturnType<typeof spyOn>
+  const fetchMock = mock()
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    process.argv = originalArgv
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    error = spyOn(console, 'error').mockImplementation(() => {})
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${code}`)
+    }) as never
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    globalThis.fetch = originalFetch
+    log.mockRestore()
+    error.mockRestore()
+  })
+
+  it('prints a JSON repair plan and does not mutate without --yes', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockPlan),
+      text: () => Promise.resolve(''),
+    })
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--fix', '--json']
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/plugins/health/doctor/repair/plan')
+    expect(fetchMock.mock.calls[0][1]?.method).toBeUndefined()
+    const body = JSON.parse(String(log.mock.calls[0][0]))
+    expect(body.ok).toBe(false)
+    expect(body.error.code).toBe('CONFIRMATION_REQUIRED')
+    expect(body.data.plan.summary.safeItems).toBe(1)
+  })
+
+  it('applies deterministic repairs with --yes', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockApply),
+      text: () => Promise.resolve(''),
+    })
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--fix', '--json', '--yes']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/plugins/health/doctor/repair/apply')
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' })
+    expect(fetchMock.mock.calls[0][1]?.body).toBe(JSON.stringify({ accepted: true }))
+    const body = JSON.parse(String(log.mock.calls[0][0]))
+    expect(body.ok).toBe(true)
+    expect(body.data.summary.applied).toBe(1)
+  })
+})

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -34,6 +34,23 @@ const mockApply = {
   summary: { planned: 1, applied: 1, skipped: 0, failed: 0, verificationErrors: 0, verificationWarnings: 0 },
 }
 
+const mockDelegate = {
+  status: 'sent',
+  request: {
+    id: 'repair-1',
+    kind: 'delegate',
+    status: 'sent',
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:01:00.000Z',
+    plan: mockPlan,
+    unresolved: mockPlan.diagnostics,
+    taskId: 'task-repair-1',
+    agentId: 'main',
+    events: [],
+  },
+  unresolved: mockPlan.diagnostics,
+}
+
 describe('legacy CLI doctor repair', () => {
   const originalArgv = process.argv
   const originalExit = process.exit
@@ -99,5 +116,84 @@ describe('legacy CLI doctor repair', () => {
     const body = JSON.parse(String(log.mock.calls[0][0]))
     expect(body.ok).toBe(true)
     expect(body.data.summary.applied).toBe(1)
+  })
+
+  it('previews delegated repair without creating the task when --yes is omitted', async () => {
+    const delegatePlan = {
+      ...mockPlan,
+      diagnostics: [
+        ...mockPlan.diagnostics,
+        { check: 'runtime', status: 'error', message: 'Runtime unreachable', autoFixable: false },
+      ],
+      summary: { ...mockPlan.summary, diagnostics: 2 },
+    }
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(delegatePlan),
+      text: () => Promise.resolve(''),
+    })
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--delegate', '--json']
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:1')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/plugins/health/doctor/repair/plan')
+    const body = JSON.parse(String(log.mock.calls[0][0]))
+    expect(body.error.code).toBe('CONFIRMATION_REQUIRED')
+    expect(body.data.unresolved).toHaveLength(1)
+  })
+
+  it('creates a delegated repair task with --yes', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockDelegate),
+      text: () => Promise.resolve(''),
+    })
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--delegate', '--json', '--yes']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/plugins/health/doctor/delegate')
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' })
+    expect(fetchMock.mock.calls[0][1]?.body).toBe(JSON.stringify({ accepted: true }))
+    const body = JSON.parse(String(log.mock.calls[0][0]))
+    expect(body.ok).toBe(true)
+    expect(body.data.request.taskId).toBe('task-repair-1')
+  })
+
+  it('lists delegated repair requests', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ requests: [mockDelegate.request] }),
+      text: () => Promise.resolve(''),
+    })
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', 'repair', 'list', '--json']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/plugins/health/doctor/repair')
+    const body = JSON.parse(String(log.mock.calls[0][0]))
+    expect(body.data.requests[0].id).toBe('repair-1')
+  })
+
+  it('verifies delegated repair requests', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ request: { ...mockDelegate.request, status: 'verified' }, remaining: [], verified: true }),
+      text: () => Promise.resolve(''),
+    })
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', 'repair', 'verify', 'repair-1', '--json']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/plugins/health/doctor/repair/repair-1/verify')
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' })
+    const body = JSON.parse(String(log.mock.calls[0][0]))
+    expect(body.data.verified).toBe(true)
   })
 })

--- a/tests/core/doctor-delegate.test.ts
+++ b/tests/core/doctor-delegate.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = mkdtempSync(join(tmpdir(), 'bakin-doctor-delegate-'))
+
+process.env.BAKIN_HOME = testDir
+
+const mockPlan = {
+  diagnostics: [
+    { check: 'runtime', status: 'error', message: 'Runtime unreachable', autoFixable: false },
+    { check: 'taskboard', status: 'warn', message: 'Missing columns', autoFixable: true },
+  ],
+  items: [{
+    id: 'repair.taskboard',
+    checkId: 'taskboard',
+    healthCheckId: 'tasks.taskboard',
+    pluginId: 'tasks',
+    checkName: 'Taskboard',
+    title: 'Repair taskboard',
+    reason: 'Missing columns',
+    safety: 'safe',
+    requiresConfirmation: true,
+    changes: [{ kind: 'file', target: 'tasks/board.json', action: 'update', description: 'Add missing columns' }],
+  }],
+  errors: [],
+  summary: { diagnostics: 2, repairableChecks: 1, totalItems: 1, safeItems: 1, blockedItems: 0, planErrors: 0 },
+}
+
+const createTaskWithEffects = mock(async () => ({ id: 'task-doctor-repair' }))
+const dispatchSingleTask = mock(async () => {})
+
+mock.module('../../src/core/doctor-repair', () => ({
+  planDoctorRepair: mock(async () => mockPlan),
+}))
+
+mock.module('../../src/core/task-service', () => ({
+  createTaskWithEffects,
+}))
+
+mock.module('../../src/core/dispatch', () => ({
+  dispatchSingleTask,
+}))
+
+mock.module('../../src/core/app-services', () => ({
+  getAppServices: () => ({
+    runtime: {
+      agents: {
+        list: async () => [{ id: 'main', name: 'Main', role: 'Orchestrator' }],
+      },
+    },
+  }),
+}))
+
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+import { delegateDoctorRepair } from '../../src/core/doctor-delegate'
+import { getDoctorRepairRequest, listDoctorRepairRequests } from '../../src/core/doctor-repair-store'
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mock.clearAllMocks()
+})
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('delegateDoctorRepair', () => {
+  it('creates a planned request without task mutation until accepted', async () => {
+    const report = await delegateDoctorRepair({
+      contentDir: testDir,
+      projectRoot: testDir,
+      accepted: false,
+    })
+
+    expect(report.status).toBe('confirmation_required')
+    expect(report.request.status).toBe('planned')
+    expect(report.unresolved.map(row => row.check)).toEqual(['runtime'])
+    expect(createTaskWithEffects).not.toHaveBeenCalled()
+    expect(dispatchSingleTask).not.toHaveBeenCalled()
+
+    const stored = getDoctorRepairRequest(testDir, report.request.id)
+    expect(stored?.status).toBe('planned')
+  })
+
+  it('creates a board task assigned to main and kicks dispatch when accepted', async () => {
+    const report = await delegateDoctorRepair({
+      contentDir: testDir,
+      projectRoot: testDir,
+      accepted: true,
+    })
+
+    expect(report.status).toBe('sent')
+    expect(report.request.taskId).toBe('task-doctor-repair')
+    expect(report.request.agentId).toBe('main')
+    expect(createTaskWithEffects).toHaveBeenCalledWith(expect.objectContaining({
+      title: expect.stringContaining('Doctor repair'),
+      column: 'todo',
+      assignee: 'main',
+      createdBy: 'system',
+      source: expect.objectContaining({
+        pluginId: 'health',
+        entityType: 'doctor-repair',
+        entityId: report.request.id,
+        purpose: 'delegated-repair',
+      }),
+    }))
+    expect(dispatchSingleTask).toHaveBeenCalledWith('task-doctor-repair', testDir, 3737, 'kick')
+
+    const stored = getDoctorRepairRequest(testDir, report.request.id)
+    expect(stored?.status).toBe('sent')
+    expect(stored?.events.map(event => event.type)).toEqual(['created', 'task-created', 'dispatch-kicked'])
+    expect(listDoctorRepairRequests(testDir)).toHaveLength(1)
+  })
+})

--- a/tests/core/doctor-plugin-checks.test.ts
+++ b/tests/core/doctor-plugin-checks.test.ts
@@ -45,7 +45,7 @@ import {
   registerPluginHealthCheck,
   unregisterPluginHealthChecks,
 } from '../../src/core/health-check-registry'
-import { runPluginHealthChecks } from '../../src/core/doctor'
+import { runDetailedPluginHealthChecks, runPluginHealthChecks } from '../../src/core/doctor'
 
 beforeEach(() => {
   // Clean registry before each test
@@ -174,5 +174,52 @@ describe('runPluginHealthChecks', () => {
     expect(results[0].check).toBe('test-a.bad-shape')
     expect(results[0].status).toBe('error')
     expect(results[0].message).toMatch(/non-array/)
+  })
+})
+
+describe('runDetailedPluginHealthChecks', () => {
+  it('returns each check definition with its isolated result rows', async () => {
+    registerPluginHealthCheck('test-a', {
+      id: 'repairable',
+      name: 'Repairable check',
+      run: async () => [{
+        check: 'repairable-row',
+        status: 'warn',
+        message: 'Needs repair',
+        autoFixable: true,
+      }],
+      repair: {
+        plan: async () => [],
+        apply: async () => [],
+      },
+    })
+    registerPluginHealthCheck('test-b', {
+      id: 'thrower',
+      name: 'Thrower',
+      run: async () => {
+        throw new Error('Detailed failure')
+      },
+    })
+
+    const groups = await runDetailedPluginHealthChecks()
+
+    expect(groups).toHaveLength(2)
+    expect(groups[0].def.id).toBe('test-a.repairable')
+    expect(groups[0].def.repair).toBeDefined()
+    expect(groups[0].results).toEqual([{
+      check: 'repairable-row',
+      status: 'warn',
+      message: 'Needs repair',
+      autoFixable: true,
+    }])
+
+    expect(groups[1].def.id).toBe('test-b.thrower')
+    expect(groups[1].results).toHaveLength(1)
+    expect(groups[1].results[0]).toEqual(expect.objectContaining({
+      check: 'test-b.thrower',
+      status: 'error',
+      autoFixable: false,
+    }))
+    expect(groups[1].results[0].message).toMatch(/Detailed failure/)
   })
 })

--- a/tests/core/doctor-repair.test.ts
+++ b/tests/core/doctor-repair.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, afterEach, beforeEach, mock } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = mkdtempSync(join(tmpdir(), 'bakin-doctor-repair-'))
+
+process.env.BAKIN_HOME = testDir
+
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+import {
+  planDoctorRepair,
+  applyDoctorRepair,
+} from '../../src/core/doctor-repair'
+import {
+  registerHealthCheck,
+  unregisterHealthCheck,
+} from '../../src/core/health-check-registry'
+import type {
+  HealthCheckDef,
+  HealthCheckResult,
+  HealthRepairApplyResult,
+  HealthRepairPlanItem,
+} from '../../packages/core/src/plugin-types'
+
+const registered: string[] = []
+
+function warn(check: string, message = 'needs repair'): HealthCheckResult {
+  return { check, status: 'warn', message, autoFixable: true }
+}
+
+function ok(check: string, message = 'healthy'): HealthCheckResult {
+  return { check, status: 'ok', message, autoFixable: false }
+}
+
+function registerTestCheck(input: Partial<HealthCheckDef> & Pick<HealthCheckDef, 'id' | 'run'>): HealthCheckDef {
+  const def: HealthCheckDef = {
+    runtime: 'plugin',
+    pluginId: 'repair-test',
+    name: input.name ?? input.id,
+    autoFix: input.autoFix,
+    repair: input.repair,
+    ...input,
+  }
+  registerHealthCheck(def)
+  registered.push(def.id)
+  return def
+}
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+afterEach(() => {
+  for (const id of registered.splice(0)) {
+    unregisterHealthCheck(id)
+  }
+})
+
+describe('planDoctorRepair', () => {
+  it('plans repair items from checks that expose repair handlers', async () => {
+    const planItems: HealthRepairPlanItem[] = [{
+      id: 'repair.safe',
+      checkId: 'drift',
+      title: 'Repair drift',
+      reason: 'drifted',
+      safety: 'safe',
+      requiresConfirmation: true,
+      changes: [{ kind: 'file', target: 'AGENTS.md', action: 'update', description: 'Rewrite managed block' }],
+    }]
+    registerTestCheck({
+      id: 'repair-test.drift',
+      run: async () => [warn('drift', 'drifted')],
+      repair: {
+        plan: async (rows) => {
+          expect(rows).toHaveLength(1)
+          expect(rows[0].check).toBe('drift')
+          return planItems
+        },
+        apply: async () => [],
+      },
+    })
+    registerTestCheck({
+      id: 'repair-test.report-only',
+      run: async () => [warn('report-only')],
+    })
+
+    const report = await planDoctorRepair({ contentDir: testDir, projectRoot: testDir })
+
+    expect(report.diagnostics).toHaveLength(2)
+    expect(report.items).toHaveLength(1)
+    expect(report.items[0]).toMatchObject({
+      id: 'repair.safe',
+      checkId: 'drift',
+      healthCheckId: 'repair-test.drift',
+      pluginId: 'repair-test',
+      checkName: 'repair-test.drift',
+    })
+    expect(report.summary).toMatchObject({ totalItems: 1, safeItems: 1, blockedItems: 0, planErrors: 0 })
+  })
+
+  it('keeps non-safe plan items blocked from automatic application', async () => {
+    registerTestCheck({
+      id: 'repair-test.manual',
+      run: async () => [warn('manual')],
+      repair: {
+        plan: async () => [{
+          id: 'repair.manual',
+          checkId: 'manual',
+          title: 'Manual repair',
+          reason: 'needs judgement',
+          safety: 'manual',
+          requiresConfirmation: true,
+          changes: [{ kind: 'other', target: 'operator', action: 'invoke', description: 'Decide manually' }],
+        }],
+        apply: async () => {
+          throw new Error('manual item should not apply')
+        },
+      },
+    })
+
+    const report = await planDoctorRepair({ contentDir: testDir, projectRoot: testDir })
+
+    expect(report.items).toHaveLength(1)
+    expect(report.items[0].safety).toBe('manual')
+    expect(report.summary).toMatchObject({ totalItems: 1, safeItems: 0, blockedItems: 1 })
+  })
+})
+
+describe('applyDoctorRepair', () => {
+  it('requires explicit acceptance before applying repairs', async () => {
+    let applied = false
+    registerTestCheck({
+      id: 'repair-test.confirm',
+      run: async () => [warn('confirm')],
+      repair: {
+        plan: async () => [{
+          id: 'repair.confirm',
+          checkId: 'confirm',
+          title: 'Repair confirm',
+          reason: 'needs repair',
+          safety: 'safe',
+          requiresConfirmation: true,
+          changes: [{ kind: 'file', target: 'file', action: 'update', description: 'update file' }],
+        }],
+        apply: async () => {
+          applied = true
+          return []
+        },
+      },
+    })
+
+    const report = await applyDoctorRepair({ contentDir: testDir, projectRoot: testDir, accepted: false })
+
+    expect(report.status).toBe('confirmation_required')
+    expect(report.plan.items).toHaveLength(1)
+    expect(report.applied).toEqual([])
+    expect(applied).toBe(false)
+  })
+
+  it('applies safe items, skips non-safe items, and reruns affected checks', async () => {
+    let repaired = false
+    registerTestCheck({
+      id: 'repair-test.apply',
+      run: async () => repaired ? [ok('apply')] : [warn('apply')],
+      repair: {
+        plan: async () => [
+          {
+            id: 'repair.apply.safe',
+            checkId: 'apply',
+            title: 'Safe repair',
+            reason: 'drifted',
+            safety: 'safe',
+            requiresConfirmation: true,
+            changes: [{ kind: 'file', target: 'file', action: 'update', description: 'update file' }],
+          },
+          {
+            id: 'repair.apply.manual',
+            checkId: 'apply',
+            title: 'Manual repair',
+            reason: 'ambiguous',
+            safety: 'manual',
+            requiresConfirmation: true,
+            changes: [{ kind: 'other', target: 'operator', action: 'invoke', description: 'manual step' }],
+          },
+        ],
+        apply: async (items): Promise<HealthRepairApplyResult[]> => {
+          expect(items.map(item => item.id)).toEqual(['repair.apply.safe'])
+          repaired = true
+          return [{
+            id: 'repair.apply.safe',
+            checkId: 'apply',
+            status: 'applied',
+            message: 'updated file',
+            changes: items[0].changes,
+          }]
+        },
+      },
+    })
+
+    const report = await applyDoctorRepair({ contentDir: testDir, projectRoot: testDir, accepted: true })
+
+    expect(report.status).toBe('applied')
+    expect(report.applied).toHaveLength(1)
+    expect(report.skipped).toHaveLength(1)
+    expect(report.verification).toEqual([ok('apply')])
+    expect(report.summary).toMatchObject({ applied: 1, skipped: 1, failed: 0, verificationErrors: 0, verificationWarnings: 0 })
+  })
+
+  it('isolates apply failures and continues unrelated repairs', async () => {
+    registerTestCheck({
+      id: 'repair-test.fail',
+      run: async () => [warn('fail')],
+      repair: {
+        plan: async () => [{
+          id: 'repair.fail',
+          checkId: 'fail',
+          title: 'Failing repair',
+          reason: 'broken',
+          safety: 'safe',
+          requiresConfirmation: true,
+          changes: [{ kind: 'service', target: 'svc', action: 'install', description: 'install svc' }],
+        }],
+        apply: async () => {
+          throw new Error('boom')
+        },
+      },
+    })
+    registerTestCheck({
+      id: 'repair-test.ok',
+      run: async () => [warn('ok')],
+      repair: {
+        plan: async () => [{
+          id: 'repair.ok',
+          checkId: 'ok',
+          title: 'Working repair',
+          reason: 'broken',
+          safety: 'safe',
+          requiresConfirmation: true,
+          changes: [{ kind: 'file', target: 'ok', action: 'update', description: 'update ok' }],
+        }],
+        apply: async (items) => [{
+          id: items[0].id,
+          checkId: 'ok',
+          status: 'applied',
+          message: 'ok',
+          changes: items[0].changes,
+        }],
+      },
+    })
+
+    const report = await applyDoctorRepair({ contentDir: testDir, projectRoot: testDir, accepted: true })
+
+    expect(report.status).toBe('applied')
+    expect(report.applied.some(result => result.id === 'repair.ok' && result.status === 'applied')).toBe(true)
+    expect(report.applied.some(result => result.id === 'repair-test.fail.apply-error' && result.status === 'failed')).toBe(true)
+    expect(report.errors).toContainEqual(expect.objectContaining({
+      phase: 'apply',
+      healthCheckId: 'repair-test.fail',
+      message: 'boom',
+    }))
+  })
+})

--- a/tests/core/doctor.test.ts
+++ b/tests/core/doctor.test.ts
@@ -47,7 +47,7 @@ mock.module('@/core/settings', () => ({
       settings: {},
     },
     search: { adapter: 'antfly', settings: { enabled: false } },
-    doctor: { intervalMs: 1800000, autoFixSkill: false },
+    doctor: { intervalMs: 1800000 },
     service: { enabled: false },
   })),
 }))
@@ -259,7 +259,7 @@ describe('doctor', () => {
           settings: {},
         },
         search: { adapter: 'antfly', settings: { enabled: false } },
-        doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: true },
+        doctor: { intervalMs: 1800000, requireOnboard: true },
         service: { enabled: false },
       })
       // (vi.resetModules is a no-op in the bun:test shim — getSettings reads
@@ -283,7 +283,7 @@ describe('doctor', () => {
           settings: {},
         },
         search: { adapter: 'antfly', settings: { enabled: false } },
-        doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: true },
+        doctor: { intervalMs: 1800000, requireOnboard: true },
         service: { enabled: false },
       })
       // (vi.resetModules is a no-op in the bun:test shim — getSettings reads
@@ -309,7 +309,7 @@ describe('doctor', () => {
           settings: {},
         },
         search: { adapter: 'antfly', settings: { enabled: false } },
-        doctor: { intervalMs: 1800000, autoFixSkill: false, requireOnboard: false },
+        doctor: { intervalMs: 1800000, requireOnboard: false },
         service: { enabled: false },
       })
       // (vi.resetModules is a no-op in the bun:test shim — getSettings reads

--- a/tests/core/settings.test.ts
+++ b/tests/core/settings.test.ts
@@ -36,7 +36,6 @@ describe('Settings', () => {
   it('returns doctor defaults including requireOnboard', () => {
     const settings = getSettings()
     expect(settings.doctor.intervalMs).toBe(30 * 60 * 1000)
-    expect(settings.doctor.autoFixSkill).toBe(true)
     // First-run onboarding gate — default true so new users get walked
     // through `bakin onboard` before doctor runs its full check suite.
     expect(settings.doctor.requireOnboard).toBe(true)
@@ -52,7 +51,6 @@ describe('Settings', () => {
     expect(settings.doctor.requireOnboard).toBe(false)
     // Other doctor defaults preserved
     expect(settings.doctor.intervalMs).toBe(30 * 60 * 1000)
-    expect(settings.doctor.autoFixSkill).toBe(true)
   })
 
   it('returns search adapter defaults', () => {

--- a/tests/plugins/assets/health-checks.test.ts
+++ b/tests/plugins/assets/health-checks.test.ts
@@ -49,12 +49,6 @@ mock.module('../../../packages/adapter-openclaw/src/home', () => ({
   resetOpenClawHome: () => {},
 }))
 
-let mockAutoFix = false
-mock.module('../../../src/core/settings', () => ({
-  getSettings: () => ({ doctor: { autoFixSkill: mockAutoFix } }),
-  resetSettingsCache: () => {},
-}))
-
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
 }))
@@ -68,7 +62,6 @@ const storeDir = join(storeRoot, '2026-03')
 beforeEach(() => {
   rmSync(testDir, { recursive: true, force: true })
   mkdirSync(testDir, { recursive: true })
-  mockAutoFix = false
 })
 
 afterAll(() => {
@@ -146,8 +139,7 @@ describe('checkAssets — missing sidecars', () => {
     expect(sidecarWarn!.autoFixable).toBe(true)
   })
 
-  it('does not create stub sidecars during diagnostics even when legacy autoFix setting is true', () => {
-    mockAutoFix = true
+  it('does not create stub sidecars during diagnostics', () => {
     seedFullAssetsTree()
     writeFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png'), 'fake-image')
 

--- a/tests/plugins/assets/health-checks.test.ts
+++ b/tests/plugins/assets/health-checks.test.ts
@@ -59,7 +59,7 @@ mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
 }))
 
-import { checkAssets } from '../../../plugins/assets/lib/health-checks'
+import { assetRepair, checkAssets } from '../../../plugins/assets/lib/health-checks'
 
 const assetsRoot = join(testDir, 'assets')
 const storeRoot = join(assetsRoot, 'store')
@@ -93,17 +93,18 @@ describe('checkAssets — store shape', () => {
     expect(results.some(r => r.status === 'warn' && r.message.includes('assets/ directory not found') && r.autoFixable)).toBe(true)
   })
 
-  it('creates the assets/ tree under autoFix', () => {
-    mockAutoFix = true
+  it('repairs the assets/ tree explicitly', async () => {
     const results = checkAssets(testDir)
+    const repair = assetRepair(testDir)
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
     expect(existsSync(assetsRoot)).toBe(true)
     expect(existsSync(join(assetsRoot, 'store'))).toBe(true)
     expect(existsSync(join(assetsRoot, 'inbox'))).toBe(true)
     expect(existsSync(join(assetsRoot, '.trash'))).toBe(true)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Created assets/ directory'))).toBe(true)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('assets/store/'))).toBe(true)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('assets/inbox/'))).toBe(true)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Created assets/.trash/'))).toBe(true)
+    expect(applied[0].status).toBe('applied')
+    expect(applied[0].changes.some(change => change.description.includes('Created assets/ directory'))).toBe(true)
   })
 
   it('warns about missing required store directories without autoFix when assets/ exists', () => {
@@ -145,18 +146,28 @@ describe('checkAssets — missing sidecars', () => {
     expect(sidecarWarn!.autoFixable).toBe(true)
   })
 
-  it('creates stub sidecars in autoFix mode', () => {
+  it('does not create stub sidecars during diagnostics even when legacy autoFix setting is true', () => {
     mockAutoFix = true
     seedFullAssetsTree()
     writeFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png'), 'fake-image')
 
     const results = checkAssets(testDir)
+    expect(results.some(r => r.status === 'warn' && r.message.includes('missing .meta.json sidecar'))).toBe(true)
+    expect(existsSync(join(storeDir, '20260323-hero-a1b2c3d4.png.meta.json'))).toBe(false)
+  })
+
+  it('creates stub sidecars through explicit repair', async () => {
+    seedFullAssetsTree()
+    writeFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png'), 'fake-image')
+
+    const results = checkAssets(testDir)
+    const applied = await assetRepair(testDir).apply(await assetRepair(testDir).plan(results))
     expect(existsSync(join(storeDir, '20260323-hero-a1b2c3d4.png.meta.json'))).toBe(true)
     const stub = JSON.parse(readFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png.meta.json'), 'utf-8'))
     expect(stub.agent).toBe('unknown')
     expect(stub.taskId).toBeNull()
     expect(stub.type).toBe('images')
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Created 1 stub sidecar'))).toBe(true)
+    expect(applied[0].changes.some(change => change.description.includes('Created 1 stub sidecar'))).toBe(true)
   })
 
   it('warns about non-canonical asset filenames in the store', () => {
@@ -185,8 +196,7 @@ describe('checkAssets — mismatched sidecars', () => {
     expect(warns.some(r => r.message.includes('misnamed') || r.message.includes('missing'))).toBe(true)
   })
 
-  it('merges misnamed sidecar into the correctly-named stub under autoFix, normalizing field names', () => {
-    mockAutoFix = true
+  it('merges misnamed sidecar into the correctly-named stub through explicit repair, normalizing field names', async () => {
     seedFullAssetsTree()
     writeFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png'), 'fake-image')
 
@@ -215,7 +225,8 @@ describe('checkAssets — mismatched sidecars', () => {
     )
 
     const results = checkAssets(testDir)
-    expect(results.some(r => r.status === 'fixed' && (r.message.includes('Merged') || r.message.includes('misnamed')))).toBe(true)
+    const applied = await assetRepair(testDir).apply(await assetRepair(testDir).plan(results))
+    expect(applied[0].changes.some(change => change.description.includes('Merged') || change.description.includes('misnamed'))).toBe(true)
 
     const merged = JSON.parse(readFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png.meta.json'), 'utf-8'))
     expect(merged.agent).toBe('pixel')           // normalized from author
@@ -224,8 +235,7 @@ describe('checkAssets — mismatched sidecars', () => {
     expect(existsSync(join(storeDir, 'hero.meta.json'))).toBe(false)  // mismatched removed
   })
 
-  it('removes the misnamed sidecar when the correctly-named one already has real content', () => {
-    mockAutoFix = true
+  it('removes the misnamed sidecar through explicit repair when the correctly-named one already has real content', async () => {
     seedFullAssetsTree()
     writeFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png'), 'fake-image')
 
@@ -241,7 +251,8 @@ describe('checkAssets — mismatched sidecars', () => {
     // Misnamed orphan
     writeFileSync(join(storeDir, 'hero.meta.json'), JSON.stringify({ author: 'someone-else' }))
 
-    checkAssets(testDir)
+    const results = checkAssets(testDir)
+    await assetRepair(testDir).apply(await assetRepair(testDir).plan(results))
 
     // Real sidecar untouched, mismatched removed
     expect(JSON.parse(readFileSync(join(storeDir, '20260323-hero-a1b2c3d4.png.meta.json'), 'utf-8'))).toEqual(realMeta)
@@ -267,8 +278,7 @@ describe('checkAssets — orphaned meta', () => {
 // ─── Trash purge ──────────────────────────────────────────────────────────
 
 describe('checkAssets — trash purge', () => {
-  it('purges trash items older than 7 days under autoFix', () => {
-    mockAutoFix = true
+  it('purges trash items older than 7 days through explicit repair', async () => {
     seedFullAssetsTree()
     const trashDir = join(assetsRoot, '.trash')
     const oldFile = join(trashDir, 'ancient.bin')
@@ -280,9 +290,10 @@ describe('checkAssets — trash purge', () => {
     utimesSync(oldFile, thirtyDaysAgo / 1000, thirtyDaysAgo / 1000)
 
     const results = checkAssets(testDir)
+    const applied = await assetRepair(testDir).apply(await assetRepair(testDir).plan(results))
     expect(existsSync(oldFile)).toBe(false)
     expect(existsSync(freshFile)).toBe(true)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Purged 1 expired'))).toBe(true)
+    expect(applied[0].changes.some(change => change.description.includes('Purged 1 expired'))).toBe(true)
   })
 
   it('does not purge trash items without autoFix', () => {

--- a/tests/plugins/health/checks-route.test.ts
+++ b/tests/plugins/health/checks-route.test.ts
@@ -59,9 +59,23 @@ const taskStoreMock = {
   readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getTask: () => null,
+  getTaskWithColumn: () => null,
+  getTasksByAgent: () => [],
+  getTodoTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] }, todoTasks: [] }),
+  createTask: mock(async () => ({ id: 'task-1', title: 'Task', checked: false })),
+  updateTask: mock(async () => ({ id: 'task-1', title: 'Task', checked: false })),
+  deleteTask: mock(async () => {}),
+  assignTask: mock(async () => {}),
   addTaskLog: mock(async () => {}),
   blockTask: mock(async () => {}),
   moveTask: mock(async () => {}),
+  setDependency: mock(async () => {}),
+  clearDependency: mock(async () => {}),
+  reorderTasks: mock(async () => {}),
+  moveTaskToInProgress: mock(async () => {}),
+  archiveOldTasks: mock(async () => {}),
+  localDateString: () => '2026-01-01',
+  VALID_TRANSITIONS: {},
 }
 mock.module('@/core/task-store', () => taskStoreMock)
 mock.module('../../../src/core/task-store', () => taskStoreMock)

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -69,6 +69,48 @@ mock.module('../../../src/core/doctor', () => ({
   runDiagnostics: mock(async () => mockDoctorResults),
 }))
 
+const mockRepairPlan = {
+  diagnostics: mockDoctorResults,
+  items: [{
+    id: 'repair.taskboard',
+    checkId: 'taskboard',
+    healthCheckId: 'tasks.taskboard',
+    pluginId: 'tasks',
+    checkName: 'Task board',
+    title: 'Repair taskboard',
+    reason: 'Missing columns',
+    safety: 'safe',
+    requiresConfirmation: true,
+    changes: [{ kind: 'file', target: 'tasks/board.json', action: 'update', description: 'Add missing columns' }],
+  }],
+  errors: [],
+  summary: { diagnostics: 3, repairableChecks: 1, totalItems: 1, safeItems: 1, blockedItems: 0, planErrors: 0 },
+}
+const mockRepairApply = {
+  status: 'applied',
+  plan: mockRepairPlan,
+  applied: [{
+    id: 'repair.taskboard',
+    checkId: 'taskboard',
+    status: 'applied',
+    message: 'Added missing columns',
+    changes: [{ kind: 'file', target: 'tasks/board.json', action: 'update', description: 'Add missing columns' }],
+  }],
+  skipped: [],
+  errors: [],
+  verification: [{ check: 'taskboard', status: 'ok', message: 'Taskboard healthy', autoFixable: false }],
+  summary: { planned: 1, applied: 1, skipped: 0, failed: 0, verificationErrors: 0, verificationWarnings: 0 },
+}
+const planDoctorRepairMock = mock(async () => mockRepairPlan)
+const applyDoctorRepairMock = mock(async (options: { accepted: boolean }) => (
+  options.accepted ? mockRepairApply : { ...mockRepairApply, status: 'confirmation_required', applied: [], verification: [] }
+))
+
+mock.module('../../../src/core/doctor-repair', () => ({
+  planDoctorRepair: planDoctorRepairMock,
+  applyDoctorRepair: applyDoctorRepairMock,
+}))
+
 mock.module('../../../src/core/agent-usage', () => ({
   getAllAgentUsage: () => [
     { agent: 'patch', sessionId: 's1', model: 'claude-4', messages: 10, tokens: { total: 1000 }, cost: { total: 0.05 } },
@@ -151,8 +193,8 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('Health Plugin Routes', () => {
-  it('registers 7 routes', () => {
-    expect(activated.routes.length).toBe(7)
+  it('registers 9 routes', () => {
+    expect(activated.routes.length).toBe(9)
   })
 
   it('registers 2 exec tools', () => {
@@ -334,6 +376,50 @@ describe('Health Plugin Routes', () => {
       expect(status).toBe(200)
       expect(body.cachedAt).toBeDefined()
       expect(runDiagnostics).toHaveBeenCalled()
+    })
+  })
+
+  describe('doctor repair routes', () => {
+    it('returns a deterministic repair plan without applying it', async () => {
+      const route = findRoute(activated.routes, 'GET', '/doctor/repair/plan')!
+      expect(route).toBeDefined()
+
+      const { status, body } = await callRoute(route, activated.ctx)
+
+      expect(status).toBe(200)
+      expect(body.summary).toMatchObject({ totalItems: 1, safeItems: 1 })
+      expect(body.items).toEqual(mockRepairPlan.items)
+      expect(planDoctorRepairMock).toHaveBeenCalled()
+      expect(applyDoctorRepairMock).not.toHaveBeenCalled()
+    })
+
+    it('requires accepted=true before applying deterministic repairs', async () => {
+      const route = findRoute(activated.routes, 'POST', '/doctor/repair/apply')!
+      expect(route).toBeDefined()
+
+      const { status, body } = await callRoute(route, activated.ctx, {
+        body: { accepted: false },
+      })
+
+      expect(status).toBe(409)
+      expect(body.status).toBe('confirmation_required')
+      expect(applyDoctorRepairMock).toHaveBeenCalledWith(expect.objectContaining({ accepted: false }))
+    })
+
+    it('applies deterministic repairs when accepted=true', async () => {
+      const route = findRoute(activated.routes, 'POST', '/doctor/repair/apply')!
+
+      const { status, body } = await callRoute(route, activated.ctx, {
+        body: { accepted: true, itemIds: ['repair.taskboard'] },
+      })
+
+      expect(status).toBe(200)
+      expect(body.status).toBe('applied')
+      expect(body.summary).toMatchObject({ applied: 1, failed: 0 })
+      expect(applyDoctorRepairMock).toHaveBeenCalledWith(expect.objectContaining({
+        accepted: true,
+        itemIds: ['repair.taskboard'],
+      }))
     })
   })
 })

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -111,6 +111,39 @@ mock.module('../../../src/core/doctor-repair', () => ({
   applyDoctorRepair: applyDoctorRepairMock,
 }))
 
+const mockDelegateRequest = {
+  id: 'repair-1',
+  kind: 'delegate',
+  status: 'sent',
+  createdAt: '2026-04-01T00:00:00.000Z',
+  updatedAt: '2026-04-01T00:01:00.000Z',
+  plan: mockRepairPlan,
+  unresolved: [mockDoctorResults[2]],
+  taskId: 'task-repair-1',
+  agentId: 'main',
+  events: [{ ts: '2026-04-01T00:00:00.000Z', type: 'created', message: 'created' }],
+}
+const delegateDoctorRepairMock = mock(async (options: { accepted: boolean }) => (
+  options.accepted
+    ? { status: 'sent', request: mockDelegateRequest, unresolved: mockDelegateRequest.unresolved }
+    : { status: 'confirmation_required', request: { ...mockDelegateRequest, status: 'planned', taskId: undefined, agentId: undefined }, unresolved: mockDelegateRequest.unresolved }
+))
+const verifyDoctorRepairRequestMock = mock(async () => ({
+  request: { ...mockDelegateRequest, status: 'verified' },
+  remaining: [],
+  verified: true,
+}))
+
+mock.module('../../../src/core/doctor-delegate', () => ({
+  delegateDoctorRepair: delegateDoctorRepairMock,
+  verifyDoctorRepairRequest: verifyDoctorRepairRequestMock,
+}))
+
+mock.module('../../../src/core/doctor-repair-store', () => ({
+  listDoctorRepairRequests: mock(() => [mockDelegateRequest]),
+  getDoctorRepairRequest: mock((_contentDir: string, id: string) => id === 'repair-1' ? mockDelegateRequest : null),
+}))
+
 mock.module('../../../src/core/agent-usage', () => ({
   getAllAgentUsage: () => [
     { agent: 'patch', sessionId: 's1', model: 'claude-4', messages: 10, tokens: { total: 1000 }, cost: { total: 0.05 } },
@@ -193,8 +226,8 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('Health Plugin Routes', () => {
-  it('registers 9 routes', () => {
-    expect(activated.routes.length).toBe(9)
+  it('registers 13 routes', () => {
+    expect(activated.routes.length).toBe(13)
   })
 
   it('registers 2 exec tools', () => {
@@ -420,6 +453,61 @@ describe('Health Plugin Routes', () => {
         accepted: true,
         itemIds: ['repair.taskboard'],
       }))
+    })
+  })
+
+  describe('delegated repair routes', () => {
+    it('requires accepted=true before creating a delegated repair task', async () => {
+      const route = findRoute(activated.routes, 'POST', '/doctor/delegate')!
+      expect(route).toBeDefined()
+
+      const { status, body } = await callRoute(route, activated.ctx, {
+        body: { accepted: false },
+      })
+
+      expect(status).toBe(409)
+      expect(body.status).toBe('confirmation_required')
+      expect(delegateDoctorRepairMock).toHaveBeenCalledWith(expect.objectContaining({ accepted: false }))
+    })
+
+    it('creates a delegated repair request when accepted=true', async () => {
+      const route = findRoute(activated.routes, 'POST', '/doctor/delegate')!
+
+      const { status, body } = await callRoute(route, activated.ctx, {
+        body: { accepted: true },
+      })
+
+      expect(status).toBe(200)
+      expect(body.status).toBe('sent')
+      expect((body.request as Record<string, unknown>).taskId).toBe('task-repair-1')
+      expect(delegateDoctorRepairMock).toHaveBeenCalledWith(expect.objectContaining({ accepted: true }))
+    })
+
+    it('lists and shows delegated repair requests', async () => {
+      const listRoute = findRoute(activated.routes, 'GET', '/doctor/repair')!
+      const showRoute = findRoute(activated.routes, 'GET', '/doctor/repair/:requestId')!
+
+      const list = await callRoute(listRoute, activated.ctx)
+      expect(list.status).toBe(200)
+      expect(list.body.requests).toEqual([mockDelegateRequest])
+
+      const show = await callRoute(showRoute, activated.ctx, {
+        path: '/doctor/repair/repair-1',
+      })
+      expect(show.status).toBe(200)
+      expect(show.body.request).toEqual(mockDelegateRequest)
+    })
+
+    it('verifies delegated repair requests', async () => {
+      const route = findRoute(activated.routes, 'POST', '/doctor/repair/:requestId/verify')!
+
+      const { status, body } = await callRoute(route, activated.ctx, {
+        path: '/doctor/repair/repair-1/verify',
+      })
+
+      expect(status).toBe(200)
+      expect(body.verified).toBe(true)
+      expect(verifyDoctorRepairRequestMock).toHaveBeenCalledWith(expect.objectContaining({ requestId: 'repair-1' }))
     })
   })
 })

--- a/tests/plugins/health/system-checks.test.ts
+++ b/tests/plugins/health/system-checks.test.ts
@@ -53,7 +53,6 @@ mock.module('../../../packages/adapter-openclaw/src/home', () => ({
 }))
 
 let mockServiceEnabled = false
-let mockAutoFix = false
 
 let mockMcporterInstalled = true
 let mockInstallMcporterReturn = true
@@ -98,7 +97,6 @@ function restoreFetch() {
 mock.module('../../../src/core/settings', () => ({
   getSettings: () => ({
     service: { enabled: mockServiceEnabled },
-    doctor: { autoFixSkill: mockAutoFix },
     search: { adapter: 'antfly', settings: { enabled: mockSearchEnabled, url: mockSearchUrl } },
   }),
   resetSettingsCache: () => {},
@@ -138,11 +136,11 @@ mock.module('../../../scripts/lib/registry', () => ({
 
 import { checkContentDir } from '../../../plugins/health/lib/system-checks/content-dir'
 import { checkService } from '../../../plugins/health/lib/system-checks/service'
-import { checkMcporter } from '../../../plugins/health/lib/system-checks/mcporter'
+import { checkMcporter, mcporterRepair } from '../../../plugins/health/lib/system-checks/mcporter'
 import { checkRuntime } from '../../../plugins/health/lib/system-checks/runtime'
 import { checkChannelApprovals } from '../../../plugins/health/lib/system-checks/channel-approvals'
 import { checkSearchAdapter } from '../../../plugins/health/lib/system-checks/search'
-import { checkAndSyncSkill } from '../../../plugins/health/lib/system-checks/sync-skill'
+import { checkAndSyncSkill, syncSkillRepair } from '../../../plugins/health/lib/system-checks/sync-skill'
 import { checkPluginAssets } from '../../../plugins/health/lib/system-checks/plugin-assets'
 import { createMockRuntimeAdapter } from '@bakin/core/adapters/runtime/testing'
 import type { AgentRuntimeAdapter, RuntimeSkill } from '@bakin/core/adapters/runtime'
@@ -178,7 +176,6 @@ beforeEach(() => {
   mockUsingBakinHome = true
   mockContentDir = testDir
   mockServiceEnabled = false
-  mockAutoFix = false
   mockMcporterInstalled = true
   mockInstallMcporterReturn = true
   mockAgentEntries = []
@@ -279,20 +276,32 @@ describe('checkMcporter', () => {
     expect(results[0].message).toMatch(/not installed/)
   })
 
-  it('installs mcporter under autoFix when missing', async () => {
+  it('does not install mcporter during diagnostics', async () => {
     mockMcporterInstalled = false
-    mockAutoFix = true
     mockAgentEntries = [{ agent: 'main', correct: true }]
     const results = await checkMcporter()
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Installed mcporter'))).toBe(true)
+    expect(results.some(r => r.status === 'warn' && r.message.includes('not installed'))).toBe(true)
+    expect(mockMcporterInstalled).toBe(false)
   })
 
-  it('returns an error when install fails under autoFix', async () => {
+  it('installs mcporter through explicit repair when missing', async () => {
     mockMcporterInstalled = false
-    mockAutoFix = true
+    const results = await checkMcporter()
+    const repair = mcporterRepair()
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
+    expect(applied[0].status).toBe('applied')
+    expect(applied[0].message).toMatch(/Installed mcporter/)
+  })
+
+  it('returns a failed repair result when install fails', async () => {
+    mockMcporterInstalled = false
     mockInstallMcporterReturn = false
     const results = await checkMcporter()
-    expect(results.some(r => r.status === 'error' && r.message.includes('Failed to install mcporter'))).toBe(true)
+    const applied = await mcporterRepair().apply(await mcporterRepair().plan(results))
+    expect(applied[0].status).toBe('failed')
+    expect(applied[0].message).toMatch(/Failed to install mcporter/)
   })
 
   it('reports ok when all agent entries are correct', async () => {
@@ -310,12 +319,13 @@ describe('checkMcporter', () => {
     expect(results.some(r => r.status === 'warn' && r.message.includes('1 agent(s) missing or outdated'))).toBe(true)
   })
 
-  it('runs syncConfig under autoFix when entries are wrong', async () => {
-    mockAutoFix = true
+  it('runs syncConfig through explicit repair when entries are wrong', async () => {
     mockAgentEntries = [{ agent: 'main', correct: false }]
     const results = await checkMcporter()
+    const applied = await mcporterRepair().apply(await mcporterRepair().plan(results))
     expect(syncConfigCalls).toBeGreaterThanOrEqual(1)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Config updated'))).toBe(true)
+    expect(applied[0].status).toBe('applied')
+    expect(applied[0].message).toMatch(/Config updated/)
   })
 })
 
@@ -481,8 +491,7 @@ describe('checkAndSyncSkill', () => {
     expect(results[0].message).toMatch(/not installed in runtime/)
   })
 
-  it('installs the skill under autoFix when missing', async () => {
-    mockAutoFix = true
+  it('installs the skill through explicit repair when missing', async () => {
     const projectRoot = pathJoin(testDir, 'project-install')
     mkdirSync(join(projectRoot, 'skill'), { recursive: true })
     writeFileSync(
@@ -490,8 +499,12 @@ describe('checkAndSyncSkill', () => {
       '# Bakin Skill\n<!-- bakin:exec-tools:start -->\n<!-- bakin:exec-tools:end -->\n',
     )
     const results = await checkAndSyncSkill(projectRoot, mockRuntime)
-    expect(results[0].status).toBe('fixed')
-    expect(results[0].message).toMatch(/installed in runtime/)
+    expect(results[0].status).toBe('warn')
+    const applied = await syncSkillRepair(projectRoot, mockRuntime).apply(
+      await syncSkillRepair(projectRoot, mockRuntime).plan(results),
+    )
+    expect(applied[0].status).toBe('applied')
+    expect(applied[0].message).toMatch(/installed in runtime/)
     expect(runtimeSkill?.instructions).toContain('<!-- bakin:exec-tools:start -->')
   })
 })

--- a/tests/plugins/memory/health-checks.test.ts
+++ b/tests/plugins/memory/health-checks.test.ts
@@ -54,7 +54,6 @@ let mockSearchEnabled = true
 mock.module('../../../src/core/settings', () => ({
   getSettings: () => ({
     search: { adapter: 'antfly', settings: { enabled: mockSearchEnabled } },
-    doctor: { autoFixSkill: false },
   }),
   resetSettingsCache: () => {},
 }))

--- a/tests/plugins/schedule/health-checks.test.ts
+++ b/tests/plugins/schedule/health-checks.test.ts
@@ -59,7 +59,7 @@ mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
 }))
 
-import { checkScheduleSync } from '../../../plugins/schedule/lib/health-checks'
+import { checkScheduleSync, scheduleSyncRepair } from '../../../plugins/schedule/lib/health-checks'
 
 const sidecarPath = join(testDir, 'schedule', 'sidecar.json')
 let runtimeJobs: CronJob[] = []
@@ -140,16 +140,32 @@ describe('checkScheduleSync - orphan detection', () => {
   })
 })
 
-describe('checkScheduleSync - auto-track', () => {
-  it('tracks orphaned runtime cron jobs in the sidecar without guessing the agent', async () => {
+describe('checkScheduleSync - repair', () => {
+  it('does not track orphaned runtime cron jobs during diagnostics even when legacy autoFix setting is true', async () => {
     mockAutoFix = true
     runtimeJobs = [makeCronJob({ id: 'orphan-1', name: 'rogue-cron' })]
     writeFileSync(sidecarPath, JSON.stringify({ version: 1, jobs: {} }))
 
     const results = await checkScheduleSync(testDir, cronReader, 'boss')
     expect(results).toHaveLength(1)
-    expect(results[0].status).toBe('fixed')
-    expect(results[0].message).toMatch(/Tracked/)
+    expect(results[0].status).toBe('warn')
+
+    const updated = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
+    expect(updated.jobs['orphan-1']).toBeUndefined()
+  })
+
+  it('tracks orphaned runtime cron jobs in the sidecar through explicit repair without guessing the agent', async () => {
+    runtimeJobs = [makeCronJob({ id: 'orphan-1', name: 'rogue-cron' })]
+    writeFileSync(sidecarPath, JSON.stringify({ version: 1, jobs: {} }))
+
+    const results = await checkScheduleSync(testDir, cronReader, 'boss')
+    const repair = scheduleSyncRepair(testDir, cronReader, async () => 'boss')
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
+    expect(results).toHaveLength(1)
+    expect(applied[0].status).toBe('applied')
+    expect(applied[0].message).toMatch(/Tracked/)
 
     const updated = JSON.parse(readFileSync(sidecarPath, 'utf-8'))
     expect(updated.jobs['orphan-1']).toBeDefined()
@@ -161,13 +177,15 @@ describe('checkScheduleSync - auto-track', () => {
     expect(updated.jobs['orphan-1'].agentId).toBeUndefined()
   })
 
-  it('creates schedule/ directory when sidecar parent is missing', async () => {
-    mockAutoFix = true
+  it('creates schedule/ directory through explicit repair when sidecar parent is missing', async () => {
     runtimeJobs = [makeCronJob({ id: 'orphan-1', name: 'rogue-cron' })]
     rmSync(join(testDir, 'schedule'), { recursive: true, force: true })
     expect(existsSync(join(testDir, 'schedule'))).toBe(false)
 
-    await checkScheduleSync(testDir, cronReader, 'main')
+    const results = await checkScheduleSync(testDir, cronReader, 'main')
+    await scheduleSyncRepair(testDir, cronReader, async () => 'main').apply(
+      await scheduleSyncRepair(testDir, cronReader, async () => 'main').plan(results),
+    )
     expect(existsSync(sidecarPath)).toBe(true)
   })
 })

--- a/tests/plugins/schedule/health-checks.test.ts
+++ b/tests/plugins/schedule/health-checks.test.ts
@@ -38,12 +38,6 @@ mock.module('../../../packages/core/src/content-dir', () => ({
   isUsingBakinHome: () => true,
 }))
 
-let mockAutoFix = false
-mock.module('../../../src/core/settings', () => ({
-  getSettings: () => ({ doctor: { autoFixSkill: mockAutoFix } }),
-  resetSettingsCache: () => {},
-}))
-
 mock.module('../../../packages/adapter-openclaw/src/main-agent', () => ({
   getMainAgentId: () => 'main',
   tryGetMainAgentId: () => 'main',
@@ -86,7 +80,6 @@ function makeCronJob(overrides: Partial<CronJob> = {}): CronJob {
 beforeEach(() => {
   rmSync(testDir, { recursive: true, force: true })
   mkdirSync(join(testDir, 'schedule'), { recursive: true })
-  mockAutoFix = false
   runtimeJobs = []
   runtimeError = null
 })
@@ -141,8 +134,7 @@ describe('checkScheduleSync - orphan detection', () => {
 })
 
 describe('checkScheduleSync - repair', () => {
-  it('does not track orphaned runtime cron jobs during diagnostics even when legacy autoFix setting is true', async () => {
-    mockAutoFix = true
+  it('does not track orphaned runtime cron jobs during diagnostics', async () => {
     runtimeJobs = [makeCronJob({ id: 'orphan-1', name: 'rogue-cron' })]
     writeFileSync(sidecarPath, JSON.stringify({ version: 1, jobs: {} }))
 

--- a/tests/plugins/tasks/health-checks.test.ts
+++ b/tests/plugins/tasks/health-checks.test.ts
@@ -40,12 +40,6 @@ mock.module('../../../packages/core/src/content-dir', () => ({
   isUsingBakinHome: () => true,
 }))
 
-let mockAutoFix = false
-mock.module('../../../src/core/settings', () => ({
-  getSettings: () => ({ doctor: { autoFixSkill: mockAutoFix } }),
-  resetSettingsCache: () => {},
-}))
-
 let mockKnownAgents: string[] = ['main', 'patch', 'pixel']
 mock.module('../../../packages/adapter-openclaw/src/main-agent', () => ({
   getMainAgentId: () => 'main',
@@ -173,7 +167,6 @@ afterAll(() => {
 
 beforeEach(() => {
   storeBoard = emptyStoreBoard()
-  mockAutoFix = false
   mockKnownAgents = ['main', 'patch', 'pixel']
   clearedDependencies.length = 0
   clearDependencyShouldThrow = false
@@ -255,8 +248,7 @@ describe('checkTaskConsistency', () => {
     expect(results.some(r => r.status === 'warn' && r.message.includes('orphaned dependsOn') && r.autoFixable)).toBe(true)
   })
 
-  it('does not clear orphaned dependsOn during diagnostics even when legacy autoFix setting is true', async () => {
-    mockAutoFix = true
+  it('does not clear orphaned dependsOn during diagnostics', async () => {
     storeBoard.columns.done.push({ id: 'd2', title: 'Auto-clear', dependsOn: 'orphan' })
     const results = await checkTaskConsistency(testDir)
     expect(results.some(r => r.status === 'warn' && r.message.includes('orphaned dependsOn'))).toBe(true)
@@ -320,8 +312,7 @@ describe('checkTaskPositionIntegrity', () => {
     expect(results[0].message).toMatch(/duplicates/)
   })
 
-  it('does not reorder during diagnostics even when legacy autoFix setting is true', async () => {
-    mockAutoFix = true
+  it('does not reorder during diagnostics', async () => {
     const older: StoreTask = { id: 'older', title: 'Older', updatedAt: 100 }
     const newer: StoreTask = { id: 'newer', title: 'Newer', updatedAt: 200 }
     storeBoard.columns.todo.push(older, newer)

--- a/tests/plugins/tasks/health-checks.test.ts
+++ b/tests/plugins/tasks/health-checks.test.ts
@@ -163,6 +163,8 @@ import {
   checkTaskboard,
   checkTaskConsistency,
   checkTaskPositionIntegrity,
+  taskConsistencyRepair,
+  taskOrderRepair,
 } from '../../../plugins/tasks/lib/health-checks'
 
 afterAll(() => {
@@ -253,20 +255,25 @@ describe('checkTaskConsistency', () => {
     expect(results.some(r => r.status === 'warn' && r.message.includes('orphaned dependsOn') && r.autoFixable)).toBe(true)
   })
 
-  it('clears orphaned dependsOn in autoFix mode', async () => {
+  it('does not clear orphaned dependsOn during diagnostics even when legacy autoFix setting is true', async () => {
     mockAutoFix = true
     storeBoard.columns.done.push({ id: 'd2', title: 'Auto-clear', dependsOn: 'orphan' })
     const results = await checkTaskConsistency(testDir)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Cleared orphaned dependsOn'))).toBe(true)
-    expect(clearedDependencies).toContain('d2')
+    expect(results.some(r => r.status === 'warn' && r.message.includes('orphaned dependsOn'))).toBe(true)
+    expect(clearedDependencies).toEqual([])
   })
 
-  it('falls back to a warn when clearDependency hook throws under autoFix', async () => {
-    mockAutoFix = true
-    clearDependencyShouldThrow = true
-    storeBoard.columns.done.push({ id: 'd3', title: 'Failed clear', dependsOn: 'orphan' })
+  it('plans and applies orphaned dependsOn repair explicitly', async () => {
+    storeBoard.columns.done.push({ id: 'd2', title: 'Repair clear', dependsOn: 'orphan' })
     const results = await checkTaskConsistency(testDir)
-    expect(results.some(r => r.status === 'warn' && r.message.includes('failed to clear'))).toBe(true)
+    const repair = taskConsistencyRepair()
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    expect(plan[0].id).toBe('tasks.clear-done-depends-on')
+
+    const applied = await repair.apply(plan)
+    expect(applied[0].status).toBe('applied')
+    expect(clearedDependencies).toContain('d2')
   })
 })
 
@@ -313,14 +320,29 @@ describe('checkTaskPositionIntegrity', () => {
     expect(results[0].message).toMatch(/duplicates/)
   })
 
-  it('auto-fixes by reassigning order zero-indexed by updatedAt desc', async () => {
+  it('does not reorder during diagnostics even when legacy autoFix setting is true', async () => {
     mockAutoFix = true
     const older: StoreTask = { id: 'older', title: 'Older', updatedAt: 100 }
     const newer: StoreTask = { id: 'newer', title: 'Newer', updatedAt: 200 }
     storeBoard.columns.todo.push(older, newer)
 
     const results = await checkTaskPositionIntegrity()
-    expect(results[0].status).toBe('fixed')
+    expect(results[0].status).toBe('warn')
+    expect(newer.order).toBeUndefined()
+    expect(older.order).toBeUndefined()
+  })
+
+  it('repair handler reassigns order zero-indexed by updatedAt desc', async () => {
+    const older: StoreTask = { id: 'older', title: 'Older', updatedAt: 100 }
+    const newer: StoreTask = { id: 'newer', title: 'Newer', updatedAt: 200 }
+    storeBoard.columns.todo.push(older, newer)
+
+    const results = await checkTaskPositionIntegrity()
+    const repair = taskOrderRepair()
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
+    expect(applied[0].status).toBe('applied')
     expect(newer.order).toBe(0)
     expect(older.order).toBe(1)
   })

--- a/tests/plugins/team/health-checks.test.ts
+++ b/tests/plugins/team/health-checks.test.ts
@@ -56,20 +56,6 @@ mock.module('../../../packages/adapter-openclaw/src/home', () => ({
   resetOpenClawHome: () => {},
 }))
 
-let mockAutoFix = false
-mock.module('../../../src/core/settings', () => ({
-  getSettings: () => ({
-    doctor: { autoFixSkill: mockAutoFix },
-  }),
-  resetSettingsCache: () => {},
-}))
-mock.module('@/core/settings', () => ({
-  getSettings: () => ({
-    doctor: { autoFixSkill: mockAutoFix },
-  }),
-  resetSettingsCache: () => {},
-}))
-
 let runtimeAgents: RuntimeAgent[] = []
 let runtimeError: Error | null = null
 const runtimeAgentStore = new Map<string, RuntimeAgent>()
@@ -140,7 +126,6 @@ beforeEach(() => {
   runtimeAgentStore.clear()
   runtimeWorkspaceFiles.clear()
   runtimeError = null
-  mockAutoFix = false
 })
 
 // ─── checkAgentRoster ──────────────────────────────────────────────────────
@@ -214,8 +199,7 @@ describe('checkPersonas', () => {
     expect(results.some(r => r.status === 'warn' && r.message.includes('No personas directory'))).toBe(true)
   })
 
-  it('does not create stub persona files during diagnostics even when legacy autoFix setting is true', async () => {
-    mockAutoFix = true
+  it('does not create stub persona files during diagnostics', async () => {
     const personasDir = join(testDir, 'team', 'personas')
     mkdirSync(personasDir, { recursive: true })
     writeFileSync(join(personasDir, 'main.md'), '# Main')

--- a/tests/plugins/team/health-checks.test.ts
+++ b/tests/plugins/team/health-checks.test.ts
@@ -110,9 +110,11 @@ mock.module('../../../src/core/logger', () => ({
 import { agentAssetsComponent } from '../../../src/core/onboarding/agent-assets'
 import { installPackage } from '../../../src/core/agent-packages/installer'
 import {
+  agentAssetsRepair,
   checkAgentRoster,
   checkPersonas,
   checkAgentAssets,
+  personaRepair,
 } from '../../../plugins/team/lib/health-checks'
 
 const runtimeAgentReader = {
@@ -212,31 +214,33 @@ describe('checkPersonas', () => {
     expect(results.some(r => r.status === 'warn' && r.message.includes('No personas directory'))).toBe(true)
   })
 
-  it('creates stub persona files in autoFix mode', async () => {
+  it('does not create stub persona files during diagnostics even when legacy autoFix setting is true', async () => {
     mockAutoFix = true
     const personasDir = join(testDir, 'team', 'personas')
     mkdirSync(personasDir, { recursive: true })
     writeFileSync(join(personasDir, 'main.md'), '# Main')
 
     const results = await checkPersonas(testDir, runtimeAgentReader)
-    const fixes = results.filter(r => r.status === 'fixed')
-    expect(fixes.length).toBeGreaterThan(0)
-    // Stubs were written
+    expect(results.some(r => r.status === 'warn' && r.message.includes('patch'))).toBe(true)
     const after = readdirSync(personasDir)
-    expect(after).toContain('patch.md')
-    expect(after).toContain('pixel.md')
-    const stub = readFileSync(join(personasDir, 'patch.md'), 'utf-8')
-    expect(stub).toMatch(/Persona not yet configured/)
+    expect(after).not.toContain('patch.md')
+    expect(after).not.toContain('pixel.md')
   })
 
-  it('creates the personas directory in autoFix mode when missing', async () => {
-    mockAutoFix = true
+  it('persona repair creates the personas directory and stub files explicitly', async () => {
     const personasDir = join(testDir, 'team', 'personas')
     expect(existsSync(personasDir)).toBe(false)
 
     const results = await checkPersonas(testDir, runtimeAgentReader)
+    const repair = personaRepair(testDir, runtimeAgentReader)
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
+    expect(applied[0].status).toBe('applied')
     expect(existsSync(personasDir)).toBe(true)
-    expect(results.some(r => r.status === 'fixed' && r.message.includes('Created missing personas directory'))).toBe(true)
+    expect(readdirSync(personasDir)).toEqual(expect.arrayContaining(['main.md', 'patch.md', 'pixel.md']))
+    const stub = readFileSync(join(personasDir, 'patch.md'), 'utf-8')
+    expect(stub).toMatch(/Persona not yet configured/)
   })
 })
 
@@ -278,6 +282,30 @@ describe('checkAgentAssets — wrapper', () => {
     expect(results[0].status).toBe('warn')
     expect(results[0].autoFixable).toBe(true)
     expect(results[0].message).toMatch(/bakin install agent-assets/)
+  })
+
+  it('plans and applies agent-assets repair explicitly', async () => {
+    checkSpy = spyOn(agentAssetsComponent, 'check').mockImplementation(async () => ({
+      name: 'agent-assets',
+      status: 'warn' as const,
+      message: '1 projection drifted',
+      remediation: 'Run `bakin install agent-assets` to repair.',
+    }))
+    const installSpy = spyOn(agentAssetsComponent, 'install').mockImplementation(async () => ({
+      name: 'agent-assets',
+      status: 'installed' as const,
+      message: 'projection repaired',
+      durationMs: 1,
+    }))
+
+    const results = await checkAgentAssets()
+    const repair = agentAssetsRepair()
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
+    expect(applied[0].status).toBe('applied')
+    expect(installSpy).toHaveBeenCalled()
+    installSpy.mockRestore()
   })
 })
 

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -43,9 +43,6 @@ mock.module('@bakin/adapter-openclaw/home', () => ({
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
 }))
-mock.module('../../../src/core/settings', () => ({
-  getSettings: () => ({ doctor: { autoFixSkill: false } }),
-}))
 mock.module('@/core/task-store', () => ({
   readTaskboard: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),
   getAllTasks: () => ({ columns: { todo: [], 'in-progress': [], done: [] } }),

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -7,7 +7,7 @@
  * against fixture workflow data written to a temp directory.
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from 'bun:test'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -73,6 +73,7 @@ import {
   checkWorkflowSkills,
   checkWorkflowDefinitions,
   checkStaleWorkflowInstances,
+  staleWorkflowInstancesRepair,
 } from '../../../plugins/workflows/lib/health-checks'
 
 const skillsDir = join(testDir, 'workflows', 'skills')
@@ -181,6 +182,28 @@ describe('checkStaleWorkflowInstances', () => {
     )
     const results = await checkStaleWorkflowInstances(testDir)
     expect(results.some(r => r.status === 'warn' && r.message.includes(orphanedId))).toBe(true)
+    expect(existsSync(join(instancesDir, `${orphanedId}.json`))).toBe(true)
+  })
+
+  it('removes orphaned instances through explicit repair', async () => {
+    const orphanedId = 'task-deleted'
+    writeFileSync(
+      join(instancesDir, `${orphanedId}.json`),
+      JSON.stringify({
+        instanceId: 'i1',
+        taskId: orphanedId,
+        status: 'in_progress',
+        currentStepId: 's1',
+        updatedAt: new Date().toISOString(),
+      }),
+    )
+    const results = await checkStaleWorkflowInstances(testDir)
+    const repair = staleWorkflowInstancesRepair(testDir)
+    const plan = await repair.plan(results)
+    expect(plan).toHaveLength(1)
+    const applied = await repair.apply(plan)
+    expect(applied[0].status).toBe('applied')
+    expect(existsSync(join(instancesDir, `${orphanedId}.json`))).toBe(false)
   })
 
   it('flags a stale in-progress instance (>2h old)', async () => {


### PR DESCRIPTION
## Summary

- Keeps normal `bakin doctor`, cron diagnostics, health dashboard refreshes, and MCP doctor checks report-only.
- Adds explicit deterministic repair contracts plus `bakin doctor --fix`, with plan/apply/verify behavior and confirmation guards.
- Adds delegated repair requests via `bakin doctor --delegate`, creating a linked board task assigned to the runtime main agent and kicking dispatch.
- Adds repair request inspection with `bakin doctor repair list`, `show`, and `verify`.
- Removes `doctor.autoFixSkill` and migrates existing safe repair paths into explicit repair handlers.
- Updates docs, generated API/CLI references, and Bakin knowledge notes.

Closes #268.
Closes #269.

## Verification

- `bun test --isolate tests/core/doctor-repair.test.ts tests/core/doctor-delegate.test.ts tests/plugins/health/routes.test.ts tests/cli/doctor-repair.test.ts tests/plugins/health/system-checks.test.ts tests/plugins/tasks/health-checks.test.ts tests/plugins/team/health-checks.test.ts tests/plugins/assets/health-checks.test.ts tests/plugins/schedule/health-checks.test.ts tests/plugins/workflows/health-checks.test.ts tests/plugins/memory/health-checks.test.ts tests/core/settings.test.ts tests/core/doctor.test.ts tests/core/doctor-plugin-checks.test.ts`
- `bun run typecheck`
- `bun run docs:validate`
- `bun run docs:validate:routes`
