### PR TITLE
Render already-onboarded state with TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -3233,7 +3233,7 @@ async function cmdOnboardingInstallSingle(target: string, args: string[]): Promi
 async function cmdOnboard(args: string[]): Promise<void> {
   const { runOnboard, isOnboarded, loadState, COMPONENT_ORDER } = await import('../src/core/onboarding/index')
   const { collectOnboardingSelections } = await import('../src/core/cli/onboarding-interactive')
-  const { OnboardingBusy, OnboardingSummary } = await import('../src/core/cli/ui/onboarding')
+  const { OnboardingAlreadyCompleteReport, OnboardingBusy, OnboardingSummary } = await import('../src/core/cli/ui/onboarding')
   const { render, renderToString } = await import('ink')
   const { createElement } = await import('react')
   const checkOnly = args.includes('--check')
@@ -3243,21 +3243,24 @@ async function cmdOnboard(args: string[]): Promise<void> {
   const verbose = args.includes('--verbose')
   const isTTY = Boolean(process.stdout.isTTY)
 
-  const previousConsoleFormat = process.env.BAKIN_CONSOLE_FORMAT
-  if (!verbose && previousConsoleFormat === undefined) {
-    process.env.BAKIN_CONSOLE_FORMAT = 'silent'
-  }
-
   // Early exit for already-onboarded machines unless --force or --check
   if (!force && !checkOnly && isOnboarded()) {
     const state = loadState()
-    if (!json) {
+    if (!json && isTTY) {
+      console.log(renderToString(createElement(OnboardingAlreadyCompleteReport, { state })))
+    } else if (!json) {
       console.log(`[OK] Already onboarded on ${state?.completedAt?.slice(0, 10) ?? 'unknown date'}.`)
       console.log('     Re-run with --force to replay the full flow.')
     } else {
       console.log(JSON.stringify({ status: 'already_onboarded', completedAt: state?.completedAt }))
     }
     process.exit(0)
+    return
+  }
+
+  const previousConsoleFormat = process.env.BAKIN_CONSOLE_FORMAT
+  if (!verbose && previousConsoleFormat === undefined) {
+    process.env.BAKIN_CONSOLE_FORMAT = 'silent'
   }
 
   const baseOpts = {

--- a/src/core/cli/ui/onboarding.tsx
+++ b/src/core/cli/ui/onboarding.tsx
@@ -7,6 +7,7 @@ import type {
   InstallResult,
   InstallStatus,
 } from '../../onboarding'
+import type { OnboardingState } from '../../onboarding/state'
 import {
   FindingRows,
   NextActions,
@@ -339,6 +340,43 @@ export function OnboardingRequiredReport({ color = true }: { color?: boolean }) 
       <NextActions actions={[
         'Run `bakin onboard` to complete first-run setup.',
         'Run `bakin onboard --check` to inspect readiness without changing anything.',
+      ]} color={color} />
+    </Box>
+  )
+}
+
+export function OnboardingAlreadyCompleteReport({ state, color = true }: {
+  state: OnboardingState | null
+  color?: boolean
+}) {
+  const completedAt = state?.completedAt?.slice(0, 10) ?? 'unknown date'
+  const componentCount = Object.keys(state?.components ?? {}).length
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Onboarding" subtitle="Machine setup already complete" meta={`completed: ${completedAt}`} color={color} />
+      <SummaryStrip items={[
+        { label: 'status', value: 'ready', status: 'ok' },
+        { label: 'components', value: componentCount, status: componentCount > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      <Section title="Result" color={color}>
+        <FindingRows rows={[
+          {
+            status: 'ok',
+            label: 'onboarded',
+            message: `Already onboarded on ${completedAt}.`,
+            detail: state?.bakinVersion ? `Bakin version: ${state.bakinVersion}` : undefined,
+          },
+          {
+            status: 'ready',
+            label: 'replay',
+            message: 'Re-run with `--force` to replay the full onboarding flow.',
+          },
+        ]} color={color} />
+      </Section>
+      <NextActions actions={[
+        'Run `bakin start` to launch Bakin.',
+        'Run `bakin onboard --force` to replay first-run setup.',
       ]} color={color} />
     </Box>
   )

--- a/tests/cli/onboard-command.test.ts
+++ b/tests/cli/onboard-command.test.ts
@@ -17,6 +17,14 @@ const outcomes = [
   },
 ]
 
+let onboarded = false
+let onboardingState: {
+  version: number
+  completedAt: string
+  bakinVersion: string
+  components: Record<string, 'ok' | 'warn' | 'skipped' | 'error'>
+} | null = null
+
 const runOnboard = mock(async (opts: {
   onProgress?: (message: string) => void
   onOutcome?: (outcome: { name: string; finalStatus: 'ok'; message: string }) => void
@@ -28,8 +36,8 @@ const runOnboard = mock(async (opts: {
 
 mock.module('../../src/core/onboarding/index', () => ({
   runOnboard,
-  isOnboarded: () => false,
-  loadState: () => null,
+  isOnboarded: () => onboarded,
+  loadState: () => onboardingState,
   COMPONENT_ORDER: outcomes.map(outcome => ({ name: outcome.name })),
 }))
 
@@ -51,6 +59,8 @@ describe('CLI onboard command', () => {
 
   beforeEach(() => {
     mock.clearAllMocks()
+    onboarded = false
+    onboardingState = null
     process.argv = originalArgv
     log = spyOn(console, 'log').mockImplementation(() => {})
     stdoutWrite = spyOn(process.stdout, 'write').mockImplementation(() => true)
@@ -86,5 +96,27 @@ describe('CLI onboard command', () => {
     expect(output).toContain('Machine setup complete')
     expect(output).toContain('PREREQUISITES')
     expect(output).toContain('Run `bakin start` to launch Bakin.')
+  })
+
+  it('renders already-onboarded state with shared onboarding UI in a TTY', async () => {
+    onboarded = true
+    onboardingState = {
+      version: 3,
+      completedAt: '2026-05-19T12:00:00.000Z',
+      bakinVersion: '1.0.0',
+      components: { mkdir: 'ok', settings: 'ok' },
+    }
+    process.argv = ['bun', 'cli/bakin.ts', 'onboard']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Machine setup already complete')
+    expect(output).toContain('Already onboarded on 2026-05-19.')
+    expect(output).toContain('Run `bakin onboard --force`')
+    expect(output).not.toContain('[OK] Already onboarded')
+    expect(runOnboard).not.toHaveBeenCalled()
   })
 })

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -6,6 +6,7 @@ import {
   OnboardingBusy,
   OnboardingCheckAllReport,
   OnboardingCheckReport,
+  OnboardingAlreadyCompleteReport,
   OnboardingDecisionPrompt,
   OnboardingInstallReport,
   OnboardingIntro,
@@ -158,6 +159,21 @@ describe('onboarding CLI UI', () => {
     expect(rendered).toContain('REQUIRED SETUP')
     expect(rendered).toContain('Bakin has not been onboarded on this machine.')
     expect(rendered).toContain('Run `bakin onboard` to complete first-run setup.')
+    expect(rendered).not.toContain('[OK]')
+  })
+
+  it('renders already-onboarded state with shared onboarding UI', () => {
+    const rendered = renderToString(<OnboardingAlreadyCompleteReport state={{
+      version: 3,
+      completedAt: '2026-05-19T12:00:00.000Z',
+      bakinVersion: '1.0.0',
+      components: { mkdir: 'ok', settings: 'ok' },
+    }} />)
+    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain('Onboarding')
+    expect(rendered).toContain('Machine setup already complete')
+    expect(rendered).toContain('Already onboarded on 2026-05-19.')
+    expect(rendered).toContain('Run `bakin onboard --force`')
     expect(rendered).not.toContain('[OK]')
   })
 


### PR DESCRIPTION
## Summary
- add a shared onboarding report for machines that are already onboarded
- render interactive `bakin onboard` early exit with the compact Bakin TUI
- preserve existing JSON and non-TTY text output for scripts

## Tests
- bun run typecheck
- bun test --isolate tests/cli/onboard-command.test.ts tests/cli/onboarding-ui.test.tsx
- bun test --isolate tests/cli
- git diff --check