### PR TITLE
Fix release binary CSS and GitHub plugin dist reuse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Test
         run: bun test --isolate
 
+      - name: Build CSS
+        run: bun run build:css
+
       - name: Build vendor bundles
         run: bun run build:vendors
 

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -24,6 +24,7 @@ import type { Dirent } from 'node:fs'
 import { spawn } from 'node:child_process'
 import { join, resolve } from 'node:path'
 import { builtinModules } from 'node:module'
+import { readPluginLockfile, type PluginLockEntry } from '@bakin/core/plugins/lockfile'
 
 const CLIENT_EXTERNAL = [
   'react', 'react-dom', 'react-dom/client',
@@ -387,6 +388,12 @@ export async function buildAllUserPlugins(
   log: BuildLogger,
 ): Promise<void> {
   if (!existsSync(userPluginsDir)) return
+  let lockedPlugins: Record<string, PluginLockEntry> = {}
+  try {
+    lockedPlugins = readPluginLockfile().plugins
+  } catch (err) {
+    log.error('Failed to read plugin lockfile before building user plugins', err)
+  }
   let entries: Dirent[]
   try {
     entries = readdirSync(userPluginsDir, { withFileTypes: true }) as Dirent[]
@@ -400,7 +407,8 @@ export async function buildAllUserPlugins(
     const pluginDir = join(userPluginsDir, name)
     if (!existsSync(join(pluginDir, 'bakin-plugin.json'))) continue
     try {
-      await buildUserPlugin(pluginDir)
+      const trustExistingDist = lockedPlugins[name]?.type === 'github' && lockedPlugins[name]?.linked !== true
+      await buildUserPlugin(pluginDir, trustExistingDist ? { trustExistingDist: true } : undefined)
       log.info(`Built user plugin "${name}"`)
     } catch (err) {
       log.error(

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -8,7 +8,7 @@
  * + plugins/<id>/dist trees.
  *
  * Prerequisites (chained by the "build" script in package.json):
- *   bun run build:vendors && bun run build:plugins && bun run build:host-shell
+ *   bun run build:css && bun run build:vendors && bun run build:plugins && bun run build:host-shell
  *
  * Acceptance (from spec):
  *   - Produces 3 files under dist/ each well under 120 MB.

--- a/scripts/generate-embedded-assets.ts
+++ b/scripts/generate-embedded-assets.ts
@@ -23,6 +23,16 @@ import { join, resolve, relative, dirname } from 'node:path'
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const OUT_FILE = join(REPO_ROOT, 'packages/host/src/api/_embedded-assets-static.ts')
+const REQUIRED_ASSETS: Array<{ path: string; build: string }> = [
+  {
+    path: join(REPO_ROOT, 'packages/host/public/globals.css'),
+    build: 'bun run build:css',
+  },
+  {
+    path: join(REPO_ROOT, 'packages/host/dist/main.js'),
+    build: 'bun run build:host-shell',
+  },
+]
 
 interface AssetSource {
   /** Absolute path on disk. */
@@ -127,6 +137,18 @@ function collectAssets(): AssetSource[] {
   return assets
 }
 
+function assertRequiredAssetsExist(): void {
+  const missing = REQUIRED_ASSETS.filter(asset => !existsSync(asset.path))
+  if (missing.length === 0) return
+
+  const lines = missing.map(asset => (
+    `  - ${relative(REPO_ROOT, asset.path)} missing; run \`${asset.build}\` first`
+  ))
+  throw new Error(
+    `Cannot generate embedded assets because required host assets are missing:\n${lines.join('\n')}`,
+  )
+}
+
 function emitManifest(assets: AssetSource[]): string {
   const header = `// @ts-nocheck — every import below uses \`with { type: 'file' }\`;
 // Bun resolves these at build time (for --compile) or dev time (as on-disk
@@ -175,6 +197,7 @@ export const EMBEDDED_ASSET_COUNT = ${assets.length}
 }
 
 function main(): void {
+  assertRequiredAssetsExist()
   const assets = collectAssets()
   if (assets.length === 0) {
     throw new Error(

--- a/tests/api/curated.test.ts
+++ b/tests/api/curated.test.ts
@@ -121,3 +121,16 @@ describe('embedded-assets builder excludes agents/', () => {
     expect(script).toContain('walk(distDir')
   })
 })
+
+describe('embedded-assets builder required host assets', () => {
+  it('guards against release binaries missing generated CSS', () => {
+    const script = readFileSync(
+      join(import.meta.dir, '..', '..', 'scripts/generate-embedded-assets.ts'),
+      'utf-8',
+    )
+
+    expect(script).toContain('packages/host/public/globals.css')
+    expect(script).toContain('bun run build:css')
+    expect(script).toContain('Cannot generate embedded assets because required host assets are missing')
+  })
+})

--- a/tests/api/plugins-build.test.ts
+++ b/tests/api/plugins-build.test.ts
@@ -59,7 +59,8 @@ mock.module('../../src/core/logger', () => ({
   }),
 }))
 
-import { buildUserPlugin } from '../../packages/host/src/plugin-host/user-plugin-builder'
+import { addPlugin, readPluginLockfile, writePluginLockfile } from '../../packages/core/src/plugins/lockfile'
+import { buildAllUserPlugins, buildUserPlugin } from '../../packages/host/src/plugin-host/user-plugin-builder'
 
 const FIXTURE_DIR = join(__dirname, '..', 'fixtures', 'sample-user-plugin')
 const targetDir = join(testDir, 'plugins', 'sample')
@@ -190,5 +191,39 @@ describe('buildUserPlugin', () => {
 
     await expect(buildUserPlugin(dir)).resolves.toBeUndefined()
     expect(existsSync(join(dir, 'dist', 'index.js'))).toBe(true)
+  }, 60_000)
+})
+
+describe('buildAllUserPlugins', () => {
+  it('trusts complete shipped dist artifacts for github-locked plugins', async () => {
+    const pluginsDir = join(testDir, 'startup-plugins')
+    const dir = join(pluginsDir, 'github-prebuilt')
+    writeMinimalPlugin(dir, `export default { id: 'github-prebuilt', name: 'x', version: '0.1.0', activate() { return 'source build' } }`)
+    mkdirSync(join(dir, 'dist'), { recursive: true })
+    const distServer = join(dir, 'dist', 'index.js')
+    const prebuilt = `export default { id: 'github-prebuilt', activate() { return 'prebuilt dist' } }\n`
+    writeFileSync(distServer, prebuilt)
+
+    const older = new Date(Date.now() - 10_000)
+    const newer = new Date()
+    utimesSync(distServer, older, older)
+    utimesSync(join(dir, 'index.ts'), newer, newer)
+
+    writePluginLockfile(addPlugin(readPluginLockfile(), 'github-prebuilt', {
+      source: 'github:markhayden/bakin-bits-official#plugins/projects',
+      type: 'github',
+      ref: 'main',
+      commitSha: 'a'.repeat(40),
+      installedAt: new Date().toISOString(),
+      version: '0.1.0',
+      permissions: [],
+      manifestSha: 'test-manifest-sha',
+    }))
+
+    const log = { info: mock(), error: mock() }
+    await buildAllUserPlugins(pluginsDir, log)
+
+    expect(readFileSync(distServer, 'utf-8')).toBe(prebuilt)
+    expect(log.error).not.toHaveBeenCalled()
   }, 60_000)
 })


### PR DESCRIPTION
## Summary
- run `build:css` in the release workflow before embedding binary assets
- make embedded asset generation fail fast when generated host CSS or main.js is missing
- trust shipped dist artifacts for GitHub-installed plugins during server startup, matching install/upgrade behavior

## Tests
- `bun test --isolate tests/api/plugins-build.test.ts tests/api/curated.test.ts tests/api/host-static.test.ts tests/api/plugin-manifest-embedded.test.ts`
- `bun run typecheck`
- `bun run build:assets-manifest`