### PR TITLE
Avoid onboarding busy header replay

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -3647,6 +3647,7 @@ async function cmdOnboard(args: string[]): Promise<void> {
   try {
     const selections = await collectOnboardingSelections(baseOpts)
     const opts = { ...baseOpts, ...selections, interactive: false }
+    const busyShowsBrand = !selections.renderedWizardScreens
 
     let busyFrame = 0
     let busyDetail: string | undefined
@@ -3668,6 +3669,7 @@ async function cmdOnboard(args: string[]): Promise<void> {
       frame: busyFrame,
       completed: completedOutcomes,
       totalSteps: COMPONENT_ORDER.length,
+      showBrand: busyShowsBrand,
     })
     const busy = isTTY && !json
       ? render(renderBusy())

--- a/src/core/cli/onboarding-interactive.tsx
+++ b/src/core/cli/onboarding-interactive.tsx
@@ -37,6 +37,7 @@ export interface OnboardingSelections {
   selectedRecommendedPluginIds?: readonly string[];
   selectedRecommendedAgentIds?: readonly string[];
   approvedComponents?: readonly string[];
+  renderedWizardScreens?: boolean;
 }
 
 function choicesFromCheck(check: CheckResult): CatalogChoice[] {
@@ -270,5 +271,6 @@ export async function collectOnboardingSelections(
     selectedRecommendedPluginIds,
     selectedRecommendedAgentIds,
     approvedComponents,
+    renderedWizardScreens: hasWizardSteps,
   };
 }

--- a/src/core/cli/ui/onboarding.tsx
+++ b/src/core/cli/ui/onboarding.tsx
@@ -230,7 +230,7 @@ export function OnboardingFinalStatus({ outcomes, exitCode }: {
   return <NextActions actions={actions} />
 }
 
-export function OnboardingBusy({ label = 'Running onboarding', detail, frame = 0, details = ONBOARDING_BUSY_DETAILS, completed, totalSteps = 1 }: {
+export function OnboardingBusy({ label = 'Running onboarding', detail, frame = 0, details = ONBOARDING_BUSY_DETAILS, completed, totalSteps = 1, showBrand = true }: {
   label?: string
   detail?: string
   frame?: number
@@ -241,6 +241,7 @@ export function OnboardingBusy({ label = 'Running onboarding', detail, frame = 0
     message: string
   }>
   totalSteps?: number
+  showBrand?: boolean
 }) {
   const safeDetails = details.length > 0 ? details : ONBOARDING_BUSY_DETAILS
   const spinnerFrame = ONBOARDING_SPINNER_FRAMES[frame % ONBOARDING_SPINNER_FRAMES.length]
@@ -262,7 +263,7 @@ export function OnboardingBusy({ label = 'Running onboarding', detail, frame = 0
 
   return (
     <Box flexDirection="column">
-      <ScreenHeader title="Onboard" subtitle="Interactive setup in progress" meta={`step ${currentStep} of ${boundedTotalSteps}`} />
+      <ScreenHeader title="Onboard" subtitle="Interactive setup in progress" meta={`step ${currentStep} of ${boundedTotalSteps}`} showBrand={showBrand} />
       <SummaryStrip items={[
         { label: 'complete', value: completed?.filter(item => item.status === 'complete').length ?? 0, status: 'ok' },
         { label: 'running', value: 1, status: 'run' },

--- a/tests/cli/onboard-command.test.ts
+++ b/tests/cli/onboard-command.test.ts
@@ -18,6 +18,7 @@ const outcomes = [
 ]
 
 let onboarded = false
+let onboardingSelections: Record<string, unknown> = {}
 let onboardingState: {
   version: number
   completedAt: string
@@ -42,7 +43,7 @@ mock.module('../../src/core/onboarding/index', () => ({
 }))
 
 mock.module('../../src/core/cli/onboarding-interactive', () => ({
-  collectOnboardingSelections: async () => ({}),
+  collectOnboardingSelections: async () => onboardingSelections,
 }))
 
 describe('CLI onboard command', () => {
@@ -60,6 +61,7 @@ describe('CLI onboard command', () => {
   beforeEach(() => {
     mock.clearAllMocks()
     onboarded = false
+    onboardingSelections = {}
     onboardingState = null
     process.argv = originalArgv
     log = spyOn(console, 'log').mockImplementation(() => {})
@@ -96,6 +98,18 @@ describe('CLI onboard command', () => {
     expect(output).toContain('Machine setup complete')
     expect(output).toContain('PREREQUISITES')
     expect(output).toContain('Run `bakin start` to launch Bakin.')
+  })
+
+  it('continues onboarding progress without replaying the brand after wizard screens', async () => {
+    onboardingSelections = { renderedWizardScreens: true }
+    process.argv = ['bun', 'cli/bakin.ts', 'onboard', '--force']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    const liveOutput = stdoutWrite.mock.calls.map((call: unknown[]) => String(call[0])).join('')
+    expect(liveOutput).toContain('Onboard')
+    expect(liveOutput).not.toContain("┃ 🐷 Bakin'")
   })
 
   it('renders already-onboarded state with shared onboarding UI in a TTY', async () => {

--- a/tests/cli/onboarding-ui.test.tsx
+++ b/tests/cli/onboarding-ui.test.tsx
@@ -126,6 +126,18 @@ describe('onboarding CLI UI', () => {
     expect(rendered).toContain('Checking prerequisites and runtime access')
   })
 
+  it('can render the async onboarding busy state as a continuation without the brand', () => {
+    const rendered = renderToString(
+      <OnboardingBusy
+        label="Running onboarding checks and installs"
+        totalSteps={12}
+        showBrand={false}
+      />,
+    )
+    expect(rendered).toContain('Onboard')
+    expect(rendered).not.toContain("┃ 🐷 Bakin'")
+  })
+
   it('renders completed onboarding rows above the busy state', () => {
     const rendered = renderToString(
       <OnboardingBusy


### PR DESCRIPTION
## Summary
- track whether interactive onboarding wizard screens already rendered
- render the busy progress view as a continuation after those screens
- keep the standalone busy progress view branded when it is the first TTY screen

## Tests
- bun test --isolate tests/cli/onboarding-ui.test.tsx tests/cli/onboard-command.test.ts
- bun run typecheck