### PR TITLE
[codex] Prepare v0.0.1-rc.14 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 ## [0.0.1-rc.14] - 2026-06-04
 
 ### Fixed
-- Build installed plugin client bundles with the production JSX runtime in release binaries, and repair stale installed client bundles that still import `react/jsx-dev-runtime`.
+- Build release plugin client bundles with the production JSX runtime so packaged core plugins do not import `react/jsx-dev-runtime`.
+- Rebuild stale installed-plugin `dist/client.js` bundles that still contain JSX dev-runtime output, even when existing GitHub-installed plugin artifacts would otherwise be trusted.
 
 ## [0.0.1-rc.13] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+## [0.0.1-rc.14] - 2026-06-04
+
 ### Fixed
 - Build installed plugin client bundles with the production JSX runtime in release binaries, and repair stale installed client bundles that still import `react/jsx-dev-runtime`.
 
@@ -192,5 +194,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 [0.0.1-rc.12]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.12
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.13...HEAD
 [0.0.1-rc.13]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.13
+
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.14...HEAD
+[0.0.1-rc.14]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.14


### PR DESCRIPTION
## Summary

- Add the `0.0.1-rc.14` changelog section dated 2026-06-04.
- Document the production JSX runtime fix for release plugin client bundles.
- Document stale installed-plugin client bundle rebuilds when `dist/client.js` still contains JSX dev-runtime output.
- Update the `Unreleased` compare link to start from `v0.0.1-rc.14` and add the rc.14 release tag link.

## Impact

This prepares the changelog for the `v0.0.1-rc.14` release. The release notes now describe the actual fix: packaged plugin clients and stale installed-plugin client bundles no longer ship or retain `react/jsx-dev-runtime` output in release paths.

## Validation

- Reviewed the rc.14 changelog section.
- Extracted release notes with `scripts/extract-release-notes.ts --version 0.0.1-rc.14`.
