### PR TITLE
Release v0.0.1-rc.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [Unreleased]
 
+## [0.0.1-rc.15] - 2026-06-04
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.0.1-rc.14] - 2026-06-04
 
 ### Fixed
@@ -197,5 +205,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 [0.0.1-rc.13]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.13
 
-[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.14...HEAD
 [0.0.1-rc.14]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.14
+
+[Unreleased]: https://github.com/markhayden/bakin/compare/v0.0.1-rc.15...HEAD
+[0.0.1-rc.15]: https://github.com/markhayden/bakin/releases/tag/v0.0.1-rc.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), with Ba
 
 ## [0.0.1-rc.15] - 2026-06-04
 
-### Added
-
-### Changed
-
 ### Fixed
+- Add a production JSX dev-runtime compatibility shim so stale installed plugin client bundles that still call `jsxDEV(...)` load instead of crashing after the production asset build change.
 
 ## [0.0.1-rc.14] - 2026-06-04
 


### PR DESCRIPTION
## Summary

- release `v0.0.1-rc.15`
- include the production JSX dev-runtime compatibility shim from #432
- update `CHANGELOG.md` with non-empty rc.15 release notes

## Verification

- `bun run scripts/extract-release-notes.ts --version 0.0.1-rc.15 --out /private/tmp/bakin-rc15-notes.md`