### PR TITLE
fix: reconcile accepted runtime dispatch failures

### DIFF
--- a/.claude/knowledge/dispatch.md
+++ b/.claude/knowledge/dispatch.md
@@ -32,6 +32,29 @@ Cooldown chosen by class:
 
 Both classes share the `count` field. `settings.dispatch.maxRetries` (default 5) escalates to **blocked** regardless of classification.
 
+## Post-send task reconciliation
+
+Dispatch moves a task to `inProgress` before sending the runtime message so a
+fast agent cannot complete before Bakin records active work. If
+`runtime.messaging.send` later rejects, `dispatch.ts` must re-read the current
+task state before deciding what to do:
+
+- If the task already left active work (`done`, `blocked`, `review`, or
+  `archived`), Bakin leaves it alone and removes stale dispatch markers. This
+  handles late gateway errors after an agent already called
+  `bakin_exec_tasks_complete` or `bakin_exec_tasks_block`.
+- If the task is still `inProgress` and the error is a known accepted-run
+  terminal failure, such as `codex app-server turn idle timed out waiting for
+  turn/completed`, Bakin moves the task to `blocked` and appends a sanitized
+  system log.
+- If the task is still `inProgress` but there is no evidence the agent accepted
+  the work, Bakin returns it to `todo`, records `failedDispatches`, and lets the
+  existing cooldown/retry policy handle the next attempt.
+
+Task logs and audit entries use short sanitized summaries such as
+`codex app-server idle timeout waiting for turn completion`; do not write raw
+prompts, local paths, tokens, or full runtime trajectories to task logs.
+
 ## Task Eligibility
 
 Dispatch only considers `todo` tasks that are actually eligible to run.

--- a/.claude/specs/agent-runtime-timeout-reconciliation.md
+++ b/.claude/specs/agent-runtime-timeout-reconciliation.md
@@ -1,0 +1,47 @@
+# Spec: Agent Runtime Timeout Reconciliation
+
+## Objective
+Prevent Bakin-dispatched tasks from staying silently `inProgress` after the backing OpenClaw/Codex turn has already ended with a terminal runtime failure. A task that never reached an agent should return to `todo` under the existing dispatch retry/cooldown policy. A task that reached an agent and then failed before `tasks_complete` or `tasks_block` should move to `blocked` with a sanitized system log.
+
+## Commands
+- Focused test: `bun test --isolate tests/core/dispatch.test.ts`
+- Typecheck: `bun run typecheck`
+- Broader check: `bun test --isolate tests/core/dispatch.test.ts tests/core/watchdog.test.ts tests/core/restart-recovery.test.ts`
+
+## Project Structure
+- `src/core/dispatch.ts` owns task dispatch, runtime send handling, and dispatch-state reconciliation.
+- `src/core/watchdog.ts` remains the slower stale-task backstop.
+- `src/core/restart-recovery.ts` remains the one-shot boot repair path.
+- `.claude/knowledge/dispatch.md` documents operational dispatch behavior.
+- `tests/core/dispatch.test.ts` covers dispatch retry, failure handling, and marker reconciliation.
+
+## Code Style
+Dispatch code should keep provider-specific details behind the runtime adapter and classify only sanitized error shapes:
+
+```ts
+if (runtimeFailureWasTerminal) {
+  await blockStoredTask(task.id, 'Agent runtime timed out before reporting completion.')
+  await addTaskLog(task.id, 'system', 'Agent run ended before task completion: codex app-server idle timeout waiting for turn completion.')
+}
+```
+
+## Testing Strategy
+- Unit-level dispatch tests reproduce late runtime rejection after task completion, terminal idle timeout while still active, and stale `dispatched[]` cleanup.
+- Existing cooldown tests continue to prove transport/delivery failures retry through `failedDispatches`.
+- Typecheck must pass because dispatch uses shared task/runtime types.
+
+## Boundaries
+- Always: Re-read task state after `runtime.messaging.send` rejects before mutating task state.
+- Always: Use sanitized summaries in task logs/audit for runtime failure diagnostics.
+- Always: Preserve completed/blocked/review task state when a late runtime error arrives.
+- Ask first: Introduce a new task column such as `failed` or require a new runtime execution API contract.
+- Never: Dump full prompts, local paths, tokens, or trajectory payloads into task logs.
+
+## Success Criteria
+- A task cannot remain indefinitely `inProgress` after a known Codex app-server turn idle timeout.
+- Runtime failure after a task already completed does not add a misleading task log or failure retry record.
+- Dispatch markers are retained only for active `inProgress` tasks.
+- Existing dispatch retry/cooldown behavior still works for delivery failures that did not reach an agent.
+
+## Open Questions
+- OpenClaw currently does not provide a populated Bakin `task.execution.flowId` for these dispatches. If a stable runtime execution API becomes available, Bakin should consume it from a watchdog-style reconciler instead of relying only on `runtime.messaging.send` rejection.

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -19,6 +19,7 @@ import {
 import {
   addTaskLog as appendTaskLog,
   blockTask as blockStoredTask,
+  moveTask as moveStoredTask,
   readTaskboard,
   updateTask as updateStoredTask,
 } from './task-store'
@@ -109,7 +110,12 @@ type DispatchTask = {
   projectId?: string
   availableAt?: string
   dependsOn?: string
-  log?: Array<{ timestamp: string }>
+  log?: Array<{ timestamp: string; message?: string }>
+}
+
+type DispatchTaskSnapshot = {
+  column: keyof DispatchColumns
+  task: DispatchTask
 }
 
 type DispatchEligibilityContext = {
@@ -241,6 +247,141 @@ function getDispatchMarkerTaskId(marker: string): string {
   return separator === -1 ? marker : marker.slice(0, separator)
 }
 
+function removeDispatchMarkersForTask(
+  state: DispatchState,
+  dispatchedSet: Set<string> | null,
+  taskId: string,
+): void {
+  state.dispatched = state.dispatched.filter(marker => getDispatchMarkerTaskId(marker) !== taskId)
+  if (dispatchedSet) {
+    for (const marker of Array.from(dispatchedSet)) {
+      if (getDispatchMarkerTaskId(marker) === taskId) dispatchedSet.delete(marker)
+    }
+  }
+}
+
+function findDispatchTaskSnapshot(taskId: string): DispatchTaskSnapshot | null {
+  const { columns } = readTaskboard() as unknown as { columns: DispatchColumns }
+  for (const column of Object.keys(emptyDispatchColumns()) as Array<keyof DispatchColumns>) {
+    const task = columns[column]?.find(t => t.id === taskId)
+    if (task) return { column, task }
+  }
+  return null
+}
+
+function taskAlreadyLeftActiveWork(column: keyof DispatchColumns): boolean {
+  return column === 'done' || column === 'blocked' || column === 'review' || column === 'archived'
+}
+
+async function tryAddTaskLog(taskId: string, author: string, message: string): Promise<void> {
+  try {
+    await addTaskLog(taskId, author, message)
+  } catch (err) {
+    log.warn('Failed to append dispatch reconciliation task log', err, { id: taskId })
+  }
+}
+
+function formatSanitizedRuntimeFailure(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err)
+  const lower = raw.toLowerCase()
+  if (lower.includes('turn_completion_idle_timeout') || lower.includes('idle timed out waiting for turn/completed')) {
+    return 'codex app-server idle timeout waiting for turn completion'
+  }
+  if (lower.includes('request timed out')) return 'runtime gateway request timed out'
+  if (lower.includes('socket error')) return 'runtime gateway socket error'
+  if (lower.includes('fetch failed')) return 'runtime transport fetch failed'
+  if (err instanceof Error && err.name === 'AbortError') return 'runtime transport request aborted'
+  const http = raw.match(/\bfailed \((\d{3})\)/)
+  if (http) return `runtime adapter returned HTTP ${http[1]}`
+  return 'runtime dispatch failed before task completion'
+}
+
+function isAcceptedRunTerminalFailure(err: unknown): boolean {
+  const raw = err instanceof Error ? err.message : String(err)
+  const lower = raw.toLowerCase()
+  return lower.includes('turn_completion_idle_timeout')
+    || lower.includes('idle timed out waiting for turn/completed')
+}
+
+function shouldBlockAfterDispatchFailure(
+  err: unknown,
+  snapshot: DispatchTaskSnapshot,
+  initialLogCount: number,
+): boolean {
+  if (isAcceptedRunTerminalFailure(err)) return true
+  return (snapshot.task.log?.length ?? 0) > initialLogCount
+}
+
+async function reconcileRejectedDispatch(input: {
+  contentDir: string
+  state: DispatchState
+  dispatchedSet: Set<string> | null
+  task: DispatchTask
+  targetAgent: string
+  err: unknown
+  initialLogCount: number
+  logPrefix: string
+  dispatchKind: 'regular' | 'workflow'
+}): Promise<void> {
+  const snapshot = findDispatchTaskSnapshot(input.task.id)
+  removeDispatchMarkersForTask(input.state, input.dispatchedSet, input.task.id)
+
+  if (snapshot && taskAlreadyLeftActiveWork(snapshot.column)) {
+    delete input.state.failedDispatches?.[input.task.id]
+    appendAudit(input.contentDir, 'task.dispatch_failure_ignored', input.targetAgent, {
+      id: input.task.id,
+      title: input.task.title,
+      column: snapshot.column,
+      error: formatSanitizedRuntimeFailure(input.err),
+    })
+    return
+  }
+
+  const summary = formatSanitizedRuntimeFailure(input.err)
+  if (snapshot?.column === 'inProgress' && shouldBlockAfterDispatchFailure(input.err, snapshot, input.initialLogCount)) {
+    delete input.state.failedDispatches?.[input.task.id]
+    const reason = isAcceptedRunTerminalFailure(input.err)
+      ? 'Agent runtime timed out before reporting completion.'
+      : 'Agent run ended before reporting completion.'
+    await blockStoredTask(input.task.id, `${reason} ${summary}.`)
+    await tryAddTaskLog(input.task.id, 'system', `Agent run ended before task completion: ${summary}. Task moved to blocked for review.`)
+    appendAudit(input.contentDir, 'task.runtime_failed_blocked', input.targetAgent, {
+      id: input.task.id,
+      title: input.task.title,
+      kind: input.dispatchKind,
+      error: summary,
+    })
+    return
+  }
+
+  if (!input.state.failedDispatches) input.state.failedDispatches = {}
+  const prev = getFailureRecord(input.state.failedDispatches[input.task.id])
+  const kind = classifyDispatchError(input.err)
+  const attempt = (prev?.count || 0) + 1
+  input.state.failedDispatches[input.task.id] = { lastAttempt: Date.now(), count: attempt, kind }
+
+  if (snapshot?.column === 'inProgress') {
+    try {
+      await moveStoredTask(input.task.id, 'todo', 'inProgress')
+    } catch (err) {
+      log.warn('Failed to return task to todo after dispatch rejection', err, { id: input.task.id })
+    }
+  }
+
+  await tryAddTaskLog(
+    input.task.id,
+    'system',
+    `${input.logPrefix} (attempt ${attempt}, ${kind}) → ${input.targetAgent}: ${summary}. Returned to Todo for retry when cooldown expires.`,
+  )
+  appendAudit(input.contentDir, 'task.dispatch_failed', input.targetAgent, {
+    id: input.task.id,
+    title: input.task.title,
+    error: summary,
+    attempt,
+    kind,
+  })
+}
+
 export function loadDispatchState(contentDir: string): DispatchState {
   const stateFile = getStateFile(contentDir)
   try {
@@ -282,15 +423,19 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
     // Reconcile dispatch state with taskboard reality
     const columns = await readDispatchColumns()
     const todoTasks = columns.todo
-    const activeIds = new Set([
-      ...columns.inProgress.map(t => t.id),
-      ...columns.done.map(t => t.id),
-      ...columns.archived.map(t => t.id),
-    ])
+    const activeIds = new Set(columns.inProgress.map(t => t.id))
     const completedTaskIds = new Set([
       ...columns.done.map(t => t.id),
       ...columns.archived.map(t => t.id),
     ])
+    for (const task of [
+      ...columns.done,
+      ...columns.archived,
+      ...columns.blocked,
+      ...columns.review,
+    ]) {
+      delete state.failedDispatches?.[task.id]
+    }
     state.dispatched = state.dispatched.filter(id => activeIds.has(getDispatchMarkerTaskId(id)))
     // Rebuild dispatchedSet AFTER reconciliation so tasks moved back to todo are eligible
     const dispatchedSet = new Set(state.dispatched)
@@ -380,6 +525,7 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
         query: buildTaskLessonQuery(task),
       })
       const message = buildDispatchMessage(task, targetAgent, contentDir, port, mainAgentId, lessonBlock)
+      const initialLogCount = task.log?.length ?? 0
 
       try {
         // Move to inProgress BEFORE sending message to eliminate race condition
@@ -389,25 +535,23 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
 
         await sendDispatchMessage(targetAgent, message)
         dispatchedSet.add(task.id)
+        delete state.failedDispatches?.[task.id]
 
         appendAudit(contentDir, 'task.dispatched', targetAgent, { id: task.id, title: task.title })
         log.info('Task dispatched', { id: task.id, title: task.title, agent: targetAgent })
       } catch (err) {
         log.error(`Failed to dispatch "${task.title}" to ${targetAgent}`, err)
-
-        if (!state.failedDispatches) state.failedDispatches = {}
-        const prev = getFailureRecord(state.failedDispatches[task.id])
-        const kind = classifyDispatchError(err)
-        state.failedDispatches[task.id] = { lastAttempt: Date.now(), count: (prev?.count || 0) + 1, kind }
-
-        const errMsg = formatDispatchError(err)
-        try {
-          await addTaskLog(task.id, 'system', `Dispatch failed (attempt ${(prev?.count || 0) + 1}, ${kind}) → ${targetAgent}: ${errMsg}`)
-        } catch {
-          // best effort
-        }
-
-        appendAudit(contentDir, 'task.dispatch_failed', targetAgent, { id: task.id, title: task.title, error: errMsg, attempt: (prev?.count || 0) + 1, kind })
+        await reconcileRejectedDispatch({
+          contentDir,
+          state,
+          dispatchedSet,
+          task,
+          targetAgent,
+          err,
+          initialLogCount,
+          logPrefix: 'Dispatch failed',
+          dispatchKind: 'regular',
+        })
       }
     }
 
@@ -528,6 +672,7 @@ export async function dispatchSingleTask(
     })
     const message = buildDispatchMessage(task, targetAgent, contentDir, port, mainAgentId, lessonBlock)
     const dispatchStart = Date.now()
+    const initialLogCount = task.log?.length ?? 0
 
     try {
       // Move to inProgress BEFORE sending message to eliminate race condition
@@ -535,6 +680,7 @@ export async function dispatchSingleTask(
       appendAudit(contentDir, 'task.moved', 'dispatch', { id: task.id, title: task.title, from: 'todo', to: 'inProgress' })
 
       await sendDispatchMessage(targetAgent, message)
+      delete state.failedDispatches?.[task.id]
 
       state.dispatched.push(task.id)
       saveDispatchState(contentDir, state)
@@ -552,19 +698,18 @@ export async function dispatchSingleTask(
       })
     } catch (err) {
       log.error(`dispatchSingleTask: failed to dispatch "${task.title}" to ${targetAgent}`, err)
-
-      if (!state.failedDispatches) state.failedDispatches = {}
-      const prev = getFailureRecord(state.failedDispatches[task.id])
-      const kind = classifyDispatchError(err)
-      state.failedDispatches[task.id] = { lastAttempt: Date.now(), count: (prev?.count || 0) + 1, kind }
+      await reconcileRejectedDispatch({
+        contentDir,
+        state,
+        dispatchedSet: null,
+        task,
+        targetAgent,
+        err,
+        initialLogCount,
+        logPrefix: 'Immediate dispatch failed',
+        dispatchKind: 'regular',
+      })
       saveDispatchState(contentDir, state)
-
-      try {
-        const errMsg = formatDispatchError(err)
-        await addTaskLog(task.id, 'system', `Immediate dispatch failed (attempt ${(prev?.count || 0) + 1}, ${kind}) → ${targetAgent}: ${errMsg}`)
-      } catch {
-        // best effort
-      }
 
       recordUsage({
         kind: 'agent',
@@ -810,10 +955,12 @@ async function dispatchWorkflowTask(
     })
     // Pass contextTaskId so the step/complete API targets the right instance
     const message = buildWorkflowDispatchMessage({ ...task, id: contextTaskId }, ctx, agent, port, lessonBlock)
+    const initialLogCount = findDispatchTaskSnapshot(task.id)?.task.log?.length ?? 0
 
     try {
       await sendDispatchMessage(targetAgent, message)
       dispatchedSet.add(`${task.id}:${stepId}`)
+      delete state.failedDispatches?.[task.id]
 
       appendAudit(contentDir, 'task.dispatched', targetAgent, {
         id: task.id,
@@ -824,17 +971,17 @@ async function dispatchWorkflowTask(
       log.info('Workflow step dispatched', { taskId: task.id, stepId, agent: targetAgent })
     } catch (err) {
       log.error(`Failed to dispatch workflow step "${stepId}" to ${targetAgent}`, err)
-      if (!state.failedDispatches) state.failedDispatches = {}
-      const prev = getFailureRecord(state.failedDispatches[task.id])
-      const kind = classifyDispatchError(err)
-      state.failedDispatches[task.id] = { lastAttempt: Date.now(), count: (prev?.count || 0) + 1, kind }
-
-      try {
-        const errMsg = formatDispatchError(err)
-        await addTaskLog(task.id, 'system', `Workflow dispatch failed (attempt ${(prev?.count || 0) + 1}, ${kind}) for step "${stepId}" → ${targetAgent}: ${errMsg}`)
-      } catch {
-        // best effort
-      }
+      await reconcileRejectedDispatch({
+        contentDir,
+        state,
+        dispatchedSet,
+        task,
+        targetAgent,
+        err,
+        initialLogCount,
+        logPrefix: `Workflow dispatch failed for step "${stepId}"`,
+        dispatchKind: 'workflow',
+      })
     }
   }
 }

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -310,7 +310,8 @@ describe('dispatch', () => {
   // -------------------------------------------------------------------------
 
   describe('failure classification and cooldown', () => {
-    type ColumnsShape = { todo: Array<{ id: string; title: string; agent?: string }>; inProgress: unknown[]; done: unknown[]; archived: unknown[] }
+    type DispatchTaskShape = { id: string; title: string; agent?: string; log?: Array<{ timestamp: string; message?: string }> }
+    type ColumnsShape = { todo: DispatchTaskShape[]; inProgress: DispatchTaskShape[]; done: DispatchTaskShape[]; archived: DispatchTaskShape[] }
 
     function setupTodoTask(
       task: { id: string; title: string; agent?: string },
@@ -500,6 +501,72 @@ describe('dispatch', () => {
       expect(record.count).toBe(1)
       expect(typeof record.lastAttempt).toBe('number')
     })
+
+    it('blocks an in-progress task when the accepted agent run terminates before completion', async () => {
+      const task = { id: 't-idle-timeout', title: 'Terminal timeout task', agent: 'pixel', log: [] }
+      setupTodoTask(task)
+      mockRuntimeSend.mockImplementationOnce(async () => {
+        setDispatchColumns({
+          todo: [],
+          inProgress: [{
+            ...task,
+            log: [
+              { timestamp: new Date().toISOString(), message: 'Started work' },
+            ],
+          }],
+          done: [],
+          archived: [],
+        })
+        throw new Error('OpenClaw chat failed: codex app-server turn idle timed out waiting for turn/completed')
+      })
+
+      await dispatchTasks(tempDir, 3737)
+
+      expect(mockStoreBlockTask).toHaveBeenCalledWith(
+        't-idle-timeout',
+        expect.stringContaining('Agent runtime timed out before reporting completion'),
+      )
+      expect(mockStoreAddTaskLog).toHaveBeenCalledWith(
+        't-idle-timeout',
+        'system',
+        expect.stringContaining('Agent run ended before task completion'),
+      )
+      const state = readState()
+      expect(state.failedDispatches['t-idle-timeout']).toBeUndefined()
+      expect(state.dispatched).not.toContain('t-idle-timeout')
+    })
+
+    it('does not mutate or log dispatch failure when a late runtime error arrives after task completion', async () => {
+      const task = { id: 't-completed-before-timeout', title: 'Completed before timeout', agent: 'pixel', log: [] }
+      setupTodoTask(task)
+      mockRuntimeSend.mockImplementationOnce(async () => {
+        setDispatchColumns({
+          todo: [],
+          inProgress: [],
+          done: [{
+            ...task,
+            log: [
+              { timestamp: new Date().toISOString(), message: 'Task complete' },
+            ],
+          }],
+          archived: [],
+        })
+        throw new Error('OpenClaw chat gateway request timed out: agent')
+      })
+
+      await dispatchTasks(tempDir, 3737)
+
+      expect(mockStoreBlockTask).not.toHaveBeenCalled()
+      expect(mockStoreMoveTask).not.toHaveBeenCalled()
+      expect(mockStoreAddTaskLog).not.toHaveBeenCalledWith(
+        't-completed-before-timeout',
+        'system',
+        expect.stringContaining('Dispatch failed'),
+      )
+      const state = readState()
+      expect(state.failedDispatches['t-completed-before-timeout']).toBeUndefined()
+      expect(state.dispatched).not.toContain('t-completed-before-timeout')
+    })
   })
 
   describe('workflow re-dispatch guard', () => {
@@ -536,6 +603,30 @@ describe('dispatch', () => {
 
       const state = JSON.parse(readFileSync(join(tempDir, '.dispatch-state.json'), 'utf-8'))
       expect(state.dispatched).toContain('wf-1:step-generate')
+    })
+
+    it('drops dispatch markers for completed tasks during reconciliation', async () => {
+      writeFileSync(join(tempDir, '.dispatch-state.json'), JSON.stringify({
+        lastRun: Date.now(),
+        serverStart: Date.now(),
+        dispatched: ['done-1', 'active-1'],
+        failedDispatches: {
+          'done-1': { lastAttempt: Date.now() - 1000, count: 1, kind: 'structural' },
+        },
+      }))
+
+      setDispatchColumns({
+        todo: [],
+        inProgress: [{ id: 'active-1', title: 'Still running', agent: 'pixel' }],
+        done: [{ id: 'done-1', title: 'Already done', agent: 'pixel' }],
+        archived: [],
+      })
+
+      await dispatchTasks(tempDir, 3737)
+
+      const state = JSON.parse(readFileSync(join(tempDir, '.dispatch-state.json'), 'utf-8'))
+      expect(state.dispatched).toEqual(['active-1'])
+      expect(state.failedDispatches['done-1']).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Summary

- reconcile task state when an accepted runtime dispatch later rejects
- block in-progress tasks on known Codex app-server idle terminal failures with sanitized task logs
- ignore late gateway/runtime errors after a task has already completed or otherwise left active work
- keep delivery failures on the existing todo retry/cooldown path and clear stale dispatch markers for completed tasks

Fixes #351.

## Verification

- `bun test --isolate tests/core/dispatch.test.ts`
- Earlier full local verification before PR prep: `bun run typecheck`, `bun run lint`, and `bun test --isolate`

## Follow-up

- #352 tracks user-facing troubleshooting docs for OpenClaw/Codex runtime timeout diagnosis and mitigation.
