### PR TITLE
chore(ci): bump GitHub Actions to Node 24 (v5) releases

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # docs:check walks the sibling bakin-bits-official repo for the
       # extracted messaging + projects plugins (see scripts/docs/source-

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # docs:check walks the sibling bakin-bits-official repo for the
       # extracted messaging + projects plugins (see scripts/docs/source-

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.version_ref || github.ref }}
 
@@ -55,7 +55,7 @@ jobs:
         run: bun run docs:check
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bakin-docs
           path: docs/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       release_id: ${{ steps.release.outputs.release_id }}
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
       NPM_TAG: ${{ needs.gate.outputs.npm_tag }}
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.gate.outputs.commit }}
           fetch-depth: 0
@@ -175,7 +175,7 @@ jobs:
         run: bun run scripts/publish-sdk.ts --dry-run --version "${VERSION}" --package-dir "${RUNNER_TEMP}/sdk-package-dry-run" --tag "${NPM_TAG}"
 
       - name: Upload unsigned binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-binaries-unsigned
           if-no-files-found: error
@@ -194,7 +194,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.gate.outputs.commit }}
 
@@ -204,7 +204,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Download unsigned binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-binaries-unsigned
           path: dist
@@ -222,7 +222,7 @@ jobs:
           bun run scripts/sign-macos-binary.ts --binary "dist/${DARWIN_BINARY}"
 
       - name: Upload signed macOS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: signed-macos-binary
           if-no-files-found: error
@@ -244,7 +244,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.gate.outputs.commit }}
           fetch-depth: 0
@@ -258,7 +258,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Setup Node for trusted publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -278,13 +278,13 @@ jobs:
           fi
 
       - name: Download unsigned binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-binaries-unsigned
           path: dist
 
       - name: Download signed macOS binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: signed-macos-binary
           path: signed-macos
@@ -437,7 +437,7 @@ jobs:
       VERSION: ${{ needs.gate.outputs.version }}
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.gate.outputs.commit }}
 


### PR DESCRIPTION
## What

Bumps four GitHub Actions from `@v4` to `@v5` across all workflows:

- `actions/checkout`
- `actions/upload-artifact`
- `actions/download-artifact`
- `actions/setup-node`

## Why

GitHub flagged Node.js 20 deprecation warnings on our runs. The `v4` releases of these actions run on Node 20, which gets force-migrated to Node 24 on **2026-06-16** and removed entirely on **2026-09-16**. The `v5` releases run on Node 24 natively, clearing the warnings ahead of the cutover.

## Verified non-breaking for our usage

- **`download-artifact@v5`** — the only breaking change is the path layout for downloads **by ID**; all our calls download **by name**, so unaffected.
- **`setup-node@v5`** — new auto-caching only triggers when `package.json` declares a `packageManager` field, which ours does not.
- **`checkout@v5` / `upload-artifact@v5`** — Node 24 bump only; no functional change.

## Test coverage note

`ci-pr.yml` and `docs-deploy.yml` are exercised by this PR. `release.yml` only runs on a `v*` release tag, so its bumps won't get a live run until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)