### PR TITLE
Render binary dispatch failures with shared TUI

### DIFF
--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -16,9 +16,40 @@
  */
 import { APP_VERSION } from '../../packages/core/src/constants'
 import { getCliUsageGroups, renderCliUsage } from './cli/registry'
+import type { CommandFailureData, RuntimeActionData } from './cli/ui/readonly'
 import { isOnboarded } from './onboarding/state'
 
 const BAKIN_URL = process.env.BAKIN_URL || 'http://localhost:3737'
+
+function invocationCommand(args: string[]): string {
+  return args.length > 0 ? `bakin ${args.join(' ')}` : 'bakin'
+}
+
+async function printCommandFailure(
+  failure: CommandFailureData,
+  plainLines: string[] = [`Error: ${String(failure.message ?? 'Command failed')}`],
+): Promise<void> {
+  if (process.stdout.isTTY) {
+    const [{ CommandFailureReport }, { renderToString }, { createElement }] = await Promise.all([
+      import('./cli/ui/readonly'),
+      import('./cli/ui/render-to-string'),
+      import('react'),
+    ])
+    console.log(renderToString(createElement(CommandFailureReport, { failure })))
+    return
+  }
+
+  for (const line of plainLines) console.error(line)
+}
+
+async function printRuntimeAction(action: RuntimeActionData): Promise<void> {
+  const [{ RuntimeActionReport }, { renderToString }, { createElement }] = await Promise.all([
+    import('./cli/ui/readonly'),
+    import('./cli/ui/render-to-string'),
+    import('react'),
+  ])
+  console.log(renderToString(createElement(RuntimeActionReport, { action })))
+}
 
 async function cmdVersion(): Promise<number> {
   if (process.stdout.isTTY) {
@@ -65,11 +96,59 @@ async function checkOnboardedBeforeStart(args: string[]): Promise<number | null>
 async function cmdUpdate(): Promise<number> {
   // Use a variable specifier so TypeScript doesn't require this optional
   // implementation at build time.
+  let mod: { selfUpdate: (reporter?: {
+    log: (message: string) => void
+    error: (message: string) => void
+  }) => Promise<number> }
   try {
-    const mod = await import(/* @vite-ignore */ './self-update' as string) as { selfUpdate: () => Promise<number> }
-    return mod.selfUpdate()
+    mod = await import(/* @vite-ignore */ './self-update' as string) as typeof mod
   } catch (err) {
-    console.error(`update is not available: ${err instanceof Error ? err.message : String(err)}`)
+    const detail = err instanceof Error ? err.message : String(err)
+    await printCommandFailure({
+      command: 'bakin update',
+      message: 'update is not available.',
+      detail,
+      code: 'UPDATE_UNAVAILABLE',
+    }, [`update is not available: ${detail}`])
+    return 1
+  }
+
+  if (!process.stdout.isTTY) return await mod.selfUpdate()
+
+  const events: Array<{ level: 'info' | 'error'; message: string }> = []
+  const reporter = {
+    log: (message: string) => events.push({ level: 'info' as const, message }),
+    error: (message: string) => events.push({ level: 'error' as const, message }),
+  }
+
+  try {
+    const exitCode = await mod.selfUpdate(reporter)
+    const detail = events.map(event => event.message).join('\n')
+    if (exitCode === 0) {
+      await printRuntimeAction({
+        action: 'updated',
+        target: 'Bakin binary',
+        result: { ok: true, status: 'ok' },
+        message: events.at(-1)?.message ?? 'Bakin update completed.',
+        detail,
+      })
+    } else {
+      await printCommandFailure({
+        command: 'bakin update',
+        message: events.findLast(event => event.level === 'error')?.message ?? 'Bakin update failed.',
+        detail,
+        code: 'UPDATE_FAILED',
+      })
+    }
+    return exitCode
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    await printCommandFailure({
+      command: 'bakin update',
+      message: 'Bakin update failed.',
+      detail: [...events.map(event => event.message), detail].join('\n'),
+      code: 'UPDATE_FAILED',
+    })
     return 1
   }
 }
@@ -113,8 +192,15 @@ export async function cmdDev(devArgs: string[] = process.argv.slice(3)): Promise
   const repoRoot = here ? resolve(dirname(here), '..', '..') : process.cwd()
   const devScript = join(repoRoot, 'scripts', 'dev.ts')
   if (!existsSync(devScript)) {
-    console.error('`bakin dev` only runs from a bakin source tree.')
-    console.error('Clone https://github.com/markhayden/bakin and run `bakin dev` from the repo root.')
+    await printCommandFailure({
+      command: 'bakin dev',
+      message: '`bakin dev` only runs from a bakin source tree.',
+      detail: 'Clone https://github.com/markhayden/bakin and run `bakin dev` from the repo root.',
+      code: 'SOURCE_TREE_REQUIRED',
+    }, [
+      '`bakin dev` only runs from a bakin source tree.',
+      'Clone https://github.com/markhayden/bakin and run `bakin dev` from the repo root.',
+    ])
     return 1
   }
 
@@ -122,8 +208,14 @@ export async function cmdDev(devArgs: string[] = process.argv.slice(3)): Promise
   const proc = spawn('bun', ['run', devScript, ...devArgs], { stdio: 'inherit', cwd: repoRoot })
   return await new Promise<number>((resolvePromise) => {
     proc.once('close', (code: number | null) => resolvePromise(code ?? 0))
-    proc.once('error', (err) => {
-      console.error('Failed to spawn dev:', err instanceof Error ? err.message : String(err))
+    proc.once('error', async (err) => {
+      const detail = err instanceof Error ? err.message : String(err)
+      await printCommandFailure({
+        command: 'bakin dev',
+        message: 'Failed to spawn dev.',
+        detail,
+        code: 'DEV_SPAWN_FAILED',
+      }, [`Failed to spawn dev: ${detail}`])
       resolvePromise(1)
     })
   })
@@ -220,7 +312,12 @@ export async function dispatchCli(argv: string[]): Promise<CliResult> {
       }
     }
   } catch (err) {
-    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`)
+    const message = err instanceof Error ? err.message : String(err)
+    await printCommandFailure({
+      command: invocationCommand(args),
+      message,
+      code: 'COMMAND_FAILED',
+    }, [`Error: ${message}`])
     return { startServer: false, exitCode: 1 }
   }
 }

--- a/src/core/self-update.ts
+++ b/src/core/self-update.ts
@@ -34,6 +34,16 @@ interface GithubRelease {
   assets: GithubAsset[]
 }
 
+export interface SelfUpdateReporter {
+  log: (message: string) => void
+  error: (message: string) => void
+}
+
+const consoleReporter: SelfUpdateReporter = {
+  log: message => console.log(message),
+  error: message => console.error(message),
+}
+
 function currentTriple(): string | null {
   const plat = process.platform
   const arch = process.arch
@@ -75,14 +85,14 @@ function parseChecksums(text: string): Map<string, string> {
   return map
 }
 
-export async function selfUpdate(): Promise<number> {
+export async function selfUpdate(reporter: SelfUpdateReporter = consoleReporter): Promise<number> {
   const triple = currentTriple()
   if (!triple) {
-    console.error(`No prebuilt binary for ${process.platform}/${process.arch}`)
+    reporter.error(`No prebuilt binary for ${process.platform}/${process.arch}`)
     return 1
   }
 
-  console.log(`Fetching latest release from ${RELEASE_API}`)
+  reporter.log(`Fetching latest release from ${RELEASE_API}`)
   let release: GithubRelease
   try {
     const res = await fetch(RELEASE_API, {
@@ -91,7 +101,7 @@ export async function selfUpdate(): Promise<number> {
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     release = (await res.json()) as GithubRelease
   } catch (err) {
-    console.error(`Could not fetch release info: ${err instanceof Error ? err.message : String(err)}`)
+    reporter.error(`Could not fetch release info: ${err instanceof Error ? err.message : String(err)}`)
     return 1
   }
 
@@ -99,11 +109,11 @@ export async function selfUpdate(): Promise<number> {
   const binAsset = release.assets.find(a => a.name === binName)
   const sumAsset = release.assets.find(a => a.name === 'checksums.txt')
   if (!binAsset) {
-    console.error(`Release ${release.tag_name} is missing asset ${binName}`)
+    reporter.error(`Release ${release.tag_name} is missing asset ${binName}`)
     return 1
   }
   if (!sumAsset) {
-    console.error(`Release ${release.tag_name} is missing checksums.txt`)
+    reporter.error(`Release ${release.tag_name} is missing checksums.txt`)
     return 1
   }
 
@@ -112,12 +122,12 @@ export async function selfUpdate(): Promise<number> {
   const sumsPath = `${currentPath}.checksums.txt`
 
   try {
-    console.log(`Downloading ${binAsset.name} (${release.tag_name})...`)
+    reporter.log(`Downloading ${binAsset.name} (${release.tag_name})...`)
     await downloadTo(binAsset.browser_download_url, newPath)
     await downloadTo(sumAsset.browser_download_url, sumsPath)
   } catch (err) {
     for (const p of [newPath, sumsPath]) if (existsSync(p)) unlinkSync(p)
-    console.error(`Download failed: ${err instanceof Error ? err.message : String(err)}`)
+    reporter.error(`Download failed: ${err instanceof Error ? err.message : String(err)}`)
     return 1
   }
 
@@ -126,14 +136,14 @@ export async function selfUpdate(): Promise<number> {
     sums = parseChecksums(readFileSync(sumsPath, 'utf-8'))
   } catch (err) {
     for (const p of [newPath, sumsPath]) if (existsSync(p)) unlinkSync(p)
-    console.error(`Could not parse checksums.txt: ${err instanceof Error ? err.message : String(err)}`)
+    reporter.error(`Could not parse checksums.txt: ${err instanceof Error ? err.message : String(err)}`)
     return 1
   }
 
   const expected = sums.get(binName)
   if (!expected) {
     for (const p of [newPath, sumsPath]) if (existsSync(p)) unlinkSync(p)
-    console.error(`checksums.txt has no entry for ${binName}`)
+    reporter.error(`checksums.txt has no entry for ${binName}`)
     return 1
   }
 
@@ -142,15 +152,15 @@ export async function selfUpdate(): Promise<number> {
     actual = await sha256File(newPath)
   } catch (err) {
     for (const p of [newPath, sumsPath]) if (existsSync(p)) unlinkSync(p)
-    console.error(`Could not hash downloaded file: ${err instanceof Error ? err.message : String(err)}`)
+    reporter.error(`Could not hash downloaded file: ${err instanceof Error ? err.message : String(err)}`)
     return 1
   }
 
   if (actual.toLowerCase() !== expected.toLowerCase()) {
     for (const p of [newPath, sumsPath]) if (existsSync(p)) unlinkSync(p)
-    console.error(`Checksum mismatch for ${binName}`)
-    console.error(`  expected: ${expected}`)
-    console.error(`  actual:   ${actual}`)
+    reporter.error(`Checksum mismatch for ${binName}`)
+    reporter.error(`  expected: ${expected}`)
+    reporter.error(`  actual:   ${actual}`)
     return 1
   }
 
@@ -161,10 +171,10 @@ export async function selfUpdate(): Promise<number> {
   } catch (err) {
     if (existsSync(newPath)) unlinkSync(newPath)
     if (existsSync(sumsPath)) unlinkSync(sumsPath)
-    console.error(`Could not replace binary: ${err instanceof Error ? err.message : String(err)}`)
+    reporter.error(`Could not replace binary: ${err instanceof Error ? err.message : String(err)}`)
     return 1
   }
 
-  console.log(`Updated to ${release.tag_name}. Restart to run the new version.`)
+  reporter.log(`Updated to ${release.tag_name}. Restart to run the new version.`)
   return 0
 }

--- a/tests/cli/runtime-dispatch.test.ts
+++ b/tests/cli/runtime-dispatch.test.ts
@@ -86,6 +86,31 @@ describe('bakin runtime binary dispatch', () => {
     expect(errorOutput()).toBe('')
   })
 
+  it('renders binary update failures with the shared TUI when stdout is a TTY', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', 'update'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 1 })
+    expect(output()).toContain('Command failed  bakin update')
+    expect(output()).toContain('Could not fetch release info: HTTP 500')
+    expect(output()).toContain('UPDATE_FAILED')
+    expect(errorOutput()).toBe('')
+  })
+
+  it('keeps binary update failures plain outside TTY', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true })
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+    const { dispatchCli } = await import('../../src/core/cli')
+
+    const result = await dispatchCli(['bun', 'bakin', 'update'])
+
+    expect(result).toEqual({ startServer: false, exitCode: 1 })
+    expect(output()).toContain('Fetching latest release')
+    expect(errorOutput()).toContain('Could not fetch release info: HTTP 500')
+  })
+
   it('delegates status to the shared source CLI TUI', async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({


### PR DESCRIPTION
## Summary
- add shared command-failure/runtime-action rendering to the binary-facing dispatcher
- render `bakin update` failures through the shared TUI in interactive terminals while preserving raw progress/errors outside TTY
- let the self-updater report progress/errors through an optional reporter instead of hard-wiring console output
- route `bakin dev` source-tree/spawn failures and unexpected dispatch errors through the shared failure screen in TTY mode

## Verification
- bun test --isolate tests/cli/runtime-dispatch.test.ts
- bun run typecheck
- bun run lint
- bun test --isolate tests/cli