### PR TITLE
fix(images): idempotent billed image calls (no double-bill on client retry)

### DIFF
--- a/plugins/images/lib/idempotency.ts
+++ b/plugins/images/lib/idempotency.ts
@@ -1,0 +1,110 @@
+/**
+ * Idempotency for billed image calls.
+ *
+ * A billed `generate`/`edit` is non-idempotent at the provider, so a client
+ * (mcporter) that times out and retries an identical call would bill twice —
+ * Bakin finished server-side, but the client gave up and re-issued. This guards
+ * against that WITHOUT adding a retry: an identical call that is still in flight
+ * awaits the same promise, and an identical call within a short TTL after
+ * completion returns the cached result (the already-saved asset). Failures are
+ * never cached, so a genuine retry of a failed call proceeds.
+ *
+ * Process-local and in-memory by design (single user, single process).
+ */
+import { createHash } from 'node:crypto'
+import type { ExecToolResult } from '@bakin/core/plugin-types'
+
+/** Stable identity of a billed image call. Same parts ⇒ same provider work. */
+export interface ImageCallKey {
+  taskId: string
+  op: 'generate' | 'edit'
+  /** Source identifier for edits (managed filename or local path); null for generate. */
+  source: string | null
+  promptHash: string
+  provider: string
+  model: string
+  width: number
+  height: number
+  quality: string
+}
+
+export function imageCallSignature(key: ImageCallKey): string {
+  // Order-stable serialization of the fields that determine provider work.
+  const canonical = JSON.stringify([
+    key.taskId,
+    key.op,
+    key.source,
+    key.promptHash,
+    key.provider,
+    key.model,
+    key.width,
+    key.height,
+    key.quality,
+  ])
+  return createHash('sha256').update(canonical).digest('hex')
+}
+
+export interface IdempotencyOptions {
+  /** How long a completed result is reused, in ms. Default 5 minutes. */
+  ttlMs?: number
+  /** Injectable clock for tests. */
+  now?: () => number
+}
+
+export interface IdempotencyRegistry<T> {
+  run(signature: string, fn: () => Promise<T>, opts?: { cacheable?: (result: T) => boolean }): Promise<T>
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000
+
+/**
+ * Creates an isolated registry. The module-level `imageCallRegistry` below is the
+ * one production instances use; tests construct their own with an injected clock.
+ */
+export function createIdempotencyRegistry<T>(opts: IdempotencyOptions = {}): IdempotencyRegistry<T> {
+  const ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
+  const now = opts.now ?? (() => Date.now())
+  const inflight = new Map<string, Promise<T>>()
+  const completed = new Map<string, { result: T; expiresAt: number }>()
+
+  return {
+    run(signature, fn, runOpts) {
+      const pending = inflight.get(signature)
+      if (pending) return pending
+
+      const cached = completed.get(signature)
+      if (cached) {
+        if (cached.expiresAt > now()) return Promise.resolve(cached.result)
+        completed.delete(signature)
+      }
+
+      const promise = (async () => {
+        const result = await fn()
+        const cacheable = runOpts?.cacheable ? runOpts.cacheable(result) : true
+        if (cacheable) completed.set(signature, { result, expiresAt: now() + ttlMs })
+        return result
+      })()
+
+      inflight.set(signature, promise)
+      // Clear the in-flight slot once settled (success or failure); a failure is
+      // not cached above, so the next identical call re-issues.
+      return promise.finally(() => {
+        if (inflight.get(signature) === promise) inflight.delete(signature)
+      })
+    },
+  }
+}
+
+/** Production registry shared across all billed image calls in this process. */
+const imageCallRegistry = createIdempotencyRegistry<ExecToolResult>()
+
+/**
+ * Run a billed image operation idempotently. The result is cached only when it
+ * succeeded (`ok === true`); failures re-issue on the next identical call.
+ */
+export function runBilledImageCall(
+  key: ImageCallKey,
+  fn: () => Promise<ExecToolResult>,
+): Promise<ExecToolResult> {
+  return imageCallRegistry.run(imageCallSignature(key), fn, { cacheable: (r) => r.ok === true })
+}

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -9,6 +9,7 @@ import type { ImageProviderId } from '../types'
 import { effectiveImageSettings, getImageProvider, providerReadiness } from './providers'
 import { resolveImageRoute } from './routing'
 import { getImageProfile } from './platform-profiles'
+import { runBilledImageCall, type ImageCallKey } from './idempotency'
 import { getContentDir } from '../../../src/core/content-dir'
 
 /** Largest edge we send to a provider / feed into sharp, to bound cost. */
@@ -269,21 +270,37 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
   // can, or composes the shared direct-provider shim when it can't. The plugin
   // never touches provider HTTP or credentials.
   if (!ctx.runtime.images) return fail('The active runtime does not provide an image generation capability')
+  const runGenerate = ctx.runtime.images.generate
 
-  try {
-    const result = await ctx.runtime.images.generate({
-      prompt: req.prompt,
-      provider: req.route.provider,
-      model: req.route.model,
-      width: req.dims.width,
-      height: req.dims.height,
-      outputFormat: 'png',
-      metadata: { quality: req.quality },
-    })
-    return await persistImageAsset(ctx, params, agent, { req, result, tool: 'bakin_exec_images_generate', tag: 'generated' })
-  } catch (err) {
-    return fail(`Image generation failed: ${errorMessage(err)}`)
+  // Idempotent: a client (mcporter) timeout that retries this identical billed
+  // call must not bill twice — return the in-flight / just-saved result instead.
+  const key: ImageCallKey = {
+    taskId: params.taskId,
+    op: 'generate',
+    source: null,
+    promptHash: hashPrompt(req.prompt),
+    provider: req.route.provider,
+    model: req.route.model,
+    width: req.dims.width,
+    height: req.dims.height,
+    quality: req.quality,
   }
+  return runBilledImageCall(key, async () => {
+    try {
+      const result = await runGenerate({
+        prompt: req.prompt,
+        provider: req.route.provider,
+        model: req.route.model,
+        width: req.dims.width,
+        height: req.dims.height,
+        outputFormat: 'png',
+        metadata: { quality: req.quality },
+      })
+      return await persistImageAsset(ctx, params, agent, { req, result, tool: 'bakin_exec_images_generate', tag: 'generated' })
+    } catch (err) {
+      return fail(`Image generation failed: ${errorMessage(err)}`)
+    }
+  })
 }
 
 export async function editImage(ctx: PluginContext, params: ImagesEditParams, agent: string): Promise<ExecToolResult> {
@@ -305,22 +322,37 @@ export async function editImage(ctx: PluginContext, params: ImagesEditParams, ag
 
   // Edit is runtime-only — the shared shim does generation, not editing.
   if (!ctx.runtime.images?.edit) return fail('The active runtime does not provide an image edit capability')
+  const runEdit = ctx.runtime.images.edit
 
-  try {
-    const result = await ctx.runtime.images.edit({
-      prompt: req.prompt,
-      provider: req.route.provider,
-      model: req.route.model,
-      width: req.dims.width,
-      height: req.dims.height,
-      outputFormat: 'png',
-      files: [sourcePath],
-      metadata: { quality: req.quality },
-    })
-    return await persistImageAsset(ctx, params, agent, { req, result, tool: 'bakin_exec_images_edit', tag: 'edited' })
-  } catch (err) {
-    return fail(`Image edit failed: ${errorMessage(err)}`)
+  // Idempotent like generate: an identical retried edit must not double-bill.
+  const key: ImageCallKey = {
+    taskId: params.taskId,
+    op: 'edit',
+    source: params.filename ?? params.sourcePath ?? null,
+    promptHash: hashPrompt(req.prompt),
+    provider: req.route.provider,
+    model: req.route.model,
+    width: req.dims.width,
+    height: req.dims.height,
+    quality: req.quality,
   }
+  return runBilledImageCall(key, async () => {
+    try {
+      const result = await runEdit({
+        prompt: req.prompt,
+        provider: req.route.provider,
+        model: req.route.model,
+        width: req.dims.width,
+        height: req.dims.height,
+        outputFormat: 'png',
+        files: [sourcePath],
+        metadata: { quality: req.quality },
+      })
+      return await persistImageAsset(ctx, params, agent, { req, result, tool: 'bakin_exec_images_edit', tag: 'edited' })
+    } catch (err) {
+      return fail(`Image edit failed: ${errorMessage(err)}`)
+    }
+  })
 }
 
 export async function exportImage(ctx: PluginContext, params: ImagesExportParams, agent: string): Promise<ExecToolResult> {

--- a/tests/plugins/images/idempotency.test.ts
+++ b/tests/plugins/images/idempotency.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure in-memory idempotency registry for billed image calls — no filesystem,
+ * no content-dir, no runtime. Guards against the client-timeout double-bill:
+ * a retried identical billed call must NOT issue a second provider call.
+ */
+import { describe, it, expect } from 'bun:test'
+import {
+  imageCallSignature,
+  createIdempotencyRegistry,
+  type ImageCallKey,
+} from '../../../plugins/images/lib/idempotency'
+
+const baseKey: ImageCallKey = {
+  taskId: 'task-1',
+  op: 'generate',
+  source: null,
+  promptHash: 'sha256:abc',
+  provider: 'openai',
+  model: 'gpt-image-2',
+  width: 1024,
+  height: 1536,
+  quality: 'standard',
+}
+
+const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
+
+describe('imageCallSignature', () => {
+  it('is stable for identical keys', () => {
+    expect(imageCallSignature(baseKey)).toBe(imageCallSignature({ ...baseKey }))
+  })
+
+  it('differs when any field differs', () => {
+    const sig = imageCallSignature(baseKey)
+    expect(imageCallSignature({ ...baseKey, op: 'edit' })).not.toBe(sig)
+    expect(imageCallSignature({ ...baseKey, promptHash: 'sha256:def' })).not.toBe(sig)
+    expect(imageCallSignature({ ...baseKey, model: 'other' })).not.toBe(sig)
+    expect(imageCallSignature({ ...baseKey, width: 512 })).not.toBe(sig)
+    expect(imageCallSignature({ ...baseKey, source: 'a.png' })).not.toBe(sig)
+    expect(imageCallSignature({ ...baseKey, taskId: 'task-2' })).not.toBe(sig)
+  })
+})
+
+describe('createIdempotencyRegistry', () => {
+  it('dedups concurrent identical calls to a single fn invocation', async () => {
+    const reg = createIdempotencyRegistry<{ ok: true; n: number }>()
+    let calls = 0
+    const fn = async () => { calls++; await delay(10); return { ok: true as const, n: calls } }
+    const [a, b] = await Promise.all([reg.run('sig', fn), reg.run('sig', fn)])
+    expect(calls).toBe(1)
+    expect(a).toBe(b) // same result object — second caller got the first's result
+  })
+
+  it('returns the cached result for an identical call within TTL (no re-issue)', async () => {
+    const reg = createIdempotencyRegistry<{ ok: true }>()
+    let calls = 0
+    const fn = async () => { calls++; return { ok: true as const } }
+    await reg.run('sig', fn)
+    await reg.run('sig', fn)
+    expect(calls).toBe(1)
+  })
+
+  it('issues separate calls for distinct signatures', async () => {
+    const reg = createIdempotencyRegistry<{ ok: true }>()
+    let calls = 0
+    const fn = async () => { calls++; return { ok: true as const } }
+    await reg.run('sig-a', fn)
+    await reg.run('sig-b', fn)
+    expect(calls).toBe(2)
+  })
+
+  it('does not cache a non-cacheable (failed) result — a later call re-issues', async () => {
+    const reg = createIdempotencyRegistry<{ ok: boolean }>()
+    let calls = 0
+    const fn = async () => { calls++; return { ok: false } }
+    await reg.run('sig', fn, { cacheable: r => r.ok })
+    await reg.run('sig', fn, { cacheable: r => r.ok })
+    expect(calls).toBe(2)
+  })
+
+  it('does not cache a thrown error — a later call re-issues', async () => {
+    const reg = createIdempotencyRegistry<{ ok: true }>()
+    let calls = 0
+    const fn = async () => { calls++; throw new Error('boom') }
+    await expect(reg.run('sig', fn)).rejects.toThrow('boom')
+    await expect(reg.run('sig', fn)).rejects.toThrow('boom')
+    expect(calls).toBe(2)
+  })
+
+  it('re-issues once the cached result has expired (TTL)', async () => {
+    let t = 1000
+    const reg = createIdempotencyRegistry<{ ok: true }>({ ttlMs: 100, now: () => t })
+    let calls = 0
+    const fn = async () => { calls++; return { ok: true as const } }
+    await reg.run('sig', fn)          // calls=1, cached until t=1100
+    t = 1050; await reg.run('sig', fn) // within TTL → cached
+    expect(calls).toBe(1)
+    t = 1200; await reg.run('sig', fn) // expired → re-issue
+    expect(calls).toBe(2)
+  })
+})


### PR DESCRIPTION
## What
Guards billed `generate`/`edit` against the **client-timeout double-bill**: when the MCP client (mcporter) call timeout is shorter than gpt-image-2's ~60–90s, the agent retries a call that already succeeded server-side — billing twice and minting a duplicate asset.

Observed: task `033d9a50`, two `edit.ok`, duplicate assets `5cdc25a9` ≈ `189e8b37`. Bakin's own subprocess timeout (`OPENCLAW_IMAGE_PROCESS_TIMEOUT_MS = 600000`, 10 min) was never the limiter — the give-up is client-side.

## How
New process-local idempotency registry (`plugins/images/lib/idempotency.ts`) keyed by a signature over `{taskId, op, source, promptHash, provider, model, width, height, quality}`:
- identical call **in flight** → awaits the same promise (one provider call)
- identical call **within a 5-min TTL** after completion → returns the cached result (the already-saved asset)
- **failures are never cached** → a genuine retry still proceeds

This does **not** add a retry — it preserves the "no auto-retry on billed calls" invariant; it dedups. Wired around `runtime.images.generate`/`.edit` in `generateImage`/`editImage`.

## Tests
`tests/plugins/images/idempotency.test.ts` (pure, in-memory): signature stability, concurrent identical → 1 call, sequential identical within TTL → cached, distinct signatures → 2 calls, failure not cached, TTL expiry re-issues. Full suite 4262 pass / 0 fail; typecheck clean.

## Follow-up (separate)
Pixel's mcporter call-timeout bump ships in bakin-bits. This is PR A of the versioned-assets effort (spec `.claude/specs/versioned-assets.md`); PR B (the asset-as-directory refactor) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)