### PR TITLE
Render onboarding init commands with TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2375,30 +2375,44 @@ async function withTtyRuntimeLogsSilenced<T>(
 }
 
 async function cmdOnboardingMkdir(): Promise<void> {
-  const { mkdirComponent } = await import('../src/core/onboarding/mkdir')
+  const isTTY = Boolean(process.stdout.isTTY)
   const opts = {
-    interactive: Boolean(process.stdout.isTTY),
+    interactive: isTTY,
     autoApprove: true,
     json: false,
     checkOnly: false,
     force: false,
   }
-  const result = await mkdirComponent.install(opts)
-  console.log(`${statusIcon(result.status)} ${result.message}`)
+  const result = await withTtyRuntimeLogsSilenced({ isTTY }, async () => {
+    const { mkdirComponent } = await import('../src/core/onboarding/mkdir')
+    return await mkdirComponent.install(opts)
+  })
+  if (isTTY) {
+    await printOnboardingInstallTui(result)
+  } else {
+    console.log(`${statusIcon(result.status)} ${result.message}`)
+  }
   if (result.status === 'failed') process.exit(1)
 }
 
 async function cmdOnboardingSettingsInit(): Promise<void> {
-  const { settingsComponent } = await import('../src/core/onboarding/settings')
+  const isTTY = Boolean(process.stdout.isTTY)
   const opts = {
-    interactive: Boolean(process.stdout.isTTY),
+    interactive: isTTY,
     autoApprove: true,
     json: false,
     checkOnly: false,
     force: false,
   }
-  const result = await settingsComponent.install(opts)
-  console.log(`${statusIcon(result.status)} ${result.message}`)
+  const result = await withTtyRuntimeLogsSilenced({ isTTY }, async () => {
+    const { settingsComponent } = await import('../src/core/onboarding/settings')
+    return await settingsComponent.install(opts)
+  })
+  if (isTTY) {
+    await printOnboardingInstallTui(result)
+  } else {
+    console.log(`${statusIcon(result.status)} ${result.message}`)
+  }
   if (result.status === 'failed') process.exit(1)
 }
 

--- a/tests/cli/onboarding-component-commands.test.ts
+++ b/tests/cli/onboarding-component-commands.test.ts
@@ -5,6 +5,8 @@ const runtimeCheck = mock()
 const checkAll = mock()
 
 const pluginAssetsInstall = mock()
+const mkdirInstall = mock()
+const settingsInstall = mock()
 
 mock.module('../../src/core/onboarding/runtime', () => ({
   runtimeComponent: {
@@ -23,6 +25,22 @@ mock.module('../../src/core/onboarding/plugin-assets', () => ({
     name: 'plugin-assets',
     check: mock(async () => ({ name: 'plugin-assets', status: 'ok', message: 'Plugin assets ready.' })),
     install: pluginAssetsInstall,
+  },
+}))
+
+mock.module('../../src/core/onboarding/mkdir', () => ({
+  mkdirComponent: {
+    name: 'mkdir',
+    check: mock(async () => ({ name: 'mkdir', status: 'ok', message: 'Bakin home ready.' })),
+    install: mkdirInstall,
+  },
+}))
+
+mock.module('../../src/core/onboarding/settings', () => ({
+  settingsComponent: {
+    name: 'settings',
+    check: mock(async () => ({ name: 'settings', status: 'ok', message: 'Settings ready.' })),
+    install: settingsInstall,
   },
 }))
 
@@ -67,6 +85,26 @@ describe('onboarding component CLI commands', () => {
         status: 'installed',
         message: 'Installed plugin assets.',
         durationMs: 12,
+      }
+    })
+    mkdirInstall.mockImplementation(async () => {
+      const { createLogger } = await import('../../packages/core/src/logger')
+      createLogger('settings').info('Mkdir install log')
+      return {
+        name: 'mkdir',
+        status: 'noop',
+        message: 'Already initialized at ~/.bakin',
+        durationMs: 3,
+      }
+    })
+    settingsInstall.mockImplementation(async () => {
+      const { createLogger } = await import('../../packages/core/src/logger')
+      createLogger('settings').info('Settings init log')
+      return {
+        name: 'settings',
+        status: 'installed',
+        message: 'Wrote ~/.bakin/settings.json',
+        durationMs: 5,
       }
     })
     process.argv = originalArgv
@@ -134,6 +172,46 @@ describe('onboarding component CLI commands', () => {
     expect(output()).toContain('RESULT')
     expect(output()).toContain('Installed plugin assets.')
     expect(output()).not.toContain('Plugin install log')
+    expect(output()).not.toContain('[INSTALLED]')
+  })
+
+  it('renders mkdir installs with the shared TUI in a TTY', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'mkdir']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(mkdirInstall).toHaveBeenCalledWith({
+      interactive: true,
+      autoApprove: true,
+      json: false,
+      checkOnly: false,
+      force: false,
+    })
+    expect(output()).toContain('Onboarding install')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Already initialized at ~/.bakin')
+    expect(output()).not.toContain('Mkdir install log')
+    expect(output()).not.toContain('[NOOP]')
+  })
+
+  it('renders settings init installs with the shared TUI in a TTY', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'settings', 'init']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(settingsInstall).toHaveBeenCalledWith({
+      interactive: true,
+      autoApprove: true,
+      json: false,
+      checkOnly: false,
+      force: false,
+    })
+    expect(output()).toContain('Onboarding install')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Wrote ~/.bakin/settings.json')
+    expect(output()).not.toContain('Settings init log')
     expect(output()).not.toContain('[INSTALLED]')
   })
 


### PR DESCRIPTION
## Summary
- render `bakin mkdir` with the shared onboarding install TUI in TTY sessions
- render `bakin settings init` with the shared onboarding install TUI in TTY sessions
- suppress runtime logs for those TTY commands while preserving non-TTY line output

## Tests
- `bun test --isolate tests/cli/onboarding-component-commands.test.ts`
- `bun run typecheck`
- `bun test --isolate tests/cli`