### PR TITLE
release: v0.0.1-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+## [0.0.1-rc.5] - 2026-05-27
+
+### Added
+- Seed imitation-crab with the production five-agent roster, canonical asset fixtures, projects and messaging plugin data, expanded schedule fixtures, and Health usage/session cost data for richer local smoke testing.
+- Add workflow editor support for ordered canvas editing, node configuration, add/reorder/delete/copy flows, enable/disable handling, availability tracking, and unsaved-change protection.
+
+### Changed
+- Update release-candidate install commands to pin `v0.0.1-rc.5`.
+- Keep Health cost reporting tied to runtime-provided values, including nullable unavailable costs and totals derived from runtime cost components.
+
+### Fixed
+- Reconcile accepted runtime dispatch failures when app-server idle or runtime errors arrive after handoff, while preserving the existing retry and cooldown path for delivery failures.
+- Route OpenClaw schedule cron list/create/update/delete/run-history operations through the CLI/Gateway path, preserve provider-generated ids and timezones, expose full-day calendar coverage, and confirm scheduled job deletes.
+- Show current Health search document counts by normalizing adapter document count fields across memory, search, and CLI health surfaces.
+
 ## [0.0.1-rc.4] - 2026-05-25
 
 ### Fixed
@@ -57,5 +72,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 [0.0.1-rc.3]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.3
 [0.0.1-rc.2]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.2
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.4...HEAD
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.5...HEAD
+[0.0.1-rc.5]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.5
 [0.0.1-rc.4]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The product is local-first: Bakin' owns its data under `~/.bakin/`, talks to the
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.4 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.5 bash
 ```
 
 The installer uses `/usr/local/bin` when it can write there, otherwise it falls back to `~/.local/bin`. If `bakin` is not found after install, add the fallback directory to your `PATH`:

--- a/docs/src/content/docs/start/install.mdx
+++ b/docs/src/content/docs/start/install.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install Bakin
 description: One line, one binary, you're running.
-lastUpdated: 2026-05-25
+lastUpdated: 2026-05-27
 ---
 
 import { Aside, LinkButton } from '@astrojs/starlight/components'
@@ -9,7 +9,7 @@ import { Aside, LinkButton } from '@astrojs/starlight/components'
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.4 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.5 bash
 ```
 
 The install script picks the right binary for your machine, verifies the SHA-256, and installs it as `bakin`. The `BAKIN_VERSION` pin is temporary while the public release is still a release candidate; update it when the live stable release is published.
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | 
 `BAKIN_VERSION` grabs a specific release tag instead of the latest:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.4 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.5 bash
 ```
 
 ### Manual download


### PR DESCRIPTION
## Summary
- prepare the `v0.0.1-rc.5` changelog as the next patch release candidate
- cover the merged runtime dispatch, imitation-crab, workflow editor, Health, and Schedule plugin changes since `v0.0.1-rc.4`
- update README and install docs to pin `BAKIN_VERSION=v0.0.1-rc.5`

## Verification
- `git diff --check`
- `bun run scripts/extract-release-notes.ts --version 0.0.1-rc.5 --out /tmp/bakin-rc5-notes.md`
- `bun test --isolate tests/scripts/extract-release-notes.test.ts tests/scripts/prep-release.test.ts`
- `bun run release --version 0.0.1-rc.5 --dry-run` -> target `v0.0.1-rc.5`, date `2026-05-27`, 7 changelog bullets