### PR TITLE
feat(plugins): Whiskin publish CLI + live artifact install

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -5,6 +5,14 @@
  */
 import { readFileSync, writeFileSync } from 'node:fs'
 import { APP_VERSION } from '../packages/core/src/constants'
+import { assemblePluginArtifact, indexFromEntries } from '../src/core/whiskin/publish'
+import {
+  INDEX_FILENAME,
+  NEUTRAL_PLATFORM,
+  mergeArtifactsIndex,
+  readArtifactsIndex,
+  writeArtifactsIndex,
+} from '../src/core/whiskin/artifacts-index'
 import {
   cmdScheduleList, cmdScheduleAdd, cmdSchedulePause,
   cmdScheduleResume, cmdScheduleRemove, cmdScheduleRun, cmdScheduleRuns,
@@ -991,6 +999,91 @@ async function cmdDiagnosticsStartup(action: string | undefined, args: string[])
   }
 
   await exitUnknownSubcommand('diagnostics startup', action, ['status', 'on', 'off'])
+}
+
+/**
+ * `bakin plugins publish <builtPluginDir> --out <dir>` — assemble a published
+ * artifact from a BUILT plugin directory (Whiskin Phase 4). Purely local: reads
+ * the manifest, stamps provenance, tars + checksums the artifact, and writes (or
+ * carries forward into) whiskin-artifacts.json. Building the plugin is the
+ * producer's step (run before this); `--build` is a future addition.
+ */
+async function cmdPluginsPublish(
+  pluginDir: string,
+  opts: { out: string; baseUrl?: string; platform?: string; json?: boolean },
+): Promise<void> {
+  const { existsSync } = await import('node:fs')
+  const { resolve, join } = await import('node:path')
+
+  const abs = resolve(pluginDir)
+  const manifestPath = join(abs, 'bakin-plugin.json')
+  if (!existsSync(manifestPath)) {
+    await exitCommandIssue(`No bakin-plugin.json found in ${abs}`, {
+      command: 'bakin plugins publish',
+      usage: 'bakin plugins publish <builtPluginDir> --out <dir> [--base-url <url>] [--platform <p>] [--json]',
+    })
+    return
+  }
+  let manifest: { id?: string; version?: string; bakin?: string }
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+  } catch (err) {
+    await exitCommandIssue(`Invalid bakin-plugin.json: ${err instanceof Error ? err.message : String(err)}`, {
+      command: 'bakin plugins publish',
+    })
+    return
+  }
+  if (!manifest.id || !manifest.version) {
+    await exitCommandIssue('bakin-plugin.json must declare "id" and "version"', {
+      command: 'bakin plugins publish',
+    })
+    return
+  }
+  if (!existsSync(join(abs, 'dist', 'index.js'))) {
+    await exitCommandIssue(`No dist/index.js in ${abs} — build the plugin before publishing.`, {
+      command: 'bakin plugins publish',
+    })
+    return
+  }
+
+  const platform = opts.platform || NEUTRAL_PLATFORM
+  const bakinRange = manifest.bakin || `>=${APP_VERSION}`
+  const filename = `${manifest.id}-${manifest.version}-${platform}.tar.gz`
+  const artifactUrl = opts.baseUrl ? `${opts.baseUrl.replace(/\/+$/, '')}/${filename}` : filename
+  const outDir = resolve(opts.out)
+
+  const result = await assemblePluginArtifact({
+    builtDir: abs,
+    pluginId: manifest.id,
+    pluginVersion: manifest.version,
+    bakinVersion: APP_VERSION,
+    bakinRange,
+    platform,
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    artifactUrl,
+    outDir,
+    builtAt: new Date().toISOString(),
+  })
+
+  // Carry forward an existing index in the same out dir (so messaging+projects
+  // publish into one complete release catalog).
+  const indexPath = join(outDir, INDEX_FILENAME)
+  const fresh = indexFromEntries([result.indexEntry])
+  const index = existsSync(indexPath)
+    ? mergeArtifactsIndex(readArtifactsIndex(indexPath), fresh)
+    : fresh
+  writeArtifactsIndex(indexPath, index)
+
+  if (opts.json) {
+    print({ pluginId: manifest.id, version: manifest.version, platform, artifact: result.artifactPath, sha256: result.sha256, index: indexPath })
+    return
+  }
+  console.log(`Published ${manifest.id}@${manifest.version} (${platform})`)
+  console.log(`  artifact: ${result.artifactPath}`)
+  console.log(`  sha256:   ${result.sha256}`)
+  console.log(`  checksum: ${result.artifactPath}.sha256`)
+  console.log(`  index:    ${indexPath}`)
 }
 
 async function cmdPluginsList(opts: { json?: boolean; check?: boolean } = {}): Promise<void> {
@@ -4189,6 +4282,28 @@ export async function main(): Promise<void> {
             force: parsed.force,
             ref: parsed.ref,
             json: parsed.json,
+          })
+        } else if (sub === 'publish') {
+          const PUBLISH_USAGE = 'bakin plugins publish <builtPluginDir> --out <dir> [--base-url <url>] [--platform <p>] [--json]'
+          const flags = args.slice(2)
+          const dir = flags.find(arg => !arg.startsWith('--'))
+          const flagValue = (name: string): string | undefined => {
+            const i = flags.indexOf(name)
+            return i >= 0 && i + 1 < flags.length ? flags[i + 1] : undefined
+          }
+          const out = flagValue('--out')
+          if (!dir || !out) {
+            await exitCommandIssue(!dir ? 'Missing <builtPluginDir>.' : 'Missing required --out <dir>.', {
+              command: 'bakin plugins publish',
+              usage: PUBLISH_USAGE,
+            })
+            return
+          }
+          await cmdPluginsPublish(dir, {
+            out,
+            baseUrl: flagValue('--base-url'),
+            platform: flagValue('--platform'),
+            json: flags.includes('--json'),
           })
         } else if (sub === 'export') {
           const flags = args.slice(2)

--- a/src/core/whiskin/consumer-install.ts
+++ b/src/core/whiskin/consumer-install.ts
@@ -8,7 +8,7 @@
  * ~/.bakin/plugins/<id> via the shared install-core commitStaging (next slice +
  * the live install.ts rewrite).
  */
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { downloadToFile } from './download'
@@ -46,6 +46,12 @@ export async function materializeArtifact(
   pluginId: string,
   version: string,
   platform: string,
+  /**
+   * Root for the materialization work dir. Defaults to the OS temp dir; the
+   * live-install layer passes a dir UNDER the content dir so the subsequent
+   * commit is a same-filesystem rename (a cross-device rename would EXDEV-fail).
+   */
+  workRoot: string = tmpdir(),
 ): Promise<MaterializedArtifact> {
   const location = await resolver.resolve(pluginId, version, platform)
   if (!location) {
@@ -55,7 +61,8 @@ export async function materializeArtifact(
     )
   }
 
-  const workDir = mkdtempSync(join(tmpdir(), `whiskin-install-${pluginId}-`))
+  mkdirSync(workRoot, { recursive: true })
+  const workDir = mkdtempSync(join(workRoot, `whiskin-install-${pluginId}-`))
   const cleanup = () => rmSync(workDir, { recursive: true, force: true })
   try {
     const tarball = join(workDir, 'artifact.tar.gz')

--- a/src/core/whiskin/github-resolver.ts
+++ b/src/core/whiskin/github-resolver.ts
@@ -1,0 +1,54 @@
+/**
+ * GitHub-release artifact resolver (Open Q2, v1 backend).
+ *
+ * Turns a `github:owner/repo[@ref]#subpath` source into a resolver pointed at
+ * the right release's `whiskin-artifacts.json`, plus the pluginId derived from
+ * the subpath:
+ *   - no `@ref`  → the stable, non-API `releases/latest/download/` redirect.
+ *   - `@<tag>`   → that tag's `releases/download/<tag>/`.
+ *
+ * Reuses the single source-string parser (`parseGithubSource`) so the github
+ * shorthand / `@ref` / `#subpath` rules stay in one place.
+ *
+ * Part of the Whiskin consumer install path (Phase 6).
+ */
+import { parseGithubSource } from '@bakin/core/plugins/source'
+import { httpIndexResolver, type WhiskinArtifactResolver } from './resolver'
+
+export interface GithubArtifactSource {
+  resolver: WhiskinArtifactResolver
+  /** Plugin id, derived from the last segment of the `#subpath`. */
+  pluginId: string
+  /** Base URL the index is read from (exposed for diagnostics/tests). */
+  baseUrl: string
+}
+
+function ownerRepoFromCloneUrl(cloneUrl: string): { owner: string; repo: string } | null {
+  const m = cloneUrl.match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
+  if (!m) return null
+  return { owner: m[1]!, repo: m[2]! }
+}
+
+/**
+ * Build a GitHub-release resolver + pluginId from a plugin source string.
+ * Throws on a non-github source, a source without a `#subpath`, or one whose
+ * owner/repo can't be derived.
+ */
+export function githubArtifactSource(source: string): GithubArtifactSource {
+  const parsed = parseGithubSource(source)
+  const ownerRepo = ownerRepoFromCloneUrl(parsed.cloneUrl)
+  if (!ownerRepo) {
+    throw new Error(`Whiskin: cannot derive owner/repo from source "${source}"`)
+  }
+  if (!parsed.subpath) {
+    throw new Error(
+      `Whiskin: a published plugin source needs a "#subpath" (e.g. github:owner/repo#plugins/messaging)`,
+    )
+  }
+  const pluginId = parsed.subpath.split('/').filter(Boolean).pop()!
+  const baseUrl = parsed.ref
+    ? `https://github.com/${ownerRepo.owner}/${ownerRepo.repo}/releases/download/${parsed.ref}`
+    : `https://github.com/${ownerRepo.owner}/${ownerRepo.repo}/releases/latest/download`
+
+  return { resolver: httpIndexResolver(baseUrl, 'github'), pluginId, baseUrl }
+}

--- a/src/core/whiskin/live-install.ts
+++ b/src/core/whiskin/live-install.ts
@@ -1,0 +1,133 @@
+/**
+ * Live artifact install (Phase 6) — the toolchain-free consumer install that
+ * lands a published plugin into `~/.bakin/plugins/<id>` and records it in the
+ * plugin lockfile.
+ *
+ * Flow: acquire the (now-shared) install lock → materialize the artifact into a
+ * staging dir UNDER the content dir (same filesystem, so the commit is an atomic
+ * rename) → validate the manifest → check externals-contract compatibility →
+ * atomically commit via the shared `commitStaging` → write the lockfile entry.
+ * On any failure nothing is committed and the lock is released.
+ *
+ * This is the consumer half going live. It deliberately reuses the shared
+ * install-core primitives (lock + commit) so plugins now get the same
+ * concurrency + atomicity guarantees agent packages already had.
+ */
+import { existsSync, readFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { getContentDir } from '@/core/content-dir'
+import {
+  addPlugin,
+  readPluginLockfile,
+  writePluginLockfile,
+  type PluginLockEntry,
+} from '@bakin/core/plugins/lockfile'
+import { parseManifestPermissions } from '@bakin/core/plugins/permissions'
+import { acquireLock, releaseLock } from '@/core/install-core/install-lock'
+import { commitStaging } from '@/core/install-core/transaction'
+import { materializeArtifact } from './consumer-install'
+import { isExternalsContractCompatible } from './provenance'
+import type { WhiskinArtifactResolver } from './resolver'
+
+export type LiveInstallErrorCode = 'MANIFEST_MISMATCH' | 'EXTERNALS_CONTRACT_INCOMPATIBLE'
+
+export class LiveInstallError extends Error {
+  readonly code: LiveInstallErrorCode
+  constructor(code: LiveInstallErrorCode, message: string) {
+    super(message)
+    this.name = 'LiveInstallError'
+    this.code = code
+  }
+}
+
+export interface InstallArtifactOptions {
+  resolver: WhiskinArtifactResolver
+  /** Original install source string, recorded in the lockfile. */
+  source: string
+  pluginId: string
+  version: string
+  platform: string
+}
+
+export interface InstallArtifactResult {
+  pluginId: string
+  version: string
+  installDir: string
+}
+
+/**
+ * Install a published artifact into the content dir + lockfile. Throws
+ * NO_PREBUILT_ARTIFACT / CHECKSUM_MISMATCH (from materialize) or
+ * MANIFEST_MISMATCH / EXTERNALS_CONTRACT_INCOMPATIBLE.
+ */
+export async function installArtifact(opts: InstallArtifactOptions): Promise<InstallArtifactResult> {
+  const contentDir = getContentDir()
+  const pluginsDir = join(contentDir, 'plugins')
+  const lockPath = join(pluginsDir, '.install.lock')
+  const stagingRoot = join(contentDir, '.whiskin-staging')
+
+  acquireLock(lockPath)
+  try {
+    const materialized = await materializeArtifact(
+      opts.resolver,
+      opts.pluginId,
+      opts.version,
+      opts.platform,
+      stagingRoot,
+    )
+    try {
+      // Validate the manifest in the extracted artifact.
+      const manifestPath = join(materialized.stagingDir, 'bakin-plugin.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as {
+        id?: string
+        version?: string
+        permissions?: unknown
+      }
+      if (manifest.id !== opts.pluginId) {
+        throw new LiveInstallError(
+          'MANIFEST_MISMATCH',
+          `artifact manifest id "${manifest.id}" does not match requested plugin "${opts.pluginId}"`,
+        )
+      }
+
+      // The host must still provide the externals the artifact was built for.
+      if (!isExternalsContractCompatible(materialized.provenance)) {
+        throw new LiveInstallError(
+          'EXTERNALS_CONTRACT_INCOMPATIBLE',
+          `artifact externals contract "${materialized.provenance.externalsContract}" is not compatible with this host`,
+        )
+      }
+
+      // Atomic publish into ~/.bakin/plugins/<id> (same-filesystem rename).
+      const installDir = join(pluginsDir, opts.pluginId)
+      commitStaging(materialized.stagingDir, installDir)
+
+      const entry: PluginLockEntry = {
+        source: opts.source,
+        type: 'github',
+        ref: '',
+        commitSha: materialized.provenance.sourceCommitSha || '',
+        installedAt: new Date().toISOString(),
+        version: materialized.provenance.pluginVersion,
+        permissions: parseManifestPermissions(manifest.permissions),
+        manifestSha: materialized.provenance.manifestSha,
+      }
+      writePluginLockfile(addPlugin(readPluginLockfile(), opts.pluginId, entry))
+
+      return { pluginId: opts.pluginId, version: entry.version, installDir }
+    } finally {
+      // commitStaging renamed the extracted dir out; this clears the leftover
+      // work dir (downloaded tarball) only.
+      materialized.cleanup()
+    }
+  } finally {
+    releaseLock(lockPath)
+    if (existsSync(stagingRoot)) {
+      try {
+        rmSync(stagingRoot, { recursive: true, force: true })
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}

--- a/src/core/whiskin/publish.ts
+++ b/src/core/whiskin/publish.ts
@@ -61,8 +61,15 @@ export interface AssembledArtifact {
   indexEntry: IndexEntryRef
 }
 
-/** Top-level entries copied into the artifact (must match artifact.ts ALLOWED_TOP_LEVEL). */
-const ARTIFACT_CONTENTS = ['bakin-plugin.json', 'dist', 'node_modules'] as const
+/**
+ * Top-level entries copied into the artifact (a subset of artifact.ts
+ * ALLOWED_TOP_LEVEL). v1 is pure-JS only: the build inlines real deps and the
+ * host provides React/SDK externals, so `node_modules/` is NOT shipped — it
+ * would bloat the artifact and ship duplicate React/SDK copies, breaking the
+ * "one React, one SDK" invariant. Native support (deferred Phase 7) will add
+ * only the specific runtime modules listed in provenance.outputs.runtimeModules.
+ */
+const ARTIFACT_CONTENTS = ['bakin-plugin.json', 'dist'] as const
 
 /**
  * Assemble a published artifact from a built plugin directory. Stages only the

--- a/tests/core/whiskin/github-resolver.test.ts
+++ b/tests/core/whiskin/github-resolver.test.ts
@@ -1,0 +1,55 @@
+/**
+ * GitHub-release resolver URL construction (Phase 6). Pure — no network.
+ * Mandatory isolation mocks per project rule.
+ */
+import { describe, it, expect, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+const mockDir = join(tmpdir(), `whiskin-ghres-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { githubArtifactSource } from '../../../src/core/whiskin/github-resolver'
+
+describe('githubArtifactSource', () => {
+  it('uses the releases/latest/download redirect when no @ref', () => {
+    const r = githubArtifactSource('github:markhayden/bakin-bits-official#plugins/messaging')
+    expect(r.pluginId).toBe('messaging')
+    expect(r.baseUrl).toBe(
+      'https://github.com/markhayden/bakin-bits-official/releases/latest/download',
+    )
+    expect(r.resolver.scheme).toBe('github')
+  })
+
+  it('pins to a tag download path when @ref is given', () => {
+    const r = githubArtifactSource('github:markhayden/bakin-bits-official@messaging-v0.2.0#plugins/messaging')
+    expect(r.pluginId).toBe('messaging')
+    expect(r.baseUrl).toBe(
+      'https://github.com/markhayden/bakin-bits-official/releases/download/messaging-v0.2.0',
+    )
+  })
+
+  it('derives pluginId from the last subpath segment', () => {
+    expect(githubArtifactSource('github:owner/repo#plugins/projects').pluginId).toBe('projects')
+    expect(githubArtifactSource('owner/repo#a/b/my-plugin').pluginId).toBe('my-plugin')
+  })
+
+  it('requires a #subpath', () => {
+    expect(() => githubArtifactSource('github:owner/repo')).toThrow(/#subpath/i)
+  })
+})

--- a/tests/core/whiskin/live-install.test.ts
+++ b/tests/core/whiskin/live-install.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Live artifact install (Phase 6): a published artifact lands in the content
+ * dir + plugin lockfile, toolchain-free. Mocks content-dir so the install
+ * targets a temp ~/.bakin.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-whiskin-live-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = pathJoin(testDir, 'openclaw')
+
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { startArtifactServer, type ArtifactServer } from '../../fixtures/whiskin-artifact-server'
+import { assemblePluginArtifact, indexFromEntries } from '../../../src/core/whiskin/publish'
+import { writeArtifactsIndex, NEUTRAL_PLATFORM, INDEX_FILENAME } from '../../../src/core/whiskin/artifacts-index'
+import { httpIndexResolver } from '../../../src/core/whiskin/resolver'
+import { installArtifact } from '../../../src/core/whiskin/live-install'
+import { readPluginLockfile } from '../../../packages/core/src/plugins/lockfile'
+
+let host: ArtifactServer | null = null
+const extraDirs: string[] = []
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(testDir, { recursive: true })
+})
+
+function freshDir(prefix: string): string {
+  const d = pathJoin(tmpdir(), `whiskin-${prefix}-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  extraDirs.push(d)
+  return d
+}
+
+async function publishServedPlugin(origin: string): Promise<string> {
+  const built = freshDir('built')
+  writeFileSync(
+    join(built, 'bakin-plugin.json'),
+    JSON.stringify({ id: 'messaging', version: '0.1.0', permissions: ['storage.read'] }),
+  )
+  mkdirSync(join(built, 'dist'), { recursive: true })
+  writeFileSync(join(built, 'dist', 'index.js'), 'module.exports = {}\n')
+  writeFileSync(join(built, 'dist', 'client.js'), 'console.log(1)\n')
+
+  const releaseDir = freshDir('release')
+  const filename = `messaging-0.1.0-${NEUTRAL_PLATFORM}.tar.gz`
+  const result = await assemblePluginArtifact({
+    builtDir: built,
+    pluginId: 'messaging',
+    pluginVersion: '0.1.0',
+    bakinVersion: '0.0.1-rc.15',
+    bakinRange: '>=0.0.1-rc.1',
+    platform: NEUTRAL_PLATFORM,
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    artifactUrl: `${origin}/${filename}`,
+    outDir: releaseDir,
+    builtAt: '2026-06-04T00:00:00.000Z',
+  })
+  writeArtifactsIndex(join(releaseDir, INDEX_FILENAME), indexFromEntries([result.indexEntry]))
+  return releaseDir
+}
+
+describe('installArtifact (live consumer install)', () => {
+  it('installs a published artifact into the content dir + lockfile', async () => {
+    const releaseDir = await (async () => {
+      // Serve a placeholder dir first to get the origin, then publish into it.
+      const dir = freshDir('serve')
+      host = await startArtifactServer(dir)
+      const published = await publishServedPlugin(host.origin)
+      // Move published files into the served dir.
+      const { cpSync } = await import('fs')
+      cpSync(published, dir, { recursive: true })
+      return dir
+    })()
+    expect(existsSync(releaseDir)).toBe(true)
+
+    const resolver = httpIndexResolver(host!.origin)
+    const result = await installArtifact({
+      resolver,
+      source: 'github:markhayden/bakin-bits-official#plugins/messaging',
+      pluginId: 'messaging',
+      version: 'latest',
+      platform: 'darwin-arm64',
+    })
+
+    // Landed in the content dir.
+    expect(result.installDir).toBe(join(testDir, 'plugins', 'messaging'))
+    expect(existsSync(join(testDir, 'plugins', 'messaging', 'bakin-plugin.json'))).toBe(true)
+    expect(existsSync(join(testDir, 'plugins', 'messaging', 'dist', 'index.js'))).toBe(true)
+    expect(existsSync(join(testDir, 'plugins', 'messaging', '.whiskin', 'build.json'))).toBe(true)
+
+    // Recorded in the lockfile.
+    const entry = readPluginLockfile().plugins['messaging']
+    expect(entry).toBeDefined()
+    expect(entry.version).toBe('0.1.0')
+    expect(entry.type).toBe('github')
+    expect(entry.permissions).toContain('storage.read')
+
+    // No staging leftover.
+    expect(existsSync(join(testDir, '.whiskin-staging'))).toBe(false)
+  })
+
+  it('throws NO_PREBUILT_ARTIFACT for a plugin not in the index', async () => {
+    const dir = freshDir('serve')
+    host = await startArtifactServer(dir)
+    const published = await publishServedPlugin(host.origin)
+    const { cpSync } = await import('fs')
+    cpSync(published, dir, { recursive: true })
+
+    const resolver = httpIndexResolver(host.origin)
+    await expect(
+      installArtifact({
+        resolver,
+        source: 'github:owner/repo#plugins/ghost',
+        pluginId: 'ghost',
+        version: 'latest',
+        platform: 'darwin-arm64',
+      }),
+    ).rejects.toMatchObject({ code: 'NO_PREBUILT_ARTIFACT' })
+  })
+})
+
+afterAll(() => {
+  if (host) void host.stop()
+  for (const d of extraDirs) rmSync(d, { recursive: true, force: true })
+})

--- a/tests/core/whiskin/publish.test.ts
+++ b/tests/core/whiskin/publish.test.ts
@@ -42,7 +42,7 @@ function freshDir(prefix: string): string {
   return d
 }
 
-/** A fake built plugin dir: manifest + dist + a stray SOURCE file. */
+/** A fake built plugin dir: manifest + dist + a stray SOURCE file + node_modules. */
 function seedBuilt(): string {
   const dir = freshDir('built')
   writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({ id: 'messaging', version: '0.1.0' }))
@@ -50,6 +50,9 @@ function seedBuilt(): string {
   mkdirSync(join(dir, 'dist'), { recursive: true })
   writeFileSync(join(dir, 'dist', 'index.js'), 'module.exports = {}\n')
   writeFileSync(join(dir, 'dist', 'client.js'), 'console.log(1)\n')
+  // node_modules (incl. host-provided externals) must NOT end up in the artifact.
+  mkdirSync(join(dir, 'node_modules', 'react'), { recursive: true })
+  writeFileSync(join(dir, 'node_modules', 'react', 'index.js'), 'module.exports = {}\n')
   return dir
 }
 
@@ -94,6 +97,8 @@ describe('assemblePluginArtifact', () => {
     expect(existsSync(join(dest, '.whiskin', 'build.json'))).toBe(true)
     // The stray index.ts source must not be present.
     expect(existsSync(join(dest, 'index.ts'))).toBe(false)
+    // node_modules (host-provided externals) must not be shipped in v1.
+    expect(existsSync(join(dest, 'node_modules'))).toBe(false)
     // Provenance inside the artifact is readable + valid.
     expect(readProvenance(join(dest, '.whiskin', 'build.json')).pluginId).toBe('messaging')
   })


### PR DESCRIPTION
Stacked on #437 (now merged). The consumer/producer halves that turn the
Whiskin foundation into a working publish→install pipeline. Validated
end-to-end against the real bakin-bits-official plugins.

## What's in it (3 commits)

1. **`bakin plugins publish`** + a real-bug fix. The command assembles a
   published artifact from a built plugin dir (provenance + tar + checksum +
   carry-forward `whiskin-artifacts.json`). **Fix caught by the real smoke:** the
   assembler was shipping the plugin's full `node_modules` — including
   host-provided `react`/`@makinbakin/sdk` *and bun-style symlinks the consumer
   safe-extractor rejects* — so artifacts would have failed to install. v1 is
   pure-JS, so `node_modules` is no longer shipped.
2. **Live artifact install** — `installArtifact()`: acquire shared install lock →
   materialize under the content dir (same-fs commit) → validate manifest →
   externals-contract check → atomic `commitStaging` → lockfile entry. Plugins
   now get the lock + atomic-commit guarantees agent packages already had.
3. **GitHub-release resolver** — `github:owner/repo[@ref]#subpath` →
   `releases/latest/download` (or `releases/download/<tag>`) + derived pluginId.

## Verified (real plugins, no mocks)

- `bakin plugins publish` on real bits `messaging` + `projects` → carry-forward
  index lists both.
- Full real smoke: published `messaging` → served over HTTP → installed into a
  fresh `~/.bakin` via the live path (download → SHA256 verify → safe-extract →
  commit → lockfile), toolchain-free.
- typecheck clean; whiskin suite 42/42.

## NOT in this PR (next)

Wiring the artifact path into the live install REST handler's two-phase consent
flow (`install.ts`) so `bakin plugins install github:…` is one command. The
engine is done + tested; that's the careful integration to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)