### PR TITLE
feat(health): nav badge for failing checks

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -884,6 +884,20 @@ refresh signal) per plugin; the hook is deliberately refresh-agnostic.
 `setNavBadge` itself is **idempotent** — a set with an identical value is
 a no-op (no snapshot rebuild, no subscriber notification).
 
+The refresh signal is per-plugin — the hook doesn't prescribe one. The
+three adopters show the range:
+- **messaging** (Plans, `attention`) — its own `EventSource` filtering
+  `messaging/plans/` file events.
+- **tasks** (blocked→`error` / review→`attention`, winning-severity) —
+  the SSE content-store's `taskboardVersion`.
+- **health** (failing checks, `error`-only) — the content-store's
+  `doctorVersion`, a counter bumped in `use-sse` when a `doctor.run`
+  audit event arrives (every doctor run already emits one). This rides
+  the existing audit SSE — no new broadcast, no poll — and is the clean
+  pattern for any cron/cache-backed source. (Health is errors-only on
+  purpose: many `warn` checks are steady-state, so an amber badge would
+  be permanent noise.)
+
 ### Sidebar rendering
 
 `AppSidebar` (`packages/host/src/components/layout/app-sidebar.tsx`)

--- a/.claude/specs/health-nav-badge.md
+++ b/.claude/specs/health-nav-badge.md
@@ -1,0 +1,94 @@
+# Spec: Health nav badge (failing checks)
+
+Branch: `feat/health-nav-badge` (bakin, single-repo).
+Builds on: #265 (nav-badge infra), #377 (`error` tone), #383 (`useNavBadge` hook).
+
+## Objective
+
+Show a red `error` badge on the **Health** nav item carrying the count of failing doctor checks, so a genuinely-broken state (runtime down, service/search failure) is visible from any page without opening Health. Third adopter of the nav-badge infra — and the canonical use of the `error` tone.
+
+The interesting part is the **refresh signal**: Health's doctor results are cached server-side and refreshed by the watchdog cron, with no per-update SSE event that the existing adopters' patterns (Tasks `taskboardVersion`, messaging file SSE) could ride. But `runDiagnostics()` already calls `appendAudit('doctor.run', …)` on every run (startup, interval, on-demand), and audit entries already broadcast over SSE and reach the client (`use-sse.ts` → content-store). We turn that into a reactive signal.
+
+**Target users:** the single Bakin user (ambient "something is broken" indicator) and future plugin authors (a clean reusable `doctorVersion` signal).
+
+## Scope
+
+### In scope
+
+**Workstream 1 — `doctorVersion` SSE signal (host)**
+- `src/hooks/use-content-store.ts` — add `doctorVersion: number` to state (init `0`) and a `bumpDoctor: () => void` action, mirroring `taskboardVersion` / `bumpTaskboard`.
+- `src/hooks/use-sse.ts` — in the `data.type === 'audit'` handler, when `entry.event === 'doctor.run'`, call `bumpDoctor()` (in addition to the existing `appendAuditEntry`). Add `bumpDoctor` to the effect deps.
+
+**Workstream 2 — Health badge (plugin)**
+- `plugins/health/hooks/use-health-summary.ts` *(new)* — fetch `GET /api/plugins/health/summary`, read `doctor?.summary?.errors ?? 0`; refetch on mount and whenever `useContentStore(s => s.doctorVersion)` changes (no new EventSource). Returns `{ errors: number }` (or `null` until first load). Log fetch failures at debug, keep last good value (matches `use-task-summary`).
+- `plugins/health/components/health-badge-provider.tsx` *(new)* — background component (renders `null`). Derives `badge = errors > 0 ? { count: errors, tone: 'error' } : null` and calls `useNavBadge('health', 'health', badge)`. **Errors only** — warnings never badge (many `warn` conditions are steady-state per install: search disabled, mcporter absent, plugin-assets, restart-recovery — an amber badge would be permanently lit and ignored).
+- `plugins/health/client.tsx` — add `slots: { 'nav-badge-providers': HealthBadgeProvider }` to the existing `registerPlugin` call.
+
+**Workstream 3 — docs**
+- `.claude/knowledge/plugin-system.md` — note Health as the third adopter, and document the `doctorVersion` content-store signal (rides the `doctor.run` audit SSE) alongside `taskboardVersion`.
+
+**Tests**
+- `tests/components/use-health-summary.test.tsx` *(or co-located)* — mock fetch + `useContentStore`; assert it reads `doctor.summary.errors`, refetches when `doctorVersion` bumps, handles missing `doctor`/error path → 0.
+- `tests/components/health-badge-provider.test.tsx` — mock `use-health-summary` + `useNavBadge` (spy); assert errors>0 → `{count, tone:'error'}`, errors=0 → null, pre-load → null, transition.
+- `tests/.../use-sse` or content-store test — assert a `doctor.run` audit bumps `doctorVersion` (and a non-doctor audit does not). Follow the existing use-sse/content-store test setup.
+
+### Out of scope
+
+- Warnings in the badge (decided: errors-only).
+- A dedicated count endpoint (reuse the cheap in-memory `/summary`).
+- `errors1h` / usage-derived errors (badge reflects doctor check failures only).
+- Auto-clear on unmount (handled by `unregisterPlugin`).
+- Migrating other plugins; the deferred `count:0`/`navBadgeKey` items.
+
+## Acceptance criteria
+
+- ✅ Health nav item shows a red badge with the count of `status === 'error'` doctor checks when ≥1 exists; cleared at zero.
+- ✅ Warnings never produce a badge.
+- ✅ Badge refreshes within ~1 render of a `doctor.run` (startup / watchdog interval / on-demand `/doctor`) via `doctorVersion` — no new EventSource, no poll, no cron/heartbeat coupling.
+- ✅ `doctorVersion` bumps only on `doctor.run` audit events, not on other audits.
+- ✅ Uses the shared `useNavBadge` hook (no hand-rolled `setNavBadge` effect).
+- ✅ `bun run typecheck` clean; touched-file tests green.
+- ✅ Manual (imitation-crab): with a failing check seeded, Health shows a red count; once it clears (or all pass), the badge clears.
+
+## Design decisions (from kickoff)
+
+| Decision | Choice | Why |
+|---|---|---|
+| Refresh signal | `doctorVersion` counter in the SSE content-store, bumped on `doctor.run` audit | Rides the existing audit SSE (no new broadcast/poll); reactive value mirrors `taskboardVersion`; reusable; single SSE connection. |
+| Badge scope | Errors only (red), no warnings | Many `warn` conditions are steady-state → amber would be permanent banner-blindness; errors are rare + actionable. |
+| Data source | Reuse `GET /summary`, read `doctor.summary.errors` | Already a cheap in-memory aggregate; adding a count endpoint is redundant surface (unlike Tasks, whose board fetch was heavy). |
+| Hook | Shared `useNavBadge` | Consistent with Tasks/messaging; idempotent + value-keyed. |
+
+## Architecture impact
+
+- Adds a reusable `doctorVersion` reactive signal to the SSE content-store — generalizes "doctor ran" for any future consumer, fed by the audit event that already crosses SSE. No new server broadcast, no new endpoint.
+- Health becomes the third nav-badge adopter, validating the infra for a **cron/cache-backed** data source (Tasks = file/SSE, messaging = file/SSE; Health = audit-event-driven cache).
+- No SDK API change (`doctorVersion` is internal content-store state; `useContentStore` export shape unchanged) — so no `sdk.md` regeneration.
+
+## Commit strategy
+
+Three commits, each independently revertable, each with tests:
+
+1. **`feat(host): doctorVersion SSE signal`**
+   - `use-content-store.ts` (`doctorVersion` + `bumpDoctor`), `use-sse.ts` (bump on `doctor.run` audit).
+   - Test: a `doctor.run` audit bumps `doctorVersion`; a non-doctor audit doesn't.
+   - Reusable infra; no Health code yet.
+
+2. **`feat(health): nav badge for failing checks`**
+   - `use-health-summary.ts`, `health-badge-provider.tsx`, `client.tsx` slot wiring.
+   - Tests: summary hook (reads errors, refetch on `doctorVersion`, missing-doctor → 0) + provider (errors→red, zero→null, transitions).
+
+3. **`docs: Health nav badge + doctorVersion signal`**
+   - `.claude/knowledge/plugin-system.md`.
+
+## Testing strategy
+
+- **Unit:** content-store/use-sse `doctorVersion` bump; the summary hook (mock fetch + `useContentStore`); the provider (mock the hook + `useNavBadge`).
+- **Manual:** imitation-crab — induce a failing check (e.g. stop the runtime / seed an error condition), confirm a red count appears on Health, clears when resolved; confirm it updates on the next `doctor.run` without reload.
+- No e2e.
+
+## Boundaries
+
+**Always:** `bun test --isolate` for touched files; update `.claude/knowledge/plugin-system.md` for the new signal/adopter.
+
+**Never:** poll or add a cron/heartbeat for the badge; badge on warnings; add a redundant count endpoint; auto-clear on unmount; add a second EventSource (reuse `doctorVersion`).

--- a/plugins/health/client.tsx
+++ b/plugins/health/client.tsx
@@ -4,6 +4,7 @@
 import { registerPlugin } from '@makinbakin/sdk'
 import type { NavItem } from '@makinbakin/sdk'
 import { HealthPage } from './components/health-page'
+import { HealthBadgeProvider } from './components/health-badge-provider'
 
 const navItems: NavItem[] = [
   { id: 'health', label: 'Health', icon: 'Activity', href: '/health', order: 85 },
@@ -14,5 +15,8 @@ registerPlugin({
   navItems,
   slots: {
     'page:/health': HealthPage,
+    // Background runner that keeps the Health nav badge (failing-check
+    // count) in sync. Renders nothing; stays mounted while registered.
+    'nav-badge-providers': HealthBadgeProvider,
   },
 })

--- a/plugins/health/components/health-badge-provider.tsx
+++ b/plugins/health/components/health-badge-provider.tsx
@@ -15,7 +15,7 @@ import { useHealthSummary } from '../hooks/use-health-summary'
 export function HealthBadgeProvider() {
   const { errors } = useHealthSummary()
 
-  const badge: NavBadge | null = errors && errors > 0
+  const badge: NavBadge | null = errors !== null && errors > 0
     ? { count: errors, tone: 'error' }
     : null
 

--- a/plugins/health/components/health-badge-provider.tsx
+++ b/plugins/health/components/health-badge-provider.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import type { NavBadge } from '@makinbakin/sdk'
+import { useNavBadge } from '@makinbakin/sdk/hooks'
+import { useHealthSummary } from '../hooks/use-health-summary'
+
+/**
+ * Background component (renders nothing) mounted via the host's
+ * `nav-badge-providers` slot. Shows a red `error` count on the Health nav
+ * item when doctor reports ≥1 failing check, cleared otherwise (bakin
+ * #265). Errors only — warnings are often steady-state per install and
+ * would make the badge permanent noise. Refresh rides the `doctorVersion`
+ * SSE signal — no cron, heartbeat, or poll.
+ */
+export function HealthBadgeProvider() {
+  const { errors } = useHealthSummary()
+
+  const badge: NavBadge | null = errors && errors > 0
+    ? { count: errors, tone: 'error' }
+    : null
+
+  useNavBadge('health', 'health', badge)
+
+  return null
+}

--- a/plugins/health/hooks/use-health-summary.ts
+++ b/plugins/health/hooks/use-health-summary.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useContentStore } from '@makinbakin/sdk/hooks'
+
+interface HealthSummaryResponse {
+  doctor: { summary?: { errors?: number; warnings?: number; total?: number } } | null
+}
+
+interface UseHealthSummaryResult {
+  errors: number | null
+}
+
+/**
+ * Count of failing (`status: 'error'`) doctor checks for the Health nav
+ * badge. Reads the existing `/summary` aggregate (cheap, in-memory) and
+ * refetches whenever the SSE-driven `doctorVersion` bumps — i.e. on every
+ * `doctor.run` (startup / watchdog interval / on-demand). No new EventSource,
+ * no poll. `errors` is null until the first load.
+ */
+export function useHealthSummary(): UseHealthSummaryResult {
+  const [errors, setErrors] = useState<number | null>(null)
+  const doctorVersion = useContentStore((s) => s.doctorVersion)
+
+  const refresh = useCallback(async () => {
+    try {
+      const response = await fetch('/api/plugins/health/summary')
+      if (!response.ok) throw new Error(`Failed to load health summary (${response.status})`)
+      const data = await response.json() as HealthSummaryResponse
+      setErrors(data.doctor?.summary?.errors ?? 0)
+    } catch (err) {
+      // Keep the last good value; the next doctor.run retries. Log at debug
+      // so a persistently-failing summary is diagnosable without noise.
+      console.debug('[health] nav-badge summary fetch failed', err)
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh, doctorVersion])
+
+  return { errors }
+}

--- a/src/hooks/use-content-store.ts
+++ b/src/hooks/use-content-store.ts
@@ -20,6 +20,7 @@ interface ContentStore extends ContentState {
   activityEvents: ActivityEvent[]
   sseConnected: boolean
   taskboardVersion: number
+  doctorVersion: number
   debug: boolean
   reindexProgress: Record<string, ReindexProgressEntry>
   setFiles: (files: Record<string, string>) => void
@@ -31,6 +32,7 @@ interface ContentStore extends ContentState {
   setActivityEvents: (events: ActivityEvent[]) => void
   setSseConnected: (connected: boolean) => void
   bumpTaskboard: () => void
+  bumpDoctor: () => void
   setDebug: (debug: boolean) => void
   toggleDebug: () => void
   setReindexProgress: (table: string, indexed: number, done: boolean) => void
@@ -47,6 +49,7 @@ export const useContentStore = create<ContentStore>((set, get) => ({
   activityEvents: [],
   sseConnected: false,
   taskboardVersion: 0,
+  doctorVersion: 0,
   debug: false,
   reindexProgress: {},
 
@@ -67,6 +70,7 @@ export const useContentStore = create<ContentStore>((set, get) => ({
     set({ activityEvents: events.filter((e) => !isNoisyEvent(e)).slice(0, 100) }),
   setSseConnected: (connected) => set({ sseConnected: connected }),
   bumpTaskboard: () => set((state) => ({ taskboardVersion: state.taskboardVersion + 1 })),
+  bumpDoctor: () => set((state) => ({ doctorVersion: state.doctorVersion + 1 })),
   setDebug: (debug) => {
     set({ debug })
     try { localStorage.setItem('bakin-debug', String(debug)) } catch {}

--- a/src/hooks/use-sse.ts
+++ b/src/hooks/use-sse.ts
@@ -23,6 +23,7 @@ export function useSSE() {
   const appendActivityEvent = useContentStore((s) => s.appendActivityEvent)
   const setSseConnected = useContentStore((s) => s.setSseConnected)
   const bumpTaskboard = useContentStore((s) => s.bumpTaskboard)
+  const bumpDoctor = useContentStore((s) => s.bumpDoctor)
   const setReindexProgress = useContentStore((s) => s.setReindexProgress)
   const esRef = useRef<EventSource | null>(null)
   const retryRef = useRef(0)
@@ -86,6 +87,9 @@ export function useSSE() {
             const entry = data.entry
             const entryData = entry.data || {}
             appendAuditEntry(entry)
+            // A doctor run just refreshed the health-check cache — bump a
+            // reactive signal the Health nav badge refetches on.
+            if (entry.event === 'doctor.run') bumpDoctor()
             appendActivityEvent({
               id: `${entry.ts}-${entry.event}-${entry.agent}`,
               ts: entry.ts,
@@ -233,5 +237,5 @@ export function useSSE() {
       esRef.current?.close()
       esRef.current = null
     }
-  }, [updateFile, setConnected, setHeartbeats, initialize, appendAuditEntry, appendActivityEvent, setSseConnected, bumpTaskboard, setReindexProgress])
+  }, [updateFile, setConnected, setHeartbeats, initialize, appendAuditEntry, appendActivityEvent, setSseConnected, bumpTaskboard, bumpDoctor, setReindexProgress])
 }

--- a/tests/components/content-store.test.ts
+++ b/tests/components/content-store.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-content-store-${Date.now()}`)
+
+// Defensive content-dir mocks per CLAUDE.md.
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+import { useContentStore } from '@/hooks/use-content-store'
+
+beforeEach(() => {
+  useContentStore.setState({ doctorVersion: 0, taskboardVersion: 0 })
+})
+
+describe('useContentStore — doctorVersion signal', () => {
+  it('bumpDoctor increments doctorVersion', () => {
+    expect(useContentStore.getState().doctorVersion).toBe(0)
+    useContentStore.getState().bumpDoctor()
+    expect(useContentStore.getState().doctorVersion).toBe(1)
+    useContentStore.getState().bumpDoctor()
+    expect(useContentStore.getState().doctorVersion).toBe(2)
+  })
+
+  it('bumpDoctor does not touch taskboardVersion (and vice versa)', () => {
+    useContentStore.getState().bumpDoctor()
+    expect(useContentStore.getState().taskboardVersion).toBe(0)
+    useContentStore.getState().bumpTaskboard()
+    expect(useContentStore.getState().doctorVersion).toBe(1)
+    expect(useContentStore.getState().taskboardVersion).toBe(1)
+  })
+})

--- a/tests/components/health-badge-provider.test.tsx
+++ b/tests/components/health-badge-provider.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-health-badge-${Date.now()}`)
+
+// Defensive content-dir mocks per CLAUDE.md (this test touches neither).
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+// Controllable error count from the mocked data hook.
+let mockErrors: number | null = null
+mock.module('../../plugins/health/hooks/use-health-summary', () => ({
+  useHealthSummary: () => ({ errors: mockErrors }),
+}))
+
+// Mock the shared useNavBadge hook — its wiring is covered in
+// tests/components/use-nav-badge.test.tsx. Assert the provider derives +
+// passes the right badge.
+const useNavBadge = mock()
+mock.module('@makinbakin/sdk/hooks', () => ({ useNavBadge }))
+
+import { cleanup, render } from '@testing-library/react'
+import { HealthBadgeProvider } from '../../plugins/health/components/health-badge-provider'
+
+beforeEach(() => {
+  mockErrors = null
+  useNavBadge.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('HealthBadgeProvider', () => {
+  it('renders nothing', () => {
+    const { container } = render(<HealthBadgeProvider />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('passes a red error badge with the failing-check count', () => {
+    mockErrors = 2
+    render(<HealthBadgeProvider />)
+    expect(useNavBadge).toHaveBeenLastCalledWith('health', 'health', { count: 2, tone: 'error' })
+  })
+
+  it('passes null when there are zero errors', () => {
+    mockErrors = 0
+    render(<HealthBadgeProvider />)
+    expect(useNavBadge).toHaveBeenLastCalledWith('health', 'health', null)
+  })
+
+  it('passes null before the summary has loaded', () => {
+    mockErrors = null
+    render(<HealthBadgeProvider />)
+    expect(useNavBadge).toHaveBeenLastCalledWith('health', 'health', null)
+  })
+
+  it('transitions error count → 0 (cleared)', () => {
+    mockErrors = 3
+    const { rerender } = render(<HealthBadgeProvider />)
+    expect(useNavBadge).toHaveBeenLastCalledWith('health', 'health', { count: 3, tone: 'error' })
+
+    mockErrors = 0
+    rerender(<HealthBadgeProvider />)
+    expect(useNavBadge).toHaveBeenLastCalledWith('health', 'health', null)
+  })
+})

--- a/tests/components/use-health-summary.test.tsx
+++ b/tests/components/use-health-summary.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-use-health-summary-${Date.now()}`)
+
+// Defensive content-dir mocks per CLAUDE.md.
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+// Controllable doctorVersion via a stubbed useContentStore selector.
+let mockDoctorVersion = 0
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useContentStore: (selector: (s: { doctorVersion: number }) => unknown) =>
+    selector({ doctorVersion: mockDoctorVersion }),
+}))
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { useHealthSummary } from '../../plugins/health/hooks/use-health-summary'
+
+function Probe() {
+  const { errors } = useHealthSummary()
+  return <span data-testid="errors">{errors === null ? 'null' : String(errors)}</span>
+}
+
+const fetchMock = mock()
+
+beforeEach(() => {
+  mockDoctorVersion = 0
+  fetchMock.mockReset()
+  ;(globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function summaryResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+}
+
+describe('useHealthSummary', () => {
+  it('extracts doctor.summary.errors', async () => {
+    fetchMock.mockResolvedValue(summaryResponse({ doctor: { summary: { errors: 3, warnings: 5 } } }))
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('errors').textContent).toBe('3'))
+  })
+
+  it('returns 0 when doctor is null', async () => {
+    fetchMock.mockResolvedValue(summaryResponse({ doctor: null }))
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('errors').textContent).toBe('0'))
+  })
+
+  it('returns 0 when the summary has no errors field', async () => {
+    fetchMock.mockResolvedValue(summaryResponse({ doctor: { summary: { warnings: 2 } } }))
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('errors').textContent).toBe('0'))
+  })
+
+  it('refetches when doctorVersion bumps', async () => {
+    fetchMock.mockResolvedValue(summaryResponse({ doctor: { summary: { errors: 1 } } }))
+    const { rerender } = render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('errors').textContent).toBe('1'))
+
+    fetchMock.mockClear()
+    fetchMock.mockResolvedValue(summaryResponse({ doctor: { summary: { errors: 4 } } }))
+    mockDoctorVersion = 1
+    rerender(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('errors').textContent).toBe('4'))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last good value on a failed fetch', async () => {
+    fetchMock.mockResolvedValue(summaryResponse({ doctor: { summary: { errors: 2 } } }))
+    const { rerender } = render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('errors').textContent).toBe('2'))
+
+    fetchMock.mockRejectedValue(new Error('network down'))
+    mockDoctorVersion = 1
+    rerender(<Probe />)
+    // Value is retained (no throw, no reset to null).
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(screen.getByTestId('errors').textContent).toBe('2')
+  })
+})

--- a/tests/components/use-sse-doctor.test.tsx
+++ b/tests/components/use-sse-doctor.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-use-sse-doctor-${Date.now()}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+import { render, waitFor } from '@testing-library/react'
+import { useSSE } from '@/hooks/use-sse'
+import { useContentStore } from '@/hooks/use-content-store'
+
+// Controllable EventSource — captures the instance so the test can drive
+// onmessage directly (no real network).
+let lastES: { onmessage: ((e: { data: string }) => void) | null; onopen: (() => void) | null; onerror: ((e?: unknown) => void) | null; close: () => void } | null = null
+class MockEventSource {
+  onmessage: ((e: { data: string }) => void) | null = null
+  onopen: (() => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  url: string
+  constructor(url: string) {
+    this.url = url
+    lastES = this
+  }
+  close() {}
+}
+
+function Probe() {
+  useSSE()
+  return null
+}
+
+function emitAudit(event: string) {
+  lastES?.onmessage?.({
+    data: JSON.stringify({ type: 'audit', entry: { event, ts: new Date().toISOString(), agent: 'system', data: {} } }),
+  })
+}
+
+beforeEach(() => {
+  lastES = null
+  useContentStore.setState({ doctorVersion: 0 })
+  ;(globalThis as { EventSource: unknown }).EventSource = MockEventSource as unknown
+  // initialize() fetches a few endpoints on mount — stub them to empty.
+  ;(globalThis as { fetch: typeof fetch }).fetch = (mock(async () => new Response('{}', { status: 200 }))) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  // Reset doctorVersion for isolation.
+  useContentStore.setState({ doctorVersion: 0 })
+})
+
+describe('useSSE — doctorVersion wiring', () => {
+  it('bumps doctorVersion on a doctor.run audit event', async () => {
+    render(<Probe />)
+    await waitFor(() => expect(lastES).not.toBeNull())
+
+    expect(useContentStore.getState().doctorVersion).toBe(0)
+    emitAudit('doctor.run')
+    expect(useContentStore.getState().doctorVersion).toBe(1)
+    emitAudit('doctor.run')
+    expect(useContentStore.getState().doctorVersion).toBe(2)
+  })
+
+  it('does NOT bump doctorVersion on a non-doctor audit event', async () => {
+    render(<Probe />)
+    await waitFor(() => expect(lastES).not.toBeNull())
+
+    emitAudit('task.created')
+    emitAudit('plan.updated')
+    expect(useContentStore.getState().doctorVersion).toBe(0)
+  })
+})


### PR DESCRIPTION
Third nav-badge adopter (after Tasks #377, messaging #40) — and the canonical use of the `error` tone. No change to existing badges.

## Summary
- **`doctorVersion` SSE signal (host)** — a reactive counter in the content-store (mirroring `taskboardVersion`), bumped in `use-sse` when a `doctor.run` audit event arrives. `runDiagnostics()` already emits that audit on every run, so this gives a "doctor ran" signal with **no new broadcast and no poll** — the clean pattern for a cron/cache-backed source.
- **Health badge** — `useHealthSummary` reads the existing `GET /summary` aggregate's `doctor.summary.errors` and refetches on `doctorVersion`; `HealthBadgeProvider` shows a red `error` count when ≥1 check fails, cleared otherwise, via the shared `useNavBadge` hook.
- **Errors only** — many `warn` checks are steady-state per install (search disabled, mcporter absent, …), so an amber fallback would be permanent banner-blindness.

## Commits
1. `feat(host): doctorVersion SSE signal`
2. `feat(health): nav badge for failing checks`
3. `docs: Health nav badge + doctorVersion signal`
4. `test(host): cover doctor.run→doctorVersion wiring; provider readability` (review fixes)

## Test plan
- [x] `bun test --isolate` on touched files — 14 pass (doctorVersion bump + isolation; summary hook extract/0-cases/refetch-on-bump/keep-on-failure; provider derive+transitions; **use-sse doctor.run→bump wiring** + non-doctor no-op)
- [x] `bun run typecheck` clean
- [x] Code review (high effort, 2 finders): top gap (untested SSE wiring) closed; readability nit fixed; inherent keep-last-value/no-poll tradeoffs documented (self-heal on next doctor.run)
- [x] Manual (imitation-crab): induce a failing check (e.g. stop the mock runtime) → Health shows red count on the next `doctor.run`; resolve → clears; no reload needed

## Scope
Single repo (bakin). Reuses `/summary` (no new endpoint). Spec: `.claude/specs/health-nav-badge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)