### PR TITLE
Shim production JSX dev runtime for stale plugin clients

### DIFF
--- a/scripts/build-vendors.ts
+++ b/scripts/build-vendors.ts
@@ -28,6 +28,8 @@
 import { rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { jsxDevRuntimeEntrySource } from './vendor-entrypoints'
+
 const VENDOR_DIR = './packages/host/public/vendor'
 const TMP_DIR = './packages/host/public/vendor/.tmp-entries'
 const PRODUCTION = process.env.BAKIN_DEV !== '1'
@@ -112,12 +114,11 @@ export const { jsx, jsxs, Fragment } = JsxRuntime
 export default JsxRuntime
 `)
 
-const jsxDevRuntimeEntry = writeEntry('jsx-dev-runtime', `
-// GENERATED. Same rationale as jsx-runtime.
-import JsxDevRuntime from '${JSX_DEV_RUNTIME_ABS}'
-export const { jsxDEV, Fragment } = JsxDevRuntime
-export default JsxDevRuntime
-`)
+const jsxDevRuntimeEntry = writeEntry('jsx-dev-runtime', jsxDevRuntimeEntrySource({
+  production: PRODUCTION,
+  jsxRuntimeAbs: JSX_RUNTIME_ABS,
+  jsxDevRuntimeAbs: JSX_DEV_RUNTIME_ABS,
+}))
 
 const tanstackRouterEntry = writeEntry('tanstack-router', `
 // GENERATED. Native ESM package, so \`export *\` preserves every name

--- a/scripts/vendor-entrypoints.ts
+++ b/scripts/vendor-entrypoints.ts
@@ -1,0 +1,29 @@
+export interface JsxDevRuntimeEntryOptions {
+  production: boolean
+  jsxRuntimeAbs: string
+  jsxDevRuntimeAbs: string
+}
+
+export function jsxDevRuntimeEntrySource(opts: JsxDevRuntimeEntryOptions): string {
+  if (opts.production) {
+    return `
+// GENERATED. Production compatibility shim for stale installed plugin
+// clients that still import react/jsx-dev-runtime. New production builds
+// should emit react/jsx-runtime imports, but release binaries cannot assume
+// Bun is available to rebuild every previously installed plugin.
+import { jsx, jsxs, Fragment } from '${opts.jsxRuntimeAbs}'
+export function jsxDEV(type, props, key, isStaticChildren) {
+  return (isStaticChildren ? jsxs : jsx)(type, props, key)
+}
+export { Fragment }
+export default { jsxDEV, Fragment }
+`
+  }
+
+  return `
+// GENERATED. Same rationale as jsx-runtime.
+import JsxDevRuntime from '${opts.jsxDevRuntimeAbs}'
+export const { jsxDEV, Fragment } = JsxDevRuntime
+export default JsxDevRuntime
+`
+}

--- a/tests/scripts/vendor-entrypoints.test.ts
+++ b/tests/scripts/vendor-entrypoints.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test'
+
+import { jsxDevRuntimeEntrySource } from '../../scripts/vendor-entrypoints'
+
+describe('vendor entrypoints', () => {
+  it('generates a production jsxDEV shim for stale installed plugin clients', () => {
+    const source = jsxDevRuntimeEntrySource({
+      production: true,
+      jsxRuntimeAbs: '/abs/react/jsx-runtime.js',
+      jsxDevRuntimeAbs: '/abs/react/jsx-dev-runtime.js',
+    })
+
+    expect(source).toContain('export function jsxDEV')
+    expect(source).toContain('isStaticChildren ? jsxs : jsx')
+    expect(source).toContain("from '/abs/react/jsx-runtime.js'")
+    expect(source).not.toContain('/abs/react/jsx-dev-runtime.js')
+  })
+
+  it('keeps the real dev runtime wrapper for dev builds', () => {
+    const source = jsxDevRuntimeEntrySource({
+      production: false,
+      jsxRuntimeAbs: '/abs/react/jsx-runtime.js',
+      jsxDevRuntimeAbs: '/abs/react/jsx-dev-runtime.js',
+    })
+
+    expect(source).toContain('/abs/react/jsx-dev-runtime.js')
+    expect(source).toContain('JsxDevRuntime')
+  })
+})


### PR DESCRIPTION
## Summary

- generate a small production `react/jsx-dev-runtime` compatibility shim from the vendor build
- make stale installed plugin clients that still call `jsxDEV(...)` delegate to production `jsx` / `jsxs`
- keep dev builds using the real React dev JSX runtime

This is intentionally a small unblocker for the current production breakage. The real architecture fix remains #267 / Whisk: plugin repos should be source-only, Bakin should own plugin artifact builds, and production startup should not depend on shipped `dist/` or ambient Bun.

## Why

`v0.0.1-rc.13` moved Bakin browser/vendor assets to production mode. Existing installed plugin `dist/client.js` files were built in dev mode and still imported `react/jsx-dev-runtime`. In production React, that path did not provide a callable `jsxDEV`, causing plugin client imports to fail with `TypeError: jsxDEV* is not a function`.

## Verification

- `bun test --isolate tests/scripts/vendor-entrypoints.test.ts tests/scripts/assert-production-assets.test.ts`
- `bun run typecheck`
- `bun run build:vendors`
- imported generated `packages/host/public/vendor/jsx-dev-runtime.js` and verified `jsxDEV` is a function returning a React element
- `bun run build:plugins`
- `bun run build:assert-production-assets`
- `bun run lint`
- `bun test --isolate tests/api/plugins-build.test.ts tests/scripts/dev-build-one-plugin.test.ts tests/scripts/vendor-entrypoints.test.ts tests/scripts/assert-production-assets.test.ts`