### PR TITLE
Migrate doctor repair flows to shared CLI TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1054,6 +1054,7 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
     return
   }
   if (options.isTTY) {
+    if (acceptedInteractively) console.log('')
     await printDoctorRepairApplyTui(report, { showBrand: !acceptedInteractively })
   } else {
     printDoctorRepairApply(report)
@@ -1103,6 +1104,7 @@ async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: 
     return
   }
   if (options.isTTY) {
+    if (acceptedInteractively) console.log('')
     await printDoctorDelegateResultTui(report, { showBrand: !acceptedInteractively })
   } else {
     printDoctorDelegateResult(report)

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -957,13 +957,13 @@ async function printDoctorRepairPlanTui(plan: CliDoctorRepairPlan): Promise<void
   console.log(renderToString(createElement(DoctorRepairPlan, { plan })))
 }
 
-async function printDoctorRepairApplyTui(report: CliDoctorRepairApply): Promise<void> {
+async function printDoctorRepairApplyTui(report: CliDoctorRepairApply, opts: { showBrand?: boolean } = {}): Promise<void> {
   const [{ DoctorRepairApplyReport }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/doctor-repair'),
     import('ink'),
     import('react'),
   ])
-  console.log(renderToString(createElement(DoctorRepairApplyReport, { report })))
+  console.log(renderToString(createElement(DoctorRepairApplyReport, { report, showBrand: opts.showBrand })))
 }
 
 async function printDoctorDelegatePreviewTui(unresolved: CliDoctorRepairPlan['diagnostics']): Promise<void> {
@@ -975,13 +975,13 @@ async function printDoctorDelegatePreviewTui(unresolved: CliDoctorRepairPlan['di
   console.log(renderToString(createElement(DoctorDelegatePreview, { unresolved })))
 }
 
-async function printDoctorDelegateResultTui(report: CliDoctorDelegateReport): Promise<void> {
+async function printDoctorDelegateResultTui(report: CliDoctorDelegateReport, opts: { showBrand?: boolean } = {}): Promise<void> {
   const [{ DoctorDelegateResult }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/doctor-repair'),
     import('ink'),
     import('react'),
   ])
-  console.log(renderToString(createElement(DoctorDelegateResult, { report })))
+  console.log(renderToString(createElement(DoctorDelegateResult, { report, showBrand: opts.showBrand })))
 }
 
 async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> {
@@ -989,7 +989,7 @@ async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> 
   const readline = await import('node:readline/promises')
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
   try {
-    const answer = await rl.question(`Apply ${plan.summary.safeItems} safe repair item${plan.summary.safeItems === 1 ? '' : 's'}? [y/N] `)
+    const answer = await rl.question(`\nApply ${plan.summary.safeItems} safe repair item${plan.summary.safeItems === 1 ? '' : 's'}? [y/N] `)
     return /^(y|yes)$/i.test(answer.trim())
   } finally {
     rl.close()
@@ -1001,7 +1001,7 @@ async function confirmDoctorDelegate(unresolved: CliDoctorRepairPlan['diagnostic
   const readline = await import('node:readline/promises')
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
   try {
-    const answer = await rl.question(`Create a delegated repair task for ${unresolved.length} finding${unresolved.length === 1 ? '' : 's'}? [y/N] `)
+    const answer = await rl.question(`\nCreate a delegated repair task for ${unresolved.length} finding${unresolved.length === 1 ? '' : 's'}? [y/N] `)
     return /^(y|yes)$/i.test(answer.trim())
   } finally {
     rl.close()
@@ -1009,6 +1009,7 @@ async function confirmDoctorDelegate(unresolved: CliDoctorRepairPlan['diagnostic
 }
 
 async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boolean }): Promise<void> {
+  let acceptedInteractively = false
   if (!options.yes) {
     const plan = await runDoctorRepairPlan()
     if (options.json) {
@@ -1040,6 +1041,7 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
       console.log('Repair cancelled.')
       process.exit(1)
     }
+    acceptedInteractively = true
   }
 
   const report = await runDoctorRepairApply()
@@ -1052,7 +1054,7 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
     return
   }
   if (options.isTTY) {
-    await printDoctorRepairApplyTui(report)
+    await printDoctorRepairApplyTui(report, { showBrand: !acceptedInteractively })
   } else {
     printDoctorRepairApply(report)
   }
@@ -1060,6 +1062,7 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
 }
 
 async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: boolean }): Promise<void> {
+  let acceptedInteractively = false
   if (!options.yes) {
     const plan = await runDoctorRepairPlan()
     const unresolved = unresolvedDelegateRows(plan)
@@ -1091,6 +1094,7 @@ async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: 
       console.log('Delegated repair cancelled.')
       process.exit(1)
     }
+    acceptedInteractively = true
   }
 
   const report = await runDoctorDelegateApply()
@@ -1099,7 +1103,7 @@ async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: 
     return
   }
   if (options.isTTY) {
-    await printDoctorDelegateResultTui(report)
+    await printDoctorDelegateResultTui(report, { showBrand: !acceptedInteractively })
   } else {
     printDoctorDelegateResult(report)
   }

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -948,6 +948,42 @@ function printDoctorDelegateResult(report: CliDoctorDelegateReport): void {
   if (request.agentId) console.log(`Agent: ${request.agentId}`)
 }
 
+async function printDoctorRepairPlanTui(plan: CliDoctorRepairPlan): Promise<void> {
+  const [{ DoctorRepairPlan }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorRepairPlan, { plan })))
+}
+
+async function printDoctorRepairApplyTui(report: CliDoctorRepairApply): Promise<void> {
+  const [{ DoctorRepairApplyReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorRepairApplyReport, { report })))
+}
+
+async function printDoctorDelegatePreviewTui(unresolved: CliDoctorRepairPlan['diagnostics']): Promise<void> {
+  const [{ DoctorDelegatePreview }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorDelegatePreview, { unresolved })))
+}
+
+async function printDoctorDelegateResultTui(report: CliDoctorDelegateReport): Promise<void> {
+  const [{ DoctorDelegateResult }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorDelegateResult, { report })))
+}
+
 async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> {
   if (plan.summary.safeItems === 0) return false
   const readline = await import('node:readline/promises')
@@ -988,7 +1024,11 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
       process.exit(1)
     }
 
-    printDoctorRepairPlan(plan)
+    if (options.isTTY) {
+      await printDoctorRepairPlanTui(plan)
+    } else {
+      printDoctorRepairPlan(plan)
+    }
     if (plan.summary.totalItems === 0) return
 
     if (!options.isTTY) {
@@ -1011,7 +1051,11 @@ async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boole
     if (exitCode !== 0) process.exit(exitCode)
     return
   }
-  printDoctorRepairApply(report)
+  if (options.isTTY) {
+    await printDoctorRepairApplyTui(report)
+  } else {
+    printDoctorRepairApply(report)
+  }
   if (exitCode !== 0) process.exit(exitCode)
 }
 
@@ -1032,7 +1076,11 @@ async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: 
       process.exit(1)
     }
 
-    printDoctorDelegatePreview(plan, unresolved)
+    if (options.isTTY) {
+      await printDoctorDelegatePreviewTui(unresolved)
+    } else {
+      printDoctorDelegatePreview(plan, unresolved)
+    }
     if (unresolved.length === 0) return
     if (!options.isTTY) {
       console.log('\nRun `bakin doctor --delegate --yes` to create the delegated repair task.')
@@ -1050,7 +1098,11 @@ async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: 
     printDoctorRepairJson(report, 0)
     return
   }
-  printDoctorDelegateResult(report)
+  if (options.isTTY) {
+    await printDoctorDelegateResultTui(report)
+  } else {
+    printDoctorDelegateResult(report)
+  }
 }
 
 async function cmdDoctorRepair(args: string[], options: { json: boolean }): Promise<void> {

--- a/src/core/cli/ui/doctor-repair.tsx
+++ b/src/core/cli/ui/doctor-repair.tsx
@@ -214,13 +214,14 @@ export function DoctorRepairPlan({ plan, color = true }: {
   )
 }
 
-export function DoctorRepairApplyReport({ report, color = true }: {
+export function DoctorRepairApplyReport({ report, color = true, showBrand }: {
   report: DoctorRepairApplyData
   color?: boolean
+  showBrand?: boolean
 }) {
   return (
     <Box flexDirection="column">
-      <ScreenHeader title="Doctor repair results" subtitle="Safe deterministic repairs applied" color={color} />
+      <ScreenHeader title="Doctor repair results" subtitle="Safe deterministic repairs applied" color={color} showBrand={showBrand} />
       <SummaryStrip items={applySummary(report)} color={color} />
       {report.applied.length > 0 ? (
         <Section title="Applied" color={color}>
@@ -268,9 +269,10 @@ export function DoctorDelegatePreview({ unresolved, color = true }: {
   )
 }
 
-export function DoctorDelegateResult({ report, color = true }: {
+export function DoctorDelegateResult({ report, color = true, showBrand }: {
   report: DoctorDelegateReportData
   color?: boolean
+  showBrand?: boolean
 }) {
   if (report.status === 'no_unresolved') {
     return <DoctorDelegatePreview unresolved={[]} color={color} />
@@ -282,7 +284,7 @@ export function DoctorDelegateResult({ report, color = true }: {
 
   return (
     <Box flexDirection="column">
-      <ScreenHeader title="Delegated doctor repair" subtitle="A board task was created for unresolved work" color={color} />
+      <ScreenHeader title="Delegated doctor repair" subtitle="A board task was created for unresolved work" color={color} showBrand={showBrand} />
       <SummaryStrip items={[
         { label: 'request', value: requestId, status: 'sent' },
         ...(taskId ? [{ label: 'task', value: taskId, status: 'todo' as const }] : []),

--- a/src/core/cli/ui/doctor-repair.tsx
+++ b/src/core/cli/ui/doctor-repair.tsx
@@ -210,15 +210,6 @@ export function DoctorRepairPlan({ plan, color = true }: {
           <FindingRows rows={errorRows(plan.errors)} color={color} />
         </Section>
       ) : null}
-      {plan.summary.safeItems > 0 ? (
-        <NextActions
-          color={color}
-          actions={[
-            'Run `bakin doctor --fix --yes` to apply the safe repairs.',
-            'Run `bakin doctor --delegate --yes` to create a board task for unresolved manual work.',
-          ]}
-        />
-      ) : null}
     </Box>
   )
 }
@@ -273,9 +264,6 @@ export function DoctorDelegatePreview({ unresolved, color = true }: {
             : [{ status: 'ok', label: 'delegate', message: 'No unresolved findings need delegated repair.' }]}
         />
       </Section>
-      {unresolved.length > 0 ? (
-        <NextActions color={color} actions={['Run `bakin doctor --delegate --yes` to create the delegated repair task.']} />
-      ) : null}
     </Box>
   )
 }

--- a/src/core/cli/ui/doctor-repair.tsx
+++ b/src/core/cli/ui/doctor-repair.tsx
@@ -1,0 +1,315 @@
+import { Box } from 'ink'
+import type { TuiStatus } from './style-tokens'
+import {
+  FindingRows,
+  NextActions,
+  ScreenHeader,
+  Section,
+  SummaryStrip,
+  type FindingRow,
+  type SummaryItem,
+} from './tui'
+
+export interface DoctorRepairDiagnostic {
+  check: string
+  status: string
+  message: string
+  autoFixable?: boolean
+}
+
+export interface DoctorRepairChange {
+  kind: string
+  target: string
+  action: string
+  description: string
+}
+
+export interface DoctorRepairPlanItem {
+  id: string
+  checkId: string
+  healthCheckId?: string
+  pluginId?: string
+  checkName?: string
+  title: string
+  reason: string
+  safety: 'safe' | 'manual' | 'destructive'
+  requiresConfirmation: boolean
+  changes: DoctorRepairChange[]
+}
+
+export interface DoctorRepairPlanData {
+  diagnostics: DoctorRepairDiagnostic[]
+  items: DoctorRepairPlanItem[]
+  errors: Array<{ phase: string; healthCheckId: string; message: string }>
+  summary: {
+    diagnostics: number
+    repairableChecks: number
+    totalItems: number
+    safeItems: number
+    blockedItems: number
+    planErrors: number
+  }
+}
+
+export interface DoctorRepairApplyData {
+  status: 'confirmation_required' | 'applied'
+  plan: DoctorRepairPlanData
+  applied: Array<{ id: string; checkId: string; status: string; message: string; changes: DoctorRepairChange[] }>
+  skipped: Array<{ id: string; checkId: string; status: string; message: string; changes: DoctorRepairChange[] }>
+  errors: Array<{ phase: string; healthCheckId: string; message: string }>
+  verification: DoctorRepairDiagnostic[]
+  summary: {
+    planned: number
+    applied: number
+    skipped: number
+    failed: number
+    verificationErrors: number
+    verificationWarnings: number
+  }
+}
+
+export interface DoctorDelegateReportData {
+  status: 'confirmation_required' | 'sent' | 'no_unresolved'
+  request: Record<string, unknown>
+  unresolved: DoctorRepairDiagnostic[]
+}
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return count === 1 ? singular : pluralLabel
+}
+
+function statusForDiagnostic(status: string): TuiStatus {
+  switch (status) {
+    case 'ok':
+      return 'ok'
+    case 'fixed':
+    case 'applied':
+      return 'applied'
+    case 'warn':
+      return 'warn'
+    case 'error':
+    case 'failed':
+      return 'fail'
+    case 'skipped':
+      return 'skip'
+    default:
+      return 'run'
+  }
+}
+
+function statusForSafety(safety: DoctorRepairPlanItem['safety']): TuiStatus {
+  if (safety === 'safe') return 'ready'
+  if (safety === 'manual') return 'warn'
+  return 'blocked'
+}
+
+function changesDetail(changes: DoctorRepairChange[]): string | undefined {
+  if (changes.length === 0) return undefined
+  return changes
+    .map(change => `${change.action} ${change.target}: ${change.description}`)
+    .join('; ')
+}
+
+function itemRows(items: DoctorRepairPlanItem[]): FindingRow[] {
+  return items.map((item) => {
+    const reason = item.reason.replace(/[.!?]+$/, '')
+    const changes = changesDetail(item.changes)
+    return {
+      status: statusForSafety(item.safety),
+      label: item.checkId,
+      message: item.title,
+      detail: changes ? `Reason: ${reason}. Change: ${changes}` : `Reason: ${item.reason}`,
+    }
+  })
+}
+
+function diagnosticRows(rows: DoctorRepairDiagnostic[]): FindingRow[] {
+  return rows.map(row => ({
+    status: statusForDiagnostic(row.status),
+    label: row.check,
+    message: row.message,
+  }))
+}
+
+function errorRows(errors: DoctorRepairPlanData['errors'] | DoctorRepairApplyData['errors']): FindingRow[] {
+  return errors.map(error => ({
+    status: 'fail',
+    label: error.healthCheckId || error.phase,
+    message: error.message,
+    detail: `Phase: ${error.phase}`,
+  }))
+}
+
+function repairPlanSummary(plan: DoctorRepairPlanData): SummaryItem[] {
+  const manualItems = plan.items.filter(item => item.safety === 'manual' || item.safety === 'destructive').length
+  const items: SummaryItem[] = [
+    { label: 'safe', value: plan.summary.safeItems, status: plan.summary.safeItems > 0 ? 'ready' : 'ok' },
+    { label: 'manual', value: manualItems, status: manualItems > 0 ? 'warn' : 'ok' },
+    { label: 'blocked', value: plan.summary.blockedItems, status: plan.summary.blockedItems > 0 ? 'blocked' : 'ok' },
+  ]
+  if (plan.summary.planErrors > 0) {
+    items.push({ label: plural(plan.summary.planErrors, 'plan error'), value: plan.summary.planErrors, status: 'fail' })
+  }
+  return items
+}
+
+function applySummary(report: DoctorRepairApplyData): SummaryItem[] {
+  return [
+    { label: 'applied', value: report.summary.applied, status: report.summary.applied > 0 ? 'applied' : 'ok' },
+    { label: 'skipped', value: report.summary.skipped, status: report.summary.skipped > 0 ? 'skip' : 'ok' },
+    { label: 'failed', value: report.summary.failed, status: report.summary.failed > 0 ? 'fail' : 'ok' },
+    {
+      label: 'verification',
+      value: report.summary.verificationErrors + report.summary.verificationWarnings,
+      status: report.summary.verificationErrors > 0 ? 'fail' : report.summary.verificationWarnings > 0 ? 'warn' : 'ok',
+    },
+  ]
+}
+
+function resultRows(results: DoctorRepairApplyData['applied'] | DoctorRepairApplyData['skipped']): FindingRow[] {
+  return results.map(result => ({
+    status: statusForDiagnostic(result.status),
+    label: result.checkId || result.id,
+    message: result.message,
+    detail: changesDetail(result.changes),
+  }))
+}
+
+function requestField(report: DoctorDelegateReportData, key: string): string | undefined {
+  const value = report.request[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+export function DoctorRepairPlan({ plan, color = true }: {
+  plan: DoctorRepairPlanData
+  color?: boolean
+}) {
+  const safeItems = plan.items.filter(item => item.safety === 'safe')
+  const manualItems = plan.items.filter(item => item.safety !== 'safe')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Doctor repair plan" subtitle="Preview only; no changes have been applied" color={color} />
+      <SummaryStrip items={repairPlanSummary(plan)} color={color} />
+      {safeItems.length > 0 ? (
+        <Section title="Safe deterministic repairs" color={color}>
+          <FindingRows rows={itemRows(safeItems)} color={color} />
+        </Section>
+      ) : (
+        <Section title="Safe deterministic repairs" color={color}>
+          <FindingRows rows={[{ status: 'ok', label: 'repairs', message: 'No deterministic repairs available.' }]} color={color} />
+        </Section>
+      )}
+      {manualItems.length > 0 ? (
+        <Section title="Manual follow-up" color={color}>
+          <FindingRows rows={itemRows(manualItems)} color={color} />
+        </Section>
+      ) : null}
+      {plan.errors.length > 0 ? (
+        <Section title="Plan errors" color={color}>
+          <FindingRows rows={errorRows(plan.errors)} color={color} />
+        </Section>
+      ) : null}
+      {plan.summary.safeItems > 0 ? (
+        <NextActions
+          color={color}
+          actions={[
+            'Run `bakin doctor --fix --yes` to apply the safe repairs.',
+            'Run `bakin doctor --delegate --yes` to create a board task for unresolved manual work.',
+          ]}
+        />
+      ) : null}
+    </Box>
+  )
+}
+
+export function DoctorRepairApplyReport({ report, color = true }: {
+  report: DoctorRepairApplyData
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Doctor repair results" subtitle="Safe deterministic repairs applied" color={color} />
+      <SummaryStrip items={applySummary(report)} color={color} />
+      {report.applied.length > 0 ? (
+        <Section title="Applied" color={color}>
+          <FindingRows rows={resultRows(report.applied)} color={color} />
+        </Section>
+      ) : null}
+      {report.skipped.length > 0 ? (
+        <Section title="Skipped" color={color}>
+          <FindingRows rows={resultRows(report.skipped)} color={color} />
+        </Section>
+      ) : null}
+      {report.verification.length > 0 ? (
+        <Section title="Verification" color={color}>
+          <FindingRows rows={diagnosticRows(report.verification)} color={color} />
+        </Section>
+      ) : null}
+      {report.errors.length > 0 ? (
+        <Section title="Errors" color={color}>
+          <FindingRows rows={errorRows(report.errors)} color={color} />
+        </Section>
+      ) : null}
+    </Box>
+  )
+}
+
+export function DoctorDelegatePreview({ unresolved, color = true }: {
+  unresolved: DoctorRepairDiagnostic[]
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Doctor delegated repair preview" subtitle="Preview only; no task has been created" color={color} />
+      <SummaryStrip items={[
+        { label: 'unresolved', value: unresolved.length, status: unresolved.length > 0 ? 'warn' : 'ok' },
+      ]} color={color} />
+      <Section title="Unresolved findings" color={color}>
+        <FindingRows
+          color={color}
+          rows={unresolved.length > 0
+            ? diagnosticRows(unresolved)
+            : [{ status: 'ok', label: 'delegate', message: 'No unresolved findings need delegated repair.' }]}
+        />
+      </Section>
+      {unresolved.length > 0 ? (
+        <NextActions color={color} actions={['Run `bakin doctor --delegate --yes` to create the delegated repair task.']} />
+      ) : null}
+    </Box>
+  )
+}
+
+export function DoctorDelegateResult({ report, color = true }: {
+  report: DoctorDelegateReportData
+  color?: boolean
+}) {
+  if (report.status === 'no_unresolved') {
+    return <DoctorDelegatePreview unresolved={[]} color={color} />
+  }
+
+  const requestId = requestField(report, 'id') ?? '(unknown)'
+  const taskId = requestField(report, 'taskId')
+  const agentId = requestField(report, 'agentId')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Delegated doctor repair" subtitle="A board task was created for unresolved work" color={color} />
+      <SummaryStrip items={[
+        { label: 'request', value: requestId, status: 'sent' },
+        ...(taskId ? [{ label: 'task', value: taskId, status: 'todo' as const }] : []),
+        ...(agentId ? [{ label: 'agent', value: agentId }] : []),
+      ]} color={color} />
+      <Section title="Repair brief" color={color}>
+        <FindingRows rows={diagnosticRows(report.unresolved)} color={color} />
+      </Section>
+      <NextActions
+        color={color}
+        actions={[
+          taskId ? `Watch the board for ${taskId} moving from todo to in-progress.` : 'Watch the board for the delegated repair task.',
+          `Run \`bakin doctor repair verify ${requestId}\` after the agent reports completion.`,
+        ]}
+      />
+    </Box>
+  )
+}

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -180,6 +180,7 @@ export function NextActions({ actions, color = true }: { actions: string[]; colo
           </Box>
         </Box>
       ))}
+      <Text> </Text>
     </Section>
   )
 }

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -41,15 +41,16 @@ export function BakinHeader({ color = true }: { color?: boolean } = {}) {
   )
 }
 
-export function ScreenHeader({ title, subtitle, meta, color = true }: {
+export function ScreenHeader({ title, subtitle, meta, color = true, showBrand = true }: {
   title: string
   subtitle?: string
   meta?: string
   color?: boolean
+  showBrand?: boolean
 }) {
   return (
     <Box flexDirection="column">
-      <BakinHeader color={color} />
+      {showBrand ? <BakinHeader color={color} /> : null}
       <Box>
         <Text bold>{title}</Text>
         {meta ? <Text dimColor>  {meta}</Text> : null}

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -72,7 +72,8 @@ describe('doctor repair CLI UI', () => {
     expect(rendered).toContain('SAFE DETERMINISTIC REPAIRS')
     expect(rendered).toContain('team.install-agent')
     expect(rendered).toContain('Repair agent-package projections')
-    expect(rendered).toContain('NEXT\n------------')
+    expect(rendered).not.toContain('NEXT\n------------')
+    expect(rendered).not.toContain('bakin doctor --fix --yes')
     expect(rendered).not.toContain('[SAFE]')
   })
 
@@ -95,6 +96,8 @@ describe('doctor repair CLI UI', () => {
     expect(preview).toContain('Doctor delegated repair preview')
     expect(preview).toContain('UNRESOLVED FINDINGS')
     expect(preview).toContain('channels')
+    expect(preview).not.toContain('NEXT\n------------')
+    expect(preview).not.toContain('bakin doctor --delegate --yes')
     expect(preview).not.toContain('[WARN]')
 
     expect(result).toContain('Delegated doctor repair')

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -89,6 +89,13 @@ describe('doctor repair CLI UI', () => {
     expect(rendered).not.toContain('[APPLIED]')
   })
 
+  it('can render repair results as a continuation without the brand header', () => {
+    const rendered = renderToString(<DoctorRepairApplyReport report={repairApply} color={false} showBrand={false} />)
+
+    expect(rendered).toContain('Doctor repair results')
+    expect(rendered).not.toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+  })
+
   it('renders delegated repair preview and sent result', () => {
     const preview = renderToString(<DoctorDelegatePreview unresolved={delegateReport.unresolved} color={false} />)
     const result = renderToString(<DoctorDelegateResult report={delegateReport} color={false} />)

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToString } from 'ink'
+
+import {
+  DoctorDelegatePreview,
+  DoctorDelegateResult,
+  DoctorRepairApplyReport,
+  DoctorRepairPlan,
+} from '../../src/core/cli/ui/doctor-repair'
+
+const repairPlan = {
+  diagnostics: [
+    { check: 'team.install-agent-assets', status: 'warn', message: '1 agent-package projection needs repair.', autoFixable: true },
+    { check: 'channels', status: 'warn', message: 'Approval channel requires manual configuration.', autoFixable: false },
+  ],
+  items: [{
+    id: 'repair.team.install-agent-assets',
+    checkId: 'team.install-agent-assets',
+    healthCheckId: 'team.install-agent-assets',
+    pluginId: 'team',
+    checkName: 'Agent assets',
+    title: 'Repair agent-package projections',
+    reason: '1 agent-package projection needs repair.',
+    safety: 'safe' as const,
+    requiresConfirmation: true,
+    changes: [{
+      kind: 'command',
+      target: 'agent-assets',
+      action: 'invoke',
+      description: 'Run the agent-package install flow to repair missing or drifted projected files.',
+    }],
+  }],
+  errors: [],
+  summary: { diagnostics: 2, repairableChecks: 1, totalItems: 1, safeItems: 1, blockedItems: 0, planErrors: 0 },
+}
+
+const repairApply = {
+  status: 'applied' as const,
+  plan: repairPlan,
+  applied: [{
+    id: 'repair.team.install-agent-assets',
+    checkId: 'team.install-agent-assets',
+    status: 'applied',
+    message: 'Repaired agent-package projections.',
+    changes: repairPlan.items[0].changes,
+  }],
+  skipped: [],
+  errors: [],
+  verification: [{ check: 'team.install-agent-assets', status: 'ok', message: 'Agent assets are healthy.', autoFixable: false }],
+  summary: { planned: 1, applied: 1, skipped: 0, failed: 0, verificationErrors: 0, verificationWarnings: 0 },
+}
+
+const delegateReport = {
+  status: 'sent' as const,
+  request: {
+    id: 'repair-1',
+    taskId: 'task-repair-1',
+    agentId: 'main',
+  },
+  unresolved: [
+    { check: 'channels', status: 'warn', message: 'Approval channel requires manual configuration.', autoFixable: false },
+  ],
+}
+
+describe('doctor repair CLI UI', () => {
+  it('renders a repair plan with shared TUI primitives', () => {
+    const rendered = renderToString(<DoctorRepairPlan plan={repairPlan} color={false} />)
+
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Doctor repair plan')
+    expect(rendered).toContain(' READY    1 safe')
+    expect(rendered).toContain('SAFE DETERMINISTIC REPAIRS')
+    expect(rendered).toContain('team.install-agent')
+    expect(rendered).toContain('Repair agent-package projections')
+    expect(rendered).toContain('NEXT\n------------')
+    expect(rendered).not.toContain('[SAFE]')
+  })
+
+  it('renders applied repair results and verification', () => {
+    const rendered = renderToString(<DoctorRepairApplyReport report={repairApply} color={false} />)
+
+    expect(rendered).toContain('Doctor repair results')
+    expect(rendered).toContain(' APPLIED  1 applied')
+    expect(rendered).toContain('APPLIED\n------------')
+    expect(rendered).toContain('Repaired agent-package projections.')
+    expect(rendered).toContain('VERIFICATION\n------------')
+    expect(rendered).toContain('Agent assets are healthy.')
+    expect(rendered).not.toContain('[APPLIED]')
+  })
+
+  it('renders delegated repair preview and sent result', () => {
+    const preview = renderToString(<DoctorDelegatePreview unresolved={delegateReport.unresolved} color={false} />)
+    const result = renderToString(<DoctorDelegateResult report={delegateReport} color={false} />)
+
+    expect(preview).toContain('Doctor delegated repair preview')
+    expect(preview).toContain('UNRESOLVED FINDINGS')
+    expect(preview).toContain('channels')
+    expect(preview).not.toContain('[WARN]')
+
+    expect(result).toContain('Delegated doctor repair')
+    expect(result).toContain(' SENT     repair-1 request')
+    expect(result).toContain(' TODO     task-repair-1 task')
+    expect(result).toContain('Watch the board for task-repair-1')
+  })
+})

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -55,9 +55,18 @@ describe('legacy CLI doctor repair', () => {
   const originalArgv = process.argv
   const originalExit = process.exit
   const originalFetch = globalThis.fetch
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
   let log: ReturnType<typeof spyOn>
   let error: ReturnType<typeof spyOn>
   const fetchMock = mock()
+
+  function setStdoutIsTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+  }
+
+  function loggedOutput(): string {
+    return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+  }
 
   beforeEach(() => {
     mock.clearAllMocks()
@@ -74,6 +83,8 @@ describe('legacy CLI doctor repair', () => {
     process.argv = originalArgv
     process.exit = originalExit
     globalThis.fetch = originalFetch
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
     log.mockRestore()
     error.mockRestore()
   })
@@ -118,6 +129,50 @@ describe('legacy CLI doctor repair', () => {
     expect(body.data.summary.applied).toBe(1)
   })
 
+  it('renders the TTY repair plan with the shared doctor repair UI', async () => {
+    const emptyPlan = {
+      ...mockPlan,
+      diagnostics: [],
+      items: [],
+      summary: { diagnostics: 0, repairableChecks: 0, totalItems: 0, safeItems: 0, blockedItems: 0, planErrors: 0 },
+    }
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(emptyPlan),
+      text: () => Promise.resolve(''),
+    })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--fix']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Doctor repair plan')
+    expect(output).toContain('No deterministic repairs available.')
+    expect(output).not.toContain('[SAFE]')
+  })
+
+  it('renders TTY repair application results with the shared doctor repair UI', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApply),
+      text: () => Promise.resolve(''),
+    })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--fix', '--yes']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(output).toContain('Doctor repair results')
+    expect(output).toContain('APPLIED\n------------')
+    expect(output).toContain('Taskboard healthy')
+    expect(output).not.toContain('[APPLIED]')
+  })
+
   it('previews delegated repair without creating the task when --yes is omitted', async () => {
     const delegatePlan = {
       ...mockPlan,
@@ -145,7 +200,7 @@ describe('legacy CLI doctor repair', () => {
   })
 
   it('creates a delegated repair task with --yes', async () => {
-    fetchMock.mockResolvedValueOnce({
+    fetchMock.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockDelegate),
       text: () => Promise.resolve(''),
@@ -162,6 +217,25 @@ describe('legacy CLI doctor repair', () => {
     const body = JSON.parse(String(log.mock.calls[0][0]))
     expect(body.ok).toBe(true)
     expect(body.data.request.taskId).toBe('task-repair-1')
+  })
+
+  it('renders TTY delegated repair results with the shared doctor repair UI', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockDelegate),
+      text: () => Promise.resolve(''),
+    })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--delegate', '--yes']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(output).toContain('Delegated doctor repair')
+    expect(output).toContain('task-repair-1')
+    expect(output).toContain('Watch the board for task-repair-1')
+    expect(output).not.toContain('Task: task-repair-1')
   })
 
   it('lists delegated repair requests', async () => {

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -215,6 +215,9 @@ describe('legacy CLI doctor repair', () => {
     expect(output).toContain('Doctor repair plan')
     expect(output).toContain('Doctor repair results')
     expect(headerCount(output)).toBe(1)
+    const logLines: string[] = log.mock.calls.map((call: unknown[]) => String(call[0] ?? ''))
+    const resultIndex = logLines.findIndex(line => line.includes('Doctor repair results'))
+    expect(logLines[resultIndex - 1]).toBe('')
   })
 
   it('previews delegated repair without creating the task when --yes is omitted', async () => {

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -1,5 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 
+let nextQuestionAnswer = 'y'
+let prompts: string[] = []
+
+mock.module('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: async (prompt: string) => {
+      prompts.push(prompt)
+      return nextQuestionAnswer
+    },
+    close: () => {},
+  }),
+}))
+
 const mockPlan = {
   diagnostics: [{ check: 'taskboard', status: 'warn', message: 'Missing columns', autoFixable: true }],
   items: [{
@@ -68,8 +81,14 @@ describe('legacy CLI doctor repair', () => {
     return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
   }
 
+  function headerCount(output: string): number {
+    return output.split("┃  🐷 Bakin'                  (v1.0.0) ┃").length - 1
+  }
+
   beforeEach(() => {
     mock.clearAllMocks()
+    prompts = []
+    nextQuestionAnswer = 'y'
     process.argv = originalArgv
     globalThis.fetch = fetchMock as unknown as typeof fetch
     log = spyOn(console, 'log').mockImplementation(() => {})
@@ -171,6 +190,31 @@ describe('legacy CLI doctor repair', () => {
     expect(output).toContain('APPLIED\n------------')
     expect(output).toContain('Taskboard healthy')
     expect(output).not.toContain('[APPLIED]')
+  })
+
+  it('continues interactive repair results without replaying the brand header', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockPlan),
+        text: () => Promise.resolve(''),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockApply),
+        text: () => Promise.resolve(''),
+      })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', '--fix']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(prompts[0]).toStartWith('\nApply 1 safe repair item? [y/N]')
+    expect(output).toContain('Doctor repair plan')
+    expect(output).toContain('Doctor repair results')
+    expect(headerCount(output)).toBe(1)
   })
 
   it('previews delegated repair without creating the task when --yes is omitted', async () => {

--- a/tests/cli/ui.test.tsx
+++ b/tests/cli/ui.test.tsx
@@ -67,6 +67,7 @@ describe('CLI UI primitives', () => {
     expect(output).toContain('###################-----------')
     expect(output).toContain('NEXT\n------------')
     expect(output).toContain('- Run `bakin doctor --full` after `bakin start`.')
+    expect(output.endsWith('\n')).toBe(true)
   })
 
   it('renders shared TUI status tokens without color when requested', () => {


### PR DESCRIPTION
## Summary
- add shared Ink screens for doctor repair plan, repair apply results, delegated preview, and delegated result
- route TTY `bakin doctor --fix`, `--fix --yes`, and `--delegate --yes` through the new repair TUI
- preserve existing JSON and non-TTY/plain doctor repair output paths
- add component and CLI wiring tests for the migrated repair flows

## Verification
- bun test --isolate tests/cli/doctor-repair-ui.test.tsx tests/cli/doctor-repair.test.ts
- bun test --isolate tests/cli
- bun run typecheck