### PR TITLE
fix(release): gate smoke-sdk on npm version visibility (#371)

### DIFF
--- a/.claude/knowledge/release-pipeline.md
+++ b/.claude/knowledge/release-pipeline.md
@@ -57,7 +57,7 @@ On success, the script moves `[Unreleased]` into a concrete changelog section, c
 11. Render the Homebrew formula for all tags.
 12. Stable only: push `Formula/bakin.rb` to `markhayden/homebrew-tap`.
 13. Publish/undraft the GitHub release.
-14. `release.yml` runs post-publish smoke jobs, which verify binaries, SDK install/imports, and stable Homebrew install/test.
+14. `release.yml` runs post-publish smoke jobs, which verify binaries, SDK install/imports, and stable Homebrew install/test. The SDK smoke first runs `scripts/wait-for-npm-version.ts` to gate on the exact version becoming resolvable on npm (bounded exponential backoff, loud failure at the deadline), closing the read-after-write propagation race before `bun add`.
 
 If the Homebrew push fails, the GitHub release remains draft. Fix the tap/push issue and rerun the tail before publishing the release.
 

--- a/.claude/specs/371-npm-availability-gate.md
+++ b/.claude/specs/371-npm-availability-gate.md
@@ -63,7 +63,7 @@ export interface WaitOptions {
   maxDelayMs: number      // default 30_000
 }
 
-export function parseArgs(argv: string[], env?: ...): WaitOptions
+export function parseArgs(argv: string[]): WaitOptions
   // flags: --package, --version, --timeout (seconds), --base-delay (seconds), --max-delay (seconds)
 
 export async function waitForNpmVersion(

--- a/.claude/specs/371-npm-availability-gate.md
+++ b/.claude/specs/371-npm-availability-gate.md
@@ -1,0 +1,159 @@
+# Spec: npm availability gate before SDK smoke install
+
+Tracking issue: [#371](https://github.com/markhayden/bakin/issues/371) — "Fix release SDK smoke race after npm publish"
+
+## 1. Objective
+
+The release workflow's `smoke-sdk` job runs `bun add ... "@makinbakin/sdk@${VERSION}"` immediately after the `publish` job finishes. npm registry propagation for a freshly published exact version is not always instantaneous, so the install can fail with:
+
+```
+error: No version matching "0.0.1-rc.8" found for specifier "@makinbakin/sdk" (but package exists)
+```
+
+This is a read-after-write propagation race, not a bad build — rerunning the failed job later succeeds. The objective is to make the release pipeline resilient to npm propagation delay by gating the smoke install on the exact version becoming resolvable, with a bounded wait and loud failure if it never appears.
+
+**Target user:** the release maintainer (this machine is the only user). Success = no manual `smoke-sdk` reruns required for this race.
+
+## 2. Decisions (resolved during interview)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Where the gate lives | New standalone, unit-tested TS script `scripts/wait-for-npm-version.ts`, mirroring the `publish-sdk.ts` pattern (injectable `CommandRunner`, `parseArgs`, loud failure). The `smoke-sdk` job calls it via `bun run` before `bun add`. |
+| 2 | Polling policy | Exponential backoff, **time-bounded**. Per-attempt delay `min(baseDelay * 2^n, maxDelay)`, capped at `maxDelay`; stop on success or when a total deadline (`timeout`) elapses. Defaults: `timeout` 120s, `baseDelay` 2s, `maxDelay` 30s. All configurable via flags. |
+| 3 | `bun add` retry | **Gate only.** Trust that once `npm view pkg@version` resolves, a single `bun add` will succeed. No belt-and-suspenders retry on `bun add`. |
+| 4 | Code sharing | **Extract** `scripts/lib/npm-registry.ts` as the single source of truth for the "version resolves vs 404 vs real error" classification and the `CommandRunner`/`CommandResult` types. Both `publish-sdk.ts` and the new gate import it. (`scripts/lib/common.ts` is exec-tool-oriented and imports `@bakin/core/plugin-types`, so it is the wrong home.) |
+| 5 | Interface generality | **Generic, defaults to SDK.** `--package` defaults to `PUBLIC_SDK_PACKAGE_NAME` (`@makinbakin/sdk`); `--version` required and validated with the same `RELEASE_VERSION_RE` as `publish-sdk.ts`. Smoke step only needs to pass `--version`. |
+
+Standing project constraints (from kickoff): reduce tech debt; no backwards-compat shims; this machine is the only user; keep it clean and clear.
+
+## 3. Components
+
+### 3.1 `scripts/lib/npm-registry.ts` (new shared module)
+
+Single source of truth for npm-view classification, extracted from `publish-sdk.ts`.
+
+```ts
+export interface CommandResult { status: number | null; stdout: string; stderr: string }
+export type CommandRunner = (cmd: string, args: string[], cwd: string) => CommandResult
+
+/**
+ * Classify the result of `npm view <pkg>@<version> version --json`.
+ *  true  -> the exact version resolves (exit 0)
+ *  false -> registry says it does not exist yet (E404 / 404 / "is not in this registry" / "No match found")
+ *  null  -> ambiguous/real error (network, auth, etc.) — caller must fail loudly
+ */
+export function versionResolves(result: CommandResult): boolean | null
+
+export function runCommand(cmd: string, args: string[], cwd: string): CommandResult // spawnSync wrapper
+export function npmViewArgs(pkg: string, version: string): string[] // ['view', `${pkg}@${version}`, 'version', '--json']
+```
+
+- `versionResolves` is the renamed/relocated `packageAlreadyExistsResult` (same regex, same semantics).
+- `runCommand` is the `spawnSync` wrapper currently private in `publish-sdk.ts`.
+- `publish-sdk.ts` is refactored to import `CommandResult`, `CommandRunner`, `runCommand`, `versionResolves`, `npmViewArgs` from this module. Its public `CommandRunner` type re-export stays (the test imports it from `../../scripts/publish-sdk`) — re-export from the new module to avoid churn in the publish-sdk test, OR update the import; chosen approach: **re-export the type** from `publish-sdk.ts` so `publish-sdk.test.ts` is untouched. (No behavior change to `publish-sdk.ts`.)
+
+### 3.2 `scripts/wait-for-npm-version.ts` (new gate script)
+
+```ts
+export interface WaitOptions {
+  package: string       // default PUBLIC_SDK_PACKAGE_NAME
+  version: string       // required, RELEASE_VERSION_RE
+  timeoutMs: number      // default 120_000
+  baseDelayMs: number    // default 2_000
+  maxDelayMs: number      // default 30_000
+}
+
+export function parseArgs(argv: string[], env?: ...): WaitOptions
+  // flags: --package, --version, --timeout (seconds), --base-delay (seconds), --max-delay (seconds)
+
+export async function waitForNpmVersion(
+  opts: WaitOptions,
+  deps?: { runner?: CommandRunner; sleep?: (ms: number) => Promise<void>; now?: () => number },
+): Promise<void>   // resolves when version is visible; throws on timeout or real error
+```
+
+Behavior:
+- Loop: run `npm view <pkg>@<version> version --json`, classify with `versionResolves`.
+  - `true` → log success (attempt #, elapsed) and return.
+  - `null` → throw immediately (real error; echo npm output). Do **not** keep polling through a genuine failure.
+  - `false` → not visible yet; if the next delay would exceed the deadline, throw a clear timeout error; else log attempt + next delay, `await sleep(delay)`, continue.
+- Per-attempt log line: attempt number, elapsed seconds, and the next delay (e.g. `[wait-for-npm-version] @makinbakin/sdk@X not visible yet (attempt 3, 6s elapsed); retrying in 8s`).
+- Timeout error message names the package, version, elapsed time, and attempt count.
+- `main()` mirrors `publish-sdk.ts`: parse argv, run, `catch` → print message + `process.exit(1)`. No GitHub-specific `::error::` annotations (consistent with `publish-sdk.ts`).
+- **Testability:** `sleep` and `now` are injectable so unit tests simulate transient 404→availability and deadline exhaustion with zero real time elapsed.
+
+### 3.3 `.github/workflows/release.yml` — `smoke-sdk` job
+
+Insert a gate step before the existing install. The job already has Bun set up.
+
+```yaml
+- name: Wait for SDK version to be resolvable on npm
+  shell: bash
+  run: bun run scripts/wait-for-npm-version.ts --version "${VERSION}"
+
+- name: Install exact SDK version and import subpaths
+  shell: bash
+  run: |
+    set -euo pipefail
+    ... (unchanged bun add + import checks)
+```
+
+(`--package` omitted — defaults to `@makinbakin/sdk`.) The repo is not checked out in `smoke-sdk` today; add a checkout step pinned to the release commit (matching other jobs: `ref: ${{ needs.gate.outputs.commit }}`) plus `bun install --frozen-lockfile` only if the script needs deps — the gate only shells out to `npm`/`bun -e`, so it needs the **repo source** but not node_modules. Add a lightweight checkout of `needs.gate.outputs.commit`; no `bun install` required. (`smoke-sdk` gains `needs: [gate, publish]` already present.)
+
+## 4. Commands
+
+- Run gate locally / in CI: `bun run scripts/wait-for-npm-version.ts --version <X> [--package <name>] [--timeout <s>] [--base-delay <s>] [--max-delay <s>]`
+- Tests: `bun test tests/scripts/wait-for-npm-version.test.ts --isolate`
+- Full suite: `bun test --isolate`
+- Lint / typecheck: `bun run lint && bun run typecheck`
+
+## 5. Testing strategy
+
+New file `tests/scripts/wait-for-npm-version.test.ts`, following `publish-sdk.test.ts` conventions (injected `runner`, no real npm calls). Inject `sleep` (no-op) and `now` (manual clock) so no test waits in real time.
+
+`parseArgs`:
+- Resolves `--version`, defaults `--package` to `@makinbakin/sdk`, defaults timing values.
+- Parses `--timeout`/`--base-delay`/`--max-delay` (seconds → ms).
+- Rejects malformed version (reuses `RELEASE_VERSION_RE`) and missing flag values (`requires a value`).
+
+`waitForNpmVersion`:
+- **Transient 404 then availability** (the core acceptance criterion): runner returns E404 for the first N calls, then a resolving `"X"` JSON; assert it returns, polled the expected number of times, and slept between attempts.
+- **Immediate availability:** resolves on first `npm view` with no sleep.
+- **Real error fails fast:** runner returns a non-404 failure (e.g. `network failed`); assert it throws without exhausting the timeout (does not treat it as "not visible yet").
+- **Deadline exhaustion:** runner always returns E404; with a manual clock advanced past `timeout`, assert it throws a bounded timeout error naming package/version and does not loop forever.
+- **Backoff shape:** assert delays follow `min(base*2^n, maxDelay)` and are capped at `maxDelay`.
+
+Existing `tests/scripts/publish-sdk.test.ts` must stay green after the helper extraction (no behavior change). If the type re-export approach is taken, that test needs no edits.
+
+## 6. Documentation impact
+
+- `.claude/knowledge/release-pipeline.md` — CI Sequence section: note the smoke-sdk job waits for npm visibility before install.
+- `.claude/specs/release-pipeline.md` — update the smoke-jobs description to include the availability gate.
+- `CHANGELOG.md` — add a bullet under `## [Unreleased]` (`### Fixed`): release SDK smoke no longer races npm propagation.
+- README.md — **not impacted** (no smoke/propagation content; verified).
+
+## 7. Boundaries
+
+**Always:** keep the gate failure loud and bounded; preserve `publish-sdk.ts` behavior exactly during extraction; mirror existing script/test conventions; update the three docs above.
+
+**Ask first:** any change that alters `publish-sdk.ts` *behavior* (vs. pure extraction); changing default timing values materially; touching other release jobs (`smoke-binaries`, `smoke-homebrew`, `publish`).
+
+**Never:** add a `bun add` retry (explicitly out of scope per decision #3); fold the wait into `publish-sdk.ts` (decision #1); introduce a long-lived npm token or any new secret; add backwards-compat shims.
+
+## 8. Acceptance criteria (from issue)
+
+- [x] `smoke-sdk` waits for the exact SDK version to be resolvable before `bun add`.
+- [x] The wait is bounded and emits useful attempt/timing logs.
+- [x] A script test covers transient npm 404 followed by availability.
+- [x] No future rerun needed for this specific race.
+
+## 9. Commit strategy
+
+Natural checkpoints for rollback (filled in detail during `/agent-skills:plan`):
+
+1. `refactor(scripts): extract shared npm-registry helper from publish-sdk` — pure extraction; `publish-sdk.test.ts` stays green. Safe standalone checkpoint.
+2. `feat(scripts): add bounded npm version availability gate` — new `wait-for-npm-version.ts` + its test.
+3. `ci(release): gate smoke-sdk on npm version visibility` — wire the step (+ checkout) into `release.yml`.
+4. `docs: record npm availability gate in release pipeline + changelog` — knowledge/spec/CHANGELOG updates.
+
+Each commit builds, lints, typechecks, and passes tests independently.

--- a/.claude/specs/release-pipeline.md
+++ b/.claude/specs/release-pipeline.md
@@ -296,11 +296,12 @@ Each step:
 4. `actual=$(./<artifact> --version)`; `expected=${{ github.event.release.tag_name }}`; assert `actual == ${expected#v}`
 
 **`sdk` job:**
-1. `runs-on: ubuntu-latest`, install Bun (`oven-sh/setup-bun`)
-2. `mkdir scratch && cd scratch && bun init -y`
-3. `bun add react@^19 react-dom@^19 @makinbakin/sdk@<exact-tag-version>` (not `latest` — verify the exact published version)
-4. `bun -e "import('@makinbakin/sdk').then(m => { if (typeof m.registerPlugin !== 'function') throw new Error('missing registerPlugin'); })"`
-5. One `bun -e "import('@makinbakin/sdk/<subpath>')"` line per entry in the SDK's `exports` map
+1. `runs-on: ubuntu-latest`, check out the release commit (needed for the gate script), install Bun (`oven-sh/setup-bun`)
+2. **npm availability gate:** `bun run scripts/wait-for-npm-version.ts --version <exact-tag-version>` polls `npm view` with bounded exponential backoff until the exact version resolves, then proceeds; it fails loudly at the deadline. Closes the read-after-write propagation race that previously let `bun add` fail right after publish. (Helper logic shared with `publish-sdk.ts` via `scripts/lib/npm-registry.ts`.)
+3. `mkdir scratch && cd scratch && bun init -y`
+4. `bun add react@^19 react-dom@^19 @makinbakin/sdk@<exact-tag-version>` (not `latest` — verify the exact published version)
+5. `bun -e "import('@makinbakin/sdk').then(m => { if (typeof m.registerPlugin !== 'function') throw new Error('missing registerPlugin'); })"`
+6. One `bun -e "import('@makinbakin/sdk/<subpath>')"` line per entry in the SDK's `exports` map
 
 **Critical:** the smoke uses Bun because Bakin plugin authors target Bun. The package must still be a real published package: built JS, declarations, no repo-only imports, and installable from a clean directory.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,8 +436,19 @@ jobs:
     env:
       VERSION: ${{ needs.gate.outputs.version }}
     steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.commit }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Wait for SDK version to be resolvable on npm
+        shell: bash
+        run: bun run scripts/wait-for-npm-version.ts --version "${VERSION}"
 
       - name: Install exact SDK version and import subpaths
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+### Fixed
+- Gate the release `smoke-sdk` job on the exact SDK version becoming resolvable on npm (bounded exponential backoff via `scripts/wait-for-npm-version.ts`) so it no longer races registry propagation right after publish.
+
 ## [0.0.1-rc.8] - 2026-05-28
 
 ### Changed

--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -595,7 +595,10 @@ function readSdkExports(): SdkSubpath[] {
     },
   })
 
-  const checker = program.getTypeChecker()
+  // Binds the program so node.getSourceFile()/getText() resolve while walking
+  // declarations below. The checker value itself is unused — only this side
+  // effect matters — so it is not threaded through the extract helpers.
+  program.getTypeChecker()
   const result: SdkSubpath[] = []
 
   for (const { importPath, sourcePath } of subpathSources) {
@@ -604,7 +607,7 @@ function readSdkExports(): SdkSubpath[] {
       result.push({ importPath, source: relativeSource(sourcePath), symbols: [] })
       continue
     }
-    const symbols = extractSdkSymbols(sourceFile, checker)
+    const symbols = extractSdkSymbols(sourceFile)
     result.push({ importPath, source: relativeSource(sourcePath), symbols })
   }
   return result
@@ -626,7 +629,7 @@ function jsdocTextOf(node: ts.Node): string {
   return ''
 }
 
-function extractSdkSymbols(sourceFile: ts.SourceFile, checker: ts.TypeChecker): SdkSymbol[] {
+function extractSdkSymbols(sourceFile: ts.SourceFile): SdkSymbol[] {
   const symbols: SdkSymbol[] = []
 
   ts.forEachChild(sourceFile, (node) => {
@@ -644,7 +647,7 @@ function extractSdkSymbols(sourceFile: ts.SourceFile, checker: ts.TypeChecker): 
         jsdoc: jsdocTextOf(node),
       }
       if (CORE_TYPES.has(name)) {
-        sym.members = extractInterfaceMembers(node, checker)
+        sym.members = extractInterfaceMembers(node)
       }
       symbols.push(sym)
       return
@@ -744,7 +747,7 @@ function inferKindFromName(name: string): SdkSymbol['kind'] {
   return 'function'
 }
 
-function extractInterfaceMembers(node: ts.InterfaceDeclaration, checker: ts.TypeChecker): SdkMember[] {
+function extractInterfaceMembers(node: ts.InterfaceDeclaration): SdkMember[] {
   const members: SdkMember[] = []
   for (const member of node.members) {
     if (!ts.isPropertySignature(member) && !ts.isMethodSignature(member)) continue

--- a/scripts/lib/npm-registry.ts
+++ b/scripts/lib/npm-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared npm registry helpers for release tooling.
+ *
+ * Single source of truth for classifying `npm view <pkg>@<version>` results
+ * ("resolves" vs "not in registry yet" vs "real error") and for the small
+ * command-runner seam that lets release scripts be unit-tested without
+ * shelling out. Consumed by both `publish-sdk.ts` and `wait-for-npm-version.ts`.
+ */
+import { spawnSync } from 'node:child_process'
+
+export interface CommandResult {
+  status: number | null
+  stdout: string
+  stderr: string
+}
+
+export type CommandRunner = (cmd: string, args: string[], cwd: string) => CommandResult
+
+export function runCommand(cmd: string, args: string[], cwd: string): CommandResult {
+  const result = spawnSync(cmd, args, {
+    cwd,
+    encoding: 'utf-8',
+  })
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+/** Args for `npm view <pkg>@<version> version --json`. */
+export function npmViewArgs(pkg: string, version: string): string[] {
+  return ['view', `${pkg}@${version}`, 'version', '--json']
+}
+
+/**
+ * Classify the result of `npm view <pkg>@<version> version --json`.
+ *   true  → the exact version resolves on the registry (exit 0)
+ *   false → the registry reports it does not exist yet (E404 / 404 / not-in-registry)
+ *   null  → ambiguous / real failure (network, auth, etc.); caller must fail loudly
+ */
+export function versionResolves(result: CommandResult): boolean | null {
+  if (result.status === 0) return true
+  const output = `${result.stdout}\n${result.stderr}`
+  if (/E404|404 Not Found|is not in this registry|No match found/i.test(output)) return false
+  return null
+}

--- a/scripts/lib/npm-registry.ts
+++ b/scripts/lib/npm-registry.ts
@@ -16,10 +16,16 @@ export interface CommandResult {
 
 export type CommandRunner = (cmd: string, args: string[], cwd: string) => CommandResult
 
-export function runCommand(cmd: string, args: string[], cwd: string): CommandResult {
+export interface RunCommandOptions {
+  /** Hard cap per invocation; a timed-out process is killed and surfaces as status null. */
+  timeoutMs?: number
+}
+
+export function runCommand(cmd: string, args: string[], cwd: string, opts: RunCommandOptions = {}): CommandResult {
   const result = spawnSync(cmd, args, {
     cwd,
     encoding: 'utf-8',
+    ...(opts.timeoutMs ? { timeout: opts.timeoutMs } : {}),
   })
   return {
     status: result.status,
@@ -37,7 +43,10 @@ export function npmViewArgs(pkg: string, version: string): string[] {
  * Classify the result of `npm view <pkg>@<version> version --json`.
  *   true  → the exact version resolves on the registry (exit 0)
  *   false → the registry reports it does not exist yet (E404 / 404 / not-in-registry)
- *   null  → ambiguous / real failure (network, auth, etc.); caller must fail loudly
+ *   null  → ambiguous / real failure (network, auth, timeout/kill → status null); caller must fail loudly
+ *
+ * The not-found match is best-effort; the `null` default is the real safety net,
+ * so anything we cannot confidently read as "not published yet" fails loudly.
  */
 export function versionResolves(result: CommandResult): boolean | null {
   if (result.status === 0) return true

--- a/scripts/publish-sdk.ts
+++ b/scripts/publish-sdk.ts
@@ -8,16 +8,23 @@
  * source repositories.
  */
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
-import { spawnSync } from 'node:child_process'
 import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
 import { PUBLIC_SDK_PACKAGE_NAME, buildSdkPackage } from './build-sdk-package'
+import {
+  type CommandResult,
+  type CommandRunner,
+  npmViewArgs,
+  runCommand,
+  versionResolves,
+} from './lib/npm-registry'
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const SDK_PACKAGE_NAME = PUBLIC_SDK_PACKAGE_NAME
 const RELEASE_VERSION_RE = /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/
 
 export { PUBLIC_SDK_PACKAGE_NAME }
+export type { CommandRunner }
 
 export interface PublishSdkOptions {
   version: string
@@ -28,29 +35,10 @@ export interface PublishSdkOptions {
   provenance: boolean
 }
 
-interface CommandResult {
-  status: number | null
-  stdout: string
-  stderr: string
-}
-
-export type CommandRunner = (cmd: string, args: string[], cwd: string) => CommandResult
 export type SdkPackageBuilder = (opts: { version: string; outDir: string }) => Promise<void>
 
 function readJson<T>(path: string): T {
   return JSON.parse(readFileSync(path, 'utf-8')) as T
-}
-
-function runCommand(cmd: string, args: string[], cwd: string): CommandResult {
-  const result = spawnSync(cmd, args, {
-    cwd,
-    encoding: 'utf-8',
-  })
-  return {
-    status: result.status,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-  }
 }
 
 function stripTagPrefix(ref: string): string {
@@ -125,13 +113,6 @@ export function parseArgs(argv: string[], env: Record<string, string | undefined
   }
 }
 
-function packageAlreadyExistsResult(result: CommandResult): boolean | null {
-  if (result.status === 0) return true
-  const output = `${result.stdout}\n${result.stderr}`
-  if (/E404|404 Not Found|is not in this registry|No match found/i.test(output)) return false
-  return null
-}
-
 function echoResult(result: CommandResult): void {
   if (result.stdout) process.stdout.write(result.stdout)
   if (result.stderr) process.stderr.write(result.stderr)
@@ -155,7 +136,7 @@ function isDuplicateTransparencyLogError(result: CommandResult): boolean {
 }
 
 function packageExists(runner: CommandRunner, viewArgs: string[]): boolean | null {
-  return packageAlreadyExistsResult(runner('npm', viewArgs, REPO_ROOT))
+  return versionResolves(runner('npm', viewArgs, REPO_ROOT))
 }
 
 export async function publishSdkPackage(
@@ -172,7 +153,7 @@ export async function publishSdkPackage(
   await builder({ version: opts.version, outDir: packageDir })
   assertGeneratedPackage(packageDir, opts.version)
 
-  const viewArgs = ['view', `${SDK_PACKAGE_NAME}@${opts.version}`, 'version', '--json']
+  const viewArgs = npmViewArgs(SDK_PACKAGE_NAME, opts.version)
   const primaryPublishArgs = publishArgs(opts.tag, opts.provenance)
 
   if (opts.dryRun) {
@@ -183,7 +164,7 @@ export async function publishSdkPackage(
   }
 
   const view = runner('npm', viewArgs, REPO_ROOT)
-  const exists = packageAlreadyExistsResult(view)
+  const exists = versionResolves(view)
   if (exists === true) {
     echoResult(view)
     console.log(`${SDK_PACKAGE_NAME}@${opts.version} already exists on npm; skipping publish`)

--- a/scripts/wait-for-npm-version.ts
+++ b/scripts/wait-for-npm-version.ts
@@ -21,6 +21,9 @@ import {
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const RELEASE_VERSION_RE = /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/
+// Hard cap per `npm view` so a stalled registry call can never hang the gate
+// past its deadline; a killed call surfaces as status null → loud failure.
+const NPM_VIEW_TIMEOUT_MS = 30_000
 
 export { PUBLIC_SDK_PACKAGE_NAME }
 
@@ -97,8 +100,9 @@ export function parseArgs(argv: string[]): WaitOptions {
 }
 
 function echoResult(result: CommandResult): void {
-  if (result.stdout) process.stdout.write(result.stdout)
-  if (result.stderr) process.stderr.write(result.stderr)
+  const trailingNewline = (text: string): string => (text.endsWith('\n') ? text : `${text}\n`)
+  if (result.stdout) process.stdout.write(trailingNewline(result.stdout))
+  if (result.stderr) process.stderr.write(trailingNewline(result.stderr))
 }
 
 /**
@@ -106,21 +110,22 @@ function echoResult(result: CommandResult): void {
  * a real npm error or when the version is still unavailable at the deadline.
  */
 export async function waitForNpmVersion(opts: WaitOptions, deps: WaitDeps = {}): Promise<void> {
-  const runner = deps.runner ?? runCommand
+  const runner = deps.runner ?? ((cmd, args, cwd) => runCommand(cmd, args, cwd, { timeoutMs: NPM_VIEW_TIMEOUT_MS }))
   const sleep = deps.sleep ?? realSleep
   const now = deps.now ?? Date.now
 
   const target = `${opts.package}@${opts.version}`
   const viewArgs = npmViewArgs(opts.package, opts.version)
   const start = now()
-  const elapsedSeconds = () => Math.round((now() - start) / 1000)
+  const secs = (ms: number): number => Math.round(ms / 1000)
 
   for (let attempt = 0; ; attempt++) {
     const result = runner('npm', viewArgs, REPO_ROOT)
     const resolved = versionResolves(result)
+    const elapsed = now() - start
 
     if (resolved === true) {
-      console.log(`${target} is resolvable on npm (attempt ${attempt + 1}, ${elapsedSeconds()}s elapsed)`)
+      console.log(`${target} is resolvable on npm (attempt ${attempt + 1}, ${secs(elapsed)}s elapsed)`)
       return
     }
     if (resolved === null) {
@@ -128,17 +133,20 @@ export async function waitForNpmVersion(opts: WaitOptions, deps: WaitDeps = {}):
       throw new Error(`Could not check npm package version ${target}`)
     }
 
-    const delay = Math.min(opts.baseDelayMs * 2 ** attempt, opts.maxDelayMs)
-    if (now() - start + delay > opts.timeoutMs) {
+    // Clamp the backoff to the remaining budget so the full --timeout is used;
+    // give up only once there is no time left for another check.
+    const remaining = opts.timeoutMs - elapsed
+    const delay = Math.min(opts.baseDelayMs * 2 ** attempt, opts.maxDelayMs, remaining)
+    if (delay <= 0) {
       throw new Error(
-        `${target} did not become resolvable on npm within ${Math.round(opts.timeoutMs / 1000)}s ` +
-          `(${attempt + 1} attempts, ${elapsedSeconds()}s elapsed)`,
+        `${target} did not become resolvable on npm within ${secs(opts.timeoutMs)}s ` +
+          `(${attempt + 1} attempts, ${secs(elapsed)}s elapsed)`,
       )
     }
 
     console.log(
-      `${target} not visible on npm yet (attempt ${attempt + 1}, ${elapsedSeconds()}s elapsed); ` +
-        `retrying in ${Math.round(delay / 1000)}s`,
+      `${target} not visible on npm yet (attempt ${attempt + 1}, ${secs(elapsed)}s elapsed); ` +
+        `retrying in ${secs(delay)}s`,
     )
     await sleep(delay)
   }

--- a/scripts/wait-for-npm-version.ts
+++ b/scripts/wait-for-npm-version.ts
@@ -1,0 +1,156 @@
+/**
+ * Bounded npm registry availability gate.
+ *
+ * Polls `npm view <pkg>@<version> version --json` until the exact version
+ * resolves on the registry, using exponential backoff under a total deadline.
+ * Exists to close the read-after-write propagation race between publishing a
+ * package and installing it (e.g. the release `smoke-sdk` job's `bun add`).
+ *
+ * Resolves silently once the version is visible; throws (and exits non-zero)
+ * on a real npm error or when the version is still unavailable at the deadline.
+ */
+import { resolve } from 'node:path'
+import { PUBLIC_SDK_PACKAGE_NAME } from './build-sdk-package'
+import {
+  type CommandResult,
+  type CommandRunner,
+  npmViewArgs,
+  runCommand,
+  versionResolves,
+} from './lib/npm-registry'
+
+const REPO_ROOT = resolve(import.meta.dir, '..')
+const RELEASE_VERSION_RE = /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/
+
+export { PUBLIC_SDK_PACKAGE_NAME }
+
+export interface WaitOptions {
+  package: string
+  version: string
+  timeoutMs: number
+  baseDelayMs: number
+  maxDelayMs: number
+}
+
+export interface WaitDeps {
+  runner?: CommandRunner
+  sleep?: (ms: number) => Promise<void>
+  now?: () => number
+}
+
+function realSleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms))
+}
+
+export function parseArgs(argv: string[]): WaitOptions {
+  let pkg = ''
+  let version = ''
+  let timeoutSeconds = 120
+  let baseDelaySeconds = 2
+  let maxDelaySeconds = 30
+
+  const takeValue = (index: number, name: string): string => {
+    const value = argv[index + 1] ?? ''
+    if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`)
+    return value
+  }
+
+  const takeSeconds = (index: number, name: string): number => {
+    const value = Number(takeValue(index, name))
+    if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a positive number of seconds`)
+    return value
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--package') {
+      pkg = takeValue(i, '--package')
+      i += 1
+    } else if (arg === '--version') {
+      version = takeValue(i, '--version')
+      i += 1
+    } else if (arg === '--timeout') {
+      timeoutSeconds = takeSeconds(i, '--timeout')
+      i += 1
+    } else if (arg === '--base-delay') {
+      baseDelaySeconds = takeSeconds(i, '--base-delay')
+      i += 1
+    } else if (arg === '--max-delay') {
+      maxDelaySeconds = takeSeconds(i, '--max-delay')
+      i += 1
+    } else {
+      throw new Error(`Unexpected argument: ${arg}`)
+    }
+  }
+
+  if (!RELEASE_VERSION_RE.test(version)) {
+    throw new Error('version must be MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-rc.N')
+  }
+
+  return {
+    package: pkg || PUBLIC_SDK_PACKAGE_NAME,
+    version,
+    timeoutMs: timeoutSeconds * 1000,
+    baseDelayMs: baseDelaySeconds * 1000,
+    maxDelayMs: maxDelaySeconds * 1000,
+  }
+}
+
+function echoResult(result: CommandResult): void {
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+}
+
+/**
+ * Poll npm until `package@version` resolves. Resolves on visibility; throws on
+ * a real npm error or when the version is still unavailable at the deadline.
+ */
+export async function waitForNpmVersion(opts: WaitOptions, deps: WaitDeps = {}): Promise<void> {
+  const runner = deps.runner ?? runCommand
+  const sleep = deps.sleep ?? realSleep
+  const now = deps.now ?? Date.now
+
+  const target = `${opts.package}@${opts.version}`
+  const viewArgs = npmViewArgs(opts.package, opts.version)
+  const start = now()
+  const elapsedSeconds = () => Math.round((now() - start) / 1000)
+
+  for (let attempt = 0; ; attempt++) {
+    const result = runner('npm', viewArgs, REPO_ROOT)
+    const resolved = versionResolves(result)
+
+    if (resolved === true) {
+      console.log(`${target} is resolvable on npm (attempt ${attempt + 1}, ${elapsedSeconds()}s elapsed)`)
+      return
+    }
+    if (resolved === null) {
+      echoResult(result)
+      throw new Error(`Could not check npm package version ${target}`)
+    }
+
+    const delay = Math.min(opts.baseDelayMs * 2 ** attempt, opts.maxDelayMs)
+    if (now() - start + delay > opts.timeoutMs) {
+      throw new Error(
+        `${target} did not become resolvable on npm within ${Math.round(opts.timeoutMs / 1000)}s ` +
+          `(${attempt + 1} attempts, ${elapsedSeconds()}s elapsed)`,
+      )
+    }
+
+    console.log(
+      `${target} not visible on npm yet (attempt ${attempt + 1}, ${elapsedSeconds()}s elapsed); ` +
+        `retrying in ${Math.round(delay / 1000)}s`,
+    )
+    await sleep(delay)
+  }
+}
+
+async function main(): Promise<void> {
+  await waitForNpmVersion(parseArgs(process.argv.slice(2)))
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err))
+    process.exit(1)
+  })
+}

--- a/src/hooks/use-nav-badge.ts
+++ b/src/hooks/use-nav-badge.ts
@@ -21,5 +21,6 @@ export function useNavBadge(pluginId: string, navItemId: string, badge: NavBadge
   const key = badge ? `${badge.count ?? ''}:${badge.tone ?? ''}` : 'null'
   useEffect(() => {
     setNavBadge(pluginId, navItemId, badge)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: keyed on `key`, not `badge` identity (see above)
   }, [pluginId, navItemId, key])
 }

--- a/tests/components/use-sse-doctor.test.tsx
+++ b/tests/components/use-sse-doctor.test.tsx
@@ -19,18 +19,20 @@ import { useSSE } from '@/hooks/use-sse'
 import { useContentStore } from '@/hooks/use-content-store'
 
 // Controllable EventSource — captures the instance so the test can drive
-// onmessage directly (no real network).
-let lastES: { onmessage: ((e: { data: string }) => void) | null; onopen: (() => void) | null; onerror: ((e?: unknown) => void) | null; close: () => void } | null = null
-class MockEventSource {
-  onmessage: ((e: { data: string }) => void) | null = null
-  onopen: (() => void) | null = null
-  onerror: ((e?: unknown) => void) | null = null
+// onmessage directly (no real network). A factory (constructor returning an
+// object) avoids aliasing `this` while still satisfying `new EventSource()`.
+interface MockEventSource {
+  onmessage: ((e: { data: string }) => void) | null
+  onopen: (() => void) | null
+  onerror: ((e?: unknown) => void) | null
   url: string
-  constructor(url: string) {
-    this.url = url
-    lastES = this
-  }
-  close() {}
+  close: () => void
+}
+let lastES: MockEventSource | null = null
+function createMockEventSource(url: string): MockEventSource {
+  const es: MockEventSource = { onmessage: null, onopen: null, onerror: null, url, close() {} }
+  lastES = es
+  return es
 }
 
 function Probe() {
@@ -47,7 +49,7 @@ function emitAudit(event: string) {
 beforeEach(() => {
   lastES = null
   useContentStore.setState({ doctorVersion: 0 })
-  ;(globalThis as { EventSource: unknown }).EventSource = MockEventSource as unknown
+  ;(globalThis as { EventSource: unknown }).EventSource = createMockEventSource as unknown
   // initialize() fetches a few endpoints on mount — stub them to empty.
   ;(globalThis as { fetch: typeof fetch }).fetch = (mock(async () => new Response('{}', { status: 200 }))) as unknown as typeof fetch
 })

--- a/tests/scripts/npm-registry.test.ts
+++ b/tests/scripts/npm-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { npmViewArgs, versionResolves, type CommandResult } from '../../scripts/lib/npm-registry'
+import { npmViewArgs, runCommand, versionResolves, type CommandResult } from '../../scripts/lib/npm-registry'
 
 function result(partial: Partial<CommandResult>): CommandResult {
   return { status: 1, stdout: '', stderr: '', ...partial }
@@ -40,5 +40,13 @@ describe('versionResolves', () => {
   it('returns null for an ambiguous / real failure so the caller fails loudly', () => {
     expect(versionResolves(result({ stderr: 'npm ERR! network request failed' }))).toBeNull()
     expect(versionResolves(result({ status: null, stderr: 'killed by signal' }))).toBeNull()
+  })
+})
+
+describe('runCommand timeout', () => {
+  it('kills a hung process at the deadline and surfaces a null status (classified as a loud failure)', () => {
+    const result = runCommand('sleep', ['5'], process.cwd(), { timeoutMs: 50 })
+    expect(result.status).toBeNull()
+    expect(versionResolves(result)).toBeNull()
   })
 })

--- a/tests/scripts/npm-registry.test.ts
+++ b/tests/scripts/npm-registry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test'
+import { npmViewArgs, versionResolves, type CommandResult } from '../../scripts/lib/npm-registry'
+
+function result(partial: Partial<CommandResult>): CommandResult {
+  return { status: 1, stdout: '', stderr: '', ...partial }
+}
+
+describe('npmViewArgs', () => {
+  it('builds the npm view command for an exact version', () => {
+    expect(npmViewArgs('@makinbakin/sdk', '0.0.1-rc.8')).toEqual([
+      'view',
+      '@makinbakin/sdk@0.0.1-rc.8',
+      'version',
+      '--json',
+    ])
+  })
+})
+
+describe('versionResolves', () => {
+  it('returns true when npm view exits 0', () => {
+    expect(versionResolves(result({ status: 0, stdout: '"0.0.1-rc.8"\n' }))).toBe(true)
+  })
+
+  it('returns false for every recognized "not in registry yet" signal', () => {
+    const notFoundSignals = [
+      'npm ERR! code E404',
+      'npm ERR! 404 Not Found - GET https://registry.npmjs.org/@makinbakin%2fsdk',
+      'npm ERR! @makinbakin/sdk@9.9.9 is not in this registry',
+      'No match found for version 9.9.9',
+    ]
+    for (const stderr of notFoundSignals) {
+      expect(versionResolves(result({ stderr }))).toBe(false)
+    }
+  })
+
+  it('detects the not-found signal in stdout as well as stderr', () => {
+    expect(versionResolves(result({ stdout: 'E404 not found' }))).toBe(false)
+  })
+
+  it('returns null for an ambiguous / real failure so the caller fails loudly', () => {
+    expect(versionResolves(result({ stderr: 'npm ERR! network request failed' }))).toBeNull()
+    expect(versionResolves(result({ status: null, stderr: 'killed by signal' }))).toBeNull()
+  })
+})

--- a/tests/scripts/wait-for-npm-version.test.ts
+++ b/tests/scripts/wait-for-npm-version.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  PUBLIC_SDK_PACKAGE_NAME,
+  parseArgs,
+  waitForNpmVersion,
+  type WaitDeps,
+} from '../../scripts/wait-for-npm-version'
+import type { CommandResult, CommandRunner } from '../../scripts/lib/npm-registry'
+
+const NOT_FOUND: CommandResult = {
+  status: 1,
+  stdout: '',
+  stderr: 'npm ERR! code E404\nnpm ERR! 404 Not Found - GET https://registry.npmjs.org/...',
+}
+
+function resolved(version: string): CommandResult {
+  return { status: 0, stdout: `"${version}"\n`, stderr: '' }
+}
+
+/** Manual clock: advances only when sleep() is called, so tests never wait in real time. */
+function fakeClock(): WaitDeps & { slept: number[]; viewCalls: number } {
+  let clock = 0
+  const slept: number[] = []
+  const harness = {
+    slept,
+    viewCalls: 0,
+    sleep: async (ms: number) => {
+      slept.push(ms)
+      clock += ms
+    },
+    now: () => clock,
+  }
+  return harness as WaitDeps & { slept: number[]; viewCalls: number }
+}
+
+function runnerFrom(sequence: CommandResult[], harness: { viewCalls: number }): CommandRunner {
+  let i = 0
+  return ((cmd, args) => {
+    expect(cmd).toBe('npm')
+    expect(args[0]).toBe('view')
+    harness.viewCalls += 1
+    const result = sequence[Math.min(i, sequence.length - 1)]
+    i += 1
+    return result
+  }) satisfies CommandRunner
+}
+
+describe('parseArgs', () => {
+  it('defaults package to the SDK and applies default timing', () => {
+    expect(parseArgs(['--version', '0.1.0-rc.1'])).toEqual({
+      package: PUBLIC_SDK_PACKAGE_NAME,
+      version: '0.1.0-rc.1',
+      timeoutMs: 120_000,
+      baseDelayMs: 2_000,
+      maxDelayMs: 30_000,
+    })
+  })
+
+  it('parses package override and converts timing flags from seconds to ms', () => {
+    expect(parseArgs([
+      '--package', '@scope/foo',
+      '--version', '1.2.3',
+      '--timeout', '30',
+      '--base-delay', '1',
+      '--max-delay', '10',
+    ])).toEqual({
+      package: '@scope/foo',
+      version: '1.2.3',
+      timeoutMs: 30_000,
+      baseDelayMs: 1_000,
+      maxDelayMs: 10_000,
+    })
+  })
+
+  it('rejects malformed versions, missing values, and non-positive timing', () => {
+    expect(() => parseArgs(['--version', '0.1.0-beta.1'])).toThrow('version must')
+    expect(() => parseArgs([])).toThrow('version must')
+    expect(() => parseArgs(['--version'])).toThrow('requires a value')
+    expect(() => parseArgs(['--version', '1.0.0', '--timeout', '0'])).toThrow('positive')
+    expect(() => parseArgs(['--version', '1.0.0', '--unknown'])).toThrow('Unexpected argument')
+  })
+})
+
+describe('waitForNpmVersion', () => {
+  it('returns immediately when the version already resolves', async () => {
+    const harness = fakeClock()
+    const runner = runnerFrom([resolved('1.0.0')], harness)
+    await waitForNpmVersion(
+      { package: PUBLIC_SDK_PACKAGE_NAME, version: '1.0.0', timeoutMs: 120_000, baseDelayMs: 2_000, maxDelayMs: 30_000 },
+      { ...harness, runner },
+    )
+    expect(harness.viewCalls).toBe(1)
+    expect(harness.slept).toEqual([])
+  })
+
+  it('polls past transient 404s until the version becomes visible', async () => {
+    const harness = fakeClock()
+    const runner = runnerFrom([NOT_FOUND, NOT_FOUND, resolved('0.0.1-rc.8')], harness)
+    await waitForNpmVersion(
+      { package: PUBLIC_SDK_PACKAGE_NAME, version: '0.0.1-rc.8', timeoutMs: 120_000, baseDelayMs: 2_000, maxDelayMs: 30_000 },
+      { ...harness, runner },
+    )
+    expect(harness.viewCalls).toBe(3)
+    expect(harness.slept).toEqual([2_000, 4_000])
+  })
+
+  it('fails fast on a real (non-404) error without exhausting the timeout', async () => {
+    const harness = fakeClock()
+    const runner = runnerFrom([{ status: 1, stdout: '', stderr: 'network failed' }], harness)
+    await expect(waitForNpmVersion(
+      { package: PUBLIC_SDK_PACKAGE_NAME, version: '1.0.0', timeoutMs: 120_000, baseDelayMs: 2_000, maxDelayMs: 30_000 },
+      { ...harness, runner },
+    )).rejects.toThrow('Could not check')
+    expect(harness.viewCalls).toBe(1)
+    expect(harness.slept).toEqual([])
+  })
+
+  it('throws a bounded error when the version never appears before the deadline', async () => {
+    const harness = fakeClock()
+    const runner = runnerFrom([NOT_FOUND], harness)
+    await expect(waitForNpmVersion(
+      { package: PUBLIC_SDK_PACKAGE_NAME, version: '2.0.0', timeoutMs: 10_000, baseDelayMs: 2_000, maxDelayMs: 30_000 },
+      { ...harness, runner },
+    )).rejects.toThrow(/2\.0\.0/)
+    // 0s: delay 2000 (ok) -> 2000; delay 4000 (ok) -> 6000; delay 8000 would pass 10000 -> throw
+    expect(harness.viewCalls).toBe(3)
+    expect(harness.slept).toEqual([2_000, 4_000])
+  })
+
+  it('caps the backoff delay at maxDelayMs', async () => {
+    const harness = fakeClock()
+    const seq = [NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, resolved('3.0.0')]
+    const runner = runnerFrom(seq, harness)
+    await waitForNpmVersion(
+      { package: PUBLIC_SDK_PACKAGE_NAME, version: '3.0.0', timeoutMs: 1_000_000_000, baseDelayMs: 2_000, maxDelayMs: 30_000 },
+      { ...harness, runner },
+    )
+    expect(harness.slept).toEqual([2_000, 4_000, 8_000, 16_000, 30_000, 30_000])
+  })
+})

--- a/tests/scripts/wait-for-npm-version.test.ts
+++ b/tests/scripts/wait-for-npm-version.test.ts
@@ -122,9 +122,11 @@ describe('waitForNpmVersion', () => {
       { package: PUBLIC_SDK_PACKAGE_NAME, version: '2.0.0', timeoutMs: 10_000, baseDelayMs: 2_000, maxDelayMs: 30_000 },
       { ...harness, runner },
     )).rejects.toThrow(/2\.0\.0/)
-    // 0s: delay 2000 (ok) -> 2000; delay 4000 (ok) -> 6000; delay 8000 would pass 10000 -> throw
-    expect(harness.viewCalls).toBe(3)
-    expect(harness.slept).toEqual([2_000, 4_000])
+    // Delay is clamped to the remaining budget so the full 10s is used:
+    // 0s -> sleep 2000; 2s -> sleep 4000; 6s -> sleep min(8000, 4000)=4000;
+    // 10s -> no budget left -> throw. Four checks, full deadline consumed.
+    expect(harness.viewCalls).toBe(4)
+    expect(harness.slept).toEqual([2_000, 4_000, 4_000])
   })
 
   it('caps the backoff delay at maxDelayMs', async () => {


### PR DESCRIPTION
## Summary

Fixes #371 — the release `smoke-sdk` job could fail in `bun add "@makinbakin/sdk@${VERSION}"` immediately after a successful `Publish SDK to npm`, because npm registry propagation for the freshly published exact version is not always instantaneous (a read-after-write race). Reruns later succeeded, confirming propagation lag rather than a bad build.

This adds a bounded npm availability gate that `smoke-sdk` runs before `bun add`, so the exact version is confirmed resolvable on the registry first.

## What changed

- **`scripts/lib/npm-registry.ts`** (new) — single source of truth for npm-view classification (`versionResolves`: resolves / not-in-registry / ambiguous-error), the `CommandRunner`/`CommandResult` seam, and `npmViewArgs`. Extracted from `publish-sdk.ts`, which now imports it (behavior unchanged, `CommandRunner` re-exported so its test is untouched).
- **`scripts/wait-for-npm-version.ts`** (new) — bounded gate. Polls `npm view <pkg>@<version>` with exponential backoff (`min(base*2^n, maxDelay)`) under a total deadline; resolves on visibility, fails fast on a real npm error, fails loudly at the deadline. `--package` defaults to `@makinbakin/sdk`; `--timeout`/`--base-delay`/`--max-delay` configurable (defaults 120s / 2s / 30s).
- **`.github/workflows/release.yml`** — `smoke-sdk` checks out the release commit and runs the gate before `bun add`. Pinned `setup-bun` to `.bun-version` to match the other release jobs.
- **Docs** — release runbook + spec updated; `CHANGELOG.md [Unreleased]` entry; issue #371 decision record under `.claude/specs/`.
- **Lint cleanup** — cleared three pre-existing repo lint violations (unused `checker` param in docs generator, `no-this-alias` in an SSE test, intentional `exhaustive-deps` omission documented).

## Testing

- `tests/scripts/wait-for-npm-version.test.ts` — transient 404→available (core AC), immediate hit, real-error fast-fail, bounded deadline exhaustion, backoff capping; `parseArgs` defaults/validation. Injected `runner`/`sleep`/`now` so no real time elapses.
- `tests/scripts/npm-registry.test.ts` — direct coverage of the shared classifier across all branches + every recognized 404 signal.
- Full suite: **4267 pass / 0 fail**. `typecheck` + `lint` clean. `docs:generate` exits 0 with no output drift.
- Real npm sanity check: a published version resolves on attempt 1 (exit 0); a nonexistent version fails loudly at the deadline (exit 1).

## Acceptance criteria (#371)

- [x] `smoke-sdk` waits for the exact version to be resolvable before `bun add`
- [x] Bounded wait with attempt/timing logs
- [x] Script test covers transient npm 404 followed by availability
- [x] No future rerun needed for this race

🤖 Generated with [Claude Code](https://claude.com/claude-code)
