### PR TITLE
Make Health runtime costs explicit

### DIFF
--- a/.claude/knowledge/usage-recording.md
+++ b/.claude/knowledge/usage-recording.md
@@ -21,6 +21,15 @@ recordUsage({ kind, name, agent, durationMs, status, meta })
 
 The ring buffer holds 10 000 entries, FIFO-evicted.
 
+## Runtime session usage
+
+Health's context and cost cards do **not** come from the in-memory usage recorder above. They are derived from runtime session JSONL entries via `src/core/agent-usage.ts`, then served by `plugins/health` at `/usage`.
+
+- Token fields (`input`, `output`, `cacheRead`, `cacheWrite`, `totalTokens`) are summed from assistant messages in each agent's latest session.
+- Cost fields are runtime-reported only. Bakin does not map model ids to pricing tables for Health.
+- Missing runtime cost is represented as unavailable, not `$0.00`.
+- Historical token/cost aggregation across multiple sessions is separate follow-up work; the current Health card is latest-session scoped.
+
 ## Reading
 
 | API | Use |

--- a/docs/src/content/docs/using/health.md
+++ b/docs/src/content/docs/using/health.md
@@ -16,7 +16,7 @@ Live token counts, session costs, MCP and REST volumes, error rates, plugin stat
 Two cards anchor the top of the dashboard side by side. They cover the questions that pile up fastest when you've got a roster running: what each agent is costing you, and whose context is about to overflow. Glance at them on the way past, look closer when something looks off.
 
 <figure class="screenshot-frame">
-  <figcaption>Context usage on the left (tokens in each agent's latest session), session cost on the right with the day's running total.</figcaption>
+  <figcaption>Context usage on the left (tokens in each agent's latest session), runtime-reported cost estimates on the right.</figcaption>
 </figure>
 
 <div class="table-light-full table-label-wrap">
@@ -24,7 +24,7 @@ Two cards anchor the top of the dashboard side by side. They cover the questions
 | Card | What it answers |
 | --- | --- |
 | **Context Usage** | Total tokens in each agent's latest session, bar-charted. Spot who's pushing the model's window before they hit it. |
-| **Session Cost** | Input, output, cache-read, cache-write, and total per agent with the day's running total at the top. Pulled from the runtime's posted rates, directional not invoice-grade. Answers "is Main Operator's day eating my budget?" without making you go ask the gateway. |
+| **Runtime Cost Estimate** | Input, output, cache-read, cache-write, and total per agent for each agent's latest session. Bakin reports cost values only when the runtime includes them in session usage events; it does not maintain its own model pricing table. These values are directional, not invoice-grade. When the runtime omits cost, Health shows the cost as unavailable instead of treating it as `$0.00`. |
 
 </div>
 

--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -66,11 +66,12 @@ interface AgentUsage {
     total: number
   }
   cost: {
-    input: number
-    output: number
-    cacheRead: number
-    cacheWrite: number
-    total: number
+    input: number | null
+    output: number | null
+    cacheRead: number | null
+    cacheWrite: number | null
+    total: number | null
+    source: 'runtime' | 'unavailable'
   }
 }
 
@@ -147,6 +148,13 @@ function formatTokenCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
   return String(n)
+}
+
+function formatRuntimeCost(value: number | null): string {
+  if (value === null) return 'unavailable'
+  if (value === 0) return '$0.00'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
 }
 
 function formatDateShort(date: Date): string {
@@ -747,9 +755,11 @@ export function HealthPage() {
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center justify-between">
-                <span>Session Cost (est.)</span>
+                <span>Runtime Cost Estimate</span>
                 <Badge variant="secondary" className="font-mono text-xs">
-                  ~${usage.reduce((sum, u) => sum + u.cost.total, 0).toFixed(2)} total
+                  {usage.some((u) => u.cost.total !== null)
+                    ? `~${formatRuntimeCost(usage.reduce((sum, u) => sum + (u.cost.total ?? 0), 0))} reported`
+                    : 'cost unavailable'}
                 </Badge>
               </CardTitle>
             </CardHeader>
@@ -778,8 +788,8 @@ export function HealthPage() {
                     <span className="w-16 text-right font-mono text-xs text-muted-foreground">
                       {formatTokenCount(u.tokens.cacheWrite)}
                     </span>
-                    <span className="w-16 text-right font-mono text-xs font-medium">
-                      ${u.cost.total.toFixed(2)}
+                    <span className={`w-16 text-right font-mono text-xs font-medium ${u.cost.total === null ? 'text-muted-foreground' : ''}`}>
+                      {formatRuntimeCost(u.cost.total)}
                     </span>
                   </div>
                 ))}

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -104,7 +104,8 @@ function fmtNum(n: number): string {
   return n.toLocaleString()
 }
 
-function fmtCost(n: number): string {
+function fmtCost(n: number | null): string {
+  if (n === null) return '—'
   if (n === 0) return '$0.00'
   if (n < 0.01) return `$${n.toFixed(4)}`
   return `$${n.toFixed(2)}`
@@ -259,8 +260,8 @@ export function OverviewTab({
           />
           <MetricTile
             label="Cost"
-            value={loading ? '—' : fmtCost(usage?.cost.total ?? 0)}
-            sublabel={usage && usage.messages > 0 ? `${fmtCost(usage.cost.total / usage.messages)}/msg` : undefined}
+            value={loading ? '—' : fmtCost(usage?.cost.total ?? null)}
+            sublabel={usage && usage.messages > 0 && usage.cost.total !== null ? `${fmtCost(usage.cost.total / usage.messages)}/msg` : undefined}
             icon={Coins}
             accent="text-emerald-300"
             accentBg="bg-emerald-500/15"

--- a/src/core/agent-usage.ts
+++ b/src/core/agent-usage.ts
@@ -23,12 +23,30 @@ export interface AgentUsage {
     total: number
   }
   cost: {
-    input: number
-    output: number
-    cacheRead: number
-    cacheWrite: number
-    total: number
+    input: number | null
+    output: number | null
+    cacheRead: number | null
+    cacheWrite: number | null
+    total: number | null
+    source: 'runtime' | 'unavailable'
   }
+}
+
+interface SessionUsageCost {
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheWrite?: number
+  total?: number
+}
+
+interface SessionUsage {
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheWrite?: number
+  totalTokens?: number
+  cost?: SessionUsageCost
 }
 
 interface SessionMessage {
@@ -38,20 +56,7 @@ interface SessionMessage {
   message?: {
     role?: string
     model?: string
-    usage?: {
-      input?: number
-      output?: number
-      cacheRead?: number
-      cacheWrite?: number
-      totalTokens?: number
-      cost?: {
-        input?: number
-        output?: number
-        cacheRead?: number
-        cacheWrite?: number
-        total?: number
-      }
-    }
+    usage?: SessionUsage
   }
 }
 
@@ -67,7 +72,8 @@ export function parseSessionUsageContent(content: string, agentName: string): Ag
     let model = ''
     let messageCount = 0
     const tokens = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
-    const cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+    const costValues = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+    const costSeen = { input: false, output: false, cacheRead: false, cacheWrite: false, total: false }
 
     for (const line of lines) {
       try {
@@ -83,18 +89,14 @@ export function parseSessionUsageContent(content: string, agentName: string): Ag
           const u = entry.message.usage
           if (entry.message.model) model = entry.message.model
 
-          tokens.input += u.input || 0
-          tokens.output += u.output || 0
-          tokens.cacheRead += u.cacheRead || 0
-          tokens.cacheWrite += u.cacheWrite || 0
-          tokens.total += u.totalTokens || 0
+          tokens.input += u.input ?? 0
+          tokens.output += u.output ?? 0
+          tokens.cacheRead += u.cacheRead ?? 0
+          tokens.cacheWrite += u.cacheWrite ?? 0
+          tokens.total += u.totalTokens ?? 0
 
           if (u.cost) {
-            cost.input += u.cost.input || 0
-            cost.output += u.cost.output || 0
-            cost.cacheRead += u.cost.cacheRead || 0
-            cost.cacheWrite += u.cost.cacheWrite || 0
-            cost.total += u.cost.total || 0
+            addUsageCost(costValues, costSeen, u.cost)
           }
         }
       } catch {
@@ -104,6 +106,9 @@ export function parseSessionUsageContent(content: string, agentName: string): Ag
 
     if (messageCount === 0) return null
 
+    const hasAnyComponentCost = costSeen.input || costSeen.output || costSeen.cacheRead || costSeen.cacheWrite
+    const hasAnyCost = hasAnyComponentCost || costSeen.total
+
     return {
       agent: agentName,
       sessionId,
@@ -111,12 +116,53 @@ export function parseSessionUsageContent(content: string, agentName: string): Ag
       model,
       messages: messageCount,
       tokens,
-      cost,
+      cost: {
+        input: costSeen.input ? costValues.input : null,
+        output: costSeen.output ? costValues.output : null,
+        cacheRead: costSeen.cacheRead ? costValues.cacheRead : null,
+        cacheWrite: costSeen.cacheWrite ? costValues.cacheWrite : null,
+        total: costSeen.total ? costValues.total : null,
+        source: hasAnyCost ? 'runtime' : 'unavailable',
+      },
     }
   } catch (err) {
     log.debug('Failed to parse session usage', { agentName, error: err instanceof Error ? err.message : String(err) })
     return null
   }
+}
+
+type CostField = 'input' | 'output' | 'cacheRead' | 'cacheWrite' | 'total'
+
+function addUsageCost(
+  values: Record<CostField, number>,
+  seen: Record<CostField, boolean>,
+  cost: SessionUsageCost,
+) {
+  const componentValues = [
+    addCostField(values, seen, 'input', cost.input),
+    addCostField(values, seen, 'output', cost.output),
+    addCostField(values, seen, 'cacheRead', cost.cacheRead),
+    addCostField(values, seen, 'cacheWrite', cost.cacheWrite),
+  ]
+  const hasExplicitTotal = addCostField(values, seen, 'total', cost.total)
+  if (hasExplicitTotal) return
+
+  const knownComponents = componentValues.filter((value): value is number => value !== null)
+  if (knownComponents.length === 0) return
+  values.total += knownComponents.reduce((sum, value) => sum + value, 0)
+  seen.total = true
+}
+
+function addCostField(
+  values: Record<CostField, number>,
+  seen: Record<CostField, boolean>,
+  field: CostField,
+  value: number | undefined,
+): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  values[field] += value
+  seen[field] = true
+  return value
 }
 
 /**

--- a/tests/core/agent-usage.test.ts
+++ b/tests/core/agent-usage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { createMockRuntimeAdapter } from '@bakin/core/adapters/runtime/testing'
 import type { AgentRuntimeAdapter, RuntimeMemoryEntry } from '@bakin/core/adapters/runtime'
-import { getAllAgentUsage } from '../../src/core/agent-usage'
+import { getAllAgentUsage, parseSessionUsageContent } from '../../src/core/agent-usage'
 
 interface FixtureSession {
   agentId: string
@@ -60,6 +60,125 @@ function writeSession(agentId: string, id: string, lines: object[], opts: { upda
 
 beforeEach(() => {
   sessions = []
+})
+
+describe('parseSessionUsageContent', () => {
+  it('marks cost unavailable when runtime usage omits cost data', () => {
+    const content = [
+      JSON.stringify({ type: 'session', id: 'sess-unknown-cost', timestamp: '2026-03-26T10:00:00Z' }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg-1',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-4-6',
+          usage: { input: 1000, output: 500, cacheRead: 200, cacheWrite: 0, totalTokens: 1700 },
+        },
+      }),
+    ].join('\n') + '\n'
+
+    const result = parseSessionUsageContent(content, 'patch')
+
+    expect(result).not.toBeNull()
+    expect(result?.tokens).toEqual({ input: 1000, output: 500, cacheRead: 200, cacheWrite: 0, total: 1700 })
+    expect(result?.cost.source).toBe('unavailable')
+    expect(result?.cost.total).toBeNull()
+  })
+
+  it('keeps runtime-reported zero cost distinct from unavailable cost', () => {
+    const content = [
+      JSON.stringify({ type: 'session', id: 'sess-zero-cost', timestamp: '2026-03-26T10:00:00Z' }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg-1',
+        message: {
+          role: 'assistant',
+          model: 'local-model',
+          usage: {
+            input: 100,
+            output: 50,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 150,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+        },
+      }),
+    ].join('\n') + '\n'
+
+    const result = parseSessionUsageContent(content, 'local')
+
+    expect(result).not.toBeNull()
+    expect(result?.cost.source).toBe('runtime')
+    expect(result?.cost.total).toBe(0)
+  })
+
+  it('derives total cost from runtime component costs when total is omitted', () => {
+    const content = [
+      JSON.stringify({ type: 'session', id: 'sess-component-cost', timestamp: '2026-03-26T10:00:00Z' }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg-1',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-4-6',
+          usage: {
+            input: 1000,
+            output: 500,
+            cacheRead: 200,
+            cacheWrite: 300,
+            totalTokens: 2000,
+            cost: { input: 0.01, output: 0.005, cacheRead: 0.001, cacheWrite: 0.002 },
+          },
+        },
+      }),
+    ].join('\n') + '\n'
+
+    const result = parseSessionUsageContent(content, 'patch')
+
+    expect(result).not.toBeNull()
+    expect(result?.cost.source).toBe('runtime')
+    expect(result?.cost.total).toBeCloseTo(0.018)
+  })
+
+  it('sums explicit totals with component-derived totals across messages', () => {
+    const content = [
+      JSON.stringify({ type: 'session', id: 'sess-mixed-cost', timestamp: '2026-03-26T10:00:00Z' }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg-explicit',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-4-6',
+          usage: {
+            input: 100,
+            output: 50,
+            totalTokens: 150,
+            cost: { input: 0.01, output: 0.02, total: 0.03 },
+          },
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        id: 'msg-components',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-4-6',
+          usage: {
+            input: 200,
+            output: 100,
+            totalTokens: 300,
+            cost: { input: 0.04, output: 0.05 },
+          },
+        },
+      }),
+    ].join('\n') + '\n'
+
+    const result = parseSessionUsageContent(content, 'patch')
+
+    expect(result).not.toBeNull()
+    expect(result?.cost.total).toBeCloseTo(0.12)
+  })
 })
 
 describe('getAllAgentUsage', () => {

--- a/tests/plugins/health/health-page.test.tsx
+++ b/tests/plugins/health/health-page.test.tsx
@@ -38,6 +38,46 @@ function jsonResponse(body: unknown): Response {
   })
 }
 
+function setupHealthFetch(options: {
+  usage?: unknown[]
+  searchTables?: unknown[]
+} = {}) {
+  const fetchMock = mock((url: string) => {
+    if (url === '/api/plugins/health/summary') {
+      return Promise.resolve(jsonResponse({
+        doctor: null,
+        errors1h: { total: 0, byKind: { mcp: 0, rest: 0, agent: 0 } },
+        activeSessions: [],
+        upSince: '2026-05-01T00:00:00.000Z',
+        server: { port: 3737, pid: 1, nodeVersion: 'v22.0.0', memoryMB: 512, totalMemoryMB: 4096 },
+      }))
+    }
+    if (url === '/api/plugins/health/registry') {
+      return Promise.resolve(jsonResponse({ plugins: [] }))
+    }
+    if (url === '/api/plugins/health/usage') {
+      return Promise.resolve(jsonResponse(options.usage ?? []))
+    }
+    if (url === '/api/plugins/health/search-status') {
+      return Promise.resolve(jsonResponse({
+        enabled: true,
+        tables: options.searchTables ?? [],
+      }))
+    }
+    if (url.startsWith('/api/plugins/health/usage-feed')) {
+      return Promise.resolve(jsonResponse({
+        totals: { count: 0, errors: 0, errorRate: 0 },
+        topByName: [],
+        byAgent: [],
+        recent: [],
+      }))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
 afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
@@ -46,49 +86,52 @@ afterEach(() => {
 
 describe('HealthPage search stats', () => {
   it('renders adapter document counts from the stable documents field', async () => {
-    const fetchMock = mock((url: string) => {
-      if (url === '/api/plugins/health/summary') {
-        return Promise.resolve(jsonResponse({
-          doctor: null,
-          errors1h: { total: 0, byKind: { mcp: 0, rest: 0, agent: 0 } },
-          activeSessions: [],
-          upSince: '2026-05-01T00:00:00.000Z',
-          server: { port: 3737, pid: 1, nodeVersion: 'v22.0.0', memoryMB: 512, totalMemoryMB: 4096 },
-        }))
-      }
-      if (url === '/api/plugins/health/registry') {
-        return Promise.resolve(jsonResponse({ plugins: [] }))
-      }
-      if (url === '/api/plugins/health/usage') {
-        return Promise.resolve(jsonResponse([]))
-      }
-      if (url === '/api/plugins/health/search-status') {
-        return Promise.resolve(jsonResponse({
-          enabled: true,
-          tables: [{
-            table: 'bakin_tasks',
-            pluginId: 'tasks',
-            healthy: true,
-            stats: { table: 'bakin_tasks', documents: 17 },
-          }],
-        }))
-      }
-      if (url.startsWith('/api/plugins/health/usage-feed')) {
-        return Promise.resolve(jsonResponse({
-          totals: { count: 0, errors: 0, errorRate: 0 },
-          topByName: [],
-          byAgent: [],
-          recent: [],
-        }))
-      }
-      return Promise.resolve(jsonResponse({}))
+    const fetchMock = setupHealthFetch({
+      searchTables: [{
+        table: 'bakin_tasks',
+        pluginId: 'tasks',
+        healthy: true,
+        stats: { table: 'bakin_tasks', documents: 17 },
+      }],
     })
-    vi.stubGlobal('fetch', fetchMock)
 
     render(<HealthPage />)
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/plugins/health/search-status'))
     expect(await screen.findByText('bakin_tasks')).toBeDefined()
     expect(screen.getByText('17')).toBeDefined()
+  })
+})
+
+describe('HealthPage runtime cost display', () => {
+  it('separates runtime-reported cost from unavailable cost', async () => {
+    setupHealthFetch({
+      usage: [
+        {
+          agent: 'patch',
+          sessionId: 's1',
+          sessionStarted: '2026-05-26T10:00:00.000Z',
+          model: 'claude-4',
+          messages: 2,
+          tokens: { input: 1000, output: 500, cacheRead: 200, cacheWrite: 0, total: 1700 },
+          cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0, total: 0.031, source: 'runtime' },
+        },
+        {
+          agent: 'local',
+          sessionId: 's2',
+          sessionStarted: '2026-05-26T11:00:00.000Z',
+          model: 'local-model',
+          messages: 1,
+          tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+          cost: { input: null, output: null, cacheRead: null, cacheWrite: null, total: null, source: 'unavailable' },
+        },
+      ],
+    })
+
+    render(<HealthPage />)
+
+    expect(await screen.findByText('Runtime Cost Estimate')).toBeDefined()
+    expect(screen.getByText('~$0.03 reported')).toBeDefined()
+    expect(screen.getByText('unavailable')).toBeDefined()
   })
 })

--- a/tests/plugins/health/routes.test.ts
+++ b/tests/plugins/health/routes.test.ts
@@ -146,7 +146,7 @@ mock.module('../../../src/core/doctor-repair-store', () => ({
 
 mock.module('../../../src/core/agent-usage', () => ({
   getAllAgentUsage: () => [
-    { agent: 'patch', sessionId: 's1', model: 'claude-4', messages: 10, tokens: { total: 1000 }, cost: { total: 0.05 } },
+    { agent: 'patch', sessionId: 's1', model: 'claude-4', messages: 10, tokens: { total: 1000 }, cost: { total: 0.05, source: 'runtime' } },
   ],
 }))
 

--- a/tests/plugins/team/overview-tab.test.tsx
+++ b/tests/plugins/team/overview-tab.test.tsx
@@ -58,7 +58,7 @@ const PROFILE = {
 }
 
 interface FetchExpectation {
-  stats?: { usage: { agent: string; sessionId: string; sessionStarted: string; model: string; messages: number; tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }; cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } } | null }
+  stats?: { usage: { agent: string; sessionId: string; sessionStarted: string; model: string; messages: number; tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number }; cost: { input: number | null; output: number | null; cacheRead: number | null; cacheWrite: number | null; total: number | null; source: 'runtime' | 'unavailable' } } | null }
   recentActivity?: { ok: boolean; activity?: { windowMs: Record<string, number>; errors: Record<string, number>; sinceServerStart: string } }
   skills?: { skills: Array<{ id: string }> }
   lessons?: { ok: boolean; lessons?: Array<{ enabled: boolean }> }
@@ -141,7 +141,7 @@ describe('OverviewTab', () => {
 
   it('fetches stats / recent-activity / skills / lessons in parallel and renders the counts', async () => {
     setupFetch({
-      stats: { usage: { agent: 'pixel', sessionId: 's', sessionStarted: '', model: 'claude-opus-4-7', messages: 12, tokens: { input: 1000, output: 500, cacheRead: 200, cacheWrite: 50, total: 1750 }, cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0.001, total: 0.03 } } },
+      stats: { usage: { agent: 'pixel', sessionId: 's', sessionStarted: '', model: 'claude-opus-4-7', messages: 12, tokens: { input: 1000, output: 500, cacheRead: 200, cacheWrite: 50, total: 1750 }, cost: { input: 0.01, output: 0.02, cacheRead: 0.001, cacheWrite: 0.001, total: 0.03, source: 'runtime' } } },
       recentActivity: { ok: true, activity: { windowMs: { '5m': 1, '1h': 7, '24h': 23 }, errors: { '5m': 0, '1h': 1, '24h': 1 }, sinceServerStart: new Date().toISOString() } },
       skills: { skills: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] },
       lessons: { ok: true, lessons: [{ enabled: true }, { enabled: true }, { enabled: false }, { enabled: false }, { enabled: false }] },
@@ -167,6 +167,25 @@ describe('OverviewTab', () => {
     expect(screen.queryByText('Cache reads')).toBeNull()
     expect(screen.queryByText('Cache writes')).toBeNull()
     expect(screen.queryByText('Messages')).toBeNull()
+  })
+
+  it('does not render missing runtime cost as zero dollars', async () => {
+    setupFetch({
+      stats: {
+        usage: {
+          agent: 'pixel',
+          sessionId: 's',
+          sessionStarted: '',
+          model: 'local-model',
+          messages: 1,
+          tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+          cost: { input: null, output: null, cacheRead: null, cacheWrite: null, total: null, source: 'unavailable' },
+        },
+      },
+    })
+    renderTab()
+    await waitFor(() => expect(screen.getByText('150')).toBeDefined())
+    expect(screen.queryByText('$0.00')).toBeNull()
   })
 
   it('writes /team on team select change', async () => {


### PR DESCRIPTION
## Summary

Fixes #358.

- keep Health costs runtime-reported only, with no Bakin-owned pricing table
- distinguish missing runtime cost from real `$0.00` cost using nullable fields plus `source`
- derive total cost from runtime component costs when `cost.total` is omitted
- update Health and Team UI so unavailable cost is not displayed as zero
- clarify docs/knowledge around latest-session scope and runtime-reported estimates

## Verification

- `bun test --isolate tests/core/agent-usage.test.ts tests/plugins/health/health-page.test.tsx tests/plugins/health/routes.test.ts tests/plugins/team/overview-tab.test.tsx`
- `bun run typecheck`
- `bun run docs:validate`
- `bun run lint`

Note: lint still reports one existing unrelated warning in `dev/imitation-crab/gateway.ts` about an unused eslint-disable directive.