### PR TITLE
release: v0.0.1-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
-## [0.0.1-rc.5] - 2026-05-27
+## [0.0.1-rc.6] - 2026-05-27
 
 ### Added
 - Seed imitation-crab with the production five-agent roster, canonical asset fixtures, projects and messaging plugin data, expanded schedule fixtures, and Health usage/session cost data for richer local smoke testing.
 - Add workflow editor support for ordered canvas editing, node configuration, add/reorder/delete/copy flows, enable/disable handling, availability tracking, and unsaved-change protection.
 
 ### Changed
-- Update release-candidate install commands to pin `v0.0.1-rc.5`.
+- Update release-candidate install commands to pin `v0.0.1-rc.6`.
 - Keep Health cost reporting tied to runtime-provided values, including nullable unavailable costs and totals derived from runtime cost components.
 
 ### Fixed
 - Reconcile accepted runtime dispatch failures when app-server idle or runtime errors arrive after handoff, while preserving the existing retry and cooldown path for delivery failures.
 - Route OpenClaw schedule cron list/create/update/delete/run-history operations through the CLI/Gateway path, preserve provider-generated ids and timezones, expose full-day calendar coverage, and confirm scheduled job deletes.
 - Show current Health search document counts by normalizing adapter document count fields across memory, search, and CLI health surfaces.
+- Retry SDK publishes without provenance when npm records a duplicate transparency-log entry before the package version reaches the registry.
+
+## [0.0.1-rc.5] - 2026-05-27
+
+### Changed
+- Superseded by `0.0.1-rc.6`; the release workflow created this tag but did not publish public artifacts after npm returned a duplicate transparency-log entry during SDK publish.
 
 ## [0.0.1-rc.4] - 2026-05-25
 
@@ -72,6 +78,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 [0.0.1-rc.3]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.3
 [0.0.1-rc.2]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.2
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.5...HEAD
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.6...HEAD
+[0.0.1-rc.6]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.6
 [0.0.1-rc.5]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.5
 [0.0.1-rc.4]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The product is local-first: Bakin' owns its data under `~/.bakin/`, talks to the
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.5 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.6 bash
 ```
 
 The installer uses `/usr/local/bin` when it can write there, otherwise it falls back to `~/.local/bin`. If `bakin` is not found after install, add the fallback directory to your `PATH`:

--- a/docs/src/content/docs/start/install.mdx
+++ b/docs/src/content/docs/start/install.mdx
@@ -9,7 +9,7 @@ import { Aside, LinkButton } from '@astrojs/starlight/components'
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.5 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.6 bash
 ```
 
 The install script picks the right binary for your machine, verifies the SHA-256, and installs it as `bakin`. The `BAKIN_VERSION` pin is temporary while the public release is still a release candidate; update it when the live stable release is published.
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | 
 `BAKIN_VERSION` grabs a specific release tag instead of the latest:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.5 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.6 bash
 ```
 
 ### Manual download

--- a/scripts/publish-sdk.ts
+++ b/scripts/publish-sdk.ts
@@ -145,6 +145,19 @@ function assertGeneratedPackage(packageDir: string, version: string): void {
   if (pkg.version !== version) throw new Error(`Generated package version is ${pkg.version}, expected ${version}`)
 }
 
+function publishArgs(tag: PublishSdkOptions['tag'], provenance: boolean): string[] {
+  return ['publish', provenance ? '--provenance' : '--provenance=false', '--access', 'public', '--tag', tag]
+}
+
+function isDuplicateTransparencyLogError(result: CommandResult): boolean {
+  const output = `${result.stdout}\n${result.stderr}`
+  return /TLOG_CREATE_ENTRY_ERROR/i.test(output) && /equivalent entry already exists|409/i.test(output)
+}
+
+function packageExists(runner: CommandRunner, viewArgs: string[]): boolean | null {
+  return packageAlreadyExistsResult(runner('npm', viewArgs, REPO_ROOT))
+}
+
 export async function publishSdkPackage(
   opts: PublishSdkOptions,
   deps: {
@@ -160,12 +173,12 @@ export async function publishSdkPackage(
   assertGeneratedPackage(packageDir, opts.version)
 
   const viewArgs = ['view', `${SDK_PACKAGE_NAME}@${opts.version}`, 'version', '--json']
-  const publishArgs = ['publish', ...(opts.provenance ? ['--provenance'] : []), '--access', 'public', '--tag', opts.tag]
+  const primaryPublishArgs = publishArgs(opts.tag, opts.provenance)
 
   if (opts.dryRun) {
     console.log(`[dry-run] Built ${SDK_PACKAGE_NAME}@${opts.version} at ${packageDir}`)
     console.log(`[dry-run] Would run: npm ${viewArgs.join(' ')}`)
-    console.log(`[dry-run] Would run: npm ${publishArgs.join(' ')} (in ${packageDir})`)
+    console.log(`[dry-run] Would run: npm ${primaryPublishArgs.join(' ')} (in ${packageDir})`)
     return 'dry-run'
   }
 
@@ -181,9 +194,31 @@ export async function publishSdkPackage(
     throw new Error(`Could not check npm package version ${SDK_PACKAGE_NAME}@${opts.version}`)
   }
 
-  const publish = runner('npm', publishArgs, packageDir)
+  const publish = runner('npm', primaryPublishArgs, packageDir)
   echoResult(publish)
   if (publish.status !== 0) {
+    const afterPublishExists = packageExists(runner, viewArgs)
+    if (afterPublishExists === true) {
+      console.log(`${SDK_PACKAGE_NAME}@${opts.version} exists on npm after publish failure; treating publish as complete`)
+      return 'exists'
+    }
+
+    if (opts.provenance && isDuplicateTransparencyLogError(publish)) {
+      console.warn('npm provenance publish hit a duplicate transparency-log entry before the package reached the registry; retrying once with provenance disabled')
+      const retry = runner('npm', publishArgs(opts.tag, false), packageDir)
+      echoResult(retry)
+      if (retry.status === 0) {
+        console.log(`Published ${SDK_PACKAGE_NAME}@${opts.version} with dist-tag ${opts.tag} without provenance`)
+        return 'published'
+      }
+
+      const afterRetryExists = packageExists(runner, viewArgs)
+      if (afterRetryExists === true) {
+        console.log(`${SDK_PACKAGE_NAME}@${opts.version} exists on npm after retry failure; treating publish as complete`)
+        return 'exists'
+      }
+    }
+
     throw new Error(`npm publish failed for ${SDK_PACKAGE_NAME}@${opts.version}`)
   }
   console.log(`Published ${SDK_PACKAGE_NAME}@${opts.version} with dist-tag ${opts.tag}`)

--- a/tests/scripts/publish-sdk.test.ts
+++ b/tests/scripts/publish-sdk.test.ts
@@ -154,8 +154,66 @@ describe('publishSdkPackage', () => {
     })
 
     expect(result).toBe('published')
-    expect(calls[1]).toContain('npm publish --access public --tag next')
-    expect(calls[1]).not.toContain('--provenance')
+    expect(calls[1]).toContain('npm publish --provenance=false --access public --tag next')
+  })
+
+  it('retries without provenance when npm records a duplicate tlog entry before publishing', async () => {
+    const calls: string[] = []
+    const result = await publishSdkPackage({
+      version: '0.1.0-rc.3',
+      packageDir: join(testRoot, 'tlog-retry-package'),
+      tag: 'next',
+      dryRun: false,
+      keepPackageDir: false,
+      provenance: true,
+    }, {
+      builder: packageBuilder(),
+      runner: ((cmd, args, cwd) => {
+        calls.push(`${cwd}: ${cmd} ${args.join(' ')}`)
+        if (args[0] === 'view') {
+          return { status: 1, stdout: '', stderr: 'npm ERR! code E404\nnpm ERR! 404 Not Found' }
+        }
+        if (args.includes('--provenance')) {
+          return {
+            status: 1,
+            stdout: '',
+            stderr: 'npm ERR! code TLOG_CREATE_ENTRY_ERROR\nnpm ERR! error creating tlog entry - (409) an equivalent entry already exists',
+          }
+        }
+        return { status: 0, stdout: 'published\n', stderr: '' }
+      }) satisfies CommandRunner,
+    })
+
+    expect(result).toBe('published')
+    expect(calls[1]).toContain('npm publish --provenance --access public --tag next')
+    expect(calls[3]).toContain('npm publish --provenance=false --access public --tag next')
+  })
+
+  it('treats a failed publish as complete when the version appears on npm afterward', async () => {
+    const calls: string[] = []
+    const result = await publishSdkPackage({
+      version: '0.1.0-rc.4',
+      packageDir: join(testRoot, 'post-failure-exists-package'),
+      tag: 'next',
+      dryRun: false,
+      keepPackageDir: false,
+      provenance: true,
+    }, {
+      builder: packageBuilder(),
+      runner: ((cmd, args, cwd) => {
+        calls.push(`${cwd}: ${cmd} ${args.join(' ')}`)
+        if (args[0] === 'view') {
+          const viewCalls = calls.filter((call) => call.includes(' npm view ')).length
+          return viewCalls === 1
+            ? { status: 1, stdout: '', stderr: 'npm ERR! code E404\nnpm ERR! 404 Not Found' }
+            : { status: 0, stdout: '"0.1.0-rc.4"\n', stderr: '' }
+        }
+        return { status: 1, stdout: '', stderr: 'transient registry failure after publish' }
+      }) satisfies CommandRunner,
+    })
+
+    expect(result).toBe('exists')
+    expect(calls).toHaveLength(3)
   })
 
   it('fails loudly on unexpected npm view and publish errors', async () => {


### PR DESCRIPTION
## Summary
- prepare `v0.0.1-rc.6` as the recovery release candidate after `v0.0.1-rc.5` failed during SDK publish
- move the intended RC notes forward to `0.0.1-rc.6` and mark `0.0.1-rc.5` as superseded
- update install pins to `BAKIN_VERSION=v0.0.1-rc.6`
- make SDK publish resilient to npm duplicate transparency-log failures by retrying once with provenance explicitly disabled when the package version is still absent from npm

## Verification
- `bun test --isolate tests/scripts/publish-sdk.test.ts tests/scripts/extract-release-notes.test.ts tests/scripts/prep-release.test.ts`
- `bun run scripts/extract-release-notes.ts --version 0.0.1-rc.6 --out /tmp/bakin-rc6-notes.md`
- `git diff --check`
- `bun run typecheck`
- `bun run lint` (passes with existing unused eslint-disable warning in `dev/imitation-crab/gateway.ts`)
- `bun run release patch --rc --dry-run` -> target `v0.0.1-rc.6`, date `2026-05-27`, 8 changelog bullets