### PR TITLE
Render setup service with runtime TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2232,6 +2232,22 @@ async function cmdSetupService(options: { uninstall?: boolean } = {}): Promise<v
   const { join, dirname, resolve } = await import('path')
   const { homedir } = await import('os')
   const { getBakinPaths } = await import('../packages/core/src/content-dir')
+  const isTTY = process.stdout.isTTY
+
+  const printServiceResult = async (
+    result: Record<string, unknown>,
+    detail?: string,
+  ): Promise<void> => {
+    const action = options.uninstall ? 'disable autostart' : 'enable autostart'
+    const message = typeof result.message === 'string' ? result.message : 'Bakin service configuration updated.'
+    await printRuntimeActionTui({
+      action,
+      target: 'Bakin service',
+      result,
+      message,
+      detail,
+    })
+  }
 
   const programArgs = await serviceProgramArgs()
   const projectDir = resolve(dirname(new URL(import.meta.url).pathname), '..')
@@ -2250,12 +2266,22 @@ async function cmdSetupService(options: { uninstall?: boolean } = {}): Promise<v
     }
 
     if (options.uninstall) {
-      console.log('[..] Removing Bakin LaunchAgent...')
+      if (!isTTY) console.log('[..] Removing Bakin LaunchAgent...')
       removePlist(plistPath)
       for (const label of LEGACY_SERVICE_LABELS) {
         removePlist(join(launchAgentsDir, `${label}.plist`))
       }
-      console.log('[OK] Bakin autostart disabled')
+      if (isTTY) {
+        await printServiceResult({
+          ok: true,
+          status: 'ok',
+          message: 'Bakin autostart disabled.',
+          service: SERVICE_LABEL,
+          platform: 'darwin',
+        }, `Service: ${SERVICE_LABEL}`)
+      } else {
+        console.log('[OK] Bakin autostart disabled')
+      }
       return
     }
 
@@ -2272,10 +2298,24 @@ async function cmdSetupService(options: { uninstall?: boolean } = {}): Promise<v
     }), 'utf-8')
     execFileSync('launchctl', ['bootstrap', `gui/${uid}`, plistPath], { stdio: 'pipe' })
     execFileSync('launchctl', ['kickstart', '-k', `gui/${uid}/${SERVICE_LABEL}`], { stdio: 'pipe' })
-    console.log('[OK] Bakin autostart enabled')
-    console.log(`  Service: ${SERVICE_LABEL}`)
-    console.log(`  Logs:    ${stdoutPath}`)
-    console.log('  Disable: bakin setup service --uninstall')
+    if (isTTY) {
+      await printServiceResult({
+        ok: true,
+        status: 'ok',
+        message: 'Bakin autostart enabled.',
+        service: SERVICE_LABEL,
+        platform: 'darwin',
+      }, [
+        `Service: ${SERVICE_LABEL}`,
+        `Logs: ${stdoutPath}`,
+        'Disable: bakin setup service --uninstall',
+      ].join('\n'))
+    } else {
+      console.log('[OK] Bakin autostart enabled')
+      console.log(`  Service: ${SERVICE_LABEL}`)
+      console.log(`  Logs:    ${stdoutPath}`)
+      console.log('  Disable: bakin setup service --uninstall')
+    }
     return
   }
 
@@ -2283,11 +2323,21 @@ async function cmdSetupService(options: { uninstall?: boolean } = {}): Promise<v
     const systemdDir = join(homedir(), '.config', 'systemd', 'user')
     const unitPath = join(systemdDir, `${SERVICE_LABEL}.service`)
     if (options.uninstall) {
-      console.log('[..] Removing Bakin user service...')
+      if (!isTTY) console.log('[..] Removing Bakin user service...')
       try { execFileSync('systemctl', ['--user', 'disable', '--now', `${SERVICE_LABEL}.service`], { stdio: 'pipe' }) } catch { /* not enabled */ }
       if (existsSync(unitPath)) unlinkSync(unitPath)
       try { execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' }) } catch { /* systemd unavailable */ }
-      console.log('[OK] Bakin autostart disabled')
+      if (isTTY) {
+        await printServiceResult({
+          ok: true,
+          status: 'ok',
+          message: 'Bakin autostart disabled.',
+          service: `${SERVICE_LABEL}.service`,
+          platform: 'linux',
+        }, `Service: ${SERVICE_LABEL}.service`)
+      } else {
+        console.log('[OK] Bakin autostart disabled')
+      }
       return
     }
 
@@ -2300,14 +2350,33 @@ async function cmdSetupService(options: { uninstall?: boolean } = {}): Promise<v
     }), 'utf-8')
     execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' })
     execFileSync('systemctl', ['--user', 'enable', '--now', `${SERVICE_LABEL}.service`], { stdio: 'pipe' })
-    console.log('[OK] Bakin autostart enabled')
-    console.log(`  Service: ${SERVICE_LABEL}.service`)
-    console.log(`  Logs:    ${stdoutPath}`)
-    console.log('  Disable: bakin setup service --uninstall')
+    if (isTTY) {
+      await printServiceResult({
+        ok: true,
+        status: 'ok',
+        message: 'Bakin autostart enabled.',
+        service: `${SERVICE_LABEL}.service`,
+        platform: 'linux',
+      }, [
+        `Service: ${SERVICE_LABEL}.service`,
+        `Logs: ${stdoutPath}`,
+        'Disable: bakin setup service --uninstall',
+      ].join('\n'))
+    } else {
+      console.log('[OK] Bakin autostart enabled')
+      console.log(`  Service: ${SERVICE_LABEL}.service`)
+      console.log(`  Logs:    ${stdoutPath}`)
+      console.log('  Disable: bakin setup service --uninstall')
+    }
     return
   }
 
-  console.error(`Service management is not supported on ${process.platform}.`)
+  const error = `Service management is not supported on ${process.platform}.`
+  if (isTTY) {
+    await printServiceResult({ ok: false, status: 'fail', error })
+  } else {
+    console.error(error)
+  }
   process.exit(1)
 }
 

--- a/tests/cli/system-actions.test.ts
+++ b/tests/cli/system-actions.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+import * as nodeFs from 'node:fs'
+import * as nodeOs from 'node:os'
 
-const execFileSync = mock(() => '')
+const execFileSync = mock((..._args: unknown[]) => '')
+const existsSync = mock(() => false)
+const mkdirSync = mock()
+const unlinkSync = mock()
+const writeFileSync = mock()
+const homedir = mock(() => '/Users/tester')
 const spawn = mock(() => ({
   pid: 4242,
   unref: mock(),
@@ -11,11 +18,25 @@ mock.module('child_process', () => ({
   spawn,
 }))
 
+mock.module('fs', () => ({
+  ...nodeFs,
+  existsSync,
+  mkdirSync,
+  unlinkSync,
+  writeFileSync,
+}))
+
+mock.module('os', () => ({
+  ...nodeOs,
+  homedir,
+}))
+
 describe('CLI system action TUI commands', () => {
   const originalArgv = process.argv
   const originalExit = process.exit
   const originalFetch = globalThis.fetch
   const originalSetTimeout = globalThis.setTimeout
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
   const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
   let log: ReturnType<typeof spyOn>
   let error: ReturnType<typeof spyOn>
@@ -26,14 +47,17 @@ describe('CLI system action TUI commands', () => {
 
   beforeEach(() => {
     mock.clearAllMocks()
-    execFileSync.mockReturnValue('')
+    execFileSync.mockImplementation((...args: unknown[]) => args[0] === 'id' ? '501\n' : '')
+    existsSync.mockReturnValue(false)
     spawn.mockReturnValue({ pid: 4242, unref: mock() })
+    homedir.mockReturnValue('/Users/tester')
     process.argv = originalArgv
     globalThis.fetch = mock(async () => ({ ok: true, json: async () => ({ version: 'test' }) })) as unknown as typeof fetch
     globalThis.setTimeout = ((handler: TimerHandler, _timeout?: number, ...args: unknown[]) => {
       if (typeof handler === 'function') handler(...args)
       return 0 as unknown as ReturnType<typeof setTimeout>
     }) as unknown as typeof setTimeout
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
     log = spyOn(console, 'log').mockImplementation(() => {})
     error = spyOn(console, 'error').mockImplementation(() => {})
     process.exit = ((code?: number) => {
@@ -48,6 +72,7 @@ describe('CLI system action TUI commands', () => {
     process.exit = originalExit
     globalThis.fetch = originalFetch
     globalThis.setTimeout = originalSetTimeout
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
     if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
     else delete (process.stdout as { isTTY?: boolean }).isTTY
     log.mockRestore()
@@ -80,6 +105,37 @@ describe('CLI system action TUI commands', () => {
     expect(output()).toContain('Version: test')
     expect(output()).not.toContain('[..] Starting Bakin server')
     expect(spawn).toHaveBeenCalled()
+    expect(error.mock.calls).toHaveLength(0)
+  })
+
+  it('renders setup service enable results with the shared runtime action TUI in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    process.argv = ['bun', 'cli/bakin.ts', 'setup', 'service']
+    await main()
+
+    expect(output()).toContain('Runtime action')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Bakin autostart enabled.')
+    expect(output()).toContain('Service: com.makinbakin.bakin')
+    expect(output()).toContain('Disable: bakin setup service --uninstall')
+    expect(output()).not.toContain('[OK]')
+    expect(writeFileSync).toHaveBeenCalled()
+    expect(execFileSync).toHaveBeenCalledWith('launchctl', expect.arrayContaining(['bootstrap', 'gui/501', expect.any(String)]), expect.any(Object))
+    expect(error.mock.calls).toHaveLength(0)
+  })
+
+  it('renders setup service uninstall results with the shared runtime action TUI in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    process.argv = ['bun', 'cli/bakin.ts', 'setup', 'service', '--uninstall']
+    await main()
+
+    expect(output()).toContain('Runtime action')
+    expect(output()).toContain('RESULT')
+    expect(output()).toContain('Bakin autostart disabled.')
+    expect(output()).toContain('Service: com.makinbakin.bakin')
+    expect(output()).not.toContain('[OK]')
     expect(error.mock.calls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary
- render setup service and setup service --uninstall terminal output through the shared Runtime action screen
- preserve existing non-TTY setup service output for scripts
- add mocked system-action tests for macOS service enable/disable without touching LaunchAgents

## Tests
- bun run typecheck
- bun test --isolate tests/cli/system-actions.test.ts tests/cli/readonly-ui.test.tsx
- bun test --isolate tests/cli
- git diff --check