### PR TITLE
fix: route OpenClaw channel delivery through CLI

### DIFF
--- a/.claude/knowledge/messaging-plugin.md
+++ b/.claude/knowledge/messaging-plugin.md
@@ -23,11 +23,18 @@ The official plugin must use task-backed scheduling for production work:
 - Activating a Plan creates one Deliverable and one scheduled board task per
   channel.
 - The task has `availableAt`, `dueAt`, and `source.pluginId = "messaging"`.
+- Workflow-backed Deliverables start `planned`; bare-task Deliverables start
+  `in_prep` because agents can only mark `in_prep` or `changes_requested`
+  Deliverables ready for review.
 - Messaging must not register cron jobs, sweep hooks, or Schedule-owned jobs
   for content prep/publish polling.
 - Failed Deliverables recover through explicit web/API actions owned by the
   official plugin. Workflow-backed recovery must call Workflow hooks such as
   `workflows.loadInstance` and `workflows.reopenFromStep`; it must not read or
   write Workflow instance files directly.
+- Workflow completion publish failures must stay visible on the task board.
+  The official plugin creates or reuses a blocked task with
+  `source.purpose = "publish-failure"` when publish validation or runtime
+  channel delivery fails after workflow completion.
 
 Do not restore `plugins/messaging/`, `tests/plugins/messaging/`, `src/core/messaging-cron.ts`, `~/.bakin/messaging.json`, or a top-level `~/.bakin/messaging/` data path in this repo.

--- a/docs/src/content/docs/using/messaging.md
+++ b/docs/src/content/docs/using/messaging.md
@@ -46,9 +46,11 @@ or video assets must be present before approval.
 
 </div>
 
-Bare-task Deliverables publish from the sweep after approval. Workflow-backed
-Deliverables publish when their workflow completes after Messaging has approved
-the gate.
+Bare-task Deliverables publish through explicit publish actions after approval.
+Workflow-backed Deliverables publish when their workflow completes after
+Messaging has approved the gate. If workflow completion reaches publishing and
+validation or channel delivery fails, Messaging creates a blocked repair task
+linked to the failed Deliverable so the issue remains visible on the board.
 
 ## Plans
 
@@ -152,6 +154,9 @@ Deliverable per channel, and creates one kickoff task per Deliverable through
 Deliverable `prepStartAt`, `dueAt` from the target publish time, and `source`
 metadata that links the task back to the Messaging Deliverable. Dispatch is the
 single wakeup path: it ignores future tasks until `availableAt` is reached.
+Workflow-backed Deliverables start `planned`; bare-task Deliverables start
+`in_prep` so their assigned agents can save drafts and mark them ready for
+review through the lifecycle tool.
 
 Workflow-backed prep is created through `ctx.tasks.create({ workflowId })`.
 Messaging listens for `workflow.gate_reached` and `workflow.complete`, and
@@ -169,7 +174,7 @@ paths.
     deliverables/<id>.json        # channel-specific work and publish state
     legacy/                       # archived pre-refactor messaging.json files
   plugin-settings/
-    messaging.json                # content types, channels, sweep cron, defaults
+    messaging.json                # content types, channels, defaults
 ```
 
 Sessions index into search as `messaging_brainstorm`. Plans and Deliverables
@@ -250,6 +255,5 @@ Full schemas in the [Exec tools reference](/docs/reference/generated/exec-tools/
 
 - [Team](/docs/using/team/): the agents you brainstorm and plan with
 - [Workflows](/docs/using/workflows/): workflow-backed prep and review gates
-- [Schedule](/docs/using/schedule/): cron-backed plugin sweeps
 - [Tasks](/docs/using/tasks/): content planning and prep work run as Bakin tasks
 - [Assets](/docs/using/assets/): draft images and videos used for publishing

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -532,7 +532,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
         channels: args.channels,
         message: {
           title: args.notification.title,
-          body: `${args.notification.title}\n\n${args.notification.body}`,
+          body: args.notification.body,
           metadata: args.notification.metadata,
         },
       })
@@ -542,22 +542,8 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       const deliveries = []
       for (const channel of args.channels) {
         const ref = splitChannelRef(channel, args.message.metadata)
-        const payload: Record<string, unknown> = { channel: ref.channel, message: args.message.body }
         const files = metadataFiles(args.message.metadata)
-        if (ref.target) payload.target = ref.target
-        if (args.message.title) payload.title = args.message.title
-        if (args.message.threadId) payload.threadId = args.message.threadId
-        if (files.length > 0) {
-          payload.files = files
-          payload.media = files.map(file => file.path)
-        }
-        try {
-          await this.invokeTool('message_send', payload)
-        } catch (err) {
-          if (!ref.target) throw err
-          const cliArgs = ['message', 'send', '--channel', ref.channel, '--target', ref.target, '--message', args.message.body]
-          await this.exec(cliArgs)
-        }
+        await this.exec(openClawMessageSendArgs(ref, args.message, files))
         deliveries.push({ channelId: channel, ref: `message:${Date.now()}`, renderedAt })
       }
       return { deliveries }
@@ -567,7 +553,7 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
         channels: args.channels,
         message: {
           title: args.content.title,
-          body: [args.content.title, args.content.body, args.content.url].filter(Boolean).join('\n\n'),
+          body: [args.content.body, args.content.url].filter(Boolean).join('\n\n'),
           metadata: {
             ...(args.content.metadata ?? {}),
             ...(args.content.files ? { files: args.content.files } : {}),
@@ -711,7 +697,6 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       message: {
         title: args.request.title,
         body: [
-          args.request.title,
           args.request.body,
           optionText,
           approvalUrl ? `Open in Bakin: ${approvalUrl}` : undefined,
@@ -1510,6 +1495,20 @@ function splitChannelRef(channelId: string, metadata: RuntimeMetadata | undefine
   const [channel, ...targetParts] = channelId.split(':')
   if (channel && targetParts.length > 0) return { channel, target: targetParts.join(':') }
   return { channel: channelId }
+}
+
+function openClawMessageSendArgs(
+  ref: { channel: string; target?: string },
+  message: { body: string; title?: string; threadId?: string; metadata?: RuntimeMetadata },
+  files: Array<{ name: string; path: string; contentType?: string }>,
+): string[] {
+  const args = ['message', 'send', '--channel', ref.channel]
+  if (ref.target) args.push('--target', ref.target)
+  const body = [message.title, message.body].filter(Boolean).join('\n\n')
+  if (body) args.push('--message', body)
+  if (message.threadId) args.push('--thread-id', message.threadId)
+  for (const file of files) args.push('--media', file.path)
+  return args
 }
 
 function readChannelInfos(): ChannelInfo[] {

--- a/tests/adapter-openclaw/runtime-channels.test.ts
+++ b/tests/adapter-openclaw/runtime-channels.test.ts
@@ -1,17 +1,44 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+function installOpenClawCliRecorder(testDir: string): { binaryPath: string; calls: () => string[][] } {
+  const cliLog = join(testDir, `openclaw-cli-calls-${randomUUID()}.jsonl`)
+  const shimPath = join(testDir, `openclaw-shim-${randomUUID()}.ts`)
+  writeFileSync(shimPath, [
+    '#!/usr/bin/env bun',
+    'import { appendFileSync } from "fs"',
+    'appendFileSync(process.env.OPENCLAW_CLI_LOG!, JSON.stringify(process.argv.slice(2)) + "\\n")',
+    'process.stdout.write(JSON.stringify({ ok: true }))',
+    '',
+  ].join('\n'), 'utf-8')
+  chmodSync(shimPath, 0o755)
+  process.env.OPENCLAW_CLI_LOG = cliLog
+
+  return {
+    binaryPath: shimPath,
+    calls: () => readFileSync(cliLog, 'utf-8').trim().split('\n').filter(Boolean).map(line => JSON.parse(line)),
+  }
+}
+
+function messageArg(call: string[]): string {
+  const index = call.indexOf('--message')
+  return index >= 0 ? call[index + 1] ?? '' : ''
+}
 
 describe('OpenClaw runtime channels', () => {
   let testDir: string
   let originalOpenClawHome: string | undefined
+  let originalOpenClawCliLog: string | undefined
   let originalFetch: typeof globalThis.fetch
   let originalWebSocket: typeof globalThis.WebSocket
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), 'bakin-openclaw-channel-test-'))
     originalOpenClawHome = process.env.OPENCLAW_HOME
+    originalOpenClawCliLog = process.env.OPENCLAW_CLI_LOG
     originalFetch = globalThis.fetch
     originalWebSocket = globalThis.WebSocket
     FakeWebSocket.instances.length = 0
@@ -30,6 +57,8 @@ describe('OpenClaw runtime channels', () => {
     globalThis.WebSocket = originalWebSocket
     if (originalOpenClawHome === undefined) delete process.env.OPENCLAW_HOME
     else process.env.OPENCLAW_HOME = originalOpenClawHome
+    if (originalOpenClawCliLog === undefined) delete process.env.OPENCLAW_CLI_LOG
+    else process.env.OPENCLAW_CLI_LOG = originalOpenClawCliLog
     rmSync(testDir, { recursive: true, force: true })
   })
 
@@ -70,15 +99,77 @@ describe('OpenClaw runtime channels', () => {
     })])
   })
 
-  it('renders approval requests with an explicit Bakin UI decision notice', async () => {
+  it('sends channel messages through the OpenClaw message CLI without requiring a Gateway tool', async () => {
     const calls: Array<Record<string, unknown>> = []
     globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
       calls.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
-      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+      return new Response(JSON.stringify({
+        ok: false,
+        error: { type: 'not_found', message: 'Tool not available: message_send' },
+      }), { status: 404 })
     }) as unknown as typeof fetch
 
+    const recorder = installOpenClawCliRecorder(testDir)
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
-    const runtime = createOpenClawRuntimeAdapter()
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: recorder.binaryPath } })
+    await runtime.initialize({ contentDir: testDir })
+
+    const result = await runtime.channels.deliverContent({
+      channels: ['discord'],
+      content: {
+        title: 'Launch post',
+        body: 'Ship it.',
+        files: [{ name: 'hero.png', path: '/tmp/hero.png', contentType: 'image/png' }],
+      },
+    })
+
+    expect(result.deliveries).toEqual([expect.objectContaining({ channelId: 'discord' })])
+    expect(calls).toHaveLength(0)
+    expect(recorder.calls()).toEqual([[
+      'message',
+      'send',
+      '--channel',
+      'discord',
+      '--message',
+      'Launch post\n\nShip it.',
+      '--media',
+      '/tmp/hero.png',
+    ]])
+  })
+
+  it('preserves direct channel message titles when rendering CLI message text', async () => {
+    const recorder = installOpenClawCliRecorder(testDir)
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: recorder.binaryPath } })
+    await runtime.initialize({ contentDir: testDir })
+
+    await runtime.channels.sendMessage({
+      channels: ['discord:launch-room'],
+      message: {
+        title: 'Workflow publish failed',
+        body: 'Channel delivery failed.',
+        threadId: 'thread-123',
+      },
+    })
+
+    expect(recorder.calls()).toEqual([[
+      'message',
+      'send',
+      '--channel',
+      'discord',
+      '--target',
+      'launch-room',
+      '--message',
+      'Workflow publish failed\n\nChannel delivery failed.',
+      '--thread-id',
+      'thread-123',
+    ]])
+  })
+
+  it('renders approval requests with an explicit Bakin UI decision notice', async () => {
+    const recorder = installOpenClawCliRecorder(testDir)
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: recorder.binaryPath } })
     await runtime.initialize({ contentDir: testDir })
 
     await runtime.channels.createApproval({
@@ -91,10 +182,10 @@ describe('OpenClaw runtime channels', () => {
       },
     })
 
+    const calls = recorder.calls()
     expect(calls).toHaveLength(1)
-    const args = calls[0]!.args as Record<string, unknown>
-    expect(args.message).toContain('This channel cannot return approval decisions to Bakin')
-    expect(args.message).toContain('approve/reject this gate in the Bakin UI')
+    expect(messageArg(calls[0]!)).toContain('This channel cannot return approval decisions to Bakin')
+    expect(messageArg(calls[0]!)).toContain('approve/reject this gate in the Bakin UI')
   })
 
   it('creates native OpenClaw plugin approvals for interactive channels', async () => {
@@ -165,15 +256,11 @@ describe('OpenClaw runtime channels', () => {
         },
       },
     }), 'utf-8')
-    const calls: Array<Record<string, unknown>> = []
-    globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-      calls.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
-      return new Response(JSON.stringify({ ok: true }), { status: 200 })
-    }) as unknown as typeof fetch
+    const recorder = installOpenClawCliRecorder(testDir)
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
 
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
-    const runtime = createOpenClawRuntimeAdapter()
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: recorder.binaryPath } })
     await runtime.initialize({ contentDir: testDir })
 
     await runtime.channels.createApproval({
@@ -194,10 +281,10 @@ describe('OpenClaw runtime channels', () => {
     })
 
     expect(FakeWebSocket.instances).toHaveLength(0)
+    const calls = recorder.calls()
     expect(calls).toHaveLength(1)
-    const args = calls[0]!.args as Record<string, unknown>
-    expect(args.message).toContain('This gate requires a reject reason')
-    expect(args.message).toContain('Open in Bakin:')
+    expect(messageArg(calls[0]!)).toContain('This gate requires a reject reason')
+    expect(messageArg(calls[0]!)).toContain('Open in Bakin:')
   })
 
   it('falls back to render-only messages when approval options are not approve/reject', async () => {
@@ -210,15 +297,11 @@ describe('OpenClaw runtime channels', () => {
         },
       },
     }), 'utf-8')
-    const calls: Array<Record<string, unknown>> = []
-    globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
-      calls.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>)
-      return new Response(JSON.stringify({ ok: true }), { status: 200 })
-    }) as unknown as typeof fetch
+    const recorder = installOpenClawCliRecorder(testDir)
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
 
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
-    const runtime = createOpenClawRuntimeAdapter()
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: recorder.binaryPath } })
     await runtime.initialize({ contentDir: testDir })
 
     await runtime.channels.createApproval({
@@ -238,10 +321,10 @@ describe('OpenClaw runtime channels', () => {
     })
 
     expect(FakeWebSocket.instances).toHaveLength(0)
+    const calls = recorder.calls()
     expect(calls).toHaveLength(1)
-    const args = calls[0]!.args as Record<string, unknown>
-    expect(args.message).toContain('Needs changes')
-    expect(args.message).toContain('Open in Bakin:')
+    expect(messageArg(calls[0]!)).toContain('Needs changes')
+    expect(messageArg(calls[0]!)).toContain('Open in Bakin:')
   })
 
   it('maps OpenClaw plugin approval resolved events into Bakin approval events', async () => {

--- a/tests/dev/mock-runtime-failure-contract.test.ts
+++ b/tests/dev/mock-runtime-failure-contract.test.ts
@@ -30,7 +30,7 @@ describe('imitation-crab runtime failure contract', () => {
     }))).rejects.toThrow('OpenClaw chat failed: Mock error mode; code=mock_error')
   })
 
-  it('rejects loudly when the mock tool gateway returns an error', async () => {
+  it('rejects raw tool calls when the mock tool gateway returns an error', async () => {
     harness = await createImitationCrabHarness({ toolMode: 'error' })
     const { runtime } = harness.services
 
@@ -40,6 +40,8 @@ describe('imitation-crab runtime failure contract', () => {
     await expect(runtime.channels.sendMessage({
       channels: ['discord'],
       message: { body: 'This channel message should fail' },
-    })).rejects.toThrow('OpenClaw invokeTool failed (500)')
+    })).resolves.toEqual(expect.objectContaining({
+      deliveries: [expect.objectContaining({ channelId: 'discord' })],
+    }))
   })
 })


### PR DESCRIPTION
## Summary
- route OpenClaw runtime channel delivery through `openclaw message send` instead of Gateway `message_send`
- preserve title/body rendering, thread ids, and media attachments for channel messages
- update Messaging launch docs/knowledge for bare-task lifecycle and publish-failure visibility

## Verification
- `bun test tests/adapter-openclaw/runtime-channels.test.ts --timeout 30000`
- `bun test tests/dev/mock-runtime-contract.test.ts tests/dev/mock-runtime-failure-contract.test.ts --timeout 30000`
- `bun test tests/scripts/post-channel.test.ts --timeout 30000`
- `bun run typecheck`
- `git diff --check`

Companion Messaging plugin PR: https://github.com/markhayden/bakin-bits-official/pull/58