### PR TITLE
Fix GitHub plugin installs from release binaries

### DIFF
--- a/packages/host/src/api/plugins/install.ts
+++ b/packages/host/src/api/plugins/install.ts
@@ -728,7 +728,7 @@ export async function post(req: Request, _url: URL): Promise<Response> {
       // install request — shipping an installed-but-unbuilt plugin would
       // crash startup instead of surfacing the error to the user now.
       try {
-        await buildUserPlugin(targetDir)
+        await buildUserPlugin(targetDir, { trustExistingDist: body.type === 'github' })
       } catch (buildErr) {
         // Build failed — clean up the installed files so the install
         // appears atomic from the user's perspective.

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -80,6 +80,16 @@ interface RunResult {
   stderr: string
 }
 
+export interface BuildUserPluginOptions {
+  /**
+   * GitHub-installed plugins may ship prebuilt dist artifacts. Release
+   * binaries should use those artifacts when complete instead of trying to
+   * rebuild against repo-local SDK source paths that do not exist on a
+   * normal user's machine.
+   */
+  trustExistingDist?: boolean
+}
+
 /**
  * Portable subprocess runner. Passing the binary through `spawn` with an
  * argv array avoids shell interpolation and path-traversal tricks.
@@ -268,12 +278,18 @@ function validatePluginImports(pluginDir: string, pkg: PluginPackageJson): void 
  *   the plugin directory first. Peer deps stay external via the bundler
  *   externals list, so this is mostly for dev deps / rare plugin-owned
  *   npm packages.
+ * - When `trustExistingDist` is set and every expected dist output is
+ *   present, skips the rebuild. This is used for GitHub-installed plugins
+ *   that ship their own build artifacts.
  * - Runs `bun build` on `index.ts` (server) and `client.tsx` (browser, if
  *   present). Both land in `dist/` with `index.js` / `client.js`. The server
  *   bundle is self-contained except for shared runtime singletons.
  * - Skips the build when the dist outputs are newer than every source file.
  */
-export async function buildUserPlugin(pluginDir: string): Promise<void> {
+export async function buildUserPlugin(
+  pluginDir: string,
+  options: BuildUserPluginOptions = {},
+): Promise<void> {
   const serverEntry = join(pluginDir, 'index.ts')
   if (!existsSync(serverEntry)) {
     throw new Error(`buildUserPlugin: ${serverEntry} not found`)
@@ -293,6 +309,8 @@ export async function buildUserPlugin(pluginDir: string): Promise<void> {
   const expectedDist = [distServer, ...(hasClient ? [distClient] : [])]
   const allDistPresent = expectedDist.every(p => existsSync(p))
   if (allDistPresent) {
+    if (options.trustExistingDist) return
+
     const newestSource = newestMtimeMs(pluginDir, new Set(['dist', 'node_modules']))
     const oldestDist = oldestMtimeMs(expectedDist)
     if (oldestDist > 0 && newestSource > 0 && oldestDist >= newestSource) {

--- a/src/core/plugins/upgrade.ts
+++ b/src/core/plugins/upgrade.ts
@@ -534,7 +534,7 @@ async function upgradeGithub(
     run('git', ['merge', '--ff-only', `origin/${entry.ref}`], pluginDir)
   }
 
-  await buildUserPlugin(pluginDir)
+  await buildUserPlugin(pluginDir, { trustExistingDist: true })
 
   const assets = await installUpgradedPluginAssets(id, pluginDir)
 
@@ -650,7 +650,7 @@ async function upgradeGithubSubpath(
     rmSync(pluginDir, { recursive: true, force: true })
     cpSync(subpathDir, pluginDir, { recursive: true, dereference: false })
 
-    await buildUserPlugin(pluginDir)
+    await buildUserPlugin(pluginDir, { trustExistingDist: true })
 
     const assets = await installUpgradedPluginAssets(id, pluginDir)
 

--- a/tests/api/plugins-build.test.ts
+++ b/tests/api/plugins-build.test.ts
@@ -20,6 +20,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from 'fs'
 import { join } from 'path'
@@ -91,6 +92,23 @@ describe('buildUserPlugin', () => {
     await buildUserPlugin(targetDir)
     expect(existsSync(join(targetDir, 'dist', 'index.js'))).toBe(true)
     expect(existsSync(join(targetDir, 'dist', 'client.js'))).toBe(true)
+  }, 60_000)
+
+  it('trusts complete shipped dist artifacts when requested', async () => {
+    const dir = join(testDir, 'plugins', 'prebuilt-dist')
+    writeMinimalPlugin(dir, `export default { id: 'minimal', name: 'x', version: '0.1.0', activate() { return 'source build' } }`)
+    mkdirSync(join(dir, 'dist'), { recursive: true })
+    const distServer = join(dir, 'dist', 'index.js')
+    const prebuilt = `export default { id: 'minimal', activate() { return 'prebuilt dist' } }\n`
+    writeFileSync(distServer, prebuilt)
+
+    const older = new Date(Date.now() - 10_000)
+    const newer = new Date()
+    utimesSync(distServer, older, older)
+    utimesSync(join(dir, 'index.ts'), newer, newer)
+
+    await expect(buildUserPlugin(dir, { trustExistingDist: true })).resolves.toBeUndefined()
+    expect(readFileSync(distServer, 'utf-8')).toBe(prebuilt)
   }, 60_000)
 
   it('preserves externals for @makinbakin/sdk/* in client.js', () => {

--- a/tests/plugins/lifecycle/install-subpath.test.ts
+++ b/tests/plugins/lifecycle/install-subpath.test.ts
@@ -43,9 +43,14 @@ mock.module('../../../src/core/logger', () => ({
 // Subpath install still calls the real Bun build at the end; stub it so
 // the test stays hermetic. The build step is exercised separately in
 // tests/api/plugins-build.test.ts.
+const buildUserPluginCalls: Array<{ pluginDir: string; options?: { trustExistingDist?: boolean } }> = []
 mock.module(
   '../../../packages/host/src/plugin-host/user-plugin-builder',
-  () => ({ buildUserPlugin: async () => {} }),
+  () => ({
+    buildUserPlugin: async (pluginDir: string, options?: { trustExistingDist?: boolean }) => {
+      buildUserPluginCalls.push({ pluginDir, options })
+    },
+  }),
 )
 
 import { post as installPOST } from '../../../packages/host/src/api/plugins/install'
@@ -116,6 +121,7 @@ afterAll(() => {
 })
 
 beforeEach(() => {
+  buildUserPluginCalls.length = 0
   rmSync(join(testDir, 'plugins'), { recursive: true, force: true })
 })
 
@@ -140,6 +146,7 @@ describe.skipIf(!gitAvailable())('install subpath — happy path', () => {
     expect(existsSync(join(fooDir, 'README.md'))).toBe(false)
     // Subpath installs intentionally drop the cloned repo's `.git/`.
     expect(existsSync(join(fooDir, '.git'))).toBe(false)
+    expect(buildUserPluginCalls.at(-1)?.options).toEqual({ trustExistingDist: true })
   })
 
   it('records the full source string (with #subpath) in the lockfile', async () => {


### PR DESCRIPTION
## Summary
- let GitHub plugin installs and upgrades trust complete shipped dist artifacts
- keep local installs, links, and hot reload rebuilding from source
- add regression coverage for prebuilt dist skip and install route options

## Tests
- bun test --isolate tests/api/plugins-build.test.ts tests/plugins/lifecycle/install-subpath.test.ts tests/plugins/lifecycle/upgrade-flow.integration.test.ts tests/api/plugins-install.test.ts
- bun run typecheck