### PR TITLE
Migrate schedule lists to shared TUI

### DIFF
--- a/src/cli/schedule.ts
+++ b/src/cli/schedule.ts
@@ -57,6 +57,15 @@ interface ListResult {
   }>
 }
 
+async function printScheduleListTui(jobs: ListResult['jobs']): Promise<void> {
+  const [{ ScheduleListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(ScheduleListReport, { jobs })))
+}
+
 export async function cmdScheduleList(opts: {
   all?: boolean
   agent?: string
@@ -70,6 +79,11 @@ export async function cmdScheduleList(opts: {
 
   if (opts.json) {
     console.log(JSON.stringify(jobs, null, 2))
+    return
+  }
+
+  if (process.stdout.isTTY) {
+    await printScheduleListTui(jobs)
     return
   }
 
@@ -142,10 +156,24 @@ interface RunsResult {
   }>
 }
 
+async function printScheduleRunsTui(jobId: string, runs: RunsResult['runs']): Promise<void> {
+  const [{ ScheduleRunsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(ScheduleRunsReport, { jobId, runs })))
+}
+
 export async function cmdScheduleRuns(jobId: string, opts: {
   limit?: number
 }): Promise<void> {
   const data = await apiGet<RunsResult>(`/${jobId}/runs?limit=${opts.limit ?? 20}`)
+
+  if (process.stdout.isTTY) {
+    await printScheduleRunsTui(jobId, data.runs)
+    return
+  }
 
   if (data.runs.length === 0) {
     console.log(`No run history for ${jobId}`)

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -68,6 +68,24 @@ export interface PackageData {
   dependents?: unknown
 }
 
+export interface ScheduleJobData {
+  id?: unknown
+  displayName?: unknown
+  agentId?: unknown
+  humanSchedule?: unknown
+  paused?: unknown
+  enabled?: unknown
+  isBakinJob?: unknown
+}
+
+export interface ScheduleRunData {
+  runId?: unknown
+  timestamp?: unknown
+  status?: unknown
+  taskId?: unknown
+  error?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -121,6 +139,22 @@ interface PackageTableRow {
   dependents: string
 }
 
+interface ScheduleJobTableRow {
+  status: TuiStatus
+  name: string
+  agent: string
+  schedule: string
+  state: string
+}
+
+interface ScheduleRunTableRow {
+  status: TuiStatus
+  time: string
+  state: string
+  task: string
+  error: string
+}
+
 const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
 
 function valueText(value: unknown, fallback = '-'): string {
@@ -140,6 +174,12 @@ function listText(value: unknown, fallback = '-'): string {
   if (!Array.isArray(value)) return valueText(value, fallback)
   if (value.length === 0) return fallback
   return value.map(item => valueText(item)).join(', ')
+}
+
+function timestampText(value: unknown): string {
+  const text = valueText(value)
+  const date = new Date(text)
+  return Number.isNaN(date.getTime()) ? text : date.toLocaleString()
 }
 
 function taskColumnStatus(column: string): TuiStatus {
@@ -302,6 +342,71 @@ function packageTableRows(packages: PackageData[]): PackageTableRow[] {
     refs: valueText(pkg.refCount, '0'),
     dependents: listText(pkg.dependents),
   }))
+}
+
+function scheduleJobState(job: ScheduleJobData): string {
+  if (job.paused === true) return 'paused'
+  return job.enabled === false ? 'disabled' : 'active'
+}
+
+function scheduleJobStatus(state: string): TuiStatus {
+  switch (state) {
+    case 'active':
+      return 'ok'
+    case 'paused':
+      return 'warn'
+    case 'disabled':
+      return 'skip'
+    default:
+      return 'skip'
+  }
+}
+
+function scheduleJobTableRows(jobs: ScheduleJobData[]): ScheduleJobTableRow[] {
+  return jobs.map(job => {
+    const state = scheduleJobState(job)
+    return {
+      status: scheduleJobStatus(state),
+      name: valueText(job.displayName, '(unnamed job)'),
+      agent: valueText(job.agentId),
+      schedule: valueText(job.humanSchedule),
+      state,
+    }
+  })
+}
+
+function scheduleRunStatus(status: string): TuiStatus {
+  switch (status) {
+    case 'ok':
+    case 'success':
+    case 'completed':
+      return 'ok'
+    case 'error':
+    case 'failed':
+    case 'fail':
+      return 'fail'
+    case 'running':
+      return 'run'
+    case 'skipped':
+    case 'cancelled':
+    case 'canceled':
+      return 'skip'
+    default:
+      return 'skip'
+  }
+}
+
+function scheduleRunTableRows(runs: ScheduleRunData[]): ScheduleRunTableRow[] {
+  return runs.map(run => {
+    const state = valueText(run.status)
+    return {
+      status: scheduleRunStatus(state),
+      time: timestampText(run.timestamp),
+      state,
+      task: valueText(run.taskId),
+      error: valueText(run.error, ''),
+    }
+  })
 }
 
 export function StatusReport({ dispatch, roster, color = true }: {
@@ -578,6 +683,81 @@ export function PackagesListReport({ packages, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No packages installed.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function ScheduleListReport({ jobs, color = true }: {
+  jobs: ScheduleJobData[]
+  color?: boolean
+}) {
+  const rows = scheduleJobTableRows(jobs)
+  const active = rows.filter(row => row.state === 'active').length
+  const paused = rows.filter(row => row.state === 'paused').length
+  const disabled = rows.filter(row => row.state === 'disabled').length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Schedule" subtitle="Scheduled Bakin jobs" color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'job'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'active', value: active, status: active > 0 ? 'ok' : 'skip' },
+        { label: 'paused', value: paused, status: paused > 0 ? 'warn' : 'ok' },
+        { label: 'disabled', value: disabled, status: disabled > 0 ? 'skip' : 'ok' },
+      ]} color={color} />
+      <Section title="Jobs" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'name', header: 'NAME', width: 28, grow: true, render: row => row.name },
+              { key: 'agent', header: 'AGENT', width: 14, render: row => row.agent },
+              { key: 'schedule', header: 'SCHEDULE', width: 28, render: row => row.schedule },
+              { key: 'state', header: 'STATE', width: 10, render: row => row.state },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No scheduled jobs found.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function ScheduleRunsReport({ jobId, runs, color = true }: {
+  jobId: string
+  runs: ScheduleRunData[]
+  color?: boolean
+}) {
+  const rows = scheduleRunTableRows(runs)
+  const failed = rows.filter(row => row.status === 'fail').length
+  const withTasks = rows.filter(row => row.task !== '-').length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Schedule Runs" subtitle="Run history" meta={`job: ${jobId}`} color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'run'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'failed', value: failed, status: failed > 0 ? 'fail' : 'ok' },
+        { label: 'tasks', value: withTasks, status: withTasks > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Run history" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'time', header: 'TIME', width: 24, render: row => row.time },
+              { key: 'state', header: 'STATE', width: 12, render: row => row.state },
+              { key: 'task', header: 'TASK', width: 16, render: row => row.task },
+              { key: 'error', header: 'ERROR', width: 40, grow: true, render: row => row.error },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: `No run history for ${jobId}.` }]} color={color} />
         )}
       </Section>
     </Box>

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -188,4 +188,43 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('patch, docs')
     expect(output()).not.toContain('Installed packages:')
   })
+
+  it('renders schedule list and run history with shared TUI screens in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      jobs: [
+        {
+          id: 'job-1',
+          displayName: 'Daily Doctor',
+          agentId: 'main',
+          humanSchedule: 'Every day at 9:00 AM',
+          paused: false,
+          enabled: true,
+          isBakinJob: true,
+        },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'schedule', 'list']
+    await main()
+    expect(output()).toContain('Schedule')
+    expect(output()).toContain('JOBS')
+    expect(output()).toContain('Daily Doctor')
+    expect(output()).not.toContain('Name                      Agent')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      runs: [
+        { runId: 'run-1', timestamp: '2026-05-18T09:00:00.000Z', status: 'ok', taskId: 'task-1' },
+        { runId: 'run-2', timestamp: '2026-05-17T09:00:00.000Z', status: 'error', error: 'timeout' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'schedule', 'runs', 'job-1']
+    await main()
+    expect(output()).toContain('Schedule Runs')
+    expect(output()).toContain('RUN HISTORY')
+    expect(output()).toContain('task-1')
+    expect(output()).toContain('timeout')
+    expect(output()).not.toContain('Time                   Status')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -7,6 +7,8 @@ import {
   AgentsListReport,
   PackagesListReport,
   PluginsListReport,
+  ScheduleListReport,
+  ScheduleRunsReport,
   StatusReport,
   TasksListReport,
   WorkflowsListReport,
@@ -158,5 +160,50 @@ describe('read-only CLI TUI screens', () => {
     expect(packages).toContain('Packages')
     expect(packages).toContain('DEPENDENTS')
     expect(packages).toContain('patch, docs')
+  })
+
+  it('renders schedule lists and run history as shared TUI tables', () => {
+    const schedule = renderToString(
+      <ScheduleListReport
+        jobs={[
+          {
+            id: 'job-1',
+            displayName: 'Daily Doctor',
+            agentId: 'main',
+            humanSchedule: 'Every day at 9:00 AM',
+            paused: false,
+            enabled: true,
+            isBakinJob: true,
+          },
+          {
+            id: 'job-2',
+            displayName: 'Paused Cleanup',
+            agentId: 'patch',
+            humanSchedule: 'Every Friday',
+            paused: true,
+            enabled: true,
+            isBakinJob: true,
+          },
+        ]}
+      />,
+    )
+    const runs = renderToString(
+      <ScheduleRunsReport
+        jobId="job-1"
+        runs={[
+          { runId: 'run-1', timestamp: '2026-05-18T09:00:00.000Z', status: 'ok', taskId: 'task-1' },
+          { runId: 'run-2', timestamp: '2026-05-17T09:00:00.000Z', status: 'error', error: 'timeout' },
+        ]}
+      />,
+    )
+
+    expect(schedule).toContain('Schedule')
+    expect(schedule).toContain('JOBS')
+    expect(schedule).toContain('Daily Doctor')
+    expect(schedule).toContain('Every day at 9:00 AM')
+    expect(runs).toContain('Schedule Runs')
+    expect(runs).toContain('RUN HISTORY')
+    expect(runs).toContain('task-1')
+    expect(runs).toContain('timeout')
   })
 })


### PR DESCRIPTION
## Summary
- render schedule list with the shared read-only TUI table in TTYs
- render schedule runs with the shared read-only TUI table in TTYs
- preserve JSON and non-TTY plain output paths

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts tests/cli/schedule.test.ts
- bun run typecheck
- bun test --isolate tests/cli