### PR TITLE
refactor: nav-badge infra hardening (idempotent setNavBadge + useNavBadge hook)

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -868,14 +868,21 @@ registerPlugin({
 
 // plugins/messaging/components/plans-badge-provider.tsx
 function PlansBadgeProvider() {
-  const { summary } = usePlansSummary()
-  useEffect(() => {
-    setNavBadge('messaging', 'messaging-plans',
-      summary?.needsReview ? { count: summary.needsReview } : null)
-  }, [summary])
+  const { summary } = usePlansSummary()      // your own fetch + refresh
+  const badge = summary?.needsReview ? { count: summary.needsReview } : null
+  useNavBadge('messaging', 'messaging-plans', badge)
   return null
 }
 ```
+
+Use the `useNavBadge(pluginId, navItemId, badge)` hook from
+`@makinbakin/sdk/hooks` for the glue (recommended over calling
+`setNavBadge` in a raw `useEffect`): it syncs the badge keyed on its
+value (`count` + `tone`), so it only writes when the value actually
+changes — not on every render. Keep your own summary hook (fetch +
+refresh signal) per plugin; the hook is deliberately refresh-agnostic.
+`setNavBadge` itself is **idempotent** — a set with an identical value is
+a no-op (no snapshot rebuild, no subscriber notification).
 
 ### Sidebar rendering
 

--- a/.claude/specs/nav-badge-hardening.md
+++ b/.claude/specs/nav-badge-hardening.md
@@ -1,0 +1,105 @@
+# Spec: Nav-badge infrastructure hardening
+
+Branch: `feat/nav-badge-hardening` (bakin) + a follow-up branch in `bakin-bits-official`.
+Follow-up to #265 (infra), #40 (messaging adopter), #377 (Tasks adopter + `error` tone).
+
+## Objective
+
+Harden the nav-badge infrastructure now that it has two adopters (messaging, Tasks). Three things, surfaced by the #377 code review:
+
+1. **Idempotent `setNavBadge`** — make a `set` with an identical `{count, tone}` a no-op, so the public API doesn't rebuild the badge snapshot / notify subscribers on redundant calls.
+2. **Shared `useNavBadge` hook** — the two adopters' providers contain identical `useEffect → setNavBadge` glue that has already drifted. Extract the minimal, refresh-agnostic part into `@makinbakin/sdk/hooks` so both consume it and future adopters (e.g. Health) get it for free.
+3. **Test headroom** — the happy-dom nav-badge component tests mount React trees; the full `bun test --isolate` suite sits near a Bun segfault threshold. Convert them to `renderToStaticMarkup` (string output, no DOM mount) to cut that file's footprint.
+
+**Target users:** plugin authors writing badge providers (one-liner instead of boilerplate) and the maintainer (less drift, idempotent API, more test headroom). No user-facing behavior change.
+
+## Scope
+
+### bakin PR — `feat/nav-badge-hardening`
+
+**Workstream 1 — idempotent `setNavBadge`** (`packages/sdk/src/register.ts`)
+- In the non-null branch of `setNavBadge`, before `plugin.set(navItemId, badge)` + `bumpBadges()`, compare against the current value and return early if `count` and `tone` are equal (treating missing `count`/`tone` consistently). Null/clear branch already early-returns when absent — leave it.
+- Rationale: public-API idempotency that protects any direct caller; defense-in-depth with the hook's value-keying.
+
+**Workstream 2 — `useNavBadge` hook** (`src/hooks/use-nav-badge.ts` *(new)*, re-exported via `packages/sdk/src/hooks/index.ts`)
+- Signature: `useNavBadge(pluginId: string, navItemId: string, badge: NavBadge | null): void`.
+- Calls `setNavBadge(pluginId, navItemId, badge)` inside a `useEffect` keyed on a stable serialization of the badge value (`count` + `tone`), so the effect fires only when the badge actually changes — not on every render (the `badge` object is recreated each render).
+- Imports `setNavBadge` from `@makinbakin/sdk` (root); no fetch, no refresh logic — refresh stays in each plugin's own summary hook.
+- Does NOT auto-clear on unmount — plugin teardown is already handled by `unregisterPlugin`; clearing on unmount would cause flicker on dev hot-reload.
+
+**Workstream 3 — Tasks migration** (`plugins/tasks/components/tasks-badge-provider.tsx`)
+- Replace the `useEffect → setNavBadge` block with `useNavBadge('tasks', 'tasks', badge)`. `useTaskSummary` and the winning-severity derivation stay.
+
+**Workstream 4 — test lightening** (`tests/components/nav-badge.test.tsx`)
+- Convert the `NavBadge` / `NavBadgeDot` render assertions from `@testing-library/react` `render` (happy-dom mount) to `renderToStaticMarkup` (HTML string). Assert on the markup string (testid, count text, tone class). `navBadgeAriaSuffix` tests are already pure — leave them.
+
+**Workstream 5 — docs**
+- `.claude/knowledge/plugin-system.md` — document `useNavBadge` as the recommended provider glue + the `setNavBadge` idempotency guarantee.
+- `docs/src/content/docs/extending/plugins/client-ui.md` — show the provider using `useNavBadge` (simpler than the raw `useEffect`).
+- `docs/src/content/docs/reference/generated/sdk.md` — regenerate (`bun run docs:generate`) so `useNavBadge` appears under hooks.
+
+### bakin-bits-official PR (follow-up, after bakin merges + SDK vendor-sync)
+
+- Vendor-sync: add `useNavBadge` to `test-sdk/hooks.js` (runtime stub) and the `@makinbakin/sdk/hooks` module in `types/sdk-ambient.d.ts`.
+- Migrate `plugins/messaging/components/plans-badge-provider.tsx` to `useNavBadge('messaging', 'messaging-plans', badge)`. `usePlansSummary` (with its SSE refresh) stays.
+- Update its provider test.
+
+### Out of scope
+
+- A fuller fetch-owning `useNavBadgeProvider` (rejected: would force messaging's SSE refresh into a `refreshDeps` mold — leaky). The summary hooks legitimately differ and stay per-plugin.
+- Auto-clear-on-unmount in `useNavBadge` (unregisterPlugin handles teardown).
+- Migrating other plugins / new adopters (Health) — separate work.
+- Broader `bun test --isolate` suite restructuring — only the nav-badge component test is lightened here.
+
+## Acceptance criteria
+
+- ✅ `setNavBadge` with an identical `{count, tone}` does not call `bumpBadges()` (no snapshot rebuild, no subscriber notification) — verified by a test that subscribes and asserts no tick on a redundant set.
+- ✅ `useNavBadge` calls `setNavBadge` once on mount and again only when the badge value changes; a re-render with an equal-value badge does not re-call.
+- ✅ `TasksBadgeProvider` behaves identically (red blocked count → amber review → cleared) using `useNavBadge`; existing provider tests still pass (adjusted to the hook).
+- ✅ `nav-badge.test.tsx` uses `renderToStaticMarkup`, no happy-dom mount; same assertions hold.
+- ✅ `bun run typecheck` clean; touched-file tests green.
+- ✅ Docs updated; `useNavBadge` in the generated SDK reference.
+- ✅ (bits PR) messaging badge unchanged in behavior, now via `useNavBadge`.
+
+## Design decisions (from kickoff)
+
+| Decision | Choice | Why |
+|---|---|---|
+| PR split | One bakin PR (3 bakin workstreams) + follow-up bits PR | Cohesive theme; messaging is cross-repo and needs the SDK vendor-synced first (mirrors #265→#40). |
+| Helper shape | Minimal `useNavBadge(pluginId, navItemId, badge)` | Shares only the identical, refresh-agnostic glue; no leaky abstraction over the two refresh models; composes with any adopter. |
+| Equality guard | Keep, as public-API idempotency | Cheap; protects any direct caller; defense-in-depth with the hook's value-keying. |
+| Unmount behavior | No auto-clear | Teardown handled by `unregisterPlugin`; avoids hot-reload flicker. |
+| Test lightening | `renderToStaticMarkup` for nav-badge component tests | Removes happy-dom mounts; cuts the file's contribution to the suite's memory peak. |
+
+## Architecture impact
+
+- `setNavBadge` gains an equality short-circuit — externally observable only as "fewer redundant ticks." No signature/shape change.
+- New public hook `useNavBadge` in `@makinbakin/sdk/hooks` — additive surface. Becomes the documented way to wire a badge provider; the raw `setNavBadge` stays public for non-React/edge callers.
+- Both adopters' providers shrink to a `useNavBadge(...)` call; the genuinely-different part (summary fetch + refresh) stays per-plugin.
+
+## Commit strategy
+
+### bakin PR — 5 commits, each independently revertable, each with tests
+
+1. **`feat(sdk): idempotent setNavBadge`** — equality guard in `register.ts` + a `tests/sdk/register.test.ts` case (redundant set → no `subscribeNavBadges` tick; changed value → tick).
+2. **`feat(sdk): useNavBadge hook`** — `src/hooks/use-nav-badge.ts` + barrel export + a hook test (mount calls once; equal-value re-render no-ops; changed value re-calls). Mocks `setNavBadge`.
+3. **`refactor(tasks): adopt useNavBadge`** — `tasks-badge-provider.tsx` uses the hook; update `tasks-badge-provider.test.tsx` (assertions unchanged in spirit — `setNavBadge` still called with the right payloads).
+4. **`test(host): lighten nav-badge component tests`** — `nav-badge.test.tsx` → `renderToStaticMarkup`.
+5. **`docs: useNavBadge + setNavBadge idempotency`** — knowledge + client-ui + regenerated sdk.md.
+
+### bits PR — 2 commits (opens after bakin merges + SDK published/vendored)
+
+1. **`chore(sdk): vendor useNavBadge for tests`** — `test-sdk/hooks.js` + `types/sdk-ambient.d.ts`.
+2. **`refactor(messaging): adopt useNavBadge`** — `plans-badge-provider.tsx` + its test.
+
+## Testing strategy
+
+- **Unit:** `setNavBadge` idempotency (subscribe + assert tick count); `useNavBadge` (mount/equal/changed) via a tiny null-rendering test component with `setNavBadge` mocked; the migrated Tasks provider test; the lightened `nav-badge.test.tsx` (string assertions).
+- **Manual:** imitation-crab — confirm the Tasks badge still behaves (blocked red → review amber → clear) after the migration; confirm no regression in messaging (after the bits PR).
+- No e2e.
+
+## Boundaries
+
+**Always:** `bun test --isolate` for touched files; update `.claude/knowledge/plugin-system.md` when the SDK hook surface changes; regenerate `sdk.md`.
+
+**Never:** build the fuller fetch-owning helper; auto-clear badges on unmount; couple `useNavBadge` to a specific refresh model; touch `bakin-bits-official` in the bakin PR; add compat shims for the pre-hook provider shape.

--- a/docs/src/content/docs/extending/plugins/client-ui.md
+++ b/docs/src/content/docs/extending/plugins/client-ui.md
@@ -63,17 +63,18 @@ inbox count.
 The contract is identical for core and installed plugins.
 
 ```tsx
-import { registerPlugin, setNavBadge } from '@makinbakin/sdk'
-import { useEffect } from 'react'
+import { registerPlugin } from '@makinbakin/sdk'
+import { useNavBadge } from '@makinbakin/sdk/hooks'
 
 function PlansBadgeProvider() {
   // Use whatever data hook the plugin already has — REST, SSE, local cache.
   const { summary } = usePlansSummary()
-  useEffect(() => {
-    const needsReview = summary?.needsReview ?? 0
-    setNavBadge('messaging', 'messaging-plans',
-      needsReview > 0 ? { count: needsReview, tone: 'attention' } : null)
-  }, [summary])
+  const needsReview = summary?.needsReview ?? 0
+  // useNavBadge syncs the badge keyed on its value, so it only writes when
+  // count/tone actually change. (setNavBadge is also idempotent if you call
+  // it directly.)
+  useNavBadge('messaging', 'messaging-plans',
+    needsReview > 0 ? { count: needsReview, tone: 'attention' } : null)
   return null
 }
 

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -128,6 +128,12 @@ import { useSearch, useAssets, useDebug } from '@makinbakin/sdk/hooks'
 | `useRuntimeStatus` | Subscribe to runtime connection status (online/offline, last heartbeat). |
 | `useSSE` | Subscribe to a Server-Sent Events endpoint with auto-reconnect. |
 
+### Other
+
+| Hook | Description |
+| --- | --- |
+| `useNavBadge` | Sync a nav item's badge to a derived value; the recommended provider glue. |
+
 ## `@makinbakin/sdk/components`
 
 Source: `packages/sdk/src/components/index.ts`.

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -15,6 +15,8 @@ export { useAssets } from '@/hooks/use-assets'
 export { useTrash } from '@/hooks/use-assets'
 /** Access the global Zustand store for SSE-driven content state. */
 export { useContentStore } from '@/hooks/use-content-store'
+/** Sync a nav item's badge to a derived value; the recommended provider glue. */
+export { useNavBadge } from '@/hooks/use-nav-badge'
 /** Read/toggle the global debug (X-Ray) flag. */
 export { useDebug } from '@/hooks/use-debug'
 /** Guard a form against unmounting while submission is in flight. */

--- a/packages/sdk/src/register.ts
+++ b/packages/sdk/src/register.ts
@@ -261,14 +261,18 @@ export function setNavBadge(pluginId: string, navItemId: string, badge: NavBadge
   }
   // Idempotent: a set with an identical value is a no-op, so a redundant
   // call (e.g. an SSE tick that didn't change the count) doesn't rebuild the
-  // snapshot or notify subscribers.
+  // snapshot or notify subscribers. (`useNavBadge` keys on the same
+  // {count, tone} identity — keep the two in lockstep if NavBadge grows.)
   const prev = plugin?.get(navItemId)
   if (prev && prev.count === badge.count && prev.tone === badge.tone) return
   if (!plugin) {
     plugin = new Map()
     registry.badgesByPlugin.set(pluginId, plugin)
   }
-  plugin.set(navItemId, badge)
+  // Store a copy so the registry owns its value — a caller can't mutate a
+  // previously-passed object and have the guard self-compare (dropping the
+  // update), and registry state can't be mutated out from under the snapshot.
+  plugin.set(navItemId, { count: badge.count, tone: badge.tone })
   bumpBadges()
 }
 

--- a/packages/sdk/src/register.ts
+++ b/packages/sdk/src/register.ts
@@ -259,6 +259,11 @@ export function setNavBadge(pluginId: string, navItemId: string, badge: NavBadge
     bumpBadges()
     return
   }
+  // Idempotent: a set with an identical value is a no-op, so a redundant
+  // call (e.g. an SSE tick that didn't change the count) doesn't rebuild the
+  // snapshot or notify subscribers.
+  const prev = plugin?.get(navItemId)
+  if (prev && prev.count === badge.count && prev.tone === badge.tone) return
   if (!plugin) {
     plugin = new Map()
     registry.badgesByPlugin.set(pluginId, plugin)

--- a/plugins/tasks/components/tasks-badge-provider.tsx
+++ b/plugins/tasks/components/tasks-badge-provider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useEffect } from 'react'
-import { setNavBadge } from '@makinbakin/sdk'
+import type { NavBadge } from '@makinbakin/sdk'
+import { useNavBadge } from '@makinbakin/sdk/hooks'
 import { useTaskSummary } from '../hooks/use-task-summary'
 
 /**
@@ -17,15 +17,15 @@ import { useTaskSummary } from '../hooks/use-task-summary'
 export function TasksBadgeProvider() {
   const { summary } = useTaskSummary()
 
-  useEffect(() => {
-    if (!summary) return
-    const badge = summary.blocked > 0
-      ? { count: summary.blocked, tone: 'error' as const }
+  const badge: NavBadge | null = !summary
+    ? null
+    : summary.blocked > 0
+      ? { count: summary.blocked, tone: 'error' }
       : summary.review > 0
-        ? { count: summary.review, tone: 'attention' as const }
+        ? { count: summary.review, tone: 'attention' }
         : null
-    setNavBadge('tasks', 'tasks', badge)
-  }, [summary])
+
+  useNavBadge('tasks', 'tasks', badge)
 
   return null
 }

--- a/src/hooks/use-nav-badge.ts
+++ b/src/hooks/use-nav-badge.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+import { setNavBadge, type NavBadge } from '@makinbakin/sdk'
+
+/**
+ * Sync a nav item's badge to the value passed each render. Calls
+ * `setNavBadge(pluginId, navItemId, badge)` only when the badge's value
+ * actually changes — the effect is keyed on a serialization of `count` +
+ * `tone`, not the object identity (which a parent recreates every render).
+ *
+ * This is the recommended glue for a badge provider: keep your own summary
+ * hook (fetch + refresh) per plugin, derive a `NavBadge | null`, and pass it
+ * here. Teardown is handled by `unregisterPlugin`, so this does not clear on
+ * unmount (which would flicker on dev hot-reload).
+ */
+export function useNavBadge(pluginId: string, navItemId: string, badge: NavBadge | null): void {
+  // `key` captures the badge's value; `badge` itself is intentionally not a
+  // dep — its object identity changes every render, but the effect should
+  // only re-run (and re-call setNavBadge) when count/tone actually change.
+  const key = badge ? `${badge.count ?? ''}:${badge.tone ?? ''}` : 'null'
+  useEffect(() => {
+    setNavBadge(pluginId, navItemId, badge)
+  }, [pluginId, navItemId, key])
+}

--- a/tests/components/nav-badge.test.tsx
+++ b/tests/components/nav-badge.test.tsx
@@ -14,60 +14,57 @@ mock.module('../../packages/core/src/content-dir', () => ({
   getBakinPaths: () => ({ root: testDir }),
 }))
 
-import { render, screen } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { NavBadge, NavBadgeDot, navBadgeAriaSuffix } from '../../packages/host/src/components/layout/nav-badge'
+
+// Render to an HTML string rather than mounting into happy-dom — these are
+// pure presentational components, so the markup is enough to assert on, and
+// it keeps this file's memory footprint near zero (the full --isolate suite
+// sits close to a Bun segfault threshold; mounting here would add to it).
 
 describe('NavBadge', () => {
   it('renders nothing when badge is undefined', () => {
-    const { container } = render(<NavBadge badge={undefined} />)
-    expect(container.firstChild).toBeNull()
+    expect(renderToStaticMarkup(<NavBadge badge={undefined} />)).toBe('')
   })
 
   it('renders nothing when count is 0', () => {
-    const { container } = render(<NavBadge badge={{ count: 0 }} />)
-    expect(container.firstChild).toBeNull()
+    expect(renderToStaticMarkup(<NavBadge badge={{ count: 0 }} />)).toBe('')
   })
 
   it('renders a pill with the count when count is positive', () => {
-    render(<NavBadge badge={{ count: 3 }} />)
-    expect(screen.getByTestId('nav-badge-pill').textContent).toBe('3')
+    const html = renderToStaticMarkup(<NavBadge badge={{ count: 3 }} />)
+    expect(html).toContain('nav-badge-pill')
+    expect(html).toContain('>3<')
   })
 
   it('clamps counts above 99 to "99+"', () => {
-    render(<NavBadge badge={{ count: 250 }} />)
-    expect(screen.getByTestId('nav-badge-pill').textContent).toBe('99+')
+    expect(renderToStaticMarkup(<NavBadge badge={{ count: 250 }} />)).toContain('99+')
   })
 
-  it('renders a dot when count is omitted', () => {
-    render(<NavBadge badge={{ tone: 'info' }} />)
-    expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-sky-400')
+  it('renders a dot (no count) when count is omitted', () => {
+    expect(renderToStaticMarkup(<NavBadge badge={{ tone: 'info' }} />)).toContain('bg-sky-400')
   })
 
   it('applies the attention palette by default', () => {
-    render(<NavBadge badge={{ count: 1 }} />)
-    expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-amber-500/20')
+    expect(renderToStaticMarkup(<NavBadge badge={{ count: 1 }} />)).toContain('bg-amber-500/20')
   })
 
   it('applies the info palette when tone is info', () => {
-    render(<NavBadge badge={{ count: 1, tone: 'info' }} />)
-    expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-sky-500/20')
+    expect(renderToStaticMarkup(<NavBadge badge={{ count: 1, tone: 'info' }} />)).toContain('bg-sky-500/20')
   })
 
   it('applies the success palette when tone is success', () => {
-    render(<NavBadge badge={{ count: 1, tone: 'success' }} />)
-    expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-emerald-500/20')
+    expect(renderToStaticMarkup(<NavBadge badge={{ count: 1, tone: 'success' }} />)).toContain('bg-emerald-500/20')
   })
 
   it('applies the error palette (red) when tone is error', () => {
-    render(<NavBadge badge={{ count: 1, tone: 'error' }} />)
-    expect(screen.getByTestId('nav-badge-pill').className).toContain('bg-red-500/20')
+    expect(renderToStaticMarkup(<NavBadge badge={{ count: 1, tone: 'error' }} />)).toContain('bg-red-500/20')
   })
 })
 
 describe('NavBadgeDot', () => {
   it('renders a small dot using the given tone', () => {
-    render(<NavBadgeDot tone="attention" />)
-    expect(screen.getByTestId('nav-badge-dot').className).toContain('bg-amber-400')
+    expect(renderToStaticMarkup(<NavBadgeDot tone="attention" />)).toContain('bg-amber-400')
   })
 })
 

--- a/tests/components/use-nav-badge.test.tsx
+++ b/tests/components/use-nav-badge.test.tsx
@@ -64,4 +64,13 @@ describe('useNavBadge', () => {
     render(<Probe badge={null} />)
     expect(setNavBadge).toHaveBeenCalledWith('p', 'p-nav', null)
   })
+
+  it('re-calls across the clear boundary (value → null → value)', () => {
+    const { rerender } = render(<Probe badge={{ count: 3, tone: 'attention' }} />)
+    setNavBadge.mockClear()
+    rerender(<Probe badge={null} />)
+    expect(setNavBadge).toHaveBeenLastCalledWith('p', 'p-nav', null)
+    rerender(<Probe badge={{ count: 2, tone: 'attention' }} />)
+    expect(setNavBadge).toHaveBeenLastCalledWith('p', 'p-nav', { count: 2, tone: 'attention' })
+  })
 })

--- a/tests/components/use-nav-badge.test.tsx
+++ b/tests/components/use-nav-badge.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { NavBadge } from '@makinbakin/sdk'
+
+const testDir = join(tmpdir(), `bakin-test-use-nav-badge-${Date.now()}`)
+
+// Defensive content-dir mocks per CLAUDE.md (this test touches neither).
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+const setNavBadge = mock()
+mock.module('@makinbakin/sdk', () => ({ setNavBadge }))
+
+import { cleanup, render } from '@testing-library/react'
+import { useNavBadge } from '@/hooks/use-nav-badge'
+
+function Probe({ badge }: { badge: NavBadge | null }) {
+  useNavBadge('p', 'p-nav', badge)
+  return null
+}
+
+afterEach(() => {
+  cleanup()
+  setNavBadge.mockClear()
+})
+
+describe('useNavBadge', () => {
+  it('calls setNavBadge once on mount', () => {
+    render(<Probe badge={{ count: 2, tone: 'attention' }} />)
+    expect(setNavBadge).toHaveBeenCalledTimes(1)
+    expect(setNavBadge).toHaveBeenCalledWith('p', 'p-nav', { count: 2, tone: 'attention' })
+  })
+
+  it('does NOT re-call when re-rendered with an equal-value badge (fresh object)', () => {
+    const { rerender } = render(<Probe badge={{ count: 2, tone: 'attention' }} />)
+    setNavBadge.mockClear()
+    rerender(<Probe badge={{ count: 2, tone: 'attention' }} />)
+    expect(setNavBadge).not.toHaveBeenCalled()
+  })
+
+  it('re-calls when the count changes', () => {
+    const { rerender } = render(<Probe badge={{ count: 2, tone: 'attention' }} />)
+    setNavBadge.mockClear()
+    rerender(<Probe badge={{ count: 5, tone: 'attention' }} />)
+    expect(setNavBadge).toHaveBeenCalledWith('p', 'p-nav', { count: 5, tone: 'attention' })
+  })
+
+  it('re-calls when only the tone changes', () => {
+    const { rerender } = render(<Probe badge={{ count: 2, tone: 'attention' }} />)
+    setNavBadge.mockClear()
+    rerender(<Probe badge={{ count: 2, tone: 'error' }} />)
+    expect(setNavBadge).toHaveBeenCalledWith('p', 'p-nav', { count: 2, tone: 'error' })
+  })
+
+  it('passes null through to clear', () => {
+    render(<Probe badge={null} />)
+    expect(setNavBadge).toHaveBeenCalledWith('p', 'p-nav', null)
+  })
+})

--- a/tests/plugins/tasks/tasks-badge-provider.test.tsx
+++ b/tests/plugins/tasks/tasks-badge-provider.test.tsx
@@ -16,27 +16,28 @@ mock.module('../../../packages/core/src/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ root: testDir }),
 }))
-// Defensive: the provider's real data hook is mocked below so task-store
-// never loads, but satisfy the isolation checker so it can't ever leak.
 mock.module('../../../src/core/task-store', () => ({
   readTaskboard: () => ({ columns: { blocked: [], review: [] } }),
 }))
 
-// Controllable summary returned by the mocked hook.
+// Controllable summary returned by the mocked data hook.
 let mockSummary: TaskSummary | null = null
 mock.module('../../../plugins/tasks/hooks/use-task-summary', () => ({
-  useTaskSummary: () => ({ summary: mockSummary, refresh: async () => {} }),
+  useTaskSummary: () => ({ summary: mockSummary }),
 }))
 
-const setNavBadge = mock()
-mock.module('@makinbakin/sdk', () => ({ setNavBadge }))
+// Mock the shared useNavBadge hook — its own behavior (effect-keying,
+// setNavBadge wiring) is covered in tests/components/use-nav-badge.test.tsx.
+// Here we only assert the provider derives + passes the right badge.
+const useNavBadge = mock()
+mock.module('@makinbakin/sdk/hooks', () => ({ useNavBadge }))
 
 import { cleanup, render } from '@testing-library/react'
 import { TasksBadgeProvider } from '../../../plugins/tasks/components/tasks-badge-provider'
 
 beforeEach(() => {
   mockSummary = null
-  setNavBadge.mockClear()
+  useNavBadge.mockClear()
 })
 
 afterEach(() => {
@@ -49,41 +50,41 @@ describe('TasksBadgeProvider', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('shows a red error badge with the blocked count (blocked beats review)', () => {
+  it('passes a red error badge with the blocked count (blocked beats review)', () => {
     mockSummary = { blocked: 3, review: 5 }
     render(<TasksBadgeProvider />)
-    expect(setNavBadge).toHaveBeenCalledWith('tasks', 'tasks', { count: 3, tone: 'error' })
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 3, tone: 'error' })
   })
 
   it('falls back to an amber attention badge with the review count when nothing is blocked', () => {
     mockSummary = { blocked: 0, review: 5 }
     render(<TasksBadgeProvider />)
-    expect(setNavBadge).toHaveBeenCalledWith('tasks', 'tasks', { count: 5, tone: 'attention' })
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 5, tone: 'attention' })
   })
 
-  it('clears the badge (null) when neither blocked nor review has tasks', () => {
+  it('passes null when neither blocked nor review has tasks', () => {
     mockSummary = { blocked: 0, review: 0 }
     render(<TasksBadgeProvider />)
-    expect(setNavBadge).toHaveBeenCalledWith('tasks', 'tasks', null)
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', null)
   })
 
-  it('does not call setNavBadge before the summary has loaded', () => {
+  it('passes null before the summary has loaded', () => {
     mockSummary = null
     render(<TasksBadgeProvider />)
-    expect(setNavBadge).not.toHaveBeenCalled()
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', null)
   })
 
   it('transitions blocked → review → cleared as the summary changes', () => {
     mockSummary = { blocked: 2, review: 1 }
     const { rerender } = render(<TasksBadgeProvider />)
-    expect(setNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 2, tone: 'error' })
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 2, tone: 'error' })
 
     mockSummary = { blocked: 0, review: 1 }
     rerender(<TasksBadgeProvider />)
-    expect(setNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 1, tone: 'attention' })
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', { count: 1, tone: 'attention' })
 
     mockSummary = { blocked: 0, review: 0 }
     rerender(<TasksBadgeProvider />)
-    expect(setNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', null)
+    expect(useNavBadge).toHaveBeenLastCalledWith('tasks', 'tasks', null)
   })
 })

--- a/tests/sdk/register.test.ts
+++ b/tests/sdk/register.test.ts
@@ -310,6 +310,28 @@ describe('nav badge registry', () => {
     expect(listener).toHaveBeenCalledTimes(2)
   })
 
+  it('is idempotent — a set with an identical value does not fire subscribers or rebuild the snapshot', () => {
+    setNavBadge('badge-A', 'badge-A-item', { count: 3, tone: 'attention' })
+    const snapshot = getNavBadgesSnapshot()
+    const listener = mock()
+    const unsub = subscribeNavBadges(listener)
+
+    // Same value → no-op: no tick, same snapshot identity.
+    setNavBadge('badge-A', 'badge-A-item', { count: 3, tone: 'attention' })
+    expect(listener).not.toHaveBeenCalled()
+    expect(getNavBadgesSnapshot()).toBe(snapshot)
+
+    // Changed count → fires.
+    setNavBadge('badge-A', 'badge-A-item', { count: 4, tone: 'attention' })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(getNavBadgesSnapshot()).not.toBe(snapshot)
+
+    // Changed tone only → fires.
+    setNavBadge('badge-A', 'badge-A-item', { count: 4, tone: 'error' })
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsub()
+  })
+
   it('subscribeNavBadges does NOT fire on plain registerPlugin nav mutations', () => {
     const listener = mock()
     const unsub = subscribeNavBadges(listener)

--- a/tests/sdk/register.test.ts
+++ b/tests/sdk/register.test.ts
@@ -332,6 +332,18 @@ describe('nav badge registry', () => {
     unsub()
   })
 
+  it('stores a copy — a mutated-and-resubmitted object still updates (no self-compare drop)', () => {
+    const badge = { count: 1, tone: 'attention' as const }
+    setNavBadge('badge-A', 'badge-A-item', badge)
+    badge.count = 9 // mutate the same object the caller passed in
+    const listener = mock()
+    const unsub = subscribeNavBadges(listener)
+    setNavBadge('badge-A', 'badge-A-item', badge) // resubmit the mutated object
+    expect(listener).toHaveBeenCalledTimes(1) // not skipped as a self-compare no-op
+    expect(getNavBadge('badge-A-item')).toEqual({ count: 9, tone: 'attention' })
+    unsub()
+  })
+
   it('subscribeNavBadges does NOT fire on plain registerPlugin nav mutations', () => {
     const listener = mock()
     const unsub = subscribeNavBadges(listener)


### PR DESCRIPTION
Hardening follow-up to #265/#377 (the #377 review surfaced these). No user-facing behavior change.

## Summary

- **Idempotent `setNavBadge`** — a set with a value-identical `{count, tone}` is now a no-op (no snapshot rebuild, no subscriber notification). Also stores a defensive copy so the registry owns its value (a mutated-and-resubmitted caller object can't self-compare and drop the update).
- **Shared `useNavBadge(pluginId, navItemId, badge)` hook** (`@makinbakin/sdk/hooks`) — the refresh-agnostic glue both badge providers had duplicated. Keyed on the badge's value, so it writes only when `count`/`tone` actually change. Each plugin keeps its own summary hook (fetch + refresh).
- **Tasks migrated** onto `useNavBadge` (winning-severity derivation + `useTaskSummary` unchanged; behavior identical).
- **Test lightening** — `nav-badge.test.tsx` converted from happy-dom `render` to `renderToStaticMarkup`, trimming this file's contribution to the `bun test --isolate` memory peak (which sits near a Bun segfault threshold).

## Commits (each independently revertable, each with tests)
1. `feat(sdk): idempotent setNavBadge`
2. `feat(sdk): useNavBadge hook`
3. `refactor(tasks): adopt useNavBadge`
4. `test(host): lighten nav-badge component tests`
5. `docs: useNavBadge + setNavBadge idempotency`
6. `refactor(sdk): setNavBadge stores a copy; close review test gaps` (code-review fixes)

## Follow-up
A **bits-official PR** migrates the messaging provider onto `useNavBadge` after this merges + the SDK is vendor-synced (`test-sdk/hooks.js` + ambient `.d.ts`), mirroring #40.

## Test plan
- [x] `bun test --isolate` on touched files — 53 pass (idempotency + defensive-copy, useNavBadge mount/equal/changed/null/clear-boundary, migrated Tasks provider, lightened nav-badge tests)
- [x] `bun run typecheck` clean; `bun run docs:generate` clean (`useNavBadge` now in the SDK reference)
- [x] Code review (high effort): the two surfaced issues fixed (defensive copy + clear-boundary test); the rest deliberately deferred (see commit 6 message)
- [x] Manual (imitation-crab): Tasks badge still behaves (blocked red → review amber → clear); no re-set churn on unrelated taskboard bumps

## Scope
Single repo (bakin). Spec: `.claude/specs/nav-badge-hardening.md`. Deliberately NOT the fuller fetch-owning helper, no auto-clear-on-unmount, no bits changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)