### PR TITLE
Harden runtime capability handling

### DIFF
--- a/.claude/knowledge/adapter-architecture.md
+++ b/.claude/knowledge/adapter-architecture.md
@@ -119,6 +119,27 @@ into runtime provider metadata. The runtime may expose execution status through
 `runtime.tasks.*`, but task title, column, priority, blockers, workflow state,
 and logs belong to the Bakin task store.
 
+## Permission Layers
+
+Bakin has several permission and capability layers. Do not treat a failure in
+one layer as evidence that the others should be loosened:
+
+- Filesystem/process sandbox policy controls what a local command may read,
+  write, or reach over the network.
+- Plugin manifest permissions control which `ctx.runtime.*` surfaces an
+  installed plugin can call through `src/lib/plugin-permissions.ts`.
+- Workflow step ownership controls `bakin_exec_*` tools with
+  `assertWorkflowToolAllowed`; the current step owner may log progress, submit
+  work, block work, or post an output according to the active step type.
+- Runtime messaging tool policy controls the tools available to one live
+  runtime agent turn. `RuntimeMessageArgs` supports `toolsMode`, `toolsAllow`,
+  and `toolsDeny`; the OpenClaw adapter forwards these to Gateway agent
+  requests. Use `toolsMode: 'none'` when a delegated turn must produce text
+  only.
+- Runtime cron `toolsAllow` is native isolated cron agent policy. It is exposed
+  as `CronJob.toolsAllow` for scheduling visibility and is separate from live
+  messaging policy and MCP routing.
+
 ## Runtime Messaging Streams
 
 Messaging callers pass stable Bakin `threadId` values such as
@@ -146,6 +167,16 @@ available as the provider-agnostic fallback.
 Channel operations go through `runtime.channels.*`. Cron operations go through
 `runtime.cron.*`. Plugin notification channel definitions still belong to the
 Bakin workflow/channel registry; provider delivery is adapter-backed.
+
+Logical channel labels such as `general` or `#general` are not assumed to be
+runtime delivery targets. Exec tools that deliver content resolve labels through
+`settings.notifications.channelAliases` before calling the runtime adapter. A
+fully-qualified target such as `discord:<target>` passes through unchanged; a
+bare id is allowed only when it matches `runtime.channels.list()`. The
+`health.channel-aliases` check validates alias targets without sending a
+message. For backwards compatibility, a legacy
+`notifications.channel` + `notifications.target` pair supplies the default
+`general` alias only when `channelAliases.general` is not set.
 
 Cron adapter policy fields should be normalized at the runtime boundary. For
 OpenClaw, native isolated agent-turn cron tool allowlists live on

--- a/.claude/knowledge/doctor-and-health-checks.md
+++ b/.claude/knowledge/doctor-and-health-checks.md
@@ -46,7 +46,7 @@ The orchestrator is intentionally trivial — it has no opinion about what's bei
 
 (Plus 3 workflow checks already migrated under #137: `definitions`, `stale-instances`, `skills`.)
 
-### System-owned (10 checks, registered by health plugin)
+### System-owned (13 checks, registered by health plugin)
 
 | File | Registered id |
 |---|---|
@@ -54,10 +54,13 @@ The orchestrator is intentionally trivial — it has no opinion about what's bei
 | `plugins/health/lib/system-checks/service.ts` | `service` |
 | `plugins/health/lib/system-checks/mcporter.ts` | `mcporter` |
 | `plugins/health/lib/system-checks/runtime.ts` | `runtime` |
+| `plugins/health/lib/system-checks/channel-aliases.ts` | `channel-aliases` |
+| `plugins/health/lib/system-checks/restart-recovery.ts` | `restart-recovery` |
 | `plugins/health/lib/system-checks/channel-approvals.ts` | `channel-approvals` |
 | `plugins/health/lib/system-checks/search.ts` | `search` |
 | `plugins/health/lib/system-checks/sync-skill.ts` | `skill` |
 | `plugins/health/lib/system-checks/plugin-assets.ts` | `plugin-assets` |
+| `plugins/health/index.ts` | `plugin-registry` |
 | `src/core/agent-rules/managed-blocks.ts` | `orchestrator-rules` |
 | `src/core/agent-rules/managed-blocks.ts` | `managed-blocks` |
 

--- a/.claude/knowledge/messaging-plugin.md
+++ b/.claude/knowledge/messaging-plugin.md
@@ -10,6 +10,13 @@ Core Bakin keeps only the stable host surface for installed plugins:
 
 Planning sessions are plugin-owned durable records. The plugin stores visible user, assistant, and `activity` timeline entries under `messaging/sessions/<id>.json`, plus proposals. Runtime conversation continuity is adapter-owned: session message routes and exec tools pass a stable SDK-built `threadId` (`messaging:${sessionId}:${agentId}`) through `ctx.runtime.messaging`, rather than replaying prior stored messages into every prompt. Search indexes user/assistant planning text and proposal summaries; tool activity stays available in the UI timeline but is excluded from `message_body`.
 
+Live runtime turns can be scoped per request with `RuntimeMessageArgs`:
+`toolsMode`, `toolsAllow`, and `toolsDeny`. Use this on
+`ctx.runtime.messaging.send()` or `.stream()` when a planning/prep turn needs a
+hard tool boundary, for example `toolsMode: 'none'` for text-only planning. This
+is separate from cron `toolsAllow`, plugin manifest permissions, and workflow
+step ownership.
+
 The official plugin must use task-backed scheduling for production work:
 
 - Plans hold concrete `channels`, not core-owned state.

--- a/.claude/knowledge/workflows-plugin.md
+++ b/.claude/knowledge/workflows-plugin.md
@@ -111,6 +111,13 @@ blocking are allowed only for the current step owner. Direct task completion is
 denied while a workflow is active. Channel posts are allowed only for the current
 owner of the active `output` step.
 
+When a workflow-backed task is explicitly blocked through `blockTaskWithEffects`,
+core task-service invokes `workflows.cancelInstance` best-effort with the block
+reason. A blocked board task must not leave a stale `in_progress` workflow
+instance behind. Recovery should happen through explicit reopen/retry flows
+such as `workflows.reopenFromStep`, not by silently continuing the canceled
+instance.
+
 ## Node-Type Registry
 
 `plugins/workflows/lib/node-type-registry.ts`. Builtins self-register at module load; plugins add more via `ctx.registerNodeType`:
@@ -168,6 +175,15 @@ Plugin ids are auto-namespaced as `{pluginId}.{id}`; builtins keep their short r
 Teardown: `unregisterPluginNotificationChannels(pluginId)` is called by `src/lib/plugin-registry.ts` in the user-plugin-overrides-builtin path alongside `unregisterPluginNodeTypes`, so hot reload of a plugin that registered channels doesn't leak `{pluginId}.{id}` entries.
 
 The official Messaging plugin resolves channels through this registry from `bakin-bits-official/plugins/messaging`; the old hardcoded channel label/icon maps are gone.
+
+Registry ids are logical workflow/UI ids, not guaranteed provider delivery
+targets. Delivery tools resolve `#general`, `general`, and other labels through
+`settings.notifications.channelAliases` via `src/core/channel-aliases.ts`
+before they call `runtime.channels.*`. Use fully-qualified runtime targets such
+as `discord:<target>` in aliases. A bare value is accepted only when it matches
+an id from `runtime.channels.list()`. Legacy
+`notifications.channel` + `notifications.target` settings act as the default
+`general` alias only when no explicit `channelAliases.general` exists.
 
 ## Runtime Gate Approvals
 

--- a/.claude/specs/permissions-capabilities-audit.md
+++ b/.claude/specs/permissions-capabilities-audit.md
@@ -1,0 +1,266 @@
+# Spec: Permissions And Runtime Capability Hardening
+
+## Objective
+
+Audit and harden the places where Bakin conflates permissions, tool policy, runtime capabilities, and workflow state. The immediate goal is to prevent agents from being dispatched into work that cannot complete, and to make failures actionable when runtime dependencies such as channel delivery or image generation are unavailable.
+
+Success means the two observed blocked tasks are explained by precise system failures, those classes of failures are caught before agent work starts where possible, and workflow/task state stays consistent when a tool failure blocks work.
+
+## Assumptions
+
+- Bakin remains the orchestration authority for tasks, audit, assets, workflows, and plugin permissions.
+- OpenClaw remains the runtime authority for agent turns, model auth, native tools, channel drivers, and cron.
+- Agent package MCP allowlists are not the root cause of the current failures; current installed package manifests do not declare restrictive `allowedTools`.
+- Runtime channel names like `#general` should not be treated as the same thing as adapter-native delivery targets unless Bakin has an explicit mapping.
+- Existing installs may have a legacy `notifications.channel` + `notifications.target` pair; that pair can supply the default `general` alias for compatibility, but explicit `notifications.channelAliases.general` remains canonical.
+- The open channel-alias design question was answered "yes" during kickoff.
+
+## Audit Summary
+
+### Open Tickets
+
+- #266: Runtime messaging lacks hard per-turn tool scoping for `ctx.runtime.messaging.send/stream`. Directly related.
+- #296: LLM onboarding checks only accept non-empty `apiKey`, so Codex/OAuth token auth is incorrectly reported as missing. Directly related.
+- #203: Workflow cleanup tracks strict step ownership and workflow capability gaps. Adjacent and relevant.
+- #267: Plugin builder prerequisite failures should fail before mutating state. Adjacent pattern for capability preflight.
+- #98: Per-gate Discord formatting is channel-adjacent, but not the cause of these failures.
+
+### Failure 1: `55fb21a2` Channel Post
+
+Task: `Share an inspirational quote`
+
+Observed failure:
+
+```text
+Runtime channel delivery failed: OpenClaw invokeTool failed (404): Tool not available: message_send
+```
+
+Root causes:
+
+- `bakin_exec_post_channel` accepts a human channel string and normalizes `#general` to `general`.
+- The OpenClaw adapter treats the first channel segment as the runtime channel driver id, so `general` becomes a runtime channel id, not a Discord target.
+- The installed runtime config has a Discord channel driver, but Bakin has no explicit `general -> discord:<target>` mapping.
+- OpenClaw adapter delivery first calls `/tools/invoke` with `message_send`; that tool is unavailable in the current runtime.
+- The adapter only falls back to `openclaw message send` when a target exists. `general` had no target, so the fallback path could not run.
+- Doctor/onboarding only validated that channel credentials exist; they did not validate that channel delivery is actually possible.
+
+This was not caused by MCP tool restrictions. The Bakin MCP tool existed and the agent was allowed to call it.
+
+### Failure 2: `messaging-7c20c5e7` Image Step
+
+Task: `Prep: Hot Dog Night, But Better - instagram`
+
+Observed failure:
+
+```text
+No Gemini API key found. Set GEMINI_API_KEY env var or configure the runtime skill entry
+```
+
+Root causes:
+
+- `bakin_exec_gen_image` only checks `GEMINI_API_KEY`, `GOOGLE_AI_API_KEY`, and `skills.entries.nano-banana-pro`.
+- The runtime config uses the newer model provider path for Google image generation, so Bakin looked in the wrong place.
+- The workflow step remained `in_progress` after the task was blocked because explicit `blockTaskWithEffects` bypasses the task-store move hook that cancels workflows.
+- Watchdog therefore continued to emit timeout logs for a workflow whose visible task card was already blocked.
+
+This was also not caused by MCP tool restrictions.
+
+## Permission And Capability Layers
+
+1. Plugin runtime permissions: `ctx.runtime.*` access is governed by plugin manifests and `src/lib/plugin-permissions.ts`. Current mode is warning-oriented for missing permissions.
+2. Agent package MCP policy: per-agent `allowedTools` in package manifests is enforced by `src/core/mcp-tool-policy.ts` and `src/core/mcp-server.ts`. Missing or empty `allowedTools` means unrestricted.
+3. Workflow tool authorization: `assertWorkflowToolAllowed` and `workflows.authorizeToolUse` gate current workflow ownership, task completion, and channel posts.
+4. Runtime provider capability: OpenClaw may or may not expose provider tools such as `message_send`, channel targets, model auth, or image model credentials.
+5. Prompt-only tool guidance: workflow `deny_tools` and dispatch text are not hard enforcement unless translated into runtime or MCP policy.
+
+The failures happened in layers 4 and workflow state coordination, not layer 2.
+
+## Tech Stack
+
+- TypeScript on Bun.
+- Runtime adapter contracts in `packages/core/src/adapters/runtime`.
+- Public SDK types in `packages/sdk/src/types`.
+- OpenClaw adapter in `packages/adapter-openclaw`.
+- Core task/workflow orchestration in `src/core`, `plugins/tasks`, and `plugins/workflows`.
+- Exec tools in `scripts/lib`.
+- Tests use `bun test`.
+
+## Commands
+
+Focused verification commands:
+
+```bash
+bun test tests/core/onboarding/credentials.test.ts
+bun test tests/scripts/generate-image.test.ts
+bun test tests/adapter-openclaw/runtime-channels.test.ts
+bun test tests/adapter-openclaw/runtime-stream.test.ts
+bun test tests/core/task-service.test.ts tests/plugins/workflows/runtime.test.ts
+bun test tests/lib/plugin-permissions.test.ts tests/core/mcp-tool-policy.test.ts
+```
+
+Broader verification before final handoff:
+
+```bash
+bun test tests/core/onboarding/credentials.test.ts tests/scripts/generate-image.test.ts tests/adapter-openclaw/runtime-channels.test.ts tests/adapter-openclaw/runtime-stream.test.ts tests/core/task-service.test.ts tests/plugins/workflows/runtime.test.ts tests/plugins/health/system-checks.test.ts
+```
+
+## Project Structure
+
+- `src/core/onboarding/credentials.ts`: LLM and channel credential readiness.
+- `scripts/lib/post-channel.ts`: Bakin channel post exec tool.
+- `scripts/lib/generate-image.ts`: image generation key/model resolution and asset save.
+- `src/core/task-service.ts` and `src/core/task-store.ts`: task state transitions and workflow cancellation hooks.
+- `plugins/workflows/lib/runtime.ts`: workflow instance state and tool authorization.
+- `packages/core/src/adapters/runtime/concepts.ts`: adapter-neutral runtime contract.
+- `packages/sdk/src/types/index.ts`: plugin-facing SDK contract.
+- `packages/adapter-openclaw/src/runtime.ts`: OpenClaw runtime implementation.
+- `plugins/health/lib/system-checks`: doctor-visible readiness checks.
+- `.claude/knowledge`: documentation updates for architecture and operational rules.
+
+## Code Style
+
+Prefer small, named normalization helpers over inline shape checks:
+
+```ts
+function hasUsableAuthSecret(entry: unknown): entry is Record<string, unknown> {
+  if (!entry || typeof entry !== 'object') return false
+  return AUTH_SECRET_FIELDS.some((field) => {
+    const value = (entry as Record<string, unknown>)[field]
+    return typeof value === 'string' && value.trim().length > 0
+  })
+}
+```
+
+No secret values should be logged, returned in doctor details, or written to audit.
+
+## Testing Strategy
+
+- Add regression tests before each behavior change.
+- Test narrow modules first: credential normalization, image key lookup, channel reference resolution, workflow block coordination.
+- Add adapter contract tests for runtime messaging tool policy.
+- Keep live channel delivery tests mocked; do not send real Discord messages in automated tests.
+- Use existing mock OpenClaw gateway tests for request payload assertions.
+
+## Implementation Plan
+
+### Phase 1: Fix Incorrect Readiness Checks
+
+Task 1: Broaden LLM auth detection.
+
+- Acceptance: Codex/OAuth/token auth profiles count as configured; warning copy no longer implies only `apiKey` is valid.
+- Verify: `bun test tests/core/onboarding/credentials.test.ts`.
+- Likely files: `src/core/onboarding/credentials.ts`, `tests/core/onboarding/credentials.test.ts`.
+
+Task 2: Make image generation read the active runtime provider config.
+
+- Acceptance: Google provider config under runtime model/provider settings satisfies `bakin_exec_gen_image`; old env and skill-entry paths still work; no secret is exposed in errors.
+- Verify: `bun test tests/scripts/generate-image.test.ts`.
+- Likely files: `scripts/lib/generate-image.ts`, `tests/scripts/generate-image.test.ts`.
+
+Checkpoint A:
+
+- Commit: `fix readiness checks for auth and image generation`.
+- Verification: focused tests above.
+
+### Phase 2: Make Channel Delivery Explicit
+
+Task 3: Introduce deterministic channel reference resolution.
+
+- Acceptance: fully qualified refs pass through; bare names such as `#general` resolve only when Bakin has an explicit alias/default target; unresolved names fail before runtime invocation with a clear remediation.
+- Verify: `bun test tests/scripts/post-channel.test.ts tests/adapter-openclaw/runtime-channels.test.ts`.
+- Likely files: `scripts/lib/post-channel.ts`, `packages/adapter-openclaw/src/runtime.ts`, relevant tests.
+
+Task 4: Surface channel delivery capability in health.
+
+- Acceptance: doctor reports when configured channel credentials exist but Bakin cannot prove channel delivery is routable; adapter health checks are included or mirrored in plugin health output.
+- Verify: `bun test tests/plugins/health/system-checks.test.ts tests/adapter-openclaw/runtime-channels.test.ts`.
+- Likely files: `plugins/health/index.ts`, `plugins/health/lib/system-checks/*`, `packages/adapter-openclaw/src/runtime.ts`.
+
+Checkpoint B:
+
+- Commit: `harden runtime channel delivery preflight`.
+- Verification: focused channel and health tests.
+
+### Phase 3: Keep Workflow And Task State Consistent
+
+Task 5: Cancel or block workflow instances when task blocking is explicit.
+
+- Acceptance: `bakin_exec_tasks_block` on a workflow-backed task stops the active workflow instance from staying `in_progress`; watchdog no longer times out already-blocked work.
+- Verify: `bun test tests/core/task-service.test.ts tests/plugins/workflows/runtime.test.ts tests/core/watchdog.test.ts`.
+- Likely files: `src/core/task-service.ts`, `plugins/workflows/lib/runtime.ts`, tests.
+
+Task 6: Tighten workflow dispatch tool exposure.
+
+- Acceptance: workflow dispatch text only advertises tools relevant to the current step; prompt-only `deny_tools` remains documentation unless backed by hard policy.
+- Verify: `bun test tests/core/dispatch.test.ts tests/core/dispatch-assets.test.ts`.
+- Likely files: `src/core/dispatch.ts`, tests.
+
+Checkpoint C:
+
+- Commit: `keep blocked workflows out of active dispatch`.
+- Verification: workflow/task/watchdog tests.
+
+### Phase 4: Add Hard Runtime Messaging Tool Policy
+
+Task 7: Add adapter-neutral per-turn tool policy to runtime messaging.
+
+- Acceptance: SDK and core adapter types expose `toolsMode`, `toolsAllow`, and `toolsDeny` on `send` and `stream`.
+- Verify: `bun test tests/dev/mock-runtime-contract.test.ts tests/adapter-openclaw/runtime-stream.test.ts`.
+- Likely files: `packages/core/src/adapters/runtime/concepts.ts`, `packages/sdk/src/types/index.ts`, mock runtime, OpenClaw adapter.
+
+Task 8: Apply policy in OpenClaw agent turns.
+
+- Acceptance: `toolsMode: "none"` and allow/deny lists are forwarded to OpenClaw agent requests; tests prove the request payload contains the policy.
+- Verify: `bun test tests/adapter-openclaw/runtime-stream.test.ts tests/dev/mock-runtime-contract.test.ts`.
+- Likely files: `packages/adapter-openclaw/src/runtime.ts`, dev mock gateway tests.
+
+Checkpoint D:
+
+- Commit: `add runtime messaging tool policy`.
+- Verification: runtime contract and adapter tests.
+
+### Phase 5: Documentation And Review
+
+Task 9: Update docs.
+
+- Acceptance: `.claude/knowledge` explains the five permission/capability layers, channel aliasing, workflow blocking behavior, and cron `toolsAllow` vs interactive messaging tool policy.
+- Verify: docs reviewed, no stale statements in existing relevant knowledge files.
+- Likely files: `.claude/knowledge/adapter-architecture.md`, `.claude/knowledge/workflows-plugin.md`, maybe a new `.claude/knowledge/permissions-and-capabilities.md`.
+
+Task 10: Quality pass.
+
+- Acceptance: code review focuses on secret leakage, permission-layer confusion, and behavior regressions.
+- Verify: focused suite plus any broader `bun test` subset warranted by changed files.
+
+Checkpoint E:
+
+- Commit: `document permission and capability boundaries`.
+- Verification: all focused tests passing.
+
+## Boundaries
+
+- Always: preserve task/workflow audit trails, avoid logging secrets, add regression tests for every failure class.
+- Always: prefer explicit capability checks and actionable errors over hidden best-effort behavior.
+- Ask first: adding new persistent user-facing settings for channel aliases, changing workflow instance status vocabulary, or changing OpenClaw runtime config shape.
+- Never: send real channel messages from tests, bypass Bakin audit with direct runtime commands in agent-facing flows, or weaken workflow step ownership.
+
+## Success Criteria
+
+- `#general` failures become either successful routed deliveries or preflight errors that say exactly what channel alias/target is missing.
+- `bakin_exec_gen_image` recognizes the active Google image provider config.
+- Codex/OAuth token auth no longer triggers the false `apiKey` onboarding warning.
+- Blocking a workflow task removes the workflow from active `in_progress` watchdog scans.
+- Runtime messaging supports hard per-turn tool policy for plugin calls.
+- Doctor/health distinguishes credential presence from operational delivery capability.
+- Documentation clearly distinguishes plugin permissions, MCP tool policy, workflow authorization, runtime provider capabilities, and prompt-only tool guidance.
+
+## Open Design Question
+
+Should Bakin introduce explicit named channel aliases as the canonical way for agents and workflows to say `#general`, `#alerts`, etc., with each alias resolving to a runtime-native target such as `discord:<target>`?
+
+Recommended answer: yes. Agents and workflow YAML should use stable human names; adapter-native ids and targets should live in Bakin/OpenClaw configuration. If an alias is missing, Bakin should fail before dispatching or posting with a remediation message, not try to infer a target from a secret-bearing runtime config or silently bypass through direct runtime commands.
+
+Decision: yes. Explicit aliases are canonical. A legacy `notifications.channel`
+and `notifications.target` pair is accepted only as the default `general` alias so
+older local settings continue to work until the operator saves explicit
+`notifications.channelAliases`.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -12,6 +12,7 @@ import type {
   CronRun,
   CreateCronJobInput,
   CreateRuntimeAgentInput,
+  MessageArgs,
   RuntimeAgent,
   RuntimeAvailableModel,
   RuntimeMetadata,
@@ -97,6 +98,15 @@ const NATIVE_APPROVAL_NOTICE = [
 const NATIVE_APPROVAL_PROVIDERS = new Set(['discord', 'telegram', 'slack', 'matrix', 'qqbot'])
 const OPENCLAW_PLUGIN_ALLOWLIST_WARNING = 'plugins.allow is empty'
 const ANSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g
+
+interface OpenClawAgentTurnOptions {
+  agentId: string
+  messages: Array<{ role: string; content: string }>
+  sessionKey?: string
+  toolsMode?: MessageArgs['toolsMode']
+  toolsAllow?: string[]
+  toolsDeny?: string[]
+}
 
 class OpenClawCommandError extends Error {
   readonly args: string[]
@@ -470,18 +480,24 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   }
 
   messaging = {
-    send: async (args: { agentId: string; content: string; threadId?: string; metadata?: RuntimeMetadata }) => {
+    send: async (args: MessageArgs) => {
       const content = await this.chatCompletion({
         agentId: args.agentId,
         messages: [{ role: 'user', content: args.content }],
         sessionKey: args.threadId,
+        toolsMode: args.toolsMode,
+        toolsAllow: args.toolsAllow,
+        toolsDeny: args.toolsDeny,
       })
       return { id: `msg-${Date.now()}`, content }
     },
-    stream: (args: { agentId: string; content: string; threadId?: string; metadata?: RuntimeMetadata }): AsyncIterable<ChatChunk> => this.streamChat({
+    stream: (args: MessageArgs): AsyncIterable<ChatChunk> => this.streamChat({
       agentId: args.agentId,
       messages: [{ role: 'user', content: args.content }],
       sessionKey: args.threadId,
+      toolsMode: args.toolsMode,
+      toolsAllow: args.toolsAllow,
+      toolsDeny: args.toolsDeny,
     }),
   }
 
@@ -992,11 +1008,11 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     return headers
   }
 
-  private async chatCompletion(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): Promise<string> {
+  private async chatCompletion(opts: OpenClawAgentTurnOptions): Promise<string> {
     return this.runOpenClawAgentGateway(opts)
   }
 
-  private async *streamChat(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): AsyncIterable<ChatChunk> {
+  private async *streamChat(opts: OpenClawAgentTurnOptions): AsyncIterable<ChatChunk> {
     const primary = this.runOpenClawAgentGatewayStream(opts)
     if (!opts.sessionKey) {
       yield* primary
@@ -1016,13 +1032,13 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     yield* mergeChatStreams(primary, activity, () => activityAbort.abort())
   }
 
-  private async *runOpenClawAgentGatewayStream(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): AsyncIterable<ChatChunk> {
+  private async *runOpenClawAgentGatewayStream(opts: OpenClawAgentTurnOptions): AsyncIterable<ChatChunk> {
     const content = await this.runOpenClawAgentGateway(opts)
     if (content) yield { type: 'text', content }
     yield { type: 'done' }
   }
 
-  private async runOpenClawAgentGateway(opts: { agentId: string; messages: Array<{ role: string; content: string }>; sessionKey?: string }): Promise<string> {
+  private async runOpenClawAgentGateway(opts: OpenClawAgentTurnOptions): Promise<string> {
     const params: Record<string, unknown> = {
       agentId: opts.agentId,
       message: messagesToOpenClawPrompt(opts.messages),
@@ -1030,6 +1046,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       timeout: OPENCLAW_AGENT_TIMEOUT_SECONDS,
       idempotencyKey: `bakin-${randomUUID()}`,
     }
+    applyRuntimeMessageToolPolicy(params, opts)
     if (opts.sessionKey) params.sessionId = openClawCliSessionId(opts.agentId, opts.sessionKey)
     try {
       const payload = await this.openClawChatGateway().request('agent', params, {
@@ -1083,6 +1100,27 @@ function messagesToOpenClawPrompt(messages: Array<{ role: string; content: strin
   const lastUser = [...messages].reverse().find((message) => message.role === 'user' && message.content.trim())
   if (lastUser) return lastUser.content
   return messages.map((message) => message.content).filter(Boolean).join('\n\n')
+}
+
+function normalizeToolList(value: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const seen = new Set<string>()
+  const tools: string[] = []
+  for (const entry of value) {
+    const tool = typeof entry === 'string' ? entry.trim() : ''
+    if (!tool || seen.has(tool)) continue
+    seen.add(tool)
+    tools.push(tool)
+  }
+  return tools.length > 0 ? tools : undefined
+}
+
+function applyRuntimeMessageToolPolicy(params: Record<string, unknown>, opts: OpenClawAgentTurnOptions): void {
+  if (opts.toolsMode === 'none' || opts.toolsMode === 'auto') params.toolsMode = opts.toolsMode
+  const toolsAllow = normalizeToolList(opts.toolsAllow)
+  const toolsDeny = normalizeToolList(opts.toolsDeny)
+  if (toolsAllow) params.toolsAllow = toolsAllow
+  if (toolsDeny) params.toolsDeny = toolsDeny
 }
 
 function extractOpenClawAgentText(value: unknown): string {

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -46,7 +46,21 @@ export interface WorkspaceFile {
   metadata?: RuntimeMetadata
 }
 
-export interface MessageArgs {
+export type RuntimeMessageToolsMode = 'auto' | 'none'
+
+export interface RuntimeMessageToolPolicy {
+  /**
+   * Controls whether runtime-native tools are available for this agent turn.
+   * `none` disables tools. Omit or use `auto` for runtime/provider defaults.
+   */
+  toolsMode?: RuntimeMessageToolsMode
+  /** Optional runtime-native tool allowlist for this turn. */
+  toolsAllow?: string[]
+  /** Optional runtime-native tool denylist for this turn. */
+  toolsDeny?: string[]
+}
+
+export interface MessageArgs extends RuntimeMessageToolPolicy {
   agentId: string
   content: string
   /**

--- a/packages/core/src/adapters/runtime/index.ts
+++ b/packages/core/src/adapters/runtime/index.ts
@@ -55,6 +55,8 @@ export type {
   RuntimeMemoryReadRange,
   RuntimeMemorySearchResult,
   RuntimeMemoryTier,
+  RuntimeMessageToolPolicy,
+  RuntimeMessageToolsMode,
   RuntimeMetadata,
   RuntimePermissionPatch,
   RawCronSnapshot,

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -147,7 +147,9 @@ export interface BakinSettings {
   }
   notifications: {
     channel: string
+    target: string
     gateAlerts: boolean
+    channelAliases: Record<string, string>
   }
   workflow: {
     stepTimeoutMs: number
@@ -259,7 +261,9 @@ export const DEFAULT_SETTINGS: BakinSettings = {
   },
   notifications: {
     channel: '',
+    target: '',
     gateAlerts: true,
+    channelAliases: {},
   },
   workflow: {
     stepTimeoutMs: 60 * 60 * 1000,       // 1 hour

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -340,7 +340,21 @@ export interface RuntimeChannel {
   metadata?: Record<string, unknown>
 }
 
-export interface RuntimeMessageArgs {
+export type RuntimeMessageToolsMode = 'auto' | 'none'
+
+export interface RuntimeMessageToolPolicy {
+  /**
+   * Controls whether runtime-native tools are available for this agent turn.
+   * `none` disables tools. Omit or use `auto` for runtime/provider defaults.
+   */
+  toolsMode?: RuntimeMessageToolsMode
+  /** Optional runtime-native tool allowlist for this turn. */
+  toolsAllow?: string[]
+  /** Optional runtime-native tool denylist for this turn. */
+  toolsDeny?: string[]
+}
+
+export interface RuntimeMessageArgs extends RuntimeMessageToolPolicy {
   agentId: string
   content: string
   /**

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -24,6 +24,7 @@ import { checkService } from './lib/system-checks/service'
 import { checkMcporter, mcporterRepair } from './lib/system-checks/mcporter'
 import { checkRuntime } from './lib/system-checks/runtime'
 import { checkChannelApprovals } from './lib/system-checks/channel-approvals'
+import { checkChannelAliases } from './lib/system-checks/channel-aliases'
 import { checkRestartRecovery } from './lib/system-checks/restart-recovery'
 import { checkSearchAdapter } from './lib/system-checks/search'
 import { checkAndSyncSkill, syncSkillRepair } from './lib/system-checks/sync-skill'
@@ -564,6 +565,11 @@ const healthPlugin: BakinPlugin = definePlugin({
       id: 'channel-approvals',
       name: 'Runtime channel approval responses',
       run: () => checkChannelApprovals(ctx.runtime),
+    })
+    ctx.registerHealthCheck({
+      id: 'channel-aliases',
+      name: 'Runtime channel aliases',
+      run: () => checkChannelAliases(ctx.runtime),
     })
     ctx.registerHealthCheck({
       id: 'restart-recovery',

--- a/plugins/health/lib/system-checks/channel-aliases.ts
+++ b/plugins/health/lib/system-checks/channel-aliases.ts
@@ -1,0 +1,55 @@
+import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
+import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+import { getSettings } from '../../../../src/core/settings'
+import { readConfiguredChannelAliases, resolveChannelRef } from '../../../../src/core/channel-aliases'
+
+function ok(message: string): HealthCheckResult {
+  return { check: 'channel-aliases', status: 'ok', message, autoFixable: false }
+}
+
+function warn(message: string): HealthCheckResult {
+  return { check: 'channel-aliases', status: 'warn', message, autoFixable: false }
+}
+
+function targetDriver(target: string): string {
+  return target.split(':')[0]
+}
+
+export async function checkChannelAliases(runtime: Pick<AgentRuntimeAdapter, 'channels'>): Promise<HealthCheckResult[]> {
+  let knownChannelIds: string[]
+  try {
+    knownChannelIds = (await runtime.channels.list()).map((channel) => channel.id)
+  } catch (err) {
+    return [warn(`Could not inspect runtime channels for alias validation: ${err instanceof Error ? err.message : String(err)}`)]
+  }
+
+  const known = new Set(knownChannelIds)
+  const aliases = readConfiguredChannelAliases()
+  const settings = getSettings()
+  const configuredAlertChannel = settings.notifications.channel.trim()
+  const failures: string[] = []
+
+  for (const alias of Object.keys(aliases)) {
+    try {
+      const resolved = resolveChannelRef(alias, { aliases, knownChannelIds })
+      if (!known.has(targetDriver(resolved.resolved))) {
+        failures.push(`${alias} -> ${resolved.resolved} targets an unavailable runtime channel`)
+      }
+    } catch (err) {
+      failures.push(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  if (configuredAlertChannel && configuredAlertChannel !== 'none') {
+    try {
+      resolveChannelRef(configuredAlertChannel, { aliases, knownChannelIds })
+    } catch (err) {
+      failures.push(`Alert channel ${configuredAlertChannel}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  if (failures.length > 0) return [warn(failures.join('; '))]
+  const aliasCount = Object.keys(aliases).length
+  if (aliasCount === 0) return [ok('No channel aliases configured')]
+  return [ok(`${aliasCount} channel alias${aliasCount === 1 ? '' : 'es'} valid for runtime channels: ${knownChannelIds.join(', ') || 'none'}`)]
+}

--- a/scripts/lib/generate-image.ts
+++ b/scripts/lib/generate-image.ts
@@ -46,6 +46,9 @@ interface RuntimeSkillConfig {
   skills?: {
     entries?: Record<string, { apiKey?: unknown; env?: { GEMINI_API_KEY?: unknown } }>
   }
+  models?: {
+    providers?: Record<string, { apiKey?: unknown; env?: { GEMINI_API_KEY?: unknown; GOOGLE_AI_API_KEY?: unknown } }>
+  }
 }
 
 async function getApiKey(): Promise<string | null> {
@@ -59,6 +62,10 @@ async function getApiKey(): Promise<string | null> {
     const skill = config?.skills?.entries?.['nano-banana-pro']
     if (typeof skill?.apiKey === 'string') return skill.apiKey
     if (typeof skill?.env?.GEMINI_API_KEY === 'string') return skill.env.GEMINI_API_KEY
+    const google = config?.models?.providers?.google
+    if (typeof google?.apiKey === 'string') return google.apiKey
+    if (typeof google?.env?.GEMINI_API_KEY === 'string') return google.env.GEMINI_API_KEY
+    if (typeof google?.env?.GOOGLE_AI_API_KEY === 'string') return google.env.GOOGLE_AI_API_KEY
     return null
   } catch {
     return null
@@ -255,7 +262,7 @@ export async function generateImage(params: GenImageParams): Promise<ExecToolRes
 
   const apiKey = await getApiKey()
   if (!apiKey) {
-    return fail('No Gemini API key found. Set GEMINI_API_KEY env var or configure the runtime skill entry')
+    return fail('No Gemini API key found. Set GEMINI_API_KEY env var or configure the runtime Google model provider')
   }
 
   // Resolve dimensions

--- a/scripts/lib/post-channel.ts
+++ b/scripts/lib/post-channel.ts
@@ -6,6 +6,7 @@ import { existsSync } from 'fs'
 import { basename, join } from 'path'
 import { getContentDir } from '@/core/content-dir'
 import { getAppServices } from '@/core/app-services'
+import { resolveRuntimeChannelRef } from '@/core/channel-aliases'
 import { assertWorkflowToolAllowed } from '@/core/workflow-tool-authorization'
 import { pathForFilename } from '@bakin/assets/lib/path-for-filename'
 import { succeed, fail } from './common'
@@ -55,7 +56,15 @@ export async function postChannel(
   }
 
   const requestedChannel = params.channel
-  const channel = normalizeChannelTarget(isTestMode() ? TEST_CHANNEL : requestedChannel)
+  let channel: string
+  try {
+    channel = (await resolveRuntimeChannelRef(
+      runtime,
+      normalizeChannelTarget(isTestMode() ? TEST_CHANNEL : requestedChannel),
+    )).resolved
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err))
+  }
   const { content, imageFilename, videoFilename, embed, taskId } = params
 
   const files = [
@@ -75,6 +84,7 @@ export async function postChannel(
           taskId,
           embed,
           requestedChannel,
+          resolvedChannel: channel,
           ...(isTestMode() && channel !== normalizeChannelTarget(requestedChannel) ? { testMode: true } : {}),
         },
       },

--- a/src/core/channel-aliases.ts
+++ b/src/core/channel-aliases.ts
@@ -1,0 +1,105 @@
+import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
+import { getSettings } from './settings'
+
+export interface ChannelAliasResolution {
+  requested: string
+  normalized: string
+  resolved: string
+  aliasUsed?: string
+}
+
+interface ResolveChannelOptions {
+  aliases?: Record<string, string>
+  knownChannelIds?: Iterable<string>
+  allowUnknownBare?: boolean
+}
+
+function normalizeChannelName(channel: string): string {
+  return channel.trim().replace(/^#/, '')
+}
+
+export function readConfiguredChannelAliases(): Record<string, string> {
+  const notifications = getSettings().notifications as {
+    channel?: unknown
+    target?: unknown
+    channelAliases?: unknown
+  }
+  const raw = notifications.channelAliases
+  const aliases: Record<string, string> = {}
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+      const normalizedKey = normalizeChannelName(key)
+      if (!normalizedKey || typeof value !== 'string') continue
+      const normalizedValue = normalizeChannelName(value)
+      if (normalizedValue) aliases[normalizedKey] = normalizedValue
+    }
+  }
+  if (!aliases.general) {
+    const channel = typeof notifications.channel === 'string' ? normalizeChannelName(notifications.channel) : ''
+    const target = typeof notifications.target === 'string' ? normalizeChannelName(notifications.target) : ''
+    if (channel && channel !== 'none') {
+      if (channel.includes(':')) aliases.general = channel
+      else if (target) aliases.general = target.startsWith(`${channel}:`) ? target : `${channel}:${target}`
+    }
+  }
+  return aliases
+}
+
+function resolveAliasTarget(
+  channel: string,
+  aliases: Record<string, string>,
+  seen = new Set<string>(),
+): { target: string; aliasUsed?: string } {
+  const normalized = normalizeChannelName(channel)
+  const target = aliases[normalized]
+  if (!target) return { target: normalized }
+  if (seen.has(normalized)) {
+    throw new Error(`Channel alias cycle detected at "${normalized}"`)
+  }
+  seen.add(normalized)
+  const nested = resolveAliasTarget(target, aliases, seen)
+  return { target: nested.target, aliasUsed: normalized }
+}
+
+export function resolveChannelRef(channel: string, options: ResolveChannelOptions = {}): ChannelAliasResolution {
+  const normalized = normalizeChannelName(channel)
+  if (!normalized) throw new Error('Channel is required')
+
+  const aliases = options.aliases ?? readConfiguredChannelAliases()
+  const known = new Set(Array.from(options.knownChannelIds ?? []).map(normalizeChannelName).filter(Boolean))
+
+  if (normalized.includes(':')) {
+    return { requested: channel, normalized, resolved: normalized }
+  }
+
+  const resolved = resolveAliasTarget(normalized, aliases)
+  if (resolved.aliasUsed) {
+    return {
+      requested: channel,
+      normalized,
+      resolved: resolved.target,
+      aliasUsed: resolved.aliasUsed,
+    }
+  }
+
+  if (known.has(normalized) || options.allowUnknownBare) {
+    return { requested: channel, normalized, resolved: normalized }
+  }
+
+  throw new Error(
+    `No channel alias configured for #${normalized}. Configure notifications.channelAliases.${normalized} with a runtime target such as "discord:<target>", or use a runtime channel id directly.`
+  )
+}
+
+export async function resolveRuntimeChannelRef(
+  runtime: Pick<AgentRuntimeAdapter, 'channels'>,
+  channel: string,
+): Promise<ChannelAliasResolution> {
+  let knownChannelIds: string[] = []
+  try {
+    knownChannelIds = (await runtime.channels.list()).map((entry) => entry.id)
+  } catch {
+    knownChannelIds = []
+  }
+  return resolveChannelRef(channel, { knownChannelIds })
+}

--- a/src/core/onboarding/credentials.ts
+++ b/src/core/onboarding/credentials.ts
@@ -33,6 +33,7 @@ const RUNTIME_DOCS = DEFAULT_RUNTIME_ADAPTER_SUPPORT.docsUrl
  * check for any of them.
  */
 const CHANNEL_CREDENTIAL_FIELDS = ['token', 'apiKey', 'api_key', 'botToken', 'bot_token']
+const LLM_CREDENTIAL_FIELDS = ['apiKey', 'api_key', 'token', 'access', 'refresh']
 
 function hasCredentialField(entry: unknown): boolean {
   if (entry === null || typeof entry !== 'object') return false
@@ -42,6 +43,18 @@ function hasCredentialField(entry: unknown): boolean {
     if (typeof value === 'string' && value.trim().length > 0) return true
   }
   return false
+}
+
+function authProvider(entry: unknown): string | null {
+  if (entry === null || typeof entry !== 'object') return null
+  const obj = entry as Record<string, unknown>
+  const provider = obj.provider
+  if (typeof provider !== 'string' || provider.trim().length === 0) return null
+  for (const field of LLM_CREDENTIAL_FIELDS) {
+    const value = obj[field]
+    if (typeof value === 'string' && value.trim().length > 0) return provider
+  }
+  return null
 }
 
 async function getRuntimeForCredentials(): Promise<AgentRuntimeAdapter> {
@@ -123,14 +136,13 @@ async function checkLlm(): Promise<CheckResult> {
     }
   }
   const providers = entries
-    .filter((p): p is { provider?: string; apiKey?: string } => p !== null && typeof p === 'object')
-    .filter((p) => typeof p.provider === 'string' && typeof p.apiKey === 'string' && p.apiKey.trim().length > 0)
-    .map((p) => p.provider as string)
+    .map(authProvider)
+    .filter((provider): provider is string => provider !== null)
   if (providers.length === 0) {
     return {
       name: 'llm',
       status: 'warn',
-      message: 'No LLM provider in auth profiles has a non-empty apiKey',
+      message: 'No LLM provider in auth profiles has usable API key, token, or OAuth credentials',
       remediation: `Configure at least one LLM provider via the runtime adapter. Docs: ${RUNTIME_DOCS}`,
       details: { configKey, installUrl: RUNTIME_DOCS },
     }
@@ -236,4 +248,4 @@ export const channelsComponent: OnboardingComponent = {
 }
 
 export const RUNTIME_DOCS_URL = RUNTIME_DOCS
-export const _internals = { CHANNEL_CREDENTIAL_FIELDS, hasCredentialField }
+export const _internals = { CHANNEL_CREDENTIAL_FIELDS, LLM_CREDENTIAL_FIELDS, hasCredentialField, authProvider }

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -199,6 +199,16 @@ export async function blockTaskWithEffects(
     meta: { taskId, title, reason },
   })
 
+  try {
+    await getHookRegistry().invoke('workflows.cancelInstance', {
+      taskId,
+      reason: `Task blocked: ${reason}`,
+      actor: { source: agent === 'system' || agent === 'human' ? agent : 'agent', id: agent, displayName: agent },
+    })
+  } catch (err) {
+    log.debug('Could not cancel workflow for blocked task', { taskId, err: err instanceof Error ? err.message : String(err) })
+  }
+
   // Propagate block to parent task for child workflow tasks (e.g., "parentId--stepId")
   const dashIdx = taskId.indexOf('--')
   if (dashIdx > 0) {

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -108,6 +108,42 @@ describe('OpenClaw runtime Gateway chat', () => {
     expect(agentRequest?.params.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
   })
 
+  it('forwards per-turn tool policy on messaging sends', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await runtime.messaging.send({
+      agentId: 'pixel',
+      content: 'Plan without tools.',
+      toolsMode: 'none',
+      toolsAllow: ['message_send', 'message_send', ' '],
+      toolsDeny: ['schedule_create'],
+    })
+
+    const ws = FakeWebSocket.instances[0]!
+    const agentRequest = ws.sentFrames.find(frame => frame.method === 'agent')
+    expect(agentRequest?.params).toMatchObject({
+      toolsMode: 'none',
+      toolsAllow: ['message_send'],
+      toolsDeny: ['schedule_create'],
+    })
+  })
+
+  it('forwards per-turn tool policy on messaging streams', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    await collect(runtime.messaging.stream({
+      agentId: 'pixel',
+      content: 'Stream without tools.',
+      toolsMode: 'none',
+    }))
+
+    const ws = FakeWebSocket.instances[0]!
+    const agentRequest = ws.sentFrames.find(frame => frame.method === 'agent')
+    expect(agentRequest?.params).toMatchObject({ toolsMode: 'none' })
+  })
+
   it('waits for the Gateway final response after the accepted ack', async () => {
     let finalEmitted = false
     FakeWebSocket.onRequest = (frame, ws) => {

--- a/tests/core/onboarding/credentials.test.ts
+++ b/tests/core/onboarding/credentials.test.ts
@@ -104,10 +104,10 @@ describe('onboarding credentials component', () => {
       expect(result.message).toContain('no provider entries')
     })
 
-    it('reports warn when all entries have empty apiKeys', async () => {
+    it('reports warn when all entries have empty credentials', async () => {
       writeFileSync(authProfilesPath(), JSON.stringify([
         { provider: 'anthropic', apiKey: '' },
-        { provider: 'openai', apiKey: '   ' },
+        { provider: 'openai', apiKey: '   ', token: '', access: '' },
       ]))
       const result = await llmComponent.check()
       expect(result.status).toBe('warn')
@@ -121,6 +121,25 @@ describe('onboarding credentials component', () => {
       const result = await llmComponent.check()
       expect(result.status).toBe('ok')
       expect(result.details?.providers).toEqual(['anthropic'])
+    })
+
+    it('reports ok from token auth profiles', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify([
+        { provider: 'anthropic', type: 'token', token: 'anthropic-token' },
+      ]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.details?.providers).toEqual(['anthropic'])
+    })
+
+    it('reports ok from Codex OAuth auth profiles', async () => {
+      writeFileSync(authProfilesPath(), JSON.stringify([
+        { provider: 'openai-codex', type: 'oauth', access: 'access-token', refresh: 'refresh-token' },
+      ]))
+      const result = await llmComponent.check()
+      expect(result.status).toBe('ok')
+      expect(result.message).toContain('openai-codex')
+      expect(result.details?.providers).toEqual(['openai-codex'])
     })
 
     it('reports ok from { profiles: [...] } shape', async () => {
@@ -139,12 +158,12 @@ describe('onboarding credentials component', () => {
       writeFileSync(authProfilesPath(), JSON.stringify({
         profiles: {
           'default-anthropic': { provider: 'anthropic', apiKey: 'sk-ant-dict' },
-          'codex-oauth': { provider: 'openai-codex', mode: 'oauth' },
+          'codex-oauth': { provider: 'openai-codex', mode: 'oauth', access: 'access-token' },
         },
       }))
       const result = await llmComponent.check()
       expect(result.status).toBe('ok')
-      expect(result.details?.providers).toEqual(['anthropic'])
+      expect(result.details?.providers).toEqual(['anthropic', 'openai-codex'])
     })
 
     it('reports ok with multiple providers when several are configured', async () => {

--- a/tests/core/task-service.test.ts
+++ b/tests/core/task-service.test.ts
@@ -89,10 +89,12 @@ mock.module('../../src/core/task-store', () => taskStoreMock)
 
 const mockLoadInstance = mock((..._args: unknown[]) => null)
 const mockCreateInstance = mock((..._args: unknown[]) => undefined)
+const mockCancelWorkflowInstance = mock((..._args: unknown[]) => undefined)
 
 mock.module('@bakin/workflows/lib/runtime', () => ({
   createInstance: (...args: unknown[]) => mockCreateInstance(...args),
   loadInstance: (...args: unknown[]) => mockLoadInstance(...args),
+  cancelInstance: (...args: unknown[]) => mockCancelWorkflowInstance(...args),
 }))
 
 mock.module('@bakin/workflows/lib/matcher', () => ({
@@ -113,6 +115,7 @@ const hookHandlers: Record<string, (...args: unknown[]) => unknown> = {
   'workflows.matchWorkflow': () => null,
   'workflows.loadDefinition': (data: any) => mockLoadDefinition(data),
   'workflows.definitions.list': () => mockListDefinitions(),
+  'workflows.cancelInstance': (data: any) => mockCancelWorkflowInstance(data),
 }
 
 const mockHookRegistry = {
@@ -265,6 +268,18 @@ describe('task-service', () => {
         expect.objectContaining({ id: 'task-1', reason: 'API key expired' }),
         undefined,
       )
+    })
+
+    it('cancels active workflow instance when blocking a workflow-backed task', async () => {
+      mockLoadInstance.mockReturnValueOnce({ status: 'in_progress' } as any)
+
+      await service.blockTaskWithEffects('task-1', 'Image provider unavailable', 'pixel')
+
+      expect(mockCancelWorkflowInstance).toHaveBeenCalledWith({
+        taskId: 'task-1',
+        reason: 'Task blocked: Image provider unavailable',
+        actor: { source: 'agent', id: 'pixel', displayName: 'pixel' },
+      })
     })
   })
 

--- a/tests/core/watchdog.test.ts
+++ b/tests/core/watchdog.test.ts
@@ -38,7 +38,7 @@ mock.module('../../src/core/settings', () => ({
       stepTimeoutMs: 60 * 60 * 1000,
       maxRedispatches: 3,
     },
-    notifications: { channel: '', gateAlerts: true },
+    notifications: { channel: '', target: '', gateAlerts: true, channelAliases: {} },
   }),
 }))
 

--- a/tests/plugins/health/system-checks.test.ts
+++ b/tests/plugins/health/system-checks.test.ts
@@ -53,6 +53,9 @@ mock.module('../../../packages/adapter-openclaw/src/home', () => ({
 }))
 
 let mockServiceEnabled = false
+let mockNotificationChannel = ''
+let mockNotificationTarget = ''
+let mockChannelAliases: Record<string, string> = {}
 
 let mockMcporterInstalled = true
 let mockInstallMcporterReturn = true
@@ -98,6 +101,12 @@ mock.module('../../../src/core/settings', () => ({
   getSettings: () => ({
     service: { enabled: mockServiceEnabled },
     search: { adapter: 'antfly', settings: { enabled: mockSearchEnabled, url: mockSearchUrl } },
+    notifications: {
+      channel: mockNotificationChannel,
+      target: mockNotificationTarget,
+      gateAlerts: true,
+      channelAliases: mockChannelAliases,
+    },
   }),
   resetSettingsCache: () => {},
 }))
@@ -139,6 +148,7 @@ import { checkService } from '../../../plugins/health/lib/system-checks/service'
 import { checkMcporter, mcporterRepair } from '../../../plugins/health/lib/system-checks/mcporter'
 import { checkRuntime } from '../../../plugins/health/lib/system-checks/runtime'
 import { checkChannelApprovals } from '../../../plugins/health/lib/system-checks/channel-approvals'
+import { checkChannelAliases } from '../../../plugins/health/lib/system-checks/channel-aliases'
 import { checkSearchAdapter } from '../../../plugins/health/lib/system-checks/search'
 import { checkAndSyncSkill, syncSkillRepair } from '../../../plugins/health/lib/system-checks/sync-skill'
 import { checkPluginAssets } from '../../../plugins/health/lib/system-checks/plugin-assets'
@@ -176,6 +186,9 @@ beforeEach(() => {
   mockUsingBakinHome = true
   mockContentDir = testDir
   mockServiceEnabled = false
+  mockNotificationChannel = ''
+  mockNotificationTarget = ''
+  mockChannelAliases = {}
   mockMcporterInstalled = true
   mockInstallMcporterReturn = true
   mockAgentEntries = []
@@ -400,6 +413,81 @@ describe('checkChannelApprovals', () => {
   })
 })
 
+// ─── checkChannelAliases ─────────────────────────────────────────────────
+
+describe('checkChannelAliases', () => {
+  it('reports ok when no aliases are configured', async () => {
+    mockRuntime.channels.list = async () => [{
+      id: 'discord',
+      platform: 'discord',
+      label: 'Discord',
+      capabilities: ['message'],
+    }]
+
+    const results = await checkChannelAliases(mockRuntime)
+    expect(results).toHaveLength(1)
+    expect(results[0].status).toBe('ok')
+    expect(results[0].message).toContain('No channel aliases')
+  })
+
+  it('reports ok when aliases target available runtime channels', async () => {
+    mockChannelAliases = { general: 'discord:channel-123' }
+    mockRuntime.channels.list = async () => [{
+      id: 'discord',
+      platform: 'discord',
+      label: 'Discord',
+      capabilities: ['message'],
+    }]
+
+    const results = await checkChannelAliases(mockRuntime)
+    expect(results[0].status).toBe('ok')
+    expect(results[0].message).toContain('1 channel alias')
+  })
+
+  it('warns when an alias targets an unavailable runtime channel', async () => {
+    mockChannelAliases = { general: 'slack:channel-123' }
+    mockRuntime.channels.list = async () => [{
+      id: 'discord',
+      platform: 'discord',
+      label: 'Discord',
+      capabilities: ['message'],
+    }]
+
+    const results = await checkChannelAliases(mockRuntime)
+    expect(results[0].status).toBe('warn')
+    expect(results[0].message).toContain('unavailable runtime channel')
+  })
+
+  it('reports ok when a legacy notification target supplies the general alias', async () => {
+    mockNotificationChannel = 'discord'
+    mockNotificationTarget = 'channel-123'
+    mockRuntime.channels.list = async () => [{
+      id: 'discord',
+      platform: 'discord',
+      label: 'Discord',
+      capabilities: ['message'],
+    }]
+
+    const results = await checkChannelAliases(mockRuntime)
+    expect(results[0].status).toBe('ok')
+    expect(results[0].message).toContain('1 channel alias')
+  })
+
+  it('warns when the configured alert channel is a missing alias', async () => {
+    mockNotificationChannel = 'general'
+    mockRuntime.channels.list = async () => [{
+      id: 'discord',
+      platform: 'discord',
+      label: 'Discord',
+      capabilities: ['message'],
+    }]
+
+    const results = await checkChannelAliases(mockRuntime)
+    expect(results[0].status).toBe('warn')
+    expect(results[0].message).toContain('notifications.channelAliases.general')
+  })
+})
+
 // ─── checkSearchAdapter ───────────────────────────────────────────────────
 
 describe('checkSearchAdapter', () => {
@@ -538,7 +626,7 @@ describe('checkPluginAssets', () => {
 // ─── Registration smoke test ──────────────────────────────────────────────
 
 describe('plugin registration', () => {
-  it('registers all 12 system + managed-blocks health checks on activate', async () => {
+  it('registers all 13 system + managed-blocks health checks on activate', async () => {
     const healthPlugin = (await import('../../../plugins/health')).default
     const registeredIds: string[] = []
     const noop = mock()
@@ -565,12 +653,13 @@ describe('plugin registration', () => {
     }
     await healthPlugin.activate(ctx as unknown as Parameters<typeof healthPlugin.activate>[0])
 
-    // 12 health checks: 10 health-owned checks plus the 2 core managed-block scopes.
+    // 13 health checks: 11 health-owned checks plus the 2 core managed-block scopes.
     expect(registeredIds).toContain('content-dir')
     expect(registeredIds).toContain('service')
     expect(registeredIds).toContain('mcporter')
     expect(registeredIds).toContain('runtime')
     expect(registeredIds).toContain('channel-approvals')
+    expect(registeredIds).toContain('channel-aliases')
     expect(registeredIds).toContain('restart-recovery')
     expect(registeredIds).toContain('search')
     expect(registeredIds).toContain('orchestrator-rules')

--- a/tests/scripts/generate-image.test.ts
+++ b/tests/scripts/generate-image.test.ts
@@ -228,6 +228,43 @@ describe('generateImage', () => {
     )
   })
 
+  it('reads Gemini API key from runtime Google provider config', async () => {
+    delete process.env.GEMINI_API_KEY
+    delete process.env.GOOGLE_AI_API_KEY
+    mockRuntimeConfig = {
+      models: {
+        providers: {
+          google: {
+            apiKey: 'provider-key-123',
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          imageGenerationModel: {
+            primary: 'google/gemini-3-pro-image-preview',
+          },
+        },
+      },
+    }
+
+    spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
+    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
+
+    const result = await generateImage({
+      prompt: 'test',
+      taskId: 'task-google-provider',
+      agent: 'pixel',
+      thumbnail: false,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('key=provider-key-123'),
+      expect.anything(),
+    )
+  })
+
   it('returns fail when Gemini API returns error', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,

--- a/tests/scripts/post-channel.test.ts
+++ b/tests/scripts/post-channel.test.ts
@@ -19,6 +19,22 @@ const contentDirMock = {
 mock.module('../../src/core/content-dir', () => contentDirMock)
 mock.module('@/core/content-dir', () => contentDirMock)
 
+let mockChannelAliases: Record<string, string> = {}
+let mockNotificationChannel = ''
+let mockNotificationTarget = ''
+const settingsMock = {
+  getSettings: () => ({
+    notifications: {
+      channel: mockNotificationChannel,
+      target: mockNotificationTarget,
+      gateAlerts: true,
+      channelAliases: mockChannelAliases,
+    },
+  }),
+}
+mock.module('@/core/settings', () => settingsMock)
+mock.module('../../src/core/settings', () => settingsMock)
+
 let mockWorkflowAuthorizationError: Error | null = null
 const mockAssertWorkflowToolAllowed = mock(async (..._args: unknown[]) => {
   if (mockWorkflowAuthorizationError) throw mockWorkflowAuthorizationError
@@ -35,16 +51,21 @@ import { postChannel } from '../../scripts/lib/post-channel'
 describe('postChannel', () => {
   const originalEnv = { ...process.env }
   const deliverContent = mock(async () => ({
-    deliveries: [{ channelId: 'general', ref: 'message:1', renderedAt: '2026-04-11T10:00:00Z' }],
+    deliveries: [{ channelId: 'discord:channel-123', ref: 'message:1', renderedAt: '2026-04-11T10:00:00Z' }],
   }))
+  const listChannels = mock(async () => [{ id: 'discord', label: 'Discord', capabilities: ['message'] }])
   const runtime = {
-    channels: { deliverContent },
+    channels: { deliverContent, list: listChannels },
   } as unknown as AgentRuntimeAdapter
 
   beforeEach(() => {
     deliverContent.mockClear()
+    listChannels.mockClear()
     mockAssertWorkflowToolAllowed.mockClear()
     mockWorkflowAuthorizationError = null
+    mockNotificationChannel = ''
+    mockNotificationTarget = ''
+    mockChannelAliases = { general: 'discord:channel-123', 'testing-ground': 'discord:test-channel' }
     mockContentDir = tmpdir()
   })
 
@@ -62,12 +83,12 @@ describe('postChannel', () => {
     }, runtime)
 
     expect(result.ok).toBe(true)
-    expect(result.channel).toBe('#general')
+    expect(result.channel).toBe('discord:channel-123')
     expect(result.taskId).toBe('task-123')
     expect(deliverContent).toHaveBeenCalledTimes(1)
     const [call] = deliverContent.mock.calls[0] as unknown as [Record<string, unknown>]
     expect(call).toEqual({
-      channels: ['general'],
+      channels: ['discord:channel-123'],
       content: {
         title: 'Channel post',
         body: 'test message',
@@ -77,9 +98,57 @@ describe('postChannel', () => {
           taskId: 'task-123',
           embed: undefined,
           requestedChannel: '#general',
+          resolvedChannel: 'discord:channel-123',
         },
       },
     })
+  })
+
+  it('fails before runtime delivery when a bare channel has no alias or runtime channel match', async () => {
+    mockChannelAliases = {}
+
+    const result = await postChannel({
+      channel: '#general',
+      content: 'test message',
+      agent: 'chef',
+      taskId: 'task-123',
+    }, runtime)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('No channel alias configured for #general')
+    expect(result.error).toContain('notifications.channelAliases.general')
+    expect(deliverContent).not.toHaveBeenCalled()
+  })
+
+  it('allows direct runtime channel ids without aliases', async () => {
+    mockChannelAliases = {}
+
+    const result = await postChannel({
+      channel: 'discord',
+      content: 'test message',
+      agent: 'chef',
+    }, runtime)
+
+    expect(result.ok).toBe(true)
+    const [call] = deliverContent.mock.calls[0] as unknown as [Record<string, unknown>]
+    expect(call.channels).toEqual(['discord'])
+  })
+
+  it('uses the legacy notification target as the default general alias', async () => {
+    mockChannelAliases = {}
+    mockNotificationChannel = 'discord'
+    mockNotificationTarget = 'channel-123'
+
+    const result = await postChannel({
+      channel: '#general',
+      content: 'test message',
+      agent: 'chef',
+    }, runtime)
+
+    expect(result.ok).toBe(true)
+    expect(result.channel).toBe('discord:channel-123')
+    const [call] = deliverContent.mock.calls[0] as unknown as [Record<string, unknown>]
+    expect(call.channels).toEqual(['discord:channel-123'])
   })
 
   it('returns a failed exec result when runtime delivery fails', async () => {
@@ -154,10 +223,10 @@ describe('postChannel', () => {
     }, runtime)
 
     expect(result.ok).toBe(true)
-    expect(result.channel).toBe('#testing-ground')
+    expect(result.channel).toBe('discord:test-channel')
     expect(result.testMode).toBe(true)
     expect(result.requestedChannel).toBe('#general')
     const [call] = deliverContent.mock.calls[0] as unknown as [Record<string, unknown> & { channels: unknown }]
-    expect(call.channels).toEqual(['testing-ground'])
+    expect(call.channels).toEqual(['discord:test-channel'])
   })
 })


### PR DESCRIPTION
## Summary

- fix LLM onboarding auth detection for token/OAuth profiles and update warning copy so it does not imply only `apiKey` works
- resolve Gemini image credentials from runtime Google model provider config while preserving env and legacy skill config paths
- add explicit channel alias resolution for logical refs like `#general`, including legacy `notifications.channel` + `notifications.target` compatibility for the default `general` alias
- add a `channel-aliases` health check to validate runtime channel routing without sending messages
- cancel active workflow instances when workflow-backed tasks are explicitly blocked
- add adapter-neutral runtime messaging tool policy (`toolsMode`, `toolsAllow`, `toolsDeny`) and forward it through the OpenClaw adapter
- document the permission/capability layers from the kickoff audit

## Related

- Fixes #296
- Addresses #266
- Follow-up extraction of image generation into an official plugin: #338

## Verification

Automated:

```sh
bun test --isolate tests/core/onboarding/credentials.test.ts tests/scripts/generate-image.test.ts tests/scripts/post-channel.test.ts tests/core/task-service.test.ts tests/plugins/health/system-checks.test.ts tests/adapter-openclaw/runtime-stream.test.ts tests/core/watchdog.test.ts tests/dev/mock-runtime-contract.test.ts tests/architecture/adapter-boundary.test.ts
bun run typecheck
bun run lint
```

Manual:

- `bakin doctor --full` passed
- `mcporter` image generation smoke passed
- `mcporter` channel routing smoke passed

## Notes

This PR intentionally keeps `bakin_exec_gen_image` in core for now. The plugin extraction is tracked separately in #338 and is not part of this permissions/capabilities hardening work.