### PR TITLE
Migrate trash list to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -156,6 +156,15 @@ async function printWorkflowsListTui(templates: Array<Record<string, unknown>>):
   console.log(renderToString(createElement(WorkflowsListReport, { templates })))
 }
 
+async function printTrashListTui(assets: Array<Record<string, unknown>>): Promise<void> {
+  const [{ TrashListReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(TrashListReport, { assets })))
+}
+
 async function printAgentPackagesListTui(agents: Array<Record<string, unknown>>): Promise<void> {
   const [{ AgentPackagesListReport }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/readonly'),
@@ -1868,6 +1877,10 @@ function daysUntil(dateStr: string): string {
 
 async function cmdTrashList(): Promise<void> {
   const data = await apiGet('/api/plugins/assets/trash') as { assets: Array<{ filename: string; originalFilename: string; type: string; size: number; deletedAt: string; expiresAt: string; metadata: { agent?: string } | null }>; count: number }
+  if (process.stdout.isTTY) {
+    await printTrashListTui(data.assets as Array<Record<string, unknown>>)
+    return
+  }
   if (data.count === 0) {
     console.log('Trash is empty.')
     return

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -86,6 +86,16 @@ export interface ScheduleRunData {
   error?: unknown
 }
 
+export interface TrashAssetData {
+  filename?: unknown
+  originalFilename?: unknown
+  type?: unknown
+  size?: unknown
+  deletedAt?: unknown
+  expiresAt?: unknown
+  metadata?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -155,6 +165,16 @@ interface ScheduleRunTableRow {
   error: string
 }
 
+interface TrashAssetTableRow {
+  status: TuiStatus
+  filename: string
+  type: string
+  size: string
+  deleted: string
+  expires: string
+  agent: string
+}
+
 const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
 
 function valueText(value: unknown, fallback = '-'): string {
@@ -180,6 +200,29 @@ function timestampText(value: unknown): string {
   const text = valueText(value)
   const date = new Date(text)
   return Number.isNaN(date.getTime()) ? text : date.toLocaleString()
+}
+
+function metadataAgent(value: unknown): string {
+  if (!value || typeof value !== 'object') return 'unknown'
+  const agent = (value as { agent?: unknown }).agent
+  return valueText(agent, 'unknown')
+}
+
+function bytesText(value: unknown): string {
+  const bytes = typeof value === 'number' && Number.isFinite(value) ? value : Number(value)
+  if (!Number.isFinite(bytes)) return valueText(value)
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function daysUntilText(value: unknown): string {
+  const text = valueText(value)
+  const diff = new Date(text).getTime() - Date.now()
+  if (Number.isNaN(diff)) return text
+  const days = Math.ceil(diff / (24 * 60 * 60 * 1000))
+  if (days <= 0) return 'expiring'
+  return `${days}d`
 }
 
 function taskColumnStatus(column: string): TuiStatus {
@@ -407,6 +450,18 @@ function scheduleRunTableRows(runs: ScheduleRunData[]): ScheduleRunTableRow[] {
       error: valueText(run.error, ''),
     }
   })
+}
+
+function trashAssetTableRows(assets: TrashAssetData[]): TrashAssetTableRow[] {
+  return assets.map(asset => ({
+    status: 'warn',
+    filename: valueText(asset.originalFilename, valueText(asset.filename)),
+    type: valueText(asset.type),
+    size: bytesText(asset.size),
+    deleted: timestampText(asset.deletedAt),
+    expires: daysUntilText(asset.expiresAt),
+    agent: metadataAgent(asset.metadata),
+  }))
 }
 
 export function StatusReport({ dispatch, roster, color = true }: {
@@ -759,6 +814,48 @@ export function ScheduleRunsReport({ jobId, runs, color = true }: {
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: `No run history for ${jobId}.` }]} color={color} />
         )}
+      </Section>
+    </Box>
+  )
+}
+
+export function TrashListReport({ assets, color = true }: {
+  assets: TrashAssetData[]
+  color?: boolean
+}) {
+  const rows = trashAssetTableRows(assets)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Trash" subtitle="Soft-deleted assets" color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'item'), value: rows.length, status: rows.length > 0 ? 'warn' : 'skip' },
+      ]} color={color} />
+      <Section title="Trashed assets" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'filename', header: 'FILENAME', width: 18, render: row => row.filename },
+              { key: 'type', header: 'TYPE', width: 8, render: row => row.type },
+              { key: 'size', header: 'SIZE', width: 7, render: row => row.size },
+              { key: 'deleted', header: 'DELETED', width: 16, render: row => row.deleted },
+              { key: 'expires', header: 'EXPIRES', width: 7, render: row => row.expires },
+              { key: 'agent', header: 'AGENT', width: 8, render: row => row.agent },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'Trash is empty.' }]} color={color} />
+        )}
+      </Section>
+      <Section title="Restore" color={color}>
+        <FindingRows rows={[{
+          status: 'ready',
+          label: 'command',
+          message: 'bakin trash restore <trashName>',
+          detail: 'Use the full trash filename with the __deleted- suffix.',
+        }]} color={color} />
       </Section>
     </Box>
   )

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -227,4 +227,29 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('timeout')
     expect(output()).not.toContain('Time                   Status')
   })
+
+  it('renders trash list with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      count: 1,
+      assets: [{
+        filename: 'doc.md__deleted-20260518',
+        originalFilename: 'doc.md',
+        type: 'markdown',
+        size: 2048,
+        deletedAt: '2026-05-18T09:00:00.000Z',
+        expiresAt: '2026-05-25T09:00:00.000Z',
+        metadata: { agent: 'patch' },
+      }],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'trash', 'list']
+    await main()
+
+    expect(output()).toContain('Trash')
+    expect(output()).toContain('TRASHED ASSETS')
+    expect(output()).toContain('doc.md')
+    expect(output()).toContain('bakin trash restore <trashName>')
+    expect(output()).not.toContain('item in trash:')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -11,6 +11,7 @@ import {
   ScheduleRunsReport,
   StatusReport,
   TasksListReport,
+  TrashListReport,
   WorkflowsListReport,
 } from '../../src/core/cli/ui/readonly'
 
@@ -205,5 +206,31 @@ describe('read-only CLI TUI screens', () => {
     expect(runs).toContain('RUN HISTORY')
     expect(runs).toContain('task-1')
     expect(runs).toContain('timeout')
+  })
+
+  it('renders trashed assets as a shared TUI table', () => {
+    const output = renderToString(
+      <TrashListReport
+        assets={[
+          {
+            filename: 'doc.md__deleted-20260518',
+            originalFilename: 'doc.md',
+            type: 'markdown',
+            size: 2048,
+            deletedAt: '2026-05-18T09:00:00.000Z',
+            expiresAt: '2026-05-25T09:00:00.000Z',
+            metadata: { agent: 'patch' },
+          },
+        ]}
+      />,
+    )
+
+    expect(output).toContain('Trash')
+    expect(output).toContain('TRASHED ASSETS')
+    expect(output).toContain('FILENAME')
+    expect(output).toContain('doc.md')
+    expect(output).toContain('2.0 KB')
+    expect(output).toContain('patch')
+    expect(output).toContain('bakin trash restore <trashName>')
   })
 })


### PR DESCRIPTION
## Summary
- render trash list with the shared read-only TUI table in TTYs
- keep restore guidance in the shared TUI output
- preserve non-TTY plain output path

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli