### PR TITLE
Migrate reindex output to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -19,6 +19,7 @@ import {
 } from '../src/core/plugins/import-export'
 import type {
   AgentRuleResultData,
+  ReindexResultData,
   SearchAggregationsData,
   SearchMetaData,
   SearchResultData,
@@ -256,6 +257,15 @@ async function printSearchStatsTui(enabled: boolean, tables: Array<Record<string
     import('react'),
   ])
   console.log(renderToString(createElement(SearchStatsReport, { enabled, tables })))
+}
+
+async function printReindexTui(result: ReindexResultData, options: { target: string; rebuild: boolean }): Promise<void> {
+  const [{ ReindexReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(ReindexReport, { result, ...options })))
 }
 
 async function printTrashListTui(assets: Array<Record<string, unknown>>): Promise<void> {
@@ -1820,8 +1830,11 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
   if (options.rebuild) params.push('rebuild=true')
   if (params.length) url += `?${params.join('&')}`
 
-  console.log(`Reindexing ${options.table || 'all content'} into search${options.rebuild ? ' (rebuild indexes)' : ''}...`)
-  const result = await apiPost(url) as {
+  const target = options.table || 'all content'
+  if (!process.stdout.isTTY) {
+    console.log(`Reindexing ${target} into search${options.rebuild ? ' (rebuild indexes)' : ''}...`)
+  }
+  const result = await apiPost(url) as ReindexResultData & {
     ok: boolean
     total: number
     errors: number
@@ -1832,6 +1845,10 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
       error?: string
       enrichment?: { healthy: boolean; indexes: Array<{ name: string; error?: string; walBacklog: number }> }
     }>
+  }
+  if (process.stdout.isTTY) {
+    await printReindexTui(result, { target, rebuild: options.rebuild === true })
+    return
   }
   if (result.tables?.length) {
     for (const t of result.tables) {

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -110,6 +110,21 @@ export interface SearchStatsTableData {
   healthy?: unknown
 }
 
+export interface ReindexTableData {
+  table?: unknown
+  indexed?: unknown
+  error?: unknown
+  enrichment?: unknown
+}
+
+export interface ReindexResultData {
+  ok?: unknown
+  total?: unknown
+  errors?: unknown
+  enrichmentErrors?: unknown
+  tables?: ReindexTableData[]
+}
+
 export type SettingsData = Record<string, unknown>
 
 export interface AgentRuleResultData {
@@ -229,6 +244,14 @@ interface SearchStatsTableRow {
   plugin: string
   docs: string
   health: string
+}
+
+interface ReindexTableRow {
+  status: TuiStatus
+  table: string
+  docs: string
+  enrichment: string
+  issue: string
 }
 
 interface AgentPackageTableRow {
@@ -629,6 +652,36 @@ function searchStatsTableRows(tables: SearchStatsTableData[], enabled: boolean):
     docs: searchStatsDocCount(table.stats),
     health: searchStatsHealth(table, enabled),
   }))
+}
+
+function reindexEnrichmentText(value: unknown): string {
+  if (!isPlainRecord(value)) return '-'
+  const indexes = Array.isArray(value.indexes) ? value.indexes : []
+  const issues = indexes.flatMap(index => {
+    if (!isPlainRecord(index)) return []
+    const name = valueText(index.name, 'index')
+    const error = valueText(index.error, '')
+    if (error) return [`${name}: ${error}`]
+    const walBacklog = numberValue(index.walBacklog)
+    if (walBacklog > 0) return [`${name}: ${walBacklog} wal`]
+    return []
+  })
+  if (issues.length > 0) return issues.join(', ')
+  return value.healthy === false ? 'unhealthy' : 'healthy'
+}
+
+function reindexTableRows(tables: ReindexTableData[]): ReindexTableRow[] {
+  return tables.map(table => {
+    const hasError = Boolean(table.error)
+    const enrichmentUnhealthy = isPlainRecord(table.enrichment) && table.enrichment.healthy === false
+    return {
+      status: hasError ? 'fail' : enrichmentUnhealthy ? 'warn' : 'ok',
+      table: valueText(table.table, '(unknown)'),
+      docs: valueText(table.indexed, '0'),
+      enrichment: reindexEnrichmentText(table.enrichment),
+      issue: valueText(table.error),
+    }
+  })
 }
 
 function packageStateStatus(state: string): TuiStatus {
@@ -1247,6 +1300,51 @@ export function SearchStatsReport({ enabled, tables, color = true }: {
           />
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No search tables are registered.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function ReindexReport({ result, target = 'all content', rebuild = false, color = true }: {
+  result: ReindexResultData
+  target?: string
+  rebuild?: boolean
+  color?: boolean
+}) {
+  const rows = reindexTableRows(result.tables ?? [])
+  const total = numberValue(result.total)
+  const errors = numberValue(result.errors)
+  const enrichmentErrors = numberValue(result.enrichmentErrors)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader
+        title="Reindex"
+        subtitle={rebuild ? 'Search content indexed with rebuilt indexes' : 'Search content indexed'}
+        meta={`target: ${target}`}
+        color={color}
+      />
+      <SummaryStrip items={[
+        { label: plural(total, 'document'), value: total, status: total > 0 ? 'ok' : 'skip' },
+        { label: plural(rows.length, 'table'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
+        { label: 'errors', value: errors, status: errors > 0 ? 'fail' : 'ok' },
+        { label: 'enrichment', value: enrichmentErrors, status: enrichmentErrors > 0 ? 'warn' : 'ok' },
+      ]} color={color} />
+      <Section title="Tables" color={color}>
+        {rows.length > 0 ? (
+          <StatusTable
+            rows={rows}
+            columns={[
+              { key: 'table', header: 'TABLE', width: 16, render: row => row.table },
+              { key: 'docs', header: 'DOCS', width: 6, render: row => row.docs },
+              { key: 'enrichment', header: 'ENRICHMENT', width: 18, render: row => row.enrichment },
+              { key: 'issue', header: 'ISSUE', width: 24, grow: true, render: row => row.issue },
+            ]}
+            color={color}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No reindex table results returned.' }]} color={color} />
         )}
       </Section>
     </Box>

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -422,4 +422,33 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('bakin_tasks')
     expect(output()).not.toContain('Search: enabled')
   })
+
+  it('renders reindex results with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: false,
+      total: 12,
+      errors: 1,
+      enrichmentErrors: 1,
+      tables: [
+        { table: 'bakin_tasks', indexed: 12, enrichment: { healthy: true, indexes: [] } },
+        { table: 'agent_lessons', indexed: 0, error: 'schema missing' },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'reindex', '--table', 'tasks', '--rebuild']
+    await main()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3737/api/reindex?table=tasks&rebuild=true',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(output()).toContain('Reindex')
+    expect(output()).toContain('target: tasks')
+    expect(output()).toContain('TABLES')
+    expect(output()).toContain('bakin_tasks')
+    expect(output()).toContain('agent_lessons')
+    expect(output()).toContain('schema missing')
+    expect(output()).not.toContain('Reindexing tasks into search')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -12,6 +12,7 @@ import {
   PackagesListReport,
   PathsReport,
   PluginsListReport,
+  ReindexReport,
   ScheduleListReport,
   ScheduleRunsReport,
   SearchResultsReport,
@@ -173,6 +174,35 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('No runtime agents found')
     expect(output).toContain('Failed to read AGENTS.md')
     expect(output).not.toContain('[OK] managed-context')
+  })
+
+  it('renders reindex results with shared TUI tables', () => {
+    const output = renderToString(
+      <ReindexReport
+        target="tasks"
+        rebuild={true}
+        result={{
+          ok: false,
+          total: 12,
+          errors: 1,
+          enrichmentErrors: 1,
+          tables: [
+            { table: 'bakin_tasks', indexed: 12, enrichment: { healthy: true, indexes: [] } },
+            { table: 'agent_lessons', indexed: 0, error: 'schema missing' },
+            { table: 'assets', indexed: 4, enrichment: { healthy: false, indexes: [{ name: 'semantic', error: 'offline', walBacklog: 2 }] } },
+          ],
+        }}
+      />,
+    )
+
+    expect(output).toContain('Reindex')
+    expect(output).toContain('target: tasks')
+    expect(output).toContain('TABLES')
+    expect(output).toContain('bakin_tasks')
+    expect(output).toContain('agent_lessons')
+    expect(output).toContain('schema missing')
+    expect(output).toContain('semantic: offline')
+    expect(output).not.toContain('Reindexing tasks into search')
   })
 
   it('renders agents and plugins as shared TUI tables', () => {


### PR DESCRIPTION
## Summary
- render reindex results with the shared TUI in TTYs
- show per-table indexing, enrichment, and error state in a status table
- keep existing plain output for non-TTY/script usage

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli