### PR TITLE
release: v0.0.1-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+## [0.0.1-rc.4] - 2026-05-25
+
 ### Fixed
 - Embed the Bakin runtime skill template in release binaries so first-time installs can sync the `bakin` skill outside a source checkout.
 
@@ -52,6 +54,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 [0.0.1-rc.1]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.1
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.3...HEAD
 [0.0.1-rc.3]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.3
 [0.0.1-rc.2]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.2
+
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.4...HEAD
+[0.0.1-rc.4]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The product is local-first: Bakin' owns its data under `~/.bakin/`, talks to the
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.3 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.4 bash
 ```
 
 The installer uses `/usr/local/bin` when it can write there, otherwise it falls back to `~/.local/bin`. If `bakin` is not found after install, add the fallback directory to your `PATH`:

--- a/docs/src/content/docs/start/install.mdx
+++ b/docs/src/content/docs/start/install.mdx
@@ -9,7 +9,7 @@ import { Aside, LinkButton } from '@astrojs/starlight/components'
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.3 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.4 bash
 ```
 
 The install script picks the right binary for your machine, verifies the SHA-256, and installs it as `bakin`. The `BAKIN_VERSION` pin is temporary while the public release is still a release candidate; update it when the live stable release is published.
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | 
 `BAKIN_VERSION` grabs a specific release tag instead of the latest:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.3 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.4 bash
 ```
 
 ### Manual download


### PR DESCRIPTION
## Summary
- add the 0.0.1-rc.4 changelog entry for embedded runtime skill templates in release binaries
- update README and install docs to pin BAKIN_VERSION=v0.0.1-rc.4

## Verification
- bun run scripts/extract-release-notes.ts --version 0.0.1-rc.4 --out /tmp/bakin-rc4-notes.md
- bun test tests/skill/bakin-skill.test.ts tests/plugins/health/system-checks.test.ts
- bun run typecheck
- bunx eslint src/core/bakin-skill.ts src/core/bakin-skill-template.ts tests/skill/bakin-skill.test.ts tests/plugins/health/system-checks.test.ts
- bun build --compile --outfile /tmp/bakin-skill-template-smoke src/core/bakin-skill-template.ts
- bun run release patch --rc --dry-run -> target v0.0.1-rc.4, 1 changelog bullet