### PR TITLE
feat(tasks): surface provider dispatch failure context

### DIFF
--- a/.claude/knowledge/dispatch.md
+++ b/.claude/knowledge/dispatch.md
@@ -32,6 +32,29 @@ Cooldown chosen by class:
 
 Both classes share the `count` field. `settings.dispatch.maxRetries` (default 5) escalates to **blocked** regardless of classification.
 
+### Provider availability detail
+
+`task.dispatch_failed` audit entries and the matching system task log now carry
+structured dispatch failure detail in addition to the retry/cooldown class:
+
+- `category` — `model_provider_unavailable` or `runtime_unavailable`
+- `reasonCode` — currently `provider_cooldown`,
+  `auth_profile_unavailable`, `dispatch_timeout`, `transport_failure`,
+  `runtime_adapter_failure`, or `runtime_dispatch_failed`
+- `summary` — compact UI text such as
+  `Dispatch failed: model provider unavailable`
+- `specificReason` — drawer/debug detail such as
+  `Provider in cooldown after timeout` or `Auth profile unavailable`
+- `provider`, `model`, `cooldownReason` — optional extracted runtime context
+- `retryable` — whether normal dispatch retry/cooldown can reasonably recover
+- `rawError` — bounded raw runtime error text for technical details
+
+Task logs store this detail under `entry.data.dispatchFailure`. Audit entries
+store the same fields top-level for the activity feed. Compact surfaces should
+show the generic provider-unavailable label; task detail drawers and debug
+activity views may show the specific cause and raw bounded error. Do not make
+raw provider text the primary UI message.
+
 ## Post-send task reconciliation
 
 Dispatch moves a task to `inProgress` before sending the runtime message so a

--- a/.claude/specs/provider-failure-context-ui.md
+++ b/.claude/specs/provider-failure-context-ui.md
@@ -1,0 +1,250 @@
+# Spec: Provider Failure Context UI
+
+## Objective
+
+Make runtime dispatch failures explainable when a task cannot start because the
+assigned model provider is unavailable, cooling down, or missing an auth lane.
+The user should be able to tell the difference between "the task logic failed"
+and "the runtime could not even start the agent turn."
+
+This first slice is task-local: task logs, task details, task cards where useful,
+and live activity entries. It does not add a global provider health banner.
+
+## Assumptions
+
+- Runtime dispatch errors continue to enter Bakin through
+  `runtime.messaging.send()` rejection in `src/core/dispatch.ts`.
+- Bakin should preserve sanitized runtime details, not full provider traces,
+  prompts, local paths, tokens, or raw trajectory payloads.
+- The most important visible cases are OpenClaw/Codex provider cooldown and auth
+  lane unavailability errors, such as `No available auth profile for
+  openai-codex` and `Provider openai-codex is in cooldown`.
+- Structured details should be carried through existing task log and audit
+  plumbing where possible.
+
+## Tech Stack
+
+- TypeScript
+- Bun test runner
+- React task UI in `plugins/tasks/components`
+- Shared host activity feed in `src/components/tasks/activity-feed.tsx`
+- Bakin task store in `packages/core/src/tasks/store.ts`
+
+## Commands
+
+- Focused dispatch test: `bun test --isolate tests/core/dispatch.test.ts`
+- Focused audit message test: `bun test --isolate tests/lib/map-audit-message.test.ts`
+- Focused task UI tests: `bun test --isolate tests/plugins/tasks/task-detail-dialog.test.tsx tests/plugins/tasks/task-card.test.tsx`
+- Typecheck: `bun run typecheck`
+- Broader relevant check: `bun test --isolate tests/core/dispatch.test.ts tests/lib/map-audit-message.test.ts tests/plugins/tasks/task-detail-dialog.test.tsx tests/plugins/tasks/task-card.test.tsx tests/components/use-sse-doctor.test.tsx`
+
+## Project Structure
+
+- `src/core/dispatch.ts` owns runtime send rejection handling, dispatch
+  retry/cooldown state, task log writes, and dispatch audit events.
+- `src/core/task-store.ts` adapts the file-backed task store into board-shaped
+  task objects.
+- `packages/core/src/tasks/store.ts` already supports `TaskLogEntry.data`.
+- `plugins/tasks/types.ts` and `packages/sdk/src/types/index.ts` expose task log
+  shapes to plugin UI and SDK consumers.
+- `plugins/tasks/components/task-detail-dialog.tsx` renders task notes/logs.
+- `plugins/tasks/components/task-card.tsx` renders compact task context.
+- `src/lib/map-audit-message.ts`, `src/hooks/use-sse.ts`, and
+  `packages/host/src/api/activity.ts` map audit JSONL/SSE events into the live
+  activity feed.
+- `.claude/knowledge/dispatch.md` documents dispatch failure handling.
+
+## Code Style
+
+Use a small structured classifier and keep raw provider text bounded:
+
+```ts
+const detail = classifyDispatchFailure(err)
+await addTaskLog(task.id, 'system', detail.summary, {
+  reasonCode: detail.reasonCode,
+  provider: detail.provider,
+  model: detail.model,
+  retryable: detail.retryable,
+  rawError: detail.rawError,
+})
+appendAudit(contentDir, 'task.dispatch_failed', targetAgent, detail)
+```
+
+Visible UI text should lead with the user-facing cause:
+
+```tsx
+<DispatchFailureNotice detail={entry.data.dispatchFailure}>
+  Dispatch failed: model provider unavailable
+</DispatchFailureNotice>
+```
+
+## Testing Strategy
+
+- Add dispatch tests that reproduce provider cooldown and auth-profile
+  unavailability and assert structured failure details in audit and task log
+  data.
+- Add audit message tests for readable `task.dispatch_failed` messages.
+- Add task UI tests for rendering the readable reason and technical detail
+  disclosure from structured log data.
+- Keep existing transient/structural cooldown tests passing.
+- Use typecheck to catch task log shape changes across core, SDK, and plugins.
+
+## Boundaries
+
+**Always:**
+- Keep provider-specific transport behind runtime adapters; classify only the
+  sanitized error text Bakin already receives.
+- Bound and sanitize any raw error shown in technical details.
+- Mark retryability clearly for provider cooldown and auth/profile availability
+  failures.
+- Preserve existing retry/cooldown behavior.
+- Update `.claude/knowledge/dispatch.md` when the failure detail contract lands.
+
+**Ask first:**
+- Add a global provider health banner or provider-wide health aggregation.
+- Add a new task column such as `failed`.
+- Change OpenClaw auth/profile configuration behavior.
+- Retry immediately from the UI instead of relying on dispatch cooldown.
+
+**Never:**
+- Persist full prompts, local filesystem paths, tokens, or provider trajectory
+  dumps in task logs, audit entries, or activity events.
+- Reach around the runtime adapter into provider-private state from UI/plugin
+  code.
+- Add backwards-compatibility shims for obsolete task log shapes beyond reading
+  missing `data` as "plain log entry."
+
+## Success Criteria
+
+- A provider cooldown dispatch rejection appears as a readable failure, not as
+  only `runtime dispatch failed before task completion`.
+- An auth lane/profile unavailability rejection appears as a readable
+  configuration/availability failure.
+- Task logs and audit events preserve enough structured context for UI rendering:
+  `reasonCode`, `provider`, optional `model`, `retryable`, and bounded
+  `rawError`.
+- The task detail drawer exposes technical details without making raw logs the
+  primary UI text.
+- Existing dispatch retry/cooldown behavior and existing task lifecycle behavior
+  remain unchanged.
+
+## Implementation Plan
+
+### Task 1: Dispatch Failure Detail Contract
+
+Description: Add a typed `DispatchFailureDetail` classifier in
+`src/core/dispatch.ts` and test provider cooldown/auth-lane cases.
+
+Acceptance:
+- Provider cooldown error maps to `reasonCode: "provider_cooldown"`.
+- No-auth-profile error maps to `reasonCode: "auth_profile_unavailable"`.
+- Unknown dispatch failures still map to a generic structural detail.
+
+Verify:
+- `bun test --isolate tests/core/dispatch.test.ts`
+
+Files:
+- `src/core/dispatch.ts`
+- `tests/core/dispatch.test.ts`
+
+### Task 2: Persist Structured Details Through Task Logs And Audit
+
+Description: Preserve structured failure details in task log `data` and
+`task.dispatch_failed` audit data.
+
+Acceptance:
+- System task log entries for dispatch rejection include structured data.
+- Audit entries include the same sanitized structured fields.
+- Plain task logs still render normally.
+
+Verify:
+- `bun test --isolate tests/core/dispatch.test.ts`
+- `bun run typecheck`
+
+Files:
+- `src/core/dispatch.ts`
+- `src/core/task-store.ts`
+- `plugins/tasks/types.ts`
+- `packages/sdk/src/types/index.ts`
+
+### Task 3: Render Task-Local Failure Context
+
+Description: Show task-local dispatch failure context in task detail notes and a
+small card indicator when the latest relevant log entry is a dispatch failure.
+
+Acceptance:
+- Task detail drawer shows the readable reason, retryability, provider/model,
+  and expandable technical details.
+- Task card can signal the latest dispatch failure without crowding normal task
+  content.
+- Missing `data` falls back to the existing plain text note display.
+
+Verify:
+- `bun test --isolate tests/plugins/tasks/task-detail-dialog.test.tsx tests/plugins/tasks/task-card.test.tsx`
+
+Files:
+- `plugins/tasks/components/task-detail-dialog.tsx`
+- `plugins/tasks/components/task-card.tsx`
+- `tests/plugins/tasks/task-detail-dialog.test.tsx`
+- `tests/plugins/tasks/task-card.test.tsx`
+
+### Task 4: Live Activity Message Mapping
+
+Description: Map `task.dispatch_failed` audit events to readable activity feed
+messages and carry structured details through SSE/API events if needed for
+debug/technical display.
+
+Acceptance:
+- Live activity says `Dispatch failed: model provider unavailable` for provider
+  cooldown/auth unavailability rather than the raw event name.
+- X-Ray/debug mode can still show the event name and technical data.
+
+Verify:
+- `bun test --isolate tests/lib/map-audit-message.test.ts`
+- Any touched activity/SSE tests.
+
+Files:
+- `src/lib/map-audit-message.ts`
+- `src/types/index.ts`
+- `src/hooks/use-sse.ts`
+- `packages/host/src/api/activity.ts`
+- `src/components/tasks/activity-feed.tsx`
+- `tests/lib/map-audit-message.test.ts`
+
+### Task 5: Documentation And Final Review
+
+Description: Document the new structured failure context and run quality gates.
+
+Acceptance:
+- `.claude/knowledge/dispatch.md` describes reason codes and UI-facing detail.
+- The final diff has no provider-boundary leaks or unbounded raw error output.
+
+Verify:
+- `bun run typecheck`
+- Focused tests from Tasks 1, 3, and 4.
+
+Files:
+- `.claude/knowledge/dispatch.md`
+
+## Commit Strategy
+
+1. `test(core): capture provider dispatch failure details`
+   - Rollback point: test-only reproduction.
+   - Verification: new tests fail before implementation, then pass after Task 1.
+2. `feat(core): add structured dispatch failure details`
+   - Rollback point: backend data contract only.
+   - Verification: dispatch tests and typecheck.
+3. `feat(tasks): surface dispatch failure context`
+   - Rollback point: UI-only task-local rendering.
+   - Verification: task component tests.
+4. `feat(activity): map dispatch failures into readable feed entries`
+   - Rollback point: activity feed mapping only.
+   - Verification: audit message tests and relevant SSE/API tests.
+5. `docs(dispatch): document provider failure context`
+   - Rollback point: documentation only.
+   - Verification: previous gates remain green.
+
+## Open Questions
+
+1. Should auth-profile unavailable and provider-cooldown failures use the same
+   user-facing label (`model provider unavailable`) or distinct labels?

--- a/packages/host/src/api/activity.ts
+++ b/packages/host/src/api/activity.ts
@@ -41,6 +41,7 @@ export async function get(_req: Request): Promise<Response> {
             taskTitle: data.title as string | undefined,
             eventName: entry.event,
             ...(data.duplicate ? { duplicate: true } : {}),
+            data,
           })
         } catch { /* skip malformed lines */ }
       }

--- a/plugins/tasks/components/task-card.tsx
+++ b/plugins/tasks/components/task-card.tsx
@@ -2,9 +2,10 @@
 
 import type { CSSProperties } from 'react'
 import { useSortable } from '@dnd-kit/react/sortable'
-import { X } from 'lucide-react'
+import { AlertTriangle, X } from 'lucide-react'
 import { AgentAvatar } from "@makinbakin/sdk/components"
 import { STATUS_BADGE_STYLES } from '../constants'
+import { compactDispatchFailureLabel, getLatestDispatchFailure } from '../lib/dispatch-failure'
 import { getTaskAvailableAtMs } from '../lib/scheduled'
 import type { Task, ColumnId } from '../types'
 
@@ -58,6 +59,7 @@ export function TaskCardContent({ task, columnId, className, gateLabel, childTas
   const isComplete = task.checked || columnId === 'done' || columnId === 'archived'
   const availableAtMs = getTaskAvailableAtMs(task)
   const isFutureScheduled = availableAtMs !== null && availableAtMs > Date.now()
+  const dispatchFailure = getLatestDispatchFailure(task.log)
 
   const semKey = 'embeddings'
   const bm25Key = scoreInfo?.indexScores
@@ -138,6 +140,15 @@ export function TaskCardContent({ task, columnId, className, gateLabel, childTas
       {/* Blocked reason */}
       {task.blockedReason && (
         <p className="text-xs text-destructive mt-1.5">{task.blockedReason}</p>
+      )}
+
+      {dispatchFailure && (
+        <div className="flex items-center gap-1.5 mt-1.5 px-2 py-1 rounded-md bg-amber-500/10 border border-amber-500/20 overflow-hidden">
+          <AlertTriangle className="size-3 text-amber-400 shrink-0" />
+          <span className="text-amber-300 text-[11px] font-semibold truncate">
+            {compactDispatchFailureLabel(dispatchFailure)}
+          </span>
+        </div>
       )}
 
       {isFutureScheduled && task.availableAt && (

--- a/plugins/tasks/components/task-detail-dialog.tsx
+++ b/plugins/tasks/components/task-detail-dialog.tsx
@@ -8,7 +8,7 @@ import { Textarea } from "@makinbakin/sdk/ui"
 import { Separator } from "@makinbakin/sdk/ui"
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@makinbakin/sdk/ui"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@makinbakin/sdk/ui"
-import { Send, Check, X, RefreshCw, MoreHorizontal, Copy, Trash2, Pencil, Loader2 } from 'lucide-react'
+import { AlertTriangle, Send, Check, X, RefreshCw, MoreHorizontal, Copy, Trash2, Pencil, Loader2 } from 'lucide-react'
 import { MarkdownContent } from "@makinbakin/sdk/components"
 import { Slot } from '@makinbakin/sdk/slots'
 import { AgentAvatar } from "@makinbakin/sdk/components"
@@ -16,7 +16,8 @@ import { AgentSelect } from "@makinbakin/sdk/components"
 import { useAgent } from "@makinbakin/sdk/hooks"
 import { COLUMN_CONFIG, STATUS_DOT_COLORS } from '../constants'
 import { toast } from "@makinbakin/sdk/hooks"
-import type { Task, ColumnId } from '../types'
+import type { Task, ColumnId, TaskLogEntry } from '../types'
+import { compactDispatchFailureLabel, getDispatchFailureDetail, specificDispatchFailureLabel, type DispatchFailureDetail } from '../lib/dispatch-failure'
 import { isRenderableAssetRef } from '../lib/output-assets'
 import { createShortClientId } from '../lib/client-id'
 
@@ -90,6 +91,49 @@ function StepOutputViewer({ output }: { output: Record<string, unknown> | string
       ))}
     </div>
   )
+}
+
+function DispatchFailureLogPanel({ detail }: { detail: DispatchFailureDetail }) {
+  const rows = [
+    ['Cause', specificDispatchFailureLabel(detail)],
+    ...(detail.provider ? [['Provider', detail.provider]] : []),
+    ...(detail.model ? [['Model', detail.model]] : []),
+    ['Retryable', detail.retryable === false ? 'No' : 'Yes'],
+  ] as Array<[string, string]>
+
+  return (
+    <div className="mt-2 rounded-md border border-amber-500/20 bg-amber-500/10 p-3">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="size-4 text-amber-400 shrink-0 mt-0.5" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-semibold text-amber-300">{compactDispatchFailureLabel(detail)}</p>
+          <p className="mt-0.5 text-xs text-amber-200/80">{specificDispatchFailureLabel(detail)}</p>
+        </div>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        {rows.map(([label, value]) => (
+          <div key={label} className="min-w-0">
+            <p className="text-[10px] uppercase tracking-wider text-amber-200/60">{label}</p>
+            <p className="truncate text-xs text-amber-100">{value}</p>
+          </div>
+        ))}
+      </div>
+      {detail.rawError && (
+        <details className="mt-3">
+          <summary className="cursor-pointer text-[11px] font-medium text-amber-200/80">Technical details</summary>
+          <pre className="mt-2 max-h-36 overflow-auto whitespace-pre-wrap break-words rounded bg-background/70 p-2 text-[11px] text-muted-foreground">
+            {detail.rawError}
+          </pre>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function TaskLogMessage({ entry }: { entry: TaskLogEntry }) {
+  const dispatchFailure = getDispatchFailureDetail(entry)
+  if (dispatchFailure) return <DispatchFailureLogPanel detail={dispatchFailure} />
+  return <p className="text-xs text-muted-foreground">{entry.message}</p>
 }
 
 interface Workflow {
@@ -672,7 +716,7 @@ export function TaskDetailDrawer({ task, columnId, open, editing, onClose, onEdi
               <span className="text-xs font-mono text-muted-foreground">{entry.timestamp}</span>
               <span className="text-xs font-medium text-foreground">{entry.author}</span>
             </div>
-            <p className="text-xs text-muted-foreground">{entry.message}</p>
+            <TaskLogMessage entry={entry} />
           </div>
         ))}
         {hasMore && !showAllNotes && (

--- a/plugins/tasks/lib/dispatch-failure.ts
+++ b/plugins/tasks/lib/dispatch-failure.ts
@@ -1,0 +1,63 @@
+import type { TaskLogEntry } from '../types'
+
+export interface DispatchFailureDetail {
+  category?: string
+  reasonCode?: string
+  summary?: string
+  specificReason?: string
+  retryable?: boolean
+  provider?: string
+  model?: string
+  cooldownReason?: string
+  rawError?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+export function getDispatchFailureDetail(entry: TaskLogEntry): DispatchFailureDetail | null {
+  const data = entry.data
+  if (!isRecord(data)) return null
+  const raw = data.dispatchFailure
+  if (!isRecord(raw)) return null
+
+  return {
+    category: asString(raw.category),
+    reasonCode: asString(raw.reasonCode),
+    summary: asString(raw.summary),
+    specificReason: asString(raw.specificReason),
+    retryable: typeof raw.retryable === 'boolean' ? raw.retryable : undefined,
+    provider: asString(raw.provider),
+    model: asString(raw.model),
+    cooldownReason: asString(raw.cooldownReason),
+    rawError: asString(raw.rawError),
+  }
+}
+
+export function getLatestDispatchFailure(log?: TaskLogEntry[]): DispatchFailureDetail | null {
+  if (!log) return null
+  for (let i = log.length - 1; i >= 0; i--) {
+    const detail = getDispatchFailureDetail(log[i])
+    if (detail) return detail
+  }
+  return null
+}
+
+export function compactDispatchFailureLabel(detail: DispatchFailureDetail): string {
+  if (detail.category === 'model_provider_unavailable') {
+    return 'Dispatch failed: model provider unavailable'
+  }
+  return detail.summary || 'Dispatch failed'
+}
+
+export function specificDispatchFailureLabel(detail: DispatchFailureDetail): string {
+  if (detail.specificReason) return detail.specificReason
+  if (detail.reasonCode === 'provider_cooldown') return 'Provider in cooldown after timeout'
+  if (detail.reasonCode === 'auth_profile_unavailable') return 'Auth profile unavailable'
+  return 'Runtime dispatch failed'
+}

--- a/plugins/tasks/types.ts
+++ b/plugins/tasks/types.ts
@@ -2,6 +2,7 @@ export interface TaskLogEntry {
   timestamp: string
   author: string
   message: string
+  data?: Record<string, unknown>
 }
 
 export interface TaskSource {

--- a/src/components/tasks/activity-feed.tsx
+++ b/src/components/tasks/activity-feed.tsx
@@ -44,6 +44,48 @@ function relativeTime(ts: string): string {
   return `${days}d ago`
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function textField(data: Record<string, unknown>, key: string): string | null {
+  const value = data[key]
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function DispatchFailureDebug({ data }: { data?: Record<string, unknown> }) {
+  if (!isRecord(data)) return null
+  const rows = [
+    ['Cause', textField(data, 'specificReason')],
+    ['Provider', textField(data, 'provider')],
+    ['Model', textField(data, 'model')],
+    ['Retryable', typeof data.retryable === 'boolean' ? (data.retryable ? 'Yes' : 'No') : null],
+  ].filter((row): row is [string, string] => !!row[1])
+  const rawError = textField(data, 'rawError')
+  if (rows.length === 0 && !rawError) return null
+
+  return (
+    <div className="mt-2 rounded-md bg-muted/40 px-2 py-1.5 text-[10px] text-muted-foreground">
+      {rows.length > 0 && (
+        <div className="grid grid-cols-2 gap-x-2 gap-y-1">
+          {rows.map(([label, value]) => (
+            <div key={label} className="min-w-0">
+              <span className="text-muted-foreground/60">{label}: </span>
+              <span className="text-foreground/70">{value}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {rawError && (
+        <details className="mt-1">
+          <summary className="cursor-pointer text-muted-foreground/70">Raw error</summary>
+          <p className="mt-1 break-words font-mono text-[10px] leading-snug">{rawError}</p>
+        </details>
+      )}
+    </div>
+  )
+}
+
 export function ActivityFeed() {
   const { open, toggle } = useActivityContext()
   const events = useContentStore((s) => s.activityEvents)
@@ -123,6 +165,9 @@ export function ActivityFeed() {
                 }`}>{evt.message}</p>
                 {evt.eventName && (
                   <p className="text-[10px] text-muted-foreground/60 mt-0.5 truncate font-mono">{evt.eventName}</p>
+                )}
+                {debug && evt.eventName === 'task.dispatch_failed' && (
+                  <DispatchFailureDebug data={evt.data} />
                 )}
               </div>
             </div>

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -88,6 +88,25 @@ async function buildDispatchLessonBlock(input: {
 }
 
 type DispatchFailureKind = 'transient' | 'structural'
+type DispatchFailureReasonCode =
+  | 'provider_cooldown'
+  | 'auth_profile_unavailable'
+  | 'dispatch_timeout'
+  | 'transport_failure'
+  | 'runtime_adapter_failure'
+  | 'runtime_dispatch_failed'
+
+interface DispatchFailureDetail {
+  category: 'model_provider_unavailable' | 'runtime_unavailable'
+  reasonCode: DispatchFailureReasonCode
+  summary: string
+  specificReason: string
+  retryable: boolean
+  provider?: string
+  model?: string
+  cooldownReason?: string
+  rawError: string
+}
 
 interface FailureRecord {
   lastAttempt: number
@@ -180,8 +199,9 @@ export function isTaskDispatchEligible(
   return { eligible: true }
 }
 
-async function addTaskLog(taskId: string, author: string, message: string): Promise<void> {
-  await appendTaskLog(taskId, author, message)
+async function addTaskLog(taskId: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
+  if (data) await appendTaskLog(taskId, author, message, data)
+  else await appendTaskLog(taskId, author, message)
 }
 
 async function moveTaskToInProgress(taskId: string, agent: string): Promise<void> {
@@ -210,6 +230,97 @@ function classifyDispatchError(err: unknown): DispatchFailureKind {
   if (cause?.code && TRANSIENT_CODES.has(cause.code)) return 'transient'
   if (err instanceof Error && err.name === 'AbortError') return 'transient'
   return 'structural'
+}
+
+function rawDispatchError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function extractProviderFromRuntimeError(raw: string): string | undefined {
+  return raw.match(/No available auth profile for\s+([A-Za-z0-9._/-]+)/i)?.[1]
+    ?? raw.match(/Provider\s+([A-Za-z0-9._/-]+)\s+is in cooldown/i)?.[1]
+}
+
+function extractModelFromRuntimeError(raw: string): string | undefined {
+  return raw.match(/([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+):\s+Provider\s+/i)?.[1]
+}
+
+function classifyDispatchFailureDetail(err: unknown): DispatchFailureDetail {
+  const raw = rawDispatchError(err)
+  const lower = raw.toLowerCase()
+  const rawError = formatDispatchError(err)
+  const provider = extractProviderFromRuntimeError(raw)
+  const model = extractModelFromRuntimeError(raw)
+
+  if (lower.includes('no available auth profile')) {
+    return {
+      category: 'model_provider_unavailable',
+      reasonCode: 'auth_profile_unavailable',
+      summary: 'Dispatch failed: model provider unavailable',
+      specificReason: 'Auth profile unavailable',
+      retryable: true,
+      ...(provider ? { provider } : {}),
+      ...(model ? { model } : {}),
+      rawError,
+    }
+  }
+
+  if (/\bprovider\b.*\bin cooldown\b/i.test(raw) || lower.includes('suspending lanes')) {
+    return {
+      category: 'model_provider_unavailable',
+      reasonCode: 'provider_cooldown',
+      summary: 'Dispatch failed: model provider unavailable',
+      specificReason: 'Provider in cooldown after timeout',
+      retryable: true,
+      ...(provider ? { provider } : {}),
+      ...(model ? { model } : {}),
+      ...(lower.includes('timeout') ? { cooldownReason: 'timeout' } : {}),
+      rawError,
+    }
+  }
+
+  if (lower.includes('request timed out') || lower.includes('gateway request timed out')) {
+    return {
+      category: 'runtime_unavailable',
+      reasonCode: 'dispatch_timeout',
+      summary: 'Dispatch failed: runtime dispatch timed out',
+      specificReason: 'Runtime dispatch timed out',
+      retryable: true,
+      rawError,
+    }
+  }
+
+  if (lower.includes('socket error') || lower.includes('fetch failed') || err instanceof TypeError || err instanceof Error && err.name === 'AbortError') {
+    return {
+      category: 'runtime_unavailable',
+      reasonCode: 'transport_failure',
+      summary: 'Dispatch failed: runtime transport unavailable',
+      specificReason: 'Runtime transport failure',
+      retryable: true,
+      rawError,
+    }
+  }
+
+  const http = raw.match(/\bfailed \((\d{3})\)/)
+  if (http) {
+    return {
+      category: 'runtime_unavailable',
+      reasonCode: 'runtime_adapter_failure',
+      summary: `Dispatch failed: runtime adapter returned HTTP ${http[1]}`,
+      specificReason: `Runtime adapter returned HTTP ${http[1]}`,
+      retryable: Number(http[1]) >= 500,
+      rawError,
+    }
+  }
+
+  return {
+    category: 'runtime_unavailable',
+    reasonCode: 'runtime_dispatch_failed',
+    summary: 'Dispatch failed: runtime dispatch failed before task completion',
+    specificReason: 'Runtime dispatch failed before task completion',
+    retryable: true,
+    rawError,
+  }
 }
 
 let dispatching = false
@@ -274,9 +385,10 @@ function taskAlreadyLeftActiveWork(column: keyof DispatchColumns): boolean {
   return column === 'done' || column === 'blocked' || column === 'review' || column === 'archived'
 }
 
-async function tryAddTaskLog(taskId: string, author: string, message: string): Promise<void> {
+async function tryAddTaskLog(taskId: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
   try {
-    await addTaskLog(taskId, author, message)
+    if (data) await addTaskLog(taskId, author, message, data)
+    else await addTaskLog(taskId, author, message)
   } catch (err) {
     log.warn('Failed to append dispatch reconciliation task log', err, { id: taskId })
   }
@@ -358,6 +470,7 @@ async function reconcileRejectedDispatch(input: {
   if (!input.state.failedDispatches) input.state.failedDispatches = {}
   const prev = getFailureRecord(input.state.failedDispatches[input.task.id])
   const kind = classifyDispatchError(input.err)
+  const detail = classifyDispatchFailureDetail(input.err)
   const attempt = (prev?.count || 0) + 1
   input.state.failedDispatches[input.task.id] = { lastAttempt: Date.now(), count: attempt, kind }
 
@@ -372,14 +485,16 @@ async function reconcileRejectedDispatch(input: {
   await tryAddTaskLog(
     input.task.id,
     'system',
-    `${input.logPrefix} (attempt ${attempt}, ${kind}) → ${input.targetAgent}: ${summary}. Returned to Todo for retry when cooldown expires.`,
+    `${input.logPrefix} (attempt ${attempt}, ${kind}) → ${input.targetAgent}: ${detail.summary}. Returned to Todo for retry when cooldown expires.`,
+    { dispatchFailure: detail },
   )
   appendAudit(input.contentDir, 'task.dispatch_failed', input.targetAgent, {
     id: input.task.id,
     title: input.task.title,
-    error: summary,
+    error: detail.summary,
     attempt,
     kind,
+    ...detail,
   })
 }
 

--- a/src/core/task-store.ts
+++ b/src/core/task-store.ts
@@ -21,6 +21,7 @@ export interface TaskLogEntry {
   timestamp: string
   author: string
   message: string
+  data?: Record<string, unknown>
 }
 
 export interface Task {
@@ -335,10 +336,10 @@ export function deleteTask(identifier: string): Promise<void> {
   }
 }
 
-export function addTaskLog(identifier: string, author: string, message: string): Promise<void> {
+export function addTaskLog(identifier: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
   try {
     const task = requireTask(identifier)
-    getSharedBakinTaskStore().appendLogSync(task.id, { timestamp: new Date().toISOString(), author, message })
+    getSharedBakinTaskStore().appendLogSync(task.id, { timestamp: new Date().toISOString(), author, message, ...(data ? { data } : {}) })
     return Promise.resolve()
   } catch (err) {
     return Promise.reject(err)

--- a/src/hooks/use-sse.ts
+++ b/src/hooks/use-sse.ts
@@ -100,6 +100,7 @@ export function useSSE() {
               taskTitle: entryData.title as string | undefined,
               eventName: entry.event,
               ...(entryData.duplicate ? { duplicate: true } : {}),
+              data: entryData,
             })
           }
 

--- a/src/lib/map-audit-message.ts
+++ b/src/lib/map-audit-message.ts
@@ -10,6 +10,12 @@ export function mapAuditMessage(event: string, data: Record<string, unknown>): s
     case 'task.moved': return `Moved "${data.title}" → ${data.to}`
     case 'task.assigned': return `Assigned "${data.title}" to ${data.assignee}`
     case 'task.blocked': return `Blocked: ${data.title} — ${data.reason || 'no reason'}`
+    case 'task.dispatch_failed': {
+      if (data.category === 'model_provider_unavailable') return 'Dispatch failed: model provider unavailable'
+      if (typeof data.summary === 'string') return data.summary
+      if (typeof data.error === 'string' && data.error.startsWith('Dispatch failed:')) return data.error
+      return `Dispatch failed: ${data.error || 'unknown error'}`
+    }
     case 'task.updated': return `Updated: ${data.title}`
     case 'system.init': return 'Bakin started'
     case 'system.dispatch_error': return `Dispatch failed: ${data.error || 'unknown error'}`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface TaskLogEntry {
   timestamp: string
   author: string
   message: string
+  data?: Record<string, unknown>
 }
 
 export interface Task {
@@ -85,6 +86,7 @@ export interface ActivityEvent {
   taskTitle?: string
   eventName?: string
   duplicate?: boolean
+  data?: Record<string, unknown>
 }
 
 export interface ContentState {

--- a/tests/components/header-update-banner.test.tsx
+++ b/tests/components/header-update-banner.test.tsx
@@ -67,7 +67,9 @@ describe('Header update banner', () => {
     expect(screen.getByRole('status').textContent).toContain('v0.1.0')
     expect(screen.getByRole('status').textContent).toContain('v0.2.0')
     expect(screen.getByRole('button', { name: 'Update Bakin' })).toBeDefined()
-    expect(document.documentElement.style.getPropertyValue('--bakin-shell-top')).toBe('5.75rem')
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--bakin-shell-top')).toBe('5.75rem')
+    })
   })
 
   it('does not render the banner when self-update is unsupported', async () => {

--- a/tests/components/use-sse-doctor.test.tsx
+++ b/tests/components/use-sse-doctor.test.tsx
@@ -40,9 +40,9 @@ function Probe() {
   return null
 }
 
-function emitAudit(event: string) {
+function emitAudit(event: string, data: Record<string, unknown> = {}, agent = 'system') {
   lastES?.onmessage?.({
-    data: JSON.stringify({ type: 'audit', entry: { event, ts: new Date().toISOString(), agent: 'system', data: {} } }),
+    data: JSON.stringify({ type: 'audit', entry: { event, ts: new Date().toISOString(), agent, data } }),
   })
 }
 
@@ -78,5 +78,26 @@ describe('useSSE — doctorVersion wiring', () => {
     emitAudit('task.created')
     emitAudit('plan.updated')
     expect(useContentStore.getState().doctorVersion).toBe(0)
+  })
+
+  it('preserves structured audit data on activity events', async () => {
+    render(<Probe />)
+    await waitFor(() => expect(lastES).not.toBeNull())
+
+    emitAudit('task.dispatch_failed', {
+      title: 'Provider failed task',
+      category: 'model_provider_unavailable',
+      reasonCode: 'provider_cooldown',
+      provider: 'openai-codex',
+      retryable: true,
+    }, 'main')
+
+    const [event] = useContentStore.getState().activityEvents
+    expect(event.message).toBe('Dispatch failed: model provider unavailable')
+    expect(event.data).toMatchObject({
+      reasonCode: 'provider_cooldown',
+      provider: 'openai-codex',
+      retryable: true,
+    })
   })
 })

--- a/tests/core/dispatch.test.ts
+++ b/tests/core/dispatch.test.ts
@@ -447,6 +447,78 @@ describe('dispatch', () => {
       expect((dispatchFailed?.[3] as { kind: string }).kind).toBe('transient')
     })
 
+    it('records provider cooldown details in audit and task log data', async () => {
+      const { appendAudit } = require('../../src/core/audit') as typeof import('../../src/core/audit')
+      vi.mocked(appendAudit).mockClear()
+      mockStoreAddTaskLog.mockClear()
+
+      setupTodoTask({ id: 't-provider-cooldown', title: 'Provider cooldown task', agent: 'main' })
+      mockRuntimeSend.mockRejectedValueOnce(
+        new Error('OpenClaw chat failed: FallbackSummaryError: All models failed (1): openai-codex/gpt-5.5: Provider openai-codex is in cooldown (suspending lanes) (timeout); code=UNAVAILABLE'),
+      )
+
+      await dispatchTasks(tempDir, 3737)
+
+      const dispatchFailed = vi.mocked(appendAudit).mock.calls.find((c: any[]) => c[1] === 'task.dispatch_failed')
+      expect(dispatchFailed).toBeDefined()
+      expect(dispatchFailed?.[3]).toMatchObject({
+        reasonCode: 'provider_cooldown',
+        provider: 'openai-codex',
+        model: 'openai-codex/gpt-5.5',
+        retryable: true,
+      })
+      expect((dispatchFailed?.[3] as { rawError?: string }).rawError).toContain('Provider openai-codex is in cooldown')
+
+      expect(mockStoreAddTaskLog).toHaveBeenCalledWith(
+        't-provider-cooldown',
+        'system',
+        expect.stringContaining('model provider unavailable'),
+        expect.objectContaining({
+          dispatchFailure: expect.objectContaining({
+            reasonCode: 'provider_cooldown',
+            provider: 'openai-codex',
+            model: 'openai-codex/gpt-5.5',
+            retryable: true,
+          }),
+        }),
+      )
+    })
+
+    it('records auth profile availability details in audit and task log data', async () => {
+      const { appendAudit } = require('../../src/core/audit') as typeof import('../../src/core/audit')
+      vi.mocked(appendAudit).mockClear()
+      mockStoreAddTaskLog.mockClear()
+
+      setupTodoTask({ id: 't-auth-profile', title: 'Auth profile task', agent: 'main' })
+      mockRuntimeSend.mockRejectedValueOnce(
+        new Error('Failed to dispatch "Auth profile task" to main OpenClaw chat failed: Error: No available auth profile for openai-codex (all in cooldown or unavailable).; code=UNAVAILABLE'),
+      )
+
+      await dispatchTasks(tempDir, 3737)
+
+      const dispatchFailed = vi.mocked(appendAudit).mock.calls.find((c: any[]) => c[1] === 'task.dispatch_failed')
+      expect(dispatchFailed).toBeDefined()
+      expect(dispatchFailed?.[3]).toMatchObject({
+        reasonCode: 'auth_profile_unavailable',
+        provider: 'openai-codex',
+        retryable: true,
+      })
+      expect((dispatchFailed?.[3] as { rawError?: string }).rawError).toContain('No available auth profile for openai-codex')
+
+      expect(mockStoreAddTaskLog).toHaveBeenCalledWith(
+        't-auth-profile',
+        'system',
+        expect.stringContaining('model provider unavailable'),
+        expect.objectContaining({
+          dispatchFailure: expect.objectContaining({
+            reasonCode: 'auth_profile_unavailable',
+            provider: 'openai-codex',
+            retryable: true,
+          }),
+        }),
+      )
+    })
+
     it('classifies AbortError as transient', async () => {
       setupTodoTask({ id: 't-abort', title: 'AbortError task' })
       const abortErr = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' })

--- a/tests/lib/map-audit-message.test.ts
+++ b/tests/lib/map-audit-message.test.ts
@@ -20,6 +20,20 @@ describe('mapAuditMessage', () => {
     expect(mapAuditMessage('system.init', {})).toBe('Bakin started')
   })
 
+  it('maps model provider dispatch failures to a compact readable message', () => {
+    expect(mapAuditMessage('task.dispatch_failed', {
+      category: 'model_provider_unavailable',
+      reasonCode: 'provider_cooldown',
+      summary: 'Dispatch failed: model provider unavailable',
+    })).toBe('Dispatch failed: model provider unavailable')
+  })
+
+  it('maps non-provider dispatch failures from the sanitized summary', () => {
+    expect(mapAuditMessage('task.dispatch_failed', {
+      summary: 'Dispatch failed: runtime transport unavailable',
+    })).toBe('Dispatch failed: runtime transport unavailable')
+  })
+
   // Exec tool events with label in data
   it('uses data.label for exec.*.ok events', () => {
     expect(mapAuditMessage('exec.bakin_exec_tasks_create.ok', { label: 'Created a task' }))

--- a/tests/plugins/tasks/task-card.test.tsx
+++ b/tests/plugins/tasks/task-card.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, expect, it, mock } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-task-card-${Date.now()}`)
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('@makinbakin/sdk/components', () => ({
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span>{agentId}</span>,
+}))
+
+import { TaskCardContent } from '../../../plugins/tasks/components/task-card'
+import type { Task } from '../../../plugins/tasks/types'
+
+function makeTask(overrides?: Partial<Task>): Task {
+  return {
+    id: 'task1234',
+    title: 'Dispatch failure task',
+    checked: false,
+    ...overrides,
+  }
+}
+
+describe('TaskCardContent dispatch failure context', () => {
+  it('shows a compact provider-unavailable label from the latest dispatch failure log', () => {
+    render(
+      <TaskCardContent
+        task={makeTask({
+          log: [
+            { timestamp: '2026-06-03T00:00:00Z', author: 'system', message: 'older' },
+            {
+              timestamp: '2026-06-03T00:01:00Z',
+              author: 'system',
+              message: 'Dispatch failed',
+              data: {
+                dispatchFailure: {
+                  category: 'model_provider_unavailable',
+                  reasonCode: 'provider_cooldown',
+                  summary: 'Dispatch failed: model provider unavailable',
+                  specificReason: 'Provider in cooldown after timeout',
+                  provider: 'openai-codex',
+                  retryable: true,
+                },
+              },
+            },
+          ],
+        })}
+        columnId="todo"
+      />,
+    )
+
+    expect(screen.getByText('Dispatch failed: model provider unavailable')).toBeDefined()
+    expect(screen.queryByText('Provider in cooldown after timeout')).toBeNull()
+  })
+})

--- a/tests/plugins/tasks/task-detail-dialog.test.tsx
+++ b/tests/plugins/tasks/task-detail-dialog.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-task-detail-${Date.now()}`)
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+mock.module('@makinbakin/sdk/components', () => ({
+  BakinDrawer: ({ open, title, actions, children }: { open: boolean; title?: React.ReactNode; actions?: React.ReactNode; children?: React.ReactNode }) => (
+    open ? <div data-testid="drawer"><div>{title}</div><div>{actions}</div>{children}</div> : null
+  ),
+  MarkdownContent: ({ content }: { content: string }) => <div>{content}</div>,
+  AgentAvatar: ({ agentId }: { agentId: string }) => <span>{agentId}</span>,
+  AgentSelect: () => <div />,
+}))
+
+mock.module('@makinbakin/sdk/slots', () => ({
+  Slot: () => null,
+}))
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useAgent: (agentId: string) => agentId ? { id: agentId, name: agentId } : null,
+  toast: mock(),
+}))
+
+mock.module('@makinbakin/sdk/ui', () => ({
+  Button: ({ children, onClick, disabled }: { children?: React.ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+  Separator: () => <hr />,
+  Select: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+  SelectContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ children, placeholder }: { children?: React.ReactNode; placeholder?: string }) => <span>{children ?? placeholder}</span>,
+  DropdownMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) => <button onClick={onClick}>{children}</button>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+}))
+
+import { TaskDetailDrawer } from '../../../plugins/tasks/components/task-detail-dialog'
+import type { Task } from '../../../plugins/tasks/types'
+
+function makeTask(overrides?: Partial<Task>): Task {
+  return {
+    id: 'task1234',
+    title: 'Provider failure task',
+    checked: false,
+    agent: 'main',
+    log: [],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  ;(globalThis as { fetch: typeof fetch }).fetch = (mock(async () => {
+    throw new Error('workflow definitions unavailable in this test')
+  })) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TaskDetailDrawer dispatch failure context', () => {
+  it('renders specific provider failure details from structured log data', () => {
+    render(
+      <TaskDetailDrawer
+        task={makeTask({
+          log: [
+            {
+              timestamp: '2026-06-03T00:01:00Z',
+              author: 'system',
+              message: 'Dispatch failed',
+              data: {
+                dispatchFailure: {
+                  category: 'model_provider_unavailable',
+                  reasonCode: 'auth_profile_unavailable',
+                  summary: 'Dispatch failed: model provider unavailable',
+                  specificReason: 'Auth profile unavailable',
+                  provider: 'openai-codex',
+                  model: 'openai-codex/gpt-5.5',
+                  retryable: true,
+                  rawError: 'No available auth profile for openai-codex',
+                },
+              },
+            },
+          ],
+        })}
+        columnId="todo"
+        open
+        editing={false}
+        onClose={() => {}}
+        onEdit={() => {}}
+        onCancelEdit={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Dispatch failed: model provider unavailable')).toBeDefined()
+    expect(screen.getAllByText('Auth profile unavailable').length).toBeGreaterThan(0)
+    expect(screen.getByText('openai-codex')).toBeDefined()
+    expect(screen.getByText('openai-codex/gpt-5.5')).toBeDefined()
+    expect(screen.getByText('Yes')).toBeDefined()
+    expect(screen.getByText('Technical details')).toBeDefined()
+    expect(screen.getByText('No available auth profile for openai-codex')).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add structured dispatch failure details for provider cooldown and auth-profile unavailable runtime errors
- surface compact provider-unavailable labels on task cards and live activity
- show specific cause, provider/model, retryability, and bounded technical details in task detail logs
- document the dispatch failure detail contract

## Code review
- No blocking findings.
- Checked provider-boundary handling: classification uses only sanitized runtime error text already returned to dispatch; UI/plugins do not reach into provider-private state.
- Checked raw error exposure: raw runtime text is bounded and only shown under technical/debug details, not as the primary user-facing label.

## Verification
- `bun test --isolate tests/core/dispatch.test.ts tests/plugins/tasks/task-card.test.tsx tests/plugins/tasks/task-detail-dialog.test.tsx tests/lib/map-audit-message.test.ts tests/components/use-sse-doctor.test.tsx`
- `bun run typecheck`
- `bun run lint`

## Notes
- Global provider health banners are intentionally out of scope for this first task-local slice.