### PR TITLE
chore: fix lint cleanup

### DIFF
--- a/dev/imitation-crab/gateway.ts
+++ b/dev/imitation-crab/gateway.ts
@@ -9,7 +9,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'http'
 import { getChatMode, getGatewayPort, getToolMode } from './env'
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- avoid @types/ws dev dependency for mock-only code
 const { WebSocketServer } = require('ws') as { WebSocketServer: new (opts: { noServer: boolean }) => WsServer }
 
 interface WsClient { send(data: string): void; on(event: string, fn: (data: Buffer) => void): void; terminate(): void }

--- a/scripts/docs/capture-screenshots.ts
+++ b/scripts/docs/capture-screenshots.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { readFileSync, mkdirSync, existsSync, renameSync, unlinkSync } from 'fs'
+import { readFileSync, mkdirSync, renameSync, unlinkSync } from 'fs'
 import { join, resolve } from 'path'
 import { execSync, spawn as nodeSpawn } from 'child_process'
 import { load as loadYaml } from 'js-yaml'


### PR DESCRIPTION
## Summary
- Remove unused `existsSync` import from screenshot capture tooling.
- Remove stale eslint-disable directive from the imitation-crab gateway mock.

## Verification
- `bun run lint`