### PR TITLE
Migrate onboarding CLI to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2138,7 +2138,11 @@ async function cmdOnboard(args: string[]): Promise<void> {
     if (!json) {
       if (isTTY) {
         console.log('')
-        console.log(renderToString(createElement(OnboardingSummary, { outcomes: result.outcomes, exitCode: result.exitCode })))
+        console.log(renderToString(createElement(OnboardingSummary, {
+          outcomes: result.outcomes,
+          exitCode: result.exitCode,
+          showBrand: !busy,
+        })))
       } else {
         console.log('')
         for (const o of result.outcomes) {

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2036,9 +2036,9 @@ async function cmdOnboardingInstallSingle(target: string, args: string[]): Promi
 }
 
 async function cmdOnboard(args: string[]): Promise<void> {
-  const { runOnboard, isOnboarded, loadState } = await import('../src/core/onboarding/index')
+  const { runOnboard, isOnboarded, loadState, COMPONENT_ORDER } = await import('../src/core/onboarding/index')
   const { collectOnboardingSelections } = await import('../src/core/cli/onboarding-interactive')
-  const { OnboardingBusy, OnboardingFinalStatus } = await import('../src/core/cli/ui/onboarding')
+  const { OnboardingBusy, OnboardingSummary } = await import('../src/core/cli/ui/onboarding')
   const { render, renderToString } = await import('ink')
   const { createElement } = await import('react')
   const checkOnly = args.includes('--check')
@@ -2095,6 +2095,7 @@ async function cmdOnboard(args: string[]): Promise<void> {
       detail: busyDetail,
       frame: busyFrame,
       completed: completedOutcomes,
+      totalSteps: COMPONENT_ORDER.length,
     })
     const busy = isTTY && !json
       ? render(renderBusy())
@@ -2137,7 +2138,7 @@ async function cmdOnboard(args: string[]): Promise<void> {
     if (!json) {
       if (isTTY) {
         console.log('')
-        console.log(renderToString(createElement(OnboardingFinalStatus, { outcomes: result.outcomes, exitCode: result.exitCode })))
+        console.log(renderToString(createElement(OnboardingSummary, { outcomes: result.outcomes, exitCode: result.exitCode })))
       } else {
         console.log('')
         for (const o of result.outcomes) {

--- a/src/core/cli/onboarding-interactive.tsx
+++ b/src/core/cli/onboarding-interactive.tsx
@@ -1,5 +1,4 @@
-import { Badge, ConfirmInput } from "@inkjs/ui";
-import { render, renderToString, Box, Text } from "ink";
+import { render, renderToString, Box } from "ink";
 import { useState } from "react";
 import {
   MultiSelect,
@@ -7,6 +6,16 @@ import {
   type MultiSelectItem,
   type MultiSelectState,
 } from "./ui/multi-select";
+import {
+  FindingRows,
+  ScreenHeader,
+  Section,
+  SummaryStrip,
+} from "./ui/tui";
+import {
+  OnboardingDecisionPrompt,
+  OnboardingIntro,
+} from "./ui/onboarding";
 import { recommendedAgentsComponent } from "../onboarding/recommended-agents";
 import { recommendedPluginsComponent } from "../onboarding/recommended-plugins";
 import { runtimeComponent } from "../onboarding/runtime";
@@ -85,84 +94,42 @@ function MultiSelectPrompt({
   const [state, setState] = useState<MultiSelectState>(() =>
     createMultiSelectState(items),
   );
-  return (
-    <MultiSelect
-      title={title}
-      items={items}
-      state={state}
-      onChange={setState}
-      onSubmit={onSubmit}
-      marginTop={1}
-    />
-  );
-}
+  const isAgentSelection = title.toLowerCase().includes("agent");
+  const selectedCount = state.selectedIds.size;
+  const availableCount = items.filter((item) => !item.disabled).length;
+  const installedCount = items.filter((item) => item.disabled).length;
 
-function ConfirmStep({
-  title,
-  description,
-  defaultChoice,
-  onSubmit,
-}: {
-  title: string;
-  description: string;
-  defaultChoice: "confirm" | "cancel";
-  onSubmit: (approved: boolean) => void;
-}) {
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      <Badge color="#ff2bd6">{title}</Badge>
-      <Text dimColor>{description}</Text>
-      <Box marginTop={1}>
-        <Text>Continue? </Text>
-        <ConfirmInput
-          defaultChoice={defaultChoice}
-          onConfirm={() => onSubmit(true)}
-          onCancel={() => onSubmit(false)}
-        />
-      </Box>
-    </Box>
-  );
-}
-
-function OnboardingIntro() {
   return (
     <Box flexDirection="column">
-      <Text dimColor> 
-      
-      </Text>
-      <Text color="#ff2bd6">
-              oooooooooo              oooo        o88               
-      </Text>
-      <Text color="#ff2bd6">
-               888    888   ooooooo    888  ooooo oooo  oo oooooo  
-      </Text>
-      <Text color="#ff2bd6">
-               888oooo88    ooooo888   888o888     888   888   888  
-      </Text>
-      <Text color="#ff2bd6">
-               888    888 888    888   8888 88o    888   888   888  
-      </Text>
-      <Text color="#ff2bd6">
-              o888ooo888   88ooo88 8o o888o o888o o888o o888o o888o 
-      </Text>
-      <Text dimColor> 
-         ________________________________________________________________________________
-      </Text>
-      <Text dimColor> 
-         |                                                                              | 
-      </Text>
-      <Text dimColor> 
-         |  v1.0.0                                                                      | 
-      </Text>
-      <Text dimColor>
-         |  Welcome to Bakin'! Let's walk through the initial setup.                    |
-      </Text>
-      <Text dimColor>
-         |  You can revisit the configuration at any time with `bakin onboard --force`  |
-      </Text>
-      <Text dimColor> 
-         |______________________________________________________________________________|
-      </Text>
+      <ScreenHeader
+        title="Onboard"
+        subtitle={isAgentSelection ? "Choose official agents to install or adopt" : "Choose official plugins to install"}
+        meta={isAgentSelection ? "agent selection" : "plugin selection"}
+      />
+      <SummaryStrip items={[
+        { label: "selected", value: selectedCount, status: "ready" },
+        { label: "available", value: availableCount },
+        { label: "installed", value: installedCount, status: installedCount > 0 ? "ok" : "skip" },
+      ]} />
+      <Section title={isAgentSelection ? "Agents" : "Plugins"}>
+        <MultiSelect
+          title={title}
+          items={items}
+          state={state}
+          onChange={setState}
+          onSubmit={onSubmit}
+          showTitle={false}
+        />
+      </Section>
+      {items.some((item) => item.disabled) ? (
+        <Section title={isAgentSelection ? "Runtime context" : "Install plan"}>
+          <FindingRows rows={items.filter((item) => item.disabled).map((item) => ({
+            status: "ok",
+            label: item.label,
+            message: item.note ? `${item.label} is already ${item.note}.` : `${item.label} is already installed.`,
+          }))} />
+        </Section>
+      ) : null}
     </Box>
   );
 }
@@ -196,7 +163,7 @@ async function promptConfirm(
   return await new Promise((resolve) => {
     let app: ReturnType<typeof render> | null = null;
     app = render(
-      <ConfirmStep
+      <OnboardingDecisionPrompt
         title={title}
         description={description}
         defaultChoice={defaultChoice}

--- a/src/core/cli/ui/multi-select.tsx
+++ b/src/core/cli/ui/multi-select.tsx
@@ -1,7 +1,8 @@
-import { Badge, MultiSelect as InkMultiSelect, ThemeProvider, defaultTheme, extendTheme } from '@inkjs/ui'
+import { MultiSelect as InkMultiSelect, ThemeProvider, defaultTheme, extendTheme } from '@inkjs/ui'
 import { Box, Text } from 'ink'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { BAKIN_PINK } from './report'
+import { Section } from './tui'
+import { CLI_COLORS } from './style-tokens'
 
 export interface MultiSelectItem {
   id: string
@@ -76,10 +77,10 @@ const multiSelectTheme = extendTheme(defaultTheme, {
   components: {
     MultiSelect: {
       styles: {
-        focusIndicator: () => ({ color: BAKIN_PINK }),
-        selectedIndicator: () => ({ color: BAKIN_PINK }),
+        focusIndicator: () => ({ color: CLI_COLORS.info }),
+        selectedIndicator: () => ({ color: CLI_COLORS.info }),
         label: ({ isFocused }: { isFocused: boolean }) => ({
-          color: isFocused ? BAKIN_PINK : undefined,
+          color: isFocused ? CLI_COLORS.info : undefined,
         }),
       },
     },
@@ -130,9 +131,8 @@ export function MultiSelect({
     onChangeRef.current({ ...current, selectedIds: selectedIdsSet })
   }, [])
 
-  return (
-    <Box flexDirection="column" marginTop={marginTop}>
-      {showTitle ? <Badge color={BAKIN_PINK}>{title}</Badge> : null}
+  const body = (
+    <>
       <Text dimColor>Use up/down to move, space to select, enter to continue.</Text>
       <Box flexDirection="column">
         <ThemeProvider theme={multiSelectTheme}>
@@ -154,6 +154,12 @@ export function MultiSelect({
           </Box>
         ) : null}
       </Box>
+    </>
+  )
+
+  return (
+    <Box flexDirection="column" marginTop={marginTop}>
+      {showTitle ? <Section title={title} marginTop={0}>{body}</Section> : body}
     </Box>
   )
 }

--- a/src/core/cli/ui/onboarding.tsx
+++ b/src/core/cli/ui/onboarding.tsx
@@ -80,16 +80,17 @@ function outcomeRows(outcomes: ComponentOutcome[]): FindingRow[] {
   }))
 }
 
-export function OnboardingSummary({ outcomes, exitCode }: {
+export function OnboardingSummary({ outcomes, exitCode, showBrand = true }: {
   outcomes: ComponentOutcome[]
   exitCode: 0 | 1 | 2
+  showBrand?: boolean
 }) {
   const prerequisites = outcomes.filter(outcome => PREREQUISITE_COMPONENTS.has(outcome.name))
   const setup = outcomes.filter(outcome => !PREREQUISITE_COMPONENTS.has(outcome.name))
 
   return (
     <Box flexDirection="column">
-      <ScreenHeader title="Onboarding" subtitle={summarySubtitle(exitCode)} />
+      <ScreenHeader title="Onboarding" subtitle={summarySubtitle(exitCode)} showBrand={showBrand} />
       <SummaryStrip items={summaryItems(outcomes)} />
       <Section title="Prerequisites">
         <FindingRows rows={outcomeRows(prerequisites)} />

--- a/src/core/cli/ui/onboarding.tsx
+++ b/src/core/cli/ui/onboarding.tsx
@@ -1,8 +1,17 @@
 import { Box, Text } from 'ink'
-import { Alert, Badge, ProgressBar } from '@inkjs/ui'
-import { BAKIN_PINK, Report, type ReportRow } from './report'
-import { StatusBadge } from './status'
+import { ConfirmInput } from '@inkjs/ui'
 import type { ComponentOutcome } from '../../onboarding'
+import {
+  FindingRows,
+  NextActions,
+  ProgressMeter,
+  ScreenHeader,
+  Section,
+  SummaryStrip,
+  type FindingRow,
+  type SummaryItem,
+} from './tui'
+import type { TuiStatus } from './style-tokens'
 
 const ONBOARDING_BUSY_DETAILS = [
   'Checking prerequisites and runtime access',
@@ -12,52 +21,84 @@ const ONBOARDING_BUSY_DETAILS = [
 ]
 
 const ONBOARDING_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+const PREREQUISITE_COMPONENTS = new Set(['mkdir', 'settings', 'runtime'])
 
-export function onboardingStatus(status: ComponentOutcome['finalStatus']): ReportRow['status'] {
+export type OnboardingBusyStatus = 'complete' | 'warning' | 'skipped' | 'blocked'
+
+export function onboardingStatus(status: ComponentOutcome['finalStatus']): TuiStatus {
   switch (status) {
     case 'ok':
-      return 'complete'
+      return 'ok'
     case 'warn':
-      return 'warning'
+      return 'warn'
     case 'skipped':
-      return 'skipped'
+      return 'skip'
     case 'error':
       return 'blocked'
   }
+}
+
+function busyStatus(status: OnboardingBusyStatus): TuiStatus {
+  switch (status) {
+    case 'complete':
+      return 'ok'
+    case 'warning':
+      return 'warn'
+    case 'skipped':
+      return 'skip'
+    case 'blocked':
+      return 'blocked'
+  }
+}
+
+function summarySubtitle(exitCode: 0 | 1 | 2): string {
+  if (exitCode === 0) return 'Machine setup complete'
+  if (exitCode === 2) return 'Machine setup completed with warnings'
+  return 'Machine setup blocked'
+}
+
+function summaryItems(outcomes: ComponentOutcome[]): SummaryItem[] {
+  const complete = outcomes.filter(outcome => outcome.finalStatus === 'ok').length
+  const warnings = outcomes.filter(outcome => outcome.finalStatus === 'warn').length
+  const skipped = outcomes.filter(outcome => outcome.finalStatus === 'skipped').length
+  const blocked = outcomes.filter(outcome => outcome.finalStatus === 'error').length
+  const attention = warnings + skipped
+
+  return [
+    { label: 'complete', value: complete, status: 'ok' },
+    { label: 'attention', value: attention, status: warnings > 0 ? 'warn' : skipped > 0 ? 'skip' : 'ok' },
+    { label: 'blocked', value: blocked, status: blocked > 0 ? 'blocked' : 'ok' },
+  ]
+}
+
+function outcomeRows(outcomes: ComponentOutcome[]): FindingRow[] {
+  return outcomes.map(outcome => ({
+    status: onboardingStatus(outcome.finalStatus),
+    label: outcome.name,
+    message: formatOnboardingMessage(outcome.message),
+    detail: outcome.remediation ? formatOnboardingMessage(outcome.remediation) : undefined,
+  }))
 }
 
 export function OnboardingSummary({ outcomes, exitCode }: {
   outcomes: ComponentOutcome[]
   exitCode: 0 | 1 | 2
 }) {
-  const prerequisites = outcomes.filter(outcome => ['mkdir', 'settings', 'runtime'].includes(outcome.name))
-  const setup = outcomes.filter(outcome => !['mkdir', 'settings', 'runtime'].includes(outcome.name))
+  const prerequisites = outcomes.filter(outcome => PREREQUISITE_COMPONENTS.has(outcome.name))
+  const setup = outcomes.filter(outcome => !PREREQUISITE_COMPONENTS.has(outcome.name))
 
   return (
     <Box flexDirection="column">
-      <Report
-        title="Bakin onboarding"
-        groups={[
-          {
-            title: 'Prerequisites',
-            rows: prerequisites.map(outcome => ({
-              label: outcome.name,
-              status: onboardingStatus(outcome.finalStatus),
-              message: formatOnboardingMessage(outcome.message),
-              remediation: outcome.finalStatus === 'error' || outcome.finalStatus === 'warn' ? outcome.remediation : undefined,
-            })),
-          },
-          {
-            title: 'Setup',
-            rows: setup.map(outcome => ({
-              label: outcome.name,
-              status: onboardingStatus(outcome.finalStatus),
-              message: formatOnboardingMessage(outcome.message),
-              remediation: outcome.finalStatus === 'error' || outcome.finalStatus === 'warn' ? outcome.remediation : undefined,
-            })),
-          },
-        ]}
-      />
+      <ScreenHeader title="Onboarding" subtitle={summarySubtitle(exitCode)} />
+      <SummaryStrip items={summaryItems(outcomes)} />
+      <Section title="Prerequisites">
+        <FindingRows rows={outcomeRows(prerequisites)} />
+      </Section>
+      {setup.length > 0 ? (
+        <Section title="Setup">
+          <FindingRows rows={outcomeRows(setup)} />
+        </Section>
+      ) : null}
       <OnboardingFinalStatus outcomes={outcomes} exitCode={exitCode} />
     </Box>
   )
@@ -68,87 +109,133 @@ export function OnboardingFinalStatus({ outcomes, exitCode }: {
   exitCode: 0 | 1 | 2
 }) {
   const blocker = outcomes.find(outcome => outcome.finalStatus === 'error')
+  const actions = blocker
+    ? [blocker.remediation ? 'Rerun `bakin onboard` after the blocker is resolved.' : 'Fix the blocked item above, then rerun `bakin onboard`.']
+    : exitCode === 0
+      ? ['Run `bakin start` to launch Bakin.']
+      : ['Run `bakin start`, then `bakin doctor` for details.']
 
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      {blocker ? (
-        <Alert variant="error" title="Onboarding blocked">
-          {blocker.remediation ? `${blocker.message}\n${blocker.remediation}` : blocker.message}
-        </Alert>
-      ) : exitCode === 0 ? (
-        <Alert variant="success">Onboarding complete. Run `bakin start` to launch Bakin.</Alert>
-      ) : (
-        <Alert variant="warning">Onboarding finished with warnings. Run `bakin start`, then `bakin doctor` for details.</Alert>
-      )}
-    </Box>
-  )
+  return <NextActions actions={actions} />
 }
 
-export function OnboardingBusy({ label = 'Running onboarding', detail, frame = 0, details = ONBOARDING_BUSY_DETAILS, completed }: {
+export function OnboardingBusy({ label = 'Running onboarding', detail, frame = 0, details = ONBOARDING_BUSY_DETAILS, completed, totalSteps = 1 }: {
   label?: string
   detail?: string
   frame?: number
   details?: string[]
   completed?: Array<{
     name: string
-    status: ReportRow['status']
+    status: OnboardingBusyStatus
     message: string
   }>
+  totalSteps?: number
 }) {
   const safeDetails = details.length > 0 ? details : ONBOARDING_BUSY_DETAILS
   const spinnerFrame = ONBOARDING_SPINNER_FRAMES[frame % ONBOARDING_SPINNER_FRAMES.length]
   const fallbackDetail = safeDetails[Math.floor(frame / 12) % safeDetails.length]
-  const prerequisites = completed?.filter(item => ['mkdir', 'settings', 'runtime'].includes(item.name)) ?? []
-  const setup = completed?.filter(item => !['mkdir', 'settings', 'runtime'].includes(item.name)) ?? []
+  const currentStep = Math.max(1, Math.min(completed?.length ? completed.length + 1 : 1, totalSteps))
+  const boundedTotalSteps = Math.max(totalSteps, currentStep)
+  const prerequisites = completed?.filter(item => PREREQUISITE_COMPONENTS.has(item.name)) ?? []
+  const setup = completed?.filter(item => !PREREQUISITE_COMPONENTS.has(item.name)) ?? []
+  const rows = [...prerequisites, ...setup].map(item => ({
+    status: busyStatus(item.status),
+    label: item.name,
+    message: formatOnboardingMessage(item.message),
+  }))
+  const warnings = completed?.filter(item => item.status === 'warning').length ?? 0
+  const skipped = completed?.filter(item => item.status === 'skipped').length ?? 0
+  const blocked = completed?.filter(item => item.status === 'blocked').length ?? 0
+  const attention = warnings + skipped + blocked
+  const percent = Math.round((currentStep / boundedTotalSteps) * 100)
 
   return (
-    <Box flexDirection="column" marginTop={1}>
-      {completed && completed.length > 0 ? (
-        <Box flexDirection="column" marginBottom={1}>
-          {prerequisites.length > 0 ? (
-            <CompletedGroup title="Prerequisites" rows={prerequisites} />
-          ) : null}
-          {setup.length > 0 ? (
-            <CompletedGroup title="Setup" rows={setup} marginTop={prerequisites.length > 0 ? 1 : 0} />
-          ) : null}
-        </Box>
-      ) : null}
-      <Box>
-        <Text color={BAKIN_PINK}>{spinnerFrame}</Text>
-        <Text bold> {label}</Text>
-      </Box>
-      <Text dimColor>  {detail ?? fallbackDetail}</Text>
-    </Box>
-  )
-}
-
-function CompletedGroup({ title, rows, marginTop = 0 }: {
-  title: string
-  rows: Array<{
-    name: string
-    status: ReportRow['status']
-    message: string
-  }>
-  marginTop?: number
-}) {
-  return (
-    <Box flexDirection="column" marginTop={marginTop}>
-      <Badge color={BAKIN_PINK}>{title}</Badge>
-      {rows.map(item => (
-        <Box key={item.name}>
-          <StatusBadge status={item.status} />
-          <Text> {item.name.padEnd(18)} {formatOnboardingMessage(item.message)}</Text>
-        </Box>
-      ))}
+    <Box flexDirection="column">
+      <ScreenHeader title="Onboard" subtitle="Interactive setup in progress" meta={`step ${currentStep} of ${boundedTotalSteps}`} />
+      <SummaryStrip items={[
+        { label: 'complete', value: completed?.filter(item => item.status === 'complete').length ?? 0, status: 'ok' },
+        { label: 'running', value: 1, status: 'run' },
+        { label: 'attention', value: attention, status: blocked > 0 ? 'blocked' : warnings > 0 ? 'warn' : skipped > 0 ? 'skip' : 'ok' },
+      ]} />
+      <Section title="Progress">
+        <ProgressMeter label="Setting up this machine" current={currentStep} total={boundedTotalSteps} percent={percent} />
+        {rows.length > 0 ? (
+          <Box marginTop={1}>
+            <FindingRows rows={rows} />
+          </Box>
+        ) : null}
+      </Section>
+      <Section title="Current activity">
+        <FindingRows rows={[{
+          status: 'run',
+          label: spinnerFrame,
+          message: label,
+          detail: detail ?? fallbackDetail,
+        }]} />
+      </Section>
     </Box>
   )
 }
 
 export function OnboardingProgress({ label, value }: { label: string; value: number }) {
   return (
+    <ProgressMeter label={label} current={value} total={100} percent={value} />
+  )
+}
+
+export function OnboardingIntro() {
+  return (
     <Box flexDirection="column">
-      <Text>{label}</Text>
-      <ProgressBar value={value} />
+      <ScreenHeader title="Onboard" subtitle="Initial setup wizard" />
+      <SummaryStrip items={[
+        { label: 'mode', value: 'interactive', status: 'ready' },
+        { label: 'checks', value: 'prerequisites' },
+        { label: 'setup', value: 'plugins and agents' },
+      ]} />
+      <Section title="Flow">
+        <FindingRows rows={[
+          { status: 'ready', label: 'review', message: 'Confirm missing prerequisites before installation.' },
+          { status: 'ready', label: 'select', message: 'Choose official plugins and agents to install or adopt.' },
+          { status: 'run', label: 'apply', message: 'Run setup steps and stream progress as each component finishes.' },
+        ]} />
+      </Section>
+    </Box>
+  )
+}
+
+export function OnboardingDecisionPrompt({ title, description, defaultChoice, onSubmit }: {
+  title: string
+  description: string
+  defaultChoice: 'confirm' | 'cancel'
+  onSubmit: (approved: boolean) => void
+}) {
+  const defaultLabel = defaultChoice === 'confirm' ? 'Yes' : 'No'
+  const defaultHint = defaultChoice === 'confirm'
+    ? 'Default: Yes. Press Enter or y to continue; press n to skip.'
+    : 'Default: No. Press y to continue; press Enter or n to skip.'
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Onboard" subtitle="Interactive setup decision" meta={title.toLowerCase()} />
+      <SummaryStrip items={[
+        { label: 'decision', value: 1, status: 'warn' },
+        { label: 'default', value: defaultLabel, status: defaultChoice === 'confirm' ? 'ready' : 'skip' },
+      ]} />
+      <Section title="Decision">
+        <FindingRows rows={[{
+          status: 'warn',
+          label: title,
+          message: description,
+        }]} />
+        <Box marginTop={1}>
+          <Text bold>Continue? </Text>
+          <ConfirmInput
+            defaultChoice={defaultChoice}
+            onConfirm={() => onSubmit(true)}
+            onCancel={() => onSubmit(false)}
+          />
+        </Box>
+        <Text dimColor>{defaultHint}</Text>
+      </Section>
     </Box>
   )
 }

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -127,17 +127,33 @@ export function FindingRows({ rows, color = true }: { rows: FindingRow[]; color?
             </Box>
           </Box>
           {row.detail ? (
-            <Box marginLeft={33}>
+            <FindingRowContinuation>
               <Text dimColor wrap="wrap">{row.detail}</Text>
-            </Box>
+            </FindingRowContinuation>
           ) : null}
           {row.next ? (
-            <Box marginLeft={33}>
+            <FindingRowContinuation>
               <Text color={color ? CLI_COLORS.info : undefined} wrap="wrap">Next: {row.next}</Text>
-            </Box>
+            </FindingRowContinuation>
           ) : null}
         </Box>
       ))}
+    </Box>
+  )
+}
+
+function FindingRowContinuation({ children }: { children: ReactNode }) {
+  return (
+    <Box gap={1}>
+      <Box width={10} flexShrink={0}>
+        <Text> </Text>
+      </Box>
+      <Box width={22} flexShrink={0}>
+        <Text> </Text>
+      </Box>
+      <Box flexGrow={1} flexShrink={1}>
+        {children}
+      </Box>
     </Box>
   )
 }

--- a/tests/cli/onboard-command.test.ts
+++ b/tests/cli/onboard-command.test.ts
@@ -72,14 +72,16 @@ describe('CLI onboard command', () => {
     stdoutWrite.mockRestore()
   })
 
-  it('renders the shared onboarding summary for TTY completion', async () => {
+  it('continues the shared onboarding summary without replaying the brand header', async () => {
     process.argv = ['bun', 'cli/bakin.ts', 'onboard', '--force']
 
     const { main } = await import('../../cli/bakin')
     await main()
 
     const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    const liveOutput = stdoutWrite.mock.calls.map((call: unknown[]) => String(call[0])).join('')
+    expect(liveOutput).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).not.toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
     expect(output).toContain('Onboarding')
     expect(output).toContain('Machine setup complete')
     expect(output).toContain('PREREQUISITES')

--- a/tests/cli/onboard-command.test.ts
+++ b/tests/cli/onboard-command.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const outcomes = [
+  {
+    name: 'mkdir',
+    finalStatus: 'ok',
+    check: { name: 'mkdir', status: 'ok', message: 'home ready' },
+    message: 'Bakin home directory is initialized at /Users/roscoe/.bakin',
+    durationMs: 1,
+  },
+  {
+    name: 'settings',
+    finalStatus: 'ok',
+    check: { name: 'settings', status: 'ok', message: 'settings ready' },
+    message: 'settings.json is present and parses at /Users/roscoe/.bakin/settings.json',
+    durationMs: 1,
+  },
+]
+
+const runOnboard = mock(async (opts: {
+  onProgress?: (message: string) => void
+  onOutcome?: (outcome: { name: string; finalStatus: 'ok'; message: string }) => void
+}) => {
+  opts.onProgress?.('Checking mkdir')
+  opts.onOutcome?.({ name: 'mkdir', finalStatus: 'ok', message: outcomes[0].message })
+  return { outcomes, exitCode: 0, markerWritten: true }
+})
+
+mock.module('../../src/core/onboarding/index', () => ({
+  runOnboard,
+  isOnboarded: () => false,
+  loadState: () => null,
+  COMPONENT_ORDER: outcomes.map(outcome => ({ name: outcome.name })),
+}))
+
+mock.module('../../src/core/cli/onboarding-interactive', () => ({
+  collectOnboardingSelections: async () => ({}),
+}))
+
+describe('CLI onboard command', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  const originalConsoleFormat = process.env.BAKIN_CONSOLE_FORMAT
+  let log: ReturnType<typeof spyOn>
+  let stdoutWrite: ReturnType<typeof spyOn>
+
+  function setStdoutIsTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+  }
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    process.argv = originalArgv
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    stdoutWrite = spyOn(process.stdout, 'write').mockImplementation(() => true)
+    process.exit = ((code?: number) => {
+      if (code === 0) return undefined as never
+      throw new Error(`exit:${code}`)
+    }) as never
+    setStdoutIsTTY(true)
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+    if (originalConsoleFormat === undefined) delete process.env.BAKIN_CONSOLE_FORMAT
+    else process.env.BAKIN_CONSOLE_FORMAT = originalConsoleFormat
+    log.mockRestore()
+    stdoutWrite.mockRestore()
+  })
+
+  it('renders the shared onboarding summary for TTY completion', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'onboard', '--force']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Onboarding')
+    expect(output).toContain('Machine setup complete')
+    expect(output).toContain('PREREQUISITES')
+    expect(output).toContain('Run `bakin start` to launch Bakin.')
+  })
+})

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -93,6 +93,25 @@ describe('onboarding CLI UI', () => {
     expect(rendered).not.toContain(`${home}/.bakin/settings.json`)
   })
 
+  it('can render the onboarding summary as a continuation without the brand header', () => {
+    const rendered = renderToString(
+      <OnboardingSummary
+        outcomes={[{
+          name: 'settings',
+          finalStatus: 'ok',
+          check: { name: 'settings', status: 'ok', message: 'settings ready' },
+          message: 'settings ready',
+          durationMs: 1,
+        }]}
+        exitCode={0}
+        showBrand={false}
+      />,
+    )
+
+    expect(rendered).toContain('Onboarding')
+    expect(rendered).not.toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+  })
+
   it('renders an async onboarding busy state', () => {
     const rendered = renderToString(<OnboardingBusy label="Running onboarding checks and installs" totalSteps={12} />)
     expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -71,8 +71,7 @@ describe('onboarding CLI UI', () => {
     expect(rendered).toContain('PREREQUISITES')
     expect(rendered).toContain('BLOCKED')
     expect(rendered).not.toContain('[BLOCKED')
-    expect(rendered).toContain('https://makinbakin.com/docs/start/first-ti')
-    expect(rendered).toContain('me-setup/')
+    expect(rendered.replace(/\s+/g, '')).toContain('https://makinbakin.com/docs/start/first-time-setup/')
   })
 
   it('compacts home paths in the human onboarding summary', () => {

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'bun:test'
 import { renderToString } from 'ink'
 
 import { buildSelectionItems } from '../../src/core/cli/onboarding-interactive'
-import { OnboardingBusy, OnboardingProgress, OnboardingSummary } from '../../src/core/cli/ui/onboarding'
+import {
+  OnboardingBusy,
+  OnboardingDecisionPrompt,
+  OnboardingIntro,
+  OnboardingProgress,
+  OnboardingSummary,
+} from '../../src/core/cli/ui/onboarding'
 import type { ComponentOutcome } from '../../src/core/onboarding'
 
 describe('onboarding CLI UI', () => {
@@ -60,9 +66,13 @@ describe('onboarding CLI UI', () => {
     ]
 
     const rendered = renderToString(<OnboardingSummary outcomes={outcomes} exitCode={1} />)
-    expect(rendered).toContain('Bakin onboarding')
-    expect(rendered).toContain('[BLOCKED')
-    expect(rendered).toContain('https://makinbakin.com/docs/start/first-time-setup/')
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Onboarding')
+    expect(rendered).toContain('PREREQUISITES')
+    expect(rendered).toContain('BLOCKED')
+    expect(rendered).not.toContain('[BLOCKED')
+    expect(rendered).toContain('https://makinbakin.com/docs/start/first-ti')
+    expect(rendered).toContain('me-setup/')
   })
 
   it('compacts home paths in the human onboarding summary', () => {
@@ -85,7 +95,10 @@ describe('onboarding CLI UI', () => {
   })
 
   it('renders an async onboarding busy state', () => {
-    const rendered = renderToString(<OnboardingBusy label="Running onboarding checks and installs" />)
+    const rendered = renderToString(<OnboardingBusy label="Running onboarding checks and installs" totalSteps={12} />)
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Onboard')
+    expect(rendered).toContain('CURRENT ACTIVITY')
     expect(rendered).toContain('Running onboarding checks and installs')
     expect(rendered).toContain('Checking prerequisites and runtime access')
   })
@@ -95,13 +108,40 @@ describe('onboarding CLI UI', () => {
       <OnboardingBusy
         label="Running onboarding checks and installs"
         detail="Installing search"
+        totalSteps={12}
         completed={[{ name: 'settings', status: 'complete', message: 'settings.json ready: ~/.bakin/settings.json' }]}
       />,
     )
 
-    expect(rendered).toContain('[OK] settings')
+    expect(rendered).toContain('OK')
+    expect(rendered).not.toContain('[OK]')
     expect(rendered).toContain('settings.json ready: ~/.bakin/settings.json')
     expect(rendered).toContain('Installing search')
+  })
+
+  it('renders the onboarding intro with the shared compact header', () => {
+    const rendered = renderToString(<OnboardingIntro />)
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Onboard')
+    expect(rendered).toContain('Initial setup wizard')
+    expect(rendered).not.toContain('oooooooooo')
+    expect(rendered).not.toContain('Welcome to Bakin')
+  })
+
+  it('renders confirmation prompts with shared sections instead of badges', () => {
+    const rendered = renderToString(
+      <OnboardingDecisionPrompt
+        title="Search adapter"
+        description="Antfly is not installed. Bakin will install Antfly via Homebrew if you continue."
+        defaultChoice="confirm"
+        onSubmit={() => {}}
+      />,
+    )
+    expect(rendered).toContain('Onboard')
+    expect(rendered).toContain('DECISION')
+    expect(rendered).toContain('Search adapter')
+    expect(rendered).toContain('Default: Yes')
+    expect(rendered).not.toContain('[Search adapter]')
   })
 
   it('renders bounded onboarding progress with Ink UI', () => {

--- a/tests/cli/ui.test.tsx
+++ b/tests/cli/ui.test.tsx
@@ -37,6 +37,7 @@ describe('CLI UI primitives', () => {
           status: 'warn',
           label: 'agent-assets',
           message: '1 agent-package projection needs repair.',
+          detail: 'Run `bakin install agent-assets` to repair drift.',
           next: 'bakin install agent-assets',
         }]} />
       </Section>,
@@ -47,6 +48,13 @@ describe('CLI UI primitives', () => {
     expect(output).toContain('1 agent-package projection needs repair.')
     expect(output).toContain('Next: bakin install agent-assets')
     expect(output).not.toContain('[WARN]')
+
+    const lines = output.split('\n')
+    const messageLine = lines.find(line => line.includes('1 agent-package projection needs repair.'))
+    const detailLine = lines.find(line => line.includes('Run `bakin install agent-assets`'))
+    const nextLine = lines.find(line => line.includes('Next: bakin install agent-assets'))
+    expect(detailLine?.indexOf('Run')).toBe(messageLine?.indexOf('1 agent-package'))
+    expect(nextLine?.indexOf('Next')).toBe(messageLine?.indexOf('1 agent-package'))
   })
 
   it('renders shared TUI summaries, progress, and next actions', () => {


### PR DESCRIPTION
## Summary
- replace the old onboarding ASCII intro and badge prompts with shared Bakin TUI screens
- render onboarding progress and final TTY summaries with shared headers, sections, summary strips, progress meters, and status tokens
- keep JSON and non-TTY output paths unchanged

## Tests
- bun test --isolate tests/cli/onboarding-ui.test.tsx tests/cli/onboard-command.test.ts tests/cli/ui.test.tsx tests/cli/tui-gallery.test.tsx
- bun run typecheck
- bun test --isolate tests/cli