### PR TITLE
Fix managed item version reporting

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -207,6 +207,12 @@ Critical correctness rule: a runtime agent without a lockfile entry MUST surface
 as `unmanaged` (NOT `absent`). Mis-classifying lets the installer create a
 fresh runtime agent with the same id, risking the user's existing setup.
 
+Version reporting rule: managed/adopted agent package state includes a top-level
+`version` copied from the lockfile entry. The team detail view and
+`bakin agents list --packages` must render that lockfile/API version (falling
+back to nested `entry.version` only for compatibility), not infer the version
+from an install path, source ref, package id, or stale runtime state.
+
 ## Doctor integration
 
 `plugins/team/lib/health-checks.ts:checkAgentAssets()` surfaces drift in the

--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -116,6 +116,12 @@ Pure mutators (`addPlugin`, `removePlugin`, `updatePlugin`) never touch
 fs. `setCorePluginCheck(predicate)` wires defense-in-depth so mutators
 throw for core ids. Set during `pluginRegistry.initialize()`.
 
+Version reporting rule: Health and registry snapshots report core plugin
+versions from the bundled plugin export, but user plugin versions come from
+`~/.bakin/plugins/lock.json` when a lockfile entry exists. This keeps the UI
+and CLI aligned with install/upgrade provenance instead of whatever a loaded
+module or copied manifest happens to expose at runtime.
+
 ### Install flow — `bakin plugins install <src> [--ref <ref>] [--yes]`
 
 Two-phase with a HMAC-signed consent token binding to defend against a

--- a/.claude/specs/394-version-reporting.md
+++ b/.claude/specs/394-version-reporting.md
@@ -1,0 +1,201 @@
+# Spec: Issue 394 Version Reporting
+
+## Objective
+
+Fix and verify version reporting across Bakin-managed update flows.
+
+Issue: https://github.com/markhayden/bakin/issues/394
+
+Success means the CLI reports true before/after versions for update commands, and browser UI surfaces show the installed/current version for managed items after those updates.
+
+Assumptions:
+
+1. The canonical installed version for the Bakin binary is `APP_VERSION` from `packages/core/src/generated-version.ts`.
+2. The canonical installed version for user plugins is `~/.bakin/plugins/lock.json.plugins[id].version`.
+3. The canonical installed version for agent packages and standalone packages is `~/.bakin/packages/lock.json.packages[id].version`.
+4. UI surfaces should read server/API state rather than parsing package ids such as `pixel@0.2.0`.
+5. Local tests must use temp `BAKIN_HOME` and `OPENCLAW_HOME` and must not mutate real `~/.bakin` or `~/.openclaw`.
+
+## Findings From Deep Dive
+
+Existing behavior already covered:
+
+- `updatePackageById()` returns `fromVersion` and `toVersion` and updates the package lockfile entry version.
+- `upgradePlugin()` returns `before.version` and `after.version` and updates the plugin lockfile entry version.
+- `/api/packages` exposes standalone package `version`.
+- `/api/plugins/manifest` exposes plugin `version`.
+- `bakin packages list` renders package versions.
+- `bakin plugins list` renders plugin versions.
+
+Likely gaps:
+
+- `/api/agent-packages` returns raw `entry`, but the agent-package CLI table only renders agent/state/package and not the entry version.
+- The Teams package card type has `entry.version`, but the package card does not display it.
+- Agent package state rows used in tests often omit `entry.version`, so current UI/CLI tests would pass while hiding a missing version.
+- Browser refresh after CLI-driven package updates is passive today. The package state store only refreshes on initial load and after in-UI adopt.
+- Standalone non-agent package versions are currently CLI/API-only. That remains out of browser scope for this issue.
+- `bakin update` reports the target release tag (`release.tag_name`) after replacement. It does not independently run the new binary. Regression coverage should verify the reported target matches the selected release asset and that `bakin version` continues to use stamped `APP_VERSION`.
+
+## Commands
+
+Focused verification:
+
+```sh
+bun test --isolate tests/core/self-update.test.ts
+bun test --isolate tests/agent-packages/updater.test.ts tests/api/agent-packages-routes.test.ts
+bun test --isolate tests/plugins/lifecycle/upgrade-smoke.test.ts
+bun test --isolate tests/cli/readonly-ui.test.tsx tests/cli/readonly-commands.test.ts
+bun test --isolate tests/plugins/team/use-package-states.test.ts tests/plugins/team/agent-detail-package-card.test.tsx tests/plugins/team/agent-card-package-badge.test.tsx
+```
+
+Broader checks before completion:
+
+```sh
+bun run typecheck
+bun test --isolate
+```
+
+Manual local smoke, using a temp home:
+
+```sh
+BAKIN_HOME=/tmp/bakin-394 OPENCLAW_HOME=/tmp/openclaw-394 bun run server.ts --skip-onboarding-check
+BAKIN_HOME=/tmp/bakin-394 OPENCLAW_HOME=/tmp/openclaw-394 bun run cli/bakin.ts agents list --packages
+BAKIN_HOME=/tmp/bakin-394 OPENCLAW_HOME=/tmp/openclaw-394 bun run cli/bakin.ts packages list
+BAKIN_HOME=/tmp/bakin-394 OPENCLAW_HOME=/tmp/openclaw-394 bun run cli/bakin.ts plugins list
+```
+
+## Project Structure
+
+- `src/core/self-update.ts` - binary self-update release selection and update message.
+- `src/core/cli.ts` - binary-facing `version` and `update`.
+- `cli/bakin.ts` - HTTP-backed CLI commands for plugins, agents, and packages.
+- `src/core/agent-packages/updater.ts` - package update result and lockfile mutation.
+- `packages/host/src/api/agent-packages/list.ts` - agent package state API.
+- `packages/host/src/api/packages/list.ts` - standalone package inventory API.
+- `packages/host/src/api/plugins/manifest.ts` - plugin manifest API.
+- `plugins/team/hooks/use-agent-store.ts` - client package-state store.
+- `plugins/team/components/package-card.tsx` - Teams agent package version display.
+- `plugins/health/components/health-page.tsx` - existing active plugin inventory.
+- `src/core/cli/ui/readonly.tsx` - TUI tables and update result rendering.
+- `.claude/knowledge/agent-packages.md`, `.claude/knowledge/plugin-system.md`, `.claude/knowledge/release-pipeline.md` - docs coverage already checked.
+
+## Code Style
+
+Keep changes direct and source-of-truth based:
+
+```ts
+function packageVersion(row: PackageStateRow | undefined): string {
+  return row?.entry?.version ?? ''
+}
+```
+
+Do not parse versions out of ids when the lockfile entry is available. Prefer adding explicit fields to API rows or rendering `entry.version` from the existing row.
+
+## Testing Strategy
+
+Use the prove-it pattern:
+
+1. Add failing tests showing agent package list/card rows include the lockfile version.
+2. Add update-route coverage that an update response and subsequent list response agree on the new version.
+3. Add plugin Health coverage proving the Active Plugins table is backed by the installed user-plugin version when a lockfile entry exists.
+4. Add self-update tests around target version messaging without downloading real assets.
+
+Test levels:
+
+- Unit: TUI row renderers and package-card display.
+- API integration: `/api/agent-packages` and `/api/packages` from temp lockfiles.
+- Lifecycle integration: agent package update and plugin upgrade lockfile before/after.
+- Browser/component: Teams package card current version after store refresh.
+
+## Boundaries
+
+Always:
+
+- Treat lockfiles as installed-version source of truth for managed plugins/packages.
+- Keep tests isolated with temp `BAKIN_HOME` and `OPENCLAW_HOME`.
+- Preserve existing JSON output shapes unless adding explicit fields is cleaner and covered.
+- Keep UI dense and operational, matching existing Teams/Health style.
+
+Out of scope for this issue:
+
+- Adding a new browser inventory surface for standalone packages.
+- Changing `bakin update` output wording from GitHub tag form (`vX.Y.Z`) to app-version form (`X.Y.Z`).
+- Adding new cross-app SSE event types for package inventory refresh.
+
+Never:
+
+- Parse installed versions from package ids as the primary source of truth.
+- Mutate real local Bakin/OpenClaw state in tests.
+- Add backwards-compatibility shims for obsolete lockfile paths.
+
+## Success Criteria
+
+- `bakin version` reports the stamped binary version.
+- `bakin update` reports the selected target release/version consistently and is covered by tests.
+- `bakin agents update <id>` and `bakin agents update` render accurate `fromVersion -> toVersion`.
+- `bakin agents list --packages` shows the current installed version for managed/adopted agents.
+- Teams agent detail package card shows the current installed version for managed/adopted agents.
+- `bakin packages update <id>` and `bakin packages list` agree on current standalone package version.
+- `bakin plugins upgrade <id>` and `bakin plugins list` agree on current user plugin version.
+- Browser UI shows current managed item versions on refresh after update: Health for plugins, agent detail package card for agent kits.
+
+## Implementation Plan
+
+### Phase 1: Regression Tests
+
+- Add TUI tests for `AgentPackagesListReport` with `entry.version`.
+- Add Team package-card tests for visible `Version`.
+- Add API route tests proving list-after-update returns the new version.
+- Add self-update tests for release target reporting.
+
+### Phase 2: Agent Package Version Surface
+
+- Normalize `/api/agent-packages` rows so managed/adopted entries expose a top-level `version` copied from `entry.version`.
+- Render version in `bakin agents list --packages` plain output and TUI.
+- Render version in Teams package card fields.
+- Update `PackageStateRow` and related tests.
+
+### Phase 3: Plugin And Package Inventory Confirmation
+
+- Ensure the Health registry uses installed lockfile version for user plugins where present, falling back to active registry version for core plugins.
+- Keep standalone package list on `/api/packages` and CLI as-is.
+- Add Health UI version-source assertions if the plugin manifest source changes.
+
+### Phase 4: UI Freshness
+
+- If approved, add a package-state invalidation path for audit events `agent_pkg.updated`, `pkg.updated`, `agent_pkg.installed`, `pkg.installed`, `agent_pkg.removed`, `pkg.removed`.
+- Prefer a small version bump in `useContentStore` plus `useAgentStore.refreshPackageStates()` in Teams over a broad page reload.
+
+### Phase 5: Documentation
+
+- Update `.claude/knowledge/agent-packages.md` CLI/UI surface notes.
+- Update `.claude/knowledge/plugin-system.md` only if plugin manifest version source changes.
+
+## Commit Strategy
+
+1. `test(version-reporting): cover managed item versions`
+   - Regression tests only. Expected to fail before implementation.
+   - Verify with focused `bun test --isolate ...` commands.
+2. `fix(agent-packages): expose installed versions in CLI and team UI`
+   - API normalization, CLI/TUI, Teams package card.
+   - Verify focused agent package and Team tests.
+3. `fix(plugins): align installed plugin version display`
+   - Only if deep test proves manifest/health can drift from lockfile.
+   - Verify plugin lifecycle and manifest tests.
+4. `fix(update): harden binary update version report`
+   - Self-update reporting tests and small implementation change if needed.
+   - Verify `tests/core/self-update.test.ts` and CLI version tests.
+5. `docs(version-reporting): record managed version sources`
+   - Knowledge/spec updates.
+   - Verify docs-sensitive tests if affected.
+
+Rollback checkpoints:
+
+- After commit 1, no product code changed.
+- After commit 2, agent package display can be reverted independently from plugin/binary work.
+- After commit 3, plugin display can be reverted independently from package logic.
+- After commit 4, binary update message can be reverted without touching managed item UI.
+
+## Decision
+
+Health's existing Active Plugins table is the plugin version surface for this issue. Agent-kit versions should appear in the individual agent detail package block next to package source, commit, and installed metadata. Standalone non-agent package versions remain CLI/API-only for now.

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1317,7 +1317,13 @@ async function cmdAgentPackagesInstall(source: string, flags: AgentsCmdFlags): P
 async function cmdAgentPackagesList(flags: AgentsCmdFlags): Promise<void> {
   const result = await apiGet('/api/agent-packages') as {
     ok: boolean
-    agents: Array<{ agentId: string; state: string; packageId?: string }>
+    agents: Array<{
+      agentId: string
+      state: string
+      version?: string
+      packageId?: string
+      entry?: { version?: string }
+    }>
   }
   if (flags.json) {
     print(result)
@@ -1329,8 +1335,9 @@ async function cmdAgentPackagesList(flags: AgentsCmdFlags): Promise<void> {
   }
   console.log('Agents (package state):')
   for (const a of result.agents) {
+    const version = a.version ?? a.entry?.version ?? '-'
     const pkg = a.packageId ? `  [${a.packageId}]` : ''
-    console.log(`  ${a.agentId.padEnd(20)} ${a.state}${pkg}`)
+    console.log(`  ${a.agentId.padEnd(20)} ${a.state.padEnd(10)} ${version.padEnd(10)}${pkg}`)
   }
 }
 

--- a/plugins/team/components/package-card.tsx
+++ b/plugins/team/components/package-card.tsx
@@ -43,13 +43,28 @@ function CliHint({ command }: { command: string }) {
   )
 }
 
-function PackageEntryFields({ entry, packageId }: { entry: NonNullable<PackageStateRow['entry']>; packageId?: string }) {
+function PackageEntryFields({
+  entry,
+  packageId,
+  version,
+}: {
+  entry: NonNullable<PackageStateRow['entry']>
+  packageId?: string
+  version?: string
+}) {
+  const installedVersion = version ?? entry.version
   return (
     <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-xs">
       {packageId && (
         <>
           <dt className="text-muted-foreground">Package</dt>
           <dd className="font-mono text-foreground break-all">{packageId}</dd>
+        </>
+      )}
+      {installedVersion && (
+        <>
+          <dt className="text-muted-foreground">Version</dt>
+          <dd className="font-mono text-foreground">{installedVersion}</dd>
         </>
       )}
       <dt className="text-muted-foreground">Source</dt>
@@ -135,7 +150,11 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
         </p>
       )}
       {packageState?.entry && (state === 'managed' || state === 'adopted') && (
-        <PackageEntryFields entry={packageState.entry} packageId={packageState.packageId} />
+        <PackageEntryFields
+          entry={packageState.entry}
+          packageId={packageState.packageId}
+          version={packageState.version}
+        />
       )}
       {state === 'drifted' && (
         <div className="space-y-1.5">

--- a/plugins/team/types.ts
+++ b/plugins/team/types.ts
@@ -82,6 +82,7 @@ export interface SkillSummary {
 export interface PackageStateRow {
   agentId: string
   state: 'absent' | 'unmanaged' | 'adopted' | 'managed' | 'drifted' | 'update-available'
+  version?: string
   packageId?: string
   entry?: {
     source: string

--- a/src/core/agent-packages/agent-state.ts
+++ b/src/core/agent-packages/agent-state.ts
@@ -36,6 +36,8 @@ export type AgentState = 'absent' | 'unmanaged' | 'adopted' | 'managed'
 export interface AgentStateInfo {
   agentId: string
   state: AgentState
+  /** Installed package version from the lockfile entry, when managed/adopted. */
+  version?: string
   /** Lockfile package id (typically === agentId for kind:'agent' entries). */
   packageId?: string
   /** Lockfile entry — only populated when state is 'managed' or 'adopted'. */
@@ -71,7 +73,13 @@ export async function getAgentState(
     // Lockfile says we own this agent but the runtime doesn't have it. This is
     // drift the doctor sweep should flag — for the state lookup we treat the
     // package side as authoritative because the entry is real, just orphaned.
-    return { agentId, state: owner.entry.state ?? 'managed', packageId: owner.id, entry: owner.entry }
+    return {
+      agentId,
+      state: owner.entry.state ?? 'managed',
+      version: owner.entry.version,
+      packageId: owner.id,
+      entry: owner.entry,
+    }
   }
   if (inRuntime && !owner) {
     return { agentId, state: 'unmanaged' }
@@ -81,6 +89,7 @@ export async function getAgentState(
   return {
     agentId,
     state: entry.state ?? 'managed',
+    version: entry.version,
     packageId: owner!.id,
     entry,
   }
@@ -112,6 +121,7 @@ export async function listAllAgentStates(lockfile?: Lockfile): Promise<AgentStat
     results.push({
       agentId,
       state: entry.state ?? 'managed',
+      version: entry.version,
       packageId,
       entry,
     })

--- a/src/core/cli/ui/readonly.tsx
+++ b/src/core/cli/ui/readonly.tsx
@@ -212,7 +212,9 @@ export interface AgentRuleResultData {
 export interface AgentPackageData {
   agentId?: unknown
   state?: unknown
+  version?: unknown
   packageId?: unknown
+  entry?: unknown
 }
 
 export interface AgentLessonData {
@@ -404,6 +406,7 @@ interface AgentPackageTableRow {
   status: TuiStatus
   agent: string
   state: string
+  version: string
   package: string
 }
 
@@ -1437,10 +1440,12 @@ function packageStateStatus(state: string): TuiStatus {
 function agentPackageTableRows(agents: AgentPackageData[]): AgentPackageTableRow[] {
   return agents.map(agent => {
     const state = valueText(agent.state)
+    const entry = isPlainRecord(agent.entry) ? agent.entry : {}
     return {
       status: packageStateStatus(state),
       agent: valueText(agent.agentId),
       state,
+      version: valueText(agent.version ?? entry.version),
       package: valueText(agent.packageId),
     }
   })
@@ -2553,7 +2558,8 @@ export function AgentPackagesListReport({ agents, color = true }: {
             columns={[
               { key: 'agent', header: 'AGENT', width: 18, render: row => row.agent },
               { key: 'state', header: 'STATE', width: 12, render: row => row.state },
-              { key: 'package', header: 'PACKAGE', width: 34, grow: true, render: row => row.package },
+              { key: 'version', header: 'VERSION', width: 12, render: row => row.version },
+              { key: 'package', header: 'PACKAGE', width: 28, grow: true, render: row => row.package },
             ]}
             color={color}
           />

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -1302,10 +1302,20 @@ class PluginRegistryImpl {
     missingDependencies?: string[]
     routes: number
   }> {
+    let installedUserPluginVersions: Record<string, string | undefined> = {}
+    try {
+      const lock = readPluginLockfile()
+      installedUserPluginVersions = Object.fromEntries(
+        Object.entries(lock.plugins).map(([id, entry]) => [id, entry.version]),
+      )
+    } catch (err) {
+      log.warn('Failed to read plugin lockfile for registry snapshot', err)
+    }
+
     const active = [...this.plugins.entries()].map(([id, state]) => ({
       id,
       name: state.plugin.name,
-      version: state.plugin.version,
+      version: isCorePlugin(id) ? state.plugin.version : installedUserPluginVersions[id] ?? state.plugin.version,
       description: state.description,
       contributes: state.manifest?.contributes,
       // Was a `id.startsWith('user:')` heuristic that always evaluated to

--- a/tests/api/agent-packages-routes.test.ts
+++ b/tests/api/agent-packages-routes.test.ts
@@ -193,6 +193,37 @@ describe('GET /api/agent-packages', () => {
     expect(body.ok).toBe(true)
     const pixelEntry = body.agents.find((a: { agentId: string }) => a.agentId === 'pixel')
     expect(pixelEntry?.state).toBe('managed')
+    expect(pixelEntry?.version).toBe('0.1.0')
+    expect(pixelEntry?.entry?.version).toBe('0.1.0')
+  })
+
+  it('returns the updated version after an agent package update', async () => {
+    const src = seedAgentPackage()
+    {
+      const { req, url } = makeRequest('POST', '/api/agent-packages/install', { source: src })
+      await installRoute.post(req, url)
+    }
+
+    const manifestPath = join(src, 'bakin-package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+    writeFileSync(manifestPath, JSON.stringify({ ...manifest, version: '0.2.0' }))
+
+    const { req: updateReq, url: updateUrl } = makeRequest('POST', '/api/agent-packages/pixel/update', {})
+    const updateRes = await dynamicRoute.handler(updateReq, updateUrl)
+    expect(updateRes.status).toBe(200)
+    const updateBody = await updateRes.json()
+    expect(updateBody.ok).toBe(true)
+    expect(updateBody.result.fromVersion).toBe('0.1.0')
+    expect(updateBody.result.toVersion).toBe('0.2.0')
+
+    const { req, url } = makeRequest('GET', '/api/agent-packages')
+    const res = await listRoute.get(req, url)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const pixelEntry = body.agents.find((a: { agentId: string }) => a.agentId === 'pixel')
+    expect(pixelEntry?.state).toBe('managed')
+    expect(pixelEntry?.version).toBe('0.2.0')
+    expect(pixelEntry?.entry?.version).toBe('0.2.0')
   })
 })
 

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -870,15 +870,18 @@ describe('read-only CLI TTY commands', () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({
       ok: true,
       agents: [
-        { agentId: 'patch', state: 'managed', packageId: 'bakin.patch' },
-        { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs' },
+        { agentId: 'patch', state: 'managed', packageId: 'bakin.patch', version: '1.2.0' },
+        { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs', entry: { version: '1.1.0' } },
       ],
     }))
     process.argv = ['bun', 'cli/bakin.ts', 'agents', 'list', '--packages']
     await main()
     expect(output()).toContain('Agent Packages')
+    expect(output()).toContain('VERSION')
     expect(output()).toContain('PACKAGE')
     expect(output()).toContain('bakin.patch')
+    expect(output()).toContain('1.2.0')
+    expect(output()).toContain('1.1.0')
     expect(output()).not.toContain('Agents (package state):')
 
     log.mockClear()
@@ -912,6 +915,28 @@ describe('read-only CLI TTY commands', () => {
     expect(output()).toContain('lessons')
     expect(output()).not.toContain('bakin.patch')
     expect(output()).not.toContain('Installed packages:')
+  })
+
+  it('prints agent package versions in plain output outside a TTY', async () => {
+    setStdoutIsTTY(false)
+    const { main } = await import('../../cli/bakin')
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      ok: true,
+      agents: [
+        { agentId: 'patch', state: 'managed', packageId: 'bakin.patch', version: '1.2.0' },
+        { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs', entry: { version: '1.1.0' } },
+      ],
+    }))
+    process.argv = ['bun', 'cli/bakin.ts', 'agents', 'list', '--packages']
+
+    await main()
+
+    expect(output()).toContain('Agents (package state):')
+    expect(output()).toContain('patch')
+    expect(output()).toContain('1.2.0')
+    expect(output()).toContain('docs')
+    expect(output()).toContain('1.1.0')
   })
 
   it('renders package action confirmations with the shared TUI screen in a TTY', async () => {

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -691,8 +691,8 @@ describe('read-only CLI TUI screens', () => {
     const agentPackages = renderToString(
       <AgentPackagesListReport
         agents={[
-          { agentId: 'patch', state: 'managed', packageId: 'bakin.patch' },
-          { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs' },
+          { agentId: 'patch', state: 'managed', packageId: 'bakin.patch', version: '1.2.0' },
+          { agentId: 'docs', state: 'adopted', packageId: 'bakin.docs', entry: { version: '1.1.0' } },
         ]}
       />,
     )
@@ -716,8 +716,11 @@ describe('read-only CLI TUI screens', () => {
     )
 
     expect(agentPackages).toContain('Agent Packages')
+    expect(agentPackages).toContain('VERSION')
     expect(agentPackages).toContain('PACKAGE')
     expect(agentPackages).toContain('bakin.patch')
+    expect(agentPackages).toContain('1.2.0')
+    expect(agentPackages).toContain('1.1.0')
     expect(lessons).toContain('Agent Lessons')
     expect(lessons).toContain('LESSON')
     expect(lessons).toContain('ENABLED')

--- a/tests/core/plugin-registry.test.ts
+++ b/tests/core/plugin-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn, type Mock } from 'bun:test'
 import { AsyncResource } from 'async_hooks'
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { tmpdir } from 'os'
 import { HookRegistry } from '../../packages/core/src/hooks/hook-registry'
 import { createHealthService } from '@bakin/core/app-services'
@@ -696,6 +696,39 @@ describe('PluginRegistryImpl', () => {
       expect(pluginRegistry.getPluginIds()).toContain('dist-only-user')
       const active = pluginRegistry.getRegistrySnapshot().find((entry: any) => entry.id === 'dist-only-user')
       expect(active).toMatchObject({ status: 'active' })
+    })
+
+    it('uses the installed lockfile version for active user plugin snapshots', async () => {
+      const pluginDir = writeUserPlugin('versioned-user')
+      const contentDir = await import('../../packages/core/src/content-dir')
+      contentDir.resetContentDir()
+      const { getPluginLockfilePath } = await import('../../packages/core/src/plugins/lockfile')
+      const lockPath = getPluginLockfilePath()
+      mkdirSync(dirname(lockPath), { recursive: true })
+      writeFileSync(lockPath, JSON.stringify({
+        version: 1,
+        plugins: {
+          'versioned-user': {
+            source: pluginDir,
+            type: 'local',
+            ref: '',
+            commitSha: '',
+            installedAt: '2026-05-25T02:57:29.278Z',
+            version: '2.5.0',
+            permissions: [],
+            manifestSha: 'sha256:test',
+          },
+        },
+      }))
+
+      await pluginRegistry.initialize({ plugins: [] }, mockStorage(), mockEvents())
+
+      const active = pluginRegistry.getRegistrySnapshot().find((entry: any) => entry.id === 'versioned-user')
+      expect(active).toMatchObject({
+        status: 'active',
+        source: 'user',
+        version: '2.5.0',
+      })
     })
 
     it('reports a clear failure when a user plugin is not built', async () => {

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -141,6 +141,7 @@ describe('PackageCard — read-only display per state', () => {
         state: 'managed',
         packageId: 'examples/pixel@0.1.0',
         entry: {
+          version: '0.1.0',
           source: 'github:examples/pixel',
           ref: 'v0.1.0',
           commitSha: 'abc1234567',
@@ -151,6 +152,7 @@ describe('PackageCard — read-only display per state', () => {
     })
     await renderDetail()
     expect(screen.getByText('managed')).toBeDefined()
+    expect(screen.getByText('0.1.0')).toBeDefined()
     expect(screen.getByText('github:examples/pixel')).toBeDefined()
     expect(screen.getByText('v0.1.0')).toBeDefined()
     // commitSha gets sliced to 7 chars
@@ -160,6 +162,27 @@ describe('PackageCard — read-only display per state', () => {
     expect(screen.queryByRole('button', { name: 'Adopt' })).toBeNull()
   })
 
+  it('prefers the top-level installed version over nested entry metadata', async () => {
+    primeState({
+      pixel: {
+        agentId: 'pixel',
+        state: 'managed',
+        version: '0.2.0',
+        packageId: 'examples/pixel',
+        entry: {
+          version: '0.1.0',
+          source: 'github:examples/pixel',
+          ref: 'main',
+          commitSha: 'abc1234567',
+          installedAt: '2026-04-25T00:00:00Z',
+        },
+      },
+    })
+    await renderDetail()
+    expect(screen.getByText('0.2.0')).toBeDefined()
+    expect(screen.queryByText('0.1.0')).toBeNull()
+  })
+
   it('renders an adopted badge + entry fields when state=adopted', async () => {
     primeState({
       pixel: {
@@ -167,6 +190,7 @@ describe('PackageCard — read-only display per state', () => {
         state: 'adopted',
         packageId: 'examples/pixel@0.1.0',
         entry: {
+          version: '0.1.0',
           source: 'github:examples/pixel',
           ref: 'main',
           commitSha: 'feedface',
@@ -176,6 +200,7 @@ describe('PackageCard — read-only display per state', () => {
     })
     await renderDetail()
     expect(screen.getByText('adopted')).toBeDefined()
+    expect(screen.getByText('0.1.0')).toBeDefined()
     expect(screen.getByText('github:examples/pixel')).toBeDefined()
     expect(screen.queryByRole('button', { name: 'Adopt' })).toBeNull()
   })
@@ -240,7 +265,7 @@ describe('PackageCard — main agent special-case', () => {
         agentId: 'main',
         state: 'managed',
         packageId: 'examples/main@0.1.0',
-        entry: { source: 'github:examples/main', ref: 'v0.1.0', commitSha: 'abcdefg', installedAt: '2026-04-25T00:00:00Z' },
+        entry: { version: '0.1.0', source: 'github:examples/main', ref: 'v0.1.0', commitSha: 'abcdefg', installedAt: '2026-04-25T00:00:00Z' },
       },
     })
     render(<AgentDetail agentId="main" />)
@@ -249,6 +274,7 @@ describe('PackageCard — main agent special-case', () => {
     // Managed/adopted main bypasses the Self-managed special-case and shows
     // standard package fields. (This is an unusual state but should not crash.)
     expect(screen.getByText('managed')).toBeDefined()
+    expect(screen.getByText('0.1.0')).toBeDefined()
     expect(screen.getByText('github:examples/main')).toBeDefined()
   })
 })

--- a/tests/plugins/team/use-package-states.test.ts
+++ b/tests/plugins/team/use-package-states.test.ts
@@ -60,8 +60,9 @@ const PKG_OK: PkgResponse = {
     {
       agentId: 'pixel',
       state: 'managed',
+      version: '0.1.0',
       packageId: 'examples/pixel@0.1.0',
-      entry: { source: 'github:examples/pixel', ref: 'v0.1.0', commitSha: 'abc1234', installedAt: '2026-04-25T00:00:00Z' },
+      entry: { version: '0.1.0', source: 'github:examples/pixel', ref: 'v0.1.0', commitSha: 'abc1234', installedAt: '2026-04-25T00:00:00Z' },
     },
     { agentId: 'orca', state: 'unmanaged' },
   ],
@@ -139,8 +140,11 @@ describe('useAgentStore — package state plumbing', () => {
     expect(packageStates['pixel']).toMatchObject({
       agentId: 'pixel',
       state: 'managed',
+      version: '0.1.0',
       packageId: 'examples/pixel@0.1.0',
     })
+    expect(packageStates['pixel']?.version).toBe('0.1.0')
+    expect(packageStates['pixel']?.entry?.version).toBe('0.1.0')
     expect(packageStates['orca']).toMatchObject({ agentId: 'orca', state: 'unmanaged' })
     expect(packageStates['nonexistent']).toBeUndefined()
   })
@@ -204,13 +208,14 @@ describe('useAgentStore — package state plumbing', () => {
     pkgVariant = {
       ok: true,
       agents: [
-        { agentId: 'pixel', state: 'managed', packageId: 'examples/pixel@0.1.0', entry: PKG_OK.agents?.[0].entry },
-        { agentId: 'orca', state: 'adopted', packageId: 'examples/orca@0.1.0' },
+        { agentId: 'pixel', state: 'managed', version: '0.1.0', packageId: 'examples/pixel@0.1.0', entry: PKG_OK.agents?.[0].entry },
+        { agentId: 'orca', state: 'adopted', version: '0.2.0', packageId: 'examples/orca@0.2.0', entry: { version: '0.2.0', source: 'github:examples/orca', ref: 'main', commitSha: 'def5678', installedAt: '2026-04-25T00:00:00Z' } },
       ],
     }
     await useAgentStore.getState().refreshPackageStates()
 
     expect(useAgentStore.getState().packageStates['orca']?.state).toBe('adopted')
+    expect(useAgentStore.getState().packageStates['orca']?.version).toBe('0.2.0')
   })
 
   it('roster fetch failure short-circuits before package merge', async () => {


### PR DESCRIPTION
## Summary
- Expose lockfile-backed agent package versions on package state and render them in plain CLI/TUI package lists.
- Show installed agent-kit versions in the Team agent detail package block next to package/source/commit/installed metadata.
- Use the user plugin lockfile version for Health/registry snapshots while keeping core plugin versions sourced from bundled plugin exports.
- Document the version source-of-truth decisions in the issue spec and knowledge notes.

## Review
- Local code review found no blocking issues.
- Main risk checked: stale nested package metadata cannot override the top-level installed version in the agent detail card.
- Scope intentionally leaves standalone non-agent package browser inventory and update-available buttons for later.

## Verification
- `bun run typecheck`
- `bun test --isolate` (`4130 pass`, `10 skip`, `0 fail`)

Fixes #394
