### PR TITLE
Surface workflow skill drift repair

### DIFF
--- a/.claude/knowledge/workflows-plugin.md
+++ b/.claude/knowledge/workflows-plugin.md
@@ -18,7 +18,7 @@ The workflows surface uses the word "skill" in two different places. They are un
 | **Where it lives** | In-memory `pluginSkills` map + `~/.bakin/workflows/skills/*.md` | Runtime adapter skill store (+ `scripts/`) |
 | **Who reads it** | Bakin's workflow runtime (injects body into agent prompt) | Runtime agents |
 | **How it ships** | `defaults/workflow-skills/*.md` → auto-registered by plugin loader at activation (`ctx.registerSkill`) | `defaults/runtime-skills/{name}/` → installed to disk by `bakin install plugin-assets` |
-| **Drift detection** | None — rebuilt every server boot | `.installedBy` JSON marker (sha256), `.userEdited` sentinel, `bakin doctor` surface |
+| **Drift detection** | Local-shadow scanner for `~/.bakin/workflows/skills/*.md` using managed `sourcePath`, `<skill>.md.installedBy`, `<skill>.md.userEdited`, Health/Workflows UI surfaces | `.installedBy` JSON marker (sha256), `.userEdited` sentinel, `bakin doctor` surface |
 
 **Rule of thumb:** if it's a workflow `step.skill: write-copy`, it's S-A. If it's something an agent invokes through the runtime skill mechanism, it's S-B.
 
@@ -44,7 +44,30 @@ None of the three are required. A plugin can ship any subset.
 | `defaults/workflow-skills/` | `src/lib/plugin-skill-loader.ts` (invoked by `src/lib/plugin-registry.ts` after every `activate()`) | Server boot, every startup, generic across all plugins |
 | `defaults/runtime-skills/` | `src/core/onboarding/plugin-assets.ts` (`scanPluginAssets` + `installPluginAssets`) | `bakin install plugin-assets` (manual), or surfaced by `bakin doctor` |
 
-The first two paths are in-memory only — every reboot rebuilds them from disk. The third writes to the runtime skill store and needs explicit drift management.
+The workflow definition and managed workflow-skill registries are rebuilt on every boot. User workflow-skill files under `~/.bakin/workflows/skills/*.md` still win over managed sources, so those local shadows need drift visibility when a shipped skill contract changes.
+
+### S-A drift detection and repair
+
+`plugins/workflows/lib/workflow-skill-drift.ts` scans local workflow skill markdown files only when they shadow a managed plugin or agent-package skill with the same name. Managed loaders preserve `SkillDefinition.sourcePath`, letting the scanner compare the local file against the current shipped markdown without materializing every managed skill to disk.
+
+Stale patterns are intentionally narrow and contract-oriented: old generated media path fields (`image_path`, `imagePath`, `video_path`, `videoPath`, `audio_path`, `audioPath`), old image filename/prompt-packet fields (`image_filename`, `promptAssetFilename`, `savePromptPacket`), and legacy execution tool names such as `beacon_exec_` / `bakin_exec_gen_image`.
+
+Workflow skill sidecars live next to the markdown file:
+
+```
+~/.bakin/workflows/skills/generate-image.md
+~/.bakin/workflows/skills/generate-image.md.installedBy
+~/.bakin/workflows/skills/generate-image.md.userEdited
+```
+
+Repair is full-file replacement from the current managed source, never phrase-level patching. It is available only when `.installedBy` proves the local file is still managed and unedited, or when the exact local hash matches a repo-shipped known-old hash from `plugins/workflows/defaults/workflow-skill-legacy-hashes.json`. `.userEdited`, unknown, or customized files are advisory-only.
+
+Surfaces:
+
+- Health check `workflows.skills` reports stale local shadows and contributes a doctor repair plan for safe cases.
+- `GET /api/plugins/workflows/definitions` and `GET /api/plugins/workflows/definitions/:name` include `skillDrift` summaries for affected workflows and steps.
+- `POST /api/plugins/workflows/skills/:name/repair` applies the same safe repair path used by Health.
+- The Workflows UI shows stale-skill badges on workflow cards, a detail banner, highlighted step nodes, and a drawer repair button when the file is safe to replace.
 
 ## Source Registry
 

--- a/.claude/specs/workflow-cleanup-and-refactor-plan.md
+++ b/.claude/specs/workflow-cleanup-and-refactor-plan.md
@@ -200,13 +200,12 @@ Release note headline:
 
 Scope:
 
-- Add managed provenance for installed workflow skills.
-- Add a workflow-skill materializer/installer because plugin and agent-package workflow skills currently live in memory and otherwise have no sidecar location.
+- Add managed provenance for plugin and agent-package workflow skills.
+- Detect local user workflow skill files that shadow those managed sources. Do not proactively materialize every managed workflow skill to disk.
 - Store workflow skill provenance in sidecars next to the markdown file:
   - `<skill>.md.installedBy`
   - `<skill>.md.userEdited`
-- Materialize managed workflow skills to `~/.bakin/workflows/skills/{name}.md` only when safe:
-  - missing target
+- Replace `~/.bakin/workflows/skills/{name}.md` only through explicit repair when safe:
   - target has matching managed provenance
   - target exactly matches a known old repo-shipped skill hash and user confirms adopt-and-replace
 - Detect stale installed workflow skill patterns:
@@ -220,7 +219,7 @@ Scope:
   - path-based generated image outputs
   - path-based generated media outputs
   - manual-save instructions that conflict with managed asset generation
-- Surface results through doctor/health UI and CLI.
+- Surface results through Health/doctor and contextual Workflows UI.
 - Add repair planning for managed, unedited stale skills.
 - Repair by full-file replacement only when provenance proves the current file is managed and unedited.
 - Offer adopt-and-replace for unmarked files only when the current hash exactly matches a known old repo-shipped workflow skill hash from a repo-shipped manifest.
@@ -233,27 +232,29 @@ Non-scope:
 - No repair without explicit doctor repair flow.
 - No phrase-level patching of customized or unknown workflow skill files.
 - No repo default contract cleanup, already handled in PR 2.
+- No proactive boot-time materialization of all managed workflow skills.
 
 Likely files:
 
 - `plugins/workflows/lib/health-checks.ts`
 - `plugins/workflows/lib/skill-loader.ts`
 - `plugins/workflows/lib/agent-package-skill-registry.ts`
-- `plugins/workflows/lib/workflow-skill-materializer.ts`
+- `plugins/workflows/lib/workflow-skill-drift.ts`
 - `plugins/workflows/defaults/workflow-skill-legacy-hashes.json`
 - `plugins/workflows/index.ts`
-- `src/core/doctor-repair.ts` only if existing repair orchestration needs small extension
 - `tests/plugins/workflows/health-checks.test.ts`
-- `tests/cli/doctor-repair.test.ts` if CLI behavior changes
+- `tests/plugins/workflows/workflow-skill-drift.test.ts`
+- `tests/plugins/workflows/routes.test.ts`
+- `tests/plugins/workflows/workflow-canvas.test.tsx`
+- `tests/plugins/workflows/workflow-detail.test.tsx`
 - `.claude/knowledge/workflows-plugin.md`
-- `.claude/knowledge/doctor-and-health-checks.md`
 
 Acceptance criteria:
 
 - Doctor flags the stale local `generate-image.md` patterns described by #342.
 - Doctor also flags stale path-style media output patterns such as `videoPath`, `video_path`, `audioPath`, and `audio_path`.
-- Plugin and agent-package workflow skills can be materialized to disk with sidecar provenance.
-- Existing unmarked customized local workflow skills are not overwritten by materialization.
+- Plugin and agent-package workflow skill loaders preserve source-file provenance.
+- Existing unmarked customized local workflow skills are not overwritten by repair.
 - The exact-old-hash adoption list is repo-shipped and deterministic, not network-fetched.
 - The legacy-hash manifest is manually maintained in the same PR as any
   workflow-skill change that needs adopt-and-replace repair. Each entry records
@@ -267,7 +268,7 @@ Acceptance criteria:
 - Unmarked files can be adopted and replaced only when they exactly match a known old repo-shipped skill hash and the user confirms.
 - Customized workflow skills are not auto-repaired.
 - Files marked `.userEdited`, files with missing provenance, and files whose current hash differs from the recorded installed hash are advisory-only unless they satisfy the exact old-hash adoption path.
-- UI and CLI can show the drift through health surfaces.
+- UI and CLI can show the drift through Health surfaces, and the Workflows UI can show contextual warnings for affected workflows/steps.
 - Tests cover detection and at least one safe repair path.
 
 Verification:

--- a/docs/public/llms/hooks.md
+++ b/docs/public/llms/hooks.md
@@ -397,7 +397,7 @@ Workflow hooks expose workflow definitions, instances, steps, gates, and notific
 Label: Approve workflow gate.
 Purpose: Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks.
 Kind: rpc
-Source: plugins/workflows/index.ts:1592
+Source: plugins/workflows/index.ts:1682
 
 Example:
 
@@ -413,7 +413,7 @@ const result = await ctx.hooks.invoke(
 Label: Authorize workflow tool use.
 Purpose: Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation.
 Kind: rpc
-Source: plugins/workflows/index.ts:1618
+Source: plugins/workflows/index.ts:1708
 
 Example:
 
@@ -429,7 +429,7 @@ const result = await ctx.hooks.invoke(
 Label: Cancel workflow instance.
 Purpose: Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue.
 Kind: event
-Source: plugins/workflows/index.ts:1622
+Source: plugins/workflows/index.ts:1712
 
 Example:
 
@@ -447,7 +447,7 @@ await ctx.hooks.callAll(
 Label: Complete workflow step.
 Purpose: Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action.
 Kind: rpc
-Source: plugins/workflows/index.ts:1610
+Source: plugins/workflows/index.ts:1700
 
 Example:
 
@@ -469,7 +469,7 @@ const result = await ctx.hooks.invoke(
 Label: Create workflow instance.
 Purpose: Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.
 Kind: rpc
-Source: plugins/workflows/index.ts:1591
+Source: plugins/workflows/index.ts:1681
 
 Example:
 
@@ -489,7 +489,7 @@ const result = await ctx.hooks.invoke(
 Label: List workflow definitions.
 Purpose: Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances.
 Kind: rpc
-Source: plugins/workflows/index.ts:1612
+Source: plugins/workflows/index.ts:1702
 
 Example:
 
@@ -505,7 +505,7 @@ const result = await ctx.hooks.invoke(
 Label: List active workflow agents.
 Purpose: Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants.
 Kind: rpc
-Source: plugins/workflows/index.ts:1617
+Source: plugins/workflows/index.ts:1707
 
 Example:
 
@@ -523,7 +523,7 @@ const result = await ctx.hooks.invoke(
 Label: Get current step.
 Purpose: Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable.
 Kind: rpc
-Source: plugins/workflows/index.ts:1609
+Source: plugins/workflows/index.ts:1699
 
 Example:
 
@@ -542,7 +542,7 @@ const result = await ctx.hooks.invoke(
 Label: Get notification channel.
 Purpose: Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation.
 Kind: rpc
-Source: plugins/workflows/index.ts:1628
+Source: plugins/workflows/index.ts:1718
 
 Example:
 
@@ -560,7 +560,7 @@ const result = await ctx.hooks.invoke(
 Label: List workflow instances.
 Purpose: Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state.
 Kind: rpc
-Source: plugins/workflows/index.ts:1608
+Source: plugins/workflows/index.ts:1698
 
 Example:
 
@@ -578,7 +578,7 @@ const result = await ctx.hooks.invoke(
 Label: Check gate notification.
 Purpose: Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.
 Kind: rpc
-Source: plugins/workflows/index.ts:1619
+Source: plugins/workflows/index.ts:1709
 
 Example:
 
@@ -597,7 +597,7 @@ const result = await ctx.hooks.invoke(
 Label: Load workflow definition.
 Purpose: Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.
 Kind: rpc
-Source: plugins/workflows/index.ts:1613
+Source: plugins/workflows/index.ts:1703
 
 Example:
 
@@ -615,7 +615,7 @@ const result = await ctx.hooks.invoke(
 Label: Load workflow instance.
 Purpose: Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly.
 Kind: rpc
-Source: plugins/workflows/index.ts:1589
+Source: plugins/workflows/index.ts:1679
 
 Example:
 
@@ -633,7 +633,7 @@ const result = await ctx.hooks.invoke(
 Label: Mark gate notified.
 Purpose: Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates.
 Kind: rpc
-Source: plugins/workflows/index.ts:1620
+Source: plugins/workflows/index.ts:1710
 
 Example:
 
@@ -652,7 +652,7 @@ const result = await ctx.hooks.invoke(
 Label: Match workflow.
 Purpose: Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template.
 Kind: rpc
-Source: plugins/workflows/index.ts:1611
+Source: plugins/workflows/index.ts:1701
 
 Example:
 
@@ -671,7 +671,7 @@ const result = await ctx.hooks.invoke(
 Label: List notification channels.
 Purpose: Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts.
 Kind: rpc
-Source: plugins/workflows/index.ts:1627
+Source: plugins/workflows/index.ts:1717
 
 Example:
 
@@ -687,7 +687,7 @@ const result = await ctx.hooks.invoke(
 Label: Reject workflow gate.
 Purpose: Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks.
 Kind: rpc
-Source: plugins/workflows/index.ts:1596
+Source: plugins/workflows/index.ts:1686
 
 Example:
 
@@ -703,7 +703,7 @@ const result = await ctx.hooks.invoke(
 Label: Reopen workflow from step.
 Purpose: Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task.
 Kind: rpc
-Source: plugins/workflows/index.ts:1601
+Source: plugins/workflows/index.ts:1691
 
 Example:
 
@@ -719,7 +719,7 @@ const result = await ctx.hooks.invoke(
 Label: Save workflow instance.
 Purpose: Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer.
 Kind: rpc
-Source: plugins/workflows/index.ts:1590
+Source: plugins/workflows/index.ts:1680
 
 Example:
 
@@ -740,7 +740,7 @@ const result = await ctx.hooks.invoke(
 Label: Validate step output.
 Purpose: Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow.
 Kind: rpc
-Source: plugins/workflows/index.ts:1621
+Source: plugins/workflows/index.ts:1711
 
 Example:
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -12434,6 +12434,173 @@
         "x-bakin-full-path": "/api/plugins/workflows/definitions/:name"
       }
     },
+    "/api/plugins/workflows/skills/{name}/repair": {
+      "post": {
+        "operationId": "workflows.post.skills-name-repair",
+        "summary": "Repair stale workflow skill",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type — body content type does not match the declared content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ],
+        "description": "Repair a stale local workflow skill from its managed source when safe",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "confirmKnownOld": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-bakin-full-path": "/api/plugins/workflows/skills/:name/repair"
+      }
+    },
     "/api/plugins/workflows/definitions/{name}/availability": {
       "patch": {
         "operationId": "workflows.patch.definitions-name-availability",

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -1575,6 +1575,16 @@ curl -sS \
 ```
 </OpenApiReference>
 
+<OpenApiReference operationId="workflows.post.skills-name-repair">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/workflows/skills/<name>/repair' \
+  -H 'Content-Type: application/json' \
+  --data '{"confirmKnownOld":true}'
+```
+</OpenApiReference>
+
 <OpenApiReference operationId="workflows.get.steps-task-id">
 ```sh frame="terminal" showLineNumbers
 curl -sS \
@@ -1591,5 +1601,5 @@ curl -sS \
 </OpenApiReference>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/cli.mdx
+++ b/docs/src/content/docs/reference/generated/cli.mdx
@@ -838,5 +838,5 @@ bakin serve
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/core-plugins.md
+++ b/docs/src/content/docs/reference/generated/core-plugins.md
@@ -100,5 +100,5 @@ description: Generated catalog of official plugins supported by Bakin.
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/exec-tools.mdx
+++ b/docs/src/content/docs/reference/generated/exec-tools.mdx
@@ -111,7 +111,7 @@ mcporter call bakin-<agent>.bakin_exec_assets_save --args '{
 <p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="check-gates" name="bakin_exec_check_gates" label="Checked workflow gates" description="Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending." source="plugins/workflows/index.ts:1881" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (or workflow instance ID)"}]}>
+<McpToolCard id="check-gates" name="bakin_exec_check_gates" label="Checked workflow gates" description="Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending." source="plugins/workflows/index.ts:1972" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (or workflow instance ID)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_check_gates --args '{
   "taskId": "value"
@@ -130,7 +130,7 @@ mcporter call bakin-<agent>.bakin_exec_check_gates --args '{
 mcporter call bakin-<agent>.bakin_exec_get_paths
 ```
 </McpToolCard>
-<McpToolCard id="get-step" name="bakin_exec_get_step" label="Read workflow step" description="Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure." source="plugins/workflows/index.ts:1805" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="get-step" name="bakin_exec_get_step" label="Read workflow step" description="Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure." source="plugins/workflows/index.ts:1896" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_get_step --args '{
   "taskId": "value"
@@ -885,7 +885,7 @@ mcporter call bakin-<agent>.bakin_exec_search_table --args '{
 <p class="mcp-section-description">Workflow submission tools let agents submit step output back to the workflow engine.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="submit-step" name="bakin_exec_submit_step" label="Submitted workflow step" description="Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip." source="plugins/workflows/index.ts:1825" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to submit for"},{"name":"output","type":"record","required":true,"description":"JSON output matching the step schema"}]}>
+<McpToolCard id="submit-step" name="bakin_exec_submit_step" label="Submitted workflow step" description="Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip." source="plugins/workflows/index.ts:1916" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to submit for"},{"name":"output","type":"record","required":true,"description":"JSON output matching the step schema"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_submit_step --args '{
   "taskId": "value",
@@ -1124,7 +1124,7 @@ mcporter call bakin-<agent>.bakin_exec_team_update_identity --args '{
 <p class="mcp-section-description">Workflow tools expose workflow definitions, active instances, current steps, and step completion.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="workflows-complete-step" name="bakin_exec_workflows_complete_step" label="Completed workflow step" description="Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete." source="plugins/workflows/index.ts:1769" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to complete"},{"name":"output","type":"record","required":true,"description":"Step output object"}]}>
+<McpToolCard id="workflows-complete-step" name="bakin_exec_workflows_complete_step" label="Completed workflow step" description="Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete." source="plugins/workflows/index.ts:1860" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to complete"},{"name":"output","type":"record","required":true,"description":"Step output object"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_complete_step --args '{
   "taskId": "value",
@@ -1135,40 +1135,40 @@ mcporter call bakin-<agent>.bakin_exec_workflows_complete_step --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-definition" name="bakin_exec_workflows_get_definition" label="Read workflow definition" description="Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows." source="plugins/workflows/index.ts:1675" parameters={[{"name":"name","type":"string","required":true,"description":"Workflow definition filename (e.g. \"content-pipeline\")"}]}>
+<McpToolCard id="workflows-get-definition" name="bakin_exec_workflows_get_definition" label="Read workflow definition" description="Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows." source="plugins/workflows/index.ts:1766" parameters={[{"name":"name","type":"string","required":true,"description":"Workflow definition filename (e.g. \"content-pipeline\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_definition --args '{
   "name": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-instance" name="bakin_exec_workflows_get_instance" label="Read workflow instance" description="Get the full state of a workflow instance for a task, including step states and history." source="plugins/workflows/index.ts:1741" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="workflows-get-instance" name="bakin_exec_workflows_get_instance" label="Read workflow instance" description="Get the full state of a workflow instance for a task, including step states and history." source="plugins/workflows/index.ts:1832" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_instance --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-step" name="bakin_exec_workflows_get_step" label="Read workflow step" description="Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next." source="plugins/workflows/index.ts:1755" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="workflows-get-step" name="bakin_exec_workflows_get_step" label="Read workflow step" description="Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next." source="plugins/workflows/index.ts:1846" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_step --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-list" name="bakin_exec_workflows_list" label="Listed workflows" description="List all workflow definitions (templates). Returns name, filename, description, and step count for each." source="plugins/workflows/index.ts:1656">
+<McpToolCard id="workflows-list" name="bakin_exec_workflows_list" label="Listed workflows" description="List all workflow definitions (templates). Returns name, filename, description, and step count for each." source="plugins/workflows/index.ts:1747">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_list
 ```
 </McpToolCard>
-<McpToolCard id="workflows-list-instances" name="bakin_exec_workflows_list_instances" label="Listed workflow runs" description="List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled)." source="plugins/workflows/index.ts:1728" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by instance status"}]}>
+<McpToolCard id="workflows-list-instances" name="bakin_exec_workflows_list_instances" label="Listed workflow runs" description="List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled)." source="plugins/workflows/index.ts:1819" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by instance status"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_list_instances --args '{
   "status": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-start" name="bakin_exec_workflows_start" label="Started a workflow" description="Start a workflow instance for a task. The task must exist on the board. Returns the created instance." source="plugins/workflows/index.ts:1693" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID to start workflow for"},{"name":"workflowId","type":"string","required":true,"description":"Workflow definition filename"}]}>
+<McpToolCard id="workflows-start" name="bakin_exec_workflows_start" label="Started a workflow" description="Start a workflow instance for a task. The task must exist on the board. Returns the created instance." source="plugins/workflows/index.ts:1784" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID to start workflow for"},{"name":"workflowId","type":"string","required":true,"description":"Workflow definition filename"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
   "taskId": "value",
@@ -1179,5 +1179,5 @@ mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -249,7 +249,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Workflow hooks expose workflow definitions, instances, steps, gates, and notification helpers for task automation.</p>
 
 <div class="hook-card-list">
-<HookCard id="workflows-approvegate" name="workflows.approveGate" label="Approve workflow gate." summary="Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1592" badges={["rpc"]}>
+<HookCard id="workflows-approvegate" name="workflows.approveGate" label="Approve workflow gate." summary="Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1682" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.approveGate',
@@ -257,7 +257,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-authorizetooluse" name="workflows.authorizeToolUse" label="Authorize workflow tool use." summary="Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation." source="plugins/workflows/index.ts:1618" badges={["rpc"]}>
+<HookCard id="workflows-authorizetooluse" name="workflows.authorizeToolUse" label="Authorize workflow tool use." summary="Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation." source="plugins/workflows/index.ts:1708" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.authorizeToolUse',
@@ -265,7 +265,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-cancelinstance" name="workflows.cancelInstance" label="Cancel workflow instance." summary="Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue." source="plugins/workflows/index.ts:1622" badges={["event"]}>
+<HookCard id="workflows-cancelinstance" name="workflows.cancelInstance" label="Cancel workflow instance." summary="Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue." source="plugins/workflows/index.ts:1712" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'workflows.cancelInstance',
@@ -275,7 +275,7 @@ await ctx.hooks.callAll(
 )
 ```
 </HookCard>
-<HookCard id="workflows-completestep" name="workflows.completeStep" label="Complete workflow step." summary="Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action." source="plugins/workflows/index.ts:1610" badges={["rpc"]}>
+<HookCard id="workflows-completestep" name="workflows.completeStep" label="Complete workflow step." summary="Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action." source="plugins/workflows/index.ts:1700" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.completeStep',
@@ -289,7 +289,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-createinstance" name="workflows.createInstance" label="Create workflow instance." summary="Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow." source="plugins/workflows/index.ts:1591" badges={["rpc"]}>
+<HookCard id="workflows-createinstance" name="workflows.createInstance" label="Create workflow instance." summary="Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow." source="plugins/workflows/index.ts:1681" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.createInstance',
@@ -301,7 +301,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-definitions-list" name="workflows.definitions.list" label="List workflow definitions." summary="Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances." source="plugins/workflows/index.ts:1612" badges={["rpc"]}>
+<HookCard id="workflows-definitions-list" name="workflows.definitions.list" label="List workflow definitions." summary="Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances." source="plugins/workflows/index.ts:1702" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.definitions.list',
@@ -309,7 +309,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getactiveagents" name="workflows.getActiveAgents" label="List active workflow agents." summary="Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants." source="plugins/workflows/index.ts:1617" badges={["rpc"]}>
+<HookCard id="workflows-getactiveagents" name="workflows.getActiveAgents" label="List active workflow agents." summary="Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants." source="plugins/workflows/index.ts:1707" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getActiveAgents',
@@ -319,7 +319,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getcurrentstep" name="workflows.getCurrentStep" label="Get current step." summary="Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable." source="plugins/workflows/index.ts:1609" badges={["rpc"]}>
+<HookCard id="workflows-getcurrentstep" name="workflows.getCurrentStep" label="Get current step." summary="Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable." source="plugins/workflows/index.ts:1699" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getCurrentStep',
@@ -330,7 +330,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getnotificationchannel" name="workflows.getNotificationChannel" label="Get notification channel." summary="Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation." source="plugins/workflows/index.ts:1628" badges={["rpc"]}>
+<HookCard id="workflows-getnotificationchannel" name="workflows.getNotificationChannel" label="Get notification channel." summary="Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation." source="plugins/workflows/index.ts:1718" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getNotificationChannel',
@@ -340,7 +340,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-instances-list" name="workflows.instances.list" label="List workflow instances." summary="Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state." source="plugins/workflows/index.ts:1608" badges={["rpc"]}>
+<HookCard id="workflows-instances-list" name="workflows.instances.list" label="List workflow instances." summary="Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state." source="plugins/workflows/index.ts:1698" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.instances.list',
@@ -350,7 +350,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-isgatenotified" name="workflows.isGateNotified" label="Check gate notification." summary="Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step." source="plugins/workflows/index.ts:1619" badges={["rpc"]}>
+<HookCard id="workflows-isgatenotified" name="workflows.isGateNotified" label="Check gate notification." summary="Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step." source="plugins/workflows/index.ts:1709" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.isGateNotified',
@@ -361,7 +361,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-loaddefinition" name="workflows.loadDefinition" label="Load workflow definition." summary="Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id." source="plugins/workflows/index.ts:1613" badges={["rpc"]}>
+<HookCard id="workflows-loaddefinition" name="workflows.loadDefinition" label="Load workflow definition." summary="Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id." source="plugins/workflows/index.ts:1703" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.loadDefinition',
@@ -371,7 +371,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-loadinstance" name="workflows.loadInstance" label="Load workflow instance." summary="Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly." source="plugins/workflows/index.ts:1589" badges={["rpc"]}>
+<HookCard id="workflows-loadinstance" name="workflows.loadInstance" label="Load workflow instance." summary="Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly." source="plugins/workflows/index.ts:1679" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.loadInstance',
@@ -381,7 +381,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-markgatenotified" name="workflows.markGateNotified" label="Mark gate notified." summary="Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates." source="plugins/workflows/index.ts:1620" badges={["rpc"]}>
+<HookCard id="workflows-markgatenotified" name="workflows.markGateNotified" label="Mark gate notified." summary="Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates." source="plugins/workflows/index.ts:1710" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.markGateNotified',
@@ -392,7 +392,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-matchworkflow" name="workflows.matchWorkflow" label="Match workflow." summary="Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template." source="plugins/workflows/index.ts:1611" badges={["rpc"]}>
+<HookCard id="workflows-matchworkflow" name="workflows.matchWorkflow" label="Match workflow." summary="Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template." source="plugins/workflows/index.ts:1701" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.matchWorkflow',
@@ -403,7 +403,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-notificationchannels-list" name="workflows.notificationChannels.list" label="List notification channels." summary="Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts." source="plugins/workflows/index.ts:1627" badges={["rpc"]}>
+<HookCard id="workflows-notificationchannels-list" name="workflows.notificationChannels.list" label="List notification channels." summary="Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts." source="plugins/workflows/index.ts:1717" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.notificationChannels.list',
@@ -411,7 +411,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-rejectgate" name="workflows.rejectGate" label="Reject workflow gate." summary="Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1596" badges={["rpc"]}>
+<HookCard id="workflows-rejectgate" name="workflows.rejectGate" label="Reject workflow gate." summary="Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1686" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.rejectGate',
@@ -419,7 +419,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-reopenfromstep" name="workflows.reopenFromStep" label="Reopen workflow from step." summary="Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task." source="plugins/workflows/index.ts:1601" badges={["rpc"]}>
+<HookCard id="workflows-reopenfromstep" name="workflows.reopenFromStep" label="Reopen workflow from step." summary="Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task." source="plugins/workflows/index.ts:1691" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.reopenFromStep',
@@ -427,7 +427,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-saveinstance" name="workflows.saveInstance" label="Save workflow instance." summary="Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer." source="plugins/workflows/index.ts:1590" badges={["rpc"]}>
+<HookCard id="workflows-saveinstance" name="workflows.saveInstance" label="Save workflow instance." summary="Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer." source="plugins/workflows/index.ts:1680" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.saveInstance',
@@ -440,7 +440,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-validatestepoutput" name="workflows.validateStepOutput" label="Validate step output." summary="Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow." source="plugins/workflows/index.ts:1621" badges={["rpc"]}>
+<HookCard id="workflows-validatestepoutput" name="workflows.validateStepOutput" label="Validate step output." summary="Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow." source="plugins/workflows/index.ts:1711" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.validateStepOutput',
@@ -458,5 +458,5 @@ const result = await ctx.hooks.invoke(
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/runtime-paths.md
+++ b/docs/src/content/docs/reference/generated/runtime-paths.md
@@ -100,5 +100,5 @@ description: Reference for Bakin runtime files under the resolved Bakin home dir
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -655,5 +655,5 @@ Source: `packages/sdk/src/routing/index.ts`.
 | `DefinePluginInput` | — |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -361,5 +361,5 @@ description: Generated reference for Bakin core settings defaults.
 
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 1, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 2, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/using/workflows.md
+++ b/docs/src/content/docs/using/workflows.md
@@ -49,6 +49,12 @@ Gates pause the workflow until you decide. The task's detail panel shows the gat
 
 Workflows cancel automatically when their task moves to `Done` or `Blocked`, or when the task is deleted. No separate stop button.
 
+### Stale workflow skills
+
+Workflow steps can use markdown skills. If you have a local skill file under `~/.bakin/workflows/skills/` that shadows a managed plugin or agent package skill, Bakin checks whether that file still matches current workflow contracts.
+
+When a stale local skill affects a workflow, the Workflows UI shows a warning on the workflow card, the workflow detail header, and the affected step node. Open the highlighted step to see what changed. If Bakin can prove the file is still managed and unedited, the drawer offers a repair action that replaces the entire local skill from the current managed source. Files marked `.userEdited` or customized without known provenance are shown as advisory warnings and are not overwritten.
+
 ## Concepts
 
 - **Definitions vs instances.** A definition is the recipe. An instance is one run of that recipe tied to a specific task. Many instances of one definition.
@@ -61,7 +67,7 @@ Workflows cancel automatically when their task moves to `Done` or `Blocked`, or 
 ~/.bakin/workflows/
   definitions/*.yaml       # the recipes
   instances/<taskId>.json  # per-task runtime state
-  skills/                  # workflow skill markdown
+  skills/                  # local workflow skill markdown and optional .installedBy/.userEdited sidecars
 ```
 
 Definitions and instances both index into search (table `bakin_workflows`) on name, description, and step content.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1450,20 +1450,6 @@ function updateAgentAllowlist(agentId: string, updater: (current: string[]) => s
   writeOpenClawConfig(config as unknown as Record<string, unknown>)
 }
 
-function removeAgentFromAllAllowlists(agentId: string): void {
-  const config = readOpenClawConfig()
-  const agents = config?.agents?.list
-  if (!agents) return
-  let changed = false
-  for (const agent of agents) {
-    const allowAgents = agent.subagents?.allowAgents
-    if (!allowAgents?.includes(agentId)) continue
-    agent.subagents!.allowAgents = allowAgents.filter((id) => id !== agentId)
-    changed = true
-  }
-  if (changed) writeOpenClawConfig(config as unknown as Record<string, unknown>)
-}
-
 function removeOpenClawAgentConfig(agentId: string): void {
   const config = readOpenClawConfig()
   const agents = config?.agents?.list

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -141,6 +141,8 @@ export interface SkillDefinition {
   instructions: string
   output_schema?: Record<string, unknown>
   source?: string // 'built-in' | 'user' | 'plugin:<id>' — set automatically
+  /** Absolute source markdown file path when the skill was loaded from a managed package/plugin file. */
+  sourcePath?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -973,6 +973,8 @@ export interface SkillDefinition {
   instructions: string
   output_schema?: Record<string, unknown>
   source?: string
+  /** Absolute source markdown file path when the skill was loaded from a managed package/plugin file. */
+  sourcePath?: string
 }
 
 /** Layout hints for a workflow's canvas rendering. */

--- a/plugins/workflows/components/nodes/agent-node.tsx
+++ b/plugins/workflows/components/nodes/agent-node.tsx
@@ -19,25 +19,30 @@ export function AgentNode({ data }: NodeProps) {
   const excerpt = task && task.length > 80 ? task.slice(0, 80).trim() + '…' : task
 
   return (
-    <div className={`flex h-full w-full flex-col justify-center rounded-lg border-2 bg-zinc-900 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-zinc-700'}`}>
-      <div className="mb-2 flex items-center gap-2">
-        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-emerald-500/10 ring-1 ring-emerald-500/25">
-          <User className="size-3.5 text-emerald-400" />
-        </span>
-        <span className="text-xs font-bold uppercase tracking-wider text-emerald-400">
-          Agent Task
-        </span>
-      </div>
-      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
-      <AgentAssignmentLabel agent={agent} className="mt-1" />
-      {hasSkillDrift && (
-        <div className="mt-1 inline-flex w-fit items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-200">
-          <AlertTriangle className="size-3" />
-          Stale skill
+    <div className={`flex h-full w-full flex-col overflow-hidden rounded-lg border-2 bg-zinc-900 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-zinc-700'}`}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-emerald-500/10 ring-1 ring-emerald-500/25">
+            <User className="size-3.5 text-emerald-400" />
+          </span>
+          <span className="truncate text-xs font-bold uppercase tracking-wider text-emerald-400">
+            Agent Task
+          </span>
         </div>
-      )}
+        {hasSkillDrift && (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-amber-200"
+            title="This step uses a stale workflow skill"
+          >
+            <AlertTriangle className="size-3" />
+            Stale
+          </span>
+        )}
+      </div>
+      <div className="truncate text-sm font-medium leading-5 text-zinc-100">{label}</div>
+      <AgentAssignmentLabel agent={agent} className="mt-1" />
       {excerpt && (
-        <p className="mt-0.5 truncate text-[11px] leading-snug text-zinc-500">{excerpt}</p>
+        <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-zinc-500">{excerpt}</p>
       )}
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />

--- a/plugins/workflows/components/nodes/agent-node.tsx
+++ b/plugins/workflows/components/nodes/agent-node.tsx
@@ -1,23 +1,25 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
-import { User } from 'lucide-react'
+import { AlertTriangle, User } from 'lucide-react'
 import { AgentAssignmentLabel } from './agent-assignment-label'
 
 interface AgentNodeData extends Record<string, unknown> {
   label: string
   agent?: string
   task?: string
+  skillDrift?: unknown
 }
 
 export function AgentNode({ data }: NodeProps) {
-  const { label, agent, task } = data as AgentNodeData
+  const { label, agent, task, skillDrift } = data as AgentNodeData
+  const hasSkillDrift = Boolean(skillDrift)
 
   // Show first ~80 chars of task as excerpt
   const excerpt = task && task.length > 80 ? task.slice(0, 80).trim() + '…' : task
 
   return (
-    <div className="flex h-full w-full flex-col justify-center rounded-lg border-2 border-zinc-700 bg-zinc-900 px-4 py-3 shadow-lg">
+    <div className={`flex h-full w-full flex-col justify-center rounded-lg border-2 bg-zinc-900 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-zinc-700'}`}>
       <div className="mb-2 flex items-center gap-2">
         <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-emerald-500/10 ring-1 ring-emerald-500/25">
           <User className="size-3.5 text-emerald-400" />
@@ -28,6 +30,12 @@ export function AgentNode({ data }: NodeProps) {
       </div>
       <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
       <AgentAssignmentLabel agent={agent} className="mt-1" />
+      {hasSkillDrift && (
+        <div className="mt-1 inline-flex w-fit items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-200">
+          <AlertTriangle className="size-3" />
+          Stale skill
+        </div>
+      )}
       {excerpt && (
         <p className="mt-0.5 truncate text-[11px] leading-snug text-zinc-500">{excerpt}</p>
       )}

--- a/plugins/workflows/components/nodes/output-node.tsx
+++ b/plugins/workflows/components/nodes/output-node.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
-import { Radio } from 'lucide-react'
+import { AlertTriangle, Radio } from 'lucide-react'
 import { AgentAssignmentLabel } from './agent-assignment-label'
 
 interface OutputNodeData extends Record<string, unknown> {
@@ -9,14 +9,16 @@ interface OutputNodeData extends Record<string, unknown> {
   agent?: string
   channels?: string[]
   description?: string
+  skillDrift?: unknown
 }
 
 export function OutputNode({ data }: NodeProps) {
-  const { label, agent, channels, description } = data as OutputNodeData
+  const { label, agent, channels, description, skillDrift } = data as OutputNodeData
+  const hasSkillDrift = Boolean(skillDrift)
   const channelText = channels && channels.length > 0 ? channels.join(', ') : undefined
 
   return (
-    <div className="flex h-full w-full flex-col justify-center rounded-lg border border-purple-500/50 bg-zinc-900 px-4 py-3 shadow-lg">
+    <div className={`flex h-full w-full flex-col justify-center rounded-lg border bg-zinc-900 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-purple-500/50'}`}>
       <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-purple-400">
         <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-purple-500/10">
           <Radio className="size-3.5" />
@@ -25,6 +27,12 @@ export function OutputNode({ data }: NodeProps) {
       </div>
       <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
       {agent && <AgentAssignmentLabel agent={agent} className="mt-1" />}
+      {hasSkillDrift && (
+        <div className="mt-1 inline-flex w-fit items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-200">
+          <AlertTriangle className="size-3" />
+          Stale skill
+        </div>
+      )}
       {channelText ? (
         <div className={`${agent ? 'mt-0.5' : 'mt-1'} truncate text-[11px] text-zinc-400`}>
           Channels: {channelText}

--- a/plugins/workflows/components/nodes/output-node.tsx
+++ b/plugins/workflows/components/nodes/output-node.tsx
@@ -18,21 +18,26 @@ export function OutputNode({ data }: NodeProps) {
   const channelText = channels && channels.length > 0 ? channels.join(', ') : undefined
 
   return (
-    <div className={`flex h-full w-full flex-col justify-center rounded-lg border bg-zinc-900 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-purple-500/50'}`}>
-      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-purple-400">
-        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-purple-500/10">
-          <Radio className="size-3.5" />
-        </span>
-        Completion
-      </div>
-      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
-      {agent && <AgentAssignmentLabel agent={agent} className="mt-1" />}
-      {hasSkillDrift && (
-        <div className="mt-1 inline-flex w-fit items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium text-amber-200">
-          <AlertTriangle className="size-3" />
-          Stale skill
+    <div className={`flex h-full w-full flex-col overflow-hidden rounded-lg border bg-zinc-900 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-purple-500/50'}`}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2 text-xs font-bold uppercase tracking-wider text-purple-400">
+          <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-purple-500/10">
+            <Radio className="size-3.5" />
+          </span>
+          <span className="truncate">Completion</span>
         </div>
-      )}
+        {hasSkillDrift && (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-amber-200"
+            title="This step uses a stale workflow skill"
+          >
+            <AlertTriangle className="size-3" />
+            Stale
+          </span>
+        )}
+      </div>
+      <div className="truncate text-sm font-medium leading-5 text-zinc-100">{label}</div>
+      {agent && <AgentAssignmentLabel agent={agent} className="mt-1" />}
       {channelText ? (
         <div className={`${agent ? 'mt-0.5' : 'mt-1'} truncate text-[11px] text-zinc-400`}>
           Channels: {channelText}

--- a/plugins/workflows/components/nodes/parallel-node.tsx
+++ b/plugins/workflows/components/nodes/parallel-node.tsx
@@ -1,26 +1,39 @@
 'use client'
 
 import { Handle, Position, type NodeProps } from '@xyflow/react'
-import { GitBranch } from 'lucide-react'
+import { AlertTriangle, GitBranch } from 'lucide-react'
 
 interface ParallelNodeData extends Record<string, unknown> {
   label: string
   width?: number
   height?: number
+  skillDrift?: unknown
 }
 
 export function ParallelNode({ data }: NodeProps) {
-  const { label } = data as ParallelNodeData
+  const { label, skillDrift } = data as ParallelNodeData
+  const hasSkillDrift = Boolean(skillDrift)
 
   return (
-    <div className="flex h-full w-full flex-col justify-center rounded-lg border border-dashed border-blue-500/50 bg-zinc-900/70 px-4 py-3 shadow-lg">
-      <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-blue-300">
-        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-blue-500/10">
-          <GitBranch className="size-3.5" />
-        </span>
-        Parallel Group
+    <div className={`flex h-full w-full flex-col justify-center overflow-hidden rounded-lg border bg-zinc-900/70 px-4 py-3 shadow-lg ${hasSkillDrift ? 'border-amber-500/70 ring-1 ring-amber-500/25' : 'border-dashed border-blue-500/50'}`}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2 text-xs font-bold uppercase tracking-wider text-blue-300">
+          <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-blue-500/10">
+            <GitBranch className="size-3.5" />
+          </span>
+          <span className="truncate">Parallel Group</span>
+        </div>
+        {hasSkillDrift && (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-amber-200"
+            title="This group includes a stale workflow skill"
+          >
+            <AlertTriangle className="size-3" />
+            Stale
+          </span>
+        )}
       </div>
-      <div className="truncate text-sm font-medium text-zinc-100">{label}</div>
+      <div className="truncate text-sm font-medium leading-5 text-zinc-100">{label}</div>
       <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
       <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />
     </div>

--- a/plugins/workflows/components/step-detail-drawer.tsx
+++ b/plugins/workflows/components/step-detail-drawer.tsx
@@ -418,21 +418,61 @@ function stepSkillName(step: WorkflowStep | null): string | undefined {
 }
 
 function sourceLabel(report: WorkflowSkillDriftReport): string {
+  const sourceName = report.managedSource.id
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase())
+
   return report.managedSource.kind === 'plugin'
-    ? `plugin ${report.managedSource.id}`
-    : `agent package ${report.managedSource.id}`
+    ? `${sourceName} plugin`
+    : `${sourceName} agent package`
+}
+
+function findingDisplayLabel(id: string, fallback: string): string {
+  switch (id) {
+    case 'image-output-asset-id':
+      return 'Old image output fields'
+    case 'media-output-asset-id':
+      return 'Old media output fields'
+    case 'prompt-packet-sidecar':
+      return 'Old prompt packet output'
+    case 'legacy-tool-rename':
+      return 'Old tool name'
+    default:
+      return fallback
+  }
+}
+
+function driftImpactText(report: WorkflowSkillDriftReport): string {
+  const findingIds = new Set(report.findings.map(finding => finding.id))
+  if (findingIds.has('image-output-asset-id') || findingIds.has('prompt-packet-sidecar')) {
+    return 'The current image flow saves generated files as managed assets. This local copy still asks for older filename fields, so generated images can fail or lose their saved-asset link.'
+  }
+  if (findingIds.has('media-output-asset-id')) {
+    return 'The current media flow tracks generated files as managed assets. This local copy still asks for older path fields, so generated media can be left untracked.'
+  }
+  if (findingIds.has('legacy-tool-rename')) {
+    return 'This local copy calls an older Bakin tool name, so the workflow step may fail when it runs.'
+  }
+  return 'This local copy uses older instructions than the managed version, so this workflow step may not behave like the current package expects.'
+}
+
+function repairActionText(report: WorkflowSkillDriftReport): string {
+  if (report.repairable) {
+    return `Bakin can replace only the local ${report.skillName} instruction file with the current version from the ${sourceLabel(report)}. The workflow, task, and agent stay the same.`
+  }
+  return `Bakin will not change this file automatically. Review the local ${report.skillName} instruction file and compare it with the current ${sourceLabel(report)} version.`
 }
 
 function repairabilityText(report: WorkflowSkillDriftReport): string {
   switch (report.repairability) {
     case 'safe-managed':
-      return 'Bakin can replace this local skill from the current managed source.'
+      return 'This local copy is still tracked as Bakin-managed, so it is safe to replace.'
     case 'known-old-confirmable':
-      return 'This matches a known old managed skill and can be replaced after confirmation.'
+      return 'This matches an older Bakin-managed copy, so it is safe to replace.'
     case 'user-edited':
-      return 'This file is marked user-edited, so Bakin will not overwrite it.'
+      return 'This file is marked as edited by you, so Bakin will only warn and will not overwrite it.'
     case 'custom-advisory':
-      return 'This local shadow is unmarked or customized, so Bakin will not overwrite it automatically.'
+      return 'This local copy is customized or untracked, so Bakin will only warn and will not overwrite it.'
   }
 }
 
@@ -457,20 +497,37 @@ function SkillDriftSection({
             <span className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-amber-500/15 ring-1 ring-amber-500/25">
               <AlertTriangle className="size-3.5 text-amber-200" />
             </span>
-            <div className="min-w-0 flex-1 space-y-2">
+            <div className="min-w-0 flex-1 space-y-3">
               <div>
-                <div className="text-sm font-medium text-amber-100">Stale workflow skill</div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="text-sm font-medium text-amber-100">This step is using old instructions</div>
+                  <Badge variant="outline" className="border-amber-500/35 text-[10px] font-mono text-amber-100">
+                    {report.skillName}
+                  </Badge>
+                </div>
                 <p className="mt-1 text-xs leading-relaxed text-amber-100/80">
-                  This step uses <span className="font-mono">{report.skillName}</span>, a local file that shadows {sourceLabel(report)}.
+                  A local copy is overriding the current {sourceLabel(report)} version.
                 </p>
               </div>
-              <div className="flex flex-wrap gap-1.5">
-                {report.findings.map((finding) => (
-                  <Badge key={finding.id} variant="outline" className="border-amber-500/35 text-[10px] text-amber-100">
-                    {finding.label}
-                  </Badge>
-                ))}
+
+              <div className="space-y-3 border-t border-amber-500/20 pt-3">
+                <div>
+                  <div className="text-[10px] font-medium uppercase tracking-wider text-amber-100/60">What can break</div>
+                  <p className="mt-1 text-xs leading-relaxed text-amber-100/80">{driftImpactText(report)}</p>
+                </div>
+                <div>
+                  <div className="text-[10px] font-medium uppercase tracking-wider text-amber-100/60">What the fix does</div>
+                  <p className="mt-1 text-xs leading-relaxed text-amber-100/80">{repairActionText(report)}</p>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {report.findings.map((finding) => (
+                    <Badge key={finding.id} variant="outline" className="border-amber-500/35 text-[10px] text-amber-100">
+                      {findingDisplayLabel(finding.id, finding.label)}
+                    </Badge>
+                  ))}
+                </div>
               </div>
+
               <p className="text-xs leading-relaxed text-amber-100/75">{repairabilityText(report)}</p>
               {repairError && (
                 <p className="text-xs leading-relaxed text-red-300">{repairError}</p>
@@ -487,7 +544,7 @@ function SkillDriftSection({
                 className="border-amber-500/35 text-amber-100 hover:bg-amber-500/15"
               >
                 <Wrench className="mr-1.5 size-3.5" />
-                {repairingSkill === report.skillName ? 'Repairing...' : 'Repair skill'}
+                {repairingSkill === report.skillName ? 'Updating...' : 'Use latest version'}
               </Button>
             </div>
           )}

--- a/plugins/workflows/components/step-detail-drawer.tsx
+++ b/plugins/workflows/components/step-detail-drawer.tsx
@@ -417,6 +417,19 @@ function stepSkillName(step: WorkflowStep | null): string | undefined {
   return typeof skill === 'string' ? skill : undefined
 }
 
+function stepSkillNames(step: WorkflowStep | null): string[] {
+  if (!step) return []
+  const names: string[] = []
+  const skillName = stepSkillName(step)
+  if (skillName) names.push(skillName)
+  if (step.type === 'parallel') {
+    for (const child of step.steps) {
+      names.push(...stepSkillNames(child))
+    }
+  }
+  return Array.from(new Set(names))
+}
+
 function sourceLabel(report: WorkflowSkillDriftReport): string {
   const sourceName = report.managedSource.id
     .replace(/[-_]+/g, ' ')
@@ -563,9 +576,9 @@ export function StepDetailDrawer({
   const [repairingSkill, setRepairingSkill] = useState<string | null>(null)
   const [repairError, setRepairError] = useState<string | null>(null)
   const driftReports = useMemo(() => {
-    const skillName = stepSkillName(step)
-    if (!skillName || !skillDrift) return []
-    return skillDrift.reports.filter(report => report.skillName === skillName)
+    const skillNames = stepSkillNames(step)
+    if (skillNames.length === 0 || !skillDrift) return []
+    return skillDrift.reports.filter(report => skillNames.includes(report.skillName))
   }, [step, skillDrift])
 
   useEffect(() => {

--- a/plugins/workflows/components/step-detail-drawer.tsx
+++ b/plugins/workflows/components/step-detail-drawer.tsx
@@ -535,16 +535,15 @@ function SkillDriftSection({
             </div>
           </div>
           {report.repairable && (
-            <div className="mt-3 flex justify-end">
+            <div className="mt-4 flex justify-stretch sm:justify-end">
               <Button
-                size="sm"
                 variant="outline"
                 onClick={() => onRepair(report)}
                 disabled={repairingSkill === report.skillName}
-                className="border-amber-500/35 text-amber-100 hover:bg-amber-500/15"
+                className="h-10 w-full border-amber-500/35 px-4 text-sm font-semibold text-amber-100 hover:bg-amber-500/15 sm:w-auto"
               >
-                <Wrench className="mr-1.5 size-3.5" />
-                {repairingSkill === report.skillName ? 'Updating...' : 'Use latest version'}
+                <Wrench className="mr-2 size-4" />
+                {repairingSkill === report.skillName ? 'Upgrading...' : 'Upgrade to latest instructions'}
               </Button>
             </div>
           )}
@@ -610,17 +609,17 @@ export function StepDetailDrawer({
     >
       {step && (
         <div className="space-y-6">
+          {step.type === 'agent' && <AgentStepDetail step={step as AgentStep} />}
+          {step.type === 'gate' && <GateStepDetail step={step as GateStep} />}
+          {step.type === 'output' && <OutputStepDetail step={step as OutputStep} />}
+          {step.type === 'parallel' && <ParallelStepDetail step={step as ParallelStep} />}
+          {step.type === 'workflow' && <WorkflowStepDetail step={step as NestedWorkflowStep} />}
           <SkillDriftSection
             reports={driftReports}
             repairingSkill={repairingSkill}
             repairError={repairError}
             onRepair={handleRepair}
           />
-          {step.type === 'agent' && <AgentStepDetail step={step as AgentStep} />}
-          {step.type === 'gate' && <GateStepDetail step={step as GateStep} />}
-          {step.type === 'output' && <OutputStepDetail step={step as OutputStep} />}
-          {step.type === 'parallel' && <ParallelStepDetail step={step as ParallelStep} />}
-          {step.type === 'workflow' && <WorkflowStepDetail step={step as NestedWorkflowStep} />}
         </div>
       )}
     </BakinDrawer>

--- a/plugins/workflows/components/step-detail-drawer.tsx
+++ b/plugins/workflows/components/step-detail-drawer.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { useEffect, useMemo, useState } from 'react'
 import { BakinDrawer } from "@makinbakin/sdk/components"
 import { Badge } from "@makinbakin/sdk/ui"
+import { Button } from "@makinbakin/sdk/ui"
 import { Separator } from "@makinbakin/sdk/ui"
 import { AgentAvatar } from "@makinbakin/sdk/components"
 import { useAgent } from "@makinbakin/sdk/hooks"
@@ -17,10 +19,12 @@ import {
   GitBranch,
   Ban,
   ArrowRight,
+  AlertTriangle,
   Clock,
   Zap,
   Package,
   RefreshCw,
+  Wrench,
 } from 'lucide-react'
 import type {
   WorkflowStep,
@@ -29,7 +33,9 @@ import type {
   OutputStep,
   ParallelStep,
   NestedWorkflowStep,
+  WorkflowSkillDriftSummary,
 } from '../types'
+import type { WorkflowSkillDriftReport } from '../lib/workflow-skill-drift'
 
 function StepTypeBadge({ type }: { type: string }) {
   const colors: Record<string, string> = {
@@ -402,9 +408,136 @@ interface StepDetailDrawerProps {
   allSteps?: WorkflowStep[]
   open: boolean
   onOpenChange: (open: boolean) => void
+  skillDrift?: WorkflowSkillDriftSummary
+  onSkillRepaired?: () => Promise<void> | void
 }
 
-export function StepDetailDrawer({ step, open, onOpenChange }: StepDetailDrawerProps) {
+function stepSkillName(step: WorkflowStep | null): string | undefined {
+  const skill = step ? (step as { skill?: unknown }).skill : undefined
+  return typeof skill === 'string' ? skill : undefined
+}
+
+function sourceLabel(report: WorkflowSkillDriftReport): string {
+  return report.managedSource.kind === 'plugin'
+    ? `plugin ${report.managedSource.id}`
+    : `agent package ${report.managedSource.id}`
+}
+
+function repairabilityText(report: WorkflowSkillDriftReport): string {
+  switch (report.repairability) {
+    case 'safe-managed':
+      return 'Bakin can replace this local skill from the current managed source.'
+    case 'known-old-confirmable':
+      return 'This matches a known old managed skill and can be replaced after confirmation.'
+    case 'user-edited':
+      return 'This file is marked user-edited, so Bakin will not overwrite it.'
+    case 'custom-advisory':
+      return 'This local shadow is unmarked or customized, so Bakin will not overwrite it automatically.'
+  }
+}
+
+function SkillDriftSection({
+  reports,
+  repairingSkill,
+  repairError,
+  onRepair,
+}: {
+  reports: WorkflowSkillDriftReport[]
+  repairingSkill: string | null
+  repairError: string | null
+  onRepair: (report: WorkflowSkillDriftReport) => void
+}) {
+  if (reports.length === 0) return null
+
+  return (
+    <div className="space-y-3">
+      {reports.map((report) => (
+        <div key={report.skillName} className="rounded-lg border border-amber-500/35 bg-amber-500/10 p-4">
+          <div className="flex items-start gap-3">
+            <span className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-amber-500/15 ring-1 ring-amber-500/25">
+              <AlertTriangle className="size-3.5 text-amber-200" />
+            </span>
+            <div className="min-w-0 flex-1 space-y-2">
+              <div>
+                <div className="text-sm font-medium text-amber-100">Stale workflow skill</div>
+                <p className="mt-1 text-xs leading-relaxed text-amber-100/80">
+                  This step uses <span className="font-mono">{report.skillName}</span>, a local file that shadows {sourceLabel(report)}.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {report.findings.map((finding) => (
+                  <Badge key={finding.id} variant="outline" className="border-amber-500/35 text-[10px] text-amber-100">
+                    {finding.label}
+                  </Badge>
+                ))}
+              </div>
+              <p className="text-xs leading-relaxed text-amber-100/75">{repairabilityText(report)}</p>
+              {repairError && (
+                <p className="text-xs leading-relaxed text-red-300">{repairError}</p>
+              )}
+            </div>
+          </div>
+          {report.repairable && (
+            <div className="mt-3 flex justify-end">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onRepair(report)}
+                disabled={repairingSkill === report.skillName}
+                className="border-amber-500/35 text-amber-100 hover:bg-amber-500/15"
+              >
+                <Wrench className="mr-1.5 size-3.5" />
+                {repairingSkill === report.skillName ? 'Repairing...' : 'Repair skill'}
+              </Button>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function StepDetailDrawer({
+  step,
+  open,
+  onOpenChange,
+  skillDrift,
+  onSkillRepaired,
+}: StepDetailDrawerProps) {
+  const [repairingSkill, setRepairingSkill] = useState<string | null>(null)
+  const [repairError, setRepairError] = useState<string | null>(null)
+  const driftReports = useMemo(() => {
+    const skillName = stepSkillName(step)
+    if (!skillName || !skillDrift) return []
+    return skillDrift.reports.filter(report => report.skillName === skillName)
+  }, [step, skillDrift])
+
+  useEffect(() => {
+    setRepairError(null)
+  }, [open, step?.id])
+
+  async function handleRepair(report: WorkflowSkillDriftReport) {
+    setRepairingSkill(report.skillName)
+    setRepairError(null)
+    try {
+      const res = await fetch(`/api/plugins/workflows/skills/${encodeURIComponent(report.skillName)}/repair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirmKnownOld: true }),
+      })
+      const data = (await res.json().catch(() => ({}))) as { message?: string; status?: string }
+      if (!res.ok || data.status !== 'applied') {
+        setRepairError(data.message || `Repair failed (${res.status})`)
+        return
+      }
+      await onSkillRepaired?.()
+    } catch (err) {
+      setRepairError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setRepairingSkill(null)
+    }
+  }
+
   return (
     <BakinDrawer
       open={open}
@@ -420,6 +553,12 @@ export function StepDetailDrawer({ step, open, onOpenChange }: StepDetailDrawerP
     >
       {step && (
         <div className="space-y-6">
+          <SkillDriftSection
+            reports={driftReports}
+            repairingSkill={repairingSkill}
+            repairError={repairError}
+            onRepair={handleRepair}
+          />
           {step.type === 'agent' && <AgentStepDetail step={step as AgentStep} />}
           {step.type === 'gate' && <GateStepDetail step={step as GateStep} />}
           {step.type === 'output' && <OutputStepDetail step={step as OutputStep} />}

--- a/plugins/workflows/components/workflow-canvas.tsx
+++ b/plugins/workflows/components/workflow-canvas.tsx
@@ -55,11 +55,23 @@ function stepNodeType(step: WorkflowStep): string {
 }
 
 /** Build node data from a step */
+function stepSkillNames(step: WorkflowStep): string[] {
+  const skill = (step as { skill?: unknown }).skill
+  const names = typeof skill === 'string' ? [skill] : []
+  if (step.type === 'parallel') {
+    for (const child of step.steps) {
+      names.push(...stepSkillNames(child))
+    }
+  }
+  return Array.from(new Set(names))
+}
+
 function stepNodeData(step: WorkflowStep, skillDrift?: WorkflowSkillDriftSummary) {
   const skill = (step as { skill?: unknown }).skill
   const skillName = typeof skill === 'string' ? skill : undefined
-  const drift = skillName
-    ? skillDrift?.reports.find(report => report.skillName === skillName)
+  const skillNames = stepSkillNames(step)
+  const drift = skillNames.length > 0
+    ? skillDrift?.reports.find(report => skillNames.includes(report.skillName))
     : undefined
   return {
     label: step.label,

--- a/plugins/workflows/components/workflow-canvas.tsx
+++ b/plugins/workflows/components/workflow-canvas.tsx
@@ -27,7 +27,7 @@ const RESET_NODE_STYLES = `
 `
 
 import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-renderer-registry'
-import type { WorkflowDefinition, WorkflowStep } from '../types'
+import type { WorkflowDefinition, WorkflowStep, WorkflowSkillDriftSummary } from '../types'
 
 const NODE_WIDTH = 280
 const NODE_HEIGHT = 120
@@ -40,6 +40,7 @@ const SUBFLOW_PADDING_BOTTOM = 32
 interface WorkflowCanvasProps {
   definition: WorkflowDefinition
   subWorkflows?: Record<string, WorkflowDefinition>
+  skillDrift?: WorkflowSkillDriftSummary
   onNodeClick?: (nodeId: string) => void
 }
 
@@ -54,9 +55,16 @@ function stepNodeType(step: WorkflowStep): string {
 }
 
 /** Build node data from a step */
-function stepNodeData(step: WorkflowStep) {
+function stepNodeData(step: WorkflowStep, skillDrift?: WorkflowSkillDriftSummary) {
+  const skill = (step as { skill?: unknown }).skill
+  const skillName = typeof skill === 'string' ? skill : undefined
+  const drift = skillName
+    ? skillDrift?.reports.find(report => report.skillName === skillName)
+    : undefined
   return {
     label: step.label,
+    skill: skillName,
+    skillDrift: drift,
     agent: step.type === 'agent' || step.type === 'output' || step.type === 'createTask'
       ? step.agent
       : undefined,
@@ -92,6 +100,7 @@ function measureSubWorkflowStepCount(def: WorkflowDefinition, subWorkflows: Reco
 function buildGraph(
   definition: WorkflowDefinition,
   subWorkflows: Record<string, WorkflowDefinition> = {},
+  skillDrift?: WorkflowSkillDriftSummary,
 ) {
   const nodes: Node[] = []
   const edges: Edge[] = []
@@ -216,7 +225,7 @@ function buildGraph(
                     id: nestedNodeId,
                     type: stepNodeType(nestedStep),
                     position: { x: SUBFLOW_PADDING_X, y: nestedY },
-                    data: stepNodeData(nestedStep),
+                    data: stepNodeData(nestedStep, skillDrift),
                     style: STANDARD_NODE_STYLE,
                     parentId: subNodeId,
                     extent: 'parent' as const,
@@ -238,7 +247,7 @@ function buildGraph(
               id: subNodeId,
               type: subNodeType,
               position: { x: SUBFLOW_PADDING_X, y: innerY },
-              data: stepNodeData(subStep),
+              data: stepNodeData(subStep, skillDrift),
               style: STANDARD_NODE_STYLE,
               parentId: groupId,
               extent: 'parent' as const,
@@ -270,7 +279,7 @@ function buildGraph(
         id: nodeId,
         type: nodeType,
         position,
-        data: stepNodeData(step),
+        data: stepNodeData(step, skillDrift),
         style: STANDARD_NODE_STYLE,
         ...(parentId ? { parentId, extent: 'parent' as const } : {}),
       })
@@ -296,15 +305,15 @@ function buildGraph(
   return { nodes, edges }
 }
 
-export function WorkflowCanvas({ definition, subWorkflows, onNodeClick }: WorkflowCanvasProps) {
+export function WorkflowCanvas({ definition, subWorkflows, skillDrift, onNodeClick }: WorkflowCanvasProps) {
   // Subscribe to registry mutations so late-arriving kinds (lazy plugin
   // load, hot install) trigger a re-render — ESM hoisting means a
   // module-scope snapshot would be empty, and a one-shot mount-time memo
   // would miss anything registered after the canvas mounts.
   const nodeTypes = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererSnapshot, getNodeRendererSnapshot) as NodeTypes
   const { nodes: initialNodes, edges } = useMemo(
-    () => buildGraph(definition, subWorkflows),
-    [definition, subWorkflows],
+    () => buildGraph(definition, subWorkflows, skillDrift),
+    [definition, subWorkflows, skillDrift],
   )
   const [nodes, setNodes] = useState<Node[]>(initialNodes)
 

--- a/plugins/workflows/components/workflow-card.tsx
+++ b/plugins/workflows/components/workflow-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Workflow, Lock, PauseCircle, GitBranch } from 'lucide-react'
+import { Workflow, Lock, PauseCircle, GitBranch, AlertTriangle } from 'lucide-react'
 import { Badge } from "@makinbakin/sdk/ui"
 import { AgentAvatar } from "@makinbakin/sdk/components"
 import type { WorkflowTemplate, WorkflowStep, AgentStep } from '../types'
@@ -97,6 +97,16 @@ export function WorkflowCard({
             >
               <GitBranch className="size-2.5" />
               shadows default
+            </Badge>
+          )}
+          {template.skillDrift && (
+            <Badge
+              variant="outline"
+              className="text-[10px] gap-1 border-amber-500/40 text-amber-200"
+              title="This workflow references a stale local workflow skill"
+            >
+              <AlertTriangle className="size-2.5" />
+              {template.skillDrift.count === 1 ? 'stale skill' : `${template.skillDrift.count} stale skills`}
             </Badge>
           )}
           {disabled && (

--- a/plugins/workflows/components/workflow-detail.tsx
+++ b/plugins/workflows/components/workflow-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useRouter } from '@makinbakin/sdk/hooks'
-import { ArrowLeft, Workflow, Lock, Pencil, GitBranch } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Workflow, Lock, Pencil, GitBranch } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
 import { Switch } from "@makinbakin/sdk/ui"
 import { WorkflowCanvas } from './workflow-canvas'
@@ -16,7 +16,7 @@ import {
   type WorkflowDialogFieldErrors,
 } from './workflow-dialog-validation'
 import { WorkflowDeleteAction } from './workflow-delete-action'
-import type { WorkflowDefinition, WorkflowStep, ParallelStep, NestedWorkflowStep, WorkflowShadowedSource } from '../types'
+import type { WorkflowDefinition, WorkflowStep, ParallelStep, NestedWorkflowStep, WorkflowShadowedSource, WorkflowSkillDriftSummary } from '../types'
 
 /** Find a step by ID in the step tree (top-level, parallel children, sub-workflow expansions) */
 function findStepById(
@@ -96,6 +96,7 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
   const [subWorkflows, setSubWorkflows] = useState<Record<string, WorkflowDefinition>>({})
   const [source, setSource] = useState<'plugin' | 'agent-package' | 'user' | undefined>()
   const [shadowedSource, setShadowedSource] = useState<WorkflowShadowedSource | undefined>()
+  const [skillDrift, setSkillDrift] = useState<WorkflowSkillDriftSummary | undefined>()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedStep, setSelectedStep] = useState<WorkflowStep | null>(null)
@@ -114,37 +115,41 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
 
-  useEffect(() => {
-    async function fetchDefinition() {
-      try {
-        const res = await fetch(`/api/plugins/workflows/definitions/${workflowId}`)
-        if (!res.ok) {
-          setError(res.status === 404 ? 'Workflow not found' : 'Failed to load workflow')
-          return
-        }
-        const data = await res.json()
-        const loadedDefinition = data.definition as WorkflowDefinition
-        const defaultCopyName = loadedDefinition.name ? `${loadedDefinition.name} Copy` : `${workflowId} Copy`
-        setDefinition(loadedDefinition)
-        setSubWorkflows(data.subWorkflows ?? {})
-        setSource(data.source)
-        setShadowedSource(data.shadowedSource)
-        setWorkflowDisabled(data.disabled === true)
-        setAvailabilityError(null)
-        setCopyError(null)
-        setCopyFieldErrors({})
-        setCopyName(defaultCopyName)
-        setCopyId(slugify(defaultCopyName))
-        setCopyIdEdited(false)
-        setDisableOriginal(true)
-      } catch {
-        setError('Failed to load workflow')
-      } finally {
-        setLoading(false)
+  const fetchDefinition = useCallback(async (options: { preserveLoading?: boolean } = {}) => {
+    if (!options.preserveLoading) setLoading(true)
+    try {
+      const res = await fetch(`/api/plugins/workflows/definitions/${workflowId}`)
+      if (!res.ok) {
+        setError(res.status === 404 ? 'Workflow not found' : 'Failed to load workflow')
+        return
       }
+      const data = await res.json()
+      const loadedDefinition = data.definition as WorkflowDefinition
+      const defaultCopyName = loadedDefinition.name ? `${loadedDefinition.name} Copy` : `${workflowId} Copy`
+      setDefinition(loadedDefinition)
+      setSubWorkflows(data.subWorkflows ?? {})
+      setSource(data.source)
+      setShadowedSource(data.shadowedSource)
+      setSkillDrift(data.skillDrift)
+      setWorkflowDisabled(data.disabled === true)
+      setAvailabilityError(null)
+      setCopyError(null)
+      setCopyFieldErrors({})
+      setCopyName(defaultCopyName)
+      setCopyId(slugify(defaultCopyName))
+      setCopyIdEdited(false)
+      setDisableOriginal(true)
+      setError(null)
+    } catch {
+      setError('Failed to load workflow')
+    } finally {
+      setLoading(false)
     }
-    fetchDefinition()
   }, [workflowId])
+
+  useEffect(() => {
+    fetchDefinition()
+  }, [fetchDefinition])
 
   const handleNodeClick = useCallback((nodeId: string) => {
     if (!definition) return
@@ -395,11 +400,21 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
         </div>
       )}
 
+      {skillDrift && (
+        <div className="flex items-center gap-2 border-b border-border bg-amber-500/10 px-6 py-2 text-xs text-amber-200">
+          <AlertTriangle className="size-3.5" />
+          <span>
+            This workflow uses {skillDrift.count === 1 ? 'a stale workflow skill' : `${skillDrift.count} stale workflow skills`}. Open the highlighted step to review the impact and repair options.
+          </span>
+        </div>
+      )}
+
       {/* Canvas */}
       <div className="flex-1 overflow-hidden">
         <WorkflowCanvas
           definition={definition}
           subWorkflows={subWorkflows}
+          skillDrift={skillDrift}
           onNodeClick={handleNodeClick}
         />
       </div>
@@ -410,6 +425,8 @@ export function WorkflowDetail({ workflowId, onBack }: WorkflowDetailProps) {
         allSteps={definition.steps}
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
+        skillDrift={skillDrift}
+        onSkillRepaired={() => fetchDefinition({ preserveLoading: true })}
       />
 
       <ManagedWorkflowCopyDialog

--- a/plugins/workflows/defaults/workflow-skill-legacy-hashes.json
+++ b/plugins/workflows/defaults/workflow-skill-legacy-hashes.json
@@ -1,0 +1,9 @@
+[
+  {
+    "skillName": "generate-image",
+    "sourceKind": "plugin",
+    "sourceId": "images",
+    "sha256": "6c32bb64d3ea8e4477a20197e93a517b88c2099ef5f3c3d58e80ef983948caf5",
+    "reason": "Pre-assetId generated-image skill returned image filename and prompt packet sidecars."
+  }
+]

--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -24,8 +24,14 @@ import {
   checkWorkflowDefinitions,
   checkStaleWorkflowInstances,
   checkWorkflowSkills,
+  workflowSkillDriftRepair,
   staleWorkflowInstancesRepair,
 } from './lib/health-checks'
+import {
+  repairWorkflowSkillDrift,
+  scanWorkflowSkillDrift,
+  type WorkflowSkillDriftReport,
+} from './lib/workflow-skill-drift'
 import {
   isReadOnly,
   getDefinition as getRegistryDefinition,
@@ -69,7 +75,7 @@ import {
 } from './lib/notifications'
 import { approvalRefFromRecord, findPendingApprovalForGate, getApprovalRecord } from './lib/approval-store'
 import { rehydratePendingApprovals } from './lib/approval-rehydration'
-import type { WorkflowTemplate, WorkflowDefinition, WorkflowInstance, NestedWorkflowStep } from './types'
+import type { WorkflowTemplate, WorkflowDefinition, WorkflowInstance, NestedWorkflowStep, WorkflowSkillDriftSummary } from './types'
 
 const log = createLogger('workflows')
 let unsubscribeApprovalResponses: (() => void) | null = null
@@ -80,6 +86,7 @@ let pluginCtx: PluginContext | null = null
 const passthroughWf = z.object({}).passthrough()
 const errorResponseWf = z.object({ error: z.string() }).passthrough()
 const htmlResponseWf = { contentType: 'text/html' as const }
+const repairSkillBodyWf = z.object({ confirmKnownOld: z.boolean().optional() }).optional()
 let gateNotificationSettings: GateNotificationSettings = {
   approvalChannelAlerts: false,
   approvalChannel: 'general',
@@ -110,6 +117,7 @@ function buildTemplateList(options: { includeDisabled?: boolean } = {}): { templ
   const defs = listDefinitions()
   const disabledWorkflowIds = readDisabledWorkflowIds()
   const subWorkflows: Record<string, WorkflowDefinition> = {}
+  const driftBySkill = workflowSkillDriftBySkill()
   const templates: WorkflowTemplate[] = defs.flatMap(d => {
     const disabled = d.source !== 'user' && disabledWorkflowIds.has(d.name)
     const shadowedSource = d.source === 'user' ? getShadowedSource(d.name) : undefined
@@ -126,9 +134,67 @@ function buildTemplateList(options: { includeDisabled?: boolean } = {}): { templ
       packageId: d.packageId,
       disabled,
       shadowedSource,
+      skillDrift: workflowSkillDriftForDefinition(d.definition, driftBySkill, subWorkflows),
     }]
   })
   return { templates, subWorkflows }
+}
+
+function workflowSkillDriftBySkill(): Map<string, WorkflowSkillDriftReport> {
+  return new Map(scanWorkflowSkillDrift(getContentDir()).map(report => [report.skillName, report]))
+}
+
+function workflowSkillDriftForDefinition(
+  definition: WorkflowDefinition,
+  driftBySkill: Map<string, WorkflowSkillDriftReport>,
+  subWorkflows: Record<string, WorkflowDefinition> = {},
+): WorkflowSkillDriftSummary | undefined {
+  const byStep: Record<string, string[]> = {}
+  const reports = new Map<string, WorkflowSkillDriftReport>()
+  for (const ref of collectWorkflowSkillRefs(definition.steps, subWorkflows)) {
+    const report = driftBySkill.get(ref.skill)
+    if (!report) continue
+    reports.set(report.skillName, report)
+    byStep[ref.stepId] = [...(byStep[ref.stepId] ?? []), ref.skill]
+  }
+  const uniqueReports = Array.from(reports.values())
+  if (uniqueReports.length === 0) return undefined
+  return {
+    count: uniqueReports.length,
+    repairableCount: uniqueReports.filter(report => report.repairable).length,
+    skills: uniqueReports.map(report => report.skillName),
+    reports: uniqueReports,
+    byStep,
+  }
+}
+
+function collectWorkflowSkillRefs(
+  steps: WorkflowDefinition['steps'],
+  subWorkflows: Record<string, WorkflowDefinition> = {},
+  idPrefix = '',
+  workflowStack = new Set<string>(),
+): Array<{ stepId: string; skill: string }> {
+  const refs: Array<{ stepId: string; skill: string }> = []
+  for (const step of steps) {
+    const stepId = idPrefix ? `${idPrefix}__${step.id}` : step.id
+    const skill = (step as { skill?: unknown }).skill
+    if (typeof skill === 'string' && skill.length > 0) {
+      refs.push({ stepId, skill })
+    }
+    if (step.type === 'parallel') {
+      refs.push(...collectWorkflowSkillRefs(step.steps, subWorkflows, idPrefix, workflowStack))
+    }
+    if (step.type === 'workflow') {
+      const workflowId = (step as NestedWorkflowStep).workflow_id
+      const nested = workflowId ? subWorkflows[workflowId] : undefined
+      if (nested && !workflowStack.has(workflowId)) {
+        const nextStack = new Set(workflowStack)
+        nextStack.add(workflowId)
+        refs.push(...collectWorkflowSkillRefs(nested.steps, subWorkflows, stepId, nextStack))
+      }
+    }
+  }
+  return refs
 }
 
 function instanceToSearchDoc(inst: WorkflowInstance): Record<string, unknown> {
@@ -427,9 +493,33 @@ function populateWorkflowRoutes(arr: any[]): void {
       pluginId: definition.pluginId,
       disabled: definition.source !== 'user' && isWorkflowDisabled(name),
       shadowedSource: definition.source === 'user' ? getShadowedSource(name) : undefined,
+      skillDrift: workflowSkillDriftForDefinition(definition, workflowSkillDriftBySkill(), subWorkflows),
     })
   }
   arr.push(defineRoute({ path: '/definitions/:name', method: 'GET', description: 'Get a specific workflow definition by name', summary: 'Get a specific workflow definition by name', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: getDefinitionHandler }))
+
+  // POST /skills/:name/repair — replace a stale local workflow skill when provenance proves it is safe.
+  const repairSkillHandler = async (_req: Request, _ctx: PluginContextLite, parsed?: { params?: { name?: string }; body?: { confirmKnownOld?: boolean } }) => {
+    const name = parsed?.params?.name
+    if (!name) {
+      return Response.json({ error: 'name param required' }, { status: 400 })
+    }
+
+    const result = repairWorkflowSkillDrift({
+      contentDir: getContentDir(),
+      skillName: name,
+      confirmKnownOld: parsed?.body?.confirmKnownOld === true,
+    })
+    const status = result.status === 'applied'
+      ? 200
+      : result.status === 'not-found'
+        ? 404
+        : result.status === 'failed'
+          ? 500
+          : 409
+    return Response.json(result.status === 'failed' ? { ...result, error: result.message } : result, { status })
+  }
+  arr.push(defineRoute({ path: '/skills/:name/repair', method: 'POST', description: 'Repair a stale local workflow skill from its managed source when safe', summary: 'Repair stale workflow skill', params: z.object({ name: z.string() }), body: repairSkillBodyWf, responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: passthroughWf, 409: passthroughWf, 500: errorResponseWf }, handler: repairSkillHandler }))
 
   // ─── CRUD Routes (user definitions only) ──────────────────────────
   // User YAML files live at ~/.bakin/workflows/definitions/{id}.yaml.
@@ -1647,6 +1737,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
       id: 'skills',
       name: 'Workflow skills validation',
       run: async () => checkWorkflowSkills(getContentDir()),
+      repair: workflowSkillDriftRepair(getContentDir()),
     })
 
 

--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -17,6 +17,11 @@ import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/c
 
 import { listDefinitions } from './parser'
 import { listInstances } from './runtime'
+import {
+  repairWorkflowSkillDrift,
+  scanWorkflowSkillDrift,
+  type WorkflowSkillDriftReport,
+} from './workflow-skill-drift'
 
 // ─── Result constructors (inlined; eventual migration target) ─────────────
 
@@ -63,11 +68,108 @@ export function checkWorkflowSkills(contentDir: string): HealthCheckResult[] {
     // skills dir exists but can't be read
   }
 
+  for (const report of scanWorkflowSkillDrift(contentDir)) {
+    results.push(warn(
+      'workflow-skills',
+      workflowSkillDriftMessage(report),
+      report.repairable,
+    ))
+  }
+
   if (results.length === 0) {
     results.push(ok('workflow-skills', 'All workflow skills have output_schema'))
   }
 
   return results
+}
+
+export function workflowSkillDriftRepair(contentDir: string): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      if (!rows.some(row => row.check === 'workflow-skills')) return []
+      return scanWorkflowSkillDrift(contentDir)
+        .filter(report => report.repairable)
+        .map(report => ({
+          id: workflowSkillRepairItemId(report.skillName),
+          checkId: 'workflow-skills',
+          title: `Repair workflow skill ${report.skillName}`,
+          reason: workflowSkillDriftMessage(report),
+          safety: 'safe' as const,
+          requiresConfirmation: true,
+          changes: [{
+            kind: 'file' as const,
+            target: report.filePath,
+            action: 'update' as const,
+            description: `Replace ${report.skillName}.md from the current ${report.managedSource.kind} source.`,
+          }],
+        }))
+    },
+    async apply(items) {
+      const results = []
+      for (const item of items) {
+        const skillName = skillNameFromRepairItemId(item.id)
+        if (!skillName) {
+          results.push({
+            id: item.id,
+            checkId: 'workflow-skills',
+            status: 'skipped' as const,
+            message: `Skipped unknown workflow skill repair item "${item.id}".`,
+            changes: [],
+          })
+          continue
+        }
+        const result = repairWorkflowSkillDrift({
+          contentDir,
+          skillName,
+          confirmKnownOld: true,
+        })
+        results.push({
+          id: item.id,
+          checkId: 'workflow-skills',
+          status: result.status === 'applied' ? 'applied' as const : result.status === 'failed' ? 'failed' as const : 'skipped' as const,
+          message: result.message,
+          changes: result.status === 'applied'
+            ? item.changes
+            : [],
+        })
+      }
+      return results
+    },
+  }
+}
+
+function workflowSkillRepairItemId(skillName: string): string {
+  return `workflows.repair-workflow-skill-drift.${skillName}`
+}
+
+function skillNameFromRepairItemId(id: string): string | null {
+  const prefix = 'workflows.repair-workflow-skill-drift.'
+  if (!id.startsWith(prefix)) return null
+  return id.slice(prefix.length) || null
+}
+
+function workflowSkillDriftMessage(report: WorkflowSkillDriftReport): string {
+  const source = report.managedSource.kind === 'plugin'
+    ? `plugin ${report.managedSource.id}`
+    : `agent package ${report.managedSource.id}`
+  const findings = report.findings.map(finding => finding.label).join('; ')
+  const repairNote = report.repairable
+    ? 'Safe repair is available.'
+    : `Advisory only: ${workflowSkillRepairabilityLabel(report.repairability)}.`
+  return `Workflow skill "${report.skillName}" shadows managed ${source} skill and appears stale: ${findings}. ${repairNote}`
+}
+
+function workflowSkillRepairabilityLabel(repairability: WorkflowSkillDriftReport['repairability']): string {
+  switch (repairability) {
+    case 'custom-advisory':
+      return 'local file is unmarked or customized'
+    case 'user-edited':
+      return 'local file is marked user-edited'
+    case 'known-old-confirmable':
+      return 'known old managed file requires confirmation'
+    case 'safe-managed':
+      return 'file is managed and unedited'
+  }
 }
 
 // ─── Workflow definitions: skill reference integrity ──────────────────────

--- a/plugins/workflows/lib/workflow-skill-drift.ts
+++ b/plugins/workflows/lib/workflow-skill-drift.ts
@@ -1,0 +1,464 @@
+import { createHash } from 'crypto'
+import { existsSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import { basename, join } from 'path'
+
+import type { SkillDefinition } from '@bakin/core/plugin-types'
+
+import { getPluginSkills } from '../../../src/lib/plugin-registry'
+import {
+  getAgentPackageSkillOwner,
+  getAgentPackageSkills,
+} from './agent-package-skill-registry'
+import legacyWorkflowSkillHashes from '../defaults/workflow-skill-legacy-hashes.json'
+
+export type WorkflowSkillManagedSourceKind = 'plugin' | 'agent-package'
+
+export type WorkflowSkillDriftRepairability =
+  | 'safe-managed'
+  | 'known-old-confirmable'
+  | 'custom-advisory'
+  | 'user-edited'
+
+export interface WorkflowSkillManagedSource {
+  kind: WorkflowSkillManagedSourceKind
+  id: string
+  sourcePath?: string
+  skillName: string
+}
+
+export interface WorkflowSkillInstallMarker {
+  sourceKind: WorkflowSkillManagedSourceKind
+  sourceId: string
+  sourcePath?: string
+  sha256: string
+  installedAt: string
+}
+
+export interface WorkflowSkillDriftFinding {
+  id: string
+  label: string
+  description: string
+  evidence: string[]
+}
+
+export interface WorkflowSkillDriftReport {
+  skillName: string
+  filePath: string
+  currentSha256: string
+  managedSha256?: string
+  managedSource: WorkflowSkillManagedSource
+  findings: WorkflowSkillDriftFinding[]
+  userEdited: boolean
+  installedBy: WorkflowSkillInstallMarker | null
+  repairability: WorkflowSkillDriftRepairability
+  repairable: boolean
+}
+
+export interface RepairWorkflowSkillDriftOptions {
+  contentDir: string
+  skillName: string
+  confirmKnownOld?: boolean
+}
+
+export type RepairWorkflowSkillDriftStatus =
+  | 'applied'
+  | 'not-found'
+  | 'not-repairable'
+  | 'requires-confirmation'
+  | 'source-unavailable'
+  | 'failed'
+
+export interface RepairWorkflowSkillDriftResult {
+  status: RepairWorkflowSkillDriftStatus
+  skillName: string
+  message: string
+  report?: WorkflowSkillDriftReport
+}
+
+interface ManagedSkillSource extends WorkflowSkillManagedSource {
+  skill: SkillDefinition
+  raw?: string
+}
+
+interface DriftPattern {
+  id: string
+  label: string
+  description: string
+  stale: RegExp[]
+  current?: RegExp[]
+}
+
+interface KnownOldWorkflowSkillHash {
+  skillName: string
+  sourceKind: WorkflowSkillManagedSourceKind
+  sourceId: string
+  sha256: string
+  reason: string
+}
+
+const WORKFLOW_SKILL_LEGACY_HASHES = legacyWorkflowSkillHashes as KnownOldWorkflowSkillHash[]
+
+const DRIFT_PATTERNS: DriftPattern[] = [
+  {
+    id: 'image-output-asset-id',
+    label: 'Generated image output contract is stale',
+    description: 'This skill still asks agents to return path or filename fields instead of the current assetId.',
+    stale: [
+      /\bimage_filename\b/g,
+      /\bimage_path\b/g,
+      /\bimagePath\b/g,
+    ],
+    current: [/\bassetId\b/g],
+  },
+  {
+    id: 'media-output-asset-id',
+    label: 'Generated media output contract is stale',
+    description: 'This skill still uses path-style generated media outputs instead of the current managed asset identity.',
+    stale: [
+      /\bvideo_path\b/g,
+      /\bvideoPath\b/g,
+      /\baudio_path\b/g,
+      /\baudioPath\b/g,
+    ],
+    current: [/\bassetId\b/g, /\basset_id\b/g],
+  },
+  {
+    id: 'prompt-packet-sidecar',
+    label: 'Prompt packet sidecar contract is stale',
+    description: 'This skill still references prompt packet sidecar fields that are no longer part of the current image workflow output.',
+    stale: [
+      /\bpromptAssetFilename\b/g,
+      /\bsavePromptPacket\b/g,
+    ],
+    current: [/\bassetId\b/g],
+  },
+  {
+    id: 'legacy-tool-rename',
+    label: 'Legacy execution tool name is stale',
+    description: 'This skill still references old execution tool names and may fail when the runtime dispatches the workflow step.',
+    stale: [
+      /\bbeacon_exec_[A-Za-z0-9_]*\b/g,
+      /\bbakin_exec_gen_image\b/g,
+    ],
+  },
+]
+
+export function workflowSkillInstallMarkerPath(skillPath: string): string {
+  return `${skillPath}.installedBy`
+}
+
+export function workflowSkillUserEditedPath(skillPath: string): string {
+  return `${skillPath}.userEdited`
+}
+
+export function hashWorkflowSkillContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex')
+}
+
+export function readWorkflowSkillInstallMarker(skillPath: string): WorkflowSkillInstallMarker | null {
+  const markerPath = workflowSkillInstallMarkerPath(skillPath)
+  if (!existsSync(markerPath)) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(markerPath, 'utf-8'))
+  } catch {
+    return null
+  }
+  if (!isWorkflowSkillInstallMarker(parsed)) return null
+  return parsed
+}
+
+export function writeWorkflowSkillInstallMarker(skillPath: string, marker: WorkflowSkillInstallMarker): void {
+  writeFileSync(
+    workflowSkillInstallMarkerPath(skillPath),
+    `${JSON.stringify(marker, null, 2)}\n`,
+    'utf-8',
+  )
+}
+
+export function scanWorkflowSkillDrift(contentDir: string): WorkflowSkillDriftReport[] {
+  const skillsDir = join(contentDir, 'workflows', 'skills')
+  if (!existsSync(skillsDir)) return []
+
+  let files: string[]
+  try {
+    files = readdirSync(skillsDir).filter((file) => file.endsWith('.md'))
+  } catch {
+    return []
+  }
+
+  const reports: WorkflowSkillDriftReport[] = []
+  for (const file of files) {
+    const skillName = basename(file, '.md')
+    const managed = findManagedSkillSource(skillName)
+    if (!managed) continue
+
+    const filePath = join(skillsDir, file)
+    let localRaw: string
+    try {
+      localRaw = readFileSync(filePath, 'utf-8')
+    } catch {
+      continue
+    }
+
+    const managedRaw = managed.raw ?? managed.skill.instructions
+    const findings = findDriftFindings(localRaw, managedRaw)
+    if (findings.length === 0) continue
+
+    const currentSha256 = hashWorkflowSkillContent(localRaw)
+    const managedSha256 = managed.raw ? hashWorkflowSkillContent(managed.raw) : undefined
+    const installedBy = readWorkflowSkillInstallMarker(filePath)
+    const userEdited = existsSync(workflowSkillUserEditedPath(filePath))
+    const repairability = classifyRepairability({
+      skillName,
+      currentSha256,
+      managed,
+      installedBy,
+      userEdited,
+    })
+
+    reports.push({
+      skillName,
+      filePath,
+      currentSha256,
+      managedSha256,
+      managedSource: {
+        kind: managed.kind,
+        id: managed.id,
+        sourcePath: managed.sourcePath,
+        skillName: managed.skillName,
+      },
+      findings,
+      userEdited,
+      installedBy,
+      repairability,
+      repairable: repairability === 'safe-managed' || repairability === 'known-old-confirmable',
+    })
+  }
+
+  return reports
+}
+
+export function repairWorkflowSkillDrift(options: RepairWorkflowSkillDriftOptions): RepairWorkflowSkillDriftResult {
+  const report = scanWorkflowSkillDrift(options.contentDir)
+    .find((entry) => entry.skillName === options.skillName)
+  if (!report) {
+    return {
+      status: 'not-found',
+      skillName: options.skillName,
+      message: `Workflow skill "${options.skillName}" has no detected managed drift.`,
+    }
+  }
+
+  if (report.repairability === 'known-old-confirmable' && options.confirmKnownOld !== true) {
+    return {
+      status: 'requires-confirmation',
+      skillName: options.skillName,
+      message: `Workflow skill "${options.skillName}" matches a known old managed file and requires explicit confirmation before replacement.`,
+      report,
+    }
+  }
+
+  if (report.repairability !== 'safe-managed' && report.repairability !== 'known-old-confirmable') {
+    return {
+      status: 'not-repairable',
+      skillName: options.skillName,
+      message: `Workflow skill "${options.skillName}" is not safely repairable because it is ${humanRepairability(report.repairability)}.`,
+      report,
+    }
+  }
+
+  const sourcePath = report.managedSource.sourcePath
+  if (!sourcePath || !existsSync(sourcePath)) {
+    return {
+      status: 'source-unavailable',
+      skillName: options.skillName,
+      message: `Workflow skill "${options.skillName}" cannot be repaired because the managed source file is unavailable.`,
+      report,
+    }
+  }
+
+  let sourceRaw: string
+  try {
+    sourceRaw = readFileSync(sourcePath, 'utf-8')
+  } catch (err) {
+    return {
+      status: 'source-unavailable',
+      skillName: options.skillName,
+      message: `Workflow skill "${options.skillName}" cannot be repaired: ${errorMessage(err)}`,
+      report,
+    }
+  }
+
+  const tmpPath = `${report.filePath}.repair-${process.pid}-${Date.now()}.tmp`
+  try {
+    writeFileSync(tmpPath, sourceRaw, 'utf-8')
+    renameSync(tmpPath, report.filePath)
+    writeWorkflowSkillInstallMarker(report.filePath, {
+      sourceKind: report.managedSource.kind,
+      sourceId: report.managedSource.id,
+      sourcePath,
+      sha256: hashWorkflowSkillContent(sourceRaw),
+      installedAt: new Date().toISOString(),
+    })
+  } catch (err) {
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath)
+    } catch {
+      // best-effort cleanup only
+    }
+    return {
+      status: 'failed',
+      skillName: options.skillName,
+      message: `Workflow skill "${options.skillName}" repair failed: ${errorMessage(err)}`,
+      report,
+    }
+  }
+
+  return {
+    status: 'applied',
+    skillName: options.skillName,
+    message: `Workflow skill "${options.skillName}" was replaced from the current managed source.`,
+    report,
+  }
+}
+
+function findManagedSkillSource(skillName: string): ManagedSkillSource | null {
+  const packageSkill = getAgentPackageSkills().get(skillName)
+  if (packageSkill) {
+    const sourcePath = packageSkill.sourcePath
+    return {
+      kind: 'agent-package',
+      id: getAgentPackageSkillOwner(skillName) ?? 'unknown',
+      skillName,
+      skill: packageSkill,
+      sourcePath,
+      raw: readOptionalFile(sourcePath),
+    }
+  }
+
+  const pluginSkill = getPluginSkills().get(skillName)
+  if (pluginSkill) {
+    const sourcePath = pluginSkill.sourcePath
+    return {
+      kind: 'plugin',
+      id: pluginIdForSkill(pluginSkill),
+      skillName,
+      skill: pluginSkill,
+      sourcePath,
+      raw: readOptionalFile(sourcePath),
+    }
+  }
+
+  return null
+}
+
+function findDriftFindings(localRaw: string, managedRaw: string): WorkflowSkillDriftFinding[] {
+  const findings: WorkflowSkillDriftFinding[] = []
+  for (const pattern of DRIFT_PATTERNS) {
+    if (pattern.current && !pattern.current.some((matcher) => regexMatches(managedRaw, matcher))) continue
+    const localEvidence = Array.from(new Set(pattern.stale.flatMap((matcher) => collectMatches(localRaw, matcher))))
+    if (localEvidence.length === 0) continue
+    const managedEvidence = new Set(pattern.stale.flatMap((matcher) => collectMatches(managedRaw, matcher)))
+    const evidence = localEvidence.filter((token) => !managedEvidence.has(token))
+    if (evidence.length === 0) continue
+    findings.push({
+      id: pattern.id,
+      label: pattern.label,
+      description: pattern.description,
+      evidence,
+    })
+  }
+  return findings
+}
+
+function regexMatches(text: string, matcher: RegExp): boolean {
+  const flags = matcher.flags.replace('g', '')
+  return new RegExp(matcher.source, flags).test(text)
+}
+
+function classifyRepairability(input: {
+  skillName: string
+  currentSha256: string
+  managed: ManagedSkillSource
+  installedBy: WorkflowSkillInstallMarker | null
+  userEdited: boolean
+}): WorkflowSkillDriftRepairability {
+  if (input.userEdited) return 'user-edited'
+  if (markerMatchesManagedSource(input.installedBy, input.managed) && input.installedBy?.sha256 === input.currentSha256) {
+    return 'safe-managed'
+  }
+  if (isKnownOldWorkflowSkillHash(input.skillName, input.currentSha256, input.managed)) {
+    return 'known-old-confirmable'
+  }
+  return 'custom-advisory'
+}
+
+function markerMatchesManagedSource(marker: WorkflowSkillInstallMarker | null, managed: ManagedSkillSource): boolean {
+  if (!marker) return false
+  return marker.sourceKind === managed.kind && marker.sourceId === managed.id
+}
+
+function isKnownOldWorkflowSkillHash(skillName: string, sha256: string, managed: ManagedSkillSource): boolean {
+  return WORKFLOW_SKILL_LEGACY_HASHES.some((entry) =>
+    entry.skillName === skillName &&
+    entry.sha256 === sha256 &&
+    entry.sourceKind === managed.kind &&
+    entry.sourceId === managed.id
+  )
+}
+
+function humanRepairability(repairability: WorkflowSkillDriftRepairability): string {
+  switch (repairability) {
+    case 'custom-advisory':
+      return 'an unmarked or customized local shadow file'
+    case 'user-edited':
+      return 'marked as user-edited'
+    case 'known-old-confirmable':
+      return 'a known old managed file that requires confirmation'
+    case 'safe-managed':
+      return 'managed and unedited'
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function isWorkflowSkillInstallMarker(value: unknown): value is WorkflowSkillInstallMarker {
+  if (!value || typeof value !== 'object') return false
+  const marker = value as Record<string, unknown>
+  return (
+    (marker.sourceKind === 'plugin' || marker.sourceKind === 'agent-package') &&
+    typeof marker.sourceId === 'string' &&
+    typeof marker.sha256 === 'string' &&
+    typeof marker.installedAt === 'string' &&
+    (marker.sourcePath === undefined || typeof marker.sourcePath === 'string')
+  )
+}
+
+function pluginIdForSkill(skill: SkillDefinition): string {
+  if (skill.source?.startsWith('plugin:')) {
+    return skill.source.slice('plugin:'.length)
+  }
+  return 'unknown'
+}
+
+function readOptionalFile(path: string | undefined): string | undefined {
+  if (!path || !existsSync(path)) return undefined
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch {
+    return undefined
+  }
+}
+
+function collectMatches(text: string, matcher: RegExp): string[] {
+  const flags = matcher.flags.includes('g') ? matcher.flags : `${matcher.flags}g`
+  const regex = new RegExp(matcher.source, flags)
+  const matches: string[] = []
+  for (const match of text.matchAll(regex)) {
+    if (match[0]) matches.push(match[0])
+  }
+  return matches
+}

--- a/plugins/workflows/types.ts
+++ b/plugins/workflows/types.ts
@@ -4,6 +4,7 @@
 
 import type { ApprovalActor } from '@bakin/core/plugin-types'
 import type { ApprovalRenderRef } from '@bakin/core/adapters/runtime'
+import type { WorkflowSkillDriftReport } from './lib/workflow-skill-drift'
 
 export type { ApprovalActor }
 
@@ -168,6 +169,16 @@ export interface WorkflowTemplate {
   disabled?: boolean
   /** Set when a user workflow shadows a managed definition with the same id. */
   shadowedSource?: WorkflowShadowedSource
+  /** Set when this workflow references one or more stale local workflow skills. */
+  skillDrift?: WorkflowSkillDriftSummary
+}
+
+export interface WorkflowSkillDriftSummary {
+  count: number
+  repairableCount: number
+  skills: string[]
+  reports: WorkflowSkillDriftReport[]
+  byStep: Record<string, string[]>
 }
 
 // ─── Skill Types ────────────────────────────────────────────────────────────
@@ -176,6 +187,8 @@ export interface SkillDefinition {
   name: string
   output_schema?: Record<string, unknown>
   instructions: string
+  source?: string
+  sourcePath?: string
 }
 
 // ─── Instance Types ─────────────────────────────────────────────────────────

--- a/src/core/agent-packages/load-sources.ts
+++ b/src/core/agent-packages/load-sources.ts
@@ -194,6 +194,7 @@ function loadWorkflowSkillsForPackage(
     const skill: SkillDefinition = {
       name: (frontmatter.name as string) || filenameId,
       instructions: body,
+      sourcePath: abs,
     }
     if (frontmatter.output_schema) {
       skill.output_schema = frontmatter.output_schema as Record<string, unknown>

--- a/src/lib/plugin-skill-loader.ts
+++ b/src/lib/plugin-skill-loader.ts
@@ -55,12 +55,14 @@ export function loadPluginSkills(
   for (const file of files) {
     const filenameId = file.replace(/\.md$/, '')
     try {
-      const raw = readFileSync(join(skillsDir, file), 'utf-8')
+      const sourcePath = join(skillsDir, file)
+      const raw = readFileSync(sourcePath, 'utf-8')
       const { frontmatter, body } = parseSkillFile(raw)
 
       const skill: SkillDefinition = {
         name: (frontmatter.name as string) || filenameId,
         instructions: body,
+        sourcePath,
       }
       if (frontmatter.output_schema) {
         skill.output_schema = frontmatter.output_schema as Record<string, unknown>

--- a/tests/agent-packages/load-sources.test.ts
+++ b/tests/agent-packages/load-sources.test.ts
@@ -153,7 +153,7 @@ describe('loadAgentPackageSources — empty + missing states', () => {
 
 describe('loadAgentPackageSources — happy path', () => {
   it('registers workflow + workflow-skill from a managed agent package', () => {
-    seedPixelPackage()
+    const { packageDir } = seedPixelPackage()
     writeLockfile({ version: 1, packages: { pixel: pixelEntry() } })
 
     const result = loadAgentPackageSources(testDir)
@@ -174,6 +174,7 @@ describe('loadAgentPackageSources — happy path', () => {
     const skills = getAgentPackageSkills()
     expect(skills.has('generate-image')).toBe(true)
     expect(skills.get('generate-image')!.name).toBe('Generate Image')
+    expect(skills.get('generate-image')!.sourcePath).toBe(join(packageDir, 'workflow-skills', 'generate-image.md'))
   })
 
   it('falls back to slugged-name id when manifest workflow has no id field', () => {

--- a/tests/lib/plugin-skill-loader.test.ts
+++ b/tests/lib/plugin-skill-loader.test.ts
@@ -140,6 +140,16 @@ describe('loadPluginSkills', () => {
     expect(calls[0].instructions.trim()).toBe('Push the post live.')
   })
 
+  it('records the source file path for managed skill comparison', () => {
+    const sourcePath = join(skillsDir, 'publish.md')
+    writeFileSync(sourcePath, publishSkill)
+
+    const { ctx, calls } = buildCtx()
+    loadPluginSkills(pluginPath, ctx, fakeLog)
+
+    expect(calls[0].sourcePath).toBe(sourcePath)
+  })
+
   it('returns empty result when defaults/workflow-skills/ does not exist', () => {
     rmSync(skillsDir, { recursive: true, force: true })
 

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -22,6 +22,8 @@ const testDir = (() => {
 process.env.BAKIN_HOME = testDir
 process.env.OPENCLAW_HOME = testDir + '-openclaw'
 
+const mockWorkflowPluginSkills = new Map<string, any>()
+
 mock.module('@bakin/core/main-agent', () => ({
   getMainAgentId: () => 'main',
   tryGetMainAgentId: () => 'main',
@@ -57,6 +59,7 @@ mock.module('@/core/task-store', () => ({
 
 // Hook registry remains available for plugin activation paths.
 mock.module('../../../src/lib/plugin-registry', () => ({
+  getPluginSkills: () => mockWorkflowPluginSkills,
   getHookRegistry: () => ({
     invoke: async (_name: string) => {
       return undefined
@@ -71,7 +74,12 @@ import {
   checkWorkflowDefinitions,
   checkStaleWorkflowInstances,
   staleWorkflowInstancesRepair,
+  workflowSkillDriftRepair,
 } from '../../../plugins/workflows/lib/health-checks'
+import {
+  hashWorkflowSkillContent,
+  writeWorkflowSkillInstallMarker,
+} from '../../../plugins/workflows/lib/workflow-skill-drift'
 
 const skillsDir = join(testDir, 'workflows', 'skills')
 const definitionsDir = join(testDir, 'workflows', 'definitions')
@@ -93,6 +101,7 @@ beforeEach(() => {
     rmSync(dir, { recursive: true, force: true })
     mkdirSync(dir, { recursive: true })
   }
+  mockWorkflowPluginSkills.clear()
 })
 
 describe('checkWorkflowSkills', () => {
@@ -125,6 +134,94 @@ describe('checkWorkflowSkills', () => {
     const results = checkWorkflowSkills(testDir)
     expect(results).toHaveLength(1)
     expect(results[0].status).toBe('ok')
+  })
+
+  it('flags stale local skills that shadow managed plugin skills', () => {
+    const sourcePath = join(testDir, 'managed-generate-image.md')
+    writeFileSync(
+      sourcePath,
+      `---
+name: Generate Image
+output_schema:
+  type: object
+  required: [assetId]
+---
+
+Return assetId.
+`,
+    )
+    mockWorkflowPluginSkills.set('generate-image', {
+      name: 'Generate Image',
+      instructions: 'Return assetId.',
+      source: 'plugin:images',
+      sourcePath,
+    })
+    writeFileSync(
+      join(skillsDir, 'generate-image.md'),
+      `---
+name: Generate Image
+output_schema:
+  type: object
+  required: [image_filename]
+---
+
+Return image_filename and promptAssetFilename after savePromptPacket.
+`,
+    )
+
+    const results = checkWorkflowSkills(testDir)
+
+    const stale = results.find(result => result.message.includes('appears stale'))
+    expect(stale?.status).toBe('warn')
+    expect(stale?.autoFixable).toBe(false)
+  })
+
+  it('plans and applies safe repair for managed stale skills', async () => {
+    const sourcePath = join(testDir, 'managed-generate-image.md')
+    const current = `---
+name: Generate Image
+output_schema:
+  type: object
+  required: [assetId]
+---
+
+Return assetId.
+`
+    const stale = `---
+name: Generate Image
+output_schema:
+  type: object
+  required: [image_filename]
+---
+
+Return image_filename and promptAssetFilename after savePromptPacket.
+`
+    writeFileSync(sourcePath, current)
+    mockWorkflowPluginSkills.set('generate-image', {
+      name: 'Generate Image',
+      instructions: 'Return assetId.',
+      source: 'plugin:images',
+      sourcePath,
+    })
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, stale)
+    writeWorkflowSkillInstallMarker(target, {
+      sourceKind: 'plugin',
+      sourceId: 'images',
+      sourcePath,
+      sha256: hashWorkflowSkillContent(stale),
+      installedAt: '2026-06-02T00:00:00.000Z',
+    })
+
+    const rows = checkWorkflowSkills(testDir)
+    const repair = workflowSkillDriftRepair(testDir)
+    const plan = await repair.plan(rows)
+    const applied = await repair.apply(plan)
+
+    expect(plan).toHaveLength(1)
+    expect(plan[0].title).toContain('generate-image')
+    expect(applied[0].status).toBe('applied')
+    expect(checkWorkflowSkills(testDir)[0].status).toBe('ok')
   })
 })
 

--- a/tests/plugins/workflows/routes.test.ts
+++ b/tests/plugins/workflows/routes.test.ts
@@ -10,12 +10,14 @@
  * `/search` route.
  */
 import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test'
-import { mkdirSync, rmSync, existsSync } from 'fs'
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import {
   activatePlugin,
+  callRoute,
   callSearchRoute,
+  findRoute,
   type ActivatedPlugin,
 } from '../test-helpers'
 
@@ -73,16 +75,81 @@ mock.module('@/core/task-store', () => ({
 // ─── Plugin import (after mocks) ───────────────────────────────────────────
 
 import workflowsPlugin from '../../../plugins/workflows'
+import { getPluginSkills } from '../../../src/lib/plugin-registry'
+import {
+  hashWorkflowSkillContent,
+  writeWorkflowSkillInstallMarker,
+} from '../../../plugins/workflows/lib/workflow-skill-drift'
 
 // ─── Setup ─────────────────────────────────────────────────────────────────
 
 let activated: ActivatedPlugin
+const skillsDir = join(testDir, 'workflows', 'skills')
+const managedDir = join(testDir, 'managed-workflow-skills')
+
+const currentGenerateImageSkill = `---
+name: Generate Image
+output_schema:
+  type: object
+  required: [assetId]
+---
+
+Return assetId from the images tool.
+`
+
+const staleGenerateImageSkill = `---
+name: Generate Image
+output_schema:
+  type: object
+  required: [image_filename]
+---
+
+Return image_filename and promptAssetFilename after savePromptPacket.
+`
 
 beforeAll(async () => {
   if (!existsSync(testDir)) {
     mkdirSync(testDir, { recursive: true })
   }
   activated = await activatePlugin(workflowsPlugin, testDir)
+  activated.ctx.registerWorkflow({
+    id: 'drift-route-test',
+    name: 'Drift Route Test',
+    description: 'Route fixture for workflow skill drift.',
+    version: 1,
+    steps: [{
+      id: 'gen',
+      type: 'agent',
+      label: 'Generate',
+      agent: 'pixel',
+      skill: 'generate-image',
+    }],
+  })
+  activated.ctx.registerWorkflow({
+    id: 'drift-nested-child',
+    name: 'Drift Nested Child',
+    description: 'Child workflow with a managed skill.',
+    version: 1,
+    steps: [{
+      id: 'nested-gen',
+      type: 'agent',
+      label: 'Nested Generate',
+      agent: 'pixel',
+      skill: 'generate-image',
+    }],
+  })
+  activated.ctx.registerWorkflow({
+    id: 'drift-nested-parent',
+    name: 'Drift Nested Parent',
+    description: 'Parent workflow that expands a child workflow.',
+    version: 1,
+    steps: [{
+      id: 'child-flow',
+      type: 'workflow',
+      label: 'Run Child',
+      workflow_id: 'drift-nested-child',
+    }],
+  })
 })
 
 afterAll(() => {
@@ -93,7 +160,34 @@ afterAll(() => {
 
 beforeEach(() => {
   activated.seedResults([])
+  getPluginSkills().clear()
+  rmSync(skillsDir, { recursive: true, force: true })
+  rmSync(managedDir, { recursive: true, force: true })
+  mkdirSync(skillsDir, { recursive: true })
+  mkdirSync(managedDir, { recursive: true })
 })
+
+function seedManagedGenerateImageSkill(options: { repairable?: boolean } = {}): void {
+  const sourcePath = join(managedDir, 'generate-image.md')
+  const target = join(skillsDir, 'generate-image.md')
+  writeFileSync(sourcePath, currentGenerateImageSkill, 'utf-8')
+  writeFileSync(target, staleGenerateImageSkill, 'utf-8')
+  getPluginSkills().set('generate-image', {
+    name: 'Generate Image',
+    instructions: 'Return assetId from the images tool.',
+    source: 'plugin:images',
+    sourcePath,
+  })
+  if (options.repairable) {
+    writeWorkflowSkillInstallMarker(target, {
+      sourceKind: 'plugin',
+      sourceId: 'images',
+      sourcePath,
+      sha256: hashWorkflowSkillContent(staleGenerateImageSkill),
+      installedAt: '2026-06-02T00:00:00.000Z',
+    })
+  }
+}
 
 // ─── Search Route ──────────────────────────────────────────────────────────
 
@@ -164,5 +258,91 @@ describe('Workflows Plugin — GET /search', () => {
         facets: ['type', 'status'],
       }),
     )
+  })
+})
+
+describe('Workflows Plugin — workflow skill drift routes', () => {
+  it('includes workflow skill drift summaries in the definitions list', async () => {
+    seedManagedGenerateImageSkill()
+    const route = findRoute(activated.routes, 'GET', '/definitions')!
+
+    const { status, body } = await callRoute(route, activated.ctx)
+
+    expect(status).toBe(200)
+    const templates = body.templates as Array<{ filename: string; skillDrift?: any }>
+    const template = templates.find(item => item.filename === 'drift-route-test')
+    expect(template?.skillDrift?.count).toBe(1)
+    expect(template?.skillDrift?.skills).toEqual(['generate-image'])
+    expect(template?.skillDrift?.byStep.gen).toEqual(['generate-image'])
+  })
+
+  it('includes workflow skill drift summaries in definition detail', async () => {
+    seedManagedGenerateImageSkill()
+    const route = findRoute(activated.routes, 'GET', '/definitions/:name')!
+
+    const { status, body } = await callRoute(route, activated.ctx, {
+      path: '/definitions/drift-route-test',
+      searchParams: { name: 'drift-route-test' },
+    })
+
+    expect(status).toBe(200)
+    expect((body.skillDrift as { count: number }).count).toBe(1)
+    expect((body.skillDrift as { byStep: Record<string, string[]> }).byStep.gen).toEqual(['generate-image'])
+  })
+
+  it('includes nested workflow skill drift summaries in parent definition detail', async () => {
+    seedManagedGenerateImageSkill()
+    const route = findRoute(activated.routes, 'GET', '/definitions/:name')!
+
+    const { status, body } = await callRoute(route, activated.ctx, {
+      path: '/definitions/drift-nested-parent',
+      searchParams: { name: 'drift-nested-parent' },
+    })
+
+    expect(status).toBe(200)
+    expect((body.skillDrift as { count: number }).count).toBe(1)
+    expect((body.skillDrift as { byStep: Record<string, string[]> }).byStep['child-flow__nested-gen']).toEqual(['generate-image'])
+  })
+
+  it('repairs a safe stale workflow skill through the direct repair route', async () => {
+    seedManagedGenerateImageSkill({ repairable: true })
+    const repairRoute = findRoute(activated.routes, 'POST', '/skills/:name/repair')!
+    const detailRoute = findRoute(activated.routes, 'GET', '/definitions/:name')!
+
+    const repaired = await callRoute(repairRoute, activated.ctx, {
+      path: '/skills/generate-image/repair',
+    })
+    const detail = await callRoute(detailRoute, activated.ctx, {
+      path: '/definitions/drift-route-test',
+      searchParams: { name: 'drift-route-test' },
+    })
+
+    expect(repaired.status).toBe(200)
+    expect(repaired.body.status).toBe('applied')
+    expect(detail.status).toBe(200)
+    expect(detail.body.skillDrift).toBeUndefined()
+  })
+
+  it('returns 500 when direct repair cannot write the replacement file', async () => {
+    seedManagedGenerateImageSkill({ repairable: true })
+    const repairRoute = findRoute(activated.routes, 'POST', '/skills/:name/repair')!
+    const originalDateNow = Date.now
+    const fixedNow = 1780431742000
+    const target = join(skillsDir, 'generate-image.md')
+    const collidingTempPath = `${target}.repair-${process.pid}-${fixedNow}.tmp`
+    Date.now = () => fixedNow
+    mkdirSync(collidingTempPath, { recursive: true })
+
+    try {
+      const repaired = await callRoute(repairRoute, activated.ctx, {
+        path: '/skills/generate-image/repair',
+      })
+
+      expect(repaired.status).toBe(500)
+      expect(repaired.body.status).toBe('failed')
+    } finally {
+      Date.now = originalDateNow
+      rmSync(collidingTempPath, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/plugins/workflows/workflow-canvas.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas.test.tsx
@@ -132,4 +132,49 @@ describe('WorkflowCanvas', () => {
 
     expect(screen.getByTestId('node-generate').getAttribute('data-has-skill-drift')).toBe('true')
   })
+
+  it('passes child stale skill drift through parallel group node data', () => {
+    const definition: WorkflowDefinition = {
+      name: 'Parallel image workflow',
+      description: 'Uses a generated image skill inside a parallel group',
+      version: 1,
+      steps: [{
+        id: 'parallel-work',
+        type: 'parallel',
+        label: 'Parallel Work',
+        steps: [{
+          id: 'generate',
+          type: 'agent',
+          label: 'Generate',
+          agent: 'pixel',
+          skill: 'generate-image',
+        }],
+      }],
+    }
+
+    render(
+      <WorkflowCanvas
+        definition={definition}
+        skillDrift={{
+          count: 1,
+          repairableCount: 0,
+          skills: ['generate-image'],
+          byStep: { generate: ['generate-image'] },
+          reports: [{
+            skillName: 'generate-image',
+            filePath: '/tmp/generate-image.md',
+            currentSha256: 'old',
+            managedSource: { kind: 'plugin', id: 'images', skillName: 'generate-image' },
+            findings: [],
+            userEdited: false,
+            installedBy: null,
+            repairability: 'custom-advisory',
+            repairable: false,
+          }],
+        }}
+      />,
+    )
+
+    expect(screen.getByTestId('node-parallel-work').getAttribute('data-has-skill-drift')).toBe('true')
+  })
 })

--- a/tests/plugins/workflows/workflow-canvas.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas.test.tsx
@@ -26,7 +26,7 @@ mock.module('@/core/task-store', () => ({}))
 
 interface ReactFlowStubProps {
   children?: ReactNode
-  nodes?: Array<{ id: string; type?: string }>
+  nodes?: Array<{ id: string; type?: string; data?: Record<string, unknown> }>
   edges?: Array<{ id: string; source: string; target: string }>
   nodeTypes?: Record<string, unknown>
   onNodeClick?: (event: unknown, node: { id: string }) => void
@@ -43,6 +43,7 @@ mock.module('@xyflow/react', () => ({
             type="button"
             data-testid={`node-${node.id}`}
             data-node-type={node.type}
+            data-has-skill-drift={Boolean(node.data?.skillDrift)}
             onClick={(event) => onNodeClick?.(event, node)}
           >
             {node.id}
@@ -90,5 +91,45 @@ describe('WorkflowCanvas', () => {
     render(<WorkflowCanvas definition={definition} />)
 
     expect(screen.getByTestId('node-denoise').getAttribute('data-node-type')).toBe('media.noise-gate')
+  })
+
+  it('passes stale skill drift through node data for highlighted steps', () => {
+    const definition: WorkflowDefinition = {
+      name: 'Image workflow',
+      description: 'Uses a generated image skill',
+      version: 1,
+      steps: [{
+        id: 'generate',
+        type: 'agent',
+        label: 'Generate',
+        agent: 'pixel',
+        skill: 'generate-image',
+      }],
+    }
+
+    render(
+      <WorkflowCanvas
+        definition={definition}
+        skillDrift={{
+          count: 1,
+          repairableCount: 0,
+          skills: ['generate-image'],
+          byStep: { generate: ['generate-image'] },
+          reports: [{
+            skillName: 'generate-image',
+            filePath: '/tmp/generate-image.md',
+            currentSha256: 'old',
+            managedSource: { kind: 'plugin', id: 'images', skillName: 'generate-image' },
+            findings: [],
+            userEdited: false,
+            installedBy: null,
+            repairability: 'custom-advisory',
+            repairable: false,
+          }],
+        }}
+      />,
+    )
+
+    expect(screen.getByTestId('node-generate').getAttribute('data-has-skill-drift')).toBe('true')
   })
 })

--- a/tests/plugins/workflows/workflow-detail.test.tsx
+++ b/tests/plugins/workflows/workflow-detail.test.tsx
@@ -7,6 +7,8 @@ import { tmpdir } from 'os'
 
 const testDir = join(tmpdir(), `bakin-test-workflow-detail-${Date.now()}`)
 const routerPush = mock()
+const workflowCanvasCalls: Array<Record<string, unknown>> = []
+const stepDetailDrawerCalls: Array<Record<string, unknown>> = []
 
 mock.module('@bakin/core/main-agent', () => ({
   getMainAgentId: () => 'main',
@@ -57,11 +59,17 @@ mock.module('@makinbakin/sdk/components', () => ({
 }))
 
 mock.module('../../../plugins/workflows/components/workflow-canvas', () => ({
-  WorkflowCanvas: () => <div data-testid="workflow-canvas" />,
+  WorkflowCanvas: (props: Record<string, unknown>) => {
+    workflowCanvasCalls.push(props)
+    return <div data-testid="workflow-canvas" data-has-skill-drift={Boolean(props.skillDrift)} />
+  },
 }))
 
 mock.module('../../../plugins/workflows/components/step-detail-drawer', () => ({
-  StepDetailDrawer: () => null,
+  StepDetailDrawer: (props: Record<string, unknown>) => {
+    stepDetailDrawerCalls.push(props)
+    return null
+  },
 }))
 
 mock.module('../../../plugins/workflows/components/workflow-card', () => ({
@@ -100,7 +108,7 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
-function setupPluginDefinitionFetch(options: { disabled?: boolean; availabilityStatus?: number } = {}) {
+function setupPluginDefinitionFetch(options: { disabled?: boolean; availabilityStatus?: number; skillDrift?: unknown } = {}) {
   const fetchMock = mock((url: string, init?: RequestInit) => {
     if (url === '/api/plugins/workflows/definitions/video-script' && !init) {
       return Promise.resolve(jsonResponse({
@@ -109,6 +117,7 @@ function setupPluginDefinitionFetch(options: { disabled?: boolean; availabilityS
         source: 'plugin',
         pluginId: 'workflows',
         disabled: options.disabled === true,
+        skillDrift: options.skillDrift,
       }))
     }
     if (url === '/api/plugins/workflows/definitions' && init?.method === 'POST') {
@@ -151,10 +160,14 @@ afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
   routerPush.mockClear()
+  workflowCanvasCalls.length = 0
+  stepDetailDrawerCalls.length = 0
 })
 
 beforeEach(() => {
   routerPush.mockClear()
+  workflowCanvasCalls.length = 0
+  stepDetailDrawerCalls.length = 0
 })
 
 describe('WorkflowDetail', () => {
@@ -230,6 +243,34 @@ describe('WorkflowDetail', () => {
     expect(screen.getByText('Disabled')).toBeDefined()
     expect(screen.getByText(/matching and automatic starts skip this workflow/i)).toBeDefined()
     expect((screen.getByRole('button', { name: /^edit$/i }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('surfaces workflow skill drift in the detail header and child components', async () => {
+    const skillDrift = {
+      count: 1,
+      repairableCount: 1,
+      skills: ['generate-image'],
+      byStep: { write: ['generate-image'] },
+      reports: [{
+        skillName: 'generate-image',
+        filePath: '/tmp/generate-image.md',
+        currentSha256: 'old',
+        managedSource: { kind: 'plugin', id: 'images', skillName: 'generate-image' },
+        findings: [],
+        userEdited: false,
+        installedBy: null,
+        repairability: 'safe-managed',
+        repairable: true,
+      }],
+    }
+    setupPluginDefinitionFetch({ skillDrift })
+
+    render(<WorkflowDetail workflowId="video-script" onBack={() => {}} />)
+
+    expect(await screen.findByText(/uses a stale workflow skill/i)).toBeDefined()
+    await waitFor(() => expect(workflowCanvasCalls.length).toBeGreaterThan(0))
+    expect(workflowCanvasCalls.at(-1)?.skillDrift).toEqual(skillDrift)
+    expect(stepDetailDrawerCalls.at(-1)?.skillDrift).toEqual(skillDrift)
   })
 
   it('can re-enable a disabled managed workflow from the detail header', async () => {

--- a/tests/plugins/workflows/workflow-skill-drift.test.ts
+++ b/tests/plugins/workflows/workflow-skill-drift.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-workflow-skill-drift-${Date.now()}-${randomUUID()}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/task-store', () => ({}))
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+import {
+  readWorkflowSkillInstallMarker,
+  hashWorkflowSkillContent,
+  repairWorkflowSkillDrift,
+  scanWorkflowSkillDrift,
+  workflowSkillInstallMarkerPath,
+  workflowSkillUserEditedPath,
+  writeWorkflowSkillInstallMarker,
+} from '../../../plugins/workflows/lib/workflow-skill-drift'
+import {
+  clearAgentPackageSkillRegistry,
+  registerAgentPackageSkill,
+} from '../../../plugins/workflows/lib/agent-package-skill-registry'
+import { getPluginSkills } from '../../../src/lib/plugin-registry'
+
+const skillsDir = join(testDir, 'workflows', 'skills')
+const managedDir = join(testDir, 'managed')
+
+const currentGenerateImageSkill = `---
+name: Generate Image
+output_schema:
+  type: object
+  required:
+    - assetId
+  properties:
+    assetId:
+      type: string
+---
+
+Return the generated assetId from bakin_exec_images_generate.
+`
+
+const documentedStaleTokenGenerateImageSkill = `---
+name: Generate Image
+output_schema:
+  type: object
+  required:
+    - assetId
+  properties:
+    assetId:
+      type: string
+---
+
+Return the generated assetId. Do not return image_filename.
+`
+
+const staleGenerateImageSkill = `---
+name: Generate Image
+output_schema:
+  type: object
+  required:
+    - image_filename
+  properties:
+    image_filename:
+      type: string
+    promptAssetFilename:
+      type: string
+---
+
+Return image_filename, filename, and promptAssetFilename after savePromptPacket completes.
+`
+
+const knownOldGenerateImageSkill = `---
+output_schema:
+  type: object
+  required:
+    - image_filename
+    - filename
+    - provider
+    - model
+    - surface
+  properties:
+    image_filename:
+      type: string
+      description: "Canonical generated image asset filename. Do not emit a directory path."
+    filename:
+      type: string
+      description: "Same canonical generated image asset filename."
+    provider:
+      type: string
+    model:
+      type: string
+    surface:
+      type: string
+    width:
+      type: number
+    height:
+      type: number
+    promptHash:
+      type: string
+    promptAssetFilename:
+      type: string
+---
+
+## Instructions
+
+Generate the approved image through the images plugin. The plugin owns
+runtime/native routing, provider authentication, asset saving, and sidecar
+metadata.
+
+1. Read the approved prompt, promptPacket, route, surface, and quality from priorStepOutput.
+2. Call \`bakin_exec_images_generate\` with the current task id, \`promptPacket\`, \`prompt\`, \`provider\`, \`model\`, \`surface\`, \`quality\`, and \`savePromptPacket: true\` when the workflow has an approval gate.
+3. Verify the tool returned \`ok: true\`.
+4. Submit the tool's returned \`image_filename\`, \`filename\`, provider, model, surface, width, height, promptHash, and promptAssetFilename.
+
+Do not call legacy image tools. Do not write image files, thumbnails, or sidecars by hand. Do not emit a local filesystem path as the image identity.
+`
+
+function seedPluginManagedSkill(): string {
+  mkdirSync(managedDir, { recursive: true })
+  const sourcePath = join(managedDir, 'generate-image.md')
+  writeFileSync(sourcePath, currentGenerateImageSkill, 'utf-8')
+  getPluginSkills().set('generate-image', {
+    name: 'Generate Image',
+    instructions: 'Return the generated assetId from bakin_exec_images_generate.',
+    output_schema: {
+      type: 'object',
+      required: ['assetId'],
+      properties: { assetId: { type: 'string' } },
+    },
+    source: 'plugin:images',
+    sourcePath,
+  })
+  return sourcePath
+}
+
+describe('workflow skill drift scanner', () => {
+  beforeEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+    mkdirSync(skillsDir, { recursive: true })
+    getPluginSkills().clear()
+    clearAgentPackageSkillRegistry()
+  })
+
+  afterEach(() => {
+    getPluginSkills().clear()
+    clearAgentPackageSkillRegistry()
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('flags a local workflow skill that shadows a managed plugin skill with stale image-output fields', () => {
+    seedPluginManagedSkill()
+    writeFileSync(join(skillsDir, 'generate-image.md'), staleGenerateImageSkill, 'utf-8')
+
+    const reports = scanWorkflowSkillDrift(testDir)
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0].skillName).toBe('generate-image')
+    expect(reports[0].managedSource).toEqual(expect.objectContaining({
+      kind: 'plugin',
+      id: 'images',
+    }))
+    expect(reports[0].findings.map((finding) => finding.id)).toContain('image-output-asset-id')
+    expect(reports[0].findings.map((finding) => finding.id)).toContain('prompt-packet-sidecar')
+    expect(reports[0].repairability).toBe('custom-advisory')
+    expect(reports[0].repairable).toBe(false)
+  })
+
+  it('does not flag user-only workflow skills that do not shadow a managed source', () => {
+    writeFileSync(join(skillsDir, 'generate-image.md'), staleGenerateImageSkill, 'utf-8')
+
+    expect(scanWorkflowSkillDrift(testDir)).toEqual([])
+  })
+
+  it('does not flag exact managed content that documents a stale token', () => {
+    const sourcePath = seedPluginManagedSkill()
+    writeFileSync(sourcePath, documentedStaleTokenGenerateImageSkill, 'utf-8')
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, documentedStaleTokenGenerateImageSkill, 'utf-8')
+
+    const reports = scanWorkflowSkillDrift(testDir)
+
+    expect(reports).toEqual([])
+  })
+
+  it('marks user-edited stale shadow files as advisory-only', () => {
+    seedPluginManagedSkill()
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, staleGenerateImageSkill, 'utf-8')
+    writeFileSync(workflowSkillUserEditedPath(target), '', 'utf-8')
+
+    const [report] = scanWorkflowSkillDrift(testDir)
+
+    expect(report.userEdited).toBe(true)
+    expect(report.repairability).toBe('user-edited')
+    expect(report.repairable).toBe(false)
+  })
+
+  it('marks stale files repairable when .installedBy proves the file is still managed and unedited', () => {
+    const sourcePath = seedPluginManagedSkill()
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, staleGenerateImageSkill, 'utf-8')
+    writeWorkflowSkillInstallMarker(target, {
+      sourceKind: 'plugin',
+      sourceId: 'images',
+      sourcePath,
+      sha256: hashWorkflowSkillContent(staleGenerateImageSkill),
+      installedAt: '2026-06-02T00:00:00.000Z',
+    })
+
+    const [report] = scanWorkflowSkillDrift(testDir)
+
+    expect(report.repairability).toBe('safe-managed')
+    expect(report.repairable).toBe(true)
+    expect(readWorkflowSkillInstallMarker(target)?.sourceId).toBe('images')
+    expect(workflowSkillInstallMarkerPath(target)).toBe(`${target}.installedBy`)
+  })
+
+  it('uses the agent-package source when a package skill shadows a plugin skill', () => {
+    seedPluginManagedSkill()
+    const packageSourcePath = join(managedDir, 'pkg-generate-image.md')
+    writeFileSync(packageSourcePath, currentGenerateImageSkill, 'utf-8')
+    registerAgentPackageSkill('pixel', 'generate-image', {
+      name: 'Generate Image',
+      instructions: 'Return the generated assetId from package source.',
+      sourcePath: packageSourcePath,
+    })
+    writeFileSync(join(skillsDir, 'generate-image.md'), staleGenerateImageSkill, 'utf-8')
+
+    const [report] = scanWorkflowSkillDrift(testDir)
+
+    expect(report.managedSource.kind).toBe('agent-package')
+    expect(report.managedSource.id).toBe('pixel')
+    expect(report.managedSource.sourcePath).toBe(packageSourcePath)
+  })
+
+  it('repairs a stale managed skill by replacing it from the current source', () => {
+    const sourcePath = seedPluginManagedSkill()
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, staleGenerateImageSkill, 'utf-8')
+    writeWorkflowSkillInstallMarker(target, {
+      sourceKind: 'plugin',
+      sourceId: 'images',
+      sourcePath,
+      sha256: hashWorkflowSkillContent(staleGenerateImageSkill),
+      installedAt: '2026-06-02T00:00:00.000Z',
+    })
+
+    const result = repairWorkflowSkillDrift({
+      contentDir: testDir,
+      skillName: 'generate-image',
+    })
+
+    expect(result.status).toBe('applied')
+    expect(readFileSync(target, 'utf-8')).toBe(currentGenerateImageSkill)
+    expect(readWorkflowSkillInstallMarker(target)).toEqual(expect.objectContaining({
+      sourceKind: 'plugin',
+      sourceId: 'images',
+      sourcePath,
+      sha256: hashWorkflowSkillContent(currentGenerateImageSkill),
+    }))
+  })
+
+  it('requires confirmation before replacing a known old managed skill without an install marker', () => {
+    seedPluginManagedSkill()
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, knownOldGenerateImageSkill, 'utf-8')
+
+    const [report] = scanWorkflowSkillDrift(testDir)
+
+    expect(report.repairability).toBe('known-old-confirmable')
+    expect(report.repairable).toBe(true)
+
+    const blocked = repairWorkflowSkillDrift({
+      contentDir: testDir,
+      skillName: 'generate-image',
+    })
+
+    expect(blocked.status).toBe('requires-confirmation')
+    expect(readFileSync(target, 'utf-8')).toBe(knownOldGenerateImageSkill)
+
+    const applied = repairWorkflowSkillDrift({
+      contentDir: testDir,
+      skillName: 'generate-image',
+      confirmKnownOld: true,
+    })
+
+    expect(applied.status).toBe('applied')
+    expect(readFileSync(target, 'utf-8')).toBe(currentGenerateImageSkill)
+  })
+
+  it('does not repair stale custom shadows without managed provenance', () => {
+    seedPluginManagedSkill()
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, staleGenerateImageSkill, 'utf-8')
+
+    const result = repairWorkflowSkillDrift({
+      contentDir: testDir,
+      skillName: 'generate-image',
+    })
+
+    expect(result.status).toBe('not-repairable')
+    expect(readFileSync(target, 'utf-8')).toBe(staleGenerateImageSkill)
+  })
+
+  it('does not repair stale user-edited shadows', () => {
+    const sourcePath = seedPluginManagedSkill()
+    const target = join(skillsDir, 'generate-image.md')
+    writeFileSync(target, staleGenerateImageSkill, 'utf-8')
+    writeFileSync(workflowSkillUserEditedPath(target), '', 'utf-8')
+    writeWorkflowSkillInstallMarker(target, {
+      sourceKind: 'plugin',
+      sourceId: 'images',
+      sourcePath,
+      sha256: hashWorkflowSkillContent(staleGenerateImageSkill),
+      installedAt: '2026-06-02T00:00:00.000Z',
+    })
+
+    const result = repairWorkflowSkillDrift({
+      contentDir: testDir,
+      skillName: 'generate-image',
+    })
+
+    expect(result.status).toBe('not-repairable')
+    expect(readFileSync(target, 'utf-8')).toBe(staleGenerateImageSkill)
+  })
+})


### PR DESCRIPTION
## Summary
- detect stale local workflow-skill shadows against managed plugin and agent-package sources
- surface drift in Health plus Workflows cards, detail banners, canvas nodes, and step drawers
- add safe full-file repair through Health and `POST /api/plugins/workflows/skills/:name/repair`
- document source-of-truth and repairability decisions, including `.installedBy`, `.userEdited`, and known-old hashes

## Review Notes
- repair stays conservative: user-edited, unmarked, or customized files are advisory-only unless they match a known-old hash
- nested workflow skill drift is included in parent summaries with canvas-aligned prefixed step ids
- failed direct repairs now return HTTP 500 with an error payload

## Verification
- `bun test --isolate tests/plugins/workflows/workflow-detail.test.tsx tests/plugins/workflows/workflow-canvas.test.tsx tests/plugins/workflows/routes.test.ts tests/plugins/workflows/workflow-skill-drift.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run docs:generate`
- `bun run docs:validate`
- `bun run docs:validate:routes`
- `git diff --check`

Full `bun test --isolate` result: 4258 pass, 10 skip, 1 fail. The failure was `Header update banner > renders a top banner when a Bakin update is available`; rerunning `tests/components/header-update-banner.test.tsx` by itself passed, so this appears to be an unrelated order-dependent full-suite issue.

Fixes #342