### PR TITLE
feat(docs): rewrite SDK reference generator + Bakin' Bits callout

### DIFF
--- a/docs/public/llms/sdk-reference.md
+++ b/docs/public/llms/sdk-reference.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The SDK reference is currently generated from packages/sdk/package.json and SDK barrel files. Current SDK subpath count: 9. Full TypeDoc output and TSDoc coverage checks are still required before public launch.
+The SDK reference is generated from JSDoc comments on SDK barrel files (`packages/sdk/src/*/index.ts`). Current SDK subpath count: 9. Core plugin contract types (BakinPlugin, PluginContext, etc.) include field-level documentation; remaining types are grouped by domain with one-line summaries.

--- a/docs/src/content/docs/extending/overview.md
+++ b/docs/src/content/docs/extending/overview.md
@@ -3,6 +3,10 @@ title: Extend Bakin
 description: Choose the right extension surface for plugins, agent kits, SDK code, and Bakin core work.
 ---
 
+:::note[Looking for official plugins and agent kits?]
+The [Bakin' Bits](https://github.com/markhayden/bakin-bits-official) repo is the official source for supported plugins and agent kits. Install from there with `bakin plugins install github:markhayden/bakin-bits-official#<plugin-name>` or `bakin agents install github:markhayden/bakin-bits-official#<agent-name>`.
+:::
+
 Bakin is meant to be shaped by the people using it. Start here when you want to add a plugin, package an agent, share a workflow, expose a new tool for agents, or improve the core app without fighting the system.
 
 ## Surfaces

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -1,270 +1,644 @@
 ---
 title: SDK Reference
-description: Generated audit reference for @makinbakin/sdk subpath exports.
+description: Public API surface of @makinbakin/sdk — hooks, components, types, and utilities for plugin authors.
 ---
+
+The Bakin SDK is a single package with multiple subpaths. Plugin authors mark `@makinbakin/sdk` (and `react`/`react-dom`) as externals at build time; the host serves a single shared instance at runtime.
+
+```ts
+import { registerPlugin } from '@makinbakin/sdk'
+import { useSearch } from '@makinbakin/sdk/hooks'
+import { PluginHeader } from '@makinbakin/sdk/components'
+import type { BakinPlugin, PluginContext } from '@makinbakin/sdk/types'
+```
 
 ## `@makinbakin/sdk`
 
-Source: `packages/sdk/src/index.ts`
+The main entry. Re-exports the plugin contract types (`./types`) plus the high-traffic plugin lifecycle helpers (`registerPlugin`, `defineRoute`, `definePlugin`). Source: `packages/sdk/src/index.ts`.
 
-| Export declaration |
-| --- |
-| `export * from './types'` |
-| `export {` |
-| `export type { ClientRouteEntry, MatchedPluginRoute, NavItem, PluginRegistration } from './register'` |
-| `export { defineRoute, defineCoreRoute, definePlugin } from './routing'` |
-| `export type {` |
-
-## `@makinbakin/sdk/ui`
-
-Source: `packages/sdk/src/ui/index.ts`
-
-| Export declaration |
-| --- |
-| `export * from '@/components/ui/alert'` |
-| `export * from '@/components/ui/avatar'` |
-| `export * from '@/components/ui/badge'` |
-| `export * from '@/components/ui/button'` |
-| `export * from '@/components/ui/card'` |
-| `export * from '@/components/ui/checkbox'` |
-| `export * from '@/components/ui/collapsible'` |
-| `export * from '@/components/ui/command'` |
-| `export * from '@/components/ui/dialog'` |
-| `export * from '@/components/ui/dropdown-menu'` |
-| `export * from '@/components/ui/form'` |
-| `export * from '@/components/ui/input'` |
-| `export * from '@/components/ui/input-group'` |
-| `export * from '@/components/ui/label'` |
-| `export * from '@/components/ui/popover'` |
-| `export * from '@/components/ui/progress'` |
-| `export * from '@/components/ui/select'` |
-| `export * from '@/components/ui/separator'` |
-| `export * from '@/components/ui/sheet'` |
-| `export * from '@/components/ui/skeleton'` |
-| `export * from '@/components/ui/switch'` |
-| `export * from '@/components/ui/table'` |
-| `export * from '@/components/ui/tabs'` |
-| `export * from '@/components/ui/textarea'` |
-| `export * from '@/components/ui/tooltip'` |
+| Export | Description |
+| --- | --- |
+| `registerPlugin` | Register a plugin (single-call entry from a plugin's `client.tsx`). |
+| `unregisterPlugin` | Tear down all registrations owned by a plugin (used during hot-swap). |
+| `registerPluginCleanup` | Register a cleanup callback fired when the plugin is unregistered. |
+| `getRegistryVersion` | Current registry version — bumps on every mutation (for useSyncExternalStore). |
+| `subscribeRegistry` | Subscribe to registry-version changes. |
+| `getAllNavItems` | Get every registered nav item across all plugins. |
+| `getNavItemsSnapshot` | Get a snapshot of the current nav items (non-subscribing). |
+| `getPluginNavItems` | Get nav items contributed by a specific plugin. |
+| `getPluginRoute` | Look up a specific client route by plugin id + path. |
+| `getPluginRoutes` | Get all registered client routes (across all plugins). |
+| `ClientRouteEntry` | — |
+| `MatchedPluginRoute` | — |
+| `PluginRegistration` | — |
+| `defineRoute` | Define a plugin HTTP route with typed input/output schemas. |
+| `defineCoreRoute` | Define a core (non-plugin) HTTP route. |
+| `definePlugin` | Compose a plugin's routes into a single definition for the server. |
+| `HttpStatus` | — |
+| `RouteContext` | — |
+| `PluginContextLite` | — |
+| `CoreContext` | — |
+| `BodySpec` | — |
+| `ResponseSpec` | — |
+| `ParsedInput` | — |
 
 ## `@makinbakin/sdk/hooks`
 
-Source: `packages/sdk/src/hooks/index.ts`
+Source: `packages/sdk/src/hooks/index.ts`.
 
-| Export declaration |
-| --- |
-| `export { useAssets, useTrash } from '@/hooks/use-assets'` |
-| `export { useContentStore } from '@/hooks/use-content-store'` |
-| `export { useDebug } from '@/hooks/use-debug'` |
-| `export { useFormGuard } from '@/hooks/use-form-guard'` |
-| `export { useRuntimeStatus } from '@/hooks/use-runtime-status'` |
-| `export { useQueryState, useQueryArrayState } from '@/hooks/use-query-state'` |
-| `export { useScheduleJobs, useRunHistory } from '@/hooks/use-schedule'` |
-| `export type { ScheduleJob, RunEntry } from '@/hooks/use-schedule'` |
-| `export { useSearch, reorderBySearchResults } from '@/hooks/use-search'` |
-| `export type { SearchResult, SearchResponse, UseSearchOptions, UseSearchReturn } from '@/hooks/use-search'` |
-| `export { useSidebar } from '@/hooks/use-sidebar'` |
-| `export { useSSE } from '@/hooks/use-sse'` |
-| `export { toast, useToastStore } from '@/hooks/use-toast'` |
-| `export { useVerticalResize } from '@/hooks/use-vertical-resize'` |
-| `export {` |
-| `export {` |
-| `export { useRouter, usePathname, useSearchParams, useParams } from './router'` |
+```ts
+import { useSearch, useAssets, useDebug } from '@makinbakin/sdk/hooks'
+```
+
+### Data & State
+
+| Hook | Description |
+| --- | --- |
+| `useAssets` | Fetch and filter the asset library with live SSE updates. |
+| `useTrash` | Fetch trashed assets eligible for restore or permanent delete. |
+| `useContentStore` | Access the global Zustand store for SSE-driven content state. |
+| `useScheduleJobs` | List scheduled jobs with live updates. |
+| `useRunHistory` | Fetch run history for a scheduled job. |
+| `ScheduleJob` | — |
+| `RunEntry` | — |
+
+### Search
+
+| Hook | Description |
+| --- | --- |
+| `useSearch` | Hybrid full-text + semantic search across plugins with facet filtering. |
+| `reorderBySearchResults` | Re-rank a local list to match the order returned by a search query. |
+| `SearchResult` | — |
+| `SearchResponse` | — |
+| `UseSearchOptions` | — |
+| `UseSearchReturn` | — |
+
+### Navigation & URL
+
+| Hook | Description |
+| --- | --- |
+| `useQueryState` | Bind a single component-state value to a URL query param. |
+| `useQueryArrayState` | Bind a multi-value (array) component state to a URL query param. |
+| `useSidebar` | Read sidebar open/closed state and toggle helper. |
+| `useRouter` | Access the TanStack Router instance for imperative navigation. |
+| `usePathname` | Current URL pathname (Next.js-shape compatible). |
+| `useSearchParams` | Current URL search params as a URLSearchParams instance. |
+| `useParams` | Current route's typed path parameters. |
+
+### Agent Data
+
+| Hook | Description |
+| --- | --- |
+| `useAgentStore` | Access the agent registry store (Zustand). |
+| `useAgent` | Look up a single agent by ID. |
+| `useAgentList` | List all registered agents. |
+| `useAgentColor` | Get an agent's brand color (hex string). |
+| `useAgentDisplayName` | Get an agent's display name (fallback to ID). |
+| `useAgentIds` | List all registered agent IDs. |
+| `useMainAgentId` | Get the ID of the designated main/orchestrator agent. |
+| `usePackageState` | Read agent-package install state (managed/adopted/unmanaged). |
+| `hexToMuted` | Convert a hex color to a muted variant for backgrounds. |
+
+### Notification Channels
+
+| Hook | Description |
+| --- | --- |
+| `useNotificationChannels` | List configured notification channels (Discord, Slack, email, etc.). |
+| `getChannelLabel` | Get a human-readable label for a channel ID. |
+| `getChannelInitials` | Get initials for a channel (e.g. "Discord" → "D"). |
+
+### UI Controls
+
+| Hook | Description |
+| --- | --- |
+| `useDebug` | Read/toggle the global debug (X-Ray) flag. |
+| `useFormGuard` | Guard a form against unmounting while submission is in flight. |
+| `toast` | Fire a toast notification (success/error/info). |
+| `useToastStore` | Subscribe to the toast store for custom toast UIs. |
+| `useVerticalResize` | Imperatively resize a vertical pane via mouse drag handle. |
+
+### Runtime
+
+| Hook | Description |
+| --- | --- |
+| `useRuntimeStatus` | Subscribe to runtime connection status (online/offline, last heartbeat). |
+| `useSSE` | Subscribe to a Server-Sent Events endpoint with auto-reconnect. |
 
 ## `@makinbakin/sdk/components`
 
-Source: `packages/sdk/src/components/index.ts`
+Source: `packages/sdk/src/components/index.ts`.
 
-| Export declaration |
-| --- |
-| `export { AgentAvatar } from '@/components/agent-avatar'` |
-| `export { AgentFilter } from '@/components/agent-filter'` |
-| `export { AgentSelect } from '@/components/agent-select'` |
-| `export { AgentDot, AgentStatus } from '@/components/agent-status'` |
-| `export { BakinDrawer } from '@/components/bakin-drawer'` |
-| `export { ColorPicker } from '@/components/color-picker'` |
-| `export { EmptyState } from '@/components/empty-state'` |
-| `export { ErrorBanner } from '@/components/error-banner'` |
-| `export { ErrorState } from '@/components/error-state'` |
-| `export { FacetFilter } from '@/components/facet-filter'` |
-| `export type { FacetOption } from '@/components/facet-filter'` |
-| `export { IntegratedBrainstorm } from '@/components/integrated-brainstorm'` |
-| `export type {` |
-| `export {` |
-| `export { MarkdownContent } from '@/components/markdown-content'` |
-| `export { MarkdownEditor } from '@/components/markdown-editor'` |
-| `export { ModelSelect } from '@/components/model-select'` |
-| `export { PageLayout } from '@/components/page-layout'` |
-| `export { PluginHeader } from '@/components/plugin-header'` |
-| `export { PluginSettingsRenderer } from '@/components/plugin-settings-renderer'` |
-| `export type { PluginSettingsSchema } from '@/components/plugin-settings-renderer'` |
-| `export { SortableHead } from '@/components/sortable-head'` |
-| `export type { SortDir } from '@/components/sortable-head'` |
-| `export { UnderlineTabs } from '@/components/underline-tabs'` |
-| `export type { UnderlineTab } from '@/components/underline-tabs'` |
-| `export { ChannelIcon } from '@bakin/workflows/hooks/channel-icon'` |
+```ts
+import { PluginHeader, FacetFilter, AgentAvatar } from '@makinbakin/sdk/components'
+```
+
+| Component | Description |
+| --- | --- |
+| `AgentAvatar` | Round avatar image for an agent, falls back to initials. |
+| `AgentFilter` | Multi-select facet filter scoped to agents. |
+| `AgentSelect` | Single-agent picker dropdown for form fields. |
+| `AgentDot` | Small status dot showing an agent's online/offline state. |
+| `AgentStatus` | Compound agent status (dot + label + last-seen timestamp). |
+| `BakinDrawer` | Right-side slide-out drawer with backdrop and focus trap. |
+| `ColorPicker` | Color picker swatch grid for tag/agent color assignment. |
+| `EmptyState` | Centered empty-state component with icon, title, and CTA. |
+| `ErrorBanner` | Inline error banner with dismiss + retry actions. |
+| `ErrorState` | Full-page error state with title, description, and retry button. |
+| `FacetFilter` | Popover multi-select facet filter (column, owner, tag, etc.). |
+| `FacetOption` | — |
+| `IntegratedBrainstorm` | Chat + plan-proposal review panel for brainstorm sessions. |
+| `BrainstormMessage` | — |
+| `IntegratedBrainstormProps` | — |
+| `BrainstormOnSend` | — |
+| `SendContext` | — |
+| `AssistantTransformed` | — |
+| `BrainstormActivityInput` | — |
+| `BrainstormActivityStorageInput` | — |
+| `BrainstormActivityStorageRecord` | — |
+| `BrainstormTimelineActivityInput` | — |
+| `BrainstormTimelineMessageInput` | — |
+| `brainstormActivityMessageFromCustom` | Convert a custom activity message back into a brainstorm activity. |
+| `brainstormThreadId` | Compute the canonical thread ID for a brainstorm session. |
+| `normalizeBrainstormActivityForStorage` | Normalize a brainstorm activity payload for persistence. |
+| `normalizeBrainstormActivityMessageForStorage` | Normalize a single brainstorm message for persistence. |
+| `readBrainstormSseResponse` | Read an SSE response stream into brainstorm activity events. |
+| `runtimeChunkToBrainstormActivity` | Convert a runtime chat chunk to a brainstorm activity event. |
+| `toBrainstormTimeline` | Fold a brainstorm session's events into a renderable timeline. |
+| `MarkdownContent` | Render markdown content with syntax highlighting and link handling. |
+| `MarkdownEditor` | Editable markdown text area with preview toggle. |
+| `ModelSelect` | Model picker dropdown listing available models from the catalog. |
+| `PageLayout` | Standard plugin page wrapper with header, content area, and toaster. |
+| `PluginHeader` | Plugin page header with title, count badge, search, and action buttons. |
+| `PluginSettingsRenderer` | Render a settings form from a PluginSettingsSchema definition. |
+| `PluginSettingsSchema` | — |
+| `SortableHead` | Sortable table column header with ascending/descending indicator. |
+| `SortDir` | — |
+| `UnderlineTabs` | Tab list with animated underline indicator. |
+| `UnderlineTab` | — |
+| `ChannelIcon` | Icon component for a notification channel (Discord, Slack, email, etc.). |
+
+## `@makinbakin/sdk/ui`
+
+Source: `packages/sdk/src/ui/index.ts`. Re-exports of [shadcn/ui](https://ui.shadcn.com) primitives bundled with Bakin's design tokens. For usage, see the upstream component docs.
+
+```ts
+import { Button, Card, Dialog, Input } from '@makinbakin/sdk/ui'
+```
 
 ## `@makinbakin/sdk/slots`
 
-Source: `packages/sdk/src/slots/index.tsx`
+Source: `packages/sdk/src/slots/index.tsx`.
 
-| Export declaration |
-| --- |
-| `export function registerSlot<TProps>(` |
-| `export function getSlotEntries(name: string): ReadonlyArray<SlotEntry> {` |
-| `export function clearSlotsOwnedBy(pluginId: string): void {` |
-| `export function Slot({ name, ...props }: SlotProps): JSX.Element \| null {` |
+| Slot system | Description |
+| --- | --- |
+| `registerSlot` | Register a component for a named slot. Lower `order` renders first; entries |
+| `getSlotEntries` | Read the registered entries for a slot. Exported for tooling / tests. |
+| `clearSlotsOwnedBy` | Remove every slot entry owned by the given plugin. Used by |
+| `Slot` | Render all components registered for the named slot, in order. Extra props |
 
 ## `@makinbakin/sdk/types`
 
-Source: `packages/sdk/src/types/index.ts`
+Source: `packages/sdk/src/types/index.ts`. The full plugin contract surface. Below: detailed field-level docs for the types most plugin authors directly implement, then summary tables grouped by domain.
 
-| Export declaration |
-| --- |
-| `export type HttpMethod = 'GET' \| 'POST' \| 'PUT' \| 'PATCH' \| 'DELETE'` |
-| `export type ContractVisibility = 'public' \| 'internal' \| 'experimental'` |
-| `export type ContractStability = 'stable' \| 'beta' \| 'experimental' \| 'deprecated'` |
-| `export interface SchemaLike<T = unknown> {` |
-| `export interface SourceLocation {` |
-| `export interface DocsExample {` |
-| `export type PluginPermission =` |
-| `export type RuntimeCapability =` |
-| `export interface PluginEntryPoints {` |
-| `export interface SecretDeclaration {` |
-| `export interface ApiRouteContribution {` |
-| `export type JsonSchemaContribution = Record<string, unknown>` |
-| `export interface ApiParameterContribution {` |
-| `export interface ApiRequestBodyContribution {` |
-| `export interface ApiResponseContribution {` |
-| `export interface ClientRouteContribution {` |
-| `export interface ExecToolContribution {` |
-| `export interface CliCommandContribution {` |
-| `export interface SettingsContribution {` |
-| `export interface DocsContribution {` |
-| `export interface PluginContributions {` |
-| `export interface PluginManifestSignature {` |
-| `export interface PluginManifest {` |
-| `export interface StorageStat {` |
-| `export interface StorageAdapter {` |
-| `export interface EventBus {` |
-| `export interface ActivityAPI {` |
-| `export interface PluginLogger {` |
-| `export interface HookAPI {` |
-| `export interface HookRegistrationMetadata {` |
-| `export type HookKind = 'rpc' \| 'event' \| 'waterfall'` |
-| `export interface NavItem {` |
-| `export interface APIRoute {` |
-| `export interface UISlotRegistration {` |
-| `export interface ContentFile {` |
-| `export interface RuntimeAgent {` |
-| `export interface RuntimeChannel {` |
-| `export interface RuntimeMessageArgs {` |
-| `export interface RuntimeMessageResult {` |
-| `export interface RuntimeToolActivity {` |
-| `export interface RuntimeChatChunk {` |
-| `export interface CronJob {` |
-| `export interface CronRun {` |
-| `export interface RuntimeSkill {` |
-| `export interface WorkspaceFile {` |
-| `export interface AgentRuntimeAdapter {` |
-| `export interface TaskLogEntry {` |
-| `export interface Task {` |
-| `export interface TaskSource {` |
-| `export interface TaskColumns {` |
-| `export interface TaskBoard {` |
-| `export type ColumnId = keyof TaskColumns` |
-| `export interface TaskCreateInput {` |
-| `export interface TaskUpdateInput {` |
-| `export interface TaskService {` |
-| `export interface SearchSchemaField {` |
-| `export interface SearchIndexDefinition {` |
-| `export interface SearchContentTypeDefinition {` |
-| `export interface FilePatternMapper {` |
-| `export interface FileBackedContentTypeDefinition extends SearchContentTypeDefinition {` |
-| `export interface SearchQueryParams {` |
-| `export interface SearchResult {` |
-| `export interface SearchResponse {` |
-| `export interface SearchHealthSnapshot {` |
-| `export interface SearchTransformOp {` |
-| `export interface SearchAPI {` |
-| `export interface AssetVariantMeta {` |
-| `export interface AssetMeta {` |
-| `export interface TrashedAssetMeta {` |
-| `export interface AssetFileRef {` |
-| `export interface AssetsAPI {` |
-| `export interface ExecToolResult {` |
-| `export interface PluginToolContext {` |
-| `export interface ExecToolDefinition {` |
-| `export interface SkillDefinition {` |
-| `export interface WorkflowDefinitionInput {` |
-| `export type FormFieldType = 'string' \| 'text' \| 'number' \| 'boolean' \| 'select' \| 'agent' \| 'skill' \| 'list'` |
-| `export interface FormField {` |
-| `export interface EdgeRules {` |
-| `export interface PluginNodeTypeInput<T = unknown> {` |
-| `export interface PluginNotificationChannelInput {` |
-| `export interface HealthCheckResult {` |
-| `export type HealthRepairSafety = 'safe' \| 'manual' \| 'destructive'` |
-| `export interface HealthRepairChange {` |
-| `export interface HealthRepairPlanItem {` |
-| `export interface HealthRepairApplyResult {` |
-| `export interface HealthRepairHandler {` |
-| `export interface PluginHealthCheckInput {` |
-| `export interface StringSettingsField extends BaseSettingsField {` |
-| `export interface NumberSettingsField extends BaseSettingsField {` |
-| `export interface BooleanSettingsField extends BaseSettingsField {` |
-| `export interface SelectSettingsField extends BaseSettingsField {` |
-| `export interface ListSettingsField extends BaseSettingsField {` |
-| `export type SettingsField =` |
-| `export interface PluginSettingsSchema {` |
-| `export interface PluginContext {` |
-| `export interface BakinPlugin {` |
-| `export interface CalendarEvent {` |
-| `export interface CalendarDay {` |
-| `export interface RecurringEvent {` |
-| `export interface MemoryEntry {` |
-| `export interface MemoryDay {` |
-| `export interface Heartbeat {` |
-| `export interface ProjectMeta {` |
-| `export interface AvailableModel {` |
-| `export interface WorkflowDefinition {` |
-| `export interface WorkflowInstance {` |
-| `export interface WorkflowStep {` |
-| `export type WorkflowTemplate = WorkflowDefinition` |
-| `export interface BakinConfig {` |
-| `export interface PluginEntry {` |
+```ts
+import type { BakinPlugin, PluginContext, ExecToolDefinition } from '@makinbakin/sdk/types'
+```
+
+### Core types (full field docs)
+
+#### `BakinPlugin`
+
+The main plugin interface. The default export of a plugin's `index.ts`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Unique plugin identifier (matches manifest `id`). |
+| `name` | `string` | Display name. |
+| `version` | `string` | Plugin version (semver). |
+| `activate` | `(ctx: PluginContext) => void \| Promise&lt;void>` | Called once at plugin load. Register routes/tools/nav/etc. here. |
+| `onReady?` | `() => void \| Promise&lt;void>` | Called after all plugins have activated. Useful for cross-plugin setup. |
+| `onShutdown?` | `() => void \| Promise&lt;void>` | Called when the server shuts down or the plugin is hot-swapped out. |
+| `onSettingsChange?` | `(settings: Record&lt;string, unknown>) => void \| Promise&lt;void>` | Called when this plugin's settings are persisted. |
+| `onUninstall?` | `(ctx: PluginContext) => void \| Promise&lt;void>` | Called when the plugin is uninstalled — clean up persisted data here. |
+| `settingsSchema?` | `PluginSettingsSchema` | Settings schema rendered on this plugin's settings page. |
+| `navItems?` | `NavItem[]` | Convenience: nav items to auto-register at activation. |
+| `contentFiles?` | `ContentFile[]` | Convenience: static content files declared at construction. |
+
+#### `PluginContext`
+
+The activation context passed to a plugin's `activate(ctx)` method.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `storage` | `StorageAdapter` | Plugin-scoped filesystem storage adapter. |
+| `events` | `EventBus` | Cross-plugin event bus. |
+| `pluginId` | `string` | ID of the plugin this context belongs to. |
+| `runtime` | `AgentRuntimeAdapter` | Agent runtime adapter (agents, messaging, channels, cron, skills). |
+| `tasks` | `TaskService` | Task CRUD service. |
+| `assets` | `AssetsAPI` | Assets API for asset metadata + file lookups. |
+| `registerNav` | `(items: NavItem[]) => void` | Register sidebar navigation items. |
+| `registerRoute` | `(route: APIRoute) => void` | Register an HTTP route under `/api/plugins/{pluginId}`. |
+| `registerSlot` | `(registration: UISlotRegistration) => void` | Register a component for a named slot (legacy — prefer `&lt;Slot>` from `/slots`). |
+| `registerExecTool` | `(tool: ExecToolDefinition) => void` | Register an MCP exec tool agents can call. |
+| `registerSkill` | `(skill: SkillDefinition) => void` | Register a runtime skill (capability definition). |
+| `registerWorkflow` | `(definition: WorkflowDefinitionInput, opts?: { readOnly?: boolean }) => void` | Register a workflow definition (or template) the plugin ships. |
+| `registerNodeType` | `(def: PluginNodeTypeInput&lt;T>) => string` | Register a custom workflow node type (step kind). |
+| `registerNotificationChannel` | `(def: PluginNotificationChannelInput) => string` | Register a notification channel the runtime can deliver to. |
+| `registerHealthCheck` | `(def: PluginHealthCheckInput) => string` | Register a health check that runs on `bakin doctor`. |
+| `watchFiles` | `(patterns: string[]) => void` | Subscribe to file globs for live updates (Chokidar-based). |
+| `getSettings` | `() => T` | Read this plugin's persisted settings. |
+| `updateSettings` | `(patch: Record&lt;string, unknown>) => void` | Patch this plugin's persisted settings. |
+| `activity` | `ActivityAPI` | Activity feed + audit log API. |
+| `log?` | `PluginLogger` | Plugin-scoped structured logger. Optional — falls back to console. |
+| `hooks` | `HookAPI` | Cross-plugin hook registry. |
+| `search` | `SearchAPI` | Search API for indexing and querying. |
+
+#### `PluginManifest`
+
+The `bakin-plugin.json` manifest. Required for every plugin.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Unique plugin identifier (kebab-case). |
+| `name` | `string` | Human-readable plugin name. |
+| `version` | `string` | Plugin version (semver). |
+| `bakin` | `string` | Minimum Bakin version this plugin supports. |
+| `description` | `string` | One-line summary shown in the plugin manager. |
+| `entry` | `PluginEntryPoints` | Server + optional client entry-point file paths. |
+| `contentFiles?` | `string[]` | Static content files the plugin ships (rendered as docs/pages). |
+| `secrets?` | `SecretDeclaration[]` | Environment-variable secrets the plugin requires. |
+| `tests?` | `string` | Path to a test entry-point (for `bakin plugins test`). |
+| `dependencies?` | `string[]` | Other plugin IDs this plugin depends on. |
+| `permissions?` | `PluginPermission[]` | Capabilities this plugin requests access to. |
+| `runtimeCapabilities?` | `RuntimeCapability[]` | Runtime features this plugin needs to function. |
+| `contributes?` | `PluginContributions` | Everything the plugin adds to the host (routes, tools, settings, etc.). |
+| `devWatch?` | `string[]` | File globs that trigger a hot reload in dev. |
+| `signature?` | `PluginManifestSignature` | Optional Ed25519 signature for authenticity. |
+
+#### `PluginContributions`
+
+The full contributions block in `bakin-plugin.json` — everything a plugin adds to the host.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `apiRoutes?` | `ApiRouteContribution[]` | HTTP routes the plugin exposes under `/api/plugins/{id}/...`. |
+| `clientRoutes?` | `ClientRouteContribution[]` | Client-side routes the plugin renders (sidebar nav targets). |
+| `execTools?` | `ExecToolContribution[]` | MCP exec tools agents can call. |
+| `cliCommands?` | `CliCommandContribution[]` | CLI commands the plugin contributes to the `bakin` binary. |
+| `settings?` | `SettingsContribution[]` | Settings keys this plugin owns in the settings UI. |
+| `docs?` | `DocsContribution` | Optional docs page slug. |
+
+#### `ExecToolDefinition`
+
+MCP exec tool definition registered via `ctx.registerExecTool()`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Tool name. Convention: `bakin_exec_{pluginId}_{action}`. |
+| `description` | `string` | Description shown to the agent (used for tool selection). |
+| `label?` | `string` | Optional UI label for the activity feed. |
+| `activityDuplicate?` | `boolean` | If true, this tool can fire multiple times in a single agent turn. |
+| `parameters` | `ZodRawShape` | Zod raw shape describing the tool's parameters. |
+| `handler` | `(params: Record&lt;string, unknown>, agent: string, ctx?: PluginToolContext) => Promise&lt;ExecToolResult>` | Handler that executes the tool. |
+| `source?` | `string` | Optional source-file path for generated docs. |
+
+#### `PluginToolContext`
+
+Context passed to an exec tool handler. Subset of PluginContext sans UI registration.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `storage` | `StorageAdapter` | Plugin-scoped storage adapter. |
+| `events` | `EventBus` | Cross-plugin event bus. |
+| `pluginId` | `string` | ID of the plugin owning this tool. |
+| `runtime` | `AgentRuntimeAdapter` | Agent runtime adapter (messaging, agents, channels, cron). |
+| `tasks` | `TaskService` | Task CRUD service. |
+| `search` | `SearchAPI` | Search API. |
+| `assets` | `AssetsAPI` | Assets API. |
+| `hooks` | `HookAPI` | Hook registry. |
+| `activity` | `ActivityAPI` | Activity feed and audit log. |
+| `getSettings` | `() => T` | Read this plugin's persisted settings. |
+
+#### `NavItem`
+
+Sidebar navigation item registered by a plugin via `ctx.registerNav()`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Unique nav item id (used for active-state tracking). |
+| `label` | `string` | Display label in the sidebar. |
+| `icon` | `string` | Lucide icon name (e.g. "tasks", "calendar"). |
+| `href` | `string` | Target route path. |
+| `order?` | `number` | Sort order within the parent group. Lower renders first. |
+| `children?` | `NavItem[]` | Optional nested nav items for groups. |
+| `alwaysExpanded?` | `boolean` | If true, the group cannot be collapsed. |
+
+#### `APIRoute`
+
+HTTP route handler registered by a plugin via `ctx.registerRoute()`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `path` | `string` | Route path relative to `/api/plugins/{pluginId}`. |
+| `method` | `HttpMethod` | HTTP method. |
+| `handler` | `(req: Request, ctx: PluginContext) => Response \| Promise&lt;Response>` | Request handler. Receives a standard Request and the plugin context. |
+| `summary?` | `string` | One-line summary for docs. |
+| `description?` | `string` | Full description for docs. |
+| `params?` | `string` | Path param descriptor (e.g. ":id"). |
+| `input?` | `SchemaLike` | Input schema for validation and docs. |
+| `output?` | `SchemaLike` | Output schema for docs. |
+| `visibility?` | `ContractVisibility` | Visibility tier (public/internal/experimental). |
+| `stability?` | `ContractStability` | Stability tier. |
+| `examples?` | `DocsExample[]` | Reference examples for the docs site. |
+| `source?` | `SourceLocation` | Source location for generated docs back-references. |
+| `permissions?` | `string[]` | Permissions required to call this route. |
+
+#### `PluginSettingsSchema`
+
+Plugin settings schema — declares fields rendered on the settings page.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `fields` | `SettingsField[]` | Ordered list of settings fields for the form. |
+
+#### `HealthCheckResult`
+
+Result row returned by a health check (doctor).
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `check` | `string` | Stable check identifier. |
+| `status` | `'ok' \| 'warn' \| 'error' \| 'fixed'` | Severity of the result. |
+| `message` | `string` | Human-readable message describing the finding. |
+| `autoFixable` | `boolean` | Whether the issue can be auto-fixed by an attached repair handler. |
+
+#### `BakinConfig`
+
+The `bakin.config.ts` shape — root configuration for a Bakin installation.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `plugins` | `PluginEntry[]` | Plugins to load at startup. |
+| `theme?` | `Record&lt;string, string>` | Theme overrides for CSS custom properties. |
+| `storage?` | `{ /** Override the default content directory. */ contentDir?: string }` | Storage configuration. |
+
+### Shared Primitives
+
+| Type | Description |
+| --- | --- |
+| `HttpMethod` | HTTP method literal used in route and contribution definitions. |
+| `ContractVisibility` | Visibility tier for a documented contract (route, hook, tool, etc.). |
+| `ContractStability` | Stability tier for a documented contract. |
+| `SchemaLike` | Minimal interface a validation schema must satisfy (Zod-compatible). |
+| `SourceLocation` | Pointer to a symbol's source file location, used in generated docs. |
+| `DocsExample` | Reference example for a documented contract (request/response or code snippet). |
+
+### Manifest Contracts
+
+| Type | Description |
+| --- | --- |
+| `PluginPermission` | Capability a plugin can request in its manifest (gates access to APIs). |
+| `RuntimeCapability` | Runtime feature a plugin declares it needs (used by doctor/health checks). |
+| `PluginEntryPoints` | Server and client entry-point file paths for a plugin. |
+| `SecretDeclaration` | Secret (env var) a plugin declares it needs (rendered in setup/health). |
+| `ApiRouteContribution` | Manifest declaration of an HTTP route the plugin exposes. |
+| `JsonSchemaContribution` | Raw JSON Schema object embedded in API contributions. |
+| `ApiParameterContribution` | Path/query/header/cookie parameter declaration for an API route. |
+| `ApiRequestBodyContribution` | Request body declaration for an API route. |
+| `ApiResponseContribution` | Response declaration for one HTTP status code on an API route. |
+| `ClientRouteContribution` | Manifest declaration of a client-side route the plugin contributes. |
+| `ExecToolContribution` | Manifest declaration of an MCP exec tool the plugin exposes. |
+| `CliCommandContribution` | Manifest declaration of a CLI command the plugin contributes. |
+| `SettingsContribution` | Manifest declaration of a settings key the plugin owns. |
+| `DocsContribution` | Manifest declaration of the plugin's docs page slug. |
+| `PluginManifestSignature` | Optional Ed25519 signature block proving manifest authenticity. |
+
+### Storage & Events
+
+| Type | Description |
+| --- | --- |
+| `StorageStat` | File metadata returned by storage adapter `stat()`. |
+| `StorageAdapter` | Plugin-scoped filesystem adapter passed via `ctx.storage`. |
+| `EventBus` | Cross-plugin event bus. Emit and subscribe by pattern. |
+| `ActivityAPI` | Activity feed + structured audit log API exposed on the plugin context. |
+| `PluginLogger` | Plugin-scoped structured logger (writes to server log + stdout). |
+| `HookAPI` | Cross-plugin RPC/event/waterfall hook registry. |
+| `HookRegistrationMetadata` | Optional documentation metadata for a registered hook. |
+| `HookKind` | Hook semantics: single-return RPC, fire-and-forget event, or input transform waterfall. |
+
+### UI & Navigation
+
+| Type | Description |
+| --- | --- |
+| `UISlotRegistration` | Slot registration record: place a component at a named extension point. |
+| `ContentFile` | Static content file shipped with a plugin (e.g. README, docs page). |
+
+### Runtime
+
+| Type | Description |
+| --- | --- |
+| `RuntimeAgent` | An agent registered with the runtime (OpenClaw, etc.). |
+| `RuntimeChannel` | A messaging channel (Discord, Slack, email, etc.) registered with the runtime. |
+| `RuntimeMessageToolsMode` | Whether to expose runtime-native tools for this agent turn. |
+| `RuntimeMessageToolPolicy` | Per-turn policy for which runtime tools the agent may call. |
+| `RuntimeMessageArgs` | Arguments for a single message dispatched to an agent. |
+| `RuntimeMessageResult` | Result returned by a non-streaming runtime message. |
+| `RuntimeToolActivity` | Tool call/result event surfaced during a streaming agent turn. |
+| `RuntimeChatChunk` | One chunk in a streaming agent response (text, tool, status, done, error). |
+| `CronJob` | A cron-scheduled job tracked by the runtime. |
+| `CronRun` | Execution record for a single cron job run. |
+| `RuntimeSkill` | A skill (runtime-side capability) registered with an agent. |
+| `WorkspaceFile` | A file in an agent's runtime workspace. |
+| `AgentRuntimeAdapter` | Provider-agnostic interface for agent runtime adapters (OpenClaw, etc.). |
+
+### Tasks
+
+| Type | Description |
+| --- | --- |
+| `TaskLogEntry` | One entry in a task's activity log. |
+| `Task` | A task on the Bakin board. |
+| `TaskSource` | Identifies the plugin/entity that originated a task. |
+| `TaskColumns` | The seven task board columns. |
+| `TaskBoard` | The full task board snapshot (columns + timestamp). |
+| `ColumnId` | Valid task column identifier (keyof TaskColumns). |
+| `TaskCreateInput` | Payload for `tasks.create()`. |
+| `TaskUpdateInput` | Patch payload for `tasks.update()`. Nullable fields explicitly clear. |
+| `TaskService` | CRUD service for tasks, exposed via `ctx.tasks`. |
+
+### Search
+
+| Type | Description |
+| --- | --- |
+| `SearchSchemaField` | Field schema entry for a search content type. |
+| `SearchIndexDefinition` | Named index definition (embedder + chunker config) for a content type. |
+| `SearchContentTypeDefinition` | Full content-type definition: schema, indexes, facets, reindex generator. |
+| `FilePatternMapper` | File glob + mappers used by file-backed search content types. |
+| `FileBackedContentTypeDefinition` | File-backed content type: indexes documents derived from on-disk files. |
+| `SearchQueryParams` | Query payload for `search.query()` — filters, facets, paging, strategy. |
+| `SearchResult` | A single search hit with score and field projection. |
+| `SearchResponse` | Full search response: results, aggregations, and query metadata. |
+| `SearchHealthSnapshot` | Health snapshot reported by the search adapter (per-table state). |
+| `SearchTransformOp` | Atomic transform operation applied to an indexed document. |
+| `SearchAPI` | Search API exposed via `ctx.search` — index, query, transform documents. |
+
+### Assets
+
+| Type | Description |
+| --- | --- |
+| `AssetVariantMeta` | Auto-generated variant (thumbnail/optimized/webp) for an asset. |
+| `AssetMeta` | Full asset record: file info + sidecar metadata + auto-generated variants. |
+| `TrashedAssetMeta` | Asset record while in trash (with deleted/expires timestamps). |
+| `AssetFileRef` | Compact reference to an asset by filename — used in channel deliveries. |
+| `AssetsAPI` | Assets API exposed via `ctx.assets` — read-only asset lookups. |
+
+### Exec Tools & Workflows
+
+| Type | Description |
+| --- | --- |
+| `ExecToolResult` | Result returned from an exec tool handler. |
+| `SkillDefinition` | Runtime skill definition registered via `ctx.registerSkill()`. |
+| `WorkflowLayoutInput` | Layout hints for a workflow's canvas rendering. |
+| `WorkflowDefinitionInput` | Plugin-contributed workflow definition input shape. |
+| `FormFieldType` | Field types supported by FormField. |
+| `FormField` | Form field descriptor for plugin-contributed workflow nodes. |
+| `EdgeRules` | Edge constraints for a plugin-contributed workflow node type. |
+| `PluginNodeTypeInput` | Workflow node type contributed by a plugin (custom step kind). |
+| `PluginNotificationChannelInput` | Notification channel definition contributed by a plugin. |
+
+### Health
+
+| Type | Description |
+| --- | --- |
+| `HealthRepairSafety` | Repair safety tier: safe (auto), manual (needs review), destructive (data-affecting). |
+| `HealthRepairChange` | Single change a repair plan will apply. |
+| `HealthRepairPlanItem` | One item in a repair plan: what will change and why. |
+| `HealthRepairApplyResult` | Result of applying a single repair plan item. |
+| `HealthRepairHandler` | Two-phase repair handler attached to a health check. |
+| `PluginHealthCheckInput` | Health check registration input passed to `ctx.registerHealthCheck()`. |
+
+### Settings
+
+| Type | Description |
+| --- | --- |
+| `StringSettingsField` | Single-line text settings field. |
+| `NumberSettingsField` | Numeric settings field with optional default. |
+| `BooleanSettingsField` | Boolean toggle settings field. |
+| `SelectSettingsField` | Dropdown settings field with predefined options. |
+| `ListSettingsField` | Repeatable list settings field with per-item shape. |
+| `SettingsField` | Union of all supported settings field types. |
+
+### Workflows
+
+| Type | Description |
+| --- | --- |
+| `WorkflowDefinition` | A workflow definition stored on disk (YAML or programmatic). |
+| `WorkflowInstance` | A running instance of a workflow attached to a task. |
+| `WorkflowStep` | One step in a workflow definition or instance. |
+| `WorkflowTemplate` | Alias for WorkflowDefinition when used as a reusable template. |
+
+### Calendar & Memory
+
+| Type | Description |
+| --- | --- |
+| `CalendarEvent` | Single calendar event (time + text). |
+| `CalendarDay` | One day on an agent's calendar (date + list of events). |
+| `RecurringEvent` | A recurring event (cron expression + display text). |
+| `MemoryEntry` | Single memory entry (decision, learned-thing, or freeform note). |
+| `MemoryDay` | Memory entries grouped by day. |
+| `Heartbeat` | Agent heartbeat snapshot (status + current task + timestamp). |
+
+### Projects & Models
+
+| Type | Description |
+| --- | --- |
+| `ProjectMeta` | Project metadata loaded from a markdown project file. |
+| `AvailableModel` | A model available in the models catalog (LLM, image, or video). |
+
+### Configuration
+
+| Type | Description |
+| --- | --- |
+| `PluginEntry` | A plugin entry in `bakin.config.ts`. |
 
 ## `@makinbakin/sdk/utils`
 
-Source: `packages/sdk/src/utils/index.ts`
+Source: `packages/sdk/src/utils/index.ts`.
 
-| Export declaration |
-| --- |
-| `export { cn } from '../../../../src/lib/utils'` |
-| `export { formatAge, formatSize, isStale } from '@bakin/core/format'` |
-| `export {` |
-| `export {` |
-| `export type {` |
-| `export type {` |
-| `export { readBrainstormSseResponse } from '../../../../src/components/integrated-brainstorm/sse'` |
+| Utility | Description |
+| --- | --- |
+| `cn` | Tailwind class merger (clsx + tailwind-merge). |
+| `formatAge` | Format a Date or ISO string as a relative age (e.g. "5m ago"). |
+| `formatSize` | Format a byte count as a human-readable size string (e.g. "1.2 MB"). |
+| `isStale` | Returns true if a timestamp is older than a configurable staleness threshold. |
+| `brainstormActivityMessageFromCustom` | Convert a custom activity message into a brainstorm activity input. |
+| `runtimeChunkToBrainstormActivity` | Convert a runtime chat chunk into a brainstorm activity event. |
+| `toBrainstormTimeline` | Fold brainstorm events into a renderable timeline. |
+| `brainstormThreadId` | Compute the canonical thread id for a brainstorm session. |
+| `normalizeBrainstormActivityForStorage` | Normalize a brainstorm activity payload for persistence. |
+| `normalizeBrainstormActivityMessageForStorage` | Normalize a single brainstorm message for persistence. |
+| `BrainstormActivityInput` | — |
+| `BrainstormTimelineActivityInput` | — |
+| `BrainstormTimelineMessageInput` | — |
+| `BrainstormActivityStorageInput` | — |
+| `BrainstormActivityStorageRecord` | — |
+| `readBrainstormSseResponse` | Read an SSE response stream into brainstorm activity events. |
 
 ## `@makinbakin/sdk/metadata`
 
-Source: `packages/sdk/src/metadata/index.ts`
+Source: `packages/sdk/src/metadata/index.ts`.
 
-| Export declaration |
-| --- |
-| `export type {` |
-| `export {` |
+| Contract helper | Description |
+| --- | --- |
+| `ContractMetadata` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `ContractStability` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `ContractVisibility` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `CliCommandContract` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `DocsAwareAPIRoute` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `DocsExample` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `ExecToolContract` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `HookContract` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `HookKind` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `PublicContract` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `RouteContract` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `SchemaLike` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `SlotContract` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `SourceLocation` | `@makinbakin/sdk/metadata` — docs-aware contract helpers. |
+| `defineApiRoute` | Legacy: declare an API route with docs metadata. Prefer `defineRoute` from `/routing`. |
+| `defineCliCommandContract` | Define a CLI command contract for documentation. |
+| `defineExecToolContract` | Define an MCP exec tool contract for documentation. |
+| `defineHookContract` | Define a cross-plugin hook contract for documentation. |
+| `definePluginRoute` | Legacy: declare a plugin route with docs metadata. Prefer `defineRoute` from `/routing`. |
+| `defineRouteContract` | Define a generic route contract (shared shape for API + plugin routes). |
+| `defineSlotContract` | Define a UI slot contract for documentation. |
 
 ## `@makinbakin/sdk/routing`
 
-Source: `packages/sdk/src/routing/index.ts`
+Source: `packages/sdk/src/routing/index.ts`.
 
-| Export declaration |
-| --- |
-| `export {` |
-| `export type {` |
+| Routing | Description |
+| --- | --- |
+| `defineRoute` | Define a plugin HTTP route with typed input/output and handler. |
+| `defineCoreRoute` | Define a core (non-plugin) HTTP route. |
+| `definePlugin` | Compose a plugin's routes into a single definition for the server. |
+| `HttpMethod` | — |
+| `HttpStatus` | — |
+| `RouteContext` | — |
+| `PluginContextLite` | — |
+| `CoreContext` | — |
+| `JsonBodySpec` | — |
+| `MultipartBodySpec` | — |
+| `RawBodySpec` | — |
+| `NoBodySpec` | — |
+| `BodySpec` | — |
+| `JsonResponseSpec` | — |
+| `NoContentResponseSpec` | — |
+| `NonJsonResponseSpec` | — |
+| `ResponseSpec` | — |
+| `ParsedInput` | — |
+| `APIRoute` | — |
+| `PluginWithRoutes` | — |
+| `DefinePluginInput` | — |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated May 16, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated May 27, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/packages/sdk/src/components/index.ts
+++ b/packages/sdk/src/components/index.ts
@@ -6,17 +6,31 @@
  * not include layout chrome (sidebar, header, toaster) — those are Bakin's
  * shell, not plugin-author territory.
  */
+
+/** Round avatar image for an agent, falls back to initials. */
 export { AgentAvatar } from '@/components/agent-avatar'
+/** Multi-select facet filter scoped to agents. */
 export { AgentFilter } from '@/components/agent-filter'
+/** Single-agent picker dropdown for form fields. */
 export { AgentSelect } from '@/components/agent-select'
-export { AgentDot, AgentStatus } from '@/components/agent-status'
+/** Small status dot showing an agent's online/offline state. */
+export { AgentDot } from '@/components/agent-status'
+/** Compound agent status (dot + label + last-seen timestamp). */
+export { AgentStatus } from '@/components/agent-status'
+/** Right-side slide-out drawer with backdrop and focus trap. */
 export { BakinDrawer } from '@/components/bakin-drawer'
+/** Color picker swatch grid for tag/agent color assignment. */
 export { ColorPicker } from '@/components/color-picker'
+/** Centered empty-state component with icon, title, and CTA. */
 export { EmptyState } from '@/components/empty-state'
+/** Inline error banner with dismiss + retry actions. */
 export { ErrorBanner } from '@/components/error-banner'
+/** Full-page error state with title, description, and retry button. */
 export { ErrorState } from '@/components/error-state'
+/** Popover multi-select facet filter (column, owner, tag, etc.). */
 export { FacetFilter } from '@/components/facet-filter'
 export type { FacetOption } from '@/components/facet-filter'
+/** Chat + plan-proposal review panel for brainstorm sessions. */
 export { IntegratedBrainstorm } from '@/components/integrated-brainstorm'
 export type {
   BrainstormMessage,
@@ -30,30 +44,45 @@ export type {
   BrainstormTimelineActivityInput,
   BrainstormTimelineMessageInput,
 } from '@/components/integrated-brainstorm'
-export {
-  brainstormActivityMessageFromCustom,
-  brainstormThreadId,
-  normalizeBrainstormActivityForStorage,
-  normalizeBrainstormActivityMessageForStorage,
-  readBrainstormSseResponse,
-  runtimeChunkToBrainstormActivity,
-  toBrainstormTimeline,
-} from '@/components/integrated-brainstorm'
+/** Convert a custom activity message back into a brainstorm activity. */
+export { brainstormActivityMessageFromCustom } from '@/components/integrated-brainstorm'
+/** Compute the canonical thread ID for a brainstorm session. */
+export { brainstormThreadId } from '@/components/integrated-brainstorm'
+/** Normalize a brainstorm activity payload for persistence. */
+export { normalizeBrainstormActivityForStorage } from '@/components/integrated-brainstorm'
+/** Normalize a single brainstorm message for persistence. */
+export { normalizeBrainstormActivityMessageForStorage } from '@/components/integrated-brainstorm'
+/** Read an SSE response stream into brainstorm activity events. */
+export { readBrainstormSseResponse } from '@/components/integrated-brainstorm'
+/** Convert a runtime chat chunk to a brainstorm activity event. */
+export { runtimeChunkToBrainstormActivity } from '@/components/integrated-brainstorm'
+/** Fold a brainstorm session's events into a renderable timeline. */
+export { toBrainstormTimeline } from '@/components/integrated-brainstorm'
+/** Render markdown content with syntax highlighting and link handling. */
 export { MarkdownContent } from '@/components/markdown-content'
+/** Editable markdown text area with preview toggle. */
 export { MarkdownEditor } from '@/components/markdown-editor'
+/** Model picker dropdown listing available models from the catalog. */
 export { ModelSelect } from '@/components/model-select'
+/** Standard plugin page wrapper with header, content area, and toaster. */
 export { PageLayout } from '@/components/page-layout'
+/** Plugin page header with title, count badge, search, and action buttons. */
 export { PluginHeader } from '@/components/plugin-header'
+/** Render a settings form from a PluginSettingsSchema definition. */
 export { PluginSettingsRenderer } from '@/components/plugin-settings-renderer'
 export type { PluginSettingsSchema } from '@/components/plugin-settings-renderer'
 // Note: PluginSlot is NOT re-exported here. The Phase 2 `<Slot>` primitive
 // (with cleaner plugin-contributed renderer registration) supersedes it. The
 // existing `PluginSlot` pulls in server-only plugin-registry state and breaks
 // client SSR bundling when re-exported through this barrel.
+/** Sortable table column header with ascending/descending indicator. */
 export { SortableHead } from '@/components/sortable-head'
 export type { SortDir } from '@/components/sortable-head'
+/** Tab list with animated underline indicator. */
 export { UnderlineTabs } from '@/components/underline-tabs'
 export type { UnderlineTab } from '@/components/underline-tabs'
 
 // Notification channel icon (from workflows plugin registry)
+
+/** Icon component for a notification channel (Discord, Slack, email, etc.). */
 export { ChannelIcon } from '@bakin/workflows/hooks/channel-icon'

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -8,40 +8,81 @@
  */
 
 // Group 1: Bakin-wide hooks
-export { useAssets, useTrash } from '@/hooks/use-assets'
+
+/** Fetch and filter the asset library with live SSE updates. */
+export { useAssets } from '@/hooks/use-assets'
+/** Fetch trashed assets eligible for restore or permanent delete. */
+export { useTrash } from '@/hooks/use-assets'
+/** Access the global Zustand store for SSE-driven content state. */
 export { useContentStore } from '@/hooks/use-content-store'
+/** Read/toggle the global debug (X-Ray) flag. */
 export { useDebug } from '@/hooks/use-debug'
+/** Guard a form against unmounting while submission is in flight. */
 export { useFormGuard } from '@/hooks/use-form-guard'
+/** Subscribe to runtime connection status (online/offline, last heartbeat). */
 export { useRuntimeStatus } from '@/hooks/use-runtime-status'
-export { useQueryState, useQueryArrayState } from '@/hooks/use-query-state'
-export { useScheduleJobs, useRunHistory } from '@/hooks/use-schedule'
+/** Bind a single component-state value to a URL query param. */
+export { useQueryState } from '@/hooks/use-query-state'
+/** Bind a multi-value (array) component state to a URL query param. */
+export { useQueryArrayState } from '@/hooks/use-query-state'
+/** List scheduled jobs with live updates. */
+export { useScheduleJobs } from '@/hooks/use-schedule'
+/** Fetch run history for a scheduled job. */
+export { useRunHistory } from '@/hooks/use-schedule'
 export type { ScheduleJob, RunEntry } from '@/hooks/use-schedule'
-export { useSearch, reorderBySearchResults } from '@/hooks/use-search'
+/** Hybrid full-text + semantic search across plugins with facet filtering. */
+export { useSearch } from '@/hooks/use-search'
+/** Re-rank a local list to match the order returned by a search query. */
+export { reorderBySearchResults } from '@/hooks/use-search'
 export type { SearchResult, SearchResponse, UseSearchOptions, UseSearchReturn } from '@/hooks/use-search'
+/** Read sidebar open/closed state and toggle helper. */
 export { useSidebar } from '@/hooks/use-sidebar'
+/** Subscribe to a Server-Sent Events endpoint with auto-reconnect. */
 export { useSSE } from '@/hooks/use-sse'
-export { toast, useToastStore } from '@/hooks/use-toast'
+/** Fire a toast notification (success/error/info). */
+export { toast } from '@/hooks/use-toast'
+/** Subscribe to the toast store for custom toast UIs. */
+export { useToastStore } from '@/hooks/use-toast'
+/** Imperatively resize a vertical pane via mouse drag handle. */
 export { useVerticalResize } from '@/hooks/use-vertical-resize'
 
 // Group 2: Agent data (from team plugin)
-export {
-  useAgentStore,
-  useAgent,
-  useAgentList,
-  useAgentColor,
-  useAgentDisplayName,
-  useAgentIds,
-  useMainAgentId,
-  usePackageState,
-  hexToMuted,
-} from '@bakin/team/hooks/use-agent-store'
+
+/** Access the agent registry store (Zustand). */
+export { useAgentStore } from '@bakin/team/hooks/use-agent-store'
+/** Look up a single agent by ID. */
+export { useAgent } from '@bakin/team/hooks/use-agent-store'
+/** List all registered agents. */
+export { useAgentList } from '@bakin/team/hooks/use-agent-store'
+/** Get an agent's brand color (hex string). */
+export { useAgentColor } from '@bakin/team/hooks/use-agent-store'
+/** Get an agent's display name (fallback to ID). */
+export { useAgentDisplayName } from '@bakin/team/hooks/use-agent-store'
+/** List all registered agent IDs. */
+export { useAgentIds } from '@bakin/team/hooks/use-agent-store'
+/** Get the ID of the designated main/orchestrator agent. */
+export { useMainAgentId } from '@bakin/team/hooks/use-agent-store'
+/** Read agent-package install state (managed/adopted/unmanaged). */
+export { usePackageState } from '@bakin/team/hooks/use-agent-store'
+/** Convert a hex color to a muted variant for backgrounds. */
+export { hexToMuted } from '@bakin/team/hooks/use-agent-store'
 
 // Group 3: Notification channels (from workflows plugin)
-export {
-  useNotificationChannels,
-  getChannelLabel,
-  getChannelInitials,
-} from '@bakin/workflows/hooks/use-notification-channels'
+
+/** List configured notification channels (Discord, Slack, email, etc.). */
+export { useNotificationChannels } from '@bakin/workflows/hooks/use-notification-channels'
+/** Get a human-readable label for a channel ID. */
+export { getChannelLabel } from '@bakin/workflows/hooks/use-notification-channels'
+/** Get initials for a channel (e.g. "Discord" → "D"). */
+export { getChannelInitials } from '@bakin/workflows/hooks/use-notification-channels'
 
 // Group 4: Router hooks (TanStack Router wrappers; Next.js-shape compatible)
-export { useRouter, usePathname, useSearchParams, useParams } from './router'
+
+/** Access the TanStack Router instance for imperative navigation. */
+export { useRouter } from './router'
+/** Current URL pathname (Next.js-shape compatible). */
+export { usePathname } from './router'
+/** Current URL search params as a URLSearchParams instance. */
+export { useSearchParams } from './router'
+/** Current route's typed path parameters. */
+export { useParams } from './router'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -20,21 +20,38 @@
  * (emitted by Bakin) resolves those to the host's bundled copies so there
  * is a single React instance and a single SDK.
  */
+
+/** Re-exports every plugin contract type. See `@makinbakin/sdk/types` for the full list. */
 export * from './types'
-export {
-  registerPlugin,
-  unregisterPlugin,
-  registerPluginCleanup,
-  getRegistryVersion,
-  subscribeRegistry,
-  getAllNavItems,
-  getNavItemsSnapshot,
-  getPluginNavItems,
-  getPluginRoute,
-  getPluginRoutes,
-} from './register'
+
+/** Register a plugin (single-call entry from a plugin's `client.tsx`). */
+export { registerPlugin } from './register'
+/** Tear down all registrations owned by a plugin (used during hot-swap). */
+export { unregisterPlugin } from './register'
+/** Register a cleanup callback fired when the plugin is unregistered. */
+export { registerPluginCleanup } from './register'
+/** Current registry version — bumps on every mutation (for useSyncExternalStore). */
+export { getRegistryVersion } from './register'
+/** Subscribe to registry-version changes. */
+export { subscribeRegistry } from './register'
+/** Get every registered nav item across all plugins. */
+export { getAllNavItems } from './register'
+/** Get a snapshot of the current nav items (non-subscribing). */
+export { getNavItemsSnapshot } from './register'
+/** Get nav items contributed by a specific plugin. */
+export { getPluginNavItems } from './register'
+/** Look up a specific client route by plugin id + path. */
+export { getPluginRoute } from './register'
+/** Get all registered client routes (across all plugins). */
+export { getPluginRoutes } from './register'
 export type { ClientRouteEntry, MatchedPluginRoute, NavItem, PluginRegistration } from './register'
-export { defineRoute, defineCoreRoute, definePlugin } from './routing'
+
+/** Define a plugin HTTP route with typed input/output schemas. */
+export { defineRoute } from './routing'
+/** Define a core (non-plugin) HTTP route. */
+export { defineCoreRoute } from './routing'
+/** Compose a plugin's routes into a single definition for the server. */
+export { definePlugin } from './routing'
 export type {
   APIRoute,
   HttpStatus,

--- a/packages/sdk/src/metadata/index.ts
+++ b/packages/sdk/src/metadata/index.ts
@@ -30,12 +30,17 @@ export type {
   SourceLocation,
 } from '@bakin/core/docs'
 
-export {
-  defineApiRoute,
-  defineCliCommandContract,
-  defineExecToolContract,
-  defineHookContract,
-  definePluginRoute,
-  defineRouteContract,
-  defineSlotContract,
-} from '@bakin/core/docs'
+/** Legacy: declare an API route with docs metadata. Prefer `defineRoute` from `/routing`. */
+export { defineApiRoute } from '@bakin/core/docs'
+/** Define a CLI command contract for documentation. */
+export { defineCliCommandContract } from '@bakin/core/docs'
+/** Define an MCP exec tool contract for documentation. */
+export { defineExecToolContract } from '@bakin/core/docs'
+/** Define a cross-plugin hook contract for documentation. */
+export { defineHookContract } from '@bakin/core/docs'
+/** Legacy: declare a plugin route with docs metadata. Prefer `defineRoute` from `/routing`. */
+export { definePluginRoute } from '@bakin/core/docs'
+/** Define a generic route contract (shared shape for API + plugin routes). */
+export { defineRouteContract } from '@bakin/core/docs'
+/** Define a UI slot contract for documentation. */
+export { defineSlotContract } from '@bakin/core/docs'

--- a/packages/sdk/src/routing/index.ts
+++ b/packages/sdk/src/routing/index.ts
@@ -8,11 +8,12 @@
  * deliberately avoiding.
  */
 
-export {
-  defineRoute,
-  defineCoreRoute,
-  definePlugin,
-} from '@bakin/core/routing'
+/** Define a plugin HTTP route with typed input/output and handler. */
+export { defineRoute } from '@bakin/core/routing'
+/** Define a core (non-plugin) HTTP route. */
+export { defineCoreRoute } from '@bakin/core/routing'
+/** Compose a plugin's routes into a single definition for the server. */
+export { definePlugin } from '@bakin/core/routing'
 
 export type {
   HttpMethod,

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -13,21 +13,27 @@ import type { ZodRawShape } from 'zod'
 // Shared primitives
 // ---------------------------------------------------------------------------
 
+/** HTTP method literal used in route and contribution definitions. */
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+/** Visibility tier for a documented contract (route, hook, tool, etc.). */
 export type ContractVisibility = 'public' | 'internal' | 'experimental'
+/** Stability tier for a documented contract. */
 export type ContractStability = 'stable' | 'beta' | 'experimental' | 'deprecated'
 
+/** Minimal interface a validation schema must satisfy (Zod-compatible). */
 export interface SchemaLike<T = unknown> {
   parse(data: unknown): T
   safeParse?(data: unknown): { success: true; data: T } | { success: false; error: unknown }
 }
 
+/** Pointer to a symbol's source file location, used in generated docs. */
 export interface SourceLocation {
   file: string
   symbol?: string
   line?: number
 }
 
+/** Reference example for a documented contract (request/response or code snippet). */
 export interface DocsExample {
   title: string
   description?: string
@@ -42,6 +48,7 @@ export interface DocsExample {
 // Manifest contract
 // ---------------------------------------------------------------------------
 
+/** Capability a plugin can request in its manifest (gates access to APIs). */
 export type PluginPermission =
   | 'storage.read'
   | 'storage.write'
@@ -59,6 +66,7 @@ export type PluginPermission =
   | 'search.write'
   | 'assets.read'
 
+/** Runtime feature a plugin declares it needs (used by doctor/health checks). */
 export type RuntimeCapability =
   | 'agents'
   | 'messaging'
@@ -72,11 +80,13 @@ export type RuntimeCapability =
   | 'tasks'
   | 'search'
 
+/** Server and client entry-point file paths for a plugin. */
 export interface PluginEntryPoints {
   server: string
   client?: string
 }
 
+/** Secret (env var) a plugin declares it needs (rendered in setup/health). */
 export interface SecretDeclaration {
   /** Canonical environment variable name, for example `ANTHROPIC_API_KEY`. */
   name: string
@@ -86,6 +96,7 @@ export interface SecretDeclaration {
   required: boolean
 }
 
+/** Manifest declaration of an HTTP route the plugin exposes. */
 export interface ApiRouteContribution {
   method: HttpMethod
   /** Plugin-relative path. Exposed as `/api/plugins/{pluginId}{path}`. */
@@ -102,8 +113,10 @@ export interface ApiRouteContribution {
   permissions?: PluginPermission[]
 }
 
+/** Raw JSON Schema object embedded in API contributions. */
 export type JsonSchemaContribution = Record<string, unknown>
 
+/** Path/query/header/cookie parameter declaration for an API route. */
 export interface ApiParameterContribution {
   name: string
   in: 'path' | 'query' | 'header' | 'cookie'
@@ -113,6 +126,7 @@ export interface ApiParameterContribution {
   example?: unknown
 }
 
+/** Request body declaration for an API route. */
 export interface ApiRequestBodyContribution {
   description?: string
   required?: boolean
@@ -121,6 +135,7 @@ export interface ApiRequestBodyContribution {
   example?: unknown
 }
 
+/** Response declaration for one HTTP status code on an API route. */
 export interface ApiResponseContribution {
   description: string
   contentType?: string
@@ -128,6 +143,7 @@ export interface ApiResponseContribution {
   example?: unknown
 }
 
+/** Manifest declaration of a client-side route the plugin contributes. */
 export interface ClientRouteContribution {
   /** Absolute app route, e.g. `/messaging/calendar`. */
   path: string
@@ -135,6 +151,7 @@ export interface ClientRouteContribution {
   slot?: string
 }
 
+/** Manifest declaration of an MCP exec tool the plugin exposes. */
 export interface ExecToolContribution {
   name: string
   summary: string
@@ -142,6 +159,7 @@ export interface ExecToolContribution {
   permissions?: PluginPermission[]
 }
 
+/** Manifest declaration of a CLI command the plugin contributes. */
 export interface CliCommandContribution {
   name: string
   usage: string
@@ -162,24 +180,34 @@ export interface CliCommandContribution {
   }
 }
 
+/** Manifest declaration of a settings key the plugin owns. */
 export interface SettingsContribution {
   key: string
   summary: string
 }
 
+/** Manifest declaration of the plugin's docs page slug. */
 export interface DocsContribution {
   slug: string
 }
 
+/** The full contributions block in `bakin-plugin.json` — everything a plugin adds to the host. */
 export interface PluginContributions {
+  /** HTTP routes the plugin exposes under `/api/plugins/{id}/...`. */
   apiRoutes?: ApiRouteContribution[]
+  /** Client-side routes the plugin renders (sidebar nav targets). */
   clientRoutes?: ClientRouteContribution[]
+  /** MCP exec tools agents can call. */
   execTools?: ExecToolContribution[]
+  /** CLI commands the plugin contributes to the `bakin` binary. */
   cliCommands?: CliCommandContribution[]
+  /** Settings keys this plugin owns in the settings UI. */
   settings?: SettingsContribution[]
+  /** Optional docs page slug. */
   docs?: DocsContribution
 }
 
+/** Optional Ed25519 signature block proving manifest authenticity. */
 export interface PluginManifestSignature {
   algorithm: 'ed25519'
   /** Human-readable signer label. Trust is bound to publicKey/fingerprint, not this label. */
@@ -190,21 +218,37 @@ export interface PluginManifestSignature {
   signature: string
 }
 
+/** The `bakin-plugin.json` manifest. Required for every plugin. */
 export interface PluginManifest {
+  /** Unique plugin identifier (kebab-case). */
   id: string
+  /** Human-readable plugin name. */
   name: string
+  /** Plugin version (semver). */
   version: string
+  /** Minimum Bakin version this plugin supports. */
   bakin: string
+  /** One-line summary shown in the plugin manager. */
   description: string
+  /** Server + optional client entry-point file paths. */
   entry: PluginEntryPoints
+  /** Static content files the plugin ships (rendered as docs/pages). */
   contentFiles?: string[]
+  /** Environment-variable secrets the plugin requires. */
   secrets?: SecretDeclaration[]
+  /** Path to a test entry-point (for `bakin plugins test`). */
   tests?: string
+  /** Other plugin IDs this plugin depends on. */
   dependencies?: string[]
+  /** Capabilities this plugin requests access to. */
   permissions?: PluginPermission[]
+  /** Runtime features this plugin needs to function. */
   runtimeCapabilities?: RuntimeCapability[]
+  /** Everything the plugin adds to the host (routes, tools, settings, etc.). */
   contributes?: PluginContributions
+  /** File globs that trigger a hot reload in dev. */
   devWatch?: string[]
+  /** Optional Ed25519 signature for authenticity. */
   signature?: PluginManifestSignature
 }
 
@@ -212,6 +256,7 @@ export interface PluginManifest {
 // Storage
 // ---------------------------------------------------------------------------
 
+/** File metadata returned by storage adapter `stat()`. */
 export interface StorageStat {
   path: string
   size: number
@@ -220,6 +265,7 @@ export interface StorageStat {
   isDirectory: boolean
 }
 
+/** Plugin-scoped filesystem adapter passed via `ctx.storage`. */
 export interface StorageAdapter {
   read(path: string): string | null
   write(path: string, content: string): void
@@ -239,17 +285,20 @@ export interface StorageAdapter {
 // Events, activity, hooks
 // ---------------------------------------------------------------------------
 
+/** Cross-plugin event bus. Emit and subscribe by pattern. */
 export interface EventBus {
   emit(event: string, data?: Record<string, unknown>): void
   on(pattern: string, handler: (event: string, data: Record<string, unknown>) => void): () => void
   once(pattern: string, handler: (event: string, data: Record<string, unknown>) => void): () => void
 }
 
+/** Activity feed + structured audit log API exposed on the plugin context. */
 export interface ActivityAPI {
   log(agent: string, message: string, opts?: { taskId?: string; category?: string }): void
   audit(event: string, agent: string, data?: Record<string, unknown>): void
 }
 
+/** Plugin-scoped structured logger (writes to server log + stdout). */
 export interface PluginLogger {
   debug(message: string, data?: Record<string, unknown>): void
   info(message: string, data?: Record<string, unknown>): void
@@ -257,6 +306,7 @@ export interface PluginLogger {
   error(message: string, errorOrData?: unknown, data?: Record<string, unknown>): void
 }
 
+/** Cross-plugin RPC/event/waterfall hook registry. */
 export interface HookAPI {
   register(name: string, handler: (data: unknown) => unknown, metadata?: HookRegistrationMetadata): () => void
   call<T>(name: string, data: T): Promise<T>
@@ -265,6 +315,7 @@ export interface HookAPI {
   invoke<R>(name: string, data: unknown): Promise<R | undefined>
 }
 
+/** Optional documentation metadata for a registered hook. */
 export interface HookRegistrationMetadata {
   label?: string
   summary: string
@@ -277,44 +328,69 @@ export interface HookRegistrationMetadata {
   examples?: DocsExample[]
 }
 
+/** Hook semantics: single-return RPC, fire-and-forget event, or input transform waterfall. */
 export type HookKind = 'rpc' | 'event' | 'waterfall'
 
 // ---------------------------------------------------------------------------
 // Navigation, API routes, UI slots
 // ---------------------------------------------------------------------------
 
+/** Sidebar navigation item registered by a plugin via `ctx.registerNav()`. */
 export interface NavItem {
+  /** Unique nav item id (used for active-state tracking). */
   id: string
+  /** Display label in the sidebar. */
   label: string
+  /** Lucide icon name (e.g. "tasks", "calendar"). */
   icon: string
+  /** Target route path. */
   href: string
+  /** Sort order within the parent group. Lower renders first. */
   order?: number
+  /** Optional nested nav items for groups. */
   children?: NavItem[]
+  /** If true, the group cannot be collapsed. */
   alwaysExpanded?: boolean
 }
 
+/** HTTP route handler registered by a plugin via `ctx.registerRoute()`. */
 export interface APIRoute {
+  /** Route path relative to `/api/plugins/{pluginId}`. */
   path: string
+  /** HTTP method. */
   method: HttpMethod
+  /** Request handler. Receives a standard Request and the plugin context. */
   handler: (req: Request, ctx: PluginContext) => Response | Promise<Response>
+  /** One-line summary for docs. */
   summary?: string
+  /** Full description for docs. */
   description?: string
+  /** Path param descriptor (e.g. ":id"). */
   params?: string
+  /** Input schema for validation and docs. */
   input?: SchemaLike
+  /** Output schema for docs. */
   output?: SchemaLike
+  /** Visibility tier (public/internal/experimental). */
   visibility?: ContractVisibility
+  /** Stability tier. */
   stability?: ContractStability
+  /** Reference examples for the docs site. */
   examples?: DocsExample[]
+  /** Source location for generated docs back-references. */
   source?: SourceLocation
+  /** Permissions required to call this route. */
   permissions?: string[]
 }
 
+/** Slot registration record: place a component at a named extension point. */
 export interface UISlotRegistration {
   slot: string
   component: ComponentType<Record<string, unknown>>
   order?: number
 }
 
+/** Static content file shipped with a plugin (e.g. README, docs page). */
 export interface ContentFile {
   path: string
 }
@@ -323,6 +399,7 @@ export interface ContentFile {
 // Runtime-facing public types
 // ---------------------------------------------------------------------------
 
+/** An agent registered with the runtime (OpenClaw, etc.). */
 export interface RuntimeAgent {
   id: string
   name: string
@@ -332,6 +409,7 @@ export interface RuntimeAgent {
   metadata?: Record<string, unknown>
 }
 
+/** A messaging channel (Discord, Slack, email, etc.) registered with the runtime. */
 export interface RuntimeChannel {
   id: string
   platform: string
@@ -340,8 +418,10 @@ export interface RuntimeChannel {
   metadata?: Record<string, unknown>
 }
 
+/** Whether to expose runtime-native tools for this agent turn. */
 export type RuntimeMessageToolsMode = 'auto' | 'none'
 
+/** Per-turn policy for which runtime tools the agent may call. */
 export interface RuntimeMessageToolPolicy {
   /**
    * Controls whether runtime-native tools are available for this agent turn.
@@ -354,6 +434,7 @@ export interface RuntimeMessageToolPolicy {
   toolsDeny?: string[]
 }
 
+/** Arguments for a single message dispatched to an agent. */
 export interface RuntimeMessageArgs extends RuntimeMessageToolPolicy {
   agentId: string
   content: string
@@ -365,12 +446,14 @@ export interface RuntimeMessageArgs extends RuntimeMessageToolPolicy {
   metadata?: Record<string, unknown>
 }
 
+/** Result returned by a non-streaming runtime message. */
 export interface RuntimeMessageResult {
   id: string
   content?: string
   metadata?: Record<string, unknown>
 }
 
+/** Tool call/result event surfaced during a streaming agent turn. */
 export interface RuntimeToolActivity {
   phase: 'call' | 'result'
   callId?: string
@@ -384,12 +467,14 @@ export interface RuntimeToolActivity {
   metadata?: Record<string, unknown>
 }
 
+/** One chunk in a streaming agent response (text, tool, status, done, error). */
 export interface RuntimeChatChunk {
   type: 'text' | 'tool' | 'status' | 'done' | 'error'
   content?: string
   data?: Record<string, unknown> | RuntimeToolActivity
 }
 
+/** A cron-scheduled job tracked by the runtime. */
 export interface CronJob {
   id: string
   name: string
@@ -400,6 +485,7 @@ export interface CronJob {
   metadata?: Record<string, unknown>
 }
 
+/** Execution record for a single cron job run. */
 export interface CronRun {
   id: string
   jobId: string
@@ -410,16 +496,19 @@ export interface CronRun {
   error?: string
 }
 
+/** A skill (runtime-side capability) registered with an agent. */
 export interface RuntimeSkill {
   name: string
   description?: string
 }
 
+/** A file in an agent's runtime workspace. */
 export interface WorkspaceFile {
   path: string
   content?: string
 }
 
+/** Provider-agnostic interface for agent runtime adapters (OpenClaw, etc.). */
 export interface AgentRuntimeAdapter {
   agents: {
     list(): Promise<RuntimeAgent[]>
@@ -469,6 +558,7 @@ export interface AgentRuntimeAdapter {
 // Tasks
 // ---------------------------------------------------------------------------
 
+/** One entry in a task's activity log. */
 export interface TaskLogEntry {
   timestamp: string
   author: string
@@ -476,6 +566,7 @@ export interface TaskLogEntry {
   data?: Record<string, unknown>
 }
 
+/** A task on the Bakin board. */
 export interface Task {
   id: string
   title: string
@@ -500,6 +591,7 @@ export interface Task {
   updatedAt?: string
 }
 
+/** Identifies the plugin/entity that originated a task. */
 export interface TaskSource {
   pluginId?: string
   entityType?: string
@@ -507,6 +599,7 @@ export interface TaskSource {
   purpose?: string
 }
 
+/** The seven task board columns. */
 export interface TaskColumns {
   backlog: Task[]
   inProgress: Task[]
@@ -517,13 +610,16 @@ export interface TaskColumns {
   archived: Task[]
 }
 
+/** The full task board snapshot (columns + timestamp). */
 export interface TaskBoard {
   columns: TaskColumns
   timestamp?: string
 }
 
+/** Valid task column identifier (keyof TaskColumns). */
 export type ColumnId = keyof TaskColumns
 
+/** Payload for `tasks.create()`. */
 export interface TaskCreateInput {
   id?: string
   title: string
@@ -541,6 +637,7 @@ export interface TaskCreateInput {
   skipWorkflowReason?: string
 }
 
+/** Patch payload for `tasks.update()`. Nullable fields explicitly clear. */
 export interface TaskUpdateInput {
   title?: string
   description?: string
@@ -559,6 +656,7 @@ export interface TaskUpdateInput {
   source?: TaskSource | null
 }
 
+/** CRUD service for tasks, exposed via `ctx.tasks`. */
 export interface TaskService {
   create(input: TaskCreateInput): Promise<Task>
   update(id: string, patch: TaskUpdateInput): Promise<Task>
@@ -573,10 +671,12 @@ export interface TaskService {
 // Search
 // ---------------------------------------------------------------------------
 
+/** Field schema entry for a search content type. */
 export interface SearchSchemaField {
   type: 'text' | 'keyword' | 'number' | 'boolean' | 'datetime' | 'array'
 }
 
+/** Named index definition (embedder + chunker config) for a content type. */
 export interface SearchIndexDefinition {
   name: string
   embedderRef: string
@@ -589,6 +689,7 @@ export interface SearchIndexDefinition {
   }
 }
 
+/** Full content-type definition: schema, indexes, facets, reindex generator. */
 export interface SearchContentTypeDefinition {
   table: string
   schema: Record<string, SearchSchemaField>
@@ -608,12 +709,14 @@ export interface SearchContentTypeDefinition {
   verifyExists: (key: string) => Promise<boolean>
 }
 
+/** File glob + mappers used by file-backed search content types. */
 export interface FilePatternMapper {
   pattern: string
   fileToId: (relPath: string) => string | null
   fileToDoc: (relPath: string, content: string) => Promise<Record<string, unknown> | null>
 }
 
+/** File-backed content type: indexes documents derived from on-disk files. */
 export interface FileBackedContentTypeDefinition extends SearchContentTypeDefinition {
   filePatterns: FilePatternMapper[]
   excludePatterns?: string[]
@@ -623,6 +726,7 @@ export interface FileBackedContentTypeDefinition extends SearchContentTypeDefini
   preserveVirtualDocuments?: boolean
 }
 
+/** Query payload for `search.query()` — filters, facets, paging, strategy. */
 export interface SearchQueryParams {
   q: string
   filters?: Record<string, string | boolean | number>
@@ -634,6 +738,7 @@ export interface SearchQueryParams {
   strategy?: 'rrf' | 'semantic_only' | 'full_text_only'
 }
 
+/** A single search hit with score and field projection. */
 export interface SearchResult {
   id: string
   table: string
@@ -642,6 +747,7 @@ export interface SearchResult {
   rerankScore?: number
 }
 
+/** Full search response: results, aggregations, and query metadata. */
 export interface SearchResponse {
   results: SearchResult[]
   aggregations?: Record<string, Array<{ value: string; count: number }>>
@@ -654,6 +760,7 @@ export interface SearchResponse {
   }
 }
 
+/** Health snapshot reported by the search adapter (per-table state). */
 export interface SearchHealthSnapshot {
   enabled: boolean
   tables: Array<{
@@ -664,12 +771,14 @@ export interface SearchHealthSnapshot {
   }>
 }
 
+/** Atomic transform operation applied to an indexed document. */
 export interface SearchTransformOp {
   op: '$set' | '$inc' | '$push'
   field?: string
   value: unknown
 }
 
+/** Search API exposed via `ctx.search` — index, query, transform documents. */
 export interface SearchAPI {
   registerContentType(def: SearchContentTypeDefinition): void
   registerFileBackedContentType(def: FileBackedContentTypeDefinition): void
@@ -684,6 +793,7 @@ export interface SearchAPI {
 // Assets
 // ---------------------------------------------------------------------------
 
+/** Auto-generated variant (thumbnail/optimized/webp) for an asset. */
 export interface AssetVariantMeta {
   role: 'thumbnail' | 'optimized' | 'webp'
   path: string
@@ -692,6 +802,7 @@ export interface AssetVariantMeta {
   mimeType: string
 }
 
+/** Full asset record: file info + sidecar metadata + auto-generated variants. */
 export interface AssetMeta {
   path: string
   filename: string
@@ -711,6 +822,7 @@ export interface AssetMeta {
   variants?: AssetVariantMeta[]
 }
 
+/** Asset record while in trash (with deleted/expires timestamps). */
 export interface TrashedAssetMeta {
   filename: string
   originalFilename: string
@@ -722,12 +834,14 @@ export interface TrashedAssetMeta {
   metadata: AssetMeta['metadata'] | null
 }
 
+/** Compact reference to an asset by filename — used in channel deliveries. */
 export interface AssetFileRef {
   kind: 'asset'
   filename: string
   mimeType?: string
 }
 
+/** Assets API exposed via `ctx.assets` — read-only asset lookups. */
 export interface AssetsAPI {
   getByFilename(filename: string): Promise<AssetMeta | null>
   list(filter?: { type?: AssetMeta['type']; taskId?: string | null }): Promise<AssetMeta[]>
@@ -739,6 +853,7 @@ export interface AssetsAPI {
 // Execution tools, skills, health, workflows
 // ---------------------------------------------------------------------------
 
+/** Result returned from an exec tool handler. */
 export interface ExecToolResult {
   ok: boolean
   error?: string
@@ -746,29 +861,49 @@ export interface ExecToolResult {
   [key: string]: unknown
 }
 
+/** Context passed to an exec tool handler. Subset of PluginContext sans UI registration. */
 export interface PluginToolContext {
+  /** Plugin-scoped storage adapter. */
   storage: StorageAdapter
+  /** Cross-plugin event bus. */
   events: EventBus
+  /** ID of the plugin owning this tool. */
   pluginId: string
+  /** Agent runtime adapter (messaging, agents, channels, cron). */
   runtime: AgentRuntimeAdapter
+  /** Task CRUD service. */
   tasks: TaskService
+  /** Search API. */
   search: SearchAPI
+  /** Assets API. */
   assets: AssetsAPI
+  /** Hook registry. */
   hooks: HookAPI
+  /** Activity feed and audit log. */
   activity: ActivityAPI
+  /** Read this plugin's persisted settings. */
   getSettings<T = Record<string, unknown>>(): T
 }
 
+/** MCP exec tool definition registered via `ctx.registerExecTool()`. */
 export interface ExecToolDefinition {
+  /** Tool name. Convention: `bakin_exec_{pluginId}_{action}`. */
   name: string
+  /** Description shown to the agent (used for tool selection). */
   description: string
+  /** Optional UI label for the activity feed. */
   label?: string
+  /** If true, this tool can fire multiple times in a single agent turn. */
   activityDuplicate?: boolean
+  /** Zod raw shape describing the tool's parameters. */
   parameters: ZodRawShape
+  /** Handler that executes the tool. */
   handler: (params: Record<string, unknown>, agent: string, ctx?: PluginToolContext) => Promise<ExecToolResult>
+  /** Optional source-file path for generated docs. */
   source?: string
 }
 
+/** Runtime skill definition registered via `ctx.registerSkill()`. */
 export interface SkillDefinition {
   name: string
   instructions: string
@@ -776,11 +911,13 @@ export interface SkillDefinition {
   source?: string
 }
 
+/** Layout hints for a workflow's canvas rendering. */
 export interface WorkflowLayoutInput {
   positions?: Record<string, { x: number; y: number; [key: string]: unknown }>
   [key: string]: unknown
 }
 
+/** Plugin-contributed workflow definition input shape. */
 export interface WorkflowDefinitionInput {
   id?: string
   name: string
@@ -792,8 +929,10 @@ export interface WorkflowDefinitionInput {
   [key: string]: unknown
 }
 
+/** Field types supported by FormField. */
 export type FormFieldType = 'string' | 'text' | 'number' | 'boolean' | 'select' | 'agent' | 'skill' | 'list'
 
+/** Form field descriptor for plugin-contributed workflow nodes. */
 export interface FormField {
   name: string
   type: FormFieldType
@@ -802,11 +941,13 @@ export interface FormField {
   options?: { value: string; label: string }[]
 }
 
+/** Edge constraints for a plugin-contributed workflow node type. */
 export interface EdgeRules {
   maxInbound?: number
   maxOutbound?: number
 }
 
+/** Workflow node type contributed by a plugin (custom step kind). */
 export interface PluginNodeTypeInput<T = unknown> {
   kind: string
   zodSchema: SchemaLike<T>
@@ -814,6 +955,7 @@ export interface PluginNodeTypeInput<T = unknown> {
   edgeRules?: EdgeRules
 }
 
+/** Notification channel definition contributed by a plugin. */
 export interface PluginNotificationChannelInput {
   id: string
   label: string
@@ -821,15 +963,22 @@ export interface PluginNotificationChannelInput {
   icon?: string
 }
 
+/** Result row returned by a health check (doctor). */
 export interface HealthCheckResult {
+  /** Stable check identifier. */
   check: string
+  /** Severity of the result. */
   status: 'ok' | 'warn' | 'error' | 'fixed'
+  /** Human-readable message describing the finding. */
   message: string
+  /** Whether the issue can be auto-fixed by an attached repair handler. */
   autoFixable: boolean
 }
 
+/** Repair safety tier: safe (auto), manual (needs review), destructive (data-affecting). */
 export type HealthRepairSafety = 'safe' | 'manual' | 'destructive'
 
+/** Single change a repair plan will apply. */
 export interface HealthRepairChange {
   kind: 'file' | 'setting' | 'service' | 'runtime' | 'task' | 'other'
   target: string
@@ -837,6 +986,7 @@ export interface HealthRepairChange {
   description: string
 }
 
+/** One item in a repair plan: what will change and why. */
 export interface HealthRepairPlanItem {
   id: string
   checkId: string
@@ -847,6 +997,7 @@ export interface HealthRepairPlanItem {
   changes: HealthRepairChange[]
 }
 
+/** Result of applying a single repair plan item. */
 export interface HealthRepairApplyResult {
   id: string
   checkId: string
@@ -855,11 +1006,13 @@ export interface HealthRepairApplyResult {
   changes: HealthRepairChange[]
 }
 
+/** Two-phase repair handler attached to a health check. */
 export interface HealthRepairHandler {
   plan(rows: HealthCheckResult[]): Promise<HealthRepairPlanItem[]>
   apply(items: HealthRepairPlanItem[]): Promise<HealthRepairApplyResult[]>
 }
 
+/** Health check registration input passed to `ctx.registerHealthCheck()`. */
 export interface PluginHealthCheckInput {
   id: string
   name: string
@@ -879,27 +1032,32 @@ interface BaseSettingsField {
   required?: boolean
 }
 
+/** Single-line text settings field. */
 export interface StringSettingsField extends BaseSettingsField {
   type: 'string'
   default?: string
 }
 
+/** Numeric settings field with optional default. */
 export interface NumberSettingsField extends BaseSettingsField {
   type: 'number'
   default?: number
 }
 
+/** Boolean toggle settings field. */
 export interface BooleanSettingsField extends BaseSettingsField {
   type: 'boolean'
   default?: boolean
 }
 
+/** Dropdown settings field with predefined options. */
 export interface SelectSettingsField extends BaseSettingsField {
   type: 'select'
   options: { value: string; label: string }[]
   default?: string
 }
 
+/** Repeatable list settings field with per-item shape. */
 export interface ListSettingsField extends BaseSettingsField {
   type: 'list'
   itemShape: Record<string, StringSettingsField | NumberSettingsField | BooleanSettingsField | SelectSettingsField>
@@ -910,6 +1068,7 @@ export interface ListSettingsField extends BaseSettingsField {
   uniqueField?: string
 }
 
+/** Union of all supported settings field types. */
 export type SettingsField =
   | StringSettingsField
   | NumberSettingsField
@@ -917,7 +1076,9 @@ export type SettingsField =
   | SelectSettingsField
   | ListSettingsField
 
+/** Plugin settings schema — declares fields rendered on the settings page. */
 export interface PluginSettingsSchema {
+  /** Ordered list of settings fields for the form. */
   fields: SettingsField[]
 }
 
@@ -925,42 +1086,80 @@ export interface PluginSettingsSchema {
 // Plugin context and plugin object
 // ---------------------------------------------------------------------------
 
+/** The activation context passed to a plugin's `activate(ctx)` method.
+ *  This is the primary API surface for plugin authors. Everything a plugin
+ *  needs to register with the host — routes, tools, nav, slots, health checks,
+ *  settings — flows through this object. */
 export interface PluginContext {
+  /** Plugin-scoped filesystem storage adapter. */
   storage: StorageAdapter
+  /** Cross-plugin event bus. */
   events: EventBus
+  /** ID of the plugin this context belongs to. */
   pluginId: string
+  /** Agent runtime adapter (agents, messaging, channels, cron, skills). */
   runtime: AgentRuntimeAdapter
+  /** Task CRUD service. */
   tasks: TaskService
+  /** Assets API for asset metadata + file lookups. */
   assets: AssetsAPI
+  /** Register sidebar navigation items. */
   registerNav(items: NavItem[]): void
+  /** Register an HTTP route under `/api/plugins/{pluginId}`. */
   registerRoute(route: APIRoute): void
+  /** Register a component for a named slot (legacy — prefer `<Slot>` from `/slots`). */
   registerSlot(registration: UISlotRegistration): void
+  /** Register an MCP exec tool agents can call. */
   registerExecTool(tool: ExecToolDefinition): void
+  /** Register a runtime skill (capability definition). */
   registerSkill(skill: SkillDefinition): void
+  /** Register a workflow definition (or template) the plugin ships. */
   registerWorkflow(definition: WorkflowDefinitionInput, opts?: { readOnly?: boolean }): void
+  /** Register a custom workflow node type (step kind). */
   registerNodeType<T = unknown>(def: PluginNodeTypeInput<T>): string
+  /** Register a notification channel the runtime can deliver to. */
   registerNotificationChannel(def: PluginNotificationChannelInput): string
+  /** Register a health check that runs on `bakin doctor`. */
   registerHealthCheck(def: PluginHealthCheckInput): string
+  /** Subscribe to file globs for live updates (Chokidar-based). */
   watchFiles(patterns: string[]): void
+  /** Read this plugin's persisted settings. */
   getSettings<T = Record<string, unknown>>(): T
+  /** Patch this plugin's persisted settings. */
   updateSettings(patch: Record<string, unknown>): void
+  /** Activity feed + audit log API. */
   activity: ActivityAPI
+  /** Plugin-scoped structured logger. Optional — falls back to console. */
   log?: PluginLogger
+  /** Cross-plugin hook registry. */
   hooks: HookAPI
+  /** Search API for indexing and querying. */
   search: SearchAPI
 }
 
+/** The main plugin interface. The default export of a plugin's `index.ts`. */
 export interface BakinPlugin {
+  /** Unique plugin identifier (matches manifest `id`). */
   id: string
+  /** Display name. */
   name: string
+  /** Plugin version (semver). */
   version: string
+  /** Called once at plugin load. Register routes/tools/nav/etc. here. */
   activate(ctx: PluginContext): void | Promise<void>
+  /** Called after all plugins have activated. Useful for cross-plugin setup. */
   onReady?(): void | Promise<void>
+  /** Called when the server shuts down or the plugin is hot-swapped out. */
   onShutdown?(): void | Promise<void>
+  /** Called when this plugin's settings are persisted. */
   onSettingsChange?(settings: Record<string, unknown>): void | Promise<void>
+  /** Called when the plugin is uninstalled — clean up persisted data here. */
   onUninstall?(ctx: PluginContext): void | Promise<void>
+  /** Settings schema rendered on this plugin's settings page. */
   settingsSchema?: PluginSettingsSchema
+  /** Convenience: nav items to auto-register at activation. */
   navItems?: NavItem[]
+  /** Convenience: static content files declared at construction. */
   contentFiles?: ContentFile[]
 }
 
@@ -968,38 +1167,45 @@ export interface BakinPlugin {
 // Misc public domain types used by existing plugins
 // ---------------------------------------------------------------------------
 
+/** Single calendar event (time + text). */
 export interface CalendarEvent {
   time?: string
   text: string
 }
 
+/** One day on an agent's calendar (date + list of events). */
 export interface CalendarDay {
   date: string
   label?: string
   events: CalendarEvent[]
 }
 
+/** A recurring event (cron expression + display text). */
 export interface RecurringEvent {
   schedule: string
   text: string
 }
 
+/** Single memory entry (decision, learned-thing, or freeform note). */
 export interface MemoryEntry {
   type: 'decision' | 'learned' | 'note'
   text: string
 }
 
+/** Memory entries grouped by day. */
 export interface MemoryDay {
   date: string
   entries: MemoryEntry[]
 }
 
+/** Agent heartbeat snapshot (status + current task + timestamp). */
 export interface Heartbeat {
   status: 'working' | 'idle' | 'down'
   currentTask?: string
   timestamp: string
 }
 
+/** Project metadata loaded from a markdown project file. */
 export interface ProjectMeta {
   filename: string
   title: string
@@ -1007,6 +1213,7 @@ export interface ProjectMeta {
   content: string
 }
 
+/** A model available in the models catalog (LLM, image, or video). */
 export interface AvailableModel {
   id: string
   name?: string
@@ -1032,6 +1239,7 @@ export interface AvailableModel {
   providerBrandColor?: string
 }
 
+/** A workflow definition stored on disk (YAML or programmatic). */
 export interface WorkflowDefinition {
   id?: string
   name: string
@@ -1041,6 +1249,7 @@ export interface WorkflowDefinition {
   [key: string]: unknown
 }
 
+/** A running instance of a workflow attached to a task. */
 export interface WorkflowInstance {
   id: string
   taskId?: string
@@ -1048,23 +1257,33 @@ export interface WorkflowInstance {
   [key: string]: unknown
 }
 
+/** One step in a workflow definition or instance. */
 export interface WorkflowStep {
   id: string
   type: string
   [key: string]: unknown
 }
 
+/** Alias for WorkflowDefinition when used as a reusable template. */
 export type WorkflowTemplate = WorkflowDefinition
 
+/** The `bakin.config.ts` shape — root configuration for a Bakin installation. */
 export interface BakinConfig {
+  /** Plugins to load at startup. */
   plugins: PluginEntry[]
+  /** Theme overrides for CSS custom properties. */
   theme?: Record<string, string>
+  /** Storage configuration. */
   storage?: {
+    /** Override the default content directory. */
     contentDir?: string
   }
 }
 
+/** A plugin entry in `bakin.config.ts`. */
 export interface PluginEntry {
+  /** Path or package specifier resolving to the plugin's entry file. */
   path: string
+  /** If false, the plugin is loaded but not activated. Default true. */
   enabled?: boolean
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -5,18 +5,30 @@
  * needs. The `format*` helpers are re-exported from `@bakin/core/format`
  * so plugins have a single import path instead of reaching into `@/lib/*`.
  */
+
+/** Tailwind class merger (clsx + tailwind-merge). */
 export { cn } from '../../../../src/lib/utils'
-export { formatAge, formatSize, isStale } from '@bakin/core/format'
-export {
-  brainstormActivityMessageFromCustom,
-  runtimeChunkToBrainstormActivity,
-  toBrainstormTimeline,
-} from '../../../../src/components/integrated-brainstorm/activity'
-export {
-  brainstormThreadId,
-  normalizeBrainstormActivityForStorage,
-  normalizeBrainstormActivityMessageForStorage,
-} from '../../../../src/components/integrated-brainstorm/session'
+
+/** Format a Date or ISO string as a relative age (e.g. "5m ago"). */
+export { formatAge } from '@bakin/core/format'
+/** Format a byte count as a human-readable size string (e.g. "1.2 MB"). */
+export { formatSize } from '@bakin/core/format'
+/** Returns true if a timestamp is older than a configurable staleness threshold. */
+export { isStale } from '@bakin/core/format'
+
+/** Convert a custom activity message into a brainstorm activity input. */
+export { brainstormActivityMessageFromCustom } from '../../../../src/components/integrated-brainstorm/activity'
+/** Convert a runtime chat chunk into a brainstorm activity event. */
+export { runtimeChunkToBrainstormActivity } from '../../../../src/components/integrated-brainstorm/activity'
+/** Fold brainstorm events into a renderable timeline. */
+export { toBrainstormTimeline } from '../../../../src/components/integrated-brainstorm/activity'
+/** Compute the canonical thread id for a brainstorm session. */
+export { brainstormThreadId } from '../../../../src/components/integrated-brainstorm/session'
+/** Normalize a brainstorm activity payload for persistence. */
+export { normalizeBrainstormActivityForStorage } from '../../../../src/components/integrated-brainstorm/session'
+/** Normalize a single brainstorm message for persistence. */
+export { normalizeBrainstormActivityMessageForStorage } from '../../../../src/components/integrated-brainstorm/session'
+
 export type {
   BrainstormActivityInput,
   BrainstormTimelineActivityInput,
@@ -26,4 +38,6 @@ export type {
   BrainstormActivityStorageInput,
   BrainstormActivityStorageRecord,
 } from '../../../../src/components/integrated-brainstorm/session'
+
+/** Read an SSE response stream into brainstorm activity events. */
 export { readBrainstormSseResponse } from '../../../../src/components/integrated-brainstorm/sse'

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import * as ts from 'typescript'
 import {
   extractExecTools,
   extractPluginSettings,
@@ -316,10 +317,198 @@ interface PluginManifestDoc {
   file: string
 }
 
-interface SdkExportDoc {
+interface SdkSymbol {
+  name: string
+  kind: 'function' | 'type' | 'interface' | 'const' | 'enum' | 'class' | 'variable'
+  jsdoc: string
+  members?: SdkMember[]
+}
+
+interface SdkMember {
+  name: string
+  type: string
+  jsdoc: string
+  optional: boolean
+}
+
+interface SdkSubpath {
   importPath: string
   source: string
-  exports: string[]
+  symbols: SdkSymbol[]
+}
+
+const CORE_TYPES = new Set([
+  'BakinPlugin',
+  'PluginContext',
+  'PluginManifest',
+  'ExecToolDefinition',
+  'PluginToolContext',
+  'NavItem',
+  'APIRoute',
+  'HealthCheckResult',
+  'PluginSettingsSchema',
+  'BakinConfig',
+  'PluginContributions',
+])
+
+const HOOKS_GROUPS: Record<string, string> = {
+  useAssets: 'Data & State',
+  useTrash: 'Data & State',
+  useContentStore: 'Data & State',
+  useScheduleJobs: 'Data & State',
+  useRunHistory: 'Data & State',
+  ScheduleJob: 'Data & State',
+  RunEntry: 'Data & State',
+  useSearch: 'Search',
+  reorderBySearchResults: 'Search',
+  SearchResult: 'Search',
+  SearchResponse: 'Search',
+  UseSearchOptions: 'Search',
+  UseSearchReturn: 'Search',
+  useQueryState: 'Navigation & URL',
+  useQueryArrayState: 'Navigation & URL',
+  useRouter: 'Navigation & URL',
+  usePathname: 'Navigation & URL',
+  useSearchParams: 'Navigation & URL',
+  useParams: 'Navigation & URL',
+  useSidebar: 'Navigation & URL',
+  useAgentStore: 'Agent Data',
+  useAgent: 'Agent Data',
+  useAgentList: 'Agent Data',
+  useAgentColor: 'Agent Data',
+  useAgentDisplayName: 'Agent Data',
+  useAgentIds: 'Agent Data',
+  useMainAgentId: 'Agent Data',
+  usePackageState: 'Agent Data',
+  hexToMuted: 'Agent Data',
+  useNotificationChannels: 'Notification Channels',
+  getChannelLabel: 'Notification Channels',
+  getChannelInitials: 'Notification Channels',
+  useDebug: 'UI Controls',
+  useFormGuard: 'UI Controls',
+  useVerticalResize: 'UI Controls',
+  toast: 'UI Controls',
+  useToastStore: 'UI Controls',
+  useRuntimeStatus: 'Runtime',
+  useSSE: 'Runtime',
+}
+
+const TYPE_DOMAIN_GROUPS: Record<string, string> = {
+  // Shared primitives
+  HttpMethod: 'Shared Primitives',
+  ContractVisibility: 'Shared Primitives',
+  ContractStability: 'Shared Primitives',
+  SchemaLike: 'Shared Primitives',
+  SourceLocation: 'Shared Primitives',
+  DocsExample: 'Shared Primitives',
+  // Manifest
+  PluginPermission: 'Manifest Contracts',
+  RuntimeCapability: 'Manifest Contracts',
+  PluginEntryPoints: 'Manifest Contracts',
+  SecretDeclaration: 'Manifest Contracts',
+  ApiRouteContribution: 'Manifest Contracts',
+  JsonSchemaContribution: 'Manifest Contracts',
+  ApiParameterContribution: 'Manifest Contracts',
+  ApiRequestBodyContribution: 'Manifest Contracts',
+  ApiResponseContribution: 'Manifest Contracts',
+  ClientRouteContribution: 'Manifest Contracts',
+  ExecToolContribution: 'Manifest Contracts',
+  CliCommandContribution: 'Manifest Contracts',
+  SettingsContribution: 'Manifest Contracts',
+  DocsContribution: 'Manifest Contracts',
+  PluginManifestSignature: 'Manifest Contracts',
+  // Storage / Events
+  StorageStat: 'Storage & Events',
+  StorageAdapter: 'Storage & Events',
+  EventBus: 'Storage & Events',
+  ActivityAPI: 'Storage & Events',
+  PluginLogger: 'Storage & Events',
+  HookAPI: 'Storage & Events',
+  HookRegistrationMetadata: 'Storage & Events',
+  HookKind: 'Storage & Events',
+  // Navigation & routes (NavItem/APIRoute are core, handled separately)
+  UISlotRegistration: 'UI & Navigation',
+  ContentFile: 'UI & Navigation',
+  // Runtime
+  RuntimeAgent: 'Runtime',
+  RuntimeChannel: 'Runtime',
+  RuntimeMessageToolsMode: 'Runtime',
+  RuntimeMessageToolPolicy: 'Runtime',
+  RuntimeMessageArgs: 'Runtime',
+  RuntimeMessageResult: 'Runtime',
+  RuntimeToolActivity: 'Runtime',
+  RuntimeChatChunk: 'Runtime',
+  CronJob: 'Runtime',
+  CronRun: 'Runtime',
+  RuntimeSkill: 'Runtime',
+  WorkspaceFile: 'Runtime',
+  AgentRuntimeAdapter: 'Runtime',
+  // Tasks
+  TaskLogEntry: 'Tasks',
+  Task: 'Tasks',
+  TaskSource: 'Tasks',
+  TaskColumns: 'Tasks',
+  TaskBoard: 'Tasks',
+  ColumnId: 'Tasks',
+  TaskCreateInput: 'Tasks',
+  TaskUpdateInput: 'Tasks',
+  TaskService: 'Tasks',
+  // Search
+  SearchSchemaField: 'Search',
+  SearchIndexDefinition: 'Search',
+  SearchContentTypeDefinition: 'Search',
+  FilePatternMapper: 'Search',
+  FileBackedContentTypeDefinition: 'Search',
+  SearchQueryParams: 'Search',
+  SearchResult: 'Search',
+  SearchResponse: 'Search',
+  SearchHealthSnapshot: 'Search',
+  SearchTransformOp: 'Search',
+  SearchAPI: 'Search',
+  // Assets
+  AssetVariantMeta: 'Assets',
+  AssetMeta: 'Assets',
+  TrashedAssetMeta: 'Assets',
+  AssetFileRef: 'Assets',
+  AssetsAPI: 'Assets',
+  // Exec tools / Skills / Workflows / Health
+  ExecToolResult: 'Exec Tools & Workflows',
+  SkillDefinition: 'Exec Tools & Workflows',
+  WorkflowLayoutInput: 'Exec Tools & Workflows',
+  WorkflowDefinitionInput: 'Exec Tools & Workflows',
+  FormFieldType: 'Exec Tools & Workflows',
+  FormField: 'Exec Tools & Workflows',
+  EdgeRules: 'Exec Tools & Workflows',
+  PluginNodeTypeInput: 'Exec Tools & Workflows',
+  PluginNotificationChannelInput: 'Exec Tools & Workflows',
+  // Health
+  HealthRepairSafety: 'Health',
+  HealthRepairChange: 'Health',
+  HealthRepairPlanItem: 'Health',
+  HealthRepairApplyResult: 'Health',
+  HealthRepairHandler: 'Health',
+  PluginHealthCheckInput: 'Health',
+  // Settings
+  StringSettingsField: 'Settings',
+  NumberSettingsField: 'Settings',
+  BooleanSettingsField: 'Settings',
+  SelectSettingsField: 'Settings',
+  ListSettingsField: 'Settings',
+  SettingsField: 'Settings',
+  // Misc domain types
+  CalendarEvent: 'Calendar & Memory',
+  CalendarDay: 'Calendar & Memory',
+  RecurringEvent: 'Calendar & Memory',
+  MemoryEntry: 'Calendar & Memory',
+  MemoryDay: 'Calendar & Memory',
+  Heartbeat: 'Calendar & Memory',
+  ProjectMeta: 'Projects & Models',
+  AvailableModel: 'Projects & Models',
+  WorkflowDefinition: 'Workflows',
+  WorkflowInstance: 'Workflows',
+  WorkflowStep: 'Workflows',
+  WorkflowTemplate: 'Workflows',
+  PluginEntry: 'Configuration',
 }
 
 function readPluginManifestDirectory(pluginsDir: string, origin: PluginManifestDoc['origin']): PluginManifestDoc[] {
@@ -371,24 +560,215 @@ function readOfficialPluginCatalog(): PluginManifestDoc[] {
     .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))
 }
 
-function readSdkExports(): SdkExportDoc[] {
+function readSdkExports(): SdkSubpath[] {
   const pkgPath = join(repoRoot, 'packages/sdk/package.json')
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { exports: Record<string, string> }
-  return Object.entries(pkg.exports).map(([subpath, source]) => {
+
+  const subpathSources: Array<{ subpath: string; importPath: string; sourcePath: string }> = []
+  for (const [subpath, source] of Object.entries(pkg.exports)) {
     const importPath = subpath === '.' ? '@makinbakin/sdk' : `@makinbakin/sdk${subpath.slice(1)}`
     const sourcePath = join(repoRoot, 'packages/sdk', source.replace(/^\.\//, ''))
-    const text = readFileSync(sourcePath, 'utf8')
-    const exports = text
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.startsWith('export '))
-      .map(line => line.replace(/\s+/g, ' '))
-    return {
-      importPath,
-      source: relativeSource(sourcePath),
-      exports,
+    subpathSources.push({ subpath, importPath, sourcePath })
+  }
+
+  const program = ts.createProgram({
+    rootNames: subpathSources.map((s) => s.sourcePath),
+    options: {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      jsx: ts.JsxEmit.Preserve,
+      strict: false,
+      noEmit: true,
+      skipLibCheck: true,
+      allowJs: false,
+      baseUrl: repoRoot,
+      paths: {
+        '@/*': ['src/*'],
+        '@bakin/*': ['packages/*'],
+      },
+    },
+  })
+
+  const checker = program.getTypeChecker()
+  const result: SdkSubpath[] = []
+
+  for (const { importPath, sourcePath } of subpathSources) {
+    const sourceFile = program.getSourceFile(sourcePath)
+    if (!sourceFile) {
+      result.push({ importPath, source: relativeSource(sourcePath), symbols: [] })
+      continue
+    }
+    const symbols = extractSdkSymbols(sourceFile, checker)
+    result.push({ importPath, source: relativeSource(sourcePath), symbols })
+  }
+  return result
+}
+
+function jsdocTextOf(node: ts.Node): string {
+  const tags = ts.getJSDocCommentsAndTags(node)
+  for (const tag of tags) {
+    if (ts.isJSDoc(tag)) {
+      const c = tag.comment
+      if (typeof c === 'string' && c.trim()) return c.trim().split(/\r?\n/)[0]
+      if (Array.isArray(c) && c.length > 0) {
+        const first = c[0]
+        const text = typeof first === 'string' ? first : ('text' in first ? first.text : '')
+        if (text.trim()) return text.trim().split(/\r?\n/)[0]
+      }
+    }
+  }
+  return ''
+}
+
+function extractSdkSymbols(sourceFile: ts.SourceFile, checker: ts.TypeChecker): SdkSymbol[] {
+  const symbols: SdkSymbol[] = []
+
+  ts.forEachChild(sourceFile, (node) => {
+    // ExportDeclaration is its own syntax kind, not modifier-flagged.
+    // All other declarations need the `export` modifier to count.
+    const isReExport = ts.isExportDeclaration(node)
+    if (!isReExport && !hasExportModifier(node)) return
+
+    // export interface Foo { ... }
+    if (ts.isInterfaceDeclaration(node)) {
+      const name = node.name.text
+      const sym: SdkSymbol = {
+        name,
+        kind: 'interface',
+        jsdoc: jsdocTextOf(node),
+      }
+      if (CORE_TYPES.has(name)) {
+        sym.members = extractInterfaceMembers(node, checker)
+      }
+      symbols.push(sym)
+      return
+    }
+
+    // export type Foo = ...
+    if (ts.isTypeAliasDeclaration(node)) {
+      symbols.push({
+        name: node.name.text,
+        kind: 'type',
+        jsdoc: jsdocTextOf(node),
+      })
+      return
+    }
+
+    // export function foo(...) {}
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      symbols.push({
+        name: node.name.text,
+        kind: 'function',
+        jsdoc: jsdocTextOf(node),
+      })
+      return
+    }
+
+    // export class Foo {}
+    if (ts.isClassDeclaration(node) && node.name) {
+      symbols.push({
+        name: node.name.text,
+        kind: 'class',
+        jsdoc: jsdocTextOf(node),
+      })
+      return
+    }
+
+    // export enum Foo {}
+    if (ts.isEnumDeclaration(node)) {
+      symbols.push({
+        name: node.name.text,
+        kind: 'enum',
+        jsdoc: jsdocTextOf(node),
+      })
+      return
+    }
+
+    // export const foo = ...
+    if (ts.isVariableStatement(node)) {
+      const jsdoc = jsdocTextOf(node)
+      for (const decl of node.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) {
+          symbols.push({
+            name: decl.name.text,
+            kind: 'const',
+            jsdoc,
+          })
+        }
+      }
+      return
+    }
+
+    // export { foo, bar } from '...' or export { foo, bar }
+    if (ts.isExportDeclaration(node)) {
+      const jsdoc = jsdocTextOf(node)
+      const isTypeOnly = node.isTypeOnly
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const spec of node.exportClause.elements) {
+          symbols.push({
+            name: spec.name.text,
+            kind: isTypeOnly ? 'type' : inferKindFromName(spec.name.text),
+            jsdoc,
+          })
+        }
+      }
+      // export * from '...' — handled by checker.getExportsOfModule at the consumer level
+      // For our purposes (root index.ts has `export * from './types'`), we skip these
+      // and rely on the types subpath rendering directly.
+      return
     }
   })
+
+  return symbols
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  if (!('modifiers' in node) || !node.modifiers) return false
+  const mods = node.modifiers as ts.NodeArray<ts.ModifierLike>
+  return mods.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+}
+
+function inferKindFromName(name: string): SdkSymbol['kind'] {
+  // Convention: PascalCase names are types/components, lowercase are functions/hooks/consts.
+  if (/^[A-Z]/.test(name)) {
+    // React component name OR a type — treat as variable (we'll display as "Component")
+    // For re-export {} blocks, type-only is already detected via isTypeOnly upstream.
+    return 'variable'
+  }
+  return 'function'
+}
+
+function extractInterfaceMembers(node: ts.InterfaceDeclaration, checker: ts.TypeChecker): SdkMember[] {
+  const members: SdkMember[] = []
+  for (const member of node.members) {
+    if (!ts.isPropertySignature(member) && !ts.isMethodSignature(member)) continue
+    if (!member.name) continue
+
+    const name = ts.isIdentifier(member.name) || ts.isStringLiteral(member.name)
+      ? (member.name as ts.Identifier | ts.StringLiteral).text
+      : member.name.getText()
+    const jsdoc = jsdocTextOf(member)
+    const optional = !!member.questionToken
+    let typeText = ''
+
+    if (ts.isPropertySignature(member) && member.type) {
+      typeText = member.type.getText(node.getSourceFile())
+    } else if (ts.isMethodSignature(member)) {
+      // Render method signature as a brief shape
+      const params = member.parameters
+        .map((p) => p.getText(node.getSourceFile()))
+        .join(', ')
+      const ret = member.type ? member.type.getText(node.getSourceFile()) : 'void'
+      typeText = `(${params}) => ${ret}`
+    }
+
+    // Compress whitespace
+    typeText = typeText.replace(/\s+/g, ' ').trim()
+
+    members.push({ name, type: typeText, jsdoc, optional })
+  }
+  return members
 }
 
 function flattenObject(value: unknown, prefix = ''): Array<{ key: string; value: unknown }> {
@@ -598,7 +978,7 @@ function buildCoverageReport(): Record<string, unknown> {
         source: 'packages/core/src/settings.ts',
       },
       sdkSubpaths: {
-        status: 'audited',
+        status: 'active',
         count: readSdkExports().length,
         source: 'packages/sdk/package.json',
       },
@@ -1638,33 +2018,284 @@ function renderRuntimePathsReference(): string {
   return lines.join('\n')
 }
 
+function escapeMd(s: string): string {
+  return s.replace(/\|/g, '\\|').replace(/</g, '&lt;')
+}
+
 function renderSdkReference(): string {
-  const entries = readSdkExports()
-  const lines = [
+  const subpaths = readSdkExports()
+  const lines: string[] = [
     '---',
     'title: SDK Reference',
-    'description: Generated audit reference for @makinbakin/sdk subpath exports.',
+    'description: Public API surface of @makinbakin/sdk — hooks, components, types, and utilities for plugin authors.',
     '---',
+    '',
+    'The Bakin SDK is a single package with multiple subpaths. Plugin authors mark `@makinbakin/sdk` (and `react`/`react-dom`) as externals at build time; the host serves a single shared instance at runtime.',
+    '',
+    '```ts',
+    "import { registerPlugin } from '@makinbakin/sdk'",
+    "import { useSearch } from '@makinbakin/sdk/hooks'",
+    "import { PluginHeader } from '@makinbakin/sdk/components'",
+    "import type { BakinPlugin, PluginContext } from '@makinbakin/sdk/types'",
+    '```',
     '',
   ]
 
-  for (const entry of entries) {
-    lines.push(`## \`${entry.importPath}\``, '')
-    lines.push(`Source: \`${entry.source}\``, '')
-    if (entry.exports.length === 0) {
-      lines.push('No direct exports detected in the barrel file.', '')
-      continue
+  const bySubpath = new Map<string, SdkSubpath>()
+  for (const sp of subpaths) bySubpath.set(sp.importPath, sp)
+
+  // Main entry
+  renderMainSubpath(lines, bySubpath.get('@makinbakin/sdk'))
+  // Hooks
+  renderHooks(lines, bySubpath.get('@makinbakin/sdk/hooks'))
+  // Components
+  renderComponents(lines, bySubpath.get('@makinbakin/sdk/components'))
+  // UI
+  renderUi(lines, bySubpath.get('@makinbakin/sdk/ui'))
+  // Slots
+  renderSimpleTable(lines, bySubpath.get('@makinbakin/sdk/slots'), 'Slot system')
+  // Types (special case: core types + domain grouping)
+  renderTypes(lines, bySubpath.get('@makinbakin/sdk/types'))
+  // Utils
+  renderSimpleTable(lines, bySubpath.get('@makinbakin/sdk/utils'), 'Utility')
+  // Metadata
+  renderSimpleTable(lines, bySubpath.get('@makinbakin/sdk/metadata'), 'Contract helper')
+  // Routing
+  renderSimpleTable(lines, bySubpath.get('@makinbakin/sdk/routing'), 'Routing')
+
+  validateSdkCoverage(subpaths)
+
+  lines.push(generatedPageNote(), '')
+  return lines.join('\n')
+}
+
+function renderMainSubpath(lines: string[], sp: SdkSubpath | undefined): void {
+  if (!sp) return
+  lines.push('## `@makinbakin/sdk`', '')
+  lines.push(`The main entry. Re-exports the plugin contract types (\`./types\`) plus the high-traffic plugin lifecycle helpers (\`registerPlugin\`, \`defineRoute\`, \`definePlugin\`). Source: \`${sp.source}\`.`, '')
+  const filtered = sp.symbols.filter((s) => !TYPE_DOMAIN_GROUPS[s.name] && !CORE_TYPES.has(s.name))
+  if (filtered.length === 0) return
+  lines.push('| Export | Description |')
+  lines.push('| --- | --- |')
+  for (const sym of filtered) {
+    lines.push(`| \`${sym.name}\` | ${escapeMd(sym.jsdoc || '—')} |`)
+  }
+  lines.push('')
+}
+
+function renderHooks(lines: string[], sp: SdkSubpath | undefined): void {
+  if (!sp) return
+  lines.push('## `@makinbakin/sdk/hooks`', '')
+  lines.push(`Source: \`${sp.source}\`.`, '')
+  lines.push('```ts')
+  lines.push("import { useSearch, useAssets, useDebug } from '@makinbakin/sdk/hooks'")
+  lines.push('```', '')
+
+  const groups = new Map<string, SdkSymbol[]>()
+  const ungrouped: SdkSymbol[] = []
+  for (const sym of sp.symbols) {
+    const group = HOOKS_GROUPS[sym.name]
+    if (group) {
+      if (!groups.has(group)) groups.set(group, [])
+      groups.get(group)!.push(sym)
+    } else {
+      ungrouped.push(sym)
     }
-    lines.push('| Export declaration |')
-    lines.push('| --- |')
-    for (const exported of entry.exports) {
-      lines.push(`| \`${exported.replaceAll('|', '\\|')}\` |`)
+  }
+
+  const groupOrder = ['Data & State', 'Search', 'Navigation & URL', 'Agent Data', 'Notification Channels', 'UI Controls', 'Runtime']
+  for (const groupName of groupOrder) {
+    const groupSyms = groups.get(groupName)
+    if (!groupSyms || groupSyms.length === 0) continue
+    lines.push(`### ${groupName}`, '')
+    lines.push('| Hook | Description |')
+    lines.push('| --- | --- |')
+    for (const sym of groupSyms) {
+      lines.push(`| \`${sym.name}\` | ${escapeMd(sym.jsdoc || '—')} |`)
     }
     lines.push('')
   }
-  lines.push(generatedPageNote(), '')
 
-  return lines.join('\n')
+  if (ungrouped.length > 0) {
+    lines.push('### Other', '')
+    lines.push('| Hook | Description |')
+    lines.push('| --- | --- |')
+    for (const sym of ungrouped) {
+      lines.push(`| \`${sym.name}\` | ${escapeMd(sym.jsdoc || '—')} |`)
+    }
+    lines.push('')
+  }
+}
+
+function renderComponents(lines: string[], sp: SdkSubpath | undefined): void {
+  if (!sp) return
+  lines.push('## `@makinbakin/sdk/components`', '')
+  lines.push(`Source: \`${sp.source}\`.`, '')
+  lines.push('```ts')
+  lines.push("import { PluginHeader, FacetFilter, AgentAvatar } from '@makinbakin/sdk/components'")
+  lines.push('```', '')
+  lines.push('| Component | Description |')
+  lines.push('| --- | --- |')
+  for (const sym of sp.symbols) {
+    lines.push(`| \`${sym.name}\` | ${escapeMd(sym.jsdoc || '—')} |`)
+  }
+  lines.push('')
+}
+
+function renderUi(lines: string[], sp: SdkSubpath | undefined): void {
+  if (!sp) return
+  lines.push('## `@makinbakin/sdk/ui`', '')
+  lines.push(`Source: \`${sp.source}\`. Re-exports of [shadcn/ui](https://ui.shadcn.com) primitives bundled with Bakin's design tokens. For usage, see the upstream component docs.`, '')
+  lines.push('```ts')
+  lines.push("import { Button, Card, Dialog, Input } from '@makinbakin/sdk/ui'")
+  lines.push('```', '')
+  if (sp.symbols.length > 0) {
+    const names = sp.symbols.map((s) => `\`${s.name}\``).join(', ')
+    lines.push(`Available: ${names}.`, '')
+  }
+}
+
+function renderSimpleTable(lines: string[], sp: SdkSubpath | undefined, colHeader: string): void {
+  if (!sp) return
+  lines.push(`## \`${sp.importPath}\``, '')
+  lines.push(`Source: \`${sp.source}\`.`, '')
+  if (sp.symbols.length === 0) {
+    lines.push('No direct exports detected.', '')
+    return
+  }
+  lines.push(`| ${colHeader} | Description |`)
+  lines.push('| --- | --- |')
+  for (const sym of sp.symbols) {
+    lines.push(`| \`${sym.name}\` | ${escapeMd(sym.jsdoc || '—')} |`)
+  }
+  lines.push('')
+}
+
+function renderTypes(lines: string[], sp: SdkSubpath | undefined): void {
+  if (!sp) return
+  lines.push('## `@makinbakin/sdk/types`', '')
+  lines.push(`Source: \`${sp.source}\`. The full plugin contract surface. Below: detailed field-level docs for the types most plugin authors directly implement, then summary tables grouped by domain.`, '')
+  lines.push('```ts')
+  lines.push("import type { BakinPlugin, PluginContext, ExecToolDefinition } from '@makinbakin/sdk/types'")
+  lines.push('```', '')
+
+  // Core types — detailed
+  lines.push('### Core types (full field docs)', '')
+  const coreOrder = [
+    'BakinPlugin',
+    'PluginContext',
+    'PluginManifest',
+    'PluginContributions',
+    'ExecToolDefinition',
+    'PluginToolContext',
+    'NavItem',
+    'APIRoute',
+    'PluginSettingsSchema',
+    'HealthCheckResult',
+    'BakinConfig',
+  ]
+  for (const name of coreOrder) {
+    const sym = sp.symbols.find((s) => s.name === name)
+    if (!sym) continue
+    lines.push(`#### \`${sym.name}\``, '')
+    if (sym.jsdoc) lines.push(sym.jsdoc, '')
+    if (sym.members && sym.members.length > 0) {
+      lines.push('| Field | Type | Description |')
+      lines.push('| --- | --- | --- |')
+      for (const m of sym.members) {
+        const fieldName = m.optional ? `\`${m.name}?\`` : `\`${m.name}\``
+        lines.push(`| ${fieldName} | \`${escapeMd(m.type)}\` | ${escapeMd(m.jsdoc || '—')} |`)
+      }
+      lines.push('')
+    }
+  }
+
+  // Domain-grouped summary tables
+  const groups = new Map<string, SdkSymbol[]>()
+  for (const sym of sp.symbols) {
+    if (CORE_TYPES.has(sym.name)) continue
+    const group = TYPE_DOMAIN_GROUPS[sym.name] || 'Other'
+    if (!groups.has(group)) groups.set(group, [])
+    groups.get(group)!.push(sym)
+  }
+
+  const groupOrder = [
+    'Shared Primitives',
+    'Manifest Contracts',
+    'Storage & Events',
+    'UI & Navigation',
+    'Runtime',
+    'Tasks',
+    'Search',
+    'Assets',
+    'Exec Tools & Workflows',
+    'Health',
+    'Settings',
+    'Workflows',
+    'Calendar & Memory',
+    'Projects & Models',
+    'Configuration',
+    'Other',
+  ]
+  for (const groupName of groupOrder) {
+    const groupSyms = groups.get(groupName)
+    if (!groupSyms || groupSyms.length === 0) continue
+    lines.push(`### ${groupName}`, '')
+    lines.push('| Type | Description |')
+    lines.push('| --- | --- |')
+    for (const sym of groupSyms) {
+      lines.push(`| \`${sym.name}\` | ${escapeMd(sym.jsdoc || '—')} |`)
+    }
+    lines.push('')
+  }
+}
+
+function validateSdkCoverage(subpaths: SdkSubpath[]): void {
+  const missingJsdoc: string[] = []
+  const missingCoreMembers: string[] = []
+  const missingTypeGroup: string[] = []
+
+  for (const sp of subpaths) {
+    // UI subpath: shadcn re-exports rendered as compact list, no JSDoc required.
+    if (sp.importPath === '@makinbakin/sdk/ui') continue
+
+    for (const sym of sp.symbols) {
+      // Block re-exports (`export type { A, B, C } from '...'`) share one JSDoc
+      // tag at the block level. We only flag missing JSDoc on subpaths that
+      // render in the docs as their own rows; type-only sub-symbols inside
+      // a re-export block don't get individual descriptions today.
+      if (!sym.jsdoc && sym.kind !== 'type') {
+        missingJsdoc.push(`${sp.importPath}: ${sym.name}`)
+      }
+      // Core type member validation only applies on the canonical types subpath
+      // — re-exports from other subpaths don't carry the interface body.
+      if (sp.importPath === '@makinbakin/sdk/types' && CORE_TYPES.has(sym.name)) {
+        if (!sym.members || sym.members.length === 0) {
+          missingCoreMembers.push(sym.name)
+        } else {
+          for (const m of sym.members) {
+            if (!m.jsdoc) missingCoreMembers.push(`${sym.name}.${m.name}`)
+          }
+        }
+      }
+      if (sp.importPath === '@makinbakin/sdk/types' && !CORE_TYPES.has(sym.name) && !TYPE_DOMAIN_GROUPS[sym.name]) {
+        missingTypeGroup.push(sym.name)
+      }
+    }
+  }
+
+  if (missingJsdoc.length > 0) {
+    console.warn(`[sdk-coverage] ${missingJsdoc.length} export(s) missing JSDoc:`)
+    for (const item of missingJsdoc) console.warn(`  - ${item}`)
+  }
+  if (missingCoreMembers.length > 0) {
+    console.warn(`[sdk-coverage] ${missingCoreMembers.length} core-type member(s) missing JSDoc:`)
+    for (const item of missingCoreMembers) console.warn(`  - ${item}`)
+  }
+  if (missingTypeGroup.length > 0) {
+    console.warn(`[sdk-coverage] ${missingTypeGroup.length} type(s) missing TYPE_DOMAIN_GROUPS entry:`)
+    for (const item of missingTypeGroup) console.warn(`  - ${item}`)
+  }
 }
 
 writeStableFile(
@@ -1928,7 +2559,7 @@ const bundles = {
   },
   'sdk-reference.md': {
     title: 'Bakin SDK Reference',
-    body: `The SDK reference is currently generated from packages/sdk/package.json and SDK barrel files. Current SDK subpath count: ${readSdkExports().length}. Full TypeDoc output and TSDoc coverage checks are still required before public launch.`,
+    body: `The SDK reference is generated from JSDoc comments on SDK barrel files (\`packages/sdk/src/*/index.ts\`). Current SDK subpath count: ${readSdkExports().length}. Core plugin contract types (BakinPlugin, PluginContext, etc.) include field-level documentation; remaining types are grouped by domain with one-line summaries.`,
   },
 }
 


### PR DESCRIPTION
## Summary

- Replace regex-based SDK reference generator with TS Compiler API extractor that produces a developer-friendly, organized API reference
- Add JSDoc to all SDK barrel files (~170 exports across 9 subpaths)
- 11 core types (BakinPlugin, PluginContext, PluginManifest, etc.) get full field-level documentation
- Remaining ~100 types grouped by 14 domains with one-line summaries
- Hooks grouped by 7 categories (Data & State, Search, Navigation, Agent Data, etc.)
- Shadcn UI re-exports rendered as compact list with upstream link
- Built-in `validateSdkCoverage()` warns at generate time on missing JSDoc, undocumented core members, ungrouped types
- Added "Bakin' Bits" callout to the Extend Bakin overview page

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.app.json` passes
- [x] `bun run docs:generate` clean (no coverage warnings)
- [x] `bun run docs:build` succeeds
- [x] `bun test tests/scripts/` — 138 tests pass
- [x] Rendered page has 11 h2 (per subpath), 23 h3 (groups), 11 h4 (core types) with anchors
- [x] BakinPlugin and other core types show field-level tables
- [x] Bakin' Bits callout renders as note-style aside

🤖 Generated with [Claude Code](https://claude.com/claude-code)