### PR TITLE
fix: build installed plugin clients for production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+### Fixed
+- Build installed plugin client bundles with the production JSX runtime in release binaries, and repair stale installed client bundles that still import `react/jsx-dev-runtime`.
+
 ## [0.0.1-rc.12] - 2026-06-03
 
 ### Added

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -59,6 +59,7 @@ const SDK_ENTRYPOINTS: Record<string, string> = {
 const HOST_PROVIDED_IMPORTS = new Set([
   ...CLIENT_EXTERNAL,
 ])
+const JSX_DEV_RUNTIME_RE = /(?:react\/jsx-dev-runtime|\bjsxDEV\b)/
 const BUILTIN_IMPORTS = new Set([
   ...builtinModules,
   ...builtinModules.map((name) => `node:${name}`),
@@ -178,6 +179,19 @@ function oldestMtimeMs(paths: string[]): number {
     }
   }
   return oldest === Number.POSITIVE_INFINITY ? 0 : oldest
+}
+
+function isProductionBuild(): boolean {
+  return process.env.BAKIN_DEV !== '1'
+}
+
+function isFreshClientDist(path: string): boolean {
+  if (!isProductionBuild()) return true
+  try {
+    return !JSX_DEV_RUNTIME_RE.test(readFileSync(path, 'utf-8'))
+  } catch {
+    return false
+  }
 }
 
 interface PluginPackageJson {
@@ -340,16 +354,22 @@ export async function buildUserPlugin(
     // oldest dist mtime is strictly newer than the newest source mtime.
     const expectedDist = [distServer, ...(hasClient ? [distClient] : [])]
     const allDistPresent = expectedDist.every(p => existsSync(p))
+    const clientDistFresh = !hasClient || isFreshClientDist(distClient)
+    const trustCompleteDist = options.trustExistingDist && allDistPresent
+    let buildServer = true
     if (allDistPresent) {
-      if (options.trustExistingDist) {
+      if (trustCompleteDist && clientDistFresh) {
         totalSpan?.end({ status: 'skipped', reason: 'trusted-dist', hasClient })
         return
+      }
+      if (trustCompleteDist && hasClient) {
+        buildServer = false
       }
 
       errorStage = 'freshness check failed'
       const newestSource = newestMtimeMs(pluginDir, new Set(['dist', 'node_modules']))
       const oldestDist = oldestMtimeMs(expectedDist)
-      if (oldestDist > 0 && newestSource > 0 && oldestDist >= newestSource) {
+      if (clientDistFresh && oldestDist > 0 && newestSource > 0 && oldestDist >= newestSource) {
         totalSpan?.end({ status: 'skipped', reason: 'fresh-dist', hasClient })
         return
       }
@@ -383,43 +403,45 @@ export async function buildUserPlugin(
       }
     }
 
-    const serverBuildConfig = {
-      entrypoints: [serverEntry],
-      outdir: distDir,
-      target: 'bun',
-      format: 'esm',
-      naming: 'index.[ext]',
-      external: SERVER_EXTERNAL,
-      plugins: [{
-        name: 'bakin-sdk-server-resolver',
-        setup(build: any) {
-          build.onResolve({ filter: /^@makinbakin\/sdk(\/.*)?$/ }, (args: { path: string }) => {
-            const path = SDK_ENTRYPOINTS[args.path]
-            if (!path) return
-            return { path }
-          })
-        },
-      }],
-    } as Parameters<typeof Bun.build>[0] & { plugins: Array<unknown> }
-    const serverSpan = diag ? startStartupSpan(diag, 'userPlugin.serverBuild', {
-      phase: 'user-plugin-build',
-      pluginId,
-      pluginSource: 'user',
-      thresholdMs: 1_000,
-    }) : null
-    errorStage = 'server build failed'
-    let serverResult: Awaited<ReturnType<typeof Bun.build>>
-    try {
-      serverResult = await Bun.build(serverBuildConfig)
-    } catch (err) {
-      serverSpan?.end({ status: 'error', error: 'server build failed' })
-      throw err
+    if (buildServer) {
+      const serverBuildConfig = {
+        entrypoints: [serverEntry],
+        outdir: distDir,
+        target: 'bun',
+        format: 'esm',
+        naming: 'index.[ext]',
+        external: SERVER_EXTERNAL,
+        plugins: [{
+          name: 'bakin-sdk-server-resolver',
+          setup(build: any) {
+            build.onResolve({ filter: /^@makinbakin\/sdk(\/.*)?$/ }, (args: { path: string }) => {
+              const path = SDK_ENTRYPOINTS[args.path]
+              if (!path) return
+              return { path }
+            })
+          },
+        }],
+      } as Parameters<typeof Bun.build>[0] & { plugins: Array<unknown> }
+      const serverSpan = diag ? startStartupSpan(diag, 'userPlugin.serverBuild', {
+        phase: 'user-plugin-build',
+        pluginId,
+        pluginSource: 'user',
+        thresholdMs: 1_000,
+      }) : null
+      errorStage = 'server build failed'
+      let serverResult: Awaited<ReturnType<typeof Bun.build>>
+      try {
+        serverResult = await Bun.build(serverBuildConfig)
+      } catch (err) {
+        serverSpan?.end({ status: 'error', error: 'server build failed' })
+        throw err
+      }
+      if (!serverResult.success) {
+        serverSpan?.end({ status: 'error', error: 'server build failed' })
+        throw new Error(`Failed to build server entry for ${pluginDir}:\n${serverResult.logs.join('\n')}`)
+      }
+      serverSpan?.end({ status: 'ok' })
     }
-    if (!serverResult.success) {
-      serverSpan?.end({ status: 'error', error: 'server build failed' })
-      throw new Error(`Failed to build server entry for ${pluginDir}:\n${serverResult.logs.join('\n')}`)
-    }
-    serverSpan?.end({ status: 'ok' })
 
     if (hasClient) {
       const clientSpan = diag ? startStartupSpan(diag, 'userPlugin.clientBuild', {
@@ -437,6 +459,7 @@ export async function buildUserPlugin(
           '--target', 'browser',
           '--format', 'esm',
           '--entry-naming', 'client.[ext]',
+          ...(isProductionBuild() ? ['--production'] : []),
           ...CLIENT_EXTERNAL.flatMap(e => ['--external', e]),
         ])
       } catch (err) {

--- a/tests/api/plugins-build.test.ts
+++ b/tests/api/plugins-build.test.ts
@@ -112,20 +112,58 @@ describe('buildUserPlugin', () => {
     expect(readFileSync(distServer, 'utf-8')).toBe(prebuilt)
   }, 60_000)
 
+  it('repairs stale trusted client dist without rebuilding trusted server dist', async () => {
+    const dir = join(testDir, 'plugins', 'prebuilt-dev-client')
+    writeMinimalPlugin(dir, `throw new Error('server source should not rebuild')`)
+    writeFileSync(join(dir, 'client.tsx'), `import { jsx } from 'react/jsx-runtime'; export const navItems = []; export function Page() { return jsx('div', { children: 'ok' }) }\n`)
+    mkdirSync(join(dir, 'dist'), { recursive: true })
+    const distServer = join(dir, 'dist', 'index.js')
+    const distClient = join(dir, 'dist', 'client.js')
+    const prebuiltServer = `export default { id: 'minimal', activate() { return 'trusted server' } }\n`
+    writeFileSync(distServer, prebuiltServer)
+    writeFileSync(distClient, `import { jsxDEV } from 'react/jsx-dev-runtime'\nexport const stale = jsxDEV\n`)
+
+    await buildUserPlugin(dir, { trustExistingDist: true })
+
+    expect(readFileSync(distServer, 'utf-8')).toBe(prebuiltServer)
+    const client = readFileSync(distClient, 'utf-8')
+    expect(client).not.toContain('jsxDEV')
+    expect(client).not.toContain('react/jsx-dev-runtime')
+  }, 60_000)
+
   it('preserves externals for @makinbakin/sdk/* in client.js', () => {
     const client = readFileSync(join(targetDir, 'dist', 'client.js'), 'utf-8')
     // The `@makinbakin/sdk/slots` import must survive so the runtime loader can
     // resolve it via the browser import map (not get bundled into client.js).
-    expect(client).toMatch(/from\s+["']@makinbakin\/sdk\/slots["']/)
+    expect(client).toMatch(/from\s*["']@makinbakin\/sdk\/slots["']/)
   }, 60_000)
 
   it('preserves externals for react + react/jsx-runtime in client.js', () => {
     const client = readFileSync(join(targetDir, 'dist', 'client.js'), 'utf-8')
     // React hooks must stay external — plugins share the shell's React via
     // the import map. Bundling react would break hooks dispatcher identity.
-    expect(client).toMatch(/from\s+["']react["']/)
+    expect(client).toMatch(/from\s*["']react["']/)
     // The JSX runtime must also stay external.
-    expect(client).toMatch(/from\s+["']react\/jsx-runtime["']/)
+    expect(client).toMatch(/from\s*["']react\/jsx-runtime["']/)
+  }, 60_000)
+
+  it('builds production client output without JSX dev runtime', () => {
+    const client = readFileSync(join(targetDir, 'dist', 'client.js'), 'utf-8')
+    expect(client).not.toContain('jsxDEV')
+    expect(client).not.toContain('react/jsx-dev-runtime')
+  }, 60_000)
+
+  it('rebuilds stale production dist/client.js when it contains JSX dev runtime output', async () => {
+    const clientPath = join(targetDir, 'dist', 'client.js')
+    writeFileSync(clientPath, `import { jsxDEV } from 'react/jsx-dev-runtime'\nexport const stale = jsxDEV\n`)
+    const future = new Date(Date.now() + 60_000)
+    utimesSync(clientPath, future, future)
+
+    await buildUserPlugin(targetDir)
+
+    const client = readFileSync(clientPath, 'utf-8')
+    expect(client).not.toContain('jsxDEV')
+    expect(client).not.toContain('react/jsx-dev-runtime')
   }, 60_000)
 
   it('does not bundle react into dist/client.js', () => {


### PR DESCRIPTION
## Summary
- Build installed plugin client bundles with Bun production settings in release binaries so they import `react/jsx-runtime` instead of emitting `jsxDEV` calls.
- Detect stale installed client bundles that still contain `jsxDEV` or `react/jsx-dev-runtime` and rebuild them on startup.
- Preserve trusted GitHub plugin server dist artifacts while repairing only stale trusted client bundles.

## Why
The `0.0.1-rc.13` release can serve installed plugin client bundles for plugins like `messaging` and `projects` that still call `jsxDEV`, which fails in the browser with `TypeError: jsxDEV* is not a function`.

## Validation
- `bun test tests/api/plugins-build.test.ts tests/api/user-plugin-lifecycle.test.ts`