### PR TITLE
fix: repair release binary onboarding smoke

### DIFF
--- a/packages/adapter-antfly/src/server.ts
+++ b/packages/adapter-antfly/src/server.ts
@@ -286,7 +286,7 @@ export async function startAntflyServer(
 
   const binary = findAntflyBinary()
   if (!binary) {
-    logger.warn('Antfly binary not found - install with: brew install --cask antflydb/antfly/antfly')
+    logger.warn('Antfly binary not found - install with: brew install antflydb/antfly/antfly')
     return false
   }
 

--- a/packages/adapter-antfly/src/setup.ts
+++ b/packages/adapter-antfly/src/setup.ts
@@ -14,7 +14,7 @@ const noopLogger: AdapterLogger = {
 }
 
 const BREW_CANDIDATES = ['/opt/homebrew/bin/brew', '/usr/local/bin/brew']
-const BREW_CASK = 'antflydb/antfly/antfly'
+const BREW_PACKAGE = 'antflydb/antfly/antfly'
 const BREW_INSTALL_DOCS = 'https://brew.sh/'
 
 export interface TermiteModel {
@@ -145,7 +145,7 @@ async function checkAntflyDependency() {
     name: 'antfly',
     status: 'missing' as const,
     message: 'Antfly binary not found on any known install path',
-    remediation: `Run \`bakin install search\` to install the configured search adapter via Homebrew (${BREW_CASK}).`,
+    remediation: `Run \`bakin install search\` to install the configured search adapter via Homebrew (${BREW_PACKAGE}).`,
   }
 }
 
@@ -173,7 +173,7 @@ async function installAntflyDependency(opts: SearchAdapterSetupOptions, logger: 
 
   if (opts.interactive && !opts.autoApprove) {
     const proceed = await opts.askYesNo?.(
-      `Install Antfly via Homebrew? This will download ~25MB and run \`brew install --cask ${BREW_CASK}\`.`,
+      `Install Antfly via Homebrew? This will download ~25MB and run \`brew install ${BREW_PACKAGE}\`.`,
       true
     )
     if (!proceed) {
@@ -193,11 +193,11 @@ async function installAntflyDependency(opts: SearchAdapterSetupOptions, logger: 
     }
   }
 
-  logger.info('Installing Antfly via brew', { brew, cask: BREW_CASK })
+  logger.info('Installing Antfly via brew', { brew, package: BREW_PACKAGE })
   try {
     const { code, stderr } = await runSpawn(
       brew,
-      ['install', '--cask', BREW_CASK],
+      ['install', BREW_PACKAGE],
       { interactive: opts.interactive && !opts.json }
     )
     const durationMs = Date.now() - start
@@ -467,7 +467,7 @@ export function createAntflySearchSetup(logger: AdapterLogger = noopLogger): Sea
 export const _setupInternals = {
   findBrew,
   runSpawn,
-  BREW_CASK,
+  BREW_PACKAGE,
   BREW_CANDIDATES,
   missingModels,
   missingModelEntries,

--- a/packages/host/src/api/plugins/manifest.ts
+++ b/packages/host/src/api/plugins/manifest.ts
@@ -19,6 +19,7 @@ import { createLogger } from '@/core/logger'
 import { readPluginLockfile, type PluginLockEntry } from '@bakin/core/plugins/lockfile'
 import { runChecks } from '@/core/plugins/upgrade'
 import { EMBEDDED_ASSETS } from '../_embedded-assets'
+import { APP_VERSION } from '@bakin/core/constants'
 import type { PluginContributions } from '@makinbakin/sdk/types'
 
 const log = createLogger('plugin-manifest')
@@ -69,29 +70,43 @@ function pluginAssetPath(pluginId: string, relPath: string): string | null {
   const userPath = join(getContentDir(), 'plugins', pluginId, 'dist', relPath)
   if (existsSync(userPath)) return userPath
 
-  const embeddedPath = EMBEDDED_ASSETS.get(`/api/plugins/${pluginId}/assets/${relPath}`)
-  if (embeddedPath && existsSync(embeddedPath)) return embeddedPath
-
   const repoPath = join(process.cwd(), 'plugins', pluginId, 'dist', relPath)
   if (existsSync(repoPath)) return repoPath
 
   return null
 }
 
-function pluginAssetVersion(pluginId: string, relPath: string): string | null {
-  const path = pluginAssetPath(pluginId, relPath)
-  if (!path) return null
+async function hasEmbeddedPluginAsset(pluginId: string, relPath: string): Promise<boolean> {
+  const embeddedPath = EMBEDDED_ASSETS.get(`/api/plugins/${pluginId}/assets/${relPath}`)
+  if (!embeddedPath) return false
   try {
-    const stat = statSync(path)
-    if (!stat.isFile()) return null
-    return String(Math.trunc(stat.mtimeMs))
+    return await Bun.file(embeddedPath).exists()
   } catch {
-    return null
+    return false
   }
 }
 
-function hasClientCss(pluginId: string): boolean {
-  return pluginAssetVersion(pluginId, 'client.css') !== null
+async function pluginAssetVersion(pluginId: string, relPath: string): Promise<string | null> {
+  const path = pluginAssetPath(pluginId, relPath)
+  if (path) {
+    try {
+      const stat = statSync(path)
+      if (!stat.isFile()) return null
+      return String(Math.trunc(stat.mtimeMs))
+    } catch {
+      return null
+    }
+  }
+
+  if (await hasEmbeddedPluginAsset(pluginId, relPath)) {
+    return `embedded-${APP_VERSION}`
+  }
+
+  return null
+}
+
+async function hasClientCss(pluginId: string): Promise<boolean> {
+  return (await pluginAssetVersion(pluginId, 'client.css')) !== null
 }
 
 export async function get(req: Request): Promise<Response> {
@@ -160,7 +175,7 @@ export async function get(req: Request): Promise<Response> {
       contributes: entry.contributes,
     }
     const clientVersion = entry.status === 'active'
-      ? pluginAssetVersion(entry.id, 'client.js')
+      ? await pluginAssetVersion(entry.id, 'client.js')
       : null
     if (entry.status === 'active' && clientVersion) {
       plugin.clientEntry = `/api/plugins/${entry.id}/assets/client.js`
@@ -170,7 +185,7 @@ export async function get(req: Request): Promise<Response> {
       plugin.errorMessage = entry.errorMessage
       plugin.missingDependencies = entry.missingDependencies
     }
-    if (entry.status === 'active' && hasClientCss(entry.id)) {
+    if (entry.status === 'active' && (await hasClientCss(entry.id))) {
       plugin.clientCss = `/api/plugins/${entry.id}/assets/client.css`
     }
     plugins.push(plugin)

--- a/src/core/cli/onboarding-interactive.tsx
+++ b/src/core/cli/onboarding-interactive.tsx
@@ -86,10 +86,12 @@ export function buildSelectionItems(check: CheckResult): MultiSelectItem[] {
 function MultiSelectPrompt({
   title,
   items,
+  showBrand = true,
   onSubmit,
 }: {
   title: string;
   items: MultiSelectItem[];
+  showBrand?: boolean;
   onSubmit: (ids: string[]) => void;
 }) {
   const [state, setState] = useState<MultiSelectState>(() =>
@@ -106,6 +108,7 @@ function MultiSelectPrompt({
         title="Onboard"
         subtitle={isAgentSelection ? "Choose official agents to install or adopt" : "Choose official plugins to install"}
         meta={isAgentSelection ? "agent selection" : "plugin selection"}
+        showBrand={showBrand}
       />
       <SummaryStrip items={[
         { label: "selected", value: selectedCount, status: "ready" },
@@ -138,6 +141,7 @@ function MultiSelectPrompt({
 export async function promptMultiSelect(
   title: string,
   items: MultiSelectItem[],
+  opts: { showBrand?: boolean } = {},
 ): Promise<string[]> {
   if (items.filter((item) => !item.disabled).length === 0) return [];
 
@@ -147,6 +151,7 @@ export async function promptMultiSelect(
       <MultiSelectPrompt
         title={title}
         items={items}
+        showBrand={opts.showBrand}
         onSubmit={(ids) => {
           app?.unmount();
           resolve(ids);
@@ -160,6 +165,7 @@ async function promptConfirm(
   title: string,
   description: string,
   defaultChoice: "confirm" | "cancel" = "confirm",
+  opts: { showBrand?: boolean } = {},
 ): Promise<boolean> {
   return await new Promise((resolve) => {
     let app: ReturnType<typeof render> | null = null;
@@ -168,6 +174,7 @@ async function promptConfirm(
         title={title}
         description={description}
         defaultChoice={defaultChoice}
+        showBrand={opts.showBrand}
         onSubmit={(approved) => {
           app?.unmount();
           resolve(approved);
@@ -206,21 +213,6 @@ export async function collectOnboardingSelections(
   }
 
   const approvedComponents: string[] = [];
-  const selectedRecommendedPluginIds =
-    pluginCheck.status === "missing"
-      ? await promptMultiSelect(
-          "Install official plugins",
-          buildSelectionItems(pluginCheck),
-        )
-      : undefined;
-  const selectedRecommendedAgentIds =
-    agentCheck.status === "missing"
-      ? await promptMultiSelect(
-          "Install official agents",
-          buildSelectionItems(agentCheck),
-        )
-      : undefined;
-
   const searchNeedsInstall =
     searchCheck.status === "missing" || searchCheck.status === "broken";
   const searchApproved = searchNeedsInstall
@@ -228,6 +220,7 @@ export async function collectOnboardingSelections(
         "Search adapter",
         `${searchCheck.message}. Bakin will install Antfly via Homebrew if you continue.`,
         "confirm",
+        { showBrand: false },
       )
     : true;
   if (searchNeedsInstall && searchApproved) approvedComponents.push("search");
@@ -241,6 +234,7 @@ export async function collectOnboardingSelections(
       "Search models",
       `${searchModelsCheck.message}. Bakin will download the required Termite models if you continue.`,
       "confirm",
+      { showBrand: false },
     );
     if (approved) approvedComponents.push("search-models");
   }
@@ -250,9 +244,27 @@ export async function collectOnboardingSelections(
       "MCP porter",
       `${mcporterCheck.message}. Bakin will install and configure mcporter if you continue.`,
       "confirm",
+      { showBrand: false },
     );
     if (approved) approvedComponents.push("mcporter");
   }
+
+  const selectedRecommendedPluginIds =
+    pluginCheck.status === "missing"
+      ? await promptMultiSelect(
+          "Install official plugins",
+          buildSelectionItems(pluginCheck),
+          { showBrand: false },
+        )
+      : undefined;
+  const selectedRecommendedAgentIds =
+    agentCheck.status === "missing"
+      ? await promptMultiSelect(
+          "Install official agents",
+          buildSelectionItems(agentCheck),
+          { showBrand: false },
+        )
+      : undefined;
 
   return {
     selectedRecommendedPluginIds,

--- a/src/core/cli/ui/onboarding.tsx
+++ b/src/core/cli/ui/onboarding.tsx
@@ -382,10 +382,11 @@ export function OnboardingAlreadyCompleteReport({ state, color = true }: {
   )
 }
 
-export function OnboardingDecisionPrompt({ title, description, defaultChoice, onSubmit }: {
+export function OnboardingDecisionPrompt({ title, description, defaultChoice, showBrand = true, onSubmit }: {
   title: string
   description: string
   defaultChoice: 'confirm' | 'cancel'
+  showBrand?: boolean
   onSubmit: (approved: boolean) => void
 }) {
   const defaultLabel = defaultChoice === 'confirm' ? 'Yes' : 'No'
@@ -395,7 +396,7 @@ export function OnboardingDecisionPrompt({ title, description, defaultChoice, on
 
   return (
     <Box flexDirection="column">
-      <ScreenHeader title="Onboard" subtitle="Interactive setup decision" meta={title.toLowerCase()} />
+      <ScreenHeader title="Onboard" subtitle="Interactive setup decision" meta={title.toLowerCase()} showBrand={showBrand} />
       <SummaryStrip items={[
         { label: 'decision', value: 1, status: 'warn' },
         { label: 'default', value: defaultLabel, status: defaultChoice === 'confirm' ? 'ready' : 'skip' },

--- a/src/core/onboarding/curated-catalog.ts
+++ b/src/core/onboarding/curated-catalog.ts
@@ -1,0 +1,35 @@
+import { EMBEDDED_ASSETS } from '../../../packages/host/src/api/_embedded-assets'
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function hasRows(catalog: Record<string, unknown>, key: string): boolean {
+  const rows = catalog[key]
+  return Array.isArray(rows) && rows.length > 0
+}
+
+export async function loadCuratedCatalog<T extends Record<string, unknown>>(
+  staticCatalog: unknown,
+  embeddedPath: string,
+  rowKey: string,
+): Promise<T> {
+  const staticObject = asObject(staticCatalog)
+  if (staticObject && hasRows(staticObject, rowKey)) return staticObject as T
+
+  const embedded = EMBEDDED_ASSETS.get(embeddedPath)
+  if (embedded) {
+    try {
+      const file = Bun.file(embedded)
+      if (await file.exists()) {
+        const parsed = asObject(JSON.parse(await file.text()))
+        if (parsed) return parsed as T
+      }
+    } catch {
+      // Fall back to the statically imported catalog below.
+    }
+  }
+
+  return (staticObject ?? {}) as T
+}

--- a/src/core/onboarding/recommended-agents.ts
+++ b/src/core/onboarding/recommended-agents.ts
@@ -2,6 +2,7 @@ import curatedCatalog from '../../../packages/host/src/data/curated-agents.json'
 import { readLockfile } from '../../../packages/core/src/agent-packages/lockfile'
 import { getAgentState, type AgentState } from '../agent-packages/agent-state'
 import { installPackage } from '../agent-packages/installer'
+import { loadCuratedCatalog } from './curated-catalog'
 import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
 
 export interface RecommendedAgent {
@@ -31,8 +32,7 @@ interface AgentInstallCandidate {
   state: AgentState
 }
 
-function catalogAgents(): RecommendedAgent[] {
-  const rows = (curatedCatalog as { agents?: CuratedAgentRow[] }).agents ?? []
+function normalizeCatalog(rows: readonly CuratedAgentRow[]): RecommendedAgent[] {
   return rows
     .filter(agent => agent.trust === undefined || agent.trust === 'official')
     .map(agent => ({
@@ -45,6 +45,20 @@ function catalogAgents(): RecommendedAgent[] {
       trust: agent.trust ?? 'official',
       defaultSelected: agent.defaultSelected === true,
     }))
+}
+
+function staticCatalogAgents(): RecommendedAgent[] {
+  const rows = (curatedCatalog as { agents?: CuratedAgentRow[] }).agents ?? []
+  return normalizeCatalog(rows)
+}
+
+async function catalogAgents(): Promise<RecommendedAgent[]> {
+  const catalog = await loadCuratedCatalog<{ agents?: CuratedAgentRow[] }>(
+    curatedCatalog,
+    '/data/curated-agents.json',
+    'agents',
+  )
+  return normalizeCatalog(catalog.agents ?? [])
 }
 
 function sourceWithRef(source: string, ref: string | null): string {
@@ -69,7 +83,7 @@ async function agentCandidates(): Promise<AgentInstallCandidate[]> {
   const installed = installedAgentIds()
   const candidates: AgentInstallCandidate[] = []
 
-  for (const agent of catalogAgents()) {
+  for (const agent of await catalogAgents()) {
     if (installed.has(agent.id)) continue
     const stateInfo = await getAgentState(agent.id)
     if (stateInfo.state === 'managed' || stateInfo.state === 'adopted') continue
@@ -92,14 +106,16 @@ async function check(): Promise<CheckResult> {
   }
 
   if (candidates.length === 0) {
+    const agents = await catalogAgents()
     return {
       name: 'recommended-agents',
       status: 'ok',
       message: 'Official agent packages are installed',
-      details: { available: catalogAgents().map(agent => agent.id), missing: [] },
+      details: { available: agents.map(agent => agent.id), missing: [] },
     }
   }
 
+  const agents = await catalogAgents()
   const byId = new Map(candidates.map(candidate => [candidate.agent.id, candidate.state]))
   return {
     name: 'recommended-agents',
@@ -107,7 +123,7 @@ async function check(): Promise<CheckResult> {
     message: `${candidates.length} official agent package${candidates.length === 1 ? '' : 's'} not installed or adopted`,
     remediation: 'Select official agents during onboarding or later with `bakin agents install github:markhayden/bakin-bits-official#agents/<id> --adopt` for existing runtime agents.',
     details: {
-      available: catalogAgents().map(agent => ({
+      available: agents.map(agent => ({
         id: agent.id,
         name: agent.name,
         description: agent.description,
@@ -213,4 +229,4 @@ export const recommendedAgentsComponent: OnboardingComponent = {
   install,
 }
 
-export const RECOMMENDED_AGENTS = catalogAgents()
+export const RECOMMENDED_AGENTS = staticCatalogAgents()

--- a/src/core/onboarding/recommended-plugins.ts
+++ b/src/core/onboarding/recommended-plugins.ts
@@ -5,6 +5,7 @@ import { getContentDir } from '../content-dir'
 import { readPluginLockfile } from '@bakin/core/plugins/lockfile'
 import { getInstalledPluginIds, planPluginDependencyOrder } from '../plugins/dependencies'
 import { askYesNo } from './prompts'
+import { loadCuratedCatalog } from './curated-catalog'
 import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
 
 export interface RecommendedPlugin {
@@ -27,8 +28,7 @@ interface CuratedPluginRow {
   defaultSelected?: boolean
 }
 
-function catalogPlugins(): RecommendedPlugin[] {
-  const rows = (curatedCatalog as { plugins?: CuratedPluginRow[] }).plugins ?? []
+function normalizeCatalog(rows: readonly CuratedPluginRow[]): RecommendedPlugin[] {
   return rows
     .filter(plugin => plugin.trust === undefined || plugin.trust === 'official')
     .map(plugin => ({
@@ -42,6 +42,20 @@ function catalogPlugins(): RecommendedPlugin[] {
     }))
 }
 
+function staticCatalogPlugins(): RecommendedPlugin[] {
+  const rows = (curatedCatalog as { plugins?: CuratedPluginRow[] }).plugins ?? []
+  return normalizeCatalog(rows)
+}
+
+async function catalogPlugins(): Promise<RecommendedPlugin[]> {
+  const catalog = await loadCuratedCatalog<{ plugins?: CuratedPluginRow[] }>(
+    curatedCatalog,
+    '/data/curated-plugins.json',
+    'plugins',
+  )
+  return normalizeCatalog(catalog.plugins ?? [])
+}
+
 function isInstalled(id: string): boolean {
   if (existsSync(join(getContentDir(), 'plugins', id, 'bakin-plugin.json'))) return true
   try {
@@ -51,8 +65,8 @@ function isInstalled(id: string): boolean {
   }
 }
 
-function missingPlugins(): RecommendedPlugin[] {
-  return catalogPlugins().filter(plugin => !isInstalled(plugin.id))
+async function missingPlugins(): Promise<RecommendedPlugin[]> {
+  return (await catalogPlugins()).filter(plugin => !isInstalled(plugin.id))
 }
 
 async function installSource(source: string): Promise<{ ok: true; id?: string } | { ok: false; error: string }> {
@@ -94,13 +108,14 @@ async function installSource(source: string): Promise<{ ok: true; id?: string } 
 }
 
 async function check(): Promise<CheckResult> {
-  const missing = missingPlugins()
+  const plugins = await catalogPlugins()
+  const missing = plugins.filter(plugin => !isInstalled(plugin.id))
   if (missing.length === 0) {
     return {
       name: 'recommended-plugins',
       status: 'ok',
       message: 'Recommended official plugins are installed',
-      details: { available: catalogPlugins().map(plugin => plugin.id), missing: [] },
+      details: { available: plugins.map(plugin => plugin.id), missing: [] },
     }
   }
   return {
@@ -109,7 +124,7 @@ async function check(): Promise<CheckResult> {
     message: `${missing.length} recommended official plugin${missing.length === 1 ? '' : 's'} not installed`,
     remediation: 'Install during onboarding or later with `bakin plugins install github:markhayden/bakin-bits-official#plugins/<id> --yes`.',
     details: {
-      available: catalogPlugins().map(plugin => ({
+      available: plugins.map(plugin => ({
         id: plugin.id,
         name: plugin.name,
         description: plugin.description,
@@ -125,7 +140,7 @@ async function check(): Promise<CheckResult> {
 
 async function install(opts: OnboardingOptions): Promise<InstallResult> {
   const start = Date.now()
-  const missing = missingPlugins()
+  const missing = await missingPlugins()
   if (missing.length === 0) {
     return {
       name: 'recommended-plugins',
@@ -206,4 +221,4 @@ export const recommendedPluginsComponent: OnboardingComponent = {
   install,
 }
 
-export const RECOMMENDED_PLUGINS = catalogPlugins()
+export const RECOMMENDED_PLUGINS = staticCatalogPlugins()

--- a/tests/api/plugin-manifest-embedded.test.ts
+++ b/tests/api/plugin-manifest-embedded.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-manifest-embedded-'))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+}))
+
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+mock.module('@bakin/core/plugins/lockfile', () => ({
+  readPluginLockfile: () => ({ version: 1, plugins: {} }),
+}))
+
+mock.module('@/core/plugins/upgrade', () => ({
+  runChecks: async () => [],
+}))
+
+mock.module('@/lib/plugin-registry', () => ({
+  isCorePlugin: (id: string) => id === 'tasks',
+  pluginRegistry: {
+    getRegistrySnapshot: () => [{
+      id: 'tasks',
+      name: 'Tasks',
+      version: '1.0.0',
+      status: 'active',
+      contributes: {},
+    }],
+  },
+}))
+
+import { setEmbeddedAssets } from '../../packages/host/src/api/_embedded-assets'
+import { get } from '../../packages/host/src/api/plugins/manifest'
+
+const originalBunFile = Bun.file
+const originalCwd = process.cwd()
+
+describe('plugin manifest embedded assets', () => {
+  afterEach(() => {
+    Bun.file = originalBunFile
+    setEmbeddedAssets(new Map())
+    process.chdir(originalCwd)
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('advertises core plugin clients that only exist in the embedded binary asset map', async () => {
+    const cwdWithoutRepoFallback = mkdtempSync(join(tmpdir(), 'bakin-manifest-no-repo-'))
+    process.chdir(cwdWithoutRepoFallback)
+    setEmbeddedAssets(new Map([
+      ['/api/plugins/tasks/assets/client.js', '/$bunfs/tasks-client.js'],
+    ]))
+    Bun.file = ((path: string) => ({
+      exists: async () => path === '/$bunfs/tasks-client.js',
+    })) as unknown as typeof Bun.file
+
+    const res = await get(new Request('http://localhost/api/plugins/manifest'))
+    const body = await res.json() as {
+      plugins: Array<{ id: string; clientEntry?: string; clientVersion?: string }>
+    }
+
+    expect(body.plugins[0]?.id).toBe('tasks')
+    expect(body.plugins[0]?.clientEntry).toBe('/api/plugins/tasks/assets/client.js')
+    expect(body.plugins[0]?.clientVersion?.startsWith('embedded-')).toBe(true)
+
+    rmSync(cwdWithoutRepoFallback, { recursive: true, force: true })
+  })
+})

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -193,6 +193,21 @@ describe('onboarding CLI UI', () => {
     expect(rendered).not.toContain('[Search adapter]')
   })
 
+  it('can render confirmation prompts as onboarding continuations without repeating the brand', () => {
+    const rendered = renderToString(
+      <OnboardingDecisionPrompt
+        title="Search adapter"
+        description="Antfly is not installed."
+        defaultChoice="confirm"
+        showBrand={false}
+        onSubmit={() => {}}
+      />,
+    )
+
+    expect(rendered).toContain('Onboard')
+    expect(rendered).not.toContain("┃ 🐷 Bakin'")
+  })
+
   it('renders bounded onboarding progress with Ink UI', () => {
     const rendered = renderToString(<OnboardingProgress label="Installing official agents" value={50} />)
     expect(rendered).toContain('Installing official agents')

--- a/tests/core/onboarding/antfly.test.ts
+++ b/tests/core/onboarding/antfly.test.ts
@@ -163,7 +163,7 @@ describe('Antfly search setup component', () => {
       expect(lastSpawnArgs).toBeNull()
     })
 
-    it('runs brew install --cask with the correct argument shape', async () => {
+    it('runs brew install with the correct argument shape', async () => {
       // First findBinary call (pre-spawn) returns null → missing.
       // Second (post-spawn verification) returns the installed path.
       findBinaryQueue = [null, '/opt/homebrew/bin/antfly']
@@ -172,7 +172,7 @@ describe('Antfly search setup component', () => {
 
       expect(lastSpawnArgs).not.toBeNull()
       expect(lastSpawnArgs!.cmd).toBe('/opt/homebrew/bin/brew')
-      expect(lastSpawnArgs!.args).toEqual(['install', '--cask', 'antflydb/antfly/antfly'])
+      expect(lastSpawnArgs!.args).toEqual(['install', 'antflydb/antfly/antfly'])
       // Never uses shell: true — that's a hard rule in the spec
       expect(lastSpawnArgs!.opts).not.toHaveProperty('shell', true)
       expect(result.status).toBe('installed')

--- a/tests/core/onboarding/curated-catalog.test.ts
+++ b/tests/core/onboarding/curated-catalog.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { setEmbeddedAssets } from '../../../packages/host/src/api/_embedded-assets'
+import { loadCuratedCatalog } from '../../../src/core/onboarding/curated-catalog'
+
+const originalBunFile = Bun.file
+
+describe('curated onboarding catalog loader', () => {
+  afterEach(() => {
+    Bun.file = originalBunFile
+    setEmbeddedAssets(new Map())
+  })
+
+  it('uses embedded catalog data when the static JSON import has no rows', async () => {
+    setEmbeddedAssets(new Map([['/data/curated-plugins.json', '/$bunfs/curated-plugins.json']]))
+    Bun.file = ((path: string) => ({
+      exists: async () => path === '/$bunfs/curated-plugins.json',
+      text: async () => JSON.stringify({
+        version: 1,
+        plugins: [{ id: 'messaging', name: 'Messaging' }],
+      }),
+    })) as unknown as typeof Bun.file
+
+    const catalog = await loadCuratedCatalog<{ plugins?: Array<{ id: string }> }>(
+      { version: 1, plugins: [] },
+      '/data/curated-plugins.json',
+      'plugins',
+    )
+
+    expect(catalog.plugins?.map(plugin => plugin.id)).toEqual(['messaging'])
+  })
+
+  it('prefers non-empty static catalog data', async () => {
+    let readEmbedded = false
+    setEmbeddedAssets(new Map([['/data/curated-plugins.json', '/$bunfs/curated-plugins.json']]))
+    Bun.file = ((path: string) => ({
+      exists: async () => {
+        readEmbedded = true
+        return path === '/$bunfs/curated-plugins.json'
+      },
+      text: async () => JSON.stringify({ plugins: [{ id: 'embedded' }] }),
+    })) as unknown as typeof Bun.file
+
+    const catalog = await loadCuratedCatalog<{ plugins?: Array<{ id: string }> }>(
+      { version: 1, plugins: [{ id: 'static' }] },
+      '/data/curated-plugins.json',
+      'plugins',
+    )
+
+    expect(catalog.plugins?.map(plugin => plugin.id)).toEqual(['static'])
+    expect(readEmbedded).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- suppress repeated Bakin brand headers for continuation onboarding prompts and keep prompt order aligned with the intro flow
- switch Antfly Homebrew install from cask syntax to the formula command: `brew install antflydb/antfly/antfly`
- load curated onboarding catalogs from embedded binary assets when compiled JSON imports are empty, so fresh release binaries prompt for official plugins and agents
- advertise embedded core plugin client bundles in `/api/plugins/manifest`, so the task UI loads without a repo checkout fallback

## Verification
- `bun run typecheck`
- `bun test --isolate tests/core/onboarding/index.test.ts tests/cli/onboard-command.test.ts tests/cli/onboarding-component-commands.test.ts tests/cli/runtime-dispatch.test.ts tests/api/user-plugin-lifecycle.test.ts tests/api/plugin-manifest-embedded.test.ts tests/core/onboarding/curated-catalog.test.ts tests/core/onboarding/antfly.test.ts tests/core/onboarding/recommended-agents.test.ts tests/cli/onboarding-ui.test.tsx`
- `bun test --isolate` (3962 pass, 10 skip)
- `bun run build:binary`
- compiled binary smoke from `/private/tmp`: fresh `BAKIN_HOME` now reports `recommended-plugins` and `recommended-agents` as missing instead of incorrectly installed

Note: local server bind smoke was blocked in this sandbox, so the embedded manifest path is covered by the targeted API test.