### PR TITLE
Render onboarding check and install commands with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -26,6 +26,7 @@ import type {
   SearchMetaData,
   SearchResultData,
 } from '../src/core/cli/ui/readonly'
+import type { CheckResult, InstallResult } from '../src/core/onboarding/types'
 
 const BASE_URL = process.env.BAKIN_URL || 'http://localhost:3737'
 
@@ -326,6 +327,33 @@ async function printPackagesListTui(packages: Array<Record<string, unknown>>): P
     import('react'),
   ])
   console.log(renderToString(createElement(PackagesListReport, { packages })))
+}
+
+async function printOnboardingCheckTui(result: CheckResult): Promise<void> {
+  const [{ OnboardingCheckReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/onboarding'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(OnboardingCheckReport, { result })))
+}
+
+async function printOnboardingCheckAllTui(results: CheckResult[]): Promise<void> {
+  const [{ OnboardingCheckAllReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/onboarding'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(OnboardingCheckAllReport, { results })))
+}
+
+async function printOnboardingInstallTui(result: InstallResult): Promise<void> {
+  const [{ OnboardingInstallReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/onboarding'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(OnboardingInstallReport, { result })))
 }
 
 // ---------------------------------------------------------------------------
@@ -2374,8 +2402,12 @@ async function cmdOnboardingCheckSingle(target: 'runtime' | 'search' | 'search-m
   }
   const component = await componentMap[target]()
   const result = await component.check()
-  console.log(`${statusIcon(result.status)} ${result.message}`)
-  if (result.remediation) console.log(`  → ${result.remediation}`)
+  if (process.stdout.isTTY) {
+    await printOnboardingCheckTui(result)
+  } else {
+    console.log(`${statusIcon(result.status)} ${result.message}`)
+    if (result.remediation) console.log(`  → ${result.remediation}`)
+  }
   if (result.status === 'missing' || result.status === 'error' || result.status === 'broken') process.exit(1)
   if (result.status === 'warn') process.exit(2)
 }
@@ -2383,9 +2415,13 @@ async function cmdOnboardingCheckSingle(target: 'runtime' | 'search' | 'search-m
 async function cmdOnboardingCheckAll(): Promise<void> {
   const { checkAll } = await import('../src/core/onboarding/index')
   const results = await checkAll()
-  for (const r of results) {
-    console.log(`${statusIcon(r.status)} ${r.name.padEnd(10)} ${r.message}`)
-    if (r.remediation) console.log(`  → ${r.remediation}`)
+  if (process.stdout.isTTY) {
+    await printOnboardingCheckAllTui(results)
+  } else {
+    for (const r of results) {
+      console.log(`${statusIcon(r.status)} ${r.name.padEnd(10)} ${r.message}`)
+      if (r.remediation) console.log(`  → ${r.remediation}`)
+    }
   }
   const hasError = results.some(r => r.status === 'error' || r.status === 'missing' || r.status === 'broken')
   const hasWarn = results.some(r => r.status === 'warn')
@@ -2416,6 +2452,8 @@ async function cmdOnboardingInstallSingle(target: string, args: string[]): Promi
   const result = await component.install(opts)
   if (json) {
     console.log(JSON.stringify({ component: component.name, status: result.status, message: result.message, durationMs: result.durationMs }))
+  } else if (isTTY) {
+    await printOnboardingInstallTui(result)
   } else {
     console.log(`${statusIcon(result.status)} ${result.message}`)
   }

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2360,6 +2360,20 @@ function statusIcon(status: string): string {
   }
 }
 
+async function withTtyRuntimeLogsSilenced<T>(
+  options: { isTTY: boolean; verbose?: boolean },
+  run: () => Promise<T>,
+): Promise<T> {
+  const previousConsoleFormat = process.env.BAKIN_CONSOLE_FORMAT
+  const shouldSilenceRuntimeLogs = options.isTTY && options.verbose !== true && previousConsoleFormat === undefined
+  try {
+    if (shouldSilenceRuntimeLogs) process.env.BAKIN_CONSOLE_FORMAT = 'silent'
+    return await run()
+  } finally {
+    if (shouldSilenceRuntimeLogs) delete process.env.BAKIN_CONSOLE_FORMAT
+  }
+}
+
 async function cmdOnboardingMkdir(): Promise<void> {
   const { mkdirComponent } = await import('../src/core/onboarding/mkdir')
   const opts = {
@@ -2388,7 +2402,10 @@ async function cmdOnboardingSettingsInit(): Promise<void> {
   if (result.status === 'failed') process.exit(1)
 }
 
-async function cmdOnboardingCheckSingle(target: 'runtime' | 'search' | 'search-models' | 'llm' | 'channels' | 'plugin-assets' | 'agent-assets' | 'recommended-plugins' | 'recommended-agents'): Promise<void> {
+async function cmdOnboardingCheckSingle(
+  target: 'runtime' | 'search' | 'search-models' | 'llm' | 'channels' | 'plugin-assets' | 'agent-assets' | 'recommended-plugins' | 'recommended-agents',
+  options: { verbose?: boolean } = {},
+): Promise<void> {
   const componentMap: Record<string, () => Promise<{ check(): Promise<import('../src/core/onboarding/types').CheckResult> }>> = {
     runtime: async () => (await import('../src/core/onboarding/runtime')).runtimeComponent,
     search: async () => (await import('../src/core/onboarding/search')).searchComponent,
@@ -2400,9 +2417,12 @@ async function cmdOnboardingCheckSingle(target: 'runtime' | 'search' | 'search-m
     'recommended-plugins': async () => (await import('../src/core/onboarding/recommended-plugins')).recommendedPluginsComponent,
     'recommended-agents': async () => (await import('../src/core/onboarding/recommended-agents')).recommendedAgentsComponent,
   }
-  const component = await componentMap[target]()
-  const result = await component.check()
-  if (process.stdout.isTTY) {
+  const isTTY = Boolean(process.stdout.isTTY)
+  const result = await withTtyRuntimeLogsSilenced({ isTTY, verbose: options.verbose }, async () => {
+    const component = await componentMap[target]()
+    return await component.check()
+  })
+  if (isTTY) {
     await printOnboardingCheckTui(result)
   } else {
     console.log(`${statusIcon(result.status)} ${result.message}`)
@@ -2412,10 +2432,13 @@ async function cmdOnboardingCheckSingle(target: 'runtime' | 'search' | 'search-m
   if (result.status === 'warn') process.exit(2)
 }
 
-async function cmdOnboardingCheckAll(): Promise<void> {
-  const { checkAll } = await import('../src/core/onboarding/index')
-  const results = await checkAll()
-  if (process.stdout.isTTY) {
+async function cmdOnboardingCheckAll(options: { verbose?: boolean } = {}): Promise<void> {
+  const isTTY = Boolean(process.stdout.isTTY)
+  const results = await withTtyRuntimeLogsSilenced({ isTTY, verbose: options.verbose }, async () => {
+    const { checkAll } = await import('../src/core/onboarding/index')
+    return await checkAll()
+  })
+  if (isTTY) {
     await printOnboardingCheckAllTui(results)
   } else {
     for (const r of results) {
@@ -2438,10 +2461,10 @@ async function cmdOnboardingInstallSingle(target: string, args: string[]): Promi
     'recommended-plugins': async () => (await import('../src/core/onboarding/recommended-plugins')).recommendedPluginsComponent,
     'recommended-agents': async () => (await import('../src/core/onboarding/recommended-agents')).recommendedAgentsComponent,
   }
-  const component = await componentMap[target]()
   const isTTY = Boolean(process.stdout.isTTY)
   const autoApprove = args.includes('--yes')
   const json = args.includes('--json')
+  const verbose = args.includes('--verbose')
   const opts = {
     interactive: isTTY && !json,
     autoApprove: autoApprove || (!isTTY && !json),
@@ -2449,9 +2472,12 @@ async function cmdOnboardingInstallSingle(target: string, args: string[]): Promi
     checkOnly: false,
     force: false,
   }
-  const result = await component.install(opts)
+  const result = await withTtyRuntimeLogsSilenced({ isTTY, verbose }, async () => {
+    const component = await componentMap[target]()
+    return await component.install(opts)
+  })
   if (json) {
-    console.log(JSON.stringify({ component: component.name, status: result.status, message: result.message, durationMs: result.durationMs }))
+    console.log(JSON.stringify({ component: result.name, status: result.status, message: result.message, durationMs: result.durationMs }))
   } else if (isTTY) {
     await printOnboardingInstallTui(result)
   } else {
@@ -2859,9 +2885,9 @@ export async function main(): Promise<void> {
 
       case 'check':
         if (sub === 'runtime' || sub === 'search' || sub === 'search-models' || sub === 'llm' || sub === 'channels' || sub === 'plugin-assets' || sub === 'agent-assets' || sub === 'recommended-plugins' || sub === 'recommended-agents') {
-          await cmdOnboardingCheckSingle(sub)
+          await cmdOnboardingCheckSingle(sub, { verbose: args.includes('--verbose') })
         } else if (sub === 'all') {
-          await cmdOnboardingCheckAll()
+          await cmdOnboardingCheckAll({ verbose: args.includes('--verbose') })
         } else {
           console.error(`Unknown check target: ${sub}`)
           console.error('Available: bakin check runtime | search | search-models | llm | channels | plugin-assets | agent-assets | recommended-plugins | recommended-agents | all')

--- a/src/core/cli/ui/onboarding.tsx
+++ b/src/core/cli/ui/onboarding.tsx
@@ -1,6 +1,12 @@
 import { Box, Text } from 'ink'
 import { ConfirmInput } from '@inkjs/ui'
-import type { ComponentOutcome } from '../../onboarding'
+import type {
+  CheckResult,
+  CheckStatus,
+  ComponentOutcome,
+  InstallResult,
+  InstallStatus,
+} from '../../onboarding'
 import {
   FindingRows,
   NextActions,
@@ -38,6 +44,32 @@ export function onboardingStatus(status: ComponentOutcome['finalStatus']): TuiSt
   }
 }
 
+function checkStatus(status: CheckStatus): TuiStatus {
+  switch (status) {
+    case 'ok':
+      return 'ok'
+    case 'warn':
+      return 'warn'
+    case 'missing':
+    case 'broken':
+    case 'error':
+      return 'blocked'
+  }
+}
+
+function installStatus(status: InstallStatus): TuiStatus {
+  switch (status) {
+    case 'installed':
+      return 'applied'
+    case 'noop':
+      return 'ok'
+    case 'skipped':
+      return 'skip'
+    case 'failed':
+      return 'fail'
+  }
+}
+
 function busyStatus(status: OnboardingBusyStatus): TuiStatus {
   switch (status) {
     case 'complete':
@@ -49,6 +81,17 @@ function busyStatus(status: OnboardingBusyStatus): TuiStatus {
     case 'blocked':
       return 'blocked'
   }
+}
+
+function checkSummary(results: CheckResult[]): SummaryItem[] {
+  const ok = results.filter(result => result.status === 'ok').length
+  const warnings = results.filter(result => result.status === 'warn').length
+  const blocked = results.filter(result => result.status === 'missing' || result.status === 'broken' || result.status === 'error').length
+  return [
+    { label: 'ready', value: ok, status: 'ok' },
+    { label: 'attention', value: warnings, status: warnings > 0 ? 'warn' : 'ok' },
+    { label: 'blocked', value: blocked, status: blocked > 0 ? 'blocked' : 'ok' },
+  ]
 }
 
 function summarySubtitle(exitCode: 0 | 1 | 2): string {
@@ -71,6 +114,15 @@ function summaryItems(outcomes: ComponentOutcome[]): SummaryItem[] {
   ]
 }
 
+function checkRows(results: CheckResult[]): FindingRow[] {
+  return results.map(result => ({
+    status: checkStatus(result.status),
+    label: result.name,
+    message: formatOnboardingMessage(result.message),
+    detail: result.remediation ? formatOnboardingMessage(result.remediation) : undefined,
+  }))
+}
+
 function outcomeRows(outcomes: ComponentOutcome[]): FindingRow[] {
   return outcomes.map(outcome => ({
     status: onboardingStatus(outcome.finalStatus),
@@ -78,6 +130,64 @@ function outcomeRows(outcomes: ComponentOutcome[]): FindingRow[] {
     message: formatOnboardingMessage(outcome.message),
     detail: outcome.remediation ? formatOnboardingMessage(outcome.remediation) : undefined,
   }))
+}
+
+export function OnboardingCheckReport({ result, color = true }: {
+  result: CheckResult
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Onboarding check" subtitle="Component setup checked" meta={result.name} color={color} />
+      <SummaryStrip items={[
+        { label: 'component', value: result.name, status: checkStatus(result.status) },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={checkRows([result])} color={color} />
+        <Text> </Text>
+      </Section>
+    </Box>
+  )
+}
+
+export function OnboardingCheckAllReport({ results, color = true }: {
+  results: CheckResult[]
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Onboarding checks" subtitle="Setup components checked" color={color} />
+      <SummaryStrip items={checkSummary(results)} color={color} />
+      <Section title="Checks" color={color}>
+        <FindingRows rows={checkRows(results)} color={color} />
+        <Text> </Text>
+      </Section>
+    </Box>
+  )
+}
+
+export function OnboardingInstallReport({ result, color = true }: {
+  result: InstallResult
+  color?: boolean
+}) {
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Onboarding install" subtitle="Component setup applied" meta={result.name} color={color} />
+      <SummaryStrip items={[
+        { label: 'component', value: result.name, status: installStatus(result.status) },
+        { label: 'elapsed', value: `${result.durationMs}ms` },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={[{
+          status: installStatus(result.status),
+          label: result.name,
+          message: formatOnboardingMessage(result.message),
+          detail: result.error ? String(result.error) : undefined,
+        }]} color={color} />
+        <Text> </Text>
+      </Section>
+    </Box>
+  )
 }
 
 export function OnboardingSummary({ outcomes, exitCode, showBrand = true }: {

--- a/tests/cli/onboarding-component-commands.test.ts
+++ b/tests/cli/onboarding-component-commands.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const runtimeCheck = mock()
+
+const checkAll = mock()
+
+const pluginAssetsInstall = mock()
+
+mock.module('../../src/core/onboarding/runtime', () => ({
+  runtimeComponent: {
+    name: 'runtime',
+    check: runtimeCheck,
+    install: mock(async () => ({ name: 'runtime', status: 'noop', message: 'Runtime ready.', durationMs: 1 })),
+  },
+}))
+
+mock.module('../../src/core/onboarding/index', () => ({
+  checkAll,
+}))
+
+mock.module('../../src/core/onboarding/plugin-assets', () => ({
+  pluginAssetsComponent: {
+    name: 'plugin-assets',
+    check: mock(async () => ({ name: 'plugin-assets', status: 'ok', message: 'Plugin assets ready.' })),
+    install: pluginAssetsInstall,
+  },
+}))
+
+describe('onboarding component CLI commands', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let log: ReturnType<typeof spyOn>
+
+  function setStdoutIsTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
+  }
+
+  function output(): string {
+    return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+  }
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    runtimeCheck.mockImplementation(async () => ({
+      name: 'runtime',
+      status: 'ok',
+      message: 'Runtime adapter is available.',
+    }))
+    checkAll.mockImplementation(async () => [
+      { name: 'runtime', status: 'ok', message: 'Runtime adapter is available.' },
+      { name: 'search', status: 'ok', message: 'Search adapter is available.' },
+    ])
+    pluginAssetsInstall.mockImplementation(async () => ({
+      name: 'plugin-assets',
+      status: 'installed',
+      message: 'Installed plugin assets.',
+      durationMs: 12,
+    }))
+    process.argv = originalArgv
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    process.exit = ((code?: number) => {
+      if (code === 0) return undefined as never
+      throw new Error(`exit:${code}`)
+    }) as never
+    setStdoutIsTTY(true)
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+    log.mockRestore()
+  })
+
+  it('renders single component checks with the shared TUI in a TTY', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'check', 'runtime']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain('Onboarding check')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Runtime adapter is available.')
+    expect(output()).not.toContain('[OK]')
+  })
+
+  it('renders all component checks with the shared TUI in a TTY', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'check', 'all']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(checkAll).toHaveBeenCalled()
+    expect(output()).toContain('Onboarding checks')
+    expect(output()).toContain('CHECKS')
+    expect(output()).toContain('Search adapter is available.')
+    expect(output()).not.toContain('[OK]')
+  })
+
+  it('renders component installs with the shared TUI in a TTY', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'install', 'plugin-assets']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(output()).toContain('Onboarding install')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Installed plugin assets.')
+    expect(output()).not.toContain('[INSTALLED]')
+  })
+
+  it('preserves JSON output for component installs', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'install', 'plugin-assets', '--json']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const body = JSON.parse(output())
+    expect(body.component).toBe('plugin-assets')
+    expect(body.status).toBe('installed')
+    expect(output()).not.toContain('Onboarding install')
+  })
+})

--- a/tests/cli/onboarding-component-commands.test.ts
+++ b/tests/cli/onboarding-component-commands.test.ts
@@ -42,21 +42,33 @@ describe('onboarding component CLI commands', () => {
 
   beforeEach(() => {
     mock.clearAllMocks()
-    runtimeCheck.mockImplementation(async () => ({
-      name: 'runtime',
-      status: 'ok',
-      message: 'Runtime adapter is available.',
-    }))
-    checkAll.mockImplementation(async () => [
-      { name: 'runtime', status: 'ok', message: 'Runtime adapter is available.' },
-      { name: 'search', status: 'ok', message: 'Search adapter is available.' },
-    ])
-    pluginAssetsInstall.mockImplementation(async () => ({
-      name: 'plugin-assets',
-      status: 'installed',
-      message: 'Installed plugin assets.',
-      durationMs: 12,
-    }))
+    runtimeCheck.mockImplementation(async () => {
+      const { createLogger } = await import('../../packages/core/src/logger')
+      createLogger('settings').info('Runtime check log')
+      return {
+        name: 'runtime',
+        status: 'ok',
+        message: 'Runtime adapter is available.',
+      }
+    })
+    checkAll.mockImplementation(async () => {
+      const { createLogger } = await import('../../packages/core/src/logger')
+      createLogger('settings').info('Settings loaded')
+      return [
+        { name: 'runtime', status: 'ok', message: 'Runtime adapter is available.' },
+        { name: 'search', status: 'ok', message: 'Search adapter is available.' },
+      ]
+    })
+    pluginAssetsInstall.mockImplementation(async () => {
+      const { createLogger } = await import('../../packages/core/src/logger')
+      createLogger('settings').info('Plugin install log')
+      return {
+        name: 'plugin-assets',
+        status: 'installed',
+        message: 'Installed plugin assets.',
+        durationMs: 12,
+      }
+    })
     process.argv = originalArgv
     log = spyOn(console, 'log').mockImplementation(() => {})
     process.exit = ((code?: number) => {
@@ -84,6 +96,7 @@ describe('onboarding component CLI commands', () => {
     expect(output()).toContain('Onboarding check')
     expect(output()).toContain('RESULT')
     expect(output()).toContain('Runtime adapter is available.')
+    expect(output()).not.toContain('Runtime check log')
     expect(output()).not.toContain('[OK]')
   })
 
@@ -97,7 +110,18 @@ describe('onboarding component CLI commands', () => {
     expect(output()).toContain('Onboarding checks')
     expect(output()).toContain('CHECKS')
     expect(output()).toContain('Search adapter is available.')
+    expect(output()).not.toContain('Settings loaded')
     expect(output()).not.toContain('[OK]')
+  })
+
+  it('keeps component check logs when --verbose is used', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'check', 'all', '--verbose']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(output()).toContain('Settings loaded')
+    expect(output()).toContain('Onboarding checks')
   })
 
   it('renders component installs with the shared TUI in a TTY', async () => {
@@ -109,6 +133,7 @@ describe('onboarding component CLI commands', () => {
     expect(output()).toContain('Onboarding install')
     expect(output()).toContain('RESULT')
     expect(output()).toContain('Installed plugin assets.')
+    expect(output()).not.toContain('Plugin install log')
     expect(output()).not.toContain('[INSTALLED]')
   })
 

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -4,7 +4,10 @@ import { renderToString } from 'ink'
 import { buildSelectionItems } from '../../src/core/cli/onboarding-interactive'
 import {
   OnboardingBusy,
+  OnboardingCheckAllReport,
+  OnboardingCheckReport,
   OnboardingDecisionPrompt,
+  OnboardingInstallReport,
   OnboardingIntro,
   OnboardingProgress,
   OnboardingSummary,
@@ -165,5 +168,54 @@ describe('onboarding CLI UI', () => {
   it('renders bounded onboarding progress with Ink UI', () => {
     const rendered = renderToString(<OnboardingProgress label="Installing official agents" value={50} />)
     expect(rendered).toContain('Installing official agents')
+  })
+
+  it('renders single component checks with shared TUI primitives', () => {
+    const rendered = renderToString(
+      <OnboardingCheckReport result={{
+        name: 'runtime',
+        status: 'warn',
+        message: 'No runtime adapter is available.',
+        remediation: 'Run `bakin onboard` to configure runtime access.',
+      }} color={false} />,
+    )
+
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Onboarding check')
+    expect(rendered).toContain('RESULT')
+    expect(rendered).toContain('No runtime adapter is available.')
+    expect(rendered).not.toContain('[WARN]')
+  })
+
+  it('renders all component checks with shared TUI primitives', () => {
+    const rendered = renderToString(
+      <OnboardingCheckAllReport results={[
+        { name: 'runtime', status: 'ok', message: 'Runtime ready.' },
+        { name: 'llm', status: 'warn', message: 'No LLM provider configured.', remediation: 'Configure at least one provider.' },
+      ]} color={false} />,
+    )
+
+    expect(rendered).toContain('Onboarding checks')
+    expect(rendered).toContain('CHECKS')
+    expect(rendered).toContain('runtime')
+    expect(rendered).toContain('No LLM provider configured.')
+    expect(rendered).not.toContain('[OK]')
+  })
+
+  it('renders component install results with shared TUI primitives', () => {
+    const rendered = renderToString(
+      <OnboardingInstallReport result={{
+        name: 'plugin-assets',
+        status: 'installed',
+        message: 'Installed plugin assets.',
+        durationMs: 12,
+      }} color={false} />,
+    )
+
+    expect(rendered).toContain('Onboarding install')
+    expect(rendered).toContain('RESULT')
+    expect(rendered).toContain('Installed plugin assets.')
+    expect(rendered).toContain('12ms')
+    expect(rendered).not.toContain('[INSTALLED]')
   })
 })


### PR DESCRIPTION
Summary:
- Add shared Ink reports for onboarding component check, check-all, and install results.
- Route TTY output for `bakin check <target>`, `bakin check all`, and `bakin install <target>` through the shared Bakin TUI.
- Preserve existing non-TTY output and `--json` install behavior.

Tests:
- bun test --isolate tests/cli/onboarding-ui.test.tsx tests/cli/onboarding-component-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli