### PR TITLE
Render version with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -4,6 +4,7 @@
  * All commands are thin wrappers around the Bakin HTTP API.
  */
 import { readFileSync, writeFileSync } from 'node:fs'
+import { APP_VERSION } from '../packages/core/src/constants'
 import {
   cmdScheduleList, cmdScheduleAdd, cmdSchedulePause,
   cmdScheduleResume, cmdScheduleRemove, cmdScheduleRun, cmdScheduleRuns,
@@ -36,6 +37,7 @@ import type {
   SettingsActionData,
   TaskActionData,
   TrashActionData,
+  VersionData,
   WorkflowActionData,
 } from '../src/core/cli/ui/readonly'
 import type { CheckResult, InstallResult } from '../src/core/onboarding/types'
@@ -231,6 +233,15 @@ async function printCommandFailureTui(failure: CommandFailureData): Promise<void
     import('react'),
   ])
   console.log(renderToString(createElement(CommandFailureReport, { failure })))
+}
+
+async function printVersionTui(data: VersionData): Promise<void> {
+  const [{ VersionReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('../src/core/cli/ui/readonly'),
+    import('ink'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(VersionReport, { data })))
 }
 
 function invocationCommand(args: string[]): string {
@@ -3528,6 +3539,13 @@ export async function main(): Promise<void> {
 
   try {
     switch (cmd) {
+      case 'version':
+      case '--version':
+      case '-v':
+        if (process.stdout.isTTY) await printVersionTui({ version: APP_VERSION })
+        else console.log(APP_VERSION)
+        break
+
       case 'status':
         await cmdStatus()
         break

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -88,7 +88,16 @@ async function apiPostJson(path: string, body?: unknown): Promise<{ ok: true; da
 }
 
 async function cmdVersion(): Promise<number> {
-  console.log(APP_VERSION)
+  if (process.stdout.isTTY) {
+    const [{ VersionReport }, { renderToString }, { createElement }] = await Promise.all([
+      import('./cli/ui/readonly'),
+      import('ink'),
+      import('react'),
+    ])
+    console.log(renderToString(createElement(VersionReport, { data: { version: APP_VERSION } })))
+  } else {
+    console.log(APP_VERSION)
+  }
   return 0
 }
 

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -316,6 +316,10 @@ export interface CommandFailureData {
   next?: unknown
 }
 
+export interface VersionData {
+  version?: unknown
+}
+
 interface TaskTableRow {
   status: TuiStatus
   column: string
@@ -1761,6 +1765,30 @@ export function CommandFailureReport({ failure, color = true }: {
           <Text> </Text>
         </Section>
       ) : null}
+    </Box>
+  )
+}
+
+export function VersionReport({ data, color = true }: {
+  data: VersionData
+  color?: boolean
+}) {
+  const version = valueText(data.version, 'unknown')
+
+  return (
+    <Box flexDirection="column">
+      <ScreenHeader title="Version" subtitle="Installed Bakin CLI" meta={`v${version}`} color={color} />
+      <SummaryStrip items={[
+        { label: 'version', value: 1, status: 'ok' },
+      ]} color={color} />
+      <Section title="Details" color={color}>
+        <FindingRows rows={[{
+          status: 'ok',
+          label: 'bakin',
+          message: version,
+        }]} color={color} />
+        <Text> </Text>
+      </Section>
     </Box>
   )
 }

--- a/src/core/cli/ui/tui.tsx
+++ b/src/core/cli/ui/tui.tsx
@@ -1,11 +1,19 @@
 import { Box, Text } from 'ink'
 import type { ReactNode } from 'react'
+import { APP_VERSION } from '../../../../packages/core/src/constants'
 import { CLI_COLORS, statusToken, type TuiStatus } from './style-tokens'
 
+const BAKIN_HEADER_TITLE = "🐷 Bakin'"
+const BAKIN_HEADER_VERSION = `(v${APP_VERSION})`
+const BAKIN_HEADER_WIDTH = Math.max(
+  38,
+  BAKIN_HEADER_TITLE.length + BAKIN_HEADER_VERSION.length + 6,
+)
+
 export const BAKIN_HEADER = [
-  "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓",
-  "┃  🐷 Bakin'                  (v1.0.0) ┃",
-  "┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛",
+  `┏${'━'.repeat(BAKIN_HEADER_WIDTH)}┓`,
+  `┃${` ${BAKIN_HEADER_TITLE}`.padEnd(BAKIN_HEADER_WIDTH - BAKIN_HEADER_VERSION.length - 1)}${BAKIN_HEADER_VERSION} ┃`,
+  `┗${'━'.repeat(BAKIN_HEADER_WIDTH)}┛`,
 ] as const
 
 export interface FindingRow {

--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -80,7 +80,7 @@ describe('doctor repair CLI UI', () => {
   it('renders a repair plan with shared TUI primitives', () => {
     const rendered = renderToString(<DoctorRepairPlan plan={repairPlan} color={false} />)
 
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Doctor repair plan')
     expect(rendered).toContain(' READY    1 safe')
     expect(rendered).toContain('SAFE DETERMINISTIC REPAIRS')
@@ -107,7 +107,7 @@ describe('doctor repair CLI UI', () => {
     const rendered = renderToString(<DoctorRepairApplyReport report={repairApply} color={false} showBrand={false} />)
 
     expect(rendered).toContain('Doctor repair results')
-    expect(rendered).not.toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).not.toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
   })
 
   it('renders delegated repair preview and sent result', () => {

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -82,7 +82,7 @@ describe('legacy CLI doctor repair', () => {
   }
 
   function headerCount(output: string): number {
-    return output.split("┃  🐷 Bakin'                  (v1.0.0) ┃").length - 1
+    return output.split("┃ 🐷 Bakin'               (v0.0.0-dev) ┃").length - 1
   }
 
   beforeEach(() => {
@@ -167,7 +167,7 @@ describe('legacy CLI doctor repair', () => {
     await main()
 
     const output = loggedOutput()
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Doctor repair plan')
     expect(output).toContain('No deterministic repairs available.')
     expect(output).not.toContain('[SAFE]')
@@ -314,7 +314,7 @@ describe('legacy CLI doctor repair', () => {
     await main()
 
     const output = loggedOutput()
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Doctor repair requests')
     expect(output).toContain('REQUESTS')
     expect(output).toContain('repair-1')

--- a/tests/cli/doctor-ui.test.tsx
+++ b/tests/cli/doctor-ui.test.tsx
@@ -18,7 +18,7 @@ describe('doctor CLI UI', () => {
       />,
     )
 
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Doctor  mode: offline')
     expect(rendered).toContain(' OK       0 errors')
     expect(rendered).toContain(' WARN     1 warning')

--- a/tests/cli/onboard-command.test.ts
+++ b/tests/cli/onboard-command.test.ts
@@ -90,8 +90,8 @@ describe('CLI onboard command', () => {
 
     const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
     const liveOutput = stdoutWrite.mock.calls.map((call: unknown[]) => String(call[0])).join('')
-    expect(liveOutput).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
-    expect(output).not.toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(liveOutput).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).not.toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Onboarding')
     expect(output).toContain('Machine setup complete')
     expect(output).toContain('PREREQUISITES')
@@ -112,7 +112,7 @@ describe('CLI onboard command', () => {
     await main()
 
     const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Machine setup already complete')
     expect(output).toContain('Already onboarded on 2026-05-19.')
     expect(output).toContain('Run `bakin onboard --force`')

--- a/tests/cli/onboarding-component-commands.test.ts
+++ b/tests/cli/onboarding-component-commands.test.ts
@@ -130,7 +130,7 @@ describe('onboarding component CLI commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Onboarding check')
     expect(output()).toContain('RESULT')
     expect(output()).toContain('Runtime adapter is available.')

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -71,7 +71,7 @@ describe('onboarding CLI UI', () => {
     ]
 
     const rendered = renderToString(<OnboardingSummary outcomes={outcomes} exitCode={1} />)
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Onboarding')
     expect(rendered).toContain('PREREQUISITES')
     expect(rendered).toContain('BLOCKED')
@@ -114,12 +114,12 @@ describe('onboarding CLI UI', () => {
     )
 
     expect(rendered).toContain('Onboarding')
-    expect(rendered).not.toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).not.toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
   })
 
   it('renders an async onboarding busy state', () => {
     const rendered = renderToString(<OnboardingBusy label="Running onboarding checks and installs" totalSteps={12} />)
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Onboard')
     expect(rendered).toContain('CURRENT ACTIVITY')
     expect(rendered).toContain('Running onboarding checks and installs')
@@ -144,7 +144,7 @@ describe('onboarding CLI UI', () => {
 
   it('renders the onboarding intro with the shared compact header', () => {
     const rendered = renderToString(<OnboardingIntro />)
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Onboard')
     expect(rendered).toContain('Initial setup wizard')
     expect(rendered).not.toContain('oooooooooo')
@@ -153,7 +153,7 @@ describe('onboarding CLI UI', () => {
 
   it('renders the start gate with shared onboarding UI', () => {
     const rendered = renderToString(<OnboardingRequiredReport />)
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Onboard')
     expect(rendered).toContain('Initial setup required')
     expect(rendered).toContain('REQUIRED SETUP')
@@ -169,7 +169,7 @@ describe('onboarding CLI UI', () => {
       bakinVersion: '1.0.0',
       components: { mkdir: 'ok', settings: 'ok' },
     }} />)
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Onboarding')
     expect(rendered).toContain('Machine setup already complete')
     expect(rendered).toContain('Already onboarded on 2026-05-19.')
@@ -208,7 +208,7 @@ describe('onboarding CLI UI', () => {
       }} color={false} />,
     )
 
-    expect(rendered).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(rendered).toContain('Onboarding check')
     expect(rendered).toContain('RESULT')
     expect(rendered).toContain('No runtime adapter is available.')

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:te
 import { existsSync, mkdtempSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { APP_VERSION } from '../../packages/core/src/constants'
 
 const fetchMock = mock()
 
@@ -70,7 +71,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await expect(main()).rejects.toThrow('exit:0')
 
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Help')
     expect(output()).toContain('LIFECYCLE')
     expect(output()).toContain('TASKS AND WORKFLOWS')
@@ -92,6 +93,18 @@ describe('read-only CLI TTY commands', () => {
     expect(errorOutput()).toBe('')
   })
 
+  it('renders source CLI version with the shared TUI when stdout is a TTY', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'version']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain(`Version  v${APP_VERSION}`)
+    expect(output()).toContain(APP_VERSION)
+    expect(errorOutput()).toBe('')
+  })
+
   it('renders unknown top-level commands with help in the shared TUI', async () => {
     process.exit = ((code?: number) => {
       throw new Error(`exit:${code ?? 0}`)
@@ -103,7 +116,7 @@ describe('read-only CLI TTY commands', () => {
     await expect(main()).rejects.toThrow('exit:1')
 
     expect(errorOutput()).toContain('Unknown command: wat')
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Help  unknown command')
     expect(output()).toContain('ISSUE')
     expect(output()).toContain('Unknown command: wat')
@@ -133,7 +146,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await expect(main()).rejects.toThrow('exit:1')
 
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Command issue  bakin tasks get <id>')
     expect(output()).toContain('Missing required arguments.')
     expect(output()).toContain('USAGE')
@@ -213,7 +226,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Help')
     expect(output()).toContain('AGENT RULES')
     expect(output()).toContain('bakin agent-rules --apply')
@@ -236,7 +249,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Status')
     expect(output()).toContain('DISPATCH')
     expect(output()).not.toContain('=== Bakin Status ===')
@@ -537,7 +550,7 @@ describe('read-only CLI TTY commands', () => {
     process.argv = ['bun', 'cli/bakin.ts', 'workflows', 'list']
     await main()
 
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Workflows')
     expect(output()).toContain('DEFINITIONS')
     expect(output()).toContain('FILENAME')

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -33,6 +33,7 @@ import {
   TasksListReport,
   TrashActionReport,
   TrashListReport,
+  VersionReport,
   WorkflowActionReport,
   WorkflowsListReport,
 } from '../../src/core/cli/ui/readonly'
@@ -52,7 +53,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Status')
     expect(output).toContain('DISPATCH')
     expect(output).toContain('main, patch')
@@ -83,7 +84,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Help  unknown command')
     expect(output).toContain('ISSUE\n------------')
     expect(output).toContain('Unknown command: wat')
@@ -108,7 +109,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Command issue  bakin tasks get')
     expect(output).toContain('ISSUE')
     expect(output).toContain('Missing required arguments.')
@@ -131,13 +132,22 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Command failed  bakin tasks list')
     expect(output).toContain('Cannot connect to Bakin')
     expect(output).toContain('SERVER_UNREACHABLE')
     expect(output).toContain('PROBLEM')
     expect(output).toContain('NEXT')
     expect(output).toContain('Run `bakin start`')
+  })
+
+  it('renders version with shared TUI primitives', () => {
+    const output = renderToString(<VersionReport data={{ version: '1.2.3' }} />)
+
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain('Version  v1.2.3')
+    expect(output).toContain('DETAILS')
+    expect(output).toContain('1.2.3')
   })
 
   it('renders runtime action confirmations with shared TUI primitives', () => {

--- a/tests/cli/render.test.tsx
+++ b/tests/cli/render.test.tsx
@@ -26,7 +26,7 @@ describe('CLI renderers', () => {
   it('renders a generic Ink result view to string', () => {
     const output = renderInkEnvelope(toEnvelope(okResult('version', { version: '1.2.3' })), { color: false })
 
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('version')
     expect(output).toContain(' OK       0 exit code')
     expect(output).toContain('DATA\n------------')

--- a/tests/cli/runtime-dispatch.test.ts
+++ b/tests/cli/runtime-dispatch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+import { APP_VERSION } from '../../packages/core/src/constants'
 
 const execFileSync = mock((..._args: unknown[]) => '')
 const fetchMock = mock()
@@ -55,10 +56,33 @@ describe('bakin runtime binary dispatch', () => {
     const result = await dispatchCli(['bun', 'bakin', '--help'])
 
     expect(result).toEqual({ startServer: false, exitCode: 0 })
-    expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Help')
     expect(output()).toContain('LIFECYCLE')
     expect(output()).not.toContain('Usage: bakin <command> [options]')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('renders binary version with the shared TUI when stdout is a TTY', async () => {
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', 'version'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 0 })
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain(`Version  v${APP_VERSION}`)
+    expect(output()).toContain(APP_VERSION)
+    expect(errorOutput()).toBe('')
+  })
+
+  it('keeps binary version plain outside TTY', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true })
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', '--version'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 0 })
+    expect(output()).toBe(APP_VERSION)
     expect(errorOutput()).toBe('')
   })
 

--- a/tests/cli/schedule.test.ts
+++ b/tests/cli/schedule.test.ts
@@ -209,7 +209,7 @@ describe('CLI schedule commands', () => {
       mockJsonResponse({ ok: true })
       await cmdScheduleRemove('new-1')
 
-      expect(output()).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+      expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
       expect(output()).toContain('Schedule action')
       expect(output()).toContain('RESULT')
       expect(output()).toContain('Created schedule Daily Check')

--- a/tests/cli/start-onboarding-gate.test.ts
+++ b/tests/cli/start-onboarding-gate.test.ts
@@ -33,7 +33,7 @@ describe('CLI start onboarding gate', () => {
 
     expect(result).toEqual({ startServer: false, exitCode: 1 })
     const output = logSpy.mock.calls.map(call => String(call[0])).join('\n')
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Onboard')
     expect(output).toContain('Initial setup required')
     expect(output).toContain('Run `bakin onboard`')

--- a/tests/cli/tui-gallery.test.tsx
+++ b/tests/cli/tui-gallery.test.tsx
@@ -39,7 +39,7 @@ describe('CLI TUI style gallery', () => {
       const lines = output.split('\n')
       expect(lines[0]).toBe('')
       expect(lines[1]).toBe('┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓')
-      expect(lines[2]).toBe("┃  🐷 Bakin'                  (v1.0.0) ┃")
+      expect(lines[2]).toBe("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
       expect(lines[3]).toBe('┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛')
       expect(lines[4]).toBe('')
     }
@@ -79,7 +79,7 @@ describe('CLI TUI style gallery', () => {
     const maxLineLength = Math.max(...visibleLineLengths(output))
 
     expect(maxLineLength).toBeLessThanOrEqual(100)
-    expect(output).toContain("┃  🐷 Bakin'                  (v1.0.0) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output).toContain('Onboard  step 7 of 11')
     expect(output).toContain('Setting up this machine')
     expect(output).toContain('CURRENT ACTIVITY')

--- a/tests/cli/ui.test.tsx
+++ b/tests/cli/ui.test.tsx
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'bun:test'
 import { renderToString } from 'ink'
+import { APP_VERSION } from '../../packages/core/src/constants'
 
 import { createMultiSelectState, MultiSelect, updateMultiSelectState } from '../../src/core/cli/ui/multi-select'
 import { Report } from '../../src/core/cli/ui/report'
 import { Table } from '../../src/core/cli/ui/table'
 import {
+  BAKIN_HEADER,
   DataTable,
   FindingRows,
   NextActions,
@@ -24,9 +26,11 @@ describe('CLI UI primitives', () => {
     const lines = output.split('\n')
 
     expect(lines[0]).toBe('')
-    expect(lines[1]).toBe('┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓')
-    expect(lines[2]).toBe("┃  🐷 Bakin'                  (v1.0.0) ┃")
-    expect(lines[3]).toBe('┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛')
+    expect(lines[1]).toBe(BAKIN_HEADER[0])
+    expect(lines[2]).toBe(BAKIN_HEADER[1])
+    expect(lines[2]).toContain(`(v${APP_VERSION})`)
+    expect(lines[2]).toContain("┃ 🐷 Bakin'")
+    expect(lines[3]).toBe(BAKIN_HEADER[2])
     expect(lines[4]).toBe('')
     expect(output).toContain('Doctor  mode: offline')
     expect(output).toContain('Offline diagnostics from this machine')


### PR DESCRIPTION
Summary:
- Add a shared Version TUI report and use it for source and binary version commands in TTY mode.
- Keep non-TTY version output as the bare version string for scripts.
- Build the shared Bakin header from APP_VERSION instead of a hard-coded value, and remove one leading space before the pig.

Verification:
- bun test --isolate tests/cli/ui.test.tsx tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts tests/cli/runtime-dispatch.test.ts tests/cli/tui-gallery.test.tsx tests/cli/onboarding-ui.test.tsx tests/cli/onboard-command.test.ts
- bun run typecheck
- bun test --isolate tests/cli