### PR TITLE
Migrate agent-rules output to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -18,6 +18,7 @@ import {
   type PluginImportInstallRequest,
 } from '../src/core/plugins/import-export'
 import type {
+  AgentRuleResultData,
   SearchAggregationsData,
   SearchMetaData,
   SearchResultData,
@@ -141,6 +142,18 @@ async function printPathsTui(paths: Record<string, unknown>, isBakinHome: unknow
     import('react'),
   ])
   console.log(renderToString(createElement(PathsReport, { paths, isBakinHome })))
+}
+
+async function printAgentRulesTui(
+  results: AgentRuleResultData[],
+  options: { mode: 'check' | 'apply'; scope: 'orchestrator' | 'all' },
+): Promise<void> {
+  const [{ AgentRulesReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(AgentRulesReport, { results, ...options })))
 }
 
 async function printTasksListTui(columns: Record<string, Array<Record<string, unknown>>>, column?: string): Promise<void> {
@@ -1479,21 +1492,39 @@ async function cmdAgentRules(options: { apply?: boolean; check?: boolean; applyA
     return
   }
 
-  const { applyManagedBlocks } = await import('../src/core/agent-rules/managed-blocks')
   const scope = options.apply || options.check ? 'orchestrator' : 'all'
   const autoFix = !!(options.apply || options.applyAll)
-  const results = await applyManagedBlocks(autoFix, { scope })
+
+  const previousConsoleFormat = process.env.BAKIN_CONSOLE_FORMAT
+  const shouldSilenceRuntimeLogs = process.stdout.isTTY && previousConsoleFormat === undefined
+  let results: Awaited<ReturnType<typeof import('../src/core/agent-rules/managed-blocks')['applyManagedBlocks']>>
+  try {
+    if (shouldSilenceRuntimeLogs) process.env.BAKIN_CONSOLE_FORMAT = 'silent'
+    const { applyManagedBlocks } = await import('../src/core/agent-rules/managed-blocks')
+    results = await applyManagedBlocks(autoFix, { scope })
+  } finally {
+    if (shouldSilenceRuntimeLogs) delete process.env.BAKIN_CONSOLE_FORMAT
+  }
+
   const errors = results.filter(r => r.status === 'error')
   const warnings = results.filter(r => r.status === 'warn')
   const fixes = results.filter(r => r.status === 'fixed')
   const oks = results.filter(r => r.status === 'ok')
 
-  for (const r of results) {
-    const icon = r.status === 'ok' ? '[OK]' : r.status === 'fixed' ? '[FIXED]' : r.status === 'warn' ? '[WARN]' : '[ERROR]'
-    console.log(`${icon} ${r.check}: ${r.message}`)
+  if (process.stdout.isTTY) {
+    await printAgentRulesTui(results, {
+      mode: autoFix ? 'apply' : 'check',
+      scope,
+    })
+  } else {
+    for (const r of results) {
+      const icon = r.status === 'ok' ? '[OK]' : r.status === 'fixed' ? '[FIXED]' : r.status === 'warn' ? '[WARN]' : '[ERROR]'
+      console.log(`${icon} ${r.check}: ${r.message}`)
+    }
+
+    console.log(`\n${oks.length} up to date, ${fixes.length} fixed, ${warnings.length} warnings, ${errors.length} errors`)
   }
 
-  console.log(`\n${oks.length} up to date, ${fixes.length} fixed, ${warnings.length} warnings, ${errors.length} errors`)
   if (errors.length > 0 || warnings.length > 0) process.exit(1)
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -112,6 +112,13 @@ export interface SearchStatsTableData {
 
 export type SettingsData = Record<string, unknown>
 
+export interface AgentRuleResultData {
+  check?: unknown
+  status?: unknown
+  message?: unknown
+  autoFixable?: unknown
+}
+
 export interface AgentPackageData {
   agentId?: unknown
   state?: unknown
@@ -461,6 +468,52 @@ function pathRows(paths: unknown): DetailFieldRow[] {
     .map(([field, value]) => ({ field, value: valueText(value) }))
 }
 
+function agentRuleStatus(value: unknown): TuiStatus {
+  switch (value) {
+    case 'ok':
+      return 'ok'
+    case 'fixed':
+      return 'applied'
+    case 'warn':
+      return 'warn'
+    case 'error':
+      return 'fail'
+    default:
+      return 'skip'
+  }
+}
+
+function agentRuleSummaryItems(results: AgentRuleResultData[]): SummaryItem[] {
+  const ok = results.filter(result => result.status === 'ok').length
+  const fixed = results.filter(result => result.status === 'fixed').length
+  const warnings = results.filter(result => result.status === 'warn').length
+  const errors = results.filter(result => result.status === 'error').length
+
+  return [
+    { label: 'up to date', value: ok, status: 'ok' },
+    { label: 'fixed', value: fixed, status: fixed > 0 ? 'applied' : 'ok' },
+    { label: 'warnings', value: warnings, status: warnings > 0 ? 'warn' : 'ok' },
+    { label: 'errors', value: errors, status: errors > 0 ? 'fail' : 'ok' },
+  ]
+}
+
+function agentRuleRows(results: AgentRuleResultData[], mode: 'check' | 'apply') {
+  return results.map(result => {
+    const status = agentRuleStatus(result.status)
+    const autoFixable = Boolean(result.autoFixable)
+    const next = mode === 'check' && autoFixable && (status === 'warn' || status === 'fail')
+      ? 'Run `bakin agent-rules --apply` to write managed context.'
+      : undefined
+
+    return {
+      status,
+      label: valueText(result.check, 'check'),
+      message: valueText(result.message, 'No result message returned.'),
+      next,
+    }
+  })
+}
+
 function contentPreview(value: unknown): string {
   const text = valueText(value, '')
   if (!text) return 'missing'
@@ -804,6 +857,34 @@ export function PathsReport({ paths, isBakinHome, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No paths returned by the server.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function AgentRulesReport({ results, mode, scope, color = true }: {
+  results: AgentRuleResultData[]
+  mode: 'check' | 'apply'
+  scope: 'orchestrator' | 'all'
+  color?: boolean
+}) {
+  const rows = agentRuleRows(results, mode)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader
+        title="Agent Rules"
+        subtitle={mode === 'apply' ? 'Managed AGENTS.md context applied' : 'Managed AGENTS.md context checked'}
+        meta={`scope: ${scope}`}
+        color={color}
+      />
+      <SummaryStrip items={agentRuleSummaryItems(results)} color={color} />
+      <Section title="Checks" color={color}>
+        {rows.length > 0 ? (
+          <FindingRows rows={rows} color={color} />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No agent-rules results returned.' }]} color={color} />
         )}
       </Section>
     </Box>

--- a/tests/cli/agent-rules-command.test.ts
+++ b/tests/cli/agent-rules-command.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const applyManagedBlocksMock = mock(async () => {
+  const { createLogger } = await import('../../packages/core/src/logger')
+  createLogger('settings').info('Settings loaded')
+  return [
+    { check: 'managed-context', status: 'ok', message: 'Managed context is current', autoFixable: false },
+    { check: 'subagent-context', status: 'fixed', message: 'Updated stale context', autoFixable: true },
+  ]
+})
+
+mock.module('../../src/core/agent-rules/managed-blocks', () => ({
+  applyManagedBlocks: applyManagedBlocksMock,
+}))
+
+describe('agent-rules CLI TTY output', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let log: ReturnType<typeof spyOn>
+
+  function setStdoutIsTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+  }
+
+  function output(): string {
+    return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+  }
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    applyManagedBlocksMock.mockResolvedValue([
+      { check: 'managed-context', status: 'ok', message: 'Managed context is current', autoFixable: false },
+      { check: 'subagent-context', status: 'fixed', message: 'Updated stale context', autoFixable: true },
+    ])
+    process.argv = originalArgv
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    process.exit = ((code?: number) => {
+      if (code === 0) return undefined as never
+      throw new Error(`exit:${code}`)
+    }) as never
+    setStdoutIsTTY(true)
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+    log.mockRestore()
+  })
+
+  it('renders agent-rules results with the shared TUI in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    process.argv = ['bun', 'cli/bakin.ts', 'agent-rules', '--apply']
+    await main()
+
+    expect(applyManagedBlocksMock).toHaveBeenCalledWith(true, { scope: 'orchestrator' })
+    expect(output()).toContain('Agent Rules')
+    expect(output()).toContain('scope: orchestrator')
+    expect(output()).toContain('CHECKS')
+    expect(output()).toContain('managed-context')
+    expect(output()).toContain('Updated stale context')
+    expect(output()).not.toContain('Settings loaded')
+    expect(output()).not.toContain('[OK] managed-context')
+  })
+})

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -4,6 +4,7 @@ import { renderToString } from 'ink'
 import {
   AgentLessonsListReport,
   AgentPackagesListReport,
+  AgentRulesReport,
   AgentStatusReport,
   AgentTasksReport,
   AgentsListReport,
@@ -148,6 +149,30 @@ describe('read-only CLI TUI screens', () => {
     expect(paths).toContain('DIRECTORIES')
     expect(paths).toContain('home')
     expect(paths).toContain('/Users/roscoe/.bakin')
+  })
+
+  it('renders agent-rules check results with shared TUI primitives', () => {
+    const output = renderToString(
+      <AgentRulesReport
+        mode="check"
+        scope="orchestrator"
+        results={[
+          { check: 'managed-context', status: 'ok', message: 'Managed context is current' },
+          { check: 'subagent-context', status: 'fixed', message: 'Updated stale context' },
+          { check: 'runtime-agents', status: 'warn', message: 'No runtime agents found' },
+          { check: 'workspace', status: 'error', message: 'Failed to read AGENTS.md' },
+        ]}
+      />,
+    )
+
+    expect(output).toContain('Agent Rules')
+    expect(output).toContain('scope: orchestrator')
+    expect(output).toContain('CHECKS')
+    expect(output).toContain('managed-context')
+    expect(output).toContain('Updated stale context')
+    expect(output).toContain('No runtime agents found')
+    expect(output).toContain('Failed to read AGENTS.md')
+    expect(output).not.toContain('[OK] managed-context')
   })
 
   it('renders agents and plugins as shared TUI tables', () => {


### PR DESCRIPTION
## Summary
- render agent-rules check/apply results with the shared TUI in TTYs
- keep existing plain output for non-TTY scripting
- add focused render and command coverage for the agent-rules path

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/agent-rules-command.test.ts
- bun run typecheck
- bun test --isolate tests/cli