### PR TITLE
feat(tasks): blocked/review nav badge + error tone

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -839,13 +839,17 @@ setNavBadge('messaging', 'messaging-plans', { count: 3, tone: 'attention' })
 setNavBadge('messaging', 'messaging-plans', null)
 ```
 
-The `NavBadge` shape is `{ count?: number; tone?: 'attention' | 'info' | 'success' }`.
+The `NavBadge` shape is `{ count?: number; tone?: 'error' | 'attention' | 'info' | 'success' }`.
 Rendering rules:
 - `count` present and `> 0` → small pill, clamped at `99+`.
 - `count` omitted, object present → small dot (presence-only).
 - `count: 0` or passing `null` → cleared.
-- `tone` defaults to `'attention'` (amber, matches the existing
-  `needs_review` palette).
+- `tone` defaults to `'attention'` (amber). Tones by severity:
+  `error` (red) > `attention` (amber) > `info` (blue) > `success` (green) —
+  this `TONE_PRIORITY` ordering decides which wins a collapsed-parent dot
+  rollup. The producer picks the single winning tone (one badge, one
+  color); see the Tasks plugin for a two-severity example (blocked →
+  `error`, review → `attention`).
 
 ### Mount point — `nav-badge-providers` slot
 

--- a/.claude/specs/tasks-nav-badge.md
+++ b/.claude/specs/tasks-nav-badge.md
@@ -1,0 +1,113 @@
+# Spec: Tasks nav badge (blocked / review)
+
+Branch: `feat/tasks-nav-badge`
+Builds on: #265 (nav-badge SDK infra — `setNavBadge`, `nav-badge-providers` slot, `AppSidebar` rendering).
+Repo: bakin only (Tasks is a core plugin; single-repo).
+
+## Objective
+
+Surface attention-needing Tasks as a badge on the **Tasks** nav item, using the generic nav-badge infrastructure shipped in #265. The Tasks plugin is the second adopter (after messaging) and the first to need **two severities**:
+
+- **blocked** tasks → `error` tone (red), highest severity.
+- **review** tasks → `attention` tone (amber).
+
+This also fills a gap in the shared infra: there is currently no red/`error` tone (the palette is amber/blue/green). Adding it benefits every future plugin, not just Tasks.
+
+**Target users:** the single user of this Bakin instance, who wants an at-a-glance signal that tasks are blocked or awaiting review without opening the board; and future plugin authors who need an `error`-severity badge.
+
+## Scope
+
+### In scope
+
+**Shared infra (host + SDK):**
+- `packages/sdk/src/types/index.ts` — add `'error'` to the `NavBadgeTone` union (`'error' | 'attention' | 'info' | 'success'`).
+- `packages/host/src/components/layout/nav-badge.tsx` — add `error` to `PILL_TONE` (`bg-red-500/20 text-red-300`) and `DOT_TONE` (`bg-red-400`). Extend `navBadgeAriaSuffix` so `error` reads as a neutral, plugin-agnostic word — `'urgent'` (e.g. `, 3 urgent`).
+- `packages/host/src/components/layout/nav-badge-logic.ts` — add `error: 0` to `TONE_PRIORITY` and renumber (`error:0, attention:1, info:2, success:3`) so `error` wins collapsed rollups.
+
+**Tasks plugin:**
+- `plugins/tasks/index.ts` — new route `GET /summary` → `{ blocked: number, review: number }` (counts only, from the task store; no full task bodies). The host route matcher prefers this exact path over `/:taskId`.
+- `plugins/tasks/hooks/use-task-summary.ts` *(new)* — fetches `/api/plugins/tasks/summary`; refetches whenever `useContentStore(s => s.taskboardVersion)` changes (the existing SSE-driven "taskboard changed" signal — no new EventSource). Returns `{ summary: { blocked, review } | null, refresh }`.
+- `plugins/tasks/components/tasks-badge-provider.tsx` *(new)* — background component (renders `null`). Computes a single badge via **winning-severity** rule:
+  - `blocked > 0` → `{ count: blocked, tone: 'error' }`
+  - else `review > 0` → `{ count: review, tone: 'attention' }`
+  - else `null`
+  Calls `setNavBadge('tasks', 'tasks', badge)`.
+- `plugins/tasks/client.tsx` — add `slots: { 'nav-badge-providers': TasksBadgeProvider }` to the existing `registerPlugin` call.
+
+**Tests:**
+- `tests/components/nav-badge.test.tsx` — assert the `error` pill renders `bg-red-500/20`; `navBadgeAriaSuffix` for `error`.
+- `tests/components/nav-badge-logic.test.ts` — `error` wins `pickRollupTone` / `collapsedParentRollupTone` over attention; updated `TONE_PRIORITY` ordering.
+- `tests/plugins/tasks/...` — `/summary` route returns correct blocked/review counts (and zeros when empty).
+- New: `tasks-badge-provider` test — winning-severity resolution (blocked beats review; review when no blocked; null at zero; the blocked→0 / review→0 transitions).
+
+**Docs:**
+- `.claude/knowledge/plugin-system.md` — update the "Nav badges (runtime)" section: add `error` to the tone list, note the severity ordering, and that Tasks is the second adopter.
+- `docs/src/content/docs/extending/plugins/client-ui.md` — update the `NavBadge` tone enum in the Nav badges subsection.
+- `docs/src/content/docs/reference/generated/sdk.md` — regenerate (`bun run docs:generate`) so the `NavBadgeTone` change appears.
+
+### Out of scope
+
+- `bakin-bits-official` ambient SDK type (`sdk-ambient.d.ts`) — messaging doesn't use `error`; leave it until a bits plugin needs it. Keeps this single-repo.
+- Overdue / due-date logic — there is no `overdue` column; v1 is `blocked` + `review` only.
+- Agent-filter-aware counts — badge is always global.
+- Multi-color / segmented badges — rejected during kickoff; one badge, one tone, one count.
+- Migrating other core plugins to badges — separate future work.
+
+## Acceptance criteria
+
+- ✅ Tasks nav item shows a **red** badge with the blocked count when ≥1 task is blocked.
+- ✅ When nothing is blocked but ≥1 task is in review, shows an **amber** badge with the review count.
+- ✅ Badge clears when neither blocked nor review has tasks.
+- ✅ Count always matches the tone's meaning (red number = blocked count; amber number = review count).
+- ✅ Badge updates live via the existing taskboard SSE signal (no reload, no new EventSource, no cron/heartbeat/MCP).
+- ✅ Collapsed sidebar shows the Tasks icon with a red dot (flat item — no rollup needed; `error` dot when blocked, amber when only review).
+- ✅ `error` tone added to the shared palette + priority; existing amber/blue/green badges unaffected.
+- ✅ Manual verification in imitation-crab (seed a blocked + a review task; observe red count, then amber after unblocking).
+- ✅ Tests cover the tone addition, rollup priority, the `/summary` endpoint, and the provider's winning-severity logic.
+
+## Design decisions (from kickoff interview)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Multi-severity display | Winning-severity count, one color | Number ↔ color stay consistent; a 16px pill can't legibly show two; blocked is what to act on first. |
+| Data source | Dedicated `GET /summary` + `taskboardVersion` refresh | Cheap (counts only); reuses the existing SSE-driven signal; no second EventSource. Mirrors messaging `/plans/summary`. |
+| Badge scope | Always global | Sidebar is global chrome; agent filter is page-local URL state the provider often can't see. |
+| New tone | `error` = `red-500/20` + `red-300` (pill), `red-400` (dot); priority above `attention` | Conventional blocked/error signal; matches existing tone scale; additive to the type. |
+| aria wording for `error` | `'urgent'` | The tone is plugin-agnostic in the host; "urgent" reads correctly for blocked tasks, failing health checks, etc. |
+| Repo | bakin only | Tasks is a core plugin; no bits changes needed. |
+
+## Architecture impact
+
+- `NavBadgeTone` gains a member — additive, no existing consumer breaks. The `error` tone becomes the new top of `TONE_PRIORITY`, shifting the others down by one (covered by updated tests).
+- New cheap Tasks route `GET /summary`; host matcher already prefers exact paths over `/:taskId`.
+- Second proof that the nav-badge infra is generic and works for a **core** plugin (messaging was an installed plugin) — same `setNavBadge` + slot contract, different SSE refresh source.
+
+## Commit strategy
+
+Four commits, each independently revertable, each landing with its tests:
+
+1. **`feat(host): add error tone to NavBadge`**
+   - SDK `NavBadgeTone` += `'error'`; host `PILL_TONE`/`DOT_TONE`/`navBadgeAriaSuffix`; `TONE_PRIORITY` reorder.
+   - `tests/components/nav-badge.test.tsx` + `nav-badge-logic.test.ts` extended.
+   - Pure infra; no Tasks code yet.
+
+2. **`feat(tasks): /summary counts endpoint`**
+   - `plugins/tasks/index.ts` route + Tasks route test.
+
+3. **`feat(tasks): blocked/review nav badge provider`**
+   - `use-task-summary.ts`, `tasks-badge-provider.tsx`, `client.tsx` slot wiring, provider test.
+
+4. **`docs: error tone + Tasks badge`**
+   - `.claude/knowledge/plugin-system.md`, `client-ui.md`, regenerated `sdk.md`.
+
+## Testing strategy
+
+- **Unit:** tone palette/aria (string render, no happy-dom mount — consistent with the lightened nav-badge tests), rollup priority, provider winning-severity logic, `/summary` route counts.
+- **Manual:** imitation-crab — seed `blocked` + `review` tasks (task JSON under the tasks store), watch the red count, unblock → amber, clear → hidden; collapse sidebar → red dot.
+- No e2e.
+
+## Boundaries
+
+**Always:** run `bun test --isolate` for touched files; update `.claude/knowledge/plugin-system.md` when the tone API changes; regenerate `sdk.md`.
+
+**Never:** add multi-color badges; couple the badge to the agent filter; add a second EventSource (reuse `taskboardVersion`); touch `bakin-bits-official`; introduce backwards-compat shims for the tone enum.

--- a/docs/src/content/docs/extending/plugins/client-ui.md
+++ b/docs/src/content/docs/extending/plugins/client-ui.md
@@ -89,7 +89,9 @@ registerPlugin({
 })
 ```
 
-The `NavBadge` shape is `{ count?: number; tone?: 'attention' | 'info' | 'success' }`.
+The `NavBadge` shape is `{ count?: number; tone?: 'error' | 'attention' | 'info' | 'success' }`.
+Tones render by severity — `error` (red) > `attention` (amber) > `info`
+(blue) > `success` (green) — and `error` wins a collapsed-parent rollup.
 Counts greater than 99 render as `99+`. Passing `null` to `setNavBadge`
 clears the badge. The `badge?` field on `NavItem` itself is only an
 initial seed — runtime values from `setNavBadge` take precedence and are

--- a/packages/host/src/components/layout/nav-badge-logic.ts
+++ b/packages/host/src/components/layout/nav-badge-logic.ts
@@ -10,9 +10,10 @@ import { navBadgeAriaSuffix } from './nav-badge'
  */
 
 const TONE_PRIORITY: Record<NavBadgeTone, number> = {
-  attention: 0,
-  info: 1,
-  success: 2,
+  error: 0,
+  attention: 1,
+  info: 2,
+  success: 3,
 }
 
 /**

--- a/packages/host/src/components/layout/nav-badge-logic.ts
+++ b/packages/host/src/components/layout/nav-badge-logic.ts
@@ -1,5 +1,5 @@
 import type { NavBadge as NavBadgeData, NavBadgeTone, NavItem } from '@makinbakin/sdk'
-import { navBadgeAriaSuffix } from './nav-badge'
+import { navBadgeAriaSuffix, TONE_LABEL } from './nav-badge'
 
 /**
  * Pure decision logic behind nav-badge rendering, extracted from
@@ -75,5 +75,5 @@ export function collapsedParentAriaSuffix(
 ): string {
   if (badgeIsActive(parentBadge)) return navBadgeAriaSuffix(parentBadge)
   if (!rollupTone) return ''
-  return `, children ${rollupTone === 'attention' ? 'need review' : rollupTone}`
+  return `, children ${TONE_LABEL[rollupTone]}`
 }

--- a/packages/host/src/components/layout/nav-badge.tsx
+++ b/packages/host/src/components/layout/nav-badge.tsx
@@ -1,12 +1,14 @@
 import type { NavBadge as NavBadgeData, NavBadgeTone } from '@makinbakin/sdk'
 
 const PILL_TONE: Record<NavBadgeTone, string> = {
+  error: 'bg-red-500/20 text-red-300',
   attention: 'bg-amber-500/20 text-amber-300',
   info: 'bg-sky-500/20 text-sky-300',
   success: 'bg-emerald-500/20 text-emerald-300',
 }
 
 const DOT_TONE: Record<NavBadgeTone, string> = {
+  error: 'bg-red-400',
   attention: 'bg-amber-400',
   info: 'bg-sky-400',
   success: 'bg-emerald-400',
@@ -65,7 +67,7 @@ export function NavBadgeDot({ tone }: { tone: NavBadgeTone }) {
 export function navBadgeAriaSuffix(badge: NavBadgeData | undefined): string {
   if (!badge || (typeof badge.count === 'number' && badge.count <= 0)) return ''
   const tone = badge.tone ?? 'attention'
-  const toneLabel = tone === 'attention' ? 'needing review' : tone
+  const toneLabel = tone === 'attention' ? 'needing review' : tone === 'error' ? 'urgent' : tone
   if (typeof badge.count === 'number') return `, ${formatCount(badge.count)} ${toneLabel}`
   return `, ${toneLabel}`
 }

--- a/packages/host/src/components/layout/nav-badge.tsx
+++ b/packages/host/src/components/layout/nav-badge.tsx
@@ -14,6 +14,19 @@ const DOT_TONE: Record<NavBadgeTone, string> = {
   success: 'bg-emerald-400',
 }
 
+/**
+ * Canonical screen-reader word per tone. Single source of truth shared by
+ * both aria-suffix builders (the flat/counted one here and the
+ * collapsed-parent rollup in nav-badge-logic) so the wording can't diverge
+ * per tone as the palette grows.
+ */
+export const TONE_LABEL: Record<NavBadgeTone, string> = {
+  error: 'urgent',
+  attention: 'needing review',
+  info: 'info',
+  success: 'success',
+}
+
 function formatCount(n: number): string {
   return n > 99 ? '99+' : String(n)
 }
@@ -66,8 +79,7 @@ export function NavBadgeDot({ tone }: { tone: NavBadgeTone }) {
  */
 export function navBadgeAriaSuffix(badge: NavBadgeData | undefined): string {
   if (!badge || (typeof badge.count === 'number' && badge.count <= 0)) return ''
-  const tone = badge.tone ?? 'attention'
-  const toneLabel = tone === 'attention' ? 'needing review' : tone === 'error' ? 'urgent' : tone
+  const toneLabel = TONE_LABEL[badge.tone ?? 'attention']
   if (typeof badge.count === 'number') return `, ${formatCount(badge.count)} ${toneLabel}`
   return `, ${toneLabel}`
 }

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -335,8 +335,9 @@ export type HookKind = 'rpc' | 'event' | 'waterfall'
 // Navigation, API routes, UI slots
 // ---------------------------------------------------------------------------
 
-/** Visual tone for a {@link NavBadge}. Maps to a fixed palette in the sidebar. */
-export type NavBadgeTone = 'attention' | 'info' | 'success'
+/** Visual tone for a {@link NavBadge}. Maps to a fixed palette in the sidebar.
+ *  Ordered by severity: `error` (red) is the most urgent and wins rollups. */
+export type NavBadgeTone = 'error' | 'attention' | 'info' | 'success'
 
 /**
  * Runtime badge attached to a nav item. Both fields are optional:

--- a/plugins/tasks/client.tsx
+++ b/plugins/tasks/client.tsx
@@ -5,6 +5,7 @@
 import { registerPlugin } from '@makinbakin/sdk'
 import type { NavItem } from '@makinbakin/sdk'
 import { KanbanBoard } from './components/kanban-board'
+import { TasksBadgeProvider } from './components/tasks-badge-provider'
 
 const navItems: NavItem[] = [
   { id: 'tasks', label: 'Tasks', icon: 'CheckSquare', href: '/tasks', order: 10 },
@@ -15,5 +16,8 @@ registerPlugin({
   navItems,
   slots: {
     'page:/tasks': KanbanBoard,
+    // Background runner that keeps the Tasks nav badge (blocked/review) in
+    // sync. Renders nothing; stays mounted while the plugin is registered.
+    'nav-badge-providers': TasksBadgeProvider,
   },
 })

--- a/plugins/tasks/components/tasks-badge-provider.tsx
+++ b/plugins/tasks/components/tasks-badge-provider.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect } from 'react'
+import { setNavBadge } from '@makinbakin/sdk'
+import { useTaskSummary } from '../hooks/use-task-summary'
+
+/**
+ * Background component (renders nothing) mounted via the host's
+ * `nav-badge-providers` slot. Keeps the Tasks nav item's badge in sync with
+ * tasks needing attention, by winning severity (bakin #265):
+ *   - blocked > 0 → red `error` count (most urgent)
+ *   - else review > 0 → amber `attention` count
+ *   - else cleared
+ * Source of truth is the task board; refresh rides the existing taskboard
+ * SSE signal — no cron, heartbeat, or MCP traffic.
+ */
+export function TasksBadgeProvider() {
+  const { summary } = useTaskSummary()
+
+  useEffect(() => {
+    if (!summary) return
+    const badge = summary.blocked > 0
+      ? { count: summary.blocked, tone: 'error' as const }
+      : summary.review > 0
+        ? { count: summary.review, tone: 'attention' as const }
+        : null
+    setNavBadge('tasks', 'tasks', badge)
+  }, [summary])
+
+  return null
+}

--- a/plugins/tasks/hooks/use-task-summary.ts
+++ b/plugins/tasks/hooks/use-task-summary.ts
@@ -10,7 +10,6 @@ export interface TaskSummary {
 
 interface UseTaskSummaryResult {
   summary: TaskSummary | null
-  refresh: () => Promise<void>
 }
 
 /**
@@ -41,5 +40,5 @@ export function useTaskSummary(): UseTaskSummaryResult {
 
   useEffect(() => { void refresh() }, [refresh, taskboardVersion])
 
-  return { summary, refresh }
+  return { summary }
 }

--- a/plugins/tasks/hooks/use-task-summary.ts
+++ b/plugins/tasks/hooks/use-task-summary.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useContentStore } from '@makinbakin/sdk/hooks'
+
+export interface TaskSummary {
+  blocked: number
+  review: number
+}
+
+interface UseTaskSummaryResult {
+  summary: TaskSummary | null
+  refresh: () => Promise<void>
+}
+
+/**
+ * Cheap blocked/review counts for the Tasks nav badge. Hits the dedicated
+ * `/summary` endpoint (numbers only) and refetches whenever the existing
+ * SSE-driven `taskboardVersion` bumps — the same signal the Kanban board
+ * uses — so the badge stays current with no new EventSource.
+ */
+export function useTaskSummary(): UseTaskSummaryResult {
+  const [summary, setSummary] = useState<TaskSummary | null>(null)
+  const taskboardVersion = useContentStore((s) => s.taskboardVersion)
+
+  const refresh = useCallback(async () => {
+    try {
+      const response = await fetch('/api/plugins/tasks/summary')
+      if (!response.ok) throw new Error(`Failed to load task summary (${response.status})`)
+      const data = await response.json() as Partial<TaskSummary>
+      setSummary({
+        blocked: typeof data.blocked === 'number' ? data.blocked : 0,
+        review: typeof data.review === 'number' ? data.review : 0,
+      })
+    } catch (err) {
+      // Keep the last good value; the next taskboard bump retries. Log at
+      // debug so a persistently-failing summary is diagnosable without noise.
+      console.debug('[tasks] nav-badge summary fetch failed', err)
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh, taskboardVersion])
+
+  return { summary, refresh }
+}

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -97,6 +97,8 @@ const errorResponse = z.object({ error: z.string() })
 
 const taskBoardResponse = z.object({}).passthrough()  // structural; defined elsewhere
 
+const taskSummaryResponse = z.object({ blocked: z.number(), review: z.number() })
+
 const taskSourceSchema = z.object({
   pluginId: z.string().optional(),
   entityType: z.string().optional(),
@@ -204,6 +206,25 @@ const routes = [
       try {
         const board = await readTaskboard()
         return Response.json(board)
+      } catch (err) {
+        return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
+      }
+    },
+  }),
+
+  defineRoute({
+    path: '/summary',
+    method: 'GET',
+    summary: 'Counts of tasks needing attention (nav-badge source)',
+    description: 'Returns blocked/review counts only — cheap source for the Tasks nav badge.',
+    responses: { 200: taskSummaryResponse, 500: errorResponse },
+    handler: async () => {
+      try {
+        const board = await readTaskboard()
+        return Response.json({
+          blocked: board.columns.blocked.length,
+          review: board.columns.review.length,
+        })
       } catch (err) {
         return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 })
       }

--- a/tests/components/nav-badge-logic.test.ts
+++ b/tests/components/nav-badge-logic.test.ts
@@ -90,6 +90,15 @@ describe('pickRollupTone', () => {
     const item = parent([child('a')])
     expect(pickRollupTone(item, new Map([['a', { count: 1 }]]))).toBe('attention')
   })
+
+  it('error wins over attention across children', () => {
+    const item = parent([child('a'), child('b')])
+    const badges = new Map<string, { count?: number; tone?: 'error' | 'attention' | 'info' | 'success' }>([
+      ['a', { count: 5, tone: 'attention' }],
+      ['b', { count: 1, tone: 'error' }],
+    ])
+    expect(pickRollupTone(item, badges)).toBe('error')
+  })
 })
 
 describe('collapsedParentRollupTone', () => {

--- a/tests/components/nav-badge-logic.test.ts
+++ b/tests/components/nav-badge-logic.test.ts
@@ -99,6 +99,15 @@ describe('pickRollupTone', () => {
     ])
     expect(pickRollupTone(item, badges)).toBe('error')
   })
+
+  it('info wins over success (pins the lower-priority ordering)', () => {
+    const item = parent([child('a'), child('b')])
+    const badges = new Map<string, { count?: number; tone?: 'error' | 'attention' | 'info' | 'success' }>([
+      ['a', { count: 1, tone: 'success' }],
+      ['b', { count: 1, tone: 'info' }],
+    ])
+    expect(pickRollupTone(item, badges)).toBe('info')
+  })
 })
 
 describe('collapsedParentRollupTone', () => {
@@ -125,11 +134,15 @@ describe('collapsedParentAriaSuffix', () => {
   })
 
   it('announces a children hint when the dot is child-driven', () => {
-    expect(collapsedParentAriaSuffix(undefined, 'attention')).toBe(', children need review')
+    expect(collapsedParentAriaSuffix(undefined, 'attention')).toBe(', children needing review')
   })
 
-  it('uses the tone label for non-attention child rollups', () => {
+  it('uses the shared tone label for non-attention child rollups', () => {
     expect(collapsedParentAriaSuffix(undefined, 'info')).toBe(', children info')
+  })
+
+  it('announces error child rollups as "urgent" (consistent with the counted suffix)', () => {
+    expect(collapsedParentAriaSuffix(undefined, 'error')).toBe(', children urgent')
   })
 
   it('empty string when there is no dot at all', () => {

--- a/tests/components/nav-badge.test.tsx
+++ b/tests/components/nav-badge.test.tsx
@@ -99,4 +99,8 @@ describe('navBadgeAriaSuffix', () => {
   it('formats error tone as the neutral word "urgent"', () => {
     expect(navBadgeAriaSuffix({ count: 3, tone: 'error' })).toBe(', 3 urgent')
   })
+
+  it('formats presence-only error (no count) as "urgent"', () => {
+    expect(navBadgeAriaSuffix({ tone: 'error' })).toBe(', urgent')
+  })
 })

--- a/tests/components/nav-badge.test.tsx
+++ b/tests/components/nav-badge.test.tsx
@@ -57,6 +57,11 @@ describe('NavBadge', () => {
     render(<NavBadge badge={{ count: 1, tone: 'success' }} />)
     expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-emerald-500/20')
   })
+
+  it('applies the error palette (red) when tone is error', () => {
+    render(<NavBadge badge={{ count: 1, tone: 'error' }} />)
+    expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-red-500/20')
+  })
 })
 
 describe('NavBadgeDot', () => {
@@ -89,5 +94,9 @@ describe('navBadgeAriaSuffix', () => {
 
   it('returns just the tone for presence-only badges', () => {
     expect(navBadgeAriaSuffix({ tone: 'success' })).toBe(', success')
+  })
+
+  it('formats error tone as the neutral word "urgent"', () => {
+    expect(navBadgeAriaSuffix({ count: 3, tone: 'error' })).toBe(', 3 urgent')
   })
 })

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -179,8 +179,8 @@ describe('Tasks Plugin — :taskId path-param routing', () => {
 // ─── Route Registration ────────────────────────────────────────────────────
 
 describe('Tasks Plugin — Route Registration', () => {
-  it('registers 13 routes', () => {
-    expect(activated.routes.length).toBe(13)
+  it('registers 14 routes', () => {
+    expect(activated.routes.length).toBe(14)
   })
 
   it.each([
@@ -223,6 +223,42 @@ describe('GET / — List Tasks', () => {
 
     expect(status).toBe(500)
     expect(body.error).toContain('read failed')
+  })
+})
+
+// ─── GET /summary — Nav badge counts ───────────────────────────────────────
+
+describe('GET /summary — nav badge counts', () => {
+  it('returns blocked and review counts only', async () => {
+    mockReadTaskboard.mockResolvedValue({
+      columns: {
+        blocked: [{ id: 'b1' }, { id: 'b2' }],
+        review: [{ id: 'r1' }],
+        todo: [{ id: 't1' }],
+      },
+    })
+
+    const route = findRoute(activated.routes, 'GET', '/summary')!
+    const { status, body } = await callRoute(route, activated.ctx)
+
+    expect(status).toBe(200)
+    expect(body).toEqual({ blocked: 2, review: 1 })
+  })
+
+  it('reports zeros on an empty board', async () => {
+    mockReadTaskboard.mockResolvedValue({ columns: { blocked: [], review: [] } })
+
+    const route = findRoute(activated.routes, 'GET', '/summary')!
+    const { status, body } = await callRoute(route, activated.ctx)
+
+    expect(status).toBe(200)
+    expect(body).toEqual({ blocked: 0, review: 0 })
+  })
+
+  it('resolves /summary to the exact route, not /:taskId', () => {
+    const summary = findRoute(activated.routes, 'GET', '/summary')
+    expect(summary).toBeDefined()
+    expect(summary!.path).toBe('/summary')
   })
 })
 

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -185,6 +185,7 @@ describe('Tasks Plugin — Route Registration', () => {
 
   it.each([
     ['GET', '/'],
+    ['GET', '/summary'],
     ['GET', '/:taskId'],
     ['POST', '/'],
     ['PUT', '/:taskId'],
@@ -255,10 +256,23 @@ describe('GET /summary — nav badge counts', () => {
     expect(body).toEqual({ blocked: 0, review: 0 })
   })
 
-  it('resolves /summary to the exact route, not /:taskId', () => {
+  it('returns 500 on error', async () => {
+    mockReadTaskboard.mockRejectedValue(new Error('summary read failed'))
+
+    const route = findRoute(activated.routes, 'GET', '/summary')!
+    const { status, body } = await callRoute(route, activated.ctx)
+
+    expect(status).toBe(500)
+    expect(body.error).toContain('summary read failed')
+  })
+
+  // The literal `/summary` is registered as its own route, distinct from the
+  // `/:taskId` param route. Precedence at dispatch time (literal beats param)
+  // is guaranteed + tested by the core routing registry; here we just pin that
+  // the route is registered under its own path.
+  it('registers /summary as a distinct literal route', () => {
     const summary = findRoute(activated.routes, 'GET', '/summary')
-    expect(summary).toBeDefined()
-    expect(summary!.path).toBe('/summary')
+    expect(summary?.path).toBe('/summary')
   })
 })
 

--- a/tests/plugins/tasks/tasks-badge-provider.test.tsx
+++ b/tests/plugins/tasks/tasks-badge-provider.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { TaskSummary } from '../../../plugins/tasks/hooks/use-task-summary'
+
+const testDir = join(tmpdir(), `bakin-test-tasks-badge-${Date.now()}`)
+
+// Defensive content-dir mocks per CLAUDE.md (this test touches neither, but
+// the provider lives under a plugin so the rule applies).
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+// Defensive: the provider's real data hook is mocked below so task-store
+// never loads, but satisfy the isolation checker so it can't ever leak.
+mock.module('../../../src/core/task-store', () => ({
+  readTaskboard: () => ({ columns: { blocked: [], review: [] } }),
+}))
+
+// Controllable summary returned by the mocked hook.
+let mockSummary: TaskSummary | null = null
+mock.module('../../../plugins/tasks/hooks/use-task-summary', () => ({
+  useTaskSummary: () => ({ summary: mockSummary, refresh: async () => {} }),
+}))
+
+const setNavBadge = mock()
+mock.module('@makinbakin/sdk', () => ({ setNavBadge }))
+
+import { cleanup, render } from '@testing-library/react'
+import { TasksBadgeProvider } from '../../../plugins/tasks/components/tasks-badge-provider'
+
+beforeEach(() => {
+  mockSummary = null
+  setNavBadge.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TasksBadgeProvider', () => {
+  it('renders nothing', () => {
+    const { container } = render(<TasksBadgeProvider />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows a red error badge with the blocked count (blocked beats review)', () => {
+    mockSummary = { blocked: 3, review: 5 }
+    render(<TasksBadgeProvider />)
+    expect(setNavBadge).toHaveBeenCalledWith('tasks', 'tasks', { count: 3, tone: 'error' })
+  })
+
+  it('falls back to an amber attention badge with the review count when nothing is blocked', () => {
+    mockSummary = { blocked: 0, review: 5 }
+    render(<TasksBadgeProvider />)
+    expect(setNavBadge).toHaveBeenCalledWith('tasks', 'tasks', { count: 5, tone: 'attention' })
+  })
+
+  it('clears the badge (null) when neither blocked nor review has tasks', () => {
+    mockSummary = { blocked: 0, review: 0 }
+    render(<TasksBadgeProvider />)
+    expect(setNavBadge).toHaveBeenCalledWith('tasks', 'tasks', null)
+  })
+
+  it('does not call setNavBadge before the summary has loaded', () => {
+    mockSummary = null
+    render(<TasksBadgeProvider />)
+    expect(setNavBadge).not.toHaveBeenCalled()
+  })
+
+  it('transitions blocked → review → cleared as the summary changes', () => {
+    mockSummary = { blocked: 2, review: 1 }
+    const { rerender } = render(<TasksBadgeProvider />)
+    expect(setNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 2, tone: 'error' })
+
+    mockSummary = { blocked: 0, review: 1 }
+    rerender(<TasksBadgeProvider />)
+    expect(setNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 1, tone: 'attention' })
+
+    mockSummary = { blocked: 0, review: 0 }
+    rerender(<TasksBadgeProvider />)
+    expect(setNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', null)
+  })
+})


### PR DESCRIPTION
Second adopter of the nav-badge infra (#265). Adds a badge to the **Tasks** nav item, and fills a gap in the shared system — there was no red/`error` tone.

## Summary

- **`error` tone (red), shared infra** — `NavBadgeTone` gains `'error'` (additive); host palette gets `bg-red-500/20 text-red-300` (pill) / `bg-red-400` (dot); `TONE_PRIORITY` reordered so `error` > `attention` > `info` > `success` (wins collapsed-parent rollups); `navBadgeAriaSuffix` reads `error` as the neutral word "urgent". Benefits every future plugin.
- **`GET /api/plugins/tasks/summary`** → `{ blocked, review }` (counts only, from `readTaskboard()`). The radix router scores the literal `/summary` above `/:taskId`.
- **`TasksBadgeProvider`** (mounted via the `nav-badge-providers` slot) — winning-severity: `blocked > 0` → red count; else `review > 0` → amber count; else cleared. The number always matches the tone's meaning.
- **`useTaskSummary`** — refetches on the existing SSE-driven `useContentStore.taskboardVersion` signal; **no new EventSource**.

## Why it matters
Proves the #265 infra generalizes: messaging was an *installed* plugin with its own SSE hook; Tasks is a *core* plugin reusing the host's existing taskboard signal. Same `setNavBadge` + slot contract.

## Decisions (from kickoff interview)
Winning-severity count (one color/one number, not two); always-global counts (no agent filter); dedicated `/summary` over reusing the full board fetch; `error` as new top severity. Full rationale in `.claude/specs/tasks-nav-badge.md`.

## Test plan
- [x] `bun test --isolate` on touched files — 150 pass (error pill/aria, rollup priority, `/summary` counts + empty + exact-route, provider winning-severity + transitions)
- [x] `bun run typecheck` clean
- [x] Code review: APPROVE, no blockers (one nit addressed — fetch-failure now logged at debug)
- [x] Manual (imitation-crab): move a task to `blocked` → red count; unblock → amber review count; clear → hidden; collapsed sidebar → red dot

## Scope
Single repo (bakin). Core plugin dist is gitignored/built in CI — no dist commit. `bakin-bits-official` ambient SDK type left untouched (messaging doesn't use `error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)