### PR TITLE
Migrate doctor report to shared CLI TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1146,6 +1146,7 @@ async function cmdDoctor(args: string[] = process.argv.slice(2)): Promise<void> 
     console.log(renderToString(createElement(DoctorReport, {
       results: result.results,
       summary: result.summary,
+      mode: result.mode,
     })))
     if (result.summary.errors > 0) process.exit(1)
     if (result.summary.warnings > 0) process.exit(2)

--- a/src/core/cli/ui/doctor.tsx
+++ b/src/core/cli/ui/doctor.tsx
@@ -1,5 +1,14 @@
-import { Box, Text } from 'ink'
-import { Report, type ReportRow } from './report'
+import { Box } from 'ink'
+import type { TuiStatus } from './style-tokens'
+import {
+  FindingRows,
+  NextActions,
+  ScreenHeader,
+  Section,
+  SummaryStrip,
+  type FindingRow,
+  type SummaryItem,
+} from './tui'
 
 export interface DoctorResultRow {
   check: string
@@ -13,49 +22,117 @@ export interface DoctorSummaryData {
   warnings: number
 }
 
-function doctorStatus(status: string): ReportRow['status'] {
-  switch (status) {
+export type DoctorMode = 'offline' | 'full'
+
+function isSkippedDoctorResult(result: DoctorResultRow): boolean {
+  return result.status === 'skip' || /^Skipped\b/i.test(result.message)
+}
+
+function doctorStatus(result: DoctorResultRow): TuiStatus {
+  if (isSkippedDoctorResult(result)) return 'skip'
+
+  switch (result.status) {
     case 'ok':
-      return 'complete'
+      return 'ok'
     case 'fixed':
-      return 'complete'
+      return 'applied'
     case 'warn':
-      return 'warning'
+      return 'warn'
     case 'error':
-      return 'failed'
+      return 'fail'
     default:
-      return 'checking'
+      return 'run'
   }
 }
 
-export function DoctorReport({ results, summary }: {
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return count === 1 ? singular : pluralLabel
+}
+
+function doctorCounts(results: DoctorResultRow[], summary: DoctorSummaryData): {
+  skipped: number
+  warnings: number
+  fixed: number
+} {
+  const skipped = results.filter(isSkippedDoctorResult).length
+  return {
+    skipped,
+    warnings: Math.max(0, summary.warnings - skipped),
+    fixed: results.filter(result => result.status === 'fixed').length,
+  }
+}
+
+function summaryItems(results: DoctorResultRow[], summary: DoctorSummaryData): SummaryItem[] {
+  const counts = doctorCounts(results, summary)
+  const items: SummaryItem[] = [
+    { label: plural(summary.errors, 'error'), value: summary.errors, status: summary.errors > 0 ? 'fail' : 'ok' },
+    { label: plural(counts.warnings, 'warning', 'warnings'), value: counts.warnings, status: counts.warnings > 0 ? 'warn' : 'ok' },
+  ]
+
+  if (counts.skipped > 0) {
+    items.push({ label: 'skipped', value: counts.skipped, status: 'skip' })
+  }
+
+  if (counts.fixed > 0) {
+    items.push({ label: 'fixed', value: counts.fixed, status: 'applied' })
+  }
+
+  items.push({ label: 'checks', value: summary.total })
+  return items
+}
+
+function subtitleForMode(mode?: DoctorMode): string {
+  if (mode === 'full') return 'Fresh server-backed diagnostics'
+  if (mode === 'offline') return 'Offline diagnostics from this machine'
+  return 'Health diagnostics'
+}
+
+function findingRows(results: DoctorResultRow[]): FindingRow[] {
+  return results.map(result => ({
+    status: doctorStatus(result),
+    label: result.check,
+    message: result.message,
+  }))
+}
+
+function nextActions(results: DoctorResultRow[], summary: DoctorSummaryData, mode?: DoctorMode): string[] {
+  const counts = doctorCounts(results, summary)
+  const actions: string[] = []
+
+  if (mode === 'offline' && counts.skipped > 0) {
+    actions.push('Run `bakin start`, then `bakin doctor --full` to include server-backed checks.')
+  }
+
+  if (summary.errors > 0) {
+    actions.push('Run `bakin doctor --fix` to preview deterministic repairs.')
+  } else if (counts.warnings > 0) {
+    actions.push('Run `bakin doctor --delegate` to create a board task for unresolved manual work.')
+  }
+
+  return actions
+}
+
+export function DoctorReport({ results, summary, mode, color = true }: {
   results: DoctorResultRow[]
   summary: DoctorSummaryData
+  mode?: DoctorMode
+  color?: boolean
 }) {
+  const actions = nextActions(results, summary, mode)
+
   return (
     <Box flexDirection="column">
-      <Report
-        title="Bakin doctor"
-        groups={[
-          {
-            title: 'Health checks',
-            rows: results.map(result => ({
-              label: result.check,
-              status: doctorStatus(result.status),
-              message: result.message,
-            })),
-          },
-        ]}
+      <ScreenHeader
+        title="Doctor"
+        subtitle={subtitleForMode(mode)}
+        meta={mode ? `mode: ${mode}` : undefined}
+        color={color}
       />
-      <Box marginTop={1}>
-        {summary.errors > 0 ? (
-          <Text color="red">{summary.errors} errors, {summary.warnings} warnings out of {summary.total} checks</Text>
-        ) : summary.warnings > 0 ? (
-          <Text color="yellow">{summary.warnings} warnings out of {summary.total} checks</Text>
-        ) : (
-          <Text color="green">All {summary.total} checks passed</Text>
-        )}
-      </Box>
+      <SummaryStrip items={summaryItems(results, summary)} color={color} />
+      <Section title="Health checks" color={color}>
+        <FindingRows rows={findingRows(results)} color={color} />
+      </Section>
+      {actions.length > 0 ? <NextActions actions={actions} color={color} /> : null}
     </Box>
   )
 }

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -167,13 +167,17 @@ export function DataTable<TRow>({ columns, rows }: {
   )
 }
 
-export function NextActions({ actions }: { actions: string[] }) {
+export function NextActions({ actions, color = true }: { actions: string[]; color?: boolean }) {
   return (
-    <Section title="Next" marginTop={1}>
+    <Section title="Next" marginTop={1} color={color}>
       {actions.map(action => (
         <Box key={action}>
-          <Text color={CLI_COLORS.info}>- </Text>
-          <Text wrap="wrap">{action}</Text>
+          <Box width={2} flexShrink={0}>
+            <Text color={color ? CLI_COLORS.info : undefined}>-</Text>
+          </Box>
+          <Box flexGrow={1} flexShrink={1}>
+            <Text wrap="wrap">{action}</Text>
+          </Box>
         </Box>
       ))}
     </Section>

--- a/tests/cli/doctor-ui.test.tsx
+++ b/tests/cli/doctor-ui.test.tsx
@@ -4,20 +4,52 @@ import { renderToString } from 'ink'
 import { DoctorReport } from '../../src/core/cli/ui/doctor'
 
 describe('doctor CLI UI', () => {
-  it('renders health check rows and summary', () => {
+  it('renders health check rows with shared TUI primitives', () => {
     const rendered = renderToString(
       <DoctorReport
         results={[
           { check: 'plugins.assets', status: 'ok', message: 'Assets healthy' },
           { check: 'runtime', status: 'warn', message: 'Runtime slow' },
+          { check: 'server-backed-checks', status: 'warn', message: 'Skipped checks that require the Bakin server.' },
         ]}
-        summary={{ total: 2, errors: 0, warnings: 1 }}
+        summary={{ total: 3, errors: 0, warnings: 2 }}
+        mode="offline"
+        color={false}
       />,
     )
 
-    expect(rendered).toContain('Bakin doctor')
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Doctor  mode: offline')
+    expect(rendered).toContain(' OK       0 errors')
+    expect(rendered).toContain(' WARN     1 warning')
+    expect(rendered).toContain(' SKIP     1 skipped')
+    expect(rendered).toContain('3 checks')
+    expect(rendered).toContain('HEALTH CHECKS\n-----------------')
     expect(rendered).toContain('plugins.assets')
-    expect(rendered).toContain('[WARN]')
-    expect(rendered).toContain('1 warnings out of 2 checks')
+    expect(rendered).toContain('Runtime slow')
+    expect(rendered).toContain('Skipped checks that require the Bakin server.')
+    expect(rendered).toContain('NEXT\n------------')
+    expect(rendered).toContain('Run `bakin start`, then `bakin doctor --full`')
+    expect(rendered).toContain('Run `bakin doctor --delegate`')
+    expect(rendered).not.toContain('[WARN]')
+  })
+
+  it('does not treat skipped server checks as delegated repair warnings', () => {
+    const rendered = renderToString(
+      <DoctorReport
+        results={[
+          { check: 'home', status: 'ok', message: 'Bakin home directory is initialized.' },
+          { check: 'runtime', status: 'warn', message: 'Skipped live runtime checks in offline mode.' },
+        ]}
+        summary={{ total: 2, errors: 0, warnings: 1 }}
+        mode="offline"
+        color={false}
+      />,
+    )
+
+    expect(rendered).toContain(' OK       0 warnings')
+    expect(rendered).toContain(' SKIP     1 skipped')
+    expect(rendered).toContain('Run `bakin start`, then `bakin doctor --full`')
+    expect(rendered).not.toContain('Run `bakin doctor --delegate`')
   })
 })


### PR DESCRIPTION
## Summary
- render the production doctor TTY report with the shared Bakin header, summary strip, sections, finding rows, and next actions
- pass doctor mode into the report so offline/full output can label itself consistently
- preserve skipped server checks as skipped UI rows instead of counting them as actionable repair warnings
- tighten NextActions wrapping/no-color support

## Verification
- bun test --isolate tests/cli/doctor-ui.test.tsx tests/cli/ui.test.tsx tests/cli/tui-gallery.test.tsx
- bun test --isolate tests/cli
- bun run typecheck