### PR TITLE
Render trash actions with TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -17,6 +17,7 @@ import {
   serializePluginExportManifest,
   type PluginImportInstallRequest,
 } from '../src/core/plugins/import-export'
+import { formatApiError } from '../src/core/cli/api-error'
 import type {
   AgentRuleResultData,
   PluginRestoreResultData,
@@ -61,7 +62,7 @@ async function api(path: string, options?: RequestInit): Promise<unknown> {
   })
   if (!res.ok) {
     const body = await res.text()
-    throw new Error(`HTTP ${res.status}: ${body}`)
+    throw new Error(formatApiError(res.status, body))
   }
   return res.json()
 }

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -25,6 +25,7 @@ import type {
   SearchAggregationsData,
   SearchMetaData,
   SearchResultData,
+  TrashActionData,
 } from '../src/core/cli/ui/readonly'
 import type { CheckResult, InstallResult } from '../src/core/onboarding/types'
 
@@ -296,6 +297,15 @@ async function printTrashListTui(assets: Array<Record<string, unknown>>): Promis
     import('react'),
   ])
   console.log(renderToString(createElement(TrashListReport, { assets })))
+}
+
+async function printTrashActionTui(action: TrashActionData): Promise<void> {
+  const [{ TrashActionReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(TrashActionReport, { action })))
 }
 
 async function printAgentPackagesListTui(agents: Array<Record<string, unknown>>): Promise<void> {
@@ -2191,16 +2201,42 @@ async function cmdTrashList(): Promise<void> {
 
 async function cmdTrashRestore(filename: string): Promise<void> {
   const data = await apiPost(`/api/plugins/assets/trash/${encodeURIComponent(filename)}/restore`) as { ok: boolean; restoredPath: string }
+  if (process.stdout.isTTY) {
+    await printTrashActionTui({
+      action: 'restored',
+      target: filename,
+      count: 1,
+      message: `Restored ${filename}.`,
+      detail: data.restoredPath,
+    })
+    return
+  }
   console.log(`Restored → ${data.restoredPath}`)
 }
 
 async function cmdTrashEmpty(): Promise<void> {
   const check = await apiGet('/api/plugins/assets/trash') as { count: number }
   if (check.count === 0) {
+    if (process.stdout.isTTY) {
+      await printTrashActionTui({
+        action: 'empty',
+        count: 0,
+        message: 'Trash is already empty.',
+      })
+      return
+    }
     console.log('Trash is already empty.')
     return
   }
   const data = await apiDelete('/api/plugins/assets/trash') as { ok: boolean; deleted: number }
+  if (process.stdout.isTTY) {
+    await printTrashActionTui({
+      action: 'emptied',
+      count: data.deleted,
+      message: `Permanently deleted ${data.deleted} item${data.deleted !== 1 ? 's' : ''}.`,
+    })
+    return
+  }
   console.log(`Permanently deleted ${data.deleted} item${data.deleted !== 1 ? 's' : ''}.`)
 }
 

--- a/src/cli/schedule.ts
+++ b/src/cli/schedule.ts
@@ -2,6 +2,7 @@
  * CLI helpers for `bakin schedule` commands.
  * Each function calls the Bakin schedule API and formats output.
  */
+import { formatApiError } from '../core/cli/api-error'
 
 const BASE_URL = `http://localhost:${process.env.PORT || 3737}`
 
@@ -13,7 +14,7 @@ async function apiGet<T>(path: string): Promise<T> {
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`API error ${res.status}: ${text}`)
+    throw new Error(formatApiError(res.status, text, { prefix: 'API error' }))
   }
   return res.json() as Promise<T>
 }
@@ -26,7 +27,7 @@ async function apiPost<T>(path: string, body: Record<string, unknown>): Promise<
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`API error ${res.status}: ${text}`)
+    throw new Error(formatApiError(res.status, text, { prefix: 'API error' }))
   }
   return res.json() as Promise<T>
 }
@@ -38,7 +39,7 @@ async function apiDelete<T>(path: string): Promise<T> {
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`API error ${res.status}: ${text}`)
+    throw new Error(formatApiError(res.status, text, { prefix: 'API error' }))
   }
   return res.json() as Promise<T>
 }

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -27,6 +27,7 @@ import {
   serializePluginExportManifest,
   type PluginImportInstallRequest,
 } from './plugins/import-export'
+import { formatApiError } from './cli/api-error'
 
 const BAKIN_URL = process.env.BAKIN_URL || 'http://localhost:3737'
 
@@ -40,7 +41,7 @@ async function api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const body = await res.text().catch(() => '')
-    throw new Error(`HTTP ${res.status}: ${body}`)
+    throw new Error(formatApiError(res.status, body))
   }
   return (await res.json()) as T
 }

--- a/src/core/cli/api-error.ts
+++ b/src/core/cli/api-error.ts
@@ -1,0 +1,46 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function textField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function issueMessages(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map(issue => {
+      if (typeof issue === 'string') return issue.trim()
+      if (!isRecord(issue)) return ''
+      return textField(issue.message) || textField(issue.error) || textField(issue.detail)
+    })
+    .filter(Boolean)
+}
+
+export function extractApiErrorMessage(body: string): string {
+  const trimmed = body.trim()
+  if (!trimmed) return ''
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return trimmed
+  }
+
+  if (typeof parsed === 'string') return parsed.trim()
+  if (!isRecord(parsed)) return trimmed
+
+  const primary = textField(parsed.error) || textField(parsed.message) || textField(parsed.detail)
+  const issues = issueMessages(parsed.issues)
+  if (primary && issues.length > 0) return `${primary}: ${issues.join('; ')}`
+  if (primary) return primary
+  if (issues.length > 0) return issues.join('; ')
+  return trimmed
+}
+
+export function formatApiError(status: number, body: string, options: { prefix?: string } = {}): string {
+  const prefix = options.prefix ?? 'HTTP'
+  const message = extractApiErrorMessage(body)
+  return message ? `${prefix} ${status}: ${message}` : `${prefix} ${status}`
+}

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -209,6 +209,14 @@ export interface TrashAssetData {
   metadata?: unknown
 }
 
+export interface TrashActionData {
+  action?: unknown
+  target?: unknown
+  count?: unknown
+  message?: unknown
+  detail?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -895,6 +903,32 @@ function trashAssetTableRows(assets: TrashAssetData[]): TrashAssetTableRow[] {
     expires: daysUntilText(asset.expiresAt),
     agent: metadataAgent(asset.metadata),
   }))
+}
+
+function trashActionStatus(action: TrashActionData): TuiStatus {
+  const name = valueText(action.action)
+  if (name === 'empty') return 'skip'
+  return name === 'restored' || name === 'emptied' ? 'applied' : 'ok'
+}
+
+function trashActionRows(action: TrashActionData) {
+  const status = trashActionStatus(action)
+  const actionName = valueText(action.action, 'updated')
+  const label = valueText(action.target, actionName)
+  const count = valueText(action.count, '')
+  const fallback = actionName === 'emptied'
+    ? `Permanently deleted ${count || '0'} item${count === '1' ? '' : 's'}.`
+    : actionName === 'empty'
+      ? 'Trash is already empty.'
+      : `Updated ${label}.`
+  const detail = valueText(action.detail, '')
+
+  return [{
+    status,
+    label,
+    message: valueText(action.message, fallback),
+    detail: detail || undefined,
+  }]
 }
 
 export function StatusReport({ dispatch, roster, color = true }: {
@@ -1740,6 +1774,28 @@ export function TrashListReport({ assets, color = true }: {
           message: 'bakin trash restore <trashName>',
           detail: 'Use the full trash filename with the __deleted- suffix.',
         }]} color={color} />
+      </Section>
+    </Box>
+  )
+}
+
+export function TrashActionReport({ action, color = true }: {
+  action: TrashActionData
+  color?: boolean
+}) {
+  const actionName = valueText(action.action, 'updated')
+  const count = valueText(action.count, '')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Trash action" subtitle="Soft-deleted assets updated" meta={actionName} color={color} />
+      <SummaryStrip items={[
+        { label: 'action', value: actionName, status: trashActionStatus(action) },
+        { label: 'items', value: count || '-', status: count ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={trashActionRows(action)} color={color} />
+        <Text> </Text>
       </Section>
     </Box>
   )

--- a/tests/cli/api-error.test.ts
+++ b/tests/cli/api-error.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test'
+import { extractApiErrorMessage, formatApiError } from '../../src/core/cli/api-error'
+
+describe('CLI API error formatting', () => {
+  it('extracts common JSON error fields', () => {
+    expect(formatApiError(500, '{"error":"Failed to restore asset"}')).toBe('HTTP 500: Failed to restore asset')
+    expect(formatApiError(400, '{"message":"Invalid input"}', { prefix: 'API error' })).toBe('API error 400: Invalid input')
+  })
+
+  it('includes validation issue messages when present', () => {
+    expect(extractApiErrorMessage('{"error":"invalid input","issues":[{"message":"malformed JSON body"}]}')).toBe(
+      'invalid input: malformed JSON body',
+    )
+  })
+
+  it('falls back to plain text bodies', () => {
+    expect(formatApiError(404, 'Not found')).toBe('HTTP 404: Not found')
+  })
+})

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -344,6 +344,31 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('item in trash:')
   })
 
+  it('renders trash action confirmations with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      restoredPath: '/Users/roscoe/.bakin/assets/doc.md',
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'trash', 'restore', 'doc.md__deleted-20260518']
+    await main()
+    expect(output()).toContain('Trash action')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Restored doc.md__deleted-20260518.')
+    expect(output()).not.toContain('Restored →')
+
+    log.mockClear()
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ count: 2 }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true, deleted: 2 }))
+    process.argv = ['bun', 'cli/bakin.ts', 'trash', 'empty']
+    await main()
+    expect(output()).toContain('Trash action')
+    expect(output()).toContain('Permanently deleted 2 items.')
+    expect(output()).toContain('RESULT')
+  })
+
   it('renders agent task lists with the shared TUI screen in a TTY', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -8,6 +8,7 @@ describe('read-only CLI TTY commands', () => {
   const originalFetch = globalThis.fetch
   const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
   let log: ReturnType<typeof spyOn>
+  let error: ReturnType<typeof spyOn>
 
   function setStdoutIsTTY(value: boolean): void {
     Object.defineProperty(process.stdout, 'isTTY', { value, configurable: true })
@@ -25,12 +26,19 @@ describe('read-only CLI TTY commands', () => {
     return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
   }
 
+  function errorOutput(): string {
+    return error.mock.calls
+      .map((call: unknown[]) => call.map(part => String(part)).join(' '))
+      .join('\n')
+  }
+
   beforeEach(() => {
     mock.clearAllMocks()
     process.argv = originalArgv
     globalThis.fetch = fetchMock as unknown as typeof fetch
     fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
     log = spyOn(console, 'log').mockImplementation(() => {})
+    error = spyOn(console, 'error').mockImplementation(() => {})
     process.exit = ((code?: number) => {
       if (code === 0) return undefined as never
       throw new Error(`exit:${code}`)
@@ -45,6 +53,7 @@ describe('read-only CLI TTY commands', () => {
     if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
     else delete (process.stdout as { isTTY?: boolean }).isTTY
     log.mockRestore()
+    error.mockRestore()
   })
 
   it('renders status with the shared TUI when stdout is a TTY', async () => {
@@ -367,6 +376,22 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('Trash action')
     expect(output()).toContain('Permanently deleted 2 items.')
     expect(output()).toContain('RESULT')
+  })
+
+  it('prints parsed API JSON errors without raw response bodies', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Failed to restore asset' }),
+      text: () => Promise.resolve('{"error":"Failed to restore asset"}'),
+    } as Response)
+    process.argv = ['bun', 'cli/bakin.ts', 'trash', 'restore', 'test']
+
+    await expect(main()).rejects.toThrow('exit:1')
+    expect(errorOutput()).toContain('Error: HTTP 500: Failed to restore asset')
+    expect(errorOutput()).not.toContain('{"error"')
   })
 
   it('renders agent task lists with the shared TUI screen in a TTY', async () => {

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -23,6 +23,7 @@ import {
   StatusReport,
   TaskDetailReport,
   TasksListReport,
+  TrashActionReport,
   TrashListReport,
   WorkflowsListReport,
 } from '../../src/core/cli/ui/readonly'
@@ -497,5 +498,33 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('2.0 KB')
     expect(output).toContain('patch')
     expect(output).toContain('bakin trash restore <trashName>')
+  })
+
+  it('renders trash action confirmations with shared TUI primitives', () => {
+    const restored = renderToString(
+      <TrashActionReport
+        action={{
+          action: 'restored',
+          target: 'doc.md__deleted-20260518',
+          message: 'Restored doc.md.',
+          detail: '/Users/roscoe/.bakin/assets/doc.md',
+        }}
+      />,
+    )
+    const emptied = renderToString(
+      <TrashActionReport
+        action={{
+          action: 'emptied',
+          count: 2,
+          message: 'Permanently deleted 2 items.',
+        }}
+      />,
+    )
+
+    expect(restored).toContain('Trash action')
+    expect(restored).toContain('RESULT')
+    expect(restored).toContain('doc.md__deleted')
+    expect(restored).toContain('Restored doc.md.')
+    expect(emptied).toContain('Permanently deleted 2 items.')
   })
 })


### PR DESCRIPTION
Summary: render bakin trash restore and bakin trash empty confirmations with the shared TUI in TTY sessions; preserve existing non-TTY one-line output; parse JSON API error bodies into readable CLI errors instead of showing raw response payloads; add UI, CLI, and API-error coverage. Tests: bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts; bun test --isolate tests/cli/schedule.test.ts; bun test --isolate tests/cli/api-error.test.ts tests/cli/readonly-commands.test.ts tests/cli/schedule.test.ts; bun run typecheck; bun test --isolate tests/cli.