### PR TITLE
Render task actions with TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -26,6 +26,7 @@ import type {
   SearchAggregationsData,
   SearchMetaData,
   SearchResultData,
+  TaskActionData,
   TrashActionData,
 } from '../src/core/cli/ui/readonly'
 import type { CheckResult, InstallResult } from '../src/core/onboarding/types'
@@ -169,6 +170,15 @@ async function printTasksListTui(columns: Record<string, Array<Record<string, un
     import('react'),
   ])
   console.log(renderToString(createElement(TasksListReport, { columns, column })))
+}
+
+async function printTaskActionTui(action: TaskActionData): Promise<void> {
+  const [{ TaskActionReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(TaskActionReport, { action })))
 }
 
 async function printTaskDetailTui(taskId: string, column: string, task: Record<string, unknown>): Promise<void> {
@@ -433,8 +443,24 @@ async function cmdTasksCreate(title: string, assignee?: string, workflowId?: str
     process.exit(1)
   }
 
+  const suggestedWorkflow = result.suggestedWorkflow && !workflowId && !skipWorkflowReason
+    ? result.suggestedWorkflow
+    : undefined
+
+  if (process.stdout.isTTY) {
+    await printTaskActionTui({
+      action: 'created',
+      taskId: result.id,
+      title,
+      agent: assignee,
+      workflowId: result.workflowId ?? workflowId,
+      suggestedWorkflow,
+    })
+    return
+  }
+
   // Warn if a workflow was suggested but not used and no reason given
-  if (result.suggestedWorkflow && !workflowId && !skipWorkflowReason) {
+  if (suggestedWorkflow) {
     console.warn(`\n⚠  Workflow "${result.suggestedWorkflow}" matches this task but was not started.`)
     console.warn(`   Re-run with --workflow=${result.suggestedWorkflow} to use it,`)
     console.warn(`   or --no-workflow="<reason>" to skip with an audit trail.\n`)
@@ -445,6 +471,14 @@ async function cmdTasksCreate(title: string, assignee?: string, workflowId?: str
 
 async function cmdTasksMove(id: string, to: string): Promise<void> {
   const result = await apiPost(`/api/plugins/tasks/${id}/move`, { id, to, agent: await getCliAgent() })
+  if (process.stdout.isTTY) {
+    await printTaskActionTui({
+      action: 'moved',
+      taskId: id,
+      column: to,
+    })
+    return
+  }
   print(result)
 }
 
@@ -2078,16 +2112,40 @@ async function cmdStop(): Promise<void> {
 
 async function cmdTasksLog(id: string, message: string): Promise<void> {
   const result = await apiPost(`/api/plugins/tasks/${id}/log`, { id, author: await getCliAgent(), message })
+  if (process.stdout.isTTY) {
+    await printTaskActionTui({
+      action: 'logged',
+      taskId: id,
+      detail: message,
+    })
+    return
+  }
   print(result)
 }
 
 async function cmdTasksBlock(id: string, reason: string): Promise<void> {
   const result = await apiPost(`/api/plugins/tasks/${id}/block`, { id, reason, agent: await getCliAgent() })
+  if (process.stdout.isTTY) {
+    await printTaskActionTui({
+      action: 'blocked',
+      taskId: id,
+      detail: reason,
+    })
+    return
+  }
   print(result)
 }
 
 async function cmdTasksDepend(id: string, dependsOn: string): Promise<void> {
   const result = await apiPost(`/api/plugins/tasks/${id}/dependency`, { id, dependsOn })
+  if (process.stdout.isTTY) {
+    await printTaskActionTui({
+      action: 'dependency',
+      taskId: id,
+      detail: `depends on ${dependsOn}`,
+    })
+    return
+  }
   print(result)
 }
 
@@ -2096,6 +2154,15 @@ async function cmdTasksComplete(id: string, summary: string): Promise<void> {
   // Log the summary, then move to done
   await apiPost(`/api/plugins/tasks/${id}/log`, { id, author: agent, message: `Task complete: ${summary}` })
   const result = await apiPost(`/api/plugins/tasks/${id}/move`, { id, to: 'done', agent })
+  if (process.stdout.isTTY) {
+    await printTaskActionTui({
+      action: 'completed',
+      taskId: id,
+      column: 'done',
+      detail: summary,
+    })
+    return
+  }
   print(result)
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -6,6 +6,7 @@ import {
   Section,
   StatusTable,
   SummaryStrip,
+  type FindingRow,
   type SummaryItem,
 } from './tui'
 import type { TuiStatus } from './style-tokens'
@@ -30,6 +31,18 @@ export interface TaskRowData {
 }
 
 export type TaskDetailData = Record<string, unknown>
+
+export interface TaskActionData {
+  action?: unknown
+  taskId?: unknown
+  title?: unknown
+  agent?: unknown
+  column?: unknown
+  workflowId?: unknown
+  message?: unknown
+  detail?: unknown
+  suggestedWorkflow?: unknown
+}
 
 export interface AgentTaskData {
   id?: unknown
@@ -485,6 +498,74 @@ function taskSummary(columns: Record<string, TaskRowData[]>): SummaryItem[] {
     { label: 'blocked', value: blocked, status: blocked > 0 ? 'blocked' : 'ok' },
     { label: 'done', value: done, status: done > 0 ? 'done' : 'ok' },
   ]
+}
+
+function taskActionStatus(action: TaskActionData): TuiStatus {
+  const name = valueText(action.action)
+  if (name === 'blocked') return 'blocked'
+  if (name === 'completed') return 'done'
+  if (name === 'moved') return taskColumnStatus(valueText(action.column))
+  return 'applied'
+}
+
+function taskActionMessage(action: TaskActionData): string {
+  const name = valueText(action.action, 'updated')
+  const taskId = valueText(action.taskId, 'task')
+  const title = valueText(action.title, taskId)
+  const column = valueText(action.column, '')
+  const detail = valueText(action.detail, '')
+
+  switch (name) {
+    case 'created':
+      return `Created task ${title}.`
+    case 'moved':
+      return `Moved task ${taskId}${column ? ` to ${column}` : ''}.`
+    case 'logged':
+      return `Logged progress on task ${taskId}.`
+    case 'blocked':
+      return `Blocked task ${taskId}.`
+    case 'dependency':
+      return `Added dependency for task ${taskId}.`
+    case 'completed':
+      return `Completed task ${taskId}.`
+    default:
+      return detail ? `Updated task ${taskId}.` : `Updated task ${title}.`
+  }
+}
+
+function taskActionRows(action: TaskActionData) {
+  const status = taskActionStatus(action)
+  const taskId = valueText(action.taskId, '')
+  const title = valueText(action.title, taskId || 'task')
+  const detail = valueText(action.detail, '')
+  const workflowId = valueText(action.workflowId, '')
+  const suggestedWorkflow = valueText(action.suggestedWorkflow, '')
+  const rows: FindingRow[] = [{
+    status,
+    label: taskId || title,
+    message: valueText(action.message, taskActionMessage(action)),
+    detail: detail || undefined,
+  }]
+
+  if (workflowId) {
+    rows.push({
+      status: 'ok',
+      label: 'workflow',
+      message: `Workflow ${workflowId} associated with this task.`,
+      detail: undefined,
+    })
+  }
+  if (suggestedWorkflow) {
+    rows.push({
+      status: 'warn',
+      label: 'workflow',
+      message: `Workflow ${suggestedWorkflow} matches this task but was not started.`,
+      detail: undefined,
+      next: `Re-run with --workflow=${suggestedWorkflow} or --no-workflow="<reason>".`,
+    })
+  }
+
+  return rows
 }
 
 function agentStatus(status: string): TuiStatus {
@@ -1089,6 +1170,36 @@ export function TasksListReport({ columns, column, color = true }: {
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No tasks found.' }]} color={color} />
         )}
+      </Section>
+    </Box>
+  )
+}
+
+export function TaskActionReport({ action, color = true }: {
+  action: TaskActionData
+  color?: boolean
+}) {
+  const actionName = valueText(action.action, 'updated')
+  const taskId = valueText(action.taskId, '')
+  const agent = valueText(action.agent, '')
+  const column = valueText(action.column, '')
+  const context = agent
+    ? { label: 'agent', value: agent, status: 'ok' as TuiStatus }
+    : column
+      ? { label: 'column', value: column, status: taskColumnStatus(column) }
+      : { label: 'target', value: taskId || valueText(action.title, '-'), status: taskId ? 'ok' as TuiStatus : 'skip' as TuiStatus }
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Task action" subtitle="Board task updated" meta={actionName} color={color} />
+      <SummaryStrip items={[
+        { label: 'action', value: actionName, status: taskActionStatus(action) },
+        { label: 'task', value: taskId || '-', status: taskId ? 'ok' : 'skip' },
+        context,
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={taskActionRows(action)} color={color} />
+        <Text> </Text>
       </Section>
     </Box>
   )

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -166,6 +166,25 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('"workspacePath"')
   })
 
+  it('renders task action confirmations with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      id: 'task-1',
+      workflowId: 'release',
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'create', 'Write docs', 'patch', '--workflow=release']
+    await main()
+
+    expect(output()).toContain('Task action')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('task-1')
+    expect(output()).toContain('Created task Write docs.')
+    expect(output()).toContain('workflow')
+    expect(output()).not.toContain('"ok": true')
+  })
+
   it('honors --json for task detail commands even in a TTY', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -21,6 +21,7 @@ import {
   SearchStatsReport,
   SettingsReport,
   StatusReport,
+  TaskActionReport,
   TaskDetailReport,
   TasksListReport,
   TrashActionReport,
@@ -74,6 +75,38 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('Write docs')
     expect(output).toContain('patch')
     expect(output).not.toContain('Column: todo; Agent: patch')
+  })
+
+  it('renders task action confirmations with shared TUI primitives', () => {
+    const created = renderToString(
+      <TaskActionReport
+        action={{
+          action: 'created',
+          taskId: 'task-1',
+          title: 'Write docs',
+          agent: 'patch',
+          workflowId: 'release',
+        }}
+      />,
+    )
+    const blocked = renderToString(
+      <TaskActionReport
+        action={{
+          action: 'blocked',
+          taskId: 'task-2',
+          message: 'Blocked task task-2.',
+          detail: 'Waiting on API credentials',
+        }}
+      />,
+    )
+
+    expect(created).toContain('Task action')
+    expect(created).toContain('RESULT')
+    expect(created).toContain('task-1')
+    expect(created).toContain('Created task Write docs.')
+    expect(created).toContain('workflow')
+    expect(blocked).toContain('Blocked task task-2.')
+    expect(blocked).toContain('Waiting on API credentials')
   })
 
   it('renders task and agent detail screens with shared TUI primitives', () => {


### PR DESCRIPTION
Summary: render task mutation confirmations with the shared TUI in TTY sessions for tasks create, move, log, block, depend, and complete; keep existing JSON/plain output for non-TTY use; include workflow association and suggested-workflow warnings in the task action report. Tests: bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts; bun run typecheck; bun test --isolate tests/cli.