### PR TITLE
release: v0.0.1-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+### Added
+- Add native OpenClaw MCP registration during onboarding so Bakin tools are available to fresh main-agent sessions.
+- Add a Bakin runtime skill during onboarding to explain Bakin task, project, workflow, asset, schedule, and agent coordination.
+
+### Changed
+- Make the release-candidate install command explicit in README and install docs while stable Homebrew publishing remains pending.
+- Rename the official research agent from `jessica-fetcher` to `jessica` across curated agent data and guidance.
+
+### Fixed
+- Preserve the adapter boundary while syncing Bakin MCP server entries through the runtime config interface.
+- Improve fresh-machine install guidance for shells that need `~/.local/bin` added to `PATH`.
+
 ## [0.0.1-rc.1] - 2026-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+## [0.0.1-rc.2] - 2026-05-25
+
 ### Added
 - Add native OpenClaw MCP registration during onboarding so Bakin tools are available to fresh main-agent sessions.
 - Add a Bakin runtime skill during onboarding to explain Bakin task, project, workflow, asset, schedule, and agent coordination.
@@ -37,5 +39,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 - Sign and notarize macOS release binaries.
 - Publish release assets, SDK packages, Homebrew formula updates, and post-publish smoke checks from CI.
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.1...HEAD
 [0.0.1-rc.1]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.1
+
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.2...HEAD
+[0.0.1-rc.2]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.2

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The product is local-first: Bakin' owns its data under `~/.bakin/`, talks to the
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.1 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.2 bash
 ```
 
 The installer uses `/usr/local/bin` when it can write there, otherwise it falls back to `~/.local/bin`. If `bakin` is not found after install, add the fallback directory to your `PATH`:

--- a/docs/src/content/docs/start/install.mdx
+++ b/docs/src/content/docs/start/install.mdx
@@ -9,7 +9,7 @@ import { Aside, LinkButton } from '@astrojs/starlight/components'
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.1 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.2 bash
 ```
 
 The install script picks the right binary for your machine, verifies the SHA-256, and installs it as `bakin`. The `BAKIN_VERSION` pin is temporary while the public release is still a release candidate; update it when the live stable release is published.
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | 
 `BAKIN_VERSION` grabs a specific release tag instead of the latest:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.1 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.2 bash
 ```
 
 ### Manual download


### PR DESCRIPTION
## Summary
- prepare CHANGELOG.md for v0.0.1-rc.2
- update README and install docs to pin BAKIN_VERSION=v0.0.1-rc.2

## Verification
- bun run scripts/extract-release-notes.ts --version 0.0.1-rc.2 --out /private/tmp/bakin-rc2-notes.md

## Publish after merge
Run the GitHub Actions Release workflow from main with:

version: 0.0.1-rc.2