### PR TITLE
Migrate detail read-only commands to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -134,6 +134,15 @@ async function printTasksListTui(columns: Record<string, Array<Record<string, un
   console.log(renderToString(createElement(TasksListReport, { columns, column })))
 }
 
+async function printTaskDetailTui(taskId: string, column: string, task: Record<string, unknown>): Promise<void> {
+  const [{ TaskDetailReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(TaskDetailReport, { taskId, column, task })))
+}
+
 async function printAgentsListTui(agents: Array<{ id: string; name: string; status: string; model: string }>): Promise<void> {
   const [{ AgentsListReport }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/readonly'),
@@ -141,6 +150,15 @@ async function printAgentsListTui(agents: Array<{ id: string; name: string; stat
     import('react'),
   ])
   console.log(renderToString(createElement(AgentsListReport, { agents })))
+}
+
+async function printAgentStatusTui(agentId: string, profile: Record<string, unknown>): Promise<void> {
+  const [{ AgentStatusReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(AgentStatusReport, { agentId, profile })))
 }
 
 async function printAgentTasksTui(agentId: string, tasks: Array<Record<string, unknown>>): Promise<void> {
@@ -350,7 +368,11 @@ async function cmdAgentsSend(agentId: string, message: string): Promise<void> {
 }
 
 async function cmdAgentsStatus(agentId: string): Promise<void> {
-  const result = await apiGet(`/api/plugins/team/${agentId}`)
+  const result = await apiGet(`/api/plugins/team/${agentId}`) as Record<string, unknown>
+  if (process.stdout.isTTY) {
+    await printAgentStatusTui(agentId, result)
+    return
+  }
   print(result)
 }
 
@@ -1883,6 +1905,10 @@ async function cmdTasksGet(id: string): Promise<void> {
   for (const [colName, tasks] of Object.entries(columns)) {
     const task = (tasks as Array<Record<string, unknown>>).find(t => t.id === id)
     if (task) {
+      if (process.stdout.isTTY) {
+        await printTaskDetailTui(id, colName, task)
+        return
+      }
       console.log(`Column: ${colName}`)
       print(task)
       return

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -367,9 +367,9 @@ async function cmdAgentsSend(agentId: string, message: string): Promise<void> {
   print(result)
 }
 
-async function cmdAgentsStatus(agentId: string): Promise<void> {
+async function cmdAgentsStatus(agentId: string, opts: { json?: boolean } = {}): Promise<void> {
   const result = await apiGet(`/api/plugins/team/${agentId}`) as Record<string, unknown>
-  if (process.stdout.isTTY) {
+  if (!opts.json && process.stdout.isTTY) {
     await printAgentStatusTui(agentId, result)
     return
   }
@@ -1899,12 +1899,16 @@ async function cmdTasksComplete(id: string, summary: string): Promise<void> {
   print(result)
 }
 
-async function cmdTasksGet(id: string): Promise<void> {
+async function cmdTasksGet(id: string, opts: { json?: boolean } = {}): Promise<void> {
   const result = await apiGet('/api/plugins/tasks/') as { columns: Record<string, Array<Record<string, unknown>>> }
   const columns = result.columns || {}
   for (const [colName, tasks] of Object.entries(columns)) {
     const task = (tasks as Array<Record<string, unknown>>).find(t => t.id === id)
     if (task) {
+      if (opts.json) {
+        print({ column: colName, task })
+        return
+      }
       if (process.stdout.isTTY) {
         await printTaskDetailTui(id, colName, task)
         return
@@ -2420,7 +2424,7 @@ export async function main(): Promise<void> {
           await cmdTasksList(colFlag?.split('=')[1])
         } else if (sub === 'get') {
           if (!args[2]) { console.error('Usage: bakin tasks get <id>'); process.exit(1) }
-          await cmdTasksGet(args[2])
+          await cmdTasksGet(args[2], { json: args.includes('--json') })
         } else if (sub === 'create') {
           if (!args[2]) { console.error('Usage: bakin tasks create <title> [agent] [--workflow=<id>] [--no-workflow="<reason>"]'); process.exit(1) }
           // Parse flags from remaining args
@@ -2484,7 +2488,7 @@ export async function main(): Promise<void> {
           }
         } else if (sub === 'status') {
           if (!args[2]) { console.error('Usage: bakin agents status <id>'); process.exit(1) }
-          await cmdAgentsStatus(args[2])
+          await cmdAgentsStatus(args[2], { json: args.includes('--json') })
         } else if (sub === 'tasks') {
           if (!args[2]) { console.error('Usage: bakin agents tasks <id>'); process.exit(1) }
           await cmdAgentsTasks(args[2])

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -29,6 +29,8 @@ export interface TaskRowData {
   agent?: unknown
 }
 
+export type TaskDetailData = Record<string, unknown>
+
 export interface AgentTaskData {
   id?: unknown
   title?: unknown
@@ -40,6 +42,22 @@ export interface AgentRowData {
   name: string
   status: string
   model: string
+}
+
+export interface AgentProfileData {
+  id?: unknown
+  name?: unknown
+  emoji?: unknown
+  role?: unknown
+  status?: unknown
+  model?: unknown
+  workspacePath?: unknown
+  soul?: unknown
+  identity?: unknown
+  rules?: unknown
+  tools?: unknown
+  heartbeatMd?: unknown
+  subagentPerms?: unknown
 }
 
 export interface PluginRouteData {
@@ -164,6 +182,11 @@ interface AgentTableRow {
   model: string
 }
 
+interface DetailFieldRow {
+  field: string
+  value: string
+}
+
 interface PluginTableRow {
   status: TuiStatus
   plugin: string
@@ -268,6 +291,19 @@ function listText(value: unknown, fallback = '-'): string {
   if (!Array.isArray(value)) return valueText(value, fallback)
   if (value.length === 0) return fallback
   return value.map(item => valueText(item)).join(', ')
+}
+
+function detailText(value: unknown, fallback = '-'): string {
+  if (value === null || value === undefined || value === '') return fallback
+  if (Array.isArray(value)) return listText(value, fallback)
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
 }
 
 function timestampText(value: unknown): string {
@@ -395,6 +431,23 @@ function agentTableRows(agents: AgentRowData[]): AgentTableRow[] {
     state: agent.status,
     model: agent.model,
   }))
+}
+
+function taskDetailFields(task: TaskDetailData): DetailFieldRow[] {
+  const primary = new Set(['id', 'title', 'agent', 'column'])
+  return Object.entries(task)
+    .filter(([key]) => !primary.has(key))
+    .map(([field, value]) => ({ field, value: detailText(value) }))
+}
+
+function contentPreview(value: unknown): string {
+  const text = valueText(value, '')
+  if (!text) return 'missing'
+  return text.split('\n').map(line => line.trim()).find(Boolean) ?? 'present'
+}
+
+function contentStatus(value: unknown): TuiStatus {
+  return valueText(value, '') ? 'ok' : 'skip'
 }
 
 function pluginRouteCounts(routes: PluginRouteData[]): Array<{ pluginId: string; routeCount: number }> {
@@ -740,6 +793,46 @@ export function AgentTasksReport({ agentId, tasks, color = true }: {
   )
 }
 
+export function TaskDetailReport({ taskId, column, task, color = true }: {
+  taskId: string
+  column: string
+  task: TaskDetailData
+  color?: boolean
+}) {
+  const fields = taskDetailFields(task)
+  const columnStatus = taskColumnStatus(column)
+  const agent = valueText(task.agent, 'unassigned')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Task Detail" subtitle="Board task snapshot" meta={`id: ${taskId}`} color={color} />
+      <SummaryStrip items={[
+        { label: 'column', value: column, status: columnStatus },
+        { label: 'agent', value: agent, status: agent === 'unassigned' ? 'skip' : 'ok' },
+      ]} color={color} />
+      <Section title="Task" color={color}>
+        <FindingRows rows={[
+          { status: columnStatus, label: 'title', message: valueText(task.title, '(untitled task)') },
+          { status: 'ready', label: 'id', message: valueText(task.id, taskId) },
+          { status: agent === 'unassigned' ? 'skip' : 'ok', label: 'agent', message: agent },
+          { status: columnStatus, label: 'column', message: column },
+        ]} color={color} />
+      </Section>
+      {fields.length > 0 ? (
+        <Section title="Fields" color={color}>
+          <DataTable
+            rows={fields}
+            columns={[
+              { key: 'field', header: 'FIELD', width: 18, render: row => row.field },
+              { key: 'value', header: 'VALUE', width: 58, grow: true, render: row => row.value },
+            ]}
+          />
+        </Section>
+      ) : null}
+    </Box>
+  )
+}
+
 export function AgentsListReport({ agents, color = true }: {
   agents: AgentRowData[]
   color?: boolean
@@ -771,6 +864,45 @@ export function AgentsListReport({ agents, color = true }: {
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No agents reported by the runtime.' }]} color={color} />
         )}
+      </Section>
+    </Box>
+  )
+}
+
+export function AgentStatusReport({ agentId, profile, color = true }: {
+  agentId: string
+  profile: AgentProfileData
+  color?: boolean
+}) {
+  const status = valueText(profile.status, 'profile')
+  const permissions = Array.isArray(profile.subagentPerms) ? profile.subagentPerms.length : 0
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Agent Status" subtitle="Runtime profile snapshot" meta={`agent: ${agentId}`} color={color} />
+      <SummaryStrip items={[
+        { label: 'status', value: status, status: profile.status ? agentStatus(status) : 'ok' },
+        { label: 'model', value: valueText(profile.model), status: profile.model ? 'ok' : 'skip' },
+        { label: 'permissions', value: permissions, status: permissions > 0 ? 'ready' : 'skip' },
+      ]} color={color} />
+      <Section title="Profile" color={color}>
+        <FindingRows rows={[
+          { status: 'ready', label: 'id', message: valueText(profile.id, agentId) },
+          { status: 'ok', label: 'name', message: `${valueText(profile.emoji, '').trim()} ${valueText(profile.name, '(unnamed agent)')}`.trim() },
+          { status: profile.role ? 'ok' : 'skip', label: 'role', message: valueText(profile.role, '-') },
+          { status: profile.model ? 'ok' : 'skip', label: 'model', message: valueText(profile.model, '-') },
+          { status: profile.workspacePath ? 'ok' : 'skip', label: 'workspace', message: valueText(profile.workspacePath, '-') },
+        ]} color={color} />
+      </Section>
+      <Section title="Workspace" color={color}>
+        <FindingRows rows={[
+          { status: contentStatus(profile.identity), label: 'identity', message: contentPreview(profile.identity) },
+          { status: contentStatus(profile.soul), label: 'soul', message: contentPreview(profile.soul) },
+          { status: contentStatus(profile.rules), label: 'rules', message: contentPreview(profile.rules) },
+          { status: contentStatus(profile.tools), label: 'tools', message: contentPreview(profile.tools) },
+          { status: contentStatus(profile.heartbeatMd), label: 'heartbeat', message: contentPreview(profile.heartbeatMd) },
+          { status: permissions > 0 ? 'ready' : 'skip', label: 'subagents', message: listText(profile.subagentPerms, 'none') },
+        ]} color={color} />
       </Section>
     </Box>
   )

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -157,6 +157,24 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('"workspacePath"')
   })
 
+  it('honors --json for task detail commands even in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      columns: {
+        inProgress: [{ id: 'task-1', title: 'Write docs', agent: 'patch' }],
+        todo: [],
+      },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'get', 'task-1', '--json']
+    await main()
+
+    expect(output()).toContain('"column": "inProgress"')
+    expect(output()).toContain('"title": "Write docs"')
+    expect(output()).not.toContain('Task Detail')
+    expect(output()).not.toContain('Column: inProgress')
+  })
+
   it('renders workflows list with the shared TUI screen in a TTY', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -116,6 +116,47 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('Installed plugins:')
   })
 
+  it('renders task and agent detail commands with shared TUI screens in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      columns: {
+        inProgress: [{ id: 'task-1', title: 'Write docs', agent: 'patch', priority: 'high' }],
+        todo: [],
+      },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'get', 'task-1']
+    await main()
+    expect(output()).toContain('Task Detail')
+    expect(output()).toContain('id: task-1')
+    expect(output()).toContain('Write docs')
+    expect(output()).toContain('FIELDS')
+    expect(output()).not.toContain('Column: inProgress')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      id: 'patch',
+      name: 'Patch',
+      role: 'Engineer',
+      model: 'gpt-5.5',
+      workspacePath: '/tmp/patch',
+      soul: '# Patch Soul\n',
+      identity: '# Identity\n',
+      rules: '',
+      tools: null,
+      heartbeatMd: '# Heartbeat\nWorking on docs',
+      subagentPerms: ['docs'],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'status', 'patch']
+    await main()
+    expect(output()).toContain('Agent Status')
+    expect(output()).toContain('agent: patch')
+    expect(output()).toContain('PROFILE')
+    expect(output()).toContain('Patch')
+    expect(output()).toContain('WORKSPACE')
+    expect(output()).not.toContain('"workspacePath"')
+  })
+
   it('renders workflows list with the shared TUI screen in a TTY', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -4,6 +4,7 @@ import { renderToString } from 'ink'
 import {
   AgentLessonsListReport,
   AgentPackagesListReport,
+  AgentStatusReport,
   AgentTasksReport,
   AgentsListReport,
   DocsReport,
@@ -14,6 +15,7 @@ import {
   SearchResultsReport,
   SearchStatsReport,
   StatusReport,
+  TaskDetailReport,
   TasksListReport,
   TrashListReport,
   WorkflowsListReport,
@@ -65,6 +67,54 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('Write docs')
     expect(output).toContain('patch')
     expect(output).not.toContain('Column: todo; Agent: patch')
+  })
+
+  it('renders task and agent detail screens with shared TUI primitives', () => {
+    const task = renderToString(
+      <TaskDetailReport
+        taskId="task-1"
+        column="inProgress"
+        task={{
+          id: 'task-1',
+          title: 'Write docs',
+          agent: 'patch',
+          priority: 'high',
+        }}
+      />,
+    )
+    const agent = renderToString(
+      <AgentStatusReport
+        agentId="patch"
+        profile={{
+          id: 'patch',
+          name: 'Patch',
+          role: 'Engineer',
+          model: 'gpt-5.5',
+          workspacePath: '/tmp/patch',
+          soul: '# Patch Soul\n',
+          identity: '# Identity\n',
+          rules: '',
+          tools: null,
+          heartbeatMd: '# Heartbeat\nWorking on docs',
+          subagentPerms: ['docs'],
+        }}
+      />,
+    )
+
+    expect(task).toContain('Task Detail')
+    expect(task).toContain('id: task-1')
+    expect(task).toContain('TASK')
+    expect(task).toContain('Write docs')
+    expect(task).toContain('inProgress')
+    expect(task).toContain('FIELDS')
+    expect(task).toContain('priority')
+    expect(agent).toContain('Agent Status')
+    expect(agent).toContain('agent: patch')
+    expect(agent).toContain('PROFILE')
+    expect(agent).toContain('Patch')
+    expect(agent).toContain('gpt-5.5')
+    expect(agent).toContain('WORKSPACE')
+    expect(agent).toContain('heartbeat')
   })
 
   it('renders agents and plugins as shared TUI tables', () => {


### PR DESCRIPTION
## Summary
- render tasks get with a shared task detail TUI in TTYs
- render agents status with a shared agent status TUI in TTYs
- preserve existing plain/JSON output for non-TTY usage

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli