### PR TITLE
Fix health search document counts

### DIFF
--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -153,6 +153,13 @@ function formatDateShort(date: Date): string {
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
 
+function searchStatsDocumentCount(stats: Record<string, unknown> | null | undefined): number {
+  if (!stats) return 0
+  const value = stats.documents ?? stats.num_docs ?? stats.documentCount
+  const count = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(count) ? count : 0
+}
+
 // ---------------------------------------------------------------------------
 // Horizontal bar chart component (pure CSS, no dependencies)
 // ---------------------------------------------------------------------------
@@ -627,7 +634,7 @@ export function HealthPage() {
             ) : (
               <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                 {searchHealth.tables.map(t => {
-                  const docs = typeof t.stats?.num_docs === 'number' ? t.stats.num_docs : 0
+                  const docs = searchStatsDocumentCount(t.stats)
                   const progress = reindexProgress[t.table]
                   const isActive = reindexing && progress && !progress.done
                   const hasEnrichmentError = t.indexHealth?.some(i => i.error)

--- a/plugins/memory/lib/health-checks.ts
+++ b/plugins/memory/lib/health-checks.ts
@@ -28,6 +28,13 @@ function error(check: string, message: string): HealthCheckResult {
   return { check, status: 'error', message, autoFixable: false }
 }
 
+function documentCountFromStats(stats: Record<string, unknown> | null | undefined): number | null {
+  if (!stats) return null
+  const value = stats.documents ?? stats.num_docs ?? stats.documentCount
+  const count = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(count) ? count : null
+}
+
 // ─── Search tables: registered content types have stats / non-empty docs ──
 
 /**
@@ -66,8 +73,8 @@ export async function checkSearchTables(
       }
 
       const statRecord = t.stats as Record<string, unknown>
-      const rawNumDocs = Number(statRecord.documents ?? statRecord.num_docs)
-      if (Number.isFinite(rawNumDocs)) {
+      const rawNumDocs = documentCountFromStats(statRecord)
+      if (rawNumDocs !== null) {
         if (rawNumDocs === 0) {
           if (t.pluginId === 'schedule') {
             results.push(ok('search-tables', `Table "${t.table}" (${t.pluginId}) has 0 persisted documents; schedule jobs are indexed at runtime`))
@@ -86,8 +93,8 @@ export async function checkSearchTables(
 
     if (results.length === 0) {
       const totals = health.tables
-        .map(t => Number((t.stats as Record<string, unknown>)?.num_docs))
-        .filter(n => Number.isFinite(n))
+        .map(t => documentCountFromStats(t.stats as Record<string, unknown> | null))
+        .filter((n): n is number => n !== null)
 
       if (totals.length > 0) {
         const total = totals.reduce((sum, n) => sum + n, 0)

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -1357,7 +1357,10 @@ function searchIndexHealth(value: unknown): Array<{ name?: unknown; error?: unkn
 }
 
 function searchStatsDocCount(stats: unknown): string {
-  return valueText(objectField(stats, 'num_docs'), '?')
+  return valueText(
+    objectField(stats, 'documents') ?? objectField(stats, 'num_docs') ?? objectField(stats, 'documentCount'),
+    '?',
+  )
 }
 
 function searchStatsStatus(table: SearchStatsTableData, enabled: boolean): TuiStatus {

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -1183,7 +1183,7 @@ describe('read-only CLI TTY commands', () => {
         {
           table: 'bakin_tasks',
           pluginId: 'tasks',
-          stats: { num_docs: 12 },
+          stats: { documents: 12 },
           healthy: true,
           indexHealth: [],
         },
@@ -1194,6 +1194,7 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('Search Stats')
     expect(output()).toContain('TABLES')
     expect(output()).toContain('bakin_tasks')
+    expect(output()).toContain('12')
     expect(output()).not.toContain('Search: enabled')
   })
 

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -662,7 +662,7 @@ describe('read-only CLI TUI screens', () => {
           {
             table: 'bakin_tasks',
             pluginId: 'tasks',
-            stats: { num_docs: 12 },
+            stats: { documents: 12 },
             healthy: true,
             indexHealth: [],
           },

--- a/tests/plugins/health/health-page.test.tsx
+++ b/tests/plugins/health/health-page.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from 'react'
+
+const clearReindexProgress = mock()
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useContentStore: (selector: (state: { reindexProgress: Record<string, unknown>; clearReindexProgress: () => void }) => unknown) =>
+    selector({ reindexProgress: {}, clearReindexProgress }),
+  useQueryState: (_key: string, initial: string) => [initial, mock()],
+}))
+
+mock.module('@makinbakin/sdk/ui', () => ({
+  Card: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  CardHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  CardTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+mock.module('@makinbakin/sdk/components', () => ({
+  PluginHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+  UnderlineTabs: ({ tabs }: { tabs: Array<{ label: string }> }) => (
+    <div>{tabs.map((tab) => <span key={tab.label}>{tab.label}</span>)}</div>
+  ),
+}))
+
+import { HealthPage } from '../../../plugins/health/components/health-page'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  clearReindexProgress.mockClear()
+})
+
+describe('HealthPage search stats', () => {
+  it('renders adapter document counts from the stable documents field', async () => {
+    const fetchMock = mock((url: string) => {
+      if (url === '/api/plugins/health/summary') {
+        return Promise.resolve(jsonResponse({
+          doctor: null,
+          errors1h: { total: 0, byKind: { mcp: 0, rest: 0, agent: 0 } },
+          activeSessions: [],
+          upSince: '2026-05-01T00:00:00.000Z',
+          server: { port: 3737, pid: 1, nodeVersion: 'v22.0.0', memoryMB: 512, totalMemoryMB: 4096 },
+        }))
+      }
+      if (url === '/api/plugins/health/registry') {
+        return Promise.resolve(jsonResponse({ plugins: [] }))
+      }
+      if (url === '/api/plugins/health/usage') {
+        return Promise.resolve(jsonResponse([]))
+      }
+      if (url === '/api/plugins/health/search-status') {
+        return Promise.resolve(jsonResponse({
+          enabled: true,
+          tables: [{
+            table: 'bakin_tasks',
+            pluginId: 'tasks',
+            healthy: true,
+            stats: { table: 'bakin_tasks', documents: 17 },
+          }],
+        }))
+      }
+      if (url.startsWith('/api/plugins/health/usage-feed')) {
+        return Promise.resolve(jsonResponse({
+          totals: { count: 0, errors: 0, errorRate: 0 },
+          topByName: [],
+          byAgent: [],
+          recent: [],
+        }))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<HealthPage />)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/plugins/health/search-status'))
+    expect(await screen.findByText('bakin_tasks')).toBeDefined()
+    expect(screen.getByText('17')).toBeDefined()
+  })
+})

--- a/tests/plugins/memory/health-checks.test.ts
+++ b/tests/plugins/memory/health-checks.test.ts
@@ -161,8 +161,8 @@ describe('checkSearchTables — registry shape', () => {
     mockHealth = {
       enabled: true,
       tables: [
-        { table: 'tasks', pluginId: 'tasks', healthy: true, stats: { num_docs: 12 } },
-        { table: 'projects', pluginId: 'projects', healthy: true, stats: { num_docs: 5 } },
+        { table: 'tasks', pluginId: 'tasks', healthy: true, stats: { documents: 12 } },
+        { table: 'projects', pluginId: 'projects', healthy: true, stats: { documents: 5 } },
       ],
     }
     const results = await checkSearchTables(readMockSearchHealth)


### PR DESCRIPTION
Summary:
- Fixes Health search cards reading stale num_docs stats so they now display the adapter's current documents count.
- Updates memory/search health and CLI search stats to normalize documents, num_docs, and documentCount for compatibility.
- Adds Health page coverage plus CLI and memory health regression coverage for the documents stats shape.

Validation:
- bun test --isolate tests/plugins/health tests/plugins/memory/health-checks.test.ts tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts tests/core/search-registry.test.ts: 203 pass
- bun run typecheck
- bun run lint: pass with one unrelated existing warning in dev/imitation-crab/gateway.ts
- git diff --check