### PR TITLE
fix(settings): widen form, alphabetize and group plugin list (#366)

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -631,6 +631,16 @@ renders them via `PluginSettingsRenderer`. Values persist at
 `~/.bakin/plugin-settings/{pluginId}.json` via
 `GET/PUT /api/plugin-settings/{pluginId}`.
 
+`GET /api/plugin-settings/schemas` returns each schema tagged with
+`source: 'built-in' | 'user'` (built-in iff `isCorePlugin(id)`). The
+settings page groups tabs into three sections — System & Alerts
+(pinned), Built-in (A-Z), Installed (A-Z, hidden when empty) — using the
+pure `groupAndSortSchemas` helper exported from
+`packages/host/src/routes/settings.tsx`. List-field rows in
+`PluginSettingsRenderer` use a `repeat(auto-fit, minmax(180px, 1fr))`
+grid so editors with many sub-fields (e.g. messaging's content types)
+wrap cleanly on narrow viewports.
+
 `PUT /api/plugin-settings/{pluginId}` also broadcasts an SSE event:
 `{ type: 'plugin:settings-changed', pluginId, timestamp }`. Plugin
 clients that cache settings-derived labels, filters, or routing data should

--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -633,13 +633,13 @@ renders them via `PluginSettingsRenderer`. Values persist at
 
 `GET /api/plugin-settings/schemas` returns each schema tagged with
 `source: 'built-in' | 'user'` (built-in iff `isCorePlugin(id)`). The
-settings page groups tabs into three sections — System & Alerts
-(pinned), Built-in (A-Z), Installed (A-Z, hidden when empty) — using the
-pure `groupAndSortSchemas` helper exported from
-`packages/host/src/routes/settings.tsx`. List-field rows in
-`PluginSettingsRenderer` use a `repeat(auto-fit, minmax(180px, 1fr))`
-grid so editors with many sub-fields (e.g. messaging's content types)
-wrap cleanly on narrow viewports.
+settings page groups tabs into two sections — Core (System & Alerts
+pinned at top, then built-in plugins A-Z) and Extensions (user-installed
+plugins A-Z, hidden when empty) — using the pure `groupAndSortSchemas`
+helper exported from `packages/host/src/routes/settings.tsx`. List-field
+rows in `PluginSettingsRenderer` use a `repeat(auto-fit, minmax(180px,
+1fr))` grid so editors with many sub-fields (e.g. messaging's content
+types) wrap cleanly on narrow viewports.
 
 `PUT /api/plugin-settings/{pluginId}` also broadcasts an SSE event:
 `{ type: 'plugin:settings-changed', pluginId, timestamp }`. Plugin

--- a/.claude/specs/366-messaging-settings-layout.md
+++ b/.claude/specs/366-messaging-settings-layout.md
@@ -1,0 +1,111 @@
+# Spec: #366 — Settings page layout + alphabetization
+
+GitHub issue: https://github.com/markhayden/bakin/issues/366
+
+## Objective
+
+Fix two usability bugs on the `/settings` page:
+
+1. **Cramped editor.** The Messaging settings content-type editor renders 7 sub-fields per row inside a 32rem column. Labels and inputs are clipped.
+2. **Unordered plugin list.** Plugin tabs appear in registration order, which is not stable or scannable.
+
+Both bugs live in the host (`markhayden/bakin`), not in the messaging plugin in `bakin-bits-official` — the messaging plugin cannot influence the host's max-width or the host's plugin list ordering. The issue body acknowledges this; the user's kickoff note ("fix will be in bakin-bits-official") was overridden after confirmation.
+
+**Target users:** the single user of this self-hosted Bakin instance (Mark) and any future plugin author whose `settingsSchema` declares a `list` field with more than 2-3 sub-fields.
+
+## Scope
+
+### In scope
+
+- `packages/host/src/routes/settings.tsx` — remove `max-w-lg` on the form column; group + sort the plugin list with section labels.
+- `src/components/plugin-settings-renderer.tsx` — switch list-row grid from `repeat(N, minmax(0, 1fr))` to `repeat(auto-fit, minmax(180px, 1fr))` so rows wrap on narrower viewports.
+- `src/lib/plugin-registry.ts` — `getSettingsSchemas()` returns `source: 'built-in' | 'user'` per schema.
+- `tests/core/plugin-registry.test.ts` — assert the new `source` field.
+- `tests/components/plugin-settings-renderer.test.tsx` — assert auto-fit grid style.
+- New: a small unit test for the sort/group helper extracted from `settings.tsx`.
+- `.claude/knowledge/plugin-system.md` — note the new `source` field and group-by-source UI.
+
+### Out of scope
+
+- Moving `src/components/plugin-settings-renderer.tsx` or `src/components/system-settings.tsx` to `packages/host/src/components` or `@makinbakin/sdk` (called out as TC26/TC27 tech debt; not driven by this issue).
+- Regenerating `docs/public/openapi.json` — the schemas endpoint there is documented as a generic `object`; no shape change needed.
+- Modifying the messaging plugin's `settingsSchema` — the layout fix at the host level is sufficient.
+- Backwards-compatibility shims for the `source` field — single-user app, no external API consumers, callers update in lockstep.
+
+## Acceptance criteria
+
+From the issue:
+
+- ✅ Messaging settings content-type editor expands to full available settings page width.
+- ✅ Field labels and controls do not overlap or truncate at normal desktop widths.
+- ✅ Layout remains usable on narrower viewports — sub-fields wrap onto subsequent rows.
+- ✅ Save / Cancel and Add content-type actions remain visible and aligned with the editor.
+- ✅ Settings list is alphabetized in the UI.
+
+Project-specific:
+
+- ✅ System & Alerts remains pinned at the top and is the default landing tab.
+- ✅ Built-in plugins (those in `CORE_PLUGINS`) are grouped under a "Built-in" section label, sorted A-Z by display name.
+- ✅ User-installed plugins are grouped under an "Installed" section label, sorted A-Z by display name; section hidden if empty.
+- ✅ Sort is case-insensitive (use `localeCompare(b, undefined, { sensitivity: 'base' })`).
+- ✅ Manual verification against the running `bun run dev/imitation-crab/index.ts --with-bakin` instance: open `/settings`, exercise the Messaging tab at desktop width, then resize to ~600px to confirm list-row wrap.
+
+## Design decisions
+
+(Resolved during interview; recorded here as the rationale anchor.)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Repo for the fix | `markhayden/bakin` (host) | The constraint and the unordered list both live in host code; the plugin has no way to override them. |
+| Width strategy | Remove `max-w-lg` entirely | Cleanest; PageLayout's outer padding still gives a comfortable margin; single-field forms with extra whitespace to the right are harmless. |
+| List-row responsiveness | `repeat(auto-fit, minmax(180px, 1fr))` | No breakpoints, no per-plugin knob; handles arbitrary sub-field counts; wraps cleanly when columns can't fit. |
+| Plugin ordering | Pin System & Alerts, then Built-in (A-Z), then Installed (A-Z) | Matches the user's "official included vs installed" mental model; preserves the natural entry point. |
+| Group surfacing | Small uppercase muted section label above Built-in and Installed | Self-explanatory; hides Installed section entirely when no user plugins. |
+| `source` field plumbing | Extend `getSettingsSchemas()` and `/api/plugin-settings/schemas` response | Reuses the existing `isCorePlugin()` predicate; one new field per schema. |
+
+## Architecture impact
+
+- Adds one field (`source: 'built-in' | 'user'`) to the response of `GET /api/plugin-settings/schemas`. No external consumers; openapi schema for this endpoint is already a generic `object`.
+- Extracts a small pure helper (`groupAndSortSchemas`) from `settings.tsx` so it can be unit-tested without mounting the route.
+
+## Commit strategy
+
+Three commits, each independently revertable and each landing with its own tests:
+
+1. **`feat(plugin-registry): expose source on settings schemas`**
+   - `src/lib/plugin-registry.ts` — extend `getSettingsSchemas()` return type with `source: 'built-in' | 'user'`.
+   - `tests/core/plugin-registry.test.ts` — extend existing `getSettingsSchemas` test to assert `source`.
+   - Pure data-shape change; no UI yet.
+
+2. **`fix(settings): alphabetize and group plugin list`**
+   - `packages/host/src/routes/settings.tsx` — extract `groupAndSortSchemas` helper; render three sections (System pinned, Built-in label + A-Z, Installed label + A-Z hidden when empty).
+   - New: `tests/host/settings-sort.test.ts` (or co-located) — unit test the helper across edge cases (no user plugins, mixed case names, missing source defaults to user).
+
+3. **`fix(settings): widen form and wrap list rows responsively`**
+   - `packages/host/src/routes/settings.tsx` — remove `max-w-lg`.
+   - `src/components/plugin-settings-renderer.tsx` — auto-fit grid for list rows.
+   - `tests/components/plugin-settings-renderer.test.tsx` — assert the `gridTemplateColumns` value.
+   - `.claude/knowledge/plugin-system.md` — note the `source` field and grouped UI (small append to the settings section).
+
+Validation between commits 2 and 3 uses the running imitation-crab instance for visual confirmation (Messaging tab + resize) before final commit lands.
+
+## Testing strategy
+
+- **Unit:** sort/group helper (commit 2), renderer grid style assertion (commit 3), registry schema shape (commit 1).
+- **Manual:** imitation-crab dev loop at `http://localhost:3737/settings` — verify each acceptance criterion in turn. Resize window to confirm responsive wrap.
+- **No new integration/e2e** — these are small layout changes, manual verification is appropriate.
+
+## Boundaries
+
+**Always:**
+- Run `bun test --isolate tests/...` for any test file we touch (per CLAUDE.md).
+- Update `.claude/knowledge/plugin-system.md` when the schemas API shape changes.
+
+**Ask first:**
+- (Resolved during kickoff: repo choice, width strategy, list responsiveness, group structure, commit slicing. Nothing else outstanding.)
+
+**Never:**
+- Touch `bakin-bits-official` (out of scope; the fix is host-side).
+- Introduce a per-plugin width hint API (rejected during kickoff as unnecessary coupling).
+- Add backwards-compat for the old schemas response shape (single user, no external consumers).
+- Move `plugin-settings-renderer.tsx` or related components — tracked as separate TC26/TC27 tech debt.

--- a/packages/host/src/routes/settings.tsx
+++ b/packages/host/src/routes/settings.tsx
@@ -29,14 +29,42 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { EmptyState } from '@/components/empty-state'
 import { Route as RootRoute } from './__root'
 
-interface PluginSchema {
+export interface PluginSchemaEntry {
   id: string
   name: string
   schema: PluginSettingsSchema
+  source: 'built-in' | 'user'
+}
+
+interface GroupedSchemas {
+  system: PluginSchemaEntry[]
+  builtIn: PluginSchemaEntry[]
+  installed: PluginSchemaEntry[]
+}
+
+/**
+ * Partition the settings schemas into three sections — System & Alerts
+ * (pinned), built-in plugins (A-Z), user-installed plugins (A-Z). Exported
+ * so the pure ordering logic is unit-testable without mounting the route.
+ */
+export function groupAndSortSchemas(schemas: PluginSchemaEntry[]): GroupedSchemas {
+  const system: PluginSchemaEntry[] = []
+  const builtIn: PluginSchemaEntry[] = []
+  const installed: PluginSchemaEntry[] = []
+  for (const entry of schemas) {
+    if (entry.id === SYSTEM_SETTINGS_TAB_ID) system.push(entry)
+    else if (entry.source === 'built-in') builtIn.push(entry)
+    else installed.push(entry)
+  }
+  const alpha = (a: PluginSchemaEntry, b: PluginSchemaEntry) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  builtIn.sort(alpha)
+  installed.sort(alpha)
+  return { system, builtIn, installed }
 }
 
 function SettingsPage() {
-  const [plugins, setPlugins] = useState<PluginSchema[]>([])
+  const [plugins, setPlugins] = useState<PluginSchemaEntry[]>([])
   const [activePlugin, setActivePlugin] = useState<string>('')
   const [values, setValues] = useState<Record<string, unknown>>({})
   const [loading, setLoading] = useState(true)
@@ -47,9 +75,9 @@ function SettingsPage() {
   useEffect(() => {
     fetch('/api/plugin-settings/schemas')
       .then(r => r.json())
-      .then((data: PluginSchema[]) => {
-        const withSystem: PluginSchema[] = [
-          { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema: SYSTEM_SETTINGS_SCHEMA },
+      .then((data: PluginSchemaEntry[]) => {
+        const withSystem: PluginSchemaEntry[] = [
+          { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema: SYSTEM_SETTINGS_SCHEMA, source: 'built-in' },
           ...data,
         ]
         setPlugins(withSystem)
@@ -121,24 +149,40 @@ function SettingsPage() {
     )
   }
 
+  const grouped = groupAndSortSchemas(plugins)
+  const renderTab = (p: PluginSchemaEntry) => (
+    <button
+      key={p.id}
+      onClick={() => setActivePlugin(p.id)}
+      className={`w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors ${
+        p.id === activePlugin
+          ? 'bg-muted text-foreground font-medium'
+          : 'text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {p.name}
+    </button>
+  )
+  const sectionLabel = 'px-3 pt-3 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground'
+
   return (
     <PageLayout title="Settings" subtitle="Configure plugin behavior">
       <div className="flex gap-8">
         {/* Plugin list */}
         <nav className="w-40 shrink-0 space-y-1">
-          {plugins.map(p => (
-            <button
-              key={p.id}
-              onClick={() => setActivePlugin(p.id)}
-              className={`w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors ${
-                p.id === activePlugin
-                  ? 'bg-muted text-foreground font-medium'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {p.name}
-            </button>
-          ))}
+          {grouped.system.map(renderTab)}
+          {grouped.builtIn.length > 0 && (
+            <>
+              <div className={sectionLabel}>Built-in</div>
+              {grouped.builtIn.map(renderTab)}
+            </>
+          )}
+          {grouped.installed.length > 0 && (
+            <>
+              <div className={sectionLabel}>Installed</div>
+              {grouped.installed.map(renderTab)}
+            </>
+          )}
         </nav>
 
         {/* Settings form */}

--- a/packages/host/src/routes/settings.tsx
+++ b/packages/host/src/routes/settings.tsx
@@ -186,7 +186,7 @@ function SettingsPage() {
         </nav>
 
         {/* Settings form */}
-        <div className="flex-1 max-w-lg">
+        <div className="flex-1">
           {plugin && (
             <>
               <h2 className="text-base font-semibold mb-4">{plugin.name}</h2>

--- a/packages/host/src/routes/settings.tsx
+++ b/packages/host/src/routes/settings.tsx
@@ -37,30 +37,30 @@ export interface PluginSchemaEntry {
 }
 
 interface GroupedSchemas {
-  system: PluginSchemaEntry[]
-  builtIn: PluginSchemaEntry[]
-  installed: PluginSchemaEntry[]
+  core: PluginSchemaEntry[]
+  extensions: PluginSchemaEntry[]
 }
 
 /**
- * Partition the settings schemas into three sections — System & Alerts
- * (pinned), built-in plugins (A-Z), user-installed plugins (A-Z). Exported
- * so the pure ordering logic is unit-testable without mounting the route.
+ * Partition the settings schemas into two sections — Core (System &
+ * Alerts pinned at top, then built-in plugins A-Z) and Extensions
+ * (user-installed plugins, A-Z). Exported so the pure ordering logic is
+ * unit-testable without mounting the route.
  */
 export function groupAndSortSchemas(schemas: PluginSchemaEntry[]): GroupedSchemas {
   const system: PluginSchemaEntry[] = []
-  const builtIn: PluginSchemaEntry[] = []
-  const installed: PluginSchemaEntry[] = []
+  const core: PluginSchemaEntry[] = []
+  const extensions: PluginSchemaEntry[] = []
   for (const entry of schemas) {
     if (entry.id === SYSTEM_SETTINGS_TAB_ID) system.push(entry)
-    else if (entry.source === 'built-in') builtIn.push(entry)
-    else installed.push(entry)
+    else if (entry.source === 'built-in') core.push(entry)
+    else extensions.push(entry)
   }
   const alpha = (a: PluginSchemaEntry, b: PluginSchemaEntry) =>
     a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-  builtIn.sort(alpha)
-  installed.sort(alpha)
-  return { system, builtIn, installed }
+  core.sort(alpha)
+  extensions.sort(alpha)
+  return { core: [...system, ...core], extensions }
 }
 
 function SettingsPage() {
@@ -163,25 +163,24 @@ function SettingsPage() {
       {p.name}
     </button>
   )
-  const sectionLabel = 'px-3 pt-3 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground'
+  const sectionLabel = 'px-3 pb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60'
 
   return (
     <PageLayout title="Settings" subtitle="Configure plugin behavior">
       <div className="flex gap-8">
         {/* Plugin list */}
-        <nav className="w-40 shrink-0 space-y-1">
-          {grouped.system.map(renderTab)}
-          {grouped.builtIn.length > 0 && (
-            <>
-              <div className={sectionLabel}>Built-in</div>
-              {grouped.builtIn.map(renderTab)}
-            </>
+        <nav className="w-40 shrink-0">
+          {grouped.core.length > 0 && (
+            <div className="space-y-1">
+              <div className={sectionLabel}>Core</div>
+              {grouped.core.map(renderTab)}
+            </div>
           )}
-          {grouped.installed.length > 0 && (
-            <>
-              <div className={sectionLabel}>Installed</div>
-              {grouped.installed.map(renderTab)}
-            </>
+          {grouped.extensions.length > 0 && (
+            <div className="space-y-1 mt-6">
+              <div className={sectionLabel}>Extensions</div>
+              {grouped.extensions.map(renderTab)}
+            </div>
           )}
         </nav>
 

--- a/src/components/plugin-settings-renderer.tsx
+++ b/src/components/plugin-settings-renderer.tsx
@@ -270,7 +270,7 @@ function ListField({ field, value, onChange }: ListFieldProps) {
               className="flex items-end gap-2 rounded-md border border-border/60 bg-muted/20 p-3"
               data-testid={`list-row-${field.key}-${i}`}
             >
-              <div className="flex-1 grid gap-3" style={{ gridTemplateColumns: `repeat(${subEntries.length}, minmax(0, 1fr))` }}>
+              <div className="flex-1 grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
                 {subEntries.map(([subKey, subField]) => (
                   <ScalarFieldRow
                     key={subKey}

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -1366,11 +1366,16 @@ class PluginRegistryImpl {
   }
 
   /** Get all plugin settings schemas (for the settings page). */
-  getSettingsSchemas(): Array<{ id: string; name: string; schema: PluginSettingsSchema }> {
-    const result: Array<{ id: string; name: string; schema: PluginSettingsSchema }> = []
+  getSettingsSchemas(): Array<{ id: string; name: string; schema: PluginSettingsSchema; source: 'built-in' | 'user' }> {
+    const result: Array<{ id: string; name: string; schema: PluginSettingsSchema; source: 'built-in' | 'user' }> = []
     for (const [id, state] of this.plugins) {
       if (state.plugin.settingsSchema) {
-        result.push({ id, name: state.plugin.name, schema: state.plugin.settingsSchema })
+        result.push({
+          id,
+          name: state.plugin.name,
+          schema: state.plugin.settingsSchema,
+          source: isCorePlugin(id) ? 'built-in' as const : 'user' as const,
+        })
       }
     }
     return result

--- a/tests/components/plugin-settings-renderer.test.tsx
+++ b/tests/components/plugin-settings-renderer.test.tsx
@@ -217,4 +217,19 @@ describe('PluginSettingsRenderer — list field', () => {
       expect.objectContaining({ type: 'error', message: expect.stringMatching(/at least 3/i) })
     )
   })
+
+  it('renders list-row sub-fields in a responsive auto-fit grid', () => {
+    render(
+      <PluginSettingsRenderer
+        pluginId="messaging"
+        schema={listSchema}
+        values={{ contentTypes: [{ id: 'post', label: 'Post' }] }}
+        onSave={mock()}
+      />
+    )
+    const row = screen.getByTestId('list-row-contentTypes-0')
+    const gridContainer = row.querySelector('.grid') as HTMLElement | null
+    expect(gridContainer).not.toBeNull()
+    expect(gridContainer!.style.gridTemplateColumns).toBe('repeat(auto-fit, minmax(180px, 1fr))')
+  })
 })

--- a/tests/components/settings-sort.test.ts
+++ b/tests/components/settings-sort.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const testDir = join(tmpdir(), `bakin-test-settings-sort-${Date.now()}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+
+import { groupAndSortSchemas, type PluginSchemaEntry } from '../../packages/host/src/routes/settings'
+import { SYSTEM_SETTINGS_TAB_ID } from '@/components/system-settings'
+
+const schema = { fields: [] }
+
+function entry(id: string, name: string, source: 'built-in' | 'user' = 'user'): PluginSchemaEntry {
+  return { id, name, schema, source }
+}
+
+describe('groupAndSortSchemas', () => {
+  it('returns empty buckets for empty input', () => {
+    const out = groupAndSortSchemas([])
+    expect(out.system).toEqual([])
+    expect(out.builtIn).toEqual([])
+    expect(out.installed).toEqual([])
+  })
+
+  it('pins the system tab into its own bucket', () => {
+    const out = groupAndSortSchemas([
+      { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema, source: 'built-in' },
+      entry('tasks', 'Tasks', 'built-in'),
+    ])
+    expect(out.system).toHaveLength(1)
+    expect(out.system[0].id).toBe(SYSTEM_SETTINGS_TAB_ID)
+    expect(out.builtIn).toHaveLength(1)
+    expect(out.installed).toHaveLength(0)
+  })
+
+  it('sorts built-in plugins alphabetically, case-insensitive', () => {
+    const out = groupAndSortSchemas([
+      entry('tasks', 'Tasks', 'built-in'),
+      entry('assets', 'assets', 'built-in'),
+      entry('Workflows', 'Workflows', 'built-in'),
+      entry('git', 'Git', 'built-in'),
+    ])
+    expect(out.builtIn.map(p => p.name)).toEqual(['assets', 'Git', 'Tasks', 'Workflows'])
+  })
+
+  it('sorts installed plugins alphabetically and partitions by source', () => {
+    const out = groupAndSortSchemas([
+      entry('tasks', 'Tasks', 'built-in'),
+      entry('projects', 'Projects'),
+      entry('messaging', 'Messaging'),
+      entry('assets', 'Assets', 'built-in'),
+    ])
+    expect(out.builtIn.map(p => p.name)).toEqual(['Assets', 'Tasks'])
+    expect(out.installed.map(p => p.name)).toEqual(['Messaging', 'Projects'])
+  })
+
+  it('leaves installed bucket empty when no user plugins are present', () => {
+    const out = groupAndSortSchemas([
+      { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema, source: 'built-in' },
+      entry('tasks', 'Tasks', 'built-in'),
+      entry('assets', 'Assets', 'built-in'),
+    ])
+    expect(out.installed).toEqual([])
+  })
+})

--- a/tests/components/settings-sort.test.ts
+++ b/tests/components/settings-sort.test.ts
@@ -25,49 +25,47 @@ function entry(id: string, name: string, source: 'built-in' | 'user' = 'user'): 
 describe('groupAndSortSchemas', () => {
   it('returns empty buckets for empty input', () => {
     const out = groupAndSortSchemas([])
-    expect(out.system).toEqual([])
-    expect(out.builtIn).toEqual([])
-    expect(out.installed).toEqual([])
+    expect(out.core).toEqual([])
+    expect(out.extensions).toEqual([])
   })
 
-  it('pins the system tab into its own bucket', () => {
+  it('pins System & Alerts at the top of the core bucket', () => {
     const out = groupAndSortSchemas([
+      entry('assets', 'Assets', 'built-in'),
       { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema, source: 'built-in' },
       entry('tasks', 'Tasks', 'built-in'),
     ])
-    expect(out.system).toHaveLength(1)
-    expect(out.system[0].id).toBe(SYSTEM_SETTINGS_TAB_ID)
-    expect(out.builtIn).toHaveLength(1)
-    expect(out.installed).toHaveLength(0)
+    expect(out.core.map(p => p.id)).toEqual([SYSTEM_SETTINGS_TAB_ID, 'assets', 'tasks'])
+    expect(out.extensions).toHaveLength(0)
   })
 
-  it('sorts built-in plugins alphabetically, case-insensitive', () => {
+  it('sorts core plugins (excluding System) alphabetically, case-insensitive', () => {
     const out = groupAndSortSchemas([
       entry('tasks', 'Tasks', 'built-in'),
       entry('assets', 'assets', 'built-in'),
       entry('Workflows', 'Workflows', 'built-in'),
       entry('git', 'Git', 'built-in'),
     ])
-    expect(out.builtIn.map(p => p.name)).toEqual(['assets', 'Git', 'Tasks', 'Workflows'])
+    expect(out.core.map(p => p.name)).toEqual(['assets', 'Git', 'Tasks', 'Workflows'])
   })
 
-  it('sorts installed plugins alphabetically and partitions by source', () => {
+  it('partitions extensions from core and sorts each alphabetically', () => {
     const out = groupAndSortSchemas([
       entry('tasks', 'Tasks', 'built-in'),
       entry('projects', 'Projects'),
       entry('messaging', 'Messaging'),
       entry('assets', 'Assets', 'built-in'),
     ])
-    expect(out.builtIn.map(p => p.name)).toEqual(['Assets', 'Tasks'])
-    expect(out.installed.map(p => p.name)).toEqual(['Messaging', 'Projects'])
+    expect(out.core.map(p => p.name)).toEqual(['Assets', 'Tasks'])
+    expect(out.extensions.map(p => p.name)).toEqual(['Messaging', 'Projects'])
   })
 
-  it('leaves installed bucket empty when no user plugins are present', () => {
+  it('leaves extensions bucket empty when no user plugins are present', () => {
     const out = groupAndSortSchemas([
       { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema, source: 'built-in' },
       entry('tasks', 'Tasks', 'built-in'),
       entry('assets', 'Assets', 'built-in'),
     ])
-    expect(out.installed).toEqual([])
+    expect(out.extensions).toEqual([])
   })
 })

--- a/tests/core/plugin-registry.test.ts
+++ b/tests/core/plugin-registry.test.ts
@@ -311,6 +311,7 @@ describe('PluginRegistryImpl', () => {
       deps?: string[]
       activate?: string
       onReady?: string
+      settingsSchema?: string
       manifest?: Record<string, unknown>
       root?: string
     } = {},
@@ -337,6 +338,7 @@ describe('PluginRegistryImpl', () => {
         id: '${id}',
         name: '${id.charAt(0).toUpperCase() + id.slice(1)}',
         version: '1.0.0',
+        settingsSchema: ${opts.settingsSchema || 'undefined'},
         activate: function(ctx) { ${opts.activate || ''} },
         onReady: ${opts.onReady || 'undefined'},
       }
@@ -1039,11 +1041,14 @@ describe('PluginRegistryImpl', () => {
       await pluginRegistry.notifySettingsChange('nonexistent', { foo: 'bar' })
     })
 
-    it('getSettingsSchemas returns only plugins with schemas', async () => {
+    it('getSettingsSchemas returns only plugins with schemas, tagged by source', async () => {
       const pathA = writeFakePlugin('alpha', {
         settingsSchema: `{ fields: [{ key: 'theme', type: 'string', label: 'Theme' }] }`,
       })
-      const pathB = writeFakePlugin('bravo') // no schema
+      const pathB = writeFakePlugin('bravo') // no schema — should be filtered out
+      writeUserPlugin('charlie', {
+        settingsSchema: `{ fields: [{ key: 'color', type: 'string', label: 'Color' }] }`,
+      })
 
       await pluginRegistry.initialize(
         { plugins: [{ path: pathA }, { path: pathB }] },
@@ -1052,9 +1057,12 @@ describe('PluginRegistryImpl', () => {
       )
 
       const schemas = pluginRegistry.getSettingsSchemas()
-      expect(schemas).toHaveLength(1)
-      expect(schemas[0]).toMatchObject({ id: 'alpha', name: 'Alpha' })
-      expect(schemas[0].schema.fields).toHaveLength(1)
+      expect(schemas).toHaveLength(2)
+      const alpha = schemas.find((s: { id: string }) => s.id === 'alpha')
+      const charlie = schemas.find((s: { id: string }) => s.id === 'charlie')
+      expect(alpha).toMatchObject({ id: 'alpha', name: 'Alpha', source: 'built-in' })
+      expect(alpha.schema.fields).toHaveLength(1)
+      expect(charlie).toMatchObject({ id: 'charlie', name: 'Charlie', source: 'user' })
     })
   })
 })


### PR DESCRIPTION
Closes #366.

## Summary

- **Layout** — Removed the `max-w-lg` (~32rem) cap on the settings form column and switched list-field rows from `repeat(N, minmax(0, 1fr))` to `repeat(auto-fit, minmax(180px, 1fr))`. The Messaging content-type editor (7 sub-fields per row) now uses the full settings width on desktop and wraps cleanly on narrow viewports with no per-plugin width knob required.
- **Ordering** — The plugin tab list is grouped into two sections — **Core** (System & Alerts pinned, then built-in plugins A-Z) and **Extensions** (user-installed plugins A-Z, hidden when empty) — backed by a pure exported `groupAndSortSchemas` helper. Section labels use a smaller, more recessive style with `mt-6` between sections so the divider actually reads.
- **API** — `getSettingsSchemas()` now returns `source: 'built-in' | 'user'` per schema, mirroring the same `isCorePlugin(id)` idiom already used in `getRegistrySnapshot()`. Sole caller is `GET /api/plugin-settings/schemas`; OpenAPI schema for that endpoint is already a generic object, no regen needed.

## Why these files and not the messaging plugin

The issue body acknowledged this likely belongs in the host, not in `bakin-bits-official`. Exploration confirmed it: both bugs (the host's max-width and the host's plugin list ordering) are in host code the plugin has zero ability to influence. Full design rationale in `.claude/specs/366-messaging-settings-layout.md`.

## Test plan

- [x] `bun test --isolate tests/core/plugin-registry.test.ts` — extended `getSettingsSchemas` test covers both `built-in` and `user` source paths via writeFakePlugin + writeUserPlugin (the latter helper extended to accept `settingsSchema`)
- [x] `bun test --isolate tests/components/settings-sort.test.ts` — new file, 5 cases (empty input, System pinned, case-insensitive alpha, source partitioning, empty Extensions)
- [x] `bun test --isolate tests/components/plugin-settings-renderer.test.tsx` — added an assertion that the list-row grid uses `repeat(auto-fit, minmax(180px, 1fr))`
- [x] `bun run typecheck` clean
- [x] Manual verification against the running imitation-crab dev instance: `/settings` shows the Core/Extensions split correctly; Messaging editor uses the full settings width with all 7 sub-fields visible; resize down wraps sub-fields onto subsequent rows.

## Commit slicing

Each commit is independently revertable and lands with its own tests:

1. `feat(plugin-registry): expose source on settings schemas` — pure registry shape change.
2. `fix(settings): alphabetize and group plugin list (#366)` — group/sort UI + helper.
3. `fix(settings): widen form and wrap list rows responsively (#366)` — `max-w-lg` removal + auto-fit grid + docs append.
4. `fix(settings): merge System into Core, rename sections, tighten label styling` — follow-up visual refinement after first screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)