### PR TITLE
Fix schedule cron double execution

### DIFF
--- a/.claude/specs/schedule-plugin-audit.md
+++ b/.claude/specs/schedule-plugin-audit.md
@@ -19,7 +19,8 @@ Success means we can answer, with evidence:
 - Runtime timing is delegated to `ctx.runtime.cron`.
 - Bakin metadata is stored in `~/.bakin/schedule/sidecar.json`.
 - OpenClaw cron records are managed by the Gateway-backed `openclaw cron` CLI. Raw snapshot capture/restore still reads `OPENCLAW_HOME/cron/jobs.json` to preserve provider-specific fields during adoption.
-- OpenClaw adapter creates Bakin schedules as main-session `systemEvent` cron jobs with payload text like `bakin:schedule:<name-or-id>`.
+- Prior to the 2026-05-31 follow-up fix, the OpenClaw adapter created Bakin schedules as main-session `systemEvent` cron jobs with payload text like `bakin:schedule:<name-or-id>`.
+- The affected machine showed one enabled OpenClaw cron job and one successful cron fire, but two Bakin execution paths: the Schedule reconciler created the canonical scheduled task, while the cron-launched main session separately called `bakin_exec_tasks_create`.
 - Installed OpenClaw 2026.5.4 reports `openclaw cron` as "Manage cron jobs (via Gateway)" and exposes `cron add|edit|rm|run|runs|show|status`.
 - The Bakin OpenClaw adapter previously shelled out for `cron run`, but create/update/delete/list/get read or wrote `cron/jobs.json` directly. That was fixed so live cron operations go through the OpenClaw CLI/Gateway path.
 - The maintainer README says OpenClaw webhook delivery is not canonical for task creation; the Schedule plugin reconciler polls successful runtime cron runs and creates Bakin tasks.
@@ -59,6 +60,20 @@ The reported symptom, a visually Bakin-owned schedule with no run history, is mo
 
 The fix is to make OpenClaw cron list/get/create/update/delete and run-history reads use the same `openclaw cron` CLI surface the scheduler owns. Schedule continues to own sidecar metadata and task creation. Raw snapshot capture/restore remains file-based only for native-job adoption rollback.
 
+## Follow-Up Triage: Duplicate Scheduled Runs
+
+The later affected-machine triage ruled out duplicate cron registration for issue #393. The persisted evidence showed:
+
+- one enabled OpenClaw cron job
+- one OpenClaw run at `2026-05-31T15:00:00Z`
+- one Schedule-reconciled task created at `2026-05-31T15:00:59Z`
+- one separate main-session-created Bakin task at `2026-05-31T15:02:15Z`
+- both tasks posted to Discord
+
+Root cause: Bakin-owned cron jobs were delivered to OpenClaw as main-session system events. OpenClaw recorded the timer run, which Schedule correctly reconciled into a task, but it also woke the main Bakin session with normal orchestrator context. The main session interpreted the schedule event as work and created its own task.
+
+The Bakin-side fix is to keep OpenClaw as the timer but stop waking `main` for Bakin-owned schedules. Since OpenClaw requires a payload, the OpenClaw adapter now registers Bakin cron jobs as isolated, no-delivery, light-context agent turns with the reserved `bakin:*` marker. Schedule remains the only canonical creator of tasks for successful runtime runs.
+
 ## Commands
 
 - Focused verification: `bun test --isolate tests/plugins/schedule tests/adapter-openclaw/runtime-cron.test.ts tests/plugins/tasks/scheduled.test.ts tests/dev/mock-runtime-contract.test.ts`
@@ -85,7 +100,7 @@ The fix is to make OpenClaw cron list/get/create/update/delete and run-history r
 ## Testing Strategy
 
 - Preserve existing focused Schedule/OpenClaw cron suite.
-- Add adapter regression coverage proving Bakin schedules call `openclaw cron add --session main --system-event`.
+- Add adapter regression coverage proving Bakin schedules do not call `openclaw cron add --session main --system-event`; they use isolated no-delivery timer payloads.
 - Add adapter regression coverage proving native cron tool allowlists use `--tools` / `--clear-tools`.
 - Add a contract test proving provider-generated cron ids are accepted by Schedule sidecar metadata.
 - Update docs where the bridge/reconciler contract is inconsistent.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1068,8 +1068,23 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     const args = cronUpdateArgs(id, current, patch)
     if (args.length > 5) await this.execCron(args)
 
+    const effective = cronJobFromUpdatePatch(id, current, patch)
     const refreshed = await this.getCronJob(id).catch(() => null)
-    return refreshed ?? cronJobFromUpdatePatch(id, current, patch)
+    if (!refreshed) return effective
+
+    const command = patch.command ?? refreshed.command
+    const metadata = patch.metadata ?? refreshed.metadata
+    const bakinCron = isBakinCron(command, metadata)
+    return {
+      ...refreshed,
+      command,
+      metadata,
+      toolsAllow: bakinCron
+        ? undefined
+        : patch.toolsAllow !== undefined
+          ? effective.toolsAllow
+          : refreshed.toolsAllow,
+    }
   }
 
   private async listCronRuns(jobId: string): Promise<CronRun[]> {
@@ -1652,15 +1667,16 @@ function cronStoreJobToRuntime(job: OpenClawCronStoreJob): CronJob {
   const metadata = scheduleTz && !metadataValue(job.metadata, 'tz')
     ? { ...(job.metadata ?? {}), tz: scheduleTz }
     : job.metadata
+  const command = typeof job.payload?.message === 'string'
+    ? job.payload.message
+    : typeof job.payload?.text === 'string'
+      ? job.payload.text
+      : ''
   return {
     id: job.id,
     name: job.name ?? job.id,
     schedule: cronScheduleToString(job.schedule),
-    command: typeof job.payload?.message === 'string'
-      ? job.payload.message
-      : typeof job.payload?.text === 'string'
-        ? job.payload.text
-        : '',
+    command,
     enabled: job.enabled ?? true,
     toolsAllow: normalizeCronToolsAllow(job.payload?.toolsAllow),
     metadata,
@@ -1722,7 +1738,15 @@ function appendCronPayloadArgs(
   opts: { allowClearTools?: boolean } = {},
 ): void {
   if (isBakinCron(command, metadata)) {
-    args.push('--session', 'main', '--system-event', command)
+    args.push(
+      '--session',
+      'isolated',
+      '--message',
+      command,
+      '--no-deliver',
+      '--light-context',
+    )
+    if (opts.allowClearTools !== false) args.push('--clear-tools')
     return
   }
 
@@ -1788,7 +1812,10 @@ function cronPayloadForCommand(
   current: OpenClawCronStoreJob['payload'],
   bakinSchedule: boolean,
 ): OpenClawCronStoreJob['payload'] {
-  if (bakinSchedule || current?.kind === 'systemEvent') {
+  if (bakinSchedule) {
+    return { kind: 'agentTurn', message: command }
+  }
+  if (current?.kind === 'systemEvent') {
     return { kind: 'systemEvent', text: command }
   }
   return { ...(current ?? {}), kind: 'agentTurn', message: command }

--- a/plugins/schedule/README.md
+++ b/plugins/schedule/README.md
@@ -26,6 +26,14 @@ Runtime cron fires   →  OpenClaw records a cron run
 
 The `/bridge` endpoint remains as a private callback path for future runtimes or explicit webhook callers, but OpenClaw webhook delivery is not the canonical path for task creation.
 
+OpenClaw currently requires cron jobs to have either an agent-turn message or a
+main-session system-event payload. Bakin-owned schedules use an isolated,
+no-delivery, light-context agent-turn whose message stays in the reserved
+`bakin:*` namespace. This keeps OpenClaw's cron runner and run history active
+without waking the main Bakin session, which would otherwise see the schedule
+event as normal work and could create a second task before the reconciler creates
+the canonical scheduled task.
+
 ### Runtime vs Bakin Ownership
 
 Schedule jobs have three user-visible states:
@@ -159,7 +167,7 @@ When the reconciler or bridge processes a successful runtime run, the shared tas
 
 OpenClaw supports per-cron tool policy on native isolated agent-turn jobs through `payload.toolsAllow` (`openclaw cron add/edit --tools`). The OpenClaw runtime adapter maps that field to `CronJob.toolsAllow` so Schedule can display and audit it without shelling out to the provider CLI.
 
-Bakin-owned schedules are different: runtime cron acts as a timer and Bakin creates tasks after successful runs are reconciled. Those jobs do not rely on cron `toolsAllow` for the eventual task's MCP permissions. Hard scoping of `bakin_exec_*` MCP tools is a separate Bakin routing-layer concern tracked outside this plugin.
+Bakin-owned schedules are different: runtime cron acts as a timer and Bakin creates tasks after successful runs are reconciled. The OpenClaw adapter deliberately leaves cron `toolsAllow` unset for Bakin-owned schedule timers because OpenClaw treats an allowlist with no registered tools as a failed run. These jobs do not rely on cron `toolsAllow` for the eventual task's MCP permissions. Hard scoping of `bakin_exec_*` MCP tools is a separate Bakin routing-layer concern tracked outside this plugin.
 
 Common native cron examples:
 

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -4,7 +4,7 @@
  */
 import { randomBytes, timingSafeEqual } from 'crypto'
 import { z } from 'zod'
-import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
+import type { BakinPlugin, HealthCheckResult, HealthRepairHandler, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin, defineRoute, searchRoute } from '@bakin/core/routing'
 import type { CronJob, CronRun, UpdateCronJobInput } from '@bakin/core/adapters/runtime'
 import { readMergedJobs } from './lib/jobs-reader'
@@ -209,6 +209,174 @@ function scheduleUpdateMetadata(meta: BakinJobMeta): UpdateCronJobInput['metadat
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function needsBakinCronWakeRepair(raw: unknown): boolean {
+  if (!isRecord(raw)) return false
+  const payload = isRecord(raw.payload) ? raw.payload : null
+  return raw.sessionTarget === 'main' || payload?.kind === 'systemEvent'
+}
+
+function scheduleMetadataForRepair(meta: BakinJobMeta): UpdateCronJobInput['metadata'] {
+  return scheduleUpdateMetadata(meta) ?? {
+    scheduleType: 'cron',
+    bakinSchedule: true,
+    ...(meta.logicalJobId ? { logicalJobId: meta.logicalJobId } : {}),
+  }
+}
+
+interface LegacyCronRepairSummary {
+  checked: number
+  repaired: number
+  failed: number
+  remainingLegacy: number
+}
+
+async function repairMainSessionBakinCronPayloads(ctx: PluginContext): Promise<LegacyCronRepairSummary> {
+  const summary: LegacyCronRepairSummary = { checked: 0, repaired: 0, failed: 0, remainingLegacy: 0 }
+  const jobs = Object.values(readSidecar().jobs).filter(job => job.isBakinJob)
+  for (const meta of jobs) {
+    summary.checked += 1
+    try {
+      const raw = await ctx.runtime.cron.getRaw(meta.jobId, 'schedule startup checks for legacy main-session Bakin cron payloads')
+      if (!needsBakinCronWakeRepair(raw)) continue
+      const runtime = await ctx.runtime.cron.get(meta.jobId)
+      const runtimeCommand = runtime?.command?.trim() ?? ''
+      const command = runtimeCommand.startsWith('bakin:')
+        ? runtimeCommand
+        : `bakin:schedule:${meta.displayName ?? meta.jobId}`
+      await ctx.runtime.cron.update(meta.jobId, {
+        command,
+        metadata: scheduleMetadataForRepair(meta),
+      })
+      summary.repaired += 1
+      log.info('Repaired Bakin schedule cron payload to avoid main-session wake', { jobId: meta.jobId })
+    } catch (err) {
+      summary.failed += 1
+      summary.remainingLegacy += 1
+      log.warn('Failed to repair legacy Bakin schedule cron payload', {
+        jobId: meta.jobId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  return summary
+}
+
+function shouldRetryLegacyCronRepair(summary: LegacyCronRepairSummary): boolean {
+  return summary.failed > 0 || summary.remainingLegacy > 0
+}
+
+function scheduleLegacyCronRepairRetry(ctx: PluginContext, attempt: number): void {
+  if (legacyCronRepairTimer) clearTimeout(legacyCronRepairTimer)
+  const delay = LEGACY_CRON_REPAIR_RETRY_DELAYS_MS[attempt]
+  if (delay === undefined) return
+  legacyCronRepairTimer = setTimeout(() => {
+    legacyCronRepairTimer = null
+    runLegacyCronRepair(ctx, attempt + 1).catch((err) => {
+      log.warn('Legacy Bakin schedule cron repair retry failed', err)
+    })
+  }, delay)
+  legacyCronRepairTimer.unref?.()
+}
+
+async function runLegacyCronRepair(ctx: PluginContext, attempt = 0): Promise<void> {
+  const summary = await repairMainSessionBakinCronPayloads(ctx)
+  if (shouldRetryLegacyCronRepair(summary)) {
+    if (attempt < LEGACY_CRON_REPAIR_RETRY_DELAYS_MS.length) {
+      scheduleLegacyCronRepairRetry(ctx, attempt)
+    } else {
+      log.warn('Legacy Bakin schedule cron repair exhausted retries', summary)
+    }
+  }
+}
+
+async function checkLegacyBakinCronPayloads(ctx: PluginContext): Promise<HealthCheckResult[]> {
+  const check = 'schedule-legacy-cron-wake'
+  const jobs = Object.values(readSidecar().jobs).filter(job => job.isBakinJob)
+  if (jobs.length === 0) {
+    return [{ check, status: 'ok', message: 'No Bakin schedule cron jobs to inspect', autoFixable: false }]
+  }
+
+  const legacy: string[] = []
+  const failures: string[] = []
+  for (const meta of jobs) {
+    try {
+      const raw = await ctx.runtime.cron.getRaw(meta.jobId, 'schedule health checks for legacy main-session Bakin cron payloads')
+      if (needsBakinCronWakeRepair(raw)) legacy.push(meta.displayName ?? meta.jobId)
+    } catch (err) {
+      failures.push(`${meta.displayName ?? meta.jobId}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  const rows: HealthCheckResult[] = []
+  if (legacy.length > 0) {
+    rows.push({
+      check,
+      status: 'warn',
+      message: `${legacy.length} Bakin schedule cron job(s) still wake the main session: ${legacy.join(', ')}`,
+      autoFixable: true,
+    })
+  }
+  if (failures.length > 0) {
+    rows.push({
+      check,
+      status: 'warn',
+      message: `Failed to inspect ${failures.length} Bakin schedule cron job(s): ${failures.join('; ')}`,
+      autoFixable: false,
+    })
+  }
+
+  return rows.length > 0
+    ? rows
+    : [{ check, status: 'ok', message: `${jobs.length} Bakin schedule cron job(s), none wake the main session`, autoFixable: false }]
+}
+
+function legacyCronWakeRepair(ctx: PluginContext): HealthRepairHandler {
+  const check = 'schedule-legacy-cron-wake'
+  return {
+    async plan(rows) {
+      const matching = rows.filter(row => row.check === check && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: 'schedule.repair-legacy-cron-wake',
+        checkId: check,
+        title: 'Repair legacy Bakin schedule cron payloads',
+        reason: matching.map(row => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'runtime',
+          target: 'OpenClaw cron jobs',
+          action: 'update',
+          description: 'Rewrite Bakin-owned cron payloads so they no longer wake the main session.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const summary = await repairMainSessionBakinCronPayloads(ctx)
+      const failed = shouldRetryLegacyCronRepair(summary)
+      return [{
+        id: 'schedule.repair-legacy-cron-wake',
+        checkId: check,
+        status: failed ? 'failed' : 'applied',
+        message: `Checked ${summary.checked}, repaired ${summary.repaired}, failed ${summary.failed}`,
+        changes: summary.repaired > 0
+          ? [{
+              kind: 'runtime' as const,
+              target: 'OpenClaw cron jobs',
+              action: 'update' as const,
+              description: `Repaired ${summary.repaired} legacy Bakin schedule cron job(s).`,
+            }]
+          : [],
+      }]
+    },
+  }
+}
+
 function isCronAlreadyGoneError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err)
   return /\bnot found\b/i.test(message) && /\b(cron|job)\b/i.test(message)
@@ -238,9 +406,11 @@ async function deleteScheduleJob(ctx: ScheduleDeleteContext, jobId: string): Pro
 /** Module-level ctx set during activate(), used by handleBridge + routes */
 let pluginCtx: PluginContext | null = null
 let reconcileTimer: ReturnType<typeof setInterval> | null = null
+let legacyCronRepairTimer: ReturnType<typeof setTimeout> | null = null
 let reconcileRunning = false
 
 const RECONCILE_INTERVAL_MS = 60_000
+const LEGACY_CRON_REPAIR_RETRY_DELAYS_MS = [30_000, 120_000, 300_000] as const
 
 // ─── Module-scope helpers (use pluginCtx for runtime access) ─────────────
 
@@ -554,6 +724,13 @@ async function processScheduledRun(payload: BridgePayload): Promise<ProcessRunRe
       assignee: defaults.requireTriage ? undefined : meta.agentId,
       workflowId: meta.workflowId,
       createdBy: 'schedule',
+      scheduleJobId: jobId,
+      source: {
+        pluginId: 'schedule',
+        entityType: 'job',
+        entityId: jobId,
+        purpose: 'scheduled-run',
+      },
     })
     const taskId = result.id
 
@@ -1437,8 +1614,18 @@ const schedulePlugin: BakinPlugin = definePlugin({
       repair: scheduleSyncRepair(getContentDir(), ctx.runtime.cron, () => getRuntimeMainAgentId(ctx.runtime)),
     })
 
-    log.info('Schedule plugin activated')
+    ctx.registerHealthCheck({
+      id: 'schedule-legacy-cron-wake',
+      name: 'Bakin schedule cron wake mode',
+      run: async () => checkLegacyBakinCronPayloads(ctx),
+      repair: legacyCronWakeRepair(ctx),
+    })
+
     startReconciler()
+    log.info('Schedule plugin activated')
+    runLegacyCronRepair(ctx).catch((err) => {
+      log.warn('Legacy Bakin schedule cron repair failed', err)
+    })
   },
 
   async onReady() {
@@ -1452,6 +1639,10 @@ const schedulePlugin: BakinPlugin = definePlugin({
 
   onShutdown() {
     stopReconciler()
+    if (legacyCronRepairTimer) {
+      clearTimeout(legacyCronRepairTimer)
+      legacyCronRepairTimer = null
+    }
     log.info('Schedule plugin shutting down')
   },
 }) as unknown as BakinPlugin

--- a/tests/adapter-openclaw/runtime-cron.test.ts
+++ b/tests/adapter-openclaw/runtime-cron.test.ts
@@ -22,7 +22,7 @@ describe('OpenClaw runtime cron adapter', () => {
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  it('creates Bakin schedule cron jobs as OpenClaw main-session system events through the CLI', async () => {
+  it('creates Bakin schedule cron jobs as isolated no-delivery timer messages through the CLI', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
     const exec = mock(async (_args: string[]) => JSON.stringify({
@@ -30,10 +30,13 @@ describe('OpenClaw runtime cron adapter', () => {
       name: 'Schedule One',
       enabled: true,
       schedule: { kind: 'cron', expr: '0 9 * * *', tz: 'America/Denver' },
-      sessionTarget: 'main',
+      sessionTarget: 'isolated',
       wakeMode: 'now',
       delivery: { mode: 'none' },
-      payload: { kind: 'systemEvent', text: 'bakin:schedule:schedule-1' },
+      payload: {
+        kind: 'agentTurn',
+        message: 'bakin:schedule:schedule-1',
+      },
     }))
     ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
@@ -65,9 +68,11 @@ describe('OpenClaw runtime cron adapter', () => {
       '--tz',
       'America/Denver',
       '--session',
-      'main',
-      '--system-event',
+      'isolated',
+      '--message',
       'bakin:schedule:schedule-1',
+      '--no-deliver',
+      '--light-context',
     ], cronExecOpts)
   })
 
@@ -203,7 +208,7 @@ describe('OpenClaw runtime cron adapter', () => {
     ], cronExecOpts)
   })
 
-  it('does not attach toolsAllow to Bakin schedule system-event cron jobs', async () => {
+  it('does not attach toolsAllow to Bakin schedule timer cron jobs', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
     const exec = mock(async (_args: string[]) => JSON.stringify({
@@ -211,8 +216,11 @@ describe('OpenClaw runtime cron adapter', () => {
       name: 'Schedule Tools',
       enabled: true,
       schedule: { kind: 'cron', expr: '0 9 * * *' },
-      sessionTarget: 'main',
-      payload: { kind: 'systemEvent', text: 'bakin:schedule:schedule-tools' },
+      sessionTarget: 'isolated',
+      payload: {
+        kind: 'agentTurn',
+        message: 'bakin:schedule:schedule-tools',
+      },
     }))
     ;(runtime as unknown as { exec: typeof exec }).exec = exec
 
@@ -227,6 +235,32 @@ describe('OpenClaw runtime cron adapter', () => {
 
     expect(created.toolsAllow).toBeUndefined()
     expect(exec.mock.calls[0][0]).not.toContain('--tools')
+  })
+
+  it('preserves provider tool allowlists when listing runtime cron jobs with bakin commands', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const exec = mock(async () => JSON.stringify([{
+      id: 'openclaw-schedule-listed',
+      name: 'Schedule Listed',
+      enabled: true,
+      schedule: { kind: 'cron', expr: '0 9 * * *' },
+      sessionTarget: 'isolated',
+      payload: {
+        kind: 'agentTurn',
+        message: 'bakin:schedule:schedule-listed',
+        toolsAllow: ['message'],
+      },
+    }]))
+    ;(runtime as unknown as { exec: typeof exec }).exec = exec
+
+    await expect(runtime.cron.list()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'openclaw-schedule-listed',
+        command: 'bakin:schedule:schedule-listed',
+        toolsAllow: ['message'],
+      }),
+    ])
   })
 
   it('preserves the timezone from OpenClaw cron schedule objects when listing jobs', async () => {
@@ -281,7 +315,7 @@ describe('OpenClaw runtime cron adapter', () => {
     expect(store.jobs[0]).toEqual(raw)
   })
 
-  it('converts metadata-only Bakin updates to system-event payloads through the CLI', async () => {
+  it('converts metadata-only Bakin updates to isolated timer payloads through the CLI', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()
     const rawJob: {
@@ -303,8 +337,12 @@ describe('OpenClaw runtime cron adapter', () => {
     }
     const exec = mock(async (args: string[]) => {
       if (args[1] === 'edit') {
-        rawJob.sessionTarget = 'main'
-        rawJob.payload = { kind: 'systemEvent', text: 'Original native command' }
+        rawJob.sessionTarget = 'isolated'
+        rawJob.payload = {
+          kind: 'agentTurn',
+          message: 'Original native command',
+        }
+        rawJob.delivery = { mode: 'none', channel: 'last' }
       }
       return JSON.stringify([rawJob])
     })
@@ -323,9 +361,12 @@ describe('OpenClaw runtime cron adapter', () => {
       '--timeout',
       '30000',
       '--session',
-      'main',
-      '--system-event',
+      'isolated',
+      '--message',
       'Original native command',
+      '--no-deliver',
+      '--light-context',
+      '--clear-tools',
     ], cronExecOpts)
   })
 

--- a/tests/plugins/schedule/bridge.test.ts
+++ b/tests/plugins/schedule/bridge.test.ts
@@ -319,6 +319,13 @@ describe('schedule/bridge', () => {
     expect(args.assignee).toBe('chef')
     expect(args.createdBy).toBe('schedule')
     expect(args.column).toBe('todo')
+    expect(args.scheduleJobId).toBe('test-job')
+    expect(args.source).toEqual({
+      pluginId: 'schedule',
+      entityType: 'job',
+      entityId: 'test-job',
+      purpose: 'scheduled-run',
+    })
   })
 
   it('expands title template variables', async () => {

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -355,6 +355,89 @@ describe('schedule search indexing', () => {
       enabled: 'true',
     }))
   })
+
+  it('repairs legacy main-session Bakin cron payloads on activation', async () => {
+    upsertJob(makeMeta({
+      jobId: 'legacy-main-cron',
+      displayName: 'Legacy Main Cron',
+      tz: 'America/Denver',
+    }))
+    mockRuntimeCronJobs.push({
+      id: 'legacy-main-cron',
+      name: 'Legacy Main Cron',
+      schedule: '0 9 * * *',
+      command: 'bakin:schedule:Legacy Main Cron',
+      enabled: true,
+      sessionTarget: 'main',
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:Legacy Main Cron' },
+    } as CronJob)
+
+    await activatePlugin(schedulePlugin, testDir)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(mockCronUpdate).toHaveBeenCalledWith('legacy-main-cron', expect.objectContaining({
+      command: 'bakin:schedule:Legacy Main Cron',
+      metadata: expect.objectContaining({
+        bakinSchedule: true,
+        scheduleType: 'cron',
+        tz: 'America/Denver',
+      }),
+    }))
+  })
+
+  it('registers a repairable health warning for legacy main-session cron payloads', async () => {
+    const activated = await activatePlugin(schedulePlugin, testDir)
+    const registerMock = activated.ctx.registerHealthCheck as unknown as {
+      mock: { calls: Array<[Record<string, unknown>]> }
+    }
+    const health = registerMock.mock.calls
+      .map(call => call[0])
+      .find(def => def.id === 'schedule-legacy-cron-wake') as {
+        run: () => Promise<Array<Record<string, unknown>>>
+        repair: {
+          plan: (rows: Array<Record<string, unknown>>) => Promise<Array<Record<string, unknown>>>
+          apply: (items: Array<Record<string, unknown>>) => Promise<Array<Record<string, unknown>>>
+        }
+      } | undefined
+
+    expect(health).toBeDefined()
+    upsertJob(makeMeta({
+      jobId: 'legacy-health-cron',
+      displayName: 'Legacy Health Cron',
+    }))
+    mockRuntimeCronJobs.push({
+      id: 'legacy-health-cron',
+      name: 'Legacy Health Cron',
+      schedule: '0 9 * * *',
+      command: 'bakin:schedule:Legacy Health Cron',
+      enabled: true,
+      sessionTarget: 'main',
+      payload: { kind: 'systemEvent', text: 'bakin:schedule:Legacy Health Cron' },
+    } as CronJob)
+
+    const rows = await health!.run()
+    expect(rows).toEqual([
+      expect.objectContaining({
+        check: 'schedule-legacy-cron-wake',
+        status: 'warn',
+        autoFixable: true,
+      }),
+    ])
+
+    const plan = await health!.repair.plan(rows)
+    expect(plan).toHaveLength(1)
+    const result = await health!.repair.apply(plan)
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'schedule.repair-legacy-cron-wake',
+        status: 'applied',
+      }),
+    ])
+    expect(mockCronUpdate).toHaveBeenCalledWith('legacy-health-cron', expect.objectContaining({
+      command: 'bakin:schedule:Legacy Health Cron',
+      metadata: expect.objectContaining({ bakinSchedule: true, scheduleType: 'cron' }),
+    }))
+  })
 })
 
 describe('schedule routes', () => {


### PR DESCRIPTION
## Summary
- register Bakin-owned OpenClaw schedule crons as isolated no-delivery light-context timer messages instead of main-session system events
- repair legacy main-session schedule cron payloads on startup with retries and add a repairable schedule health check
- persist schedule task provenance and update regression coverage/docs

## Verification
- bun test --isolate tests/adapter-openclaw/runtime-cron.test.ts tests/plugins/schedule/routes.test.ts tests/plugins/schedule/bridge.test.ts
- bun test --isolate tests/plugins/schedule/health-checks.test.ts
- bun run typecheck
- git diff --check
- real OpenClaw smoke test: isolated no-delivery light-context cron records status ok without delivery; sentinel no-tool allowlist records status error

Fixes #393.
Follow-up: #397 tracks true timer-only cron support to avoid model-token burn.