### PR TITLE
Render runtime actions with TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -23,6 +23,7 @@ import type {
   PluginRestoreResultData,
   PluginRestoreSnapshotData,
   ReindexResultData,
+  RuntimeActionData,
   SearchAggregationsData,
   SearchMetaData,
   SearchResultData,
@@ -132,6 +133,15 @@ async function printStatusTui(dispatch: Record<string, unknown>, roster: CliRost
     import('react'),
   ])
   console.log(renderToString(createElement(StatusReport, { dispatch, roster })))
+}
+
+async function printRuntimeActionTui(action: RuntimeActionData): Promise<void> {
+  const [{ RuntimeActionReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(RuntimeActionReport, { action })))
 }
 
 async function printSettingsTui(settings: Record<string, unknown>): Promise<void> {
@@ -409,6 +419,14 @@ async function cmdStatus(): Promise<void> {
 
 async function cmdDispatch(): Promise<void> {
   const result = await apiPost('/api/dispatch')
+  if (process.stdout.isTTY) {
+    await printRuntimeActionTui({
+      action: 'dispatch',
+      target: 'task dispatcher',
+      result,
+    })
+    return
+  }
   print(result)
 }
 
@@ -508,6 +526,15 @@ async function cmdAgentsList(): Promise<void> {
 
 async function cmdAgentsSend(agentId: string, message: string): Promise<void> {
   const result = await apiPost(`/api/agents/${agentId}/message`, { message })
+  if (process.stdout.isTTY) {
+    await printRuntimeActionTui({
+      action: 'message',
+      target: agentId,
+      detail: message,
+      result,
+    })
+    return
+  }
   print(result)
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -24,6 +24,14 @@ export interface StatusRosterData {
   mainAgentId?: string | null
 }
 
+export interface RuntimeActionData {
+  action?: unknown
+  target?: unknown
+  result?: unknown
+  message?: unknown
+  detail?: unknown
+}
+
 export interface TaskRowData {
   id?: unknown
   title?: unknown
@@ -454,6 +462,46 @@ function taskColumnStatus(column: string): TuiStatus {
     default:
       return 'todo'
   }
+}
+
+function runtimeActionResult(action: RuntimeActionData): Record<string, unknown> {
+  return isPlainRecord(action.result) ? action.result : {}
+}
+
+function runtimeActionStatus(action: RuntimeActionData): TuiStatus {
+  const result = runtimeActionResult(action)
+  if (objectField(result, 'ok') === false) return 'fail'
+  return 'sent'
+}
+
+function runtimeActionMessage(action: RuntimeActionData): string {
+  const name = valueText(action.action, 'updated')
+  const target = valueText(action.target, 'runtime')
+  const result = runtimeActionResult(action)
+  const error = valueText(objectField(result, 'error'), '')
+
+  if (error) return error
+  if (name === 'dispatch') return 'Triggered immediate task dispatch.'
+  if (name === 'message') return `Sent message to ${target}.`
+  return `Updated ${target}.`
+}
+
+function runtimeActionDetail(action: RuntimeActionData): string {
+  const detail = valueText(action.detail, '')
+  const result = runtimeActionResult(action)
+  const reply = valueText(objectField(result, 'reply'), '')
+  const ts = valueText(objectField(result, 'ts'), '')
+
+  return [detail, reply, ts].filter(Boolean).join('\n')
+}
+
+function runtimeActionRows(action: RuntimeActionData): FindingRow[] {
+  return [{
+    status: runtimeActionStatus(action),
+    label: valueText(action.target, valueText(action.action, 'runtime')),
+    message: valueText(action.message, runtimeActionMessage(action)),
+    detail: runtimeActionDetail(action) || undefined,
+  }]
 }
 
 function orderedTaskColumns(columns: Record<string, TaskRowData[]>): Array<[string, TaskRowData[]]> {
@@ -1155,6 +1203,28 @@ export function StatusReport({ dispatch, roster, color = true }: {
           label: roster.mainAgentId ?? 'main',
           message: agentCount > 0 ? roster.agentIds.join(', ') : 'No agents reported by the runtime.',
         }]} color={color} />
+      </Section>
+    </Box>
+  )
+}
+
+export function RuntimeActionReport({ action, color = true }: {
+  action: RuntimeActionData
+  color?: boolean
+}) {
+  const actionName = valueText(action.action, 'updated')
+  const target = valueText(action.target, 'runtime')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Runtime action" subtitle="Runtime request accepted" meta={actionName} color={color} />
+      <SummaryStrip items={[
+        { label: 'action', value: actionName, status: runtimeActionStatus(action) },
+        { label: 'target', value: target, status: 'ok' },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={runtimeActionRows(action)} color={color} />
+        <Text> </Text>
       </Section>
     </Box>
   )

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -77,6 +77,27 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('=== Bakin Status ===')
   })
 
+  it('renders runtime action confirmations with the shared TUI screen in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, ts: '2026-05-18T09:00:00.000Z' }))
+    process.argv = ['bun', 'cli/bakin.ts', 'dispatch']
+    await main()
+    expect(output()).toContain('Runtime action')
+    expect(output()).toContain('Triggered immediate task dispatch.')
+    expect(output()).toContain('RESULT')
+    expect(output()).not.toContain('"ok": true')
+
+    log.mockClear()
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, reply: 'Message accepted' }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'send', 'patch', 'Check the build']
+    await main()
+    expect(output()).toContain('Runtime action')
+    expect(output()).toContain('Sent message to patch.')
+    expect(output()).toContain('Message accepted')
+    expect(output()).not.toContain('"reply"')
+  })
+
   it('renders tasks, agents, and plugins with shared TUI screens', async () => {
     const { main } = await import('../../cli/bakin')
 

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -15,6 +15,7 @@ import {
   PluginRestoreSnapshotsReport,
   PluginsListReport,
   ReindexReport,
+  RuntimeActionReport,
   ScheduleListReport,
   ScheduleRunsReport,
   SearchResultsReport,
@@ -50,6 +51,35 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('DISPATCH')
     expect(output).toContain('main, patch')
     expect(output).not.toContain('=== Bakin Status ===')
+  })
+
+  it('renders runtime action confirmations with shared TUI primitives', () => {
+    const dispatch = renderToString(
+      <RuntimeActionReport
+        action={{
+          action: 'dispatch',
+          target: 'task dispatcher',
+          result: { ok: true, ts: '2026-05-18T09:00:00.000Z' },
+        }}
+      />,
+    )
+    const message = renderToString(
+      <RuntimeActionReport
+        action={{
+          action: 'message',
+          target: 'patch',
+          detail: 'Check the build',
+          result: { ok: true, reply: 'Message accepted' },
+        }}
+      />,
+    )
+
+    expect(dispatch).toContain('Runtime action')
+    expect(dispatch).toContain('RESULT')
+    expect(dispatch).toContain('Triggered immediate task dispatch.')
+    expect(dispatch).toContain('2026-05-18T09:00:00.000Z')
+    expect(message).toContain('Sent message to patch.')
+    expect(message).toContain('Message accepted')
   })
 
   it('renders task board rows as a table with column status tokens', () => {


### PR DESCRIPTION
Summary:
- Render bakin dispatch and bakin agents send results with the shared TUI in TTY sessions.
- Preserve existing non-TTY output.
- Summarize dispatch timestamps and agent message replies.

Tests:
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli