### PR TITLE
Migrate plugin restore output to shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -19,6 +19,8 @@ import {
 } from '../src/core/plugins/import-export'
 import type {
   AgentRuleResultData,
+  PluginRestoreResultData,
+  PluginRestoreSnapshotData,
   ReindexResultData,
   SearchAggregationsData,
   SearchMetaData,
@@ -209,6 +211,24 @@ async function printPluginsListTui(routes: Array<Record<string, unknown>>): Prom
     import('react'),
   ])
   console.log(renderToString(createElement(PluginsListReport, { routes })))
+}
+
+async function printPluginRestoreSnapshotsTui(pluginId: string, snapshots: PluginRestoreSnapshotData[]): Promise<void> {
+  const [{ PluginRestoreSnapshotsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(PluginRestoreSnapshotsReport, { pluginId, snapshots })))
+}
+
+async function printPluginRestoreResultTui(pluginId: string, result: PluginRestoreResultData): Promise<void> {
+  const [{ PluginRestoreResultReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(PluginRestoreResultReport, { pluginId, result })))
 }
 
 async function printDocsTui(routes: Array<Record<string, unknown>>): Promise<void> {
@@ -668,12 +688,23 @@ async function cmdPluginsRestore(pluginId: string, opts: { snapshot?: string; fo
   const result = await res.json().catch(() => ({})) as PluginRestoreResult
   if (opts.list) {
     if (result.error) throw new Error(result.error)
+    if (process.stdout.isTTY) {
+      await printPluginRestoreSnapshotsTui(pluginId, result.snapshots ?? [])
+      return
+    }
     printPluginRestoreSnapshots(pluginId, result.snapshots)
     return
   }
   if (!res.ok || result.error) {
-    if (result.snapshots && result.snapshots.length > 0) printPluginRestoreSnapshots(pluginId, result.snapshots)
+    if (result.snapshots && result.snapshots.length > 0) {
+      if (process.stdout.isTTY) await printPluginRestoreSnapshotsTui(pluginId, result.snapshots)
+      else printPluginRestoreSnapshots(pluginId, result.snapshots)
+    }
     throw new Error(result.error ?? `HTTP ${res.status}`)
+  }
+  if (process.stdout.isTTY) {
+    await printPluginRestoreResultTui(pluginId, result)
+    return
   }
   console.log(result.message ?? `Restored plugin: ${pluginId}`)
   if (result.snapshotInfo) {

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -64,6 +64,24 @@ export interface PluginRouteData {
   pluginId?: unknown
 }
 
+export interface PluginRestoreSnapshotData {
+  timestamp?: unknown
+  createdAt?: unknown
+  filename?: unknown
+  sizeBytes?: unknown
+}
+
+export interface PluginRestoreResultData {
+  ok?: unknown
+  message?: unknown
+  snapshot?: unknown
+  snapshotInfo?: PluginRestoreSnapshotData
+  snapshots?: PluginRestoreSnapshotData[]
+  skills?: unknown
+  restored?: unknown
+  activated?: unknown
+}
+
 export interface ApiRouteData {
   method?: unknown
   fullPath?: unknown
@@ -215,6 +233,13 @@ interface PluginTableRow {
   status: TuiStatus
   plugin: string
   routes: string
+}
+
+interface PluginRestoreSnapshotRow {
+  timestamp: string
+  created: string
+  size: string
+  filename: string
 }
 
 interface ApiRouteTableRow {
@@ -566,6 +591,45 @@ function pluginTableRows(routes: PluginRouteData[]): PluginTableRow[] {
     plugin: plugin.pluginId,
     routes: String(plugin.routeCount),
   }))
+}
+
+function pluginRestoreSnapshotRows(snapshots: PluginRestoreSnapshotData[]): PluginRestoreSnapshotRow[] {
+  return snapshots.map(snapshot => ({
+    timestamp: valueText(snapshot.timestamp),
+    created: timestampText(snapshot.createdAt),
+    size: bytesText(snapshot.sizeBytes),
+    filename: valueText(snapshot.filename),
+  }))
+}
+
+function pluginRestoreSnapshotName(result: PluginRestoreResultData): string {
+  return valueText(result.snapshotInfo?.filename ?? result.snapshot)
+}
+
+function pluginRestoreSkillsRestored(result: PluginRestoreResultData): number {
+  return numberValue(objectField(result.skills, 'restored'))
+}
+
+function pluginRestoreResultRows(pluginId: string, result: PluginRestoreResultData) {
+  const skillsRestored = pluginRestoreSkillsRestored(result)
+  const rows = [
+    {
+      status: result.restored === false ? 'warn' as TuiStatus : 'ok' as TuiStatus,
+      label: pluginId,
+      message: valueText(result.message, `Restored plugin: ${pluginId}`),
+    },
+  ]
+
+  rows.push({
+    status: skillsRestored > 0 ? 'ok' : 'skip',
+    label: 'runtime skills',
+    message: `${skillsRestored} restored`,
+  })
+  rows.push(result.activated === false
+    ? { status: 'warn', label: 'activation', message: 'Activation deferred until next server start.' }
+    : { status: 'ok', label: 'activation', message: 'Plugin activated.' })
+
+  return rows
 }
 
 function apiRouteTableRows(routes: ApiRouteData[]): ApiRouteTableRow[] {
@@ -1155,6 +1219,68 @@ export function PluginsListReport({ routes, color = true }: {
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No non-core plugins found.' }]} color={color} />
         )}
       </Section>
+    </Box>
+  )
+}
+
+export function PluginRestoreSnapshotsReport({ pluginId, snapshots, color = true }: {
+  pluginId: string
+  snapshots: PluginRestoreSnapshotData[]
+  color?: boolean
+}) {
+  const rows = pluginRestoreSnapshotRows(snapshots)
+  const latest = rows[0]?.timestamp ?? '-'
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Plugin Restore" subtitle="Available uninstall snapshots" meta={`plugin: ${pluginId}`} color={color} />
+      <SummaryStrip items={[
+        { label: plural(rows.length, 'snapshot'), value: rows.length, status: rows.length > 0 ? 'ready' : 'skip' },
+        { label: 'latest', value: latest, status: rows.length > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Snapshots" color={color}>
+        {rows.length > 0 ? (
+          <DataTable
+            rows={rows}
+            columns={[
+              { key: 'timestamp', header: 'TIMESTAMP', width: 25, render: row => row.timestamp },
+              { key: 'created', header: 'CREATED', width: 20, render: row => row.created },
+              { key: 'size', header: 'SIZE', width: 9, render: row => row.size },
+              { key: 'filename', header: 'FILENAME', width: 34, grow: true, render: row => row.filename },
+            ]}
+          />
+        ) : (
+          <FindingRows rows={[{ status: 'skip', label: 'empty', message: `No uninstall snapshots found for plugin "${pluginId}".` }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function PluginRestoreResultReport({ pluginId, result, color = true }: {
+  pluginId: string
+  result: PluginRestoreResultData
+  color?: boolean
+}) {
+  const skillsRestored = pluginRestoreSkillsRestored(result)
+  const snapshot = pluginRestoreSnapshotName(result)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Plugin Restore" subtitle="Plugin restored from uninstall snapshot" meta={`plugin: ${pluginId}`} color={color} />
+      <SummaryStrip items={[
+        { label: 'restored', value: pluginId, status: result.restored === false ? 'warn' : 'ok' },
+        { label: 'runtime skills', value: skillsRestored, status: skillsRestored > 0 ? 'ok' : 'skip' },
+        { label: result.activated === false ? 'deferred' : 'activated', value: result.activated === false ? 'restart' : 'now', status: result.activated === false ? 'warn' : 'ok' },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={pluginRestoreResultRows(pluginId, result)} color={color} />
+      </Section>
+      {snapshot === '-' ? null : (
+        <Section title="Snapshot" color={color}>
+          <FindingRows rows={[{ status: 'ok', label: 'file', message: snapshot }]} color={color} />
+        </Section>
+      )}
     </Box>
   )
 }

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -451,4 +451,51 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('schema missing')
     expect(output()).not.toContain('Reindexing tasks into search')
   })
+
+  it('renders plugin restore snapshots and results with shared TUI screens in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      snapshots: [
+        {
+          timestamp: '2026-05-04T00-00-00-000Z',
+          createdAt: '2026-05-04T00:00:00.000Z',
+          filename: 'demo-plugin-2026.tar.gz',
+          sizeBytes: 4096,
+        },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'plugins', 'restore', 'demo-plugin', '--list']
+    await main()
+
+    expect(output()).toContain('Plugin Restore')
+    expect(output()).toContain('plugin: demo-plugin')
+    expect(output()).toContain('SNAPSHOTS')
+    expect(output()).toContain('demo-plugin-2026.tar.gz')
+    expect(output()).not.toContain('Uninstall snapshots for')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      message: 'Restored "demo-plugin".',
+      snapshotInfo: {
+        timestamp: '2026-05-04T00-00-00-000Z',
+        createdAt: '2026-05-04T00:00:00.000Z',
+        filename: 'demo-plugin-2026.tar.gz',
+        sizeBytes: 4096,
+      },
+      skills: { restored: 2 },
+      activated: false,
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'plugins', 'restore', 'demo-plugin', '--snapshot', 'demo-plugin-2026.tar.gz', '--force']
+    await main()
+
+    expect(output()).toContain('Plugin Restore')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Restored "demo-plugin".')
+    expect(output()).toContain('demo-plugin-2026.tar.gz')
+    expect(output()).toContain('Activation deferred until next server start.')
+    expect(output()).not.toContain('Restored plugin:')
+  })
 })

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -11,6 +11,8 @@ import {
   DocsReport,
   PackagesListReport,
   PathsReport,
+  PluginRestoreResultReport,
+  PluginRestoreSnapshotsReport,
   PluginsListReport,
   ReindexReport,
   ScheduleListReport,
@@ -203,6 +205,50 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('schema missing')
     expect(output).toContain('semantic: offline')
     expect(output).not.toContain('Reindexing tasks into search')
+  })
+
+  it('renders plugin restore snapshots and results with shared TUI primitives', () => {
+    const snapshots = renderToString(
+      <PluginRestoreSnapshotsReport
+        pluginId="demo-plugin"
+        snapshots={[
+          {
+            timestamp: '2026-05-04T00-00-00-000Z',
+            createdAt: '2026-05-04T00:00:00.000Z',
+            filename: 'demo-plugin-2026.tar.gz',
+            sizeBytes: 4096,
+          },
+        ]}
+      />,
+    )
+    const result = renderToString(
+      <PluginRestoreResultReport
+        pluginId="demo-plugin"
+        result={{
+          ok: true,
+          message: 'Restored "demo-plugin".',
+          snapshotInfo: {
+            timestamp: '2026-05-04T00-00-00-000Z',
+            createdAt: '2026-05-04T00:00:00.000Z',
+            filename: 'demo-plugin-2026.tar.gz',
+            sizeBytes: 4096,
+          },
+          skills: { restored: 2 },
+          activated: false,
+        }}
+      />,
+    )
+
+    expect(snapshots).toContain('Plugin Restore')
+    expect(snapshots).toContain('plugin: demo-plugin')
+    expect(snapshots).toContain('SNAPSHOTS')
+    expect(snapshots).toContain('demo-plugin-2026.tar.gz')
+    expect(snapshots).not.toContain('Uninstall snapshots for')
+    expect(result).toContain('Plugin Restore')
+    expect(result).toContain('RESULT')
+    expect(result).toContain('Restored "demo-plugin".')
+    expect(result).toContain('demo-plugin-2026.tar.gz')
+    expect(result).toContain('Activation deferred until next server start.')
   })
 
   it('renders agents and plugins as shared TUI tables', () => {


### PR DESCRIPTION
## Summary
- render plugin restore snapshot lists with the shared TUI in TTYs
- render successful plugin restore results with the shared TUI in TTYs
- keep existing plain output for non-TTY/script usage

## Tests
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli