### PR TITLE
Harden image asset handoff

### DIFF
--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -39,6 +39,27 @@ function filenameFromRel(relPath: string): string {
   return relPath.split('/').pop() || ''
 }
 
+function existingManagedAssetResult(filePath: string): { path: string; metadataPath: string; filename: string; alreadyManaged: true } | null {
+  const contentDir = getContentDir()
+  const normalizedInput = filePath.trim()
+  if (!normalizedInput) return null
+  const contentPrefix = `${contentDir}/`
+  const relPath = normalizedInput.startsWith(contentPrefix)
+    ? normalizedInput.slice(contentPrefix.length)
+    : normalizedInput
+  if (!relPath.startsWith('assets/store/')) return null
+  const filename = filenameFromRel(relPath)
+  if (!filename || !isSafeCanonicalFilename(filename)) return null
+  if (pathForFilename(filename) !== relPath) return null
+  if (!existsSync(join(contentDir, relPath))) return null
+  return {
+    path: relPath,
+    metadataPath: `${relPath}.meta.json`,
+    filename,
+    alreadyManaged: true,
+  }
+}
+
 const log = createLogger('assets')
 
 // ─── Module-scope plugin ctx (set during activate) ──────────────────────
@@ -704,7 +725,7 @@ const assetsPlugin: BakinPlugin = definePlugin({
       label: 'Saved an asset',
       description: 'Save an agent-created file to the assets directory with standardized naming (YYYYMMDD-slug.ext) and sidecar metadata. Handles directory creation, naming conventions, and .meta.json automatically.',
       parameters: {
-        filePath: z.string().describe('Absolute path to the source file to save'),
+        filePath: z.string().describe('Absolute path to the source file to save, or an existing managed assets/store/... path to return idempotently'),
         taskId: z.string().describe('Task ID to record in sidecar metadata'),
         type: z.enum(ASSET_TYPES).describe(TYPE_RUBRIC),
         description: z.string().optional().describe('One-sentence summary visible in the asset grid and search. Be specific — "Q2 blog hero image" not "an image".'),
@@ -713,6 +734,12 @@ const assetsPlugin: BakinPlugin = definePlugin({
         slug: z.string().optional().describe('Custom filename slug. Auto-derived from source filename if omitted.'),
       },
       handler: async (params: Record<string, unknown>, agent: string) => {
+        const filePath = typeof params.filePath === 'string' ? params.filePath : ''
+        const existing = existingManagedAssetResult(filePath)
+        if (existing) {
+          indexAsset(existing.path).catch(() => {})
+          return { ok: true, ...existing }
+        }
         const result = await saveAsset({ ...params, agent } as Parameters<typeof saveAsset>[0])
         if (result.ok && result.path) indexAsset(result.path as string).catch(() => {})
         return result

--- a/scripts/lib/generate-image.ts
+++ b/scripts/lib/generate-image.ts
@@ -218,15 +218,20 @@ export async function generateImage(params: GenImageParams): Promise<ExecToolRes
     const description = prompt || basename(filePath)
     const dims = probeImageDimensions(filePath)
 
-    const assetResult = await saveAsset({
-      filePath,
-      taskId,
-      agent,
-      type: 'images',
-      tool: 'raw-import',
-      description: description.slice(0, 200),
-      tags: ['imported'],
-    })
+    let assetResult
+    try {
+      assetResult = await saveAsset({
+        filePath,
+        taskId,
+        agent,
+        type: 'images',
+        tool: 'raw-import',
+        description: description.slice(0, 200),
+        tags: ['imported'],
+      })
+    } catch (err) {
+      return fail(`Asset save failed: ${String(err)}`)
+    }
 
     if (!assetResult.ok) {
       return fail(`Asset save failed: ${assetResult.error}`)
@@ -246,6 +251,8 @@ export async function generateImage(params: GenImageParams): Promise<ExecToolRes
     return succeed({
       path: assetResult.path,
       metadataPath: assetResult.metadataPath,
+      filename: assetResult.filename,
+      image_filename: assetResult.filename,
       thumbnailPath,
       width: dims?.width ?? 0,
       height: dims?.height ?? 0,
@@ -282,15 +289,20 @@ export async function generateImage(params: GenImageParams): Promise<ExecToolRes
 
   // Save via standard asset pipeline
   const modelName = GEMINI_MODELS[model]
-  const assetResult = await saveAsset({
-    filePath: generated.filePath,
-    taskId,
-    agent,
-    type: 'images',
-    tool: modelName,
-    description: prompt.slice(0, 200),
-    tags: [preset !== 'custom' ? preset : `${width}x${height}`, model],
-  })
+  let assetResult
+  try {
+    assetResult = await saveAsset({
+      filePath: generated.filePath,
+      taskId,
+      agent,
+      type: 'images',
+      tool: modelName,
+      description: prompt.slice(0, 200),
+      tags: [preset !== 'custom' ? preset : `${width}x${height}`, model],
+    })
+  } catch (err) {
+    return fail(`Image generated but asset save failed: ${String(err)}`)
+  }
 
   if (!assetResult.ok) {
     return fail(`Image generated but asset save failed: ${assetResult.error}`)
@@ -311,6 +323,8 @@ export async function generateImage(params: GenImageParams): Promise<ExecToolRes
   return succeed({
     path: assetResult.path,
     metadataPath: assetResult.metadataPath,
+    filename: assetResult.filename,
+    image_filename: assetResult.filename,
     thumbnailPath,
     width,
     height,

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -908,6 +908,54 @@ describe('exec tool: bakin_exec_assets_save', () => {
     expect(result.error).toMatch(/not found/i)
   })
 
+  it('returns an existing managed asset instead of re-saving it', async () => {
+    const filename = '20260521-existing-image-a1b2c3d4.jpg'
+    const relPath = `assets/store/2026-05/${filename}`
+    const fullPath = join(testDir, relPath)
+    mkdirSync(join(testDir, 'assets', 'store', '2026-05'), { recursive: true })
+    writeFileSync(fullPath, 'already-managed-image')
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_save')!
+    const result = await callTool(tool, {
+      filePath: relPath,
+      taskId: 'task-managed',
+      type: 'images',
+      description: 'Should not duplicate',
+    }, 'pixel')
+
+    expect(result).toMatchObject({
+      ok: true,
+      path: relPath,
+      metadataPath: `${relPath}.meta.json`,
+      filename,
+      alreadyManaged: true,
+    })
+  })
+
+  it('returns an existing managed asset from an absolute Bakin path instead of re-saving it', async () => {
+    const filename = '20260521-absolute-image-a1b2c3d4.jpg'
+    const relPath = `assets/store/2026-05/${filename}`
+    const fullPath = join(testDir, relPath)
+    mkdirSync(join(testDir, 'assets', 'store', '2026-05'), { recursive: true })
+    writeFileSync(fullPath, 'already-managed-image')
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_save')!
+    const result = await callTool(tool, {
+      filePath: fullPath,
+      taskId: 'task-managed',
+      type: 'images',
+      description: 'Should not duplicate',
+    }, 'pixel')
+
+    expect(result).toMatchObject({
+      ok: true,
+      path: relPath,
+      metadataPath: `${relPath}.meta.json`,
+      filename,
+      alreadyManaged: true,
+    })
+  })
+
   it('logs activity on successful save', async () => {
     const sourceFile = join(testDir, 'activity-test.txt')
     writeFileSync(sourceFile, 'activity test')

--- a/tests/scripts/generate-image.test.ts
+++ b/tests/scripts/generate-image.test.ts
@@ -1,12 +1,15 @@
-import { describe, it, expect, beforeEach, mock, spyOn, type Mock } from 'bun:test'
+import { describe, it, expect, beforeEach, afterAll, mock, spyOn } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { basename, join } from 'path'
+import { resetContentDir } from '../../src/core/content-dir'
 
-(() => {
-  const { mkdtempSync } = require('fs')
-  const { tmpdir } = require('os')
-  const { join } = require('path')
-  process.env.BAKIN_HOME = mkdtempSync(join(tmpdir(), 'bakin-test-home-'))
-  process.env.OPENCLAW_HOME = mkdtempSync(join(tmpdir(), 'bakin-test-openclaw-'))
-})()
+const originalBakinHome = process.env.BAKIN_HOME
+const originalOpenclawHome = process.env.OPENCLAW_HOME
+const testBakinHome = mkdtempSync(join(tmpdir(), 'bakin-test-home-'))
+const testOpenclawHome = mkdtempSync(join(tmpdir(), 'bakin-test-openclaw-'))
+process.env.BAKIN_HOME = testBakinHome
+process.env.OPENCLAW_HOME = testOpenclawHome
 
 mock.module('@bakin/core/main-agent', () => ({
   getMainAgentId: () => 'main',
@@ -14,28 +17,8 @@ mock.module('@bakin/core/main-agent', () => ({
   getMainAgentName: () => 'Main',
 }))
 
-mock.module('../../src/core/content-dir', () => ({
-  getContentDir: mock(() => '/tmp/bakin-test'),
-  getBakinPaths: mock(() => ({
-    home: '/tmp/bakin-test',
-    assets: '/tmp/bakin-test/assets',
-    'assets.store': '/tmp/bakin-test/assets/store',
-  isUsingBakinHome: () => true,
-  resetContentDir: () => {},
-  initBakinHome: () => {},
-})),
-}))
-
 mock.module('../../scripts/lib/registry', () => ({
   addExecTool: mock(),
-}))
-
-mock.module('../../plugins/assets/lib/save-asset', () => ({
-  saveAsset: mock(),
-}))
-
-mock.module('child_process', () => ({
-  execFileSync: mock(() => Buffer.from('1080,1920')),
 }))
 
 let mockRuntimeConfig: Record<string, unknown> = {}
@@ -49,16 +32,6 @@ mock.module('../../src/core/app-services', () => ({
     },
   }),
 }))
-
-mock.module('fs', () => {
-  const actual = require('fs') as Record<string, unknown>
-  return {
-    ...actual,
-    existsSync: mock(() => true),
-    mkdirSync: mock(),
-    writeFileSync: mock(),
-  }
-})
 
 // Mock fetch for Gemini API calls
 const mockFetchResponse = (imageData = 'fakebase64data') => ({
@@ -75,28 +48,30 @@ const mockFetchResponse = (imageData = 'fakebase64data') => ({
 }) as unknown as Response
 
 import { generateImage } from '../../scripts/lib/generate-image'
-import { saveAsset } from '../../plugins/assets/lib/save-asset'
-import { existsSync } from 'fs'
-import { execFileSync } from 'child_process'
-
-const mockSaveAsset = vi.mocked(saveAsset)
 
 describe('generateImage', () => {
+  afterAll(() => {
+    if (originalBakinHome === undefined) delete process.env.BAKIN_HOME
+    else process.env.BAKIN_HOME = originalBakinHome
+    if (originalOpenclawHome === undefined) delete process.env.OPENCLAW_HOME
+    else process.env.OPENCLAW_HOME = originalOpenclawHome
+    rmSync(testBakinHome, { recursive: true, force: true })
+    rmSync(testOpenclawHome, { recursive: true, force: true })
+    resetContentDir()
+  })
+
   beforeEach(() => {
     mock.clearAllMocks()
     mockRuntimeConfig = {}
+    process.env.BAKIN_HOME = testBakinHome
+    process.env.OPENCLAW_HOME = testOpenclawHome
+    resetContentDir()
     // Set API key for tests
     process.env.GEMINI_API_KEY = 'test-key-123'
   })
 
   it('calls Gemini API and saves asset on success', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({
-      ok: true,
-      path: 'assets/images/task-123/20260326-test.jpg',
-      metadataPath: 'assets/images/task-123/20260326-test.jpg.meta.json',
-      filename: '20260326-test.jpg',
-    })
 
     const result = await generateImage({
       prompt: 'Golden hour smoothie',
@@ -111,13 +86,10 @@ describe('generateImage', () => {
     expect(result.height).toBe(1920)
     expect(result.preset).toBe('social-portrait')
     expect(result.model).toContain('flash')
-    expect(mockSaveAsset).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: 'task-123',
-        type: 'images',
-        tool: 'gemini-3.1-flash-image-preview',
-      }),
-    )
+    expect(result.path).toContain('assets/store/')
+    expect(result.metadataPath).toBe(`${result.path}.meta.json`)
+    expect(result.filename).toBe(basename(result.path as string))
+    expect(result.image_filename).toBe(result.filename)
     // Verify Gemini API was called with flash model
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('gemini-3.1-flash-image-preview'),
@@ -127,7 +99,6 @@ describe('generateImage', () => {
 
   it('uses pro model when specified', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
 
     const result = await generateImage({
       prompt: 'test',
@@ -138,6 +109,8 @@ describe('generateImage', () => {
     })
 
     expect(result.ok).toBe(true)
+    expect(result.filename).toBeDefined()
+    expect(result.image_filename).toBe(result.filename)
     expect(result.model).toContain('pro')
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining('gemini-3-pro-image-preview'),
@@ -147,7 +120,6 @@ describe('generateImage', () => {
 
   it('uses social-square preset dimensions', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
 
     const result = await generateImage({
       prompt: 'test',
@@ -158,13 +130,14 @@ describe('generateImage', () => {
     })
 
     expect(result.ok).toBe(true)
+    expect(result.filename).toBeDefined()
+    expect(result.image_filename).toBe(result.filename)
     expect(result.width).toBe(1080)
     expect(result.height).toBe(1080)
   })
 
   it('caps custom dimensions at MAX_IMAGE_EDGE', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
 
     const result = await generateImage({
       prompt: 'test',
@@ -177,6 +150,8 @@ describe('generateImage', () => {
     })
 
     expect(result.ok).toBe(true)
+    expect(result.filename).toBeDefined()
+    expect(result.image_filename).toBe(result.filename)
     expect(result.width).toBe(1200)
     expect(result.height).toBe(1200)
   })
@@ -212,7 +187,6 @@ describe('generateImage', () => {
     }
 
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
 
     const result = await generateImage({
       prompt: 'test',
@@ -249,7 +223,6 @@ describe('generateImage', () => {
     }
 
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
 
     const result = await generateImage({
       prompt: 'test',
@@ -284,8 +257,11 @@ describe('generateImage', () => {
   }, 30_000)
 
   it('returns fail when asset save fails', async () => {
+    const brokenHome = mkdtempSync(join(tmpdir(), 'bakin-test-broken-home-'))
+    process.env.BAKIN_HOME = brokenHome
+    resetContentDir()
+    writeFileSync(join(brokenHome, 'assets'), 'not-a-directory')
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: false, error: 'disk full' })
 
     const result = await generateImage({
       prompt: 'test',
@@ -296,11 +272,13 @@ describe('generateImage', () => {
 
     expect(result.ok).toBe(false)
     expect(result.error).toContain('asset save failed')
+    rmSync(brokenHome, { recursive: true, force: true })
+    process.env.BAKIN_HOME = testBakinHome
+    resetContentDir()
   })
 
   it('truncates prompt in return value to 500 chars', async () => {
     spyOn(globalThis, 'fetch').mockResolvedValue(mockFetchResponse())
-    mockSaveAsset.mockResolvedValue({ ok: true, path: 'x', metadataPath: 'x.meta.json', filename: 'x.jpg' })
 
     const longPrompt = 'a'.repeat(1000)
     const result = await generateImage({
@@ -315,17 +293,12 @@ describe('generateImage', () => {
   })
 
   it('imports raw file through asset pipeline via filePath', async () => {
-    vi.mocked(existsSync).mockReturnValue(true)
-    vi.mocked(execFileSync).mockReturnValue(Buffer.from('1080,1920'))
-    mockSaveAsset.mockResolvedValue({
-      ok: true,
-      path: 'assets/images/task-raw/20260404-imported.jpg',
-      metadataPath: 'assets/images/task-raw/20260404-imported.jpg.meta.json',
-      filename: '20260404-imported.jpg',
-    })
+    const sourceDir = mkdtempSync(join(tmpdir(), 'bakin-test-image-src-'))
+    const sourceFile = join(sourceDir, 'some-image.jpg')
+    writeFileSync(sourceFile, 'not-a-real-jpeg')
 
     const result = await generateImage({
-      filePath: '/tmp/some-image.jpg',
+      filePath: sourceFile,
       prompt: 'Backstroke takeoff',
       taskId: 'task-raw',
       agent: 'pixel',
@@ -334,26 +307,17 @@ describe('generateImage', () => {
 
     expect(result.ok).toBe(true)
     expect(result.model).toBe('raw-import')
-    expect(result.width).toBe(1080)
-    expect(result.height).toBe(1920)
-    expect(result.path).toContain('assets/images/task-raw')
-    expect(mockSaveAsset).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: 'task-raw',
-        type: 'images',
-        tool: 'raw-import',
-        tags: ['imported'],
-      }),
-    )
+    expect(result.filename).toBe(basename(result.path as string))
+    expect(result.image_filename).toBe(result.filename)
+    expect(result.path).toContain('assets/store/')
     // Should NOT call Gemini API
     expect(globalThis.fetch).not.toHaveBeenCalled()
+    rmSync(sourceDir, { recursive: true, force: true })
   })
 
   it('fails raw import when file does not exist', async () => {
-    vi.mocked(existsSync).mockReturnValue(false)
-
     const result = await generateImage({
-      filePath: '/tmp/nonexistent.jpg',
+      filePath: join(testBakinHome, 'nonexistent.jpg'),
       taskId: 'task-missing',
       agent: 'pixel',
       thumbnail: false,


### PR DESCRIPTION
## Summary
- return canonical filename and image_filename from bakin_exec_gen_image for generated and raw-imported images
- make bakin_exec_assets_save idempotent for existing managed assets/store paths, including absolute Bakin content paths
- convert asset-save exceptions in image generation into normal tool failure results
- update image generation tests to use the real asset pipeline in a temp Bakin home and add regression coverage for managed asset re-save attempts

## Test Plan
- bun test tests/scripts/generate-image.test.ts tests/plugins/assets/routes.test.ts
- bun run typecheck
- bun run lint
- git diff --check

## Follow-ups
- #341
- #342