### PR TITLE
Stabilize workflow editor

### DIFF
--- a/.claude/specs/workflow-cleanup-and-refactor-plan.md
+++ b/.claude/specs/workflow-cleanup-and-refactor-plan.md
@@ -1,0 +1,846 @@
+# Implementation Plan: Workflow Cleanup and Refactor
+
+Companion spec: `.claude/specs/workflow-cleanup-and-refactor.md`.
+
+## Overview
+
+Ship workflow cleanup as a sequence of release-note-friendly PRs. The first PR restores a usable, runtime-honest editor. The next PRs clean known workflow contracts and drift surfaces. Only after the baseline is healthy do we add dynamic fanout for video.
+
+## Architecture Decisions
+
+- React Flow remains the editor foundation.
+- The editor reflects current ordered-step runtime semantics.
+- Connectors are derived from ordered steps, not user-authored scheduling edges.
+- Ordering controls start canvas-first, with side/list controls deferred unless testing shows they are needed.
+- No in-app YAML/source editor.
+- Plugin-owned workflows are read-only in place and support Save as new.
+- Drift visibility goes through doctor/health checks.
+- Safe repair requires provenance and explicit confirmation.
+- Installed workflow skill provenance uses `.installedBy` / `.userEdited` sidecars next to the markdown file, not markdown frontmatter.
+- Disabled default workflow state lives as workflow-owned content at `~/.bakin/workflows/disabled-defaults.json`.
+- Disabled defaults are unavailable for future matching, selection, and normal explicit starts unless a caller uses a deliberate override. Existing active instances continue unaffected.
+- Dynamic fanout uses explicit control-flow nodes, starting with video.
+- The new dynamic video fanout workflow ships enabled by default because Bakin is still pre-production; hardening can happen through test runs and follow-up PRs.
+- Video workflow outputs use canonical asset filename fields, not raw filesystem paths: `video_filename`, optional `thumbnail_filename`, optional `audio_filename`, and publish via `bakin_exec_post_channel(videoFilename=...)`.
+- PR 2 is a narrow exception to audit-before-rewrite because #341 is already confirmed in YAML contracts.
+- Existing `dependsOn` fields are preserved and warned about in PR 1; they are not shown as execution edges.
+- Full arbitrary DAG scheduling is not part of this program unless a later decision supersedes this plan.
+
+## PR Sequence
+
+Commit strategy entries are rollback checkpoints. When implemented, use
+conventional-commit-shaped subjects for each checkpoint, for example
+`test(workflows): characterize editor round trip` or
+`fix(workflows): preserve metadata-only dependsOn fields`.
+
+### PR 1: Workflow Editor Stabilization
+
+Release note headline:
+
+> Workflows: restore the visual editor and align it with runtime-supported step ordering.
+
+Scope:
+
+- Fix `/workflows/:id/edit` so existing workflows render reliably.
+- Keep React Flow, but disable user-authored freeform edges as execution state.
+- Make clear that existing user-drawn edges were already visual-only and not persisted.
+- Derive connectors from ordered `definition.steps`.
+- Add canvas-first order controls.
+- Make node add/edit/delete/save work for top-level supported node types.
+- Preserve layout positions as visual hints.
+- Preserve fields not owned by the editor, including `dependsOn`, definition-level `triggers`/`metadata`, gate notification/preview config, output metadata, createTask config, plugin-node opaque config, node-level `output_schema`, and unknown extension fields.
+- Preserve or read-only render unsupported legacy shapes instead of dropping them.
+- Show a warning for `dependsOn` because runtime validates it but still executes by order.
+- Keep plugin-owned workflows read-only in place with Save as new.
+- Label user-owned same-id shadows of plugin workflows.
+- Add simple static parallel child agent editing.
+- Add browser-backed verification for the real editor path.
+- Choose the PR 1 browser/route verification harness before implementing the editor fix. This is a PR 1 entry decision, not a later deferred decision.
+
+Non-scope:
+
+- No YAML editor.
+- No dynamic fanout.
+- No default disabling.
+- No workflow runtime scheduling rewrite.
+
+Likely files:
+
+- `plugins/workflows/components/workflow-canvas-editor.tsx`
+- `plugins/workflows/components/workflow-canvas.tsx`
+- `plugins/workflows/components/node-config-drawer.tsx`
+- `plugins/workflows/components/node-type-palette.tsx`
+- `plugins/workflows/lib/dagre-layout.ts`
+- `plugins/workflows/lib/edge-rules.ts`
+- workflow YAML serializer/round-trip helper if needed
+- `packages/host/src/routes/workflows.$id.edit.tsx`
+- `packages/host/src/routes/workflows.new.tsx`
+- `tests/plugins/workflows/workflow-canvas-editor.test.tsx`
+- `tests/plugins/workflows/yaml-roundtrip.test.ts`
+- new browser/integration coverage under `tests/plugins/workflows/`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Opening an existing workflow in edit mode shows its current nodes.
+- User can select a node and edit supported fields.
+- User can add a supported node.
+- User can reorder top-level steps through direct canvas controls.
+- User can add, remove, reorder, and edit static parallel child agent steps through a simple list/form.
+- User cannot draw/save arbitrary runtime edges.
+- Existing `dependsOn` fields are preserved and shown as metadata-only warnings, not execution edges.
+- Unsupported or invalid legacy YAML is inspectable and cannot be silently normalized into data loss.
+- Save persists ordered steps and layout hints.
+- Layout hints are stored as `definition.layout.positions[stepId] = { x, y }`; parallel child positions are optional but preserved when present.
+- Saving an unchanged user workflow is byte-stable.
+- Editing one supported field changes only the expected YAML region plus layout positions.
+- Reloading the workflow shows the saved design.
+- Plugin-owned workflows show read-only/customize messaging and use Save as new.
+- Same-id user shadows of plugin workflows are labeled as shadows and remain editable as user-owned files.
+- Tests cover the real broken path, not only React Flow stubs.
+- PR 1 explicitly decides the browser verification tool: add Playwright or define an equivalent host-route integration harness using the existing Bun + DOM stack.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows/workflow-canvas-editor.test.tsx tests/plugins/workflows/node-type-palette.test.tsx tests/plugins/workflows/node-config-drawer.test.tsx
+bun test --isolate tests/plugins/workflows
+bun run typecheck
+bun run lint
+# plus the selected PR 1 browser/route harness, for example:
+# bunx playwright test tests/plugins/workflows/workflow-editor.spec.ts
+# or
+# bun test --isolate tests/plugins/workflows/workflow-editor-host-route.test.tsx
+```
+
+Manual/browser verification:
+
+```bash
+bun run dev:mock
+```
+
+Then verify:
+
+- `/workflows`
+- `/workflows/image-social-post`
+- `/workflows/image-social-post/edit`
+- add/edit/reorder/save/reload
+
+Commit strategy:
+
+1. Failing characterization test for current editor behavior.
+2. Editor state model cleanup: derived connectors and canvas-first ordering.
+3. Node edit/add/delete/save fixes.
+4. Parallel child editor support.
+5. Browser/integration verification and docs update.
+
+Rollback boundary:
+
+- Revert this PR to return to the prior editor without touching runtime or workflow defaults.
+
+### PR 2: Image Workflow Filename Contract Cleanup
+
+Release note headline:
+
+> Workflows: image defaults now pass canonical asset filenames between steps.
+
+Scope:
+
+- Update repo-shipped image workflow YAML to use `image_filename`.
+- Remove path-based generated image output requirements.
+- Update image social post publish handoff to consume filename-based outputs.
+- Add regression tests to prevent defaults from drifting back to path contracts.
+
+Non-scope:
+
+- No installed local content repair.
+- No plugin extraction.
+- No broad workflow rewrite.
+
+Likely files:
+
+- `plugins/workflows/defaults/workflows/image-generation.yaml`
+- `plugins/workflows/defaults/workflows/image-social-post.yaml`
+- `tests/plugins/workflows/yaml-roundtrip.test.ts`
+- new default-contract tests under `tests/plugins/workflows/`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Default image workflows no longer require agents to emit generated image paths.
+- Default image workflows use canonical asset filenames as stable identity.
+- `generate-image.md` remains unchanged unless a future audit finds a real skill-level issue; it already tells the agent to emit the save tool's returned filename.
+- Tests catch `imagePath`, `image_path`, and raw path-based image outputs in shipped YAML defaults.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows/yaml-roundtrip.test.ts
+bun test --isolate tests/plugins/workflows
+bun run typecheck
+bun run lint
+```
+
+Commit strategy:
+
+1. Add failing default-contract test.
+2. Update image-generation workflow/schema/instructions.
+3. Update image-social-post handoff/publish instructions.
+4. Update docs.
+
+Rollback boundary:
+
+- Revert this PR to restore old image defaults only.
+
+### PR 3: Installed Workflow Skill Drift Detection and Repair
+
+Release note headline:
+
+> Health: workflow skill drift is now visible and safely repairable.
+
+Scope:
+
+- Add managed provenance for installed workflow skills.
+- Add a workflow-skill materializer/installer because plugin and agent-package workflow skills currently live in memory and otherwise have no sidecar location.
+- Store workflow skill provenance in sidecars next to the markdown file:
+  - `<skill>.md.installedBy`
+  - `<skill>.md.userEdited`
+- Materialize managed workflow skills to `~/.bakin/workflows/skills/{name}.md` only when safe:
+  - missing target
+  - target has matching managed provenance
+  - target exactly matches a known old repo-shipped skill hash and user confirms adopt-and-replace
+- Detect stale installed workflow skill patterns:
+  - `beacon_exec_`
+  - `image_path`
+  - `imagePath`
+  - `video_path`
+  - `videoPath`
+  - `audio_path`
+  - `audioPath`
+  - path-based generated image outputs
+  - path-based generated media outputs
+  - manual-save instructions that conflict with managed asset generation
+- Surface results through doctor/health UI and CLI.
+- Add repair planning for managed, unedited stale skills.
+- Repair by full-file replacement only when provenance proves the current file is managed and unedited.
+- Offer adopt-and-replace for unmarked files only when the current hash exactly matches a known old repo-shipped workflow skill hash from a repo-shipped manifest.
+- Keep customized/user-edited content advisory only.
+- Document seeding, shadowing, provenance, and repair behavior.
+
+Non-scope:
+
+- No silent overwrite of user edits.
+- No repair without explicit doctor repair flow.
+- No phrase-level patching of customized or unknown workflow skill files.
+- No repo default contract cleanup, already handled in PR 2.
+
+Likely files:
+
+- `plugins/workflows/lib/health-checks.ts`
+- `plugins/workflows/lib/skill-loader.ts`
+- `plugins/workflows/lib/agent-package-skill-registry.ts`
+- `plugins/workflows/lib/workflow-skill-materializer.ts`
+- `plugins/workflows/defaults/workflow-skill-legacy-hashes.json`
+- `plugins/workflows/index.ts`
+- `src/core/doctor-repair.ts` only if existing repair orchestration needs small extension
+- `tests/plugins/workflows/health-checks.test.ts`
+- `tests/cli/doctor-repair.test.ts` if CLI behavior changes
+- `.claude/knowledge/workflows-plugin.md`
+- `.claude/knowledge/doctor-and-health-checks.md`
+
+Acceptance criteria:
+
+- Doctor flags the stale local `generate-image.md` patterns described by #342.
+- Doctor also flags stale path-style media output patterns such as `videoPath`, `video_path`, `audioPath`, and `audio_path`.
+- Plugin and agent-package workflow skills can be materialized to disk with sidecar provenance.
+- Existing unmarked customized local workflow skills are not overwritten by materialization.
+- The exact-old-hash adoption list is repo-shipped and deterministic, not network-fetched.
+- The legacy-hash manifest is manually maintained in the same PR as any
+  workflow-skill change that needs adopt-and-replace repair. Each entry records
+  a reason and introducing change. The manifest is bounded to known
+  pre-production upgrade paths and should be pruned before the first production
+  release.
+- Installed workflow skill repair state is stored in sidecars, not markdown frontmatter.
+- Skill frontmatter remains reserved for behavior metadata such as `name` and `output_schema`.
+- Managed, unedited stale workflow skills have a safe repair plan.
+- Safe repair replaces the entire stale managed file from current source, rather than applying brittle text substitutions.
+- Unmarked files can be adopted and replaced only when they exactly match a known old repo-shipped skill hash and the user confirms.
+- Customized workflow skills are not auto-repaired.
+- Files marked `.userEdited`, files with missing provenance, and files whose current hash differs from the recorded installed hash are advisory-only unless they satisfy the exact old-hash adoption path.
+- UI and CLI can show the drift through health surfaces.
+- Tests cover detection and at least one safe repair path.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows/health-checks.test.ts
+bun test --isolate tests/cli/doctor-repair.test.ts tests/core/doctor-repair.test.ts
+bun test --isolate
+bun run typecheck
+bun run lint
+```
+
+Commit strategy:
+
+1. Add stale-pattern detection tests.
+2. Add provenance model for installed workflow skills.
+3. Add workflow-skill materializer with sidecars.
+4. Add full-file replacement repair for proven managed unedited skills.
+5. Add exact-old-hash adopt-and-replace path.
+6. Wire health registration and docs.
+
+Rollback boundary:
+
+- Revert this PR to remove drift detection/repair while preserving repo defaults from PR 2.
+
+### PR 4: Shipped Workflow Audit
+
+Release note headline:
+
+> Workflows: add a health audit for shipped default workflows.
+
+Scope:
+
+- Audit repo-shipped workflow definitions and workflow skills one by one.
+- Document happy path, contract health, known gaps, and recommended future action.
+- Split follow-up implementation tasks by workflow.
+- Do not rewrite every workflow in this PR.
+
+Defaults to audit:
+
+- `text-social-post`
+- `image-generation`
+- `image-social-post`
+- `video-script`
+- `clip-creation`
+- `assemble-video`
+- `video-social-post`
+
+Default workflow skills to audit:
+
+- `generate-image`
+- `generate-video`
+- `publish`
+- `write-copy`
+
+Likely files:
+
+- `.claude/specs/workflow-defaults-audit.md` or equivalent
+- `.claude/knowledge/workflows-plugin.md`
+- GitHub issues or checklist follow-ups if desired
+
+Acceptance criteria:
+
+- Every repo-shipped workflow has an audit entry.
+- Every repo-shipped workflow skill has an audit entry.
+- Each entry has a recommended path: keep, small cleanup, major redesign, or disable-by-default candidate.
+- Video workflows explicitly point to dynamic fanout work.
+- Image workflows reflect PR 2 filename contract.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows/yaml-roundtrip.test.ts
+bun run docs:validate
+bun run lint
+```
+
+Commit strategy:
+
+1. Add audit document skeleton.
+2. Audit simple text/image defaults.
+3. Audit video defaults and identify redesign needs.
+4. Update workflow knowledge docs.
+
+Rollback boundary:
+
+- Documentation-only revert.
+
+### PR 5: Default Workflow Availability Controls
+
+Release note headline:
+
+> Workflows: default workflows can be disabled when they should not be selected automatically.
+
+Scope:
+
+- Add workflow-owned storage for disabled default/core workflow ids at `~/.bakin/workflows/disabled-defaults.json`.
+- Ensure listing UI surfaces disabled status.
+- Ensure matcher/task creation does not pick disabled defaults by accident.
+- Ensure explicit starts by id reject disabled defaults unless an override is provided.
+- Define override surfaces:
+  - CLI: `--allow-disabled-workflow`
+  - HTTP/API bodies: `allowDisabledWorkflow: true`
+  - definition list endpoints: `includeDisabled=true`
+  - plugin hooks: `allowDisabledWorkflow: true`
+- Keep existing active and historical workflow instances readable/runnable.
+- Add diagnostics for disabled workflow references if needed.
+- Keep user-created workflows unaffected unless explicitly disabled by the same model.
+- Any tasks-plugin UI change must consume workflow availability through a
+  workflows-owned API route or registered hook. The tasks plugin must not import
+  workflow internals directly.
+
+Non-scope:
+
+- No dynamic fanout.
+- No workflow content rewrite unless audit identifies a tiny necessary fixture.
+
+Likely files:
+
+- `plugins/workflows/lib/availability.ts`
+- `plugins/workflows/lib/source-registry.ts`
+- `plugins/workflows/lib/matcher.ts`
+- `plugins/workflows/components/workflows-page.tsx`
+- `plugins/workflows/components/workflow-card.tsx`
+- `plugins/tasks/components/new-task-dialog.tsx`
+- `plugins/workflows/index.ts`
+- `src/core/task-service.ts`
+- `src/core/cli/registry.ts`
+- `tests/plugins/workflows/availability.test.ts`
+- `tests/plugins/workflows/matcher.test.ts`
+- `tests/plugins/workflows/workflows-page.test.tsx`
+- `tests/cli/workflows.test.ts` if CLI behavior changes
+- `tests/core/task-service.test.ts` for explicit start/create behavior and override audit assertions
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- User can disable a shipped default workflow.
+- Disabled defaults remain inspectable in management/status surfaces but are not matched or selected accidentally.
+- Auto-match ignores disabled defaults.
+- Task creation workflow selectors omit disabled defaults unless explicitly showing management/status.
+- Normal workflow definition consumer lists omit or mark disabled defaults clearly.
+- CLI workflow lists omit disabled defaults by default or expose them only with an explicit include flag.
+- Explicit starts by id reject disabled default workflows with a clear error unless an override is provided.
+- Override use is visible in audit/log output.
+- Existing active and historical workflow instances continue to load and run.
+- Disabled status is visible in the UI.
+- CLI/health can surface suspicious disabled references if relevant.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows
+bun test --isolate tests/core/task-service.test.ts tests/cli/workflows.test.ts
+bun test --isolate
+bun run typecheck
+bun run lint
+```
+
+Commit strategy:
+
+1. Add storage/model tests.
+2. Add matcher behavior.
+3. Add UI controls/status.
+4. Add docs.
+
+Rollback boundary:
+
+- Revert this PR to restore all defaults as available.
+
+### PR 6: Dynamic Video Fanout Design Spec
+
+Release note headline:
+
+> Workflows: define dynamic video fanout semantics before implementation.
+
+Scope:
+
+- Write a focused spec for `map_workflow` or equivalent.
+- Define restricted source path syntax: `<prior-step-id>.<field>[.<field>...]`, with no wildcards, array indexes, filters, or arbitrary JSONPath in v1.
+- Define empty-array behavior: source must resolve to a non-empty array unless `allow_empty: true`.
+- Define `allow_empty: true` output: complete immediately with `source.count: 0`, `results: []`, and `finalOutputs: []`.
+- Define dot-containing step id policy for `map_workflow` sources: source paths can only reference step ids without `.`.
+- Define required children as every child created from the resolved source array; optional children and partial joins are out of scope for v1.
+- Define stable child ids after script edit/retry.
+- Define fanout concurrency limit, child agent assignment, SSE/progress volume, and dispatch cost preview policy.
+- Define parent/child instance state.
+- Define visible child task behavior.
+- Define aggregation output shape:
+  - `source.path`
+  - `source.count`
+  - `childWorkflowId`
+  - ordered `results[]`
+  - convenience `finalOutputs[]`
+- Define retry/reopen behavior for one child without resetting successful siblings.
+- Define editor visualization expectations.
+- Define video-specific workflow shape.
+
+Non-scope:
+
+- No runtime implementation yet unless this PR is intentionally split.
+
+Likely files:
+
+- `.claude/specs/workflow-dynamic-fanout.md`
+- `.claude/specs/workflow-dynamic-fanout-plan.md`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Runtime semantics are unambiguous enough for tests.
+- Video is the reference use case.
+- Audio/quality decisions are resolved or explicitly listed as PR 7A-E open items with owners.
+- The future video fanout workflow is planned as enabled by default, not hidden behind disabled-default availability.
+- Fanout contracts for source path, empty source, required children, stable child ids, child assignment, concurrency, progress events, and cost preview are resolved.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows
+bun run docs:validate
+bun run lint
+```
+
+Commit strategy:
+
+1. Draft fanout contract.
+2. Add video reference workflow design.
+3. Add implementation task breakdown.
+
+Rollback boundary:
+
+- Documentation-only revert.
+
+### PR 7A: `map_workflow` Parser and Runtime State
+
+Release note headline:
+
+> Workflows: add the runtime state model for mapped child workflows.
+
+Scope:
+
+- Add `map_workflow` type definitions.
+- Add parser and validator support for restricted source paths.
+- Add instance state for mapped child records without dispatching children yet.
+- Add source resolution tests, including missing source and empty-array behavior.
+- Keep `map_workflow` non-executable until PR 7B. If runtime encounters it in
+  PR 7A, the step fails fast with a clear `map_workflow_not_implemented`
+  error; it must not hang the parent or silently skip.
+- Do not expose `map_workflow` as an editor-palette option until executable
+  child dispatch exists.
+
+Likely files:
+
+- `plugins/workflows/types.ts`
+- `plugins/workflows/lib/node-type-registry.ts`
+- `plugins/workflows/lib/parser.ts`
+- `plugins/workflows/lib/runtime.ts`
+- `tests/plugins/workflows/runtime.test.ts`
+- `tests/plugins/workflows/parser.test.ts`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Parser accepts valid `map_workflow` nodes and rejects unsupported source syntax.
+- Runtime can resolve a source array from prior step outputs.
+- Empty array behavior follows the PR 6 contract.
+- Mapped child state is serializable and stable across reload.
+- Runtime fails fast with an explicit not-implemented error if a workflow reaches
+  `map_workflow` before PR 7B lands.
+- The editor cannot add `map_workflow` nodes until PR 7C.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows/parser.test.ts tests/plugins/workflows/runtime.test.ts
+bun run typecheck
+bun run lint
+```
+
+Rollback boundary:
+
+- Revert parser/state support without touching child task creation or defaults.
+
+### PR 7B: Mapped Child Task Creation and Join
+
+Release note headline:
+
+> Workflows: mapped workflows create visible child tasks and rejoin in order.
+
+Scope:
+
+- Create one visible child Bakin task per source item.
+- Start the configured child workflow for each task.
+- Aggregate completed child outputs into ordered `results[]` and `finalOutputs[]`.
+- Keep parent step in progress until all required children complete.
+- Enforce fanout concurrency policy from PR 6.
+
+Likely files:
+
+- `plugins/workflows/lib/runtime.ts`
+- `plugins/workflows/types.ts`
+- `plugins/workflows/index.ts`
+- `src/core/task-store.ts`
+- `src/core/task-service.ts` if task creation needs service-level effects/audit
+- `src/core/sse.ts` or workflow notification files if progress events change
+- `tests/plugins/workflows/runtime.test.ts`
+- `tests/core/task-service.test.ts` if service-level task creation changes
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Parent maps `segments[]` into visible child tasks.
+- Each child runs the configured child workflow.
+- Parent joins only after all required children complete.
+- Parent output preserves child outputs in source order.
+- Parent output includes child task id, child instance id, source input, status, final output, and per-step outputs.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows/runtime.test.ts
+bun run typecheck
+bun run lint
+```
+
+Rollback boundary:
+
+- Revert child task creation/join while keeping parser/state support if useful.
+
+### PR 7C: Fanout Retry, Status UI, and Editor Node
+
+Release note headline:
+
+> Workflows: mapped child workflow status and retries are visible.
+
+Scope:
+
+- Show dynamic child task status on parent workflow detail/edit surfaces.
+- Add editor support for the `map_workflow` node without pretending dynamic children are static YAML nodes.
+- Render a positive `map_workflow` UI: source path, child workflow id, configured
+  concurrency, child count/status badge when an instance is running, and links
+  or drill-in controls for child task detail.
+- Support retry/reopen for one failed or rejected child without regenerating successful siblings.
+- Re-join automatically after the retried child completes.
+
+Likely files:
+
+- `plugins/workflows/components/workflow-detail.tsx`
+- `plugins/workflows/components/workflow-canvas-editor.tsx`
+- `plugins/workflows/components/node-config-drawer.tsx`
+- `plugins/workflows/components/workflow-canvas.tsx`
+- `plugins/workflows/lib/node-type-registry.ts`
+- `plugins/workflows/lib/runtime.ts`
+- `tests/plugins/workflows/workflow-canvas-editor.test.tsx`
+- `tests/plugins/workflows/runtime.test.ts`
+- new route/component coverage under `tests/plugins/workflows/`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Failed/rejected child can be inspected without losing the whole parent.
+- Failed children can be retried from the failed step or from the beginning of the child workflow.
+- Reopening/retrying one child does not regenerate completed sibling segments.
+- Parent assembly starts only after every required child is complete.
+- Editor shows the static `map_workflow` node and its config.
+- Running workflow detail shows child count/status and drill-in links to child tasks.
+- UI does not show runtime-created children as saved static YAML nodes.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows
+bun run typecheck
+bun run lint
+bun run dev:mock
+```
+
+Rollback boundary:
+
+- Revert retry/UI/editor support while preserving runtime primitives.
+
+### PR 7D: Video Fanout Workflow Defaults
+
+Release note headline:
+
+> Workflows: video production fans out segment creation into child tasks.
+
+Scope:
+
+- Add or update `video-social-post` to use `map_workflow`.
+- Add `video-segment-creation` child workflow.
+- Update video script/assembly contracts to use ordered `finalOutputs[]`.
+- Keep the new video fanout workflow enabled by default.
+- Standardize media outputs on filenames, not paths.
+
+Likely files:
+
+- `plugins/workflows/defaults/workflows/video-social-post.yaml`
+- `plugins/workflows/defaults/workflows/video-script.yaml`
+- `plugins/workflows/defaults/workflows/video-segment-creation.yaml`
+- `plugins/workflows/defaults/workflows/assemble-video.yaml`
+- `plugins/workflows/defaults/workflow-skills/generate-video.md`
+- `plugins/workflows/defaults/workflow-skills/publish.md`
+- `tests/plugins/workflows/yaml-roundtrip.test.ts`
+- default-contract tests under `tests/plugins/workflows/`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- Video workflow uses the primitive as the first shipped proof and is enabled by default.
+- If pre-production testing hits the spec's disablement threshold, the workflow
+  is disabled through `disabled-defaults.json` until a follow-up fixes the workflow.
+- Segment workflow outputs use `video_filename` as the required asset identity.
+- Assembly workflow outputs use final `video_filename` as the required asset identity.
+- Generated media is saved through `bakin_exec_assets_save(type=video|audio|images)`.
+- Generated media outputs do not use `videoPath`, `audioPath`, or raw filesystem paths.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows
+bun run typecheck
+bun run lint
+bun run dev:mock
+```
+
+Rollback boundary:
+
+- Revert video defaults without removing the underlying fanout runtime.
+
+### PR 7E: Video Fanout End-to-End Hardening
+
+Release note headline:
+
+> Workflows: video fanout has end-to-end mock-runtime coverage.
+
+Scope:
+
+- Run a full parent video workflow through script, segment fanout, child completion, join, assembly, and publish handoff in the mock runtime.
+- Add regression coverage for stable child ids, retry after script edits, and publish filename handoff.
+- Document known quality gaps found during real test runs.
+
+Likely files:
+
+- `tests/plugins/workflows/runtime.test.ts`
+- `tests/plugins/workflows/video-fanout.e2e.test.ts` or equivalent
+- `dev/imitation-crab/` fixtures if mock runtime needs seeded media responses
+- `plugins/workflows/defaults/workflows/*video*.yaml`
+- `.claude/specs/workflow-defaults-audit.md`
+- `.claude/knowledge/workflows-plugin.md`
+
+Acceptance criteria:
+
+- A 30-second-style video workflow can run end-to-end in the mock runtime.
+- Stable child id behavior is covered.
+- Retry does not duplicate completed child tasks.
+- Publish handoff uses `videoFilename`.
+- If two consecutive full video-fanout runs fail to produce a usable final asset
+  for workflow-design reasons after one segment retry, use PR 5 availability to
+  disable the default until fixed.
+- Follow-up quality issues are captured if real media generation still needs tuning.
+
+Verification:
+
+```bash
+bun test --isolate tests/plugins/workflows
+bun run typecheck
+bun run lint
+bun run dev:mock
+```
+
+Rollback boundary:
+
+- Revert hardening/tests/docs without removing shipped runtime behavior.
+
+## Dependency Graph
+
+```text
+Editor stabilization
+  -> workflow audit can be inspected visually
+
+Image repo contract cleanup
+  -> installed stale-skill detection can repair toward the new contract
+
+Installed drift detection/provenance
+  -> safe UI/CLI repair path
+
+Shipped workflow audit
+  -> default workflow availability decisions
+  -> per-workflow cleanup PRs
+  -> dynamic fanout video spec
+
+Dynamic fanout spec
+  -> PR 7A parser/runtime state
+  -> PR 7B child task creation/join
+  -> PR 7C retry/status UI/editor node
+  -> PR 7D video workflow defaults
+  -> PR 7E end-to-end hardening
+
+Healthy image/video workflows
+  -> later official plugin extraction
+```
+
+## Cross-Cutting Verification
+
+Before each PR:
+
+```bash
+git status --short
+```
+
+Before each PR is ready:
+
+```bash
+bun test --isolate tests/plugins/workflows
+bun run typecheck
+```
+
+When UI changes:
+
+```bash
+bun run dev:mock
+```
+
+When docs or public surfaces change:
+
+```bash
+bun run docs:validate
+```
+
+Before larger merge points:
+
+```bash
+bun run lint
+bun test --isolate
+```
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Editor still passes unit tests while broken in browser | High | Add real browser/integration verification in PR 1 |
+| Canvas implies DAG scheduling that runtime does not support | High | Derived connectors only; explicit order controls |
+| User custom workflow skills get overwritten | High | Provenance plus explicit repair plan; advisory only for customized files |
+| Local shadows hide improved defaults | Medium | Keep Save as new in UI; add drift/availability visibility later |
+| Dynamic fanout becomes too abstract | Medium | Use video as the first target and acceptance test |
+| Video quality depends on media choices not yet proven | Medium | Keep audio placement provisional and validate through actual workflow runs |
+| Default disabling breaks matching unexpectedly | Medium | Ship as separate PR with matcher-focused tests |
+| Workflow-skill provenance has no files to mark | High | PR 3 adds an explicit materializer/installer before relying on sidecars |
+| Fanout runtime overloads local task/dispatch surfaces | Medium | PR 6 defines concurrency, event volume, and cost-preview policy before implementation |
+| Many concurrent child tasks clutter the UI | Medium | PR 6 defines concurrency and PR 7C adds grouped child status/drill-in instead of only flat task noise |
+| Drift detection false positives become nagging warnings | Medium | Keep repair advisory-only for unknown/custom files and add exact stale-pattern tests before surfacing warnings |
+| Legacy hash manifest grows without bounds | Low | Maintain it manually with reason metadata and prune obsolete pre-production entries before production release |
+
+## Release Note Outline
+
+- PR 1: Visual workflow editor restored and aligned with runtime step ordering.
+- PR 2: Image workflows now pass canonical asset filenames between steps.
+- PR 3: Workflow skill drift is visible in Health/doctor and safely repairable.
+- PR 4: Shipped workflow defaults now have an explicit health audit.
+- PR 5: Default workflows can be disabled to avoid accidental selection.
+- PR 6: Dynamic fanout design for video workflows is documented.
+- PR 7A: `map_workflow` parser and runtime state are available.
+- PR 7B: Mapped workflows create visible child tasks and join in source order.
+- PR 7C: Mapped child status and retry controls are visible.
+- PR 7D: Video workflows can fan out segment production into visible child tasks.
+- PR 7E: Video fanout has end-to-end mock-runtime coverage.
+
+## Deferred Decisions
+
+These are not blockers for PR 1, but each must be resolved before its owning PR starts:
+
+- PR 3: exact workflow-skill materializer command/API surface and whether it runs on boot, doctor repair, explicit install, or a combination.
+- PR 6: source path syntax edge cases beyond the restricted dot path, fanout concurrency limit, progress event/SSE volume, child agent assignment policy, dispatch cost preview, and stable child ids after script edits followed by retry.
+- PR 7D: exact media provider/tool choices for video generation, voiceover, and assembly.

--- a/.claude/specs/workflow-cleanup-and-refactor.md
+++ b/.claude/specs/workflow-cleanup-and-refactor.md
@@ -1,0 +1,604 @@
+# Spec: Workflow Cleanup and Refactor
+
+## Status
+
+Draft kickoff spec for the workflow cleanup program.
+
+Related issues:
+
+- #203: Workflow plugin cleanup and refactor: graph semantics, dynamic fanout, and richer production flows
+- #341: Audit image workflow filename contract
+- #342: Detect and repair stale installed workflow skills
+
+Companion plan: `.claude/specs/workflow-cleanup-and-refactor-plan.md`.
+
+## Assumptions
+
+1. This work should land as meaningful PRs with release-note-friendly boundaries.
+2. PR 1 is editor-only stabilization.
+3. PR 2 is repo-shipped image workflow filename contract cleanup.
+4. PR 3 is installed workflow skill drift detection and repair.
+5. The shipped-default workflow audit is a documentation/spec PR before per-workflow rewrites.
+6. The first audit covers repo-shipped defaults only. Local installed content is handled through diagnostics and repair.
+7. React Flow remains the workflow editor foundation.
+8. The editor must reflect the current ordered-step runtime. It must not imply arbitrary graph scheduling.
+9. No in-app YAML editor is needed. Advanced users can edit workflow YAML directly in their IDE.
+10. Plugin-owned workflows are read-only in the editor and can be saved as new user workflows. Same-id local shadowing is supported through direct YAML/PUT user overrides but is not the primary editor copy path.
+11. Default/core workflow disabling is included in the editor stabilization surface as a managed-workflow availability override.
+12. Dynamic fanout/fanin should be implemented through explicit control-flow nodes, not a full arbitrary DAG runtime.
+13. Video production is the first real target for dynamic fanout.
+14. Dynamic video fanout should create visible child Bakin tasks, each running a segment workflow.
+15. Audio/voiceover belongs in parent assembly by default, but this remains provisional until real output-quality testing.
+16. PR 1 ordering controls should start canvas-first. Users should be able to interact with nodes directly; a side/list reorder affordance can be added later if real usage shows it is needed.
+17. Disabled default workflow state should live as workflow-owned content under `~/.bakin/workflows/`, not in generic plugin settings.
+18. Disabled default workflows are unavailable for future matching, selection, and normal explicit starts unless a caller uses a deliberate override. Existing active instances continue unaffected.
+19. Installed workflow skill provenance uses sidecar files next to the markdown skill file, not extra markdown frontmatter.
+20. The new video fanout workflow should ship enabled by default. Bakin is not production released yet, so we can test and harden this default workflow in place.
+21. PR 2 is a narrow exception to the audit-before-rewrite rule because #341 is already confirmed and contract-level, not a broad workflow redesign.
+22. This is a single-user, single-machine system. Do not add compatibility layers or staged migrations unless a later decision explicitly needs them.
+
+## Objective
+
+Make Bakin workflows trustworthy again by fixing the authoring experience, correcting stale workflow contracts, surfacing drift safely, auditing shipped defaults, and then adding the dynamic fanout model needed for production-grade video workflows.
+
+Success means:
+
+- Users can open, understand, edit, and save workflows through a working React Flow editor.
+- The editor presents only runtime-supported behavior.
+- Shipped image workflows use canonical asset filenames, not filesystem paths, as the step contract.
+- Installed workflow skills that drift from repo defaults are visible in UI/CLI diagnostics and repairable only when safe.
+- Shipped workflows have a written health audit before larger rewrites.
+- Video workflows have a clear path toward script segmentation, fanout child tasks, segment generation, join, assembly, review, and publish.
+
+## Non-Goals
+
+- No full arbitrary DAG runtime in the initial cleanup.
+- No in-app YAML/source editor.
+- No silent overwrite or auto-revert of customized user content.
+- No image/video plugin extraction until workflows are healthy.
+- No dynamic video fanout in PR 1, PR 2, or PR 3.
+- No broad runtime scheduling rewrite before current editor/defaults/drift surfaces are stable.
+
+## Current Findings
+
+### Editor
+
+The current editor is intended to be the sole create/edit surface:
+
+- `plugins/workflows/components/workflow-canvas-editor.tsx`
+- `plugins/workflows/components/node-type-palette.tsx`
+- `plugins/workflows/components/node-config-drawer.tsx`
+- `plugins/workflows/lib/node-type-registry.ts`
+
+Existing tests pass, but they stub React Flow and do not prove the real browser flow:
+
+```bash
+bun test --isolate tests/plugins/workflows/workflow-canvas-editor.test.tsx tests/plugins/workflows/node-type-palette.test.tsx tests/plugins/workflows/node-config-drawer.test.tsx tests/plugins/workflows/parser.test.ts tests/plugins/workflows/yaml-roundtrip.test.ts
+```
+
+The first editor PR must add browser-backed or equivalent integration verification that actually opens a workflow, renders nodes, edits a node, adds a node, changes step order, saves, and reloads.
+
+### Runtime Model
+
+Current runtime support is intentionally conservative:
+
+- Ordered top-level step list.
+- Static `parallel` groups whose children are agent steps.
+- Nested `workflow` steps.
+- Human `gate` steps.
+- `output` steps.
+- `createTask` system steps.
+- Plugin-owned node kinds through explicit registered handlers.
+
+`dependsOn` is metadata and validation only. Freeform canvas edges are not scheduler truth today.
+The current editor already does not persist drawn canvas edges; it persists
+`definition.layout.positions` only. PR 1 therefore removes a misleading visual
+affordance rather than changing runtime scheduling behavior.
+
+### Image Workflow Contract
+
+Issue #341 is confirmed:
+
+- `plugins/workflows/defaults/workflows/image-generation.yaml` still asks for `imagePath` and `thumbnailPath`.
+- `plugins/workflows/defaults/workflows/image-social-post.yaml` still reads `stepOutputs['generate-image'].finalOutput.imagePath`.
+- `plugins/workflows/defaults/workflow-skills/generate-image.md` already uses `image_filename` and tells the agent to emit the save tool's returned filename.
+
+Repo-shipped image workflows should use canonical asset filenames such as `image_filename` as the step contract.
+
+### Installed Workflow Skill Drift
+
+Current workflow health checks only inspect frontmatter and `output_schema`:
+
+- `plugins/workflows/lib/health-checks.ts::checkWorkflowSkills`
+
+They do not detect:
+
+- `beacon_exec_` legacy tool names
+- `image_path`
+- `imagePath`
+- stale manual save instructions for already managed generated assets
+- path-based generated image output contracts
+
+Installed workflow skill drift needs provenance so doctor can distinguish safely repairable managed content from customized local content.
+
+## Desired Workflow Editor Contract
+
+### Runtime-Honest Canvas
+
+The editor remains React Flow based, but it must reflect current runtime behavior.
+
+Required behavior:
+
+- Show workflow steps as a visual ordered path.
+- Show connectors derived from step order, not user-authored execution edges.
+- Disable drawing freeform edges as execution state.
+- Provide canvas-first controls to reorder, insert, duplicate, delete, and auto-arrange steps.
+- Save ordered `definition.steps`.
+- Persist visual layout hints under `definition.layout.positions`.
+- Preserve YAML-backed fields that the editor does not own.
+
+`layout.positions` shape:
+
+```json
+{
+  "positions": {
+    "step-id": { "x": 120, "y": 80 }
+  }
+}
+```
+
+Keys are step ids. Top-level step positions are required for canvas layout when
+present. Parallel child positions are optional; if present they must be
+preserved, but PR 1 may render children in the parallel node's list/form rather
+than as independent canvas nodes.
+
+`dependsOn` behavior in PR 1:
+
+- Preserve existing `dependsOn` values on save.
+- Do not visualize `dependsOn` as execution edges.
+- Show a non-blocking warning when a step contains `dependsOn`: it is validated metadata only and the current runtime still executes by top-level order.
+- Do not add new `dependsOn` authoring controls in the runtime-honest editor.
+
+Fields the editor must preserve:
+
+- Definition-level: `id`, `name`, `description`, `version`, `inputs`, `layout`, and any unknown top-level extension fields.
+- Definition-level extension examples include `triggers`, `metadata`, and any future plugin-owned blocks.
+- Agent steps: `id`, `type`, `label`, `agent`, `task`, `skill`, `description`, `outputs`, `dependsOn`, `deny_tools`, and unknown extension fields.
+- Gate steps: `approval_required`, `notify`, `preview`, `on_approve`, `on_reject`, `dependsOn`, and unknown extension fields.
+- Parallel steps: parent fields plus child agent fields. Unsupported child shapes must be preserved or made read-only; they must not be silently dropped.
+- Output steps: `agent`, `skill`, `description`, `channels`, `content`, `schedule`, `dependsOn`, `deny_tools`, and unknown extension fields.
+- Nested workflow steps: `workflow_id`, `description`, `dependsOn`, future input mapping fields, future `output_schema`, and unknown extension fields.
+- `createTask` steps: task creation fields, `source`, `skipWorkflowReason`, `dependsOn`, and unknown extension fields.
+- Plugin-owned node kinds: preserve the opaque node config unless the registered node editor owns a specific field, including any node-level `output_schema`.
+
+Round-trip safety:
+
+- Opening and saving an unchanged user workflow should be byte-stable.
+- Editing one supported field should only change the expected YAML area plus layout positions.
+- Unsupported or invalid legacy YAML should render inspectably with save disabled for unsafe edits rather than being normalized into data loss.
+
+Plugin-owned workflow behavior:
+
+- Plugin defaults are read-only in place.
+- Editor offers Save as new.
+- Same-id shadowing remains possible by direct file/API usage but is not promoted in PR 1.
+- If a user-owned workflow shadows a plugin-owned id, the editor treats the user file as editable and clearly labels that it shadows a shipped default.
+
+YAML/source behavior:
+
+- No in-app YAML editor.
+- Raw edits remain a filesystem/IDE workflow.
+- Later drift/diff work can show source/diff readouts if needed, but not as PR 1 scope.
+
+### Static Parallel Groups
+
+The editor should support the runtime's existing static parallel model.
+
+Supported in PR 1:
+
+- Open a `parallel` node.
+- Add/remove/reorder child agent steps.
+- Edit child agent fields.
+- Save children under `parallel.steps`.
+
+Not supported inside static parallel groups:
+
+- Gate children.
+- Nested workflow children.
+- Nested parallel children.
+- Per-child dependency edges.
+- Sequential child execution ordering. Reordering child rows is allowed only as
+  serialization/display order; children still run as a static parallel group.
+  The user benefit is stable render/log/review order, not execution priority.
+- Dynamic one-child-per-array fanout.
+
+## Drift and Repair Contract
+
+Drift-prone workflow content must surface through the existing doctor/health system so both UI and CLI can show it consistently.
+
+Rules:
+
+- Managed, unedited content can be flagged and repaired after explicit confirmation.
+- Known stale patterns in user content are flagged, but not silently rewritten.
+- Customized or user-edited content is never auto-reverted.
+- Repair actions must present a deterministic plan before mutation.
+- Repair should use health-check repair handlers where possible.
+- UI and CLI should both show the drift.
+- PR 3 repairs stale workflow skills by full-file replacement only when
+  provenance proves the installed file is managed and unedited.
+- Files without provenance, files marked `.userEdited`, and files whose current
+  hash differs from `.installedBy.sha256` are advisory-only.
+- An unmarked file may be offered for explicit adopt-and-replace only when its
+  current hash exactly matches a known old repo-shipped workflow skill hash.
+- PR 3 must add a workflow-skill materializer/installer. Plugin and
+  agent-package workflow skills are currently registered in memory, so no
+  sidecar exists until the skill is projected to
+  `~/.bakin/workflows/skills/{name}.md`.
+- Materialization must not overwrite an existing unmarked local file unless it
+  satisfies the exact old-hash adoption path.
+- Known old hashes should live in a repo-shipped, versioned manifest such as
+  `plugins/workflows/defaults/workflow-skill-legacy-hashes.json`. They are not
+  fetched from the network at doctor time.
+- The legacy-hash manifest is manually maintained in the same PR as any
+  repo-shipped workflow skill change that needs adopt-and-replace repair. Each
+  entry should include a reason and introducing change, and obsolete
+  pre-production entries should be pruned before the first production release.
+
+Installed workflow skills should gain managed provenance, similar in spirit to `.installedBy` and `.userEdited` used by runtime skills and agent-package projections.
+
+Workflow skill provenance lives beside the markdown file:
+
+```text
+~/.bakin/workflows/skills/generate-image.md
+~/.bakin/workflows/skills/generate-image.md.installedBy
+~/.bakin/workflows/skills/generate-image.md.userEdited
+```
+
+The marker should record enough to compare the installed file to the current source without changing the markdown content itself:
+
+```json
+{
+  "sourceKind": "plugin",
+  "sourceId": "workflows",
+  "sourcePath": "defaults/workflow-skills/generate-image.md",
+  "sha256": "<installed markdown file sha>",
+  "installedAt": "<iso timestamp>"
+}
+```
+
+Agent-package workflow skills should use the same sidecar shape with `sourceKind:
+"agent-package"` and the package id as `sourceId`.
+
+The user-edited sentinel is an empty file. When present, doctor and repair must
+treat the skill as local user-owned content and must not mutate it.
+
+Sidecars are preferred over markdown frontmatter because provenance is Bakin
+install/repair state, not authored skill metadata. Frontmatter remains reserved
+for skill behavior such as `name` and `output_schema`. If a markdown file is
+copied without its sidecars, doctor should become conservative and warn instead
+of auto-repairing.
+
+## Default Workflow Availability
+
+Default/core workflows need an availability control so a shipped workflow can be disabled and not accidentally matched or selected.
+
+Disabled state should be stored as workflow-owned content at
+`~/.bakin/workflows/disabled-defaults.json`. This keeps availability close to definitions,
+instances, and matcher behavior instead of treating it as generic plugin UI
+configuration.
+
+Disabled defaults are treated as unavailable for future use, not deleted.
+
+Required behavior:
+
+- Auto-match ignores disabled default workflows.
+- Task creation workflow selectors omit disabled defaults unless the surface is explicitly a management/status view.
+- Normal workflow definition consumer lists omit or clearly mark disabled defaults. Management views may request disabled entries with an explicit include flag.
+- CLI workflow lists omit disabled defaults by default or show them only with an explicit flag.
+- Error messages that list available workflows do not suggest disabled defaults as normal choices.
+- Explicit starts by id reject disabled default workflows with a clear disabled-workflow error unless the caller provides a deliberate override.
+- Override surfaces are explicit: CLI commands use `--allow-disabled-workflow`,
+  HTTP/API calls use `allowDisabledWorkflow: true`, list endpoints use
+  `includeDisabled=true`, and plugin hooks use `allowDisabledWorkflow: true`.
+- Existing active, completed, or historical workflow instances keep loading and running. Disabling affects future selection and starts only.
+
+The editor stabilization slice includes the managed-workflow availability override and core list/matcher filtering. Broader caller-specific override controls remain later work because they touch:
+
+- source resolution
+- listing/filtering
+- matcher behavior
+- task creation surfaces
+- diagnostics for disabled references
+
+The shipped-default audit should help decide which defaults should ship enabled.
+
+## Dynamic Fanout/Fanin Direction
+
+The future #203 work should prefer explicit control-flow nodes over a full arbitrary DAG.
+
+Initial target node:
+
+```yaml
+- id: produce-segments
+  type: map_workflow
+  source: segment-script.segments
+  workflow_id: video-segment-creation
+```
+
+Expected semantics:
+
+- `source` points at a prior step output array using a restricted dot path:
+  `<prior-step-id>.<field>[.<field>...]`.
+- The first path segment must be a completed earlier top-level step id. The
+  remaining path segments address object fields only. Wildcards, filters, array
+  indexing, and arbitrary JSONPath are out of scope for v1.
+- Source paths can only reference step ids that do not contain `.`. If a
+  workflow needs `map_workflow`, validation rejects `source` paths whose first
+  segment cannot unambiguously identify a prior step id.
+- The resolved value must be a non-empty array unless the node explicitly sets
+  `allow_empty: true`.
+- With `allow_empty: true`, the parent step completes immediately with
+  `source.count: 0`, `results: []`, and `finalOutputs: []`, and downstream
+  steps run with that empty aggregate. Without it, an empty source is a clear
+  step failure.
+- Runtime creates one visible Bakin child task per source item.
+- Each child task runs the configured child workflow.
+- Each child receives the item plus parent context.
+- Parent step remains in progress until every child resolves.
+- Parent output contains child outputs in stable source order.
+- Individual child failures/rejections are visible and recoverable.
+- Parent can join after all children complete.
+- "Required children" means all children created from the source array. Optional
+  children and partial joins are not part of v1.
+- V1 must support retrying or reopening one child task/segment without resetting
+  successful siblings or the whole parent fanout.
+- The parent `map_workflow` step remains in progress until every required child
+  has completed successfully.
+- Parent assembly does not run partially in v1. It starts only after all
+  required child outputs are complete.
+
+Completed `map_workflow` steps should output a stable ordered shape:
+
+```json
+{
+  "source": {
+    "path": "segment-script.segments",
+    "count": 3
+  },
+  "childWorkflowId": "video-segment-creation",
+  "results": [
+    {
+      "index": 0,
+      "taskId": "parent-task--produce-segments-0",
+      "instanceId": "wf_child_...",
+      "input": {
+        "segment_number": 1,
+        "script": "..."
+      },
+      "status": "complete",
+      "finalOutput": {
+        "video_filename": "20260521-segment-1.mp4"
+      },
+      "outputs": {
+        "plan-segment": {},
+        "create-video": {
+          "video_filename": "20260521-segment-1.mp4"
+        }
+      }
+    }
+  ],
+  "finalOutputs": [
+    {
+      "video_filename": "20260521-segment-1.mp4"
+    }
+  ]
+}
+```
+
+`results` is the source-of-truth aggregate for debugging, UI, retry, and
+assembly. `finalOutputs` is a convenience array for downstream workflow steps
+that only need one ordered output per child.
+
+Child retry/reopen behavior:
+
+- Reopen a child workflow from its current failed, rejected, or pending gate state
+  using existing child task/workflow controls where possible.
+- Retry a failed child from the failed step or from the beginning of the child
+  workflow.
+- Do not regenerate successful sibling children during a child retry.
+- Re-join the parent automatically once the retried child completes.
+
+This does not require a full DAG. It does require new runtime instance state for mapped children and a clear UI representation of dynamic runtime-created children.
+
+## Reference Video Workflow
+
+The first real fanout implementation should target video.
+
+Desired flow:
+
+1. Parent task starts `video-social-post`.
+2. Primary assigned agent writes full script and creative direction.
+3. Human approves script.
+4. Agent breaks the script into `segments[]`, sized for the target video.
+5. `map_workflow` creates one visible child task per segment.
+6. Each child task runs `video-segment-creation`.
+7. Segment workflow creates/chooses prompt and video model.
+8. Human approves segment prompt or generation plan.
+9. Segment workflow creates the clip and captures asset filename/metadata.
+10. Parent joins all child outputs in source order.
+11. Parent assembly workflow generates or attaches audio/voiceover, stitches clips, and prepares final output.
+12. Human reviews final assembled video.
+13. Parent publishes.
+
+Audio placement note:
+
+- Audio/voiceover starts in parent assembly by default, but real workflow testing may prove per-segment audio, no generated audio, or another pattern is better.
+
+Enablement decision:
+
+- The dynamic video fanout workflow should be enabled by default when it ships.
+- The initial quality bar is a runnable, inspectable end-to-end workflow that can
+  be tested and hardened in place.
+- This pre-production default can still be improved through follow-up workflow
+  audit and hardening PRs after real runs expose quality gaps.
+- This deliberately chooses fast pre-production feedback over the later
+  disabled-by-default mechanism. If real runs show the default is harmful or too
+  noisy, PR 5's availability controls are the escape hatch.
+- During pre-production, if two consecutive full video-fanout runs fail to
+  produce a usable final asset for workflow-design reasons after one segment
+  retry, disable the default with PR 5 availability until the workflow is fixed.
+- If media generation cost/noise becomes the blocker rather than workflow
+  correctness, keep the workflow enabled only when its configured provider/tools
+  can run inside the current local test budget.
+- It must still maintain the agreed workflow contracts: segment child tasks,
+  stable asset filename outputs, ordered parent aggregation, and child retry
+  without regenerating successful siblings.
+
+Media asset contract:
+
+- `video-segment-creation` requires `video_filename`.
+- `video-segment-creation` may also emit `thumbnail_filename`,
+  `duration_seconds`, `prompt`, `model`, and `aspect_ratio`.
+- Parent assembly requires final `video_filename`.
+- Parent assembly may also emit `audio_filename`, `clip_filenames`, and
+  `duration_seconds`.
+- Agents save media through `bakin_exec_assets_save` with `type=video`,
+  `type=audio`, or `type=images`.
+- Publishing uses `bakin_exec_post_channel(videoFilename=...)`.
+- Workflow outputs must not use `videoPath`, `audioPath`, or raw filesystem
+  paths for generated media.
+
+## Project Structure
+
+Primary implementation areas:
+
+```text
+plugins/workflows/
+  components/                  React Flow editor, detail view, node drawer, palette
+  defaults/workflows/           shipped workflow YAML
+  defaults/workflow-skills/     shipped workflow step skills
+  lib/                          parser, runtime, health checks, registries
+  types.ts                      workflow definition and instance types
+
+tests/plugins/workflows/        parser/runtime/editor/health/default coverage
+.claude/knowledge/              durable architecture notes
+.claude/specs/                  this spec and companion plan
+docs/src/content/docs/using/    user-facing docs when behavior changes
+README.md                       only if top-level architecture/user docs are impacted
+```
+
+## Commands
+
+Baseline and focused workflow tests:
+
+```bash
+bun test --isolate tests/plugins/workflows/workflow-canvas-editor.test.tsx tests/plugins/workflows/node-type-palette.test.tsx tests/plugins/workflows/node-config-drawer.test.tsx tests/plugins/workflows/parser.test.ts tests/plugins/workflows/yaml-roundtrip.test.ts
+```
+
+Workflow plugin tests:
+
+```bash
+bun test --isolate tests/plugins/workflows
+```
+
+Broader verification:
+
+```bash
+bun run typecheck
+bun run lint
+bun test --isolate
+```
+
+Dev server:
+
+```bash
+bun run dev
+```
+
+Mock runtime dev server:
+
+```bash
+bun run dev:mock
+```
+
+## Testing Strategy
+
+PR 1 must add runtime-visible UI verification, not just React unit smoke tests.
+
+Recommended coverage:
+
+- Component/integration tests for editor state transitions.
+- API route tests for save behavior and plugin-owned read-only/customization paths.
+- Browser-backed verification for `/workflows/:id/edit` with a real workflow definition.
+- Regression tests that verify connectors are derived from order and user-authored edges are not saved as runtime semantics.
+- Tests for static parallel child editing.
+
+PR 2 coverage:
+
+- Shipped workflow audit test rejecting `imagePath`, `image_path`, and raw generated image paths in YAML defaults.
+- Tests for image-generation output schema using `image_filename`.
+- Tests for publish handoff reading the filename contract.
+
+PR 3 coverage:
+
+- Health check detects known stale installed workflow skill patterns.
+- Provenance distinguishes managed stale from customized local content.
+- Repair plan updates safe managed stale content only.
+- Customized content is advisory/manual only.
+- CLI/Health UI can surface the warning through existing health routes.
+
+Fanout coverage:
+
+- Runtime creates stable child tasks from an array output.
+- Parent remains in progress until all child tasks complete.
+- Parent aggregates outputs in stable order.
+- A failed/rejected child does not require rewinding the entire parent.
+- UI displays dynamic child task status without pretending children are static YAML nodes.
+
+## Boundaries
+
+Always:
+
+- Keep workflow runtime behavior honest in the editor.
+- Add tests before behavior changes.
+- Update `.claude/knowledge` when workflow architecture changes.
+- Use doctor/health for drift visibility.
+- Preserve user-authored content unless an explicit repair plan is confirmed.
+
+Ask first:
+
+- Changing workflow runtime scheduling semantics.
+- Adding new node types.
+- Adding new dependencies.
+- Changing task matching/selection behavior.
+- Moving image or video workflows into official plugins.
+
+Never:
+
+- Silently overwrite customized workflow files.
+- Represent freeform canvas edges as runtime behavior before the runtime supports them.
+- Let repo defaults depend on local literal agent ids.
+- Add compatibility shims for obsolete workflow contracts unless explicitly requested.
+
+## Success Criteria
+
+- PR-sized milestones are defined and independently shippable.
+- Each milestone has release-note language and rollback boundaries.
+- PR 1 makes the current workflow editor usable and runtime-honest.
+- PR 2 resolves repo-shipped image filename contract drift.
+- PR 3 surfaces and safely repairs managed installed workflow skill drift.
+- The shipped-default audit records the health and intended path for every repo default workflow.
+- Later dynamic fanout work is grounded in the video workflow and not an abstract unused primitive.
+
+## Deferred Decisions
+
+These are not blockers for PR 1, but they must be resolved before the named PR
+that owns them starts:
+
+- PR 3: exact workflow-skill materializer command/API surface and whether it
+  runs on boot, doctor repair, explicit install, or some combination.
+- PR 6: fanout concurrency limit, progress event/SSE volume, child agent
+  assignment policy, dispatch cost preview, and stable child id behavior after
+  script edits followed by retry.
+- PR 7D: exact media provider/tool choices for video generation, voiceover, and
+  assembly.

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -148,6 +148,11 @@ export interface SkillDefinition {
 // workflows plugin, but core needs the type to expose ctx.registerWorkflow
 // without an upward import. The workflows plugin re-validates with Zod.)
 // ---------------------------------------------------------------------------
+export interface WorkflowLayoutInput {
+  positions?: Record<string, { x: number; y: number; [key: string]: unknown }>
+  [key: string]: unknown
+}
+
 export interface WorkflowDefinitionInput {
   /** Stable workflow id. Falls back to slug(name) when omitted. */
   id?: string
@@ -155,7 +160,9 @@ export interface WorkflowDefinitionInput {
   description: string
   version: number
   inputs?: Record<string, unknown>
+  layout?: WorkflowLayoutInput
   steps: unknown[]
+  [key: string]: unknown
 }
 
 // ---------------------------------------------------------------------------
@@ -831,6 +838,13 @@ export interface FileBackedContentTypeDefinition extends SearchContentTypeDefini
    * own initial population (rare).
    */
   buildOnStartup?: boolean
+  /**
+   * Keep indexed documents that are not represented by a matched file when
+   * verifyExists(key) still returns true. Use this only for hybrid content
+   * types that combine file-backed rows with registry/runtime rows in the
+   * same table.
+   */
+  preserveVirtualDocuments?: boolean
 }
 
 /** Search API provided to plugins via ctx.search */

--- a/packages/host/public/index.html
+++ b/packages/host/public/index.html
@@ -9,6 +9,45 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/globals.css" />
+    <style>
+      :root { color-scheme: dark; }
+      html, body, #root { min-height: 100%; }
+      body {
+        margin: 0;
+        background: #0f0e0e;
+        color: #ffffff;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .bakin-boot {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0f0e0e;
+      }
+      .bakin-boot__inner {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        color: #aeaaaa;
+        font-size: 13px;
+      }
+      .bakin-boot__spinner {
+        width: 30px;
+        height: 30px;
+        border: 3px solid rgba(255, 77, 148, 0.18);
+        border-top-color: #ff4d94;
+        border-radius: 9999px;
+        animation: bakin-spin 800ms linear infinite;
+      }
+      .bakin-boot__text {
+        display: block;
+        line-height: 1;
+      }
+      @keyframes bakin-spin {
+        to { transform: rotate(360deg); }
+      }
+    </style>
     <!--
       Import map (TD3 of #147) — resolves the externals the shell + plugins
       share at runtime. Keep ordering consistent with the externals list in
@@ -37,7 +76,14 @@
     </script>
   </head>
   <body class="bg-background text-foreground">
-    <div id="root"></div>
+    <div id="root">
+      <div class="bakin-boot" role="status" aria-live="polite">
+        <div class="bakin-boot__inner">
+          <span class="bakin-boot__spinner" aria-hidden="true"></span>
+          <span class="bakin-boot__text">Loading app</span>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/assets/main.js"></script>
   </body>
 </html>

--- a/packages/host/src/api/_embedded-assets-static.ts
+++ b/packages/host/src/api/_embedded-assets-static.ts
@@ -42,6 +42,7 @@ import asset_api_plugins_memory_assets_client_js from '../../../../plugins/memor
 import asset_api_plugins_memory_assets_index_js from '../../../../plugins/memory/dist/index.js' with { type: 'file' }
 import asset_api_plugins_health_assets_client_js from '../../../../plugins/health/dist/client.js' with { type: 'file' }
 import asset_api_plugins_health_assets_index_js from '../../../../plugins/health/dist/index.js' with { type: 'file' }
+import asset_api_plugins_health_assets_SKILL_r49bkmzv_md from '../../../../plugins/health/dist/SKILL-r49bkmzv.md' with { type: 'file' }
 import asset_api_plugins_workflows_assets_client_js from '../../../../plugins/workflows/dist/client.js' with { type: 'file' }
 import asset_api_plugins_workflows_assets_index_js from '../../../../plugins/workflows/dist/index.js' with { type: 'file' }
 import asset_api_plugins_workflows_assets_client_css from '../../../../plugins/workflows/dist/client.css' with { type: 'file' }
@@ -87,6 +88,7 @@ export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
   ['/api/plugins/memory/assets/index.js', asset_api_plugins_memory_assets_index_js],
   ['/api/plugins/health/assets/client.js', asset_api_plugins_health_assets_client_js],
   ['/api/plugins/health/assets/index.js', asset_api_plugins_health_assets_index_js],
+  ['/api/plugins/health/assets/SKILL-r49bkmzv.md', asset_api_plugins_health_assets_SKILL_r49bkmzv_md],
   ['/api/plugins/workflows/assets/client.js', asset_api_plugins_workflows_assets_client_js],
   ['/api/plugins/workflows/assets/index.js', asset_api_plugins_workflows_assets_index_js],
   ['/api/plugins/workflows/assets/client.css', asset_api_plugins_workflows_assets_client_css],
@@ -102,4 +104,4 @@ export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
   ['/data/curated-agents.json', asset_data_curated_agents_json],
 ])
 
-export const EMBEDDED_ASSET_COUNT = 40
+export const EMBEDDED_ASSET_COUNT = 41

--- a/packages/host/src/plugin-host/PluginHost.tsx
+++ b/packages/host/src/plugin-host/PluginHost.tsx
@@ -152,6 +152,19 @@ function isDevModeActive(): boolean {
   return !!document.querySelector('script[src="/__bakin-dev/client.js"]')
 }
 
+function AppBootLoader() {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-background text-foreground" role="status" aria-live="polite">
+      <div className="flex items-center gap-3.5 text-sm text-muted-foreground">
+        <span className="size-7 animate-spin rounded-full border-[3px] border-[#ff4d94]/20 border-t-[#ff4d94]" aria-hidden="true" />
+        <span className="leading-none">
+          Loading plugins
+        </span>
+      </div>
+    </div>
+  )
+}
+
 export function PluginHost({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false)
 
@@ -209,6 +222,6 @@ export function PluginHost({ children }: { children: ReactNode }) {
     return () => window.removeEventListener(VERSION_MISMATCH_EVENT, handler)
   }, [])
 
-  if (!ready) return null
+  if (!ready) return <AppBootLoader />
   return <>{children}</>
 }

--- a/packages/host/src/routes/workflows.$id.edit.tsx
+++ b/packages/host/src/routes/workflows.$id.edit.tsx
@@ -19,7 +19,8 @@ function WorkflowEditPage() {
   const { id } = Route.useParams()
   const navigate = useNavigate()
   const [definition, setDefinition] = useState<WorkflowDefinition | null>(null)
-  const [source, setSource] = useState<'plugin' | 'user' | undefined>()
+  const [source, setSource] = useState<'plugin' | 'agent-package' | 'user' | undefined>()
+  const [shadowedSource, setShadowedSource] = useState<unknown>()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -34,6 +35,7 @@ function WorkflowEditPage() {
         const data = await res.json()
         setDefinition(data.definition)
         setSource(data.source)
+        setShadowedSource(data.shadowedSource)
       } catch {
         setError('Failed to load workflow')
       } finally {
@@ -68,9 +70,11 @@ function WorkflowEditPage() {
       initialId={id}
       initialDefinition={definition}
       source={source}
+      shadowedSource={shadowedSource}
       onSaved={(savedId: string) => navigate({ to: '/workflows/$id', params: { id: savedId } })}
+      onCopied={(copiedId: string) => navigate({ to: '/workflows/$id/edit', params: { id: copiedId } })}
       onDeleted={() => navigate({ to: '/workflows' })}
-      onCancel={() => navigate({ to: '/workflows/$id', params: { id } })}
+      onCancel={() => navigate({ to: '/workflows' })}
     />
   )
 }

--- a/packages/host/src/routes/workflows.new.tsx
+++ b/packages/host/src/routes/workflows.new.tsx
@@ -3,7 +3,7 @@
  *
  * Mirrors `src/app/workflows/new/page.tsx`. The workflows plugin's
  * canvas editor handles saved/cancel lifecycle via callbacks; we
- * navigate to the new workflow's detail page on save, back to the
+ * navigate to the new workflow's editor on save, back to the
  * list on cancel.
  */
 import { createRoute, useNavigate } from '@tanstack/react-router'
@@ -16,7 +16,7 @@ function WorkflowsNewPage() {
     <Slot
       name="page:/workflows/new"
       mode="create"
-      onSaved={(savedId: string) => navigate({ to: '/workflows/$id', params: { id: savedId } })}
+      onSaved={(savedId: string) => navigate({ to: '/workflows/$id/edit', params: { id: savedId } })}
       onCancel={() => navigate({ to: '/workflows' })}
     />
   )

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -620,6 +620,7 @@ export interface FileBackedContentTypeDefinition extends SearchContentTypeDefini
   onSync?: (relPath: string, content: string) => Promise<void>
   onUnlink?: (relPath: string) => Promise<void>
   buildOnStartup?: boolean
+  preserveVirtualDocuments?: boolean
 }
 
 export interface SearchQueryParams {
@@ -775,13 +776,20 @@ export interface SkillDefinition {
   source?: string
 }
 
+export interface WorkflowLayoutInput {
+  positions?: Record<string, { x: number; y: number; [key: string]: unknown }>
+  [key: string]: unknown
+}
+
 export interface WorkflowDefinitionInput {
   id?: string
   name: string
   description: string
   version: number
   inputs?: Record<string, unknown>
+  layout?: WorkflowLayoutInput
   steps: unknown[]
+  [key: string]: unknown
 }
 
 export type FormFieldType = 'string' | 'text' | 'number' | 'boolean' | 'select' | 'agent' | 'skill' | 'list'

--- a/plugins/workflows/client.tsx
+++ b/plugins/workflows/client.tsx
@@ -4,7 +4,7 @@
  * - `registerPlugin` contributes nav items and page slots.
  * - `registerNodeRenderer` wires each xyflow node kind to its visual
  *   component. Kinds are globally unique — built-ins use their bare name
- *   (`agent`, `gate`, `parallel`, `output`, `workflow`, `trigger`,
+ *   (`agent`, `gate`, `parallel`, `output`, `workflow`, `createTask`, `trigger`,
  *   `subflowGroup`); plugin-owned kinds arrive pre-namespaced as
  *   `{pluginId}.{kind}`.
  */
@@ -17,6 +17,7 @@ import { GateNode } from './components/nodes/gate-node'
 import { ParallelNode } from './components/nodes/parallel-node'
 import { OutputNode } from './components/nodes/output-node'
 import { WorkflowNode } from './components/nodes/workflow-node'
+import { CreateTaskNode } from './components/nodes/create-task-node'
 import { SubflowGroupNode } from './components/nodes/subflow-group-node'
 import { WorkflowsPage } from './components/workflows-page'
 import { WorkflowDetail } from './components/workflow-detail'
@@ -51,6 +52,7 @@ registerNodeRenderer('gate', GateNode)
 registerNodeRenderer('parallel', ParallelNode)
 registerNodeRenderer('output', OutputNode)
 registerNodeRenderer('workflow', WorkflowNode)
+registerNodeRenderer('createTask', CreateTaskNode)
 registerNodeRenderer('subflowGroup', SubflowGroupNode)
 
 // v2 dev hot-swap teardown: the SDK's unregisterPlugin clears nav + slots,

--- a/plugins/workflows/components/managed-workflow-copy-dialog.tsx
+++ b/plugins/workflows/components/managed-workflow-copy-dialog.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import { Copy, Workflow } from 'lucide-react'
+import { Button } from "@makinbakin/sdk/ui"
+import { Checkbox } from "@makinbakin/sdk/ui"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@makinbakin/sdk/ui"
+import { Input } from "@makinbakin/sdk/ui"
+import { Label } from "@makinbakin/sdk/ui"
+import { Textarea } from "@makinbakin/sdk/ui"
+import type { WorkflowDialogFieldErrors } from './workflow-dialog-validation'
+
+interface ManagedWorkflowCopyDialogProps {
+  open: boolean
+  variant?: 'copy' | 'create'
+  creating: boolean
+  error?: string | null
+  fieldErrors?: WorkflowDialogFieldErrors
+  copyName: string
+  copyId: string
+  workflowDescription?: string
+  disableOriginal: boolean
+  showDescription?: boolean
+  showDisableOriginal?: boolean
+  onOpenChange: (open: boolean) => void
+  onCopyNameChange: (value: string) => void
+  onCopyIdChange: (value: string) => void
+  onWorkflowDescriptionChange?: (value: string) => void
+  onDisableOriginalChange: (value: boolean) => void
+  onCancel: () => void
+  onCreate: () => void
+}
+
+export function ManagedWorkflowCopyDialog({
+  open,
+  variant = 'copy',
+  creating,
+  error,
+  fieldErrors = {},
+  copyName,
+  copyId,
+  workflowDescription = '',
+  disableOriginal,
+  showDescription = false,
+  showDisableOriginal = true,
+  onOpenChange,
+  onCopyNameChange,
+  onCopyIdChange,
+  onWorkflowDescriptionChange,
+  onDisableOriginalChange,
+  onCancel,
+  onCreate,
+}: ManagedWorkflowCopyDialogProps) {
+  const isCreate = variant === 'create'
+  const title = isCreate ? 'Create workflow' : 'Edit managed workflow'
+  const description = isCreate
+    ? 'Name this workflow before opening the canvas. Bakin will create it now, then you can add and configure steps.'
+    : 'To edit this workflow, Bakin will create a custom copy. Name the copy now, then optionally disable the managed original so automatic selection skips it.'
+  const nameLabel = isCreate ? 'Workflow name' : 'Copy name'
+  const namePlaceholder = isCreate ? 'Workflow name' : 'Workflow copy name'
+  const idPlaceholder = isCreate ? 'workflow-id' : 'workflow-copy-id'
+  const submitLabel = isCreate ? 'Create workflow' : 'Create copy'
+  const creatingLabel = isCreate ? 'Creating...' : 'Creating...'
+  const cancelLabel = isCreate ? 'Cancel' : 'Back'
+  const SubmitIcon = isCreate ? Workflow : Copy
+  const nameErrorId = fieldErrors.name ? 'workflow-copy-name-error' : undefined
+  const idErrorId = fieldErrors.id ? 'workflow-copy-id-error' : undefined
+  const descriptionErrorId = fieldErrors.description ? 'workflow-copy-description-error' : undefined
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (creating) return
+        onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="bg-card border-border sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label
+              htmlFor="workflow-copy-name"
+              className={fieldErrors.name ? 'text-red-300' : undefined}
+            >
+              {nameLabel}
+            </Label>
+            <Input
+              id="workflow-copy-name"
+              value={copyName}
+              onChange={(e) => onCopyNameChange(e.target.value)}
+              placeholder={namePlaceholder}
+              aria-invalid={Boolean(fieldErrors.name) || undefined}
+              aria-describedby={nameErrorId}
+            />
+            {fieldErrors.name && (
+              <p id={nameErrorId} className="text-xs font-medium leading-relaxed text-red-300">
+                {fieldErrors.name}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label
+              htmlFor="workflow-copy-id"
+              className={fieldErrors.id ? 'text-red-300' : undefined}
+            >
+              Workflow id
+            </Label>
+            <Input
+              id="workflow-copy-id"
+              value={copyId}
+              onChange={(e) => onCopyIdChange(e.target.value)}
+              placeholder={idPlaceholder}
+              aria-invalid={Boolean(fieldErrors.id) || undefined}
+              aria-describedby={idErrorId}
+            />
+            {fieldErrors.id && (
+              <p id={idErrorId} className="text-xs font-medium leading-relaxed text-red-300">
+                {fieldErrors.id}
+              </p>
+            )}
+          </div>
+          {showDescription && (
+            <div className="flex flex-col gap-1.5">
+              <Label
+                htmlFor="workflow-copy-description"
+                className={fieldErrors.description ? 'text-red-300' : undefined}
+              >
+                Description
+              </Label>
+              <Textarea
+                id="workflow-copy-description"
+                rows={3}
+                value={workflowDescription}
+                onChange={(e) => onWorkflowDescriptionChange?.(e.target.value)}
+                placeholder="Describe when this workflow should be used"
+                aria-invalid={Boolean(fieldErrors.description) || undefined}
+                aria-describedby={descriptionErrorId}
+              />
+              {fieldErrors.description && (
+                <p id={descriptionErrorId} className="text-xs font-medium leading-relaxed text-red-300">
+                  {fieldErrors.description}
+                </p>
+              )}
+            </div>
+          )}
+          {showDisableOriginal && (
+            <Label className="items-start gap-2 rounded-md border border-border bg-muted/30 p-2 text-foreground">
+              <Checkbox
+                checked={disableOriginal}
+                onCheckedChange={(checked) => onDisableOriginalChange(checked === true)}
+                className="mt-0.5"
+              />
+              <span className="flex flex-col gap-1">
+                <span className="text-xs font-medium">Disable the managed workflow</span>
+                <span className="text-[11px] font-normal leading-snug text-muted-foreground">
+                  The original stays visible in Managed workflows, but matching and automatic starts will skip it.
+                </span>
+              </span>
+            </Label>
+          )}
+        </div>
+        {error && (
+          <div className="rounded border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-200">
+            {error}
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={onCancel}
+            disabled={creating}
+          >
+            {cancelLabel}
+          </Button>
+          <Button onClick={onCreate} disabled={creating}>
+            <SubmitIcon className="mr-1 size-3.5" />
+            {creating ? creatingLabel : submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/plugins/workflows/components/node-config-drawer.tsx
+++ b/plugins/workflows/components/node-config-drawer.tsx
@@ -9,8 +9,8 @@
  * before Apply, so the drawer and the loader cannot drift.
  */
 
-import { useMemo, useState } from 'react'
-import { X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowDown, ArrowUp, Plus, Trash2, X } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
 import { Input } from "@makinbakin/sdk/ui"
 import { Textarea } from "@makinbakin/sdk/ui"
@@ -36,9 +36,34 @@ export interface NodeConfigDrawerProps {
   } | null
   /** Kind to use when step.type isn't registered (plugin hasn't shipped yet). */
   fallbackKind?: string
-  /** Called when the user Applies; patch contains only fields the form owns. */
+  /** Called when the user Applies; payload preserves fields the form does not own. */
   onApply: (patch: Record<string, unknown>) => void
+  onDelete?: () => void
   onClose: () => void
+  onDirtyChange?: (dirty: boolean) => void
+  existingStepIds?: string[]
+  reservedStepIds?: string[]
+}
+
+type ParallelChildRow = {
+  id: string
+  type: string
+  label: string
+  [k: string]: unknown
+}
+
+type WorkflowSelectOption = {
+  id: string
+  name: string
+  disabled?: boolean
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isDrawerEditableField(kind: string, field: FormField): boolean {
+  return field.name !== 'dependsOn' && !(kind === 'parallel' && field.name === 'steps')
 }
 
 function coerceListInput(value: string): string[] {
@@ -55,13 +80,198 @@ function fieldInitialValue(step: Record<string, unknown>, field: FormField): unk
     if (field.type === 'list') return ''
     return ''
   }
+  if (field.name === 'on_reject' && isRecord(raw)) return raw.goto ?? ''
   if (field.type === 'list' && Array.isArray(raw)) return raw.join(', ')
+  if (field.type === 'text' && isRecord(raw)) return JSON.stringify(raw, null, 2)
   return raw
 }
 
-export function NodeConfigDrawer({ step, fallbackKind, onApply, onClose }: NodeConfigDrawerProps) {
+function coerceFieldValue(step: Record<string, unknown>, field: FormField, value: unknown): unknown {
+  if (field.name === 'on_reject') {
+    if (typeof value !== 'string' || value.trim().length === 0) return undefined
+    return {
+      ...(isRecord(step.on_reject) ? step.on_reject : {}),
+      goto: value.trim(),
+    }
+  }
+  if (field.name === 'content' && field.type === 'text' && typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return undefined
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      throw new Error('Enter valid JSON object content.')
+    }
+    if (!isRecord(parsed)) {
+      throw new Error('Enter a JSON object such as {"summary": "..."}.')
+    }
+    return parsed
+  }
+  if (field.type === 'list' && typeof value === 'string') return coerceListInput(value)
+  return value
+}
+
+function normalizeParallelChildren(step: Record<string, unknown> | null): ParallelChildRow[] {
+  if (!step || !Array.isArray(step.steps)) return []
+  return step.steps
+    .filter(isRecord)
+    .map((child) => ({
+      ...child,
+      id: typeof child.id === 'string' ? child.id : '',
+      type: typeof child.type === 'string' ? child.type : 'agent',
+      label: typeof child.label === 'string' ? child.label : String(child.id ?? ''),
+    }))
+}
+
+function nextChildId(children: ParallelChildRow[]): string {
+  const existing = new Set(children.map((child) => child.id))
+  for (let i = 1; i < 1000; i++) {
+    const id = `child-${i}`
+    if (!existing.has(id)) return id
+  }
+  return `child-${Date.now()}`
+}
+
+function isMissingRequiredField(field: FormField, value: unknown): boolean {
+  if (!field.required) return false
+  if (value === undefined || value === null) return true
+  if (typeof value === 'string') return value.trim().length === 0
+  if (Array.isArray(value)) return value.length === 0
+  return false
+}
+
+function requiredFieldMessage(field: FormField): string {
+  if (field.type === 'agent') return 'Choose an agent.'
+  if (field.name === 'workflow_id') return 'Select a workflow.'
+  if (field.type === 'select') return `Select ${fieldLabel(field).toLowerCase()}.`
+  return `Enter ${fieldLabel(field).toLowerCase()}.`
+}
+
+function schemaIssueMessage(field: FormField, message: string): string {
+  if (message.toLowerCase().includes('required')) return requiredFieldMessage(field)
+  return message
+}
+
+function humanizeIdentifier(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  agent: 'Agent',
+  skill: 'Skill instructions',
+  task: 'Task brief',
+  description: 'Detailed instructions',
+  deny_tools: 'Denied tools',
+  approval_required: 'Require approval',
+  on_approve: 'Approved path',
+  on_reject: 'Rejected path',
+  preview: 'Preview fields',
+  channels: 'Notification channels',
+  content: 'Output content',
+  schedule: 'Schedule',
+  workflow_id: 'Nested workflow',
+  title: 'Task title',
+  column: 'Starting column',
+  workflowId: 'Attached workflow',
+  availableAt: 'Available after',
+  dueAt: 'Due date',
+}
+
+const FIELD_HELP_TEXT: Record<string, string> = {
+  agent: 'Choose who should run this step. Use Assigned agent to reuse the task assignee.',
+  skill: 'Optional skill or instruction bundle to load before the agent works.',
+  task: 'Short, concrete instruction for the agent. Use one or two sentences.',
+  description: 'Longer context, constraints, or acceptance criteria for this step.',
+  deny_tools: 'Optional comma-separated tool names the agent may not call during this step.',
+  approval_required: 'Require a human decision before the workflow can continue.',
+  on_approve: 'Step ID to run after approval. Use done when this approval completes the workflow.',
+  on_reject: 'Step ID to return to after rejection. Leave blank when rejection should not rewind.',
+  preview: 'Comma-separated output keys to show in the approval preview.',
+  channels: 'Comma-separated channels or destinations for the final output.',
+  content: 'Structured output content. Enter JSON when this step needs fixed output keys.',
+  schedule: 'Cron schedule for recurring output delivery.',
+  workflow_id: 'Select the workflow that this nested workflow step should run.',
+  title: 'Title for the task this workflow will create.',
+  column: 'Board column where the created task should start.',
+  workflowId: 'Optional workflow ID to attach to the created task.',
+  availableAt: 'Optional ISO timestamp before which the task should not dispatch.',
+  dueAt: 'Optional ISO timestamp for the desired completion time.',
+}
+
+const FIELD_PLACEHOLDERS: Record<string, string> = {
+  skill: 'brand-voice',
+  task: 'Write a concise post caption for the approved brief.',
+  description: 'Include caption text, target platform notes, hashtags, and any required mentions.',
+  deny_tools: 'web.run, shell.exec',
+  on_approve: 'review-copy or done',
+  on_reject: 'revise-copy',
+  preview: 'caption, hashtags, mentions',
+  channels: 'general, announcements',
+  content: '{"summary": "...", "assetPath": "..."}',
+  schedule: '0 9 * * 1',
+  title: 'Draft launch announcement',
+  workflowId: 'social-post',
+  availableAt: '2026-05-25T14:00:00Z',
+  dueAt: '2026-05-26T18:00:00Z',
+}
+
+const STEP_KIND_LABELS: Record<string, string> = {
+  agent: 'Agent step',
+  gate: 'Approval gate',
+  output: 'Completion step',
+  workflow: 'Nested workflow',
+  parallel: 'Parallel group',
+  createTask: 'Task creation step',
+}
+
+function fieldLabel(field: FormField): string {
+  return FIELD_LABELS[field.name] ?? humanizeIdentifier(field.name)
+}
+
+function fieldHelpText(field: FormField): string | undefined {
+  return FIELD_HELP_TEXT[field.name] ?? field.description
+}
+
+function fieldPlaceholder(field: FormField): string | undefined {
+  return FIELD_PLACEHOLDERS[field.name]
+}
+
+function stepKindLabel(kind: string): string {
+  if (!kind) return 'Unknown step'
+  if (STEP_KIND_LABELS[kind]) return STEP_KIND_LABELS[kind]
+  const localKind = kind.includes('.') ? kind.split('.').slice(1).join(' ') : kind
+  return `${humanizeIdentifier(localKind)} step`
+}
+
+const FIELD_GROUP_CLASS = 'space-y-2.5'
+const FIELD_LABEL_CLASS = 'text-sm font-medium leading-none'
+const FIELD_HELP_CLASS = 'text-xs leading-relaxed text-muted-foreground/60'
+const CONTROL_CLASS = 'min-h-10 text-sm'
+const TEXTAREA_CLASS = 'min-h-24 text-sm leading-relaxed'
+
+export function NodeConfigDrawer({
+  step,
+  fallbackKind,
+  onApply,
+  onDelete,
+  onClose,
+  onDirtyChange,
+  existingStepIds = [],
+  reservedStepIds = [],
+}: NodeConfigDrawerProps) {
   const kind = step?.type ?? fallbackKind ?? ''
   const def = useMemo(() => (kind ? getNodeType(kind) : undefined), [kind])
+  const editableFields = useMemo(
+    () => (def?.formFields ?? []).filter((field) => isDrawerEditableField(kind, field)),
+    [def, kind],
+  )
+  const needsWorkflowOptions = editableFields.some((field) => field.name === 'workflow_id')
 
   // The parent remounts this component via `key` when `step.id`/`step.type`
   // changes, so lazy state initializers from props are safe here.
@@ -70,113 +280,329 @@ export function NodeConfigDrawer({ step, fallbackKind, onApply, onClose }: NodeC
   const [fieldValues, setFieldValues] = useState<Record<string, unknown>>(() => {
     const seeded: Record<string, unknown> = {}
     if (step && def) {
-      for (const field of def.formFields) {
+      for (const field of def.formFields.filter((f) => isDrawerEditableField(kind, f))) {
         seeded[field.name] = fieldInitialValue(step, field)
       }
     }
     return seeded
   })
+  const [parallelChildren, setParallelChildren] = useState<ParallelChildRow[]>(() => normalizeParallelChildren(step))
+  const [workflowOptions, setWorkflowOptions] = useState<WorkflowSelectOption[]>([])
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const [idError, setIdError] = useState<string | null>(null)
+  const [labelError, setLabelError] = useState<string | null>(null)
+  const [dirtyFields, setDirtyFields] = useState<Set<string>>(() => new Set())
   const [errors, setErrors] = useState<string[]>([])
+
+  function markDirty(fieldName?: string) {
+    if (fieldName) {
+      setDirtyFields((prev) => {
+        const next = new Set(prev)
+        next.add(fieldName)
+        return next
+      })
+    }
+    onDirtyChange?.(true)
+  }
+
+  useEffect(() => {
+    if (!needsWorkflowOptions) return
+    let cancelled = false
+
+    async function loadWorkflowOptions() {
+      try {
+        const res = await fetch('/api/plugins/workflows/definitions?includeDisabled=1')
+        if (!res.ok) return
+        const data = (await res.json()) as {
+          templates?: Array<{ filename: string; name: string; disabled?: boolean }>
+        }
+        if (cancelled) return
+        setWorkflowOptions(
+          (data.templates ?? []).map((template) => ({
+            id: template.filename,
+            name: template.name,
+            disabled: template.disabled,
+          })),
+        )
+      } catch {
+        if (!cancelled) setWorkflowOptions([])
+      }
+    }
+
+    void loadWorkflowOptions()
+    return () => {
+      cancelled = true
+    }
+  }, [needsWorkflowOptions])
 
   if (!step) return null
 
   if (!def) {
     return (
-      <aside className="flex w-80 flex-col border-l border-border bg-card">
-        <DrawerHeader onClose={onClose} title={step.id} subtitle={kind || 'unknown kind'} />
-        <div className="p-3 text-xs text-amber-300">
+      <aside className="flex w-[28rem] flex-col border-l border-border bg-card">
+        <DrawerHeader onClose={onClose} title={stepKindLabel(kind)} />
+        <div className="flex-1 p-5 text-sm leading-relaxed text-amber-300">
           No registered node type for <code>{kind || '(missing)'}</code>. Step is preserved
-          but cannot be edited here — the plugin may not be active.
+          but cannot be edited here - the plugin may not be active.
         </div>
+        {onDelete && (
+          <div className="border-t border-border p-5">
+            <Button type="button" size="sm" variant="destructive" onClick={onDelete}>
+              <Trash2 className="mr-1 size-3.5" />
+              Delete step
+            </Button>
+          </div>
+        )}
       </aside>
     )
   }
 
   function handleApply() {
-    if (!def) return
-    // Build the full candidate step from id/label + field values.
+    if (!def || !step) return
+    const nextFieldErrors: Record<string, string> = {}
+    const nextId = id.trim()
+    const nextLabel = label.trim()
+    let nextIdError: string | null = null
+    let nextLabelError: string | null = null
+
+    if (!nextId) {
+      nextIdError = 'Enter a step ID.'
+    } else if (reservedStepIds.includes(nextId)) {
+      nextIdError = 'This step ID is reserved by the editor.'
+    } else if (nextId !== step.id && existingStepIds.includes(nextId)) {
+      nextIdError = 'Step IDs must be unique.'
+    }
+    if (!nextLabel) nextLabelError = 'Enter a display name.'
+
+    for (const field of editableFields) {
+      if (isMissingRequiredField(field, fieldValues[field.name])) {
+        nextFieldErrors[field.name] = requiredFieldMessage(field)
+      }
+    }
+    if (nextIdError || nextLabelError || Object.keys(nextFieldErrors).length > 0) {
+      setIdError(nextIdError)
+      setLabelError(nextLabelError)
+      setFieldErrors(nextFieldErrors)
+      setErrors([])
+      return
+    }
+    setIdError(null)
+    setLabelError(null)
+
+    // Build the full candidate step from the existing YAML-backed object so
+    // fields outside this form survive a no-op edit.
     const coerced: Record<string, unknown> = {}
-    for (const field of def.formFields) {
+    for (const field of editableFields) {
       const v = fieldValues[field.name]
       if (v === '' || v === undefined || v === null) {
         // Omit empty — the Zod `.optional()` branches accept missing keys.
+        // Only dirty empty fields are deleted below. Unchanged empty values
+        // from YAML remain untouched so Apply is not destructive.
         continue
       }
-      coerced[field.name] = field.type === 'list' && typeof v === 'string' ? coerceListInput(v) : v
+      try {
+        const nextValue = coerceFieldValue(step, field, v)
+        if (nextValue !== undefined) coerced[field.name] = nextValue
+      } catch (error) {
+        nextFieldErrors[field.name] = (error as Error).message
+      }
+    }
+    if (Object.keys(nextFieldErrors).length > 0) {
+      setFieldErrors(nextFieldErrors)
+      setErrors([])
+      return
     }
 
-    const candidate = {
-      id,
+    const candidate: Record<string, unknown> = {
+      ...step,
+      id: nextId,
       type: kind,
-      label,
+      label: nextLabel,
       ...coerced,
     }
+    for (const field of editableFields) {
+      const v = fieldValues[field.name]
+      if ((v === '' || v === undefined || v === null) && dirtyFields.has(field.name)) {
+        delete candidate[field.name]
+      }
+    }
+    if (kind === 'parallel') candidate.steps = parallelChildren
 
     const result = def.zodSchema.safeParse(candidate)
     if (!result.success) {
-      setErrors(result.error.issues.map((i) => `${i.path.join('.') || 'step'}: ${i.message}`))
+      const fieldsByName = new Map(editableFields.map((field) => [field.name, field]))
+      const schemaFieldErrors: Record<string, string> = {}
+      const generalErrors: string[] = []
+      for (const issue of result.error.issues) {
+        const fieldName = typeof issue.path[0] === 'string' ? issue.path[0] : ''
+        const field = fieldsByName.get(fieldName)
+        if (field) {
+          schemaFieldErrors[fieldName] = schemaIssueMessage(field, issue.message)
+        } else {
+          generalErrors.push(`${issue.path.join('.') || 'step'}: ${issue.message}`)
+        }
+      }
+      setFieldErrors(schemaFieldErrors)
+      setErrors(generalErrors)
       return
     }
+    setFieldErrors({})
+    setDirtyFields(new Set())
+    onDirtyChange?.(false)
     setErrors([])
     const validated = (result.data ?? {}) as Record<string, unknown>
-    onApply({ ...validated, id, label })
+    onApply({ ...validated, id: nextId, label: nextLabel })
+  }
+
+  function updateFieldValue(fieldName: string, value: unknown) {
+    setFieldValues((prev) => ({ ...prev, [fieldName]: value }))
+    markDirty(fieldName)
+    setFieldErrors((prev) => {
+      if (!prev[fieldName]) return prev
+      const next = { ...prev }
+      delete next[fieldName]
+      return next
+    })
   }
 
   const canApply = id.trim().length > 0 && label.trim().length > 0
 
   return (
-    <aside className="flex w-80 flex-col border-l border-border bg-card">
-      <DrawerHeader onClose={onClose} title={step.id} subtitle={kind} />
+    <aside className="flex w-[28rem] flex-col border-l border-border bg-card">
+      <DrawerHeader onClose={onClose} title={stepKindLabel(kind)} />
 
-      <div className="flex-1 overflow-y-auto p-3">
-        <div className="mb-2">
-          <Label className="text-xs" htmlFor="node-config-id">Id</Label>
-          <Input id="node-config-id" value={id} onChange={(e) => setId(e.target.value)} />
-        </div>
-        <div className="mb-3">
-          <Label className="text-xs" htmlFor="node-config-label">Label</Label>
-          <Input
-            id="node-config-label"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-          />
-        </div>
-
-        {def.formFields.map((field) => (
-          <div key={field.name} className="mb-3">
-            <Label className="text-xs" htmlFor={`node-config-${field.name}`}>
-              {field.name}
-              {field.required && <span className="ml-1 text-red-400">*</span>}
-            </Label>
-            <FieldControl
-              field={field}
-              value={fieldValues[field.name]}
-              onChange={(v) => setFieldValues((prev) => ({ ...prev, [field.name]: v }))}
+      <div className="flex-1 overflow-y-auto p-5">
+        <div className="space-y-6">
+          <div className={FIELD_GROUP_CLASS}>
+            <Label className={FIELD_LABEL_CLASS} htmlFor="node-config-id">Step ID</Label>
+            <Input
+              id="node-config-id"
+              value={id}
+              onChange={(e) => {
+                setId(e.target.value)
+                setIdError(null)
+                markDirty()
+              }}
+              placeholder="write-copy"
+              className={CONTROL_CLASS}
+              aria-invalid={Boolean(idError) || undefined}
+              aria-describedby={idError ? 'node-config-id-error' : undefined}
             />
-            {field.description && (
-              <p className="mt-1 text-[10px] text-muted-foreground">{field.description}</p>
+            {idError && (
+              <p id="node-config-id-error" className="text-xs font-medium leading-relaxed text-red-300">
+                {idError}
+              </p>
             )}
+            <p className={FIELD_HELP_CLASS}>
+              Stable identifier used by workflow links and approval paths.
+            </p>
           </div>
-        ))}
+          <div className={FIELD_GROUP_CLASS}>
+            <Label className={FIELD_LABEL_CLASS} htmlFor="node-config-label">Display name</Label>
+            <Input
+              id="node-config-label"
+              value={label}
+              onChange={(e) => {
+                setLabel(e.target.value)
+                setLabelError(null)
+                markDirty()
+              }}
+              placeholder="Write Copy"
+              className={CONTROL_CLASS}
+              aria-invalid={Boolean(labelError) || undefined}
+              aria-describedby={labelError ? 'node-config-label-error' : undefined}
+            />
+            {labelError && (
+              <p id="node-config-label-error" className="text-xs font-medium leading-relaxed text-red-300">
+                {labelError}
+              </p>
+            )}
+            <p className={FIELD_HELP_CLASS}>
+              Human-readable name shown on the canvas node.
+            </p>
+          </div>
 
-        {errors.length > 0 && (
-          <div className="mt-2 rounded border border-red-500/40 bg-red-500/10 p-2 text-[11px] text-red-200">
-            <ul className="list-disc pl-4">
-              {errors.map((err, i) => (
-                <li key={i}>{err}</li>
-              ))}
-            </ul>
-          </div>
-        )}
+          {editableFields.map((field) => {
+            const fieldError = fieldErrors[field.name]
+            const errorId = fieldError ? `node-config-${field.name}-error` : undefined
+
+            return (
+              <div key={field.name} className={FIELD_GROUP_CLASS}>
+                <Label
+                  className={`${FIELD_LABEL_CLASS} ${fieldError ? 'text-red-300' : ''}`}
+                  htmlFor={`node-config-${field.name}`}
+                >
+                  {fieldLabel(field)}
+                  {field.required && <span className="ml-1 text-red-400">*</span>}
+                </Label>
+                <FieldControl
+                  field={field}
+                  value={fieldValues[field.name]}
+                  workflowOptions={workflowOptions}
+                  invalid={Boolean(fieldError)}
+                  describedBy={errorId}
+                  onChange={(v) => updateFieldValue(field.name, v)}
+                />
+                {fieldError && (
+                  <p id={errorId} className="text-xs font-medium leading-relaxed text-red-300">
+                    {fieldError}
+                  </p>
+                )}
+                {fieldHelpText(field) && (
+                  <p className={FIELD_HELP_CLASS}>{fieldHelpText(field)}</p>
+                )}
+              </div>
+            )
+          })}
+
+          {Boolean(step.dependsOn) && (
+            <div className="rounded border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed text-amber-200">
+              dependsOn is preserved as metadata. This editor does not author runtime dependencies.
+            </div>
+          )}
+
+          {kind === 'parallel' && (
+            <ParallelChildrenEditor
+              childrenRows={parallelChildren}
+              onChange={(next) => {
+                setParallelChildren(next)
+                markDirty('steps')
+              }}
+            />
+          )}
+
+          {errors.length > 0 && (
+            <div className="rounded border border-red-500/40 bg-red-500/10 p-3 text-xs leading-relaxed text-red-200">
+              <ul className="list-disc pl-4">
+                {errors.map((err, i) => (
+                  <li key={i}>{err}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className="flex gap-2 border-t border-border p-3">
-        <Button size="sm" onClick={handleApply} disabled={!canApply}>
-          Apply
-        </Button>
-        <Button size="sm" variant="ghost" onClick={onClose}>
-          Cancel
-        </Button>
+      <div className="flex items-center justify-between gap-2 border-t border-border p-5">
+        {onDelete && (
+          <Button
+            type="button"
+            size="sm"
+            variant="destructive"
+            onClick={onDelete}
+          >
+            <Trash2 className="mr-1 size-3.5" />
+            Delete
+          </Button>
+        )}
+        <div className="ml-auto flex gap-2">
+          <Button size="sm" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleApply} disabled={!canApply}>
+            Apply
+          </Button>
+        </div>
       </div>
     </aside>
   )
@@ -188,14 +614,14 @@ function DrawerHeader({
   onClose,
 }: {
   title: string
-  subtitle: string
+  subtitle?: string
   onClose: () => void
 }) {
   return (
-    <div className="flex items-center justify-between border-b border-border px-3 py-2">
+    <div className="flex items-center justify-between border-b border-border px-5 py-3">
       <div className="flex flex-col leading-tight">
-        <span className="text-sm font-medium">{title}</span>
-        <span className="text-[10px] text-muted-foreground">{subtitle}</span>
+        <span className="text-base font-medium">{title}</span>
+        {subtitle && <span className="text-xs text-muted-foreground/60">{subtitle}</span>}
       </div>
       <button
         type="button"
@@ -209,16 +635,235 @@ function DrawerHeader({
   )
 }
 
+function ParallelChildrenEditor({
+  childrenRows,
+  onChange,
+}: {
+  childrenRows: ParallelChildRow[]
+  onChange: (next: ParallelChildRow[]) => void
+}) {
+  const updateChild = (index: number, patch: Record<string, unknown>) => {
+    onChange(childrenRows.map((child, i) => (i === index ? { ...child, ...patch } : child)))
+  }
+  const removeChild = (index: number) => {
+    onChange(childrenRows.filter((_, i) => i !== index))
+  }
+  const moveChild = (index: number, delta: -1 | 1) => {
+    const nextIndex = index + delta
+    if (nextIndex < 0 || nextIndex >= childrenRows.length) return
+    const next = [...childrenRows]
+    const [moved] = next.splice(index, 1)
+    next.splice(nextIndex, 0, moved)
+    onChange(next)
+  }
+  const addChild = () => {
+    const id = nextChildId(childrenRows)
+    onChange([
+      ...childrenRows,
+      {
+        id,
+        type: 'agent',
+        label: id,
+        agent: '$assigned',
+      },
+    ])
+  }
+
+  return (
+    <div className="border-t border-border pt-5">
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <span className="text-sm font-medium">Parallel child steps</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={addChild}
+          aria-label="Add child agent"
+        >
+          <Plus className="mr-1 size-3.5" /> Agent
+        </Button>
+      </div>
+      <div className="space-y-5">
+        {childrenRows.map((child, index) => {
+          const childId = child.id || `child-${index + 1}`
+          if (child.type !== 'agent') {
+            return (
+              <div key={`${childId}-${index}`} className="rounded border border-amber-500/40 bg-amber-500/10 p-3 text-xs leading-relaxed text-amber-200">
+                Child {childId} has unsupported type {child.type}; it is preserved read-only.
+              </div>
+            )
+          }
+          return (
+            <div key={`${childId}-${index}`} className="rounded border border-border p-4">
+              <div className="mb-4 flex items-center justify-between gap-2">
+                <span className="min-w-0 truncate text-sm font-medium">{child.label || childId}</span>
+                <div className="flex items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Move child ${childId} up`}
+                    onClick={() => moveChild(index, -1)}
+                    disabled={index === 0}
+                  >
+                    <ArrowUp className="size-3.5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Move child ${childId} down`}
+                    onClick={() => moveChild(index, 1)}
+                    disabled={index === childrenRows.length - 1}
+                  >
+                    <ArrowDown className="size-3.5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Remove child ${childId}`}
+                    onClick={() => removeChild(index)}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              </div>
+              <div className="grid gap-5">
+                <div className={FIELD_GROUP_CLASS}>
+                  <Label className={FIELD_LABEL_CLASS} htmlFor={`parallel-child-${index}-id`}>
+                    Child step ID
+                  </Label>
+                  <Input
+                    id={`parallel-child-${index}-id`}
+                    aria-label={`Child step ID for ${childId}`}
+                    value={child.id}
+                    placeholder="write-caption"
+                    className={CONTROL_CLASS}
+                    onChange={(e) => updateChild(index, { id: e.target.value })}
+                  />
+                  <p className={FIELD_HELP_CLASS}>
+                    Stable identifier used by workflow links.
+                  </p>
+                </div>
+                <div className={FIELD_GROUP_CLASS}>
+                  <Label className={FIELD_LABEL_CLASS} htmlFor={`parallel-child-${index}-label`}>
+                    Display name
+                  </Label>
+                  <Input
+                    id={`parallel-child-${index}-label`}
+                    aria-label={`Display name for child ${childId}`}
+                    value={child.label}
+                    placeholder="Write Caption"
+                    className={CONTROL_CLASS}
+                    onChange={(e) => updateChild(index, { label: e.target.value })}
+                  />
+                  <p className={FIELD_HELP_CLASS}>
+                    Human-readable name shown inside the parallel group.
+                  </p>
+                </div>
+                <div className={FIELD_GROUP_CLASS}>
+                  <Label className={FIELD_LABEL_CLASS}>Agent</Label>
+                  <AgentSelect
+                    value={typeof child.agent === 'string' ? child.agent : ''}
+                    onValueChange={(v) => updateChild(index, { agent: v || '' })}
+                    includeAssigned
+                    allowNone={false}
+                    className={CONTROL_CLASS}
+                  />
+                  <p className={FIELD_HELP_CLASS}>
+                    Choose who should run this child step.
+                  </p>
+                </div>
+                <div className={FIELD_GROUP_CLASS}>
+                  <Label className={FIELD_LABEL_CLASS} htmlFor={`parallel-child-${index}-skill`}>
+                    Skill instructions
+                  </Label>
+                  <Input
+                    id={`parallel-child-${index}-skill`}
+                    aria-label={`Skill instructions for child ${childId}`}
+                    value={typeof child.skill === 'string' ? child.skill : ''}
+                    placeholder="brand-voice"
+                    className={CONTROL_CLASS}
+                    onChange={(e) => updateChild(index, { skill: e.target.value || undefined })}
+                  />
+                  <p className={FIELD_HELP_CLASS}>
+                    Optional skill or instruction bundle to load first.
+                  </p>
+                </div>
+                <div className={FIELD_GROUP_CLASS}>
+                  <Label className={FIELD_LABEL_CLASS} htmlFor={`parallel-child-${index}-task`}>
+                    Task brief
+                  </Label>
+                  <Textarea
+                    id={`parallel-child-${index}-task`}
+                    aria-label={`Task brief for child ${childId}`}
+                    rows={3}
+                    value={typeof child.task === 'string' ? child.task : ''}
+                    placeholder="Draft the caption for this audience segment."
+                    className={TEXTAREA_CLASS}
+                    onChange={(e) => updateChild(index, { task: e.target.value || undefined })}
+                  />
+                  <p className={FIELD_HELP_CLASS}>
+                    Short, concrete instruction for this child agent.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )
+        })}
+        {childrenRows.length === 0 && (
+          <div className="rounded border border-border p-3 text-xs leading-relaxed text-muted-foreground">
+            Add at least one child agent before saving this parallel step.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function FieldControl({
   field,
   value,
+  workflowOptions,
+  invalid,
+  describedBy,
   onChange,
 }: {
   field: FormField
   value: unknown
+  workflowOptions?: WorkflowSelectOption[]
+  invalid?: boolean
+  describedBy?: string
   onChange: (v: unknown) => void
 }) {
   const str = (value ?? '') as string
+  const placeholder = fieldPlaceholder(field)
+  if (field.name === 'workflow_id') {
+    const options = workflowOptions ?? []
+    const hasCurrent = str.length > 0 && !options.some((option) => option.id === str)
+    return (
+      <Select value={str} onValueChange={(v) => onChange(v || undefined)}>
+        <SelectTrigger
+          id={`node-config-${field.name}`}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedBy}
+          className={CONTROL_CLASS}
+        >
+          <SelectValue placeholder="Choose a workflow..." />
+        </SelectTrigger>
+        <SelectContent>
+          {hasCurrent && <SelectItem value={str}>{str}</SelectItem>}
+          {options.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              {option.name}
+              {option.disabled ? ' (disabled)' : ''}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
   switch (field.type) {
     case 'text':
       return (
@@ -226,6 +871,10 @@ function FieldControl({
           id={`node-config-${field.name}`}
           rows={3}
           value={str}
+          placeholder={placeholder}
+          className={TEXTAREA_CLASS}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedBy}
           onChange={(e) => onChange(e.target.value)}
         />
       )
@@ -235,7 +884,15 @@ function FieldControl({
           id={`node-config-${field.name}`}
           type="number"
           value={value === undefined || value === null ? '' : (value as number)}
+          placeholder={placeholder}
+          className={CONTROL_CLASS}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedBy}
           onChange={(e) => {
+            if (e.target.value.trim() === '') {
+              onChange(undefined)
+              return
+            }
             const n = Number(e.target.value)
             onChange(Number.isFinite(n) ? n : undefined)
           }}
@@ -247,6 +904,8 @@ function FieldControl({
           <Checkbox
             id={`node-config-${field.name}`}
             checked={Boolean(value)}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
             onCheckedChange={(v) => onChange(v === true)}
           />
         </div>
@@ -254,8 +913,13 @@ function FieldControl({
     case 'select':
       return (
         <Select value={str} onValueChange={(v) => onChange(v || undefined)}>
-          <SelectTrigger id={`node-config-${field.name}`}>
-            <SelectValue placeholder="Select..." />
+          <SelectTrigger
+            id={`node-config-${field.name}`}
+            aria-invalid={invalid || undefined}
+            aria-describedby={describedBy}
+            className={CONTROL_CLASS}
+          >
+            <SelectValue placeholder="Choose an option..." />
           </SelectTrigger>
           <SelectContent>
             {field.options?.map((opt) => (
@@ -269,9 +933,18 @@ function FieldControl({
     case 'agent':
       return (
         <AgentSelect
+          id={`node-config-${field.name}`}
           value={str}
           onValueChange={(v) => onChange(v || undefined)}
+          includeAssigned
           allowNone={!field.required}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedBy}
+          className={
+            invalid
+              ? `${CONTROL_CLASS} border-destructive ring-3 ring-destructive/20 dark:border-destructive/50 dark:ring-destructive/40`
+              : CONTROL_CLASS
+          }
         />
       )
     case 'skill':
@@ -280,6 +953,10 @@ function FieldControl({
         <Input
           id={`node-config-${field.name}`}
           value={str}
+          placeholder={placeholder}
+          className={CONTROL_CLASS}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedBy}
           onChange={(e) => onChange(e.target.value)}
         />
       )
@@ -288,10 +965,12 @@ function FieldControl({
         <Input
           id={`node-config-${field.name}`}
           value={str}
+          className={CONTROL_CLASS}
+          aria-invalid={invalid || undefined}
+          aria-describedby={describedBy}
           onChange={(e) => onChange(e.target.value)}
-          placeholder="comma-separated"
+          placeholder={placeholder ?? 'alpha, beta, gamma'}
         />
       )
   }
 }
-

--- a/plugins/workflows/components/node-type-palette.tsx
+++ b/plugins/workflows/components/node-type-palette.tsx
@@ -9,8 +9,19 @@
  * registry, the client just hydrates.
  */
 
-import { useEffect, useState } from 'react'
-import { ChevronLeft, ChevronRight, Puzzle } from 'lucide-react'
+import { useEffect, useState, type DragEvent } from 'react'
+import {
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  ClipboardPlus,
+  GitBranch,
+  Puzzle,
+  Radio,
+  UserRound,
+  Workflow as WorkflowIcon,
+  type LucideIcon,
+} from 'lucide-react'
 import type { FormField, EdgeRules } from '../lib/node-type-registry'
 
 export interface PaletteNodeType {
@@ -24,17 +35,98 @@ export interface PaletteNodeType {
 interface NodeTypePaletteProps {
   /** Called when an item begins drag. Consumers forward to the canvas's onDrop. */
   onDragKind?: (kind: string) => void
+  /** Node kinds that cannot currently be added to the workflow. */
+  disabledKinds?: ReadonlySet<string>
   /** Optional pre-seeded types (tests bypass the fetch). */
   initialNodeTypes?: PaletteNodeType[]
+  collapsed?: boolean
+  onCollapsedChange?: (collapsed: boolean) => void
 }
 
 const DRAG_MIME_TYPE = 'application/x-bakin-node-kind'
 
-export function NodeTypePalette({ onDragKind, initialNodeTypes }: NodeTypePaletteProps) {
-  const [collapsed, setCollapsed] = useState(false)
+const BUILTIN_DISPLAY: Record<string, {
+  label: string
+  description: string
+  icon: LucideIcon
+  toneClass: string
+}> = {
+  agent: {
+    label: 'Agent Task',
+    description: 'Assign a unit of work to the task agent or a specific agent.',
+    icon: UserRound,
+    toneClass: 'bg-emerald-500/10 text-emerald-300',
+  },
+  gate: {
+    label: 'Approval Gate',
+    description: 'Pause the workflow until a person approves or rejects.',
+    icon: CheckCircle2,
+    toneClass: 'bg-amber-500/10 text-amber-300',
+  },
+  parallel: {
+    label: 'Parallel Group',
+    description: 'Run a grouped set of child steps at the same time.',
+    icon: GitBranch,
+    toneClass: 'bg-blue-500/10 text-blue-300',
+  },
+  output: {
+    label: 'Completion',
+    description: 'Finish the workflow by publishing, handing off, or recording results.',
+    icon: Radio,
+    toneClass: 'bg-violet-500/10 text-violet-300',
+  },
+  workflow: {
+    label: 'Nested Workflow',
+    description: 'Run another workflow as a step in this one.',
+    icon: WorkflowIcon,
+    toneClass: 'bg-zinc-700/60 text-zinc-300',
+  },
+  createTask: {
+    label: 'Create Task',
+    description: 'Create a follow-up task from workflow context.',
+    icon: ClipboardPlus,
+    toneClass: 'bg-sky-500/10 text-sky-300',
+  },
+}
+
+function setPaletteDragImage(event: DragEvent<HTMLElement>, label: string) {
+  const ghost = document.createElement('div')
+  ghost.textContent = label
+  ghost.style.position = 'fixed'
+  ghost.style.top = '-1000px'
+  ghost.style.left = '-1000px'
+  ghost.style.pointerEvents = 'none'
+  ghost.style.border = '1px solid rgba(96, 165, 250, 0.65)'
+  ghost.style.borderRadius = '6px'
+  ghost.style.background = 'rgb(24, 24, 27)'
+  ghost.style.color = 'rgb(229, 231, 235)'
+  ghost.style.font = '12px system-ui, sans-serif'
+  ghost.style.padding = '4px 8px'
+  ghost.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.35)'
+  document.body.appendChild(ghost)
+  if (typeof event.dataTransfer.setDragImage === 'function') {
+    try {
+      event.dataTransfer.setDragImage(ghost, 12, 12)
+    } catch {
+      // happy-dom does not implement setDragImage; browsers do.
+    }
+  }
+  requestAnimationFrame(() => ghost.remove())
+}
+
+export function NodeTypePalette({
+  onDragKind,
+  disabledKinds,
+  initialNodeTypes,
+  collapsed: controlledCollapsed,
+  onCollapsedChange,
+}: NodeTypePaletteProps) {
+  const [internalCollapsed, setInternalCollapsed] = useState(false)
   const [nodeTypes, setNodeTypes] = useState<PaletteNodeType[]>(initialNodeTypes ?? [])
   const [loading, setLoading] = useState(!initialNodeTypes)
   const [error, setError] = useState<string | null>(null)
+  const collapsed = controlledCollapsed ?? internalCollapsed
+  const setCollapsed = onCollapsedChange ?? setInternalCollapsed
 
   useEffect(() => {
     if (initialNodeTypes) return
@@ -82,7 +174,7 @@ export function NodeTypePalette({ onDragKind, initialNodeTypes }: NodeTypePalett
     <aside className="flex w-56 flex-col border-r border-border bg-card">
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          Node types
+          Step Types
         </span>
         <button
           type="button"
@@ -99,13 +191,23 @@ export function NodeTypePalette({ onDragKind, initialNodeTypes }: NodeTypePalett
         {error && <p className="p-2 text-xs text-red-300">{error}</p>}
 
         {!loading && builtins.length > 0 && (
-          <PaletteGroup title="Builtin" items={builtins} onDragKind={onDragKind} />
+          <PaletteGroup
+            title="Builtin"
+            items={builtins}
+            disabledKinds={disabledKinds}
+            onDragKind={onDragKind}
+          />
         )}
         {!loading && plugins.length > 0 && (
-          <PaletteGroup title="Plugins" items={plugins} onDragKind={onDragKind} />
+          <PaletteGroup
+            title="Plugins"
+            items={plugins}
+            disabledKinds={disabledKinds}
+            onDragKind={onDragKind}
+          />
         )}
         {!loading && !error && nodeTypes.length === 0 && (
-          <p className="p-2 text-xs text-muted-foreground">No node types registered.</p>
+          <p className="p-2 text-xs text-muted-foreground">No step types registered.</p>
         )}
       </div>
     </aside>
@@ -115,10 +217,12 @@ export function NodeTypePalette({ onDragKind, initialNodeTypes }: NodeTypePalett
 function PaletteGroup({
   title,
   items,
+  disabledKinds,
   onDragKind,
 }: {
   title: string
   items: PaletteNodeType[]
+  disabledKinds?: ReadonlySet<string>
   onDragKind?: (kind: string) => void
 }) {
   return (
@@ -128,7 +232,12 @@ function PaletteGroup({
       </div>
       <ul className="flex flex-col gap-1">
         {items.map((item) => (
-          <PaletteItem key={item.kind} item={item} onDragKind={onDragKind} />
+          <PaletteItem
+            key={item.kind}
+            item={item}
+            disabled={disabledKinds?.has(item.kind) ?? false}
+            onDragKind={onDragKind}
+          />
         ))}
       </ul>
     </div>
@@ -137,31 +246,61 @@ function PaletteGroup({
 
 function PaletteItem({
   item,
+  disabled = false,
   onDragKind,
 }: {
   item: PaletteNodeType
+  disabled?: boolean
   onDragKind?: (kind: string) => void
 }) {
-  const displayKind = item.runtime === 'plugin' ? item.kind.split('.').slice(1).join('.') : item.kind
+  const builtinDisplay = item.runtime === 'builtin' ? BUILTIN_DISPLAY[item.kind] : undefined
+  const displayKind = builtinDisplay?.label ?? (item.runtime === 'plugin' ? item.kind.split('.').slice(1).join('.') : item.kind)
+  const description = disabled && item.kind === 'output'
+    ? 'This workflow already has a completion step.'
+    : item.runtime === 'builtin'
+      ? builtinDisplay?.description ?? 'Add this built-in workflow step.'
+      : `Provided by ${item.pluginId ?? 'a plugin'}.`
+  const Icon = builtinDisplay?.icon ?? Puzzle
+  const iconTone = builtinDisplay?.toneClass ?? 'bg-muted text-muted-foreground'
   return (
     <li
-      draggable
+      draggable={!disabled}
+      aria-disabled={disabled || undefined}
       data-kind={item.kind}
       onDragStart={(e) => {
+        if (disabled) {
+          e.preventDefault()
+          return
+        }
         e.dataTransfer.setData(DRAG_MIME_TYPE, item.kind)
         e.dataTransfer.setData('text/plain', item.kind)
         e.dataTransfer.effectAllowed = 'copy'
+        setPaletteDragImage(e, displayKind)
         onDragKind?.(item.kind)
       }}
-      className="group flex cursor-grab items-center gap-2 rounded border border-border bg-background px-2 py-1.5 text-xs hover:border-primary/50 active:cursor-grabbing"
+      className={`group flex flex-col gap-1 rounded border border-border bg-background px-2 py-2 text-xs ${
+        disabled
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-grab hover:border-primary/50 active:cursor-grabbing'
+      }`}
     >
-      {item.runtime === 'plugin' && <Puzzle className="size-3 shrink-0 text-muted-foreground" />}
-      <span className="flex-1 truncate">{displayKind}</span>
-      {item.pluginId && (
-        <span className="rounded bg-muted px-1 py-0.5 text-[9px] font-medium text-muted-foreground">
-          {item.pluginId}
+      <span className="flex w-full items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={`inline-flex size-6 shrink-0 items-center justify-center rounded-md ${iconTone}`}
+        >
+          <Icon className="size-3.5" />
         </span>
-      )}
+        <span className="min-w-0 flex-1 truncate font-medium">{displayKind}</span>
+        {item.pluginId && (
+          <span className="rounded bg-muted px-1 py-0.5 text-[9px] font-medium text-muted-foreground">
+            {item.pluginId}
+          </span>
+        )}
+      </span>
+      <span className="line-clamp-2 w-full text-[11px] leading-snug text-muted-foreground">
+        {description}
+      </span>
     </li>
   )
 }

--- a/plugins/workflows/components/nodes/agent-assignment-label.tsx
+++ b/plugins/workflows/components/nodes/agent-assignment-label.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { User } from 'lucide-react'
+import { useAgent } from '@makinbakin/sdk/hooks'
+import { AgentAvatar } from '@makinbakin/sdk/components'
+
+interface AgentAssignmentLabelProps {
+  agent?: string
+  className?: string
+}
+
+const isDynamic = (agent?: string) => agent === '$assigned'
+
+export function AgentAssignmentLabel({ agent, className }: AgentAssignmentLabelProps) {
+  const lookedUp = useAgent(agent && !isDynamic(agent) ? agent : '')
+  const label = isDynamic(agent)
+    ? 'Assigned agent'
+    : lookedUp?.name ?? agent ?? 'No agent selected'
+
+  return (
+    <div className={`flex min-w-0 items-center gap-1.5 text-[11px] text-zinc-400 ${className ?? ''}`}>
+      {agent && !isDynamic(agent) ? (
+        <AgentAvatar agentId={agent} size="xs" />
+      ) : (
+        <User className="size-3 shrink-0 text-zinc-500" />
+      )}
+      <span className="truncate">{label}</span>
+    </div>
+  )
+}

--- a/plugins/workflows/components/nodes/agent-node.tsx
+++ b/plugins/workflows/components/nodes/agent-node.tsx
@@ -2,8 +2,7 @@
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
 import { User } from 'lucide-react'
-import { useAgent } from "@makinbakin/sdk/hooks"
-import { AgentAvatar } from "@makinbakin/sdk/components"
+import { AgentAssignmentLabel } from './agent-assignment-label'
 
 interface AgentNodeData extends Record<string, unknown> {
   label: string
@@ -11,33 +10,26 @@ interface AgentNodeData extends Record<string, unknown> {
   task?: string
 }
 
-const isDynamic = (agent?: string) => agent === '$assigned'
-
 export function AgentNode({ data }: NodeProps) {
   const { label, agent, task } = data as AgentNodeData
-  const lookedUp = useAgent(agent ?? '')
-  const agentMeta = agent && !isDynamic(agent) ? lookedUp : undefined
 
   // Show first ~80 chars of task as excerpt
   const excerpt = task && task.length > 80 ? task.slice(0, 80).trim() + '…' : task
 
   return (
-    <div className="w-[280px] rounded-lg border-2 border-zinc-700 bg-zinc-900 p-3 shadow-lg">
-      <div className="mb-1.5 flex items-center gap-2">
-        {isDynamic(agent) ? (
-          <span className="inline-flex size-7 items-center justify-center rounded-full bg-blue-900/50 ring-1 ring-blue-500/40">
-            <User className="size-3.5 text-blue-400" />
-          </span>
-        ) : (
-          <AgentAvatar agentId={agent ?? 'unknown'} size="sm" />
-        )}
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border-2 border-zinc-700 bg-zinc-900 px-4 py-3 shadow-lg">
+      <div className="mb-2 flex items-center gap-2">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-emerald-500/10 ring-1 ring-emerald-500/25">
+          <User className="size-3.5 text-emerald-400" />
+        </span>
         <span className="text-xs font-bold uppercase tracking-wider text-emerald-400">
-          {isDynamic(agent) ? 'Assigned Agent' : agentMeta?.name ?? agent ?? 'Agent'}
+          Agent Task
         </span>
       </div>
-      <div className="mb-1 text-sm text-zinc-200">{label}</div>
+      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
+      <AgentAssignmentLabel agent={agent} className="mt-1" />
       {excerpt && (
-        <p className="text-xs text-zinc-500 leading-relaxed line-clamp-2">{excerpt}</p>
+        <p className="mt-0.5 truncate text-[11px] leading-snug text-zinc-500">{excerpt}</p>
       )}
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />

--- a/plugins/workflows/components/nodes/create-task-node.tsx
+++ b/plugins/workflows/components/nodes/create-task-node.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { ClipboardPlus } from 'lucide-react'
+import { AgentAssignmentLabel } from './agent-assignment-label'
+
+interface CreateTaskNodeData extends Record<string, unknown> {
+  label: string
+  agent?: string
+  title?: string
+  column?: string
+  description?: string
+}
+
+export function CreateTaskNode({ data }: NodeProps) {
+  const { label, agent, title, column, description } = data as CreateTaskNodeData
+  const detail = title || description
+
+  return (
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border border-sky-500/50 bg-zinc-900 px-4 py-3 shadow-lg">
+      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-sky-300">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-sky-500/10">
+          <ClipboardPlus className="size-3.5" />
+        </span>
+        Create Task
+      </div>
+      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
+      {agent && <AgentAssignmentLabel agent={agent} className="mt-1" />}
+      {detail && (
+        <p className={`${agent ? 'mt-0.5' : 'mt-1'} truncate text-[11px] leading-snug text-zinc-500`}>
+          {detail}
+        </p>
+      )}
+      {column && (
+        <div className="mt-0.5 truncate text-[11px] text-zinc-400">Column: {column}</div>
+      )}
+      <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
+      <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />
+    </div>
+  )
+}

--- a/plugins/workflows/components/nodes/gate-node.tsx
+++ b/plugins/workflows/components/nodes/gate-node.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { CheckCircle2 } from 'lucide-react'
 
 interface GateNodeData extends Record<string, unknown> {
   label: string
@@ -11,13 +12,16 @@ export function GateNode({ data }: NodeProps) {
   const { label, description } = data as GateNodeData
 
   return (
-    <div className="w-[280px] rounded-lg border-2 border-amber-400 bg-zinc-900 p-3 shadow-lg">
-      <div className="mb-0.5 text-xs font-bold uppercase tracking-wider text-amber-400">
-        🚦 Approval Gate
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border-2 border-amber-400 bg-zinc-900 px-4 py-3 shadow-lg">
+      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-amber-400">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-amber-500/10">
+          <CheckCircle2 className="size-3.5" />
+        </span>
+        Approval Gate
       </div>
-      <div className="text-sm text-zinc-200">{label}</div>
+      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
       {description && (
-        <p className="mt-1 text-[11px] text-zinc-500 leading-snug line-clamp-2">{description}</p>
+        <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-zinc-500">{description}</p>
       )}
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />

--- a/plugins/workflows/components/nodes/output-node.tsx
+++ b/plugins/workflows/components/nodes/output-node.tsx
@@ -1,25 +1,37 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { Radio } from 'lucide-react'
+import { AgentAssignmentLabel } from './agent-assignment-label'
 
 interface OutputNodeData extends Record<string, unknown> {
   label: string
+  agent?: string
   channels?: string[]
+  description?: string
 }
 
 export function OutputNode({ data }: NodeProps) {
-  const { label, channels } = data as OutputNodeData
+  const { label, agent, channels, description } = data as OutputNodeData
+  const channelText = channels && channels.length > 0 ? channels.join(', ') : undefined
 
   return (
-    <div className="w-[280px] rounded-lg border border-purple-500/40 bg-zinc-900 p-4 shadow-lg">
-      <div className="mb-0.5 text-xs font-bold uppercase tracking-wider text-purple-400">
-        📤 {label}
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border border-purple-500/50 bg-zinc-900 px-4 py-3 shadow-lg">
+      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-purple-400">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-purple-500/10">
+          <Radio className="size-3.5" />
+        </span>
+        Completion
       </div>
-      {channels && channels.length > 0 && (
-        <div className="text-xs text-zinc-400">
-          {channels.join(', ')}
+      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
+      {agent && <AgentAssignmentLabel agent={agent} className="mt-1" />}
+      {channelText ? (
+        <div className={`${agent ? 'mt-0.5' : 'mt-1'} truncate text-[11px] text-zinc-400`}>
+          Channels: {channelText}
         </div>
-      )}
+      ) : description ? (
+        <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-zinc-500">{description}</p>
+      ) : null}
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
     </div>
   )

--- a/plugins/workflows/components/nodes/parallel-node.tsx
+++ b/plugins/workflows/components/nodes/parallel-node.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { GitBranch } from 'lucide-react'
 
 interface ParallelNodeData extends Record<string, unknown> {
   label: string
@@ -12,10 +13,14 @@ export function ParallelNode({ data }: NodeProps) {
   const { label } = data as ParallelNodeData
 
   return (
-    <div className="h-full w-full rounded-xl border border-dashed border-zinc-600 bg-zinc-900/50 p-3">
-      <div className="text-xs font-bold uppercase tracking-wider text-zinc-500">
-        ⚡ {label}
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border border-dashed border-blue-500/50 bg-zinc-900/70 px-4 py-3 shadow-lg">
+      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-blue-300">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-blue-500/10">
+          <GitBranch className="size-3.5" />
+        </span>
+        Parallel Group
       </div>
+      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />
     </div>

--- a/plugins/workflows/components/nodes/trigger-node.tsx
+++ b/plugins/workflows/components/nodes/trigger-node.tsx
@@ -1,14 +1,18 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { Radio } from 'lucide-react'
 
 export function TriggerNode(_props: NodeProps) {
   return (
-    <div className="w-[280px] rounded-lg border border-zinc-700 bg-zinc-900 p-4 shadow-lg">
-      <div className="mb-1 text-xs font-bold uppercase tracking-wider text-blue-400">
-        📥 Start
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-3 shadow-lg">
+      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-blue-400">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-blue-500/10">
+          <Radio className="size-3.5" />
+        </span>
+        Start
       </div>
-      <div className="text-[10px] text-zinc-500 leading-relaxed">
+      <div className="line-clamp-2 text-[11px] leading-snug text-zinc-500">
         Task context &amp; description passed to first step
       </div>
       <Handle type="source" position={Position.Bottom} className="!bg-blue-500" />

--- a/plugins/workflows/components/nodes/workflow-node.tsx
+++ b/plugins/workflows/components/nodes/workflow-node.tsx
@@ -13,21 +13,21 @@ export function WorkflowNode({ data }: NodeProps) {
   const { label, workflow_id, description } = data as WorkflowNodeData
 
   return (
-    <div className="w-[280px] rounded-lg border-2 border-dashed border-cyan-500/60 bg-zinc-900 p-4 shadow-lg">
+    <div className="flex h-full w-full flex-col justify-center rounded-lg border-2 border-dashed border-cyan-500/60 bg-zinc-900 px-4 py-3 shadow-lg">
       <div className="mb-2 flex items-center gap-2">
-        <span className="inline-flex size-7 items-center justify-center rounded-full bg-cyan-900/50 ring-1 ring-cyan-500/40">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-cyan-900/50 ring-1 ring-cyan-500/40">
           <Workflow className="size-3.5 text-cyan-400" />
         </span>
         <span className="text-xs font-bold uppercase tracking-wider text-cyan-400">
-          Sub-workflow
+          Nested Workflow
         </span>
       </div>
-      <div className="mb-1 text-sm text-zinc-200">{label}</div>
+      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
       {workflow_id && (
-        <div className="text-[10px] text-zinc-500 font-mono">{workflow_id}</div>
+        <div className="mt-1 truncate font-mono text-[10px] text-zinc-500">{workflow_id}</div>
       )}
       {description && (
-        <p className="text-xs text-zinc-500 leading-relaxed mt-1 line-clamp-2">{description}</p>
+        <p className="mt-0.5 truncate text-[11px] leading-snug text-zinc-500">{description}</p>
       )}
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />

--- a/plugins/workflows/components/workflow-canvas-editor.tsx
+++ b/plugins/workflows/components/workflow-canvas-editor.tsx
@@ -14,40 +14,82 @@
  * without special-casing.
  */
 
-import { useCallback, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
 import {
   ReactFlow,
   Background,
   BackgroundVariant,
   Controls,
   MiniMap,
-  addEdge,
-  applyNodeChanges,
-  applyEdgeChanges,
+  Handle,
+  NodeToolbar,
+  Panel,
+  BaseEdge,
+  EdgeLabelRenderer,
+  getSmoothStepPath,
+  Position,
   type Node,
   type Edge,
-  type Connection,
+  type EdgeProps,
+  type EdgeTypes,
   type NodeChange,
-  type EdgeChange,
+  type NodeProps,
   type NodeTypes,
   type ReactFlowInstance,
-  type XYPosition,
 } from '@xyflow/react'
+import { useRouter as useTanStackRouter } from '@tanstack/react-router'
 import '@xyflow/react/dist/style.css'
-import { Copy, LayoutGrid, Save, Trash2 } from 'lucide-react'
+import {
+  ArrowLeft,
+  ArrowDown,
+  ArrowUp,
+  CheckCircle2,
+  ClipboardPlus,
+  Copy,
+  GitBranch,
+  Info,
+  LayoutGrid,
+  Pencil,
+  Radio,
+  Save,
+  ShieldAlert,
+  Trash2,
+  UserRound,
+  Workflow as WorkflowIcon,
+  X,
+} from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
 import { Input } from "@makinbakin/sdk/ui"
+import { Label } from "@makinbakin/sdk/ui"
+import { Textarea } from "@makinbakin/sdk/ui"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@makinbakin/sdk/ui"
 
 import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-renderer-registry'
 import { NodeTypePalette, PALETTE_DRAG_MIME_TYPE } from './node-type-palette'
 import { NodeConfigDrawer } from './node-config-drawer'
-import { canConnect } from '../lib/edge-rules'
+import { ManagedWorkflowCopyDialog } from './managed-workflow-copy-dialog'
+import { AgentAssignmentLabel } from './nodes/agent-assignment-label'
+import {
+  clearWorkflowDialogFieldError,
+  hasWorkflowDialogFieldErrors,
+  parseWorkflowDialogServerError,
+  validateWorkflowDialogFields,
+  type WorkflowDialogFieldErrors,
+} from './workflow-dialog-validation'
+import { WorkflowDeleteAction } from './workflow-delete-action'
 import { layoutNodes } from '../lib/dagre-layout'
-import { toast } from "@makinbakin/sdk/hooks"
 import type {
   WorkflowDefinition,
   WorkflowStep,
   NodePosition,
+  WorkflowShadowedSource,
 } from '../types'
 
 const RESET_NODE_STYLES = `
@@ -58,10 +100,298 @@ const RESET_NODE_STYLES = `
     padding: 0 !important;
     border-radius: 0 !important;
   }
+  .react-flow__node.bakin-workflow-node-selected > div {
+    box-shadow: 0 0 0 2px rgb(96 165 250 / 0.9), 0 18px 48px rgb(0 0 0 / 0.35) !important;
+  }
+  .react-flow__node {
+    transition: transform 160ms ease, opacity 160ms ease;
+  }
 `
 
 const NODE_WIDTH = 280
-const Y_SPACING = 130
+const NODE_HEIGHT = 120
+const Y_SPACING = 164
+const LEGACY_COMPACT_Y_SPACING = 130
+const STANDARD_NODE_STYLE = { width: NODE_WIDTH, height: NODE_HEIGHT }
+const TRIGGER_NODE_ID = '__trigger'
+const APPEND_NODE_ID = '__append'
+const RESERVED_STEP_IDS = [TRIGGER_NODE_ID, APPEND_NODE_ID]
+const NODE_DRAWER_DIRTY_MESSAGE = 'Apply or cancel the open step changes before selecting another step.'
+
+function hasPaletteDragType(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.types ?? []).includes(PALETTE_DRAG_MIME_TYPE)
+}
+
+const BUILTIN_STEP_LABELS: Record<string, string> = {
+  agent: 'Agent Task',
+  gate: 'Approval Gate',
+  parallel: 'Parallel Group',
+  output: 'Completion',
+  workflow: 'Nested Workflow',
+  createTask: 'Create Task',
+}
+
+interface EditorNodeData extends Record<string, unknown> {
+  label?: string
+  agent?: string
+  title?: string
+  task?: string
+  description?: string
+  workflow_id?: string
+  channels?: string[]
+  column?: string
+}
+
+interface EditorNodeShellProps {
+  data: EditorNodeData
+  tone: 'blue' | 'amber' | 'violet' | 'emerald' | 'zinc'
+  title: string
+  icon: ReactNode
+  sourceHandle?: boolean
+}
+
+function EditorNodeShell({ data, tone, title, icon, sourceHandle = true }: EditorNodeShellProps) {
+  const toneClass = {
+    blue: 'border-blue-500/50 text-blue-300 bg-blue-500/10',
+    amber: 'border-amber-400/60 text-amber-300 bg-amber-500/10',
+    violet: 'border-violet-500/50 text-violet-300 bg-violet-500/10',
+    emerald: 'border-emerald-500/50 text-emerald-300 bg-emerald-500/10',
+    zinc: 'border-zinc-600 text-zinc-300 bg-zinc-800/60',
+  }[tone]
+  const detail = data.task || data.title || data.description || data.workflow_id || data.column
+
+  return (
+    <div className={`flex h-full w-full flex-col justify-center rounded-lg border bg-zinc-950 px-4 py-3 shadow-lg ${toneClass}`}>
+      <div className="flex items-center gap-2">
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-black/25">
+          {icon}
+        </span>
+        <div className="min-w-0">
+          <div className="text-xs font-semibold uppercase leading-none tracking-wide opacity-80">
+            {title}
+          </div>
+          <div className="mt-1 truncate text-sm font-medium text-zinc-100">
+            {data.label || title}
+          </div>
+        </div>
+      </div>
+      {data.agent && (
+        <AgentAssignmentLabel agent={data.agent} className="mt-2" />
+      )}
+      {typeof detail === 'string' && detail.length > 0 && (
+        <p className={`${data.agent ? 'mt-1' : 'mt-2'} line-clamp-2 text-xs leading-snug text-zinc-400`}>
+          {detail}
+        </p>
+      )}
+      <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
+      {sourceHandle && <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />}
+    </div>
+  )
+}
+
+function EditorAgentNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="emerald"
+      title="Agent Task"
+      icon={<UserRound className="size-3.5" />}
+    />
+  )
+}
+
+function EditorGateNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="amber"
+      title="Approval Gate"
+      icon={<CheckCircle2 className="size-3.5" />}
+    />
+  )
+}
+
+function EditorOutputNode({ data }: NodeProps) {
+  const nodeData = data as EditorNodeData
+  return (
+    <EditorNodeShell
+      data={{
+        ...nodeData,
+        description: Array.isArray(nodeData.channels) ? nodeData.channels.join(', ') : nodeData.description,
+      }}
+      tone="violet"
+      title="Completion"
+      icon={<Radio className="size-3.5" />}
+    />
+  )
+}
+
+function EditorParallelNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="blue"
+      title="Parallel Group"
+      icon={<GitBranch className="size-3.5" />}
+    />
+  )
+}
+
+function EditorWorkflowNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="zinc"
+      title="Nested Workflow"
+      icon={<WorkflowIcon className="size-3.5" />}
+    />
+  )
+}
+
+function EditorCreateTaskNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="blue"
+      title="Create Task"
+      icon={<ClipboardPlus className="size-3.5" />}
+    />
+  )
+}
+
+function EditorTriggerNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="blue"
+      title="Trigger"
+      icon={<Radio className="size-3.5" />}
+    />
+  )
+}
+
+function EditorSubflowGroupNode({ data }: NodeProps) {
+  return (
+    <EditorNodeShell
+      data={data as EditorNodeData}
+      tone="zinc"
+      title="Subflow Group"
+      icon={<WorkflowIcon className="size-3.5" />}
+    />
+  )
+}
+
+function EditorAppendStepNode() {
+  return (
+    <div aria-hidden="true" className="h-px w-px opacity-0">
+      <Handle type="target" position={Position.Top} className="!bg-transparent" />
+    </div>
+  )
+}
+
+const BUILTIN_NODE_TYPES: NodeTypes = {
+  agent: EditorAgentNode,
+  gate: EditorGateNode,
+  output: EditorOutputNode,
+  parallel: EditorParallelNode,
+  workflow: EditorWorkflowNode,
+  createTask: EditorCreateTaskNode,
+  trigger: EditorTriggerNode,
+  subflowGroup: EditorSubflowGroupNode,
+  appendStep: EditorAppendStepNode,
+}
+
+function WorkflowDetailsDrawer({
+  definition,
+  onApply,
+  onClose,
+  applyLabel = 'Apply',
+  applying = false,
+}: {
+  definition: WorkflowDefinition
+  onApply: (patch: Pick<WorkflowDefinition, 'name' | 'description'>) => void | Promise<void>
+  onClose: () => void
+  applyLabel?: string
+  applying?: boolean
+}) {
+  const [name, setName] = useState(definition.name)
+  const [description, setDescription] = useState(definition.description ?? '')
+  const canApply = name.trim().length > 0
+
+  useEffect(() => {
+    setName(definition.name)
+    setDescription(definition.description ?? '')
+  }, [definition.description, definition.name])
+
+  return (
+    <aside className="flex w-[25rem] flex-col border-l border-border bg-card">
+      <div className="flex items-start justify-between gap-3 border-b border-border p-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-medium">Workflow details</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Edit the workflow name and description.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close workflow details"
+          onClick={onClose}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3">
+        <div className="mb-3">
+          <Label className="text-xs" htmlFor="workflow-details-name">
+            Name <span className="text-red-400">*</span>
+          </Label>
+          <Input
+            id="workflow-details-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Workflow name"
+            aria-invalid={!canApply || undefined}
+          />
+          {!canApply && (
+            <p className="mt-1 text-[11px] font-medium text-red-300">Enter a workflow name.</p>
+          )}
+        </div>
+        <div className="mb-3">
+          <Label className="text-xs" htmlFor="workflow-details-description">
+            Description
+          </Label>
+          <Textarea
+            id="workflow-details-description"
+            rows={5}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Describe when this workflow should be used"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2 border-t border-border p-3">
+        <Button size="sm" variant="ghost" onClick={onClose} disabled={applying}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={async () => {
+            if (!canApply) return
+            await onApply({
+              name: name.trim(),
+              description: description.trim(),
+            })
+          }}
+          disabled={!canApply || applying}
+        >
+          {applying ? 'Saving...' : applyLabel}
+        </Button>
+      </div>
+    </aside>
+  )
+}
 
 interface WorkflowCanvasEditorProps {
   mode: 'create' | 'edit'
@@ -69,8 +399,10 @@ interface WorkflowCanvasEditorProps {
   initialId?: string
   /** Omit in create mode to start from a blank workflow. */
   initialDefinition?: WorkflowDefinition
-  source?: 'plugin' | 'user'
+  source?: 'plugin' | 'agent-package' | 'user'
+  shadowedSource?: WorkflowShadowedSource
   onSaved?: (id: string) => void
+  onCopied?: (id: string) => void
   onDeleted?: () => void
   onCancel?: () => void
 }
@@ -101,11 +433,17 @@ function stepNodeData(step: WorkflowStep): Record<string, unknown> {
   } else if (step.type === 'gate') {
     data.description = step.description
   } else if (step.type === 'output') {
+    data.agent = step.agent
     data.channels = step.channels
     data.description = step.description
   } else if (step.type === 'workflow') {
     data.description = step.description
     data.workflow_id = step.workflow_id
+  } else if (step.type === 'createTask') {
+    data.agent = step.agent
+    data.title = step.title
+    data.column = step.column
+    data.description = step.description
   }
   return data
 }
@@ -122,30 +460,174 @@ function nextStepId(kind: string, existing: Set<string>): string {
 
 /** Build a default body for a newly-dropped step of the given kind. */
 function defaultStepBody(id: string, kind: string): WorkflowStep {
+  const label = BUILTIN_STEP_LABELS[kind] ?? id
   // Builtins have known required fields; plugin kinds get a minimal shell.
-  if (kind === 'agent') return { id, type: 'agent', label: id, agent: '' }
-  if (kind === 'gate') return { id, type: 'gate', label: id, on_approve: '' }
-  if (kind === 'output') return { id, type: 'output', label: id }
-  if (kind === 'workflow') return { id, type: 'workflow', label: id, workflow_id: '' }
-  if (kind === 'parallel') return { id, type: 'parallel', label: id, steps: [] }
+  if (kind === 'agent') return { id, type: 'agent', label, agent: '$assigned' }
+  if (kind === 'gate') return { id, type: 'gate', label, on_approve: '' }
+  if (kind === 'output') return { id, type: 'output', label }
+  if (kind === 'workflow') return { id, type: 'workflow', label, workflow_id: '' }
+  if (kind === 'parallel') return { id, type: 'parallel', label, steps: [] }
+  if (kind === 'createTask') return { id, type: 'createTask', label, title: '' }
   // Plugin kind — preserve `type` as-is; the drawer will validate against the
   // plugin's zodSchema when the user edits the node.
   return { id, type: kind, label: id } as unknown as WorkflowStep
+}
+
+function cloneStep(step: WorkflowStep): WorkflowStep {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(step)
+  }
+  return JSON.parse(JSON.stringify(step)) as WorkflowStep
+}
+
+function looksLikeLegacyHorizontalLayout(order: string[], positions: Record<string, NodePosition>): boolean {
+  if (order.length < 2) return false
+  const coords = order.map((id) => positions[id])
+  if (coords.some((pos) => !pos)) return false
+  const xs = coords.map((pos) => pos.x)
+  const ys = coords.map((pos) => pos.y)
+  const xRange = Math.max(...xs) - Math.min(...xs)
+  const yRange = Math.max(...ys) - Math.min(...ys)
+  return xRange > NODE_WIDTH && yRange < 12
+}
+
+function looksLikeLegacyCompactVerticalLayout(order: string[], positions: Record<string, NodePosition>): boolean {
+  if (order.length < 2) return false
+  const coords = order.map((id) => positions[id])
+  if (coords.some((pos) => !pos)) return false
+
+  const xs = coords.map((pos) => pos.x)
+  const xRange = Math.max(...xs) - Math.min(...xs)
+  if (xRange > 12) return false
+
+  const yDeltas = coords.slice(1).map((pos, index) => pos.y - coords[index].y)
+  return yDeltas.every((delta) => delta > 0 && delta <= LEGACY_COMPACT_Y_SPACING + 16)
 }
 
 interface EditorState {
   steps: Record<string, WorkflowStep>
   order: string[]
   positions: Record<string, NodePosition>
-  edges: Edge[]
+  measurements: Record<string, { width?: number; height?: number }>
 }
 
-function seedEdges(order: string[]): Edge[] {
+type RouteNavigationBlocker =
+  | { status: 'idle' }
+  | { status: 'blocked'; proceed: () => void; reset: () => void }
+
+interface InsertEdgeData extends Record<string, unknown> {
+  insertIndex: number
+  onInsert: (kind: string, index: number) => void
+  onOpenPalette: () => void
+}
+
+function InsertableEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}: EdgeProps) {
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  })
+  const insertData = data as InsertEdgeData | undefined
+
+  return (
+    <>
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+      {insertData && (
+        <EdgeLabelRenderer>
+          <button
+            type="button"
+            aria-label="Drop node here"
+            title="Drop a node here"
+            className={`nodrag nopan pointer-events-auto flex items-center justify-center rounded-full border transition ${
+              isDragOver
+                ? 'size-8 border-blue-300/80 bg-blue-500/20 shadow-[0_0_0_4px_rgba(59,130,246,0.16)]'
+                : 'size-5 border-transparent bg-transparent hover:border-blue-400/40 hover:bg-blue-500/10'
+            }`}
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            }}
+            onClick={(event) => {
+              event.stopPropagation()
+              insertData.onOpenPalette()
+            }}
+            onDragEnter={(event) => {
+              if (!hasPaletteDragType(event.dataTransfer)) return
+              setIsDragOver(true)
+            }}
+            onDragOver={(event) => {
+              if (!hasPaletteDragType(event.dataTransfer)) return
+              event.preventDefault()
+              if (!isDragOver) setIsDragOver(true)
+              event.dataTransfer.dropEffect = 'copy'
+            }}
+            onDragLeave={(event) => {
+              const nextTarget = event.relatedTarget
+              if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return
+              setIsDragOver(false)
+            }}
+            onDrop={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              setIsDragOver(false)
+              if (!hasPaletteDragType(event.dataTransfer)) return
+              const kind = event.dataTransfer.getData(PALETTE_DRAG_MIME_TYPE)
+              if (!kind) return
+              insertData.onInsert(kind, insertData.insertIndex)
+            }}
+          >
+            <span
+              className={`rounded-full transition-all ${
+                isDragOver
+                  ? 'size-4 bg-blue-300'
+                  : 'size-2.5 bg-zinc-500 hover:bg-blue-300'
+              }`}
+            />
+          </button>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}
+
+function seedEdges(
+  order: string[],
+  includeTrigger = false,
+  onInsert?: (kind: string, index: number) => void,
+  onOpenPalette?: () => void,
+  includeAppendTarget = false,
+): Edge[] {
   const edges: Edge[] = []
-  for (let i = 0; i < order.length - 1; i++) {
-    const source = order[i]
-    const target = order[i + 1]
-    edges.push({ id: `${source}-${target}`, source, target })
+  const nodeOrder = includeTrigger
+    ? [TRIGGER_NODE_ID, ...order]
+    : order
+  if (includeAppendTarget) nodeOrder.push(APPEND_NODE_ID)
+  for (let i = 0; i < nodeOrder.length - 1; i++) {
+    const source = nodeOrder[i]
+    const target = nodeOrder[i + 1]
+    edges.push({
+      id: `${source}-${target}`,
+      source,
+      target,
+      type: onInsert ? 'insertable' : undefined,
+      data: onInsert && onOpenPalette
+        ? { insertIndex: i, onInsert, onOpenPalette }
+        : undefined,
+    })
   }
   return edges
 }
@@ -157,36 +639,65 @@ function seedState(def: WorkflowDefinition): EditorState {
     steps[step.id] = step
     order.push(step.id)
   }
-  const edges = seedEdges(order)
+  const edges = seedEdges(order, true)
   const seeded = def.layout?.positions
 
   // If the definition carries explicit positions, use them; otherwise run
-  // dagre to give the canvas a sensible left-to-right layout instead of
+  // dagre to give the canvas a sensible top-to-bottom layout instead of
   // stacking every node at (0, 0).
   let positions: Record<string, NodePosition>
-  if (seeded && Object.keys(seeded).length > 0) {
+  if (
+    seeded &&
+    Object.keys(seeded).length > 0 &&
+    !looksLikeLegacyHorizontalLayout(order, seeded) &&
+    !looksLikeLegacyCompactVerticalLayout(order, seeded)
+  ) {
     positions = { ...seeded }
     for (let i = 0; i < order.length; i++) {
       if (!positions[order[i]]) positions[order[i]] = { x: 0, y: i * Y_SPACING }
     }
   } else {
-    const bareNodes = order.map((id) => ({
+    const bareNodes = [TRIGGER_NODE_ID, ...order].map((id) => ({
       id,
       position: { x: 0, y: 0 },
       data: {},
-      style: { width: NODE_WIDTH },
+      style: STANDARD_NODE_STYLE,
     }))
-    const arranged = layoutNodes(bareNodes, edges)
+    const arranged = layoutNodes(bareNodes, edges, {
+      rankdir: 'TB',
+      ranksep: Y_SPACING - NODE_HEIGHT,
+      nodeWidth: NODE_WIDTH,
+      nodeHeight: NODE_HEIGHT,
+    })
     positions = {}
     for (const n of arranged) {
+      if (n.id === TRIGGER_NODE_ID) continue
       positions[n.id] = { x: n.position.x, y: n.position.y }
     }
   }
-  return { steps, order, positions, edges }
+  return { steps, order, positions, measurements: {} }
 }
 
 function deriveNodes(state: EditorState): Node[] {
-  return state.order.map((id) => {
+  const firstPosition = state.order.length > 0
+    ? state.positions[state.order[0]]
+    : undefined
+  const lastId = state.order[state.order.length - 1]
+  const lastPosition = lastId ? state.positions[lastId] : undefined
+  const triggerNode: Node = {
+    id: TRIGGER_NODE_ID,
+    type: 'trigger',
+    position: {
+      x: firstPosition?.x ?? 0,
+      y: (firstPosition?.y ?? Y_SPACING) - Y_SPACING,
+    },
+    data: {},
+    measured: state.measurements[TRIGGER_NODE_ID],
+    style: STANDARD_NODE_STYLE,
+    selectable: false,
+    draggable: false,
+  }
+  const stepNodes = state.order.map((id) => {
     const step = state.steps[id]
     const pos = state.positions[id] ?? { x: 0, y: 0 }
     return {
@@ -194,9 +705,50 @@ function deriveNodes(state: EditorState): Node[] {
       type: step.type,
       position: { x: pos.x, y: pos.y },
       data: stepNodeData(step),
-      style: { width: NODE_WIDTH },
+      measured: state.measurements[id],
+      style: STANDARD_NODE_STYLE,
     }
   })
+  const appendNode: Node = {
+    id: APPEND_NODE_ID,
+    type: 'appendStep',
+    position: {
+      x: lastPosition?.x ?? firstPosition?.x ?? 0,
+      y: (lastPosition?.y ?? triggerNode.position.y) + Y_SPACING,
+    },
+    data: {},
+    measured: state.measurements[APPEND_NODE_ID],
+    style: { width: NODE_WIDTH },
+    selectable: false,
+    draggable: false,
+  }
+  return [triggerNode, ...stepNodes, appendNode]
+}
+
+function autoArrangeState(state: EditorState): EditorState {
+  const arranged = layoutNodes(deriveNodes(state), seedEdges(state.order, true), {
+    rankdir: 'TB',
+    ranksep: Y_SPACING - NODE_HEIGHT,
+    nodeWidth: NODE_WIDTH,
+    nodeHeight: NODE_HEIGHT,
+  })
+  const nextPositions: Record<string, NodePosition> = {}
+  for (const n of arranged) {
+    if (!(n.id in state.steps)) continue
+    nextPositions[n.id] = { x: n.position.x, y: n.position.y }
+  }
+  return { ...state, positions: nextPositions }
+}
+
+function samePosition(a: NodePosition | undefined, b: NodePosition): boolean {
+  return a?.x === b.x && a?.y === b.y
+}
+
+function sameMeasurement(
+  a: { width?: number; height?: number } | undefined,
+  b: { width?: number; height?: number },
+): boolean {
+  return a?.width === b.width && a?.height === b.height
 }
 
 export function WorkflowCanvasEditor({
@@ -204,133 +756,310 @@ export function WorkflowCanvasEditor({
   initialId,
   initialDefinition,
   source,
+  shadowedSource,
   onSaved,
+  onCopied,
   onDeleted,
   onCancel,
 }: WorkflowCanvasEditorProps) {
   const baseDefinition = initialDefinition ?? BLANK_DEFINITION
   const [definition, setDefinition] = useState<WorkflowDefinition>(baseDefinition)
   const [state, setState] = useState<EditorState>(() => seedState(baseDefinition))
+  const [editingId, setEditingId] = useState(initialId)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [confirmingExit, setConfirmingExit] = useState(false)
+  const [isDirty, setIsDirty] = useState(false)
+  const [nodeDrawerDirty, setNodeDrawerDirty] = useState(false)
+  const [pendingNavigationHref, setPendingNavigationHref] = useState<string | null>(null)
+  const [workflowDetailsOpen, setWorkflowDetailsOpen] = useState(false)
+  const [effectiveSource, setEffectiveSource] = useState(source)
+  const [managedCopyOpen, setManagedCopyOpen] = useState(false)
+  const [copyError, setCopyError] = useState<string | null>(null)
+  const [copyFieldErrors, setCopyFieldErrors] = useState<WorkflowDialogFieldErrors>({})
+  const [creatingLocalCopy, setCreatingLocalCopy] = useState(false)
+  const [copyName, setCopyName] = useState(baseDefinition.name ? `${baseDefinition.name} Copy` : '')
+  const [copyId, setCopyId] = useState(baseDefinition.name ? slugify(`${baseDefinition.name} Copy`) : '')
+  const [copyIdEdited, setCopyIdEdited] = useState(false)
+  const [copyDescription, setCopyDescription] = useState(baseDefinition.description ?? '')
+  const [disableOriginal, setDisableOriginal] = useState(true)
+  const [paletteCollapsed, setPaletteCollapsed] = useState(false)
+  const [createSetupOpen, setCreateSetupOpen] = useState(mode === 'create' && !initialDefinition?.id)
+  const [routeBlocker, setRouteBlocker] = useState<RouteNavigationBlocker>({ status: 'idle' })
+  const tanStackRouter = useTanStackRouter()
 
-  const wrapperRef = useRef<HTMLDivElement | null>(null)
   const rfInstanceRef = useRef<ReactFlowInstance | null>(null)
+  const lastFitViewKeyRef = useRef<string | null>(null)
+  const hasUnsavedChanges = isDirty || nodeDrawerDirty
 
   // Subscribe to registry mutations — see note in workflow-canvas.tsx.
-  const nodeTypes = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererSnapshot, getNodeRendererSnapshot) as NodeTypes
-  const nodes = useMemo(() => deriveNodes(state), [state])
-  const edges = state.edges
+  const registeredNodeTypes = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererSnapshot, getNodeRendererSnapshot) as NodeTypes
+  const nodeTypes = useMemo(
+    () => ({ ...BUILTIN_NODE_TYPES, ...registeredNodeTypes }),
+    [registeredNodeTypes],
+  )
+  const edgeTypes = useMemo<EdgeTypes>(() => ({ insertable: InsertableEdge }), [])
+  const hasCompletionStep = useMemo(
+    () => state.order.some((id) => state.steps[id]?.type === 'output'),
+    [state.order, state.steps],
+  )
+  const disabledPaletteKinds = useMemo(
+    () => (hasCompletionStep ? new Set(['output']) : undefined),
+    [hasCompletionStep],
+  )
+  const insertStepAt = useCallback((kind: string, index: number) => {
+    if (nodeDrawerDirty) {
+      setError(NODE_DRAWER_DIRTY_MESSAGE)
+      return
+    }
+    if (kind === 'output' && hasCompletionStep) return
+    const id = nextStepId(kind, new Set(state.order))
+    setIsDirty(true)
+    setNodeDrawerDirty(false)
+    setState((prev) => {
+      const order = [...prev.order]
+      const insertIndex = Math.max(0, Math.min(index, order.length))
+      order.splice(insertIndex, 0, id)
+      return autoArrangeState({
+        ...prev,
+        steps: { ...prev.steps, [id]: defaultStepBody(id, kind) },
+        order,
+        positions: { ...prev.positions, [id]: { x: 0, y: 0 } },
+      })
+    })
+    setWorkflowDetailsOpen(false)
+    setSelectedId(id)
+  }, [hasCompletionStep, nodeDrawerDirty, state.order])
+  const openStepPalette = useCallback(() => {
+    setPaletteCollapsed(false)
+  }, [])
+  const nodes = useMemo(
+    () =>
+      deriveNodes(state).map((node) => (
+        node.id === selectedId
+          ? { ...node, selected: true, className: 'bakin-workflow-node-selected' }
+          : node
+      )),
+    [selectedId, state],
+  )
+  const edges = useMemo(
+    () => seedEdges(state.order, true, insertStepAt, openStepPalette, true),
+    [insertStepAt, openStepPalette, state.order],
+  )
+  const fitViewKey = useMemo(
+    () => `${mode}:${initialId ?? 'new'}:${initialDefinition?.id ?? ''}:${initialDefinition?.steps.map((step) => step.id).join('|') ?? ''}`,
+    [initialDefinition, initialId, mode],
+  )
+
+  useEffect(() => {
+    const nextDefinition = initialDefinition ?? BLANK_DEFINITION
+    setDefinition(nextDefinition)
+    setState(seedState(nextDefinition))
+    setEditingId(initialId)
+    setSelectedId(null)
+    setConfirmingExit(false)
+    setIsDirty(false)
+    setNodeDrawerDirty(false)
+    setPendingNavigationHref(null)
+    setWorkflowDetailsOpen(false)
+    setError(null)
+    setEffectiveSource(source)
+    setCopyError(null)
+    setCopyFieldErrors({})
+    setCopyName(nextDefinition.name ? `${nextDefinition.name} Copy` : '')
+    setCopyId(nextDefinition.name ? slugify(`${nextDefinition.name} Copy`) : '')
+    setCopyIdEdited(false)
+    setCopyDescription(nextDefinition.description ?? '')
+    setDisableOriginal(true)
+    setCreateSetupOpen(mode === 'create' && !nextDefinition.id)
+  }, [mode, source, initialId, initialDefinition])
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [hasUnsavedChanges])
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    return tanStackRouter.history.block({
+      enableBeforeUnload: false,
+      blockerFn: async ({ currentLocation, nextLocation }) => {
+        const current = tanStackRouter.parseLocation(currentLocation)
+        const next = tanStackRouter.parseLocation(nextLocation)
+        if (current.pathname === next.pathname) return false
+
+        const shouldBlock = await new Promise<boolean>((resolve) => {
+          setRouteBlocker({
+            status: 'blocked',
+            proceed: () => resolve(false),
+            reset: () => resolve(true),
+          })
+        })
+        setRouteBlocker({ status: 'idle' })
+        return shouldBlock
+      },
+    })
+  }, [hasUnsavedChanges, tanStackRouter])
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (event.defaultPrevented) return
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+      const target = event.target as Element | null
+      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null
+      if (!anchor) return
+      if (anchor.target && anchor.target !== '_self') return
+      if (anchor.hasAttribute('download')) return
+      if (anchor.origin !== window.location.origin) return
+      if (anchor.href === window.location.href) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      setPendingNavigationHref(anchor.href)
+      setConfirmingExit(true)
+    }
+
+    document.addEventListener('click', handleDocumentClick, true)
+    return () => document.removeEventListener('click', handleDocumentClick, true)
+  }, [hasUnsavedChanges])
+
+  useEffect(() => {
+    if (mode !== 'edit') return
+    if (effectiveSource === 'plugin' || effectiveSource === 'agent-package') {
+      setManagedCopyOpen(true)
+      return
+    }
+    setManagedCopyOpen(false)
+  }, [effectiveSource, mode])
+
+  useEffect(() => {
+    if (state.order.length === 0) return
+    if (lastFitViewKeyRef.current === fitViewKey) return
+    lastFitViewKeyRef.current = fitViewKey
+    const frame = requestAnimationFrame(() => {
+      void rfInstanceRef.current?.fitView({ padding: 0.3 })
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [fitViewKey, state.order.length])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      // Persist position updates into state.positions; ignore everything else
-      // (applyNodeChanges returns the full node array we can diff against).
+      // Persist only the editor-owned pieces of React Flow's controlled node
+      // state. Dimension changes must be retained so React Flow can unhide
+      // custom nodes and route edges against their real rendered bounds.
       setState((prev) => {
-        const derived = deriveNodes(prev)
-        const nextNodes = applyNodeChanges(changes, derived)
         const nextPositions = { ...prev.positions }
-        for (const n of nextNodes) {
-          nextPositions[n.id] = { x: n.position.x, y: n.position.y }
+        const nextMeasurements = { ...prev.measurements }
+        let changed = false
+        let dirtyChanged = false
+
+        for (const change of changes) {
+          if (change.type === 'position' && change.position && change.id in prev.steps) {
+            if (!samePosition(prev.positions[change.id], change.position)) {
+              nextPositions[change.id] = { x: change.position.x, y: change.position.y }
+              changed = true
+              dirtyChanged = true
+            }
+          }
+
+          if (change.type === 'dimensions' && change.dimensions) {
+            const isEditorNode = change.id === TRIGGER_NODE_ID || change.id === APPEND_NODE_ID || change.id in prev.steps
+            if (!isEditorNode) continue
+            const nextMeasurement = {
+              width: change.dimensions.width,
+              height: change.dimensions.height,
+            }
+            if (!sameMeasurement(prev.measurements[change.id], nextMeasurement)) {
+              nextMeasurements[change.id] = nextMeasurement
+              changed = true
+            }
+          }
         }
-        return { ...prev, positions: nextPositions }
+
+        if (dirtyChanged) setIsDirty(true)
+        return changed ? { ...prev, positions: nextPositions, measurements: nextMeasurements } : prev
       })
     },
     [],
   )
-  const onEdgesChange = useCallback((changes: EdgeChange[]) => {
-    setState((prev) => ({ ...prev, edges: applyEdgeChanges(changes, prev.edges) }))
-  }, [])
-
-  const isValidConnection = useCallback(
-    (conn: Connection | Edge) => {
-      const source = (conn as Connection).source
-      const target = (conn as Connection).target
-      if (!source || !target) return false
-      const result = canConnect(source, target, state.edges, (id) => state.steps[id]?.type)
-      return result.ok
-    },
-    [state.edges, state.steps],
-  )
-
-  const onConnect = useCallback(
-    (conn: Connection) => {
-      if (!conn.source || !conn.target) return
-      const result = canConnect(
-        conn.source,
-        conn.target,
-        state.edges,
-        (id) => state.steps[id]?.type,
-      )
-      if (!result.ok) {
-        if (result.reason) toast(result.reason, 'error')
+  const onNodeClick = useCallback(
+    (_e: React.MouseEvent, node: Node) => {
+      if (nodeDrawerDirty && node.id !== selectedId) {
+        setError(NODE_DRAWER_DIRTY_MESSAGE)
         return
       }
-      setState((prev) => ({ ...prev, edges: addEdge(conn, prev.edges) }))
+      setWorkflowDetailsOpen(false)
+      setSelectedId(node.id === TRIGGER_NODE_ID || node.id === APPEND_NODE_ID ? null : node.id)
     },
-    [state.edges, state.steps],
+    [nodeDrawerDirty, selectedId],
   )
+  const onPaneClick = useCallback(() => {
+    if (nodeDrawerDirty) {
+      setError(NODE_DRAWER_DIRTY_MESSAGE)
+      return
+    }
+    setSelectedId(null)
+  }, [nodeDrawerDirty])
 
-  const onNodeClick = useCallback(
-    (_e: React.MouseEvent, node: Node) => setSelectedId(node.id),
-    [],
+  const closeNodeDrawer = useCallback(() => {
+    setNodeDrawerDirty(false)
+    setSelectedId(null)
+  }, [])
+
+  const openWorkflowDetails = useCallback(() => {
+    if (nodeDrawerDirty) {
+      setError(NODE_DRAWER_DIRTY_MESSAGE)
+      return
+    }
+    setSelectedId(null)
+    setWorkflowDetailsOpen(true)
+  }, [nodeDrawerDirty])
+
+  const closeWorkflowDetails = useCallback(() => {
+    setWorkflowDetailsOpen(false)
+  }, [])
+
+  const setDrawerDirty = useCallback((dirty: boolean) => {
+    setNodeDrawerDirty(dirty)
+    if (dirty) setError(null)
+  }, [])
+
+  const cancelNodeSelectionChangeMessage = useCallback(() => {
+    if (error === NODE_DRAWER_DIRTY_MESSAGE) setError(null)
+  }, [error])
+
+  useEffect(
+    () => {
+      if (!nodeDrawerDirty) cancelNodeSelectionChangeMessage()
+    },
+    [cancelNodeSelectionChangeMessage, nodeDrawerDirty],
   )
 
   const handleAutoArrange = useCallback(() => {
-    setState((prev) => {
-      const arranged = layoutNodes(deriveNodes(prev), prev.edges)
-      const nextPositions: Record<string, NodePosition> = {}
-      for (const n of arranged) {
-        nextPositions[n.id] = { x: n.position.x, y: n.position.y }
-      }
-      return { ...prev, positions: nextPositions }
-    })
-  }, [])
-
-  const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'copy'
-  }, [])
-
-  const onDrop = useCallback((event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    const kind =
-      event.dataTransfer.getData(PALETTE_DRAG_MIME_TYPE) ||
-      event.dataTransfer.getData('text/plain')
-    if (!kind) return
-
-    const bounds = wrapperRef.current?.getBoundingClientRect()
-    const rf = rfInstanceRef.current
-    const position: XYPosition =
-      bounds && rf
-        ? rf.screenToFlowPosition({
-            x: event.clientX - bounds.left,
-            y: event.clientY - bounds.top,
-          })
-        : { x: event.clientX, y: event.clientY }
-
-    setState((prev) => {
-      const id = nextStepId(kind, new Set(prev.order))
-      return {
-        ...prev,
-        steps: { ...prev.steps, [id]: defaultStepBody(id, kind) },
-        order: [...prev.order, id],
-        positions: { ...prev.positions, [id]: { x: position.x, y: position.y } },
-      }
-    })
+    setState((prev) => autoArrangeState(prev))
+    setIsDirty(true)
   }, [])
 
   const handleApply = useCallback(
     (patch: Record<string, unknown>) => {
       const prevId = selectedId
       if (!prevId) return
+      const nextId = (patch.id as string | undefined) ?? prevId
+      if (nextId !== prevId && state.steps[nextId]) {
+        setError('Step IDs must be unique.')
+        return
+      }
       setState((prev) => {
         const base = prev.steps[prevId]
         if (!base) return prev
         const merged = { ...base, ...patch } as WorkflowStep
-        const nextId = (patch.id as string | undefined) ?? prevId
         if (nextId === prevId) {
           return { ...prev, steps: { ...prev.steps, [prevId]: merged } }
         }
@@ -338,40 +1067,122 @@ export function WorkflowCanvasEditor({
         const restSteps = { ...prev.steps }
         delete restSteps[prevId]
         const { [prevId]: oldPos, ...restPositions } = prev.positions
+        const { [prevId]: oldMeasurement, ...restMeasurements } = prev.measurements
         const nextOrder = prev.order.map((o) => (o === prevId ? nextId : o))
-        const nextEdges = prev.edges.map((e) => ({
-          ...e,
-          source: e.source === prevId ? nextId : e.source,
-          target: e.target === prevId ? nextId : e.target,
-        }))
+        const nextMeasurements = oldMeasurement
+          ? { ...restMeasurements, [nextId]: oldMeasurement }
+          : restMeasurements
         return {
           steps: { ...restSteps, [nextId]: { ...merged, id: nextId } },
           order: nextOrder,
           positions: { ...restPositions, [nextId]: oldPos ?? { x: 0, y: 0 } },
-          edges: nextEdges,
+          measurements: nextMeasurements,
         }
       })
       if (typeof patch.id === 'string' && patch.id !== prevId) {
         setSelectedId(patch.id)
       }
+      setIsDirty(true)
+      setNodeDrawerDirty(false)
       setSelectedId(null)
     },
-    [selectedId],
+    [selectedId, state.steps],
   )
 
-  const isPluginSource = source === 'plugin'
-  const canSaveInPlace = mode === 'create' || !isPluginSource
-  const canDelete = mode === 'edit' && source === 'user'
+  const moveSelectedStep = useCallback((delta: -1 | 1) => {
+    if (!selectedId) return
+    setState((prev) => {
+      const current = prev.order.indexOf(selectedId)
+      const next = current + delta
+      if (current < 0 || next < 0 || next >= prev.order.length) return prev
+      setIsDirty(true)
+      const order = [...prev.order]
+      const [moved] = order.splice(current, 1)
+      order.splice(next, 0, moved)
+      return autoArrangeState({ ...prev, order })
+    })
+  }, [selectedId])
 
-  function buildDefinition(): WorkflowDefinition {
+  const duplicateSelectedStep = useCallback(() => {
+    if (!selectedId) return
+    setState((prev) => {
+      const base = prev.steps[selectedId]
+      if (!base) return prev
+      if (base.type === 'output') return prev
+      setIsDirty(true)
+      const id = nextStepId(`${selectedId}-copy`, new Set(prev.order))
+      const clone = cloneStep(base) as unknown as Record<string, unknown>
+      clone.id = id
+      clone.label = `${String(base.label || selectedId)} copy`
+      const current = prev.order.indexOf(selectedId)
+      const order = [...prev.order]
+      order.splice(current >= 0 ? current + 1 : order.length, 0, id)
+      return autoArrangeState({
+        ...prev,
+        steps: { ...prev.steps, [id]: clone as unknown as WorkflowStep },
+        order,
+        positions: { ...prev.positions, [id]: { x: 0, y: 0 } },
+      })
+    })
+  }, [selectedId])
+
+  const deleteSelectedStep = useCallback(() => {
+    if (!selectedId) return
+    setState((prev) => {
+      if (!prev.steps[selectedId]) return prev
+      setIsDirty(true)
+      const steps = { ...prev.steps }
+      delete steps[selectedId]
+      const positions = { ...prev.positions }
+      delete positions[selectedId]
+      const measurements = { ...prev.measurements }
+      delete measurements[selectedId]
+      return autoArrangeState({
+        ...prev,
+        steps,
+        order: prev.order.filter((id) => id !== selectedId),
+        positions,
+        measurements,
+      })
+    })
+    setSelectedId(null)
+  }, [selectedId])
+
+  useEffect(() => {
+    if (!selectedId) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return
+      const target = event.target as HTMLElement | null
+      if (
+        target?.closest('input, textarea, [contenteditable="true"], [role="textbox"], [role="combobox"]')
+      ) {
+        return
+      }
+      event.preventDefault()
+      deleteSelectedStep()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [deleteSelectedStep, selectedId])
+
+  const isManagedSource = effectiveSource === 'plugin' || effectiveSource === 'agent-package'
+  const canSaveInPlace = mode === 'create' || !isManagedSource
+  const canDelete = mode === 'edit' && effectiveSource === 'user'
+
+  function buildDefinition(definitionOverride = definition): WorkflowDefinition {
     return {
-      ...definition,
+      ...definitionOverride,
       steps: state.order.map((id) => state.steps[id]).filter(Boolean),
-      layout: { positions: { ...state.positions } },
+      layout: { ...(definitionOverride.layout ?? {}), positions: { ...state.positions } },
     }
   }
 
-  async function postOrPut(method: 'POST' | 'PUT', url: string, body: unknown) {
+  async function postOrPut(
+    method: 'POST' | 'PUT',
+    url: string,
+    body: unknown,
+    options: { notifySaved?: boolean } = {},
+  ): Promise<boolean> {
     setSaving(true)
     setError(null)
     try {
@@ -383,66 +1194,245 @@ export function WorkflowCanvasEditor({
       const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
         setError((data.error as string) || `Save failed (${res.status})`)
-        return
+        return false
       }
-      onSaved?.(data.id as string)
+      if (options.notifySaved !== false) {
+        onSaved?.(data.id as string)
+      }
+      return true
     } catch (e) {
       setError((e as Error).message)
+      return false
     } finally {
       setSaving(false)
     }
   }
 
-  async function handleSave() {
-    const next = buildDefinition()
-    if (mode === 'edit' && initialId && canSaveInPlace) {
-      await postOrPut('PUT', `/api/plugins/workflows/definitions/${initialId}`, next)
-      return
+  async function saveDefinition(
+    next: WorkflowDefinition,
+    options: { notifySaved?: boolean } = {},
+  ): Promise<boolean> {
+    const targetId = editingId ?? initialId
+    if ((mode === 'edit' || editingId) && targetId && canSaveInPlace) {
+      return postOrPut('PUT', `/api/plugins/workflows/definitions/${targetId}`, next, options)
     }
-    const id = (initialDefinition?.id || slugify(definition.name)) || ''
+    const id = (next.id || initialDefinition?.id || slugify(next.name)) || ''
     if (!id) {
       setError('Name is required to derive an id')
-      return
+      return false
     }
-    await postOrPut('POST', '/api/plugins/workflows/definitions', { id, ...next })
+    return postOrPut('POST', '/api/plugins/workflows/definitions', { id, ...next }, options)
   }
 
-  async function handleSaveAsNew() {
-    const suggestion = slugify(definition.name) || initialId || ''
-    const newId = typeof window !== 'undefined'
-      ? window.prompt('New workflow id:', suggestion)
-      : suggestion
-    if (!newId || !newId.trim()) return
-    await postOrPut('POST', '/api/plugins/workflows/definitions', {
-      id: newId.trim(),
-      ...buildDefinition(),
+  async function handleSave() {
+    if (nodeDrawerDirty) {
+      setError(NODE_DRAWER_DIRTY_MESSAGE)
+      return
+    }
+    if (mode === 'edit' && canSaveInPlace && !isDirty) return
+    const saved = await saveDefinition(buildDefinition())
+    if (saved) setIsDirty(false)
+  }
+
+  async function handleWorkflowDetailsApply(patch: Pick<WorkflowDefinition, 'name' | 'description'>) {
+    const nextDefinition = { ...definition, ...patch }
+    if (mode === 'edit' && canSaveInPlace) {
+      const saved = await saveDefinition(buildDefinition(nextDefinition), { notifySaved: false })
+      if (!saved) return
+      setDefinition(nextDefinition)
+      setIsDirty(false)
+      setNodeDrawerDirty(false)
+      setWorkflowDetailsOpen(false)
+      return
+    }
+    setDefinition(nextDefinition)
+    setIsDirty(true)
+    setWorkflowDetailsOpen(false)
+  }
+
+  async function handleCreateWorkflowSetup() {
+    const nextId = copyId.trim()
+    const nextName = copyName.trim()
+    const fieldErrors = validateWorkflowDialogFields({ id: nextId, name: nextName })
+    if (hasWorkflowDialogFieldErrors(fieldErrors)) {
+      setCopyFieldErrors(fieldErrors)
+      setCopyError(null)
+      return
+    }
+
+    setCreatingLocalCopy(true)
+    setCopyError(null)
+    setCopyFieldErrors({})
+    setError(null)
+    try {
+      const nextDefinition = buildDefinition({
+        ...definition,
+        id: nextId,
+        name: nextName,
+        description: copyDescription.trim(),
+      })
+      const res = await fetch('/api/plugins/workflows/definitions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...nextDefinition, id: nextId }),
+      })
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
+      if (!res.ok) {
+        const parsedError = parseWorkflowDialogServerError(data, `Create failed (${res.status})`)
+        setCopyFieldErrors(parsedError.fieldErrors)
+        setCopyError(parsedError.error)
+        return
+      }
+
+      setDefinition(nextDefinition)
+      setEditingId(nextId)
+      setEffectiveSource('user')
+      setIsDirty(false)
+      setNodeDrawerDirty(false)
+      setCreateSetupOpen(false)
+      onSaved?.((data.id as string | undefined) ?? nextId)
+    } catch (e) {
+      setCopyError((e as Error).message)
+    } finally {
+      setCreatingLocalCopy(false)
+    }
+  }
+
+  async function handleCreateLocalCopy() {
+    if (!initialId) return
+    const nextId = copyId.trim()
+    const nextName = copyName.trim()
+    const fieldErrors = validateWorkflowDialogFields({
+      id: nextId,
+      name: nextName,
+      nameRequiredMessage: 'Copy name is required.',
     })
+    if (hasWorkflowDialogFieldErrors(fieldErrors)) {
+      setCopyFieldErrors(fieldErrors)
+      setCopyError(null)
+      return
+    }
+    setCreatingLocalCopy(true)
+    setCopyError(null)
+    setCopyFieldErrors({})
+    setError(null)
+    try {
+      const nextDefinition = {
+        ...buildDefinition(),
+        id: nextId,
+        name: nextName,
+      }
+      const res = await fetch('/api/plugins/workflows/definitions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...nextDefinition, id: nextId }),
+      })
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
+      if (!res.ok) {
+        const parsedError = parseWorkflowDialogServerError(data, `Copy failed (${res.status})`)
+        setCopyFieldErrors(parsedError.fieldErrors)
+        setCopyError(parsedError.error)
+        return
+      }
+      if (disableOriginal) {
+        const availabilityRes = await fetch(`/api/plugins/workflows/definitions/${initialId}/availability`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ disabled: true }),
+        })
+        if (!availabilityRes.ok) {
+          const availabilityData = (await availabilityRes.json().catch(() => ({}))) as Record<string, unknown>
+          setError((availabilityData.error as string | undefined) || `Copied, but disabling the managed workflow failed (${availabilityRes.status})`)
+        }
+      }
+      setDefinition(nextDefinition)
+      setEditingId(nextId)
+      setEffectiveSource('user')
+      setIsDirty(false)
+      setNodeDrawerDirty(false)
+      setManagedCopyOpen(false)
+      onCopied?.(nextId)
+    } catch (e) {
+      setCopyError((e as Error).message)
+    } finally {
+      setCreatingLocalCopy(false)
+    }
   }
 
   async function handleDelete() {
-    if (!initialId) return
-    if (!confirmingDelete) {
-      setConfirmingDelete(true)
-      return
-    }
+    const targetId = editingId ?? initialId
+    if (!targetId) return false
     setSaving(true)
     setError(null)
     try {
-      const res = await fetch(`/api/plugins/workflows/definitions/${initialId}`, {
+      const res = await fetch(`/api/plugins/workflows/definitions/${targetId}`, {
         method: 'DELETE',
       })
       const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
       if (!res.ok) {
         setError((data.error as string) || `Delete failed (${res.status})`)
-        return
+        return false
       }
       onDeleted?.()
+      return true
     } catch (e) {
       setError((e as Error).message)
+      return false
     } finally {
       setSaving(false)
-      setConfirmingDelete(false)
     }
+  }
+
+  function handleCancelRequest() {
+    if (!onCancel) return
+    if (hasUnsavedChanges) {
+      setPendingNavigationHref(null)
+      setConfirmingExit(true)
+      return
+    }
+    onCancel()
+  }
+
+  function completeExit() {
+    if (routeBlocker.status === 'blocked') {
+      routeBlocker.proceed()
+      return
+    }
+    const href = pendingNavigationHref
+    setPendingNavigationHref(null)
+    if (href) {
+      window.location.assign(href)
+      return
+    }
+    onCancel?.()
+  }
+
+  async function handleSaveAndExit() {
+    if (nodeDrawerDirty) {
+      setError(NODE_DRAWER_DIRTY_MESSAGE)
+      return
+    }
+    const saved = await saveDefinition(buildDefinition(), { notifySaved: false })
+    if (!saved) return
+    setIsDirty(false)
+    setNodeDrawerDirty(false)
+    setConfirmingExit(false)
+    completeExit()
+  }
+
+  function handleDiscardAndExit() {
+    setIsDirty(false)
+    setNodeDrawerDirty(false)
+    setConfirmingExit(false)
+    completeExit()
+  }
+
+  function cancelExitPrompt() {
+    if (routeBlocker.status === 'blocked') {
+      routeBlocker.reset()
+    }
+    setPendingNavigationHref(null)
+    setConfirmingExit(false)
   }
 
   const selectedStep = selectedId ? (state.steps[selectedId] as {
@@ -451,114 +1441,359 @@ export function WorkflowCanvasEditor({
     label: string
     [k: string]: unknown
   } | undefined) : null
+  const selectedIndex = selectedId ? state.order.indexOf(selectedId) : -1
+  const selectedHasDependsOn = Boolean(
+    selectedStep &&
+    'dependsOn' in selectedStep &&
+    selectedStep.dependsOn,
+  )
+  const workflowIdLabel = editingId ?? initialId ?? (mode === 'create' ? 'new' : 'unknown')
+  const workflowNameLabel = definition.name?.trim() || 'Untitled workflow'
+  const workflowDescriptionLabel = definition.description?.trim() || 'No description'
 
   return (
     <div className="flex h-full w-full flex-col">
-      <div className="flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-2">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          <span className="whitespace-nowrap text-sm font-medium">
-            {mode === 'create' ? 'New workflow' : `Edit · ${initialId}`}
-          </span>
-          <Input
-            aria-label="Workflow name"
-            className="h-8 max-w-[240px]"
-            value={definition.name}
-            onChange={(e) => setDefinition((d) => ({ ...d, name: e.target.value }))}
-            placeholder="Workflow name"
-          />
-          <Input
-            aria-label="Workflow description"
-            className="h-8 max-w-[360px]"
-            value={definition.description}
-            onChange={(e) => setDefinition((d) => ({ ...d, description: e.target.value }))}
-            placeholder="Description"
-          />
-          {isPluginSource && (
-            <span className="text-xs text-amber-300">
-              plugin-owned — use Save as new
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {error && <span className="text-xs text-red-300">{error}</span>}
-          <Button variant="ghost" size="sm" onClick={handleAutoArrange} disabled={saving}>
-            <LayoutGrid className="mr-1 size-3.5" /> Auto-arrange
-          </Button>
-          {canDelete && (
-            <Button
-              variant={confirmingDelete ? 'destructive' : 'ghost'}
-              size="sm"
-              onClick={handleDelete}
-              disabled={saving}
-            >
-              <Trash2 className="mr-1 size-3.5" />
-              {confirmingDelete ? 'Confirm' : 'Delete'}
-            </Button>
-          )}
-          {isPluginSource && (
-            <Button variant="ghost" size="sm" onClick={handleSaveAsNew} disabled={saving}>
-              <Copy className="mr-1 size-3.5" /> Save as new
-            </Button>
-          )}
+      <div className="flex items-center justify-between gap-4 border-b border-border bg-card px-4 py-3">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
           {onCancel && (
-            <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
-              Cancel
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="self-center"
+              aria-label="Back to workflows"
+              title="Back to workflows"
+              onClick={handleCancelRequest}
+            >
+              <ArrowLeft className="size-4" />
             </Button>
           )}
+          <WorkflowIcon className="size-4 shrink-0 self-center text-amber-400" />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+              <h1 className="min-w-0 truncate text-lg font-semibold leading-tight text-foreground">
+                {workflowNameLabel}
+              </h1>
+              <code className="min-w-0 max-w-full truncate font-mono text-[11px] leading-snug text-muted-foreground">
+                {workflowIdLabel}
+              </code>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Edit workflow details"
+                title="Edit workflow details"
+                onClick={openWorkflowDetails}
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+              {isManagedSource && (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-xs font-medium leading-none text-amber-200">
+                  <ShieldAlert className="size-3.5" />
+                  Managed workflow
+                </span>
+              )}
+              {effectiveSource === 'user' && shadowedSource && (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-2 py-1 text-xs font-medium leading-none text-cyan-200">
+                  <GitBranch className="size-3.5" />
+                  Shadows managed default
+                </span>
+              )}
+            </div>
+            <p className="mt-1 line-clamp-3 min-w-0 max-w-5xl text-sm leading-snug text-muted-foreground">
+              {workflowDescriptionLabel}
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {error && <span className="max-w-[18rem] truncate text-xs text-red-300">{error}</span>}
           {canSaveInPlace && (
-            <Button size="sm" onClick={handleSave} disabled={saving}>
+            <Button size="sm" onClick={handleSave} disabled={saving || workflowDetailsOpen || createSetupOpen || Boolean(selectedStep)}>
               <Save className="mr-1 size-3.5" /> Save
             </Button>
+          )}
+          {canDelete && (
+            <WorkflowDeleteAction
+              workflowName={definition.name || editingId || initialId || 'this workflow'}
+              disabled={saving}
+              deleting={saving}
+              error={error}
+              onClearError={() => setError(null)}
+              onDelete={handleDelete}
+            />
           )}
         </div>
       </div>
 
       <div className="flex flex-1 overflow-hidden">
-        <NodeTypePalette />
+        <NodeTypePalette
+          collapsed={paletteCollapsed}
+          disabledKinds={disabledPaletteKinds}
+          onCollapsedChange={setPaletteCollapsed}
+        />
 
-        <div
-          ref={wrapperRef}
-          className="relative flex-1 bg-zinc-950"
-          onDragOver={onDragOver}
-          onDrop={onDrop}
-        >
+        <div className="relative flex-1 bg-zinc-950">
           <style dangerouslySetInnerHTML={{ __html: RESET_NODE_STYLES }} />
           <ReactFlow
             nodes={nodes}
             edges={edges}
             onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
             onNodeClick={onNodeClick}
-            onConnect={onConnect}
-            isValidConnection={isValidConnection}
+            onPaneClick={onPaneClick}
+            onDragOver={(event) => {
+              if (!hasPaletteDragType(event.dataTransfer)) return
+              event.preventDefault()
+              event.dataTransfer.dropEffect = 'copy'
+            }}
+            onDrop={(event) => {
+              if (!hasPaletteDragType(event.dataTransfer)) return
+              const kind = event.dataTransfer.getData(PALETTE_DRAG_MIME_TYPE)
+              if (!kind) return
+              event.preventDefault()
+              insertStepAt(kind, state.order.length)
+            }}
             onInit={(rf) => {
               rfInstanceRef.current = rf
             }}
             nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
             fitView
             fitViewOptions={{ padding: 0.3 }}
             proOptions={{ hideAttribution: true }}
             nodesDraggable={true}
-            nodesConnectable={true}
+            nodesConnectable={false}
             defaultEdgeOptions={{
               style: { stroke: '#525252', strokeWidth: 2 },
             }}
           >
+            {selectedStep && (
+              <NodeToolbar
+                nodeId={selectedStep.id}
+                isVisible
+                position={Position.Top}
+                align="end"
+                offset={8}
+                className="flex items-center gap-1 rounded-md border border-border bg-card/95 p-1 shadow-lg backdrop-blur"
+              >
+                <Button
+                  aria-label="Move selected step up"
+                  title="Move up"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => moveSelectedStep(-1)}
+                  disabled={selectedIndex <= 0 || nodeDrawerDirty}
+                >
+                  <ArrowUp className="size-3.5" />
+                </Button>
+                <Button
+                  aria-label="Move selected step down"
+                  title="Move down"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => moveSelectedStep(1)}
+                  disabled={selectedIndex < 0 || selectedIndex >= state.order.length - 1 || nodeDrawerDirty}
+                >
+                  <ArrowDown className="size-3.5" />
+                </Button>
+                <Button
+                  aria-label="Duplicate selected step"
+                  title="Duplicate"
+                  variant="ghost"
+                  size="sm"
+                  onClick={duplicateSelectedStep}
+                  disabled={selectedStep.type === 'output' || nodeDrawerDirty}
+                >
+                  <Copy className="size-3.5" />
+                </Button>
+                <Button
+                  aria-label="Delete selected step"
+                  title="Delete"
+                  variant="destructive"
+                  size="sm"
+                  onClick={deleteSelectedStep}
+                  disabled={nodeDrawerDirty}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+                {selectedHasDependsOn && (
+                  <span
+                    className="inline-flex max-w-[240px] items-center gap-1 px-1 text-[11px] text-amber-300"
+                    title="dependsOn is preserved as metadata; runtime still follows step order."
+                  >
+                    <Info className="size-3.5 shrink-0" />
+                    dependsOn preserved
+                  </span>
+                )}
+              </NodeToolbar>
+            )}
+            <Panel
+              position="top-left"
+              className="m-2 flex rounded-md border border-border bg-card/95 p-1 shadow-lg backdrop-blur"
+            >
+              <Button variant="ghost" size="sm" onClick={handleAutoArrange} disabled={saving}>
+                <LayoutGrid className="mr-1 size-3.5" /> Auto-arrange
+              </Button>
+            </Panel>
             <Background variant={BackgroundVariant.Dots} color="#3f3f46" gap={24} size={1.5} />
-            <Controls showInteractive={false} />
+            <Controls position="bottom-left" showInteractive={false} />
             <MiniMap nodeColor="#3f3f46" maskColor="rgba(0,0,0,0.7)" />
           </ReactFlow>
         </div>
 
-        {selectedStep && (
+        {workflowDetailsOpen && !selectedStep && (
+          <WorkflowDetailsDrawer
+            definition={definition}
+            onApply={handleWorkflowDetailsApply}
+            onClose={closeWorkflowDetails}
+            applyLabel={mode === 'edit' && canSaveInPlace ? 'Save details' : 'Apply'}
+            applying={saving}
+          />
+        )}
+
+        {selectedStep && !workflowDetailsOpen && (
           <NodeConfigDrawer
             key={`${selectedStep.id}:${selectedStep.type ?? ''}`}
             step={selectedStep}
             onApply={handleApply}
-            onClose={() => setSelectedId(null)}
+            onDelete={deleteSelectedStep}
+            onClose={closeNodeDrawer}
+            onDirtyChange={setDrawerDirty}
+            existingStepIds={state.order}
+            reservedStepIds={RESERVED_STEP_IDS}
           />
         )}
       </div>
+
+      <ManagedWorkflowCopyDialog
+        open={createSetupOpen}
+        variant="create"
+        creating={creatingLocalCopy}
+        error={copyError}
+        fieldErrors={copyFieldErrors}
+        copyName={copyName}
+        copyId={copyId}
+        workflowDescription={copyDescription}
+        disableOriginal={false}
+        showDescription
+        showDisableOriginal={false}
+        onOpenChange={(open) => {
+          setCreateSetupOpen(open)
+          if (!open) {
+            setCopyError(null)
+            setCopyFieldErrors({})
+            onCancel?.()
+          }
+        }}
+        onCopyNameChange={(value) => {
+          setCopyName(value)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => (
+            copyIdEdited
+              ? clearWorkflowDialogFieldError(prev, 'name')
+              : clearWorkflowDialogFieldError(prev, 'name', 'id')
+          ))
+          if (!copyIdEdited) setCopyId(slugify(value))
+        }}
+        onCopyIdChange={(value) => {
+          setCopyIdEdited(true)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => clearWorkflowDialogFieldError(prev, 'id'))
+          setCopyId(slugify(value))
+        }}
+        onWorkflowDescriptionChange={(value) => {
+          setCopyDescription(value)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => clearWorkflowDialogFieldError(prev, 'description'))
+        }}
+        onDisableOriginalChange={() => {}}
+        onCancel={() => {
+          setCreateSetupOpen(false)
+          onCancel?.()
+        }}
+        onCreate={handleCreateWorkflowSetup}
+      />
+
+      <ManagedWorkflowCopyDialog
+        open={managedCopyOpen}
+        creating={creatingLocalCopy}
+        error={copyError}
+        fieldErrors={copyFieldErrors}
+        copyName={copyName}
+        copyId={copyId}
+        disableOriginal={disableOriginal}
+        onOpenChange={(open) => {
+          setManagedCopyOpen(open)
+          if (!open) {
+            setCopyError(null)
+            setCopyFieldErrors({})
+            if (isManagedSource) onCancel?.()
+          }
+        }}
+        onCopyNameChange={(value) => {
+          setCopyName(value)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => (
+            copyIdEdited
+              ? clearWorkflowDialogFieldError(prev, 'name')
+              : clearWorkflowDialogFieldError(prev, 'name', 'id')
+          ))
+          if (!copyIdEdited) setCopyId(slugify(value))
+        }}
+        onCopyIdChange={(value) => {
+          setCopyIdEdited(true)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => clearWorkflowDialogFieldError(prev, 'id'))
+          setCopyId(slugify(value))
+        }}
+        onDisableOriginalChange={setDisableOriginal}
+        onCancel={() => {
+          setManagedCopyOpen(false)
+          onCancel?.()
+        }}
+        onCreate={handleCreateLocalCopy}
+      />
+
+      <Dialog
+        open={confirmingExit || routeBlocker.status === 'blocked'}
+        onOpenChange={(open) => {
+          if (!open && !saving) cancelExitPrompt()
+        }}
+      >
+        <DialogContent className="bg-card border-border sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Unsaved workflow changes</DialogTitle>
+            <DialogDescription>
+              You have unsaved changes on this workflow. Save them before leaving, discard them, or stay on the canvas.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:justify-between">
+            <Button
+              variant="destructive"
+              onClick={handleDiscardAndExit}
+              disabled={saving}
+            >
+              Discard changes
+            </Button>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                onClick={cancelExitPrompt}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+              {canSaveInPlace && (
+                <Button
+                  onClick={handleSaveAndExit}
+                  disabled={saving || nodeDrawerDirty}
+                >
+                  {saving ? 'Saving...' : 'Save and exit'}
+                </Button>
+              )}
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/plugins/workflows/components/workflow-canvas.tsx
+++ b/plugins/workflows/components/workflow-canvas.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import {
   ReactFlow,
   Background,
@@ -30,8 +30,9 @@ import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-ren
 import type { WorkflowDefinition, WorkflowStep } from '../types'
 
 const NODE_WIDTH = 280
-const NODE_HEIGHT = 100
-const Y_SPACING = 130
+const NODE_HEIGHT = 120
+const Y_SPACING = 164
+const STANDARD_NODE_STYLE = { width: NODE_WIDTH, height: NODE_HEIGHT }
 const SUBFLOW_PADDING_X = 30
 const SUBFLOW_PADDING_TOP = 48
 const SUBFLOW_PADDING_BOTTOM = 32
@@ -45,21 +46,28 @@ interface WorkflowCanvasProps {
 /** Map a step type to its ReactFlow node type */
 function stepNodeType(step: WorkflowStep): string {
   if (step.type === 'gate') return 'gate'
+  if (step.type === 'parallel') return 'parallel'
   if (step.type === 'output') return 'output'
   if (step.type === 'workflow') return 'workflow'
-  return 'agent'
+  if (step.type === 'createTask') return 'createTask'
+  return step.type
 }
 
 /** Build node data from a step */
 function stepNodeData(step: WorkflowStep) {
   return {
     label: step.label,
-    agent: step.type === 'agent' ? step.agent : undefined,
+    agent: step.type === 'agent' || step.type === 'output' || step.type === 'createTask'
+      ? step.agent
+      : undefined,
     task: step.type === 'agent' ? step.task : undefined,
+    title: step.type === 'createTask' ? step.title : undefined,
+    column: step.type === 'createTask' ? step.column : undefined,
     channels: step.type === 'output' ? step.channels : undefined,
     description: step.type === 'gate' ? step.description
       : step.type === 'workflow' ? step.description
       : step.type === 'output' ? step.description
+      : step.type === 'createTask' ? step.description
       : undefined,
     workflow_id: step.type === 'workflow' ? (step as { workflow_id?: string }).workflow_id : undefined,
   }
@@ -101,7 +109,7 @@ function buildGraph(
     type: 'trigger',
     position: { x: centerX, y },
     data: { description: inputDesc },
-    style: { width: NODE_WIDTH },
+    style: STANDARD_NODE_STYLE,
   })
 
   let prevNodeIds = ['__trigger']
@@ -131,7 +139,10 @@ function buildGraph(
         if (subDef) {
           // Inline expansion — create a group node and emit sub-workflow steps inside it
           const subStepCount = measureSubWorkflowStepCount(subDef, subWorkflows)
-          const groupHeight = SUBFLOW_PADDING_TOP + subStepCount * Y_SPACING + SUBFLOW_PADDING_BOTTOM
+          const groupHeight = SUBFLOW_PADDING_TOP
+            + Math.max(0, subStepCount - 1) * Y_SPACING
+            + NODE_HEIGHT
+            + SUBFLOW_PADDING_BOTTOM
           const groupWidth = NODE_WIDTH + SUBFLOW_PADDING_X * 2
           const groupId = nodeId
 
@@ -175,7 +186,10 @@ function buildGraph(
               const nestedDef = nestedWfId ? subWorkflows[nestedWfId] : undefined
               if (nestedDef) {
                 const nestedCount = measureSubWorkflowStepCount(nestedDef, subWorkflows)
-                const nestedGroupHeight = SUBFLOW_PADDING_TOP + nestedCount * Y_SPACING + SUBFLOW_PADDING_BOTTOM
+                const nestedGroupHeight = SUBFLOW_PADDING_TOP
+                  + Math.max(0, nestedCount - 1) * Y_SPACING
+                  + NODE_HEIGHT
+                  + SUBFLOW_PADDING_BOTTOM
                 const nestedGroupWidth = NODE_WIDTH + SUBFLOW_PADDING_X * 2
 
                 nodes.push({
@@ -203,7 +217,7 @@ function buildGraph(
                     type: stepNodeType(nestedStep),
                     position: { x: SUBFLOW_PADDING_X, y: nestedY },
                     data: stepNodeData(nestedStep),
-                    style: { width: NODE_WIDTH },
+                    style: STANDARD_NODE_STYLE,
                     parentId: subNodeId,
                     extent: 'parent' as const,
                   })
@@ -225,7 +239,7 @@ function buildGraph(
               type: subNodeType,
               position: { x: SUBFLOW_PADDING_X, y: innerY },
               data: stepNodeData(subStep),
-              style: { width: NODE_WIDTH },
+              style: STANDARD_NODE_STYLE,
               parentId: groupId,
               extent: 'parent' as const,
             })
@@ -257,7 +271,7 @@ function buildGraph(
         type: nodeType,
         position,
         data: stepNodeData(step),
-        style: { width: NODE_WIDTH },
+        style: STANDARD_NODE_STYLE,
         ...(parentId ? { parentId, extent: 'parent' as const } : {}),
       })
 
@@ -299,8 +313,8 @@ export function WorkflowCanvas({ definition, subWorkflows, onNodeClick }: Workfl
     [],
   )
 
-  // Reset nodes when definition changes
-  useMemo(() => {
+  // Reset nodes when definition changes.
+  useEffect(() => {
     setNodes(initialNodes)
   }, [initialNodes])
 

--- a/plugins/workflows/components/workflow-card.tsx
+++ b/plugins/workflows/components/workflow-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Workflow, Lock } from 'lucide-react'
+import { Workflow, Lock, PauseCircle, GitBranch } from 'lucide-react'
 import { Badge } from "@makinbakin/sdk/ui"
 import { AgentAvatar } from "@makinbakin/sdk/components"
 import type { WorkflowTemplate, WorkflowStep, AgentStep } from '../types'
@@ -36,6 +36,7 @@ export function WorkflowCard({
   scoreInfo?: ScoreInfo
 }) {
   const agentIds = collectAgents(template.definition.steps)
+  const disabled = template.disabled === true
 
   const semKey = 'embeddings'
   const bm25Key = scoreInfo?.indexScores
@@ -45,10 +46,14 @@ export function WorkflowCard({
   return (
     <button
       onClick={onClick}
-      className="relative text-left w-full rounded-lg border border-border bg-card p-4 hover:bg-[rgba(255,255,255,0.04)] transition-colors group"
+      className={`relative text-left w-full rounded-lg border border-border bg-card p-4 transition-colors group ${
+        disabled
+          ? 'opacity-55 hover:opacity-75'
+          : 'hover:bg-[rgba(255,255,255,0.04)]'
+      }`}
     >
       {scoreInfo && (
-        <div className="absolute top-1.5 left-1.5 flex flex-col gap-0.5 font-mono text-[10px] bg-black/80 px-1.5 py-1 rounded pointer-events-none">
+        <div className="pointer-events-none absolute right-3 top-3 z-10 flex flex-col items-end gap-0.5 rounded bg-black/80 px-1.5 py-1 text-right font-mono text-[10px]">
           <span className="text-amber-400">RRF {scoreInfo.score.toFixed(3)}</span>
           <span className="text-cyan-400">
             BM25 {(bm25Key ? scoreInfo.indexScores?.[bm25Key] ?? 0 : 0).toFixed(3)}
@@ -58,14 +63,14 @@ export function WorkflowCard({
           </span>
         </div>
       )}
-      <div className="flex items-start gap-2 mb-2">
+      <div className={`flex items-start gap-2 mb-2 ${scoreInfo ? 'pr-24' : ''}`}>
         <Workflow className="size-4 shrink-0 text-amber-400 mt-0.5" />
         <h3 className="text-sm font-medium text-foreground group-hover:text-white line-clamp-1">
           {template.name}
         </h3>
       </div>
 
-      <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2 mb-3">
+      <p className={`text-xs text-muted-foreground leading-relaxed line-clamp-2 mb-3 ${scoreInfo ? 'pr-24' : ''}`}>
         {template.description || 'No description'}
       </p>
 
@@ -82,6 +87,26 @@ export function WorkflowCard({
             >
               <Lock className="size-2.5" />
               {template.pluginId ?? 'plugin'}
+            </Badge>
+          )}
+          {template.source === 'user' && template.shadowedSource && (
+            <Badge
+              variant="outline"
+              className="text-[10px] gap-1 border-cyan-500/40 text-cyan-200"
+              title="This custom workflow shadows a managed workflow with the same id"
+            >
+              <GitBranch className="size-2.5" />
+              shadows default
+            </Badge>
+          )}
+          {disabled && (
+            <Badge
+              variant="outline"
+              className="text-[10px] gap-1 border-zinc-600 text-zinc-400"
+              title="Disabled for automatic workflow selection"
+            >
+              <PauseCircle className="size-2.5" />
+              disabled
             </Badge>
           )}
         </div>

--- a/plugins/workflows/components/workflow-delete-action.tsx
+++ b/plugins/workflows/components/workflow-delete-action.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { Button } from "@makinbakin/sdk/ui"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@makinbakin/sdk/ui"
+
+interface WorkflowDeleteActionProps {
+  workflowName: string
+  disabled?: boolean
+  deleting?: boolean
+  error?: string | null
+  onClearError?: () => void
+  onDelete: () => boolean | void | Promise<boolean | void>
+}
+
+export function WorkflowDeleteAction({
+  workflowName,
+  disabled = false,
+  deleting = false,
+  error,
+  onClearError,
+  onDelete,
+}: WorkflowDeleteActionProps) {
+  const [open, setOpen] = useState(false)
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && deleting) return
+    setOpen(nextOpen)
+    if (!nextOpen) onClearError?.()
+  }
+
+  async function handleDelete() {
+    const deleted = await onDelete()
+    if (deleted !== false) {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        className="bg-destructive/10 text-destructive hover:bg-destructive/15 hover:text-destructive"
+        aria-label="Delete workflow"
+        title="Delete workflow"
+        onClick={() => {
+          onClearError?.()
+          setOpen(true)
+        }}
+        disabled={disabled || deleting}
+      >
+        <Trash2 className="size-3.5" />
+      </Button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="bg-card border-border sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete workflow?</DialogTitle>
+            <DialogDescription>
+              This will delete the custom workflow &ldquo;{workflowName}&rdquo;. This can&apos;t be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void handleDelete()}
+              disabled={deleting}
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/plugins/workflows/components/workflow-detail.tsx
+++ b/plugins/workflows/components/workflow-detail.tsx
@@ -2,14 +2,21 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useRouter } from '@makinbakin/sdk/hooks'
-import { ArrowLeft, Workflow, Lock, Pencil } from 'lucide-react'
+import { ArrowLeft, Workflow, Lock, Pencil, GitBranch } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
-import { Badge } from "@makinbakin/sdk/ui"
+import { Switch } from "@makinbakin/sdk/ui"
 import { WorkflowCanvas } from './workflow-canvas'
 import { StepDetailDrawer } from './step-detail-drawer'
-import { collectAgents } from './workflow-card'
-import { AgentAvatar } from "@makinbakin/sdk/components"
-import type { WorkflowDefinition, WorkflowStep, ParallelStep, NestedWorkflowStep } from '../types'
+import { ManagedWorkflowCopyDialog } from './managed-workflow-copy-dialog'
+import {
+  clearWorkflowDialogFieldError,
+  hasWorkflowDialogFieldErrors,
+  parseWorkflowDialogServerError,
+  validateWorkflowDialogFields,
+  type WorkflowDialogFieldErrors,
+} from './workflow-dialog-validation'
+import { WorkflowDeleteAction } from './workflow-delete-action'
+import type { WorkflowDefinition, WorkflowStep, ParallelStep, NestedWorkflowStep, WorkflowShadowedSource } from '../types'
 
 /** Find a step by ID in the step tree (top-level, parallel children, sub-workflow expansions) */
 function findStepById(
@@ -75,16 +82,37 @@ interface WorkflowDetailProps {
   onBack: () => void
 }
 
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
 export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
   const router = useRouter()
   const [definition, setDefinition] = useState<WorkflowDefinition | null>(null)
   const [subWorkflows, setSubWorkflows] = useState<Record<string, WorkflowDefinition>>({})
-  const [source, setSource] = useState<'plugin' | 'user' | undefined>()
-  const [pluginId, setPluginId] = useState<string | undefined>()
+  const [source, setSource] = useState<'plugin' | 'agent-package' | 'user' | undefined>()
+  const [shadowedSource, setShadowedSource] = useState<WorkflowShadowedSource | undefined>()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedStep, setSelectedStep] = useState<WorkflowStep | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [copyOpen, setCopyOpen] = useState(false)
+  const [copyError, setCopyError] = useState<string | null>(null)
+  const [copyFieldErrors, setCopyFieldErrors] = useState<WorkflowDialogFieldErrors>({})
+  const [creatingCopy, setCreatingCopy] = useState(false)
+  const [copyName, setCopyName] = useState('')
+  const [copyId, setCopyId] = useState('')
+  const [copyIdEdited, setCopyIdEdited] = useState(false)
+  const [disableOriginal, setDisableOriginal] = useState(true)
+  const [workflowDisabled, setWorkflowDisabled] = useState(false)
+  const [availabilitySaving, setAvailabilitySaving] = useState(false)
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   useEffect(() => {
     async function fetchDefinition() {
@@ -95,10 +123,20 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
           return
         }
         const data = await res.json()
-        setDefinition(data.definition)
+        const loadedDefinition = data.definition as WorkflowDefinition
+        const defaultCopyName = loadedDefinition.name ? `${loadedDefinition.name} Copy` : `${workflowId} Copy`
+        setDefinition(loadedDefinition)
         setSubWorkflows(data.subWorkflows ?? {})
         setSource(data.source)
-        setPluginId(data.pluginId)
+        setShadowedSource(data.shadowedSource)
+        setWorkflowDisabled(data.disabled === true)
+        setAvailabilityError(null)
+        setCopyError(null)
+        setCopyFieldErrors({})
+        setCopyName(defaultCopyName)
+        setCopyId(slugify(defaultCopyName))
+        setCopyIdEdited(false)
+        setDisableOriginal(true)
       } catch {
         setError('Failed to load workflow')
       } finally {
@@ -119,6 +157,132 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
       setDrawerOpen(true)
     }
   }, [definition, subWorkflows])
+
+  const isManagedSource = source === 'plugin' || source === 'agent-package'
+  const canDelete = source === 'user'
+
+  function handlePrimaryEditAction() {
+    if (workflowDisabled) return
+    if (!isManagedSource) {
+      router.push(`/workflows/${workflowId}/edit`)
+      return
+    }
+    setCopyError(null)
+    setCopyFieldErrors({})
+    setCopyOpen(true)
+  }
+
+  async function handleAvailabilityChange(nextEnabled: boolean) {
+    if (!isManagedSource) return
+    const nextDisabled = !nextEnabled
+    const previousDisabled = workflowDisabled
+
+    setWorkflowDisabled(nextDisabled)
+    setAvailabilitySaving(true)
+    setAvailabilityError(null)
+    try {
+      const availabilityRes = await fetch(`/api/plugins/workflows/definitions/${workflowId}/availability`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ disabled: nextDisabled }),
+      })
+      const availabilityData = (await availabilityRes.json().catch(() => ({}))) as Record<string, unknown>
+      if (!availabilityRes.ok) {
+        setWorkflowDisabled(previousDisabled)
+        setAvailabilityError((availabilityData.error as string | undefined) || `Availability update failed (${availabilityRes.status})`)
+        return
+      }
+      setWorkflowDisabled(availabilityData.disabled === true)
+    } catch (e) {
+      setWorkflowDisabled(previousDisabled)
+      setAvailabilityError((e as Error).message)
+    } finally {
+      setAvailabilitySaving(false)
+    }
+  }
+
+  async function handleCreateCopy() {
+    if (!definition) return
+    const nextId = copyId.trim()
+    const nextName = copyName.trim()
+    const fieldErrors = validateWorkflowDialogFields({
+      id: nextId,
+      name: nextName,
+      nameRequiredMessage: 'Copy name is required.',
+    })
+    if (hasWorkflowDialogFieldErrors(fieldErrors)) {
+      setCopyFieldErrors(fieldErrors)
+      setCopyError(null)
+      return
+    }
+
+    setCreatingCopy(true)
+    setCopyError(null)
+    setCopyFieldErrors({})
+    try {
+      const nextDefinition = {
+        ...definition,
+        id: nextId,
+        name: nextName,
+      }
+      const createRes = await fetch('/api/plugins/workflows/definitions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...nextDefinition, id: nextId }),
+      })
+      const createData = (await createRes.json().catch(() => ({}))) as Record<string, unknown>
+      if (!createRes.ok) {
+        const parsedError = parseWorkflowDialogServerError(createData, `Copy failed (${createRes.status})`)
+        setCopyFieldErrors(parsedError.fieldErrors)
+        setCopyError(parsedError.error)
+        return
+      }
+
+      if (disableOriginal) {
+        const availabilityRes = await fetch(`/api/plugins/workflows/definitions/${workflowId}/availability`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ disabled: true }),
+        })
+        if (!availabilityRes.ok) {
+          const availabilityData = (await availabilityRes.json().catch(() => ({}))) as Record<string, unknown>
+          setCopyError((availabilityData.error as string | undefined) || `Copied, but disabling the managed workflow failed (${availabilityRes.status})`)
+        } else {
+          setWorkflowDisabled(true)
+        }
+      }
+
+      router.push(`/workflows/${nextId}/edit`)
+    } catch (e) {
+      setCopyError((e as Error).message)
+    } finally {
+      setCreatingCopy(false)
+    }
+  }
+
+  async function handleDeleteWorkflow() {
+    if (!canDelete) return false
+
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      const res = await fetch(`/api/plugins/workflows/definitions/${workflowId}`, {
+        method: 'DELETE',
+      })
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
+      if (!res.ok) {
+        setDeleteError((data.error as string | undefined) || `Delete failed (${res.status})`)
+        return false
+      }
+      onBack()
+      return true
+    } catch (e) {
+      setDeleteError((e as Error).message)
+      return false
+    } finally {
+      setDeleting(false)
+    }
+  }
 
   if (loading) {
     return (
@@ -143,8 +307,6 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
     )
   }
 
-  const agentIds = collectAgents(definition.steps)
-
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
@@ -159,38 +321,76 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
             <p className="text-xs text-muted-foreground truncate">{definition.description}</p>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2.5">
+          {isManagedSource && (
+            <div
+              className={`flex items-center gap-2 ${availabilitySaving ? 'cursor-not-allowed' : 'cursor-pointer'}`}
+              title="Controls whether this managed workflow is available for matching and automatic starts"
+            >
+              <Switch
+                size="sm"
+                checked={!workflowDisabled}
+                onCheckedChange={handleAvailabilityChange}
+                disabled={availabilitySaving}
+                aria-label={workflowDisabled ? 'Enable workflow' : 'Disable workflow'}
+              />
+              <span className={`select-none text-xs font-medium ${workflowDisabled ? 'text-muted-foreground' : 'text-foreground'}`}>
+                {workflowDisabled ? 'Disabled' : 'Enabled'}
+              </span>
+            </div>
+          )}
           <Button
             variant="outline"
             size="sm"
-            onClick={() => router.push(`/workflows/${workflowId}/edit`)}
-            title={source === 'plugin' ? 'Edit a copy of this workflow' : 'Edit workflow'}
+            onClick={handlePrimaryEditAction}
+            title={isManagedSource ? 'Create an editable copy of this workflow' : 'Edit workflow'}
+            disabled={workflowDisabled}
           >
             <Pencil className="size-3.5 mr-1" />
-            {source === 'plugin' ? 'Customize' : 'Edit'}
+            Edit
           </Button>
-          <Badge variant="secondary" className="text-[10px]">
-            {definition.steps.length} steps
-          </Badge>
-          {agentIds.length > 0 && (
-            <div className="flex -space-x-1.5">
-              {agentIds.slice(0, 5).map(id => (
-                <AgentAvatar key={id} agentId={id} size="xs" />
-              ))}
-            </div>
+          {canDelete && (
+            <WorkflowDeleteAction
+              workflowName={definition.name || workflowId}
+              deleting={deleting}
+              error={deleteError}
+              onClearError={() => setDeleteError(null)}
+              onDelete={handleDeleteWorkflow}
+            />
           )}
         </div>
       </div>
 
-      {/* Read-only banner — plugin-shipped definitions cannot be edited in place */}
-      {source === 'plugin' && (
+      {availabilityError && (
+        <div className="border-b border-border bg-destructive/10 px-6 py-2 text-xs text-destructive">
+          {availabilityError}
+        </div>
+      )}
+
+      {isManagedSource && workflowDisabled && (
+        <div className="flex items-center gap-2 border-b border-border bg-destructive/10 px-6 py-2 text-xs text-destructive">
+          <Lock className="size-3.5" />
+          <span>
+            Disabled: matching and automatic starts skip this workflow. Enable it before editing or creating a copy.
+          </span>
+        </div>
+      )}
+
+      {/* Read-only banner — managed definitions cannot be edited in place */}
+      {isManagedSource && (
         <div className="flex items-center gap-2 border-b border-border bg-amber-500/10 px-6 py-2 text-xs text-amber-200">
           <Lock className="size-3.5" />
           <span>
-            Read-only: this workflow ships with the
-            {pluginId ? ` "${pluginId}"` : ''} plugin. Save a copy under
-            <code className="px-1 mx-1 rounded bg-black/30 font-mono text-[11px]">~/.bakin/workflows/definitions/{workflowId}.yaml</code>
-            to override it locally.
+            This workflow is managed by Bakin directly. If you&apos;d like to make changes select &ldquo;Edit&rdquo; and create a copy when prompted. You&apos;ll optionally be able to disable this default workflow as well.
+          </span>
+        </div>
+      )}
+
+      {source === 'user' && shadowedSource && (
+        <div className="flex items-center gap-2 border-b border-border bg-cyan-500/10 px-6 py-2 text-xs text-cyan-200">
+          <GitBranch className="size-3.5" />
+          <span>
+            This custom workflow shadows a managed default with the same id.
           </span>
         </div>
       )}
@@ -211,6 +411,43 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
       />
+
+      <ManagedWorkflowCopyDialog
+        open={copyOpen}
+        creating={creatingCopy}
+        error={copyError}
+        fieldErrors={copyFieldErrors}
+        copyName={copyName}
+        copyId={copyId}
+        disableOriginal={disableOriginal}
+        onOpenChange={(open) => {
+          setCopyOpen(open)
+          if (!open) {
+            setCopyError(null)
+            setCopyFieldErrors({})
+          }
+        }}
+        onCopyNameChange={(value) => {
+          setCopyName(value)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => (
+            copyIdEdited
+              ? clearWorkflowDialogFieldError(prev, 'name')
+              : clearWorkflowDialogFieldError(prev, 'name', 'id')
+          ))
+          if (!copyIdEdited) setCopyId(slugify(value))
+        }}
+        onCopyIdChange={(value) => {
+          setCopyIdEdited(true)
+          setCopyError(null)
+          setCopyFieldErrors((prev) => clearWorkflowDialogFieldError(prev, 'id'))
+          setCopyId(slugify(value))
+        }}
+        onDisableOriginalChange={setDisableOriginal}
+        onCancel={() => setCopyOpen(false)}
+        onCreate={handleCreateCopy}
+      />
+
     </div>
   )
 }

--- a/plugins/workflows/components/workflow-dialog-validation.ts
+++ b/plugins/workflows/components/workflow-dialog-validation.ts
@@ -1,0 +1,132 @@
+export interface WorkflowDialogFieldErrors {
+  name?: string
+  id?: string
+  description?: string
+}
+
+export interface WorkflowDialogServerError {
+  error: string | null
+  fieldErrors: WorkflowDialogFieldErrors
+}
+
+const WORKFLOW_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const EMPTY_DRAFT_SCHEMA_MESSAGE = 'Workflow draft creation is using an old server schema that still requires at least one step. Restart Bakin and try again.'
+
+export function hasWorkflowDialogFieldErrors(errors: WorkflowDialogFieldErrors): boolean {
+  return Boolean(errors.name || errors.id || errors.description)
+}
+
+export function validateWorkflowDialogFields({
+  name,
+  id,
+  nameRequiredMessage = 'Workflow name is required.',
+}: {
+  name: string
+  id: string
+  nameRequiredMessage?: string
+}): WorkflowDialogFieldErrors {
+  const errors: WorkflowDialogFieldErrors = {}
+  const trimmedName = name.trim()
+  const trimmedId = id.trim()
+
+  if (!trimmedName) errors.name = nameRequiredMessage
+  if (!trimmedId) {
+    errors.id = 'Workflow id is required.'
+  } else if (!WORKFLOW_ID_PATTERN.test(trimmedId)) {
+    errors.id = 'Use lowercase letters, numbers, and hyphens.'
+  }
+
+  return errors
+}
+
+export function clearWorkflowDialogFieldError(
+  errors: WorkflowDialogFieldErrors,
+  ...fields: Array<keyof WorkflowDialogFieldErrors>
+): WorkflowDialogFieldErrors {
+  if (fields.every((field) => !errors[field])) return errors
+  const next = { ...errors }
+  for (const field of fields) delete next[field]
+  return next
+}
+
+function issueMessage(issue: unknown): string {
+  if (typeof issue === 'string') return issue
+  if (issue && typeof issue === 'object' && 'message' in issue) {
+    return String((issue as { message: unknown }).message)
+  }
+  return String(issue)
+}
+
+function issuePath(issue: unknown): string[] {
+  if (!issue || typeof issue !== 'object' || !('path' in issue)) return []
+  const path = (issue as { path: unknown }).path
+  if (!Array.isArray(path)) return []
+  return path.map(String)
+}
+
+export function parseWorkflowDialogServerError(
+  data: Record<string, unknown>,
+  fallback: string,
+): WorkflowDialogServerError {
+  const fieldErrors: WorkflowDialogFieldErrors = {}
+  const messages: string[] = []
+  let emptyDraftSchemaError = false
+
+  const addIssue = (issue: unknown) => {
+    const message = issueMessage(issue)
+    const [field] = issuePath(issue)
+
+    if (field === 'name') {
+      fieldErrors.name = message
+      return
+    }
+    if (field === 'id') {
+      fieldErrors.id = message
+      return
+    }
+    if (field === 'description') {
+      fieldErrors.description = message
+      return
+    }
+    if (field === 'steps' && /too small|>=1|at least one/i.test(message)) {
+      emptyDraftSchemaError = true
+      return
+    }
+    if (/workflow must have at least one step/i.test(message)) {
+      emptyDraftSchemaError = true
+      return
+    }
+
+    messages.push(message)
+  }
+
+  if (Array.isArray(data.issues)) {
+    for (const issue of data.issues) addIssue(issue)
+  }
+  if (Array.isArray(data.errors)) {
+    for (const issue of data.errors) addIssue(issue)
+  }
+
+  const serverError = typeof data.error === 'string' ? data.error : ''
+  if (/^id is required$/i.test(serverError)) {
+    fieldErrors.id = 'Workflow id is required.'
+  } else if (
+    serverError &&
+    serverError !== 'validation failed' &&
+    messages.length === 0 &&
+    !emptyDraftSchemaError
+  ) {
+    messages.push(serverError)
+  }
+
+  return {
+    fieldErrors,
+    error: emptyDraftSchemaError
+      ? EMPTY_DRAFT_SCHEMA_MESSAGE
+      : messages.length > 0
+        ? messages.join(', ')
+        : hasWorkflowDialogFieldErrors(fieldErrors)
+          ? null
+          : fallback,
+  }
+}

--- a/plugins/workflows/components/workflows-page.tsx
+++ b/plugins/workflows/components/workflows-page.tsx
@@ -11,11 +11,29 @@ import { useQueryState } from "@makinbakin/sdk/hooks"
 import { useSearch } from "@makinbakin/sdk/hooks"
 import { useDebug } from "@makinbakin/sdk/hooks"
 import { WorkflowCard } from './workflow-card'
+import { ManagedWorkflowCopyDialog } from './managed-workflow-copy-dialog'
+import {
+  clearWorkflowDialogFieldError,
+  hasWorkflowDialogFieldErrors,
+  parseWorkflowDialogServerError,
+  validateWorkflowDialogFields,
+  type WorkflowDialogFieldErrors,
+} from './workflow-dialog-validation'
 import type { WorkflowTemplate } from '../types'
 
 interface ScoreInfo {
   score: number
   indexScores?: Record<string, number>
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60)
 }
 
 export function WorkflowsPage() {
@@ -24,10 +42,19 @@ export function WorkflowsPage() {
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useQueryState('q', '')
   const [debug] = useDebug()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [createFieldErrors, setCreateFieldErrors] = useState<WorkflowDialogFieldErrors>({})
+  const [createName, setCreateName] = useState('')
+  const [createId, setCreateId] = useState('')
+  const [createIdEdited, setCreateIdEdited] = useState(false)
+  const [createDescription, setCreateDescription] = useState('')
+  const normalizedSearch = search.trim()
 
   const fetchTemplates = useCallback(async () => {
     try {
-      const res = await fetch('/api/plugins/workflows/definitions')
+      const res = await fetch('/api/plugins/workflows/definitions?includeDisabled=1')
       const data = await res.json()
       setTemplates(data.templates ?? [])
     } catch {
@@ -48,29 +75,134 @@ export function WorkflowsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search])
 
-  // Build a score map keyed by workflow name (stripping the `def:` search key prefix).
+  // Build a score map keyed by workflow id/filename (stripping the `def:` search key prefix).
   // Used for both the relevance reorder AND the debug-mode RRF/BM25/SEM overlay.
   const scoreMap = useMemo(() => {
     const map = new Map<string, ScoreInfo>()
+    if (searchHook.meta?.query !== normalizedSearch) return map
     for (const r of searchHook.results) {
+      if (!r.id.startsWith('def:')) continue
       const id = r.id.startsWith('def:') ? r.id.slice('def:'.length) : r.id
       map.set(id, { score: r.score, indexScores: r.indexScores })
     }
     return map
-  }, [searchHook.results])
+  }, [normalizedSearch, searchHook.meta?.query, searchHook.results])
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return templates
-    if (searchHook.results.length) {
+    if (!normalizedSearch) return templates
+    if (scoreMap.size > 0) {
       return templates
-        .filter(t => scoreMap.has(t.name))
-        .sort((a, b) => (scoreMap.get(b.name)?.score ?? 0) - (scoreMap.get(a.name)?.score ?? 0))
+        .filter(t => scoreMap.has(t.filename))
+        .sort((a, b) => (scoreMap.get(b.filename)?.score ?? 0) - (scoreMap.get(a.filename)?.score ?? 0))
     }
-    const q = search.toLowerCase()
+    const q = normalizedSearch.toLowerCase()
     return templates.filter(t =>
       t.name.toLowerCase().includes(q) || t.description?.toLowerCase().includes(q)
     )
-  }, [templates, search, searchHook.results, scoreMap])
+  }, [templates, normalizedSearch, scoreMap])
+
+  const isManagedWorkflow = (template: WorkflowTemplate) => template.source === 'plugin' || template.source === 'agent-package'
+  const managedWorkflows = filtered.filter(isManagedWorkflow)
+  const customWorkflows = filtered.filter(t => !isManagedWorkflow(t))
+
+  function openCreateWorkflowDialog() {
+    setCreateError(null)
+    setCreateFieldErrors({})
+    setCreateOpen(true)
+  }
+
+  function closeCreateWorkflowDialog() {
+    if (creating) return
+    setCreateOpen(false)
+    setCreateError(null)
+    setCreateFieldErrors({})
+  }
+
+  async function handleCreateWorkflow() {
+    const id = createId.trim()
+    const name = createName.trim()
+    const fieldErrors = validateWorkflowDialogFields({ id, name })
+    if (hasWorkflowDialogFieldErrors(fieldErrors)) {
+      setCreateFieldErrors(fieldErrors)
+      setCreateError(null)
+      return
+    }
+
+    setCreating(true)
+    setCreateError(null)
+    setCreateFieldErrors({})
+    try {
+      const res = await fetch('/api/plugins/workflows/definitions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id,
+          name,
+          description: createDescription.trim(),
+          version: 1,
+          steps: [],
+        }),
+      })
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
+      if (!res.ok) {
+        const parsedError = parseWorkflowDialogServerError(data, `Create failed (${res.status})`)
+        setCreateFieldErrors(parsedError.fieldErrors)
+        setCreateError(parsedError.error)
+        return
+      }
+
+      const savedId = (data.id as string | undefined) || id
+      setCreateOpen(false)
+      router.push(`/workflows/${savedId}/edit`)
+    } catch (e) {
+      setCreateError((e as Error).message)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  function WorkflowSection({
+    title,
+    workflows,
+    empty,
+  }: {
+    title: string
+    workflows: WorkflowTemplate[]
+    empty: string
+  }) {
+    return (
+      <section className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {title}
+          </h2>
+          <span className="rounded-full border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            {workflows.length}
+          </span>
+        </div>
+        {workflows.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-card/40 px-3 py-4 text-sm text-muted-foreground">
+            {empty}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {workflows.map((t) => {
+              const scoreInfo = scoreMap.get(t.filename)
+              const showScores = debug && normalizedSearch && scoreInfo ? scoreInfo : undefined
+              return (
+                <WorkflowCard
+                  key={t.filename}
+                  template={t}
+                  onClick={() => router.push(`/workflows/${t.filename}`)}
+                  scoreInfo={showScores}
+                />
+              )
+            })}
+          </div>
+        )}
+      </section>
+    )
+  }
 
   return (
     <div className="p-6 flex flex-col h-full min-h-0 gap-4">
@@ -79,7 +211,7 @@ export function WorkflowsPage() {
         count={loading ? undefined : filtered.length}
         search={{ value: search, onChange: setSearch, placeholder: 'Search workflows...' }}
         actions={
-          <Button size="sm" onClick={() => router.push('/workflows/new')}>
+          <Button size="sm" onClick={openCreateWorkflowDialog}>
             <Plus className="size-3.5 mr-1" /> New workflow
           </Button>
         }
@@ -98,22 +230,62 @@ export function WorkflowsPage() {
             title={search ? 'No matching workflows' : 'No workflow templates found'}
           />
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {filtered.map((t) => {
-              const scoreInfo = scoreMap.get(t.name)
-              const showScores = debug && search.trim() && scoreInfo ? scoreInfo : undefined
-              return (
-                <WorkflowCard
-                  key={t.filename}
-                  template={t}
-                  onClick={() => router.push(`/workflows/${t.filename}`)}
-                  scoreInfo={showScores}
-                />
-              )
-            })}
+          <div className="flex flex-col gap-6">
+            <WorkflowSection
+              title="Custom workflows"
+              workflows={customWorkflows}
+              empty="No custom workflows yet."
+            />
+            <WorkflowSection
+              title="Managed workflows"
+              workflows={managedWorkflows}
+              empty="No managed workflows match this view."
+            />
           </div>
         )}
       </div>
+
+      <ManagedWorkflowCopyDialog
+        open={createOpen}
+        variant="create"
+        creating={creating}
+        error={createError}
+        fieldErrors={createFieldErrors}
+        copyName={createName}
+        copyId={createId}
+        workflowDescription={createDescription}
+        disableOriginal={false}
+        showDescription
+        showDisableOriginal={false}
+        onOpenChange={(open) => {
+          if (!open) closeCreateWorkflowDialog()
+          else openCreateWorkflowDialog()
+        }}
+        onCopyNameChange={(value) => {
+          setCreateName(value)
+          setCreateError(null)
+          setCreateFieldErrors((prev) => (
+            createIdEdited
+              ? clearWorkflowDialogFieldError(prev, 'name')
+              : clearWorkflowDialogFieldError(prev, 'name', 'id')
+          ))
+          if (!createIdEdited) setCreateId(slugify(value))
+        }}
+        onCopyIdChange={(value) => {
+          setCreateIdEdited(true)
+          setCreateError(null)
+          setCreateFieldErrors((prev) => clearWorkflowDialogFieldError(prev, 'id'))
+          setCreateId(slugify(value))
+        }}
+        onWorkflowDescriptionChange={(value) => {
+          setCreateDescription(value)
+          setCreateError(null)
+          setCreateFieldErrors((prev) => clearWorkflowDialogFieldError(prev, 'description'))
+        }}
+        onDisableOriginalChange={() => {}}
+        onCancel={closeCreateWorkflowDialog}
+        onCreate={handleCreateWorkflow}
+      />
     </div>
   )
 }

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -12,7 +12,7 @@ import { z } from 'zod'
 import type { ApprovalActor, BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { defineRoute, definePlugin } from '@bakin/core/routing'
 import type { PluginContextLite } from '@bakin/core/routing'
-import { listDefinitions, loadDefinition, validateDefinition } from './lib/parser'
+import { listDefinitions, loadDefinition, validateDefinition, validateWorkflowId } from './lib/parser'
 import { workflowDefinitionNameFromHookInput } from './lib/hook-input'
 import { loadDefaultWorkflows } from './lib/load-defaults'
 import { workflowDefinitionSchema, listNodeTypes } from './lib/node-type-registry'
@@ -26,7 +26,14 @@ import {
   checkWorkflowSkills,
   staleWorkflowInstancesRepair,
 } from './lib/health-checks'
-import { isReadOnly, getDefinition as getRegistryDefinition } from './lib/source-registry'
+import {
+  isReadOnly,
+  getDefinition as getRegistryDefinition,
+  getManagedDefinition,
+  getShadowedSource,
+  type DefinitionSource,
+} from './lib/source-registry'
+import { isWorkflowDisabled, readDisabledWorkflowIds, setWorkflowDisabled } from './lib/availability'
 import {
   createInstance,
   loadInstance,
@@ -99,12 +106,16 @@ function resolveSubWorkflows(steps: WorkflowDefinition['steps'], subWorkflows: R
   }
 }
 
-function buildTemplateList(): { templates: WorkflowTemplate[]; subWorkflows: Record<string, WorkflowDefinition> } {
+function buildTemplateList(options: { includeDisabled?: boolean } = {}): { templates: WorkflowTemplate[]; subWorkflows: Record<string, WorkflowDefinition> } {
   const defs = listDefinitions()
+  const disabledWorkflowIds = readDisabledWorkflowIds()
   const subWorkflows: Record<string, WorkflowDefinition> = {}
-  const templates: WorkflowTemplate[] = defs.map(d => {
+  const templates: WorkflowTemplate[] = defs.flatMap(d => {
+    const disabled = d.source !== 'user' && disabledWorkflowIds.has(d.name)
+    const shadowedSource = d.source === 'user' ? getShadowedSource(d.name) : undefined
+    if (disabled && !options.includeDisabled) return []
     resolveSubWorkflows(d.definition.steps, subWorkflows)
-    return {
+    return [{
       name: d.definition.name,
       filename: d.name,
       description: d.definition.description,
@@ -113,7 +124,9 @@ function buildTemplateList(): { templates: WorkflowTemplate[]; subWorkflows: Rec
       source: d.source,
       pluginId: d.pluginId,
       packageId: d.packageId,
-    }
+      disabled,
+      shadowedSource,
+    }]
   })
   return { templates, subWorkflows }
 }
@@ -186,12 +199,27 @@ async function validateWorkflowForStart(
   contentDir?: string,
 ): Promise<string[]> {
   const errors: string[] = []
+  const workflowIdError = validateWorkflowId(workflowId)
+  if (workflowIdError) {
+    errors.push(workflowIdError)
+    return errors
+  }
   const def = loadDefinition(workflowId, contentDir)
   if (!def) {
     errors.push(`Unknown workflow id: ${workflowId}`)
     return errors
   }
   const knownAgents = await getRuntimeAgentNames()
+  const knownWorkflowIds = new Set(listDefinitions(contentDir).map((entry) => entry.name))
+  errors.push(...validateDefinition(def, {
+    definitionId: workflowId,
+    source: def.source,
+    contentDir,
+    knownWorkflowIds,
+    runtimeAgents: knownAgents,
+    assignee,
+    requireResolvedAgents: true,
+  }))
   if (assignee && !knownAgents.has(assignee)) {
     errors.push(`Assignee "${assignee}" is not a known runtime agent`)
   }
@@ -330,6 +358,21 @@ function countSteps(steps: { type: string; steps?: unknown[] }[]): number {
   return count
 }
 
+/** Convert a workflow definition to a search document. */
+function definitionToSearchDoc(name: string, def: WorkflowDefinition, source?: DefinitionSource): Record<string, unknown> {
+  const stepsText = def.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ')
+  const definitionSource = source ?? (def as WorkflowDefinition & { source?: DefinitionSource }).source
+  return {
+    name: def.name,
+    description: def.description || '',
+    type: 'definition',
+    status: definitionSource !== 'user' && isWorkflowDisabled(name) ? 'disabled' : 'active',
+    task_id: '',
+    steps: stepsText,
+    updated_at: new Date().toISOString(),
+  }
+}
+
 function populateWorkflowRoutes(arr: any[]): void {
   arr.push(defineRoute({
     path: '/notification-channels',
@@ -345,44 +388,12 @@ function populateWorkflowRoutes(arr: any[]): void {
 
   // ─── Template Routes ──────────────────────────────────────────────
 
-  /** Collect all referenced sub-workflow definitions recursively */
-  function resolveSubWorkflows(steps: WorkflowDefinition['steps'], subWorkflows: Record<string, WorkflowDefinition>) {
-    for (const step of steps) {
-      if (step.type === 'workflow') {
-        const nested = step as NestedWorkflowStep
-        if (nested.workflow_id && !subWorkflows[nested.workflow_id]) {
-          const subDef = loadDefinition(nested.workflow_id)
-          if (subDef) {
-            subWorkflows[nested.workflow_id] = subDef
-            resolveSubWorkflows(subDef.steps, subWorkflows)
-          }
-        }
-      }
-    }
-  }
-
-  /** Build template list with sub-workflow resolution */
-  function buildTemplateList() {
-    const defs = listDefinitions()
-    const subWorkflows: Record<string, WorkflowDefinition> = {}
-    const templates: WorkflowTemplate[] = defs.map(d => {
-      resolveSubWorkflows(d.definition.steps, subWorkflows)
-      return {
-        name: d.definition.name,
-        filename: d.name,
-        description: d.definition.description,
-        stepCount: countSteps(d.definition.steps),
-        definition: d.definition,
-        source: d.source,
-        pluginId: d.pluginId,
-        packageId: d.packageId,
-      }
-    })
-    return { templates, subWorkflows }
-  }
-
   // GET /definitions — list all workflow templates
-  const listHandler = async (_req: Request, _ctx: PluginContextLite) => Response.json(buildTemplateList())
+  const listHandler = async (req: Request, _ctx: PluginContextLite) => {
+    const url = new URL(req.url)
+    const includeDisabled = url.searchParams.get('includeDisabled') === '1' || url.searchParams.get('includeDisabled') === 'true'
+    return Response.json(buildTemplateList({ includeDisabled }))
+  }
   arr.push(defineRoute({ path: '/definitions', method: 'GET', description: 'List all workflow templates with step counts and resolved sub-workflows', summary: 'List all workflow templates with step counts and resolved sub-workflows', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: listHandler }))
 
   // GET /definitions/:name — get a specific definition with resolved sub-workflows
@@ -392,6 +403,10 @@ function populateWorkflowRoutes(arr: any[]): void {
 
     if (!name) {
       return Response.json({ error: 'name param required' }, { status: 400 })
+    }
+    const nameError = validateWorkflowId(name)
+    if (nameError) {
+      return Response.json({ error: nameError }, { status: 400 })
     }
 
     const definition = loadDefinition(name)
@@ -408,6 +423,8 @@ function populateWorkflowRoutes(arr: any[]): void {
       subWorkflows,
       source: definition.source,
       pluginId: definition.pluginId,
+      disabled: definition.source !== 'user' && isWorkflowDisabled(name),
+      shadowedSource: definition.source === 'user' ? getShadowedSource(name) : undefined,
     })
   }
   arr.push(defineRoute({ path: '/definitions/:name', method: 'GET', description: 'Get a specific workflow definition by name', summary: 'Get a specific workflow definition by name', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: getDefinitionHandler }))
@@ -420,11 +437,25 @@ function populateWorkflowRoutes(arr: any[]): void {
   // because the user-wins rule lets a user override a plugin definition.
 
   const getDefinitionsDir = (): string => join(getContentDir(), 'workflows', 'definitions')
+  const getUserDefinitionPaths = (id: string): { yamlPath: string; ymlPath: string } => {
+    const dir = getDefinitionsDir()
+    return {
+      yamlPath: join(dir, `${id}.yaml`),
+      ymlPath: join(dir, `${id}.yml`),
+    }
+  }
+
+  const findExistingUserDefinitionPath = (id: string): string | null => {
+    const { yamlPath, ymlPath } = getUserDefinitionPaths(id)
+    return existsSync(yamlPath) ? yamlPath : existsSync(ymlPath) ? ymlPath : null
+  }
+
+  const userDefinitionExists = (id: string): boolean => findExistingUserDefinitionPath(id) !== null
 
   const writeUserDefinition = (id: string, def: unknown): void => {
     const dir = getDefinitionsDir()
     mkdirSync(dir, { recursive: true })
-    writeFileSync(join(dir, `${id}.yaml`), yaml.dump(def), 'utf-8')
+    writeFileSync(findExistingUserDefinitionPath(id) ?? join(dir, `${id}.yaml`), yaml.dump(def), 'utf-8')
   }
 
   // POST /definitions — create a new user-owned workflow YAML
@@ -439,6 +470,16 @@ function populateWorkflowRoutes(arr: any[]): void {
     const id = typeof body.id === 'string' ? body.id : undefined
     if (!id) {
       return Response.json({ error: 'id is required' }, { status: 400 })
+    }
+    const idError = validateWorkflowId(id)
+    if (idError) {
+      return Response.json({ error: idError }, { status: 400 })
+    }
+    if (userDefinitionExists(id)) {
+      return Response.json(
+        { error: `Workflow id "${id}" already exists. Use PUT to update it.` },
+        { status: 409 },
+      )
     }
 
     // Refuse to overwrite a plugin-only id (no user shadow yet)
@@ -464,6 +505,7 @@ function populateWorkflowRoutes(arr: any[]): void {
       definitionId: id,
       source: 'user',
       knownWorkflowIds: new Set([...listDefinitions().map((entry) => entry.name), id]),
+      allowEmptySteps: true,
     })
     if (semanticErrors.length > 0) {
       return Response.json(
@@ -483,6 +525,10 @@ function populateWorkflowRoutes(arr: any[]): void {
     const name = url.searchParams.get('name')
     if (!name) {
       return Response.json({ error: 'name param required' }, { status: 400 })
+    }
+    const nameError = validateWorkflowId(name)
+    if (nameError) {
+      return Response.json({ error: nameError }, { status: 400 })
     }
 
     let body: Record<string, unknown>
@@ -506,6 +552,7 @@ function populateWorkflowRoutes(arr: any[]): void {
       definitionId: name,
       source: 'user',
       knownWorkflowIds: new Set([...listDefinitions().map((entry) => entry.name), name]),
+      allowEmptySteps: true,
     })
     if (semanticErrors.length > 0) {
       return Response.json(
@@ -519,6 +566,47 @@ function populateWorkflowRoutes(arr: any[]): void {
   }
   arr.push(defineRoute({ path: '/definitions/:name', method: 'PUT', description: 'Update or shadow a workflow definition (writes user YAML)', summary: 'Update or shadow a workflow definition (writes user YAML)', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: updateDefinitionHandler }))
 
+  // PATCH /definitions/:name/availability — enable/disable a managed workflow
+  const updateAvailabilityHandler = async (req: Request, _ctx: PluginContextLite) => {
+    const url = new URL(req.url)
+    const name = url.searchParams.get('name')
+    if (!name) {
+      return Response.json({ error: 'name param required' }, { status: 400 })
+    }
+    const nameError = validateWorkflowId(name)
+    if (nameError) {
+      return Response.json({ error: nameError }, { status: 400 })
+    }
+
+    let body: { disabled?: unknown }
+    try {
+      body = await req.json()
+    } catch {
+      return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    if (typeof body.disabled !== 'boolean') {
+      return Response.json({ error: 'disabled must be a boolean' }, { status: 400 })
+    }
+
+    const effectiveDefinition = loadDefinition(name)
+    if (!effectiveDefinition || effectiveDefinition.source === 'user') {
+      return Response.json({ error: 'Only managed workflows can be disabled' }, { status: 409 })
+    }
+
+    setWorkflowDisabled(name, body.disabled)
+    try {
+      await pluginCtx?.search.index(
+        `def:${name}`,
+        definitionToSearchDoc(name, effectiveDefinition, effectiveDefinition.source),
+      )
+    } catch (err) {
+      log.warn('Failed to reindex workflow availability change', { name, error: err instanceof Error ? err.message : String(err) })
+    }
+    return Response.json({ id: name, disabled: body.disabled })
+  }
+  arr.push(defineRoute({ path: '/definitions/:name/availability', method: 'PATCH', description: 'Enable or disable a managed workflow definition for automatic selection', summary: 'Toggle managed workflow availability', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: updateAvailabilityHandler }))
+
   // DELETE /definitions/:name — remove the user-owned YAML for this id
   const deleteDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
     const url = new URL(req.url)
@@ -526,11 +614,12 @@ function populateWorkflowRoutes(arr: any[]): void {
     if (!name) {
       return Response.json({ error: 'name param required' }, { status: 400 })
     }
+    const nameError = validateWorkflowId(name)
+    if (nameError) {
+      return Response.json({ error: nameError }, { status: 400 })
+    }
 
-    const dir = getDefinitionsDir()
-    const yamlPath = join(dir, `${name}.yaml`)
-    const ymlPath = join(dir, `${name}.yml`)
-    const existing = existsSync(yamlPath) ? yamlPath : existsSync(ymlPath) ? ymlPath : null
+    const existing = findExistingUserDefinitionPath(name)
 
     if (!existing) {
       // No user file. If plugin owns this id, the user is trying to delete
@@ -1130,20 +1219,6 @@ const workflowsPlugin: BakinPlugin = definePlugin({
 
     // ─── Search Content Type Registration ─────────────────────────────
 
-    /** Convert a workflow definition to a search document */
-    function definitionToSearchDoc(name: string, def: WorkflowDefinition): Record<string, unknown> {
-      const stepsText = def.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ')
-      return {
-        name: def.name,
-        description: def.description || '',
-        type: 'definition',
-        status: 'active',
-        task_id: '',
-        steps: stepsText,
-        updated_at: new Date().toISOString(),
-      }
-    }
-
     /** Convert a workflow instance to a search document */
     function instanceToSearchDoc(inst: WorkflowInstance): Record<string, unknown> {
       const def = loadDefinition(inst.workflowId)
@@ -1184,7 +1259,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
           fileToDoc: async (rel) => {
             const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
             const def = loadDefinition(name)
-            return def ? definitionToSearchDoc(name, def) : null
+            return def ? definitionToSearchDoc(name, def, def.source) : null
           },
         },
         {
@@ -1203,21 +1278,51 @@ const workflowsPlugin: BakinPlugin = definePlugin({
           },
         },
       ],
+      preserveVirtualDocuments: true,
+      onUnlink: async (rel) => {
+        if (rel.startsWith('workflows/definitions/')) {
+          const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
+          const defsDir = join(getContentDir(), 'workflows', 'definitions')
+          const alternateUserPath = rel.endsWith('.yaml')
+            ? join(defsDir, `${name}.yml`)
+            : join(defsDir, `${name}.yaml`)
+
+          if (existsSync(alternateUserPath)) {
+            const alternateDefinition = yaml.load(readFileSync(alternateUserPath, 'utf-8')) as WorkflowDefinition
+            await ctx.search.index(
+              `def:${name}`,
+              definitionToSearchDoc(name, { ...alternateDefinition, source: 'user' }, 'user'),
+            )
+            return
+          }
+
+          const fallbackEntry = getManagedDefinition(name)
+          if (fallbackEntry) {
+            await ctx.search.index(
+              `def:${name}`,
+              definitionToSearchDoc(
+                name,
+                { ...fallbackEntry.definition, source: fallbackEntry.source },
+                fallbackEntry.source,
+              ),
+            )
+          } else {
+            await ctx.search.remove(`def:${name}`)
+          }
+          return
+        }
+        if (rel.startsWith('workflows/instances/')) {
+          const taskId = rel.replace(/^workflows\/instances\//, '').replace(/\.json$/, '')
+          await ctx.search.remove(`inst:${taskId}`)
+        }
+      },
       reindex: async function* () {
         const contentDir = getContentDir()
 
-        // Yield definitions
-        const defsDir = join(contentDir, 'workflows', 'definitions')
-        if (existsSync(defsDir)) {
-          for (const file of readdirSync(defsDir).filter(f => f.endsWith('.yaml') || f.endsWith('.yml'))) {
-            try {
-              const name = file.replace(/\.(yaml|yml)$/, '')
-              const def = loadDefinition(name)
-              if (def) {
-                yield { key: `def:${name}`, doc: definitionToSearchDoc(name, def) }
-              }
-            } catch { /* skip corrupt definitions */ }
-          }
+        // Yield effective definitions from every source: plugin defaults,
+        // agent-package definitions, and user YAML shadows.
+        for (const entry of listDefinitions(contentDir)) {
+          yield { key: `def:${entry.name}`, doc: definitionToSearchDoc(entry.name, entry.definition, entry.source) }
         }
 
         // Yield instances
@@ -1235,8 +1340,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
         const contentDir = getContentDir()
         if (key.startsWith('def:')) {
           const name = key.slice(4)
-          return existsSync(join(contentDir, 'workflows', 'definitions', `${name}.yaml`))
-            || existsSync(join(contentDir, 'workflows', 'definitions', `${name}.yml`))
+          return loadDefinition(name, contentDir) !== null
         }
         if (key.startsWith('inst:')) {
           const taskId = key.slice(5)
@@ -1312,6 +1416,11 @@ const workflowsPlugin: BakinPlugin = definePlugin({
       const visited = new Set<string>()
 
       const visit = (id: string, path: string[]): void => {
+        const workflowIdError = validateWorkflowId(id)
+        if (workflowIdError) {
+          errors.push(`Workflow "${id}": ${workflowIdError}`)
+          return
+        }
         if (path.includes(id)) {
           errors.push(`Workflow nesting cycle detected: ${[...path, id].join(' -> ')}`)
           return

--- a/plugins/workflows/lib/availability.ts
+++ b/plugins/workflows/lib/availability.ts
@@ -1,0 +1,81 @@
+/**
+ * User-side availability overrides for managed workflow definitions.
+ *
+ * Disabled defaults stay visible in management surfaces, but automatic
+ * selection paths should ignore them unless they explicitly opt in.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { z } from 'zod'
+import { getContentDir } from './content-dir'
+import { createLogger } from '../../../src/core/logger'
+
+const log = createLogger('workflows:availability')
+
+const disabledDefaultsFileSchema = z.object({
+  disabledWorkflowIds: z.array(z.string()).default([]),
+}).passthrough()
+
+let cachedPath: string | null = null
+let cachedDisabledWorkflowIds: Set<string> | null = null
+
+function availabilityPath(contentDir?: string): string {
+  if (contentDir && contentDir.split(/[\\/]+/).includes('..')) {
+    throw new Error('contentDir must not contain parent-directory segments')
+  }
+  return join(contentDir || getContentDir(), 'workflows', 'disabled-defaults.json')
+}
+
+export function readDisabledWorkflowIds(contentDir?: string): Set<string> {
+  const file = availabilityPath(contentDir)
+  if (cachedPath === file && cachedDisabledWorkflowIds) {
+    return new Set(cachedDisabledWorkflowIds)
+  }
+  if (!existsSync(file)) {
+    cachedPath = file
+    cachedDisabledWorkflowIds = new Set()
+    return new Set()
+  }
+  try {
+    const parsed = disabledDefaultsFileSchema.safeParse(JSON.parse(readFileSync(file, 'utf-8')))
+    if (!parsed.success) {
+      log.warn('Ignoring invalid disabled-defaults file', { file, issues: parsed.error.issues })
+      cachedPath = file
+      cachedDisabledWorkflowIds = new Set()
+      return new Set()
+    }
+    cachedPath = file
+    cachedDisabledWorkflowIds = new Set(parsed.data.disabledWorkflowIds)
+    return new Set(cachedDisabledWorkflowIds)
+  } catch (err) {
+    log.warn('Ignoring unreadable disabled-defaults file', { file, error: err instanceof Error ? err.message : String(err) })
+    cachedPath = file
+    cachedDisabledWorkflowIds = new Set()
+    return new Set()
+  }
+}
+
+export function isWorkflowDisabled(id: string, contentDir?: string): boolean {
+  return readDisabledWorkflowIds(contentDir).has(id)
+}
+
+export function setWorkflowDisabled(id: string, disabled: boolean, contentDir?: string): void {
+  const file = availabilityPath(contentDir)
+  const ids = readDisabledWorkflowIds(contentDir)
+  if (disabled) ids.add(id)
+  else ids.delete(id)
+
+  mkdirSync(dirname(file), { recursive: true })
+  cachedPath = file
+  cachedDisabledWorkflowIds = new Set(ids)
+  writeFileSync(
+    file,
+    `${JSON.stringify({ disabledWorkflowIds: Array.from(ids).sort() }, null, 2)}\n`,
+    'utf-8',
+  )
+}
+
+export function resetWorkflowAvailabilityCache(): void {
+  cachedPath = null
+  cachedDisabledWorkflowIds = null
+}

--- a/plugins/workflows/lib/matcher.ts
+++ b/plugins/workflows/lib/matcher.ts
@@ -1,4 +1,5 @@
 import { listDefinitions } from './parser'
+import { readDisabledWorkflowIds } from './availability'
 
 /**
  * Auto-match a task to a workflow based on title (and optional description).
@@ -12,11 +13,14 @@ import { listDefinitions } from './parser'
 export function matchWorkflow(title: string, description?: string): string | null {
   const text = `${title} ${description || ''}`.toLowerCase()
   const defs = listDefinitions()
+  const disabledWorkflowIds = readDisabledWorkflowIds()
 
   let bestMatch: string | null = null
   let bestScore = 0
 
-  for (const { name } of defs) {
+  for (const { name, source, definition } of defs) {
+    if (source !== 'user' && disabledWorkflowIds.has(name)) continue
+    if (!Array.isArray(definition.steps) || definition.steps.length === 0) continue
     const tokens = name.split('-')
     const allMatch = tokens.every(token => text.includes(token))
     if (allMatch && tokens.length > bestScore) {

--- a/plugins/workflows/lib/node-type-registry.ts
+++ b/plugins/workflows/lib/node-type-registry.ts
@@ -140,12 +140,12 @@ const stepOutputSchema = z.object({
   id: z.string(),
   type: z.enum(['string', 'file', 'number']).optional(),
   path: z.string().optional(),
-})
+}).passthrough()
 
 const notifyChannelSchema = z.object({
   channel: z.string().min(1),
   target: z.string(),
-})
+}).passthrough()
 
 // ─── Builtin step schemas ───────────────────────────────────────────────────
 
@@ -160,7 +160,7 @@ export const agentStepSchema = z.object({
   outputs: z.array(stepOutputSchema).optional(),
   dependsOn: dependsOnSchema,
   deny_tools: z.array(z.string()).optional(),
-})
+}).passthrough()
 
 export const gateStepSchema = z.object({
   id: z.string().min(1),
@@ -176,9 +176,10 @@ export const gateStepSchema = z.object({
       goto: z.string(),
       note_to_agent: z.boolean().optional(),
     })
+    .passthrough()
     .optional(),
   dependsOn: dependsOnSchema,
-})
+}).passthrough()
 
 export const outputStepSchema = z.object({
   id: z.string().min(1),
@@ -192,7 +193,7 @@ export const outputStepSchema = z.object({
   schedule: z.string().optional(),
   dependsOn: dependsOnSchema,
   deny_tools: z.array(z.string()).optional(),
-})
+}).passthrough()
 
 export const nestedWorkflowStepSchema = z.object({
   id: z.string().min(1),
@@ -201,14 +202,14 @@ export const nestedWorkflowStepSchema = z.object({
   workflow_id: z.string().min(1),
   description: z.string().optional(),
   dependsOn: dependsOnSchema,
-})
+}).passthrough()
 
 const taskSourceSchema = z.object({
   pluginId: z.string().optional(),
   entityType: z.string().optional(),
   entityId: z.string().optional(),
   purpose: z.string().optional(),
-})
+}).passthrough()
 
 export const createTaskStepSchema = z.object({
   id: z.string().min(1),
@@ -227,7 +228,7 @@ export const createTaskStepSchema = z.object({
   source: taskSourceSchema.optional(),
   skipWorkflowReason: z.string().optional(),
   dependsOn: dependsOnSchema,
-})
+}).passthrough()
 
 // Parallel children are a closed subset (agent | gate). Defined separately so
 // the parallel schema can reference them without recursion through the union.
@@ -238,7 +239,7 @@ export const parallelStepSchema = z.object({
   type: z.literal('parallel'),
   label: z.string().min(1),
   steps: z.array(parallelChildSchema).min(1),
-})
+}).passthrough()
 
 // ─── Builtin form-field metadata (drives the editor UI) ─────────────────────
 
@@ -405,7 +406,7 @@ export const workflowInputSchema = z.object({
   description: z.string(),
   required: z.boolean().optional(),
   default: z.unknown().optional(),
-})
+}).passthrough()
 
 /**
  * Canvas-editor layout hints. Optional — the workflow engine does not consult
@@ -416,11 +417,11 @@ export const workflowInputSchema = z.object({
 export const nodePositionSchema = z.object({
   x: z.number(),
   y: z.number(),
-})
+}).passthrough()
 
 export const workflowLayoutSchema = z.object({
   positions: z.record(z.string(), nodePositionSchema).optional(),
-})
+}).passthrough()
 
 export const workflowDefinitionSchema = z.object({
   id: z.string().optional(),
@@ -428,8 +429,8 @@ export const workflowDefinitionSchema = z.object({
   description: z.string(),
   version: z.number(),
   inputs: z.record(z.string(), workflowInputSchema).optional(),
-  steps: z.array(stepSchema).min(1),
+  steps: z.array(stepSchema),
   layout: workflowLayoutSchema.optional(),
-})
+}).passthrough()
 
 export type WorkflowDefinitionParsed = z.infer<typeof workflowDefinitionSchema>

--- a/plugins/workflows/lib/parser.ts
+++ b/plugins/workflows/lib/parser.ts
@@ -46,6 +46,16 @@ export interface ValidateDefinitionOptions {
   assignee?: string
   requireResolvedAgents?: boolean
   validateNestedWorkflowRefs?: boolean
+  allowEmptySteps?: boolean
+}
+
+export const WORKFLOW_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+export const WORKFLOW_ID_VALIDATION_MESSAGE = 'Workflow id must use lowercase letters, numbers, and hyphens.'
+
+export function validateWorkflowId(id: string, label = 'Workflow id'): string | null {
+  if (!id.trim()) return `${label} is required`
+  if (!WORKFLOW_ID_PATTERN.test(id)) return WORKFLOW_ID_VALIDATION_MESSAGE
+  return null
 }
 
 function getDefinitionsDir(contentDir?: string): string {
@@ -97,7 +107,12 @@ export function validateDefinition(def: WorkflowDefinition, opts: ValidateDefini
   const validateNestedWorkflowRefs = opts.validateNestedWorkflowRefs ?? true
 
   if (!def.name) errors.push('Missing required field: name')
-  if (!def.steps || !Array.isArray(def.steps) || def.steps.length === 0) {
+  if (!def.steps || !Array.isArray(def.steps)) {
+    errors.push('Workflow must have at least one step')
+    return errors
+  }
+  if (def.steps.length === 0) {
+    if (opts.allowEmptySteps) return errors
     errors.push('Workflow must have at least one step')
     return errors
   }

--- a/plugins/workflows/lib/runtime.ts
+++ b/plugins/workflows/lib/runtime.ts
@@ -29,7 +29,7 @@ import type {
   NestedWorkflowStep,
   CreateTaskStep,
 } from '../types'
-import { loadDefinition } from './parser'
+import { loadDefinition, validateWorkflowId } from './parser'
 import { loadSkill } from './skill-loader'
 import { validateStepOutput, detectRejectionRepeat } from './schema-validator'
 import { notifyGateReached, notifyGateApproved, notifyGateRejected, notifyWorkflowComplete, notifyWorkflowReopened, notifyStepDispatched, notifyStepComplete, sendGateApprovalRequest, getGateNotificationSettings } from './notifications'
@@ -280,8 +280,13 @@ export function createInstance(
   parentContext?: Record<string, unknown>,
 ): WorkflowInstance {
   const dir = contentDir || getContentDir()
+  const workflowIdError = validateWorkflowId(workflowId)
+  if (workflowIdError) throw new Error(workflowIdError)
   const def = loadDefinition(workflowId, dir)
   if (!def) throw new Error(`Workflow definition not found: ${workflowId}`)
+  if (!Array.isArray(def.steps) || def.steps.length === 0) {
+    throw new Error(`Workflow "${workflowId}" must have at least one step`)
+  }
 
   const now = new Date().toISOString()
   const stepStates: Record<string, StepState> = {}

--- a/plugins/workflows/lib/source-registry.ts
+++ b/plugins/workflows/lib/source-registry.ts
@@ -32,6 +32,12 @@ export interface SourceEntry {
   packageId?: string
 }
 
+export interface ShadowedSource {
+  source: 'plugin' | 'agent-package'
+  pluginId?: string
+  packageId?: string
+}
+
 interface PluginEntry {
   pluginId: string
   definition: WorkflowDefinition
@@ -181,6 +187,38 @@ export function getDefinition(id: string): SourceEntry | undefined {
       pluginId: pluginEntry.pluginId,
     }
   }
+  return undefined
+}
+
+export function getManagedDefinition(id: string): SourceEntry | undefined {
+  const store = getStore()
+  const pkgEntry = store.agentPackage.get(id)
+  if (pkgEntry) {
+    return {
+      id,
+      definition: pkgEntry.definition,
+      source: 'agent-package',
+      packageId: pkgEntry.packageId,
+    }
+  }
+  const pluginEntry = store.plugin.get(id)
+  if (pluginEntry) {
+    return {
+      id,
+      definition: pluginEntry.definition,
+      source: 'plugin',
+      pluginId: pluginEntry.pluginId,
+    }
+  }
+  return undefined
+}
+
+export function getShadowedSource(id: string): ShadowedSource | undefined {
+  const store = getStore()
+  const pkgEntry = store.agentPackage.get(id)
+  if (pkgEntry) return { source: 'agent-package', packageId: pkgEntry.packageId }
+  const pluginEntry = store.plugin.get(id)
+  if (pluginEntry) return { source: 'plugin', pluginId: pluginEntry.pluginId }
   return undefined
 }
 

--- a/plugins/workflows/types.ts
+++ b/plugins/workflows/types.ts
@@ -14,23 +14,27 @@ export interface WorkflowInput {
   description: string
   required?: boolean
   default?: unknown
+  [k: string]: unknown
 }
 
 export interface StepOutput {
   id: string
   type?: 'string' | 'file' | 'number'
   path?: string
+  [k: string]: unknown
 }
 
 export interface NotifyChannel {
   /** Channel id — resolves against the workflows.notificationChannels registry. */
   channel: string
   target: string
+  [k: string]: unknown
 }
 
 export interface BaseStep {
   id: string
   label: string
+  [k: string]: unknown
 }
 
 export interface AgentStep extends BaseStep {
@@ -54,6 +58,7 @@ export interface GateStep extends BaseStep {
   on_reject?: {
     goto: string
     note_to_agent?: boolean
+    [k: string]: unknown
   }
   dependsOn?: string | string[]
 }
@@ -99,6 +104,7 @@ export interface CreateTaskStep extends BaseStep {
     entityType?: string
     entityId?: string
     purpose?: string
+    [k: string]: unknown
   }
   skipWorkflowReason?: string
   dependsOn?: string | string[]
@@ -109,6 +115,7 @@ export type WorkflowStep = AgentStep | GateStep | ParallelStep | OutputStep | Ne
 export interface NodePosition {
   x: number
   y: number
+  [k: string]: unknown
 }
 
 /**
@@ -117,6 +124,7 @@ export interface NodePosition {
  */
 export interface WorkflowLayout {
   positions?: Record<string, NodePosition>
+  [k: string]: unknown
 }
 
 export interface WorkflowDefinition {
@@ -127,9 +135,16 @@ export interface WorkflowDefinition {
   inputs?: Record<string, WorkflowInput>
   steps: WorkflowStep[]
   layout?: WorkflowLayout
+  [k: string]: unknown
 }
 
 // ─── Template Types ─────────────────────────────────────────────────────────
+
+export interface WorkflowShadowedSource {
+  source: 'plugin' | 'agent-package'
+  pluginId?: string
+  packageId?: string
+}
 
 export interface WorkflowTemplate {
   name: string
@@ -149,6 +164,10 @@ export interface WorkflowTemplate {
   pluginId?: string
   /** Set when source === 'agent-package' — the id of the package that shipped this workflow */
   packageId?: string
+  /** True when a managed workflow has been disabled by the user. */
+  disabled?: boolean
+  /** Set when a user workflow shadows a managed definition with the same id. */
+  shadowedSource?: WorkflowShadowedSource
 }
 
 // ─── Skill Types ────────────────────────────────────────────────────────────

--- a/src/components/agent-select.tsx
+++ b/src/components/agent-select.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import type { AriaAttributes } from 'react'
+import { User } from 'lucide-react'
 import { AgentAvatar } from '@/components/agent-avatar'
 import { useAgentList } from '@makinbakin/sdk/hooks'
 import {
@@ -10,9 +12,13 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
-interface AgentSelectProps {
+interface AgentSelectProps extends Pick<AriaAttributes, 'aria-describedby' | 'aria-invalid'> {
+  id?: string
   value: string
   onValueChange: (value: string) => void
+  /** Include the workflow/task runtime assignee token (`$assigned`) */
+  includeAssigned?: boolean
+  assignedLabel?: string
   /** Show a "None" / "Unassigned" option at the top (default: false) */
   allowNone?: boolean
   /** Label for the none option (default: "Unassigned") */
@@ -27,20 +33,36 @@ interface AgentSelectProps {
 export function AgentSelect({
   value,
   onValueChange,
+  includeAssigned = false,
+  assignedLabel = 'Assigned agent',
   allowNone = false,
   noneLabel = 'Unassigned',
   placeholder = 'Select agent...',
   agentIds,
   className,
+  id,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
 }: AgentSelectProps) {
   const allAgents = useAgentList()
   const agents = agentIds ? allAgents.filter(a => agentIds.includes(a.id)) : allAgents
+  const isAssignedToken = value === '$assigned'
 
   return (
     <Select value={value} onValueChange={(v) => onValueChange(v ?? '')}>
-      <SelectTrigger className={className}>
+      <SelectTrigger
+        id={id}
+        className={className}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={ariaInvalid}
+      >
         <SelectValue placeholder={placeholder}>
-          {value ? (
+          {isAssignedToken ? (
+            <span className="flex items-center gap-2">
+              <User className="size-3.5 text-blue-400" />
+              {assignedLabel}
+            </span>
+          ) : value ? (
             <span className="flex items-center gap-2">
               <AgentAvatar agentId={value} size="xs" />
               {agents.find(a => a.id === value)?.name || value}
@@ -53,6 +75,12 @@ export function AgentSelect({
       <SelectContent>
         {allowNone && (
           <SelectItem value="">{noneLabel}</SelectItem>
+        )}
+        {includeAssigned && (
+          <SelectItem value="$assigned">
+            <User className="size-3.5 text-blue-400" />
+            {assignedLabel}
+          </SelectItem>
         )}
         {agents.map(a => (
           <SelectItem key={a.id} value={a.id}>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -16,7 +16,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "peer group/switch relative inline-flex shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 after:cursor-pointer focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:after:cursor-not-allowed",
         className
       )}
       {...props}

--- a/src/core/search-reconcile.ts
+++ b/src/core/search-reconcile.ts
@@ -257,6 +257,24 @@ export async function performStartupReconcile(
   }
 
   const useEscapeHatch = typeof def.onSync === 'function'
+  const reconciledVirtualKeys = new Set<string>()
+
+  if (def.preserveVirtualDocuments && typeof def.reindex === 'function') {
+    for await (const { key, doc } of def.reindex()) {
+      if (!key || fsByKey.has(key)) continue
+      try {
+        if (!await def.verifyExists(key)) {
+          continue
+        }
+        await deps.index(key, { ...doc, [MTIME_FIELD]: 0 })
+        reconciledVirtualKeys.add(key)
+        result.indexed++
+      } catch (err) {
+        log.warn('Reconcile virtual index failed', err, { table: tableName, key })
+        result.errors++
+      }
+    }
+  }
 
   for (const [key, { entry, mapper }] of fsByKey) {
     const indexedMtime = indexedMtimes.get(key) ?? 0
@@ -301,7 +319,12 @@ export async function performStartupReconcile(
       continue
     }
     if (fsByKey.has(indexedKey)) continue
+    if (reconciledVirtualKeys.has(indexedKey)) continue
     try {
+      if (def.preserveVirtualDocuments && await def.verifyExists(indexedKey)) {
+        result.skipped++
+        continue
+      }
       // Escape-hatch and default paths both delegate to deps.remove. The
       // plugin can observe the removal through its own bookkeeping if it
       // registered an onUnlink hook.

--- a/tests/api/host-static.test.ts
+++ b/tests/api/host-static.test.ts
@@ -7,6 +7,8 @@
  *      the compiled binary serves production index.html byte-identical.
  */
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 
 // Per CLAUDE.md testing rules — mock content-dir even when the test
 // doesn't appear to need storage. Transitive imports can surprise you.
@@ -82,6 +84,15 @@ describe('transformIndexHtmlForDev', () => {
     const input = Buffer.from('<html><body></html>', 'utf-8') // malformed, no </body>
     const output = transformIndexHtmlForDev(input)
     expect(output.toString('utf-8')).not.toContain('__bakin-dev')
+  })
+})
+
+describe('host index boot fallback', () => {
+  it('includes visible fallback content inside #root before the app bundle loads', () => {
+    const html = readFileSync(join(process.cwd(), 'packages/host/public/index.html'), 'utf-8')
+    expect(html).toContain('class="bakin-boot"')
+    expect(html).toContain('Loading app')
+    expect(html.indexOf('class="bakin-boot"')).toBeLessThan(html.indexOf('/assets/main.js'))
   })
 })
 

--- a/tests/components/plugin-host.test.tsx
+++ b/tests/components/plugin-host.test.tsx
@@ -116,17 +116,25 @@ afterEach(() => {
 })
 
 describe('PluginHost — boot', () => {
+  it('shows a loader while the manifest request is pending', () => {
+    vi.stubGlobal('fetch', mock(() => new Promise(() => {})))
+
+    render(
+      <PluginHost>
+        <ProbeTree />
+      </PluginHost>,
+    )
+
+    expect(screen.getByText('Loading plugins')).toBeDefined()
+  })
+
   it('renders children after the manifest fetch resolves', async () => {
     render(
       <PluginHost>
         <ProbeTree />
       </PluginHost>,
     )
-    // Slot with no entries renders null, but the parent <div> is still there.
-    await waitFor(() => {
-      // The <ProbeTree>'s <div> wrapper is visible in the DOM
-      expect(document.querySelector('div')).not.toBeNull()
-    })
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
   })
 })
 
@@ -137,7 +145,7 @@ describe('PluginHost — window.__bakinHotSwapPlugin bridge', () => {
         <ProbeTree />
       </PluginHost>,
     )
-    await waitFor(() => expect(document.querySelector('div')).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
     expect((window as unknown as { __bakinHotSwapPlugin?: unknown }).__bakinHotSwapPlugin)
       .toBeUndefined()
   })
@@ -149,7 +157,7 @@ describe('PluginHost — window.__bakinHotSwapPlugin bridge', () => {
         <ProbeTree />
       </PluginHost>,
     )
-    await waitFor(() => expect(document.querySelector('div')).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
     await waitFor(() => {
       expect(typeof (window as unknown as { __bakinHotSwapPlugin?: unknown })
         .__bakinHotSwapPlugin).toBe('function')
@@ -165,7 +173,7 @@ describe('PluginHost — hot-swap unregisters synchronously', () => {
         <ProbeTree />
       </PluginHost>,
     )
-    await waitFor(() => expect(document.querySelector('div')).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
 
     act(() => {
       registerPlugin({
@@ -198,7 +206,7 @@ describe('PluginHost — hot-swap unregisters synchronously', () => {
         <ProbeTree />
       </PluginHost>,
     )
-    await waitFor(() => expect(document.querySelector('div')).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
 
     const moduleDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-host-hotswap-'))
     const modulePath = join(moduleDir, 'client.mjs')
@@ -245,7 +253,7 @@ describe('Slot — re-renders on registry change', () => {
         <ProbeTree />
       </PluginHost>,
     )
-    await waitFor(() => expect(document.querySelector('div')).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
 
     // Initial: no registration → Slot renders null
     expect(screen.queryByTestId('slot-content')).toBeNull()
@@ -277,7 +285,7 @@ describe('Slot — re-renders on registry change', () => {
         <ProbeTree />
       </PluginHost>,
     )
-    await waitFor(() => expect(document.querySelector('div')).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
 
     act(() => {
       registerPlugin({ id: 'x', slots: { 'page:/probe': SlotPage } })

--- a/tests/core/search-reconcile.test.ts
+++ b/tests/core/search-reconcile.test.ts
@@ -221,6 +221,52 @@ describe('search-reconcile', () => {
     expect(result.removed).toBe(1)
   })
 
+  it('keeps virtual index entries that still exist according to verifyExists', async () => {
+    mkdirSync(join(tempDir, 'projects'), { recursive: true })
+
+    const removed: string[] = []
+    const result = await performStartupReconcile(makeDef({
+      preserveVirtualDocuments: true,
+      verifyExists: async (key) => key === 'virtual',
+    }), tempDir, {
+      index: async () => {},
+      remove: async (key) => { removed.push(key) },
+      scanIndex: async function* () {
+        yield { key: 'virtual', mtimeMs: 1000 }
+        yield { key: 'stale', mtimeMs: 1000 }
+      },
+    })
+
+    expect(removed).toEqual(['stale'])
+    expect(result.removed).toBe(1)
+    expect(result.skipped).toBe(1)
+  })
+
+  it('indexes virtual documents from reindex when preserveVirtualDocuments is enabled', async () => {
+    mkdirSync(join(tempDir, 'projects'), { recursive: true })
+
+    const indexed: Array<{ key: string; doc: Record<string, unknown> }> = []
+    const removed: string[] = []
+    const result = await performStartupReconcile(makeDef({
+      preserveVirtualDocuments: true,
+      reindex: async function* () {
+        yield { key: 'virtual', doc: { title: 'Virtual doc' } }
+      },
+      verifyExists: async (key) => key === 'virtual',
+    }), tempDir, {
+      index: async (key, doc) => { indexed.push({ key, doc }) },
+      remove: async (key) => { removed.push(key) },
+      scanIndex: async function* () {},
+    })
+
+    expect(indexed).toHaveLength(1)
+    expect(indexed[0].key).toBe('virtual')
+    expect(indexed[0].doc.title).toBe('Virtual doc')
+    expect(indexed[0].doc[MTIME_FIELD]).toBe(0)
+    expect(removed).toEqual([])
+    expect(result.indexed).toBe(1)
+  })
+
   it('skips files whose mtime matches the indexed mtime', async () => {
     mkdirSync(join(tempDir, 'projects'), { recursive: true })
     const filePath = join(tempDir, 'projects', 'beta.md')

--- a/tests/plugins/workflows/availability.test.ts
+++ b/tests/plugins/workflows/availability.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-workflow-availability-${Date.now()}`)
+const availabilityFile = join(testDir, 'workflows', 'disabled-defaults.json')
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows'), logs: join(testDir, 'logs') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows'), logs: join(testDir, 'logs') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows'), logs: join(testDir, 'logs') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+}))
+
+import {
+  isWorkflowDisabled,
+  readDisabledWorkflowIds,
+  resetWorkflowAvailabilityCache,
+  setWorkflowDisabled,
+} from '@bakin/workflows/lib/availability'
+
+describe('workflow availability storage', () => {
+  beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+    mkdirSync(join(testDir, 'workflows'), { recursive: true })
+    resetWorkflowAvailabilityCache()
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+    resetWorkflowAvailabilityCache()
+  })
+
+  it('returns an empty set when the file does not exist', () => {
+    expect(readDisabledWorkflowIds()).toEqual(new Set())
+    expect(isWorkflowDisabled('video-social-post')).toBe(false)
+  })
+
+  it('writes, sorts, and clears disabled workflow ids', () => {
+    setWorkflowDisabled('video-social-post', true)
+    setWorkflowDisabled('image-social-post', true)
+
+    expect(readDisabledWorkflowIds()).toEqual(new Set(['image-social-post', 'video-social-post']))
+    expect(JSON.parse(readFileSync(availabilityFile, 'utf-8'))).toEqual({
+      disabledWorkflowIds: ['image-social-post', 'video-social-post'],
+    })
+
+    setWorkflowDisabled('image-social-post', false)
+
+    expect(readDisabledWorkflowIds()).toEqual(new Set(['video-social-post']))
+    expect(JSON.parse(readFileSync(availabilityFile, 'utf-8'))).toEqual({
+      disabledWorkflowIds: ['video-social-post'],
+    })
+  })
+
+  it('ignores malformed or schema-invalid JSON without rewriting it', () => {
+    writeFileSync(availabilityFile, '{"disabledWorkflowIds":[42]}', 'utf-8')
+
+    expect(readDisabledWorkflowIds()).toEqual(new Set())
+    expect(readFileSync(availabilityFile, 'utf-8')).toBe('{"disabledWorkflowIds":[42]}')
+  })
+
+  it('caches reads until explicitly reset or a write invalidates the cache', () => {
+    writeFileSync(availabilityFile, '{"disabledWorkflowIds":["video-social-post"]}', 'utf-8')
+    expect(readDisabledWorkflowIds()).toEqual(new Set(['video-social-post']))
+
+    writeFileSync(availabilityFile, '{"disabledWorkflowIds":["image-social-post"]}', 'utf-8')
+    expect(readDisabledWorkflowIds()).toEqual(new Set(['video-social-post']))
+
+    resetWorkflowAvailabilityCache()
+    expect(readDisabledWorkflowIds()).toEqual(new Set(['image-social-post']))
+  })
+
+  it('rejects contentDir values with parent-directory segments', () => {
+    expect(() => readDisabledWorkflowIds(`${testDir}/../other`)).toThrow(/parent-directory/)
+    expect(existsSync(join(testDir, '..', 'other', 'workflows', 'disabled-defaults.json'))).toBe(false)
+  })
+})

--- a/tests/plugins/workflows/definitions-crud.test.ts
+++ b/tests/plugins/workflows/definitions-crud.test.ts
@@ -17,6 +17,20 @@ mock.module('@/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
 }))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({}))
 mock.module('@bakin/adapter-openclaw/home', () => ({
   getOpenClawHome: () => join(testDir, 'openclaw'),
@@ -28,6 +42,8 @@ import {
   clearSourceRegistry,
   registerPluginDefinition,
 } from '@bakin/workflows/lib/source-registry'
+import { matchWorkflow } from '@bakin/workflows/lib/matcher'
+import { resetWorkflowAvailabilityCache } from '@bakin/workflows/lib/availability'
 import { activatePlugin, callRoute, findRoute } from '../test-helpers'
 import type { WorkflowDefinition } from '@bakin/workflows/types'
 
@@ -42,10 +58,12 @@ describe('workflows CRUD routes', () => {
   beforeEach(() => {
     mkdirSync(defsDir, { recursive: true })
     clearSourceRegistry()
+    resetWorkflowAvailabilityCache()
   })
   afterEach(() => {
     rmSync(testDir, { recursive: true, force: true })
     clearSourceRegistry()
+    resetWorkflowAvailabilityCache()
   })
 
   it('declares workflow gate approval fallback routes as HTML responses', async () => {
@@ -79,16 +97,17 @@ describe('workflows CRUD routes', () => {
       expect(parsed.name).toBe('New Demo')
     })
 
-    it('rejects an invalid definition (missing steps)', async () => {
+    it('creates an empty draft workflow definition on disk', async () => {
       const activated = await activatePlugin(workflowsPlugin, testDir)
       const route = findRoute(activated.routes, 'POST', '/definitions')!
 
       const res = await callRoute(route, activated.ctx, {
-        body: { id: 'bad', name: 'Bad', description: 'x', version: 1, steps: [] },
+        body: { id: 'draft', name: 'Draft', description: 'x', version: 1, steps: [] },
       })
 
-      expect(res.status).toBe(400)
-      expect(res.body.error).toMatch(/validation|invalid/i)
+      expect(res.status).toBe(201)
+      const onDisk = yaml.load(readFileSync(join(defsDir, 'draft.yaml'), 'utf-8')) as Record<string, unknown>
+      expect(onDisk.steps).toEqual([])
     })
 
     it('refuses to overwrite a plugin-owned id', async () => {
@@ -104,6 +123,35 @@ describe('workflows CRUD routes', () => {
       expect(res.body.error).toMatch(/plugin/i)
       expect(existsSync(join(defsDir, 'shared-id.yaml'))).toBe(false)
     })
+
+    it('refuses to overwrite an existing user-owned id', async () => {
+      writeFileSync(join(defsDir, 'existing.yaml'), yaml.dump({ ...validDef, name: 'Original' }))
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const route = findRoute(activated.routes, 'POST', '/definitions')!
+
+      const res = await callRoute(route, activated.ctx, {
+        body: { id: 'existing', ...validDef, name: 'Updated' },
+      })
+
+      expect(res.status).toBe(409)
+      expect(res.body.error).toMatch(/already exists/i)
+      const onDisk = yaml.load(readFileSync(join(defsDir, 'existing.yaml'), 'utf-8')) as Record<string, unknown>
+      expect(onDisk.name).toBe('Original')
+    })
+
+    it('rejects unsafe workflow ids before writing to disk', async () => {
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const route = findRoute(activated.routes, 'POST', '/definitions')!
+
+      const res = await callRoute(route, activated.ctx, {
+        body: { id: '../escape', ...validDef },
+      })
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toMatch(/lowercase letters/)
+      expect(existsSync(join(testDir, 'workflows', 'escape.yaml'))).toBe(false)
+      expect(existsSync(join(defsDir, '..', 'escape.yaml'))).toBe(false)
+    })
   })
 
   describe('PUT /definitions/:name', () => {
@@ -118,12 +166,13 @@ describe('workflows CRUD routes', () => {
       const res = await callRoute(route, activated.ctx, {
         path: '/definitions/edit-me',
         searchParams: { name: 'edit-me' },
-        body: { ...validDef, name: 'Updated' },
+        body: { ...validDef, name: 'Updated', description: 'updated description' },
       })
 
       expect(res.status).toBe(200)
       const onDisk = yaml.load(readFileSync(join(defsDir, 'edit-me.yaml'), 'utf-8')) as Record<string, unknown>
       expect(onDisk.name).toBe('Updated')
+      expect(onDisk.description).toBe('updated description')
     })
 
     it('refuses to write a user shadow when only :readOnly query is set', async () => {
@@ -144,6 +193,14 @@ describe('workflows CRUD routes', () => {
       // The disk file is the user shadow — plugin entry is unchanged
       const onDisk = yaml.load(readFileSync(join(defsDir, 'plug-only.yaml'), 'utf-8')) as Record<string, unknown>
       expect(onDisk.name).toBe('User Override')
+
+      const listRoute = findRoute(activated.routes, 'GET', '/definitions')!
+      const listRes = await callRoute(listRoute, activated.ctx)
+      const shadowed = (listRes.body.templates as Array<{ filename: string; source?: string; shadowedSource?: { source: string; pluginId?: string } }>).find(
+        (template) => template.filename === 'plug-only',
+      )
+      expect(shadowed?.source).toBe('user')
+      expect(shadowed?.shadowedSource).toEqual({ source: 'plugin', pluginId: 'workflows' })
     })
 
     it('returns 400 on invalid body', async () => {
@@ -154,10 +211,191 @@ describe('workflows CRUD routes', () => {
       const res = await callRoute(route, activated.ctx, {
         path: '/definitions/edit-me',
         searchParams: { name: 'edit-me' },
-        body: { name: 'No Steps', description: '', version: 1, steps: [] },
+        body: { name: '', description: '', version: 1, steps: [] },
       })
 
       expect(res.status).toBe(400)
+    })
+
+    it('rejects unsafe workflow ids before updating disk', async () => {
+      const outsidePath = join(testDir, 'workflows', 'escape.yaml')
+      writeFileSync(outsidePath, yaml.dump({ ...validDef, name: 'Outside' }))
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const route = findRoute(activated.routes, 'PUT', '/definitions/:name')!
+
+      const res = await callRoute(route, activated.ctx, {
+        path: '/definitions/..%2Fescape',
+        searchParams: { name: '../escape' },
+        body: { ...validDef, name: 'Updated Outside' },
+      })
+
+      expect(res.status).toBe(400)
+      const onDisk = yaml.load(readFileSync(outsidePath, 'utf-8')) as Record<string, unknown>
+      expect(onDisk.name).toBe('Outside')
+    })
+  })
+
+  describe('PATCH /definitions/:name/availability', () => {
+    it('disables a managed workflow and hides it from default list results', async () => {
+      registerPluginDefinition('workflows', 'plug-only', validDef as unknown as WorkflowDefinition)
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const availabilityRoute = findRoute(activated.routes, 'PATCH', '/definitions/:name/availability')!
+      const listRoute = findRoute(activated.routes, 'GET', '/definitions')!
+
+      const res = await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: true },
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ id: 'plug-only', disabled: true })
+      const availabilityFile = join(testDir, 'workflows', 'disabled-defaults.json')
+      expect(JSON.parse(readFileSync(availabilityFile, 'utf-8'))).toEqual({
+        disabledWorkflowIds: ['plug-only'],
+      })
+
+      const defaultList = await callRoute(listRoute, activated.ctx)
+      const defaultNames = (defaultList.body.templates as Array<{ filename: string }>).map((template) => template.filename)
+      expect(defaultNames).not.toContain('plug-only')
+
+      const includedList = await callRoute(listRoute, activated.ctx, {
+        searchParams: { includeDisabled: '1' },
+      })
+      const included = (includedList.body.templates as Array<{ filename: string; disabled?: boolean }>).find(
+        (template) => template.filename === 'plug-only',
+      )
+      expect(included?.disabled).toBe(true)
+    })
+
+    it('reindexes managed workflow search status when availability changes', async () => {
+      registerPluginDefinition('workflows', 'plug-only', validDef as unknown as WorkflowDefinition)
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const availabilityRoute = findRoute(activated.routes, 'PATCH', '/definitions/:name/availability')!
+
+      await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: true },
+      })
+
+      expect(activated.ctx.search.index).toHaveBeenLastCalledWith(
+        'def:plug-only',
+        expect.objectContaining({
+          name: 'New Demo',
+          type: 'definition',
+          status: 'disabled',
+        }),
+      )
+
+      await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: false },
+      })
+
+      expect(activated.ctx.search.index).toHaveBeenLastCalledWith(
+        'def:plug-only',
+        expect.objectContaining({
+          name: 'New Demo',
+          type: 'definition',
+          status: 'active',
+        }),
+      )
+    })
+
+    it('does not disable user-owned workflows', async () => {
+      writeFileSync(join(defsDir, 'user-only.yaml'), yaml.dump(validDef))
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const route = findRoute(activated.routes, 'PATCH', '/definitions/:name/availability')!
+
+      const res = await callRoute(route, activated.ctx, {
+        path: '/definitions/user-only/availability',
+        searchParams: { name: 'user-only' },
+        body: { disabled: true },
+      })
+
+      expect(res.status).toBe(409)
+      expect(res.body.error).toMatch(/managed/i)
+    })
+
+    it('does not apply a managed disabled override to a user shadow', async () => {
+      registerPluginDefinition('workflows', 'plug-only', validDef as unknown as WorkflowDefinition)
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const availabilityRoute = findRoute(activated.routes, 'PATCH', '/definitions/:name/availability')!
+      const putRoute = findRoute(activated.routes, 'PUT', '/definitions/:name')!
+      const getRoute = findRoute(activated.routes, 'GET', '/definitions/:name')!
+      const listRoute = findRoute(activated.routes, 'GET', '/definitions')!
+
+      await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: true },
+      })
+
+      const shadowRes = await callRoute(putRoute, activated.ctx, {
+        path: '/definitions/plug-only',
+        searchParams: { name: 'plug-only' },
+        body: { ...validDef, name: 'User Shadow' },
+      })
+      expect(shadowRes.status).toBe(200)
+
+      const defaultList = await callRoute(listRoute, activated.ctx)
+      const listed = (defaultList.body.templates as Array<{ filename: string; disabled?: boolean; source?: string }>).find(
+        (template) => template.filename === 'plug-only',
+      )
+      expect(listed?.source).toBe('user')
+      expect(listed?.disabled).toBe(false)
+
+      const detail = await callRoute(getRoute, activated.ctx, {
+        path: '/definitions/plug-only',
+        searchParams: { name: 'plug-only' },
+      })
+      expect(detail.body.source).toBe('user')
+      expect(detail.body.disabled).toBe(false)
+      expect(matchWorkflow('run the plug only workflow')).toBe('plug-only')
+
+      const disableShadowRes = await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: true },
+      })
+      expect(disableShadowRes.status).toBe(409)
+      expect(disableShadowRes.body.error).toMatch(/managed/i)
+    })
+
+    it('excludes disabled managed workflows from matching until re-enabled', async () => {
+      registerPluginDefinition('workflows', 'plug-only', validDef as unknown as WorkflowDefinition)
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const availabilityRoute = findRoute(activated.routes, 'PATCH', '/definitions/:name/availability')!
+
+      await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: true },
+      })
+
+      expect(matchWorkflow('run the plug only workflow')).toBeNull()
+
+      await callRoute(availabilityRoute, activated.ctx, {
+        path: '/definitions/plug-only/availability',
+        searchParams: { name: 'plug-only' },
+        body: { disabled: false },
+      })
+
+      expect(matchWorkflow('run the plug only workflow')).toBe('plug-only')
+    })
+
+    it('does not match empty draft workflows', async () => {
+      writeFileSync(join(defsDir, 'draft-only.yaml'), yaml.dump({
+        name: 'Draft Only',
+        description: 'not ready to run',
+        version: 1,
+        steps: [],
+      }))
+      await activatePlugin(workflowsPlugin, testDir)
+
+      expect(matchWorkflow('run the draft only workflow')).toBeNull()
     })
   })
 
@@ -200,6 +438,21 @@ describe('workflows CRUD routes', () => {
       })
 
       expect(res.status).toBe(404)
+    })
+
+    it('rejects unsafe workflow ids before deleting disk files', async () => {
+      const outsidePath = join(testDir, 'workflows', 'escape.yaml')
+      writeFileSync(outsidePath, yaml.dump({ ...validDef, name: 'Outside' }))
+      const activated = await activatePlugin(workflowsPlugin, testDir)
+      const route = findRoute(activated.routes, 'DELETE', '/definitions/:name')!
+
+      const res = await callRoute(route, activated.ctx, {
+        path: '/definitions/..%2Fescape',
+        searchParams: { name: '../escape' },
+      })
+
+      expect(res.status).toBe(400)
+      expect(existsSync(outsidePath)).toBe(true)
     })
   })
 })

--- a/tests/plugins/workflows/node-config-drawer.test.tsx
+++ b/tests/plugins/workflows/node-config-drawer.test.tsx
@@ -15,9 +15,10 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { z } from 'zod'
 
 const testDir = join(tmpdir(), `bakin-test-node-config-drawer-${Date.now()}`)
 
@@ -50,8 +51,12 @@ mock.module('@/components/agent-avatar', () => ({
 }))
 
 import { NodeConfigDrawer } from '../../../plugins/workflows/components/node-config-drawer'
+import { registerNodeType, unregisterNodeType } from '../../../plugins/workflows/lib/node-type-registry'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe('NodeConfigDrawer', () => {
   it('renders formFields for a builtin agent step', () => {
@@ -63,10 +68,12 @@ describe('NodeConfigDrawer', () => {
       />,
     )
     // id + label + agent + task + skill fields from agentFormFields are present
-    expect(screen.getByLabelText(/^id$/i)).toBeDefined()
-    expect(screen.getByLabelText(/^label$/i)).toBeDefined()
+    expect(screen.getByLabelText(/step id/i)).toBeDefined()
+    expect(screen.getByLabelText(/display name/i)).toBeDefined()
     expect(screen.getAllByText(/agent/i).length).toBeGreaterThan(0)
-    expect(screen.getByLabelText(/^task$/i)).toBeDefined()
+    expect(screen.getByLabelText(/task brief/i)).toBeDefined()
+    expect(screen.getByText(/stable identifier used by workflow links/i)).toBeDefined()
+    expect(screen.getByPlaceholderText('Write a concise post caption for the approved brief.')).toBeDefined()
   })
 
   it('calls onApply with the merged patch when Apply is clicked on valid input', () => {
@@ -86,21 +93,290 @@ describe('NodeConfigDrawer', () => {
     expect(patch.type).toBe('gate')
   })
 
-  it('surfaces Zod errors when required fields are missing', () => {
+  it('round-trips structured output content as an object', () => {
     const onApply = mock()
     render(
       <NodeConfigDrawer
-        // gate with empty on_approve should fail min(1) validation.
-        step={{ id: 'g', type: 'gate', label: 'G', on_approve: '' }}
+        step={{
+          id: 'publish',
+          type: 'output',
+          label: 'Publish',
+          agent: 'chef',
+          content: { message: 'Ready to publish' },
+        }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+
+    expect((screen.getByLabelText(/output content/i) as HTMLTextAreaElement).value).toBe('{\n  "message": "Ready to publish"\n}')
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+    expect(patch.content).toEqual({ message: 'Ready to publish' })
+  })
+
+  it('shows an inline error for invalid output content JSON', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{ id: 'publish', type: 'output', label: 'Publish', agent: 'chef' }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/output content/i), { target: { value: '{bad json' } })
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).not.toHaveBeenCalled()
+    expect(screen.getByText('Enter valid JSON object content.')).toBeDefined()
+  })
+
+  it('preserves YAML-backed fields the drawer does not own', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{
+          id: 'write',
+          type: 'agent',
+          label: 'Write',
+          agent: 'chef',
+          dependsOn: 'outline',
+          output_schema: { type: 'object' },
+        }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Write draft' } })
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+    expect(patch.label).toBe('Write draft')
+    expect(patch.dependsOn).toBe('outline')
+    expect(patch.output_schema).toEqual({ type: 'object' })
+  })
+
+  it('keeps unchanged empty optional fields instead of deleting YAML content', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{
+          id: 'write',
+          type: 'agent',
+          label: 'Write',
+          agent: 'chef',
+          skill: '',
+          description: '',
+        }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+    expect(patch.skill).toBe('')
+    expect(patch.description).toBe('')
+  })
+
+  it('rejects duplicate step IDs before applying a patch', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{ id: 'write', type: 'agent', label: 'Write', agent: 'chef' }}
+        existingStepIds={['write', 'review']}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/step id/i), { target: { value: 'review' } })
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).not.toHaveBeenCalled()
+    expect(screen.getByText('Step IDs must be unique.')).toBeDefined()
+  })
+
+  it('reports drawer dirty state and clears it after a valid apply', () => {
+    const onApply = mock()
+    const onDirtyChange = mock()
+    render(
+      <NodeConfigDrawer
+        step={{ id: 'write', type: 'agent', label: 'Write', agent: 'chef' }}
+        onApply={onApply}
+        onDirtyChange={onDirtyChange}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText(/display name/i), { target: { value: 'Write draft' } })
+    expect(onDirtyChange).toHaveBeenCalledWith(true)
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('renders the assigned-agent token as a selectable agent option', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{ id: 'write', type: 'agent', label: 'Write', agent: '$assigned' }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Assigned agent')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+    expect(patch.agent).toBe('$assigned')
+  })
+
+  it('edits gate on_reject.goto without dropping sibling reject metadata', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{
+          id: 'approve',
+          type: 'gate',
+          label: 'Approve',
+          on_approve: 'done',
+          on_reject: { goto: 'write', note_to_agent: true },
+        }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+    fireEvent.change(screen.getByLabelText(/rejected path/i), { target: { value: 'revise' } })
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+    expect(patch.on_reject).toEqual({ goto: 'revise', note_to_agent: true })
+  })
+
+  it('edits static parallel agent children as structured rows', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{
+          id: 'fanout',
+          type: 'parallel',
+          label: 'Fan out',
+          steps: [
+            {
+              id: 'segment-a',
+              type: 'agent',
+              label: 'Segment A',
+              agent: 'chef',
+              task: 'Make the first segment',
+            },
+          ],
+        }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+    fireEvent.change(screen.getByLabelText(/task brief for child segment-a/i), {
+      target: { value: 'Create segment one' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalled()
+    const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+    expect(patch.steps).toEqual([
+      {
+        id: 'segment-a',
+        type: 'agent',
+        label: 'Segment A',
+        agent: 'chef',
+        task: 'Create segment one',
+      },
+    ])
+  })
+
+  it('marks required empty fields inline before schema validation', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{ id: 'agent', type: 'agent', label: 'agent', agent: '', task: 'Do something.' }}
         onApply={onApply}
         onClose={() => {}}
       />,
     )
     fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
     expect(onApply).not.toHaveBeenCalled()
-    // Error surface — one of the issue messages mentions on_approve.
-    const errors = screen.getAllByRole('listitem')
-    expect(errors.length).toBeGreaterThan(0)
+    expect(screen.getByText('Choose an agent.')).toBeDefined()
+    expect(screen.queryByText(/Invalid input/)).toBeNull()
+  })
+
+  it('surfaces schema errors that are not owned by required field checks', () => {
+    const onApply = mock()
+    render(
+      <NodeConfigDrawer
+        step={{
+          id: 'g',
+          type: 'gate',
+          label: 'G',
+          on_approve: 'done',
+          approval_required: 'yes',
+        }}
+        onApply={onApply}
+        onClose={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+    expect(onApply).not.toHaveBeenCalled()
+    expect(screen.getByText(/expected boolean/i)).toBeDefined()
+    expect(screen.queryByRole('listitem')).toBeNull()
+  })
+
+  it('lets optional numeric plugin fields be cleared instead of saving zero', () => {
+    const kind = 'test.optional-number'
+    registerNodeType({
+      kind,
+      runtime: 'plugin',
+      pluginId: 'test',
+      zodSchema: z.object({
+        id: z.string(),
+        type: z.literal(kind),
+        label: z.string(),
+        retries: z.number().optional(),
+      }).passthrough(),
+      formFields: [
+        { name: 'retries', type: 'number', description: 'Retry count' },
+      ],
+    })
+    try {
+      const onApply = mock()
+      render(
+        <NodeConfigDrawer
+          step={{ id: 'retry', type: kind, label: 'Retry', retries: 3 }}
+          onApply={onApply}
+          onClose={() => {}}
+        />,
+      )
+
+      fireEvent.change(screen.getByLabelText(/retries/i), { target: { value: '' } })
+      fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+
+      expect(onApply).toHaveBeenCalled()
+      const patch = onApply.mock.calls[0][0] as Record<string, unknown>
+      expect('retries' in patch).toBe(false)
+    } finally {
+      unregisterNodeType(kind)
+    }
   })
 
   it('shows a friendly notice when the kind is unregistered', () => {
@@ -125,5 +401,59 @@ describe('NodeConfigDrawer', () => {
     )
     fireEvent.click(screen.getByLabelText(/close drawer/i))
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('exposes a delete action for the selected step', () => {
+    const onDelete = mock()
+    render(
+      <NodeConfigDrawer
+        step={{ id: 's1', type: 'agent', label: 'S', agent: 'chef' }}
+        onApply={() => {}}
+        onDelete={onDelete}
+        onClose={() => {}}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    expect(onDelete).toHaveBeenCalled()
+  })
+
+  it('renders workflow_id as a workflow selector', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            templates: [
+              { filename: 'video-script', name: 'Video Script' },
+              { filename: 'assemble-video', name: 'Assemble Video', disabled: true },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <NodeConfigDrawer
+        step={{
+          id: 'script-video',
+          type: 'workflow',
+          label: 'Script Video',
+          workflow_id: 'video-script',
+        }}
+        onApply={() => {}}
+        onClose={() => {}}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/plugins/workflows/definitions?includeDisabled=1')
+    })
+    expect(screen.getByRole('combobox')).toBeDefined()
+    expect(screen.queryByRole('textbox', { name: /^workflow_id$/i })).toBeNull()
   })
 })

--- a/tests/plugins/workflows/node-type-palette.test.tsx
+++ b/tests/plugins/workflows/node-type-palette.test.tsx
@@ -44,6 +44,7 @@ import {
 const FIXTURES: PaletteNodeType[] = [
   { kind: 'agent', runtime: 'builtin', formFields: [] },
   { kind: 'gate', runtime: 'builtin', formFields: [] },
+  { kind: 'output', runtime: 'builtin', formFields: [] },
   { kind: 'fx.noise-gate', runtime: 'plugin', pluginId: 'fx', formFields: [] },
 ]
 
@@ -52,13 +53,40 @@ afterEach(cleanup)
 describe('NodeTypePalette', () => {
   it('renders Builtin and Plugins groups from initialNodeTypes', () => {
     render(<NodeTypePalette initialNodeTypes={FIXTURES} />)
+    expect(screen.getByText('Step Types')).toBeDefined()
     expect(screen.getByText('Builtin')).toBeDefined()
     expect(screen.getByText('Plugins')).toBeDefined()
-    expect(screen.getByText('agent')).toBeDefined()
-    expect(screen.getByText('gate')).toBeDefined()
+    expect(screen.getByText('Agent Task')).toBeDefined()
+    expect(screen.getByText('Approval Gate')).toBeDefined()
+    expect(screen.getByText('Completion')).toBeDefined()
+    const agentItem = screen.getByText('Agent Task').closest('li')!
+    expect(agentItem.querySelector('svg')).toBeDefined()
     // Plugin display strips the prefix; the pluginId appears as a badge.
     expect(screen.getByText('noise-gate')).toBeDefined()
     expect(screen.getByText('fx')).toBeDefined()
+  })
+
+  it('disables node types the editor says cannot be added', () => {
+    const onDragKind = mock()
+    render(
+      <NodeTypePalette
+        initialNodeTypes={FIXTURES}
+        disabledKinds={new Set(['output'])}
+        onDragKind={onDragKind}
+      />,
+    )
+
+    const item = screen.getByText('Completion').closest('li')!
+    expect(item.getAttribute('aria-disabled')).toBe('true')
+    expect(screen.getByText('This workflow already has a completion step.')).toBeDefined()
+
+    const setData = mock()
+    fireEvent.dragStart(item, {
+      dataTransfer: { setData, effectAllowed: '' },
+    })
+
+    expect(setData).not.toHaveBeenCalled()
+    expect(onDragKind).not.toHaveBeenCalled()
   })
 
   it('sets the drag MIME payload to the namespaced kind on dragstart', () => {
@@ -97,7 +125,7 @@ describe('NodeTypePalette', () => {
 
     render(<NodeTypePalette />)
     // Wait a tick for fetch resolution.
-    await screen.findByText('agent')
+    await screen.findByText('Agent Task')
     expect(fetchMock).toHaveBeenCalledWith('/api/plugins/workflows/node-types')
 
     vi.unstubAllGlobals()

--- a/tests/plugins/workflows/node-type-registry.test.ts
+++ b/tests/plugins/workflows/node-type-registry.test.ts
@@ -237,14 +237,14 @@ describe('node-type-registry', () => {
       expect(result.success).toBe(false)
     })
 
-    it('rejects a definition with no steps', () => {
+    it('accepts an empty draft definition before semantic runtime validation', () => {
       const result = workflowDefinitionSchema.safeParse({
         name: 'Empty',
         description: 'x',
         version: 1,
         steps: [],
       })
-      expect(result.success).toBe(false)
+      expect(result.success).toBe(true)
     })
 
     it('rejects a definition missing required top-level fields', () => {

--- a/tests/plugins/workflows/parser.test.ts
+++ b/tests/plugins/workflows/parser.test.ts
@@ -39,7 +39,14 @@ mock.module('@bakin/adapter-openclaw/home', () => ({
   getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
 }))
 
-import { parseYAML, validateDefinition, loadDefinition, listDefinitions } from '@bakin/workflows/lib/parser'
+import {
+  WORKFLOW_ID_VALIDATION_MESSAGE,
+  parseYAML,
+  validateDefinition,
+  validateWorkflowId,
+  loadDefinition,
+  listDefinitions,
+} from '@bakin/workflows/lib/parser'
 import {
   registerPluginDefinition,
   clearSourceRegistry,
@@ -82,6 +89,14 @@ steps:
   })
 
   describe('validateDefinition', () => {
+    it('validates workflow ids used for disk-backed definitions', () => {
+      expect(validateWorkflowId('social-post')).toBeNull()
+      expect(validateWorkflowId('clip-creation-2')).toBeNull()
+      expect(validateWorkflowId('../escape')).toBe(WORKFLOW_ID_VALIDATION_MESSAGE)
+      expect(validateWorkflowId('Bad Id')).toBe(WORKFLOW_ID_VALIDATION_MESSAGE)
+      expect(validateWorkflowId('trailing-')).toBe(WORKFLOW_ID_VALIDATION_MESSAGE)
+    })
+
     it('accepts a valid definition', () => {
       const def: WorkflowDefinition = {
         name: 'Test',
@@ -93,6 +108,28 @@ steps:
         ],
       }
       expect(validateDefinition(def)).toEqual([])
+    })
+
+    it('rejects empty workflows for runtime validation by default', () => {
+      const def: WorkflowDefinition = {
+        name: 'Draft',
+        description: 'Empty draft',
+        version: 1,
+        steps: [],
+      }
+
+      expect(validateDefinition(def)).toContain('Workflow must have at least one step')
+    })
+
+    it('allows empty steps when validating draft CRUD saves', () => {
+      const def: WorkflowDefinition = {
+        name: 'Draft',
+        description: 'Empty draft',
+        version: 1,
+        steps: [],
+      }
+
+      expect(validateDefinition(def, { allowEmptySteps: true })).toEqual([])
     })
 
     it('rejects definition with duplicate step IDs', () => {

--- a/tests/plugins/workflows/runtime.test.ts
+++ b/tests/plugins/workflows/runtime.test.ts
@@ -376,6 +376,17 @@ Write a great caption.
     it('throws for unknown workflow definition', () => {
       expect(() => createInstance('task-x', 'nonexistent', testDir)).toThrow()
     })
+
+    it('throws for empty draft workflows before reading the first step', () => {
+      writeFileSync(join(defsDir, 'draft.yaml'), `
+name: Draft
+description: Not ready to run
+version: 1
+steps: []
+`)
+
+      expect(() => createInstance('task-draft', 'draft', testDir)).toThrow(/at least one step/)
+    })
   })
 
   // ─── getCurrentStep ─────────────────────────────────────────────────

--- a/tests/plugins/workflows/source-registry.test.ts
+++ b/tests/plugins/workflows/source-registry.test.ts
@@ -31,6 +31,7 @@ import {
   unregisterAgentPackageDefinitions,
   unregisterUserDefinition,
   getDefinition,
+  getManagedDefinition,
   listAll,
   isReadOnly,
   getSource,
@@ -180,6 +181,16 @@ describe('source-registry', () => {
       const entry = getDefinition('wf')
       expect(entry!.source).toBe('user')
       expect(entry!.definition.name).toBe('User')
+    })
+
+    it('getManagedDefinition ignores user shadows and resolves the managed fallback', () => {
+      registerPluginDefinition('workflows', 'wf', def('Plugin'))
+      registerAgentPackageDefinition('pixel', 'wf', def('Package'))
+      registerUserDefinition('wf', def('User'))
+
+      const entry = getManagedDefinition('wf')
+      expect(entry!.source).toBe('agent-package')
+      expect(entry!.definition.name).toBe('Package')
     })
 
     it('unregistering the agent-package falls back through the precedence chain', () => {

--- a/tests/plugins/workflows/sync-hook.test.ts
+++ b/tests/plugins/workflows/sync-hook.test.ts
@@ -17,6 +17,7 @@ import type {
   PluginContext,
   FileBackedContentTypeDefinition,
 } from '@bakin/core/plugin-types'
+import type { WorkflowDefinition } from '../../../plugins/workflows/types'
 import { BakinEventBus } from '../../../src/lib/events/event-bus'
 import { MarkdownStorageAdapter } from '../../../src/lib/storage/markdown-adapter'
 import { createMockRuntimeAdapter } from '@bakin/core/adapters/runtime/testing'
@@ -65,6 +66,8 @@ mock.module('@/core/task-store', () => ({
 }))
 
 import workflowsPlugin from '../../../plugins/workflows'
+import { clearSourceRegistry, registerPluginDefinition } from '../../../plugins/workflows/lib/source-registry'
+import { resetWorkflowAvailabilityCache, setWorkflowDisabled } from '../../../plugins/workflows/lib/availability'
 
 afterAll(() => {
   rmSync(testDir, { recursive: true, force: true })
@@ -159,11 +162,28 @@ const SAMPLE_INSTANCE = (taskId: string) => JSON.stringify({
   updatedAt: '2026-04-12T00:00:00.000Z',
 })
 
+const MANAGED_DEF: WorkflowDefinition = {
+  name: 'Managed Flow',
+  description: 'A plugin-shipped workflow',
+  version: 1,
+  steps: [
+    {
+      id: 'managed-step',
+      type: 'agent',
+      label: 'Managed step',
+      agent: 'writer',
+      prompt: 'run managed step',
+    },
+  ],
+}
+
 describe('workflows plugin — file-backed sync hook', () => {
   beforeEach(() => {
     rmSync(testDir, { recursive: true, force: true })
     mkdirSync(defsDir, { recursive: true })
     mkdirSync(instancesDir, { recursive: true })
+    clearSourceRegistry()
+    resetWorkflowAvailabilityCache()
   })
 
   it('registers a file-backed content type with TWO filePatterns', async () => {
@@ -245,11 +265,12 @@ describe('workflows plugin — file-backed sync hook', () => {
     expect(doc).toBeNull()
   })
 
-  it('reindex generator yields both definitions and instances', async () => {
+  it('reindex generator yields effective definitions from every source and instances', async () => {
     writeFileSync(join(defsDir, 'one.yaml'), SAMPLE_DEF.replace('Sample Flow', 'One'))
     writeFileSync(join(defsDir, 'two.yml'), SAMPLE_DEF.replace('Sample Flow', 'Two'))
     writeFileSync(join(instancesDir, 'task-1.json'), SAMPLE_INSTANCE('task-1'))
     writeFileSync(join(instancesDir, 'task-2.json'), SAMPLE_INSTANCE('task-2'))
+    registerPluginDefinition('workflows', 'managed', MANAGED_DEF)
 
     const captured = makeCtx()
     await workflowsPlugin.activate(captured.ctx)
@@ -259,22 +280,92 @@ describe('workflows plugin — file-backed sync hook', () => {
       yielded.push(item as { key: string; doc: Record<string, unknown> })
     }
     const keys = yielded.map(y => y.key).sort()
-    expect(keys).toEqual(['def:one', 'def:two', 'inst:task-1', 'inst:task-2'])
+    expect(keys).toEqual(['def:managed', 'def:one', 'def:two', 'inst:task-1', 'inst:task-2'])
+    expect(yielded.find(y => y.key === 'def:managed')?.doc).toMatchObject({
+      name: 'Managed Flow',
+      type: 'definition',
+      status: 'active',
+    })
+  })
+
+  it('indexes a user shadow as active even when the managed fallback is disabled', async () => {
+    registerPluginDefinition('workflows', 'shadowed', MANAGED_DEF)
+    setWorkflowDisabled('shadowed', true)
+    writeFileSync(join(defsDir, 'shadowed.yaml'), SAMPLE_DEF.replace('Sample Flow', 'User Shadow'))
+
+    const captured = makeCtx()
+    await workflowsPlugin.activate(captured.ctx)
+
+    const yielded: Array<{ key: string; doc: Record<string, unknown> }> = []
+    for await (const item of captured.capturedDef!.reindex()) {
+      yielded.push(item as { key: string; doc: Record<string, unknown> })
+    }
+
+    expect(yielded.find(y => y.key === 'def:shadowed')?.doc).toMatchObject({
+      name: 'User Shadow',
+      type: 'definition',
+      status: 'active',
+    })
   })
 
   it('verifyExists handles def: keys (yaml and yml) and inst: keys', async () => {
     writeFileSync(join(defsDir, 'present.yaml'), SAMPLE_DEF)
     writeFileSync(join(defsDir, 'present-yml.yml'), SAMPLE_DEF)
     writeFileSync(join(instancesDir, 'task-99.json'), SAMPLE_INSTANCE('task-99'))
+    registerPluginDefinition('workflows', 'managed', MANAGED_DEF)
 
     const captured = makeCtx()
     await workflowsPlugin.activate(captured.ctx)
 
     expect(await captured.capturedDef!.verifyExists!('def:present')).toBe(true)
     expect(await captured.capturedDef!.verifyExists!('def:present-yml')).toBe(true)
+    expect(await captured.capturedDef!.verifyExists!('def:managed')).toBe(true)
     expect(await captured.capturedDef!.verifyExists!('def:missing')).toBe(false)
     expect(await captured.capturedDef!.verifyExists!('inst:task-99')).toBe(true)
     expect(await captured.capturedDef!.verifyExists!('inst:task-nope')).toBe(false)
     expect(await captured.capturedDef!.verifyExists!('unknown:foo')).toBe(false)
+  })
+
+  it('unlinking a user definition reindexes the managed fallback when one exists', async () => {
+    registerPluginDefinition('workflows', 'shadowed', {
+      ...MANAGED_DEF,
+      name: 'Managed Shadowed Flow',
+      description: 'Fallback managed workflow',
+    })
+
+    const captured = makeCtx()
+    await workflowsPlugin.activate(captured.ctx)
+
+    await captured.capturedDef!.onUnlink!('workflows/definitions/shadowed.yaml')
+
+    expect(captured.removeCalls).toEqual([])
+    expect(captured.indexCalls).toHaveLength(1)
+    expect(captured.indexCalls[0]).toMatchObject({
+      key: 'def:shadowed',
+      doc: {
+        name: 'Managed Shadowed Flow',
+        type: 'definition',
+      },
+    })
+  })
+
+  it('unlinking one user definition extension keeps the alternate extension indexed', async () => {
+    writeFileSync(join(defsDir, 'alternate.yml'), SAMPLE_DEF.replace('Sample Flow', 'Alternate Extension Flow'))
+
+    const captured = makeCtx()
+    await workflowsPlugin.activate(captured.ctx)
+
+    await captured.capturedDef!.onUnlink!('workflows/definitions/alternate.yaml')
+
+    expect(captured.removeCalls).toEqual([])
+    expect(captured.indexCalls).toHaveLength(1)
+    expect(captured.indexCalls[0]).toMatchObject({
+      key: 'def:alternate',
+      doc: {
+        name: 'Alternate Extension Flow',
+        type: 'definition',
+        status: 'active',
+      },
+    })
   })
 })

--- a/tests/plugins/workflows/workflow-actions.test.tsx
+++ b/tests/plugins/workflows/workflow-actions.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-workflow-actions-${Date.now()}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+
+import { ManagedWorkflowCopyDialog } from '../../../plugins/workflows/components/managed-workflow-copy-dialog'
+import { WorkflowDeleteAction } from '../../../plugins/workflows/components/workflow-delete-action'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('workflow action components', () => {
+  it('collects copy metadata before creating a managed workflow copy', () => {
+    const onCopyNameChange = mock()
+    const onCopyIdChange = mock()
+    const onDisableOriginalChange = mock()
+    const onCancel = mock()
+    const onCreate = mock()
+    render(
+      <ManagedWorkflowCopyDialog
+        open
+        creating={false}
+        copyName="Video Script Copy"
+        copyId="video-script-copy"
+        disableOriginal
+        onOpenChange={() => {}}
+        onCopyNameChange={onCopyNameChange}
+        onCopyIdChange={onCopyIdChange}
+        onDisableOriginalChange={onDisableOriginalChange}
+        onCancel={onCancel}
+        onCreate={onCreate}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Edit managed workflow')).toBeDefined()
+    expect(within(dialog).getByText(/Bakin will create a custom copy/i)).toBeDefined()
+
+    fireEvent.change(within(dialog).getByLabelText(/copy name/i), {
+      target: { value: 'Draft Script Copy' },
+    })
+    fireEvent.change(within(dialog).getByLabelText(/workflow id/i), {
+      target: { value: 'draft-script-copy' },
+    })
+    fireEvent.click(within(dialog).getByRole('checkbox'))
+    fireEvent.click(within(dialog).getByRole('button', { name: /create copy/i }))
+    fireEvent.click(within(dialog).getByRole('button', { name: /back/i }))
+
+    expect(onCopyNameChange).toHaveBeenCalledWith('Draft Script Copy')
+    expect(onCopyIdChange).toHaveBeenCalledWith('draft-script-copy')
+    expect(onDisableOriginalChange).toHaveBeenCalledWith(false)
+    expect(onCreate).toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('uses a confirmation dialog for workflow deletion and closes after success', async () => {
+    const onDelete = mock(() => Promise.resolve(true))
+    const onClearError = mock()
+    render(
+      <WorkflowDeleteAction
+        workflowName="Video Script Copy"
+        error="Previous delete failed"
+        onClearError={onClearError}
+        onDelete={onDelete}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /delete workflow/i }))
+    expect(onClearError).toHaveBeenCalled()
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText(/Video Script Copy/)).toBeDefined()
+    expect(within(dialog).getByText('Previous delete failed')).toBeDefined()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }))
+
+    expect(onDelete).toHaveBeenCalled()
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+
+  it('keeps the delete confirmation open when deletion reports failure', async () => {
+    const onDelete = mock(() => Promise.resolve(false))
+    render(
+      <WorkflowDeleteAction
+        workflowName="Video Script Copy"
+        onDelete={onDelete}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /delete workflow/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }))
+
+    expect(onDelete).toHaveBeenCalled()
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined())
+  })
+})

--- a/tests/plugins/workflows/workflow-canvas-editor.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas-editor.test.tsx
@@ -10,11 +10,20 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
 const testDir = join(tmpdir(), `bakin-test-canvas-editor-${Date.now()}`)
+let latestHistoryBlock: {
+  enableBeforeUnload?: boolean
+  blockerFn: (args: {
+    action: string
+    currentLocation: { pathname: string }
+    nextLocation: { pathname: string }
+  }) => Promise<boolean>
+} | null = null
+let unblockHistory: ReturnType<typeof mock>
 
 // CLAUDE.md — content-dir mock even for pure UI tests.
 mock.module('@bakin/core/main-agent', () => ({
@@ -46,19 +55,154 @@ mock.module('@/core/task-store', () => ({
   getTaskWithColumn: mock(() => null),
 }))
 
-// Stub xyflow so we render in jsdom without pulling its real DOM layer.
-// The scaffold we're testing only cares about the Save button in the
-// toolbar — `nodes` / `edges` plumbing is ReactFlow's problem once the
-// library is loaded, not ours.
+mock.module('@tanstack/react-router', () => ({
+  useRouter: () => ({
+    parseLocation: (location: { pathname: string }) => location,
+    history: {
+      block: (options: typeof latestHistoryBlock) => {
+        latestHistoryBlock = options
+        return unblockHistory
+      },
+    },
+  }),
+  useNavigate: () => mock(),
+  useLocation: () => ({ pathname: '/workflows/video-script/edit', search: {} }),
+  useParams: () => ({}),
+}))
+
+interface ReactFlowStubProps {
+  children?: React.ReactNode
+  nodes?: Array<{
+    id: string
+    className?: string
+    data?: {
+      insertIndex?: number
+      onInsert?: (kind: string, index: number) => void
+      onOpenPalette?: () => void
+    }
+    selected?: boolean
+    initialWidth?: number
+    initialHeight?: number
+    measured?: { width?: number; height?: number }
+    style?: { width?: number; height?: number }
+  }>
+  edges?: Array<{
+    id: string
+    source: string
+    target: string
+    data?: {
+      insertIndex?: number
+      onInsert?: (kind: string, index: number) => void
+      onOpenPalette?: () => void
+    }
+  }>
+  onNodeClick?: (event: React.MouseEvent, node: { id: string }) => void
+  onPaneClick?: React.MouseEventHandler<HTMLDivElement>
+  onDragOver?: React.DragEventHandler<HTMLDivElement>
+  onDrop?: React.DragEventHandler<HTMLDivElement>
+  nodesConnectable?: boolean
+  nodeTypes?: Record<string, unknown>
+}
+
+// Stub xyflow so we render in jsdom without pulling its real DOM layer. The
+// stub exposes the controlled node/edge props so editor tests can assert the
+// Bakin workflow contract without depending on React Flow internals.
 mock.module('@xyflow/react', () => ({
   __esModule: true,
-  ReactFlow: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="react-flow-stub">{children}</div>
-  ),
+  ReactFlow: (props: ReactFlowStubProps) => {
+    const {
+      children,
+      nodes = [],
+      edges = [],
+      onNodeClick,
+      onPaneClick,
+      onDragOver,
+      onDrop,
+      nodesConnectable,
+      nodeTypes = {},
+    } = props
+    return (
+      <div
+        data-testid="react-flow-stub"
+        data-connectable={String(nodesConnectable)}
+        data-node-types={Object.keys(nodeTypes).sort().join(',')}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        onClick={(event) => {
+          if (event.target === event.currentTarget) onPaneClick?.(event)
+        }}
+      >
+        <div data-testid="flow-nodes">
+          {nodes.map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              data-testid={`node-${node.id}`}
+              data-class-name={node.className ?? ''}
+              data-selected={String(node.selected ?? false)}
+              data-node-data={JSON.stringify(node.data ?? {})}
+              data-initial-size={`${node.initialWidth ?? ''}x${node.initialHeight ?? ''}`}
+              data-measured-size={`${node.measured?.width ?? ''}x${node.measured?.height ?? ''}`}
+              data-style-size={`${node.style?.width ?? ''}x${node.style?.height ?? ''}`}
+              onClick={(event) => onNodeClick?.(event, node)}
+            >
+              {node.id}
+            </button>
+          ))}
+        </div>
+        <div data-testid="flow-edges">
+          {edges.map((edge) => (
+            <span
+              key={edge.id}
+              data-testid={`edge-${edge.source}-${edge.target}`}
+            >
+              {edge.data?.onInsert && (
+                <>
+                  <button
+                    type="button"
+                    data-testid={`insert-${edge.source}-${edge.target}`}
+                    onClick={() => edge.data?.onInsert?.('agent', edge.data.insertIndex ?? 0)}
+                  >
+                    Insert agent
+                  </button>
+                  <button
+                    type="button"
+                    data-testid={`insert-output-${edge.source}-${edge.target}`}
+                    onClick={() => edge.data?.onInsert?.('output', edge.data.insertIndex ?? 0)}
+                  >
+                    Insert output
+                  </button>
+                </>
+              )}
+              {edge.data?.onOpenPalette && (
+                <button
+                  type="button"
+                  data-testid={`open-palette-${edge.source}-${edge.target}`}
+                  onClick={() => edge.data?.onOpenPalette?.()}
+                >
+                  Open palette
+                </button>
+              )}
+            </span>
+          ))}
+        </div>
+        {children}
+      </div>
+    )
+  },
   Background: () => null,
   BackgroundVariant: { Dots: 'dots' },
   Controls: () => null,
   MiniMap: () => null,
+  NodeToolbar: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="node-toolbar">{children}</div>
+  ),
+  Panel: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="flow-panel">{children}</div>
+  ),
+  BaseEdge: () => null,
+  EdgeLabelRenderer: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  getSmoothStepPath: () => ['M0 0 L1 1', 0, 0],
   applyNodeChanges: (_c: unknown, nds: unknown) => nds,
   applyEdgeChanges: (_c: unknown, eds: unknown) => eds,
 }))
@@ -66,11 +210,47 @@ mock.module('@xyflow/react', () => ({
 // Stub palette + drawer — they have their own dedicated tests. Keeps
 // canvas-editor tests focused on the save pipeline.
 mock.module('../../../plugins/workflows/components/node-type-palette', () => ({
-  NodeTypePalette: () => null,
+  NodeTypePalette: ({
+    collapsed,
+    disabledKinds,
+    onCollapsedChange,
+  }: {
+    collapsed?: boolean
+    disabledKinds?: ReadonlySet<string>
+    onCollapsedChange?: (collapsed: boolean) => void
+  }) => (
+    <aside
+      data-testid="node-type-palette"
+      data-collapsed={String(collapsed ?? false)}
+      data-disabled-kinds={Array.from(disabledKinds ?? []).sort().join(',')}
+    >
+      <button type="button" data-testid="collapse-palette" onClick={() => onCollapsedChange?.(true)}>
+        Collapse palette
+      </button>
+    </aside>
+  ),
   PALETTE_DRAG_MIME_TYPE: 'application/x-bakin-node-kind',
 }))
 mock.module('../../../plugins/workflows/components/node-config-drawer', () => ({
-  NodeConfigDrawer: () => null,
+  NodeConfigDrawer: ({
+    step,
+    onClose,
+    onDirtyChange,
+  }: {
+    step: { id: string }
+    onClose?: () => void
+    onDirtyChange?: (dirty: boolean) => void
+  }) => (
+    <aside data-testid="node-config-drawer" data-step-id={step.id}>
+      {step.id}
+      <button type="button" onClick={onClose}>
+        Close node drawer
+      </button>
+      <button type="button" onClick={() => onDirtyChange?.(true)}>
+        Mark node dirty
+      </button>
+    </aside>
+  ),
 }))
 
 // Imported AFTER mocks.
@@ -96,6 +276,8 @@ const sampleDefinition: WorkflowDefinition = {
 let fetchMock: ReturnType<typeof mock>
 
 beforeEach(() => {
+  latestHistoryBlock = null
+  unblockHistory = mock()
   fetchMock = mock(() =>
     Promise.resolve(
       new Response(JSON.stringify({ id: 'video-script', source: 'user' }), {
@@ -112,8 +294,50 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+function closeNodeDrawer() {
+  fireEvent.click(screen.getByRole('button', { name: /close node drawer/i }))
+}
+
+function nodeData(id: string): Record<string, unknown> {
+  return JSON.parse(screen.getByTestId(`node-${id}`).getAttribute('data-node-data') || '{}') as Record<string, unknown>
+}
+
 describe('WorkflowCanvasEditor', () => {
   it('renders the toolbar with the workflow id in edit mode', () => {
+    const onCancel = mock()
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+        onCancel={onCancel}
+      />,
+    )
+    expect(screen.getByText('Video Script')).toBeDefined()
+    expect(screen.getByText('video-script')).toBeDefined()
+    expect(screen.getByText('Write a script')).toBeDefined()
+    expect(screen.getByRole('button', { name: /edit workflow details/i })).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /back to workflows/i }))
+    expect(onCancel).toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /save/i })).toBeDefined()
+  })
+
+  it('labels user workflows that shadow a managed default', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+        shadowedSource={{ source: 'plugin', pluginId: 'workflows' }}
+      />,
+    )
+
+    expect(screen.getByText('Shadows managed default')).toBeDefined()
+  })
+
+  it('saves workflow metadata from the details drawer in edit mode', async () => {
     render(
       <WorkflowCanvasEditor
         mode="edit"
@@ -122,8 +346,55 @@ describe('WorkflowCanvasEditor', () => {
         source="user"
       />,
     )
-    expect(screen.getByText(/Edit · video-script/)).toBeDefined()
-    expect(screen.getByRole('button', { name: /save/i })).toBeDefined()
+
+    const canvasSave = screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement
+    expect(canvasSave.disabled).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: /edit workflow details/i }))
+    expect(screen.getByText('Workflow details')).toBeDefined()
+    expect(canvasSave.disabled).toBe(true)
+    const cancel = screen.getByRole('button', { name: /cancel/i })
+    const saveDetails = screen.getByRole('button', { name: /save details/i })
+    expect(cancel.compareDocumentPosition(saveDetails) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText(/^name/i), {
+      target: { value: 'Video Script Draft' },
+    })
+    fireEvent.change(screen.getByLabelText(/^description/i), {
+      target: { value: 'Draft and review a video script.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /save details/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(canvasSave.disabled).toBe(false))
+    expect(screen.getByText('Video Script Draft')).toBeDefined()
+    expect(screen.getByText('Draft and review a video script.')).toBeDefined()
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/plugins/workflows/definitions/video-script')
+    expect(init.method).toBe('PUT')
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.name).toBe('Video Script Draft')
+    expect(body.description).toBe('Draft and review a video script.')
+  })
+
+  it('disables the canvas Save button while a step drawer is open', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    const canvasSave = screen.getByRole('button', { name: /^save$/i }) as HTMLButtonElement
+    expect(canvasSave.disabled).toBe(false)
+    fireEvent.click(screen.getByTestId('node-write'))
+    expect(screen.getByTestId('node-config-drawer')).toBeDefined()
+    expect(canvasSave.disabled).toBe(true)
+    closeNodeDrawer()
+    expect(canvasSave.disabled).toBe(false)
   })
 
   it('saves via PUT and includes layout.positions in the payload', async () => {
@@ -135,7 +406,8 @@ describe('WorkflowCanvasEditor', () => {
         source="user"
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /auto-arrange/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
     const [url, init] = fetchMock.mock.calls[0]
@@ -144,12 +416,650 @@ describe('WorkflowCanvasEditor', () => {
 
     const body = JSON.parse(init.body as string) as WorkflowDefinition
     expect(body.name).toBe('Video Script')
-    expect(body.layout?.positions?.write).toEqual({ x: 100, y: 50 })
-    expect(body.layout?.positions?.review).toEqual({ x: 100, y: 200 })
+    expect(body.layout?.positions?.write).toBeDefined()
+    expect(body.layout?.positions?.review).toBeDefined()
   })
 
-  it('shows plugin-owned hint when source is "plugin"', () => {
+  it('does not rewrite a clean workflow when Save is clicked unchanged', () => {
     render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('creates a workflow from the setup dialog before entering the canvas', async () => {
+    const onSaved = mock()
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ id: 'launch-plan', source: 'user' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+
+    render(
+      <WorkflowCanvasEditor
+        mode="create"
+        onSaved={onSaved}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getAllByText('Create workflow').length).toBeGreaterThan(0)
+
+    fireEvent.change(within(dialog).getByLabelText(/workflow name/i), {
+      target: { value: 'Launch Plan' },
+    })
+    expect((within(dialog).getByLabelText(/workflow id/i) as HTMLInputElement).value).toBe('launch-plan')
+    fireEvent.change(within(dialog).getByLabelText(/description/i), {
+      target: { value: 'Plan and approve a campaign launch.' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: /create workflow/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/plugins/workflows/definitions')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as WorkflowDefinition & { id: string }
+    expect(body.id).toBe('launch-plan')
+    expect(body.name).toBe('Launch Plan')
+    expect(body.description).toBe('Plan and approve a campaign launch.')
+    expect(body.steps).toEqual([])
+    expect(onSaved).toHaveBeenCalledWith('launch-plan')
+  })
+
+  it('shows field-level setup validation before creating a workflow', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="create"
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /create workflow/i }))
+
+    expect(within(dialog).getByText('Workflow name is required.')).toBeDefined()
+    expect(within(dialog).getByText('Workflow id is required.')).toBeDefined()
+    expect(within(dialog).queryByText(/validation failed/i)).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('explains stale empty-step server validation in the setup dialog', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({
+          error: 'validation failed',
+          issues: [
+            {
+              code: 'too_small',
+              path: ['steps'],
+              message: 'Too small: expected array to have >=1 items',
+            },
+          ],
+        }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+
+    render(
+      <WorkflowCanvasEditor
+        mode="create"
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText(/workflow name/i), {
+      target: { value: 'Testing' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: /create workflow/i }))
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(/old server schema/i)).toBeDefined()
+    })
+    expect(within(dialog).queryByText(/^validation failed$/i)).toBeNull()
+  })
+
+  it('disables manual edge authoring and renders derived order edges', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+    expect(screen.getByTestId('react-flow-stub').getAttribute('data-connectable')).toBe('false')
+    expect(screen.getByTestId('react-flow-stub').getAttribute('data-node-types')).toContain('agent')
+    expect(screen.getByTestId('react-flow-stub').getAttribute('data-node-types')).toContain('appendStep')
+    expect(screen.getByTestId('node-__trigger')).toBeDefined()
+    expect(screen.getByTestId('node-__append')).toBeDefined()
+    expect(screen.getByTestId('node-write').getAttribute('data-initial-size')).toBe('x')
+    expect(screen.getByTestId('node-write').getAttribute('data-measured-size')).toBe('x')
+    expect(screen.getByTestId('node-write').getAttribute('data-style-size')).toBe('280x120')
+    expect(screen.getByTestId('edge-__trigger-write')).toBeDefined()
+    expect(screen.getByTestId('edge-write-review')).toBeDefined()
+    expect(screen.getByTestId('edge-review-__append')).toBeDefined()
+  })
+
+  it('passes assignee metadata through edit canvas nodes consistently', () => {
+    const withAssignmentMetadata: WorkflowDefinition = {
+      name: 'Publishing flow',
+      description: 'Metadata rendering',
+      version: 1,
+      steps: [
+        { id: 'write', type: 'agent', label: 'Write Copy', agent: '$assigned', task: 'Draft copy.' },
+        { id: 'publish', type: 'output', label: 'Publish', agent: 'hugo', channels: ['general'] },
+        {
+          id: 'follow-up',
+          type: 'createTask',
+          label: 'Follow Up',
+          title: 'Review published post',
+          agent: 'jessica',
+          column: 'todo',
+          description: 'Check the published result.',
+        },
+      ],
+      layout: {
+        positions: {
+          write: { x: 100, y: 50 },
+          publish: { x: 100, y: 200 },
+          'follow-up': { x: 100, y: 350 },
+        },
+      },
+    }
+
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="publishing-flow"
+        initialDefinition={withAssignmentMetadata}
+        source="user"
+      />,
+    )
+
+    expect(nodeData('write').agent).toBe('$assigned')
+    expect(nodeData('publish')).toMatchObject({
+      agent: 'hugo',
+      channels: ['general'],
+    })
+    expect(nodeData('follow-up')).toMatchObject({
+      agent: 'jessica',
+      title: 'Review published post',
+      column: 'todo',
+      description: 'Check the published result.',
+    })
+  })
+
+  it('reopens the step palette when the edge insert affordance is clicked', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    expect(screen.getByTestId('node-type-palette').getAttribute('data-collapsed')).toBe('false')
+    fireEvent.click(screen.getByTestId('collapse-palette'))
+    expect(screen.getByTestId('node-type-palette').getAttribute('data-collapsed')).toBe('true')
+    fireEvent.click(screen.getByTestId('open-palette-__trigger-write'))
+    expect(screen.getByTestId('node-type-palette').getAttribute('data-collapsed')).toBe('false')
+  })
+
+  it('renders nodes when the workflow definition arrives after mount', () => {
+    const { rerender } = render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        source="user"
+      />,
+    )
+
+    expect(screen.queryByTestId('node-write')).toBeNull()
+
+    rerender(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    expect(screen.getByTestId('node-write')).toBeDefined()
+    expect(screen.getByTestId('node-review')).toBeDefined()
+    expect(screen.getByTestId('edge-write-review')).toBeDefined()
+  })
+
+  it('preserves dependsOn and YAML fields the editor does not own on save', async () => {
+    const withMetadata = {
+      ...sampleDefinition,
+      metadata: { owner: 'workflow-audit' },
+      triggers: [{ type: 'manual', enabled: true }],
+      steps: [
+        {
+          id: 'write',
+          type: 'agent',
+          label: 'Write',
+          agent: 'chef',
+          model_policy: { maxCostUsd: 3 },
+        },
+        {
+          id: 'review',
+          type: 'gate',
+          label: 'Review',
+          on_approve: 'done',
+          dependsOn: 'write',
+        },
+      ],
+      layout: {
+        ...sampleDefinition.layout,
+        viewport: { x: 12, y: 18, zoom: 0.75 },
+      },
+    } as unknown as WorkflowDefinition
+
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={withMetadata}
+        source="user"
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /auto-arrange/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition & Record<string, unknown>
+    expect(body.metadata).toEqual({ owner: 'workflow-audit' })
+    expect(body.triggers).toEqual([{ type: 'manual', enabled: true }])
+    expect((body.steps[0] as unknown as Record<string, unknown>).model_policy).toEqual({ maxCostUsd: 3 })
+    expect((body.steps[1] as unknown as Record<string, unknown>).dependsOn).toBe('write')
+    expect((body.layout as Record<string, unknown>).viewport).toEqual({ x: 12, y: 18, zoom: 0.75 })
+  })
+
+  it('reorders the selected node and saves the new runtime order', async () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+    fireEvent.click(screen.getByTestId('node-review'))
+    expect(screen.getByTestId('node-review').getAttribute('data-selected')).toBe('true')
+    expect(screen.getByTestId('node-review').getAttribute('data-class-name')).toContain('bakin-workflow-node-selected')
+    fireEvent.click(screen.getByRole('button', { name: /move selected step up/i }))
+    closeNodeDrawer()
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.steps.map((step) => step.id)).toEqual(['review', 'write'])
+  })
+
+  it('deletes the selected node and keeps the saved workflow connected', async () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('node-review'))
+    fireEvent.click(screen.getByRole('button', { name: /delete selected step/i }))
+    expect(screen.queryByTestId('node-review')).toBeNull()
+    expect(screen.getByTestId('edge-__trigger-write')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.steps.map((step) => step.id)).toEqual(['write'])
+  })
+
+  it('defaults inserted agent steps to the assigned task agent token', async () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('insert-__trigger-write'))
+    closeNodeDrawer()
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.steps[0]).toMatchObject({
+      id: 'agent',
+      type: 'agent',
+      label: 'Agent Task',
+      agent: '$assigned',
+    })
+  })
+
+  it('opens the config drawer for a newly dropped step', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    expect(screen.queryByTestId('node-config-drawer')).toBeNull()
+
+    const dataTransfer = {
+      types: ['application/x-bakin-node-kind', 'text/plain'],
+      dropEffect: 'move',
+      getData: mock((type: string) => (
+        type === 'application/x-bakin-node-kind' || type === 'text/plain' ? 'agent' : ''
+      )),
+    }
+    const canvas = screen.getByTestId('react-flow-stub')
+    fireEvent.dragOver(canvas, { dataTransfer })
+    fireEvent.drop(canvas, { dataTransfer })
+
+    expect(screen.getByTestId('node-config-drawer').getAttribute('data-step-id')).toBe('agent')
+    expect(screen.getByTestId('node-agent').getAttribute('data-selected')).toBe('true')
+  })
+
+  it('ignores drops that only provide text/plain data', () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    const dataTransfer = {
+      types: ['text/plain'],
+      dropEffect: 'move',
+      getData: mock((type: string) => (type === 'text/plain' ? 'agent' : '')),
+    }
+    const canvas = screen.getByTestId('react-flow-stub')
+    fireEvent.dragOver(canvas, { dataTransfer })
+    fireEvent.drop(canvas, { dataTransfer })
+
+    expect(screen.queryByTestId('node-agent')).toBeNull()
+    expect(screen.queryByTestId('node-config-drawer')).toBeNull()
+  })
+
+  it('appends a step from the end-of-workflow target', async () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('insert-review-__append'))
+    expect(screen.getByTestId('node-config-drawer').getAttribute('data-step-id')).toBe('agent')
+
+    closeNodeDrawer()
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.steps.map((step) => step.id)).toEqual(['write', 'review', 'agent'])
+  })
+
+  it('disables completion when the workflow already has one and blocks duplicate insertion', async () => {
+    const withCompletion: WorkflowDefinition = {
+      ...sampleDefinition,
+      steps: [
+        ...sampleDefinition.steps,
+        { id: 'publish', type: 'output', label: 'Publish', channels: ['general'] },
+      ],
+      layout: {
+        positions: {
+          ...sampleDefinition.layout!.positions!,
+          publish: { x: 100, y: 350 },
+        },
+      },
+    }
+
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={withCompletion}
+        source="user"
+      />,
+    )
+
+    expect(screen.getByTestId('node-type-palette').getAttribute('data-disabled-kinds')).toBe('output')
+    fireEvent.click(screen.getByTestId('insert-output-publish-__append'))
+    expect(screen.queryByTestId('node-output')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /auto-arrange/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.steps.filter((step) => step.type === 'output')).toHaveLength(1)
+    expect(body.steps.map((step) => step.id)).toEqual(['write', 'review', 'publish'])
+  })
+
+  it('prompts before leaving with unsaved changes and can save before exit', async () => {
+    const onCancel = mock()
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+        onCancel={onCancel}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('insert-review-__append'))
+    fireEvent.click(screen.getByRole('button', { name: /back to workflows/i }))
+
+    expect(onCancel).not.toHaveBeenCalled()
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Unsaved workflow changes')).toBeDefined()
+    fireEvent.click(within(dialog).getByRole('button', { name: /save and exit/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(onCancel).toHaveBeenCalled())
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(init.body as string) as WorkflowDefinition
+    expect(body.steps.map((step) => step.id)).toEqual(['write', 'review', 'agent'])
+  })
+
+  it('registers a router navigation blocker while the editor has unsaved changes', async () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+      />,
+    )
+
+    expect(latestHistoryBlock).toBeNull()
+    fireEvent.click(screen.getByTestId('insert-review-__append'))
+    await waitFor(() => expect(latestHistoryBlock).not.toBeNull())
+    expect(latestHistoryBlock?.enableBeforeUnload).toBe(false)
+
+    await expect(latestHistoryBlock!.blockerFn({
+      action: 'REPLACE',
+      currentLocation: { pathname: '/workflows/video-script/edit' },
+      nextLocation: { pathname: '/workflows/video-script/edit' },
+    })).resolves.toBe(false)
+
+    let routeDecision!: Promise<boolean>
+    await act(async () => {
+      routeDecision = latestHistoryBlock!.blockerFn({
+        action: 'PUSH',
+        currentLocation: { pathname: '/workflows/video-script/edit' },
+        nextLocation: { pathname: '/workflows' },
+      })
+    })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Unsaved workflow changes')).toBeDefined()
+    let shouldBlockRoute = false
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole('button', { name: /^cancel$/i }))
+      shouldBlockRoute = await routeDecision
+    })
+    expect(shouldBlockRoute).toBe(true)
+  })
+
+  it('shows a managed-workflow modal when editing a plugin-owned workflow', () => {
+    const onCancel = mock()
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="plugin"
+        onCancel={onCancel}
+      />,
+    )
+    expect(screen.getByText('Managed workflow')).toBeDefined()
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText(/Edit managed workflow/)).toBeDefined()
+    expect(within(dialog).getByText(/To edit this workflow, Bakin will create a custom copy/i)).toBeDefined()
+    fireEvent.click(within(dialog).getByRole('button', { name: /back/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('uses a confirmation dialog before deleting a workflow', async () => {
+    const onDeleted = mock()
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={sampleDefinition}
+        source="user"
+        onDeleted={onDeleted}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /delete workflow/i }))
+    expect(fetchMock).not.toHaveBeenCalled()
+    let dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Delete workflow?')).toBeDefined()
+    fireEvent.click(within(dialog).getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /delete workflow/i }))
+    dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/plugins/workflows/definitions/video-script')
+    expect(init.method).toBe('DELETE')
+    expect(onDeleted).toHaveBeenCalled()
+  })
+
+  it('creates a named custom copy and can disable the managed workflow', async () => {
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={{ ...sampleDefinition, id: 'video-script' }}
+        source="plugin"
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /create copy/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/plugins/workflows/definitions')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as WorkflowDefinition & { id: string }
+    expect(body.id).toBe('video-script-copy')
+    expect(body.name).toBe('Video Script Copy')
+    expect(body.steps.map((step) => step.id)).toEqual(['write', 'review'])
+
+    const [availabilityUrl, availabilityInit] = fetchMock.mock.calls[1]
+    expect(availabilityUrl).toBe('/api/plugins/workflows/definitions/video-script/availability')
+    expect(availabilityInit.method).toBe('PATCH')
+    expect(JSON.parse(availabilityInit.body as string)).toEqual({ disabled: true })
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save/i })).toBeDefined())
+  })
+
+  it('continues into the custom copy when disabling the managed workflow fails', async () => {
+    const onCopied = mock()
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === '/api/plugins/workflows/definitions' && init?.method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 'video-script-copy', source: 'user' }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      if (url === '/api/plugins/workflows/definitions/video-script/availability' && init?.method === 'PATCH') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'availability unavailable' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: `unexpected ${url}` }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+
+    render(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script"
+        initialDefinition={{ ...sampleDefinition, id: 'video-script' }}
+        source="plugin"
+        onCopied={onCopied}
+      />,
+    )
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /create copy/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(onCopied).toHaveBeenCalledWith('video-script-copy')
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('closes the managed-workflow modal after navigating to a custom copy', () => {
+    const { rerender } = render(
       <WorkflowCanvasEditor
         mode="edit"
         initialId="video-script"
@@ -157,7 +1067,19 @@ describe('WorkflowCanvasEditor', () => {
         source="plugin"
       />,
     )
-    expect(screen.getByText(/plugin-owned/)).toBeDefined()
+
+    expect(screen.getByRole('dialog')).toBeDefined()
+
+    rerender(
+      <WorkflowCanvasEditor
+        mode="edit"
+        initialId="video-script-copy"
+        initialDefinition={{ ...sampleDefinition, id: 'video-script-copy', name: 'Video Script Copy' }}
+        source="user"
+      />,
+    )
+
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('auto-arranges nodes when layout.positions is absent', async () => {
@@ -173,18 +1095,19 @@ describe('WorkflowCanvasEditor', () => {
         source="user"
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+    fireEvent.click(screen.getByRole('button', { name: /auto-arrange/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
     const [, init] = fetchMock.mock.calls[0]
     const body = JSON.parse(init.body as string) as WorkflowDefinition
-    // Dagre produces a left-to-right arrangement (rankdir: 'LR'); we only
-    // assert that write is to the left of review — the exact coordinates
+    // Dagre produces a top-to-bottom arrangement (rankdir: 'TB'); we only
+    // assert that write is above review — the exact coordinates
     // depend on the layout engine's internals.
     const write = body.layout?.positions?.write
     const review = body.layout?.positions?.review
     expect(write).toBeDefined()
     expect(review).toBeDefined()
-    expect(write!.x).toBeLessThan(review!.x)
+    expect(write!.y).toBeLessThan(review!.y)
   })
 })

--- a/tests/plugins/workflows/workflow-canvas.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { ReactNode } from 'react'
+
+const testDir = join(tmpdir(), `bakin-test-workflow-canvas-${Date.now()}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@/core/task-store', () => ({}))
+
+interface ReactFlowStubProps {
+  children?: ReactNode
+  nodes?: Array<{ id: string; type?: string }>
+  edges?: Array<{ id: string; source: string; target: string }>
+  nodeTypes?: Record<string, unknown>
+  onNodeClick?: (event: unknown, node: { id: string }) => void
+}
+
+mock.module('@xyflow/react', () => ({
+  __esModule: true,
+  ReactFlow: ({ children, nodes = [], edges = [], nodeTypes = {}, onNodeClick }: ReactFlowStubProps) => (
+    <div data-testid="react-flow-stub" data-node-types={Object.keys(nodeTypes).sort().join(',')}>
+      <div data-testid="flow-nodes">
+        {nodes.map((node) => (
+          <button
+            key={node.id}
+            type="button"
+            data-testid={`node-${node.id}`}
+            data-node-type={node.type}
+            onClick={(event) => onNodeClick?.(event, node)}
+          >
+            {node.id}
+          </button>
+        ))}
+      </div>
+      <div data-testid="flow-edges">
+        {edges.map((edge) => (
+          <span key={edge.id} data-testid={`edge-${edge.source}-${edge.target}`} />
+        ))}
+      </div>
+      {children}
+    </div>
+  ),
+  Background: () => null,
+  BackgroundVariant: { Dots: 'dots' },
+  Controls: () => null,
+  MiniMap: () => null,
+  applyNodeChanges: (_changes: unknown, nodes: unknown) => nodes,
+}))
+
+import { WorkflowCanvas } from '../../../plugins/workflows/components/workflow-canvas'
+import type { WorkflowDefinition, WorkflowStep } from '../../../plugins/workflows/types'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('WorkflowCanvas', () => {
+  it('preserves plugin-owned step types so registered renderers can display them', () => {
+    const pluginStep = {
+      id: 'denoise',
+      type: 'media.noise-gate',
+      label: 'Denoise',
+      threshold: 0.7,
+    } as unknown as WorkflowStep
+    const definition: WorkflowDefinition = {
+      name: 'Plugin workflow',
+      description: 'Uses a plugin node',
+      version: 1,
+      steps: [pluginStep],
+    }
+
+    render(<WorkflowCanvas definition={definition} />)
+
+    expect(screen.getByTestId('node-denoise').getAttribute('data-node-type')).toBe('media.noise-gate')
+  })
+})

--- a/tests/plugins/workflows/workflow-detail.test.tsx
+++ b/tests/plugins/workflows/workflow-detail.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-workflow-detail-${Date.now()}`)
+const routerPush = mock()
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+
+mock.module('@/core/task-store', () => ({
+  createTask: mock(),
+  addTaskLog: mock(),
+  moveTask: mock(),
+  readTaskboard: mock(() => ({
+    columns: { backlog: [], inProgress: [], todo: [], review: [], done: [], archived: [], blocked: [] },
+  })),
+  getTask: mock(() => null),
+  getTaskWithColumn: mock(() => null),
+}))
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useRouter: () => ({
+    push: routerPush,
+    replace: () => {},
+    back: () => {},
+    forward: () => {},
+    refresh: () => {},
+    prefetch: () => {},
+  }),
+}))
+
+mock.module('@makinbakin/sdk/components', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span data-testid={`agent-${agentId}`} />,
+}))
+
+mock.module('../../../plugins/workflows/components/workflow-canvas', () => ({
+  WorkflowCanvas: () => <div data-testid="workflow-canvas" />,
+}))
+
+mock.module('../../../plugins/workflows/components/step-detail-drawer', () => ({
+  StepDetailDrawer: () => null,
+}))
+
+mock.module('../../../plugins/workflows/components/workflow-card', () => ({
+  collectAgents: () => [],
+}))
+
+import { WorkflowDetail } from '../../../plugins/workflows/components/workflow-detail'
+
+const pluginDefinition = {
+  id: 'video-script',
+  name: 'Video Script',
+  description: 'Draft a video script',
+  version: 1,
+  steps: [
+    {
+      id: 'write',
+      type: 'agent',
+      label: 'Write',
+      agent: 'chef',
+      task: 'Write the script',
+    },
+  ],
+}
+
+const userDefinition = {
+  ...pluginDefinition,
+  id: 'clip-creation-copy',
+  name: 'Clip Creation Copy',
+  description: 'Custom clip workflow',
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function setupPluginDefinitionFetch(options: { disabled?: boolean; availabilityStatus?: number } = {}) {
+  const fetchMock = mock((url: string, init?: RequestInit) => {
+    if (url === '/api/plugins/workflows/definitions/video-script' && !init) {
+      return Promise.resolve(jsonResponse({
+        definition: pluginDefinition,
+        subWorkflows: {},
+        source: 'plugin',
+        pluginId: 'workflows',
+        disabled: options.disabled === true,
+      }))
+    }
+    if (url === '/api/plugins/workflows/definitions' && init?.method === 'POST') {
+      return Promise.resolve(jsonResponse({ id: 'video-script-copy', source: 'user' }, 201))
+    }
+    if (url === '/api/plugins/workflows/definitions/video-script/availability' && init?.method === 'PATCH') {
+      const body = JSON.parse(init.body as string) as { disabled: boolean }
+      if (options.availabilityStatus && options.availabilityStatus !== 200) {
+        return Promise.resolve(jsonResponse({ error: 'availability unavailable' }, options.availabilityStatus))
+      }
+      return Promise.resolve(jsonResponse({ id: 'video-script', disabled: body.disabled }))
+    }
+    return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, 500))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function setupUserDefinitionFetch() {
+  const fetchMock = mock((url: string, init?: RequestInit) => {
+    if (url === '/api/plugins/workflows/definitions/clip-creation-copy' && !init) {
+      return Promise.resolve(jsonResponse({
+        definition: userDefinition,
+        subWorkflows: {},
+        source: 'user',
+        shadowedSource: { source: 'plugin', pluginId: 'workflows' },
+        disabled: false,
+      }))
+    }
+    if (url === '/api/plugins/workflows/definitions/clip-creation-copy' && init?.method === 'DELETE') {
+      return Promise.resolve(jsonResponse({ id: 'clip-creation-copy', deleted: true }))
+    }
+    return Promise.resolve(jsonResponse({ error: `unexpected ${url}` }, 500))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  routerPush.mockClear()
+})
+
+beforeEach(() => {
+  routerPush.mockClear()
+})
+
+describe('WorkflowDetail', () => {
+  it('opens the edit dialog before creating a managed workflow copy', async () => {
+    const fetchMock = setupPluginDefinitionFetch()
+
+    render(<WorkflowDetail workflowId="video-script" onBack={() => {}} />)
+
+    const edit = await screen.findByRole('button', { name: /^edit$/i })
+    expect(screen.getByText(/This workflow is managed by Bakin directly/i)).toBeDefined()
+    expect(screen.queryByRole('button', { name: /delete workflow/i })).toBeNull()
+    fireEvent.click(edit)
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText(/Edit managed workflow/)).toBeDefined()
+    expect(within(dialog).getByText(/To edit this workflow, Bakin will create a custom copy/i)).toBeDefined()
+    expect((screen.getByLabelText(/copy name/i) as HTMLInputElement).value).toBe('Video Script Copy')
+    expect((screen.getByLabelText(/workflow id/i) as HTMLInputElement).value).toBe('video-script-copy')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('creates the named copy, disables the managed original, and navigates to the copy editor', async () => {
+    const fetchMock = setupPluginDefinitionFetch()
+
+    render(<WorkflowDetail workflowId="video-script" onBack={() => {}} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /^edit$/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText(/copy name/i), {
+      target: { value: 'My Better Flow' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: /create copy/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    const [, createInit] = fetchMock.mock.calls[1]
+    expect(createInit).toBeDefined()
+    const createBody = JSON.parse(createInit!.body as string) as Record<string, unknown>
+    expect(createBody.id).toBe('my-better-flow')
+    expect(createBody.name).toBe('My Better Flow')
+
+    const [, availabilityInit] = fetchMock.mock.calls[2]
+    expect(availabilityInit).toBeDefined()
+    expect(JSON.parse(availabilityInit!.body as string)).toEqual({ disabled: true })
+    expect(routerPush).toHaveBeenCalledWith('/workflows/my-better-flow/edit')
+  })
+
+  it('still navigates to the copy editor when disabling the managed original fails', async () => {
+    const fetchMock = setupPluginDefinitionFetch({ availabilityStatus: 500 })
+
+    render(<WorkflowDetail workflowId="video-script" onBack={() => {}} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /^edit$/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /create copy/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(routerPush).toHaveBeenCalledWith('/workflows/video-script-copy/edit')
+  })
+
+  it('toggles managed workflow availability from the detail header', async () => {
+    const fetchMock = setupPluginDefinitionFetch()
+
+    render(<WorkflowDetail workflowId="video-script" onBack={() => {}} />)
+
+    expect(await screen.findByText('Enabled')).toBeDefined()
+    fireEvent.click(screen.getByRole('switch', { name: /disable workflow/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const [, availabilityInit] = fetchMock.mock.calls[1]
+    expect(availabilityInit).toBeDefined()
+    expect(JSON.parse(availabilityInit!.body as string)).toEqual({ disabled: true })
+    expect(screen.getByText('Disabled')).toBeDefined()
+    expect(screen.getByText(/matching and automatic starts skip this workflow/i)).toBeDefined()
+    expect((screen.getByRole('button', { name: /^edit$/i }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('can re-enable a disabled managed workflow from the detail header', async () => {
+    const fetchMock = setupPluginDefinitionFetch({ disabled: true })
+
+    render(<WorkflowDetail workflowId="video-script" onBack={() => {}} />)
+
+    expect(await screen.findByText('Disabled')).toBeDefined()
+    expect(screen.getByText(/matching and automatic starts skip this workflow/i)).toBeDefined()
+    expect((screen.getByRole('button', { name: /^edit$/i }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(screen.getByRole('switch', { name: /enable workflow/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const [, availabilityInit] = fetchMock.mock.calls[1]
+    expect(availabilityInit).toBeDefined()
+    expect(JSON.parse(availabilityInit!.body as string)).toEqual({ disabled: false })
+    expect(screen.getByText('Enabled')).toBeDefined()
+    expect(screen.queryByText(/matching and automatic starts skip this workflow/i)).toBeNull()
+    expect((screen.getByRole('button', { name: /^edit$/i }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('deletes a custom workflow from the detail header after confirmation', async () => {
+    const fetchMock = setupUserDefinitionFetch()
+    const onBack = mock()
+
+    render(<WorkflowDetail workflowId="clip-creation-copy" onBack={onBack} />)
+
+    expect(await screen.findByText('Clip Creation Copy')).toBeDefined()
+    expect(screen.getByText(/shadows a managed default/i)).toBeDefined()
+    expect(screen.queryByText(/steps/i)).toBeNull()
+    expect(screen.queryByTestId(/agent-/i)).toBeNull()
+    expect(screen.queryByRole('switch')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /delete workflow/i }))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByText('Delete workflow?')).toBeDefined()
+    fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const [url, init] = fetchMock.mock.calls[1]
+    expect(url).toBe('/api/plugins/workflows/definitions/clip-creation-copy')
+    expect(init?.method).toBe('DELETE')
+    expect(onBack).toHaveBeenCalled()
+  })
+})

--- a/tests/plugins/workflows/workflow-editor-route.test.tsx
+++ b/tests/plugins/workflows/workflow-editor-route.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { ComponentType } from 'react'
+
+const testDir = join(tmpdir(), `bakin-test-workflow-editor-route-${Date.now()}`)
+const navigateMock = mock()
+let currentParams = { id: 'video-script' }
+let slotProps: Record<string, unknown> | null = null
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+
+mock.module('@tanstack/react-router', () => ({
+  createRoute: (config: Record<string, unknown>) => ({
+    ...config,
+    options: config,
+    useParams: () => currentParams,
+  }),
+  useNavigate: () => navigateMock,
+}))
+
+mock.module('../../../packages/host/src/routes/__root', () => ({
+  Route: {},
+}))
+
+mock.module('@makinbakin/sdk/ui', () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}))
+
+mock.module('@makinbakin/sdk/slots', () => ({
+  Slot: (props: Record<string, unknown>) => {
+    slotProps = props
+    const definition = props.initialDefinition as { name?: string } | undefined
+    return (
+      <div data-testid="workflow-edit-slot">
+        {definition?.name ?? 'missing definition'}
+      </div>
+    )
+  },
+}))
+
+import { Route } from '../../../packages/host/src/routes/workflows.$id.edit'
+
+;(Route as unknown as { useParams: () => { id: string } }).useParams = () => currentParams
+
+function getWorkflowEditRouteComponent(): ComponentType {
+  const component = (Route as unknown as {
+    component?: ComponentType
+    options?: { component?: ComponentType }
+  }).component ?? (Route as unknown as { options?: { component?: ComponentType } }).options?.component
+  if (!component) throw new Error('Workflow edit route component was not registered')
+  return component
+}
+
+const WorkflowEditRouteComponent = getWorkflowEditRouteComponent()
+
+describe('/workflows/$id/edit route', () => {
+  let fetchMock: ReturnType<typeof mock>
+
+  beforeEach(() => {
+    currentParams = { id: 'video-script' }
+    slotProps = null
+    navigateMock.mockClear()
+    fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            definition: {
+              id: 'video-script',
+              name: 'Video Script',
+              description: 'Write a script',
+              version: 1,
+              steps: [],
+            },
+            source: 'user',
+            shadowedSource: { source: 'plugin', pluginId: 'workflows' },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches a workflow definition and passes edit props into the workflow editor slot', async () => {
+    expect(WorkflowEditRouteComponent).toBeDefined()
+    render(<WorkflowEditRouteComponent />)
+
+    expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0)
+    await screen.findByTestId('workflow-edit-slot')
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/plugins/workflows/definitions/video-script')
+    expect(slotProps?.name).toBe('page:/workflows/[id]/edit')
+    expect(slotProps?.mode).toBe('edit')
+    expect(slotProps?.initialId).toBe('video-script')
+    expect(slotProps?.source).toBe('user')
+    expect(slotProps?.shadowedSource).toEqual({ source: 'plugin', pluginId: 'workflows' })
+    expect((slotProps?.initialDefinition as { name?: string } | undefined)?.name).toBe('Video Script')
+  })
+
+  it('shows the not-found state instead of mounting the editor slot on a 404', async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'not found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+
+    render(<WorkflowEditRouteComponent />)
+
+    await screen.findByText('Workflow not found')
+    expect(slotProps).toBeNull()
+  })
+
+  it('routes saved, copied, deleted, and cancelled editor actions through TanStack navigation', async () => {
+    render(<WorkflowEditRouteComponent />)
+
+    await waitFor(() => expect(slotProps).not.toBeNull())
+
+    ;(slotProps?.onSaved as (id: string) => void)('video-script-copy')
+    ;(slotProps?.onCopied as (id: string) => void)('video-script-copy')
+    ;(slotProps?.onDeleted as () => void)()
+    ;(slotProps?.onCancel as () => void)()
+
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/workflows/$id', params: { id: 'video-script-copy' } })
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/workflows/$id/edit', params: { id: 'video-script-copy' } })
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/workflows' })
+    expect(navigateMock).toHaveBeenCalledTimes(4)
+  })
+})

--- a/tests/plugins/workflows/workflows-page.test.tsx
+++ b/tests/plugins/workflows/workflows-page.test.tsx
@@ -11,9 +11,10 @@
  *  5. Clicking a card triggers router.push.
  */
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import type { ReactNode } from 'react'
 
 // ─── Test isolation mocks (mandatory per CLAUDE.md) ────────────────────────
 //
@@ -85,10 +86,12 @@ mock.module('@/hooks/use-query-state', () => ({
 // useSearch stub — returns whatever the test sets in `searchState`.
 const searchState: {
   results: Array<{ id: string; table: string; score: number; fields: Record<string, unknown> }>
+  meta: { query: string; total: number; took_ms: number; source: 'search' | 'fallback' } | null
   search: ReturnType<typeof mock>
   clear: ReturnType<typeof mock>
 } = {
   results: [],
+  meta: null,
   search: mock(),
   clear: mock(),
 }
@@ -99,7 +102,7 @@ mock.module('@/hooks/use-search', () => ({
     aggregations: {},
     loading: false,
     error: null,
-    meta: null,
+    meta: searchState.meta,
     search: searchState.search,
     clear: searchState.clear,
   }),
@@ -110,9 +113,11 @@ mock.module('@/components/plugin-header', () => ({
   PluginHeader: ({
     title,
     search,
+    actions,
   }: {
     title: string
     search?: { value: string; onChange: (v: string) => void; placeholder?: string }
+    actions?: ReactNode
   }) => (
     <div>
       <h1>{title}</h1>
@@ -124,6 +129,7 @@ mock.module('@/components/plugin-header', () => ({
           onChange={(e) => search.onChange(e.target.value)}
         />
       )}
+      {actions}
     </div>
   ),
 }))
@@ -148,9 +154,10 @@ mock.module('@bakin/workflows/components/workflow-card', () => ({
 const TEMPLATES = [
   {
     filename: 'content-pipeline',
-    name: 'content-pipeline',
+    name: 'Content Pipeline',
+    source: 'plugin',
     definition: {
-      name: 'content-pipeline',
+      name: 'Content Pipeline',
       description: 'Generate and publish content',
       steps: [],
     },
@@ -158,6 +165,7 @@ const TEMPLATES = [
   {
     filename: 'onboarding',
     name: 'onboarding',
+    source: 'user',
     definition: {
       name: 'onboarding',
       description: 'Welcome new agents',
@@ -167,6 +175,8 @@ const TEMPLATES = [
   {
     filename: 'release',
     name: 'release',
+    source: 'plugin',
+    disabled: true,
     definition: {
       name: 'release',
       description: 'Ship a new build',
@@ -183,6 +193,7 @@ import { WorkflowsPage } from '../../../plugins/workflows/components/workflows-p
 beforeEach(() => {
   routerPush.mockReset()
   searchState.results = []
+  searchState.meta = null
   searchState.search.mockReset()
   searchState.clear.mockReset()
 
@@ -222,6 +233,9 @@ describe('WorkflowsPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('card-content-pipeline')).toBeDefined()
     })
+    const customHeading = screen.getByText('Custom workflows')
+    const managedHeading = screen.getByText('Managed workflows')
+    expect(customHeading.compareDocumentPosition(managedHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(screen.getByTestId('card-onboarding')).toBeDefined()
     expect(screen.getByTestId('card-release')).toBeDefined()
   })
@@ -242,6 +256,7 @@ describe('WorkflowsPage', () => {
         fields: { name: 'content-pipeline' },
       },
     ]
+    searchState.meta = { query: 'pipeline', total: 1, took_ms: 1, source: 'search' }
 
     const input = screen.getByLabelText('search') as HTMLInputElement
     fireEvent.change(input, { target: { value: 'pipeline' } })
@@ -255,6 +270,32 @@ describe('WorkflowsPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('card-content-pipeline')).toBeDefined()
       expect(screen.queryByTestId('card-onboarding')).toBeNull()
+      expect(screen.queryByTestId('card-release')).toBeNull()
+    })
+  })
+
+  it('falls back to local filtering when search returns only workflow instance rows', async () => {
+    render(<WorkflowsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-content-pipeline')).toBeDefined()
+    })
+
+    searchState.results = [
+      {
+        id: 'inst:task-123',
+        table: 'bakin_workflows',
+        score: 0.88,
+        fields: { name: 'Onboarding instance', type: 'instance' },
+      },
+    ]
+
+    const input = screen.getByLabelText('search') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'onboard' } })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-onboarding')).toBeDefined()
+      expect(screen.queryByTestId('card-content-pipeline')).toBeNull()
       expect(screen.queryByTestId('card-release')).toBeNull()
     })
   })
@@ -279,6 +320,32 @@ describe('WorkflowsPage', () => {
     })
   })
 
+  it('ignores stale search results from a previous query while filtering the current query', async () => {
+    render(<WorkflowsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-content-pipeline')).toBeDefined()
+    })
+
+    searchState.results = [
+      {
+        id: 'def:content-pipeline',
+        table: 'bakin_workflows',
+        score: 0.92,
+        fields: { name: 'Content Pipeline', type: 'definition' },
+      },
+    ]
+    searchState.meta = { query: 'content', total: 1, took_ms: 1, source: 'search' }
+
+    const input = screen.getByLabelText('search') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'onboard' } })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-onboarding')).toBeDefined()
+      expect(screen.queryByTestId('card-content-pipeline')).toBeNull()
+    })
+  })
+
   it('navigates via router.push when a card is clicked', async () => {
     render(<WorkflowsPage />)
 
@@ -289,5 +356,129 @@ describe('WorkflowsPage', () => {
     fireEvent.click(screen.getByTestId('card-onboarding'))
 
     expect(routerPush).toHaveBeenCalledWith('/workflows/onboarding')
+  })
+
+  it('creates a workflow from the list modal before navigating to the editor', async () => {
+    const fetchMock = mock((url: string, init?: RequestInit) => {
+      if (url === '/api/plugins/workflows/definitions' && init?.method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify({ id: 'custom-launch', source: 'user' }), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ templates: TEMPLATES }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<WorkflowsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-onboarding')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /new workflow/i }))
+    expect(routerPush).not.toHaveBeenCalled()
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getAllByText('Create workflow').length).toBeGreaterThan(0)
+    fireEvent.change(within(dialog).getByLabelText(/workflow name/i), {
+      target: { value: 'Launch Plan' },
+    })
+    expect((within(dialog).getByLabelText(/workflow id/i) as HTMLInputElement).value).toBe('launch-plan')
+    fireEvent.change(within(dialog).getByLabelText(/workflow id/i), {
+      target: { value: 'custom-launch' },
+    })
+    fireEvent.change(within(dialog).getByLabelText(/workflow name/i), {
+      target: { value: 'Launch Plan Updated' },
+    })
+    expect((within(dialog).getByLabelText(/workflow id/i) as HTMLInputElement).value).toBe('custom-launch')
+    fireEvent.change(within(dialog).getByLabelText(/description/i), {
+      target: { value: 'Plan and approve a campaign launch.' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: /create workflow/i }))
+
+    await waitFor(() => expect(routerPush).toHaveBeenCalledWith('/workflows/custom-launch/edit'))
+    const [, init] = fetchMock.mock.calls.find(([url, request]) => (
+      url === '/api/plugins/workflows/definitions' && request?.method === 'POST'
+    ))!
+    const body = JSON.parse(init!.body as string) as Record<string, unknown>
+    expect(body).toMatchObject({
+      id: 'custom-launch',
+      name: 'Launch Plan Updated',
+      description: 'Plan and approve a campaign launch.',
+      version: 1,
+      steps: [],
+    })
+  })
+
+  it('shows field-level create workflow validation before posting', async () => {
+    render(<WorkflowsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-onboarding')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /new workflow/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: /create workflow/i }))
+
+    expect(within(dialog).getByText('Workflow name is required.')).toBeDefined()
+    expect(within(dialog).getByText('Workflow id is required.')).toBeDefined()
+    expect(within(dialog).queryByText(/validation failed/i)).toBeNull()
+    expect((globalThis.fetch as unknown as ReturnType<typeof mock>).mock.calls).toHaveLength(1)
+  })
+
+  it('explains stale empty-step server validation during workflow creation', async () => {
+    const fetchMock = mock((url: string, init?: RequestInit) => {
+      if (url === '/api/plugins/workflows/definitions' && init?.method === 'POST') {
+        return Promise.resolve(
+          new Response(JSON.stringify({
+            error: 'validation failed',
+            issues: [
+              {
+                code: 'too_small',
+                path: ['steps'],
+                message: 'Too small: expected array to have >=1 items',
+              },
+            ],
+          }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ templates: TEMPLATES }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<WorkflowsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('card-onboarding')).toBeDefined()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /new workflow/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText(/workflow name/i), {
+      target: { value: 'Testing' },
+    })
+    fireEvent.click(within(dialog).getByRole('button', { name: /create workflow/i }))
+
+    await waitFor(() => {
+      expect(within(dialog).getByText(/old server schema/i)).toBeDefined()
+    })
+    expect(within(dialog).queryByText(/^validation failed$/i)).toBeNull()
   })
 })

--- a/tests/plugins/workflows/yaml-roundtrip.test.ts
+++ b/tests/plugins/workflows/yaml-roundtrip.test.ts
@@ -81,6 +81,46 @@ describe('live workflow YAML round-trip', () => {
     expect(files.length).toBeGreaterThan(0)
   })
 
+  it('preserves YAML-backed fields outside the editor-owned field set', () => {
+    const parsed = workflowDefinitionSchema.safeParse({
+      name: 'Round Trip',
+      description: 'Synthetic preserve-set fixture',
+      version: 1,
+      metadata: { owner: 'roundtrip-test' },
+      triggers: [{ type: 'manual', enabled: true }],
+      inputs: {
+        topic: {
+          type: 'string',
+          description: 'Subject',
+          ui: { widget: 'longtext' },
+        },
+      },
+      steps: [
+        {
+          id: 'write',
+          type: 'agent',
+          label: 'Write',
+          agent: 'chef',
+          output_schema: { type: 'object' },
+          plugin_config: { keep: true },
+        },
+      ],
+      layout: {
+        positions: { write: { x: 1, y: 2 } },
+        viewport: { x: 10, y: 20, zoom: 0.8 },
+      },
+    })
+
+    expect(parsed.success).toBe(true)
+    if (!parsed.success) return
+    expect((parsed.data as Record<string, unknown>).metadata).toEqual({ owner: 'roundtrip-test' })
+    expect((parsed.data as Record<string, unknown>).triggers).toEqual([{ type: 'manual', enabled: true }])
+    expect((parsed.data.inputs?.topic as Record<string, unknown>).ui).toEqual({ widget: 'longtext' })
+    expect((parsed.data.steps[0] as Record<string, unknown>).output_schema).toEqual({ type: 'object' })
+    expect((parsed.data.steps[0] as Record<string, unknown>).plugin_config).toEqual({ keep: true })
+    expect((parsed.data.layout as Record<string, unknown>).viewport).toEqual({ x: 10, y: 20, zoom: 0.8 })
+  })
+
   for (const file of files) {
     const relPath = file.slice(REPO_ROOT.length + 1)
 


### PR DESCRIPTION
Summary:
- Reworks the workflow editor into a runtime-honest ordered canvas with node editing, add/reorder/delete, copy/edit flows, enable/disable handling, and unsaved-change protection.
- Preserves workflow definition fields and search/index state across edits, availability changes, and source file add/delete events.
- Adds workflow search indexing, availability storage, route/editor validation, reusable delete/copy dialogs, and the boot loader polish.
- Documents the workflow cleanup/refactor plan for the follow-up PR sequence.

Validation:
- bun test --isolate: 4079 pass, 10 skip, 0 fail
- bun run typecheck
- bun run lint
- bun run build:plugins
- git diff --check