### PR TITLE
Migrate config read-only summaries to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -125,6 +125,24 @@ async function printStatusTui(dispatch: Record<string, unknown>, roster: CliRost
   console.log(renderToString(createElement(StatusReport, { dispatch, roster })))
 }
 
+async function printSettingsTui(settings: Record<string, unknown>): Promise<void> {
+  const [{ SettingsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(SettingsReport, { settings })))
+}
+
+async function printPathsTui(paths: Record<string, unknown>, isBakinHome: unknown): Promise<void> {
+  const [{ PathsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(PathsReport, { paths, isBakinHome })))
+}
+
 async function printTasksListTui(columns: Record<string, Array<Record<string, unknown>>>, column?: string): Promise<void> {
   const [{ TasksListReport }, { renderToString }, { createElement }] = await Promise.all([
     import('../src/core/cli/ui/readonly'),
@@ -396,6 +414,10 @@ async function cmdSettingsGet(key?: string): Promise<void> {
     }
     print(val)
   } else {
+    if (process.stdout.isTTY) {
+      await printSettingsTui(settings)
+      return
+    }
     print(settings)
   }
 }
@@ -1482,7 +1504,11 @@ async function cmdPaths(key?: string): Promise<void> {
     // Single path — print just the value (useful for scripting: bakin paths assets)
     console.log(result.path)
   } else {
-    const paths = result.paths as Record<string, string>
+    const paths = result.paths as Record<string, unknown>
+    if (process.stdout.isTTY) {
+      await printPathsTui(paths, result.isBakinHome)
+      return
+    }
     const isHome = result.isBakinHome ? '~/.bakin' : './content (not migrated)'
     console.log(`Content dir: ${isHome}`)
     console.log('')

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -110,6 +110,8 @@ export interface SearchStatsTableData {
   healthy?: unknown
 }
 
+export type SettingsData = Record<string, unknown>
+
 export interface AgentPackageData {
   agentId?: unknown
   state?: unknown
@@ -323,6 +325,10 @@ function objectField(value: unknown, key: string): unknown {
   return (value as Record<string, unknown>)[key]
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
 function bytesText(value: unknown): string {
   const bytes = typeof value === 'number' && Number.isFinite(value) ? value : Number(value)
   if (!Number.isFinite(bytes)) return valueText(value)
@@ -438,6 +444,21 @@ function taskDetailFields(task: TaskDetailData): DetailFieldRow[] {
   return Object.entries(task)
     .filter(([key]) => !primary.has(key))
     .map(([field, value]) => ({ field, value: detailText(value) }))
+}
+
+function flattenDetailFields(record: Record<string, unknown>, prefix = ''): DetailFieldRow[] {
+  return Object.entries(record).flatMap(([key, value]) => {
+    const field = prefix ? `${prefix}.${key}` : key
+    if (isPlainRecord(value)) return flattenDetailFields(value, field)
+    return [{ field, value: detailText(value) }]
+  })
+}
+
+function pathRows(paths: unknown): DetailFieldRow[] {
+  if (!isPlainRecord(paths)) return []
+  return Object.entries(paths)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([field, value]) => ({ field, value: valueText(value) }))
 }
 
 function contentPreview(value: unknown): string {
@@ -721,6 +742,69 @@ export function StatusReport({ dispatch, roster, color = true }: {
           label: roster.mainAgentId ?? 'main',
           message: agentCount > 0 ? roster.agentIds.join(', ') : 'No agents reported by the runtime.',
         }]} color={color} />
+      </Section>
+    </Box>
+  )
+}
+
+export function SettingsReport({ settings, color = true }: {
+  settings: SettingsData
+  color?: boolean
+}) {
+  const rows = flattenDetailFields(settings)
+  const sections = Object.keys(settings).length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Settings" subtitle="Runtime configuration snapshot" color={color} />
+      <SummaryStrip items={[
+        { label: plural(sections, 'section'), value: sections, status: sections > 0 ? 'ok' : 'skip' },
+        { label: plural(rows.length, 'value'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Configuration" color={color}>
+        {rows.length > 0 ? (
+          <DataTable
+            rows={rows}
+            columns={[
+              { key: 'field', header: 'FIELD', width: 34, render: row => row.field },
+              { key: 'value', header: 'VALUE', width: 52, grow: true, render: row => row.value },
+            ]}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No settings returned by the server.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function PathsReport({ paths, isBakinHome, color = true }: {
+  paths: Record<string, unknown>
+  isBakinHome?: unknown
+  color?: boolean
+}) {
+  const rows = pathRows(paths)
+  const homeLabel = isBakinHome ? '~/.bakin' : './content'
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Paths" subtitle="Bakin content directories" meta={`home: ${homeLabel}`} color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'path'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: isBakinHome ? 'bakin home' : 'legacy content', value: homeLabel, status: isBakinHome ? 'ok' : 'warn' },
+      ]} color={color} />
+      <Section title="Directories" color={color}>
+        {rows.length > 0 ? (
+          <DataTable
+            rows={rows}
+            columns={[
+              { key: 'field', header: 'KEY', width: 18, render: row => row.field },
+              { key: 'value', header: 'PATH', width: 64, grow: true, render: row => row.value },
+            ]}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No paths returned by the server.' }]} color={color} />
+        )}
       </Section>
     </Box>
   )

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -175,6 +175,38 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('Column: inProgress')
   })
 
+  it('renders setup configuration summaries with shared TUI screens in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      dispatch: { intervalMs: 300000, maxRetries: 3 },
+      runtime: { adapter: 'openclaw' },
+      plugins: { requireSignatures: false },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'settings', 'get']
+    await main()
+    expect(output()).toContain('Settings')
+    expect(output()).toContain('CONFIGURATION')
+    expect(output()).toContain('dispatch.intervalMs')
+    expect(output()).not.toContain('"dispatch"')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      isBakinHome: true,
+      paths: {
+        home: '/Users/roscoe/.bakin',
+        tasks: '/Users/roscoe/.bakin/tasks',
+        audit: '/Users/roscoe/.bakin/audit.jsonl',
+      },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'paths']
+    await main()
+    expect(output()).toContain('Paths')
+    expect(output()).toContain('DIRECTORIES')
+    expect(output()).toContain('/Users/roscoe/.bakin')
+    expect(output()).not.toContain('Content dir:')
+  })
+
   it('renders workflows list with the shared TUI screen in a TTY', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -9,11 +9,13 @@ import {
   AgentsListReport,
   DocsReport,
   PackagesListReport,
+  PathsReport,
   PluginsListReport,
   ScheduleListReport,
   ScheduleRunsReport,
   SearchResultsReport,
   SearchStatsReport,
+  SettingsReport,
   StatusReport,
   TaskDetailReport,
   TasksListReport,
@@ -115,6 +117,37 @@ describe('read-only CLI TUI screens', () => {
     expect(agent).toContain('gpt-5.5')
     expect(agent).toContain('WORKSPACE')
     expect(agent).toContain('heartbeat')
+  })
+
+  it('renders setup configuration summaries with shared TUI tables', () => {
+    const settings = renderToString(
+      <SettingsReport
+        settings={{
+          dispatch: { intervalMs: 300000, maxRetries: 3 },
+          runtime: { adapter: 'openclaw' },
+          plugins: { requireSignatures: false },
+        }}
+      />,
+    )
+    const paths = renderToString(
+      <PathsReport
+        isBakinHome={true}
+        paths={{
+          home: '/Users/roscoe/.bakin',
+          tasks: '/Users/roscoe/.bakin/tasks',
+          audit: '/Users/roscoe/.bakin/audit.jsonl',
+        }}
+      />,
+    )
+
+    expect(settings).toContain('Settings')
+    expect(settings).toContain('CONFIGURATION')
+    expect(settings).toContain('dispatch.intervalMs')
+    expect(settings).toContain('openclaw')
+    expect(paths).toContain('Paths')
+    expect(paths).toContain('DIRECTORIES')
+    expect(paths).toContain('home')
+    expect(paths).toContain('/Users/roscoe/.bakin')
   })
 
   it('renders agents and plugins as shared TUI tables', () => {


### PR DESCRIPTION
## Summary
- render no-key settings get with a shared settings TUI in TTYs
- render no-key paths with a shared paths TUI in TTYs
- preserve keyed/scalar output for scripting

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli