### PR TITLE
Render CLI help with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -8,7 +8,7 @@ import {
   cmdScheduleList, cmdScheduleAdd, cmdSchedulePause,
   cmdScheduleResume, cmdScheduleRemove, cmdScheduleRun, cmdScheduleRuns,
 } from '../src/cli/schedule'
-import { renderCliUsage } from '../src/core/cli/registry'
+import { getCliUsageGroups, renderCliUsage } from '../src/core/cli/registry'
 import { parsePluginInstallArgs, PLUGIN_INSTALL_USAGE } from '../src/core/cli/plugin-install-args'
 import {
   createPluginExportManifest,
@@ -124,6 +124,13 @@ function apiErrorPayload(status: number, body: string): Record<string, unknown> 
   }
 }
 
+function isServerConnectionError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return message.includes('ECONNREFUSED') ||
+    message.includes('Unable to connect') ||
+    message.includes('fetch failed')
+}
+
 async function apiPostJson(path: string, body?: unknown): Promise<{ ok: true; data: unknown } | { ok: false; data: Record<string, unknown> }> {
   const res = await fetch(`${BASE_URL}${path}`, {
     method: 'POST',
@@ -185,6 +192,20 @@ async function printRuntimeActionTui(action: RuntimeActionData): Promise<void> {
     import('react'),
   ])
   console.log(renderToString(createElement(RuntimeActionReport, { action })))
+}
+
+async function printHelpTui(error?: string, errorDetail?: string): Promise<void> {
+  const [{ HelpReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(HelpReport, {
+    groups: getCliUsageGroups({ excludeNames: BINARY_ONLY_COMMANDS }),
+    env: { bakinUrl: BASE_URL },
+    error,
+    errorDetail,
+  })))
 }
 
 async function printSettingsTui(settings: Record<string, unknown>): Promise<void> {
@@ -3372,8 +3393,9 @@ async function cmdOnboard(args: string[]): Promise<void> {
 export async function main(): Promise<void> {
   const args = process.argv.slice(2)
 
-  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
-    console.log(USAGE.trim())
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h' || args[0] === 'help') {
+    if (process.stdout.isTTY) await printHelpTui()
+    else console.log(USAGE.trim())
     process.exit(0)
   }
 
@@ -3801,11 +3823,21 @@ export async function main(): Promise<void> {
         break
 
       default:
-        if (!BINARY_ONLY_COMMANDS.has(cmd) && await dispatchPluginCliCommand(cmd, args.slice(1))) {
-          break
+        let pluginLookupError: string | undefined
+        if (!BINARY_ONLY_COMMANDS.has(cmd)) {
+          try {
+            if (await dispatchPluginCliCommand(cmd, args.slice(1))) {
+              break
+            }
+          } catch (err) {
+            if (!isServerConnectionError(err)) throw err
+            pluginLookupError = `Plugin command lookup skipped because Bakin is not reachable at ${BASE_URL}.`
+          }
         }
         console.error(`Unknown command: ${cmd}`)
-        console.log(USAGE.trim())
+        if (pluginLookupError) console.error(pluginLookupError)
+        if (process.stdout.isTTY) await printHelpTui(`Unknown command: ${cmd}`, pluginLookupError)
+        else console.log(USAGE.trim())
         process.exit(1)
     }
   } catch (err) {
@@ -3813,10 +3845,7 @@ export async function main(): Promise<void> {
       throw err
     }
     if (
-      err instanceof Error &&
-      (err.message.includes('ECONNREFUSED') ||
-        err.message.includes('Unable to connect') ||
-        err.message.includes('fetch failed'))
+      isServerConnectionError(err)
     ) {
       console.error('Error: Cannot connect to Bakin. Is the server running?')
       console.error(`  Tried: ${BASE_URL}`)

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -17,7 +17,7 @@
  */
 import { readFileSync, writeFileSync } from 'node:fs'
 import { APP_VERSION } from '../../packages/core/src/constants'
-import { renderCliUsage } from './cli/registry'
+import { getCliUsageGroups, renderCliUsage } from './cli/registry'
 import { parsePluginInstallArgs, PLUGIN_INSTALL_USAGE } from './cli/plugin-install-args'
 import { isOnboarded } from './onboarding/state'
 import {
@@ -727,7 +727,19 @@ async function cmdUpdate(): Promise<number> {
 }
 
 async function cmdHelp(): Promise<number> {
-  console.log(renderCliUsage({ bakinUrl: BAKIN_URL }))
+  if (process.stdout.isTTY) {
+    const [{ HelpReport }, { renderToString }, { createElement }] = await Promise.all([
+      import('./cli/ui/readonly'),
+      import('ink'),
+      import('react'),
+    ])
+    console.log(renderToString(createElement(HelpReport, {
+      groups: getCliUsageGroups(),
+      env: { bakinUrl: BAKIN_URL },
+    })))
+  } else {
+    console.log(renderCliUsage({ bakinUrl: BAKIN_URL }))
+  }
   return 0
 }
 

--- a/src/core/cli/registry.ts
+++ b/src/core/cli/registry.ts
@@ -159,7 +159,12 @@ export const CLI_COMMANDS = [
   cli({ name: 'trash', usage: 'bakin trash [list|restore|empty] ...', group: 'Assets and search', summary: 'Manage trashed assets.', description: 'Lists, restores, or permanently empties soft-deleted assets.', examples: [{ title: 'List trash', code: 'bakin trash list', test: 'illustrative', reason: 'Depends on local asset state.' }] }),
 ] as const satisfies readonly CliDef[]
 
-export function renderCliUsage(env: { bakinUrl?: string } = {}, opts: { excludeNames?: ReadonlySet<string> } = {}): string {
+export interface CliUsageGroup {
+  group: string
+  commands: CliDef[]
+}
+
+export function getCliUsageGroups(opts: { excludeNames?: ReadonlySet<string> } = {}): CliUsageGroup[] {
   const grouped = new Map<string, CliDef[]>()
   for (const command of CLI_COMMANDS) {
     if (opts.excludeNames?.has(command.name)) continue
@@ -167,10 +172,14 @@ export function renderCliUsage(env: { bakinUrl?: string } = {}, opts: { excludeN
     if (!grouped.has(group)) grouped.set(group, [])
     grouped.get(group)!.push(command)
   }
+  return Array.from(grouped, ([group, commands]) => ({ group, commands }))
+}
 
+export function renderCliUsage(env: { bakinUrl?: string } = {}, opts: { excludeNames?: ReadonlySet<string> } = {}): string {
   const lines = ['Usage: bakin <command> [options]', '']
-  for (const [group, commands] of grouped) {
-    lines.push(`${group}:`)
+  for (const usageGroup of getCliUsageGroups(opts)) {
+    lines.push(`${usageGroup.group}:`)
+    const { commands } = usageGroup
     for (const command of commands) {
       lines.push(`  ${command.usage.padEnd(58)} ${command.summary}`)
     }

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -284,6 +284,21 @@ export interface TrashActionData {
   detail?: unknown
 }
 
+export interface HelpCommandData {
+  name?: unknown
+  usage?: unknown
+  summary?: unknown
+}
+
+export interface HelpGroupData {
+  group: string
+  commands: HelpCommandData[]
+}
+
+export interface HelpEnvData {
+  bakinUrl?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -412,6 +427,11 @@ interface TrashAssetTableRow {
   deleted: string
   expires: string
   agent: string
+}
+
+interface HelpCommandRow {
+  command: string
+  summary: string
 }
 
 const TASK_COLUMN_ORDER = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as const
@@ -1542,6 +1562,95 @@ function trashActionRows(action: TrashActionData) {
     message: valueText(action.message, fallback),
     detail: detail || undefined,
   }]
+}
+
+function helpCommandRows(commands: HelpCommandData[]): HelpCommandRow[] {
+  return commands.map(command => ({
+    command: valueText(command.usage, valueText(command.name, 'bakin')),
+    summary: valueText(command.summary),
+  }))
+}
+
+function helpCommandCount(groups: HelpGroupData[]): number {
+  return groups.reduce((total, group) => total + group.commands.length, 0)
+}
+
+function HelpCommandTable({ rows }: { rows: HelpCommandRow[] }) {
+  return (
+    <Box flexDirection="column">
+      <Box gap={2}>
+        <Box width={58} flexShrink={0}>
+          <Text bold>COMMAND</Text>
+        </Box>
+        <Box flexGrow={1} flexShrink={1}>
+          <Text bold>SUMMARY</Text>
+        </Box>
+      </Box>
+      {rows.map(row => (
+        <Box key={row.command} gap={2}>
+          <Box width={58} flexShrink={0}>
+            <Text wrap="wrap">{row.command}</Text>
+          </Box>
+          <Box flexGrow={1} flexShrink={1}>
+            <Text wrap="wrap">{row.summary}</Text>
+          </Box>
+        </Box>
+      ))}
+      <Text> </Text>
+    </Box>
+  )
+}
+
+export function HelpReport({ groups, env = {}, error, errorDetail, color = true }: {
+  groups: HelpGroupData[]
+  env?: HelpEnvData
+  error?: string
+  errorDetail?: string
+  color?: boolean
+}) {
+  const commandCount = helpCommandCount(groups)
+  const groupCount = groups.length
+  const envRows: DetailFieldRow[] = [
+    { field: 'BAKIN_URL', value: `Base URL for the running server (default: ${valueText(env.bakinUrl, 'http://localhost:3737')})` },
+    { field: 'BAKIN_HOME', value: 'Override for ~/.bakin' },
+    { field: 'PORT', value: 'Port to bind when `start` launches (default: 3737)' },
+  ]
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Help" subtitle="Command reference" meta={error ? 'unknown command' : undefined} color={color} />
+      <SummaryStrip items={[
+        { label: plural(commandCount, 'command'), value: commandCount, status: commandCount > 0 ? 'ok' : 'skip' },
+        { label: plural(groupCount, 'group'), value: groupCount, status: groupCount > 0 ? 'ok' : 'skip' },
+      ]} color={color} />
+      {error ? (
+        <Section title="Issue" color={color}>
+          <FindingRows rows={[{
+            status: 'fail',
+            label: 'command',
+            message: error,
+            detail: errorDetail,
+            next: 'Run `bakin --help` to see available commands.',
+          }]} color={color} />
+          <Text> </Text>
+        </Section>
+      ) : null}
+      {groups.map(group => (
+        <Section key={group.group} title={group.group} color={color}>
+          <HelpCommandTable rows={helpCommandRows(group.commands)} />
+        </Section>
+      ))}
+      <Section title="Environment" color={color}>
+        <DataTable
+          columns={[
+            { key: 'field', header: 'NAME', width: 14, render: row => row.field },
+            { key: 'value', header: 'VALUE', width: 52, grow: true, render: row => row.value },
+          ]}
+          rows={envRows}
+        />
+      </Section>
+    </Box>
+  )
 }
 
 export function StatusReport({ dispatch, roster, color = true }: {

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -61,6 +61,72 @@ describe('read-only CLI TTY commands', () => {
     error.mockRestore()
   })
 
+  it('renders top-level help with the shared TUI when stdout is a TTY', async () => {
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`)
+    }) as never
+    process.argv = ['bun', 'cli/bakin.ts', '--help']
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:0')
+
+    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain('Help')
+    expect(output()).toContain('LIFECYCLE')
+    expect(output()).toContain('TASKS AND WORKFLOWS')
+    expect(output()).not.toContain('Usage: bakin <command> [options]')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('accepts help as a source CLI alias for the shared TUI help', async () => {
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`)
+    }) as never
+    process.argv = ['bun', 'cli/bakin.ts', 'help']
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:0')
+
+    expect(output()).toContain('Help')
+    expect(output()).toContain('LIFECYCLE')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('renders unknown top-level commands with help in the shared TUI', async () => {
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`)
+    }) as never
+    fetchMock.mockResolvedValueOnce(jsonResponse({ plugins: [] }))
+    process.argv = ['bun', 'cli/bakin.ts', 'wat']
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:1')
+
+    expect(errorOutput()).toContain('Unknown command: wat')
+    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain('Help  unknown command')
+    expect(output()).toContain('ISSUE')
+    expect(output()).toContain('Unknown command: wat')
+    expect(output()).not.toContain('Usage: bakin <command> [options]')
+  })
+
+  it('still renders unknown-command help when plugin command lookup cannot reach the server', async () => {
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${code ?? 0}`)
+    }) as never
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'))
+    process.argv = ['bun', 'cli/bakin.ts', 'wat']
+
+    const { main } = await import('../../cli/bakin')
+    await expect(main()).rejects.toThrow('exit:1')
+
+    expect(errorOutput()).toContain('Unknown command: wat')
+    expect(errorOutput()).toContain('Plugin command lookup skipped')
+    expect(output()).toContain('Help  unknown command')
+    expect(output()).toContain('Plugin command lookup skipped')
+    expect(output()).not.toContain('Error: Cannot connect to Bakin')
+  })
+
   it('renders status with the shared TUI when stdout is a TTY', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -9,6 +9,7 @@ import {
   AgentTasksReport,
   AgentsListReport,
   DocsReport,
+  HelpReport,
   PackageActionReport,
   PackagesListReport,
   PathsReport,
@@ -54,6 +55,43 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('DISPATCH')
     expect(output).toContain('main, patch')
     expect(output).not.toContain('=== Bakin Status ===')
+  })
+
+  it('renders command help with shared TUI primitives', () => {
+    const output = renderToString(
+      <HelpReport
+        groups={[
+          {
+            group: 'Lifecycle',
+            commands: [
+              { name: 'start', usage: 'bakin start', summary: 'Start the Bakin server.' },
+              { name: 'doctor', usage: 'bakin doctor [--json] [--full]', summary: 'Run health checks.' },
+            ],
+          },
+          {
+            group: 'Tasks and workflows',
+            commands: [
+              { name: 'tasks list', usage: 'bakin tasks list [--column=<column>]', summary: 'List tasks.' },
+            ],
+          },
+        ]}
+        env={{ bakinUrl: 'http://localhost:3737' }}
+        error="Unknown command: wat"
+        errorDetail="Plugin command lookup skipped because Bakin is not reachable."
+      />,
+    )
+
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Help  unknown command')
+    expect(output).toContain('ISSUE\n------------')
+    expect(output).toContain('Unknown command: wat')
+    expect(output).toContain('Plugin command lookup skipped')
+    expect(output).toContain('LIFECYCLE')
+    expect(output).toContain('COMMAND')
+    expect(output).toContain('bakin start')
+    expect(output).toContain('Tasks and workflows'.toUpperCase())
+    expect(output).toContain('ENVIRONMENT')
+    expect(output).not.toContain('Usage: bakin <command> [options]')
   })
 
   it('renders runtime action confirmations with shared TUI primitives', () => {

--- a/tests/cli/runtime-dispatch.test.ts
+++ b/tests/cli/runtime-dispatch.test.ts
@@ -49,6 +49,19 @@ describe('bakin runtime binary dispatch', () => {
     error.mockRestore()
   })
 
+  it('renders binary help with the shared TUI when stdout is a TTY', async () => {
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', '--help'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 0 })
+    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain('Help')
+    expect(output()).toContain('LIFECYCLE')
+    expect(output()).not.toContain('Usage: bakin <command> [options]')
+    expect(errorOutput()).toBe('')
+  })
+
   it('delegates status to the shared source CLI TUI', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({


### PR DESCRIPTION
Summary:
- Add grouped CLI usage metadata for shared renderers while preserving plain non-TTY usage output.
- Add a read-only Help TUI report with the Bakin header, command sections, environment rows, and unknown-command issue state.
- Wire source CLI help/unknown-command paths and binary help to the shared TUI in TTY mode.
- Let source CLI accept bakin help, and keep unknown-command help useful when plugin command lookup cannot reach the server.

Verification:
- bun test tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts tests/cli/runtime-dispatch.test.ts
- bun run typecheck
- bun test --isolate passed during this slice before the final server-down unknown-command edge; focused CLI tests were rerun after that edge.