### PR TITLE
[codex] Prevent asset delete requests from hanging

### DIFF
--- a/packages/core/src/routing/dispatcher.ts
+++ b/packages/core/src/routing/dispatcher.ts
@@ -205,6 +205,7 @@ async function isEmptyBody(req: Request): Promise<boolean> {
   if (req.method === 'GET' || req.method === 'HEAD') return true
   const cl = req.headers.get('content-length')
   if (cl === '0') return true
+  if (cl === null && !req.headers.has('transfer-encoding') && !req.headers.has('content-type')) return true
   // Read the body; empty buffers count as no body.
   try {
     const buf = await req.clone().arrayBuffer()

--- a/plugins/assets/components/versioned/VersionedAssetDetail.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetDetail.tsx
@@ -17,6 +17,8 @@ export function VersionedAssetDetail() {
   const [loading, setLoading] = useState(true)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleteScope, setDeleteScope] = useState<'asset' | 'current'>('asset')
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
   const [addingVersion, setAddingVersion] = useState(false)
   const [versionError, setVersionError] = useState<string | null>(null)
   const [lightbox, setLightbox] = useState(false)
@@ -77,12 +79,43 @@ export function VersionedAssetDetail() {
   }, [assetId, fetchManifest])
 
   const doDelete = async () => {
-    if (deleteScope === 'current' && manifest) {
-      await deleteVersion(manifest.currentVersion)
-      setConfirmDelete(false)
-    } else {
-      await fetch(`${VERSIONED_API}/${encodeURIComponent(assetId)}`, { method: 'DELETE' })
-      navigate({ to: '/assets' })
+    setDeleting(true)
+    setDeleteError(null)
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), 10000)
+    try {
+      if (deleteScope === 'current' && manifest) {
+        const res = await fetch(`${VERSIONED_API}/${encodeURIComponent(assetId)}/v/${manifest.currentVersion}`, {
+          method: 'DELETE',
+          signal: controller.signal,
+        })
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({})) as { error?: string }
+          throw new Error(body.error || `Delete failed (${res.status})`)
+        }
+        fetchManifest()
+        setConfirmDelete(false)
+      } else {
+        const res = await fetch(`${VERSIONED_API}/${encodeURIComponent(assetId)}`, {
+          method: 'DELETE',
+          signal: controller.signal,
+        })
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({})) as { error?: string }
+          throw new Error(body.error || `Delete failed (${res.status})`)
+        }
+        navigate({ to: '/assets' })
+      }
+    } catch (err) {
+      const message = err instanceof DOMException && err.name === 'AbortError'
+        ? 'Delete timed out. Check the server log and try again.'
+        : err instanceof Error
+          ? err.message
+          : 'Delete failed.'
+      setDeleteError(message)
+    } finally {
+      window.clearTimeout(timeout)
+      setDeleting(false)
     }
   }
 
@@ -124,7 +157,7 @@ export function VersionedAssetDetail() {
           {addingVersion ? <Loader2 className="size-4 animate-spin mr-1" /> : <Upload className="size-4 mr-1" />}
           {addingVersion ? 'Uploading…' : 'Add version'}
         </Button>
-        <Button size="sm" variant="ghost" className="text-red-400 hover:text-red-300" onClick={() => { setDeleteScope('asset'); setConfirmDelete(true) }} data-testid="delete-asset">
+        <Button size="sm" variant="ghost" className="text-red-400 hover:text-red-300" onClick={() => { setDeleteScope('asset'); setDeleteError(null); setConfirmDelete(true) }} data-testid="delete-asset">
           <Trash2 className="size-4" />
         </Button>
       </div>
@@ -222,8 +255,11 @@ export function VersionedAssetDetail() {
               <p className="mb-3 text-sm text-muted-foreground">Delete this asset?</p>
             )}
             <div className="flex justify-end gap-2">
-              <Button size="sm" variant="ghost" onClick={() => setConfirmDelete(false)}>Cancel</Button>
-              <Button size="sm" variant="destructive" onClick={doDelete} data-testid="confirm-delete">Delete</Button>
+              {deleteError && <p className="mr-auto max-w-40 text-xs text-destructive">{deleteError}</p>}
+              <Button size="sm" variant="ghost" onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</Button>
+              <Button size="sm" variant="destructive" onClick={doDelete} disabled={deleting} data-testid="confirm-delete">
+                {deleting ? 'Deleting...' : 'Delete'}
+              </Button>
             </div>
           </div>
         </div>

--- a/tests/core/route-dispatcher.test.ts
+++ b/tests/core/route-dispatcher.test.ts
@@ -209,6 +209,26 @@ describe('dispatchRoute — input validation', () => {
     expect(res.status).toBe(415)
   })
 
+  it('does not read an absent body for body: { contentType: "none" }', async () => {
+    const route = defineRoute({
+      path: '/:assetId',
+      method: 'DELETE',
+      summary: 'Delete asset',
+      params: z.object({ assetId: z.string() }),
+      body: { contentType: 'none' },
+      responses: { 200: z.object({ ok: z.literal(true) }) },
+      handler: async () => Response.json({ ok: true as const }),
+    })
+    const req = new Request('http://x/api/plugins/assets/versioned/asset-1', {
+      method: 'DELETE',
+    })
+
+    const res = await dispatchRoute({ req, ctx: stubCtx, route, params: { assetId: 'asset-1' } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+  })
+
   it('accepts an optional JSON body schema when the request has no body', async () => {
     const route = defineRoute({
       path: '/:jobId',


### PR DESCRIPTION
## Summary

- avoid reading an absent request body for body: none routes when browsers omit body-related headers
- add a dispatcher regression test for browser-style DELETE requests with no body
- harden the versioned asset delete modal with timeout, disabled state, and inline errors

## Root Cause

Browser DELETE requests with no body may omit content-length. The dispatcher still attempted to clone/read the body for body: none routes, which could hang asset delete requests before they reached the route handler.

## Validation

- bun test tests/core/route-dispatcher.test.ts tests/plugins/assets/versioned-routes.test.ts
- bun run typecheck