### PR TITLE
Delegate runtime binary commands to TUI CLI

### DIFF
--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -826,20 +826,16 @@ export async function dispatchCli(argv: string[]): Promise<CliResult> {
       case '-v':
         return { startServer: false, exitCode: await cmdVersion() }
 
-      case 'status':
-        return { startServer: false, exitCode: await cmdStatus() }
-
-      case 'stop':
-        return { startServer: false, exitCode: await cmdStop() }
-
       case 'update':
         return { startServer: false, exitCode: await cmdUpdate() }
 
       case 'dev':
         return { startServer: false, exitCode: await cmdDev(args.slice(1)) }
 
-      // `restart` and `plugins` delegate to the source CLI so the compiled
+      // Runtime/status commands delegate to the source CLI so the compiled
       // binary uses the same TUI/JSON implementation as the npm-linked entry.
+      case 'status':
+      case 'stop':
       case 'plugins':
         return await delegateToSourceCli(argv)
 

--- a/tests/cli/runtime-dispatch.test.ts
+++ b/tests/cli/runtime-dispatch.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+
+const execFileSync = mock((..._args: unknown[]) => '')
+const fetchMock = mock()
+
+mock.module('child_process', () => ({
+  execFileSync,
+}))
+
+describe('bakin runtime binary dispatch', () => {
+  const originalFetch = globalThis.fetch
+  const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  let log: ReturnType<typeof spyOn>
+  let error: ReturnType<typeof spyOn>
+
+  function jsonResponse(body: unknown): Response {
+    return {
+      ok: true,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(''),
+    } as Response
+  }
+
+  function output(): string {
+    return log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+  }
+
+  function errorOutput(): string {
+    return error.mock.calls
+      .map((call: unknown[]) => call.map(part => String(part)).join(' '))
+      .join('\n')
+  }
+
+  beforeEach(() => {
+    mock.clearAllMocks()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true }))
+    execFileSync.mockReturnValue('')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    log = spyOn(console, 'log').mockImplementation(() => {})
+    error = spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+    log.mockRestore()
+    error.mockRestore()
+  })
+
+  it('delegates status to the shared source CLI TUI', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        intervalMin: 5,
+        lastRun: '2026-05-18T04:00:00.000Z',
+        nextRun: '2026-05-18T04:05:00.000Z',
+        secondsUntilNext: 120,
+        dispatchedCount: 7,
+      }))
+      .mockResolvedValueOnce(jsonResponse({ agents: [{ id: 'main' }, { id: 'patch' }], mainAgentId: 'main' }))
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', 'status'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 0 })
+    expect(output()).toContain('Status')
+    expect(output()).toContain('DISPATCH')
+    expect(output()).not.toContain('=== Bakin Status ===')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('delegates stop to the shared source CLI TUI', async () => {
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', 'stop'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 0 })
+    expect(output()).toContain('Runtime action')
+    expect(output()).toContain('No running Bakin process found.')
+    expect(output()).not.toContain('No running Bakin server at')
+    expect(errorOutput()).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- delegate compiled-binary status and stop commands to the shared source CLI
- remove the binary-only legacy status/stop output path from dispatch
- add regression tests proving binary status and stop render the shared TUI screens

## Tests
- bun run typecheck
- bun test --isolate tests/cli/runtime-dispatch.test.ts tests/cli/plugins-dispatch.test.ts tests/cli/system-actions.test.ts tests/cli/readonly-commands.test.ts
- bun test --isolate tests/cli
- git diff --check