### PR TITLE
Migrate read-only CLI lists to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -147,6 +147,15 @@ async function printPluginsListTui(routes: Array<Record<string, unknown>>): Prom
   console.log(renderToString(createElement(PluginsListReport, { routes })))
 }
 
+async function printWorkflowsListTui(templates: Array<Record<string, unknown>>): Promise<void> {
+  const [{ WorkflowsListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(WorkflowsListReport, { templates })))
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -1764,6 +1773,10 @@ async function cmdTasksGet(id: string): Promise<void> {
 async function cmdWorkflowsList(): Promise<void> {
   const result = await apiGet('/api/plugins/workflows/definitions') as { templates?: Array<Record<string, unknown>> }
   const templates = result?.templates || []
+  if (process.stdout.isTTY) {
+    await printWorkflowsListTui(templates)
+    return
+  }
   if (templates.length === 0) {
     console.log('No workflow definitions found.')
     return

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -111,12 +111,53 @@ function printTable(rows: Record<string, unknown>[], columns?: string[]): void {
   }
 }
 
+async function printStatusTui(dispatch: Record<string, unknown>, roster: CliRoster): Promise<void> {
+  const [{ StatusReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(StatusReport, { dispatch, roster })))
+}
+
+async function printTasksListTui(columns: Record<string, Array<Record<string, unknown>>>, column?: string): Promise<void> {
+  const [{ TasksListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(TasksListReport, { columns, column })))
+}
+
+async function printAgentsListTui(agents: Array<{ id: string; name: string; status: string; model: string }>): Promise<void> {
+  const [{ AgentsListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(AgentsListReport, { agents })))
+}
+
+async function printPluginsListTui(routes: Array<Record<string, unknown>>): Promise<void> {
+  const [{ PluginsListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(PluginsListReport, { routes })))
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
 async function cmdStatus(): Promise<void> {
   const dispatch = await apiGet('/api/dispatch') as Record<string, unknown>
   const roster = await getCliRoster()
+
+  if (process.stdout.isTTY) {
+    await printStatusTui(dispatch, roster)
+    return
+  }
 
   console.log('=== Bakin Status ===')
   console.log(`Dispatch interval: ${dispatch.intervalMin}min`)
@@ -142,8 +183,16 @@ async function cmdTasksList(column?: string): Promise<void> {
       console.error(`Unknown column: ${column}. Available: ${Object.keys(columns).join(', ')}`)
       process.exit(1)
     }
+    if (process.stdout.isTTY) {
+      await printTasksListTui({ [column]: col as Array<Record<string, unknown>> }, column)
+      return
+    }
     printTable(col as Record<string, unknown>[], ['id', 'title', 'agent'])
   } else {
+    if (process.stdout.isTTY) {
+      await printTasksListTui(columns as Record<string, Array<Record<string, unknown>>>)
+      return
+    }
     for (const [name, tasks] of Object.entries(columns)) {
       if ((tasks as unknown[]).length === 0) continue
       console.log(`\n=== ${name} ===`)
@@ -182,6 +231,10 @@ async function cmdTasksMove(id: string, to: string): Promise<void> {
 async function cmdAgentsList(): Promise<void> {
   const result = await apiGet('/api/plugins/team/') as {
     agents: Array<{ id: string; name: string; status: string; model: string }>
+  }
+  if (process.stdout.isTTY) {
+    await printAgentsListTui(result.agents)
+    return
   }
   for (const agent of result.agents) {
     const statusIcon = agent.status === 'working' ? '●' : agent.status === 'online' ? '○' : '·'
@@ -244,6 +297,10 @@ async function cmdPluginsList(): Promise<void> {
   const plugins = new Set<string>()
   for (const route of docs.routes) {
     if (route.pluginId !== 'core') plugins.add(route.pluginId as string)
+  }
+  if (process.stdout.isTTY) {
+    await printPluginsListTui(docs.routes)
+    return
   }
   console.log('Installed plugins:')
   for (const p of plugins) {

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -1,0 +1,259 @@
+import { Box } from 'ink'
+import {
+  FindingRows,
+  ScreenHeader,
+  Section,
+  SummaryStrip,
+  type FindingRow,
+  type SummaryItem,
+} from './tui'
+import type { TuiStatus } from './style-tokens'
+
+export interface StatusDispatchData {
+  intervalMin?: unknown
+  lastRun?: unknown
+  nextRun?: unknown
+  secondsUntilNext?: unknown
+  dispatchedCount?: unknown
+}
+
+export interface StatusRosterData {
+  agentIds: string[]
+  mainAgentId?: string | null
+}
+
+export interface TaskRowData {
+  id?: unknown
+  title?: unknown
+  agent?: unknown
+}
+
+export interface AgentRowData {
+  id: string
+  name: string
+  status: string
+  model: string
+}
+
+export interface PluginRouteData {
+  pluginId?: unknown
+}
+
+const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
+
+function valueText(value: unknown, fallback = '-'): string {
+  if (value === null || value === undefined || value === '') return fallback
+  return String(value)
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : Number(value) || 0
+}
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return count === 1 ? singular : pluralLabel
+}
+
+function taskColumnStatus(column: string): TuiStatus {
+  switch (column) {
+    case 'blocked':
+      return 'blocked'
+    case 'inProgress':
+      return 'run'
+    case 'review':
+      return 'ready'
+    case 'done':
+    case 'archived':
+      return 'done'
+    default:
+      return 'todo'
+  }
+}
+
+function orderedTaskColumns(columns: Record<string, TaskRowData[]>): Array<[string, TaskRowData[]]> {
+  const known = TASK_COLUMN_ORDER
+    .filter(column => Array.isArray(columns[column]))
+    .map(column => [column, columns[column]] as [string, TaskRowData[]])
+  const knownNames = new Set(TASK_COLUMN_ORDER)
+  const unknown = Object.entries(columns)
+    .filter(([column]) => !knownNames.has(column as typeof TASK_COLUMN_ORDER[number]))
+    .filter(([, tasks]) => Array.isArray(tasks))
+    .sort(([a], [b]) => a.localeCompare(b))
+
+  return [...known, ...unknown]
+}
+
+function taskRows(columns: Record<string, TaskRowData[]>): FindingRow[] {
+  const rows = orderedTaskColumns(columns).flatMap(([column, tasks]) => (
+    tasks.map(task => ({
+      status: taskColumnStatus(column),
+      label: valueText(task.id, '(no id)'),
+      message: valueText(task.title, '(untitled task)'),
+      detail: `Column: ${column}; Agent: ${valueText(task.agent)}`,
+    }))
+  ))
+
+  if (rows.length === 0) {
+    return [{ status: 'skip', label: 'empty', message: 'No tasks found.' }]
+  }
+
+  return rows
+}
+
+function taskSummary(columns: Record<string, TaskRowData[]>): SummaryItem[] {
+  const entries = orderedTaskColumns(columns)
+  const total = entries.reduce((sum, [, tasks]) => sum + tasks.length, 0)
+  const active = entries
+    .filter(([column]) => ['todo', 'inProgress', 'review'].includes(column))
+    .reduce((sum, [, tasks]) => sum + tasks.length, 0)
+  const blocked = columns.blocked?.length ?? 0
+  const done = (columns.done?.length ?? 0) + (columns.archived?.length ?? 0)
+
+  return [
+    { label: plural(total, 'task'), value: total, status: total > 0 ? 'todo' : 'skip' },
+    { label: 'active', value: active, status: active > 0 ? 'run' : 'ok' },
+    { label: 'blocked', value: blocked, status: blocked > 0 ? 'blocked' : 'ok' },
+    { label: 'done', value: done, status: done > 0 ? 'done' : 'ok' },
+  ]
+}
+
+function agentStatus(status: string): TuiStatus {
+  switch (status) {
+    case 'working':
+      return 'run'
+    case 'online':
+      return 'ok'
+    case 'blocked':
+      return 'blocked'
+    default:
+      return 'skip'
+  }
+}
+
+function pluginRouteCounts(routes: PluginRouteData[]): Array<{ pluginId: string; routeCount: number }> {
+  const counts = new Map<string, number>()
+  for (const route of routes) {
+    const pluginId = typeof route.pluginId === 'string' ? route.pluginId : ''
+    if (!pluginId || pluginId === 'core') continue
+    counts.set(pluginId, (counts.get(pluginId) ?? 0) + 1)
+  }
+
+  return [...counts.entries()]
+    .map(([pluginId, routeCount]) => ({ pluginId, routeCount }))
+    .sort((a, b) => a.pluginId.localeCompare(b.pluginId))
+}
+
+export function StatusReport({ dispatch, roster, color = true }: {
+  dispatch: StatusDispatchData
+  roster: StatusRosterData
+  color?: boolean
+}) {
+  const agentCount = roster.agentIds.length
+  const dispatched = numberValue(dispatch.dispatchedCount)
+  const interval = valueText(dispatch.intervalMin)
+  const nextRun = valueText(dispatch.nextRun, 'not scheduled')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Status" subtitle="Runtime dispatch snapshot" color={color} />
+      <SummaryStrip items={[
+        { label: plural(agentCount, 'agent'), value: agentCount, status: agentCount > 0 ? 'ok' : 'skip' },
+        { label: 'tasks dispatched', value: dispatched, status: dispatched > 0 ? 'done' : 'ok' },
+        { label: 'interval', value: `${interval}m` },
+      ]} color={color} />
+      <Section title="Dispatch" color={color}>
+        <FindingRows rows={[
+          { status: 'ok', label: 'interval', message: `${interval} minute${interval === '1' ? '' : 's'}` },
+          { status: dispatch.lastRun ? 'ok' : 'skip', label: 'last run', message: valueText(dispatch.lastRun, 'never') },
+          {
+            status: 'ready',
+            label: 'next run',
+            message: nextRun,
+            detail: dispatch.secondsUntilNext === undefined ? undefined : `${valueText(dispatch.secondsUntilNext)} seconds until next run`,
+          },
+        ]} color={color} />
+      </Section>
+      <Section title="Agents" color={color}>
+        <FindingRows rows={[{
+          status: agentCount > 0 ? 'ok' : 'skip',
+          label: roster.mainAgentId ?? 'main',
+          message: agentCount > 0 ? roster.agentIds.join(', ') : 'No agents reported by the runtime.',
+        }]} color={color} />
+      </Section>
+    </Box>
+  )
+}
+
+export function TasksListReport({ columns, column, color = true }: {
+  columns: Record<string, TaskRowData[]>
+  column?: string
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Tasks" subtitle="Board snapshot" meta={column ? `column: ${column}` : undefined} color={color} />
+      <SummaryStrip items={taskSummary(columns)} color={color} />
+      <Section title={column ? `Column ${column}` : 'Board'} color={color}>
+        <FindingRows rows={taskRows(columns)} color={color} />
+      </Section>
+    </Box>
+  )
+}
+
+export function AgentsListReport({ agents, color = true }: {
+  agents: AgentRowData[]
+  color?: boolean
+}) {
+  const working = agents.filter(agent => agent.status === 'working').length
+  const online = agents.filter(agent => agent.status === 'online').length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Agents" subtitle="Runtime roster" color={color} />
+      <SummaryStrip items={[
+        { label: plural(agents.length, 'agent'), value: agents.length, status: agents.length > 0 ? 'ok' : 'skip' },
+        { label: 'working', value: working, status: working > 0 ? 'run' : 'ok' },
+        { label: 'online', value: online, status: online > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Roster" color={color}>
+        <FindingRows rows={agents.length > 0
+          ? agents.map(agent => ({
+            status: agentStatus(agent.status),
+            label: agent.id,
+            message: `${agent.name} (${agent.status})`,
+            detail: `Model: ${agent.model}`,
+          }))
+          : [{ status: 'skip', label: 'empty', message: 'No agents reported by the runtime.' }]
+        } color={color} />
+      </Section>
+    </Box>
+  )
+}
+
+export function PluginsListReport({ routes, color = true }: {
+  routes: PluginRouteData[]
+  color?: boolean
+}) {
+  const plugins = pluginRouteCounts(routes)
+  const routeTotal = plugins.reduce((sum, plugin) => sum + plugin.routeCount, 0)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Plugins" subtitle="Installed plugin routes" color={color} />
+      <SummaryStrip items={[
+        { label: plural(plugins.length, 'plugin'), value: plugins.length, status: plugins.length > 0 ? 'ok' : 'skip' },
+        { label: plural(routeTotal, 'route'), value: routeTotal, status: routeTotal > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Installed plugins" color={color}>
+        <FindingRows rows={plugins.length > 0
+          ? plugins.map(plugin => ({
+            status: 'ok',
+            label: plugin.pluginId,
+            message: `${plugin.routeCount} ${plural(plugin.routeCount, 'route')}`,
+          }))
+          : [{ status: 'skip', label: 'empty', message: 'No non-core plugins found.' }]
+        } color={color} />
+      </Section>
+    </Box>
+  )
+}

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -1,10 +1,10 @@
-import { Box } from 'ink'
+import { Box, Text } from 'ink'
 import {
   FindingRows,
   ScreenHeader,
   Section,
+  StatusToken,
   SummaryStrip,
-  type FindingRow,
   type SummaryItem,
 } from './tui'
 import type { TuiStatus } from './style-tokens'
@@ -37,6 +37,37 @@ export interface AgentRowData {
 
 export interface PluginRouteData {
   pluginId?: unknown
+}
+
+interface StatusTableColumn<TRow> {
+  key: string
+  header: string
+  width: number
+  grow?: boolean
+  render: (row: TRow) => string
+}
+
+interface StatusTableRow {
+  status: TuiStatus
+}
+
+interface TaskTableRow extends StatusTableRow {
+  column: string
+  id: string
+  title: string
+  agent: string
+}
+
+interface AgentTableRow extends StatusTableRow {
+  id: string
+  name: string
+  state: string
+  model: string
+}
+
+interface PluginTableRow extends StatusTableRow {
+  plugin: string
+  routes: string
 }
 
 const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
@@ -83,21 +114,16 @@ function orderedTaskColumns(columns: Record<string, TaskRowData[]>): Array<[stri
   return [...known, ...unknown]
 }
 
-function taskRows(columns: Record<string, TaskRowData[]>): FindingRow[] {
-  const rows = orderedTaskColumns(columns).flatMap(([column, tasks]) => (
+function taskTableRows(columns: Record<string, TaskRowData[]>): TaskTableRow[] {
+  return orderedTaskColumns(columns).flatMap(([column, tasks]) => (
     tasks.map(task => ({
       status: taskColumnStatus(column),
-      label: valueText(task.id, '(no id)'),
-      message: valueText(task.title, '(untitled task)'),
-      detail: `Column: ${column}; Agent: ${valueText(task.agent)}`,
+      column,
+      id: valueText(task.id, '(no id)'),
+      title: valueText(task.title, '(untitled task)'),
+      agent: valueText(task.agent),
     }))
   ))
-
-  if (rows.length === 0) {
-    return [{ status: 'skip', label: 'empty', message: 'No tasks found.' }]
-  }
-
-  return rows
 }
 
 function taskSummary(columns: Record<string, TaskRowData[]>): SummaryItem[] {
@@ -130,6 +156,16 @@ function agentStatus(status: string): TuiStatus {
   }
 }
 
+function agentTableRows(agents: AgentRowData[]): AgentTableRow[] {
+  return agents.map(agent => ({
+    status: agentStatus(agent.status),
+    id: agent.id,
+    name: agent.name,
+    state: agent.status,
+    model: agent.model,
+  }))
+}
+
 function pluginRouteCounts(routes: PluginRouteData[]): Array<{ pluginId: string; routeCount: number }> {
   const counts = new Map<string, number>()
   for (const route of routes) {
@@ -141,6 +177,57 @@ function pluginRouteCounts(routes: PluginRouteData[]): Array<{ pluginId: string;
   return [...counts.entries()]
     .map(([pluginId, routeCount]) => ({ pluginId, routeCount }))
     .sort((a, b) => a.pluginId.localeCompare(b.pluginId))
+}
+
+function pluginTableRows(routes: PluginRouteData[]): PluginTableRow[] {
+  return pluginRouteCounts(routes).map(plugin => ({
+    status: 'ok',
+    plugin: plugin.pluginId,
+    routes: String(plugin.routeCount),
+  }))
+}
+
+function StatusTable<TRow extends StatusTableRow>({ rows, columns, color = true }: {
+  rows: TRow[]
+  columns: Array<StatusTableColumn<TRow>>
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <Box gap={1}>
+        <Box width={10} flexShrink={0}>
+          <Text bold>STATUS</Text>
+        </Box>
+        {columns.map(column => (
+          <Box
+            key={column.key}
+            width={column.width}
+            flexGrow={column.grow ? 1 : 0}
+            flexShrink={column.grow ? 1 : 0}
+          >
+            <Text bold wrap="truncate-end">{column.header}</Text>
+          </Box>
+        ))}
+      </Box>
+      {rows.map((row, rowIndex) => (
+        <Box key={rowIndex} gap={1}>
+          <Box width={10} flexShrink={0}>
+            <StatusToken status={row.status} color={color} />
+          </Box>
+          {columns.map(column => (
+            <Box
+              key={column.key}
+              width={column.width}
+              flexGrow={column.grow ? 1 : 0}
+              flexShrink={column.grow ? 1 : 0}
+            >
+              <Text wrap={column.grow ? 'wrap' : 'truncate-end'}>{column.render(row)}</Text>
+            </Box>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  )
 }
 
 export function StatusReport({ dispatch, roster, color = true }: {
@@ -189,12 +276,27 @@ export function TasksListReport({ columns, column, color = true }: {
   column?: string
   color?: boolean
 }) {
+  const rows = taskTableRows(columns)
+
   return (
     <Box flexDirection="column">
       <ScreenHeader title="Tasks" subtitle="Board snapshot" meta={column ? `column: ${column}` : undefined} color={color} />
       <SummaryStrip items={taskSummary(columns)} color={color} />
       <Section title={column ? `Column ${column}` : 'Board'} color={color}>
-        <FindingRows rows={taskRows(columns)} color={color} />
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'column', header: 'COLUMN', width: 12, render: row => row.column },
+              { key: 'id', header: 'ID', width: 16, render: row => row.id },
+              { key: 'title', header: 'TITLE', width: 40, grow: true, render: row => row.title },
+              { key: 'agent', header: 'AGENT', width: 16, render: row => row.agent },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No tasks found.' }]} color={color} />
+        )}
       </Section>
     </Box>
   )
@@ -206,6 +308,7 @@ export function AgentsListReport({ agents, color = true }: {
 }) {
   const working = agents.filter(agent => agent.status === 'working').length
   const online = agents.filter(agent => agent.status === 'online').length
+  const rows = agentTableRows(agents)
 
   return (
     <Box flexDirection="column">
@@ -216,15 +319,20 @@ export function AgentsListReport({ agents, color = true }: {
         { label: 'online', value: online, status: online > 0 ? 'ok' : 'skip' },
       ]} color={color} />
       <Section title="Roster" color={color}>
-        <FindingRows rows={agents.length > 0
-          ? agents.map(agent => ({
-            status: agentStatus(agent.status),
-            label: agent.id,
-            message: `${agent.name} (${agent.status})`,
-            detail: `Model: ${agent.model}`,
-          }))
-          : [{ status: 'skip', label: 'empty', message: 'No agents reported by the runtime.' }]
-        } color={color} />
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'id', header: 'ID', width: 18, render: row => row.id },
+              { key: 'name', header: 'NAME', width: 26, grow: true, render: row => row.name },
+              { key: 'state', header: 'STATE', width: 12, render: row => row.state },
+              { key: 'model', header: 'MODEL', width: 20, render: row => row.model },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No agents reported by the runtime.' }]} color={color} />
+        )}
       </Section>
     </Box>
   )
@@ -236,6 +344,7 @@ export function PluginsListReport({ routes, color = true }: {
 }) {
   const plugins = pluginRouteCounts(routes)
   const routeTotal = plugins.reduce((sum, plugin) => sum + plugin.routeCount, 0)
+  const rows = pluginTableRows(routes)
 
   return (
     <Box flexDirection="column">
@@ -245,14 +354,18 @@ export function PluginsListReport({ routes, color = true }: {
         { label: plural(routeTotal, 'route'), value: routeTotal, status: routeTotal > 0 ? 'ok' : 'skip' },
       ]} color={color} />
       <Section title="Installed plugins" color={color}>
-        <FindingRows rows={plugins.length > 0
-          ? plugins.map(plugin => ({
-            status: 'ok',
-            label: plugin.pluginId,
-            message: `${plugin.routeCount} ${plural(plugin.routeCount, 'route')}`,
-          }))
-          : [{ status: 'skip', label: 'empty', message: 'No non-core plugins found.' }]
-        } color={color} />
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'plugin', header: 'PLUGIN', width: 28, grow: true, render: row => row.plugin },
+              { key: 'routes', header: 'ROUTES', width: 8, render: row => row.routes },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No non-core plugins found.' }]} color={color} />
+        )}
       </Section>
     </Box>
   )

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -1,9 +1,10 @@
-import { Box, Text } from 'ink'
+import { Box } from 'ink'
 import {
+  DataTable,
   FindingRows,
   ScreenHeader,
   Section,
-  StatusToken,
+  StatusTable,
   SummaryStrip,
   type SummaryItem,
 } from './tui'
@@ -39,35 +40,40 @@ export interface PluginRouteData {
   pluginId?: unknown
 }
 
-interface StatusTableColumn<TRow> {
-  key: string
-  header: string
-  width: number
-  grow?: boolean
-  render: (row: TRow) => string
+export interface WorkflowTemplateData {
+  filename?: unknown
+  name?: unknown
+  description?: unknown
+  stepCount?: unknown
 }
 
-interface StatusTableRow {
+interface TaskTableRow {
   status: TuiStatus
-}
-
-interface TaskTableRow extends StatusTableRow {
   column: string
   id: string
   title: string
   agent: string
 }
 
-interface AgentTableRow extends StatusTableRow {
+interface AgentTableRow {
+  status: TuiStatus
   id: string
   name: string
   state: string
   model: string
 }
 
-interface PluginTableRow extends StatusTableRow {
+interface PluginTableRow {
+  status: TuiStatus
   plugin: string
   routes: string
+}
+
+interface WorkflowTableRow {
+  filename: string
+  name: string
+  description: string
+  steps: string
 }
 
 const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
@@ -187,47 +193,13 @@ function pluginTableRows(routes: PluginRouteData[]): PluginTableRow[] {
   }))
 }
 
-function StatusTable<TRow extends StatusTableRow>({ rows, columns, color = true }: {
-  rows: TRow[]
-  columns: Array<StatusTableColumn<TRow>>
-  color?: boolean
-}) {
-  return (
-    <Box flexDirection="column">
-      <Box gap={1}>
-        <Box width={10} flexShrink={0}>
-          <Text bold>STATUS</Text>
-        </Box>
-        {columns.map(column => (
-          <Box
-            key={column.key}
-            width={column.width}
-            flexGrow={column.grow ? 1 : 0}
-            flexShrink={column.grow ? 1 : 0}
-          >
-            <Text bold wrap="truncate-end">{column.header}</Text>
-          </Box>
-        ))}
-      </Box>
-      {rows.map((row, rowIndex) => (
-        <Box key={rowIndex} gap={1}>
-          <Box width={10} flexShrink={0}>
-            <StatusToken status={row.status} color={color} />
-          </Box>
-          {columns.map(column => (
-            <Box
-              key={column.key}
-              width={column.width}
-              flexGrow={column.grow ? 1 : 0}
-              flexShrink={column.grow ? 1 : 0}
-            >
-              <Text wrap={column.grow ? 'wrap' : 'truncate-end'}>{column.render(row)}</Text>
-            </Box>
-          ))}
-        </Box>
-      ))}
-    </Box>
-  )
+function workflowTableRows(templates: WorkflowTemplateData[]): WorkflowTableRow[] {
+  return templates.map(template => ({
+    filename: valueText(template.filename),
+    name: valueText(template.name, '(unnamed)'),
+    description: valueText(template.description),
+    steps: valueText(template.stepCount),
+  }))
 }
 
 export function StatusReport({ dispatch, roster, color = true }: {
@@ -365,6 +337,37 @@ export function PluginsListReport({ routes, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No non-core plugins found.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function WorkflowsListReport({ templates, color = true }: {
+  templates: WorkflowTemplateData[]
+  color?: boolean
+}) {
+  const rows = workflowTableRows(templates)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Workflows" subtitle="Available workflow definitions" color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'workflow'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Definitions" color={color}>
+        {rows.length > 0 ? (
+          <DataTable
+            rows={rows}
+            columns={[
+              { key: 'filename', header: 'FILENAME', width: 18, render: row => row.filename },
+              { key: 'name', header: 'NAME', width: 22, render: row => row.name },
+              { key: 'description', header: 'DESCRIPTION', width: 46, grow: true, render: row => row.description },
+              { key: 'steps', header: 'STEPS', width: 7, render: row => row.steps },
+            ]}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No workflow definitions found.' }]} color={color} />
         )}
       </Section>
     </Box>

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -26,6 +26,7 @@ export interface TableColumn<TRow> {
   key: string
   header: string
   width: number
+  grow?: boolean
   render: (row: TRow) => string
 }
 
@@ -166,7 +167,12 @@ export function DataTable<TRow>({ columns, rows }: {
     <Box flexDirection="column">
       <Box gap={1}>
         {columns.map(column => (
-          <Box key={column.key} width={column.width} flexShrink={0}>
+          <Box
+            key={column.key}
+            width={column.width}
+            flexGrow={column.grow ? 1 : 0}
+            flexShrink={column.grow ? 1 : 0}
+          >
             <Text bold wrap="truncate-end">{column.header}</Text>
           </Box>
         ))}
@@ -174,8 +180,56 @@ export function DataTable<TRow>({ columns, rows }: {
       {rows.map((row, rowIndex) => (
         <Box key={rowIndex} gap={1}>
           {columns.map(column => (
-            <Box key={column.key} width={column.width} flexShrink={0}>
-              <Text wrap="truncate-end">{column.render(row)}</Text>
+            <Box
+              key={column.key}
+              width={column.width}
+              flexGrow={column.grow ? 1 : 0}
+              flexShrink={column.grow ? 1 : 0}
+            >
+              <Text wrap={column.grow ? 'wrap' : 'truncate-end'}>{column.render(row)}</Text>
+            </Box>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export function StatusTable<TRow extends { status: TuiStatus }>({ columns, rows, color = true }: {
+  columns: Array<TableColumn<TRow>>
+  rows: TRow[]
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <Box gap={1}>
+        <Box width={10} flexShrink={0}>
+          <Text bold>STATUS</Text>
+        </Box>
+        {columns.map(column => (
+          <Box
+            key={column.key}
+            width={column.width}
+            flexGrow={column.grow ? 1 : 0}
+            flexShrink={column.grow ? 1 : 0}
+          >
+            <Text bold wrap="truncate-end">{column.header}</Text>
+          </Box>
+        ))}
+      </Box>
+      {rows.map((row, rowIndex) => (
+        <Box key={rowIndex} gap={1}>
+          <Box width={10} flexShrink={0}>
+            <StatusToken status={row.status} color={color} />
+          </Box>
+          {columns.map(column => (
+            <Box
+              key={column.key}
+              width={column.width}
+              flexGrow={column.grow ? 1 : 0}
+              flexShrink={column.grow ? 1 : 0}
+            >
+              <Text wrap={column.grow ? 'wrap' : 'truncate-end'}>{column.render(row)}</Text>
             </Box>
           ))}
         </Box>

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const fetchMock = mock()
+
+describe('read-only CLI TTY commands', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+  const originalFetch = globalThis.fetch
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let log: ReturnType<typeof spyOn>
+
+  function setStdoutIsTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+  }
+
+  function jsonResponse(body: unknown): Response {
+    return {
+      ok: true,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(''),
+    } as Response
+  }
+
+  function output(): string {
+    return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+  }
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    process.argv = originalArgv
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    process.exit = ((code?: number) => {
+      if (code === 0) return undefined as never
+      throw new Error(`exit:${code}`)
+    }) as never
+    setStdoutIsTTY(true)
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    globalThis.fetch = originalFetch
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+    log.mockRestore()
+  })
+
+  it('renders status with the shared TUI when stdout is a TTY', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        intervalMin: 5,
+        lastRun: '2026-05-18T04:00:00.000Z',
+        nextRun: '2026-05-18T04:05:00.000Z',
+        secondsUntilNext: 120,
+        dispatchedCount: 7,
+      }))
+      .mockResolvedValueOnce(jsonResponse({ agents: [{ id: 'main' }, { id: 'patch' }], mainAgentId: 'main' }))
+    process.argv = ['bun', 'cli/bakin.ts', 'status']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain('Status')
+    expect(output()).toContain('DISPATCH')
+    expect(output()).not.toContain('=== Bakin Status ===')
+  })
+
+  it('renders tasks, agents, and plugins with shared TUI screens', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      columns: {
+        todo: [{ id: 'task-1', title: 'Write docs', agent: 'patch' }],
+        blocked: [{ id: 'task-2', title: 'Waiting on runtime', agent: 'main' }],
+      },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'list']
+    await main()
+    expect(output()).toContain('Tasks')
+    expect(output()).toContain('BOARD')
+    expect(output()).not.toContain('=== todo ===')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      agents: [
+        { id: 'main', name: 'Main Agent', status: 'online', model: 'gpt-5.5' },
+        { id: 'patch', name: 'Patch', status: 'working', model: 'gpt-5.5' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'list']
+    await main()
+    expect(output()).toContain('Agents')
+    expect(output()).toContain('Main Agent')
+    expect(output()).not.toContain('○ main:')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      routes: [
+        { pluginId: 'tasks' },
+        { pluginId: 'tasks' },
+        { pluginId: 'team' },
+        { pluginId: 'core' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'plugins', 'list']
+    await main()
+    expect(output()).toContain('Plugins')
+    expect(output()).toContain('tasks')
+    expect(output()).not.toContain('Installed plugins:')
+  })
+})

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -81,6 +81,8 @@ describe('read-only CLI TTY commands', () => {
     await main()
     expect(output()).toContain('Tasks')
     expect(output()).toContain('BOARD')
+    expect(output()).toContain('COLUMN')
+    expect(output()).toContain('AGENT')
     expect(output()).not.toContain('=== todo ===')
 
     log.mockClear()
@@ -93,6 +95,7 @@ describe('read-only CLI TTY commands', () => {
     process.argv = ['bun', 'cli/bakin.ts', 'agents', 'list']
     await main()
     expect(output()).toContain('Agents')
+    expect(output()).toContain('MODEL')
     expect(output()).toContain('Main Agent')
     expect(output()).not.toContain('○ main:')
 
@@ -108,6 +111,7 @@ describe('read-only CLI TTY commands', () => {
     process.argv = ['bun', 'cli/bakin.ts', 'plugins', 'list']
     await main()
     expect(output()).toContain('Plugins')
+    expect(output()).toContain('ROUTES')
     expect(output()).toContain('tasks')
     expect(output()).not.toContain('Installed plugins:')
   })

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -115,4 +115,29 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('tasks')
     expect(output()).not.toContain('Installed plugins:')
   })
+
+  it('renders workflows list with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      templates: [
+        {
+          filename: 'release.yml',
+          name: 'Release',
+          description: 'Prepare release notes and verification',
+          stepCount: 4,
+        },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'workflows', 'list']
+    await main()
+
+    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain('Workflows')
+    expect(output()).toContain('DEFINITIONS')
+    expect(output()).toContain('FILENAME')
+    expect(output()).toContain('STEPS')
+    expect(output()).toContain('release.yml')
+    expect(output()).not.toContain('-----------  -------')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -6,6 +6,7 @@ import {
   PluginsListReport,
   StatusReport,
   TasksListReport,
+  WorkflowsListReport,
 } from '../../src/core/cli/ui/readonly'
 
 describe('read-only CLI TUI screens', () => {
@@ -91,5 +92,29 @@ describe('read-only CLI TUI screens', () => {
     expect(plugins).toContain('tasks')
     expect(plugins).toContain('2')
     expect(plugins).not.toContain('core')
+  })
+
+  it('renders workflow definitions as a shared TUI table', () => {
+    const output = renderToString(
+      <WorkflowsListReport
+        templates={[
+          {
+            filename: 'release.yml',
+            name: 'Release',
+            description: 'Prepare release notes and verification',
+            stepCount: 4,
+          },
+        ]}
+      />,
+    )
+
+    expect(output).toContain('Workflows')
+    expect(output).toContain('DEFINITIONS')
+    expect(output).toContain('FILENAME')
+    expect(output).toContain('NAME')
+    expect(output).toContain('DESCRIPTION')
+    expect(output).toContain('STEPS')
+    expect(output).toContain('release.yml')
+    expect(output).toContain('Release')
   })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -30,7 +30,7 @@ describe('read-only CLI TUI screens', () => {
     expect(output).not.toContain('=== Bakin Status ===')
   })
 
-  it('renders task board rows with column status tokens', () => {
+  it('renders task board rows as a table with column status tokens', () => {
     const output = renderToString(
       <TasksListReport
         columns={{
@@ -46,11 +46,17 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('TODO')
     expect(output).toContain('BLOCKED')
     expect(output).toContain('DONE')
+    expect(output).toContain('COLUMN')
+    expect(output).toContain('ID')
+    expect(output).toContain('TITLE')
+    expect(output).toContain('AGENT')
     expect(output).toContain('task-1')
-    expect(output).toContain('Column: todo; Agent: patch')
+    expect(output).toContain('Write docs')
+    expect(output).toContain('patch')
+    expect(output).not.toContain('Column: todo; Agent: patch')
   })
 
-  it('renders agents and plugins as shared TUI reports', () => {
+  it('renders agents and plugins as shared TUI tables', () => {
     const agents = renderToString(
       <AgentsListReport
         agents={[
@@ -71,11 +77,19 @@ describe('read-only CLI TUI screens', () => {
     )
 
     expect(agents).toContain('Agents')
+    expect(agents).toContain('STATUS')
+    expect(agents).toContain('ID')
+    expect(agents).toContain('NAME')
+    expect(agents).toContain('STATE')
+    expect(agents).toContain('MODEL')
     expect(agents).toContain('Main Agent')
-    expect(agents).toContain('Model: gpt-5.5')
+    expect(agents).toContain('gpt-5.5')
+    expect(agents).not.toContain('Model: gpt-5.5')
     expect(plugins).toContain('Plugins')
+    expect(plugins).toContain('PLUGIN')
+    expect(plugins).toContain('ROUTES')
     expect(plugins).toContain('tasks')
-    expect(plugins).toContain('2 routes')
+    expect(plugins).toContain('2')
     expect(plugins).not.toContain('core')
   })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToString } from 'ink'
+
+import {
+  AgentsListReport,
+  PluginsListReport,
+  StatusReport,
+  TasksListReport,
+} from '../../src/core/cli/ui/readonly'
+
+describe('read-only CLI TUI screens', () => {
+  it('renders status with shared TUI primitives', () => {
+    const output = renderToString(
+      <StatusReport
+        dispatch={{
+          intervalMin: 5,
+          lastRun: '2026-05-18T04:00:00.000Z',
+          nextRun: '2026-05-18T04:05:00.000Z',
+          secondsUntilNext: 120,
+          dispatchedCount: 7,
+        }}
+        roster={{ agentIds: ['main', 'patch'], mainAgentId: 'main' }}
+      />,
+    )
+
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Status')
+    expect(output).toContain('DISPATCH')
+    expect(output).toContain('main, patch')
+    expect(output).not.toContain('=== Bakin Status ===')
+  })
+
+  it('renders task board rows with column status tokens', () => {
+    const output = renderToString(
+      <TasksListReport
+        columns={{
+          todo: [{ id: 'task-1', title: 'Write docs', agent: 'patch' }],
+          blocked: [{ id: 'task-2', title: 'Waiting on runtime', agent: 'main' }],
+          done: [{ id: 'task-3', title: 'Ship doctor TUI', agent: 'patch' }],
+        }}
+      />,
+    )
+
+    expect(output).toContain('Tasks')
+    expect(output).toContain('BOARD')
+    expect(output).toContain('TODO')
+    expect(output).toContain('BLOCKED')
+    expect(output).toContain('DONE')
+    expect(output).toContain('task-1')
+    expect(output).toContain('Column: todo; Agent: patch')
+  })
+
+  it('renders agents and plugins as shared TUI reports', () => {
+    const agents = renderToString(
+      <AgentsListReport
+        agents={[
+          { id: 'main', name: 'Main Agent', status: 'online', model: 'gpt-5.5' },
+          { id: 'patch', name: 'Patch', status: 'working', model: 'gpt-5.5' },
+        ]}
+      />,
+    )
+    const plugins = renderToString(
+      <PluginsListReport
+        routes={[
+          { pluginId: 'tasks' },
+          { pluginId: 'tasks' },
+          { pluginId: 'team' },
+          { pluginId: 'core' },
+        ]}
+      />,
+    )
+
+    expect(agents).toContain('Agents')
+    expect(agents).toContain('Main Agent')
+    expect(agents).toContain('Model: gpt-5.5')
+    expect(plugins).toContain('Plugins')
+    expect(plugins).toContain('tasks')
+    expect(plugins).toContain('2 routes')
+    expect(plugins).not.toContain('core')
+  })
+})


### PR DESCRIPTION
## Summary
- add shared TUI reports for status, tasks list, agents list, and plugins list
- render those commands with the shared Bakin header, summary strips, sections, and status tokens when stdout is a TTY
- preserve existing plain text/table output for non-TTY usage

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli