### PR TITLE
Migrate package list commands to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -156,6 +156,37 @@ async function printWorkflowsListTui(templates: Array<Record<string, unknown>>):
   console.log(renderToString(createElement(WorkflowsListReport, { templates })))
 }
 
+async function printAgentPackagesListTui(agents: Array<Record<string, unknown>>): Promise<void> {
+  const [{ AgentPackagesListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(AgentPackagesListReport, { agents })))
+}
+
+async function printAgentLessonsListTui(
+  agentId: string,
+  packageId: string,
+  lessons: Array<Record<string, unknown>>,
+): Promise<void> {
+  const [{ AgentLessonsListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(AgentLessonsListReport, { agentId, packageId, lessons })))
+}
+
+async function printPackagesListTui(packages: Array<Record<string, unknown>>): Promise<void> {
+  const [{ PackagesListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(PackagesListReport, { packages })))
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -567,6 +598,10 @@ async function cmdAgentPackagesList(flags: AgentsCmdFlags): Promise<void> {
     print(result)
     return
   }
+  if (process.stdout.isTTY) {
+    await printAgentPackagesListTui(result.agents)
+    return
+  }
   console.log('Agents (package state):')
   for (const a of result.agents) {
     const pkg = a.packageId ? `  [${a.packageId}]` : ''
@@ -615,6 +650,10 @@ async function cmdAgentPackagesLessonsList(agentId: string): Promise<void> {
     packageId: string
     lessons: Array<{ lessonId: string; title: string; tags: string[]; enabled: boolean }>
   }
+  if (process.stdout.isTTY) {
+    await printAgentLessonsListTui(agentId, result.packageId, result.lessons)
+    return
+  }
   console.log(`Lessons for ${agentId} (package: ${result.packageId})`)
   for (const l of result.lessons) {
     const mark = l.enabled ? '[x]' : '[ ]'
@@ -644,6 +683,10 @@ async function cmdPackagesList(flags: AgentsCmdFlags): Promise<void> {
   }
   if (flags.json) {
     print(result)
+    return
+  }
+  if (process.stdout.isTTY) {
+    await printPackagesListTui(result.packages)
     return
   }
   console.log('Installed packages:')

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -47,6 +47,27 @@ export interface WorkflowTemplateData {
   stepCount?: unknown
 }
 
+export interface AgentPackageData {
+  agentId?: unknown
+  state?: unknown
+  packageId?: unknown
+}
+
+export interface AgentLessonData {
+  lessonId?: unknown
+  title?: unknown
+  tags?: unknown
+  enabled?: unknown
+}
+
+export interface PackageData {
+  id?: unknown
+  kind?: unknown
+  version?: unknown
+  refCount?: unknown
+  dependents?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -76,6 +97,30 @@ interface WorkflowTableRow {
   steps: string
 }
 
+interface AgentPackageTableRow {
+  status: TuiStatus
+  agent: string
+  state: string
+  package: string
+}
+
+interface AgentLessonTableRow {
+  status: TuiStatus
+  enabled: string
+  lesson: string
+  title: string
+  tags: string
+}
+
+interface PackageTableRow {
+  status: TuiStatus
+  package: string
+  kind: string
+  version: string
+  refs: string
+  dependents: string
+}
+
 const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
 
 function valueText(value: unknown, fallback = '-'): string {
@@ -89,6 +134,12 @@ function numberValue(value: unknown): number {
 
 function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
   return count === 1 ? singular : pluralLabel
+}
+
+function listText(value: unknown, fallback = '-'): string {
+  if (!Array.isArray(value)) return valueText(value, fallback)
+  if (value.length === 0) return fallback
+  return value.map(item => valueText(item)).join(', ')
 }
 
 function taskColumnStatus(column: string): TuiStatus {
@@ -199,6 +250,57 @@ function workflowTableRows(templates: WorkflowTemplateData[]): WorkflowTableRow[
     name: valueText(template.name, '(unnamed)'),
     description: valueText(template.description),
     steps: valueText(template.stepCount),
+  }))
+}
+
+function packageStateStatus(state: string): TuiStatus {
+  switch (state) {
+    case 'managed':
+    case 'adopted':
+      return 'ok'
+    case 'missing':
+    case 'drifted':
+      return 'warn'
+    case 'blocked':
+      return 'blocked'
+    default:
+      return 'skip'
+  }
+}
+
+function agentPackageTableRows(agents: AgentPackageData[]): AgentPackageTableRow[] {
+  return agents.map(agent => {
+    const state = valueText(agent.state)
+    return {
+      status: packageStateStatus(state),
+      agent: valueText(agent.agentId),
+      state,
+      package: valueText(agent.packageId),
+    }
+  })
+}
+
+function agentLessonTableRows(lessons: AgentLessonData[]): AgentLessonTableRow[] {
+  return lessons.map(lesson => {
+    const enabled = lesson.enabled === true
+    return {
+      status: enabled ? 'ok' : 'skip',
+      enabled: enabled ? 'yes' : 'no',
+      lesson: valueText(lesson.lessonId),
+      title: valueText(lesson.title, '(untitled lesson)'),
+      tags: listText(lesson.tags),
+    }
+  })
+}
+
+function packageTableRows(packages: PackageData[]): PackageTableRow[] {
+  return packages.map(pkg => ({
+    status: 'ok',
+    package: valueText(pkg.id),
+    kind: valueText(pkg.kind),
+    version: valueText(pkg.version),
+    refs: valueText(pkg.refCount, '0'),
+    dependents: listText(pkg.dependents),
   }))
 }
 
@@ -368,6 +470,114 @@ export function WorkflowsListReport({ templates, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No workflow definitions found.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function AgentPackagesListReport({ agents, color = true }: {
+  agents: AgentPackageData[]
+  color?: boolean
+}) {
+  const rows = agentPackageTableRows(agents)
+  const managed = rows.filter(row => row.state === 'managed').length
+  const adopted = rows.filter(row => row.state === 'adopted').length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Agent Packages" subtitle="Installed agent package state" color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'agent'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'managed', value: managed, status: managed > 0 ? 'ok' : 'skip' },
+        { label: 'adopted', value: adopted, status: adopted > 0 ? 'ready' : 'skip' },
+      ]} color={color} />
+      <Section title="Package state" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'agent', header: 'AGENT', width: 18, render: row => row.agent },
+              { key: 'state', header: 'STATE', width: 12, render: row => row.state },
+              { key: 'package', header: 'PACKAGE', width: 34, grow: true, render: row => row.package },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No agent package state found.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function AgentLessonsListReport({ agentId, packageId, lessons, color = true }: {
+  agentId: string
+  packageId: string
+  lessons: AgentLessonData[]
+  color?: boolean
+}) {
+  const rows = agentLessonTableRows(lessons)
+  const enabled = rows.filter(row => row.enabled === 'yes').length
+  const disabled = rows.length - enabled
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Agent Lessons" subtitle={`Lesson toggles for ${agentId}`} meta={`package: ${packageId}`} color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'lesson'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'enabled', value: enabled, status: enabled > 0 ? 'ok' : 'skip' },
+        { label: 'disabled', value: disabled, status: disabled > 0 ? 'skip' : 'ok' },
+      ]} color={color} />
+      <Section title="Lessons" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'enabled', header: 'ENABLED', width: 8, render: row => row.enabled },
+              { key: 'lesson', header: 'LESSON', width: 24, render: row => row.lesson },
+              { key: 'title', header: 'TITLE', width: 34, grow: true, render: row => row.title },
+              { key: 'tags', header: 'TAGS', width: 22, render: row => row.tags },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No lessons found for this agent package.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function PackagesListReport({ packages, color = true }: {
+  packages: PackageData[]
+  color?: boolean
+}) {
+  const rows = packageTableRows(packages)
+  const referenced = rows.filter(row => row.refs !== '0').length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Packages" subtitle="Installed standalone packages" color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'package'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'referenced', value: referenced, status: referenced > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Installed packages" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'package', header: 'PACKAGE', width: 30, grow: true, render: row => row.package },
+              { key: 'kind', header: 'KIND', width: 12, render: row => row.kind },
+              { key: 'version', header: 'VERSION', width: 12, render: row => row.version },
+              { key: 'refs', header: 'REFS', width: 6, render: row => row.refs },
+              { key: 'dependents', header: 'DEPENDENTS', width: 24, render: row => row.dependents },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No packages installed.' }]} color={color} />
         )}
       </Section>
     </Box>

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -191,6 +191,7 @@ export function DataTable<TRow>({ columns, rows }: {
           ))}
         </Box>
       ))}
+      <Text> </Text>
     </Box>
   )
 }
@@ -234,6 +235,7 @@ export function StatusTable<TRow extends { status: TuiStatus }>({ columns, rows,
           ))}
         </Box>
       ))}
+      <Text> </Text>
     </Box>
   )
 }

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -140,4 +140,52 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('release.yml')
     expect(output()).not.toContain('-----------  -------')
   })
+
+  it('renders package-oriented list commands with shared TUI screens in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      agents: [
+        { agentId: 'patch', state: 'managed', packageId: 'bakin.patch' },
+        { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'list', '--packages']
+    await main()
+    expect(output()).toContain('Agent Packages')
+    expect(output()).toContain('PACKAGE')
+    expect(output()).toContain('bakin.patch')
+    expect(output()).not.toContain('Agents (package state):')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      packageId: 'bakin.patch',
+      lessons: [
+        { lessonId: 'handoff', title: 'Handoff Notes', tags: ['workflow'], enabled: true },
+        { lessonId: 'release', title: 'Release Notes', tags: [], enabled: false },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'lessons', 'list', 'patch']
+    await main()
+    expect(output()).toContain('Agent Lessons')
+    expect(output()).toContain('LESSON')
+    expect(output()).toContain('handoff')
+    expect(output()).not.toContain('Lessons for patch')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      packages: [
+        { id: 'bakin.patch', kind: 'agent', version: '1.0.0', refCount: 2, dependents: ['patch', 'docs'] },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'packages', 'list']
+    await main()
+    expect(output()).toContain('Packages')
+    expect(output()).toContain('DEPENDENTS')
+    expect(output()).toContain('patch, docs')
+    expect(output()).not.toContain('Installed packages:')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'bun:test'
 import { renderToString } from 'ink'
 
 import {
+  AgentLessonsListReport,
+  AgentPackagesListReport,
   AgentsListReport,
+  PackagesListReport,
   PluginsListReport,
   StatusReport,
   TasksListReport,
@@ -116,5 +119,44 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('STEPS')
     expect(output).toContain('release.yml')
     expect(output).toContain('Release')
+  })
+
+  it('renders package-oriented lists as shared TUI tables', () => {
+    const agentPackages = renderToString(
+      <AgentPackagesListReport
+        agents={[
+          { agentId: 'patch', state: 'managed', packageId: 'bakin.patch' },
+          { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs' },
+        ]}
+      />,
+    )
+    const lessons = renderToString(
+      <AgentLessonsListReport
+        agentId="patch"
+        packageId="bakin.patch"
+        lessons={[
+          { lessonId: 'handoff', title: 'Handoff Notes', tags: ['workflow'], enabled: true },
+          { lessonId: 'release', title: 'Release Notes', tags: [], enabled: false },
+        ]}
+      />,
+    )
+    const packages = renderToString(
+      <PackagesListReport
+        packages={[
+          { id: 'bakin.patch', kind: 'agent', version: '1.0.0', refCount: 2, dependents: ['patch', 'docs'] },
+        ]}
+      />,
+    )
+
+    expect(agentPackages).toContain('Agent Packages')
+    expect(agentPackages).toContain('PACKAGE')
+    expect(agentPackages).toContain('bakin.patch')
+    expect(lessons).toContain('Agent Lessons')
+    expect(lessons).toContain('LESSON')
+    expect(lessons).toContain('ENABLED')
+    expect(lessons).toContain('handoff')
+    expect(packages).toContain('Packages')
+    expect(packages).toContain('DEPENDENTS')
+    expect(packages).toContain('patch, docs')
   })
 })

--- a/tests/cli/ui.test.tsx
+++ b/tests/cli/ui.test.tsx
@@ -5,11 +5,13 @@ import { createMultiSelectState, MultiSelect, updateMultiSelectState } from '../
 import { Report } from '../../src/core/cli/ui/report'
 import { Table } from '../../src/core/cli/ui/table'
 import {
+  DataTable,
   FindingRows,
   NextActions,
   ProgressMeter,
   ScreenHeader,
   Section,
+  StatusTable,
   StatusToken,
   SummaryStrip,
 } from '../../src/core/cli/ui/tui'
@@ -122,6 +124,28 @@ describe('CLI UI primitives', () => {
     )
 
     expect(output).toBe('ID       NAME\na        Short\nlong-id  Longer Name')
+  })
+
+  it('renders shared TUI tables with trailing breathing room', () => {
+    const dataTable = renderToString(
+      <DataTable
+        columns={[
+          { key: 'id', header: 'ID', width: 8, render: (row: { id: string }) => row.id },
+        ]}
+        rows={[{ id: 'task-1' }]}
+      />,
+    )
+    const statusTable = renderToString(
+      <StatusTable
+        columns={[
+          { key: 'name', header: 'NAME', width: 12, render: (row: { status: 'ok'; name: string }) => row.name },
+        ]}
+        rows={[{ status: 'ok', name: 'patch' }]}
+      />,
+    )
+
+    expect(dataTable.endsWith('\n')).toBe(true)
+    expect(statusTable.endsWith('\n')).toBe(true)
   })
 
   it('moves focus and toggles enabled items in multi-select state', () => {


### PR DESCRIPTION
## Summary
- render agents list --packages with the shared read-only TUI table in TTYs
- render agents lessons list with the shared read-only TUI table in TTYs
- render packages list with the shared read-only TUI table in TTYs
- preserve --json and non-TTY plain output paths

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli