### PR TITLE
Allow stamped release TUI headers in tests

### DIFF
--- a/tests/cli/doctor-repair-ui.test.tsx
+++ b/tests/cli/doctor-repair-ui.test.tsx
@@ -80,7 +80,7 @@ describe('doctor repair CLI UI', () => {
   it('renders a repair plan with shared TUI primitives', () => {
     const rendered = renderToString(<DoctorRepairPlan plan={repairPlan} color={false} />)
 
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Doctor repair plan')
     expect(rendered).toContain(' READY    1 safe')
     expect(rendered).toContain('SAFE DETERMINISTIC REPAIRS')
@@ -107,7 +107,7 @@ describe('doctor repair CLI UI', () => {
     const rendered = renderToString(<DoctorRepairApplyReport report={repairApply} color={false} showBrand={false} />)
 
     expect(rendered).toContain('Doctor repair results')
-    expect(rendered).not.toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).not.toContain("┃ 🐷 Bakin'")
   })
 
   it('renders delegated repair preview and sent result', () => {

--- a/tests/cli/doctor-repair.test.ts
+++ b/tests/cli/doctor-repair.test.ts
@@ -82,7 +82,7 @@ describe('legacy CLI doctor repair', () => {
   }
 
   function headerCount(output: string): number {
-    return output.split("┃ 🐷 Bakin'               (v0.0.0-dev) ┃").length - 1
+    return output.split("┃ 🐷 Bakin'").length - 1
   }
 
   beforeEach(() => {
@@ -167,7 +167,7 @@ describe('legacy CLI doctor repair', () => {
     await main()
 
     const output = loggedOutput()
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Doctor repair plan')
     expect(output).toContain('No deterministic repairs available.')
     expect(output).not.toContain('[SAFE]')
@@ -314,7 +314,7 @@ describe('legacy CLI doctor repair', () => {
     await main()
 
     const output = loggedOutput()
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Doctor repair requests')
     expect(output).toContain('REQUESTS')
     expect(output).toContain('repair-1')

--- a/tests/cli/doctor-ui.test.tsx
+++ b/tests/cli/doctor-ui.test.tsx
@@ -18,7 +18,7 @@ describe('doctor CLI UI', () => {
       />,
     )
 
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Doctor  mode: offline')
     expect(rendered).toContain(' OK       0 errors')
     expect(rendered).toContain(' WARN     1 warning')

--- a/tests/cli/onboard-command.test.ts
+++ b/tests/cli/onboard-command.test.ts
@@ -90,8 +90,8 @@ describe('CLI onboard command', () => {
 
     const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
     const liveOutput = stdoutWrite.mock.calls.map((call: unknown[]) => String(call[0])).join('')
-    expect(liveOutput).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
-    expect(output).not.toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(liveOutput).toContain("┃ 🐷 Bakin'")
+    expect(output).not.toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Onboarding')
     expect(output).toContain('Machine setup complete')
     expect(output).toContain('PREREQUISITES')
@@ -112,7 +112,7 @@ describe('CLI onboard command', () => {
     await main()
 
     const output = log.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Machine setup already complete')
     expect(output).toContain('Already onboarded on 2026-05-19.')
     expect(output).toContain('Run `bakin onboard --force`')

--- a/tests/cli/onboarding-component-commands.test.ts
+++ b/tests/cli/onboarding-component-commands.test.ts
@@ -130,7 +130,7 @@ describe('onboarding component CLI commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Onboarding check')
     expect(output()).toContain('RESULT')
     expect(output()).toContain('Runtime adapter is available.')

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -71,7 +71,7 @@ describe('onboarding CLI UI', () => {
     ]
 
     const rendered = renderToString(<OnboardingSummary outcomes={outcomes} exitCode={1} />)
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Onboarding')
     expect(rendered).toContain('PREREQUISITES')
     expect(rendered).toContain('BLOCKED')
@@ -114,12 +114,12 @@ describe('onboarding CLI UI', () => {
     )
 
     expect(rendered).toContain('Onboarding')
-    expect(rendered).not.toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).not.toContain("┃ 🐷 Bakin'")
   })
 
   it('renders an async onboarding busy state', () => {
     const rendered = renderToString(<OnboardingBusy label="Running onboarding checks and installs" totalSteps={12} />)
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Onboard')
     expect(rendered).toContain('CURRENT ACTIVITY')
     expect(rendered).toContain('Running onboarding checks and installs')
@@ -144,7 +144,7 @@ describe('onboarding CLI UI', () => {
 
   it('renders the onboarding intro with the shared compact header', () => {
     const rendered = renderToString(<OnboardingIntro />)
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Onboard')
     expect(rendered).toContain('Initial setup wizard')
     expect(rendered).not.toContain('oooooooooo')
@@ -153,7 +153,7 @@ describe('onboarding CLI UI', () => {
 
   it('renders the start gate with shared onboarding UI', () => {
     const rendered = renderToString(<OnboardingRequiredReport />)
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Onboard')
     expect(rendered).toContain('Initial setup required')
     expect(rendered).toContain('REQUIRED SETUP')
@@ -169,7 +169,7 @@ describe('onboarding CLI UI', () => {
       bakinVersion: '1.0.0',
       components: { mkdir: 'ok', settings: 'ok' },
     }} />)
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Onboarding')
     expect(rendered).toContain('Machine setup already complete')
     expect(rendered).toContain('Already onboarded on 2026-05-19.')
@@ -208,7 +208,7 @@ describe('onboarding CLI UI', () => {
       }} color={false} />,
     )
 
-    expect(rendered).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(rendered).toContain("┃ 🐷 Bakin'")
     expect(rendered).toContain('Onboarding check')
     expect(rendered).toContain('RESULT')
     expect(rendered).toContain('No runtime adapter is available.')

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -71,7 +71,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await expect(main()).rejects.toThrow('exit:0')
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Help')
     expect(output()).toContain('LIFECYCLE')
     expect(output()).toContain('TASKS AND WORKFLOWS')
@@ -99,7 +99,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain(`Version  v${APP_VERSION}`)
     expect(output()).toContain(APP_VERSION)
     expect(errorOutput()).toBe('')
@@ -116,7 +116,7 @@ describe('read-only CLI TTY commands', () => {
     await expect(main()).rejects.toThrow('exit:1')
 
     expect(errorOutput()).toBe('')
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Help  unknown command')
     expect(output()).toContain('ISSUE')
     expect(output()).toContain('Unknown command: wat')
@@ -172,7 +172,7 @@ describe('read-only CLI TTY commands', () => {
         body: JSON.stringify({ loud: true, target: 'smoke' }),
       }),
     )
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('bakin demo run smoke --loud=true')
     expect(output()).toContain('DATA')
     expect(output()).toContain('"target": "smoke"')
@@ -244,7 +244,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await expect(main()).rejects.toThrow('exit:1')
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Command issue  bakin tasks get <id>')
     expect(output()).toContain('Missing required arguments.')
     expect(output()).toContain('USAGE')
@@ -394,7 +394,7 @@ describe('read-only CLI TTY commands', () => {
       resetContentDir()
     }
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Logs  filter: all')
     expect(output()).toContain('RECENT EVENTS')
     expect(output()).toContain('doctor.run')
@@ -490,7 +490,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Help')
     expect(output()).toContain('AGENT RULES')
     expect(output()).toContain('bakin agent-rules --apply')
@@ -513,7 +513,7 @@ describe('read-only CLI TTY commands', () => {
     const { main } = await import('../../cli/bakin')
     await main()
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Status')
     expect(output()).toContain('DISPATCH')
     expect(output()).not.toContain('=== Bakin Status ===')
@@ -814,7 +814,7 @@ describe('read-only CLI TTY commands', () => {
     process.argv = ['bun', 'cli/bakin.ts', 'workflows', 'list']
     await main()
 
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Workflows')
     expect(output()).toContain('DEFINITIONS')
     expect(output()).toContain('FILENAME')

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -53,7 +53,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Status')
     expect(output).toContain('DISPATCH')
     expect(output).toContain('main, patch')
@@ -84,7 +84,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Help  unknown command')
     expect(output).toContain('ISSUE\n------------')
     expect(output).toContain('Unknown command: wat')
@@ -109,7 +109,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Command issue  bakin tasks get')
     expect(output).toContain('ISSUE')
     expect(output).toContain('Missing required arguments.')
@@ -132,7 +132,7 @@ describe('read-only CLI TUI screens', () => {
       />,
     )
 
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Command failed  bakin tasks list')
     expect(output).toContain('Cannot connect to Bakin')
     expect(output).toContain('SERVER_UNREACHABLE')
@@ -144,7 +144,7 @@ describe('read-only CLI TUI screens', () => {
   it('renders version with shared TUI primitives', () => {
     const output = renderToString(<VersionReport data={{ version: '1.2.3' }} />)
 
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Version  v1.2.3')
     expect(output).toContain('DETAILS')
     expect(output).toContain('1.2.3')

--- a/tests/cli/render.test.tsx
+++ b/tests/cli/render.test.tsx
@@ -26,7 +26,7 @@ describe('CLI renderers', () => {
   it('renders a generic Ink result view to string', () => {
     const output = renderInkEnvelope(toEnvelope(okResult('version', { version: '1.2.3' })), { color: false })
 
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('version')
     expect(output).toContain(' OK       0 exit code')
     expect(output).toContain('DATA\n------------')

--- a/tests/cli/runtime-dispatch.test.ts
+++ b/tests/cli/runtime-dispatch.test.ts
@@ -56,7 +56,7 @@ describe('bakin runtime binary dispatch', () => {
     const result = await dispatchCli(['bun', 'bakin', '--help'])
 
     expect(result).toEqual({ startServer: false, exitCode: 0 })
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain('Help')
     expect(output()).toContain('LIFECYCLE')
     expect(output()).not.toContain('Usage: bakin <command> [options]')
@@ -69,7 +69,7 @@ describe('bakin runtime binary dispatch', () => {
     const result = await dispatchCli(['bun', 'bakin', 'version'])
 
     expect(result).toEqual({ startServer: false, exitCode: 0 })
-    expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output()).toContain("┃ 🐷 Bakin'")
     expect(output()).toContain(`Version  v${APP_VERSION}`)
     expect(output()).toContain(APP_VERSION)
     expect(errorOutput()).toBe('')

--- a/tests/cli/schedule.test.ts
+++ b/tests/cli/schedule.test.ts
@@ -209,7 +209,7 @@ describe('CLI schedule commands', () => {
       mockJsonResponse({ ok: true })
       await cmdScheduleRemove('new-1')
 
-      expect(output()).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+      expect(output()).toContain("┃ 🐷 Bakin'")
       expect(output()).toContain('Schedule action')
       expect(output()).toContain('RESULT')
       expect(output()).toContain('Created schedule Daily Check')

--- a/tests/cli/start-onboarding-gate.test.ts
+++ b/tests/cli/start-onboarding-gate.test.ts
@@ -33,7 +33,7 @@ describe('CLI start onboarding gate', () => {
 
     expect(result).toEqual({ startServer: false, exitCode: 1 })
     const output = logSpy.mock.calls.map(call => String(call[0])).join('\n')
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Onboard')
     expect(output).toContain('Initial setup required')
     expect(output).toContain('Run `bakin onboard`')

--- a/tests/cli/tui-gallery.test.tsx
+++ b/tests/cli/tui-gallery.test.tsx
@@ -39,7 +39,8 @@ describe('CLI TUI style gallery', () => {
       const lines = output.split('\n')
       expect(lines[0]).toBe('')
       expect(lines[1]).toBe('┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓')
-      expect(lines[2]).toBe("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+      expect(lines[2]).toContain("┃ 🐷 Bakin'")
+      expect(lines[2]).toContain('(v')
       expect(lines[3]).toBe('┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛')
       expect(lines[4]).toBe('')
     }
@@ -79,7 +80,7 @@ describe('CLI TUI style gallery', () => {
     const maxLineLength = Math.max(...visibleLineLengths(output))
 
     expect(maxLineLength).toBeLessThanOrEqual(100)
-    expect(output).toContain("┃ 🐷 Bakin'               (v0.0.0-dev) ┃")
+    expect(output).toContain("┃ 🐷 Bakin'")
     expect(output).toContain('Onboard  step 7 of 11')
     expect(output).toContain('Setting up this machine')
     expect(output).toContain('CURRENT ACTIVITY')


### PR DESCRIPTION
## Summary
- relax shared TUI header assertions so tests pass for both local dev builds and stamped release builds
- keep coverage for brand presence and version display without freezing v0.0.0-dev into every TUI test

## Testing
- bun test --isolate ./tests/cli/onboarding-component-commands.test.ts ./tests/cli/tui-gallery.test.tsx ./tests/cli/runtime-dispatch.test.ts ./tests/cli/onboard-command.test.ts ./tests/cli/onboarding-ui.test.tsx ./tests/cli/doctor-repair-ui.test.tsx ./tests/cli/readonly-ui.test.tsx ./tests/cli/schedule.test.ts ./tests/cli/start-onboarding-gate.test.ts ./tests/cli/doctor-ui.test.tsx ./tests/cli/doctor-repair.test.ts ./tests/cli/readonly-commands.test.ts ./tests/cli/render.test.tsx
- bun run scripts/stamp-version.ts && bun test --isolate
- bun run typecheck

Note: packages/core/src/generated-version.ts was restored to 0.0.0-dev after the stamped test run.