### PR TITLE
chore(dev): seed a needs_review plan so dev:mock shows the nav badge

### DIFF
--- a/dev/imitation-crab/fixtures/bakin/plugin-data/messaging/messaging/plans/plan-may-content.json
+++ b/dev/imitation-crab/fixtures/bakin/plugin-data/messaging/messaging/plans/plan-may-content.json
@@ -4,7 +4,7 @@
   "brief": "Six-piece content plan for May: menu kickoff, farmers market guide, Mother's Day brunch, grilled salmon, cookie reel, plus late-April carryover.",
   "targetDate": "2026-05-15",
   "agent": "jessica",
-  "status": "planning",
+  "status": "needs_review",
   "sourceSessionId": "session-may-planning",
   "campaign": "May 2026",
   "channels": [


### PR DESCRIPTION
Follow-up to #265 (nav badges). The imitation-crab seed ships three messaging Plan fixtures but none in `needs_review`, so the new Plans nav badge stays hidden in `dev:mock` by default.

Flip the **May Content Calendar** fixture `planning` → `needs_review` so a fresh `bun run dev:mock` shows the Plans badge (count 1) out of the box — a living demo and manual-regression anchor for the badge.

## Notes
- One-line fixture change; no seed test asserts on plan status (`tests/dev/mock-seed.test.ts` still 12/12 green).
- Badge data flow is entirely Bakin-owned storage (no OpenClaw runtime), so it works in imitation-crab without touching the runtime mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)