### PR TITLE
Fix bakin update for prerelease-only releases

### DIFF
--- a/src/core/self-update.ts
+++ b/src/core/self-update.ts
@@ -2,7 +2,8 @@
  * `bakin update` — self-replacing binary update (#147 TG4).
  *
  * Flow:
- *   1. GET https://api.github.com/repos/markhayden/bakin/releases/latest
+ *   1. GET GitHub's latest stable release, falling back to the releases list
+ *      when the repo only has prereleases.
  *   2. Pick the asset whose name ends in `bakin-<platform>-<arch>`.
  *   3. Download it alongside `checksums.txt`.
  *   4. Verify SHA256 against the listed value.
@@ -22,7 +23,9 @@ import { Readable } from 'node:stream'
 import { finished } from 'node:stream/promises'
 import type { ReadableStream as WebReadableStream } from 'node:stream/web'
 
-const RELEASE_API = 'https://api.github.com/repos/markhayden/bakin/releases/latest'
+const LATEST_RELEASE_API = 'https://api.github.com/repos/markhayden/bakin/releases/latest'
+const RELEASES_API = 'https://api.github.com/repos/markhayden/bakin/releases?per_page=20'
+const GITHUB_HEADERS = { 'User-Agent': 'bakin-self-update', Accept: 'application/vnd.github+json' }
 
 interface GithubAsset {
   name: string
@@ -31,6 +34,8 @@ interface GithubAsset {
 
 interface GithubRelease {
   tag_name: string
+  draft?: boolean
+  prerelease?: boolean
   assets: GithubAsset[]
 }
 
@@ -42,6 +47,33 @@ export interface SelfUpdateReporter {
 const consoleReporter: SelfUpdateReporter = {
   log: message => console.log(message),
   error: message => console.error(message),
+}
+
+class ReleaseFetchError extends Error {
+  constructor(public readonly status: number, public readonly url: string) {
+    super(`HTTP ${status}`)
+  }
+}
+
+async function fetchGithubJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers: GITHUB_HEADERS })
+  if (!res.ok) throw new ReleaseFetchError(res.status, url)
+  return (await res.json()) as T
+}
+
+export async function fetchLatestRelease(reporter: Pick<SelfUpdateReporter, 'log'>): Promise<GithubRelease> {
+  reporter.log(`Fetching latest release from ${LATEST_RELEASE_API}`)
+  try {
+    return await fetchGithubJson<GithubRelease>(LATEST_RELEASE_API)
+  } catch (err) {
+    if (!(err instanceof ReleaseFetchError) || err.status !== 404) throw err
+  }
+
+  reporter.log(`No stable release found; checking releases from ${RELEASES_API}`)
+  const releases = await fetchGithubJson<GithubRelease[]>(RELEASES_API)
+  const release = releases.find(candidate => !candidate.draft)
+  if (!release) throw new Error('HTTP 404; no published releases found')
+  return release
 }
 
 function currentTriple(): string | null {
@@ -92,14 +124,9 @@ export async function selfUpdate(reporter: SelfUpdateReporter = consoleReporter)
     return 1
   }
 
-  reporter.log(`Fetching latest release from ${RELEASE_API}`)
   let release: GithubRelease
   try {
-    const res = await fetch(RELEASE_API, {
-      headers: { 'User-Agent': 'bakin-self-update', Accept: 'application/vnd.github+json' },
-    })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    release = (await res.json()) as GithubRelease
+    release = await fetchLatestRelease(reporter)
   } catch (err) {
     reporter.error(`Could not fetch release info: ${err instanceof Error ? err.message : String(err)}`)
     return 1

--- a/tests/core/self-update.test.ts
+++ b/tests/core/self-update.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { fetchLatestRelease } from '../../src/core/self-update'
+
+describe('fetchLatestRelease', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restore()
+  })
+
+  function response(status: number, body: unknown): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response
+  }
+
+  function release(tagName: string, options: { draft?: boolean; prerelease?: boolean } = {}) {
+    return {
+      tag_name: tagName,
+      draft: options.draft ?? false,
+      prerelease: options.prerelease ?? false,
+      assets: [],
+    }
+  }
+
+  it('uses GitHub latest when a stable release exists', async () => {
+    const logs: string[] = []
+    const fetchMock = mock(() => Promise.resolve(response(200, release('v0.0.2'))))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const resolved = await fetchLatestRelease({ log: message => logs.push(message) })
+
+    expect(resolved.tag_name).toBe('v0.0.2')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(logs).toEqual([
+      'Fetching latest release from https://api.github.com/repos/markhayden/bakin/releases/latest',
+    ])
+  })
+
+  it('falls back to the newest published prerelease when no stable release exists', async () => {
+    const logs: string[] = []
+    const fetchMock = mock()
+      .mockResolvedValueOnce(response(404, { message: 'Not Found' }))
+      .mockResolvedValueOnce(response(200, [
+        release('v0.0.1-rc.2', { prerelease: true }),
+        release('v0.0.1-rc.1', { prerelease: true }),
+      ]))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const resolved = await fetchLatestRelease({ log: message => logs.push(message) })
+
+    expect(resolved.tag_name).toBe('v0.0.1-rc.2')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://api.github.com/repos/markhayden/bakin/releases?per_page=20')
+    expect(logs).toContain('No stable release found; checking releases from https://api.github.com/repos/markhayden/bakin/releases?per_page=20')
+  })
+
+  it('preserves non-404 latest release failures', async () => {
+    const fetchMock = mock(() => Promise.resolve(response(500, { message: 'Server Error' })))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    await expect(fetchLatestRelease({ log: () => {} })).rejects.toThrow('HTTP 500')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- keep using GitHub's latest stable release endpoint when a stable release exists
- fall back to the releases list when /releases/latest returns 404, so prerelease-only repos can update to the newest published RC
- add focused coverage for stable, prerelease fallback, and non-404 failure behavior

## Verification
- bun test tests/core/self-update.test.ts tests/cli/runtime-dispatch.test.ts
- bun run typecheck
- bunx eslint src/core/self-update.ts tests/core/self-update.test.ts
- live API check: /releases/latest returns 404, while /releases?per_page=3 returns v0.0.1-rc.2 first with release assets