### PR TITLE
Keep unknown command errors inside TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -4186,10 +4186,13 @@ export async function main(): Promise<void> {
             pluginLookupError = `Plugin command lookup skipped because Bakin is not reachable at ${BASE_URL}.`
           }
         }
-        console.error(`Unknown command: ${cmd}`)
-        if (pluginLookupError) console.error(pluginLookupError)
-        if (process.stdout.isTTY) await printHelpTui(`Unknown command: ${cmd}`, pluginLookupError)
-        else console.log(USAGE.trim())
+        if (process.stdout.isTTY) {
+          await printHelpTui(`Unknown command: ${cmd}`, pluginLookupError)
+        } else {
+          console.error(`Unknown command: ${cmd}`)
+          if (pluginLookupError) console.error(pluginLookupError)
+          console.log(USAGE.trim())
+        }
         process.exit(1)
       }
     }

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -115,7 +115,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await expect(main()).rejects.toThrow('exit:1')
 
-    expect(errorOutput()).toContain('Unknown command: wat')
+    expect(errorOutput()).toBe('')
     expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
     expect(output()).toContain('Help  unknown command')
     expect(output()).toContain('ISSUE')
@@ -133,8 +133,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await expect(main()).rejects.toThrow('exit:1')
 
-    expect(errorOutput()).toContain('Unknown command: wat')
-    expect(errorOutput()).toContain('Plugin command lookup skipped')
+    expect(errorOutput()).toBe('')
     expect(output()).toContain('Help  unknown command')
     expect(output()).toContain('Plugin command lookup skipped')
     expect(output()).not.toContain('Error: Cannot connect to Bakin')


### PR DESCRIPTION
## Summary
- stop writing legacy unknown-command stderr before the interactive help TUI
- keep plain stderr plus usage for non-TTY callers
- update CLI tests to assert interactive unknown-command output stays on the shared TUI path

## Verification
- bun test --isolate tests/cli/readonly-commands.test.ts
- bun run typecheck
- bun test --isolate tests/cli
- bun run lint (passes with existing multi-select exhaustive-deps warning)