### PR TITLE
[codex] Embed core plugin manifest permissions

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -556,7 +556,11 @@ Allowed values:
 Grant source:
 - User-installed plugins are checked against lockfile-accepted
   permissions (`~/.bakin/plugins/lock.json`).
-- Built-in/core plugins are checked against their manifest permissions.
+- Built-in/core plugins are checked against their manifest permissions. In
+  compiled installs, those manifests are embedded through the static core
+  plugin registration table (`src/lib/plugin-static-imports.ts`) instead of
+  being re-read from `plugins/*/bakin-plugin.json` source paths that may not
+  exist beside the installed binary.
 - If a user plugin has no lockfile entry, Bakin falls back to its
   manifest and logs that fallback.
 

--- a/.claude/specs/boot-health-permissions-startup-plan.md
+++ b/.claude/specs/boot-health-permissions-startup-plan.md
@@ -1,0 +1,219 @@
+# Implementation Plan: Boot Health, Core Plugin Permissions, and Startup Readiness
+
+## Overview
+
+Implement this in two slices. Slice 1 fixes the confirmed rc.10 regression:
+compiled installs statically load core plugin modules but lose core manifest
+permissions because `plugins/*/bakin-plugin.json` is read from source paths that
+do not exist in the installed binary context. Slice 2 adds startup timing and
+readiness improvements after the warning storm is fixed.
+
+This plan covers Slice 1 in detail and defines the Slice 2 discovery checkpoint.
+
+## Architecture Decisions
+
+- Core plugin registrations should carry both the plugin module and the parsed
+  manifest.
+  Rationale: the registry needs one source of truth for dependency order,
+  description, audit, and runtime permission grants.
+
+- JSON `bakin-plugin.json` files remain the source of truth.
+  Rationale: duplicating permissions in TypeScript would reintroduce drift.
+
+- User plugin behavior remains unchanged.
+  Rationale: user plugins must continue using lockfile-accepted grants for
+  runtime enforcement.
+
+- Filesystem manifest loading remains as fallback for dynamic core-plugin tests
+  and source-tree development.
+  Rationale: existing tests use temp plugin directories and should not need the
+  static core table.
+
+- Startup readiness restructuring waits until after Slice 1.
+  Rationale: permission warnings are confirmed and low-risk to fix; boot timing
+  needs measured phase timings before moving work across readiness boundaries.
+
+## Task List
+
+### Phase 1: Core Manifest Permission Fix
+
+#### Task 1: Add Failing Regression Coverage
+
+**Description:** Add a registry test that simulates a compiled core plugin:
+the plugin module is supplied through `registerCorePlugins`, the configured
+plugin path has no readable `bakin-plugin.json`, and the static registration
+also supplies the manifest permissions.
+
+**Acceptance criteria:**
+
+- The test proves core plugins can activate with manifest permissions even when
+  source manifest files are absent.
+- The test asserts no `plugin.permission_missing` audit is emitted for a core
+  method that is granted by the static manifest.
+- The test fails before the implementation change.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/plugin-registry.test.ts
+```
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `tests/core/plugin-registry.test.ts`
+
+**Estimated scope:** Small
+
+#### Task 2: Carry Parsed Manifests in Static Core Plugin Registrations
+
+**Description:** Change `registerCorePlugins` and `CORE_PLUGIN_IMPORTS` from
+`Record<string, BakinPlugin>` to a typed registration object containing
+`plugin` and `manifest`. Import each core `bakin-plugin.json`, parse it through
+`readPluginManifestJson`, and pass the parsed manifest into the registry.
+
+**Acceptance criteria:**
+
+- Static core plugin registrations include non-empty manifest permissions.
+- Core plugin ids are still seeded synchronously for lockfile guard behavior.
+- Dynamic-import fallback for tests/source paths still works.
+- No permission list is duplicated outside `bakin-plugin.json`.
+
+**Verification:**
+
+```bash
+bun test --isolate tests/core/plugin-registry.test.ts
+bun test --isolate tests/lib/plugin-permissions.test.ts
+```
+
+**Dependencies:** Task 1
+
+**Files likely touched:**
+
+- `src/lib/plugin-static-imports.ts`
+- `src/lib/plugin-registry.ts`
+
+**Estimated scope:** Medium
+
+#### Task 3: Update Permission/Plugin System Docs
+
+**Description:** Update `.claude/knowledge/plugin-system.md` to document that
+compiled core plugins receive manifest grants from embedded static
+registrations, while user plugins continue to use lockfile grants.
+
+**Acceptance criteria:**
+
+- Docs explain the compiled-install failure mode and the new invariant.
+- Docs preserve the existing user-plugin lockfile grant description.
+
+**Verification:**
+
+```bash
+rg -n "Built-in/core plugins|static|manifest permissions" .claude/knowledge/plugin-system.md
+```
+
+**Dependencies:** Task 2
+
+**Files likely touched:**
+
+- `.claude/knowledge/plugin-system.md`
+
+**Estimated scope:** XS
+
+### Checkpoint: Slice 1 Complete
+
+- `bun test --isolate tests/core/plugin-registry.test.ts`
+- `bun test --isolate tests/lib/plugin-permissions.test.ts`
+- `bun run typecheck`
+- `bun run build`
+- Manual log expectation for installed binary: core `plugin.activate` audit
+  entries include declared permissions, and granted core calls do not emit
+  missing-permission warnings.
+
+### Phase 2: Startup Timing and Readiness Discovery
+
+#### Task 4: Add Boot Phase Timing
+
+**Description:** Add structured timing logs around pre-listen startup stages:
+app services, user plugin rebuild, plugin registry initialize, agent package
+source load, search migration/bootstrap/reconcile, docs generation,
+`mcporter.setup`, watcher start, `pluginRegistry.onAllReady`, and `server.listen`.
+
+**Acceptance criteria:**
+
+- Logs show duration per boot phase.
+- Timing instrumentation has minimal logic and no behavior changes.
+- The next slow affected-machine boot can identify the exact timeout source.
+
+**Verification:**
+
+```bash
+bun run typecheck
+bun run build
+```
+
+**Dependencies:** Slice 1 complete
+
+**Files likely touched:**
+
+- `server.ts`
+
+**Estimated scope:** Small
+
+#### Task 5: Decide Post-Ready Moves From Timing Data
+
+**Description:** Use measured phase durations to decide which non-critical work
+can safely move after `server.listen`.
+
+**Acceptance criteria:**
+
+- Each moved phase has a documented reason and fallback behavior.
+- Critical readiness dependencies remain pre-listen.
+- Doctor warnings and search reconcile remain visible after readiness.
+
+**Verification:** To be defined after Task 4 data.
+
+**Dependencies:** Task 4 and affected-machine timing logs
+
+**Files likely touched:** TBD
+
+**Estimated scope:** TBD
+
+## Commit Strategy
+
+1. `test(plugin-registry): cover embedded core manifest permissions`
+   - Adds the failing regression test only.
+   - Rollback checkpoint: removes only test coverage, no runtime behavior.
+
+2. `fix(plugin-registry): embed core plugin manifests for compiled installs`
+   - Changes static core registration shape and registry consumption.
+   - Rollback checkpoint: reverts runtime behavior to previous manifest path
+     lookup if needed.
+
+3. `docs(plugin-system): document core manifest grant source`
+   - Updates `.claude/knowledge`.
+   - Rollback checkpoint: docs only.
+
+4. `chore(server): log boot phase timings`
+   - Slice 2 discovery instrumentation after Slice 1 is healthy.
+   - Rollback checkpoint: instrumentation only.
+
+Startup readiness restructuring should be its own commit after phase timing
+identifies a specific blocking stage.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---:|---|
+| JSON imports behave differently in Bun compile | High | Keep manifests statically imported from `server.ts` graph and validate with `bun run build`. |
+| Registry tests depend on old `registerCorePlugins` shape | Medium | Update tests and provide a narrow typed registration helper. |
+| Core plugin dependency ordering still uses missing manifest data | High | Ensure `initialize()` consults the static manifest before sorting. |
+| Permission warnings are reduced but startup is still slow | Medium | Treat as expected; Slice 2 measures and optimizes boot separately. |
+| User plugin lockfile grants regress | High | Keep user plugin path untouched and run permission/registry tests. |
+
+## Open Questions
+
+None for Slice 1.
+
+Slice 2 will need affected-machine phase timing logs before moving startup work.

--- a/.claude/specs/boot-health-permissions-startup.md
+++ b/.claude/specs/boot-health-permissions-startup.md
@@ -1,0 +1,232 @@
+# Spec: Boot Health, Core Plugin Permissions, and Startup Readiness
+
+## Objective
+
+Diagnose and fix rc.10 boot slowdown and warning spam observed on an installed
+Bakin machine. The affected machine runs:
+
+- `bakin` at `/Users/margo/.local/bin/bakin`
+- `bakin version` = `v0.0.1-rc.10`
+- user plugins installed under `~/.bakin/plugins`: `messaging`, `projects`
+
+Success means:
+
+- Built-in/core plugins load with their declared manifest permissions in
+  compiled installs.
+- Startup logs no longer emit `plugin-permissions` warnings for core plugins
+  whose manifests already grant the required capability.
+- Bakin reaches HTTP readiness promptly and predictably after restart.
+- Long-running startup work is either bounded, timed, or moved after readiness
+  when it is not required to accept HTTP requests.
+- Doctor warnings represent actual health issues, not permission-manifest drift.
+- `doctor --full --json` stays clean for this issue; unrelated agent-context
+  drift warnings are not treated as permission-gating failures.
+
+## Assumptions
+
+1. Priority is reducing tech debt over preserving old startup behavior.
+2. This machine is the only user; no compatibility shim is needed for older
+   malformed core plugin packaging.
+3. User plugins should continue using lockfile-granted permissions.
+4. Core plugins should use embedded/source-controlled manifest permissions,
+   not filesystem paths that may not exist in compiled installs.
+5. Runtime capability mode should remain `warn` by default, but the warning
+   signal must be clean enough to trust.
+
+## Evidence
+
+Affected-machine logs show every core plugin activation recorded with an empty
+permission set:
+
+```text
+plugin activated ... pluginId="team" permissions=[] source="core"
+plugin activated ... pluginId="tasks" permissions=[] source="core"
+plugin activated ... pluginId="memory" permissions=[] source="core"
+...
+```
+
+The same boot then reports permission warnings such as:
+
+```text
+Plugin "team" used ctx.search.registerContentType without declaring "search.write"
+Plugin "memory" used ctx.runtime.memory.watchPaths without declaring "runtime.read"
+Plugin "health" used ctx.runtime.ping without declaring "runtime.read"
+Plugin "git" used ctx.storage.read without declaring "storage.read"
+```
+
+Current repo source manifests already declare these permissions. Example:
+
+- `plugins/team/bakin-plugin.json` declares `runtime.read`,
+  `runtime.agents`, `search.read`, and `search.write`.
+- `plugins/memory/bakin-plugin.json` declares `runtime.read`,
+  `runtime.agents`, `search.read`, and `search.write`.
+- `plugins/images/bakin-plugin.json` declares `runtime.images`.
+- `plugins/health/bakin-plugin.json` declares `runtime.read`,
+  `runtime.agents`, `runtime.channels`, `runtime.skills`, and `search.read`.
+- `plugins/git/bakin-plugin.json` declares `storage.read` and
+  `storage.write`.
+
+Repo code currently reads core manifests from `join(entry.path,
+'bakin-plugin.json')`. In a compiled install, that relative source path may not
+exist, so core `PluginLoadEntry.manifest` becomes `undefined`. The registry then
+wraps core plugin contexts with `manifestPermissions:
+state.manifest?.permissions ?? []`, producing the exact affected-machine
+symptom.
+
+Startup timing from affected logs:
+
+- App services / Antfly initialize before plugin loading.
+- User plugins are rebuilt before registry import.
+- Core and user plugins activate.
+- Search tables and startup reconcile run before readiness.
+- `pluginRegistry.onAllReady()` runs before `server.listen`.
+- HTTP readiness appears at `2026-06-03T02:46:36.323Z`.
+- Doctor and memory TTL prune continue after readiness.
+
+The reported timeout is therefore most likely caused by readiness being gated
+on one or more pre-listen boot stages: app service startup, user plugin
+rebuild, plugin activation, search bootstrap/reconcile, `mcporter.setup()`, or
+`onAllReady()`.
+
+Additional affected-machine triage confirms:
+
+- Updating to `0.0.1-rc.10` and restarting does not resolve the warnings.
+- `bakin doctor --full --json` reports 0 errors.
+- Doctor's 22 warnings are separate agent-context drift warnings, not
+  `plugin.permission_missing` events.
+- The installed user plugins (`projects`, `messaging`) declare permissions
+  correctly, further isolating the descriptor bug to bundled core plugins.
+
+## Tech Stack
+
+- Runtime: Bun
+- Language: TypeScript
+- Server entry: `server.ts`
+- Core plugin registry: `src/lib/plugin-registry.ts`
+- Permission taxonomy: `packages/core/src/plugins/permissions.ts`
+- Manifest parser: `packages/core/src/plugins/manifest.ts`
+- Built-in plugin manifests: `plugins/*/bakin-plugin.json`
+- Tests: Bun test
+
+## Commands
+
+Primary verification:
+
+```bash
+bun test --isolate tests/lib/plugin-permissions.test.ts
+bun test --isolate tests/core/plugin-registry.test.ts
+bun test --isolate tests/plugins/lifecycle/permissions-smoke.test.ts
+bun run typecheck
+bun run build
+```
+
+Incident/debug commands for affected machines:
+
+```bash
+which bakin
+bakin version
+ls -la ~/.bakin/plugins
+cat ~/.bakin/audit.jsonl | jq 'select(.event == "plugin.activate") | {ts, pluginId: .data.pluginId, source: .data.source, permissions: .data.permissions}'
+tail -n 300 ~/.bakin/logs/server.log
+```
+
+## Project Structure
+
+- `server.ts` starts services, registers embedded core plugins, loads plugins,
+  prepares search, starts watchers, and begins listening.
+- `src/lib/plugin-registry.ts` discovers plugin manifests, computes activation
+  order, builds plugin contexts, wraps runtime permissions, and loads user
+  plugins.
+- `src/lib/plugin-static-imports.ts` statically imports built-in plugin modules
+  for compiled binaries.
+- `packages/core/src/plugins/manifest.ts` parses `bakin-plugin.json`.
+- `packages/core/src/plugins/permissions.ts` defines the permission enum and
+  validation helpers.
+- `.claude/knowledge/plugin-system.md` documents permission grant sources.
+- `.claude/knowledge/search-system.md` documents startup reconcile and search
+  boot behavior.
+- `.claude/knowledge/doctor-and-health-checks.md` documents doctor timing and
+  health-check ownership.
+
+## Code Style
+
+Keep the fix explicit and typed. Prefer carrying a parsed manifest alongside
+the statically imported plugin over re-reading source paths.
+
+Example shape:
+
+```ts
+interface CorePluginRegistration {
+  plugin: BakinPlugin
+  manifest: PublicPluginManifest
+}
+
+export const CORE_PLUGIN_IMPORTS: Readonly<Record<string, CorePluginRegistration>> = {
+  'plugins/team': { plugin: teamPlugin, manifest: teamManifest },
+}
+```
+
+The registry should consume the same manifest object for:
+
+- dependency ordering
+- description
+- runtime permission grants
+- activation audit
+
+Do not duplicate permission lists in TypeScript if JSON manifests can be
+imported or embedded directly.
+
+## Testing Strategy
+
+Use the Prove-It pattern:
+
+1. Add a failing registry test that simulates a compiled core plugin where the
+   plugin module is statically registered but `plugins/*/bakin-plugin.json`
+   is not readable from the filesystem.
+2. Assert the plugin activates with its manifest permissions and does not emit
+   `plugin.permission_missing` for a granted core capability.
+3. Add or update a release/packaging smoke test so at least one built-in plugin
+   manifest permission survives the compiled/static registration path.
+4. Add startup instrumentation tests only around pure orchestration helpers if
+   the implementation extracts them; avoid slow process-level tests unless the
+   behavior cannot be covered otherwise.
+
+## Boundaries
+
+- Always: preserve user-plugin lockfile permission checks.
+- Always: keep runtime capability mode defaults unchanged.
+- Always: keep core manifests as the source of truth.
+- Always: update `.claude/knowledge` docs when the manifest-loading contract or
+  startup ordering changes.
+- Ask first: deleting or resetting `~/.antfly`, `~/.termite`, or `~/.bakin`
+  data on the affected machine.
+- Ask first: removing startup reconcile, doctor checks, or user plugin rebuilds
+  entirely.
+- Never: silence permission warnings globally as the primary fix.
+- Never: hard-code grants in the permission wrapper.
+- Never: require user plugin lockfile migration for a core-plugin packaging
+  bug.
+
+## Success Criteria
+
+- Core plugin activation audit entries in compiled installs show non-empty
+  manifest permissions.
+- Existing core plugin calls that are already covered by manifests do not log
+  missing-permission warnings.
+- A test fails on the current rc.10-style path and passes after the fix.
+- Startup logs include enough phase timing to identify slow boot stages without
+  reading raw Antfly internals line-by-line.
+- Bakin can begin listening before non-critical post-ready work, or every
+  remaining pre-listen stage has a documented reason and bounded behavior.
+- `bun run build` completes.
+- Relevant docs in `.claude/knowledge` and the spec/plan are updated.
+
+## Open Questions
+
+1. Should the first implementation slice stop at the confirmed core-manifest
+   permissions bug, or include startup readiness restructuring in the same
+   change set?
+
+Recommended answer: split them. First fix and test core manifest permissions
+because the root cause is confirmed and low-risk. Then add startup phase timing
+and move only clearly non-critical work after readiness based on measured data.

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -74,10 +74,18 @@ import { wrapPluginContextPermissions } from './plugin-permissions'
  * that import the registry don't transitively drag every plugin
  * (and every plugin's side effects) into their module graph.
  *
- * Shape: { 'plugins/team': BakinPluginInstance, ... }
+ * Shape: { 'plugins/team': { plugin: BakinPluginInstance, manifest }, ... }
  */
-let corePluginTable: Readonly<Record<string, BakinPlugin>> = {}
-export function registerCorePlugins(table: Readonly<Record<string, BakinPlugin>>): void {
+export interface CorePluginRegistration {
+  plugin: BakinPlugin
+  manifest: PublicPluginManifest
+}
+
+let corePluginTable: Readonly<Record<string, CorePluginRegistration>> = {}
+export function registerCorePlugins(table: Readonly<Record<string, CorePluginRegistration>>): void {
+  for (const { plugin } of Object.values(corePluginTable)) {
+    if (plugin?.id) corePluginIds.delete(plugin.id)
+  }
   corePluginTable = table
   // Seed corePluginIds synchronously from the static table so the predicate
   // is correct from the moment any code can call into the registry — not
@@ -86,7 +94,7 @@ export function registerCorePlugins(table: Readonly<Record<string, BakinPlugin>>
   // bypass the defense-in-depth guard. The activation-time add in
   // loadPlugin still runs as a backstop for dynamic-import test paths
   // where the table stays empty.
-  for (const plugin of Object.values(table)) {
+  for (const { plugin } of Object.values(table)) {
     if (plugin?.id) corePluginIds.add(plugin.id)
   }
 }
@@ -269,12 +277,15 @@ function logPluginActivation(args: {
   plugin: BakinPlugin
   source: 'core' | 'user'
   manifestPath?: string
+  manifest?: PublicPluginManifest
 }): void {
-  const { plugin, source, manifestPath } = args
+  const { plugin, source, manifestPath, manifest: embeddedManifest } = args
   let permissions: string[] = []
   let resolvedSource: 'core' | 'github' | 'local' = source === 'core' ? 'core' : 'local'
 
-  if (manifestPath && existsSync(manifestPath)) {
+  if (embeddedManifest) {
+    permissions = parseManifestPermissions(embeddedManifest.permissions)
+  } else if (manifestPath && existsSync(manifestPath)) {
     try {
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>
       permissions = parseManifestPermissions(manifest.permissions)
@@ -396,8 +407,11 @@ class PluginRegistryImpl {
       const manifestPath = join(entry.path, 'bakin-plugin.json')
       let id = entry.path.split('/').pop() || entry.path
       let deps: string[] = []
-      let manifest: PublicPluginManifest | undefined
-      if (existsSync(manifestPath)) {
+      let manifest: PublicPluginManifest | undefined = corePluginTable[entry.path]?.manifest
+      if (manifest) {
+        id = manifest.id || id
+        deps = manifest.dependencies || []
+      } else if (existsSync(manifestPath)) {
         try {
           manifest = readPluginManifestJson(readFileSync(manifestPath, 'utf-8'))
           id = manifest.id || id
@@ -948,7 +962,8 @@ class PluginRegistryImpl {
       // trace and embed each plugin's module graph. In tests the table
       // stays empty, so we fall back to dynamic import by path (which
       // is how the registry worked before TG1).
-      let plugin: BakinPlugin | undefined = corePluginTable[pluginPath]
+      const staticCore = corePluginTable[pluginPath]
+      let plugin: BakinPlugin | undefined = staticCore?.plugin
       if (!plugin) {
         // Absolute paths (used by tests + user plugins under ~/.bakin/plugins/)
         // resolve directly. Relative paths (used by core plugins in
@@ -975,9 +990,10 @@ class PluginRegistryImpl {
       }
 
       // Read description from manifest if available
-      let description = ''
+      const resolvedManifest = manifest ?? staticCore?.manifest
+      let description = resolvedManifest?.description ?? ''
       const manifestPath = join(pluginPath, 'bakin-plugin.json')
-      if (existsSync(manifestPath)) {
+      if (!description && existsSync(manifestPath)) {
         try {
           const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
           description = manifest.description || ''
@@ -986,7 +1002,7 @@ class PluginRegistryImpl {
 
       const state: PluginState = {
         plugin,
-        manifest,
+        manifest: resolvedManifest,
         source: 'core',
         description,
         navItems: plugin.navItems || [],
@@ -1022,7 +1038,7 @@ class PluginRegistryImpl {
       // #142 layer 1 — log requested permissions on every activation so
       // `cat ~/.bakin/audit.jsonl | jq 'select(.event=="plugin.activate")'`
       // shows the full surface the user authorized.
-      logPluginActivation({ plugin, source: 'core', manifestPath })
+      logPluginActivation({ plugin, source: 'core', manifestPath, manifest: resolvedManifest })
       log.info(`Plugin loaded: ${plugin.name} v${plugin.version}`, {
         source: 'plugin',
         pluginId: plugin.id,
@@ -1407,6 +1423,8 @@ class PluginRegistryImpl {
   _resetForTests(): void {
     this.plugins.clear()
     this.failedPlugins.clear()
+    corePluginTable = {}
+    corePluginIds.clear()
     pluginSkills.clear()
     this.initialized = false
     this.runtime = null

--- a/src/lib/plugin-static-imports.ts
+++ b/src/lib/plugin-static-imports.ts
@@ -25,17 +25,37 @@ import schedulePlugin from '../../plugins/schedule'
 import healthPlugin from '../../plugins/health'
 import gitPlugin from '../../plugins/git'
 
+import teamManifestJson from '../../plugins/team/bakin-plugin.json'
+import tasksManifestJson from '../../plugins/tasks/bakin-plugin.json'
+import memoryManifestJson from '../../plugins/memory/bakin-plugin.json'
+import modelsManifestJson from '../../plugins/models/bakin-plugin.json'
+import assetsManifestJson from '../../plugins/assets/bakin-plugin.json'
+import imagesManifestJson from '../../plugins/images/bakin-plugin.json'
+import workflowsManifestJson from '../../plugins/workflows/bakin-plugin.json'
+import scheduleManifestJson from '../../plugins/schedule/bakin-plugin.json'
+import healthManifestJson from '../../plugins/health/bakin-plugin.json'
+import gitManifestJson from '../../plugins/git/bakin-plugin.json'
+
+import { readPluginManifestJson } from '../../packages/core/src/plugins/manifest'
+import type { CorePluginRegistration } from './plugin-registry'
 import type { BakinPlugin } from '@bakin/core/plugin-types'
 
-export const CORE_PLUGIN_IMPORTS: Readonly<Record<string, BakinPlugin>> = {
-  'plugins/team': teamPlugin,
-  'plugins/tasks': tasksPlugin,
-  'plugins/memory': memoryPlugin,
-  'plugins/models': modelsPlugin,
-  'plugins/assets': assetsPlugin,
-  'plugins/images': imagesPlugin,
-  'plugins/workflows': workflowsPlugin,
-  'plugins/schedule': schedulePlugin,
-  'plugins/health': healthPlugin,
-  'plugins/git': gitPlugin,
+function corePlugin(plugin: BakinPlugin, manifestJson: unknown): CorePluginRegistration {
+  return {
+    plugin,
+    manifest: readPluginManifestJson(JSON.stringify(manifestJson)),
+  }
+}
+
+export const CORE_PLUGIN_IMPORTS: Readonly<Record<string, CorePluginRegistration>> = {
+  'plugins/team': corePlugin(teamPlugin, teamManifestJson),
+  'plugins/tasks': corePlugin(tasksPlugin, tasksManifestJson),
+  'plugins/memory': corePlugin(memoryPlugin, memoryManifestJson),
+  'plugins/models': corePlugin(modelsPlugin, modelsManifestJson),
+  'plugins/assets': corePlugin(assetsPlugin, assetsManifestJson),
+  'plugins/images': corePlugin(imagesPlugin, imagesManifestJson),
+  'plugins/workflows': corePlugin(workflowsPlugin, workflowsManifestJson),
+  'plugins/schedule': corePlugin(schedulePlugin, scheduleManifestJson),
+  'plugins/health': corePlugin(healthPlugin, healthManifestJson),
+  'plugins/git': corePlugin(gitPlugin, gitManifestJson),
 }

--- a/tests/core/plugin-registry.test.ts
+++ b/tests/core/plugin-registry.test.ts
@@ -167,6 +167,7 @@ describe('PluginRegistryImpl', () => {
   let pluginRegistry: any
   let getHookRegistry: any
   let getPluginSkills: any
+  let registerCorePlugins: any
   let mockGetContentDir: any
   let mockAppendAudit: any
   let mockAddExecTool: any
@@ -216,6 +217,7 @@ describe('PluginRegistryImpl', () => {
     pluginRegistry = mod.pluginRegistry
     getHookRegistry = mod.getHookRegistry
     getPluginSkills = mod.getPluginSkills
+    registerCorePlugins = mod.registerCorePlugins
     // bun:test has no vi.resetModules; reset the singleton via its own API
     pluginRegistry._resetForTests()
     // Also clear the hook registry — it's a separate globalThis singleton
@@ -230,6 +232,7 @@ describe('PluginRegistryImpl', () => {
       process.env.BAKIN_HOME = previousBakinHome
     }
     mockGetContentDir?.mockImplementation(() => process.env.BAKIN_HOME || '/tmp/test')
+    registerCorePlugins?.({})
     // Clean up any globalThis test vars
     for (const key of Object.keys(globalThis)) {
       if (key.startsWith('__') && key !== '__bakinPluginRegistry' && key !== '__bakinHookRegistry') {
@@ -818,6 +821,51 @@ describe('PluginRegistryImpl', () => {
         }),
         'system',
       )
+    })
+
+    it('uses embedded static manifests for core plugin permissions when source manifests are absent', async () => {
+      registerCorePlugins({
+        'embedded/core-storage': {
+          plugin: {
+            id: 'core-storage',
+            name: 'Core Storage',
+            version: '1.0.0',
+            activate(ctx: any) {
+              ctx.storage.read('state.txt')
+            },
+          },
+          manifest: {
+            id: 'core-storage',
+            name: 'Core Storage',
+            version: '1.0.0',
+            bakin: '>=1.0.0',
+            description: 'Core plugin loaded from an embedded registration',
+            entry: { server: 'index.js' },
+            permissions: ['storage.read'],
+          },
+        },
+      })
+
+      await pluginRegistry.initialize(
+        { plugins: [{ path: 'embedded/core-storage' }] },
+        mockStorage(),
+        mockEvents(),
+      )
+
+      const active = pluginRegistry.getRegistrySnapshot().find((entry: any) => entry.id === 'core-storage')
+      expect(active).toMatchObject({ status: 'active', source: 'built-in' })
+
+      const permissionMissing = mockAppendAudit.mock.calls.find((call: any[]) =>
+        call[1] === 'plugin.permission_missing' &&
+        call[3]?.pluginId === 'core-storage'
+      )
+      expect(permissionMissing).toBeUndefined()
+
+      const activation = mockAppendAudit.mock.calls.find((call: any[]) =>
+        call[1] === 'plugin.activate' &&
+        call[3]?.pluginId === 'core-storage'
+      )
+      expect(activation?.[3]?.permissions).toEqual(['storage.read'])
     })
 
     it('fails user plugins that register undeclared API routes', async () => {


### PR DESCRIPTION
## Summary

Fixes the rc.10 installed-binary issue where bundled core plugins activated with permissions: [], causing plugin.permission_missing warning noise even though the source manifests declare the required grants.

The static core plugin registration table now carries both the plugin module and its parsed manifest. The registry uses that embedded manifest for dependency ordering, activation audit entries, descriptions, and runtime permission grants when source manifest files are not readable beside the compiled binary. User plugins continue to use lockfile-granted permissions.

## Review Notes

Self-review found one cleanup: re-registering the static core table could leave stale core ids in the guard set. The registration path now removes ids from the previous table before seeding the new table.

No blocking review findings remain.

## Validation

- bun test --isolate tests/core/plugin-registry.test.ts
- bun test --isolate tests/lib/plugin-permissions.test.ts
- bun test --isolate tests/plugins/lifecycle/permissions-smoke.test.ts
- bun run typecheck
- bun run build

Note: the first build attempt failed in the sandbox because Bun could not write to its tempdir. Rerunning with approval outside the sandbox passed, and unrelated generated build churn was removed before commit.