### PR TITLE
Render workflow actions with TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -28,6 +28,7 @@ import type {
   SearchResultData,
   TaskActionData,
   TrashActionData,
+  WorkflowActionData,
 } from '../src/core/cli/ui/readonly'
 import type { CheckResult, InstallResult } from '../src/core/onboarding/types'
 
@@ -260,6 +261,15 @@ async function printWorkflowsListTui(templates: Array<Record<string, unknown>>):
     import('react'),
   ])
   console.log(renderToString(createElement(WorkflowsListReport, { templates })))
+}
+
+async function printWorkflowActionTui(action: WorkflowActionData): Promise<void> {
+  const [{ WorkflowActionReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(WorkflowActionReport, { action })))
 }
 
 async function printSearchResultsTui(query: string, result: Record<string, unknown>): Promise<void> {
@@ -2205,11 +2215,28 @@ async function cmdWorkflowsList(): Promise<void> {
 
 async function cmdWorkflowsStart(taskId: string, workflowId: string): Promise<void> {
   const result = await apiPost('/api/plugins/workflows/instances/start', { taskId, workflowId })
+  if (process.stdout.isTTY) {
+    await printWorkflowActionTui({
+      action: 'started',
+      taskId,
+      workflowId,
+      result,
+    })
+    return
+  }
   print(result)
 }
 
 async function cmdWorkflowsStep(taskId: string): Promise<void> {
   const result = await apiGet(`/api/plugins/workflows/steps/${encodeURIComponent(taskId)}`)
+  if (process.stdout.isTTY) {
+    await printWorkflowActionTui({
+      action: 'step',
+      taskId,
+      result,
+    })
+    return
+  }
   print(result)
 }
 
@@ -2222,6 +2249,15 @@ async function cmdWorkflowsSubmit(taskId: string, stepId: string, outputJson: st
     process.exit(1)
   }
   const result = await apiPost(`/api/plugins/workflows/steps/${encodeURIComponent(taskId)}/complete`, { stepId, agentId: await getCliAgent(), output })
+  if (process.stdout.isTTY) {
+    await printWorkflowActionTui({
+      action: 'submitted',
+      taskId,
+      stepId,
+      result,
+    })
+    return
+  }
   print(result)
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -109,6 +109,16 @@ export interface WorkflowTemplateData {
   stepCount?: unknown
 }
 
+export interface WorkflowActionData {
+  action?: unknown
+  taskId?: unknown
+  workflowId?: unknown
+  stepId?: unknown
+  result?: unknown
+  message?: unknown
+  detail?: unknown
+}
+
 export interface SearchResultData {
   id?: unknown
   key?: unknown
@@ -745,6 +755,103 @@ function workflowTableRows(templates: WorkflowTemplateData[]): WorkflowTableRow[
     description: valueText(template.description),
     steps: valueText(template.stepCount),
   }))
+}
+
+function workflowResultRecord(action: WorkflowActionData): Record<string, unknown> {
+  return isPlainRecord(action.result) ? action.result : {}
+}
+
+function workflowActionStatus(action: WorkflowActionData): TuiStatus {
+  const name = valueText(action.action)
+  const result = workflowResultRecord(action)
+  const instance = objectField(result, 'instance')
+  const status = valueText(
+    objectField(instance, 'status')
+      ?? objectField(result, 'status')
+      ?? objectField(objectField(result, 'nextStep'), 'status'),
+    '',
+  )
+
+  if (status === 'complete' || objectField(result, 'workflowComplete') === true) return 'done'
+  if (status === 'failed' || status === 'cancelled') return 'fail'
+  if (status === 'pending_approval') return 'ready'
+  if (name === 'step') return 'run'
+  return 'applied'
+}
+
+function workflowActionMessage(action: WorkflowActionData): string {
+  const name = valueText(action.action, 'updated')
+  const result = workflowResultRecord(action)
+  const taskId = valueText(action.taskId, 'task')
+  const workflowId = valueText(action.workflowId ?? objectField(objectField(result, 'instance'), 'workflowId'), 'workflow')
+  const stepId = valueText(action.stepId ?? objectField(result, 'stepId'), 'step')
+  const label = valueText(objectField(result, 'label'), stepId)
+  const status = valueText(objectField(result, 'status'), '')
+
+  switch (name) {
+    case 'started':
+      return `Started workflow ${workflowId} for task ${taskId}.`
+    case 'step':
+      if (status === 'complete') return `Workflow for task ${taskId} is complete.`
+      if (status === 'pending_approval') return `Workflow step ${stepId} is waiting for approval.`
+      return `Current workflow step ${stepId}: ${label}.`
+    case 'submitted':
+      return `Completed workflow step ${stepId}.`
+    default:
+      return `Updated workflow for task ${taskId}.`
+  }
+}
+
+function workflowActionDetail(action: WorkflowActionData): string {
+  const detail = valueText(action.detail, '')
+  if (detail) return detail
+
+  const name = valueText(action.action, 'updated')
+  const result = workflowResultRecord(action)
+  const instance = objectField(result, 'instance')
+  const nextStep = objectField(result, 'nextStep')
+
+  if (name === 'started') {
+    const currentStep = valueText(objectField(instance, 'currentStepId'), '')
+    const status = valueText(objectField(instance, 'status'), '')
+    return [
+      currentStep ? `current step: ${currentStep}` : '',
+      status ? `status: ${status}` : '',
+    ].filter(Boolean).join(', ')
+  }
+
+  if (name === 'step') {
+    const agent = valueText(objectField(result, 'agent'), '')
+    const type = valueText(objectField(result, 'type'), '')
+    const status = valueText(objectField(result, 'status'), '')
+    return [
+      agent ? `agent: ${agent}` : '',
+      type ? `type: ${type}` : '',
+      status ? `status: ${status}` : '',
+    ].filter(Boolean).join(', ')
+  }
+
+  if (name === 'submitted') {
+    if (objectField(result, 'workflowComplete') === true) return 'Workflow complete.'
+    if (isPlainRecord(nextStep)) {
+      const stepId = valueText(nextStep.stepId, 'next')
+      const label = valueText(nextStep.label, stepId)
+      return `Next step ${stepId}: ${label}`
+    }
+  }
+
+  return ''
+}
+
+function workflowActionRows(action: WorkflowActionData): FindingRow[] {
+  const status = workflowActionStatus(action)
+  const taskId = valueText(action.taskId, 'task')
+  return [{
+    status,
+    label: taskId,
+    message: valueText(action.message, workflowActionMessage(action)),
+    detail: workflowActionDetail(action) || undefined,
+  }]
 }
 
 function searchTableName(value: unknown): string {
@@ -1510,6 +1617,33 @@ export function WorkflowsListReport({ templates, color = true }: {
         ) : (
           <FindingRows rows={[{ status: 'skip', label: 'empty', message: 'No workflow definitions found.' }]} color={color} />
         )}
+      </Section>
+    </Box>
+  )
+}
+
+export function WorkflowActionReport({ action, color = true }: {
+  action: WorkflowActionData
+  color?: boolean
+}) {
+  const actionName = valueText(action.action, 'updated')
+  const taskId = valueText(action.taskId, '')
+  const workflowId = valueText(action.workflowId, '')
+  const stepId = valueText(action.stepId, '')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Workflow action" subtitle="Workflow state updated" meta={actionName} color={color} />
+      <SummaryStrip items={[
+        { label: 'action', value: actionName, status: workflowActionStatus(action) },
+        { label: 'task', value: taskId || '-', status: taskId ? 'ok' : 'skip' },
+        workflowId
+          ? { label: 'workflow', value: workflowId, status: 'ok' }
+          : { label: 'step', value: stepId || '-', status: stepId ? 'ready' : 'skip' },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={workflowActionRows(action)} color={color} />
+        <Text> </Text>
       </Section>
     </Box>
   )

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -260,6 +260,47 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('-----------  -------')
   })
 
+  it('renders workflow actions with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      instance: { taskId: 'task-1', workflowId: 'release', status: 'in_progress', currentStepId: 'draft' },
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'workflows', 'start', 'task-1', 'release']
+    await main()
+    expect(output()).toContain('Workflow action')
+    expect(output()).toContain('Started workflow release')
+    expect(output()).toContain('RESULT')
+    expect(output()).not.toContain('"instance"')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      stepId: 'draft',
+      label: 'Draft release notes',
+      type: 'agent',
+      agent: 'patch',
+      status: 'in_progress',
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'workflows', 'step', 'task-1']
+    await main()
+    expect(output()).toContain('Current workflow step draft')
+    expect(output()).toContain('Draft release')
+
+    log.mockClear()
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ agents: [{ id: 'patch' }], mainAgentId: 'patch' }))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        workflowComplete: false,
+        nextStep: { stepId: 'review', label: 'Review release notes', status: 'pending' },
+      }))
+    process.argv = ['bun', 'cli/bakin.ts', 'workflows', 'submit', 'task-1', 'draft', '{"summary":"done"}']
+    await main()
+    expect(output()).toContain('Completed workflow step draft.')
+    expect(output()).toContain('Next step review')
+    expect(output()).not.toContain('"success": true')
+  })
+
   it('renders package-oriented list commands with shared TUI screens in a TTY', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -26,6 +26,7 @@ import {
   TasksListReport,
   TrashActionReport,
   TrashListReport,
+  WorkflowActionReport,
   WorkflowsListReport,
 } from '../../src/core/cli/ui/readonly'
 
@@ -363,6 +364,36 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('STEPS')
     expect(output).toContain('release.yml')
     expect(output).toContain('Release')
+  })
+
+  it('renders workflow action confirmations with shared TUI primitives', () => {
+    const started = renderToString(
+      <WorkflowActionReport
+        action={{
+          action: 'started',
+          taskId: 'task-1',
+          workflowId: 'release',
+          result: { instance: { status: 'in_progress', currentStepId: 'draft' } },
+        }}
+      />,
+    )
+    const submitted = renderToString(
+      <WorkflowActionReport
+        action={{
+          action: 'submitted',
+          taskId: 'task-1',
+          stepId: 'draft',
+          result: { success: true, workflowComplete: false, nextStep: { stepId: 'review', label: 'Review draft', status: 'pending' } },
+        }}
+      />,
+    )
+
+    expect(started).toContain('Workflow action')
+    expect(started).toContain('RESULT')
+    expect(started).toContain('Started workflow release')
+    expect(started).toContain('current step: draft')
+    expect(submitted).toContain('Completed workflow step draft.')
+    expect(submitted).toContain('Next step review: Review draft')
   })
 
   it('renders docs and search screens with shared TUI tables', () => {


### PR DESCRIPTION
Summary: render workflows start, workflows step, and workflows submit results with the shared TUI in TTY sessions; keep existing JSON/plain output for non-TTY use; summarize started workflow state, current step context, and submitted-step next-step/complete status. Tests: bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts; bun run typecheck; bun test --isolate tests/cli.