### PR TITLE
feat(plugins): Whiskin foundation — shared install core, build module, artifact format + publish/consumer core

### DIFF
--- a/.claude/specs/whiskin-plugin-builder-plan.md
+++ b/.claude/specs/whiskin-plugin-builder-plan.md
@@ -1,0 +1,725 @@
+# Implementation Plan: Whiskin Plugin Builder
+
+Spec: `.claude/specs/whiskin-plugin-builder.md`
+Date: 2026-06-04
+
+## Overview
+
+Whiskin is a multi-PR architecture change built around the **two-lane model**:
+consumers download and verify prebuilt artifacts (never build); producers and
+developers build from local source with system `bun` (CI publish or `--dev`).
+
+The safest route is to ship the decoupled, high-value lazy-loading fix first,
+then land the shared build backend, artifact format, and publish pipeline; in
+parallel extract the **shared install core** from the proven agent-package
+patterns; move plugin install onto it; then migrate official repos to
+source-only; **converge the agent-package installer onto the shared core last**
+(behavior-preserving); and finally harden for release. `BUN_BE_BUN` self-invoke
+is not on the critical path and is deferred.
+
+Every phase leaves Bakin in a working state with a natural rollback point.
+
+## Phase Numbering Note
+
+The dependency graph and the phase headings use the **same numbers**: phase N ==
+graph node N. Each phase is one PR/commit, labeled `C<N>` below, except Phase 10
+(producer repo migration), which spans two repos and therefore two PRs (`C10a`
+Bakin, `C10b` official repo). There is no separate global commit counter — the
+commit label always matches its phase number. Two phases are about install
+reliability for both primitives: **P5 shared install core** and **P11
+agent-package convergence**.
+
+## Dependency Graph
+
+```text
+P0 baseline + fixtures + agent-package characterization tests
+P1 lazy browser plugin loading            (decoupled; ships first; fixes #267 UX)
+P2 shared build backend (system bun)
+   -> P3 artifact format + provenance + checksum (signing deferred post-v1)
+      -> P4 producer publish pipeline (bakin plugins publish + CI action)
+P5 shared install core (extract from the proven agent-package patterns)
+   -> P6 consumer plugin install path on the shared core (download/verify/publish)
+      -> P7 [DEFERRED post-v1] elevated install-script / native trust
+         -> P8 dev-link / hot-reload on the system-bun backend
+            -> P9 startup verifier + legacy-install migration + host-upgrade refetch
+               -> P10 producer repo migration: no committed dist (a: Bakin docs, b: official repo)
+P11 agent-package convergence onto the shared core (LAST, behavior-preserving)
+   -> P12 release hardening (smoke BOTH install paths)
+```
+
+P5 (shared core) and the plugin build/publish track (P2–P4) are independent and
+can proceed in parallel; P6 depends on both. P11 (agent convergence) is
+deliberately last and gated on P5 being proven by the plugin path first, plus
+the P0 characterization tests staying green — we do not destabilize the
+currently-robust agent-package installer to achieve sharing.
+
+Notes:
+
+- P1 (lazy loading) is intentionally first and independent. It is the actual
+  user-visible complaint in #267 and does not depend on any builder change.
+  `Promise.all` eager import can be restored in isolation if it regresses.
+- P6 (consumer install) depends on P3/P4 (artifacts must exist to download) and
+  on P5 (the shared install core it runs on).
+- P10 (remove committed dist from official repos) must come after P4/P6 prove
+  artifacts can be published and consumed, so installs never break for a
+  released Bakin.
+- `BUN_BE_BUN` self-invoke and remote-source-build-on-consumer are explicitly
+  out of scope (see spec "Deferred: Remote Source Build"). No phase implements
+  them.
+
+## Phase 0: Baseline And Fixtures
+
+Purpose: capture today's behavior and create the fixtures every later phase
+needs, before changing anything.
+
+Tasks:
+
+- Add source-only fixture plugins:
+  - pure server-only plugin
+  - server + client plugin
+  - plugin with a declared pure-JS dependency
+  - plugin requiring a blocked install script
+  - plugin with an explicitly approved (producer-consented) script package
+  - native fixture (or a stubbed native addon) to exercise per-platform
+    artifacts and the runtime `node_modules` layout
+- Add a hermetic **fixture artifact server/host** helper so consumer-path tests
+  download from a local source, never live network or `~/.bakin`/`~/.openclaw`.
+- **Add characterization tests that lock the CURRENT agent-package installer
+  behavior** (staging→atomic-rename, install lock, write-log rollback,
+  `.installedBy`/`.userEdited`, lockfile fields). These are the safety net that
+  must stay green through P5 and gate P11 — they prove the agent path is not
+  regressed when it moves onto the shared core.
+- Add tests describing desired behavior, marked pending until the relevant phase
+  lands.
+
+Likely files:
+
+- `tests/fixtures/plugins/whiskin-*`
+- `tests/fixtures/whiskin-artifact-server.ts`
+- `tests/core/whiskin/`
+
+Commit:
+
+- C0. `test(plugins): add Whiskin fixtures and hermetic artifact host`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/whiskin
+bun run typecheck
+```
+
+Rollback: tests/fixtures only.
+
+## Phase 1: Lazy Browser Plugin Loading (ships first, decoupled)
+
+Purpose: fix the user-visible "Loading plugins" delay independently of the
+builder rework. This is the **only** phase that speeds up the browser — prebuilt
+artifacts do not (clients are already prebuilt today).
+
+Scope reality (verified in code): this is NOT a host-only change. Today
+`registerPlugin` takes eager `ComponentType` route/slot refs, each plugin
+imports all page components at `client.tsx` module top, plugins build as a single
+non-split bundle, and nav lives only in the runtime registry (not the manifest).
+So it requires a manifest-schema + per-plugin change touching `@makinbakin/sdk`
+(published), every core plugin, and the two official plugins.
+
+APPROACH: **(a) declarative manifest metadata** (chosen — see spec). Nav/route/
+slot metadata moves into `bakin-plugin.json` (extending existing
+`contributes.clientRoutes`); the sidebar renders from manifest JSON; a plugin's
+`client.js` loads only on first navigation into its routes. No code-splitting
+(deliberately avoided to not disturb import-map / hot-reload machinery).
+Approach (b) factories+splitting is a future per-plugin optimization, not in v1.
+
+Tasks:
+
+- Add declarative `contributes.nav` / `contributes.routes` / `contributes.slots`
+  to the manifest schema and serve it from `/api/plugins/manifest`.
+- Render the sidebar/shell from manifest metadata after the manifest fetch only
+  (replace the `Promise.all` full-bundle import in `PluginHost.tsx`); load a
+  plugin's `client.js` lazily on first navigation into one of its routes.
+- Keep `registerPlugin` runtime registration as the **escape hatch** for
+  `eager: true` plugins (background providers / `nav-badge-providers` /
+  conditional nav), loaded eagerly.
+- Add a **drift validation check** (build/publish + startup diagnostic): every
+  declared manifest route/nav has a matching runtime registration and vice versa.
+- Add plugin-local error boundaries for failed lazy plugin imports.
+- Update every core plugin's `bakin-plugin.json` + `client.tsx` (and coordinate
+  the two official plugins in `bakin-bits-official`) to the declarative shape.
+- Preserve dev hot-swap and version-mismatch behavior.
+
+Likely files:
+
+- `packages/host/src/plugin-host/PluginHost.tsx`
+- `packages/sdk/src/register.ts`
+- `packages/sdk/src/slots/index.tsx`
+- `packages/host/src/components/layout/app-sidebar.tsx`
+- `packages/host/src/api/plugins/manifest.ts` (serve declarative nav/route/slot)
+- `packages/core/src/plugins/manifest.ts` (schema for `contributes.nav` etc.)
+- every `plugins/<id>/bakin-plugin.json` + `plugins/<id>/client.tsx`
+- component tests
+
+Commit:
+
+- C1. `perf(host): lazy-load noncritical plugin clients`
+
+Verification:
+
+```sh
+bun test --isolate tests/components/plugin-host.test.tsx tests/plugins/contract.test.ts
+bun run typecheck
+```
+
+Manual browser verification:
+
+- Cold load shell with plugin diagnostics enabled; confirm only the eager
+  registration step runs before render, not full plugin bundles.
+- Navigate to a plugin route; confirm lazy import of that plugin's route code.
+- Trigger dev hot swap; confirm route/slot refresh.
+
+Rollback: restore eager `Promise.all` import behavior + revert the SDK shape.
+Independent of all later phases, but note the SDK-contract change ships in the
+published package, so coordinate with plugin authors.
+
+## Phase 2: Shared Build Backend (system bun)
+
+Purpose: one build code path that runs identically in CI and on dev machines,
+shelling out to system `bun` so it does not depend on in-process `Bun.build()`
+inside a compiled binary.
+
+Tasks:
+
+- Add `src/core/whiskin/types.ts` (build + artifact + failure types).
+- Add `src/core/whiskin/externals.ts` as the single source for host externals,
+  SDK entrypoints, and the `externalsContract` string.
+- Add `src/core/whiskin/import-scan.ts` (move the scanner out of
+  `user-plugin-builder.ts`).
+- Add `src/core/whiskin/source-hash.ts`.
+- Add `src/core/whiskin/command.ts`: stable system-`bun` runner with timeout,
+  cwd, env allowlist, stderr capture, sanitized errors.
+- Add `src/core/whiskin/build.ts`: server **and** client builds shell out to
+  system `bun build` for the publish/install paths (so the same code works under
+  a compiled binary), **plus `bun install` for declared deps.** Match the proven
+  externals strategy: client externalizes React + SDK; **server externalizes
+  React/router but inlines the SDK** (the official `bakin-bits-official` build
+  does exactly this via an esbuild SDK resolver — Whiskin must reproduce it or
+  server output diverges). Run `bun install --ignore-scripts` (pure-JS only; the
+  elevated install-script path is deferred to Phase 7).
+- **Hot-reload speed guard:** keep an in-process `Bun.build()` fast path for
+  source-run dev mode so per-save reload latency does not regress vs. today.
+  Shelling out is for publish/install, not the dev hot loop.
+- Keep `buildUserPlugin()` as a thin adapter over the new backend so existing
+  install/dev/startup callers keep working until later phases move them.
+
+Likely files:
+
+- `src/core/whiskin/{types,externals,import-scan,source-hash,command,build}.ts`
+- `packages/host/src/plugin-host/user-plugin-builder.ts`
+- `scripts/dev-build-one-plugin.ts`
+- tests under `tests/core/whiskin/`
+
+Commit:
+
+- C2. `feat(plugins): shared Whiskin build backend on system bun`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/whiskin tests/api/plugins-build.test.ts tests/scripts/dev-build-one-plugin.test.ts
+bun run typecheck
+```
+
+Rollback: revert backend; restore prior `buildUserPlugin` body.
+
+## Phase 3: Artifact Format, Provenance, Verification
+
+Purpose: define the Lane-1 distribution unit and how it is verified.
+
+Tasks:
+
+- Add `src/core/whiskin/provenance.ts` (read/write/validate `build.json`,
+  schema `version: 2`, includes `externalsContract`, `bakinRange`,
+  `sourceCommitSha`, approved scripts with name+version, runtimeModules).
+- Add `src/core/whiskin/artifact.ts`: assemble tarball (`dist/` + required
+  `node_modules/` + `.whiskin/build.json`), compute checksum, and verify
+  checksum + provenance on the consumer side (signing deferred post-v1).
+- Add safe extraction (zip-slip / path-traversal guard, escaping-symlink
+  rejection, decompressed size cap).
+- Define `whiskin-artifacts.json` index schema (platforms, versions, checksums,
+  externalsContract).
+- Signing: **checksum only in v1** (Open Q1 resolved). Reserve the optional
+  `.sig` asset + signed-index shape in the format so authenticity signing can be
+  added post-v1 without a layout change. Do not implement signature verification
+  now.
+
+Likely files:
+
+- `src/core/whiskin/{provenance,artifact}.ts`
+- `packages/core/src/plugins/manifest.ts` (reuse existing `bakin` compat field +
+  add build-trust schema; provenance stores resolved range as `bakinRange`)
+- tests under `tests/core/whiskin/`
+
+Commit:
+
+- C3. `feat(plugins): Whiskin artifact format, provenance, and verification`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/whiskin
+bun run typecheck
+```
+
+Rollback: artifact module is additive; nothing consumes it yet.
+
+## Phase 4: Producer Publish Pipeline
+
+Purpose: turn local source into checksummed artifacts (per-platform only when the
+plugin is platform-sensitive; pure-JS is a single artifact).
+
+Tasks:
+
+- Add `bakin plugins publish <dir> [--platforms] [--allow-install-scripts]`.
+- Locally builds the host platform; CI builds the declared matrix.
+- Detect platform-sensitivity from resolved deps (Open Q5): `os`/`cpu`
+  constraints, platform-keyed `optionalDependencies`, or native addons force
+  per-platform artifacts; otherwise emit one platform-neutral artifact.
+- Stamp `bakinRange` from the build when the manifest omits it (Open Q4).
+- Assemble + checksum artifacts; build a per-release immutable
+  `whiskin-artifacts.json` by **carrying forward** the previous latest index's
+  entries for plugins not rebuilt (Open Q3), so each release is a complete
+  catalog and plugins release independently; attach index + artifacts to the
+  GitHub release (or emit to a target dir for CI to upload).
+- Add the reusable GitHub Action wrapper with a platform matrix.
+
+Likely files:
+
+- `src/core/whiskin/publish.ts`
+- `src/core/cli/registry.ts` (register `plugins publish`)
+- `.github/actions/whiskin-publish/` (reusable action)
+- tests under `tests/core/whiskin/` and `tests/cli/`
+
+Commit:
+
+- C4. `feat(plugins): bakin plugins publish + reusable CI action`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/whiskin tests/cli/plugin-publish.test.ts
+bun run typecheck
+bakin plugins publish ./tests/fixtures/plugins/whiskin-server-client --platforms <host>
+```
+
+Rollback: publish command is additive; producers can still ship the old way
+until P10.
+
+## Phase 5: Shared Install Core (extract from the proven agent-package patterns)
+
+Purpose: one hardened install backbone consumed by both primitives, eliminating
+the parallel-drift regression class. Built by **generalizing the agent-package
+installer's existing patterns** (it is the reference) — NOT inventing new ones,
+and NOT yet moving agent packages onto it (that is P11).
+
+Tasks:
+
+- Extract a shared module set under `src/core/install-core/`:
+  - **Source parsing** — unify `parseGithubSource` (plugins) and
+    `parseGithubSpec` (agent packages) into one parser with identical
+    path-traversal / `..` / subpath-containment guards.
+  - **Source materialization** — one fetch path over the shared
+    `github-source-cache.ts` (system git for dev/source installs) and HTTPS
+    artifact download (consumers, P6); bounded timeout, size cap, git-arg
+    allowlist.
+  - **Transaction** — staging → atomic rename, advisory install lock, and
+    **write-log rollback** lifted from the agent-package projector
+    (`src/core/agent-packages/projector.ts`, `install-lock.ts`).
+  - **Lockfile IO** — one generic `atomicWriteLockfile(path, schema, content)`
+    (tmp+rename+fsync) used by both lockfiles.
+  - **Provenance** — generalize `.installedBy` sidecars so both primitives can
+    record per-file provenance.
+- Keep the agent-package installer calling the SAME underlying behavior via a
+  thin adapter so P0 characterization tests stay green (no behavior change yet).
+- No consumer of the new core in this phase except a parity test harness.
+
+Likely files:
+
+- `src/core/install-core/{source,materialize,transaction,lockfile-io,provenance}.ts`
+- `packages/core/src/plugins/source.ts` + `src/core/agent-packages/source-fetcher.ts`
+  (route through the unified parser)
+- `src/core/github-source-cache.ts`
+- tests under `tests/core/install-core/`
+
+Commit:
+
+- C5. `refactor(install): extract shared hardened install core`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/install-core tests/core/agent-packages
+bun run typecheck
+```
+
+Rollback: the core is additive + adapter-backed; agent/plugin install behavior
+is unchanged until P6/P11 adopt it. P0 characterization tests must stay green.
+
+## Phase 6: Consumer Plugin Install Path (on the shared core)
+
+Purpose: install on a consumer machine with no build toolchain, using the shared
+core's transaction/rollback/lock so plugins reach the agent-package robustness
+standard.
+
+Tasks:
+
+- Add `src/core/whiskin/resolver.ts`: the `WhiskinArtifactResolver` interface
+  (Open Q2) + the single v1 `github-release-assets` implementation. Downstream
+  download/verify/extract/validate/publish must not reference GitHub directly.
+- Add `src/core/whiskin/source-materializer.ts` consumer path:
+  - parse via `packages/core/src/plugins/source.ts`
+  - resolve platform + artifact location via the resolver (`whiskin-artifacts.json`)
+  - download artifact + checksum over HTTPS (public repos; private-repo token
+    auth deferred)
+  - verify checksum, then safe-extract to staging
+  - clear `NO_PREBUILT_ARTIFACT` / `CHECKSUM_MISMATCH` errors
+- Rewrite install/upgrade transaction (`install.ts`) to run **on the P5 shared
+  install core** (so the build-in-place-with-no-rollback regression surface is
+  gone — plugins now get staging → atomic publish, install lock, and write-log
+  rollback like agent packages):
+  - download/verify/validate artifact in staging
+  - shared atomic publish to `~/.bakin/plugins/<id>` with rollback on failure
+  - shared install lock + pre-flight collision check
+  - lockfile write (shared IO) with artifact provenance + `.installedBy`
+  - live-activate with a cache-busted `import()`
+- Remove `trustExistingDist` as install policy.
+- Replace `git clone` materialization for the consumer path; keep git only for
+  developer/source convenience.
+- Forward-compatible lockfile schema bump (additive, version-gated).
+
+Likely files:
+
+- `packages/host/src/api/plugins/install.ts`
+- `src/core/plugins/upgrade.ts`
+- `packages/core/src/plugins/lockfile.ts`
+- `src/core/whiskin/source-materializer.ts`
+- lifecycle tests
+
+Commit:
+
+- C6. `feat(plugins): install verified Whiskin artifacts on the shared core`
+
+Verification:
+
+```sh
+bun test --isolate tests/plugins/lifecycle/install-artifact.test.ts tests/plugins/lifecycle/install-subpath.test.ts tests/api/user-plugin-lifecycle.test.ts tests/plugins/lifecycle/upgrade-flow.integration.test.ts
+bun run typecheck
+```
+
+Rollback: revert install/upgrade callers to old builder + `trustExistingDist`.
+
+## Phase 7: Dependency And Install-Script Trust (publish/dev side) — DEFERRED post-v1
+
+**Deferred (2026-06-04):** no current plugin needs it — both official plugins
+are pure-JS, and pure-JS dependency install (`bun install --ignore-scripts`)
+already lives in Phase 2. This phase (elevated install-script trust, native
+deps, per-platform matrix, name+version re-consent) is implemented only when a
+real native/scripted plugin appears. v1 ships **pure-JS plugins only**; a plugin
+that declares `build.installScripts` fails with a clear "elevated install
+scripts are not supported yet" error until this phase lands. The design below is
+retained as the spec for that future work.
+
+Purpose: make dependency install explicit and safe — on the build side only.
+
+Tasks:
+
+- Add manifest parser for `build.installScripts` (resolved field per Open Q4:
+  entries of `package` + `version` + `reason` + `platforms`; no
+  `nativeDependencies`).
+- Validate: no wildcard trusted packages; each trusted package is in
+  `dependencies`; supported platform includes the build platform; reason present.
+- Producer consent at publish: `--allow-install-scripts` / interactive prompt,
+  separate from the permission `--yes` shortcut.
+- Record approved packages by **name + version**; re-consent triggers on
+  identity change (name+version or `packageLockSha`).
+- `bun install --ignore-scripts` default; package-level trusted deps only after
+  approval.
+- Errors: `SCRIPT_BLOCKED`, `SCRIPT_CONSENT_REQUIRED`, `DEPENDENCY_INSTALL_FAILED`.
+- Reject third-party deps that import React / host singletons (one-React guard).
+
+Likely files:
+
+- `packages/core/src/plugins/manifest.ts`
+- `src/core/whiskin/{dependencies,script-trust}.ts`
+- `src/core/whiskin/publish.ts`
+- tests under `tests/core/whiskin/` and `tests/cli/`
+
+Commit:
+
+- C7. `feat(plugins): gate install scripts through producer-side Whiskin trust`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/whiskin tests/cli/plugin-publish-scripts.test.ts
+bun run typecheck
+```
+
+Rollback: leave pure-JS publish active; disable elevated script mode.
+
+## Phase 8: Dev Link And Hot Reload On Whiskin
+
+Purpose: keep developer experience fast on the shared system-`bun` backend.
+
+Tasks:
+
+- Make `bakin plugins install --dev` and the hot-reload coordinator call the
+  Whiskin build backend (local source, system `bun`).
+- Confirm it works whether Bakin runs from source or as a compiled binary, as
+  long as system `bun` is present.
+- Preserve per-plugin debounce/inflight, old-plugin-stays-active on failure,
+  watcher survival on build error, and client hot-swap.
+- Use the in-process `Bun.build()` fast path in source-run dev (no subprocess per
+  save); benchmark reload latency against today to prove no regression.
+- Add diagnostics for Whiskin dev rebuild spans.
+
+Likely files:
+
+- `src/core/plugins/link.ts`
+- `src/core/plugin-host/hot-reload-coordinator.ts`
+- `src/core/plugin-host/reload-pipeline.ts`
+- `packages/host/src/plugin-host/PluginHost.tsx`
+- hot reload tests
+
+Commit:
+
+- C8. `feat(plugins): route dev hot reload through Whiskin`
+
+Verification:
+
+```sh
+bun test --isolate tests/plugins/lifecycle/hot-reload-coordinator.test.ts tests/plugins/lifecycle/hot-reload-integration.test.ts tests/components/plugin-host.test.tsx
+bun run typecheck
+```
+
+Rollback: switch dev-link back to the P2 adapter.
+
+## Phase 9: Startup Verifier, Doctor Repair, Host-Upgrade Refetch
+
+Purpose: remove install-grade builds from startup and handle host upgrades.
+
+Tasks:
+
+- Replace `buildAllUserPlugins()` startup behavior with artifact verification:
+  - manifest present, `dist/index.js` present, `.whiskin/build.json` valid
+  - checksum status acceptable (signature deferred post-v1)
+  - `externalsContract` + Bakin range compatible
+- Mark incompatible artifacts **needs-update** (not permanently inactive); the
+  repair path **re-fetches a compatible published artifact**, it does not
+  rebuild locally.
+- Mark genuinely failed plugins inactive with error metadata.
+- **Migrate pre-Whiskin installs (regression guard).** Plugins installed before
+  Whiskin have committed dist, no `.whiskin/build.json`, and no artifact
+  provenance. On the first startup after upgrade they must NOT be silently
+  marked inactive. Detect "legacy install" (lockfile entry without artifact
+  provenance) and either grandfather the existing dist as valid-but-unverified,
+  or auto-refetch the published artifact once. A one-time
+  `bakin plugins migrate` / doctor repair drives it. This must be covered by a
+  test that upgrades a legacy-install fixture and asserts the plugin stays
+  active.
+- `bakin doctor` checks + repair: re-fetch missing/stale/incompatible artifacts,
+  clear Whiskin cache, explain when a newer release is required.
+- Update the health plugin to surface plugin artifact failures.
+
+Likely files:
+
+- `server.ts`
+- `packages/host/src/plugin-host/user-plugin-builder.ts` (or replacement)
+- `src/core/doctor.ts`
+- `plugins/health/lib/system-checks/plugin-assets.ts`
+- plugin manifest route + tests
+
+Commit:
+
+- C9. `perf(plugins): verify artifacts at startup, refetch on host upgrade`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/doctor-plugin-checks.test.ts tests/core/plugin-startup-diagnostics.test.ts tests/api/plugin-manifest-embedded.test.ts
+bun run typecheck
+```
+
+Rollback: restore `buildAllUserPlugins()` startup behavior while keeping the
+Whiskin install path.
+
+## Phase 10: Producer Repo Migration (source-only)
+
+Purpose: make official plugin repos source-only and artifact-published.
+
+Tasks in Bakin (10a):
+
+- Docs: source-only producer repos + artifact publishing is the contract.
+- Update recommended install paths if needed.
+- CI check / docs test that no official catalog entry requires committed `dist`.
+
+Tasks in `markhayden/bakin-bits-official` (10b) — scoped against the actual repo:
+
+- Two plugins today: `messaging`, `projects`. Both are **pure-JS** (`js-yaml`,
+  `lucide-react`, `zod` — zero native, zero install scripts), so they produce a
+  **single platform-neutral artifact each; no platform matrix needed** (Open Q5
+  detection confirms pure). Per-platform/matrix work is deferred until a native
+  plugin actually exists.
+- Remove committed `plugins/*/dist/**`. Today `.gitignore` explicitly
+  **un-ignores** `!plugins/*/dist/` + `!plugins/*/dist/**` — invert that to
+  ignore dist. Decide whether to purge dist from git history (~2 MB of bundles)
+  or just stop tracking going forward (simpler; history stays).
+- **Flip the CI gate.** Current `ci.yml` builds dist and **fails if it is
+  stale** ("dist/ is out of date") — the exact opposite of the target. Replace
+  with: build via Whiskin, publish artifacts, and assert dist is **absent**.
+- Replace `scripts/build-plugins.ts` with the `bakin plugins publish` action.
+  Preserve its externals strategy (server inlines SDK; client externalizes it).
+- Add a release workflow that publishes per-plugin checksummed artifacts +
+  `whiskin-artifacts.json` (carry-forward) to GitHub Releases, keyed off the
+  existing `<plugin-id>-v<semver>` tag convention.
+- Update README install examples (still git-subpath source string; now resolves
+  to a published artifact, not committed dist).
+
+Commits/PRs:
+
+- C10a. Bakin PR: `docs(plugins): document source-only Whiskin plugin repos`
+- C10b. Official repo PR: `refactor: publish artifacts, drop committed dist`
+
+Verification:
+
+```sh
+# consumer install against a freshly published release, no toolchain
+BAKIN_HOME=/tmp/bakin-whiskin-home ./dist/bakin-<plat> \
+  plugins install github:markhayden/bakin-bits-official#plugins/messaging
+```
+
+Rollback: the official repo can temporarily keep committed dist until the Bakin
+Whiskin release is tagged; the target contract remains source-only + published
+artifacts.
+
+## Phase 11: Agent-Package Convergence (LAST, behavior-preserving)
+
+Purpose: move the agent-package installer onto the P5 shared core so the two
+primitives stop drifting — without regressing the currently-robust content path.
+
+Why last: the shared core is proven by the plugin path (P5/P6) first; only then
+does the working agent installer migrate, gated on the P0 characterization tests
+staying green at every step.
+
+Tasks:
+
+- Route agent-package source parse + fetch + transaction + lockfile IO +
+  provenance through `src/core/install-core/` (replacing the parallel
+  `source-fetcher.ts` / projector internals with the shared implementations).
+- Behavior-preserving: P0 characterization tests must pass unchanged; any
+  intended difference is an explicit, reviewed delta.
+- Close the two known agent-package gaps now that they are cheap on the shared
+  core: finish the deferred pre-flight collision check (today
+  `preflightCollisions()` returns `[]`), and add manifest-integrity hashing
+  (parity with plugin `manifestSha`).
+- Delete the now-dead parallel implementations (unify, don't leave both).
+
+Likely files:
+
+- `src/core/agent-packages/{installer,source-fetcher,projector}.ts`
+- `packages/core/src/agent-packages/{manifest,lockfile,markers}.ts`
+- `tests/core/agent-packages/` + the P0 characterization suite
+
+Commit:
+
+- C11. `refactor(agent-packages): converge install onto the shared core`
+
+Verification:
+
+```sh
+bun test --isolate tests/core/install-core tests/core/agent-packages tests/api/agent-packages
+bun run typecheck
+```
+
+Rollback: the agent installer keeps its pre-convergence path until this lands;
+revert routes it back. P0 characterization tests are the gate.
+
+## Phase 12: Release Hardening
+
+Purpose: prevent regressions before launch.
+
+Tasks:
+
+- Release workflow smoke (**both install paths**):
+  - consumer binary installs a published plugin fixture artifact with no system
+    bun/git
+  - agent-package install of a source-only fixture succeeds on the shared core
+  - failed install (bad artifact / interrupted) rolls back cleanly for both
+    primitives — no partial state
+  - `CHECKSUM_MISMATCH` / zip-slip fixtures rejected
+- Binary artifact size report (executable / embedded host assets / embedded core
+  plugin assets / vendor bundles).
+- Startup benchmark: artifact verification vs. old rebuild behavior.
+
+Likely files:
+
+- `.github/workflows/release.yml`
+- `scripts/build-binary.ts`
+- `scripts/report-binary-size.ts`
+- `scripts/bench/plugin-startup.ts`
+
+Commit:
+
+- C12. `ci(release): smoke Whiskin install + publish (both primitives)`
+
+Verification:
+
+```sh
+bun run build:binary
+gh workflow run release.yml   # or PR checks when wired
+```
+
+Rollback: release checks can be disabled temporarily without reverting runtime
+Whiskin behavior, but should block launch once stabilized.
+
+## Risks And Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| No signing in v1 (checksum only) | A compromised GitHub release could swap artifact + checksum together | Accepted for v1: trust = GitHub HTTPS + account security, same as Obsidian community plugins. Format reserves signing for post-v1 if impersonation risk appears |
+| Native deps in the artifact mismatch consumer platform | Plugin fails at activation | Per-platform artifacts built+tested in CI matrix; `UNSUPPORTED_PLATFORM` on resolve; runtime `node_modules` shipped inside the artifact |
+| Hard GitHub dependency for artifact hosting | Installs fail if GitHub is down/changed | Keep "no SaaS" runtime; allow a content-addressed mirror later (Open Q2) |
+| Host upgrade invalidates externals contract | Plugins go inactive after Bakin update | Needs-update state + refetch a compatible published artifact, never local rebuild (P9) |
+| System bun absent on a dev machine | Dev build / publish fails | Dev/publish require system bun (already the contributor requirement); consumers never need it |
+| Lockfile schema change breaks rollback | Rollback can't read new lockfiles | Additive, version-gated, forward-compatible parsing |
+| Install scripts run untrusted code at publish | Producer/supply-chain risk | Package name+version trust, explicit producer consent, staging, timeout, checksummed provenance (deferred Phase 7) |
+| Runtime trust overstated | Users think pure-JS deps are sandboxed | Spec states explicitly: install-time gating only, no runtime sandbox |
+| Producer repo migration too early | Installs break for released Bakin | Ship publish + consumer install (P4/P6) first, then migrate repos (P10) |
+| `BUN_BE_BUN` temptation creeps back | Reintroduces the consumer-build risk | Explicitly deferred; no phase implements it; consumer never builds |
+| Converging onto the shared core regresses the working agent-package installer | Breaks the currently-robust content path | Agent installer is the reference, not the rewrite target; P0 characterization tests lock current behavior; P11 is last + behavior-preserving + gated on those tests staying green |
+| Plugin install loses state on failure (build-in-place, no rollback) — current bug | Half-installed plugins | P5/P6 move plugins onto the shared staging→atomic→rollback core, matching agent packages |
+
+## Commit Strategy
+
+Keep commits small and independently revertible. Commit label == phase number
+(`C10` spans `C10a`/`C10b` across two repos):
+
+- C0   Fixtures + hermetic artifact host + agent-package characterization tests.
+- C1   Lazy browser plugin loading (ships first, decoupled).
+- C2   Shared system-bun build backend.
+- C3   Artifact format + provenance + verification.
+- C4   Producer publish pipeline + CI action.
+- C5   Shared install core (extract from the proven agent-package patterns).
+- C6   Consumer plugin install on the shared core.
+- C7   [DEFERRED post-v1] Elevated install-script / native trust.
+- C8   Dev hot reload on Whiskin.
+- C9   Startup verifier + legacy-install migration + doctor refetch.
+- C10a Bakin docs: source-only producer contract.
+- C10b Official repo migration: publish artifacts, drop committed dist.
+- C11  Agent-package convergence onto the shared core (last, behavior-preserving).
+- C12  Release hardening (both primitives).
+
+Ship C1 (lazy loading) on its own PR ahead of everything else. Keep C11
+(agent-package convergence) last and on its own PR, gated on the C0
+characterization tests — do not fold it into a builder PR. Avoid combining C10
+(repo migration) with any builder PR — different failure modes, separate review.
+```

--- a/.claude/specs/whiskin-plugin-builder.md
+++ b/.claude/specs/whiskin-plugin-builder.md
@@ -1,0 +1,902 @@
+# Spec: Whiskin Plugin Builder
+
+Status: Revised draft — pivot to publish-first / two-lane model
+Date: 2026-06-04
+Related issue: https://github.com/markhayden/bakin/issues/267
+Companion plan: `.claude/specs/whiskin-plugin-builder-plan.md`
+
+## Objective
+
+**Primary goal: rock-solid, regression-free installation for both Bakin
+install primitives — plugins and agent packages (agent kits).** No more
+battling dependencies, partial/half-applied installs, or fragile
+build-and-commit `dist/` dances that bloat repos and silently go stale when
+someone forgets to rebuild. A continuous secondary aim is keeping the UI feeling
+fast (addressed by lazy loading, decoupled from the install work).
+
+Whiskin is therefore two things:
+
+1. A **shared, hardened install core** — source parsing, fetch, atomic
+   staging→publish with rollback, install locking, lockfile IO, and provenance —
+   consumed by **both** the plugin and agent-package install paths, so the two
+   stop drifting into subtly-different implementations of "the same install."
+2. A **plugin-specific layer** on top: build, validation, publish (checksummed;
+   signing reserved post-v1), and the consumer-side path that materializes
+   published plugin artifacts — so a non-developer never compiles a plugin, and
+   producer repos never commit `dist/`.
+
+Agent packages are pure content (no build, no dependencies, no `dist/`), so they
+need only layer 1; plugins need both.
+
+The plugin layer's reliability sub-goal is to make installation work for
+non-developer users while keeping authoring fast for developers — **without ever
+asking a non-developer's machine to compile a plugin.**
+
+Normal users should be able to install Bakin and plugins with:
+
+```sh
+bakin plugins install github:markhayden/bakin-bits-official#plugins/messaging
+```
+
+They should not need to install or understand Bun, Node, npm, git, a source
+checkout, committed `dist/` artifacts, or a build toolchain of any kind. On
+their machine, install is **download → verify → validate → publish**, never
+build.
+
+Plugin producers ship source. The build happens where a real toolchain already
+exists — producer CI (to publish official/third-party artifacts) and developer
+machines running `--dev` against a local checkout. The same Whiskin build code
+runs in both; it never runs on a consumer's machine.
+
+## Scope: Two Primitives, One Install Core
+
+Bakin has two install primitives that today run **parallel, drifted**
+implementations of the same fundamentals — a regression source in itself:
+
+- **Plugins** ship code: build → `dist/` → activate. Source via `git clone`
+  (`github-source-cache.ts`) + `parseGithubSource`. Install **copies to target
+  then builds in place with no rollback**, has no pre-flight collision check,
+  and records no per-file provenance. This is the **weaker, more regression-prone
+  installer**.
+- **Agent packages** ship content (SOUL/IDENTITY/skills/workflows/lessons/assets;
+  no build, no deps, no `dist/`). Source via a *separate* `parseGithubSpec` +
+  fetch wrapper over the *same* `github-source-cache.ts`. Install is
+  **staging → atomic rename, with an advisory install lock, write-log rollback,
+  `.installedBy` provenance sidecars, and `.userEdited` sentinels**. This is the
+  **more robust installer** and is largely rock-solid today.
+
+Reference-implementation principle: **the agent-package installer is the proven
+reference. Plugins converge *up* to its robustness via the shared core; agent
+packages are migrated onto that core *last*, behavior-preserving, only after
+characterization tests lock their current behavior.** We do not risk the working
+content path to achieve sharing — the win is eliminating drift and lifting
+plugins, not rewriting what already works.
+
+What the shared core unifies (one implementation, both primitives consume):
+source-string parsing, source fetch/materialization (incl. the no-system-git
+HTTPS path), staging → atomic publish, rollback, install locking, lockfile IO,
+and provenance/`.installedBy`. What stays primitive-specific: the plugin build /
+artifact / publish layer (plugins only) and runtime-agent creation /
+lesson-marker projection (agent packages only).
+
+Agent packages also have two of their own gaps to close cheaply once on the
+shared core: finishing the deferred pre-flight collision check, and adding
+manifest-integrity hashing (which plugins already have via `manifestSha`).
+
+## The Two-Lane Model
+
+This is the central decision of the revised spec. There are two distinct
+personas with two distinct paths that barely overlap.
+
+### Lane 1 — Consumer (the happy path, ~all real installs)
+
+Who: a non-developer running the released Bakin binary on a Mac mini.
+
+What they install: **official / published plugins** whose build and publishing we
+(or a trusted third-party producer) control.
+
+How install works on their machine:
+
+1. Resolve the source ref to a **published release artifact** for their
+   platform.
+2. Download the artifact over HTTPS.
+3. Verify checksum and provenance (signature deferred post-v1; see Open Q1).
+4. Validate manifest, permissions, externals-contract compatibility.
+5. Atomically publish into `~/.bakin/plugins/<id>/` and activate.
+
+No Bun, Node, npm, git, compiler, or `bun install`. The binary never invokes a
+build. Install latency is a download plus a hash check.
+
+### Lane 2 — Producer / Developer
+
+Who: someone building a plugin (their own, or contributing to an official one).
+
+What they have: a **local source checkout** and **system Bun** on PATH (already
+the documented contributor requirement — see `CONTRIBUTING.md`).
+
+How build works:
+
+- `bakin plugins install --dev .` + `bakin dev` builds from local source using
+  the Whiskin build backend, which **shells out to system `bun`** for both
+  server and client builds, plus `bun install` for declared dependencies. Hot
+  reload stays fast.
+- `bakin plugins publish` (or the reusable GitHub Action) runs the **same**
+  Whiskin build in CI across the supported platform matrix, then signs and
+  attaches per-platform artifacts to a GitHub release. This is how Lane-2 source
+  becomes a Lane-1 consumable.
+
+The build pipeline is identical code in dev and CI. The only difference is where
+it runs and what it emits (a hot-swapped local `dist/` vs. a checksummed release
+artifact). **It never runs on a consumer machine.**
+
+### Why this shape
+
+Every mature plugin/extension ecosystem builds in CI and distributes prebuilt
+(VS Code `.vsix`, Obsidian release `main.js`, Homebrew bottles, npm prebuilt
+native binaries), falling back to source build only for developers — exactly
+where a toolchain already exists. The earlier draft inverted this and made
+"compile a remote repo on the consumer's machine" the default, which forced a
+binary self-build mechanism (`BUN_BE_BUN`), on-device `bun install`, on-device
+install-script consent, and on-device native compilation. The two-lane model
+removes all of those from the critical path.
+
+The spec's own platform-CI requirement for native plugins already implies this:
+if CI must build and prove `sharp` on `darwin-arm64` before release anyway, ship
+that artifact rather than rebuilding it on the user's machine.
+
+## End-User Experience Walkthrough
+
+### A. Non-developer installs an official plugin (Lane 1)
+
+```sh
+bakin plugins install github:markhayden/bakin-bits-official#plugins/messaging
+```
+
+1. Whiskin parses the source string (`packages/core/src/plugins/source.ts`) and
+   resolves owner/repo/ref/subpath.
+2. Whiskin looks for a **published artifact** for `messaging` at the resolved
+   ref matching the current platform (`darwin-arm64`). The lookup target is a
+   release asset named by a stable convention (see "Published Artifact").
+3. Found → download over HTTPS, verify checksum, verify the artifact provenance
+   declares a compatible `externalsContract` and Bakin range.
+4. Validate manifest + permissions, run permission consent if needed.
+5. Atomically publish into `~/.bakin/plugins/messaging/` and live-activate.
+
+Time cost: one download + hash verify. No compiler, no network beyond the
+artifact host.
+
+### B. Non-developer wants a community plugin with no published artifact
+
+```text
+NO_PREBUILT_ARTIFACT: messaging-fork has no published release for darwin-arm64.
+
+Ask the plugin author to publish a release, or install it as a developer:
+  1. git clone / download the repo
+  2. install Bun (https://bun.sh)
+  3. bakin plugins install --dev ./messaging-fork
+```
+
+Bakin does **not** silently attempt an on-device compile. A non-developer
+machine is, by definition, not set up to build, and we will not pretend it is.
+
+### C. Developer builds their own plugin (Lane 2)
+
+```sh
+bakin plugins install --dev .
+bakin dev
+```
+
+- Whiskin builds from the local checkout using system `bun` (build + install).
+- Hot reload rebuilds + hot-swaps on save (existing coordinator behavior).
+- No remote fetch, no artifact, no signing.
+
+### D. Producer publishes a plugin (Lane 2 → Lane 1)
+
+```sh
+bakin plugins publish ./plugins/messaging
+# or, in CI, the reusable GitHub Action
+```
+
+- Runs Whiskin build across the declared platform matrix.
+- For native/scripted plugins, runs `bun install` with the producer's declared,
+  consented install-script trust — **on CI, under the producer's authority**,
+  not on a consumer.
+- Emits one checksummed artifact per platform, attached to the GitHub release
+  (signature deferred post-v1).
+
+### E. Developer installs a third-party plugin from a remote repo (residual edge)
+
+This is the only case the consumer-vs-source distinction blurs. Resolution
+order:
+
+1. If the repo publishes artifacts → Lane 1 (download/verify), even for a dev.
+2. Else, if the developer has system Bun → optional deferred path: build the
+   remote source locally with system `bun` (see "Deferred: remote source
+   build"). This is a developer convenience, gated on system Bun, never the
+   non-dev path.
+3. Else → the Lane-1 "no prebuilt artifact" error.
+
+## Core Decisions
+
+**Overarching:** install reliability for **both** primitives is the primary goal;
+a shared hardened install core serves plugin and agent-package install alike. The
+agent-package installer is the proven reference; plugins converge up to it, and
+agent packages move onto the shared core last and behavior-preserving.
+
+1. Whiskin is the public boundary. The implementation backend is private.
+2. **The consumer binary never builds.** Lane-1 install is download → verify →
+   validate → publish. Build happens only in CI (publish) and on developer
+   machines (`--dev`), both of which have system Bun.
+3. The Whiskin build backend shells out to **system `bun`** for build and
+   `bun install`. It does not depend on in-process `Bun.build()` being available
+   inside a compiled binary, and does not depend on a binary self-invoke trick.
+4. `BUN_BE_BUN=1` self-invoke is **deferred / rejected for v1**. It is only
+   relevant to the residual edge case of compiling remote source on a non-dev
+   machine, which the two-lane model removes from the critical path. See
+   "Deferred: remote source build."
+5. GitHub plugin installs for consumers fetch **published release artifacts**
+   over HTTPS. No system git required. Developer/source paths may keep system
+   git and/or a local checkout.
+6. Plugin repos that serve plugins must not commit `dist/`. Built artifacts are
+   produced by CI and distributed as checksummed release assets (signing reserved
+   post-v1), never committed to the source tree.
+7. Native and install-script dependencies are resolved **at publish time in CI**
+   on the supported platform matrix, and shipped inside the per-platform
+   artifact. They are not installed or compiled on consumer machines.
+8. Install scripts are allowed only through explicit producer-side trust
+   declarations, visible producer consent at publish time, staging isolation,
+   and checksummed provenance recorded in the artifact and the consumer lockfile
+   (signing deferred post-v1).
+9. Startup never performs install-grade plugin builds. Startup verifies recorded
+   artifact provenance + checksum and activates verified artifacts.
+10. Dev-linked plugins keep hot reload fast using the system-`bun` build backend
+    against a local source checkout.
+11. Official plugins with elevated install scripts or native dependencies must
+    prove install/build on every supported platform in CI before release — and
+    those CI outputs **are** the shipped artifacts.
+
+## Current State
+
+Current plugin build behavior is split:
+
+- Core plugins build through `scripts/build-plugins.ts`, delegating to
+  `scripts/dev-build-one-plugin.ts` (shells out to `bun build`; does not run
+  `bun install`).
+- User plugins build through
+  `packages/host/src/plugin-host/user-plugin-builder.ts`. `buildUserPlugin()`
+  runs `bun install` when deps are declared, scans imports with a Bun
+  `Transpiler`, builds the **server in-process via `Bun.build()`**, and builds
+  the **client by shelling out to `bun build`**.
+- User install, dev-link, upgrade, startup, and hot reload all call the user
+  plugin builder directly.
+- Normal startup calls `buildAllUserPlugins()` before the registry imports user
+  plugins — it rebuilds stale plugins on every cold start.
+- GitHub source materialization uses **system `git clone --depth 1`** via
+  `src/core/github-source-cache.ts`. It does not download archives over HTTPS.
+- GitHub-installed plugins are currently treated as trusted prebuilt `dist/`
+  when present, via the `trustExistingDist` policy in the builder and lockfile.
+- `bakin-bits-official` currently has a publisher-side build script and
+  explicitly unignores `plugins/*/dist/**` in `.gitignore`.
+
+Implications for this revision:
+
+- The server-side in-process `Bun.build()` path will not work inside a compiled
+  consumer binary — which is precisely why the consumer path must not build. The
+  build backend should standardize on shelling out to system `bun` so the same
+  code works in dev (compiled binary or source run) and CI.
+- `trustExistingDist` is the ad-hoc precursor to a real verified-artifact model
+  (checksummed; signing reserved post-v1). It is replaced, not extended.
+
+Local measurements from 2026-06-04:
+
+- `dist/bakin-darwin-arm64`: about 73 MB.
+- `dist/bakin-linux-x64`: about 110 MB.
+- `dist/bakin-linux-arm64`: about 109 MB.
+- Host/vendor/core-plugin browser JS/CSS: about 3.6 MB uncompressed and about
+  0.93 MB gzip.
+- Core plugin client JS only: about 1.2 MB uncompressed.
+
+Conclusion: Whiskin is primarily an install-correctness, plugin-repo-hygiene,
+distribution, and startup/load-time architecture project. It will not by itself
+cut the compiled binary in half. The user-visible "Loading plugins" delay is
+addressed by lazy browser loading, which is decoupled and can ship first.
+
+## Published Artifact
+
+A published plugin artifact is the Lane-1 distribution unit. One per supported
+platform when the plugin has native/platform-specific content; one
+platform-neutral artifact when the plugin is pure JS/TS.
+
+Proposed layout (tarball):
+
+```text
+messaging-0.1.0-darwin-arm64.tar.zst
+  bakin-plugin.json
+  dist/
+    index.js
+    client.js        optional
+    client.css       optional
+  node_modules/       only the runtime deps the bundle cannot inline
+    ...               (e.g. native addons: sharp/*.node, ffmpeg binary)
+  .whiskin/
+    build.json        provenance (see "Build Provenance")
+```
+
+Accompanying release assets:
+
+- `messaging-0.1.0-darwin-arm64.tar.zst.sha256` (mandatory; consumer verifies)
+- A per-plugin `whiskin-artifacts.json` index listing available platforms,
+  versions, checksums, and the `externalsContract` each was built against.
+- `messaging-0.1.0-darwin-arm64.tar.zst.sig` — **deferred (post-v1)**. The
+  format reserves an optional signature asset so authenticity signing can be
+  added later without changing the layout. Not produced or required in v1.
+
+Key properties:
+
+- **Pure-JS plugins** produce a single platform-neutral artifact; the bundle
+  inlines pure-JS deps, so `node_modules/` is absent or empty. Publish verifies
+  pureness by inspecting resolved deps (Open Q5) — a dep with `os`/`cpu`
+  constraints, platform-keyed `optionalDependencies`, or a native addon forces
+  the plugin into the per-platform path.
+- **Native/scripted plugins** produce per-platform artifacts; `node_modules/`
+  carries only the runtime files the bundle cannot inline (native addons,
+  downloaded binaries). This is the answer to "where do native deps live at
+  runtime" — they ship inside the artifact, produced once in CI.
+- The consumer never runs `bun install`; whatever the plugin needs at runtime is
+  already in the artifact.
+
+## Whiskin Contract
+
+Whiskin exposes one internal build contract used by `--dev` build, CI publish,
+and (deferred) remote source build. It also exposes a separate consumer-side
+materialize/verify contract.
+
+```ts
+// Build contract — runs in CI (publish) and on dev machines (--dev). Never on a
+// consumer machine.
+interface WhiskinBuildRequest {
+  pluginId: string
+  sourceDir: string
+  outputDir: string
+  mode: 'production' | 'development'
+  sourceKind: 'local-copy' | 'linked-source' | 'core'
+  platform: string            // build target, e.g. 'darwin-arm64'
+  allowInstallScripts: boolean
+  approvedScriptPackages: string[]
+  expectedBakinVersion: string
+}
+
+interface WhiskinBuildResult {
+  ok: true
+  manifest: PublicPluginManifest
+  buildId: string
+  sourceTreeSha: string
+  manifestSha: string
+  packageLockSha?: string
+  externalsContract: string
+  platform: string
+  outputs: {
+    serverEntry: string
+    clientEntry?: string
+    clientCss?: string
+    runtimeModules?: string[]  // native/runtime files kept in node_modules
+  }
+  provenance: WhiskinBuildProvenance
+}
+
+// Consumer contract — runs on every machine, including the released binary.
+interface WhiskinArtifactRequest {
+  pluginId: string
+  source: string              // parsed via packages/core/src/plugins/source.ts
+  platform: string
+  expectedBakinVersion: string
+}
+
+// Pluggable artifact resolution (Open Q2). v1 ships only the
+// github-release-assets implementation. Everything below resolve() —
+// download, checksum-verify, extract, validate, publish — is shared and
+// ecosystem-agnostic.
+interface WhiskinArtifactResolver {
+  scheme: string                              // 'github' (v1), later 'mirror' | 'npm' | ...
+  canResolve(source: ParsedSource): boolean
+  resolve(req: WhiskinArtifactRequest): Promise<WhiskinArtifactLocation | WhiskinFailure>
+}
+
+interface WhiskinArtifactLocation {
+  artifactUrl: string
+  checksum: string            // SHA256, from the signed-later whiskin-artifacts.json index
+  indexUrl: string
+  sourceCommitSha?: string
+}
+
+interface WhiskinArtifactResult {
+  ok: true
+  artifactPath: string        // verified, in staging
+  manifest: PublicPluginManifest
+  provenance: WhiskinBuildProvenance
+  checksum: string            // mandatory, verified in v1
+  signatureVerified?: boolean // reserved; signing deferred post-v1 (Open Q1)
+}
+
+interface WhiskinFailure {
+  ok: false
+  code:
+    | 'SOURCE_PARSE_FAILED'
+    | 'NO_PREBUILT_ARTIFACT'
+    | 'ARTIFACT_FETCH_FAILED'
+    | 'CHECKSUM_MISMATCH'
+    | 'SIGNATURE_INVALID'        // reserved; signing deferred post-v1 (Open Q1)
+    | 'MANIFEST_INVALID'
+    | 'BAKIN_RANGE_INCOMPATIBLE'
+    | 'EXTERNALS_CONTRACT_INCOMPATIBLE'
+    | 'UNSUPPORTED_PLATFORM'
+    // build-path only (CI/dev):
+    | 'DEPENDENCY_DECLARATION_INVALID'
+    | 'SCRIPT_CONSENT_REQUIRED'
+    | 'SCRIPT_BLOCKED'
+    | 'DEPENDENCY_INSTALL_FAILED'
+    | 'SERVER_BUILD_FAILED'
+    | 'CLIENT_BUILD_FAILED'
+    | 'OUTPUT_VALIDATION_FAILED'
+  message: string
+  details?: Record<string, unknown>
+}
+```
+
+Public CLI/API layers render stable error codes and concise messages. Raw `bun`
+output attaches to verbose logs only; it is not the contract.
+
+## Publish Pipeline
+
+Producers turn source into Lane-1 artifacts.
+
+`bakin plugins publish <pluginDir> [--platforms ...] [--allow-install-scripts]`:
+
+1. Validate manifest, dependency declarations, Bakin range, and script-trust
+   declarations.
+2. For each requested platform (locally only the host platform; full matrix in
+   CI):
+   - Materialize source to staging.
+   - Run Whiskin build with system `bun` (build + `bun install`).
+   - For native/scripted plugins, run the producer's consented install scripts.
+   - Validate outputs.
+   - Assemble the artifact tarball with `dist/`, required `node_modules/`, and
+     `.whiskin/build.json`.
+   - Emit checksum (signature deferred post-v1).
+3. Assemble `whiskin-artifacts.json` for this release: the rebuilt plugin's new
+   entries, **carried forward** with the previous latest index's entries for all
+   plugins not rebuilt (their absolute URLs still point at older releases). Attach
+   the index + new artifacts to the GitHub release. This makes each release a
+   complete catalog while letting plugins release independently.
+
+A reusable GitHub Action wraps the same command with a platform matrix so a
+hobbyist producer adds ~10 lines of workflow to get multi-platform artifacts.
+Pure-JS plugins need only the host platform job.
+
+## Source Materialization
+
+Lane-1 consumer install does **not** fetch source. It fetches the published
+artifact:
+
+1. Parse the source string through `packages/core/src/plugins/source.ts`,
+   keeping the existing `github:owner/repo@ref#subpath` and `--ref` behavior as
+   the single source of truth.
+2. Resolve owner/repo/ref/subpath and the platform.
+3. Resolve `whiskin-artifacts.json` to the artifact URL for that
+   plugin/version/platform: for "latest", read the `releases/latest/download/`
+   redirect; for a pinned `@tag`, read that tag's index. The matched entry's
+   absolute URL may point at an older release (carry-forward).
+4. Download the artifact + checksum over HTTPS (signature deferred post-v1).
+5. Verify checksum and provenance compatibility.
+6. Extract into staging with path-traversal / zip-slip protection,
+   escaping-symlink rejection, and a size cap.
+7. Record provenance in the lockfile.
+
+Lane-2 dev build uses the local checkout directly (no fetch). For exact upstream
+provenance, publish records the commit SHA in the artifact at build time, so the
+consumer inherits a real commit SHA without needing the GitHub API at install.
+
+`bakin plugins list --check` for artifact-installed plugins compares the
+installed artifact version against the latest `whiskin-artifacts.json` via the
+`releases/latest/download/` redirect over HTTPS — no GitHub API, no rate limit,
+not `git ls-remote`.
+
+## Dependency Install And Script Trust
+
+Dependency installation happens **only in the build path (CI/dev)**, never on a
+consumer.
+
+Default build mode:
+
+- Install only runtime dependencies needed to build/activate the plugin.
+- Use Whiskin-controlled cache directories.
+- Run `bun install` with `--ignore-scripts` by default.
+- Allow Bun's package-level `trustedDependencies` only for packages explicitly
+  declared in the manifest and consented by the **producer** at publish time.
+- No wildcard package trust.
+- Bounded timeouts and output capture; staging only.
+
+Elevated install-script mode (publish/dev only):
+
+- Requires manifest-declared packages, each with reason + platforms.
+- Requires producer consent at publish time (`--allow-install-scripts` or
+  interactive prompt). This is the producer's machine/CI, not the consumer's.
+- Records approved package **name + version** (not just name), platform, Whiskin
+  version, build backend, and result in `.whiskin/build.json`.
+- Re-consent is keyed on package identity (name + version) or `packageLockSha`,
+  so a version bump of an already-trusted scripted package re-prompts rather
+  than silently running new code.
+
+Consumer side:
+
+- The consumer never runs install scripts. It verifies the artifact checksum and
+  the `approvedInstallScripts` provenance, and may surface what scripts ran at
+  publish time for transparency.
+
+## Build Outputs
+
+Lane-1 installed layout (extracted artifact):
+
+```text
+~/.bakin/plugins/<id>/
+  bakin-plugin.json
+  dist/
+    index.js
+    client.js        optional
+    client.css       optional
+  node_modules/       only when the plugin has native/runtime deps
+  .whiskin/
+    build.json
+```
+
+The runtime registry imports only `dist/index.js` for user plugins. `dist/` and
+`node_modules/` are artifact contents — not committed in producer repos, safe to
+delete and re-fetch, covered by checksummed provenance.
+
+Lane-2 dev layout is the developer's own checkout plus a locally built `dist/`
+(gitignored).
+
+## Build Provenance
+
+Whiskin writes a build record into the artifact at publish time:
+
+```json
+{
+  "version": 2,
+  "pluginId": "messaging",
+  "pluginVersion": "0.1.0",
+  "bakinVersion": "0.0.1-rc.15",
+  "bakinRange": ">=0.0.1-rc.15 <0.1.0",
+  "whiskinVersion": "1",
+  "buildBackend": "system-bun",
+  "platform": "darwin-arm64",
+  "sourceCommitSha": "...",
+  "sourceTreeSha": "...",
+  "manifestSha": "...",
+  "packageLockSha": "...",
+  "externalsContract": "react19-sdk-makinbakin-v1",
+  "approvedInstallScripts": [
+    {
+      "package": "sharp",
+      "version": "0.34.5",
+      "reason": "Installs platform image-processing binaries"
+    }
+  ],
+  "outputs": {
+    "serverEntry": "dist/index.js",
+    "clientEntry": "dist/client.js",
+    "runtimeModules": ["node_modules/sharp"]
+  },
+  "builtAt": "2026-06-04T00:00:00.000Z"
+}
+```
+
+Startup uses this record (plus checksum verification) to decide whether
+artifacts are valid. It does not rebuild on the normal cold-start path.
+
+## Install Transaction
+
+Lane-1 consumer install is all-or-nothing:
+
+1. Parse source; resolve platform + artifact URL.
+2. Download artifact + checksum into staging (signature deferred post-v1).
+3. Verify checksum, manifest, permissions, Bakin range, and `externalsContract`
+   compatibility.
+4. Run permission consent gates.
+5. Extract into staging (zip-slip / symlink / size guarded).
+6. Install plugin-owned defaults/assets from staging if needed.
+7. Atomically replace or publish `~/.bakin/plugins/<id>`.
+8. Extend the lockfile entry with artifact provenance, checksum, approved script
+   packages, and source metadata (signature status reserved post-v1).
+9. Live-activate if the registry is running, using a cache-busted `import()` so
+   an upgrade does not load a stale module.
+
+If any step before publish fails, active plugin state is unchanged. If live
+activation fails after publish, Bakin reports a clear activation failure and
+retains enough state for rollback or doctor repair. Upgrade follows the same
+shape with prior-state rollback.
+
+Lockfile schema changes are additive and version-gated so a code rollback can
+still read newer lockfiles (forward-compatible parsing).
+
+## Browser Loading Direction
+
+**Important framing:** prebuilt artifacts do **not** speed up the browser. Plugin
+client bundles are already prebuilt today — the browser imports `client.js`, it
+never builds. The build/distribution rework speeds up *install* and *server
+startup* (the startup-verifier phase stops rebuilding at boot), not the browser. The user-visible
+"Loading plugins" delay is fixed **only** by this section, which is decoupled
+from Whiskin and should ship first.
+
+The delay's actual cause (`PluginHost.tsx`): the host `Promise.all`-imports
+**every** plugin's full `client.js` and waits for all of them to download +
+execute before rendering the shell. Today that is ~1.2 MB of core-plugin client
+JS plus user/official plugins (e.g. the official `messaging` client.js is
+~690 KB), eagerly, every cold load.
+
+**This is not a host-only change.** Investigation of the current code shows:
+
+- `registerPlugin` (`packages/sdk/src/register.ts`) takes `routes`/`slots` as
+  **eager `ComponentType` references**, not lazy factories.
+- Each plugin's `client.tsx` imports all its page components at module top and
+  passes them to `registerPlugin`, so importing `client.js` pulls the whole
+  bundle's code just to register a nav item.
+- Plugins build as a **single bundle, no code-splitting**.
+- Nav items are **not** in the manifest — they exist only after `client.js`
+  executes.
+
+CHOSEN APPROACH (2026-06-04): **(a) Declarative metadata in the manifest.** Move
+nav/route/slot metadata into `bakin-plugin.json` (extending the existing
+`contributes.clientRoutes` precedent), so the sidebar renders from manifest JSON
+without executing any `client.js`; a plugin's bundle imports only on first
+navigation into one of its routes. Chosen over (b) lazy-factories+code-splitting
+because it gives the bigger boot win (zero plugin JS for unvisited plugins),
+avoids code-splitting (the riskiest interaction with the import-map / externals /
+per-plugin versioned hot-reload machinery), and builds on a pattern already in
+the repo. Param routes (`/tasks/[id]`) are fully supported — the path pattern is
+declared, the component lazy-loads. The known costs are accepted and mitigated:
+
+- **Drift** (manifest declares a path/nav the runtime registration doesn't
+  supply, or vice versa) → a validation check at build/publish + a startup
+  diagnostic.
+- **Conditional/dynamic nav visibility** is not expressible in static manifest
+  JSON. Not needed today (no conditional nav exists). Addressable later, per
+  plugin, via the retained **runtime-registration escape hatch** for `eager:
+  true` plugins — no rework required. (b)'s per-route code-splitting likewise
+  remains a future optimization layerable on top of (a) for any single oversized
+  plugin.
+
+Target behavior:
+
+- The shell renders after the manifest fetch + a small eager registration step
+  only.
+- Most plugin route component code loads when the route is first visited.
+- Background providers (e.g. the `nav-badge-providers` slot) opt in with
+  explicit `eager: true`.
+- Failed lazy imports surface plugin-local errors without blanking the app.
+
+This is still independent of the build/artifact/install pipeline (so it ships
+first), but it is a real SDK-contract + per-plugin change, not a one-file swap.
+
+## Security Boundaries
+
+Always:
+
+- Consumers verify the mandatory SHA256 checksum + provenance before extracting
+  an artifact (signature verification is deferred post-v1; see Open Question 1).
+  Treat artifacts as untrusted input regardless: guard extraction against
+  zip-slip / path traversal, cap decompressed size, and **reject symlink entries
+  that resolve outside the extraction root**. Note the tension: artifacts for
+  native plugins ship `node_modules/`, which can contain internal symlinks — so
+  the rule is "reject escaping symlinks," not "reject all symlinks," OR the
+  publish step packs `node_modules/` hoisted/symlink-free. (Pure-JS plugins ship
+  no `node_modules/`, so this only affects native plugins, of which there are
+  none today.)
+- Build from source in staging (CI/dev), validate manifests before dependency
+  install, reject imports from app internals, `@bakin/core`, old `@bakin/sdk`,
+  and undeclared third-party packages.
+- Reject third-party dependencies that themselves import React or another
+  host-singleton, so the "one React, one SDK" invariant holds. Such deps must be
+  externalized by the host or refused.
+- Keep host-provided externals explicit and one React / one SDK per instance.
+- Disable broad install-script execution by default; record elevated trust with
+  package name + version in checksummed provenance and the lockfile.
+- Redact raw command output in user-facing errors.
+- Be explicit that Whiskin gates **install-time** script execution only. All
+  plugin code is fully trusted **at runtime** — there is no runtime sandbox. A
+  pure-JS dependency with no install script still runs arbitrary code in-process
+  at activation. Consent prompts must not imply otherwise.
+
+Ask first:
+
+- Allowing install scripts for package dependencies (producer consent at
+  publish).
+- Supporting native/system dependencies for an official plugin.
+- Adding a new host-provided external.
+- Changing the plugin manifest build-trust schema after it is published.
+- Distributing or rotating artifact-signing keys.
+
+Never:
+
+- Build a plugin on a consumer machine.
+- Commit plugin `dist/` in repos that serve plugins.
+- Import user plugin source directly at runtime.
+- Mutate active plugin state before verification/build succeeds.
+- Require normal users to install Bun, Node, npm, or git.
+- Treat `BUN_BE_BUN=1` as public API, or rely on it in the consumer path.
+- Allow wildcard trusted install scripts.
+
+## Deferred: Remote Source Build
+
+Compiling a remote (non-published) plugin on the installing machine is
+explicitly out of v1 scope. It is the only case that would require either system
+Bun on a consumer machine or a `BUN_BE_BUN` self-invoke in the compiled binary.
+
+If revisited later, it is a **developer-only** convenience: `install
+github:owner/repo#sub` on a machine **with system Bun present** may build the
+remote source locally. It is never offered on a machine without system Bun, and
+never on the non-developer happy path. The `BUN_BE_BUN` self-invoke remains
+rejected unless a concrete, measured need appears that the publish model cannot
+serve.
+
+## Host Upgrade Compatibility
+
+When a Bakin release bumps React or the SDK externals contract, installed
+artifacts whose provenance `externalsContract` no longer matches are marked
+**needs-update**, not silently inactive-forever. The repair path is to fetch a
+newer compatible **published artifact** (a normal download), not a local
+rebuild. Doctor surfaces this and can perform the re-fetch. This avoids the
+"upgrade Bakin → all plugins vanish until manual rebuild" failure mode, and is
+consistent with "consumers never build."
+
+## Testing Strategy
+
+1. Unit: source parsing (the unified parser), artifact resolution, checksum
+   verification, provenance read/write/validate, source hashing, manifest
+   build-schema parsing, dependency scanning, script-trust (name+version
+   re-consent), externals-contract compatibility.
+2. Consumer-path: artifact download/verify/extract with hermetic fixtures (a
+   local fixture artifact server; no real network, no `~/.bakin`, no `~/.openclaw`
+   — per the project testing rules). Cover `NO_PREBUILT_ARTIFACT`,
+   `CHECKSUM_MISMATCH`, zip-slip rejection, escaping-symlink rejection, size-cap.
+3. Build-path: Whiskin build via system `bun` against source-only fixtures (v1
+   pure-JS; a native/scripted fixture lands with the deferred Phase 7). Use a
+   vendored offline dependency fixture or a local registry — no live npm.
+4. Shared install core / transaction (both primitives): failed verification or
+   extract does not mutate active plugin/agent-package directories or lockfiles;
+   failed upgrade keeps the prior artifact active; rollback unwinds cleanly. The
+   P0 agent-package characterization suite must stay green through the
+   convergence.
+5. Dev-link hot reload: build failures keep the old plugin active; successes
+   hot-swap; uses system `bun`, works whether Bakin runs as source or compiled
+   binary.
+6. Publish pipeline: `bakin plugins publish` emits a verifiable artifact +
+   checksum + carried-forward index (signature deferred post-v1).
+7. Browser: lazy plugin-client loading (declarative manifest metadata) and
+   failed-lazy-import behavior.
+
+## Commands
+
+Focused tests expected during implementation:
+
+```sh
+bun test --isolate tests/core/whiskin/*.test.ts
+bun test --isolate tests/api/plugins-build.test.ts
+bun test --isolate tests/plugins/lifecycle/install-artifact.test.ts
+bun test --isolate tests/plugins/lifecycle/install-subpath.test.ts
+bun test --isolate tests/plugins/lifecycle/upgrade-flow.integration.test.ts
+bun test --isolate tests/plugins/lifecycle/hot-reload-integration.test.ts
+bun test --isolate tests/components/plugin-host.test.tsx
+```
+
+Build/release checks:
+
+```sh
+bun run typecheck
+bun test --isolate
+bun run build:vendors
+bun run build:plugins
+bun run build:host-shell
+bun run build:assert-production-assets
+bun run build:binary
+```
+
+Manual smoke (consumer path, no toolchain):
+
+```sh
+BAKIN_HOME=/tmp/bakin-whiskin-home ./dist/bakin-darwin-arm64 \
+  plugins install github:markhayden/bakin-bits-official#plugins/messaging
+```
+
+Manual smoke (producer publish):
+
+```sh
+bakin plugins publish ./plugins/messaging --platforms darwin-arm64
+```
+
+## Open Questions
+
+1. RESOLVED (2026-06-04): **Checksum-only for all plugins in v1; signing
+   deferred.** Every artifact ships a mandatory SHA256 that the consumer
+   verifies on download (catches corruption/MITM). No keys, no signing, no
+   Bakin-release coupling — any developer publishes a tarball + checksum and
+   anyone installs it with zero ceremony, which is the core goal. Authenticity
+   signing (an "official producer" badge) is a later upgrade, justified only the
+   day a third party could plausibly impersonate the official producer. The
+   artifact format already reserves an optional `.sig` asset + the signed-index
+   shape, so signing slots in without a rewrite. If/when added, the likely path
+   is an Ed25519 official key anchored in the already-notarized Bakin binary,
+   with third-party staying checksum-only.
+2. RESOLVED (2026-06-04): **Pluggable artifact resolver; GitHub release assets
+   are the only v1 backend.** Artifact resolution goes through a
+   `WhiskinArtifactResolver` interface (`scheme` + `canResolve` + `resolve`)
+   whose sole job is to turn a parsed source ref into a verified-against-checksum
+   artifact location (or buildable source). Everything downstream — download,
+   checksum-verify, extract, validate, publish, activate — sits *below* the
+   resolver and is ecosystem-agnostic (never references GitHub/npm directly),
+   mirroring how `source.ts` is the single source-parse point. v1 ships exactly
+   one resolver: github-release-assets. A self-hosted mirror is a pure
+   location/transport adapter (one new `resolve()`, zero downstream changes). A
+   foreign ecosystem (npm/JSR/OCI; pip is not a fit for JS plugins) is a new
+   adapter that maps the registry's response into our artifact/source shape — a
+   new resolver, not an install rewrite. v1 assumes **public** repos; private-repo
+   token auth is deferred. `--check` polls the release's `whiskin-artifacts.json`
+   over HTTPS (a release-asset fetch, not the rate-limited GitHub API), which
+   partly subsumes Open Question 3.
+3. RESOLVED (2026-06-04): **Per-release immutable index + `releases/latest`
+   redirect + carry-forward, enabling independent per-plugin releases.**
+   - Each GitHub release attaches an **immutable** `whiskin-artifacts.json`.
+   - Index entries carry **absolute** artifact URLs, so an entry may point at a
+     tarball attached to an *older* release.
+   - On publish, the tool **carries forward** unchanged plugins' entries from the
+     previous latest index, so the latest index is always a **complete catalog**
+     even when a release rebuilt only one plugin. This is what lets plugins in a
+     monorepo release **independently** (clear blast radius; scales to many
+     plugins) without forcing a full re-publish each time.
+   - "Latest" is read via GitHub's stable, unauthenticated, **non-API** redirect
+     `https://github.com/owner/repo/releases/latest/download/whiskin-artifacts.json`
+     — no rate limit, no API call. `--check` uses the same URL.
+   - Pinned installs (`@tag`) read that tag's index directly at
+     `releases/download/<tag>/whiskin-artifacts.json`.
+4. RESOLVED (2026-06-04):
+   - **Script trust: single field `build.installScripts`.** Gate on the real
+     risk (a package running a lifecycle/postinstall script), not on
+     "native" — a pure-JS package can have a malicious postinstall and a native
+     package can ship prebuilt binaries with no script, so "native" is
+     explanatory metadata, not the trust boundary. There is no
+     `nativeDependencies` field. Each entry: `package`, `version` (a declared
+     range that must match the resolved version at publish; the lockfile records
+     the exact resolved version and drives name+version re-consent), `reason`,
+     and `platforms` (producer's proven-on claim; build fails
+     `UNSUPPORTED_PLATFORM` if the build platform isn't listed).
+   - **Compatibility: reuse the existing manifest `bakin` field** (the official
+     plugins already use `"bakin": ">=0.0.1-rc.1"` — do NOT introduce a separate
+     `bakinRange` field). It is an explicit semver range string, evaluated with
+     `includePrerelease: true`. Pre-1.0 + RC tags (`0.0.1-rc.15`) make
+     caret/tilde shorthand a foot-gun (standard semver excludes prereleases from
+     `^0.0.1`, and `0.0.z` treats every patch as breaking), so require an explicit
+     two-sided range like `">=0.0.1-rc.15 <0.1.0"`. The `bakin` field is
+     **optional**; when omitted (or only a floor like `>=x`), `bakin plugins
+     publish` stamps a range derived from the Bakin version it built against
+     (`>=<built-version> <next-minor>`) into provenance — honest by construction,
+     never broader than what was built. Provenance stores the resolved range as
+     `bakinRange`; the manifest authoring field stays `bakin`. Mismatch →
+     `BAKIN_RANGE_INCOMPATIBLE` at install, `needs-update` at startup after a host
+     upgrade.
+5. RESOLVED (2026-06-04): **Default to one platform-neutral artifact, but
+   `bakin plugins publish` detects platform-sensitivity and forces a matrix.**
+   Publish inspects resolved dependency metadata (after `bun install`) and marks
+   the plugin platform-specific if any dep has `os`/`cpu` constraints,
+   platform-keyed `optionalDependencies` (esbuild/swc/lightningcss-style), or a
+   native addon. Platform-specific → require per-platform artifacts (or fail with
+   a clear "not pure-JS; declare platforms"). Genuinely pure plugins stay
+   single-artifact and frictionless. The tool checks reality rather than trusting
+   the producer to self-classify — same spirit as deriving `bakinRange` from the
+   build.
+6. RESOLVED (2026-06-04): **Lazy browser loading ships first, in its own PR,
+   ahead of the builder rework.** It is the actual user-visible #267 complaint,
+   is fully decoupled (a self-contained host + SDK-registration change to replace
+   the `Promise.all` eager import in `PluginHost.tsx`; touches none of the
+   build/artifact/install machinery), and has a clean independent rollback. Plan
+   sequences it as Phase 1 / C1. Not gated behind the distribution rework.
+```

--- a/packages/core/src/agent-packages/lockfile.ts
+++ b/packages/core/src/agent-packages/lockfile.ts
@@ -11,8 +11,9 @@
  * never touch the filesystem. `readLockfile` and `writeLockfile` are the only
  * IO entry points.
  */
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
-import { dirname, join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { atomicWriteJson } from '../install-core/atomic-write'
 import { z } from 'zod'
 import { getContentDir } from '../content-dir'
 
@@ -120,23 +121,9 @@ export function readLockfile(path: string = getLockfilePath()): Lockfile {
  * output of pure mutators directly without separate validation.
  */
 export function writeLockfile(lock: Lockfile, path: string = getLockfilePath()): void {
-  // Validate up-front so a malformed in-memory value never lands on disk.
-  const validated = LockfileSchema.parse(lock)
-  mkdirSync(dirname(path), { recursive: true })
-  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`
-  try {
-    writeFileSync(tmpPath, JSON.stringify(validated, null, 2) + '\n', 'utf-8')
-    renameSync(tmpPath, path)
-  } catch (err) {
-    if (existsSync(tmpPath)) {
-      try {
-        unlinkSync(tmpPath)
-      } catch {
-        // best-effort cleanup; surface the original error
-      }
-    }
-    throw err
-  }
+  // Validate up-front so a malformed in-memory value never lands on disk, then
+  // hand off to the shared atomic writer.
+  atomicWriteJson(path, LockfileSchema.parse(lock))
 }
 
 // ─── Pure mutators (no fs) ───────────────────────────────────────────────────

--- a/packages/core/src/install-core/atomic-write.ts
+++ b/packages/core/src/install-core/atomic-write.ts
@@ -1,0 +1,36 @@
+/**
+ * Atomic JSON write for the install core.
+ *
+ * The plugin lockfile and the agent-package lockfile carried identical
+ * tmp-file-plus-rename write bodies (down to the temp-name scheme and the
+ * best-effort cleanup-on-throw). This owns those mechanics once so they can't
+ * drift; callers still validate their own schema before calling.
+ *
+ * Part of the Whiskin shared install core (Phase 5).
+ */
+import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import { dirname } from 'path'
+
+/**
+ * Atomically write `value` as pretty-printed JSON to `path` (temp file +
+ * rename), creating parent dirs as needed. On failure the temp file is cleaned
+ * up best-effort and the original error is rethrown — a partial or corrupt
+ * write never lands at `path`.
+ */
+export function atomicWriteJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`
+  try {
+    writeFileSync(tmpPath, JSON.stringify(value, null, 2) + '\n', 'utf-8')
+    renameSync(tmpPath, path)
+  } catch (err) {
+    if (existsSync(tmpPath)) {
+      try {
+        unlinkSync(tmpPath)
+      } catch {
+        // best-effort cleanup; surface the original error
+      }
+    }
+    throw err
+  }
+}

--- a/packages/core/src/install-core/source-guards.ts
+++ b/packages/core/src/install-core/source-guards.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared source-string guards for the install core.
+ *
+ * The plugin install parser (`packages/core/src/plugins/source.ts`) and the
+ * agent-package parser (`src/core/agent-packages/source-fetcher.ts`)
+ * historically carried byte-for-byte identical `#subpath` validation, with only
+ * their error messages differing — a textbook drift surface (one copy could
+ * tighten or loosen a rule the other didn't). This module owns the RULES once;
+ * each parser maps a violation to its own typed error + message, so observable
+ * behavior is unchanged while the rules can no longer diverge.
+ *
+ * First extraction of the Whiskin shared install core (Phase 5). The two
+ * install paths converge here further in later slices (materialization,
+ * transaction, lockfile IO, provenance). See
+ * `.claude/specs/whiskin-plugin-builder-plan.md` (Phase 5).
+ */
+
+/** Characters permitted in a monorepo `#subpath`. */
+export const SUBPATH_PATTERN = /^[A-Za-z0-9._/-]+$/
+
+export type SubpathViolation =
+  | 'empty'
+  | 'invalid-chars'
+  | 'leading-or-trailing-slash'
+  | 'dot-segment'
+
+/**
+ * Validate a `#subpath` (the part after `#` in a source string) against the
+ * shared rules. Returns the first violation, or `null` when valid. Pure — never
+ * throws — so each caller renders its own error type and message.
+ */
+export function checkSubpath(subpath: string): SubpathViolation | null {
+  if (subpath.length === 0) return 'empty'
+  if (!SUBPATH_PATTERN.test(subpath)) return 'invalid-chars'
+  if (subpath.startsWith('/') || subpath.endsWith('/')) return 'leading-or-trailing-slash'
+  if (subpath.split('/').some((segment) => segment === '..' || segment === '.')) {
+    return 'dot-segment'
+  }
+  return null
+}

--- a/packages/core/src/plugins/lockfile.ts
+++ b/packages/core/src/plugins/lockfile.ts
@@ -13,8 +13,9 @@
  * Mirrors `packages/core/src/agent-packages/lockfile.ts` style by design —
  * one mental model, one IO pattern across both ledgers.
  */
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
-import { dirname, join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { atomicWriteJson } from '../install-core/atomic-write'
 import { z } from 'zod'
 import { getContentDir } from '../content-dir'
 import { PermissionSchema } from './permissions'
@@ -243,23 +244,9 @@ export function writePluginLockfile(
   lock: PluginLockfile,
   path: string = getPluginLockfilePath(),
 ): void {
-  // Validate up-front so a malformed in-memory value never lands on disk.
-  const validated = PluginLockfileSchema.parse(lock)
-  mkdirSync(dirname(path), { recursive: true })
-  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`
-  try {
-    writeFileSync(tmpPath, JSON.stringify(validated, null, 2) + '\n', 'utf-8')
-    renameSync(tmpPath, path)
-  } catch (err) {
-    if (existsSync(tmpPath)) {
-      try {
-        unlinkSync(tmpPath)
-      } catch {
-        // best-effort cleanup; surface the original error
-      }
-    }
-    throw err
-  }
+  // Validate up-front so a malformed in-memory value never lands on disk, then
+  // hand off to the shared atomic writer.
+  atomicWriteJson(path, PluginLockfileSchema.parse(lock))
 }
 
 // ─── Defense-in-depth: core-plugin guard ─────────────────────────────────────

--- a/packages/core/src/plugins/source.ts
+++ b/packages/core/src/plugins/source.ts
@@ -20,6 +20,8 @@
  * input (CLI/REST) and re-validates defensively.
  */
 
+import { checkSubpath } from '../install-core/source-guards'
+
 export interface ParsedGithubSource {
   /** Positional URL for `git clone` / `git ls-remote`. */
   cloneUrl: string
@@ -50,19 +52,19 @@ const MAX_CLONE_URL_BYTES = 2048
  * the caller can map it to a useful HTTP/CLI message.
  */
 function assertSubpathValid(subpath: string): void {
-  if (subpath.length === 0) {
-    throw new InvalidGithubSourceError('subpath after `#` must not be empty')
-  }
-  if (!/^[A-Za-z0-9._/-]+$/.test(subpath)) {
-    throw new InvalidGithubSourceError(
-      `subpath must match /^[A-Za-z0-9._/-]+$/ — got "${subpath}"`,
-    )
-  }
-  if (subpath.startsWith('/') || subpath.endsWith('/')) {
-    throw new InvalidGithubSourceError('subpath must not start or end with "/"')
-  }
-  if (subpath.split('/').some(seg => seg === '..' || seg === '.')) {
-    throw new InvalidGithubSourceError('subpath must not contain `..` or `.` segments')
+  // Rules live in the shared install-core guard; this function owns only the
+  // plugin-side error type + message wording (preserved exactly).
+  switch (checkSubpath(subpath)) {
+    case 'empty':
+      throw new InvalidGithubSourceError('subpath after `#` must not be empty')
+    case 'invalid-chars':
+      throw new InvalidGithubSourceError(
+        `subpath must match /^[A-Za-z0-9._/-]+$/ — got "${subpath}"`,
+      )
+    case 'leading-or-trailing-slash':
+      throw new InvalidGithubSourceError('subpath must not start or end with "/"')
+    case 'dot-segment':
+      throw new InvalidGithubSourceError('subpath must not contain `..` or `.` segments')
   }
 }
 

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -26,22 +26,11 @@ import { basename, join, resolve } from 'node:path'
 import { builtinModules } from 'node:module'
 import { readPluginLockfile, type PluginLockEntry } from '@bakin/core/plugins/lockfile'
 import { startStartupSpan, type StartupDiagnosticLogger } from '@/core/startup-diagnostics'
+import { PLUGIN_CLIENT_EXTERNALS, PLUGIN_SERVER_EXTERNALS } from '@/core/whiskin/externals'
 
-const CLIENT_EXTERNAL = [
-  'react', 'react-dom', 'react-dom/client',
-  'react/jsx-runtime', 'react/jsx-dev-runtime',
-  '@tanstack/react-router',
-  '@makinbakin/sdk', '@makinbakin/sdk/ui', '@makinbakin/sdk/hooks',
-  '@makinbakin/sdk/components', '@makinbakin/sdk/slots',
-  '@makinbakin/sdk/types', '@makinbakin/sdk/utils',
-  '@makinbakin/sdk/metadata', '@makinbakin/sdk/routing',
-]
-
-const SERVER_EXTERNAL = [
-  'react', 'react-dom', 'react-dom/client',
-  'react/jsx-runtime', 'react/jsx-dev-runtime',
-  '@tanstack/react-router',
-]
+// Single source for the externals contract — see src/core/whiskin/externals.ts.
+const CLIENT_EXTERNAL = PLUGIN_CLIENT_EXTERNALS
+const SERVER_EXTERNAL = PLUGIN_SERVER_EXTERNALS
 
 const REPO_ROOT = resolve(import.meta.dir, '../../../..')
 const SDK_ENTRYPOINTS: Record<string, string> = {

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -23,10 +23,10 @@ import { existsSync, statSync, readdirSync, readFileSync } from 'node:fs'
 import type { Dirent } from 'node:fs'
 import { spawn } from 'node:child_process'
 import { basename, join, resolve } from 'node:path'
-import { builtinModules } from 'node:module'
 import { readPluginLockfile, type PluginLockEntry } from '@bakin/core/plugins/lockfile'
 import { startStartupSpan, type StartupDiagnosticLogger } from '@/core/startup-diagnostics'
 import { PLUGIN_CLIENT_EXTERNALS, PLUGIN_SERVER_EXTERNALS } from '@/core/whiskin/externals'
+import { validatePluginImports, NON_RUNTIME_DIRS, type PluginPackageJson } from '@/core/whiskin/import-scan'
 
 // Single source for the externals contract — see src/core/whiskin/externals.ts.
 const CLIENT_EXTERNAL = PLUGIN_CLIENT_EXTERNALS
@@ -45,27 +45,7 @@ const SDK_ENTRYPOINTS: Record<string, string> = {
   '@makinbakin/sdk/routing': join(REPO_ROOT, 'packages/sdk/src/routing/index.ts'),
 }
 
-const HOST_PROVIDED_IMPORTS = new Set([
-  ...CLIENT_EXTERNAL,
-])
 const JSX_DEV_RUNTIME_RE = /(?:react\/jsx-dev-runtime|\bjsxDEV\b)/
-const BUILTIN_IMPORTS = new Set([
-  ...builtinModules,
-  ...builtinModules.map((name) => `node:${name}`),
-])
-const SOURCE_EXT_RE = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/
-const NON_RUNTIME_DIRS = new Set(['dist', 'node_modules', 'tests', '__tests__', 'coverage'])
-const OLD_SDK_PACKAGE_NAME = '@bakin' + '/sdk'
-type SourceLoader = 'ts' | 'tsx' | 'js' | 'jsx'
-interface BunImportScanEntry {
-  path?: string
-}
-interface BunImportScanner {
-  scanImports(source: string): BunImportScanEntry[]
-}
-const BunTranspiler = (Bun as unknown as {
-  Transpiler: new (options: { loader: SourceLoader }) => BunImportScanner
-}).Transpiler
 
 interface RunResult {
   exitCode: number
@@ -183,45 +163,6 @@ function isFreshClientDist(path: string): boolean {
   }
 }
 
-interface PluginPackageJson {
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
-  peerDependencies?: Record<string, string>
-}
-
-function packageName(specifier: string): string {
-  if (specifier.startsWith('@')) {
-    const [scope, name] = specifier.split('/')
-    return `${scope}/${name}`
-  }
-  return specifier.split('/')[0]!
-}
-
-function isRelativeOrAbsoluteSpecifier(specifier: string): boolean {
-  return specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')
-}
-
-function collectSourceFiles(dir: string): string[] {
-  const out: string[] = []
-  const walk = (current: string): void => {
-    let entries: Dirent[]
-    try {
-      entries = readdirSync(current, { withFileTypes: true }) as Dirent[]
-    } catch {
-      return
-    }
-    for (const entry of entries) {
-      const name = String(entry.name)
-      if (NON_RUNTIME_DIRS.has(name) || name.startsWith('.')) continue
-      const full = join(current, name)
-      if (entry.isDirectory()) walk(full)
-      else if (entry.isFile() && SOURCE_EXT_RE.test(name)) out.push(full)
-    }
-  }
-  walk(dir)
-  return out
-}
-
 function readPackageJson(pluginDir: string): PluginPackageJson {
   const pkgJsonPath = join(pluginDir, 'package.json')
   if (!existsSync(pkgJsonPath)) return {}
@@ -232,64 +173,6 @@ function readPackageJson(pluginDir: string): PluginPackageJson {
       throw new Error(`Invalid package.json in ${pluginDir}: ${err.message}`)
     }
     throw err
-  }
-}
-
-function sourceLoader(file: string): SourceLoader {
-  if (file.endsWith('.tsx')) return 'tsx'
-  if (file.endsWith('.ts')) return 'ts'
-  if (file.endsWith('.jsx')) return 'jsx'
-  return 'js'
-}
-
-function collectImportSpecifiers(file: string, source: string): string[] {
-  try {
-    const transpiler = new BunTranspiler({ loader: sourceLoader(file) })
-    return transpiler
-      .scanImports(source)
-      .map((entry) => entry.path)
-      .filter((specifier): specifier is string => typeof specifier === 'string' && specifier.length > 0)
-  } catch (err) {
-    throw new Error(`Failed to parse imports in ${file}: ${err instanceof Error ? err.message : String(err)}`)
-  }
-}
-
-function validatePluginImports(pluginDir: string, pkg: PluginPackageJson): void {
-  const declared = new Set([
-    ...Object.keys(pkg.dependencies ?? {}),
-    ...Object.keys(pkg.devDependencies ?? {}),
-    ...Object.keys(pkg.peerDependencies ?? {}),
-  ])
-  const violations: string[] = []
-
-  for (const file of collectSourceFiles(pluginDir)) {
-    const source = readFileSync(file, 'utf-8')
-    for (const specifier of collectImportSpecifiers(file, source)) {
-      if (!specifier || isRelativeOrAbsoluteSpecifier(specifier) || BUILTIN_IMPORTS.has(specifier)) continue
-
-      if (specifier === OLD_SDK_PACKAGE_NAME || specifier.startsWith(`${OLD_SDK_PACKAGE_NAME}/`)) {
-        violations.push(`${file}: ${specifier} is no longer supported; use @makinbakin/sdk`)
-        continue
-      }
-      if (specifier === '@bakin/core' || specifier.startsWith('@bakin/core/') || specifier.startsWith('@bakin/')) {
-        violations.push(`${file}: ${specifier} imports Bakin internals; use @makinbakin/sdk or a declared plugin API`)
-        continue
-      }
-      if (specifier.startsWith('@/')) {
-        violations.push(`${file}: ${specifier} imports app internals; use @makinbakin/sdk or a declared plugin API`)
-        continue
-      }
-      if (HOST_PROVIDED_IMPORTS.has(specifier)) continue
-
-      const pkgName = packageName(specifier)
-      if (!declared.has(pkgName)) {
-        violations.push(`${file}: ${specifier} is not declared in package.json dependencies`)
-      }
-    }
-  }
-
-  if (violations.length > 0) {
-    throw new Error(`Plugin dependency validation failed:\n${violations.join('\n')}`)
   }
 }
 

--- a/scripts/build-plugins.ts
+++ b/scripts/build-plugins.ts
@@ -14,6 +14,7 @@
  * from the browser's point of view.
  */
 import { buildOnePlugin } from './dev-build-one-plugin'
+import { PLUGIN_CLIENT_EXTERNALS } from '../src/core/whiskin/externals'
 
 const CORE_PLUGINS = [
   'tasks', 'team', 'memory', 'models',
@@ -21,15 +22,8 @@ const CORE_PLUGINS = [
   'health', 'git',
 ]
 
-const EXTERNAL = [
-  'react', 'react-dom', 'react-dom/client',
-  'react/jsx-runtime', 'react/jsx-dev-runtime',
-  '@tanstack/react-router',
-  '@makinbakin/sdk', '@makinbakin/sdk/ui', '@makinbakin/sdk/hooks',
-  '@makinbakin/sdk/components', '@makinbakin/sdk/slots',
-  '@makinbakin/sdk/types', '@makinbakin/sdk/utils',
-  '@makinbakin/sdk/metadata', '@makinbakin/sdk/routing',
-]
+// Single source for the externals contract — see src/core/whiskin/externals.ts.
+const EXTERNAL = PLUGIN_CLIENT_EXTERNALS
 
 for (const id of CORE_PLUGINS) {
   const result = await buildOnePlugin(id, { external: EXTERNAL, production: true })

--- a/src/core/agent-packages/install-lock.ts
+++ b/src/core/agent-packages/install-lock.ts
@@ -1,88 +1,34 @@
 /**
- * Advisory install lock at ~/.bakin/packages/.lock — prevents two
- * concurrent `bakin agents install` invocations from racing on the
- * lockfile or overlapping projection targets.
+ * Advisory install lock at ~/.bakin/packages/.lock — prevents two concurrent
+ * `bakin agents install` / `bakin packages install` invocations from racing on
+ * the lockfile or overlapping projection targets.
  *
- * Release semantics: best-effort cleanup. Process exit removes the
- * lock automatically because we hold it through the lifetime of a
- * single `acquireInstallLock()` → `releaseInstallLock()` pair, never
- * across requests. Stale locks (left over from a crashed process)
- * are detected via PID liveness check.
+ * Thin wrapper over the shared install-core lock primitive (Whiskin P5). The
+ * agent lock path and this module's public API (acquire/release/isHeld) are
+ * preserved exactly; the mechanics live in `install-core/install-lock`.
  */
-import { existsSync, readFileSync, unlinkSync, writeFileSync, mkdirSync } from 'fs'
-import { dirname } from 'path'
-import { getInstallLockFile, getPackagesRoot } from '../../../packages/core/src/agent-packages/package-paths'
+import { getInstallLockFile } from '../../../packages/core/src/agent-packages/package-paths'
 import { getContentDir } from '../content-dir'
-import { createLogger } from '../logger'
+import { acquireLock, isLockHeld, releaseLock } from '../install-core/install-lock'
 
-const log = createLogger('agent-pkg:install-lock')
-
-interface LockContents {
-  pid: number
-  acquiredAt: string
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    // Sending signal 0 to a pid is a no-op on the receiving end but throws
-    // ESRCH if the pid doesn't exist. Standard liveness check on POSIX.
-    process.kill(pid, 0)
-    return true
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
-    return code !== 'ESRCH'
-  }
+function agentInstallLockPath(): string {
+  return getInstallLockFile(getContentDir())
 }
 
 /**
- * Acquire the advisory lock. Throws if another live process holds it.
- * If a stale lock exists (its pid is no longer alive), claim it and log.
+ * Acquire the advisory lock. Throws if another live process holds it. A stale
+ * lock (holder pid gone) is claimed with a warning.
  */
 export function acquireInstallLock(): void {
-  const lockPath = getInstallLockFile(getContentDir())
-  mkdirSync(getPackagesRoot(getContentDir()), { recursive: true })
-
-  if (existsSync(lockPath)) {
-    let parsed: LockContents | null = null
-    try {
-      parsed = JSON.parse(readFileSync(lockPath, 'utf-8'))
-    } catch {
-      // Malformed lock file — treat as stale and overwrite.
-    }
-    if (parsed && isProcessAlive(parsed.pid)) {
-      throw new Error(
-        `Another install is in progress (pid ${parsed.pid}, since ${parsed.acquiredAt}). ` +
-          `Wait for it to finish, or remove ${lockPath} if the holding process is gone.`,
-      )
-    }
-    log.warn('Stale install lock found — claiming it', {
-      stalePid: parsed?.pid ?? 'unparseable',
-    })
-  }
-
-  const contents: LockContents = {
-    pid: process.pid,
-    acquiredAt: new Date().toISOString(),
-  }
-  writeFileSync(lockPath, JSON.stringify(contents, null, 2), 'utf-8')
+  acquireLock(agentInstallLockPath())
 }
 
 /**
- * Release the advisory lock. Idempotent — repeated calls are no-ops.
- * Safe to call from a finally block whether the install succeeded or
- * threw.
+ * Release the advisory lock. Idempotent — repeated calls are no-ops. Safe to
+ * call from a finally block whether the install succeeded or threw.
  */
 export function releaseInstallLock(): void {
-  const lockPath = getInstallLockFile(getContentDir())
-  if (!existsSync(lockPath)) return
-  try {
-    unlinkSync(lockPath)
-  } catch (err) {
-    log.warn('Failed to release install lock', {
-      lockPath,
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
+  releaseLock(agentInstallLockPath())
 }
 
 /**
@@ -90,9 +36,5 @@ export function releaseInstallLock(): void {
  * Used by tests + diagnostic UI; not for control-flow inside install.
  */
 export function isInstallLockHeld(): boolean {
-  return existsSync(getInstallLockFile(getContentDir()))
+  return isLockHeld(agentInstallLockPath())
 }
-
-// Ensure dirname is referenced so the import isn't dropped by tree-shaking
-// if a future refactor stops using it. Defensive and trivial.
-void dirname

--- a/src/core/agent-packages/installer.ts
+++ b/src/core/agent-packages/installer.ts
@@ -27,8 +27,8 @@
  * projector's writeLog, the staging dirs are cleaned up, the lockfile
  * is left at its pre-install state, and the install lock is released.
  */
-import { existsSync, mkdirSync, renameSync, rmSync, statSync } from 'fs'
-import { dirname } from 'path'
+import { existsSync, rmSync, statSync } from 'fs'
+import { commitStaging } from '../install-core/transaction'
 import { createLogger } from '../logger'
 import { getContentDir } from '../content-dir'
 import { appendAudit } from '../audit'
@@ -112,24 +112,6 @@ export interface InstallResult {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Move the contents of `staging` into `finalDir`. The final directory's
- * parent is created if missing; if `finalDir` already exists (from a
- * previous failed install at the same version), it's removed first.
- *
- * Atomic on the same filesystem: a single `renameSync`. Cross-filesystem
- * (rare — typically when staging is on tmpfs and the destination is on a
- * persistent drive) we'd need a copy-then-delete fallback; not in V1
- * because both paths live under getContentDir().
- */
-function commitStagingToInstallDir(staging: string, finalDir: string): void {
-  mkdirSync(dirname(finalDir), { recursive: true })
-  if (existsSync(finalDir)) {
-    rmSync(finalDir, { recursive: true, force: true })
-  }
-  renameSync(staging, finalDir)
-}
 
 interface PreflightCollision {
   target: string
@@ -527,7 +509,7 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
         dep.resolvedId,
         dep.manifest.version,
       )
-      commitStagingToInstallDir(dep.fetched.stagingDir, finalDir)
+      commitStaging(dep.fetched.stagingDir, finalDir)
       finalInstallDirs.push(finalDir)
     }
     const parentFinalDir = getPackageSourceDir(
@@ -536,7 +518,7 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
       resolvedTopId,
       manifest.version,
     )
-    commitStagingToInstallDir(topFetched.stagingDir, parentFinalDir)
+    commitStaging(topFetched.stagingDir, parentFinalDir)
     finalInstallDirs.push(parentFinalDir)
 
     // ─── 11. Audit ────────────────────────────────────────────────────────

--- a/src/core/agent-packages/source-fetcher.ts
+++ b/src/core/agent-packages/source-fetcher.ts
@@ -46,6 +46,7 @@ import {
   type AsyncGitRunner,
 } from '../github-source-cache'
 import { getStagingDir, getPackagesRoot } from '../../../packages/core/src/agent-packages/package-paths'
+import { checkSubpath } from '../../../packages/core/src/install-core/source-guards'
 
 const log = createLogger('agent-pkg:fetch')
 
@@ -91,23 +92,23 @@ function isLocalPath(source: string): boolean {
 }
 
 function assertSubpathValid(source: string, subpath: string): void {
-  if (subpath.length === 0) {
-    throw new Error(`Malformed github source: "${source}" — subpath after # must not be empty`)
-  }
-  if (!/^[A-Za-z0-9._/-]+$/.test(subpath)) {
-    throw new Error(
-      `Malformed github source: "${source}" — subpath must match /^[A-Za-z0-9._/-]+$/`,
-    )
-  }
-  if (subpath.startsWith('/') || subpath.endsWith('/')) {
-    throw new Error(
-      `Malformed github source: "${source}" — subpath must not start or end with "/"`,
-    )
-  }
-  if (subpath.split('/').some((segment) => segment === '..' || segment === '.')) {
-    throw new Error(
-      `Malformed github source: "${source}" — subpath must not contain . or .. segments`,
-    )
+  // Rules live in the shared install-core guard; this function owns only the
+  // agent-package-side message wording (preserved exactly).
+  switch (checkSubpath(subpath)) {
+    case 'empty':
+      throw new Error(`Malformed github source: "${source}" — subpath after # must not be empty`)
+    case 'invalid-chars':
+      throw new Error(
+        `Malformed github source: "${source}" — subpath must match /^[A-Za-z0-9._/-]+$/`,
+      )
+    case 'leading-or-trailing-slash':
+      throw new Error(
+        `Malformed github source: "${source}" — subpath must not start or end with "/"`,
+      )
+    case 'dot-segment':
+      throw new Error(
+        `Malformed github source: "${source}" — subpath must not contain . or .. segments`,
+      )
   }
 }
 

--- a/src/core/install-core/install-lock.ts
+++ b/src/core/install-core/install-lock.ts
@@ -1,0 +1,86 @@
+/**
+ * Advisory install-lock primitive for the install core.
+ *
+ * A per-path lock file holding the owner's pid + timestamp. Acquiring while a
+ * LIVE process holds the lock throws; a stale lock (holder pid gone, or an
+ * unparseable file) is claimed with a warning. Release is best-effort and
+ * idempotent. Process exit drops the lock implicitly because it is held only
+ * across a single acquire→release pair, never across requests.
+ *
+ * Extracted from the agent-package install lock — the proven reference — so the
+ * plugin install path can take the same concurrency guarantee in Phase 6
+ * (plugins currently have no install lock). Part of the Whiskin shared install
+ * core (Phase 5).
+ */
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { dirname } from 'path'
+import { createLogger } from '../logger'
+
+const log = createLogger('install-core:lock')
+
+interface LockContents {
+  pid: number
+  acquiredAt: string
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    // Signal 0 is a no-op delivery check; throws ESRCH if the pid is gone.
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+/**
+ * Acquire the advisory lock at `lockPath`. Creates the parent dir. Throws if
+ * another live process holds it; claims (with a warning) if the existing lock
+ * is stale or unparseable.
+ */
+export function acquireLock(lockPath: string): void {
+  mkdirSync(dirname(lockPath), { recursive: true })
+
+  if (existsSync(lockPath)) {
+    let parsed: LockContents | null = null
+    try {
+      parsed = JSON.parse(readFileSync(lockPath, 'utf-8'))
+    } catch {
+      // Malformed lock file — treat as stale and overwrite.
+    }
+    if (parsed && isProcessAlive(parsed.pid)) {
+      throw new Error(
+        `Another install is in progress (pid ${parsed.pid}, since ${parsed.acquiredAt}). ` +
+          `Wait for it to finish, or remove ${lockPath} if the holding process is gone.`,
+      )
+    }
+    log.warn('Stale install lock found — claiming it', {
+      stalePid: parsed?.pid ?? 'unparseable',
+      lockPath,
+    })
+  }
+
+  const contents: LockContents = {
+    pid: process.pid,
+    acquiredAt: new Date().toISOString(),
+  }
+  writeFileSync(lockPath, JSON.stringify(contents, null, 2), 'utf-8')
+}
+
+/** Release the lock at `lockPath`. Idempotent; best-effort on failure. */
+export function releaseLock(lockPath: string): void {
+  if (!existsSync(lockPath)) return
+  try {
+    unlinkSync(lockPath)
+  } catch (err) {
+    log.warn('Failed to release install lock', {
+      lockPath,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/** True iff a lock file exists at `lockPath` (held by any process, alive or stale). */
+export function isLockHeld(lockPath: string): boolean {
+  return existsSync(lockPath)
+}

--- a/src/core/install-core/transaction.ts
+++ b/src/core/install-core/transaction.ts
@@ -1,0 +1,26 @@
+/**
+ * Staging → install-dir commit for the install core.
+ *
+ * Moves a fully-prepared staging directory into its final install location with
+ * a single rename — atomic on the same filesystem, so a reader never observes a
+ * half-populated install dir. A pre-existing target (e.g. left by a prior failed
+ * install at the same version) is removed first.
+ *
+ * Cross-filesystem renames (rare — typically staging on tmpfs, destination on a
+ * persistent drive) would need a copy-then-delete fallback; not implemented
+ * because both paths live under getContentDir().
+ *
+ * Lifted from the agent-package installer (the proven reference); Phase 6 wires
+ * the plugin install path through the same primitive. Part of the Whiskin
+ * shared install core (Phase 5).
+ */
+import { existsSync, mkdirSync, renameSync, rmSync } from 'fs'
+import { dirname } from 'path'
+
+export function commitStaging(staging: string, finalDir: string): void {
+  mkdirSync(dirname(finalDir), { recursive: true })
+  if (existsSync(finalDir)) {
+    rmSync(finalDir, { recursive: true, force: true })
+  }
+  renameSync(staging, finalDir)
+}

--- a/src/core/whiskin/artifact.ts
+++ b/src/core/whiskin/artifact.ts
@@ -1,0 +1,167 @@
+/**
+ * Whiskin artifact assembly + verification.
+ *
+ * A published artifact is a tarball of a plugin's built output:
+ *   bakin-plugin.json, dist/, optional node_modules/, .whiskin/build.json
+ * plus a sibling SHA256. Producers assemble + checksum it (Phase 4); consumers
+ * download, verify the checksum, and SAFELY extract it (Phase 6). This module
+ * owns assembly, checksum, and the guarded extractor.
+ *
+ * Tar mechanism mirrors the codebase's existing archive code
+ * (uninstall-snapshot.ts): `Bun.spawn(['tar', ...])` — both macOS and Linux
+ * ship `tar`, and it is present even on a non-developer consumer (unlike bun or
+ * git). Format is `.tar.gz`; the spec aspired to `.tar.zst` but gzip is what
+ * `tar -z` gives portably with no new dependency.
+ *
+ * Security: artifacts are untrusted input. Extraction validates every entry's
+ * path (no absolute / no `..` / no backslash / allowed top-level only) BEFORE
+ * extracting, caps the compressed size + entry count, and rejects ANY symlink
+ * after extraction into an isolated staging dir. v1 plugins are pure-JS (no
+ * node_modules), so reject-all-symlinks is correct; native-plugin support
+ * (deferred Phase 7) will need the escaping-symlink-only refinement.
+ *
+ * Part of the Whiskin artifact format (Phase 3).
+ */
+import { createHash } from 'crypto'
+import { createReadStream, mkdirSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+
+export type ArtifactErrorCode =
+  | 'CHECKSUM_MISMATCH'
+  | 'UNSAFE_ARTIFACT'
+  | 'ARTIFACT_TOO_LARGE'
+  | 'TAR_FAILED'
+
+export class ArtifactError extends Error {
+  readonly code: ArtifactErrorCode
+  constructor(code: ArtifactErrorCode, message: string) {
+    super(message)
+    this.name = 'ArtifactError'
+    this.code = code
+  }
+}
+
+/** Top-level entries permitted inside a Whiskin plugin artifact. */
+const ALLOWED_TOP_LEVEL = new Set(['bakin-plugin.json', 'dist', 'node_modules', '.whiskin'])
+/** Hard cap on the compressed artifact size (bounds fetch + most abuse). */
+const MAX_COMPRESSED_BYTES = 128 * 1024 * 1024
+/** Hard cap on entry count (bounds pathological archives). */
+const MAX_ENTRIES = 50_000
+
+async function spawnTar(args: string[]): Promise<void> {
+  const proc = Bun.spawn(['tar', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const code = await proc.exited
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text()
+    throw new ArtifactError('TAR_FAILED', `tar exited with code ${code}: ${stderr.trim() || '(no stderr)'}`)
+  }
+}
+
+async function spawnTarText(args: string[]): Promise<string> {
+  const proc = Bun.spawn(['tar', ...args], { stdout: 'pipe', stderr: 'pipe' })
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  if (code !== 0) {
+    throw new ArtifactError('TAR_FAILED', `tar exited with code ${code}: ${stderr.trim() || '(no stderr)'}`)
+  }
+  return stdout
+}
+
+/**
+ * Assemble `stagingDir`'s contents into a `.tar.gz` at `outPath`. The staging
+ * dir must already be laid out as the artifact (bakin-plugin.json, dist/, …);
+ * `-C stagingDir .` archives its contents at clean relative paths.
+ */
+export async function assembleArtifact(stagingDir: string, outPath: string): Promise<void> {
+  await spawnTar(['-czf', outPath, '-C', stagingDir, '.'])
+}
+
+/** Streaming SHA256 of a file. */
+export async function computeSha256(path: string): Promise<string> {
+  const hash = createHash('sha256')
+  await new Promise<void>((resolve, reject) => {
+    createReadStream(path)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('end', () => resolve())
+      .on('error', reject)
+  })
+  return hash.digest('hex')
+}
+
+/** Throw CHECKSUM_MISMATCH unless the file's SHA256 equals `expectedSha256`. */
+export async function verifyChecksum(path: string, expectedSha256: string): Promise<void> {
+  const actual = await computeSha256(path)
+  if (actual !== expectedSha256) {
+    throw new ArtifactError(
+      'CHECKSUM_MISMATCH',
+      `artifact checksum mismatch: expected ${expectedSha256}, got ${actual}`,
+    )
+  }
+}
+
+function normalizeTarEntry(entry: string): string | null {
+  const trimmed = entry.trim()
+  if (!trimmed || trimmed === '.' || trimmed === './') return null
+  return trimmed.startsWith('./') ? trimmed.slice(2) : trimmed
+}
+
+/**
+ * Validate a `tar -tzf` listing: reject absolute/Windows paths, `..`/`.`
+ * segments, unexpected top-level entries, and over-large entry counts.
+ * Exported for unit testing.
+ */
+export function validateArtifactListing(listing: string): void {
+  let count = 0
+  for (const raw of listing.split('\n')) {
+    const entry = normalizeTarEntry(raw)
+    if (!entry) continue
+    count++
+    if (count > MAX_ENTRIES) {
+      throw new ArtifactError('UNSAFE_ARTIFACT', `artifact has more than ${MAX_ENTRIES} entries`)
+    }
+    if (entry.startsWith('/') || entry.includes('\\')) {
+      throw new ArtifactError('UNSAFE_ARTIFACT', `artifact contains an unsafe absolute or Windows path: ${raw}`)
+    }
+    const parts = entry.split('/').filter(Boolean)
+    if (parts.some((part) => part === '..' || part === '.')) {
+      throw new ArtifactError('UNSAFE_ARTIFACT', `artifact contains an unsafe relative path: ${raw}`)
+    }
+    if (!ALLOWED_TOP_LEVEL.has(parts[0]!)) {
+      throw new ArtifactError('UNSAFE_ARTIFACT', `artifact contains an unexpected top-level entry: ${raw}`)
+    }
+  }
+}
+
+function assertNoSymlinks(dir: string): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isSymbolicLink()) {
+      throw new ArtifactError('UNSAFE_ARTIFACT', `artifact contains a symlink: ${full}`)
+    }
+    if (entry.isDirectory()) assertNoSymlinks(full)
+  }
+}
+
+/**
+ * Safely extract a verified artifact into `destDir` (which should be an
+ * isolated staging dir, not a live install location). Caps compressed size,
+ * validates the entry listing, extracts, then rejects any symlink.
+ */
+export async function safeExtractArtifact(tarballPath: string, destDir: string): Promise<void> {
+  const size = statSync(tarballPath).size
+  if (size > MAX_COMPRESSED_BYTES) {
+    throw new ArtifactError(
+      'ARTIFACT_TOO_LARGE',
+      `artifact is ${size} bytes, over the ${MAX_COMPRESSED_BYTES}-byte cap`,
+    )
+  }
+  validateArtifactListing(await spawnTarText(['-tzf', tarballPath]))
+  mkdirSync(destDir, { recursive: true })
+  await spawnTar(['-xzf', tarballPath, '-C', destDir])
+  // Belt-and-suspenders: a symlink whose NAME passed validation still gets
+  // rejected here, before the staging dir is ever committed to a live location.
+  assertNoSymlinks(destDir)
+}

--- a/src/core/whiskin/artifacts-index.ts
+++ b/src/core/whiskin/artifacts-index.ts
@@ -1,0 +1,115 @@
+/**
+ * `whiskin-artifacts.json` — the per-release catalog a plugin repo attaches to
+ * each GitHub release (Open Q3). It maps pluginId → version → platform → a
+ * verified artifact location, so a consumer can resolve "latest" (or a pinned
+ * version) for its platform via the stable releases/latest/download redirect.
+ *
+ * Each release's index is immutable; entries carry ABSOLUTE artifact URLs so an
+ * entry may point at a tarball attached to an older release. On publish the new
+ * index is built by CARRYING FORWARD the previous latest index's entries for
+ * plugins that weren't rebuilt (mergeArtifactsIndex), which is what lets plugins
+ * in a monorepo release independently while each index stays a complete catalog.
+ *
+ * Part of the Whiskin artifact format (Phase 3).
+ */
+import { readFileSync } from 'fs'
+import { z } from 'zod'
+import { atomicWriteJson } from '@bakin/core/install-core/atomic-write'
+
+export const ARTIFACTS_INDEX_VERSION = 1
+export const INDEX_FILENAME = 'whiskin-artifacts.json'
+/** Platform key for a single platform-neutral (pure-JS) artifact. */
+export const NEUTRAL_PLATFORM = 'neutral'
+
+const ArtifactEntrySchema = z.object({
+  /** Absolute URL of the artifact tarball (may point at an older release). */
+  url: z.string().min(1),
+  sha256: z.string().regex(/^[0-9a-f]{64}$/),
+  externalsContract: z.string().min(1),
+  bakinRange: z.string().min(1),
+})
+
+const VersionEntrySchema = z.object({
+  /** Keyed by platform (e.g. "darwin-arm64") or NEUTRAL_PLATFORM. */
+  platforms: z.record(z.string(), ArtifactEntrySchema),
+})
+
+const PluginIndexSchema = z.object({
+  /** The newest version present for this plugin in this index. */
+  latest: z.string().min(1),
+  versions: z.record(z.string(), VersionEntrySchema),
+})
+
+export const ArtifactsIndexSchema = z.object({
+  version: z.literal(ARTIFACTS_INDEX_VERSION),
+  plugins: z.record(z.string(), PluginIndexSchema),
+})
+
+export type ArtifactEntry = z.infer<typeof ArtifactEntrySchema>
+export type ArtifactsIndex = z.infer<typeof ArtifactsIndexSchema>
+
+export function parseArtifactsIndex(raw: unknown): ArtifactsIndex {
+  return ArtifactsIndexSchema.parse(raw)
+}
+
+export function readArtifactsIndex(path: string): ArtifactsIndex {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8'))
+  } catch (err) {
+    throw new Error(
+      `whiskin-artifacts.json at ${path} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  return parseArtifactsIndex(parsed)
+}
+
+export function writeArtifactsIndex(path: string, index: ArtifactsIndex): void {
+  atomicWriteJson(path, ArtifactsIndexSchema.parse(index))
+}
+
+/**
+ * Resolve the artifact for `pluginId` at `version` ('latest' or an exact
+ * semver) for `platform`. Falls back to a platform-neutral entry. Returns null
+ * when nothing matches.
+ */
+export function resolveArtifact(
+  index: ArtifactsIndex,
+  pluginId: string,
+  version: string,
+  platform: string,
+): ArtifactEntry | null {
+  const plugin = index.plugins[pluginId]
+  if (!plugin) return null
+  const resolvedVersion = version === 'latest' ? plugin.latest : version
+  const versionEntry = plugin.versions[resolvedVersion]
+  if (!versionEntry) return null
+  return versionEntry.platforms[platform] ?? versionEntry.platforms[NEUTRAL_PLATFORM] ?? null
+}
+
+/**
+ * Build the next index by overlaying `incoming` (this release's freshly-built
+ * plugins) onto `previous` (the prior latest index). Plugins absent from
+ * `incoming` are carried forward unchanged; for plugins present in both, the
+ * version maps merge (incoming wins on conflict) and `latest` takes incoming's
+ * value (the just-published version).
+ */
+export function mergeArtifactsIndex(
+  previous: ArtifactsIndex,
+  incoming: ArtifactsIndex,
+): ArtifactsIndex {
+  const plugins: ArtifactsIndex['plugins'] = { ...previous.plugins }
+  for (const [id, idx] of Object.entries(incoming.plugins)) {
+    const prev = plugins[id]
+    plugins[id] = {
+      latest: idx.latest,
+      versions: { ...(prev?.versions ?? {}), ...idx.versions },
+    }
+  }
+  return { version: ARTIFACTS_INDEX_VERSION, plugins }
+}
+
+/** An empty index — the seed for a repo's first release. */
+export function emptyArtifactsIndex(): ArtifactsIndex {
+  return { version: ARTIFACTS_INDEX_VERSION, plugins: {} }
+}

--- a/src/core/whiskin/consumer-install.ts
+++ b/src/core/whiskin/consumer-install.ts
@@ -1,0 +1,74 @@
+/**
+ * Consumer-side artifact materialization (Phase 6).
+ *
+ * Resolve → download → verify checksum → SAFELY extract into an isolated
+ * staging dir → read provenance. This is the toolchain-free install core a
+ * non-developer's binary runs: no build, no bun, no git. The caller then
+ * validates the manifest + compatibility and publishes the staging dir into
+ * ~/.bakin/plugins/<id> via the shared install-core commitStaging (next slice +
+ * the live install.ts rewrite).
+ */
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { downloadToFile } from './download'
+import { safeExtractArtifact, verifyChecksum } from './artifact'
+import { readProvenance, PROVENANCE_FILENAME, type WhiskinBuildProvenance } from './provenance'
+import type { WhiskinArtifactResolver } from './resolver'
+
+export type WhiskinInstallErrorCode = 'NO_PREBUILT_ARTIFACT'
+
+export class WhiskinInstallError extends Error {
+  readonly code: WhiskinInstallErrorCode
+  constructor(code: WhiskinInstallErrorCode, message: string) {
+    super(message)
+    this.name = 'WhiskinInstallError'
+    this.code = code
+  }
+}
+
+export interface MaterializedArtifact {
+  /** Isolated dir holding the extracted artifact: bakin-plugin.json, dist/, .whiskin/. */
+  stagingDir: string
+  provenance: WhiskinBuildProvenance
+  /** Remove the materialization work dir (call after publishing or on failure). */
+  cleanup: () => void
+}
+
+/**
+ * Materialize a published artifact: resolve it via the resolver, download it,
+ * verify its checksum (throws CHECKSUM_MISMATCH), safe-extract it, and read its
+ * provenance. Throws NO_PREBUILT_ARTIFACT when the index has no matching
+ * artifact. On any failure the work dir is cleaned up before rethrowing.
+ */
+export async function materializeArtifact(
+  resolver: WhiskinArtifactResolver,
+  pluginId: string,
+  version: string,
+  platform: string,
+): Promise<MaterializedArtifact> {
+  const location = await resolver.resolve(pluginId, version, platform)
+  if (!location) {
+    throw new WhiskinInstallError(
+      'NO_PREBUILT_ARTIFACT',
+      `no published artifact for ${pluginId}@${version} (${platform})`,
+    )
+  }
+
+  const workDir = mkdtempSync(join(tmpdir(), `whiskin-install-${pluginId}-`))
+  const cleanup = () => rmSync(workDir, { recursive: true, force: true })
+  try {
+    const tarball = join(workDir, 'artifact.tar.gz')
+    await downloadToFile(location.artifactUrl, tarball)
+    await verifyChecksum(tarball, location.sha256)
+
+    const stagingDir = join(workDir, 'extracted')
+    await safeExtractArtifact(tarball, stagingDir)
+
+    const provenance = readProvenance(join(stagingDir, '.whiskin', PROVENANCE_FILENAME))
+    return { stagingDir, provenance, cleanup }
+  } catch (err) {
+    cleanup()
+    throw err
+  }
+}

--- a/src/core/whiskin/download.ts
+++ b/src/core/whiskin/download.ts
@@ -1,0 +1,77 @@
+/**
+ * HTTP(S) download helpers for the consumer install path.
+ *
+ * Uses node:http/https directly (not the global fetch). In production this runs
+ * server-side where Bun's fetch would work too; but it also has to run under the
+ * test harness, whose global happy-dom fetch refuses loopback requests
+ * (Same-Origin Policy + a stricter parser). node:http(s) talks to both a local
+ * fixture host and GitHub's release-asset redirects.
+ *
+ * Part of the Whiskin consumer install path (Phase 6).
+ */
+import { createWriteStream } from 'fs'
+import { get as httpGet, type IncomingMessage } from 'http'
+import { get as httpsGet } from 'https'
+
+const MAX_REDIRECTS = 5
+
+/**
+ * Issue a GET and follow redirects (301/302/303/307/308) up to MAX_REDIRECTS,
+ * resolving with the final 200 response stream. Rejects on non-2xx or redirect
+ * loops. GitHub `releases/.../download/<asset>` 302-redirects to a CDN, so
+ * following redirects is required.
+ */
+function fetchFinal(url: string, redirectsLeft = MAX_REDIRECTS): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    let getter: typeof httpGet
+    try {
+      getter = new URL(url).protocol === 'https:' ? httpsGet : httpGet
+    } catch (err) {
+      reject(err)
+      return
+    }
+    const req = getter(url, (res) => {
+      const status = res.statusCode ?? 0
+      if (status >= 300 && status < 400 && res.headers.location) {
+        res.resume() // drain so the socket frees
+        if (redirectsLeft <= 0) {
+          reject(new Error(`too many redirects fetching ${url}`))
+          return
+        }
+        const next = new URL(res.headers.location, url).toString()
+        resolve(fetchFinal(next, redirectsLeft - 1))
+        return
+      }
+      if (status !== 200) {
+        res.resume()
+        reject(new Error(`HTTP ${status} fetching ${url}`))
+        return
+      }
+      resolve(res)
+    })
+    req.on('error', reject)
+  })
+}
+
+/** Download `url` to `dest`, following redirects. */
+export async function downloadToFile(url: string, dest: string): Promise<void> {
+  const res = await fetchFinal(url)
+  await new Promise<void>((resolve, reject) => {
+    const out = createWriteStream(dest)
+    res.on('error', reject)
+    out.on('error', reject)
+    out.on('finish', () => resolve())
+    res.pipe(out)
+  })
+}
+
+/** Download `url` and return the body as a UTF-8 string, following redirects. */
+export async function downloadText(url: string): Promise<string> {
+  const res = await fetchFinal(url)
+  const chunks: Buffer[] = []
+  return await new Promise<string>((resolve, reject) => {
+    res.on('data', (chunk: Buffer) => chunks.push(chunk))
+    res.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
+    res.on('error', reject)
+  })
+}

--- a/src/core/whiskin/externals.ts
+++ b/src/core/whiskin/externals.ts
@@ -1,0 +1,54 @@
+/**
+ * The host-provided externals contract — single source of truth.
+ *
+ * Plugin bundles must NOT bundle their own React or SDK; the host provides one
+ * instance of each via the import map (see packages/host/public/index.html).
+ * This list was previously duplicated in `user-plugin-builder.ts` (user plugin
+ * builds) and `scripts/build-plugins.ts` (core plugin builds) — if one added an
+ * SDK sub-path the other didn't, plugins broke inconsistently between the two
+ * build paths. Owning it once keeps the "one React, one SDK" invariant.
+ *
+ * First slice of the Whiskin shared build backend (Phase 2).
+ */
+
+/** React + router specifiers the host always provides. */
+export const REACT_EXTERNALS: string[] = [
+  'react',
+  'react-dom',
+  'react-dom/client',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+  '@tanstack/react-router',
+]
+
+/** The published SDK surface (root + every sub-path). */
+export const SDK_EXTERNALS: string[] = [
+  '@makinbakin/sdk',
+  '@makinbakin/sdk/ui',
+  '@makinbakin/sdk/hooks',
+  '@makinbakin/sdk/components',
+  '@makinbakin/sdk/slots',
+  '@makinbakin/sdk/types',
+  '@makinbakin/sdk/utils',
+  '@makinbakin/sdk/metadata',
+  '@makinbakin/sdk/routing',
+]
+
+/**
+ * Client bundles externalize React + router + the full SDK surface (the host
+ * import map maps each to a shared vendor bundle).
+ */
+export const PLUGIN_CLIENT_EXTERNALS: string[] = [...REACT_EXTERNALS, ...SDK_EXTERNALS]
+
+/**
+ * Server bundles externalize React + router only; the SDK is inlined and other
+ * node_modules are kept external via Bun's `--packages external`.
+ */
+export const PLUGIN_SERVER_EXTERNALS: string[] = [...REACT_EXTERNALS]
+
+/**
+ * Stable identifier for this externals contract, recorded in build provenance
+ * (Phase 3) so startup can detect a host that no longer matches an installed
+ * artifact. Bump when the externalized set changes incompatibly.
+ */
+export const EXTERNALS_CONTRACT = 'react19-sdk-makinbakin-v1'

--- a/src/core/whiskin/import-scan.ts
+++ b/src/core/whiskin/import-scan.ts
@@ -1,0 +1,141 @@
+/**
+ * Plugin import scanner — enforces the plugin import contract at build time.
+ *
+ * Every import in a plugin's source must be one of: relative/absolute, a Node
+ * builtin, a host-provided external (React / SDK surface — see externals.ts), or
+ * a package declared in the plugin's own package.json. Anything else (app
+ * internals via `@/`, Bakin internals via `@bakin/*`, the retired `@bakin/sdk`,
+ * or an undeclared third-party package) is a violation.
+ *
+ * Extracted verbatim from user-plugin-builder.ts so the shared build backend
+ * (system-bun build + publish path) and the in-process dev build use one scanner
+ * and the host-provided set is sourced from the single externals contract.
+ * Part of the Whiskin shared build backend (Phase 2).
+ */
+import { readFileSync, readdirSync, type Dirent } from 'node:fs'
+import { join } from 'node:path'
+import { builtinModules } from 'node:module'
+import { PLUGIN_CLIENT_EXTERNALS } from './externals'
+
+const HOST_PROVIDED_IMPORTS = new Set<string>(PLUGIN_CLIENT_EXTERNALS)
+const BUILTIN_IMPORTS = new Set<string>([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+])
+const SOURCE_EXT_RE = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/
+/** Directories skipped when walking a plugin's source tree (also reused by the
+ *  builder's mtime/staleness walk). */
+export const NON_RUNTIME_DIRS = new Set(['dist', 'node_modules', 'tests', '__tests__', 'coverage'])
+const OLD_SDK_PACKAGE_NAME = '@bakin' + '/sdk'
+
+type SourceLoader = 'ts' | 'tsx' | 'js' | 'jsx'
+interface BunImportScanEntry {
+  path?: string
+}
+interface BunImportScanner {
+  scanImports(source: string): BunImportScanEntry[]
+}
+const BunTranspiler = (Bun as unknown as {
+  Transpiler: new (options: { loader: SourceLoader }) => BunImportScanner
+}).Transpiler
+
+export interface PluginPackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+}
+
+function packageName(specifier: string): string {
+  if (specifier.startsWith('@')) {
+    const [scope, name] = specifier.split('/')
+    return `${scope}/${name}`
+  }
+  return specifier.split('/')[0]!
+}
+
+function isRelativeOrAbsoluteSpecifier(specifier: string): boolean {
+  return specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('file:')
+}
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = []
+  const walk = (current: string): void => {
+    let entries: Dirent[]
+    try {
+      entries = readdirSync(current, { withFileTypes: true }) as Dirent[]
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const name = String(entry.name)
+      if (NON_RUNTIME_DIRS.has(name) || name.startsWith('.')) continue
+      const full = join(current, name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.isFile() && SOURCE_EXT_RE.test(name)) out.push(full)
+    }
+  }
+  walk(dir)
+  return out
+}
+
+function sourceLoader(file: string): SourceLoader {
+  if (file.endsWith('.tsx')) return 'tsx'
+  if (file.endsWith('.ts')) return 'ts'
+  if (file.endsWith('.jsx')) return 'jsx'
+  return 'js'
+}
+
+function collectImportSpecifiers(file: string, source: string): string[] {
+  try {
+    const transpiler = new BunTranspiler({ loader: sourceLoader(file) })
+    return transpiler
+      .scanImports(source)
+      .map((entry) => entry.path)
+      .filter((specifier): specifier is string => typeof specifier === 'string' && specifier.length > 0)
+  } catch (err) {
+    throw new Error(`Failed to parse imports in ${file}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+/**
+ * Scan every source file under `pluginDir` and throw if any import violates the
+ * plugin import contract. `pkg` supplies the plugin's declared dependencies.
+ */
+export function validatePluginImports(pluginDir: string, pkg: PluginPackageJson): void {
+  const declared = new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+  ])
+  const violations: string[] = []
+
+  for (const file of collectSourceFiles(pluginDir)) {
+    const source = readFileSync(file, 'utf-8')
+    for (const specifier of collectImportSpecifiers(file, source)) {
+      if (!specifier || isRelativeOrAbsoluteSpecifier(specifier) || BUILTIN_IMPORTS.has(specifier)) continue
+
+      if (specifier === OLD_SDK_PACKAGE_NAME || specifier.startsWith(`${OLD_SDK_PACKAGE_NAME}/`)) {
+        violations.push(`${file}: ${specifier} is no longer supported; use @makinbakin/sdk`)
+        continue
+      }
+      if (specifier === '@bakin/core' || specifier.startsWith('@bakin/core/') || specifier.startsWith('@bakin/')) {
+        violations.push(`${file}: ${specifier} imports Bakin internals; use @makinbakin/sdk or a declared plugin API`)
+        continue
+      }
+      if (specifier.startsWith('@/')) {
+        violations.push(`${file}: ${specifier} imports app internals; use @makinbakin/sdk or a declared plugin API`)
+        continue
+      }
+      if (HOST_PROVIDED_IMPORTS.has(specifier)) continue
+
+      const pkgName = packageName(specifier)
+      if (!declared.has(pkgName)) {
+        violations.push(`${file}: ${specifier} is not declared in package.json dependencies`)
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new Error(`Plugin dependency validation failed:\n${violations.join('\n')}`)
+  }
+}

--- a/src/core/whiskin/provenance.ts
+++ b/src/core/whiskin/provenance.ts
@@ -1,0 +1,87 @@
+/**
+ * Whiskin build provenance — the `.whiskin/build.json` record stamped into a
+ * published artifact at build time and used by the consumer install path +
+ * startup verifier to decide whether an artifact is valid for this host.
+ *
+ * Schema is versioned (WHISKIN_PROVENANCE_VERSION); a host that no longer
+ * matches an artifact's `externalsContract` marks it needs-update rather than
+ * rebuilding (consumers never build). Part of the Whiskin artifact format
+ * (Phase 3). See `.claude/specs/whiskin-plugin-builder.md` (Build Provenance).
+ */
+import { readFileSync } from 'fs'
+import { z } from 'zod'
+import { atomicWriteJson } from '@bakin/core/install-core/atomic-write'
+import { EXTERNALS_CONTRACT } from './externals'
+
+export const WHISKIN_PROVENANCE_VERSION = 2
+
+/** Filename under the artifact's `.whiskin/` directory. */
+export const PROVENANCE_FILENAME = 'build.json'
+
+const ApprovedInstallScriptSchema = z.object({
+  package: z.string().min(1),
+  version: z.string().min(1),
+  reason: z.string().min(1),
+})
+
+export const WhiskinBuildProvenanceSchema = z.object({
+  version: z.literal(WHISKIN_PROVENANCE_VERSION),
+  pluginId: z.string().min(1),
+  pluginVersion: z.string().min(1),
+  /** Bakin version the artifact was built against. */
+  bakinVersion: z.string().min(1),
+  /** Resolved compatibility range (from the manifest `bakin` field or stamped at publish). */
+  bakinRange: z.string().min(1),
+  whiskinVersion: z.string().min(1),
+  buildBackend: z.string().min(1),
+  platform: z.string().min(1),
+  /** Resolved commit SHA for github sources; '' for local. */
+  sourceCommitSha: z.string().default(''),
+  sourceTreeSha: z.string().min(1),
+  manifestSha: z.string().min(1),
+  packageLockSha: z.string().optional(),
+  externalsContract: z.string().min(1),
+  approvedInstallScripts: z.array(ApprovedInstallScriptSchema).default([]),
+  outputs: z.object({
+    serverEntry: z.string().min(1),
+    clientEntry: z.string().optional(),
+    clientCss: z.string().optional(),
+    /** node_modules paths kept for native/runtime deps the bundle can't inline. */
+    runtimeModules: z.array(z.string()).optional(),
+  }),
+  builtAt: z.string().min(1),
+})
+
+export type WhiskinBuildProvenance = z.infer<typeof WhiskinBuildProvenanceSchema>
+
+/** Validate an untrusted value as provenance; throws a ZodError on mismatch. */
+export function parseProvenance(raw: unknown): WhiskinBuildProvenance {
+  return WhiskinBuildProvenanceSchema.parse(raw)
+}
+
+/** Read + validate provenance from disk. */
+export function readProvenance(path: string): WhiskinBuildProvenance {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8'))
+  } catch (err) {
+    throw new Error(
+      `Whiskin provenance at ${path} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+  return parseProvenance(parsed)
+}
+
+/** Validate then atomically write provenance to disk. */
+export function writeProvenance(path: string, provenance: WhiskinBuildProvenance): void {
+  atomicWriteJson(path, WhiskinBuildProvenanceSchema.parse(provenance))
+}
+
+/**
+ * True iff this host's externals contract matches the artifact's — i.e. the
+ * host still provides the React/SDK surface the artifact was built against. A
+ * false result means the artifact needs a newer published build (Phase 9).
+ */
+export function isExternalsContractCompatible(provenance: WhiskinBuildProvenance): boolean {
+  return provenance.externalsContract === EXTERNALS_CONTRACT
+}

--- a/src/core/whiskin/publish.ts
+++ b/src/core/whiskin/publish.ts
@@ -1,0 +1,158 @@
+/**
+ * Whiskin publish core — turn a BUILT plugin directory into a published
+ * artifact: stamp provenance, stage only the artifact entries, assemble the
+ * tarball + checksum, and produce the whiskin-artifacts.json index entry.
+ *
+ * This is the orchestration the `bakin plugins publish` command and the reusable
+ * GitHub Action drive (Phase 4). It assumes the plugin is already built (dist/
+ * present) — building is the build backend's job (the caller runs it first).
+ * It does NOT touch any live install state.
+ */
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { assembleArtifact, computeSha256 } from './artifact'
+import {
+  writeProvenance,
+  WHISKIN_PROVENANCE_VERSION,
+  PROVENANCE_FILENAME,
+  type WhiskinBuildProvenance,
+} from './provenance'
+import { EXTERNALS_CONTRACT } from './externals'
+import { hashFile, hashSourceTree } from './source-hash'
+import {
+  ARTIFACTS_INDEX_VERSION,
+  type ArtifactEntry,
+  type ArtifactsIndex,
+} from './artifacts-index'
+
+export interface AssembleArtifactInput {
+  /** Built plugin dir: bakin-plugin.json + dist/ (+ optional node_modules/). */
+  builtDir: string
+  pluginId: string
+  pluginVersion: string
+  bakinVersion: string
+  bakinRange: string
+  /** Platform key (NEUTRAL_PLATFORM for pure-JS). */
+  platform: string
+  whiskinVersion: string
+  buildBackend: string
+  sourceCommitSha?: string
+  /** Absolute URL the artifact will be downloadable at. */
+  artifactUrl: string
+  /** Directory to write the `.tar.gz` + `.sha256` into. */
+  outDir: string
+  approvedInstallScripts?: WhiskinBuildProvenance['approvedInstallScripts']
+  /** ISO timestamp (passed in — modules can't call Date.now). */
+  builtAt: string
+}
+
+export interface IndexEntryRef {
+  pluginId: string
+  version: string
+  platform: string
+  entry: ArtifactEntry
+}
+
+export interface AssembledArtifact {
+  artifactPath: string
+  sha256: string
+  provenance: WhiskinBuildProvenance
+  indexEntry: IndexEntryRef
+}
+
+/** Top-level entries copied into the artifact (must match artifact.ts ALLOWED_TOP_LEVEL). */
+const ARTIFACT_CONTENTS = ['bakin-plugin.json', 'dist', 'node_modules'] as const
+
+/**
+ * Assemble a published artifact from a built plugin directory. Stages only the
+ * artifact entries (so plugin SOURCE files never leak into the tarball — they
+ * would fail the consumer's safe-extract allow-list), writes provenance into
+ * `.whiskin/build.json`, tars + checksums, and returns the index entry.
+ */
+export async function assemblePluginArtifact(input: AssembleArtifactInput): Promise<AssembledArtifact> {
+  const manifestPath = join(input.builtDir, 'bakin-plugin.json')
+  if (!existsSync(manifestPath)) {
+    throw new Error(`assemblePluginArtifact: ${manifestPath} not found`)
+  }
+  if (!existsSync(join(input.builtDir, 'dist', 'index.js'))) {
+    throw new Error(`assemblePluginArtifact: ${input.builtDir}/dist/index.js not found (build first)`)
+  }
+
+  const hasClient = existsSync(join(input.builtDir, 'dist', 'client.js'))
+  const hasCss = existsSync(join(input.builtDir, 'dist', 'client.css'))
+
+  const provenance: WhiskinBuildProvenance = {
+    version: WHISKIN_PROVENANCE_VERSION,
+    pluginId: input.pluginId,
+    pluginVersion: input.pluginVersion,
+    bakinVersion: input.bakinVersion,
+    bakinRange: input.bakinRange,
+    whiskinVersion: input.whiskinVersion,
+    buildBackend: input.buildBackend,
+    platform: input.platform,
+    sourceCommitSha: input.sourceCommitSha ?? '',
+    sourceTreeSha: hashSourceTree(input.builtDir),
+    manifestSha: hashFile(manifestPath),
+    externalsContract: EXTERNALS_CONTRACT,
+    approvedInstallScripts: input.approvedInstallScripts ?? [],
+    outputs: {
+      serverEntry: 'dist/index.js',
+      clientEntry: hasClient ? 'dist/client.js' : undefined,
+      clientCss: hasCss ? 'dist/client.css' : undefined,
+    },
+    builtAt: input.builtAt,
+  }
+
+  // Stage only the artifact entries (never the plugin source).
+  const staging = mkdtempSync(join(tmpdir(), `whiskin-pack-${input.pluginId}-`))
+  try {
+    for (const name of ARTIFACT_CONTENTS) {
+      const src = join(input.builtDir, name)
+      if (!existsSync(src)) continue
+      cpSync(src, join(staging, name), { recursive: true, dereference: false })
+    }
+    mkdirSync(join(staging, '.whiskin'), { recursive: true })
+    writeProvenance(join(staging, '.whiskin', PROVENANCE_FILENAME), provenance)
+
+    mkdirSync(input.outDir, { recursive: true })
+    const filename = `${input.pluginId}-${input.pluginVersion}-${input.platform}.tar.gz`
+    const artifactPath = join(input.outDir, filename)
+    await assembleArtifact(staging, artifactPath)
+    const sha256 = await computeSha256(artifactPath)
+    await Bun.write(`${artifactPath}.sha256`, `${sha256}  ${filename}\n`)
+
+    const entry: ArtifactEntry = {
+      url: input.artifactUrl,
+      sha256,
+      externalsContract: EXTERNALS_CONTRACT,
+      bakinRange: input.bakinRange,
+    }
+    return {
+      artifactPath,
+      sha256,
+      provenance,
+      indexEntry: { pluginId: input.pluginId, version: input.pluginVersion, platform: input.platform, entry },
+    }
+  } finally {
+    rmSync(staging, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Build a fresh `whiskin-artifacts.json` for one release from its assembled
+ * entries. (Carry-forward against the previous latest index is applied
+ * separately via mergeArtifactsIndex.)
+ */
+export function indexFromEntries(entries: IndexEntryRef[]): ArtifactsIndex {
+  const plugins: ArtifactsIndex['plugins'] = {}
+  for (const { pluginId, version, platform, entry } of entries) {
+    const plugin = plugins[pluginId] ?? { latest: version, versions: {} }
+    const versionEntry = plugin.versions[version] ?? { platforms: {} }
+    versionEntry.platforms[platform] = entry
+    plugin.versions[version] = versionEntry
+    plugin.latest = version
+    plugins[pluginId] = plugin
+  }
+  return { version: ARTIFACTS_INDEX_VERSION, plugins }
+}

--- a/src/core/whiskin/resolver.ts
+++ b/src/core/whiskin/resolver.ts
@@ -1,0 +1,70 @@
+/**
+ * Pluggable artifact resolution (Open Q2). A resolver turns a parsed source ref
+ * into a verified-against-checksum artifact location. v1 ships one HTTP(S)
+ * backend that reads `whiskin-artifacts.json` from a base URL — the
+ * github-release-assets path builds that base URL from the parsed source + ref
+ * (the stable `releases/latest/download/` redirect or `releases/download/<tag>/`);
+ * tests point it at a local fixture host. Everything below `resolve()` —
+ * download, verify, extract, publish — is ecosystem-agnostic.
+ *
+ * Part of the Whiskin consumer install path (Phase 6).
+ */
+import { downloadText } from './download'
+import {
+  INDEX_FILENAME,
+  parseArtifactsIndex,
+  resolveArtifact,
+  type ArtifactsIndex,
+} from './artifacts-index'
+
+export interface WhiskinArtifactLocation {
+  artifactUrl: string
+  sha256: string
+  /** The index URL it was resolved from (for diagnostics). */
+  indexUrl: string
+}
+
+export interface WhiskinArtifactResolver {
+  readonly scheme: string
+  /**
+   * Resolve `pluginId` at `version` ('latest' or exact) for `platform` to an
+   * artifact location, or null when the index has no matching artifact.
+   */
+  resolve(
+    pluginId: string,
+    version: string,
+    platform: string,
+  ): Promise<WhiskinArtifactLocation | null>
+}
+
+export class IndexFetchError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IndexFetchError'
+  }
+}
+
+/**
+ * Resolver over an HTTP(S) base URL that serves `whiskin-artifacts.json`. The
+ * github-release-assets resolver is this with the base URL pointed at a release
+ * download path.
+ */
+export function httpIndexResolver(baseUrl: string, scheme = 'http'): WhiskinArtifactResolver {
+  const indexUrl = `${baseUrl.replace(/\/+$/, '')}/${INDEX_FILENAME}`
+  return {
+    scheme,
+    async resolve(pluginId, version, platform) {
+      let index: ArtifactsIndex
+      try {
+        index = parseArtifactsIndex(JSON.parse(await downloadText(indexUrl)))
+      } catch (err) {
+        throw new IndexFetchError(
+          `failed to fetch/parse artifact index from ${indexUrl}: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      const entry = resolveArtifact(index, pluginId, version, platform)
+      if (!entry) return null
+      return { artifactUrl: entry.url, sha256: entry.sha256, indexUrl }
+    },
+  }
+}

--- a/src/core/whiskin/source-hash.ts
+++ b/src/core/whiskin/source-hash.ts
@@ -1,0 +1,44 @@
+/**
+ * Deterministic source-tree hashing for build provenance.
+ *
+ * sourceTreeSha lets the startup verifier + upgrade checks detect whether a
+ * plugin's source changed since it was built (for linked/dev sources) without
+ * trusting mtimes. Build/dep/dot dirs are excluded so the hash reflects source,
+ * not artifacts. Part of the Whiskin build backend (Phase 2 / used by Phase 4).
+ */
+import { createHash } from 'crypto'
+import { readdirSync, readFileSync } from 'fs'
+import { join, relative, sep } from 'path'
+import { NON_RUNTIME_DIRS } from './import-scan'
+
+/** SHA256 of a single file's bytes. */
+export function hashFile(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
+/**
+ * Deterministic SHA256 of a directory's file tree: sorted relative paths each
+ * paired with their content hash, skipping NON_RUNTIME_DIRS (dist, node_modules,
+ * tests, …) and dotfiles/dotdirs (so `.whiskin/` provenance never feeds the
+ * source hash).
+ */
+export function hashSourceTree(dir: string): string {
+  const lines: string[] = []
+  const walk = (current: string): void => {
+    const entries = readdirSync(current, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )
+    for (const entry of entries) {
+      if (NON_RUNTIME_DIRS.has(entry.name) || entry.name.startsWith('.')) continue
+      const full = join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+      } else if (entry.isFile()) {
+        const rel = relative(dir, full).split(sep).join('/')
+        lines.push(`${rel}\n${hashFile(full)}`)
+      }
+    }
+  }
+  walk(dir)
+  return createHash('sha256').update(lines.join('\n')).digest('hex')
+}

--- a/tests/agent-packages/install-core-characterization.test.ts
+++ b/tests/agent-packages/install-core-characterization.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared install-core characterization gate (Whiskin P0).
+ *
+ * The agent-package installer is the PROVEN REFERENCE for the shared install
+ * core that Whiskin extracts in Phase 5 and that agent packages converge onto
+ * in Phase 11. This suite locks — in one place, explicitly labeled — the
+ * invariants the shared core MUST preserve, so any drift during the refactor
+ * fails here:
+ *
+ *   1. Atomic staging → install-dir commit (renameSync semantics).
+ *   2. Lockfile entry field shape (what the shared lockfile-IO must round-trip).
+ *   3. `.installedBy` provenance sidecar content on every projection.
+ *   4. Install-lock release after success + mutual exclusion while held.
+ *   5. Failed install leaves NO partial state (clean lockfile, no install dir,
+ *      no projection, lock released).
+ *
+ * Broader behavior (deps/refcount, adopt mode, agent-kind runtime creation,
+ * `.userEdited` skip on update, post-lockfile-write rollback) is already
+ * covered by installer.test.ts / standalone-packs.test.ts / projector.test.ts
+ * / markers.test.ts — this file is the consolidated contract, not a duplicate
+ * of those. It uses a non-agent kind (skill-pack) so the transaction is
+ * exercised without mocking the runtime adapter beyond the shared helper.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-install-core-${Date.now()}-${randomUUID()}`)
+const openClawDir = pathJoin(testDir, 'openclaw')
+process.env.OPENCLAW_HOME = openClawDir
+process.env.BAKIN_HOME = testDir
+
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { installFilesystemRuntimeAppServices } from '../helpers/runtime-app-services'
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => openClawDir,
+  getOpenClawPath: (...parts: string[]) => join(openClawDir, ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/task-store', () => ({}))
+
+import { installPackage } from '../../src/core/agent-packages/installer'
+import { readLockfile } from '../../packages/core/src/agent-packages/lockfile'
+import { readInstalledBy } from '../../packages/core/src/agent-packages/markers'
+import {
+  acquireInstallLock,
+  releaseInstallLock,
+  isInstallLockHeld,
+} from '../../src/core/agent-packages/install-lock'
+
+let openClawAgents: Array<{ id: string; identity?: { name?: string } }> = []
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(testDir, { recursive: true })
+  mkdirSync(openClawDir, { recursive: true })
+  openClawAgents = []
+  installFilesystemRuntimeAppServices({
+    openClawDir,
+    agents: () => openClawAgents,
+    onCreateAgent: (agent) => {
+      openClawAgents = [
+        ...openClawAgents.filter((existing) => existing.id !== agent.id),
+        { id: agent.id, identity: { name: agent.name } },
+      ]
+    },
+  })
+})
+
+const ID = 'core-gate-skills'
+const VERSION = '0.4.2'
+const SKILL = 'do-thing'
+
+/** A minimal, valid skill-pack source tree at a local path. */
+function seedSkillPack(): string {
+  const dir = join(testDir, `${ID}-src`)
+  mkdirSync(join(dir, 'skills', SKILL), { recursive: true })
+  writeFileSync(
+    join(dir, 'bakin-package.json'),
+    JSON.stringify({
+      id: ID,
+      kind: 'skill-pack',
+      name: ID,
+      version: VERSION,
+      contributions: { skills: [`skills/${SKILL}`] },
+    }),
+  )
+  writeFileSync(join(dir, 'skills', SKILL, 'SKILL.md'), `# ${SKILL}\n\nDo the thing.`)
+  return dir
+}
+
+const installDir = () => join(testDir, 'packages', 'skill-packs', `${ID}@${VERSION}`)
+const skillTarget = () => join(openClawDir, 'skills', SKILL)
+const lockKey = `${ID}@${VERSION}`
+
+describe('shared install-core characterization gate (P5/P11)', () => {
+  it('commits staging atomically into the canonical install dir', async () => {
+    await installPackage({ source: seedSkillPack() })
+
+    // The committed install dir exists with the manifest + source preserved.
+    expect(existsSync(join(installDir(), 'bakin-package.json'))).toBe(true)
+    expect(existsSync(join(installDir(), 'skills', SKILL, 'SKILL.md'))).toBe(true)
+  })
+
+  it('writes a lockfile entry with the field shape the shared lockfile-IO must preserve', async () => {
+    await installPackage({ source: seedSkillPack() })
+
+    const entry = readLockfile().packages[lockKey]
+    expect(entry).toBeDefined()
+    expect(entry.kind).toBe('skill-pack')
+    expect(entry.version).toBe(VERSION)
+    expect(typeof entry.source).toBe('string')
+    expect(typeof entry.ref).toBe('string') // '' for local sources
+    expect(typeof entry.commitSha).toBe('string') // '' for local sources
+    expect(typeof entry.installedAt).toBe('string')
+    expect(entry.projections).toBeDefined()
+    expect(entry.projections!.length).toBeGreaterThanOrEqual(1)
+    expect(entry.refCount).toBe(0)
+    expect(Array.isArray(entry.dependencies)).toBe(true)
+    expect(entry.dependencies).toEqual([])
+    // No agent-only fields on a non-agent kind.
+    expect(entry.agentId).toBeUndefined()
+    expect(entry.state).toBeUndefined()
+  })
+
+  it('records a .installedBy provenance sidecar on each projection', async () => {
+    await installPackage({ source: seedSkillPack() })
+
+    const marker = readInstalledBy(skillTarget())
+    expect(marker).not.toBeNull()
+    expect(marker?.package).toBe(ID)
+    expect(marker?.version).toBe(VERSION)
+    expect(typeof marker?.sha256).toBe('string')
+    expect(marker?.sha256.length).toBeGreaterThan(0)
+  })
+
+  it('releases the install lock after a successful install', async () => {
+    await installPackage({ source: seedSkillPack() })
+    expect(isInstallLockHeld()).toBe(false)
+  })
+
+  it('provides mutual exclusion: install refuses while the lock is held', async () => {
+    acquireInstallLock()
+    try {
+      expect(isInstallLockHeld()).toBe(true)
+      await expect(installPackage({ source: seedSkillPack() })).rejects.toThrow(
+        /another install is in progress/i,
+      )
+    } finally {
+      releaseInstallLock()
+    }
+    expect(isInstallLockHeld()).toBe(false)
+  })
+
+  it('leaves no partial state when install fails (clean lockfile, no install dir, no projection, lock released)', async () => {
+    const src = seedSkillPack()
+    // Remove a declared skill dir so integrity validation throws AFTER fetch
+    // but the transaction must unwind to a clean slate.
+    rmSync(join(src, 'skills', SKILL), { recursive: true, force: true })
+
+    await expect(installPackage({ source: src })).rejects.toThrow()
+
+    expect(Object.keys(readLockfile().packages)).toEqual([])
+    expect(existsSync(installDir())).toBe(false)
+    expect(existsSync(skillTarget())).toBe(false)
+    expect(isInstallLockHeld()).toBe(false)
+  })
+})

--- a/tests/core/install-core/source-guards.test.ts
+++ b/tests/core/install-core/source-guards.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared install-core source guards (Whiskin P5, first slice).
+ *
+ * Locks the `#subpath` rule set that both the plugin parser
+ * (parseGithubSource) and the agent-package parser (parseGithubSpec) now share,
+ * so the two can never drift again. Behavior preservation on each side is also
+ * covered by their own suites (tests/plugins/lifecycle/parse-github-source.test.ts,
+ * tests/agent-packages/source-fetcher.test.ts), which must stay green.
+ *
+ * Pure module — imports no app code, touches no storage. The mandatory
+ * isolation mocks are added per project rule.
+ */
+import { describe, it, expect, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+const mockDir = join(tmpdir(), `install-core-guards-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import {
+  checkSubpath,
+  type SubpathViolation,
+} from '../../../packages/core/src/install-core/source-guards'
+import {
+  parseGithubSource,
+  InvalidGithubSourceError,
+} from '../../../packages/core/src/plugins/source'
+
+describe('checkSubpath (shared install-core rule set)', () => {
+  it('accepts valid subpaths', () => {
+    for (const ok of ['a', 'agents/patch', 'plugins/messaging', 'a.b-c_d/e1']) {
+      expect(checkSubpath(ok)).toBeNull()
+    }
+  })
+
+  const cases: Array<[string, SubpathViolation]> = [
+    ['', 'empty'],
+    ['agents/patch copy', 'invalid-chars'],
+    ['a$b', 'invalid-chars'],
+    ['has#hash', 'invalid-chars'],
+    ['/leading', 'leading-or-trailing-slash'],
+    ['trailing/', 'leading-or-trailing-slash'],
+    ['a/../b', 'dot-segment'],
+    ['./a', 'dot-segment'],
+    ['a/.', 'dot-segment'],
+  ]
+  for (const [input, violation] of cases) {
+    it(`flags "${input}" as ${violation}`, () => {
+      expect(checkSubpath(input)).toBe(violation)
+    })
+  }
+})
+
+describe('parseGithubSource still maps every violation to InvalidGithubSourceError', () => {
+  const bad = [
+    'owner/repo#',
+    'owner/repo#/agents/patch',
+    'owner/repo#agents/patch/',
+    'owner/repo#agents/../patch',
+    'owner/repo#./agents/patch',
+    'owner/repo#agents patch',
+  ]
+  for (const source of bad) {
+    it(`rejects ${source}`, () => {
+      expect(() => parseGithubSource(source)).toThrow(InvalidGithubSourceError)
+    })
+  }
+
+  it('still parses a valid subpath through the shared guard', () => {
+    expect(parseGithubSource('github:owner/repo#plugins/messaging')).toEqual({
+      cloneUrl: 'https://github.com/owner/repo.git',
+      subpath: 'plugins/messaging',
+    })
+  })
+})

--- a/tests/core/whiskin/artifact-server.test.ts
+++ b/tests/core/whiskin/artifact-server.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Self-test for the hermetic Whiskin artifact host (P0 fixture helper).
+ *
+ * No app modules, no ~/.bakin, no network beyond the loopback server this test
+ * starts itself — so it needs no content-dir / openclaw mocks.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID, createHash } from 'crypto'
+import { mkdirSync, rmSync, readFileSync } from 'fs'
+import { get as httpGet } from 'http'
+
+// This test imports no app modules and never touches ~/.bakin/~/.openclaw — it
+// only serves a tmp dir over loopback. The mandatory isolation mocks are added
+// per the project rule (every FS-touching test mocks both content-dir facades +
+// the OpenClaw home) so nothing can ever leak into production homes.
+const mockDir = join(tmpdir(), `whiskin-artifact-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import {
+  startArtifactServer,
+  writeArtifactWithChecksum,
+  type ArtifactServer,
+} from '../../fixtures/whiskin-artifact-server'
+
+let host: ArtifactServer | null = null
+let dir: string | null = null
+
+afterEach(async () => {
+  if (host) {
+    await host.stop()
+    host = null
+  }
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true })
+    dir = null
+  }
+})
+
+function freshDir(): string {
+  const d = join(tmpdir(), `whiskin-artifact-test-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  return d
+}
+
+/**
+ * GET via node:http rather than the global (happy-dom) `fetch`, which the test
+ * runner registers globally and which refuses loopback requests (Same-Origin
+ * Policy + a stricter HTTP parser). Phase 6's consumer materializer must
+ * likewise avoid the DOM fetch when run under this harness.
+ */
+function httpGetBuffer(url: string): Promise<{ status: number; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const req = httpGet(url, (res) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks) }))
+    })
+    req.on('error', reject)
+  })
+}
+
+describe('whiskin-artifact-server', () => {
+  it('serves a written artifact whose bytes match the checksum sidecar', async () => {
+    dir = freshDir()
+    const bytes = new TextEncoder().encode('pretend-tarball-bytes')
+    const sha = await writeArtifactWithChecksum(dir, 'pkg-0.1.0.tar.zst', bytes)
+    expect(sha).toBe(createHash('sha256').update(bytes).digest('hex'))
+
+    host = await startArtifactServer(dir)
+
+    const res = await httpGetBuffer(`${host.origin}/pkg-0.1.0.tar.zst`)
+    expect(res.status).toBe(200)
+    expect(createHash('sha256').update(res.body).digest('hex')).toBe(sha)
+
+    const checksumLine = readFileSync(join(dir, 'pkg-0.1.0.tar.zst.sha256'), 'utf-8')
+    expect(checksumLine).toContain(sha)
+  })
+
+  it('returns 404 for a missing file', async () => {
+    dir = freshDir()
+    host = await startArtifactServer(dir)
+    const res = await httpGetBuffer(`${host.origin}/does-not-exist.tar.zst`)
+    expect(res.status).toBe(404)
+  })
+
+  it('refuses path traversal outside the served root', async () => {
+    dir = freshDir()
+    host = await startArtifactServer(dir)
+    const res = await httpGetBuffer(`${host.origin}/..%2f..%2fetc%2fpasswd`)
+    expect([403, 404]).toContain(res.status)
+  })
+
+  it('counts requests for download-once assertions', async () => {
+    dir = freshDir()
+    await writeArtifactWithChecksum(dir, 'a.bin', new Uint8Array([1, 2, 3]))
+    host = await startArtifactServer(dir)
+    expect(host.requestCount()).toBe(0)
+    await httpGetBuffer(`${host.origin}/a.bin`)
+    await httpGetBuffer(`${host.origin}/a.bin`)
+    expect(host.requestCount()).toBe(2)
+  })
+})

--- a/tests/core/whiskin/artifact.test.ts
+++ b/tests/core/whiskin/artifact.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Whiskin artifact assemble / checksum / safe-extract (Phase 3).
+ *
+ * Uses real `tar` (present on macOS/Linux) over temp dirs; no network, no
+ * ~/.bakin/~/.openclaw. Mandatory isolation mocks added per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync, symlinkSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskin-artifact-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import {
+  assembleArtifact,
+  computeSha256,
+  verifyChecksum,
+  safeExtractArtifact,
+  validateArtifactListing,
+  ArtifactError,
+} from '../../../src/core/whiskin/artifact'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function freshDir(): string {
+  const d = join(tmpdir(), `whiskin-artifact-test-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+/** A minimal valid artifact staging layout. */
+function seedStaging(): string {
+  const staging = freshDir()
+  writeFileSync(join(staging, 'bakin-plugin.json'), JSON.stringify({ id: 'p', version: '0.1.0' }))
+  mkdirSync(join(staging, 'dist'), { recursive: true })
+  writeFileSync(join(staging, 'dist', 'index.js'), 'export default {}\n')
+  mkdirSync(join(staging, '.whiskin'), { recursive: true })
+  writeFileSync(join(staging, '.whiskin', 'build.json'), '{}')
+  return staging
+}
+
+describe('whiskin artifact assemble + checksum', () => {
+  it('assembles a tarball, hashes it, and verifies the checksum', async () => {
+    const out = freshDir()
+    const tarball = join(out, 'p-0.1.0.tar.gz')
+    await assembleArtifact(seedStaging(), tarball)
+    expect(existsSync(tarball)).toBe(true)
+
+    const sha = await computeSha256(tarball)
+    expect(sha).toMatch(/^[0-9a-f]{64}$/)
+    await expect(verifyChecksum(tarball, sha)).resolves.toBeUndefined()
+  })
+
+  it('throws CHECKSUM_MISMATCH on a wrong checksum', async () => {
+    const out = freshDir()
+    const tarball = join(out, 'p.tar.gz')
+    await assembleArtifact(seedStaging(), tarball)
+    await expect(verifyChecksum(tarball, 'f'.repeat(64))).rejects.toMatchObject({
+      code: 'CHECKSUM_MISMATCH',
+    })
+  })
+})
+
+describe('whiskin artifact safe extraction', () => {
+  it('round-trips an artifact into a dest dir', async () => {
+    const out = freshDir()
+    const tarball = join(out, 'p.tar.gz')
+    await assembleArtifact(seedStaging(), tarball)
+
+    const dest = freshDir()
+    await safeExtractArtifact(tarball, dest)
+    expect(existsSync(join(dest, 'bakin-plugin.json'))).toBe(true)
+    expect(readFileSync(join(dest, 'dist', 'index.js'), 'utf-8')).toContain('export default')
+  })
+
+  it('rejects a symlink in the artifact', async () => {
+    const staging = seedStaging()
+    // A symlink whose NAME is safe (dist/link) still gets rejected post-extract.
+    symlinkSync('/etc/hosts', join(staging, 'dist', 'link'))
+    const out = freshDir()
+    const tarball = join(out, 'p.tar.gz')
+    await assembleArtifact(staging, tarball)
+
+    const dest = freshDir()
+    await expect(safeExtractArtifact(tarball, dest)).rejects.toMatchObject({
+      code: 'UNSAFE_ARTIFACT',
+    })
+  })
+})
+
+describe('validateArtifactListing', () => {
+  it('accepts a normal listing', () => {
+    expect(() =>
+      validateArtifactListing('./\n./bakin-plugin.json\n./dist/\n./dist/index.js\n./.whiskin/build.json\n'),
+    ).not.toThrow()
+  })
+
+  const bad: Array<[string, string]> = [
+    ['absolute path', '/etc/passwd\n'],
+    ['parent traversal', 'dist/../../escape\n'],
+    ['dot segment', 'dist/./x\n'],
+    ['backslash', 'dist\\evil\n'],
+    ['unexpected top-level', 'evil/x\n'],
+  ]
+  for (const [label, listing] of bad) {
+    it(`rejects ${label}`, () => {
+      expect(() => validateArtifactListing(listing)).toThrow(ArtifactError)
+    })
+  }
+})

--- a/tests/core/whiskin/artifacts-index.test.ts
+++ b/tests/core/whiskin/artifacts-index.test.ts
@@ -1,0 +1,137 @@
+/**
+ * whiskin-artifacts.json schema, resolver, and carry-forward merge (Phase 3).
+ *
+ * Pure module over temp files; mandatory isolation mocks added per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskin-index-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import {
+  ARTIFACTS_INDEX_VERSION,
+  NEUTRAL_PLATFORM,
+  parseArtifactsIndex,
+  readArtifactsIndex,
+  writeArtifactsIndex,
+  resolveArtifact,
+  mergeArtifactsIndex,
+  emptyArtifactsIndex,
+  type ArtifactsIndex,
+} from '../../../src/core/whiskin/artifacts-index'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+function freshDir(): string {
+  const d = join(tmpdir(), `whiskin-index-test-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+const SHA = 'a'.repeat(64)
+function entry(url: string) {
+  return { url, sha256: SHA, externalsContract: 'react19-sdk-makinbakin-v1', bakinRange: '>=0.0.1-rc.15 <0.1.0' }
+}
+function indexWith(pluginId: string, version: string, platform: string, url: string): ArtifactsIndex {
+  return {
+    version: ARTIFACTS_INDEX_VERSION,
+    plugins: { [pluginId]: { latest: version, versions: { [version]: { platforms: { [platform]: entry(url) } } } } },
+  }
+}
+
+describe('artifacts index schema + IO', () => {
+  it('round-trips through write + read', () => {
+    const dir = freshDir()
+    const path = join(dir, 'whiskin-artifacts.json')
+    const idx = indexWith('messaging', '0.1.0', NEUTRAL_PLATFORM, 'https://x/m.tar.gz')
+    writeArtifactsIndex(path, idx)
+    expect(readArtifactsIndex(path)).toEqual(idx)
+  })
+
+  it('rejects a malformed sha256', () => {
+    const bad = indexWith('m', '0.1.0', NEUTRAL_PLATFORM, 'u')
+    bad.plugins.m.versions['0.1.0'].platforms[NEUTRAL_PLATFORM].sha256 = 'nope'
+    expect(() => parseArtifactsIndex(bad)).toThrow()
+  })
+
+  it('rejects non-JSON on disk', () => {
+    const dir = freshDir()
+    const path = join(dir, 'whiskin-artifacts.json')
+    writeFileSync(path, '{bad', 'utf-8')
+    expect(() => readArtifactsIndex(path)).toThrow(/not valid JSON/i)
+  })
+})
+
+describe('resolveArtifact', () => {
+  const idx: ArtifactsIndex = {
+    version: ARTIFACTS_INDEX_VERSION,
+    plugins: {
+      messaging: {
+        latest: '0.2.0',
+        versions: {
+          '0.1.0': { platforms: { [NEUTRAL_PLATFORM]: entry('u-0.1.0') } },
+          '0.2.0': { platforms: { 'darwin-arm64': entry('u-darwin'), [NEUTRAL_PLATFORM]: entry('u-neutral') } },
+        },
+      },
+    },
+  }
+
+  it('resolves an exact platform match', () => {
+    expect(resolveArtifact(idx, 'messaging', '0.2.0', 'darwin-arm64')?.url).toBe('u-darwin')
+  })
+  it('falls back to the neutral artifact', () => {
+    expect(resolveArtifact(idx, 'messaging', '0.2.0', 'linux-x64')?.url).toBe('u-neutral')
+  })
+  it('resolves "latest" to the latest version', () => {
+    expect(resolveArtifact(idx, 'messaging', 'latest', 'darwin-arm64')?.url).toBe('u-darwin')
+  })
+  it('returns null for an unknown plugin/version/platform', () => {
+    expect(resolveArtifact(idx, 'nope', 'latest', 'darwin-arm64')).toBeNull()
+    expect(resolveArtifact(idx, 'messaging', '9.9.9', 'darwin-arm64')).toBeNull()
+    expect(resolveArtifact(idx, 'messaging', '0.1.0', 'darwin-arm64')?.url).toBe('u-0.1.0') // neutral fallback
+  })
+})
+
+describe('mergeArtifactsIndex (carry-forward)', () => {
+  it('carries forward untouched plugins and overlays the rebuilt one', () => {
+    const previous = mergeArtifactsIndex(
+      emptyArtifactsIndex(),
+      indexWith('projects', '0.1.0', NEUTRAL_PLATFORM, 'p-old'),
+    )
+    const withMessaging = mergeArtifactsIndex(
+      previous,
+      indexWith('messaging', '0.1.0', NEUTRAL_PLATFORM, 'm-0.1.0'),
+    )
+    // A second messaging release: projects + messaging@0.1.0 must carry forward.
+    const next = mergeArtifactsIndex(
+      withMessaging,
+      indexWith('messaging', '0.2.0', NEUTRAL_PLATFORM, 'm-0.2.0'),
+    )
+
+    expect(resolveArtifact(next, 'projects', 'latest', 'x')?.url).toBe('p-old') // carried forward
+    expect(next.plugins.messaging.latest).toBe('0.2.0') // pointer updated
+    expect(resolveArtifact(next, 'messaging', '0.1.0', 'x')?.url).toBe('m-0.1.0') // old version retained
+    expect(resolveArtifact(next, 'messaging', '0.2.0', 'x')?.url).toBe('m-0.2.0') // new version added
+  })
+})

--- a/tests/core/whiskin/e2e-artifact-flow.test.ts
+++ b/tests/core/whiskin/e2e-artifact-flow.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Whiskin artifact-lane end-to-end (Phases 3+4+6): publish a built plugin,
+ * serve the release over the hermetic host, then resolve → download → verify
+ * checksum → safe-extract on the consumer side. No build backend, no live
+ * install path, no browser — just the artifact data flow wired together.
+ *
+ * Mandatory isolation mocks per project rule (these modules don't read
+ * ~/.bakin, but the harness requires the mocks).
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync, existsSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskin-e2e-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { startArtifactServer, type ArtifactServer } from '../../fixtures/whiskin-artifact-server'
+import { assemblePluginArtifact, indexFromEntries } from '../../../src/core/whiskin/publish'
+import { writeArtifactsIndex, NEUTRAL_PLATFORM, INDEX_FILENAME } from '../../../src/core/whiskin/artifacts-index'
+import { httpIndexResolver } from '../../../src/core/whiskin/resolver'
+import { materializeArtifact, WhiskinInstallError } from '../../../src/core/whiskin/consumer-install'
+
+let host: ArtifactServer | null = null
+const dirs: string[] = []
+afterEach(async () => {
+  if (host) {
+    await host.stop()
+    host = null
+  }
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+function freshDir(prefix: string): string {
+  const d = join(tmpdir(), `whiskin-${prefix}-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+function seedBuilt(): string {
+  const dir = freshDir('built')
+  writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({ id: 'messaging', version: '0.1.0' }))
+  writeFileSync(join(dir, 'index.ts'), 'export default {}\n')
+  mkdirSync(join(dir, 'dist'), { recursive: true })
+  writeFileSync(join(dir, 'dist', 'index.js'), 'module.exports = {}\n')
+  return dir
+}
+
+const FILENAME = `messaging-0.1.0-${NEUTRAL_PLATFORM}.tar.gz`
+
+/** Publish a release into `releaseDir` served at `origin`, returning the sha. */
+async function publishInto(releaseDir: string, origin: string): Promise<string> {
+  const result = await assemblePluginArtifact({
+    builtDir: seedBuilt(),
+    pluginId: 'messaging',
+    pluginVersion: '0.1.0',
+    bakinVersion: '0.0.1-rc.15',
+    bakinRange: '>=0.0.1-rc.15 <0.1.0',
+    platform: NEUTRAL_PLATFORM,
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    artifactUrl: `${origin}/${FILENAME}`,
+    outDir: releaseDir,
+    builtAt: '2026-06-04T00:00:00.000Z',
+  })
+  writeArtifactsIndex(join(releaseDir, INDEX_FILENAME), indexFromEntries([result.indexEntry]))
+  return result.sha256
+}
+
+describe('Whiskin artifact lane end-to-end', () => {
+  it('publish -> serve -> resolve -> download -> verify -> extract', async () => {
+    const releaseDir = freshDir('release')
+    host = await startArtifactServer(releaseDir)
+    await publishInto(releaseDir, host.origin)
+
+    const resolver = httpIndexResolver(host.origin)
+    const materialized = await materializeArtifact(resolver, 'messaging', 'latest', 'darwin-arm64')
+    try {
+      expect(existsSync(join(materialized.stagingDir, 'bakin-plugin.json'))).toBe(true)
+      expect(existsSync(join(materialized.stagingDir, 'dist', 'index.js'))).toBe(true)
+      expect(existsSync(join(materialized.stagingDir, '.whiskin', 'build.json'))).toBe(true)
+      expect(materialized.provenance.pluginId).toBe('messaging')
+      expect(materialized.provenance.outputs.serverEntry).toBe('dist/index.js')
+      // Plugin source never made it into the published artifact.
+      expect(existsSync(join(materialized.stagingDir, 'index.ts'))).toBe(false)
+    } finally {
+      materialized.cleanup()
+    }
+  })
+
+  it('rejects a tampered artifact with CHECKSUM_MISMATCH', async () => {
+    const releaseDir = freshDir('release')
+    host = await startArtifactServer(releaseDir)
+    await publishInto(releaseDir, host.origin)
+
+    // Tamper with the served artifact after the index recorded its checksum.
+    writeFileSync(join(releaseDir, FILENAME), 'corrupted-bytes')
+
+    const resolver = httpIndexResolver(host.origin)
+    await expect(
+      materializeArtifact(resolver, 'messaging', 'latest', 'darwin-arm64'),
+    ).rejects.toMatchObject({ code: 'CHECKSUM_MISMATCH' })
+  })
+
+  it('throws NO_PREBUILT_ARTIFACT for an unknown plugin', async () => {
+    const releaseDir = freshDir('release')
+    host = await startArtifactServer(releaseDir)
+    await publishInto(releaseDir, host.origin)
+
+    const resolver = httpIndexResolver(host.origin)
+    await expect(
+      materializeArtifact(resolver, 'does-not-exist', 'latest', 'darwin-arm64'),
+    ).rejects.toBeInstanceOf(WhiskinInstallError)
+  })
+})

--- a/tests/core/whiskin/provenance.test.ts
+++ b/tests/core/whiskin/provenance.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Whiskin build provenance schema + IO (Phase 3).
+ *
+ * Pure module over a temp file; no ~/.bakin/~/.openclaw. Mandatory isolation
+ * mocks added per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskin-prov-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import {
+  WHISKIN_PROVENANCE_VERSION,
+  parseProvenance,
+  readProvenance,
+  writeProvenance,
+  isExternalsContractCompatible,
+  type WhiskinBuildProvenance,
+} from '../../../src/core/whiskin/provenance'
+import { EXTERNALS_CONTRACT } from '../../../src/core/whiskin/externals'
+
+let dir: string | null = null
+afterEach(() => {
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true })
+    dir = null
+  }
+})
+
+function freshDir(): string {
+  const d = join(tmpdir(), `whiskin-prov-test-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  return d
+}
+
+function validProvenance(): WhiskinBuildProvenance {
+  return {
+    version: WHISKIN_PROVENANCE_VERSION,
+    pluginId: 'messaging',
+    pluginVersion: '0.1.0',
+    bakinVersion: '0.0.1-rc.15',
+    bakinRange: '>=0.0.1-rc.15 <0.1.0',
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    platform: 'darwin-arm64',
+    sourceCommitSha: 'a'.repeat(40),
+    sourceTreeSha: 'b'.repeat(64),
+    manifestSha: 'c'.repeat(64),
+    externalsContract: EXTERNALS_CONTRACT,
+    approvedInstallScripts: [],
+    outputs: { serverEntry: 'dist/index.js', clientEntry: 'dist/client.js' },
+    builtAt: '2026-06-04T00:00:00.000Z',
+  }
+}
+
+describe('whiskin provenance', () => {
+  it('round-trips a valid record through write + read', () => {
+    dir = freshDir()
+    const path = join(dir, 'build.json')
+    const prov = validProvenance()
+    writeProvenance(path, prov)
+    expect(readProvenance(path)).toEqual(prov)
+  })
+
+  it('applies schema defaults (sourceCommitSha, approvedInstallScripts)', () => {
+    const raw = { ...validProvenance() } as Record<string, unknown>
+    delete raw.sourceCommitSha
+    delete raw.approvedInstallScripts
+    const parsed = parseProvenance(raw)
+    expect(parsed.sourceCommitSha).toBe('')
+    expect(parsed.approvedInstallScripts).toEqual([])
+  })
+
+  it('rejects a wrong schema version', () => {
+    const raw = { ...validProvenance(), version: 1 }
+    expect(() => parseProvenance(raw)).toThrow()
+  })
+
+  it('rejects a record missing required fields', () => {
+    const raw = { ...validProvenance() } as Record<string, unknown>
+    delete raw.outputs
+    expect(() => parseProvenance(raw)).toThrow()
+  })
+
+  it('rejects non-JSON on disk with a clear error', () => {
+    dir = freshDir()
+    const path = join(dir, 'build.json')
+    writeFileSync(path, 'not json{', 'utf-8')
+    expect(() => readProvenance(path)).toThrow(/not valid JSON/i)
+  })
+
+  it('reports externals-contract compatibility', () => {
+    expect(isExternalsContractCompatible(validProvenance())).toBe(true)
+    expect(
+      isExternalsContractCompatible({ ...validProvenance(), externalsContract: 'react18-old' }),
+    ).toBe(false)
+  })
+
+  it('writes pretty-printed JSON with a trailing newline (atomic writer)', () => {
+    dir = freshDir()
+    const path = join(dir, 'build.json')
+    writeProvenance(path, validProvenance())
+    const text = readFileSync(path, 'utf-8')
+    expect(text.endsWith('\n')).toBe(true)
+    expect(text).toContain('\n  "pluginId": "messaging"')
+  })
+})

--- a/tests/core/whiskin/publish.test.ts
+++ b/tests/core/whiskin/publish.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Whiskin publish core (Phase 4): assemble a published artifact from a built
+ * plugin dir + build the index. Fakes a built dir (dist/) rather than running a
+ * real build. Mandatory isolation mocks per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskin-publish-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { assemblePluginArtifact, indexFromEntries } from '../../../src/core/whiskin/publish'
+import { safeExtractArtifact } from '../../../src/core/whiskin/artifact'
+import { readProvenance } from '../../../src/core/whiskin/provenance'
+import { NEUTRAL_PLATFORM, resolveArtifact } from '../../../src/core/whiskin/artifacts-index'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+function freshDir(prefix: string): string {
+  const d = join(tmpdir(), `whiskin-${prefix}-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+/** A fake built plugin dir: manifest + dist + a stray SOURCE file. */
+function seedBuilt(): string {
+  const dir = freshDir('built')
+  writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({ id: 'messaging', version: '0.1.0' }))
+  writeFileSync(join(dir, 'index.ts'), 'export default {}\n') // source — must NOT end up in artifact
+  mkdirSync(join(dir, 'dist'), { recursive: true })
+  writeFileSync(join(dir, 'dist', 'index.js'), 'module.exports = {}\n')
+  writeFileSync(join(dir, 'dist', 'client.js'), 'console.log(1)\n')
+  return dir
+}
+
+function input(builtDir: string, outDir: string) {
+  return {
+    builtDir,
+    pluginId: 'messaging',
+    pluginVersion: '0.1.0',
+    bakinVersion: '0.0.1-rc.15',
+    bakinRange: '>=0.0.1-rc.15 <0.1.0',
+    platform: NEUTRAL_PLATFORM,
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    artifactUrl: 'https://example/messaging-0.1.0-neutral.tar.gz',
+    outDir,
+    builtAt: '2026-06-04T00:00:00.000Z',
+  }
+}
+
+describe('assemblePluginArtifact', () => {
+  it('produces an artifact + sha256 sidecar + index entry, with provenance', async () => {
+    const out = freshDir('out')
+    const result = await assemblePluginArtifact(input(seedBuilt(), out))
+
+    expect(existsSync(result.artifactPath)).toBe(true)
+    expect(existsSync(`${result.artifactPath}.sha256`)).toBe(true)
+    expect(readFileSync(`${result.artifactPath}.sha256`, 'utf-8')).toContain(result.sha256)
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.provenance.outputs.clientEntry).toBe('dist/client.js')
+    expect(result.provenance.sourceTreeSha).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.indexEntry.entry.sha256).toBe(result.sha256)
+  })
+
+  it('excludes plugin SOURCE files from the artifact (allow-list only)', async () => {
+    const out = freshDir('out')
+    const result = await assemblePluginArtifact(input(seedBuilt(), out))
+
+    const dest = freshDir('extract')
+    await safeExtractArtifact(result.artifactPath, dest)
+    expect(existsSync(join(dest, 'bakin-plugin.json'))).toBe(true)
+    expect(existsSync(join(dest, 'dist', 'index.js'))).toBe(true)
+    expect(existsSync(join(dest, '.whiskin', 'build.json'))).toBe(true)
+    // The stray index.ts source must not be present.
+    expect(existsSync(join(dest, 'index.ts'))).toBe(false)
+    // Provenance inside the artifact is readable + valid.
+    expect(readProvenance(join(dest, '.whiskin', 'build.json')).pluginId).toBe('messaging')
+  })
+
+  it('throws when dist/index.js is missing (not built)', async () => {
+    const dir = freshDir('unbuilt')
+    writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({ id: 'x', version: '0.1.0' }))
+    await expect(assemblePluginArtifact(input(dir, freshDir('out')))).rejects.toThrow(/not found/i)
+  })
+
+  it('builds an index that resolves the published artifact', async () => {
+    const out = freshDir('out')
+    const result = await assemblePluginArtifact(input(seedBuilt(), out))
+    const index = indexFromEntries([result.indexEntry])
+    const resolved = resolveArtifact(index, 'messaging', 'latest', 'darwin-arm64')
+    expect(resolved?.url).toBe('https://example/messaging-0.1.0-neutral.tar.gz')
+    expect(resolved?.sha256).toBe(result.sha256)
+  })
+})

--- a/tests/fixtures/whiskin-artifact-server.ts
+++ b/tests/fixtures/whiskin-artifact-server.ts
@@ -1,0 +1,120 @@
+/**
+ * Hermetic artifact host for Whiskin consumer-path tests.
+ *
+ * The consumer install path (Phase 6) downloads a published artifact + its
+ * `.sha256` + `whiskin-artifacts.json` over HTTPS. Tests must never hit the
+ * real network or GitHub. This helper serves a local directory over
+ * `http://127.0.0.1:<ephemeral-port>/` so a test can point a resolver at a
+ * fixture release and exercise download/verify/extract end-to-end offline.
+ *
+ * It is intentionally format-agnostic: it serves whatever bytes you place in
+ * the root dir (tarball, checksum file, index JSON). The artifact tarball
+ * format itself is defined in Phase 3; this host does not assume it.
+ *
+ * Implementation note: uses `node:http` (not `Bun.serve`) on purpose. The test
+ * runner registers happy-dom globally, whose `fetch` drives node's HTTP client
+ * — which rejects some `Bun.serve` responses with `HPE_UNEXPECTED_CONTENT_LENGTH`.
+ * A `node:http` server (the same shape Bakin's real `server.ts` uses) is fully
+ * compatible with that client.
+ *
+ * Usage:
+ *
+ *   const host = await startArtifactServer(fixtureDir)
+ *   try {
+ *     const res = await fetch(`${host.origin}/messaging-0.1.0.tar.zst`)
+ *     ...
+ *   } finally {
+ *     await host.stop()
+ *   }
+ */
+import { createServer, type Server } from 'http'
+import { createReadStream } from 'fs'
+import { readFile, stat, writeFile, mkdir } from 'fs/promises'
+import { createHash } from 'crypto'
+import { join, normalize, sep } from 'path'
+import { once } from 'events'
+
+export interface ArtifactServer {
+  /** e.g. `http://127.0.0.1:54123` — no trailing slash. */
+  origin: string
+  port: number
+  /** Stop the server and free the port. */
+  stop: () => Promise<void>
+  /** Count of requests served, for assertions ("downloaded exactly once"). */
+  requestCount: () => number
+}
+
+/**
+ * Serve `rootDir` over an ephemeral localhost port. Path traversal outside
+ * `rootDir` is refused (403). Missing files return 404. No directory listing.
+ */
+export async function startArtifactServer(rootDir: string): Promise<ArtifactServer> {
+  let requests = 0
+  const resolvedRoot = normalize(rootDir)
+
+  const server: Server = createServer((req, res) => {
+    requests++
+    void (async () => {
+      try {
+        const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname
+        const rel = normalize(decodeURIComponent(pathname)).replace(/^[/\\]+/, '')
+        const full = normalize(join(resolvedRoot, rel))
+        if (full !== resolvedRoot && !full.startsWith(resolvedRoot + sep)) {
+          res.statusCode = 403
+          res.end('forbidden')
+          return
+        }
+        const st = await stat(full)
+        if (!st.isFile()) {
+          res.statusCode = 404
+          res.end('not found')
+          return
+        }
+        res.statusCode = 200
+        res.setHeader('content-length', st.size)
+        createReadStream(full).pipe(res)
+      } catch {
+        res.statusCode = 404
+        res.end('not found')
+      }
+    })()
+  })
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('artifact server failed to bind an ephemeral port')
+  }
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    port: address.port,
+    requestCount: () => requests,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+/**
+ * Write `<name>` and its sibling `<name>.sha256` into `dir`, returning the
+ * SHA256. Mirrors how `bakin plugins publish` will emit an artifact + checksum.
+ * Format-agnostic: `bytes` can be any artifact payload.
+ */
+export async function writeArtifactWithChecksum(
+  dir: string,
+  name: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  await mkdir(dir, { recursive: true })
+  const sha = createHash('sha256').update(bytes).digest('hex')
+  await writeFile(join(dir, name), bytes)
+  await writeFile(join(dir, `${name}.sha256`), `${sha}  ${name}\n`, 'utf-8')
+  return sha
+}
+
+// `readFile` is part of the helper's public surface for tests that want to read
+// fixture bytes back without re-importing fs/promises.
+export { readFile as readFixtureFile }

--- a/tests/fixtures/whiskin/README.md
+++ b/tests/fixtures/whiskin/README.md
@@ -1,0 +1,16 @@
+# Whiskin source-only plugin fixtures
+
+Source-only plugin trees (no committed `dist/`) used by the Whiskin build,
+publish, and consumer-install phases. They are inert source until a phase
+actually builds them:
+
+- `pure-server/` — server-only plugin (no client bundle).
+- `server-client/` — server + `client.tsx` (exercises the client build).
+- `with-dep/` — declares a pure-JS npm dependency (`bun install` path).
+
+These are intentionally minimal and structurally match a real plugin
+(`bakin-plugin.json` + `index.ts` + optional `client.tsx` + `package.json`).
+They are first exercised by the shared build backend (Phase 2) and the consumer
+install path (Phase 6); expect their shape to be tightened when those land.
+
+See `.claude/specs/whiskin-plugin-builder-plan.md` (Phase 0).

--- a/tests/fixtures/whiskin/pure-server/bakin-plugin.json
+++ b/tests/fixtures/whiskin/pure-server/bakin-plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "whiskin-pure-server",
+  "name": "Whiskin Pure Server",
+  "version": "0.1.0",
+  "bakin": ">=0.0.1-rc.1",
+  "description": "Source-only server-only fixture plugin (no client bundle).",
+  "entry": {
+    "server": "index.ts"
+  },
+  "permissions": [],
+  "contributes": {}
+}

--- a/tests/fixtures/whiskin/pure-server/index.ts
+++ b/tests/fixtures/whiskin/pure-server/index.ts
@@ -1,0 +1,20 @@
+// Minimal server-only fixture plugin. Uses a local interface (not the SDK
+// BakinPlugin type) to stay decoupled from SDK internals, matching the
+// sample-user-plugin fixture pattern. Built by the Whiskin server build path.
+interface PluginLike {
+  id: string
+  name: string
+  version: string
+  activate: () => void
+}
+
+const plugin: PluginLike = {
+  id: 'whiskin-pure-server',
+  name: 'Whiskin Pure Server',
+  version: '0.1.0',
+  activate() {
+    // No-op: exists to exercise the server-only build path.
+  },
+}
+
+export default plugin

--- a/tests/fixtures/whiskin/pure-server/package.json
+++ b/tests/fixtures/whiskin/pure-server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "whiskin-pure-server",
+  "version": "0.1.0",
+  "private": true,
+  "peerDependencies": {
+    "@makinbakin/sdk": "*"
+  }
+}

--- a/tests/fixtures/whiskin/server-client/bakin-plugin.json
+++ b/tests/fixtures/whiskin/server-client/bakin-plugin.json
@@ -1,0 +1,13 @@
+{
+  "id": "whiskin-server-client",
+  "name": "Whiskin Server + Client",
+  "version": "0.1.0",
+  "bakin": ">=0.0.1-rc.1",
+  "description": "Source-only fixture plugin with a server entry and a client bundle.",
+  "entry": {
+    "server": "index.ts",
+    "client": "client.tsx"
+  },
+  "permissions": [],
+  "contributes": {}
+}

--- a/tests/fixtures/whiskin/server-client/client.tsx
+++ b/tests/fixtures/whiskin/server-client/client.tsx
@@ -1,0 +1,7 @@
+import { registerPlugin } from '@makinbakin/sdk'
+
+// Side-effect registration, matching the real plugin client contract.
+registerPlugin({
+  id: 'whiskin-server-client',
+  navItems: [],
+})

--- a/tests/fixtures/whiskin/server-client/index.ts
+++ b/tests/fixtures/whiskin/server-client/index.ts
@@ -1,0 +1,18 @@
+// Minimal server entry paired with a client.tsx (exercises both build paths).
+interface PluginLike {
+  id: string
+  name: string
+  version: string
+  activate: () => void
+}
+
+const plugin: PluginLike = {
+  id: 'whiskin-server-client',
+  name: 'Whiskin Server + Client',
+  version: '0.1.0',
+  activate() {
+    // No-op: exists to exercise the server build alongside a client.
+  },
+}
+
+export default plugin

--- a/tests/fixtures/whiskin/server-client/package.json
+++ b/tests/fixtures/whiskin/server-client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "whiskin-server-client",
+  "version": "0.1.0",
+  "private": true,
+  "peerDependencies": {
+    "@makinbakin/sdk": "*",
+    "react": "*"
+  }
+}

--- a/tests/fixtures/whiskin/with-dep/bakin-plugin.json
+++ b/tests/fixtures/whiskin/with-dep/bakin-plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "whiskin-with-dep",
+  "name": "Whiskin With Dependency",
+  "version": "0.1.0",
+  "bakin": ">=0.0.1-rc.1",
+  "description": "Source-only fixture plugin that declares a pure-JS npm dependency.",
+  "entry": {
+    "server": "index.ts"
+  },
+  "permissions": [],
+  "contributes": {}
+}

--- a/tests/fixtures/whiskin/with-dep/index.ts
+++ b/tests/fixtures/whiskin/with-dep/index.ts
@@ -1,0 +1,25 @@
+// Fixture that declares + uses a pure-JS npm dependency (no native, no install
+// scripts), exercising the `bun install` + dependency-bundling build path. The
+// dep is intentionally NOT in the repo's root node_modules — Whiskin installs
+// it into staging at build time — so this fixture is excluded from the app
+// typecheck (see tsconfig.app.json).
+import slugify from '@sindresorhus/slugify'
+
+interface PluginLike {
+  id: string
+  name: string
+  version: string
+  activate: () => void
+}
+
+const plugin: PluginLike = {
+  id: 'whiskin-with-dep',
+  name: 'Whiskin With Dependency',
+  version: '0.1.0',
+  activate() {
+    // Reference the dep so the bundler must resolve + include it.
+    void slugify('Whiskin With Dep')
+  },
+}
+
+export default plugin

--- a/tests/fixtures/whiskin/with-dep/package.json
+++ b/tests/fixtures/whiskin/with-dep/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "whiskin-with-dep",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@sindresorhus/slugify": "^2.2.1"
+  },
+  "peerDependencies": {
+    "@makinbakin/sdk": "*"
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,6 +23,7 @@
     "packages/**/dist/**",
     "plugins/**/dist/**",
     "dev/openclaw-home",
-    "dev/bakin-instances"
+    "dev/bakin-instances",
+    "tests/fixtures/whiskin"
   ]
 }


### PR DESCRIPTION
## What this is

The **foundation** for Whiskin (the plugin build/distribution rework — see
`.claude/specs/whiskin-plugin-builder.md`). It lands the tested primitives and
the full artifact data-flow **without touching the live install path or the
browser**, so it's low-risk to review and merge as the base for the follow-ups.

Built in small, independently-revertible commits, every one behavior-preserving
where it touched existing code (gated by a new characterization suite + the
existing test suites + a real `build:plugins` smoke).

## What's in it

- **P0 — foundation**: source-only plugin fixtures, a hermetic artifact host, and
  an install-core **characterization gate** locking the agent-package installer's
  behavior (the proven reference the shared core converges toward).
- **P5 — shared install core** (`src/core/install-core/` + `packages/core/src/install-core/`):
  unified `#subpath` guard, shared atomic JSON write (both lockfiles), shared
  advisory install lock, shared staging→atomic commit. *4 drift surfaces between
  the plugin and agent-package install paths eliminated.*
- **P2 — build module** (partial): single externals-contract source + the plugin
  import scanner moved into `src/core/whiskin/`. *(The in-process→shell-out
  server-build flip is deliberately deferred — see below.)*
- **P3 — artifact format** (complete): build provenance schema/IO, artifact
  assemble + checksum + **guarded safe-extraction** (zip-slip / symlink / size
  caps), and the `whiskin-artifacts.json` index with carry-forward.
- **P4 — publish core**: source-hash + `assemblePluginArtifact` (stages only the
  artifact entries so plugin source never leaks) + index builder.
- **P6 — consumer core**: redirect-following downloader, pluggable resolver, and
  `materializeArtifact` (resolve → download → verify → safe-extract), plus a
  hermetic **end-to-end test** of the whole artifact lane.

## Verification

- `bun run test`: **4376 pass / 10 skip / 0 fail** (4386 tests across 418 files).
- `bun run typecheck`: clean.
- `bun run build:plugins`: all 10 core plugins build with the shared externals.
- Whiskin suite incl. real-`tar` e2e: **36/36**.
- Playwright on the live shell: all 10 core + 2 official plugins load & render,
  plugin routes render, **0 console errors**.

## Explicitly NOT in this PR (follow-ups)

These are integration phases that touch the live path or the browser and want
runtime verification on their own:
1. **Live install wiring** — `materializeArtifact` → commit into
   `~/.bakin/plugins/<id>` + lockfile + activation, replacing `trustExistingDist`
   in `install.ts`.
2. **`bakin plugins publish` CLI** — wires the publish core into a command.
3. **Build-flip** (in-process→shell-out server build) — only needed for the
   non-existent consumer-build case; deferred.
4. **Browser P1 (lazy loading) / P8 (hot reload)**, **P9 startup verifier**,
   **P11 agent-package convergence**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)