### PR TITLE
Refactor CLI TUI primitives

### DIFF
--- a/.claude/specs/cli-tui-output-style.md
+++ b/.claude/specs/cli-tui-output-style.md
@@ -68,6 +68,7 @@ bun run typecheck
 ```text
 scripts/cli-tui-gallery.tsx             executable gallery runner
 src/core/cli/ui/style-tokens.ts         prototype status/color/spacing tokens
+src/core/cli/ui/tui.tsx                 shared TUI primitives promoted from the gallery
 src/core/cli/ui/tui-gallery.tsx         gallery components and fixture screens
 tests/cli/tui-gallery.test.tsx          width and screen coverage
 .claude/specs/cli-tui-output-style.md   this spec

--- a/src/core/cli/ui/tui-gallery.tsx
+++ b/src/core/cli/ui/tui-gallery.tsx
@@ -1,13 +1,16 @@
 import { Box, Text, renderToString } from 'ink'
-import type { ReactNode } from 'react'
 import { createMultiSelectState, MultiSelect, type MultiSelectItem } from './multi-select'
-import { CLI_COLORS, statusToken, type TuiStatus } from './style-tokens'
-
-const BAKIN_HEADER = [
-  "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓",
-  "┃  🐷 Bakin'                  (v1.0.0) ┃",
-  "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛",
-] as const
+import { CLI_COLORS } from './style-tokens'
+import {
+  DataTable,
+  FindingRows,
+  NextActions,
+  ProgressMeter,
+  ScreenHeader as Header,
+  Section,
+  SummaryStrip,
+  type FindingRow,
+} from './tui'
 
 export const GALLERY_SCREENS = [
   'doctor',
@@ -27,183 +30,8 @@ export const GALLERY_SCREENS = [
 
 export type GalleryScreen = typeof GALLERY_SCREENS[number] | 'all'
 
-interface FindingRow {
-  status: TuiStatus
-  label: string
-  message: string
-  detail?: string
-  next?: string
-}
-
-interface SummaryItem {
-  label: string
-  value: string | number
-  status?: TuiStatus
-}
-
-interface TableColumn<TRow> {
-  key: string
-  header: string
-  width: number
-  render: (row: TRow) => string
-}
-
-function Header({ title, subtitle, meta }: { title: string; subtitle?: string; meta?: string }) {
-  return (
-    <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text> </Text>
-        {BAKIN_HEADER.map(line => (
-          <Text key={line} bold color="white">{line}</Text>
-        ))}
-        <Text> </Text>
-      </Box>
-      <Box>
-        <Text bold>{title}</Text>
-        {meta ? <Text dimColor>  {meta}</Text> : null}
-      </Box>
-      {subtitle ? <Text dimColor>{subtitle}</Text> : null}
-    </Box>
-  )
-}
-
-function Section({ title, children, marginTop = 1 }: {
-  title: string
-  children: ReactNode
-  marginTop?: number
-}) {
-  const divider = '-'.repeat(Math.max(12, title.length + 4))
-
-  return (
-    <Box flexDirection="column" marginTop={marginTop}>
-      <Text bold color="white">{title.toUpperCase()}</Text>
-      <Text bold color="white">{divider}</Text>
-      <Box flexDirection="column">
-        {children}
-      </Box>
-    </Box>
-  )
-}
-
-function StatusToken({ status, color = true }: { status: TuiStatus; color?: boolean }) {
-  const token = statusToken(status)
-  const label = ` ${token.label.padEnd(7)} `
-  return (
-    <Text
-      bold
-      color={color ? token.foreground : undefined}
-      backgroundColor={color ? token.color : undefined}
-    >
-      {label}
-    </Text>
-  )
-}
-
-function SummaryStrip({ items }: { items: SummaryItem[] }) {
-  return (
-    <Box marginTop={1} gap={2} flexWrap="wrap">
-      {items.map(item => (
-        <Box key={item.label}>
-          {item.status ? <StatusToken status={item.status} /> : null}
-          <Text bold>{item.status ? ' ' : ''}{item.value}</Text>
-          <Text dimColor> {item.label}</Text>
-        </Box>
-      ))}
-    </Box>
-  )
-}
-
-function FindingRows({ rows }: { rows: FindingRow[] }) {
-  return (
-    <Box flexDirection="column">
-      {rows.map(row => (
-        <Box key={`${row.label}-${row.message}`} flexDirection="column">
-          <Box gap={1}>
-            <Box width={10} flexShrink={0}>
-              <StatusToken status={row.status} />
-            </Box>
-            <Box width={22} flexShrink={0}>
-              <Text wrap="truncate-end">{row.label}</Text>
-            </Box>
-            <Box flexGrow={1} flexShrink={1}>
-              <Text wrap="wrap">{row.message}</Text>
-            </Box>
-          </Box>
-          {row.detail ? (
-            <Box marginLeft={33}>
-              <Text dimColor wrap="wrap">{row.detail}</Text>
-            </Box>
-          ) : null}
-          {row.next ? (
-            <Box marginLeft={33}>
-              <Text color={CLI_COLORS.info} wrap="wrap">Next: {row.next}</Text>
-            </Box>
-          ) : null}
-        </Box>
-      ))}
-    </Box>
-  )
-}
-
-function DataTable<TRow>({ columns, rows }: { columns: Array<TableColumn<TRow>>; rows: TRow[] }) {
-  return (
-    <Box flexDirection="column">
-      <Box gap={1}>
-        {columns.map(column => (
-          <Box key={column.key} width={column.width} flexShrink={0}>
-            <Text bold wrap="truncate-end">{column.header}</Text>
-          </Box>
-        ))}
-      </Box>
-      {rows.map((row, rowIndex) => (
-        <Box key={rowIndex} gap={1}>
-          {columns.map(column => (
-            <Box key={column.key} width={column.width} flexShrink={0}>
-              <Text wrap="truncate-end">{column.render(row)}</Text>
-            </Box>
-          ))}
-        </Box>
-      ))}
-    </Box>
-  )
-}
-
 function ActionList({ rows }: { rows: FindingRow[] }) {
   return <FindingRows rows={rows} />
-}
-
-function NextActions({ actions }: { actions: string[] }) {
-  return (
-    <Section title="Next" marginTop={1}>
-      {actions.map(action => (
-        <Box key={action}>
-          <Text color={CLI_COLORS.info}>- </Text>
-          <Text wrap="wrap">{action}</Text>
-        </Box>
-      ))}
-    </Section>
-  )
-}
-
-function ProgressMeter({ label, current, total, percent }: {
-  label: string
-  current: number
-  total: number
-  percent: number
-}) {
-  const width = 30
-  const filled = Math.max(0, Math.min(width, Math.round((percent / 100) * width)))
-  const bar = `${'#'.repeat(filled)}${'-'.repeat(width - filled)}`
-
-  return (
-    <Box flexDirection="column">
-      <Box>
-        <Text bold>{label}</Text>
-        <Text dimColor>  {current}/{total} steps  {percent}%</Text>
-      </Box>
-      <Text color={CLI_COLORS.info}>{bar}</Text>
-    </Box>
-  )
 }
 
 function DoctorScreen() {

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -1,0 +1,200 @@
+import { Box, Text } from 'ink'
+import type { ReactNode } from 'react'
+import { CLI_COLORS, statusToken, type TuiStatus } from './style-tokens'
+
+export const BAKIN_HEADER = [
+  "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓",
+  "┃  🐷 Bakin'                  (v1.0.0) ┃",
+  "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛",
+] as const
+
+export interface FindingRow {
+  status: TuiStatus
+  label: string
+  message: string
+  detail?: string
+  next?: string
+}
+
+export interface SummaryItem {
+  label: string
+  value: string | number
+  status?: TuiStatus
+}
+
+export interface TableColumn<TRow> {
+  key: string
+  header: string
+  width: number
+  render: (row: TRow) => string
+}
+
+export function BakinHeader() {
+  return (
+    <Box flexDirection="column">
+      <Text> </Text>
+      {BAKIN_HEADER.map(line => (
+        <Text key={line} bold color="white">{line}</Text>
+      ))}
+      <Text> </Text>
+    </Box>
+  )
+}
+
+export function ScreenHeader({ title, subtitle, meta }: {
+  title: string
+  subtitle?: string
+  meta?: string
+}) {
+  return (
+    <Box flexDirection="column">
+      <BakinHeader />
+      <Box>
+        <Text bold>{title}</Text>
+        {meta ? <Text dimColor>  {meta}</Text> : null}
+      </Box>
+      {subtitle ? <Text dimColor>{subtitle}</Text> : null}
+    </Box>
+  )
+}
+
+export function Section({ title, children, marginTop = 1 }: {
+  title: string
+  children: ReactNode
+  marginTop?: number
+}) {
+  const divider = '-'.repeat(Math.max(12, title.length + 4))
+
+  return (
+    <Box flexDirection="column" marginTop={marginTop}>
+      <Text bold color="white">{title.toUpperCase()}</Text>
+      <Text bold color="white">{divider}</Text>
+      <Box flexDirection="column">
+        {children}
+      </Box>
+    </Box>
+  )
+}
+
+export function StatusToken({ status, color = true }: {
+  status: TuiStatus
+  color?: boolean
+}) {
+  const token = statusToken(status)
+  const label = ` ${token.label.padEnd(7)} `
+  return (
+    <Text
+      bold
+      color={color ? token.foreground : undefined}
+      backgroundColor={color ? token.color : undefined}
+    >
+      {label}
+    </Text>
+  )
+}
+
+export function SummaryStrip({ items }: { items: SummaryItem[] }) {
+  return (
+    <Box marginTop={1} gap={2} flexWrap="wrap">
+      {items.map(item => (
+        <Box key={item.label}>
+          {item.status ? <StatusToken status={item.status} /> : null}
+          <Text bold>{item.status ? ' ' : ''}{item.value}</Text>
+          <Text dimColor> {item.label}</Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export function FindingRows({ rows }: { rows: FindingRow[] }) {
+  return (
+    <Box flexDirection="column">
+      {rows.map(row => (
+        <Box key={`${row.label}-${row.message}`} flexDirection="column">
+          <Box gap={1}>
+            <Box width={10} flexShrink={0}>
+              <StatusToken status={row.status} />
+            </Box>
+            <Box width={22} flexShrink={0}>
+              <Text wrap="truncate-end">{row.label}</Text>
+            </Box>
+            <Box flexGrow={1} flexShrink={1}>
+              <Text wrap="wrap">{row.message}</Text>
+            </Box>
+          </Box>
+          {row.detail ? (
+            <Box marginLeft={33}>
+              <Text dimColor wrap="wrap">{row.detail}</Text>
+            </Box>
+          ) : null}
+          {row.next ? (
+            <Box marginLeft={33}>
+              <Text color={CLI_COLORS.info} wrap="wrap">Next: {row.next}</Text>
+            </Box>
+          ) : null}
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export function DataTable<TRow>({ columns, rows }: {
+  columns: Array<TableColumn<TRow>>
+  rows: TRow[]
+}) {
+  return (
+    <Box flexDirection="column">
+      <Box gap={1}>
+        {columns.map(column => (
+          <Box key={column.key} width={column.width} flexShrink={0}>
+            <Text bold wrap="truncate-end">{column.header}</Text>
+          </Box>
+        ))}
+      </Box>
+      {rows.map((row, rowIndex) => (
+        <Box key={rowIndex} gap={1}>
+          {columns.map(column => (
+            <Box key={column.key} width={column.width} flexShrink={0}>
+              <Text wrap="truncate-end">{column.render(row)}</Text>
+            </Box>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export function NextActions({ actions }: { actions: string[] }) {
+  return (
+    <Section title="Next" marginTop={1}>
+      {actions.map(action => (
+        <Box key={action}>
+          <Text color={CLI_COLORS.info}>- </Text>
+          <Text wrap="wrap">{action}</Text>
+        </Box>
+      ))}
+    </Section>
+  )
+}
+
+export function ProgressMeter({ label, current, total, percent }: {
+  label: string
+  current: number
+  total: number
+  percent: number
+}) {
+  const width = 30
+  const filled = Math.max(0, Math.min(width, Math.round((percent / 100) * width)))
+  const bar = `${'#'.repeat(filled)}${'-'.repeat(width - filled)}`
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text bold>{label}</Text>
+        <Text dimColor>  {current}/{total} steps  {percent}%</Text>
+      </Box>
+      <Text color={CLI_COLORS.info}>{bar}</Text>
+    </Box>
+  )
+}

--- a/tests/cli/ui.test.tsx
+++ b/tests/cli/ui.test.tsx
@@ -4,8 +4,77 @@ import { renderToString } from 'ink'
 import { createMultiSelectState, MultiSelect, updateMultiSelectState } from '../../src/core/cli/ui/multi-select'
 import { Report } from '../../src/core/cli/ui/report'
 import { Table } from '../../src/core/cli/ui/table'
+import {
+  FindingRows,
+  NextActions,
+  ProgressMeter,
+  ScreenHeader,
+  Section,
+  StatusToken,
+  SummaryStrip,
+} from '../../src/core/cli/ui/tui'
 
 describe('CLI UI primitives', () => {
+  it('renders the shared Bakin TUI screen header', () => {
+    const output = renderToString(
+      <ScreenHeader title="Doctor" subtitle="Offline diagnostics from this machine" meta="mode: offline" />,
+    )
+    const lines = output.split('\n')
+
+    expect(lines[0]).toBe('')
+    expect(lines[1]).toBe('┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓')
+    expect(lines[2]).toBe("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(lines[3]).toBe('┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛')
+    expect(lines[4]).toBe('')
+    expect(output).toContain('Doctor  mode: offline')
+    expect(output).toContain('Offline diagnostics from this machine')
+  })
+
+  it('renders shared TUI sections, status tokens, and remediation rows', () => {
+    const output = renderToString(
+      <Section title="Local checks">
+        <FindingRows rows={[{
+          status: 'warn',
+          label: 'agent-assets',
+          message: '1 agent-package projection needs repair.',
+          next: 'bakin install agent-assets',
+        }]} />
+      </Section>,
+    )
+
+    expect(output).toContain('LOCAL CHECKS\n------------')
+    expect(output).toContain(' WARN      agent-assets')
+    expect(output).toContain('1 agent-package projection needs repair.')
+    expect(output).toContain('Next: bakin install agent-assets')
+    expect(output).not.toContain('[WARN]')
+  })
+
+  it('renders shared TUI summaries, progress, and next actions', () => {
+    const output = renderToString(
+      <>
+        <SummaryStrip items={[
+          { label: 'complete', value: 6, status: 'ok' },
+          { label: 'pending', value: 3, status: 'todo' },
+        ]} />
+        <ProgressMeter label="Setting up this machine" current={7} total={11} percent={64} />
+        <NextActions actions={['Run `bakin doctor --full` after `bakin start`.']} />
+      </>,
+    )
+
+    expect(output).toContain(' OK       6 complete')
+    expect(output).toContain(' TODO     3 pending')
+    expect(output).toContain('Setting up this machine  7/11 steps  64%')
+    expect(output).toContain('###################-----------')
+    expect(output).toContain('NEXT\n------------')
+    expect(output).toContain('- Run `bakin doctor --full` after `bakin start`.')
+  })
+
+  it('renders shared TUI status tokens without color when requested', () => {
+    const output = renderToString(<StatusToken status="fail" color={false} />)
+
+    expect(output).toBe(' FAIL')
+  })
+
   it('renders grouped reports with remediation', () => {
     const output = renderToString(
       <Report


### PR DESCRIPTION
## Summary
- promote the approved gallery TUI pieces into shared src/core/cli/ui/tui.tsx primitives
- refactor the style gallery to consume those shared primitives without changing rendered output
- add focused primitive tests for the shared header, sections, status tokens, summaries, progress, and next actions

## Verification
- bun test --isolate tests/cli/ui.test.tsx tests/cli/tui-gallery.test.tsx
- bun test --isolate tests/cli
- bun run typecheck