### PR TITLE
Fix runtime skill sync for binary installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+### Fixed
+- Embed the Bakin runtime skill template in release binaries so first-time installs can sync the `bakin` skill outside a source checkout.
+
 ## [0.0.1-rc.3] - 2026-05-25
 
 ### Changed

--- a/bun-env.d.ts
+++ b/bun-env.d.ts
@@ -113,3 +113,8 @@ interface ImportMeta {
  * TypeScript's static resolution of these non-module files — Bun handles
  * the import at runtime / compile time.
  */
+
+declare module '*.md' {
+  const path: string
+  export default path
+}

--- a/src/core/bakin-skill-template.ts
+++ b/src/core/bakin-skill-template.ts
@@ -1,0 +1,6 @@
+import { readFileSync } from 'fs'
+import skillTemplatePath from '../../skill/SKILL.md' with { type: 'file' }
+
+export function readEmbeddedBakinSkillTemplate(): string {
+  return readFileSync(skillTemplatePath, 'utf-8')
+}

--- a/src/core/bakin-skill.ts
+++ b/src/core/bakin-skill.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 
 import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
+import { readEmbeddedBakinSkillTemplate } from './bakin-skill-template'
 
 const EXEC_TOOLS_START = '<!-- bakin:exec-tools:start -->'
 const EXEC_TOOLS_END = '<!-- bakin:exec-tools:end -->'
@@ -50,11 +51,9 @@ function getRegisteredExecTools(): unknown[] {
 
 export function renderBakinRuntimeSkill(projectRoot: string): string {
   const sourceSkill = join(projectRoot, 'skill', 'SKILL.md')
-  if (!existsSync(sourceSkill)) {
-    throw new Error('Bakin skill source not found at skill/SKILL.md')
-  }
-
-  const templateContent = readFileSync(sourceSkill, 'utf-8')
+  const templateContent = existsSync(sourceSkill)
+    ? readFileSync(sourceSkill, 'utf-8')
+    : readEmbeddedBakinSkillTemplate()
   const startIdx = templateContent.indexOf(EXEC_TOOLS_START)
   const endIdx = templateContent.indexOf(EXEC_TOOLS_END)
   if (startIdx === -1 || endIdx === -1) {

--- a/tests/plugins/health/system-checks.test.ts
+++ b/tests/plugins/health/system-checks.test.ts
@@ -612,13 +612,14 @@ describe('checkSearchAdapter', () => {
 // ─── checkAndSyncSkill ────────────────────────────────────────────────────
 
 describe('checkAndSyncSkill', () => {
-  it('errors when the skill source is missing', async () => {
+  it('uses the embedded skill template when the source checkout template is missing', async () => {
     const projectRoot = pathJoin(testDir, 'project-no-skill')
     mkdirSync(projectRoot, { recursive: true })
     const results = await checkAndSyncSkill(projectRoot, mockRuntime)
     expect(results[0].check).toBe('skill')
-    expect(results[0].status).toBe('error')
-    expect(results[0].message).toMatch(/source not found/)
+    expect(results[0].status).toBe('warn')
+    expect(results[0].autoFixable).toBe(true)
+    expect(results[0].message).toMatch(/not installed in runtime/)
   })
 
   it('errors when the template is missing the exec-tools markers', async () => {

--- a/tests/skill/bakin-skill.test.ts
+++ b/tests/skill/bakin-skill.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'bun:test'
 import { readFileSync } from 'fs'
+import { mkdtemp } from 'fs/promises'
+import { tmpdir } from 'os'
 import { join } from 'path'
+import { renderBakinRuntimeSkill } from '../../src/core/bakin-skill'
 
 describe('Bakin runtime skill', () => {
   it('documents portable mcporter command patterns', () => {
@@ -13,5 +16,15 @@ describe('Bakin runtime skill', () => {
     expect(skill).toContain('mcporter call bakin-main.bakin_exec_projects_apply_plan --args "$ARGS"')
     expect(skill).toContain('http://localhost:3737')
     expect(skill).toContain('$HOME/.local/bin/bakin')
+  })
+
+  it('renders from the embedded template outside a source checkout', async () => {
+    const notARepo = await mkdtemp(join(tmpdir(), 'bakin-skill-no-source-'))
+
+    const rendered = renderBakinRuntimeSkill(notARepo)
+
+    expect(rendered).toContain('Bakin is the local task, project, agent, workflow, asset, schedule')
+    expect(rendered).toContain('http://localhost:3737')
+    expect(rendered).toContain('mcporter list bakin-main --schema')
   })
 })


### PR DESCRIPTION
## Summary
- embed skill/SKILL.md into the compiled binary via Bun's file import path
- fall back to the embedded template when the current working directory is not a source checkout
- update health and skill tests so missing source checkout templates are repairable instead of fatal

## Verification
- bun test tests/skill/bakin-skill.test.ts tests/plugins/health/system-checks.test.ts
- bun run typecheck
- bunx eslint src/core/bakin-skill.ts src/core/bakin-skill-template.ts tests/skill/bakin-skill.test.ts tests/plugins/health/system-checks.test.ts
- bun build --compile --outfile /tmp/bakin-skill-template-smoke src/core/bakin-skill-template.ts