### PR TITLE
Render doctor repair subcommands with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1270,6 +1270,33 @@ async function printDoctorDelegateResultTui(report: CliDoctorDelegateReport, opt
   console.log(renderToString(createElement(DoctorDelegateResult, { report, showBrand: opts.showBrand })))
 }
 
+async function printDoctorRepairRequestsTui(requests: Array<Record<string, unknown>>): Promise<void> {
+  const [{ DoctorRepairRequestsReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorRepairRequestsReport, { requests })))
+}
+
+async function printDoctorRepairRequestTui(request: Record<string, unknown>): Promise<void> {
+  const [{ DoctorRepairRequestReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorRepairRequestReport, { request })))
+}
+
+async function printDoctorRepairVerifyTui(requestId: string, result: Record<string, unknown>): Promise<void> {
+  const [{ DoctorRepairVerifyReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/doctor-repair'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(DoctorRepairVerifyReport, { requestId, result })))
+}
+
 async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> {
   if (plan.summary.safeItems === 0) return false
   const readline = await import('node:readline/promises')
@@ -1397,7 +1424,24 @@ async function cmdDoctorDelegate(options: { json: boolean; yes: boolean; isTTY: 
   }
 }
 
-async function cmdDoctorRepair(args: string[], options: { json: boolean }): Promise<void> {
+function doctorRepairRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function doctorRepairRequestFromResponse(result: unknown): Record<string, unknown> {
+  const data = doctorRepairRecord(result) ?? {}
+  return doctorRepairRecord(data.request) ?? data
+}
+
+function doctorRepairRequestList(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => doctorRepairRecord(item) !== null)
+    : []
+}
+
+async function cmdDoctorRepair(args: string[], options: { json: boolean; isTTY: boolean }): Promise<void> {
   const sub = args[1] ?? 'list'
   if (sub === 'list') {
     const result = await apiGet('/api/plugins/health/doctor/repair') as { requests?: Array<Record<string, unknown>> }
@@ -1405,7 +1449,11 @@ async function cmdDoctorRepair(args: string[], options: { json: boolean }): Prom
       printDoctorRepairJson(result, 0)
       return
     }
-    const requests = result.requests ?? []
+    const requests = doctorRepairRequestList(result.requests)
+    if (options.isTTY) {
+      await printDoctorRepairRequestsTui(requests)
+      return
+    }
     if (requests.length === 0) {
       console.log('No doctor repair requests.')
       return
@@ -1428,6 +1476,10 @@ async function cmdDoctorRepair(args: string[], options: { json: boolean }): Prom
       printDoctorRepairJson(result, 0)
       return
     }
+    if (options.isTTY) {
+      await printDoctorRepairRequestTui(doctorRepairRequestFromResponse(result))
+      return
+    }
     print(result)
     return
   }
@@ -1436,6 +1488,10 @@ async function cmdDoctorRepair(args: string[], options: { json: boolean }): Prom
     const result = await apiPost(`/api/plugins/health/doctor/repair/${encodeURIComponent(requestId)}/verify`)
     if (options.json) {
       printDoctorRepairJson(result, 0)
+      return
+    }
+    if (options.isTTY) {
+      await printDoctorRepairVerifyTui(requestId, doctorRepairRecord(result) ?? {})
       return
     }
     print(result)
@@ -1455,7 +1511,7 @@ async function cmdDoctor(args: string[] = process.argv.slice(2)): Promise<void> 
   const yes = args.includes('--yes')
   const isTTY = Boolean(process.stdout.isTTY)
   if (args[0] === 'repair') {
-    await cmdDoctorRepair(args, { json })
+    await cmdDoctorRepair(args, { json, isTTY })
     return
   }
   if (fix) {

--- a/src/core/cli/ui/doctor-repair.tsx
+++ b/src/core/cli/ui/doctor-repair.tsx
@@ -5,9 +5,11 @@ import {
   NextActions,
   ScreenHeader,
   Section,
+  StatusTable,
   SummaryStrip,
   type FindingRow,
   type SummaryItem,
+  type TableColumn,
 } from './tui'
 
 export interface DoctorRepairDiagnostic {
@@ -74,8 +76,60 @@ export interface DoctorDelegateReportData {
   unresolved: DoctorRepairDiagnostic[]
 }
 
+export interface DoctorRepairRequestEventData {
+  ts?: unknown
+  type?: unknown
+  message?: unknown
+  data?: unknown
+}
+
+export interface DoctorRepairRequestData {
+  id?: unknown
+  kind?: unknown
+  status?: unknown
+  createdAt?: unknown
+  updatedAt?: unknown
+  plan?: unknown
+  unresolved?: unknown
+  taskId?: unknown
+  agentId?: unknown
+  events?: unknown
+}
+
+export interface DoctorRepairVerificationData {
+  request?: unknown
+  remaining?: unknown
+  verified?: unknown
+}
+
 function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
   return count === 1 ? singular : pluralLabel
+}
+
+function valueText(value: unknown, fallback = '-'): string {
+  if (typeof value === 'string') return value.length > 0 ? value : fallback
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return fallback
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+function diagnosticList(value: unknown): DoctorRepairDiagnostic[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((row) => {
+    const item = objectValue(row)
+    if (!item) return []
+    return [{
+      check: valueText(item.check, 'finding'),
+      status: valueText(item.status, 'warn'),
+      message: valueText(item.message, 'No message provided.'),
+      autoFixable: typeof item.autoFixable === 'boolean' ? item.autoFixable : undefined,
+    }]
+  })
 }
 
 function statusForDiagnostic(status: string): TuiStatus {
@@ -92,6 +146,36 @@ function statusForDiagnostic(status: string): TuiStatus {
       return 'fail'
     case 'skipped':
       return 'skip'
+    default:
+      return 'run'
+  }
+}
+
+function statusForRequest(status: unknown): TuiStatus {
+  switch (valueText(status, '').toLowerCase()) {
+    case 'verified':
+    case 'completed':
+      return 'done'
+    case 'sent':
+      return 'sent'
+    case 'planned':
+      return 'todo'
+    case 'failed':
+      return 'fail'
+    default:
+      return 'run'
+  }
+}
+
+function statusForEvent(type: unknown): TuiStatus {
+  switch (valueText(type, '').toLowerCase()) {
+    case 'verified':
+      return 'done'
+    case 'task-created':
+    case 'dispatch-kicked':
+      return 'sent'
+    case 'failed':
+      return 'fail'
     default:
       return 'run'
   }
@@ -175,9 +259,99 @@ function resultRows(results: DoctorRepairApplyData['applied'] | DoctorRepairAppl
   }))
 }
 
+function requestValue(request: Record<string, unknown>, key: string): string | undefined {
+  const value = request[key]
+  const text = valueText(value, '')
+  return text.length > 0 ? text : undefined
+}
+
 function requestField(report: DoctorDelegateReportData, key: string): string | undefined {
-  const value = report.request[key]
-  return typeof value === 'string' && value.length > 0 ? value : undefined
+  return requestValue(report.request, key)
+}
+
+type RequestTableRow = {
+  status: TuiStatus
+  request: string
+  state: string
+  task: string
+  agent: string
+  updated: string
+}
+
+const requestColumns: Array<TableColumn<RequestTableRow>> = [
+  { key: 'request', header: 'REQUEST', width: 26, render: row => row.request },
+  { key: 'state', header: 'STATE', width: 12, render: row => row.state },
+  { key: 'task', header: 'TASK', width: 22, render: row => row.task },
+  { key: 'agent', header: 'AGENT', width: 14, render: row => row.agent },
+  { key: 'updated', header: 'UPDATED', width: 24, grow: true, render: row => row.updated },
+]
+
+function requestTableRows(requests: DoctorRepairRequestData[]): RequestTableRow[] {
+  return requests.map(request => ({
+    status: statusForRequest(request.status),
+    request: valueText(request.id, '(unknown)'),
+    state: valueText(request.status, 'unknown'),
+    task: valueText(request.taskId),
+    agent: valueText(request.agentId),
+    updated: valueText(request.updatedAt, valueText(request.createdAt)),
+  }))
+}
+
+function requestSummary(requests: DoctorRepairRequestData[]): SummaryItem[] {
+  const active = requests.filter(request => !['verified', 'completed', 'failed'].includes(valueText(request.status, '').toLowerCase())).length
+  const verified = requests.filter(request => ['verified', 'completed'].includes(valueText(request.status, '').toLowerCase())).length
+  const failed = requests.filter(request => valueText(request.status, '').toLowerCase() === 'failed').length
+  return [
+    { label: plural(requests.length, 'request'), value: requests.length, status: requests.length > 0 ? 'ok' : 'skip' },
+    { label: 'active', value: active, status: active > 0 ? 'sent' : 'ok' },
+    { label: 'verified', value: verified, status: verified > 0 ? 'done' : 'ok' },
+    ...(failed > 0 ? [{ label: 'failed', value: failed, status: 'fail' as const }] : []),
+  ]
+}
+
+function requestDetailSummary(request: DoctorRepairRequestData): SummaryItem[] {
+  const taskId = valueText(request.taskId, '')
+  const agentId = valueText(request.agentId, '')
+  return [
+    { label: 'request', value: valueText(request.id, '(unknown)'), status: statusForRequest(request.status) },
+    ...(taskId ? [{ label: 'task', value: taskId, status: 'todo' as const }] : []),
+    ...(agentId ? [{ label: 'agent', value: agentId }] : []),
+  ]
+}
+
+function requestDetailRows(request: DoctorRepairRequestData): FindingRow[] {
+  return [
+    { status: statusForRequest(request.status), label: 'status', message: valueText(request.status, 'unknown') },
+    { status: 'todo', label: 'task', message: valueText(request.taskId) },
+    { status: 'sent', label: 'agent', message: valueText(request.agentId) },
+    { status: 'run', label: 'created', message: valueText(request.createdAt) },
+    { status: 'run', label: 'updated', message: valueText(request.updatedAt) },
+  ].filter(row => row.message !== '-') as FindingRow[]
+}
+
+function eventRows(events: unknown): FindingRow[] {
+  if (!Array.isArray(events)) return []
+  return events.flatMap((event) => {
+    const item = objectValue(event)
+    if (!item) return []
+    return [{
+      status: statusForEvent(item.type),
+      label: valueText(item.type, 'event'),
+      message: valueText(item.message, 'Event recorded.'),
+      detail: valueText(item.ts, ''),
+    }]
+  })
+}
+
+function requestFromResult(result: DoctorRepairVerificationData): DoctorRepairRequestData | null {
+  const request = objectValue(result.request)
+  return request ? request as DoctorRepairRequestData : null
+}
+
+function verificationMessage(result: DoctorRepairVerificationData, remaining: DoctorRepairDiagnostic[]): string {
+  if (result.verified === true) return 'Original delegated findings are resolved.'
+  if (remaining.length === 1) return '1 original delegated finding still reproduces.'
+  return `${remaining.length} original delegated findings still reproduce.`
 }
 
 export function DoctorRepairPlan({ plan, color = true }: {
@@ -241,6 +415,102 @@ export function DoctorRepairApplyReport({ report, color = true, showBrand }: {
       {report.errors.length > 0 ? (
         <Section title="Errors" color={color}>
           <FindingRows rows={errorRows(report.errors)} color={color} />
+        </Section>
+      ) : null}
+    </Box>
+  )
+}
+
+export function DoctorRepairRequestsReport({ requests, color = true }: {
+  requests: DoctorRepairRequestData[]
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Doctor repair requests" subtitle="Delegated doctor repair tasks" color={color} />
+      <SummaryStrip items={requestSummary(requests)} color={color} />
+      <Section title="Requests" color={color}>
+        {requests.length > 0 ? (
+          <StatusTable columns={requestColumns} rows={requestTableRows(requests)} color={color} />
+        ) : (
+          <FindingRows rows={[{ status: 'ok', label: 'requests', message: 'No doctor repair requests.' }]} color={color} />
+        )}
+      </Section>
+    </Box>
+  )
+}
+
+export function DoctorRepairRequestReport({ request, color = true }: {
+  request: DoctorRepairRequestData
+  color?: boolean
+}) {
+  const unresolved = diagnosticList(request.unresolved)
+  const events = eventRows(request.events)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader
+        title="Doctor repair request"
+        subtitle="Delegated repair task state"
+        meta={valueText(request.id, '(unknown)')}
+        color={color}
+      />
+      <SummaryStrip items={requestDetailSummary(request)} color={color} />
+      <Section title="Request" color={color}>
+        <FindingRows rows={requestDetailRows(request)} color={color} />
+      </Section>
+      <Section title="Unresolved findings" color={color}>
+        <FindingRows
+          rows={unresolved.length > 0
+            ? diagnosticRows(unresolved)
+            : [{ status: 'ok', label: 'findings', message: 'No unresolved findings are stored on this request.' }]}
+          color={color}
+        />
+      </Section>
+      {events.length > 0 ? (
+        <Section title="Events" color={color}>
+          <FindingRows rows={events} color={color} />
+        </Section>
+      ) : null}
+    </Box>
+  )
+}
+
+export function DoctorRepairVerifyReport({ requestId, result, color = true }: {
+  requestId: string
+  result: DoctorRepairVerificationData
+  color?: boolean
+}) {
+  const request = requestFromResult(result)
+  const remaining = diagnosticList(result.remaining)
+  const resolved = result.verified === true
+  const id = valueText(request?.id, requestId)
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader
+        title="Doctor repair verification"
+        subtitle={resolved ? 'Delegated repair no longer reproduces original findings' : 'Delegated repair still needs attention'}
+        meta={id}
+        color={color}
+      />
+      <SummaryStrip items={[
+        { label: 'request', value: id, status: resolved ? 'done' : 'warn' },
+        { label: 'remaining', value: remaining.length, status: remaining.length > 0 ? 'warn' : 'ok' },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows
+          rows={[{
+            status: resolved ? 'done' : 'warn',
+            label: id,
+            message: verificationMessage(result, remaining),
+          }]}
+          color={color}
+        />
+      </Section>
+      {remaining.length > 0 ? (
+        <Section title="Remaining findings" color={color}>
+          <FindingRows rows={diagnosticRows(remaining)} color={color} />
         </Section>
       ) : null}
     </Box>

--- a/src/core/cli/ui/doctor-repair.tsx
+++ b/src/core/cli/ui/doctor-repair.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'ink'
+import { Box, Text } from 'ink'
 import type { TuiStatus } from './style-tokens'
 import {
   FindingRows,
@@ -433,7 +433,10 @@ export function DoctorRepairRequestsReport({ requests, color = true }: {
         {requests.length > 0 ? (
           <StatusTable columns={requestColumns} rows={requestTableRows(requests)} color={color} />
         ) : (
-          <FindingRows rows={[{ status: 'ok', label: 'requests', message: 'No doctor repair requests.' }]} color={color} />
+          <Box flexDirection="column">
+            <FindingRows rows={[{ status: 'ok', label: 'requests', message: 'No doctor repair requests.' }]} color={color} />
+            <Text> </Text>
+          </Box>
         )}
       </Section>
     </Box>

--- a/src/core/cli/ui/doctor-repair.tsx
+++ b/src/core/cli/ui/doctor-repair.tsx
@@ -275,15 +275,13 @@ type RequestTableRow = {
   state: string
   task: string
   agent: string
-  updated: string
 }
 
 const requestColumns: Array<TableColumn<RequestTableRow>> = [
-  { key: 'request', header: 'REQUEST', width: 26, render: row => row.request },
-  { key: 'state', header: 'STATE', width: 12, render: row => row.state },
-  { key: 'task', header: 'TASK', width: 22, render: row => row.task },
-  { key: 'agent', header: 'AGENT', width: 14, render: row => row.agent },
-  { key: 'updated', header: 'UPDATED', width: 24, grow: true, render: row => row.updated },
+  { key: 'request', header: 'REQUEST', width: 30, render: row => row.request },
+  { key: 'state', header: 'STATE', width: 10, render: row => row.state },
+  { key: 'task', header: 'TASK', width: 14, render: row => row.task },
+  { key: 'agent', header: 'AGENT', width: 10, render: row => row.agent },
 ]
 
 function requestTableRows(requests: DoctorRepairRequestData[]): RequestTableRow[] {
@@ -293,17 +291,17 @@ function requestTableRows(requests: DoctorRepairRequestData[]): RequestTableRow[
     state: valueText(request.status, 'unknown'),
     task: valueText(request.taskId),
     agent: valueText(request.agentId),
-    updated: valueText(request.updatedAt, valueText(request.createdAt)),
   }))
 }
 
 function requestSummary(requests: DoctorRepairRequestData[]): SummaryItem[] {
   const active = requests.filter(request => !['verified', 'completed', 'failed'].includes(valueText(request.status, '').toLowerCase())).length
+  const activeStatus = requests.some(request => valueText(request.status, '').toLowerCase() === 'sent') ? 'sent' : 'todo'
   const verified = requests.filter(request => ['verified', 'completed'].includes(valueText(request.status, '').toLowerCase())).length
   const failed = requests.filter(request => valueText(request.status, '').toLowerCase() === 'failed').length
   return [
     { label: plural(requests.length, 'request'), value: requests.length, status: requests.length > 0 ? 'ok' : 'skip' },
-    { label: 'active', value: active, status: active > 0 ? 'sent' : 'ok' },
+    { label: 'active', value: active, status: active > 0 ? activeStatus : 'ok' },
     { label: 'verified', value: verified, status: verified > 0 ? 'done' : 'ok' },
     ...(failed > 0 ? [{ label: 'failed', value: failed, status: 'fail' as const }] : []),
   ]

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -139,6 +139,13 @@ describe('doctor repair CLI UI', () => {
     expect(rendered).not.toContain('repair-1  sent  task=task-repair-1')
   })
 
+  it('keeps trailing breathing room for empty delegated repair request lists', () => {
+    const rendered = renderToString(<DoctorRepairRequestsReport requests={[]} color={false} />)
+
+    expect(rendered).toContain('No doctor repair requests.')
+    expect(rendered.endsWith('\n')).toBe(true)
+  })
+
   it('renders delegated repair request details with findings and events', () => {
     const rendered = renderToString(<DoctorRepairRequestReport request={delegateReport.request} color={false} />)
 

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -139,6 +139,26 @@ describe('doctor repair CLI UI', () => {
     expect(rendered).not.toContain('repair-1  sent  task=task-repair-1')
   })
 
+  it('keeps delegated repair request tables compact at 80 columns', () => {
+    const rendered = renderToString(
+      <DoctorRepairRequestsReport
+        requests={[{
+          ...delegateReport.request,
+          id: 'repair-1a263583-f4d4-4927-8051-8f39c813z',
+          taskId: 'task-1a263583-f4d4-4927',
+        }]}
+        color={false}
+      />,
+      { columns: 80 },
+    )
+
+    expect(rendered).toContain('REQUEST')
+    expect(rendered).toContain('TASK')
+    expect(rendered).toContain('AGENT')
+    expect(rendered).not.toContain('UPDATED')
+    expect(rendered.split('\n').some(line => line.trim().length === 1)).toBe(false)
+  })
+
   it('keeps trailing breathing room for empty delegated repair request lists', () => {
     const rendered = renderToString(<DoctorRepairRequestsReport requests={[]} color={false} />)
 

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -6,6 +6,9 @@ import {
   DoctorDelegateResult,
   DoctorRepairApplyReport,
   DoctorRepairPlan,
+  DoctorRepairRequestReport,
+  DoctorRepairRequestsReport,
+  DoctorRepairVerifyReport,
 } from '../../src/core/cli/ui/doctor-repair'
 
 const repairPlan = {
@@ -54,8 +57,19 @@ const delegateReport = {
   status: 'sent' as const,
   request: {
     id: 'repair-1',
+    status: 'sent',
     taskId: 'task-repair-1',
     agentId: 'main',
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:01:00.000Z',
+    unresolved: [
+      { check: 'channels', status: 'warn', message: 'Approval channel requires manual configuration.', autoFixable: false },
+    ],
+    events: [{
+      ts: '2026-04-01T00:01:00.000Z',
+      type: 'task-created',
+      message: 'Created linked repair task task-repair-1.',
+    }],
   },
   unresolved: [
     { check: 'channels', status: 'warn', message: 'Approval channel requires manual configuration.', autoFixable: false },
@@ -111,5 +125,50 @@ describe('doctor repair CLI UI', () => {
     expect(result).toContain(' SENT     repair-1 request')
     expect(result).toContain(' TODO     task-repair-1 task')
     expect(result).toContain('Watch the board for task-repair-1')
+  })
+
+  it('renders delegated repair request lists with shared TUI primitives', () => {
+    const rendered = renderToString(<DoctorRepairRequestsReport requests={[delegateReport.request]} color={false} />)
+
+    expect(rendered).toContain('Doctor repair requests')
+    expect(rendered).toContain('REQUESTS')
+    expect(rendered).toContain('REQUEST')
+    expect(rendered).toContain('TASK')
+    expect(rendered).toContain('repair-1')
+    expect(rendered).toContain('task-repair-1')
+    expect(rendered).not.toContain('repair-1  sent  task=task-repair-1')
+  })
+
+  it('renders delegated repair request details with findings and events', () => {
+    const rendered = renderToString(<DoctorRepairRequestReport request={delegateReport.request} color={false} />)
+
+    expect(rendered).toContain('Doctor repair request')
+    expect(rendered).toContain('repair-1')
+    expect(rendered).toContain('REQUEST')
+    expect(rendered).toContain('UNRESOLVED FINDINGS')
+    expect(rendered).toContain('channels')
+    expect(rendered).toContain('EVENTS')
+    expect(rendered).toContain('Created linked repair task task-repair-1.')
+    expect(rendered).not.toContain('"request"')
+  })
+
+  it('renders delegated repair verification results', () => {
+    const rendered = renderToString(
+      <DoctorRepairVerifyReport
+        requestId="repair-1"
+        result={{
+          request: { ...delegateReport.request, status: 'verified' },
+          remaining: [],
+          verified: true,
+        }}
+        color={false}
+      />,
+    )
+
+    expect(rendered).toContain('Doctor repair verification')
+    expect(rendered).toContain('RESULT')
+    expect(rendered).toContain('repair-1')
+    expect(rendered).toContain('Original delegated findings are resolved.')
+    expect(rendered).not.toContain('"verified"')
   })
 })

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -301,6 +301,47 @@ describe('legacy CLI doctor repair', () => {
     expect(body.data.requests[0].id).toBe('repair-1')
   })
 
+  it('renders TTY delegated repair request lists with the shared doctor repair UI', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ requests: [mockDelegate.request] }),
+      text: () => Promise.resolve(''),
+    })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', 'repair', 'list']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Doctor repair requests')
+    expect(output).toContain('REQUESTS')
+    expect(output).toContain('repair-1')
+    expect(output).toContain('task-repair-1')
+    expect(output).not.toContain('repair-1  sent  task=task-repair-1')
+  })
+
+  it('renders TTY delegated repair request details with the shared doctor repair UI', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ request: mockDelegate.request }),
+      text: () => Promise.resolve(''),
+    })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', 'repair', 'show', 'repair-1']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(output).toContain('Doctor repair request')
+    expect(output).toContain('REQUEST')
+    expect(output).toContain('UNRESOLVED FINDINGS')
+    expect(output).toContain('task-repair-1')
+    expect(output).not.toContain('"request"')
+  })
+
   it('verifies delegated repair requests', async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -316,5 +357,24 @@ describe('legacy CLI doctor repair', () => {
     expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'POST' })
     const body = JSON.parse(String(log.mock.calls[0][0]))
     expect(body.data.verified).toBe(true)
+  })
+
+  it('renders TTY delegated repair verification with the shared doctor repair UI', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ request: { ...mockDelegate.request, status: 'verified' }, remaining: [], verified: true }),
+      text: () => Promise.resolve(''),
+    })
+    setStdoutIsTTY(true)
+    process.argv = ['bun', 'cli/bakin.ts', 'doctor', 'repair', 'verify', 'repair-1']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = loggedOutput()
+    expect(output).toContain('Doctor repair verification')
+    expect(output).toContain('RESULT')
+    expect(output).toContain('Original delegated findings are resolved.')
+    expect(output).not.toContain('"verified"')
   })
 })


### PR DESCRIPTION
Summary:
- Add shared TUI reports for doctor repair request list, detail, and verification output.
- Route doctor repair list/show/verify through the shared Ink output in TTY mode while preserving --json and non-TTY behavior.
- Cover the new report components and CLI TTY behavior with tests.

Tests:
- bun test --isolate tests/cli/doctor-repair-ui.test.tsx tests/cli/doctor-repair.test.ts
- bun run typecheck
- bun test --isolate tests/cli