### PR TITLE
fix(release): scaffold empty changelog section instead of blocking branch prep

### DIFF
--- a/scripts/prep-release.ts
+++ b/scripts/prep-release.ts
@@ -9,11 +9,13 @@ import { readFileSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { resolve } from 'node:path'
 import {
+  hasUnreleasedBullets,
   moveReleaseNotesToVersion,
   parseReleaseTag,
   resolveReleaseTarget,
+  scaffoldVersionSection,
+  versionSectionBody,
 } from './release'
-import { extractReleaseNotes } from './extract-release-notes'
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const CHANGELOG_PATH = resolve(REPO_ROOT, 'CHANGELOG.md')
@@ -117,22 +119,33 @@ export function targetTagForPrep(opts: PrepOptions, remoteTags: string[]): strin
   return resolveReleaseTarget(remoteTags, { verb: opts.bump, prerelease: opts.prerelease })
 }
 
+function countBullets(body: string): number {
+  return (body.match(/^\s*-\s+\S/gm) ?? []).length
+}
+
 export function prepareChangelog(changelog: string, tag: string, date: string): { changelog: string; changed: boolean; bulletCount: number } {
   const target = parseReleaseTag(tag)
   if (!target) throw new Error(`Malformed release tag: ${tag}`)
 
-  if (changelog.includes(`## [${target.version}]`)) {
-    const notes = extractReleaseNotes(changelog, target.version)
-    const bulletCount = (notes.match(/^\s*-\s+\S/gm) ?? []).length
-    return { changelog, changed: false, bulletCount }
+  // Idempotent: the target section already exists, leave it untouched.
+  const existing = versionSectionBody(changelog, target.version)
+  if (existing !== null) {
+    return { changelog, changed: false, bulletCount: countBullets(existing) }
   }
 
-  const next = moveReleaseNotesToVersion(changelog, target, date, {
-    verb: target.rc === null ? 'patch' : 'minor',
-    tags: [],
-  })
-  const notes = extractReleaseNotes(next, target.version)
-  return { changelog: next, changed: next !== changelog, bulletCount: (notes.match(/^\s*-\s+\S/gm) ?? []).length }
+  // Notes were written under [Unreleased] — promote them into the version section.
+  if (hasUnreleasedBullets(changelog)) {
+    const next = moveReleaseNotesToVersion(changelog, target, date, {
+      verb: target.rc === null ? 'patch' : 'minor',
+      tags: [],
+    })
+    return { changelog: next, changed: next !== changelog, bulletCount: countBullets(versionSectionBody(next, target.version) ?? '') }
+  }
+
+  // No notes yet: scaffold an empty section to fill in on the release branch.
+  // CI's note extraction is the gate that refuses to publish an empty section.
+  const next = scaffoldVersionSection(changelog, target.version, date)
+  return { changelog: next, changed: true, bulletCount: 0 }
 }
 
 function remoteReleaseTags(): string[] {
@@ -166,6 +179,13 @@ async function main(): Promise<void> {
   console.log(`CHANGELOG notes: ${prepared.bulletCount} bullets`)
   console.log(`Branch:          ${branch || '(not creating; pass --create-branch)'}`)
   console.log(`Mode:            ${opts.dryRun ? 'dry-run' : 'write'}`)
+
+  if (prepared.bulletCount === 0) {
+    console.log('')
+    console.log(`⚠  No release notes yet — scaffolded an empty ## [${parseReleaseTag(tag)?.version}] section.`)
+    console.log('   Fill in the bullets on the release branch before you push the tag.')
+    console.log('   CI extracts notes from the committed CHANGELOG and will reject an empty section.')
+  }
 
   if (opts.dryRun) return
   if (opts.createBranch) createReleaseBranch(tag)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -202,11 +202,19 @@ export function stripEmptyChangelogSections(body: string): string {
   return chunks.join('\n\n').trim()
 }
 
+export function hasUnreleasedBullets(changelog: string): boolean {
+  return hasBullets(unreleasedRange(changelog).body)
+}
+
 export function assertHasUnreleasedBullets(changelog: string): void {
-  const range = unreleasedRange(changelog)
-  if (!hasBullets(range.body)) {
+  if (!hasUnreleasedBullets(changelog)) {
     throw new Error('CHANGELOG.md [Unreleased] has no release-note bullets')
   }
+}
+
+/** Body of an existing `## [version]` section, or null when it is absent. */
+export function versionSectionBody(changelog: string, version: string): string | null {
+  return versionRange(changelog, version)?.body ?? null
 }
 
 function replaceOrAppendLinkRefs(changelog: string, version: string): string {
@@ -291,6 +299,24 @@ export function releaseNotesForTarget(
     throw new Error(`CHANGELOG.md has no release-note bullets for ${target.version} release candidates or [Unreleased]`)
   }
   return { body: notes, bulletCount: bulletCount(notes) }
+}
+
+const PLACEHOLDER_NOTES = '### Added\n\n### Changed\n\n### Fixed'
+
+/**
+ * Insert an empty `## [version]` section with the standard subheadings and no
+ * bullets. Used when preparing a release branch before notes are written — the
+ * skeleton is filled in on the branch, and CI's note extraction is the gate
+ * that refuses to publish a section that is still empty.
+ *
+ * No-ops if the section already exists, so it can never overwrite notes that
+ * have already been written for this version.
+ */
+export function scaffoldVersionSection(changelog: string, version: string, date: string): string {
+  const target = parseReleaseTag(`v${version}`)
+  if (!target) throw new Error(`Malformed release version: ${version}`)
+  if (versionRange(changelog, version)) return changelog
+  return insertVersionNotes(changelog, version, date, PLACEHOLDER_NOTES)
 }
 
 export function moveUnreleasedToVersion(changelog: string, version: string, date: string): string {

--- a/tests/scripts/prep-release.test.ts
+++ b/tests/scripts/prep-release.test.ts
@@ -73,6 +73,52 @@ describe('prepareChangelog', () => {
     expect(result.changelog).toContain('[0.2.0]: https://github.com/markhayden/bakin/releases/tag/v0.2.0')
   })
 
+  it('scaffolds an empty placeholder section when Unreleased has no bullets', () => {
+    const changelog = `# Changelog
+
+## [Unreleased]
+
+## [0.0.1-rc.9] - 2026-06-01
+
+### Added
+- Previous thing.
+
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.9...HEAD
+`
+    const result = prepareChangelog(changelog, 'v0.0.1-rc.10', '2026-06-02')
+
+    expect(result.changed).toBe(true)
+    expect(result.bulletCount).toBe(0)
+    expect(result.changelog).toContain('## [0.0.1-rc.10] - 2026-06-02')
+    expect(result.changelog).toContain('### Added')
+    expect(result.changelog).toContain('### Changed')
+    expect(result.changelog).toContain('### Fixed')
+    // Earlier notes are preserved.
+    expect(result.changelog).toContain('- Previous thing.')
+    // [Unreleased] stays empty.
+    expect(result.changelog).toMatch(/## \[Unreleased\]\s+## \[0\.0\.1-rc\.10\]/)
+  })
+
+  it('reports zero bullets for an existing but empty scaffolded section', () => {
+    const changelog = `# Changelog
+
+## [Unreleased]
+
+## [0.0.1-rc.10] - 2026-06-02
+
+### Added
+
+### Changed
+
+### Fixed
+`
+    const result = prepareChangelog(changelog, 'v0.0.1-rc.10', '2026-06-02')
+
+    expect(result.changed).toBe(false)
+    expect(result.bulletCount).toBe(0)
+    expect(result.changelog).toBe(changelog)
+  })
+
   it('is idempotent when the target version section already exists', () => {
     const changelog = `# Changelog
 

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -8,6 +8,7 @@ import {
   releaseNotesForTarget,
   releaseWorkflowUrlFromRuns,
   resolveReleaseTarget,
+  scaffoldVersionSection,
 } from '../../scripts/release'
 
 describe('parseReleaseTag', () => {
@@ -124,6 +125,29 @@ describe('CHANGELOG helpers', () => {
   it('detects non-empty Unreleased bullets', () => {
     expect(assertHasUnreleasedBullets(changelog)).toBeUndefined()
     expect(() => assertHasUnreleasedBullets('# Changelog\n\n## [Unreleased]\n\n### Added\n')).toThrow('[Unreleased]')
+  })
+
+  it('scaffolds an empty version section when absent', () => {
+    const next = scaffoldVersionSection(changelog, '0.2.0', '2026-05-05')
+    expect(next).toContain('## [0.2.0] - 2026-05-05')
+    expect(next).toContain('### Added')
+    expect(next).toContain('### Changed')
+    expect(next).toContain('### Fixed')
+  })
+
+  it('never overwrites an existing version section', () => {
+    const withSection = `# Changelog
+
+## [Unreleased]
+
+## [0.2.0] - 2026-05-05
+
+### Added
+- Hand-written note that must survive.
+`
+    const next = scaffoldVersionSection(withSection, '0.2.0', '2026-05-05')
+    expect(next).toBe(withSection)
+    expect(next).toContain('- Hand-written note that must survive.')
   })
 
   it('moves Unreleased notes into a concrete version', () => {


### PR DESCRIPTION
## Problem

`bun run release <bump> --create-branch` refused to create the release branch unless `## [Unreleased]` already had note bullets, throwing `CHANGELOG.md [Unreleased] has no release-note bullets`. This forced notes to be written *before* the branch existed — the opposite of the intended workflow, where you cut the branch first and write notes on it. Every rc bump hit the same wall.

This check was also redundant: CI's `extract-release-notes` (release.yml) already refuses to publish a version section that has no bullets, so the prep-time check added friction without adding safety.

## Change

- **`prep-release.ts`** — `prepareChangelog` now has three explicit paths:
  1. Target section already exists → idempotent, untouched.
  2. `[Unreleased]` has bullets → promote them (unchanged behavior).
  3. `[Unreleased]` is empty → scaffold an empty `### Added/Changed/Fixed` skeleton and print a loud warning to fill notes on the branch.
- **`release.ts`** — added `hasUnreleasedBullets`, `versionSectionBody` (non-throwing reader), and `scaffoldVersionSection`. The scaffolder **no-ops when the section already exists**, so it can never delete-and-replace existing notes regardless of caller.

## Safety

CI note extraction remains the real gate — an empty section still fails the release. No publish-time safety is lost; this only moves *when* notes get written.

## Tests

- prep-release: scaffolds placeholder on empty `[Unreleased]`; reports zero bullets for an existing-but-empty section without mutating it.
- release: `scaffoldVersionSection` inserts a skeleton when absent and is byte-identical (never overwrites) when the section already exists.

All 32 tests in the release script suites pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)