### PR TITLE
Render stop with runtime TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2484,16 +2484,37 @@ async function cmdLogs(filter?: string): Promise<void> {
 async function cmdStop(): Promise<void> {
   const { execFileSync } = await import('child_process')
 
-  console.log('[..] Stopping Bakin server...')
+  const printStopResult = async (result: Record<string, unknown>, detail?: string): Promise<void> => {
+    const message = typeof result.message === 'string' ? result.message : 'Bakin stop request completed.'
+    if (process.stdout.isTTY) {
+      await printRuntimeActionTui({
+        action: 'stop',
+        target: 'Bakin server',
+        result,
+        message,
+        detail,
+      })
+      return
+    }
+    if (message === 'Bakin stopped.') console.log('[OK] Bakin stopped')
+    else if (message === 'No running Bakin process found.') console.log('[OK] No running Bakin process found')
+    else if (result.status === 'warn') console.log(`[WARN] ${message}`)
+    else console.log(message)
+    if (detail) console.log(`  ${detail}`)
+  }
+
+  if (!process.stdout.isTTY) console.log('[..] Stopping Bakin server...')
   try {
     const pids = execFileSync('pgrep', ['-f', serverProcessPattern()], { encoding: 'utf-8' }).trim()
     if (pids) {
+      const signaled: string[] = []
       for (const pid of pids.split('\n')) {
         if (pid && pid !== String(process.pid)) {
           process.kill(Number(pid), 'SIGTERM')
+          signaled.push(pid)
         }
       }
-      console.log('[OK] Sent SIGTERM to Bakin server')
+      if (!process.stdout.isTTY) console.log('[OK] Sent SIGTERM to Bakin server')
 
       // Wait and verify it's actually down
       for (let i = 0; i < 10; i++) {
@@ -2501,16 +2522,36 @@ async function cmdStop(): Promise<void> {
         try {
           await fetch(`${BASE_URL}/api/version`, { signal: AbortSignal.timeout(1000) })
         } catch {
-          console.log('[OK] Bakin stopped')
+          await printStopResult({
+            ok: true,
+            status: 'ok',
+            message: 'Bakin stopped.',
+            signaled: signaled.length,
+          }, signaled.length > 0 ? `Sent SIGTERM to ${signaled.length} process(es).` : undefined)
           return
         }
       }
-      console.log('[WARN] Server may still be shutting down')
+      await printStopResult({
+        ok: true,
+        status: 'warn',
+        message: 'Server may still be shutting down.',
+        signaled: signaled.length,
+      }, signaled.length > 0 ? `Sent SIGTERM to ${signaled.length} process(es).` : undefined)
     } else {
-      console.log('[OK] No running Bakin process found')
+      await printStopResult({
+        ok: true,
+        status: 'ok',
+        message: 'No running Bakin process found.',
+        signaled: 0,
+      })
     }
   } catch {
-    console.log('[OK] No running Bakin process found')
+    await printStopResult({
+      ok: true,
+      status: 'ok',
+      message: 'No running Bakin process found.',
+      signaled: 0,
+    })
   }
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -506,9 +506,30 @@ function runtimeActionResult(action: RuntimeActionData): Record<string, unknown>
   return isPlainRecord(action.result) ? action.result : {}
 }
 
+function tuiStatusValue(value: unknown): TuiStatus | undefined {
+  switch (value) {
+    case 'ok':
+    case 'warn':
+    case 'fail':
+    case 'skip':
+    case 'ready':
+    case 'run':
+    case 'blocked':
+    case 'applied':
+    case 'sent':
+    case 'todo':
+    case 'done':
+      return value
+    default:
+      return undefined
+  }
+}
+
 function runtimeActionStatus(action: RuntimeActionData): TuiStatus {
   const result = runtimeActionResult(action)
   if (objectField(result, 'ok') === false) return 'fail'
+  const explicit = tuiStatusValue(objectField(result, 'status'))
+  if (explicit) return explicit
   return 'sent'
 }
 

--- a/tests/cli/system-actions.test.ts
+++ b/tests/cli/system-actions.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const execFileSync = mock(() => '')
+
+mock.module('child_process', () => ({
+  execFileSync,
+  spawn: mock(() => ({
+    pid: 4242,
+    unref: mock(),
+  })),
+}))
+
+describe('CLI system action TUI commands', () => {
+  const originalArgv = process.argv
+  const originalExit = process.exit
+  const originalFetch = globalThis.fetch
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let log: ReturnType<typeof spyOn>
+  let error: ReturnType<typeof spyOn>
+
+  function output(): string {
+    return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+  }
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    execFileSync.mockReturnValue('')
+    process.argv = originalArgv
+    globalThis.fetch = mock(async () => ({ ok: true, json: async () => ({ version: 'test' }) })) as unknown as typeof fetch
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    error = spyOn(console, 'error').mockImplementation(() => {})
+    process.exit = ((code?: number) => {
+      if (code === 0) return undefined as never
+      throw new Error(`exit:${code}`)
+    }) as never
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    process.exit = originalExit
+    globalThis.fetch = originalFetch
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+    log.mockRestore()
+    error.mockRestore()
+  })
+
+  it('renders stop results with the shared runtime action TUI in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    process.argv = ['bun', 'cli/bakin.ts', 'stop']
+    await main()
+
+    expect(output()).toContain('Runtime action')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('No running Bakin process found.')
+    expect(output()).not.toContain('[OK]')
+    expect(error.mock.calls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- render `bakin stop` TTY output through the shared Runtime action screen
- allow runtime action results to request explicit OK/WARN status tokens
- preserve existing non-TTY `bakin stop` text output

## Tests
- `bun test --isolate tests/cli/system-actions.test.ts tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts`
- `bun test --isolate tests/cli`
- `bun run typecheck`
- `git diff --check`