### PR TITLE
Render start spawn failures with shared TUI

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -2439,8 +2439,18 @@ async function cmdStartServer(command: 'start' | 'serve', args: string[] = []): 
   })
   const exitCode = await new Promise<number>((resolvePromise) => {
     child.once('close', (code: number | null) => resolvePromise(code ?? 0))
-    child.once('error', (err: Error) => {
-      console.error('Failed to start Bakin:', err instanceof Error ? err.message : String(err))
+    child.once('error', async (err: Error) => {
+      const detail = err instanceof Error ? err.message : String(err)
+      if (process.stdout.isTTY) {
+        await printCommandFailureTui({
+          command: `bakin ${command}`,
+          message: 'Failed to start Bakin.',
+          detail,
+          code: 'START_FAILED',
+        })
+      } else {
+        console.error('Failed to start Bakin:', detail)
+      }
       resolvePromise(1)
     })
   })

--- a/tests/cli/legacy-start.test.ts
+++ b/tests/cli/legacy-start.test.ts
@@ -2,11 +2,33 @@ import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test'
 
 let spawnCalls: unknown[][] = []
 let onboarded = false
+let spawnError: Error | null = null
 
 function fakeChildProcess() {
+  let closeHandler: ((value?: unknown) => void) | undefined
+  let errorHandler: ((value?: unknown) => void) | undefined
+  let settled = false
+
+  const settle = () => {
+    queueMicrotask(() => {
+      if (settled) return
+      if (spawnError && errorHandler) {
+        settled = true
+        errorHandler(spawnError)
+        return
+      }
+      if (!spawnError && closeHandler) {
+        settled = true
+        closeHandler(0)
+      }
+    })
+  }
+
   return {
     once(event: string, handler: (value?: unknown) => void) {
-      if (event === 'close') handler(0)
+      if (event === 'close') closeHandler = handler
+      if (event === 'error') errorHandler = handler
+      settle()
       return this
     },
   }
@@ -33,11 +55,12 @@ describe('legacy CLI start command', () => {
   afterEach(() => {
     process.argv = originalArgv
     process.exit = originalExit
-    process.exitCode = originalExitCode
+    process.exitCode = originalExitCode ?? 0
     if (originalStdoutIsTTY) Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
     else delete (process.stdout as { isTTY?: boolean }).isTTY
     spawnCalls = []
     onboarded = false
+    spawnError = null
   })
 
   it('renders the shared onboarding gate instead of the old unknown command path', async () => {
@@ -77,6 +100,29 @@ describe('legacy CLI start command', () => {
     expect(spawnCalls[0][2]).toEqual(expect.objectContaining({ stdio: 'inherit' }))
     expect(err.mock.calls).toHaveLength(0)
     expect(log.mock.calls).toHaveLength(0)
+    log.mockRestore()
+    err.mockRestore()
+  })
+
+  it('renders foreground start spawn failures with the shared TUI', async () => {
+    onboarded = true
+    spawnError = new Error('spawn denied')
+    const err = spyOn(console, 'error').mockImplementation(() => {})
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    process.argv = ['bun', 'cli/bakin.ts', 'start']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(process.exitCode).toBe(1)
+    expect(spawnCalls).toHaveLength(1)
+    const output = log.mock.calls.map(call => String(call[0])).join('\n')
+    expect(output).toContain('Command failed  bakin start')
+    expect(output).toContain('Failed to start Bakin.')
+    expect(output).toContain('START_FAILED')
+    expect(output).toContain('spawn denied')
+    expect(err.mock.calls).toHaveLength(0)
     log.mockRestore()
     err.mockRestore()
   })


### PR DESCRIPTION
## Summary
- route interactive `bakin start` / `bakin serve` spawn failures through the shared command failure TUI
- preserve the existing plain stderr output outside TTY
- add focused legacy start coverage for the foreground spawn failure path

## Verification
- bun test --isolate tests/cli/legacy-start.test.ts
- bun run typecheck
- bun run lint
- bun test --isolate tests/cli