### PR TITLE
chore(release): v0.0.1-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+### Fixed
+- Repair compiled binary service setup and restart launch paths so macOS LaunchAgents and Linux user services run the real `bakin serve` executable instead of Bun virtual filesystem paths.
+
 ## [0.0.1-rc.6] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+## [0.0.1-rc.7] - 2026-05-28
+
+### Changed
+- Update release-candidate install commands to pin `v0.0.1-rc.7`.
+
 ### Fixed
 - Repair compiled binary service setup and restart launch paths so macOS LaunchAgents and Linux user services run the real `bakin serve` executable instead of Bun virtual filesystem paths.
 
@@ -76,12 +81,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 - Sign and notarize macOS release binaries.
 - Publish release assets, SDK packages, Homebrew formula updates, and post-publish smoke checks from CI.
 
-[0.0.1-rc.1]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.1
-
-[0.0.1-rc.3]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.3
-[0.0.1-rc.2]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.2
-
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.6...HEAD
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.7...HEAD
+[0.0.1-rc.7]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.7
 [0.0.1-rc.6]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.6
 [0.0.1-rc.5]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.5
 [0.0.1-rc.4]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.4
+[0.0.1-rc.3]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.3
+[0.0.1-rc.2]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.2
+[0.0.1-rc.1]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.1

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The product is local-first: Bakin' owns its data under `~/.bakin/`, talks to the
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.6 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.7 bash
 ```
 
 The installer uses `/usr/local/bin` when it can write there, otherwise it falls back to `~/.local/bin`. If `bakin` is not found after install, add the fallback directory to your `PATH`:

--- a/docs/src/content/docs/start/install.mdx
+++ b/docs/src/content/docs/start/install.mdx
@@ -9,7 +9,7 @@ import { Aside, LinkButton } from '@astrojs/starlight/components'
 Install the current release candidate:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.6 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.7 bash
 ```
 
 The install script picks the right binary for your machine, verifies the SHA-256, and installs it as `bakin`. The `BAKIN_VERSION` pin is temporary while the public release is still a release candidate; update it when the live stable release is published.
@@ -78,7 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | 
 `BAKIN_VERSION` grabs a specific release tag instead of the latest:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.6 bash
+curl -fsSL https://raw.githubusercontent.com/markhayden/bakin/main/install.sh | BAKIN_VERSION=v0.0.1-rc.7 bash
 ```
 
 ### Manual download


### PR DESCRIPTION
## Summary
- Cut v0.0.1-rc.7 from main using `bun run release patch --rc --create-branch --date 2026-05-28`.
- Move the service restart fix release note into the rc.7 changelog section.
- Update release-candidate install pins to `v0.0.1-rc.7`.

## Verification
- `bun run release patch --rc --create-branch --dry-run --date 2026-05-28`
- `bun test --isolate tests/scripts/prep-release.test.ts`
- `git diff --check`