### PR TITLE
Render plugin CLI command results with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -164,6 +164,19 @@ function print(data: unknown): void {
   }
 }
 
+async function printGenericCommandResultTui(command: string, data: unknown): Promise<void> {
+  const [{ renderCliResult }, { okResult }] = await Promise.all([
+    import('../src/core/cli/render'),
+    import('../src/core/cli/result'),
+  ])
+  console.log(renderCliResult(okResult(command, data), { mode: 'ink' }).trimEnd())
+}
+
+async function printPluginCliCommandResult(command: string, args: string[], data: unknown): Promise<void> {
+  if (process.stdout.isTTY && !args.includes('--json')) await printGenericCommandResultTui(command, data)
+  else print(data)
+}
+
 function printTable(rows: Record<string, unknown>[], columns?: string[]): void {
   if (rows.length === 0) {
     console.log('(none)')
@@ -3201,13 +3214,14 @@ async function dispatchPluginCliCommand(cmd: string, args: string[]): Promise<bo
     if (!command.dispatch) continue
     const params = matchPluginCliCommand(command, cmd, args)
     if (!params) continue
+    const invocation = invocationCommand([cmd, ...args])
 
     if (command.dispatch.type === 'execTool') {
       const result = await apiPost(`/api/exec-tools/${encodeURIComponent(command.dispatch.name)}`, {
         params,
         agent: 'cli',
       })
-      print(result)
+      await printPluginCliCommandResult(invocation, args, result)
       return true
     }
 
@@ -3215,7 +3229,7 @@ async function dispatchPluginCliCommand(cmd: string, args: string[]): Promise<bo
       method: command.dispatch.method,
       body: command.dispatch.method === 'GET' ? undefined : JSON.stringify(params),
     })
-    print(result)
+    await printPluginCliCommandResult(invocation, args, result)
     return true
   }
   return false
@@ -3957,7 +3971,7 @@ export async function main(): Promise<void> {
         }
         break
 
-      default:
+      default: {
         let pluginLookupError: string | undefined
         if (!BINARY_ONLY_COMMANDS.has(cmd)) {
           try {
@@ -3974,6 +3988,7 @@ export async function main(): Promise<void> {
         if (process.stdout.isTTY) await printHelpTui(`Unknown command: ${cmd}`, pluginLookupError)
         else console.log(USAGE.trim())
         process.exit(1)
+      }
     }
   } catch (err) {
     if (err instanceof Error && err.name === 'BakinDelegatedCliExit') {

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -177,7 +177,6 @@ export async function dispatchCli(argv: string[]): Promise<CliResult> {
   const args = argv.slice(2)
   // No-arg invocation is `start` — the compiled binary's primary job.
   const cmd = args[0] ?? 'start'
-  const sub = args[1]
 
   if (cmd === '--help' || cmd === '-h' || cmd === 'help') {
     return { startServer: false, exitCode: await cmdHelp() }

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -140,6 +140,105 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).not.toContain('Error: Cannot connect to Bakin')
   })
 
+  it('renders plugin-contributed command results with the shared TUI in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        plugins: [{
+          id: 'demo',
+          contributes: {
+            cliCommands: [{
+              name: 'demo:run',
+              usage: 'bakin demo run <target>',
+              summary: 'Run demo command.',
+              dispatch: { type: 'apiRoute', method: 'POST', path: '/run' },
+            }],
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        accepted: true,
+        target: 'smoke',
+      }))
+    process.argv = ['bun', 'cli/bakin.ts', 'demo', 'run', 'smoke', '--loud=true']
+
+    await main()
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:3737/api/plugins/demo/run',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ loud: true, target: 'smoke' }),
+      }),
+    )
+    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain('bakin demo run smoke --loud=true')
+    expect(output()).toContain('DATA')
+    expect(output()).toContain('"target": "smoke"')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('honors --json for plugin-contributed commands even in a TTY', async () => {
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        plugins: [{
+          id: 'demo',
+          contributes: {
+            cliCommands: [{
+              name: 'demo:json',
+              usage: 'bakin demo json <target> [--json]',
+              summary: 'Show JSON command.',
+              dispatch: { type: 'apiRoute', method: 'GET', path: '/json' },
+            }],
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        target: 'machine',
+      }))
+    process.argv = ['bun', 'cli/bakin.ts', 'demo', 'json', 'machine', '--json']
+
+    await main()
+
+    expect(output()).toBe('{\n  "target": "machine"\n}')
+    expect(output()).not.toContain("Bakin'")
+    expect(errorOutput()).toBe('')
+  })
+
+  it('keeps plugin-contributed command results raw outside TTY', async () => {
+    setStdoutIsTTY(false)
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        plugins: [{
+          id: 'demo',
+          contributes: {
+            cliCommands: [{
+              name: 'demo:show',
+              usage: 'bakin demo show <target>',
+              summary: 'Show demo command.',
+              dispatch: { type: 'apiRoute', method: 'GET', path: '/show' },
+            }],
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        target: 'plain',
+      }))
+    process.argv = ['bun', 'cli/bakin.ts', 'demo', 'show', 'plain']
+
+    await main()
+
+    expect(output()).toBe('{\n  "target": "plain"\n}')
+    expect(output()).not.toContain("Bakin'")
+    expect(errorOutput()).toBe('')
+  })
+
   it('renders missing-argument usage with the shared TUI when stdout is a TTY', async () => {
     process.argv = ['bun', 'cli/bakin.ts', 'tasks', 'get']
 


### PR DESCRIPTION
## Summary
- Route manifest-dispatched plugin CLI command results through the shared generic TUI in interactive terminals
- Preserve raw output for non-TTY runs and explicit --json
- Add regression coverage for TTY, --json, and non-TTY plugin-contributed command output
- Clean up two lint blockers in touched CLI dispatch paths

## Verification
- bun run typecheck
- bun test --isolate tests/cli
- bun run lint (passes with existing multi-select hook dependency warning)