### PR TITLE
Fix release binary sharp startup failure

### DIFF
--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -14,7 +14,6 @@ import { mkdirSync, copyFileSync, existsSync, readdirSync, statSync, renameSync,
 import { join, extname } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import sharp from 'sharp'
 import { getContentDir } from '../../../src/core/content-dir'
 import { createLogger } from '../../../src/core/logger'
 import { getMimeType, type AssetType } from './constants'
@@ -31,6 +30,8 @@ import {
 } from './manifest'
 
 const log = createLogger('asset-service')
+type Sharp = typeof import('sharp')
+let sharpModule: Promise<Sharp | null> | null = null
 
 export interface AssetCreateInput {
   /** Absolute path to the source file to copy in as v1. */
@@ -82,8 +83,20 @@ function nowIso(): string {
   return new Date().toISOString()
 }
 
+async function loadSharp(): Promise<Sharp | null> {
+  sharpModule ??= import('sharp')
+    .then((mod): Sharp => (mod as unknown as { default?: Sharp }).default ?? (mod as unknown as Sharp))
+    .catch((err) => {
+      log.warn('sharp unavailable; image metadata/export support disabled', { error: err instanceof Error ? err.message : String(err) })
+      return null
+    })
+  return sharpModule
+}
+
 async function imageDimensions(filePath: string): Promise<{ width: number | null; height: number | null }> {
   try {
+    const sharp = await loadSharp()
+    if (!sharp) return { width: null, height: null }
     const meta = await sharp(filePath).metadata()
     return { width: meta.width ?? null, height: meta.height ?? null }
   } catch {
@@ -424,6 +437,8 @@ export async function addExport(assetId: string, input: AssetExportInput): Promi
     const prior = manifest.exports.find((e) => e.name === name)
     if (prior && prior.file !== file) removeFileQuietly(join(dirAbs, prior.file))
 
+    const sharp = await loadSharp()
+    if (!sharp) throw new Error('Image export requires sharp, but the native sharp package is unavailable for this runtime')
     let pipeline = sharp(join(dirAbs, src.file)).resize(input.width, input.height, { fit: 'cover' })
     if (input.format === 'jpg') pipeline = pipeline.jpeg({ quality: input.quality ?? 82 })
     else if (input.format === 'png') pipeline = pipeline.png()

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
 import { basename } from 'node:path'
-import sharp from 'sharp'
 import type { ExecToolResult, PluginContext } from '@bakin/core/plugin-types'
 import type { RuntimeImageGenerationResult } from '@bakin/core/adapters/runtime'
 import type { ImageProviderId } from '../types'
@@ -12,6 +11,8 @@ import { runBilledImageCall, type ImageCallKey } from './idempotency'
 
 /** Largest edge we send to a provider / feed into sharp, to bound cost. */
 const MAX_IMAGE_EDGE = 2048
+type Sharp = typeof import('sharp')
+let sharpModule: Promise<Sharp | null> | null = null
 
 export interface ImagesGenerateParams {
   prompt?: string
@@ -55,6 +56,13 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+async function loadSharp(): Promise<Sharp | null> {
+  sharpModule ??= import('sharp')
+    .then((mod): Sharp => (mod as unknown as { default?: Sharp }).default ?? (mod as unknown as Sharp))
+    .catch(() => null)
+  return sharpModule
+}
+
 function hashPrompt(prompt: string): string {
   return `sha256:${createHash('sha256').update(prompt).digest('hex')}`
 }
@@ -88,6 +96,8 @@ function dimensionsForSurface(surfaceId: string, width?: number, height?: number
 
 async function imageDimensions(filePath: string): Promise<{ width: number; height: number }> {
   try {
+    const sharp = await loadSharp()
+    if (!sharp) return { width: 0, height: 0 }
     const metadata = await sharp(filePath).metadata()
     return { width: metadata.width ?? 0, height: metadata.height ?? 0 }
   } catch {


### PR DESCRIPTION
## Summary

Fix the release binary startup failure where core plugin imports eagerly loaded `sharp`, causing the Linux x64 compiled binary to fail even for `--version` when sharp's native optional package was unavailable in the compiled runtime.

This changes the assets and images plugins to lazy-load `sharp` only when image metadata/export work actually needs it. Metadata probing falls back to unknown dimensions when sharp is unavailable, and image export now reports a targeted error at use time.

## Validation

- `bun run typecheck`
- `bun test --isolate tests/plugins/assets/asset-service.test.ts tests/plugins/assets/versioned-routes.test.ts tests/plugins/images/tools.test.ts`
- `bun run lint`
- `bun run build:binary`
- `./dist/bakin-darwin-arm64 --version`