### PR TITLE
Cache GitHub source checkouts during installs

### DIFF
--- a/packages/host/src/api/plugins/install.ts
+++ b/packages/host/src/api/plugins/install.ts
@@ -23,9 +23,10 @@
 import { existsSync, readFileSync, mkdirSync, cpSync, rmSync, statSync, realpathSync } from 'fs'
 import { homedir } from 'os'
 import { join, basename, resolve, isAbsolute, sep } from 'path'
-import { execFileSync, spawn } from 'child_process'
+import { execFileSync } from 'child_process'
 import { createHash } from 'crypto'
 import { getContentDir } from '@/core/content-dir'
+import { materializeCachedGithubSource } from '@/core/github-source-cache'
 import { createLogger } from '@/core/logger'
 import { isCorePlugin } from '@/lib/plugin-registry'
 import { buildUserPlugin } from '../../plugin-host/user-plugin-builder'
@@ -271,66 +272,6 @@ function consentSourceIdentity(source: string, ref: string): string {
   return ref ? JSON.stringify({ source, ref }) : source
 }
 
-function formatGitError(err: unknown): string {
-  const maybe = err as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string }
-  const stderr = Buffer.isBuffer(maybe.stderr) ? maybe.stderr.toString('utf-8') : maybe.stderr
-  const stdout = Buffer.isBuffer(maybe.stdout) ? maybe.stdout.toString('utf-8') : maybe.stdout
-  return (stderr || stdout || maybe.message || String(err)).trim()
-}
-
-async function execFileAsync(cmd: string, args: string[], opts: { cwd?: string } = {}): Promise<void> {
-  return await new Promise((resolvePromise, reject) => {
-    const child = spawn(cmd, args, {
-      cwd: opts.cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    const stdout: Buffer[] = []
-    const stderr: Buffer[] = []
-
-    child.stdout?.on('data', (chunk: Buffer) => stdout.push(chunk))
-    child.stderr?.on('data', (chunk: Buffer) => stderr.push(chunk))
-    child.on('error', reject)
-    child.on('exit', (code) => {
-      if (code === 0) {
-        resolvePromise()
-        return
-      }
-      const error = new Error(`${cmd} ${args.join(' ')} exited with code ${code}`) as Error & {
-        stdout?: Buffer
-        stderr?: Buffer
-      }
-      error.stdout = Buffer.concat(stdout)
-      error.stderr = Buffer.concat(stderr)
-      reject(error)
-    })
-  })
-}
-
-async function cloneGithubSource(cloneUrl: string, stagingDir: string, ref: string): Promise<void> {
-  try {
-    if (ref) {
-      await execFileAsync('git', ['clone', '--depth', '1', '--branch', ref, '--', cloneUrl, stagingDir])
-    } else {
-      await execFileAsync('git', ['clone', '--depth', '1', '--', cloneUrl, stagingDir])
-    }
-    return
-  } catch (firstErr) {
-    if (!ref) throw firstErr
-    // `git clone --branch <sha>` only works for branch/tag names. Fall
-    // back to a full no-checkout clone so exact commit pins are supported.
-    rmSync(stagingDir, { recursive: true, force: true })
-    mkdirSync(stagingDir, { recursive: true })
-    try {
-      await execFileAsync('git', ['clone', '--no-checkout', '--', cloneUrl, stagingDir])
-      await execFileAsync('git', ['checkout', '--detach', ref], { cwd: stagingDir })
-      return
-    } catch (fallbackErr) {
-      const detail = formatGitError(fallbackErr) || formatGitError(firstErr)
-      throw new Error(`failed to clone ${cloneUrl} at ref "${ref}": ${detail}`)
-    }
-  }
-}
-
 export async function post(req: Request, _url: URL): Promise<Response> {
   let body: InstallBody
   try {
@@ -468,7 +409,11 @@ export async function post(req: Request, _url: URL): Promise<Response> {
         requestedRef = body.ref ?? parsedUrl.ref
 
         try {
-          await cloneGithubSource(parsedUrl.url, stagingDir, requestedRef)
+          await materializeCachedGithubSource({
+            cloneUrl: parsedUrl.url,
+            ref: requestedRef || undefined,
+            stagingDir,
+          })
           gitProvenance = resolveGitProvenance(stagingDir, body.type, requestedRef)
         } catch (err) {
           rmSync(stagingDir, { recursive: true, force: true })

--- a/src/core/agent-packages/source-fetcher.ts
+++ b/src/core/agent-packages/source-fetcher.ts
@@ -16,9 +16,12 @@
  *     the user actually wants a pinned commit, they should pass
  *     `github:user/repo@<sha>`.
  *
- *   - **github** — `github:user/repo[@ref][#subpath]` form. Cloned with
- *     `--depth 1 --branch <ref>` first; if that fails (commit SHAs aren't
- *     accepted by --branch), falls back to a deeper clone + checkout.
+ *   - **github** — `github:user/repo[@ref][#subpath]` form. The sync path
+ *     clones with `--depth 1 --branch <ref>` first; if that fails (commit
+ *     SHAs aren't accepted by --branch), it falls back to a deeper clone +
+ *     checkout. The async install path uses a shared cached checkout so
+ *     onboarding can install multiple subpaths from the same repo without
+ *     redownloading it.
  *     Commit SHA is read via `git rev-parse HEAD` after checkout.
  *     When `#subpath` is present, only that directory is staged as the
  *     package source.
@@ -38,6 +41,10 @@ import { isAbsolute, join, resolve } from 'path'
 import { randomUUID } from 'crypto'
 import { createLogger } from '../logger'
 import { getContentDir } from '../content-dir'
+import {
+  materializeCachedGithubSource,
+  type AsyncGitRunner,
+} from '../github-source-cache'
 import { getStagingDir, getPackagesRoot } from '../../../packages/core/src/agent-packages/package-paths'
 
 const log = createLogger('agent-pkg:fetch')
@@ -263,11 +270,6 @@ interface GitRunner {
   (args: string[]): string
 }
 
-interface AsyncGitRunner {
-  /** Run `git <args>` and return stdout; throw on non-zero exit. */
-  (args: string[]): Promise<string>
-}
-
 const realGit: GitRunner = (args) =>
   execFileSync('git', args, { stdio: ['ignore', 'pipe', 'pipe'] }).toString('utf-8')
 
@@ -349,40 +351,22 @@ export async function fetchGithubWithRunnerAsync(
 ): Promise<FetchedSource> {
   const spec = parseGithubSpec(source)
   const url = `https://github.com/${spec.owner}/${spec.repo}.git`
-  const cloneTarget = spec.subpath ? `${staging}.clone` : staging
 
   cleanupStaging(staging)
-  if (spec.subpath) cleanupStaging(cloneTarget)
   mkdirSync(staging, { recursive: true })
 
   try {
-    if (spec.ref) {
-      try {
-        await git(['clone', '--depth', '1', '--branch', spec.ref, url, cloneTarget])
-      } catch {
-        cleanupStaging(cloneTarget)
-        if (!spec.subpath) mkdirSync(cloneTarget, { recursive: true })
-        await git(['clone', '--depth', '50', url, cloneTarget])
-        await git(['-C', cloneTarget, 'checkout', spec.ref])
-      }
-    } else {
-      await git(['clone', '--depth', '1', url, cloneTarget])
-    }
-
-    if (spec.subpath) {
-      const packageDir = ensureGithubSubpathPackagePresent(cloneTarget, spec.subpath)
-      cpSync(packageDir, staging, { recursive: true, dereference: false })
-      ensureManifestPresent(staging)
-    } else {
-      ensureManifestPresent(staging)
-    }
-
-    const commitSha = (await git(['-C', cloneTarget, 'rev-parse', 'HEAD'])).trim()
-    if (spec.subpath) cleanupStaging(cloneTarget)
-    return { stagingDir: staging, commitSha, kind: 'github', ref: spec.ref ?? '' }
+    const checkout = await materializeCachedGithubSource({
+      cloneUrl: url,
+      ref: spec.ref ?? undefined,
+      stagingDir: staging,
+      subpath: spec.subpath || undefined,
+      git,
+    })
+    ensureManifestPresent(staging)
+    return { stagingDir: staging, commitSha: checkout.commitSha, kind: 'github', ref: spec.ref ?? '' }
   } catch (err) {
     cleanupStaging(staging)
-    if (spec.subpath) cleanupStaging(cloneTarget)
     throw err
   }
 }

--- a/src/core/github-source-cache.ts
+++ b/src/core/github-source-cache.ts
@@ -1,0 +1,156 @@
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync } from 'fs'
+import { spawn } from 'child_process'
+import { tmpdir } from 'os'
+import { join, resolve, sep } from 'path'
+import { randomUUID } from 'crypto'
+
+export interface AsyncGitRunner {
+  /** Run `git <args>` and return stdout; throw on non-zero exit. */
+  (args: string[]): Promise<string>
+}
+
+export interface CachedGithubCheckout {
+  checkoutDir: string
+  commitSha: string
+}
+
+interface CacheEntry {
+  createdAt: number
+  promise: Promise<CachedGithubCheckout>
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+let cacheRoot: string | null = null
+const cache = new Map<string, CacheEntry>()
+
+const realGitAsync: AsyncGitRunner = (args) => new Promise((resolvePromise, reject) => {
+  const child = spawn('git', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+  let stdout = ''
+  let stderr = ''
+
+  child.stdout.setEncoding('utf-8')
+  child.stderr.setEncoding('utf-8')
+  child.stdout.on('data', chunk => { stdout += chunk })
+  child.stderr.on('data', chunk => { stderr += chunk })
+  child.on('error', reject)
+  child.on('close', code => {
+    if (code === 0) {
+      resolvePromise(stdout)
+      return
+    }
+    reject(new Error(stderr.trim() || `git ${args.join(' ')} exited with code ${code}`))
+  })
+})
+
+function getCacheRoot(): string {
+  if (!cacheRoot) cacheRoot = mkdtempSync(join(tmpdir(), 'bakin-github-source-cache-'))
+  return cacheRoot
+}
+
+function cacheKey(cloneUrl: string, ref: string): string {
+  return `${cloneUrl}\0${ref}`
+}
+
+function formatGitError(err: unknown): string {
+  if (err instanceof Error) return err.message.trim()
+  return String(err).trim()
+}
+
+async function cloneIntoCache(
+  cloneUrl: string,
+  ref: string,
+  git: AsyncGitRunner,
+): Promise<CachedGithubCheckout> {
+  const checkoutDir = join(getCacheRoot(), randomUUID())
+
+  try {
+    if (ref) {
+      try {
+        await git(['clone', '--depth', '1', '--branch', ref, '--', cloneUrl, checkoutDir])
+      } catch (firstErr) {
+        rmSync(checkoutDir, { recursive: true, force: true })
+        await git(['clone', '--no-checkout', '--', cloneUrl, checkoutDir])
+        try {
+          await git(['-C', checkoutDir, 'checkout', '--detach', ref])
+        } catch (fallbackErr) {
+          const detail = formatGitError(fallbackErr) || formatGitError(firstErr)
+          throw new Error(`failed to clone ${cloneUrl} at ref "${ref}": ${detail}`)
+        }
+      }
+    } else {
+      await git(['clone', '--depth', '1', '--', cloneUrl, checkoutDir])
+    }
+
+    const commitSha = (await git(['-C', checkoutDir, 'rev-parse', 'HEAD'])).trim().toLowerCase()
+    return { checkoutDir, commitSha }
+  } catch (err) {
+    rmSync(checkoutDir, { recursive: true, force: true })
+    throw err
+  }
+}
+
+export async function getCachedGithubCheckout(args: {
+  cloneUrl: string
+  ref?: string
+  git?: AsyncGitRunner
+}): Promise<CachedGithubCheckout> {
+  const ref = args.ref?.trim() ?? ''
+  const key = cacheKey(args.cloneUrl, ref)
+  const now = Date.now()
+  const existing = cache.get(key)
+  if (existing && now - existing.createdAt < CACHE_TTL_MS) {
+    return await existing.promise
+  }
+
+  const promise = cloneIntoCache(args.cloneUrl, ref, args.git ?? realGitAsync)
+  cache.set(key, { createdAt: now, promise })
+  try {
+    return await promise
+  } catch (err) {
+    if (cache.get(key)?.promise === promise) cache.delete(key)
+    throw err
+  }
+}
+
+function resolveSubpath(checkoutDir: string, subpath: string): string {
+  const checkoutRoot = resolve(checkoutDir)
+  const subpathDir = resolve(checkoutDir, subpath)
+  if (subpathDir !== checkoutRoot && !subpathDir.startsWith(checkoutRoot + sep)) {
+    throw new Error(`Github source subpath "${subpath}" escapes the cloned repository`)
+  }
+  if (!existsSync(subpathDir) || !statSync(subpathDir).isDirectory()) {
+    throw new Error(`Github source subpath "${subpath}" not found in repository`)
+  }
+  return subpathDir
+}
+
+export async function materializeCachedGithubSource(args: {
+  cloneUrl: string
+  ref?: string
+  stagingDir: string
+  subpath?: string
+  git?: AsyncGitRunner
+}): Promise<CachedGithubCheckout> {
+  const checkout = await getCachedGithubCheckout({
+    cloneUrl: args.cloneUrl,
+    ref: args.ref,
+    git: args.git,
+  })
+  const sourceDir = args.subpath
+    ? resolveSubpath(checkout.checkoutDir, args.subpath)
+    : checkout.checkoutDir
+
+  rmSync(args.stagingDir, { recursive: true, force: true })
+  mkdirSync(args.stagingDir, { recursive: true })
+  cpSync(sourceDir, args.stagingDir, { recursive: true, dereference: false })
+  return checkout
+}
+
+export function resetGithubSourceCacheForTests(): void {
+  cache.clear()
+  if (cacheRoot) {
+    rmSync(cacheRoot, { recursive: true, force: true })
+    cacheRoot = null
+  }
+}

--- a/tests/agent-packages/source-fetcher.test.ts
+++ b/tests/agent-packages/source-fetcher.test.ts
@@ -45,15 +45,19 @@ mock.module('@bakin/adapter-openclaw/home', () => ({
 
 import {
   fetchGithubWithRunner,
+  fetchGithubWithRunnerAsync,
   fetchSource,
   parseGithubSpec,
 } from '../../src/core/agent-packages/source-fetcher'
+import { resetGithubSourceCacheForTests } from '../../src/core/github-source-cache'
 
 afterAll(() => {
+  resetGithubSourceCacheForTests()
   rmSync(testDir, { recursive: true, force: true })
 })
 
 beforeEach(() => {
+  resetGithubSourceCacheForTests()
   rmSync(testDir, { recursive: true, force: true })
   mkdirSync(testDir, { recursive: true })
 })
@@ -357,6 +361,55 @@ describe('fetchSource — github (mock runner)', () => {
     expect(existsSync(join(result.stagingDir, 'bakin-package.json'))).toBe(true)
     expect(existsSync(join(result.stagingDir, 'README.md'))).toBe(true)
     expect(existsSync(join(result.stagingDir, 'agents'))).toBe(false)
+  })
+
+  it('reuses one cached checkout for repeated async subpath fetches from the same repo', async () => {
+    const calls: string[][] = []
+    const mockGit = async (args: string[]): Promise<string> => {
+      calls.push(args)
+      if (isCloneCall(args)) {
+        const target = args[args.length - 1]
+        mkdirSync(join(target, 'agents', 'pixel'), { recursive: true })
+        mkdirSync(join(target, 'agents', 'patch'), { recursive: true })
+        writeFileSync(join(target, 'README.md'), 'repo root')
+        writeFileSync(join(target, 'agents', 'pixel', 'README.md'), 'pixel package')
+        writeFileSync(join(target, 'agents', 'patch', 'README.md'), 'patch package')
+        writeFileSync(
+          join(target, 'agents', 'pixel', 'bakin-package.json'),
+          VALID_AGENT_MANIFEST,
+          'utf-8',
+        )
+        writeFileSync(
+          join(target, 'agents', 'patch', 'bakin-package.json'),
+          VALID_AGENT_MANIFEST,
+          'utf-8',
+        )
+        return ''
+      }
+      if (isRevParseCall(args)) return 'feedface\n'
+      return ''
+    }
+
+    const pixelStaging = join(testDir, 'packages', '.staging-cache-pixel')
+    const patchStaging = join(testDir, 'packages', '.staging-cache-patch')
+    const pixel = await fetchGithubWithRunnerAsync(
+      'github:markhayden/bakin-bits-official#agents/pixel',
+      mockGit,
+      pixelStaging,
+    )
+    const patch = await fetchGithubWithRunnerAsync(
+      'github:markhayden/bakin-bits-official#agents/patch',
+      mockGit,
+      patchStaging,
+    )
+
+    expect(calls.filter(isCloneCall)).toHaveLength(1)
+    expect(pixel.commitSha).toBe('feedface')
+    expect(patch.commitSha).toBe('feedface')
+    expect(existsSync(join(pixel.stagingDir, 'bakin-package.json'))).toBe(true)
+    expect(existsSync(join(patch.stagingDir, 'bakin-package.json'))).toBe(true)
+    expect(existsSync(join(pixel.stagingDir, 'agents'))).toBe(false)
+    expect(existsSync(join(patch.stagingDir, 'agents'))).toBe(false)
   })
 
   it('throws when requested package subpath is missing after clone', () => {

--- a/tests/core/github-source-cache.test.ts
+++ b/tests/core/github-source-cache.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+import {
+  materializeCachedGithubSource,
+  resetGithubSourceCacheForTests,
+} from '../../src/core/github-source-cache'
+
+const testDir = join(tmpdir(), `bakin-test-github-source-cache-${Date.now()}-${randomUUID()}`)
+
+afterAll(() => {
+  resetGithubSourceCacheForTests()
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  resetGithubSourceCacheForTests()
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(testDir, { recursive: true })
+})
+
+describe('github source cache', () => {
+  const isCloneCall = (args: string[]) => args[0] === 'clone'
+  const isRevParseCall = (args: string[]) => args[0] === '-C' && args[2] === 'rev-parse'
+
+  it('materializes repeated full-repo requests from one cached checkout', async () => {
+    const calls: string[][] = []
+    const git = async (args: string[]): Promise<string> => {
+      calls.push(args)
+      if (isCloneCall(args)) {
+        const target = args[args.length - 1]
+        mkdirSync(join(target, 'plugins', 'messaging'), { recursive: true })
+        mkdirSync(join(target, 'plugins', 'projects'), { recursive: true })
+        writeFileSync(join(target, 'plugins', 'messaging', 'bakin-plugin.json'), '{}')
+        writeFileSync(join(target, 'plugins', 'projects', 'bakin-plugin.json'), '{}')
+        return ''
+      }
+      if (isRevParseCall(args)) return 'cafebabe\n'
+      return ''
+    }
+
+    const firstStage = join(testDir, 'stage-one')
+    const secondStage = join(testDir, 'stage-two')
+    const first = await materializeCachedGithubSource({
+      cloneUrl: 'https://github.com/markhayden/bakin-bits-official.git',
+      stagingDir: firstStage,
+      git,
+    })
+    const second = await materializeCachedGithubSource({
+      cloneUrl: 'https://github.com/markhayden/bakin-bits-official.git',
+      stagingDir: secondStage,
+      git,
+    })
+
+    expect(calls.filter(isCloneCall)).toHaveLength(1)
+    expect(first.commitSha).toBe('cafebabe')
+    expect(second.commitSha).toBe('cafebabe')
+    expect(existsSync(join(firstStage, 'plugins', 'messaging', 'bakin-plugin.json'))).toBe(true)
+    expect(existsSync(join(secondStage, 'plugins', 'projects', 'bakin-plugin.json'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared in-process GitHub source checkout cache with short TTL
- reuse cached checkouts for GitHub plugin installs, including consent preflight + commit
- reuse cached checkouts for async agent package installs so multiple subpaths from the same repo do not reclone

## Tests
- bun test --isolate tests/core/github-source-cache.test.ts tests/agent-packages/source-fetcher.test.ts
- bun test --isolate tests/api/plugins-install.test.ts tests/plugins/lifecycle/install-subpath.test.ts tests/plugins/lifecycle/install-ref.test.ts
- bun test --isolate tests/agent-packages tests/core/github-source-cache.test.ts
- bun run typecheck