### PR TITLE
Migrate search docs commands to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -17,6 +17,11 @@ import {
   serializePluginExportManifest,
   type PluginImportInstallRequest,
 } from '../src/core/plugins/import-export'
+import type {
+  SearchAggregationsData,
+  SearchMetaData,
+  SearchResultData,
+} from '../src/core/cli/ui/readonly'
 
 const BASE_URL = process.env.BAKIN_URL || 'http://localhost:3737'
 
@@ -156,6 +161,15 @@ async function printPluginsListTui(routes: Array<Record<string, unknown>>): Prom
   console.log(renderToString(createElement(PluginsListReport, { routes })))
 }
 
+async function printDocsTui(routes: Array<Record<string, unknown>>): Promise<void> {
+  const [{ DocsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DocsReport, { routes })))
+}
+
 async function printWorkflowsListTui(templates: Array<Record<string, unknown>>): Promise<void> {
   const [{ WorkflowsListReport }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/readonly'),
@@ -163,6 +177,36 @@ async function printWorkflowsListTui(templates: Array<Record<string, unknown>>):
     import('react'),
   ])
   console.log(renderToString(createElement(WorkflowsListReport, { templates })))
+}
+
+async function printSearchResultsTui(query: string, result: Record<string, unknown>): Promise<void> {
+  const [{ SearchResultsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  const results = Array.isArray(result.results) ? result.results as SearchResultData[] : []
+  const aggregations = result.aggregations && typeof result.aggregations === 'object' && !Array.isArray(result.aggregations)
+    ? result.aggregations as SearchAggregationsData
+    : undefined
+  const meta = result.meta && typeof result.meta === 'object' && !Array.isArray(result.meta)
+    ? result.meta as SearchMetaData
+    : undefined
+  console.log(renderToString(createElement(SearchResultsReport, {
+    query,
+    results,
+    aggregations,
+    meta,
+  })))
+}
+
+async function printSearchStatsTui(enabled: boolean, tables: Array<Record<string, unknown>>): Promise<void> {
+  const [{ SearchStatsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(SearchStatsReport, { enabled, tables })))
 }
 
 async function printTrashListTui(assets: Array<Record<string, unknown>>): Promise<void> {
@@ -778,6 +822,10 @@ function parseAgentsFlags(args: string[]): AgentsCmdFlags {
 
 async function cmdDocs(): Promise<void> {
   const docs = await apiGet('/api/docs') as { routes: Array<Record<string, unknown>> }
+  if (process.stdout.isTTY) {
+    await printDocsTui(docs.routes)
+    return
+  }
   for (const route of docs.routes) {
     const desc = route.description ? ` — ${route.description}` : ''
     console.log(`${route.method} ${route.fullPath}${desc}`)
@@ -793,6 +841,11 @@ async function cmdSearch(query: string, options: { table?: string; limit?: numbe
     results?: Array<{ key: string; score?: number; _table?: string; document?: Record<string, unknown> }>
     aggregations?: Record<string, Array<{ value: string; count: number }>>
     meta?: { query: string; total: number; took_ms: number; source: string }
+  }
+
+  if (process.stdout.isTTY) {
+    await printSearchResultsTui(query, result as Record<string, unknown>)
+    return
   }
 
   if (result.meta) {
@@ -827,6 +880,10 @@ async function cmdSearchStats(): Promise<void> {
       indexHealth?: Array<{ name: string; error?: string; walBacklog: number; rebuilding: boolean }>
       healthy?: boolean
     }>
+  }
+  if (process.stdout.isTTY) {
+    await printSearchStatsTui(result.enabled, result.tables as Array<Record<string, unknown>>)
+    return
   }
   console.log(`Search: ${result.enabled ? 'enabled' : 'disabled'}`)
   if (result.tables?.length) {

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -46,11 +46,47 @@ export interface PluginRouteData {
   pluginId?: unknown
 }
 
+export interface ApiRouteData {
+  method?: unknown
+  fullPath?: unknown
+  pluginId?: unknown
+  description?: unknown
+}
+
 export interface WorkflowTemplateData {
   filename?: unknown
   name?: unknown
   description?: unknown
   stepCount?: unknown
+}
+
+export interface SearchResultData {
+  key?: unknown
+  score?: unknown
+  _table?: unknown
+  document?: unknown
+}
+
+export interface SearchAggregationBucketData {
+  value?: unknown
+  count?: unknown
+}
+
+export type SearchAggregationsData = Record<string, SearchAggregationBucketData[]>
+
+export interface SearchMetaData {
+  query?: unknown
+  total?: unknown
+  took_ms?: unknown
+  source?: unknown
+}
+
+export interface SearchStatsTableData {
+  table?: unknown
+  pluginId?: unknown
+  stats?: unknown
+  indexHealth?: unknown
+  healthy?: unknown
 }
 
 export interface AgentPackageData {
@@ -131,11 +167,33 @@ interface PluginTableRow {
   routes: string
 }
 
+interface ApiRouteTableRow {
+  method: string
+  path: string
+  plugin: string
+  description: string
+}
+
 interface WorkflowTableRow {
   filename: string
   name: string
   description: string
   steps: string
+}
+
+interface SearchResultTableRow {
+  title: string
+  table: string
+  score: string
+  key: string
+}
+
+interface SearchStatsTableRow {
+  status: TuiStatus
+  table: string
+  plugin: string
+  docs: string
+  health: string
 }
 
 interface AgentPackageTableRow {
@@ -219,6 +277,11 @@ function metadataAgent(value: unknown): string {
   if (!value || typeof value !== 'object') return 'unknown'
   const agent = (value as { agent?: unknown }).agent
   return valueText(agent, 'unknown')
+}
+
+function objectField(value: unknown, key: string): unknown {
+  if (!value || typeof value !== 'object') return undefined
+  return (value as Record<string, unknown>)[key]
 }
 
 function bytesText(value: unknown): string {
@@ -352,12 +415,88 @@ function pluginTableRows(routes: PluginRouteData[]): PluginTableRow[] {
   }))
 }
 
+function apiRouteTableRows(routes: ApiRouteData[]): ApiRouteTableRow[] {
+  return routes.map(route => ({
+    method: valueText(route.method),
+    path: valueText(route.fullPath),
+    plugin: valueText(route.pluginId),
+    description: valueText(route.description, ''),
+  }))
+}
+
 function workflowTableRows(templates: WorkflowTemplateData[]): WorkflowTableRow[] {
   return templates.map(template => ({
     filename: valueText(template.filename),
     name: valueText(template.name, '(unnamed)'),
     description: valueText(template.description),
     steps: valueText(template.stepCount),
+  }))
+}
+
+function searchTableName(value: unknown): string {
+  return valueText(value).replace(/^bakin_/, '')
+}
+
+function searchScoreText(value: unknown): string {
+  const score = typeof value === 'number' && Number.isFinite(value) ? value : Number(value)
+  return Number.isFinite(score) ? score.toFixed(3) : valueText(value, '?')
+}
+
+function searchResultTitle(result: SearchResultData): string {
+  const title = objectField(result.document, 'title') ?? objectField(result.document, 'name')
+  return valueText(title, valueText(result.key, '(untitled result)'))
+}
+
+function searchResultTableRows(results: SearchResultData[]): SearchResultTableRow[] {
+  return results.map(result => ({
+    title: searchResultTitle(result),
+    table: searchTableName(result._table),
+    score: searchScoreText(result.score),
+    key: valueText(result.key),
+  }))
+}
+
+function searchFacetRows(aggregations: SearchAggregationsData = {}): Array<{ status: TuiStatus; label: string; message: string }> {
+  return Object.entries(aggregations).map(([facet, values]) => ({
+    status: values.length > 0 ? 'ok' : 'skip',
+    label: facet,
+    message: values.length > 0
+      ? values.map(value => `${valueText(value.value)}(${valueText(value.count, '0')})`).join(', ')
+      : 'none',
+  }))
+}
+
+function searchIndexHealth(value: unknown): Array<{ name?: unknown; error?: unknown; walBacklog?: unknown; rebuilding?: unknown }> {
+  return Array.isArray(value) ? value : []
+}
+
+function searchStatsDocCount(stats: unknown): string {
+  return valueText(objectField(stats, 'num_docs'), '?')
+}
+
+function searchStatsStatus(table: SearchStatsTableData, enabled: boolean): TuiStatus {
+  if (!enabled) return 'skip'
+  const health = searchIndexHealth(table.indexHealth)
+  if (table.healthy === false || health.some(index => valueText(index.error, '') !== '')) return 'fail'
+  if (health.some(index => numberValue(index.walBacklog) > 0 || index.rebuilding === true)) return 'run'
+  return 'ok'
+}
+
+function searchStatsHealth(table: SearchStatsTableData, enabled: boolean): string {
+  if (!enabled) return 'disabled'
+  const health = searchIndexHealth(table.indexHealth)
+  if (table.healthy === false || health.some(index => valueText(index.error, '') !== '')) return 'unhealthy'
+  if (health.some(index => numberValue(index.walBacklog) > 0 || index.rebuilding === true)) return 'enriching'
+  return 'healthy'
+}
+
+function searchStatsTableRows(tables: SearchStatsTableData[], enabled: boolean): SearchStatsTableRow[] {
+  return tables.map(table => ({
+    status: searchStatsStatus(table, enabled),
+    table: valueText(table.table),
+    plugin: valueText(table.pluginId),
+    docs: searchStatsDocCount(table.stats),
+    health: searchStatsHealth(table, enabled),
   }))
 }
 
@@ -666,6 +805,39 @@ export function PluginsListReport({ routes, color = true }: {
   )
 }
 
+export function DocsReport({ routes, color = true }: {
+  routes: ApiRouteData[]
+  color?: boolean
+}) {
+  const rows = apiRouteTableRows(routes)
+  const pluginCount = new Set(rows.map(row => row.plugin).filter(plugin => plugin !== '-' && plugin !== 'core')).size
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Docs" subtitle="API routes from the running server" color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'route'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: plural(pluginCount, 'plugin'), value: pluginCount, status: pluginCount > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Routes" color={color}>
+        {rows.length > 0 ? (
+          <DataTable
+            rows={rows}
+            columns={[
+              { key: 'method', header: 'METHOD', width: 8, render: row => row.method },
+              { key: 'path', header: 'PATH', width: 42, grow: true, render: row => row.path },
+              { key: 'plugin', header: 'PLUGIN', width: 16, render: row => row.plugin },
+              { key: 'description', header: 'DESCRIPTION', width: 42, grow: true, render: row => row.description },
+            ]}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No API routes returned by the server.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
 export function WorkflowsListReport({ templates, color = true }: {
   templates: WorkflowTemplateData[]
   color?: boolean
@@ -691,6 +863,89 @@ export function WorkflowsListReport({ templates, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No workflow definitions found.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function SearchResultsReport({ query, results, aggregations = {}, meta, color = true }: {
+  query: string
+  results: SearchResultData[]
+  aggregations?: SearchAggregationsData
+  meta?: SearchMetaData
+  color?: boolean
+}) {
+  const rows = searchResultTableRows(results)
+  const facets = searchFacetRows(aggregations)
+  const total = numberValue(meta?.total ?? rows.length)
+  const took = meta?.took_ms === undefined ? undefined : `${numberValue(meta.took_ms)}ms`
+  const source = valueText(meta?.source, 'unknown')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Search" subtitle={valueText(meta?.query, query)} meta={`source: ${source}`} color={color} />
+      <SummaryStrip items={[
+        { label: 'total', value: total, status: total > 0 ? 'ok' : 'skip' },
+        { label: 'returned', value: rows.length, status: rows.length > 0 ? 'ready' : 'skip' },
+        ...(took ? [{ label: 'elapsed', value: took }] : []),
+      ]} color={color} />
+      <Section title="Results" color={color}>
+        {rows.length > 0 ? (
+          <DataTable
+            rows={rows}
+            columns={[
+              { key: 'title', header: 'TITLE', width: 42, grow: true, render: row => row.title },
+              { key: 'table', header: 'TABLE', width: 16, render: row => row.table },
+              { key: 'score', header: 'SCORE', width: 8, render: row => row.score },
+              { key: 'key', header: 'KEY', width: 24, render: row => row.key },
+            ]}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No results found.' }]} color={color} />
+        )}
+      </Section>
+      {facets.length > 0 ? (
+        <Section title="Facets" color={color}>
+          <FindingRows rows={facets} color={color} />
+        </Section>
+      ) : null}
+    </Box>
+  )
+}
+
+export function SearchStatsReport({ enabled, tables, color = true }: {
+  enabled: boolean
+  tables: SearchStatsTableData[]
+  color?: boolean
+}) {
+  const rows = searchStatsTableRows(tables, enabled)
+  const unhealthy = rows.filter(row => row.status === 'fail').length
+  const enriching = rows.filter(row => row.status === 'run').length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Search Stats" subtitle="Search index health and document counts" color={color} />
+      <SummaryStrip items={[
+        { label: enabled ? 'enabled' : 'disabled', value: 'search', status: enabled ? 'ok' : 'skip' },
+        { label: plural(rows.length, 'table'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'unhealthy', value: unhealthy, status: unhealthy > 0 ? 'fail' : 'ok' },
+        { label: 'enriching', value: enriching, status: enriching > 0 ? 'run' : 'ok' },
+      ]} color={color} />
+      <Section title="Tables" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'table', header: 'TABLE', width: 24, grow: true, render: row => row.table },
+              { key: 'plugin', header: 'PLUGIN', width: 16, render: row => row.plugin },
+              { key: 'docs', header: 'DOCS', width: 8, render: row => row.docs },
+              { key: 'health', header: 'HEALTH', width: 12, render: row => row.health },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No search tables are registered.' }]} color={color} />
         )}
       </Section>
     </Box>

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -61,9 +61,12 @@ export interface WorkflowTemplateData {
 }
 
 export interface SearchResultData {
+  id?: unknown
   key?: unknown
+  table?: unknown
   score?: unknown
   _table?: unknown
+  fields?: unknown
   document?: unknown
 }
 
@@ -443,16 +446,17 @@ function searchScoreText(value: unknown): string {
 }
 
 function searchResultTitle(result: SearchResultData): string {
-  const title = objectField(result.document, 'title') ?? objectField(result.document, 'name')
-  return valueText(title, valueText(result.key, '(untitled result)'))
+  const document = result.fields ?? result.document
+  const title = objectField(document, 'title') ?? objectField(document, 'name')
+  return valueText(title, valueText(result.id ?? result.key, '(untitled result)'))
 }
 
 function searchResultTableRows(results: SearchResultData[]): SearchResultTableRow[] {
   return results.map(result => ({
     title: searchResultTitle(result),
-    table: searchTableName(result._table),
+    table: searchTableName(result.table ?? result._table),
     score: searchScoreText(result.score),
-    key: valueText(result.key),
+    key: valueText(result.id ?? result.key),
   }))
 }
 

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -292,10 +292,10 @@ describe('read-only CLI TTY commands', () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({
       results: [
         {
-          key: 'task-1',
+          id: 'task-1',
           score: 0.9123,
-          _table: 'bakin_tasks',
-          document: { title: 'Blocked task' },
+          table: 'bakin_tasks',
+          fields: { title: 'Blocked task' },
         },
       ],
       aggregations: { status: [{ value: 'blocked', count: 1 }] },
@@ -306,6 +306,8 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('Search')
     expect(output()).toContain('RESULTS')
     expect(output()).toContain('Blocked task')
+    expect(output()).toContain('tasks')
+    expect(output()).toContain('task-1')
     expect(output()).toContain('FACETS')
     expect(output()).not.toContain('Search: "blocked task"')
 

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -271,4 +271,62 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('Write docs')
     expect(output()).not.toContain('id      title')
   })
+
+  it('renders docs and search read-only commands with shared TUI screens in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      routes: [
+        { method: 'GET', fullPath: '/api/plugins/tasks/', pluginId: 'tasks', description: 'List tasks' },
+        { method: 'POST', fullPath: '/api/plugins/tasks/', pluginId: 'tasks', description: 'Create task' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'docs']
+    await main()
+    expect(output()).toContain('Docs')
+    expect(output()).toContain('ROUTES')
+    expect(output()).toContain('/api/plugins/tasks/')
+    expect(output()).not.toContain('GET /api/plugins/tasks/')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      results: [
+        {
+          key: 'task-1',
+          score: 0.9123,
+          _table: 'bakin_tasks',
+          document: { title: 'Blocked task' },
+        },
+      ],
+      aggregations: { status: [{ value: 'blocked', count: 1 }] },
+      meta: { query: 'blocked task', total: 1, took_ms: 4, source: 'tantivy' },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'search', 'blocked', 'task', '--table=tasks']
+    await main()
+    expect(output()).toContain('Search')
+    expect(output()).toContain('RESULTS')
+    expect(output()).toContain('Blocked task')
+    expect(output()).toContain('FACETS')
+    expect(output()).not.toContain('Search: "blocked task"')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      enabled: true,
+      tables: [
+        {
+          table: 'bakin_tasks',
+          pluginId: 'tasks',
+          stats: { num_docs: 12 },
+          healthy: true,
+          indexHealth: [],
+        },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'search:stats']
+    await main()
+    expect(output()).toContain('Search Stats')
+    expect(output()).toContain('TABLES')
+    expect(output()).toContain('bakin_tasks')
+    expect(output()).not.toContain('Search: enabled')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -6,10 +6,13 @@ import {
   AgentPackagesListReport,
   AgentTasksReport,
   AgentsListReport,
+  DocsReport,
   PackagesListReport,
   PluginsListReport,
   ScheduleListReport,
   ScheduleRunsReport,
+  SearchResultsReport,
+  SearchStatsReport,
   StatusReport,
   TasksListReport,
   TrashListReport,
@@ -142,6 +145,62 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('STEPS')
     expect(output).toContain('release.yml')
     expect(output).toContain('Release')
+  })
+
+  it('renders docs and search screens with shared TUI tables', () => {
+    const docs = renderToString(
+      <DocsReport
+        routes={[
+          { method: 'GET', fullPath: '/api/plugins/tasks/', pluginId: 'tasks', description: 'List tasks' },
+          { method: 'POST', fullPath: '/api/plugins/tasks/', pluginId: 'tasks', description: 'Create task' },
+        ]}
+      />,
+    )
+    const search = renderToString(
+      <SearchResultsReport
+        query="blocked task"
+        results={[
+          {
+            key: 'task-1',
+            score: 0.9123,
+            _table: 'bakin_tasks',
+            document: { title: 'Blocked task' },
+          },
+        ]}
+        aggregations={{
+          status: [{ value: 'blocked', count: 1 }],
+        }}
+        meta={{ query: 'blocked task', total: 1, took_ms: 4, source: 'tantivy' }}
+      />,
+    )
+    const stats = renderToString(
+      <SearchStatsReport
+        enabled={true}
+        tables={[
+          {
+            table: 'bakin_tasks',
+            pluginId: 'tasks',
+            stats: { num_docs: 12 },
+            healthy: true,
+            indexHealth: [],
+          },
+        ]}
+      />,
+    )
+
+    expect(docs).toContain('Docs')
+    expect(docs).toContain('ROUTES')
+    expect(docs).toContain('METHOD')
+    expect(docs).toContain('/api/plugins/tasks/')
+    expect(search).toContain('Search')
+    expect(search).toContain('RESULTS')
+    expect(search).toContain('Blocked task')
+    expect(search).toContain('FACETS')
+    expect(search).toContain('blocked(1)')
+    expect(stats).toContain('Search Stats')
+    expect(stats).toContain('TABLES')
+    expect(stats).toContain('bakin_tasks')
+    expect(stats).toContain('12')
   })
 
   it('renders package-oriented lists as shared TUI tables', () => {

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -161,10 +161,10 @@ describe('read-only CLI TUI screens', () => {
         query="blocked task"
         results={[
           {
-            key: 'task-1',
+            id: 'task-1',
             score: 0.9123,
-            _table: 'bakin_tasks',
-            document: { title: 'Blocked task' },
+            table: 'bakin_tasks',
+            fields: { title: 'Blocked task' },
           },
         ]}
         aggregations={{
@@ -195,6 +195,8 @@ describe('read-only CLI TUI screens', () => {
     expect(search).toContain('Search')
     expect(search).toContain('RESULTS')
     expect(search).toContain('Blocked task')
+    expect(search).toContain('tasks')
+    expect(search).toContain('task-1')
     expect(search).toContain('FACETS')
     expect(search).toContain('blocked(1)')
     expect(stats).toContain('Search Stats')


### PR DESCRIPTION
## Summary
- render docs, search results, and search stats with shared read-only TUI screens in TTYs
- preserve existing plain text output for non-TTY usage
- add coverage for the new shared docs/search reports and command paths

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli