### PR TITLE
Fix Schedule cron handling with OpenClaw

### DIFF
--- a/.claude/specs/schedule-plugin-audit.md
+++ b/.claude/specs/schedule-plugin-audit.md
@@ -1,0 +1,122 @@
+# Spec: Schedule Plugin Audit
+
+## Objective
+
+Audit the Schedule plugin end to end because a daily scheduled task on another machine did not create or dispatch the expected Bakin task.
+
+Success means we can answer, with evidence:
+
+- how a scheduled job is created from UI, CLI, or MCP exec tool input
+- where the runtime cron record lives
+- where Bakin-owned schedule metadata lives
+- what actually causes a fired cron run to become a Bakin task
+- which conditions skip or suppress task creation
+- whether the observed failure is an OpenClaw adapter bug, a Schedule plugin bug, a documentation mismatch, or an unsupported multi-machine topology
+
+## Current Observations
+
+- The Schedule plugin creates Bakin-owned jobs through `plugins/schedule/index.ts`.
+- Runtime timing is delegated to `ctx.runtime.cron`.
+- Bakin metadata is stored in `~/.bakin/schedule/sidecar.json`.
+- OpenClaw cron records are managed by the Gateway-backed `openclaw cron` CLI. Raw snapshot capture/restore still reads `OPENCLAW_HOME/cron/jobs.json` to preserve provider-specific fields during adoption.
+- OpenClaw adapter creates Bakin schedules as main-session `systemEvent` cron jobs with payload text like `bakin:schedule:<name-or-id>`.
+- Installed OpenClaw 2026.5.4 reports `openclaw cron` as "Manage cron jobs (via Gateway)" and exposes `cron add|edit|rm|run|runs|show|status`.
+- The Bakin OpenClaw adapter previously shelled out for `cron run`, but create/update/delete/list/get read or wrote `cron/jobs.json` directly. That was fixed so live cron operations go through the OpenClaw CLI/Gateway path.
+- The maintainer README says OpenClaw webhook delivery is not canonical for task creation; the Schedule plugin reconciler polls successful runtime cron runs and creates Bakin tasks.
+- User-facing docs previously said the runtime POSTs `/api/plugins/schedule/bridge`; docs now describe the reconciler path used by OpenClaw and keep the bridge as a runtime-specific callback option.
+- Focused Schedule/OpenClaw cron tests pass with the repo-required `--isolate` flag.
+
+## Expected Flow Under Current Code
+
+1. User creates a Bakin-owned schedule through the UI, CLI, REST route, or `bakin_exec_schedule_create`.
+2. Schedule parses the natural language or raw cron string into a five-field cron expression.
+3. Schedule calls `ctx.runtime.cron.create(...)`.
+4. The OpenClaw adapter registers the cron job through `openclaw cron add`.
+5. Schedule writes a sidecar entry keyed by the runtime-returned `jobId`.
+6. OpenClaw fires the cron and records a successful run.
+7. While Bakin is running, the Schedule plugin reconciler polls runtime runs every 60 seconds.
+8. For unprocessed successful runs on Bakin-owned jobs, Schedule creates a task via `createTaskWithEffects`.
+9. Schedule records `lastTaskId` and `processedRunIds` in the sidecar.
+10. The normal Bakin dispatcher picks up the new todo task and sends it to the assigned agent.
+
+## Primary Risk Areas
+
+- A claw/agent could create a runtime-native OpenClaw cron directly instead of using Bakin's schedule creation tool. That job still appears in the Schedule list, but it is runtime-only and will not create Bakin tasks unless explicitly adopted. The affected release-summary job was visually identified as a Bakin schedule, so this is now a secondary risk rather than the leading hypothesis.
+- Bakin is not running when the OpenClaw cron fires.
+- The cron fires on one machine, but Bakin is running on another machine with a different `OPENCLAW_HOME` or `BAKIN_HOME`.
+- Runtime run history is missing, failed, malformed, or not marked `succeeded`.
+- The sidecar entry is missing, stale, keyed differently than the runtime job id, or marks the job as runtime-only.
+- The job is paused, skipped, auto-paused, or overlap-blocked by an active previous task.
+- Documentation implies bridge/webhook behavior that current OpenClaw schedules do not use.
+- Tests cover run-now bridge behavior better than daemon-fired reconciliation behavior.
+- The Schedule UI does not clearly expose whether the runtime fired, whether Bakin reconciled the run, or why task creation was skipped.
+- If a runtime adapter writes cron create/update/delete operations directly to a provider store instead of the provider's live cron API, Bakin-created jobs can appear in Schedule but never record run history.
+- On the local machine, `openclaw cron status --json --timeout 3000` failed because the Gateway connection closed. That is not the affected machine, but it confirms cron status/list are Gateway-backed surfaces rather than plain file reads in current OpenClaw.
+
+## Audit Conclusion
+
+The reported symptom, a visually Bakin-owned schedule with no run history, is most consistent with the old OpenClaw adapter writing a cron record to `OPENCLAW_HOME/cron/jobs.json` without registering it through the Gateway-backed scheduler. Schedule could list the job because Bakin read the same file, but OpenClaw never fired it, so the reconciler never saw a successful runtime run and never created the board task.
+
+The fix is to make OpenClaw cron list/get/create/update/delete and run-history reads use the same `openclaw cron` CLI surface the scheduler owns. Schedule continues to own sidecar metadata and task creation. Raw snapshot capture/restore remains file-based only for native-job adoption rollback.
+
+## Commands
+
+- Focused verification: `bun test --isolate tests/plugins/schedule tests/adapter-openclaw/runtime-cron.test.ts tests/plugins/tasks/scheduled.test.ts tests/dev/mock-runtime-contract.test.ts`
+- Full repo test command: `bun test --isolate`
+- Typecheck: `bun run typecheck`
+- Lint: `bun run lint`
+- Runtime cron inspection on the affected machine: inspect `OPENCLAW_HOME/cron/jobs.json` and `OPENCLAW_HOME/cron/runs/{jobId}.jsonl`
+- Bakin sidecar inspection on the affected machine: inspect `BAKIN_HOME/schedule/sidecar.json`
+
+## Project Structure
+
+- `plugins/schedule/index.ts` - routes, exec tools, bridge, reconciler, task creation
+- `plugins/schedule/lib/sidecar.ts` - Bakin-owned schedule metadata and skip/pause/failure state
+- `plugins/schedule/lib/jobs-reader.ts` - runtime cron plus sidecar merge logic
+- `plugins/schedule/lib/runs-reader.ts` - runtime run history mapping
+- `plugins/schedule/lib/health-checks.ts` - runtime/sidecar sync diagnostics
+- `packages/adapter-openclaw/src/runtime.ts` - OpenClaw cron adapter implementation
+- `tests/plugins/schedule/*` - Schedule plugin coverage
+- `tests/adapter-openclaw/runtime-cron.test.ts` - OpenClaw cron adapter coverage
+- `.claude/knowledge/dispatch.md` - plugin cron command convention
+- `.claude/knowledge/tasks-plugin.md` - task dispatch and scheduled task context
+- `plugins/schedule/README.md` and `docs/src/content/docs/using/schedule.md` - schedule docs that need reconciliation
+
+## Testing Strategy
+
+- Preserve existing focused Schedule/OpenClaw cron suite.
+- Add adapter regression coverage proving Bakin schedules call `openclaw cron add --session main --system-event`.
+- Add adapter regression coverage proving native cron tool allowlists use `--tools` / `--clear-tools`.
+- Add a contract test proving provider-generated cron ids are accepted by Schedule sidecar metadata.
+- Update docs where the bridge/reconciler contract is inconsistent.
+
+## Boundaries
+
+- Always: keep runtime-provider details behind the runtime adapter.
+- Always: keep Schedule-owned metadata in the sidecar and task creation in Bakin task service.
+- Always: use `bun test --isolate` for multi-file Bun tests because tests mock modules heavily.
+- Ask first: changing the canonical cron-to-task mechanism from reconciler to webhook bridge.
+- Ask first: changing multi-machine behavior or assuming shared `BAKIN_HOME` / `OPENCLAW_HOME`.
+- Never: silently adopt runtime-native cron jobs into Bakin task creation without explicit user action.
+
+## Success Criteria
+
+- A written audit explains the actual cron-to-task lifecycle and the expected files involved.
+- The audit identifies the likely failure mode for the affected daily job.
+- The audit includes a minimal reproduction or inspection checklist for the affected machine.
+- Any proposed fix has a narrow implementation plan, rollback checkpoints, and tests.
+- Docs are updated if the current bridge/reconciler story is inconsistent.
+
+## Product Contract Clarification
+
+For the release-summary case, the desired behavior is:
+
+1. A Bakin-owned schedule exists for every day at 9am.
+2. At each successful 9am runtime fire, Bakin creates one real task on the board.
+3. The task is assigned to the configured agent unless triage is required.
+4. The task prompt contains enough context to gather and post release notes.
+5. Later, the same schedule may attach a workflow for research, drafting, review, and posting, but the minimum viable behavior is schedule-to-task creation at 9am.
+
+## Open Questions
+
+1. Resolved: the adapter should call the OpenClaw cron CLI/Gateway for live cron CRUD. Direct file writes are only appropriate for raw snapshot restore.

--- a/dev/imitation-crab/cli-shim.ts
+++ b/dev/imitation-crab/cli-shim.ts
@@ -39,6 +39,12 @@ function hasFlag(name: string): boolean {
   return args.includes(`--${name}`)
 }
 
+function parseTools(value: string | undefined): string[] | undefined {
+  if (!value) return undefined
+  const tools = value.split(/[,\s]+/).map(tool => tool.trim()).filter(Boolean)
+  return tools.length > 0 ? Array.from(new Set(tools)) : undefined
+}
+
 async function main(): Promise<void> {
   if (command === 'cron') {
     switch (subcommand) {
@@ -57,10 +63,11 @@ async function main(): Promise<void> {
       case 'add': {
         const name = getFlag('name') || 'unnamed'
         const id = randomUUID().slice(0, 8)
+        const toolsAllow = parseTools(getFlag('tools'))
         const job: Record<string, unknown> = {
           id,
           name,
-          enabled: true,
+          enabled: !hasFlag('disabled'),
           createdAt: new Date().toISOString(),
         }
 
@@ -68,8 +75,20 @@ async function main(): Promise<void> {
         else if (getFlag('every')) job.schedule = { kind: 'every', expr: getFlag('every') }
         else if (getFlag('at')) job.schedule = { kind: 'at', expr: getFlag('at') }
 
-        if (getFlag('session')) job.delivery = { mode: getFlag('session') === 'main' ? 'announce' : 'none' }
-        if (getFlag('message')) job.payload = { message: getFlag('message') }
+        if (getFlag('session')) {
+          job.sessionTarget = getFlag('session')
+          job.delivery = { mode: getFlag('session') === 'main' ? 'announce' : 'none' }
+        }
+        if (getFlag('system-event')) {
+          job.payload = { kind: 'systemEvent', text: getFlag('system-event') }
+        } else if (getFlag('message')) {
+          job.payload = {
+            kind: 'agentTurn',
+            message: getFlag('message'),
+            ...(toolsAllow ? { toolsAllow } : {}),
+          }
+        }
+        if (getFlag('wake')) job.wakeMode = getFlag('wake')
 
         const data = readJobs()
         data.jobs.push(job)
@@ -79,6 +98,22 @@ async function main(): Promise<void> {
           process.stdout.write(JSON.stringify({ id }))
         } else {
           console.log(`Created job ${id}`)
+        }
+        break
+      }
+
+      case 'show': {
+        const jobId = args[2]
+        const data = readJobs()
+        const job = data.jobs.find(j => j.id === jobId || j.name === jobId)
+        if (!job) {
+          console.error(`Job ${jobId} not found`)
+          process.exit(1)
+        }
+        if (hasFlag('json')) {
+          process.stdout.write(JSON.stringify(job))
+        } else {
+          console.log(`${job.id}\t${job.name}\t${job.enabled ? 'enabled' : 'disabled'}`)
         }
         break
       }
@@ -99,6 +134,26 @@ async function main(): Promise<void> {
         if (hasFlag('enable')) job.enabled = true
         if (hasFlag('disable')) job.enabled = false
         if (getFlag('tz') && job.schedule) (job.schedule as Record<string, unknown>).tz = getFlag('tz')
+        if (getFlag('session')) job.sessionTarget = getFlag('session')
+        if (getFlag('wake')) job.wakeMode = getFlag('wake')
+        if (getFlag('system-event')) {
+          job.payload = { kind: 'systemEvent', text: getFlag('system-event') }
+        } else if (getFlag('message')) {
+          const existingPayload = typeof job.payload === 'object' && job.payload !== null ? job.payload as Record<string, unknown> : {}
+          const toolsAllow = parseTools(getFlag('tools'))
+          job.payload = {
+            ...existingPayload,
+            kind: 'agentTurn',
+            message: getFlag('message'),
+            ...(toolsAllow ? { toolsAllow } : {}),
+          }
+        } else if (getFlag('tools')) {
+          const existingPayload = typeof job.payload === 'object' && job.payload !== null ? job.payload as Record<string, unknown> : {}
+          job.payload = { ...existingPayload, toolsAllow: parseTools(getFlag('tools')) }
+        }
+        if (hasFlag('clear-tools') && typeof job.payload === 'object' && job.payload !== null) {
+          delete (job.payload as Record<string, unknown>).toolsAllow
+        }
 
         job.updatedAt = new Date().toISOString()
         writeJobs(data)
@@ -128,6 +183,16 @@ async function main(): Promise<void> {
         }
         appendFileSync(join(runsDir, `${jobId}.jsonl`), JSON.stringify(runEntry) + '\n')
         console.log(`Ran job ${jobId} (mock)`)
+        break
+      }
+
+      case 'runs': {
+        const jobId = getFlag('id') || args[2]
+        const limit = Number.parseInt(getFlag('limit') || '50', 10)
+        const runsPath = join(OPENCLAW_HOME, 'cron', 'runs', `${jobId}.jsonl`)
+        if (!existsSync(runsPath)) break
+        const lines = readFileSync(runsPath, 'utf-8').split('\n').filter(Boolean)
+        process.stdout.write(lines.slice(-limit).join('\n'))
         break
       }
 

--- a/docs/public/llms/hooks.md
+++ b/docs/public/llms/hooks.md
@@ -330,7 +330,7 @@ await ctx.hooks.callAll(
 ### schedule.ensureBakinJob
 
 Label: Ensure Bakin schedule
-Purpose: Create or update a deterministic Bakin-managed runtime cron job.
+Purpose: Create or update a Bakin-managed runtime cron job and return the provider job id.
 Kind: rpc
 Source: plugins/schedule/index.ts:1000
 

--- a/docs/src/content/docs/extending/plugins/server-contracts.md
+++ b/docs/src/content/docs/extending/plugins/server-contracts.md
@@ -145,8 +145,8 @@ async activate(ctx) {
     },
   )
 
-  await ctx.runtime.cron.create({
-    id: 'reports-refresh',
+  const result = await ctx.hooks.invoke('schedule.ensureBakinJob', {
+    jobId: 'reports-refresh',
     name: 'Reports refresh',
     schedule: '*/15 * * * *',
     command: 'bakin:reports:refresh',
@@ -156,6 +156,9 @@ async activate(ctx) {
       description: 'Refresh plugin-owned report snapshots.',
     },
   })
+
+  // Persist result.jobId if your plugin needs to reference the runtime job later.
+  // Some runtimes generate provider ids even when jobId is supplied.
 }
 ```
 

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -199,7 +199,7 @@ await ctx.hooks.callAll(
 <p class="hook-section-description">Hooks discovered from source registration audit.</p>
 
 <div class="hook-card-list">
-<HookCard id="schedule-ensurebakinjob" name="schedule.ensureBakinJob" label="Ensure Bakin schedule" summary="Create or update a deterministic Bakin-managed runtime cron job." source="plugins/schedule/index.ts:1000" badges={["rpc"]}>
+<HookCard id="schedule-ensurebakinjob" name="schedule.ensureBakinJob" label="Ensure Bakin schedule" summary="Create or update a Bakin-managed runtime cron job and return the provider job id." source="plugins/schedule/index.ts:1000" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'schedule.ensureBakinJob',

--- a/docs/src/content/docs/using/schedule.md
+++ b/docs/src/content/docs/using/schedule.md
@@ -54,7 +54,7 @@ Schedule splits ownership: the runtime owns the cron, Bakin owns everything arou
 - **The runtime owns the cron itself.** The actual cron daemon, expressions, and run logs live in the runtime home directory. Bakin asks the runtime adapter to add, edit, remove, or fire them.
 - **Bakin owns sidecar metadata.** Display name, owner, agent assignment, task title and prompt, workflow link, and pause/failure state live in `~/.bakin/schedule/sidecar.json`.
 
-When a cron fires, the runtime POSTs the **bridge endpoint** (`/api/plugins/schedule/bridge`) with an HMAC-signed payload. Bakin verifies the signature, creates a real task, optionally starts a workflow, and dispatches the work to the assigned agent. The bridge secret auto-generates on first use.
+When a cron fires, the runtime records a run. While Bakin is running, Schedule polls runtime run history, reconciles each new successful run, creates a real task, optionally starts a workflow, and dispatches the work to the assigned agent. The bridge endpoint still exists for runtimes that deliver signed webhook callbacks, but OpenClaw schedules use the reconciler path.
 
 ## Failure handling
 

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -79,6 +79,8 @@ const OPENCLAW_AGENT_TRANSPORT_TIMEOUT_MS = OPENCLAW_AGENT_TIMEOUT_MS + 30_000
 const OPENCLAW_SESSION_ACTIVITY_POLL_MS = 200
 const OPENCLAW_ACTIVITY_PREVIEW_CHARS = 500
 const OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS = 600000
+const OPENCLAW_CRON_TIMEOUT_MS = 30000
+const OPENCLAW_CRON_PROCESS_TIMEOUT_MS = OPENCLAW_CRON_TIMEOUT_MS + 5000
 const OPENCLAW_PLUGIN_APPROVAL_REF_PREFIX = 'openclaw-plugin-approval:'
 const OPENCLAW_PLUGIN_ID = 'bakin'
 const OPENCLAW_WORKFLOW_GATE_TOOL = 'workflow.gate'
@@ -866,76 +868,12 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   }
 
   cron = {
-    list: async (): Promise<CronJob[]> => readCronJobs().map(cronStoreJobToRuntime),
-    get: async (id: string): Promise<CronJob | null> => {
-      const job = readCronJobs().find((entry) => entry.id === id)
-      return job ? cronStoreJobToRuntime(job) : null
-    },
-    create: async (input: CreateCronJobInput): Promise<CronJob> => {
-      const store = readCronStore()
-      const jobs = store.jobs ?? []
-      const id = input.id ?? uniqueCronId(input.name, jobs)
-      if (jobs.some((job) => job.id === id)) throw new Error(`Cron job already exists: ${id}`)
-      const nowMs = Date.now()
-      const now = new Date(nowMs).toISOString()
-      const bakinSchedule = isBakinScheduleMetadata(input.metadata)
-      const payload = bakinSchedule
-        ? { kind: 'systemEvent', text: input.command }
-        : withCronToolsAllow({ kind: 'agentTurn', message: input.command }, input.toolsAllow)
-      const job: OpenClawCronStoreJob = {
-        id,
-        name: input.name,
-        enabled: input.enabled ?? true,
-        schedule: { kind: 'cron', expr: input.schedule },
-        sessionTarget: bakinSchedule ? 'main' : 'isolated',
-        wakeMode: 'now',
-        delivery: cronDeliveryFromMetadata(input.metadata) ?? { mode: 'none' },
-        payload,
-        createdAt: now,
-        updatedAt: now,
-        createdAtMs: nowMs,
-        updatedAtMs: nowMs,
-        state: {},
-        metadata: input.metadata,
-      }
-      writeCronStore({ ...store, jobs: [...jobs, job] })
-      return cronStoreJobToRuntime(job)
-    },
-    update: async (id: string, patch: UpdateCronJobInput): Promise<CronJob> => {
-      const store = readCronStore()
-      const jobs = store.jobs ?? []
-      const index = jobs.findIndex((job) => job.id === id)
-      if (index === -1) throw new Error(`Cron job not found: ${id}`)
-      const current = jobs[index]
-      const metadata = patch.metadata ?? current.metadata
-      const bakinSchedule = isBakinScheduleMetadata(metadata)
-      const command = patch.command ?? cronStoreJobToRuntime(current).command
-      const nowMs = Date.now()
-      const payload = bakinSchedule || patch.command !== undefined || patch.toolsAllow !== undefined
-        ? withCronToolsAllow(cronPayloadForCommand(command, current.payload, bakinSchedule), patch.toolsAllow)
-        : current.payload
-      const next: OpenClawCronStoreJob = {
-        ...current,
-        name: patch.name ?? current.name,
-        enabled: patch.enabled ?? current.enabled ?? true,
-        schedule: patch.schedule ? { kind: 'cron', expr: patch.schedule } : current.schedule,
-        sessionTarget: bakinSchedule ? 'main' : current.sessionTarget,
-        wakeMode: bakinSchedule ? 'now' : current.wakeMode,
-        delivery: bakinSchedule
-          ? { mode: 'none' }
-          : patch.metadata ? cronDeliveryFromMetadata(patch.metadata) ?? current.delivery ?? { mode: 'none' } : current.delivery,
-        payload,
-        metadata,
-        updatedAt: new Date(nowMs).toISOString(),
-        updatedAtMs: nowMs,
-      }
-      jobs[index] = next
-      writeCronStore({ ...store, jobs })
-      return cronStoreJobToRuntime(next)
-    },
+    list: async (): Promise<CronJob[]> => this.listCronJobs(),
+    get: async (id: string): Promise<CronJob | null> => this.getCronJob(id),
+    create: async (input: CreateCronJobInput): Promise<CronJob> => this.createCronJob(input),
+    update: async (id: string, patch: UpdateCronJobInput): Promise<CronJob> => this.updateCronJob(id, patch),
     remove: async (id: string): Promise<void> => {
-      const store = readCronStore()
-      writeCronStore({ ...store, jobs: (store.jobs ?? []).filter((job) => job.id !== id) })
+      await this.execCron(['cron', 'rm', id, '--timeout', String(OPENCLAW_CRON_TIMEOUT_MS)])
     },
     runNow: async (jobId: string): Promise<CronRun> => {
       await this.exec(['cron', 'run', jobId])
@@ -946,7 +884,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
         startedAt: new Date().toISOString(),
       }
     },
-    listRuns: async (jobId: string): Promise<CronRun[]> => readCronRuns(jobId),
+    listRuns: async (jobId: string): Promise<CronRun[]> => this.listCronRuns(jobId),
     getRaw: async (id: string, reason: string): Promise<unknown | null> => {
       if (!reason) throw new Error('cron.getRaw requires a reason')
       const job = readCronJobs().find((entry) => entry.id === id)
@@ -993,6 +931,68 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       if (!config) return null as T
       return (key === '*' ? config : readPath(config as Record<string, unknown>, key)) as T
     },
+  }
+
+  private async listCronJobs(): Promise<CronJob[]> {
+    const stdout = await this.execCron(['cron', 'list', '--all', '--json', '--timeout', String(OPENCLAW_CRON_TIMEOUT_MS)])
+    return extractCronStoreJobs(stdout).map(cronStoreJobToRuntime)
+  }
+
+  private async getCronJob(id: string): Promise<CronJob | null> {
+    const jobs = await this.listCronJobs()
+    return jobs.find((job) => job.id === id) ?? null
+  }
+
+  private async createCronJob(input: CreateCronJobInput): Promise<CronJob> {
+    const args = cronCreateArgs(input)
+    const stdout = await this.execCron(args)
+    const parsed = parseJsonValue(stdout)
+    const rawJob = extractCronStoreJob(parsed)
+    const id = cronJobIdFromCliResult(parsed) ?? rawJob?.id ?? input.id
+    if (!id) throw new Error('OpenClaw cron add did not return a job id')
+
+    const runtime = rawJob ? cronStoreJobToRuntime(withCronInputFallbacks(rawJob, id, input)) : cronJobFromInput(id, input)
+    return {
+      ...runtime,
+      metadata: input.metadata ?? runtime.metadata,
+      toolsAllow: isBakinCron(input.command, input.metadata)
+        ? undefined
+        : normalizeCronToolsAllow(input.toolsAllow) ?? runtime.toolsAllow,
+    }
+  }
+
+  private async updateCronJob(id: string, patch: UpdateCronJobInput): Promise<CronJob> {
+    const current = await this.getCronJob(id)
+    if (!current) throw new Error(`Cron job not found: ${id}`)
+
+    const args = cronUpdateArgs(id, current, patch)
+    if (args.length > 5) await this.execCron(args)
+
+    const refreshed = await this.getCronJob(id).catch(() => null)
+    return refreshed ?? cronJobFromUpdatePatch(id, current, patch)
+  }
+
+  private async listCronRuns(jobId: string): Promise<CronRun[]> {
+    try {
+      const stdout = await this.execCron([
+        'cron',
+        'runs',
+        '--id',
+        jobId,
+        '--limit',
+        '50',
+        '--timeout',
+        String(OPENCLAW_CRON_TIMEOUT_MS),
+      ])
+      const runs = extractCronRuns(stdout, jobId)
+      return runs.length > 0 || stdout.trim().length === 0 ? runs : readCronRuns(jobId)
+    } catch (err) {
+      this.logger.debug('OpenClaw cron runs CLI failed; falling back to JSONL run history', {
+        jobId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return readCronRuns(jobId)
+    }
   }
 
   private baseUrl(): string {
@@ -1086,13 +1086,17 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     return res.json()
   }
 
-  private async exec(args: string[], opts: { maxBuffer?: number } = {}): Promise<string> {
+  private async exec(args: string[], opts: { maxBuffer?: number; timeout?: number } = {}): Promise<string> {
     try {
       const { stdout } = await execFileAsync(this.settings.binaryPath, args, { timeout: 15000, ...opts })
       return stdout
     } catch (err) {
       throw new OpenClawCommandError(args, err)
     }
+  }
+
+  private async execCron(args: string[]): Promise<string> {
+    return this.exec(args, { timeout: OPENCLAW_CRON_PROCESS_TIMEOUT_MS })
   }
 }
 
@@ -1506,6 +1510,12 @@ function readCronJobs(): OpenClawCronStoreJob[] {
 }
 
 function cronStoreJobToRuntime(job: OpenClawCronStoreJob): CronJob {
+  const scheduleTz = typeof job.schedule === 'object' && typeof job.schedule.tz === 'string' && job.schedule.tz.length > 0
+    ? job.schedule.tz
+    : undefined
+  const metadata = scheduleTz && !metadataValue(job.metadata, 'tz')
+    ? { ...(job.metadata ?? {}), tz: scheduleTz }
+    : job.metadata
   return {
     id: job.id,
     name: job.name ?? job.id,
@@ -1517,17 +1527,124 @@ function cronStoreJobToRuntime(job: OpenClawCronStoreJob): CronJob {
         : '',
     enabled: job.enabled ?? true,
     toolsAllow: normalizeCronToolsAllow(job.payload?.toolsAllow),
-    metadata: job.metadata,
+    metadata,
   }
-}
-
-function cronDeliveryFromMetadata(metadata: RuntimeMetadata | undefined): OpenClawCronStoreJob['delivery'] | undefined {
-  const webhookUrl = metadataValue(metadata, 'webhookUrl')
-  return webhookUrl ? { mode: 'webhook', to: webhookUrl, url: webhookUrl } : undefined
 }
 
 function isBakinScheduleMetadata(metadata: RuntimeMetadata | undefined): boolean {
   return metadata?.bakinSchedule === true || metadata?.['bakin.schedule'] === true
+}
+
+function isBakinCron(command: string, metadata: RuntimeMetadata | undefined): boolean {
+  return isBakinScheduleMetadata(metadata) || command.trim().startsWith('bakin:')
+}
+
+function cronCreateArgs(input: CreateCronJobInput): string[] {
+  const args = [
+    'cron',
+    'add',
+    '--name',
+    input.name,
+    '--cron',
+    input.schedule,
+    '--wake',
+    'now',
+    '--json',
+    '--timeout',
+    String(OPENCLAW_CRON_TIMEOUT_MS),
+  ]
+  const tz = metadataValue(input.metadata, 'tz')
+  if (tz) args.push('--tz', tz)
+  if (input.enabled === false) args.push('--disabled')
+  appendCronPayloadArgs(args, input.command, input.metadata, input.toolsAllow, { allowClearTools: false })
+  return args
+}
+
+function cronUpdateArgs(id: string, current: CronJob, patch: UpdateCronJobInput): string[] {
+  const args = ['cron', 'edit', id, '--timeout', String(OPENCLAW_CRON_TIMEOUT_MS)]
+  if (patch.name !== undefined) args.push('--name', patch.name)
+  if (patch.schedule !== undefined) args.push('--cron', patch.schedule)
+  if (patch.enabled === true) args.push('--enable')
+  if (patch.enabled === false) args.push('--disable')
+
+  const metadata = patch.metadata ?? current.metadata
+  const tz = metadataValue(metadata, 'tz')
+  if (patch.metadata !== undefined && tz) args.push('--tz', tz)
+
+  if (patch.command !== undefined || patch.metadata !== undefined || patch.toolsAllow !== undefined) {
+    appendCronPayloadArgs(args, patch.command ?? current.command, metadata, patch.toolsAllow)
+  }
+
+  return args
+}
+
+function appendCronPayloadArgs(
+  args: string[],
+  command: string,
+  metadata: RuntimeMetadata | undefined,
+  toolsAllow: string[] | null | undefined,
+  opts: { allowClearTools?: boolean } = {},
+): void {
+  if (isBakinCron(command, metadata)) {
+    args.push('--session', 'main', '--system-event', command)
+    return
+  }
+
+  args.push('--session', 'isolated', '--message', command)
+  if (toolsAllow === undefined) return
+
+  const normalized = normalizeCronToolsAllow(toolsAllow)
+  if (normalized) {
+    args.push('--tools', normalized.join(','))
+  } else if (opts.allowClearTools !== false) {
+    args.push('--clear-tools')
+  }
+}
+
+function cronJobFromInput(id: string, input: CreateCronJobInput): CronJob {
+  const bakinCron = isBakinCron(input.command, input.metadata)
+  return {
+    id,
+    name: input.name,
+    schedule: input.schedule,
+    command: input.command,
+    enabled: input.enabled ?? true,
+    toolsAllow: bakinCron ? undefined : normalizeCronToolsAllow(input.toolsAllow),
+    metadata: input.metadata,
+  }
+}
+
+function cronJobFromUpdatePatch(id: string, current: CronJob, patch: UpdateCronJobInput): CronJob {
+  const command = patch.command ?? current.command
+  const metadata = patch.metadata ?? current.metadata
+  const toolsAllow = patch.toolsAllow === null
+    ? undefined
+    : patch.toolsAllow !== undefined
+      ? normalizeCronToolsAllow(patch.toolsAllow)
+      : current.toolsAllow
+
+  return {
+    id,
+    name: patch.name ?? current.name,
+    schedule: patch.schedule ?? current.schedule,
+    command,
+    enabled: patch.enabled ?? current.enabled,
+    toolsAllow: isBakinCron(command, metadata) ? undefined : toolsAllow,
+    metadata,
+  }
+}
+
+function withCronInputFallbacks(raw: OpenClawCronStoreJob, id: string, input: CreateCronJobInput): OpenClawCronStoreJob {
+  const bakinCron = isBakinCron(input.command, input.metadata)
+  return {
+    ...raw,
+    id,
+    name: raw.name ?? input.name,
+    enabled: raw.enabled ?? input.enabled ?? true,
+    schedule: raw.schedule ?? { kind: 'cron', expr: input.schedule },
+    payload: raw.payload ?? cronPayloadForCommand(input.command, undefined, bakinCron),
+    metadata: raw.metadata ?? input.metadata,
+  }
 }
 
 function cronPayloadForCommand(
@@ -1539,18 +1656,6 @@ function cronPayloadForCommand(
     return { kind: 'systemEvent', text: command }
   }
   return { ...(current ?? {}), kind: 'agentTurn', message: command }
-}
-
-function withCronToolsAllow(
-  payload: OpenClawCronStoreJob['payload'],
-  toolsAllow: string[] | null | undefined,
-): OpenClawCronStoreJob['payload'] {
-  if (payload?.kind !== 'agentTurn' || toolsAllow === undefined) return payload
-  const next = { ...payload }
-  const normalized = normalizeCronToolsAllow(toolsAllow)
-  if (normalized) next.toolsAllow = normalized
-  else delete next.toolsAllow
-  return next
 }
 
 function normalizeCronToolsAllow(value: unknown): string[] | undefined {
@@ -1576,13 +1681,154 @@ function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
 
-function uniqueCronId(name: string, jobs: OpenClawCronStoreJob[]): string {
-  const base = `cron-${slug(name)}`
-  const ids = new Set(jobs.map((job) => job.id))
-  if (!ids.has(base)) return base
-  let suffix = 2
-  while (ids.has(`${base}-${suffix}`)) suffix += 1
-  return `${base}-${suffix}`
+function extractCronStoreJobs(raw: string | unknown): OpenClawCronStoreJob[] {
+  const parsed = typeof raw === 'string' ? parseJsonValue(raw) : raw
+  const candidates = cronJobCandidates(parsed)
+  return candidates
+    .map(normalizeOpenClawCronStoreJob)
+    .filter((job): job is OpenClawCronStoreJob => job !== null)
+}
+
+function extractCronStoreJob(raw: unknown): OpenClawCronStoreJob | null {
+  return extractCronStoreJobs(raw)[0] ?? null
+}
+
+function cronJobCandidates(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value
+  if (!isPlainObject(value)) return []
+
+  for (const key of ['jobs', 'items', 'results', 'data']) {
+    const candidate = value[key]
+    if (Array.isArray(candidate)) return candidate
+  }
+
+  for (const key of ['job', 'cronJob', 'result', 'payload']) {
+    const candidate = value[key]
+    if (Array.isArray(candidate)) return candidate
+    if (isPlainObject(candidate)) {
+      const nested = cronJobCandidates(candidate)
+      if (nested.length > 0) return nested
+      if (typeof candidate.id === 'string') return [candidate]
+    }
+  }
+
+  return typeof value.id === 'string' ? [value] : []
+}
+
+function normalizeOpenClawCronStoreJob(value: unknown): OpenClawCronStoreJob | null {
+  if (!isPlainObject(value)) return null
+  const id = firstString(value.id, value.jobId, value.key)
+  if (!id) return null
+
+  const rawSchedule = value.schedule
+  const schedule = typeof rawSchedule === 'string' || isPlainObject(rawSchedule)
+    ? rawSchedule as OpenClawCronStoreJob['schedule']
+    : firstString(value.cron, value.expr)
+      ? { kind: 'cron', expr: firstString(value.cron, value.expr), tz: firstString(value.tz, value.timezone) }
+      : undefined
+
+  const rawPayload = isPlainObject(value.payload) ? value.payload : undefined
+  const systemEvent = firstString(value.systemEvent)
+  const message = firstString(value.message, value.command)
+  const rawTools = rawPayload?.toolsAllow ?? value.toolsAllow ?? value.tools
+  const toolsAllow = normalizeCronToolsAllow(Array.isArray(rawTools) ? rawTools : typeof rawTools === 'string' ? rawTools.split(/[,\s]+/) : undefined)
+  const payload = rawPayload
+    ? {
+        ...rawPayload,
+        ...(toolsAllow ? { toolsAllow } : {}),
+      } as OpenClawCronStoreJob['payload']
+    : systemEvent
+      ? { kind: 'systemEvent', text: systemEvent }
+      : message
+        ? {
+            kind: 'agentTurn',
+            message,
+            ...(toolsAllow ? { toolsAllow } : {}),
+          }
+        : undefined
+
+  return {
+    id,
+    ...(typeof value.agentId === 'string' ? { agentId: value.agentId } : {}),
+    ...(typeof value.sessionKey === 'string' ? { sessionKey: value.sessionKey } : {}),
+    ...(typeof value.name === 'string' ? { name: value.name } : {}),
+    ...(typeof value.description === 'string' ? { description: value.description } : {}),
+    ...(typeof value.enabled === 'boolean' ? { enabled: value.enabled } : {}),
+    ...(typeof value.deleteAfterRun === 'boolean' ? { deleteAfterRun: value.deleteAfterRun } : {}),
+    ...(schedule ? { schedule } : {}),
+    ...(typeof value.sessionTarget === 'string' ? { sessionTarget: value.sessionTarget } : {}),
+    ...(typeof value.wakeMode === 'string' ? { wakeMode: value.wakeMode } : {}),
+    ...(isPlainObject(value.delivery) ? { delivery: value.delivery as OpenClawCronStoreJob['delivery'] } : {}),
+    ...(payload ? { payload } : {}),
+    ...(value.failureAlert !== undefined ? { failureAlert: value.failureAlert } : {}),
+    ...(isPlainObject(value.state) ? { state: value.state } : {}),
+    ...(typeof value.createdAt === 'string' ? { createdAt: value.createdAt } : {}),
+    ...(typeof value.updatedAt === 'string' ? { updatedAt: value.updatedAt } : {}),
+    ...(typeof value.createdAtMs === 'number' ? { createdAtMs: value.createdAtMs } : {}),
+    ...(typeof value.updatedAtMs === 'number' ? { updatedAtMs: value.updatedAtMs } : {}),
+    ...(isPlainObject(value.metadata) ? { metadata: value.metadata as RuntimeMetadata } : {}),
+  }
+}
+
+function cronJobIdFromCliResult(value: unknown): string | undefined {
+  return firstString(
+    getJsonPath(value, ['id']),
+    getJsonPath(value, ['jobId']),
+    getJsonPath(value, ['job', 'id']),
+    getJsonPath(value, ['cronJob', 'id']),
+    getJsonPath(value, ['payload', 'id']),
+    getJsonPath(value, ['payload', 'job', 'id']),
+    getJsonPath(value, ['result', 'id']),
+    getJsonPath(value, ['result', 'job', 'id']),
+  )
+}
+
+function extractCronRuns(raw: string, jobId: string): CronRun[] {
+  const parsed = parseJsonValue(raw)
+  const candidates = cronRunCandidates(parsed)
+  const source = candidates.length > 0 ? candidates : parseJsonLines(raw)
+  const runs = source
+    .map((entry) => normalizeOpenClawCronRun(entry, jobId))
+    .filter((run): run is CronRun => run !== null)
+  runs.sort((a, b) => Date.parse(b.startedAt ?? '') - Date.parse(a.startedAt ?? ''))
+  return runs
+}
+
+function cronRunCandidates(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value
+  if (!isPlainObject(value)) return []
+  for (const key of ['runs', 'items', 'results', 'data']) {
+    const candidate = value[key]
+    if (Array.isArray(candidate)) return candidate
+  }
+  const payload = value.payload
+  if (Array.isArray(payload)) return payload
+  if (isPlainObject(payload)) return cronRunCandidates(payload)
+  return typeof value.runId === 'string' || typeof value.id === 'string' ? [value] : []
+}
+
+function parseJsonLines(raw: string): unknown[] {
+  const entries: unknown[] = []
+  for (const line of raw.split('\n')) {
+    const parsed = parseJsonValue(line)
+    if (parsed !== null) entries.push(parsed)
+  }
+  return entries
+}
+
+function normalizeOpenClawCronRun(value: unknown, requestedJobId: string): CronRun | null {
+  if (!isPlainObject(value)) return null
+  const runJobId = firstString(value.jobId, value.cronJobId) ?? requestedJobId
+  if (runJobId !== requestedJobId) return null
+  return {
+    id: firstString(value.runId, value.id) ?? `run-${Date.now()}`,
+    jobId: requestedJobId,
+    status: normalizeCronRunStatus(firstString(value.status)),
+    startedAt: firstString(value.startedAt, value.timestamp, value.createdAt),
+    endedAt: firstString(value.endedAt, value.finishedAt),
+    output: firstString(value.output, value.stdout),
+    error: firstString(value.error, value.stderr),
+  }
 }
 
 function readCronRuns(jobId: string, limit = 50): CronRun[] {
@@ -2064,11 +2310,15 @@ function firstString(...values: unknown[]): string | undefined {
 }
 
 function parseJsonObject(raw: string): Record<string, unknown> | null {
+  const parsed = parseJsonValue(raw)
+  return isPlainObject(parsed) ? parsed : null
+}
+
+function parseJsonValue(raw: string): unknown | null {
   const trimmed = raw.trim()
   if (!trimmed) return null
   try {
-    const parsed = JSON.parse(trimmed)
-    return isPlainObject(parsed) ? parsed : null
+    return JSON.parse(trimmed)
   } catch {
     return null
   }

--- a/plugins/schedule/README.md
+++ b/plugins/schedule/README.md
@@ -76,8 +76,8 @@ The schedule page (`schedule-page.tsx`) offers three calendar views plus a list:
 
 | View | Component | Description |
 |------|-----------|-------------|
-| Today | `calendar-today.tsx` | Timeline of today's jobs by hour |
-| Week | `calendar-weekly.tsx` | 7-day grid (6am-10pm) with job cards |
+| Today | `calendar-today.tsx` | 24-hour timeline of today's jobs |
+| Week | `calendar-weekly.tsx` | 7-day, 24-hour grid with job cards |
 | Month | `calendar-monthly.tsx` | Monthly grid with agent dot indicators |
 | List | `job-list.tsx` / `job-row.tsx` | Table with status, schedule, agent, actions |
 

--- a/plugins/schedule/components/calendar-today.tsx
+++ b/plugins/schedule/components/calendar-today.tsx
@@ -8,10 +8,9 @@ import {
   formatHour,
   jobOnDow,
   JobCard,
+  CALENDAR_HOURS,
 } from './calendar-weekly'
 import type { ScheduleJob } from "@makinbakin/sdk/hooks"
-
-const HOURS = Array.from({ length: 17 }, (_, i) => i + 6) // 6am–10pm
 
 export function CalendarToday({
   jobs,
@@ -64,7 +63,7 @@ export function CalendarToday({
       {/* Timeline */}
       <div className="overflow-auto flex-1 min-h-0 border border-border/30 rounded-lg bg-background/50">
         <div className="divide-y divide-border/[0.06]">
-          {HOURS.map(hour => {
+          {CALENDAR_HOURS.map(hour => {
             const hourJobs = hourGrid.map[hour] || []
             const isPast = hour < currentHour
             const isCurrent = hour === currentHour

--- a/plugins/schedule/components/calendar-weekly.tsx
+++ b/plugins/schedule/components/calendar-weekly.tsx
@@ -28,7 +28,7 @@ export const AGENT_STYLES: Record<string, {
 
 export const FALLBACK_STYLE = AGENT_STYLES.patch!
 
-const HOURS = Array.from({ length: 17 }, (_, i) => i + 6) // 6am–10pm
+export const CALENDAR_HOURS = Array.from({ length: 24 }, (_, i) => i)
 const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 
 function getWeekStart(date: Date): Date {
@@ -246,7 +246,7 @@ export function CalendarWeekly({
           ))}
 
           {/* Hour rows */}
-          {HOURS.map(hour => (
+          {CALENDAR_HOURS.map(hour => (
             <Fragment key={hour}>
               <div className="text-[10px] text-zinc-600 text-right pr-2.5 py-3 border-t border-border/[0.06] font-mono tabular-nums">
                 {formatHour(hour)}

--- a/plugins/schedule/components/delete-schedule-dialog.tsx
+++ b/plugins/schedule/components/delete-schedule-dialog.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@makinbakin/sdk/ui"
+import { Button } from "@makinbakin/sdk/ui"
+import type { ScheduleJob } from "@makinbakin/sdk/hooks"
+
+interface DeleteScheduleDialogProps {
+  job: Pick<ScheduleJob, 'id' | 'displayName'> | null
+  deleting?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function DeleteScheduleDialog({
+  job,
+  deleting = false,
+  onConfirm,
+  onCancel,
+}: DeleteScheduleDialogProps) {
+  return (
+    <Dialog open={!!job} onOpenChange={(open) => { if (!open) onCancel() }}>
+      <DialogContent className="bg-card border-border sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Delete scheduled job</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete &ldquo;{job?.displayName || job?.id}&rdquo;? This will remove
+            the runtime cron job and Bakin schedule records. This can&apos;t be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm} disabled={deleting}>
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/plugins/schedule/components/job-drawer.tsx
+++ b/plugins/schedule/components/job-drawer.tsx
@@ -1,6 +1,4 @@
 'use client'
-
-import { useState } from 'react'
 import { Play, Pencil, Copy, Trash2, SkipForward, MoreHorizontal, Clock, Timer, Workflow, Terminal, CirclePlus, Undo2, Power, ShieldAlert, ShieldCheck } from 'lucide-react'
 import { BakinDrawer } from "@makinbakin/sdk/components"
 import { AgentAvatar } from "@makinbakin/sdk/components"
@@ -39,7 +37,7 @@ export function JobDrawer({
   onClose: () => void
   onPause: (jobId: string, pauseUntil?: string) => Promise<boolean>
   onResume: (jobId: string) => Promise<boolean>
-  onDelete: (jobId: string) => Promise<boolean>
+  onDelete: (jobId: string) => void
   onRunNow: (jobId: string) => Promise<boolean>
   onEdit: () => void
   onDuplicate: () => void
@@ -47,19 +45,12 @@ export function JobDrawer({
   onRestoreNative: (jobId: string) => Promise<boolean>
   onSkipNext: (jobId: string, n?: number) => Promise<boolean>
 }) {
-  const [confirmDelete, setConfirmDelete] = useState(false)
   const jobAgent = useAgent(job?.agentId ?? '')
 
   if (!job) return null
 
-  const handleDelete = async () => {
-    if (!confirmDelete) {
-      setConfirmDelete(true)
-      return
-    }
-    const ok = await onDelete(job.id)
-    if (ok) onClose()
-    setConfirmDelete(false)
+  const handleDelete = () => {
+    onDelete(job.id)
   }
 
   return (
@@ -68,7 +59,6 @@ export function JobDrawer({
       onOpenChange={(o) => {
         if (!o) {
           onClose()
-          setConfirmDelete(false)
         }
       }}
       title={
@@ -80,7 +70,7 @@ export function JobDrawer({
         </span>
       }
       actions={
-        <DropdownMenu onOpenChange={(o) => { if (!o) setConfirmDelete(false) }}>
+        <DropdownMenu>
           <DropdownMenuTrigger className="p-1.5 rounded-md hover:bg-accent transition-colors">
             <MoreHorizontal className="size-4" />
           </DropdownMenuTrigger>
@@ -108,7 +98,7 @@ export function JobDrawer({
               className="text-red-400 focus:text-red-400"
             >
               <Trash2 className="size-3.5 mr-2" />
-              {confirmDelete ? 'Confirm Delete' : 'Delete'}
+              Delete
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/plugins/schedule/components/schedule-page.tsx
+++ b/plugins/schedule/components/schedule-page.tsx
@@ -16,6 +16,7 @@ import { useScheduleJobs, type ScheduleJob } from "@makinbakin/sdk/hooks"
 import { JobList } from './job-list'
 import { JobDrawer } from './job-drawer'
 import { JobForm, type JobFormData } from './job-form'
+import { DeleteScheduleDialog } from './delete-schedule-dialog'
 import { CalendarMonthly } from './calendar-monthly'
 import { CalendarWeekly } from './calendar-weekly'
 import { CalendarToday } from './calendar-today'
@@ -42,6 +43,8 @@ export function SchedulePage() {
   const [mode, setMode, pushMode] = useQueryState('mode', '')
 
   const [submitting, setSubmitting] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<ScheduleJob | null>(null)
+  const [deleting, setDeleting] = useState(false)
   const [debug] = useDebug()
 
   const {
@@ -95,6 +98,25 @@ export function SchedulePage() {
 
   const openJob = (job: ScheduleJob) => pushJobId(job.id)
   const closeJob = () => setJobIdParam('')
+
+  const requestDelete = (jobId: string) => {
+    const job = jobs.find(j => j.id === jobId) ?? (selectedJob?.id === jobId ? selectedJob : null)
+    if (job) setDeleteTarget(job)
+  }
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return
+    setDeleting(true)
+    try {
+      const ok = await deleteJob(deleteTarget.id)
+      if (ok) {
+        if (jobIdParam === deleteTarget.id) closeJob()
+        setDeleteTarget(null)
+      }
+    } finally {
+      setDeleting(false)
+    }
+  }
 
   const openCreate = () => {
     // Atomic: set mode=create, clear jobId
@@ -251,7 +273,7 @@ export function SchedulePage() {
             onPause={(id) => pauseJob(id)}
             onResume={(id) => resumeJob(id)}
             onRunNow={(id) => runNow(id)}
-            onDelete={(id) => deleteJob(id)}
+            onDelete={requestDelete}
             onEdit={openEditFor}
             onDuplicate={openDuplicateFor}
             onAdopt={(job) => {
@@ -281,13 +303,20 @@ export function SchedulePage() {
         onClose={closeJob}
         onPause={pauseJob}
         onResume={resumeJob}
-        onDelete={deleteJob}
+        onDelete={requestDelete}
         onRunNow={runNow}
         onEdit={openEdit}
         onDuplicate={openDuplicate}
         onAdopt={openAdopt}
         onRestoreNative={restoreNative}
         onSkipNext={skipNext}
+      />
+
+      <DeleteScheduleDialog
+        job={deleteTarget}
+        deleting={deleting}
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
       />
 
       {/* Create / Edit / Duplicate form */}

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -6,10 +6,10 @@ import { randomBytes, timingSafeEqual } from 'crypto'
 import { z } from 'zod'
 import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin, defineRoute, searchRoute } from '@bakin/core/routing'
-import type { CronRun } from '@bakin/core/adapters/runtime'
+import type { CronJob, CronRun, UpdateCronJobInput } from '@bakin/core/adapters/runtime'
 import { readMergedJobs } from './lib/jobs-reader'
 import { getLastRun, readRuns } from './lib/runs-reader'
-import { upsertJob, removeJob, getJob, isPaused, shouldSkip, recordFailure, recordSuccess, withDefaults, hasProcessedRun, recordProcessedRun } from './lib/sidecar'
+import { upsertJob, removeJob, getJob, readSidecar, isPaused, shouldSkip, recordFailure, recordSuccess, withDefaults, hasProcessedRun, recordProcessedRun } from './lib/sidecar'
 import { parseSchedule } from './lib/cron-parser'
 import { createTaskWithEffects } from '../../src/core/task-service'
 import { getContentDir } from '../../src/core/content-dir'
@@ -68,6 +68,8 @@ interface EnsureBakinJobResult {
   error?: string
 }
 
+type ScheduleDeleteContext = Pick<PluginContext, 'runtime' | 'search'>
+
 /** Constant-time string comparison. Returns false for any length mismatch. */
 function safeEqual(a: string, b: string): boolean {
   const aBuf = Buffer.from(a, 'utf-8')
@@ -121,27 +123,34 @@ async function ensureBakinJob(ctx: PluginContext, input: Record<string, unknown>
     metadata: {
       ...metadata,
       tz,
+      logicalJobId: jobId,
       source: metadata.source ?? 'bakin',
       scheduleType: 'cron',
       bakinSchedule: true,
     },
   }
 
-  const existingRuntime = await ctx.runtime.cron.get(jobId)
+  const logicalExisting = getJobByLogicalJobId(jobId)
+  const runtimeJobs = await ctx.runtime.cron.list()
+  const existingRuntime = findExistingBakinRuntimeJob(runtimeJobs, { jobId, runtimeJobId: logicalExisting?.jobId, name, command })
+  let runtimeJob: CronJob
   if (existingRuntime) {
-    await ctx.runtime.cron.update(jobId, runtimePatch)
+    runtimeJob = await ctx.runtime.cron.update(existingRuntime.id, runtimePatch)
   } else {
-    await ctx.runtime.cron.create({ id: jobId, ...runtimePatch })
+    runtimeJob = await ctx.runtime.cron.create({ id: jobId, ...runtimePatch })
   }
+  const runtimeJobId = runtimeJob.id || existingRuntime?.id || jobId
 
-  const existing = getJob(jobId)
+  const staleExisting = runtimeJobId !== jobId ? getJob(jobId) : null
+  const existing = getJob(runtimeJobId) ?? logicalExisting ?? staleExisting
   const owner = typeof input.owner === 'string' && input.owner.trim()
     ? input.owner.trim()
     : existing?.owner ?? await getRuntimeMainAgentId(ctx.runtime)
   const description = typeof input.description === 'string' ? input.description : existing?.description
   const meta: BakinJobMeta = {
     ...(existing ?? {}),
-    jobId,
+    jobId: runtimeJobId,
+    logicalJobId: jobId,
     isBakinJob: true,
     source: 'bakin',
     displayName: name,
@@ -160,9 +169,66 @@ async function ensureBakinJob(ctx: PluginContext, input: Record<string, unknown>
     updatedAt: now,
   }
   upsertJob(meta)
-  indexJob(jobId)
+  for (const staleId of new Set([jobId, logicalExisting?.jobId, staleExisting?.jobId])) {
+    if (staleId && staleId !== runtimeJobId) removeJob(staleId)
+  }
+  indexJob(runtimeJobId)
 
-  return { ok: true, jobId, cron: parsed.cron, human: parsed.human }
+  return { ok: true, jobId: runtimeJobId, cron: parsed.cron, human: parsed.human }
+}
+
+function findExistingBakinRuntimeJob(
+  jobs: CronJob[],
+  input: { jobId: string; runtimeJobId?: string; name: string; command: string },
+): CronJob | undefined {
+  return (input.runtimeJobId ? jobs.find(job => job.id === input.runtimeJobId) : undefined)
+    ?? jobs.find(job => job.id === input.jobId)
+    ?? findUniqueCronJob(jobs, job => job.command === input.command && job.name === input.name)
+    ?? findUniqueCronJob(jobs, job => job.name === input.name && job.command.startsWith('bakin:'))
+}
+
+function findUniqueCronJob(jobs: CronJob[], predicate: (job: CronJob) => boolean): CronJob | undefined {
+  const matches = jobs.filter(predicate)
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+function getJobByLogicalJobId(logicalJobId: string): BakinJobMeta | null {
+  const matches = Object.values(readSidecar().jobs)
+    .filter(job => job.logicalJobId === logicalJobId)
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+  return matches[0] ?? null
+}
+
+function scheduleUpdateMetadata(meta: BakinJobMeta): UpdateCronJobInput['metadata'] | undefined {
+  if (!meta.tz) return undefined
+  return {
+    tz: meta.tz,
+    scheduleType: 'cron',
+    ...(meta.isBakinJob ? { bakinSchedule: true } : {}),
+    ...(meta.logicalJobId ? { logicalJobId: meta.logicalJobId } : {}),
+  }
+}
+
+function isCronAlreadyGoneError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /\bnot found\b/i.test(message) && /\b(cron|job)\b/i.test(message)
+}
+
+async function deleteScheduleJob(ctx: ScheduleDeleteContext, jobId: string): Promise<{ runtimeMissing: boolean }> {
+  let runtimeMissing = false
+  try {
+    await ctx.runtime.cron.remove(jobId)
+  } catch (err) {
+    if (!isCronAlreadyGoneError(err)) throw err
+    runtimeMissing = true
+    log.warn('Schedule runtime cron was already gone during delete; removing Bakin records', {
+      jobId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  removeJob(jobId)
+  ctx.search.remove(jobId).catch(() => {})
+  return { runtimeMissing }
 }
 
 // ---------------------------------------------------------------------------
@@ -660,12 +726,14 @@ const routes = [
       if (!jobId) return json({ error: 'jobId required' }, 400)
       const meta = getJob(jobId)
       if (!meta) return json({ error: 'Job not found in sidecar' }, 404)
-      const runtimePatch: { name?: string; schedule?: string } = {}
+      const runtimePatch: UpdateCronJobInput = {}
       const b = body as Record<string, unknown>
       if (b.schedule && typeof b.schedule === 'string') {
         const parsed = parseSchedule(b.schedule)
         if (!parsed) return json({ error: 'Could not parse schedule' }, 400)
         runtimePatch.schedule = parsed.cron
+        const metadata = scheduleUpdateMetadata(meta)
+        if (metadata) runtimePatch.metadata = metadata
       }
       if (b.name && typeof b.name === 'string') {
         runtimePatch.name = b.name
@@ -733,12 +801,10 @@ const routes = [
     responses: { 200: okResponse, 400: errorResponse },
     handler: async (_req, ctx, { params }) => {
       const jobId = params.jobId
-      await ctx.runtime.cron.remove(jobId)
-      removeJob(jobId)
-      ctx.search.remove(jobId).catch(() => {})
+      const result = await deleteScheduleJob(ctx, jobId)
       ctx.activity.audit('job.deleted', 'system', { jobId })
       ctx.activity.log('system', `Deleted schedule "${jobId}"`)
-      return json({ ok: true })
+      return json({ ok: true, ...result })
     },
   }),
 
@@ -1000,7 +1066,7 @@ const schedulePlugin: BakinPlugin = definePlugin({
     ctx.hooks.register('schedule.ensureBakinJob', (data: Record<string, unknown>) => ensureBakinJob(ctx, data), {
       hookKind: 'rpc',
       label: 'Ensure Bakin schedule',
-      summary: 'Create or update a deterministic Bakin-managed runtime cron job.',
+      summary: 'Create or update a Bakin-managed runtime cron job and return the provider job id.',
     })
 
     // ─── Search Content Type Registration ─────────────────────────────
@@ -1147,7 +1213,10 @@ const schedulePlugin: BakinPlugin = definePlugin({
         if (params.schedule) {
           const parsed = parseSchedule(params.schedule as string)
           if (!parsed) return { ok: false, error: 'Could not parse schedule' }
-          await ctx.runtime.cron.update(params.jobId as string, { schedule: parsed.cron })
+          const patch: UpdateCronJobInput = { schedule: parsed.cron }
+          const metadata = scheduleUpdateMetadata(meta)
+          if (metadata) patch.metadata = metadata
+          await ctx.runtime.cron.update(params.jobId as string, patch)
         }
         if (params.name) await ctx.runtime.cron.update(params.jobId as string, { name: params.name as string })
 
@@ -1222,10 +1291,8 @@ const schedulePlugin: BakinPlugin = definePlugin({
       },
       handler: async (params: Record<string, unknown>) => {
         if (!params.jobId) return { ok: false, error: 'jobId required' }
-        await ctx.runtime.cron.remove(params.jobId as string)
-        removeJob(params.jobId as string)
-        ctx.search.remove(params.jobId as string).catch(() => {})
-        return { ok: true }
+        const result = await deleteScheduleJob(ctx, params.jobId as string)
+        return { ok: true, ...result }
       },
     })
 

--- a/plugins/schedule/lib/jobs-reader.ts
+++ b/plugins/schedule/lib/jobs-reader.ts
@@ -93,7 +93,7 @@ export function mergeJob(
     taskPrompt: meta?.taskPrompt ?? orphanContext.prompt,
     taskTitle: meta?.taskTitle,
     toolsAllow: job.toolsAllow,
-    toolsAllowMissing: job.toolsAllowMissing ?? false,
+    toolsAllowMissing: meta?.isBakinJob ? false : job.toolsAllowMissing ?? false,
     paused: meta?.paused ?? false,
     pauseUntil: meta?.pauseUntil,
     pauseReason: meta?.pauseReason,

--- a/plugins/schedule/types.ts
+++ b/plugins/schedule/types.ts
@@ -13,6 +13,8 @@ export interface ScheduleSidecar {
 
 export interface BakinJobMeta {
   jobId: string
+  /** Stable caller-owned id used when a runtime/provider generates a different job id. */
+  logicalJobId?: string
   isBakinJob: boolean
   source?: 'bakin' | 'runtime' | 'adopted'
   displayName?: string

--- a/tests/adapter-openclaw/runtime-cron.test.ts
+++ b/tests/adapter-openclaw/runtime-cron.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+const cronExecOpts = { timeout: 35000 }
+
 describe('OpenClaw runtime cron adapter', () => {
   let testDir: string
   let originalOpenClawHome: string | undefined
@@ -20,11 +22,22 @@ describe('OpenClaw runtime cron adapter', () => {
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  it('creates Bakin schedule cron jobs as OpenClaw main-session system events', async () => {
+  it('creates Bakin schedule cron jobs as OpenClaw main-session system events through the CLI', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
+    const exec = mock(async (_args: string[]) => JSON.stringify({
+      id: 'openclaw-schedule-1',
+      name: 'Schedule One',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'America/Denver' },
+      sessionTarget: 'main',
+      wakeMode: 'now',
+      delivery: { mode: 'none' },
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:schedule-1' },
+    }))
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
-    await runtime.cron.create({
+    const created = await runtime.cron.create({
       id: 'schedule-1',
       name: 'Schedule One',
       schedule: '0 9 * * *',
@@ -32,23 +45,54 @@ describe('OpenClaw runtime cron adapter', () => {
       metadata: { bakinSchedule: true, tz: 'America/Denver' },
     })
 
-    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(store.jobs[0]).toEqual(expect.objectContaining({
-      id: 'schedule-1',
-      sessionTarget: 'main',
-      wakeMode: 'now',
-      delivery: { mode: 'none' },
-      payload: { kind: 'systemEvent', text: 'bakin:schedule:schedule-1' },
-      metadata: expect.objectContaining({ bakinSchedule: true }),
+    expect(created).toEqual(expect.objectContaining({
+      id: 'openclaw-schedule-1',
+      command: 'bakin:schedule:schedule-1',
+      toolsAllow: undefined,
     }))
-    expect(typeof store.jobs[0].createdAtMs).toBe('number')
+    expect(exec).toHaveBeenCalledWith([
+      'cron',
+      'add',
+      '--name',
+      'Schedule One',
+      '--cron',
+      '0 9 * * *',
+      '--wake',
+      'now',
+      '--json',
+      '--timeout',
+      '30000',
+      '--tz',
+      'America/Denver',
+      '--session',
+      'main',
+      '--system-event',
+      'bakin:schedule:schedule-1',
+    ], cronExecOpts)
   })
 
   it('persists toolsAllow on native isolated cron jobs and returns it from list/get', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
+    const rawJob = {
+      id: 'openclaw-native-tools',
+      name: 'Native Tools',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 7 * * *' },
+      sessionTarget: 'isolated',
+      payload: {
+        kind: 'agentTurn',
+        message: 'Post the daily recipe',
+        toolsAllow: ['message', 'image_generate'],
+      },
+    }
+    const exec = mock(async (args: string[]) => {
+      if (args[1] === 'list') return JSON.stringify([rawJob])
+      return JSON.stringify(rawJob)
+    })
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
-    await runtime.cron.create({
+    const created = await runtime.cron.create({
       id: 'native-tools',
       name: 'Native Tools',
       schedule: '0 7 * * *',
@@ -56,78 +100,123 @@ describe('OpenClaw runtime cron adapter', () => {
       toolsAllow: ['message', 'image_generate'],
     })
 
-    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(store.jobs[0].payload).toEqual(expect.objectContaining({
-      kind: 'agentTurn',
-      message: 'Post the daily recipe',
+    expect(created).toEqual(expect.objectContaining({
+      id: 'openclaw-native-tools',
       toolsAllow: ['message', 'image_generate'],
     }))
+    expect(exec).toHaveBeenCalledWith([
+      'cron',
+      'add',
+      '--name',
+      'Native Tools',
+      '--cron',
+      '0 7 * * *',
+      '--wake',
+      'now',
+      '--json',
+      '--timeout',
+      '30000',
+      '--session',
+      'isolated',
+      '--message',
+      'Post the daily recipe',
+      '--tools',
+      'message,image_generate',
+    ], cronExecOpts)
 
-    await expect(runtime.cron.get('native-tools')).resolves.toEqual(expect.objectContaining({
-      id: 'native-tools',
+    await expect(runtime.cron.get('openclaw-native-tools')).resolves.toEqual(expect.objectContaining({
+      id: 'openclaw-native-tools',
       toolsAllow: ['message', 'image_generate'],
     }))
     await expect(runtime.cron.list()).resolves.toEqual([
-      expect.objectContaining({ id: 'native-tools', toolsAllow: ['message', 'image_generate'] }),
+      expect.objectContaining({ id: 'openclaw-native-tools', toolsAllow: ['message', 'image_generate'] }),
     ])
   })
 
-  it('updates and clears toolsAllow without dropping native cron payload fields', async () => {
-    mkdirSync(join(testDir, 'cron'), { recursive: true })
-    writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({
-      version: 1,
-      jobs: [{
-        id: 'native-update-tools',
-        name: 'Native Update Tools',
-        enabled: true,
-        schedule: { kind: 'cron', expr: '0 8 * * *' },
-        sessionTarget: 'isolated',
-        payload: {
-          kind: 'agentTurn',
-          message: 'Original native command',
-          model: 'openai/gpt-5.4',
-          toolsAllow: ['message'],
-        },
-        delivery: { mode: 'none' },
-      }],
-    }), 'utf-8')
-
+  it('updates and clears toolsAllow with OpenClaw cron edit', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
+    const rawJob: {
+      id: string
+      name: string
+      enabled: boolean
+      schedule: { kind: string; expr: string }
+      sessionTarget: string
+      payload: Record<string, unknown>
+      delivery: { mode: string }
+    } = {
+      id: 'native-update-tools',
+      name: 'Native Update Tools',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 8 * * *' },
+      sessionTarget: 'isolated',
+      payload: {
+        kind: 'agentTurn',
+        message: 'Original native command',
+        model: 'openai/gpt-5.4',
+        toolsAllow: ['message'],
+      },
+      delivery: { mode: 'none' },
+    }
+    const exec = mock(async (args: string[]) => {
+      if (args[1] === 'list') return JSON.stringify([rawJob])
+      if (args[1] === 'edit') {
+        const toolsIndex = args.indexOf('--tools')
+        if (toolsIndex !== -1) rawJob.payload.toolsAllow = args[toolsIndex + 1].split(',')
+        if (args.includes('--clear-tools')) delete rawJob.payload.toolsAllow
+      }
+      return ''
+    })
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
-    await runtime.cron.update('native-update-tools', { toolsAllow: ['message', 'exec'] })
-
-    const updatedStore = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(updatedStore.jobs[0].payload).toEqual(expect.objectContaining({
-      kind: 'agentTurn',
-      message: 'Original native command',
-      model: 'openai/gpt-5.4',
+    await expect(runtime.cron.update('native-update-tools', { toolsAllow: ['message', 'exec'] })).resolves.toEqual(expect.objectContaining({
       toolsAllow: ['message', 'exec'],
     }))
+    expect(exec).toHaveBeenCalledWith([
+      'cron',
+      'edit',
+      'native-update-tools',
+      '--timeout',
+      '30000',
+      '--session',
+      'isolated',
+      '--message',
+      'Original native command',
+      '--tools',
+      'message,exec',
+    ], cronExecOpts)
 
-    await expect(runtime.cron.get('native-update-tools')).resolves.toEqual(expect.objectContaining({
-      toolsAllow: ['message', 'exec'],
-    }))
-
-    await runtime.cron.update('native-update-tools', { toolsAllow: null })
-
-    const clearedStore = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(clearedStore.jobs[0].payload).toEqual(expect.objectContaining({
-      kind: 'agentTurn',
-      message: 'Original native command',
-      model: 'openai/gpt-5.4',
-    }))
-    expect(clearedStore.jobs[0].payload.toolsAllow).toBeUndefined()
-    await expect(runtime.cron.get('native-update-tools')).resolves.toEqual(expect.objectContaining({
+    await expect(runtime.cron.update('native-update-tools', { toolsAllow: null })).resolves.toEqual(expect.objectContaining({
       toolsAllow: undefined,
     }))
+    expect(exec).toHaveBeenCalledWith([
+      'cron',
+      'edit',
+      'native-update-tools',
+      '--timeout',
+      '30000',
+      '--session',
+      'isolated',
+      '--message',
+      'Original native command',
+      '--clear-tools',
+    ], cronExecOpts)
   })
 
   it('does not attach toolsAllow to Bakin schedule system-event cron jobs', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
+    const exec = mock(async (_args: string[]) => JSON.stringify({
+      id: 'openclaw-schedule-tools',
+      name: 'Schedule Tools',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 9 * * *' },
+      sessionTarget: 'main',
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:schedule-tools' },
+    }))
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
-    await runtime.cron.create({
+    const created = await runtime.cron.create({
       id: 'schedule-tools',
       name: 'Schedule Tools',
       schedule: '0 9 * * *',
@@ -136,11 +225,29 @@ describe('OpenClaw runtime cron adapter', () => {
       toolsAllow: ['message'],
     })
 
-    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(store.jobs[0].payload).toEqual({ kind: 'systemEvent', text: 'bakin:schedule:schedule-tools' })
-    await expect(runtime.cron.get('schedule-tools')).resolves.toEqual(expect.objectContaining({
-      toolsAllow: undefined,
-    }))
+    expect(created.toolsAllow).toBeUndefined()
+    expect(exec.mock.calls[0][0]).not.toContain('--tools')
+  })
+
+  it('preserves the timezone from OpenClaw cron schedule objects when listing jobs', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const exec = mock(async () => JSON.stringify([{
+      id: 'openclaw-tz',
+      name: 'Timezone job',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'America/Denver' },
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:timezone-job' },
+    }]))
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
+
+    await expect(runtime.cron.list()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'openclaw-tz',
+        schedule: '0 9 * * *',
+        metadata: expect.objectContaining({ tz: 'America/Denver' }),
+      }),
+    ])
   })
 
   it('captures and restores raw cron snapshots without dropping provider-specific fields', async () => {
@@ -167,54 +274,82 @@ describe('OpenClaw runtime cron adapter', () => {
     const runtime = createOpenClawRuntimeAdapter()
     const raw = await runtime.cron.getRaw('native-1', 'test capture')
 
-    await runtime.cron.update('native-1', {
-      command: 'bakin:schedule:native-1',
-      metadata: { bakinSchedule: true },
-    })
-    const adoptedStore = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(adoptedStore.jobs[0]).toEqual(expect.objectContaining({
-      sessionTarget: 'main',
-      wakeMode: 'now',
-      delivery: { mode: 'none' },
-      payload: { kind: 'systemEvent', text: 'bakin:schedule:native-1' },
-    }))
-
+    writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({ version: 1, jobs: [] }), 'utf-8')
     await runtime.cron.restoreRaw('native-1', raw, 'test restore')
 
     const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
     expect(store.jobs[0]).toEqual(raw)
   })
 
-  it('converts metadata-only Bakin updates to system-event payloads', async () => {
-    mkdirSync(join(testDir, 'cron'), { recursive: true })
-    writeFileSync(join(testDir, 'cron', 'jobs.json'), JSON.stringify({
-      version: 1,
-      jobs: [{
-        id: 'native-2',
-        name: 'Native Two',
-        enabled: true,
-        schedule: { kind: 'cron', expr: '0 8 * * *' },
-        sessionTarget: 'isolated',
-        payload: { kind: 'agentTurn', message: 'Original native command' },
-        delivery: { mode: 'announce', channel: 'last' },
-      }],
-    }), 'utf-8')
-
+  it('converts metadata-only Bakin updates to system-event payloads through the CLI', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
-
-    await runtime.cron.update('native-2', {
-      metadata: { bakinSchedule: true },
+    const rawJob: {
+      id: string
+      name: string
+      enabled: boolean
+      schedule: { kind: string; expr: string }
+      sessionTarget: string
+      payload: Record<string, unknown>
+      delivery: { mode: string; channel: string }
+    } = {
+      id: 'native-2',
+      name: 'Native Two',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 8 * * *' },
+      sessionTarget: 'isolated',
+      payload: { kind: 'agentTurn', message: 'Original native command' },
+      delivery: { mode: 'announce', channel: 'last' },
+    }
+    const exec = mock(async (args: string[]) => {
+      if (args[1] === 'edit') {
+        rawJob.sessionTarget = 'main'
+        rawJob.payload = { kind: 'systemEvent', text: 'Original native command' }
+      }
+      return JSON.stringify([rawJob])
     })
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
-    const store = JSON.parse(readFileSync(join(testDir, 'cron', 'jobs.json'), 'utf-8'))
-    expect(store.jobs[0]).toEqual(expect.objectContaining({
-      sessionTarget: 'main',
-      wakeMode: 'now',
-      delivery: { mode: 'none' },
-      payload: { kind: 'systemEvent', text: 'Original native command' },
+    await expect(runtime.cron.update('native-2', {
       metadata: { bakinSchedule: true },
+    })).resolves.toEqual(expect.objectContaining({
+      command: 'Original native command',
+      toolsAllow: undefined,
     }))
+    expect(exec).toHaveBeenCalledWith([
+      'cron',
+      'edit',
+      'native-2',
+      '--timeout',
+      '30000',
+      '--session',
+      'main',
+      '--system-event',
+      'Original native command',
+    ], cronExecOpts)
+  })
+
+  it('reads cron run history through the OpenClaw cron CLI', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const exec = mock(async () => JSON.stringify([
+      { runId: 'run-1', jobId: 'cron-history', status: 'success', timestamp: '2026-03-31T09:00:00Z' },
+    ]))
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
+
+    await expect(runtime.cron.listRuns('cron-history')).resolves.toEqual([
+      expect.objectContaining({ id: 'run-1', jobId: 'cron-history', status: 'succeeded' }),
+    ])
+    expect(exec).toHaveBeenCalledWith([
+      'cron',
+      'runs',
+      '--id',
+      'cron-history',
+      '--limit',
+      '50',
+      '--timeout',
+      '30000',
+    ], cronExecOpts)
   })
 
   it('runs cron jobs without passing unsupported force flags', async () => {

--- a/tests/dev/mock-runtime-contract.test.ts
+++ b/tests/dev/mock-runtime-contract.test.ts
@@ -113,34 +113,33 @@ describe('imitation-crab runtime contract', () => {
       deliveries: [expect.objectContaining({ channelId: 'discord:contract-channel' })],
     }))
 
-    await expect(runtime.cron.create({
-      id: 'contract-cron',
+    const createdCron = await runtime.cron.create({
       name: 'Contract Cron',
       schedule: '*/10 * * * *',
       command: 'Run contract cron',
       toolsAllow: ['message'],
-    })).resolves.toEqual(expect.objectContaining({
-      id: 'contract-cron',
+    })
+    expect(createdCron).toEqual(expect.objectContaining({
       command: 'Run contract cron',
       toolsAllow: ['message'],
     }))
-    await expect(runtime.cron.update('contract-cron', {
+    await expect(runtime.cron.update(createdCron.id, {
       schedule: '0 * * * *',
       toolsAllow: ['message', 'exec'],
     })).resolves.toEqual(expect.objectContaining({
-      id: 'contract-cron',
+      id: createdCron.id,
       schedule: '0 * * * *',
       toolsAllow: ['message', 'exec'],
     }))
-    await expect(runtime.cron.runNow('contract-cron')).resolves.toEqual(expect.objectContaining({
-      jobId: 'contract-cron',
+    await expect(runtime.cron.runNow(createdCron.id)).resolves.toEqual(expect.objectContaining({
+      jobId: createdCron.id,
       status: 'succeeded',
     }))
-    await expect(runtime.cron.listRuns('contract-cron')).resolves.toEqual([
-      expect.objectContaining({ jobId: 'contract-cron', status: 'succeeded' }),
+    await expect(runtime.cron.listRuns(createdCron.id)).resolves.toEqual([
+      expect.objectContaining({ jobId: createdCron.id, status: 'succeeded' }),
     ])
-    await runtime.cron.remove('contract-cron')
-    await expect(runtime.cron.get('contract-cron')).resolves.toBeNull()
+    await runtime.cron.remove(createdCron.id)
+    await expect(runtime.cron.get(createdCron.id)).resolves.toBeNull()
 
     await expect(runtime.tasks.dispatch({
       bakinTaskId: 'task-contract',

--- a/tests/plugins/schedule/calendar-views.test.tsx
+++ b/tests/plugins/schedule/calendar-views.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useAgent: (id: string) => id ? { id, name: id } : null,
+}))
+
+mock.module('@makinbakin/sdk/components', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span>{agentId}</span>,
+}))
+
+import { CalendarToday } from '../../../plugins/schedule/components/calendar-today'
+import { CalendarWeekly } from '../../../plugins/schedule/components/calendar-weekly'
+import type { ScheduleJob } from '../../../src/hooks/use-schedule'
+
+function makeJob(overrides: Partial<ScheduleJob> = {}): ScheduleJob {
+  return {
+    id: 'late-night-release',
+    displayName: 'Late night release',
+    agentId: 'main',
+    humanSchedule: 'Every day at 11:05pm',
+    cron: '5 23 * * *',
+    paused: false,
+    enabled: true,
+    isBakinJob: true,
+    allowOverlap: false,
+    maxFailures: 3,
+    consecutiveFailures: 0,
+    taskPrompt: 'Build release notes',
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Schedule calendar views', () => {
+  it('shows jobs scheduled after 10pm in the Today timeline', () => {
+    render(<CalendarToday jobs={[makeJob()]} onSelectJob={() => {}} />)
+
+    expect(screen.getByText('11 PM')).toBeDefined()
+    expect(screen.getByText('Late night release')).toBeDefined()
+    expect(screen.getByText('11:05pm')).toBeDefined()
+  })
+
+  it('shows jobs scheduled after 10pm in the Week grid', () => {
+    render(<CalendarWeekly jobs={[makeJob()]} onSelectJob={() => {}} />)
+
+    expect(screen.getByText('11 PM')).toBeDefined()
+    expect(screen.getAllByText('Late night release').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('11:05pm').length).toBeGreaterThan(0)
+  })
+})

--- a/tests/plugins/schedule/delete-schedule-dialog.test.tsx
+++ b/tests/plugins/schedule/delete-schedule-dialog.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+mock.module('@makinbakin/sdk/ui', () => ({
+  Dialog: ({ open, children }: { open: boolean; children?: React.ReactNode }) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children?: React.ReactNode }) => <div role="dialog">{children}</div>,
+  DialogHeader: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children?: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => <button onClick={onClick} disabled={disabled}>{children}</button>,
+}))
+
+import { DeleteScheduleDialog } from '../../../plugins/schedule/components/delete-schedule-dialog'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('DeleteScheduleDialog', () => {
+  it('renders the standard destructive confirmation dialog', () => {
+    const onConfirm = mock()
+    const onCancel = mock()
+
+    render(
+      <DeleteScheduleDialog
+        job={{ id: 'job-delete', displayName: 'Delete candidate' }}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    )
+
+    expect(screen.getByRole('dialog')).toBeDefined()
+    expect(screen.getByText('Delete scheduled job')).toBeDefined()
+    expect(screen.getByText(/Delete candidate/)).toBeDefined()
+    expect(screen.getByText(/runtime cron job and Bakin schedule records/)).toBeDefined()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(onConfirm).toHaveBeenCalled()
+  })
+})

--- a/tests/plugins/schedule/job-drawer.test.tsx
+++ b/tests/plugins/schedule/job-drawer.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useAgent: (id: string) => id ? { id, name: id } : null,
+}))
+
+mock.module('@makinbakin/sdk/components', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span>{agentId}</span>,
+  BakinDrawer: ({
+    open,
+    title,
+    actions,
+    children,
+  }: {
+    open: boolean
+    title?: React.ReactNode
+    actions?: React.ReactNode
+    children?: React.ReactNode
+  }) => open ? (
+    <section>
+      <div>{title}</div>
+      <div>{actions}</div>
+      <div>{children}</div>
+    </section>
+  ) : null,
+}))
+
+mock.module('@makinbakin/sdk/ui', () => ({
+  Badge: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  Button: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  Separator: () => <hr />,
+  DropdownMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+  DropdownMenuContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode
+    onClick?: () => void
+  }) => <button onClick={onClick}>{children}</button>,
+  DropdownMenuSeparator: () => <hr />,
+}))
+
+mock.module('@bakin/schedule/components/run-history', () => ({
+  RunHistory: () => <div>Run history</div>,
+}))
+
+mock.module('@bakin/schedule/components/pause-controls', () => ({
+  PauseControls: () => <div>Pause controls</div>,
+}))
+
+import { JobDrawer } from '../../../plugins/schedule/components/job-drawer'
+import type { ScheduleJob } from '../../../src/hooks/use-schedule'
+
+function makeJob(overrides: Partial<ScheduleJob> = {}): ScheduleJob {
+  return {
+    id: 'job-delete',
+    displayName: 'Delete me',
+    agentId: 'main',
+    humanSchedule: 'Every day at 9am',
+    cron: '0 9 * * *',
+    paused: false,
+    enabled: true,
+    isBakinJob: true,
+    allowOverlap: false,
+    maxFailures: 3,
+    consecutiveFailures: 0,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('JobDrawer', () => {
+  it('requests deletion from the drawer actions menu', () => {
+    const onDelete = mock()
+    const onClose = mock()
+
+    render(
+      <JobDrawer
+        job={makeJob()}
+        open
+        onClose={onClose}
+        onPause={mock(async () => true)}
+        onResume={mock(async () => true)}
+        onDelete={onDelete}
+        onRunNow={mock(async () => true)}
+        onEdit={mock()}
+        onDuplicate={mock()}
+        onAdopt={mock()}
+        onRestoreNative={mock(async () => true)}
+        onSkipNext={mock(async () => true)}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }))
+
+    expect(onDelete).toHaveBeenCalledWith('job-delete')
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/tests/plugins/schedule/jobs-reader.test.ts
+++ b/tests/plugins/schedule/jobs-reader.test.ts
@@ -177,6 +177,14 @@ describe('schedule/jobs-reader', () => {
       expect(merged.owner).toBe('main')
     })
 
+    it('does not flag Bakin sidecar jobs missing runtime cron toolsAllow', () => {
+      const job = makeRuntimeJob({ id: 'j1', toolsAllowMissing: true })
+      const sidecar = makeMeta({ jobId: 'j1', isBakinJob: true })
+      const merged = mergeJob(job, sidecar, defaultOwner)
+
+      expect(merged.toolsAllowMissing).toBe(false)
+    })
+
     it('uses sidecar defaults for missing fields', () => {
       const job = makeRuntimeJob({ id: 'j1', schedule: { type: 'cron', value: '0 * * * *' } })
       const sidecar = makeMeta({ jobId: 'j1' })

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -82,6 +82,7 @@ const mockMergedJobs: MergedJob[] = []
 const mockRuntimeCronJobs: CronJob[] = []
 const mockRuns: RunEntry[] = []
 let lastRunOverride: RunEntry | null = null
+let mockCronRemoveError: Error | null = null
 
 function mergedJobToCronJob(job: MergedJob): CronJob {
   return {
@@ -140,7 +141,7 @@ function runEntryToCronRun(run: RunEntry): CronRun {
 
 const mockCronCreate = mock(async (input: CreateCronJobInput): Promise<CronJob> => {
   const job = {
-    id: input.id ?? 'new-job-id',
+    id: input.id === 'plugin-nightly-sync' ? 'runtime-plugin-nightly-sync' : input.id ?? 'new-job-id',
     name: input.name,
     schedule: input.schedule,
     command: input.command,
@@ -165,6 +166,7 @@ const mockCronUpdate = mock(async (id: string, patch: UpdateCronJobInput): Promi
   return next
 })
 const mockCronRemove = mock(async (id: string) => {
+  if (mockCronRemoveError) throw mockCronRemoveError
   const index = mockRuntimeCronJobs.findIndex(job => job.id === id)
   if (index !== -1) mockRuntimeCronJobs.splice(index, 1)
 })
@@ -319,6 +321,7 @@ beforeEach(() => {
   mockRuntimeCronJobs.length = 0
   mockRuns.length = 0
   lastRunOverride = null
+  mockCronRemoveError = null
   // Reset sidecar on disk
   writeFileSync(join(sidecarDir, 'sidecar.json'), JSON.stringify({ version: 1, jobs: {} }))
 })
@@ -570,6 +573,21 @@ describe('schedule routes', () => {
       expect(mockCronUpdate).toHaveBeenCalledWith('job-123', { schedule: '0 10 * * *' })
     })
 
+    it('preserves the schedule timezone when the cron expression changes', async () => {
+      upsertJob(makeMeta({ jobId: 'job-tz', tz: 'America/Denver' }))
+
+      const route = findRoute(plugin.routes, 'PUT', '/:jobId')!
+      await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'job-tz' },
+        body: { schedule: '0 10 * * *' },
+      })
+
+      expect(mockCronUpdate).toHaveBeenCalledWith('job-tz', expect.objectContaining({
+        schedule: '0 10 * * *',
+        metadata: expect.objectContaining({ tz: 'America/Denver' }),
+      }))
+    })
+
     it('calls runtime cron update when name is changed', async () => {
       upsertJob(makeMeta({ jobId: 'job-123' }))
 
@@ -723,6 +741,23 @@ describe('schedule routes', () => {
       expect(body.ok).toBe(true)
       expect(mockCronRemove).toHaveBeenCalledWith('job-del')
       expect(getJob('job-del')).toBeNull()
+      expect(plugin.ctx.search.remove).toHaveBeenCalledWith('job-del')
+    })
+
+    it('cleans up Bakin records when the runtime cron job is already gone', async () => {
+      upsertJob(makeMeta({ jobId: 'job-stale-del' }))
+      mockCronRemoveError = new Error('Cron job not found: job-stale-del')
+
+      const route = findRoute(plugin.routes, 'DELETE', '/:jobId')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { jobId: 'job-stale-del' },
+        body: {},
+      })
+
+      expect(status).toBe(200)
+      expect(body.ok).toBe(true)
+      expect(getJob('job-stale-del')).toBeNull()
+      expect(plugin.ctx.search.remove).toHaveBeenCalledWith('job-stale-del')
     })
 
     it('deletes a job when clients send no DELETE body', async () => {
@@ -1225,6 +1260,21 @@ describe('schedule exec tools', () => {
       expect(mockCronUpdate).toHaveBeenCalledWith('job-upd-sched', { schedule: '0 10 * * *' })
     })
 
+    it('preserves timezone when the exec tool changes a schedule', async () => {
+      upsertJob(makeMeta({ jobId: 'job-upd-tz', tz: 'America/Denver' }))
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_schedule_update')!
+      await callTool(tool, {
+        jobId: 'job-upd-tz',
+        schedule: '0 10 * * *',
+      })
+
+      expect(mockCronUpdate).toHaveBeenCalledWith('job-upd-tz', expect.objectContaining({
+        schedule: '0 10 * * *',
+        metadata: expect.objectContaining({ tz: 'America/Denver' }),
+      }))
+    })
+
     it('returns error when jobId is missing', async () => {
       const tool = findTool(plugin.execTools, 'bakin_exec_schedule_update')!
       const result = await callTool(tool, { name: 'Test' })
@@ -1697,7 +1747,7 @@ describe('schedule plugin activation', () => {
     }
   })
 
-  it('registers a hook for deterministic Bakin-managed plugin jobs', async () => {
+  it('registers a hook for provider-backed Bakin-managed plugin jobs', async () => {
     const activated = await activatePlugin(schedulePlugin, testDir)
     const registerMock = activated.ctx.hooks.register as unknown as {
       mock: { calls: Array<[string, (data: Record<string, unknown>) => Promise<Record<string, unknown>>, Record<string, unknown>]> }
@@ -1716,7 +1766,7 @@ describe('schedule plugin activation', () => {
 
     expect(result).toEqual(expect.objectContaining({
       ok: true,
-      jobId: 'plugin-nightly-sync',
+      jobId: 'runtime-plugin-nightly-sync',
       cron: '*/5 * * * *',
     }))
     expect(mockCronCreate).toHaveBeenCalledWith(expect.objectContaining({
@@ -1730,10 +1780,93 @@ describe('schedule plugin activation', () => {
         scheduleType: 'cron',
       }),
     }))
-    expect(getJob('plugin-nightly-sync')).toEqual(expect.objectContaining({
+    expect(getJob('runtime-plugin-nightly-sync')).toEqual(expect.objectContaining({
       isBakinJob: true,
       source: 'bakin',
       displayName: 'Plugin nightly sync',
+      logicalJobId: 'plugin-nightly-sync',
+    }))
+  })
+
+  it('updates an existing provider-backed plugin job by logical id after a rename', async () => {
+    const activated = await activatePlugin(schedulePlugin, testDir)
+    const registerMock = activated.ctx.hooks.register as unknown as {
+      mock: { calls: Array<[string, (data: Record<string, unknown>) => Promise<Record<string, unknown>>, Record<string, unknown>]> }
+    }
+    const call = registerMock.mock.calls.find(([name]) => name === 'schedule.ensureBakinJob')
+    expect(call).toBeDefined()
+    const handler = call![1]
+
+    const first = await handler({
+      jobId: 'plugin-nightly-sync',
+      name: 'Plugin nightly sync',
+      schedule: '*/5 * * * *',
+      command: 'bakin:reports:refresh',
+      metadata: { pluginId: 'reports' },
+    })
+    expect(first.jobId).toBe('runtime-plugin-nightly-sync')
+
+    mockCronCreate.mockClear()
+    mockCronUpdate.mockClear()
+
+    const second = await handler({
+      jobId: 'plugin-nightly-sync',
+      name: 'Plugin nightly sync renamed',
+      schedule: '0 2 * * *',
+      command: 'bakin:reports:refresh',
+      metadata: { pluginId: 'reports' },
+    })
+
+    expect(second).toEqual(expect.objectContaining({
+      ok: true,
+      jobId: 'runtime-plugin-nightly-sync',
+      cron: '0 2 * * *',
+    }))
+    expect(mockCronCreate).not.toHaveBeenCalled()
+    expect(mockCronUpdate).toHaveBeenCalledWith('runtime-plugin-nightly-sync', expect.objectContaining({
+      name: 'Plugin nightly sync renamed',
+      schedule: '0 2 * * *',
+      command: 'bakin:reports:refresh',
+    }))
+    expect(getJob('runtime-plugin-nightly-sync')).toEqual(expect.objectContaining({
+      displayName: 'Plugin nightly sync renamed',
+      logicalJobId: 'plugin-nightly-sync',
+    }))
+  })
+
+  it('does not recover provider-backed plugin jobs by command alone', async () => {
+    const activated = await activatePlugin(schedulePlugin, testDir)
+    const registerMock = activated.ctx.hooks.register as unknown as {
+      mock: { calls: Array<[string, (data: Record<string, unknown>) => Promise<Record<string, unknown>>, Record<string, unknown>]> }
+    }
+    const call = registerMock.mock.calls.find(([name]) => name === 'schedule.ensureBakinJob')
+    expect(call).toBeDefined()
+
+    mockRuntimeCronJobs.push({
+      id: 'runtime-existing-reports-refresh',
+      name: 'Existing reports refresh',
+      schedule: '0 1 * * *',
+      command: 'bakin:reports:refresh',
+      enabled: true,
+    })
+
+    const result = await call![1]({
+      jobId: 'plugin-nightly-sync',
+      name: 'Plugin nightly sync',
+      schedule: '*/5 * * * *',
+      command: 'bakin:reports:refresh',
+      metadata: { pluginId: 'reports' },
+    })
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      jobId: 'runtime-plugin-nightly-sync',
+    }))
+    expect(mockCronUpdate).not.toHaveBeenCalled()
+    expect(mockCronCreate).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'plugin-nightly-sync',
+      name: 'Plugin nightly sync',
+      command: 'bakin:reports:refresh',
     }))
   })
 

--- a/tests/plugins/schedule/schedule-page.test.tsx
+++ b/tests/plugins/schedule/schedule-page.test.tsx
@@ -14,7 +14,7 @@
  * focused on filter/search behavior in `view='list'` mode.
  */
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -129,18 +129,22 @@ const scheduleState: { jobs: ScheduleJobStub[]; loading: boolean } = {
   loading: false,
 }
 
+const scheduleActions = {
+  refresh: mock(),
+  pauseJob: mock(),
+  resumeJob: mock(),
+  deleteJob: mock(async () => true),
+  runNow: mock(),
+  updateJob: mock(),
+  skipNext: mock(),
+  duplicateJob: mock(),
+}
+
 mock.module('@/hooks/use-schedule', () => ({
   useScheduleJobs: () => ({
     jobs: scheduleState.jobs,
     loading: scheduleState.loading,
-    refresh: mock(),
-    pauseJob: mock(),
-    resumeJob: mock(),
-    deleteJob: mock(),
-    runNow: mock(),
-    updateJob: mock(),
-    skipNext: mock(),
-    duplicateJob: mock(),
+    ...scheduleActions,
   }),
 }))
 
@@ -178,10 +182,13 @@ mock.module('@/components/ui/button', () => ({
 }))
 
 mock.module('@bakin/schedule/components/job-list', () => ({
-  JobList: ({ jobs }: { jobs: ScheduleJobStub[] }) => (
+  JobList: ({ jobs, onDelete }: { jobs: ScheduleJobStub[]; onDelete: (jobId: string) => void }) => (
     <ul data-testid="job-list">
       {jobs.map(j => (
-        <li key={j.id} data-testid={`job-${j.id}`}>{j.displayName}</li>
+        <li key={j.id} data-testid={`job-${j.id}`}>
+          {j.displayName}
+          <button onClick={() => onDelete(j.id)}>Delete {j.displayName}</button>
+        </li>
       ))}
     </ul>
   ),
@@ -193,6 +200,25 @@ mock.module('@bakin/schedule/components/job-drawer', () => ({
 
 mock.module('@bakin/schedule/components/job-form', () => ({
   JobForm: () => null,
+}))
+
+mock.module('@bakin/schedule/components/delete-schedule-dialog', () => ({
+  DeleteScheduleDialog: ({
+    job,
+    onConfirm,
+    onCancel,
+  }: {
+    job: ScheduleJobStub | null
+    onConfirm: () => void
+    onCancel: () => void
+  }) => job ? (
+    <div role="dialog" aria-label="Delete scheduled job">
+      <span>Delete scheduled job</span>
+      <span>{job.displayName}</span>
+      <button onClick={onCancel}>Cancel</button>
+      <button onClick={onConfirm}>Delete</button>
+    </div>
+  ) : null,
 }))
 
 mock.module('@bakin/schedule/components/calendar-monthly', () => ({
@@ -236,6 +262,8 @@ beforeEach(() => {
   searchHookState.results = []
   searchHookState.search.mockReset()
   searchHookState.clear.mockReset()
+  for (const action of Object.values(scheduleActions)) action.mockReset()
+  scheduleActions.deleteJob.mockImplementation(async () => true)
   scheduleState.jobs = []
   scheduleState.loading = false
 })
@@ -322,5 +350,24 @@ describe('SchedulePage smoke', () => {
     // AgentAvatar stubs render the agent id as text
     expect(screen.getAllByText('chef').length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText('pixel').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('confirms before deleting a scheduled job from the list', async () => {
+    scheduleState.jobs = [makeJob({ id: 'job-delete', displayName: 'Delete candidate' })]
+    queryStateRefs.view = 'list'
+
+    render(<SchedulePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Delete candidate' }))
+
+    expect(scheduleActions.deleteJob).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog', { name: 'Delete scheduled job' })).toBeDefined()
+    expect(screen.getAllByText('Delete candidate').length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete$/ }))
+
+    await waitFor(() => {
+      expect(scheduleActions.deleteJob).toHaveBeenCalledWith('job-delete')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- route OpenClaw cron list/create/update/delete/run history through the CLI/Gateway path
- track provider-generated cron ids with stable logical ids for plugin schedules
- preserve schedule timezones on updates and show full 24-hour calendar coverage
- add standard delete confirmation for scheduled jobs and clean stale records safely

## Tests
- bun test --isolate tests/plugins/schedule tests/adapter-openclaw/runtime-cron.test.ts tests/dev/mock-runtime-contract.test.ts
- bun run typecheck
- bun run lint (passes with existing unused eslint-disable warning in dev/imitation-crab/gateway.ts)
- git diff --check