### PR TITLE
Refactor generic CLI Ink renderer

### DIFF
--- a/src/core/cli/ui/generic.tsx
+++ b/src/core/cli/ui/generic.tsx
@@ -1,9 +1,11 @@
 import { Box, Text } from 'ink'
 import type { CliEnvelope } from '../result'
+import type { TuiStatus } from './style-tokens'
+import { FindingRows, ScreenHeader, Section, SummaryStrip, type SummaryItem } from './tui'
 
-function statusLabel(envelope: CliEnvelope): string {
-  if (envelope.ok && envelope.exitCode === 2) return 'WARN'
-  return envelope.ok ? 'OK' : 'FAIL'
+function envelopeStatus(envelope: CliEnvelope): TuiStatus {
+  if (!envelope.ok) return 'fail'
+  return envelope.exitCode === 2 ? 'warn' : 'ok'
 }
 
 function dataPreview(data: unknown): string[] {
@@ -25,30 +27,41 @@ export interface GenericResultViewProps {
 }
 
 export function GenericResultView({ envelope, color = true }: GenericResultViewProps) {
-  const label = statusLabel(envelope)
-  const labelColor = envelope.ok
-    ? envelope.exitCode === 2 ? 'yellow' : 'green'
-    : 'red'
+  const status = envelopeStatus(envelope)
   const preview = dataPreview(envelope.data)
+  const summary: SummaryItem[] = [
+    { label: 'exit code', value: envelope.exitCode, status },
+  ]
+  if (envelope.error) summary.push({ label: 'code', value: envelope.error.code })
 
   return (
     <Box flexDirection="column">
-      <Box>
-        <Text color={color ? labelColor : undefined}>[{label}]</Text>
-        <Text> {envelope.command}</Text>
-      </Box>
+      <ScreenHeader
+        title={envelope.error ? 'Command failed' : envelope.command}
+        subtitle={envelope.error?.message}
+        meta={envelope.error ? envelope.command : undefined}
+        color={color}
+      />
+      <SummaryStrip items={summary} color={color} />
       {envelope.error ? (
-        <Box flexDirection="column" marginTop={1}>
-          <Text>{envelope.error.message}</Text>
-          <Text dimColor={color}>Code: {envelope.error.code}</Text>
-        </Box>
+        <Section title="Problem" color={color}>
+          <FindingRows
+            color={color}
+            rows={[{
+              status: 'fail',
+              label: envelope.command,
+              message: envelope.error.message,
+              detail: `Code: ${envelope.error.code}`,
+            }]}
+          />
+        </Section>
       ) : null}
       {preview.length > 0 ? (
-        <Box flexDirection="column" marginTop={1}>
+        <Section title="Data" color={color}>
           {preview.map((line, index) => (
             <Text key={index}>{line}</Text>
           ))}
-        </Box>
+        </Section>
       ) : null}
     </Box>
   )

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -29,26 +29,27 @@ export interface TableColumn<TRow> {
   render: (row: TRow) => string
 }
 
-export function BakinHeader() {
+export function BakinHeader({ color = true }: { color?: boolean } = {}) {
   return (
     <Box flexDirection="column">
       <Text> </Text>
       {BAKIN_HEADER.map(line => (
-        <Text key={line} bold color="white">{line}</Text>
+        <Text key={line} bold color={color ? 'white' : undefined}>{line}</Text>
       ))}
       <Text> </Text>
     </Box>
   )
 }
 
-export function ScreenHeader({ title, subtitle, meta }: {
+export function ScreenHeader({ title, subtitle, meta, color = true }: {
   title: string
   subtitle?: string
   meta?: string
+  color?: boolean
 }) {
   return (
     <Box flexDirection="column">
-      <BakinHeader />
+      <BakinHeader color={color} />
       <Box>
         <Text bold>{title}</Text>
         {meta ? <Text dimColor>  {meta}</Text> : null}
@@ -58,17 +59,18 @@ export function ScreenHeader({ title, subtitle, meta }: {
   )
 }
 
-export function Section({ title, children, marginTop = 1 }: {
+export function Section({ title, children, marginTop = 1, color = true }: {
   title: string
   children: ReactNode
   marginTop?: number
+  color?: boolean
 }) {
   const divider = '-'.repeat(Math.max(12, title.length + 4))
 
   return (
     <Box flexDirection="column" marginTop={marginTop}>
-      <Text bold color="white">{title.toUpperCase()}</Text>
-      <Text bold color="white">{divider}</Text>
+      <Text bold color={color ? 'white' : undefined}>{title.toUpperCase()}</Text>
+      <Text bold color={color ? 'white' : undefined}>{divider}</Text>
       <Box flexDirection="column">
         {children}
       </Box>
@@ -93,12 +95,12 @@ export function StatusToken({ status, color = true }: {
   )
 }
 
-export function SummaryStrip({ items }: { items: SummaryItem[] }) {
+export function SummaryStrip({ items, color = true }: { items: SummaryItem[]; color?: boolean }) {
   return (
     <Box marginTop={1} gap={2} flexWrap="wrap">
       {items.map(item => (
         <Box key={item.label}>
-          {item.status ? <StatusToken status={item.status} /> : null}
+          {item.status ? <StatusToken status={item.status} color={color} /> : null}
           <Text bold>{item.status ? ' ' : ''}{item.value}</Text>
           <Text dimColor> {item.label}</Text>
         </Box>
@@ -107,14 +109,14 @@ export function SummaryStrip({ items }: { items: SummaryItem[] }) {
   )
 }
 
-export function FindingRows({ rows }: { rows: FindingRow[] }) {
+export function FindingRows({ rows, color = true }: { rows: FindingRow[]; color?: boolean }) {
   return (
     <Box flexDirection="column">
       {rows.map(row => (
         <Box key={`${row.label}-${row.message}`} flexDirection="column">
           <Box gap={1}>
             <Box width={10} flexShrink={0}>
-              <StatusToken status={row.status} />
+              <StatusToken status={row.status} color={color} />
             </Box>
             <Box width={22} flexShrink={0}>
               <Text wrap="truncate-end">{row.label}</Text>
@@ -130,7 +132,7 @@ export function FindingRows({ rows }: { rows: FindingRow[] }) {
           ) : null}
           {row.next ? (
             <Box marginLeft={33}>
-              <Text color={CLI_COLORS.info} wrap="wrap">Next: {row.next}</Text>
+              <Text color={color ? CLI_COLORS.info : undefined} wrap="wrap">Next: {row.next}</Text>
             </Box>
           ) : null}
         </Box>

--- a/tests/cli/render.test.tsx
+++ b/tests/cli/render.test.tsx
@@ -24,9 +24,26 @@ describe('CLI renderers', () => {
   })
 
   it('renders a generic Ink result view to string', () => {
-    expect(renderInkEnvelope(toEnvelope(okResult('version', { version: '1.2.3' })), { color: false })).toBe(
-      '[OK] version\n\n{\n  "version": "1.2.3"\n}\n',
-    )
+    const output = renderInkEnvelope(toEnvelope(okResult('version', { version: '1.2.3' })), { color: false })
+
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('version')
+    expect(output).toContain(' OK       0 exit code')
+    expect(output).toContain('DATA\n------------')
+    expect(output).toContain('"version": "1.2.3"')
+    expect(output).not.toContain('[OK]')
+  })
+
+  it('renders generic Ink errors with sectioned details', () => {
+    const output = renderInkEnvelope(toEnvelope(errorResult('doctor', 'SERVER_UNREACHABLE', 'Cannot reach Bakin')), { color: false })
+
+    expect(output).toContain('Command failed  doctor')
+    expect(output).toContain('Cannot reach Bakin')
+    expect(output).toContain(' FAIL     1 exit code')
+    expect(output).toContain('SERVER_UNREACHABLE code')
+    expect(output).toContain('PROBLEM\n------------')
+    expect(output).toContain(' FAIL      doctor')
+    expect(output).not.toContain('[FAIL]')
   })
 
   it('selects JSON explicitly and Ink only for TTY output', () => {


### PR DESCRIPTION
## Summary
- render generic Ink command results with the shared Bakin TUI header, summary strip, and sections
- keep JSON and plain renderers unchanged
- add render tests for success and error generic Ink output

## Verification
- bun test --isolate tests/cli/render.test.tsx tests/cli/ui.test.tsx
- bun test --isolate tests/cli
- bun run typecheck