### PR TITLE
Fix multi-select hook dependency warning

### DIFF
--- a/src/core/cli/ui/multi-select.tsx
+++ b/src/core/cli/ui/multi-select.tsx
@@ -117,7 +117,7 @@ export function MultiSelect({
     value: item.id,
     label: optionLabel(item),
   })), [enabledItems])
-  const defaultValue = useMemo(() => [...state.selectedIds], [])
+  const defaultValue = useMemo(() => [...state.selectedIds], [state.selectedIds])
 
   useEffect(() => {
     stateRef.current = state


### PR DESCRIPTION
## Summary
- include `state.selectedIds` in the multi-select default value memo dependencies
- clears the remaining lint warning without changing the TUI surface

## Verification
- bun run lint
- bun test --isolate tests/cli/ui.test.tsx tests/cli/tui-gallery.test.tsx
- bun run typecheck