### PR TITLE
Render CLI failures with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -21,6 +21,7 @@ import type { Permission } from '@bakin/core/plugins/permissions'
 import { extractApiErrorMessage, formatApiError } from '../src/core/cli/api-error'
 import type {
   AgentRuleResultData,
+  CommandFailureData,
   CommandIssueData,
   HelpGroupData,
   PackageActionData,
@@ -221,6 +222,19 @@ async function printCommandIssueTui(issue: CommandIssueData): Promise<void> {
     import('react'),
   ])
   console.log(renderToString(createElement(CommandIssueReport, { issue })))
+}
+
+async function printCommandFailureTui(failure: CommandFailureData): Promise<void> {
+  const [{ CommandFailureReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(CommandFailureReport, { failure })))
+}
+
+function invocationCommand(args: string[]): string {
+  return args.length > 0 ? `bakin ${args.join(' ')}` : 'bakin'
 }
 
 function normalizeUsage(usage: string): string {
@@ -3952,11 +3966,30 @@ export async function main(): Promise<void> {
     if (
       isServerConnectionError(err)
     ) {
-      console.error('Error: Cannot connect to Bakin. Is the server running?')
-      console.error(`  Tried: ${BASE_URL}`)
-      console.error(`  Run \`bakin start\` to launch the server.`)
+      if (process.stdout.isTTY) {
+        await printCommandFailureTui({
+          command: invocationCommand(args),
+          message: 'Cannot connect to Bakin. Is the server running?',
+          detail: `Tried: ${BASE_URL}`,
+          code: 'SERVER_UNREACHABLE',
+          next: 'Run `bakin start` to launch the server.',
+        })
+      } else {
+        console.error('Error: Cannot connect to Bakin. Is the server running?')
+        console.error(`  Tried: ${BASE_URL}`)
+        console.error(`  Run \`bakin start\` to launch the server.`)
+      }
     } else {
-      console.error('Error:', err instanceof Error ? err.message : String(err))
+      const message = err instanceof Error ? err.message : String(err)
+      if (process.stdout.isTTY) {
+        await printCommandFailureTui({
+          command: invocationCommand(args),
+          message,
+          code: 'COMMAND_FAILED',
+        })
+      } else {
+        console.error('Error:', message)
+      }
     }
     process.exit(1)
   }

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -308,6 +308,14 @@ export interface CommandIssueData {
   availableLabel?: unknown
 }
 
+export interface CommandFailureData {
+  command?: unknown
+  message?: unknown
+  detail?: unknown
+  code?: unknown
+  next?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -1708,6 +1716,47 @@ export function CommandIssueReport({ issue, color = true }: {
             status: 'ok',
             label: availableLabel,
             message: available.join(' | '),
+          }]} color={color} />
+          <Text> </Text>
+        </Section>
+      ) : null}
+    </Box>
+  )
+}
+
+export function CommandFailureReport({ failure, color = true }: {
+  failure: CommandFailureData
+  color?: boolean
+}) {
+  const command = valueText(failure.command, 'command')
+  const message = valueText(failure.message, 'Command failed.')
+  const detail = valueText(failure.detail, '')
+  const code = valueText(failure.code, 'COMMAND_FAILED')
+  const next = valueText(failure.next, '')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Command failed" subtitle={message} meta={command} color={color} />
+      <SummaryStrip items={[
+        { label: 'failure', value: 1, status: 'fail' },
+        { label: 'code', value: code, status: 'fail' },
+        { label: 'next', value: next ? 1 : 0, status: next ? 'ready' : 'skip' },
+      ]} color={color} />
+      <Section title="Problem" color={color}>
+        <FindingRows rows={[{
+          status: 'fail',
+          label: command,
+          message,
+          detail: detail || `Code: ${code}`,
+        }]} color={color} />
+        <Text> </Text>
+      </Section>
+      {next ? (
+        <Section title="Next" color={color}>
+          <FindingRows rows={[{
+            status: 'ready',
+            label: 'next',
+            message: next,
           }]} color={color} />
           <Text> </Text>
         </Section>

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -796,7 +796,7 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('RESULT')
   })
 
-  it('prints parsed API JSON errors without raw response bodies', async () => {
+  it('renders parsed API JSON errors without raw response bodies', async () => {
     const { main } = await import('../../cli/bakin')
 
     fetchMock.mockResolvedValueOnce({
@@ -808,8 +808,37 @@ describe('read-only CLI TTY commands', () => {
     process.argv = ['bun', 'cli/bakin.ts', 'trash', 'restore', 'test']
 
     await expect(main()).rejects.toThrow('exit:1')
-    expect(errorOutput()).toContain('Error: HTTP 500: Failed to restore asset')
-    expect(errorOutput()).not.toContain('{"error"')
+    expect(output()).toContain('Command failed  bakin trash restore test')
+    expect(output()).toContain('HTTP 500: Failed to restore asset')
+    expect(output()).not.toContain('{"error"')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('renders server connection failures with the shared TUI when stdout is a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'))
+    process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'list']
+
+    await expect(main()).rejects.toThrow('exit:1')
+    expect(output()).toContain('Command failed  bakin tasks list')
+    expect(output()).toContain('Cannot connect to Bakin. Is the server running?')
+    expect(output()).toContain('SERVER_UNREACHABLE')
+    expect(output()).toContain('Run `bakin start`')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('keeps server connection failures plain outside TTY', async () => {
+    setStdoutIsTTY(false)
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'))
+    process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'list']
+
+    await expect(main()).rejects.toThrow('exit:1')
+    expect(output()).toBe('')
+    expect(errorOutput()).toContain('Error: Cannot connect to Bakin. Is the server running?')
+    expect(errorOutput()).toContain('Run `bakin start` to launch the server.')
   })
 
   it('renders agent task lists with the shared TUI screen in a TTY', async () => {

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -8,6 +8,7 @@ import {
   AgentStatusReport,
   AgentTasksReport,
   AgentsListReport,
+  CommandFailureReport,
   CommandIssueReport,
   DocsReport,
   HelpReport,
@@ -115,6 +116,28 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('bakin tasks get <id>')
     expect(output).toContain('AVAILABLE')
     expect(output).toContain('list | get | create')
+  })
+
+  it('renders command runtime failures with shared TUI primitives', () => {
+    const output = renderToString(
+      <CommandFailureReport
+        failure={{
+          command: 'bakin tasks list',
+          message: 'Cannot connect to Bakin. Is the server running?',
+          detail: 'Tried: http://localhost:3737',
+          code: 'SERVER_UNREACHABLE',
+          next: 'Run `bakin start` to launch the server.',
+        }}
+      />,
+    )
+
+    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain('Command failed  bakin tasks list')
+    expect(output).toContain('Cannot connect to Bakin')
+    expect(output).toContain('SERVER_UNREACHABLE')
+    expect(output).toContain('PROBLEM')
+    expect(output).toContain('NEXT')
+    expect(output).toContain('Run `bakin start`')
   })
 
   it('renders runtime action confirmations with shared TUI primitives', () => {


### PR DESCRIPTION
Summary:
- Add a shared Command failed TUI report for runtime/API failures.
- Render source CLI server-unreachable and bubbled API errors through the shared TUI in TTY mode.
- Preserve existing plain stderr output for non-TTY failures.

Verification:
- bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts tests/cli/runtime-dispatch.test.ts
- bun run typecheck
- bun test --isolate tests/cli