### PR TITLE
Migrate agent task list to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -138,6 +138,15 @@ async function printAgentsListTui(agents: Array<{ id: string; name: string; stat
   console.log(renderToString(createElement(AgentsListReport, { agents })))
 }
 
+async function printAgentTasksTui(agentId: string, tasks: Array<Record<string, unknown>>): Promise<void> {
+  const [{ AgentTasksReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(AgentTasksReport, { agentId, tasks })))
+}
+
 async function printPluginsListTui(routes: Array<Record<string, unknown>>): Promise<void> {
   const [{ PluginsListReport }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/readonly'),
@@ -303,6 +312,10 @@ async function cmdAgentsStatus(agentId: string): Promise<void> {
 
 async function cmdAgentsTasks(agentId: string): Promise<void> {
   const result = await apiGet(`/api/agents/${agentId}/tasks`) as { tasks: Array<Record<string, unknown>> }
+  if (process.stdout.isTTY) {
+    await printAgentTasksTui(agentId, result.tasks)
+    return
+  }
   printTable(result.tasks, ['id', 'title', 'column'])
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -29,6 +29,12 @@ export interface TaskRowData {
   agent?: unknown
 }
 
+export interface AgentTaskData {
+  id?: unknown
+  title?: unknown
+  column?: unknown
+}
+
 export interface AgentRowData {
   id: string
   name: string
@@ -102,6 +108,13 @@ interface TaskTableRow {
   id: string
   title: string
   agent: string
+}
+
+interface AgentTaskTableRow {
+  status: TuiStatus
+  id: string
+  title: string
+  column: string
 }
 
 interface AgentTableRow {
@@ -264,6 +277,18 @@ function taskTableRows(columns: Record<string, TaskRowData[]>): TaskTableRow[] {
       agent: valueText(task.agent),
     }))
   ))
+}
+
+function agentTaskTableRows(tasks: AgentTaskData[]): AgentTaskTableRow[] {
+  return tasks.map(task => {
+    const column = valueText(task.column)
+    return {
+      status: taskColumnStatus(column),
+      id: valueText(task.id, '(no id)'),
+      title: valueText(task.title, '(untitled task)'),
+      column,
+    }
+  })
 }
 
 function taskSummary(columns: Record<string, TaskRowData[]>): SummaryItem[] {
@@ -530,6 +555,42 @@ export function TasksListReport({ columns, column, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No tasks found.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function AgentTasksReport({ agentId, tasks, color = true }: {
+  agentId: string
+  tasks: AgentTaskData[]
+  color?: boolean
+}) {
+  const rows = agentTaskTableRows(tasks)
+  const blocked = rows.filter(row => row.column === 'blocked').length
+  const active = rows.filter(row => ['todo', 'inProgress', 'review'].includes(row.column)).length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Agent Tasks" subtitle="Assigned task snapshot" meta={`agent: ${agentId}`} color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'task'), value: rows.length, status: rows.length > 0 ? 'todo' : 'skip' },
+        { label: 'active', value: active, status: active > 0 ? 'run' : 'ok' },
+        { label: 'blocked', value: blocked, status: blocked > 0 ? 'blocked' : 'ok' },
+      ]} color={color} />
+      <Section title="Tasks" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'id', header: 'ID', width: 16, render: row => row.id },
+              { key: 'title', header: 'TITLE', width: 42, grow: true, render: row => row.title },
+              { key: 'column', header: 'COLUMN', width: 14, render: row => row.column },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: `No tasks assigned to ${agentId}.` }]} color={color} />
         )}
       </Section>
     </Box>

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -252,4 +252,23 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('bakin trash restore <trashName>')
     expect(output()).not.toContain('item in trash:')
   })
+
+  it('renders agent task lists with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      tasks: [
+        { id: 'task-1', title: 'Write docs', column: 'todo' },
+        { id: 'task-2', title: 'Waiting on review', column: 'blocked' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'tasks', 'patch']
+    await main()
+
+    expect(output()).toContain('Agent Tasks')
+    expect(output()).toContain('agent: patch')
+    expect(output()).toContain('TASKS')
+    expect(output()).toContain('Write docs')
+    expect(output()).not.toContain('id      title')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -4,6 +4,7 @@ import { renderToString } from 'ink'
 import {
   AgentLessonsListReport,
   AgentPackagesListReport,
+  AgentTasksReport,
   AgentsListReport,
   PackagesListReport,
   PluginsListReport,
@@ -98,6 +99,25 @@ describe('read-only CLI TUI screens', () => {
     expect(plugins).toContain('tasks')
     expect(plugins).toContain('2')
     expect(plugins).not.toContain('core')
+  })
+
+  it('renders tasks assigned to one agent as a shared TUI table', () => {
+    const output = renderToString(
+      <AgentTasksReport
+        agentId="patch"
+        tasks={[
+          { id: 'task-1', title: 'Write docs', column: 'todo' },
+          { id: 'task-2', title: 'Waiting on review', column: 'blocked' },
+        ]}
+      />,
+    )
+
+    expect(output).toContain('Agent Tasks')
+    expect(output).toContain('agent: patch')
+    expect(output).toContain('TASKS')
+    expect(output).toContain('COLUMN')
+    expect(output).toContain('Write docs')
+    expect(output).toContain('blocked')
   })
 
   it('renders workflow definitions as a shared TUI table', () => {


### PR DESCRIPTION
## Summary
- render agent task lists with the shared read-only TUI table in TTYs
- preserve the non-TTY plain table output path

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli