### PR TITLE
Prepare v0.0.1 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-05-05
+## [0.0.1-rc.1] - 2026-05-19
 
 ### Added
-- Initial public release of Bakin.
-- Ship a standalone `bakin` CLI and local web app.
+- Prepare the first release-candidate binary and SDK publishing path for fresh-machine install testing.
+- Ship the standalone `bakin` CLI and local web app.
 - Add core plugins for tasks, team, assets, memory, schedule, workflows, models, health, and git worktrees.
 - Add plugin and agent package authoring surfaces.
-- Publish signed macOS and Linux binaries.
-- Publish `@makinbakin/sdk`.
-- Add Homebrew installation through `markhayden/tap/bakin`.
+- Add consistent Ink TUI output across core CLI commands, including onboarding, doctor, list/get surfaces, JSON mode, tables, prompts, logs, and error responses.
+- Add doctor repair delegation and verification output for task-board handoff workflows.
+
+### Changed
+- Align bundled adapter versions and compatibility ranges with the `0.0.1` release train.
+- Start unpublished patch release prep at `v0.0.1-rc.1` instead of `v0.1.0-rc.1`.
 
 ### Fixed
 - Stamp release versions into binaries so `bakin --version` matches the release tag.
 - Sign and notarize macOS release binaries.
 - Publish release assets, SDK packages, Homebrew formula updates, and post-publish smoke checks from CI.
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/markhayden/bakin/releases/tag/v0.1.0
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.1...HEAD
+[0.0.1-rc.1]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.1

--- a/docs/src/content/docs/start/install.mdx
+++ b/docs/src/content/docs/start/install.mdx
@@ -82,7 +82,7 @@ curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | 
 `BAKIN_VERSION` grabs a specific release tag instead of the latest:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v1.0.0 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.1 bash
 ```
 
 ### Manual download

--- a/packages/adapter-antfly/src/search.ts
+++ b/packages/adapter-antfly/src/search.ts
@@ -102,8 +102,8 @@ function sleep(ms: number): Promise<void> {
 
 export class AntflySearchAdapter implements SearchAdapter {
   readonly name = 'antfly'
-  readonly version = '0.1.0'
-  readonly requiredCoreVersion = '^1.0.0'
+  readonly version = '0.0.1-rc.1'
+  readonly requiredCoreVersion = '>=0.0.1-rc.1'
 
   private client: AntflyClient | null = null
   private settings: AntflySettings

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -232,8 +232,8 @@ interface OpenClawSessionActivityCursor {
 
 export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   readonly name = 'openclaw'
-  readonly version = '0.1.0'
-  readonly requiredCoreVersion = '^1.0.0'
+  readonly version = '0.0.1-rc.1'
+  readonly requiredCoreVersion = '>=0.0.1-rc.1'
 
   private settings: OpenClawSettings
   private logger: AdapterLogger = noopLogger

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -86,7 +86,8 @@ function tagFor(major: number, minor: number, patch: number, rc: number | null):
 function bumpedBase(latestStable: ParsedReleaseTag | null, verb: BumpVerb): { major: number; minor: number; patch: number } {
   if (!latestStable) {
     if (verb === 'major') return { major: 1, minor: 0, patch: 0 }
-    return { major: 0, minor: 1, patch: 0 }
+    if (verb === 'minor') return { major: 0, minor: 1, patch: 0 }
+    return { major: 0, minor: 0, patch: 1 }
   }
   if (verb === 'patch') return { major: latestStable.major, minor: latestStable.minor, patch: latestStable.patch + 1 }
   if (verb === 'minor') return { major: latestStable.major, minor: latestStable.minor + 1, patch: 0 }

--- a/tests/scripts/prep-release.test.ts
+++ b/tests/scripts/prep-release.test.ts
@@ -37,6 +37,11 @@ describe('targetTagForPrep', () => {
     expect(targetTagForPrep(opts, [])).toBe('v0.1.0')
   })
 
+  it('starts an unpublished patch release at v0.0.1', () => {
+    const opts = parsePrepArgs(['patch', '--rc'], '2026-05-11')
+    expect(targetTagForPrep(opts, [])).toBe('v0.0.1-rc.1')
+  })
+
   it('uses remote tags to compute the next version', () => {
     const opts = parsePrepArgs(['patch'], '2026-05-11')
     expect(targetTagForPrep(opts, ['v0.1.0'])).toBe('v0.1.1')

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -30,9 +30,9 @@ describe('parseReleaseTag', () => {
 })
 
 describe('resolveReleaseTarget', () => {
-  it('starts pre-1.0 releases at v0.1.0', () => {
+  it('starts unpublished release lines from the requested bump', () => {
     expect(resolveReleaseTarget([], { verb: 'minor', prerelease: false })).toBe('v0.1.0')
-    expect(resolveReleaseTarget([], { verb: 'patch', prerelease: true })).toBe('v0.1.0-rc.1')
+    expect(resolveReleaseTarget([], { verb: 'patch', prerelease: true })).toBe('v0.0.1-rc.1')
   })
 
   it('bumps stable versions', () => {


### PR DESCRIPTION
## Summary
- add CHANGELOG notes for v0.0.1-rc.1 and update the pinned install docs
- align bundled adapter versions and required core ranges with the 0.0.1 release train
- make first unpublished patch release prep resolve to v0.0.1-rc.1 while keeping tracked dev APP_VERSION at 0.0.0-dev for local builds

## Testing
- bun test --isolate
- bun run typecheck
- bun run docs:validate
- bun run scripts/extract-release-notes.ts --version 0.0.1-rc.1 --out /private/tmp/bakin-0.0.1-rc.1-notes.md