### PR TITLE
feat(plugins): install github plugins from published artifacts

### DIFF
--- a/packages/host/src/api/plugins/install.ts
+++ b/packages/host/src/api/plugins/install.ts
@@ -30,6 +30,11 @@ import { materializeCachedGithubSource } from '@/core/github-source-cache'
 import { createLogger } from '@/core/logger'
 import { isCorePlugin } from '@/lib/plugin-registry'
 import { buildUserPlugin } from '../../plugin-host/user-plugin-builder'
+import { githubArtifactSource } from '@/core/whiskin/github-resolver'
+import type { WhiskinArtifactLocation } from '@/core/whiskin/resolver'
+import { downloadToFile } from '@/core/whiskin/download'
+import { safeExtractArtifact, verifyChecksum } from '@/core/whiskin/artifact'
+import { readProvenance, PROVENANCE_FILENAME } from '@/core/whiskin/provenance'
 import {
   addPlugin,
   readPluginLockfile,
@@ -374,6 +379,9 @@ export async function post(req: Request, _url: URL): Promise<Response> {
       let effectivePluginDir: string = stagingDir
       let requestedRef = ''
       let gitProvenance: { ref: string; commitSha: string } | undefined
+      // True when a published Whiskin artifact was installed (already built —
+      // skip the source build step).
+      let installedFromArtifact = false
 
       if (body.type === 'local') {
         if (body.source.includes('#')) {
@@ -408,46 +416,76 @@ export async function post(req: Request, _url: URL): Promise<Response> {
         }
         requestedRef = body.ref ?? parsedUrl.ref
 
-        try {
-          await materializeCachedGithubSource({
-            cloneUrl: parsedUrl.url,
-            ref: requestedRef || undefined,
-            stagingDir,
-          })
-          gitProvenance = resolveGitProvenance(stagingDir, body.type, requestedRef)
-        } catch (err) {
-          rmSync(stagingDir, { recursive: true, force: true })
-          const message = err instanceof Error ? err.message : String(err)
-          auditInstallRejected('git_clone_failed', body.source, { ref: requestedRef, error: message })
-          return Response.json({ ok: false, error: message }, { status: 400 })
+        // Whiskin: for a subpath github source, prefer a published artifact
+        // (toolchain-free). The plugin is identified by the subpath. Only fall
+        // back to git-clone + build when no published artifact exists; a
+        // verify/extract failure AFTER a match is a hard error (never silently
+        // build a tampered artifact's source).
+        if (parsedUrl.subpath) {
+          const platform = `${process.platform}-${process.arch}`
+          let location: WhiskinArtifactLocation | null = null
+          try {
+            const gh = githubArtifactSource(body.source)
+            location = await gh.resolver.resolve(gh.pluginId, 'latest', platform)
+          } catch {
+            // No published index/release (or unresolvable) — fall back to source.
+            location = null
+          }
+          if (location) {
+            const tarball = join(stagingDir, '.whiskin-artifact.tar.gz')
+            await downloadToFile(location.artifactUrl, tarball)
+            await verifyChecksum(tarball, location.sha256)
+            await safeExtractArtifact(tarball, stagingDir)
+            rmSync(tarball, { force: true })
+            effectivePluginDir = stagingDir
+            const prov = readProvenance(join(stagingDir, '.whiskin', PROVENANCE_FILENAME))
+            gitProvenance = { ref: requestedRef, commitSha: prov.sourceCommitSha }
+            installedFromArtifact = true
+          }
         }
 
-        if (parsedUrl.subpath) {
-          // `parseGithubSource` already rejects `..` segments and leading
-          // slashes, so this `join` cannot escape `stagingDir`. Belt + suspenders:
-          // re-confirm containment before reading files from it.
-          const candidate = join(stagingDir, parsedUrl.subpath)
-          const stagingReal = realpathSync(stagingDir)
-          let candidateReal: string
+        if (!installedFromArtifact) {
           try {
-            candidateReal = realpathSync(candidate)
-          } catch {
+            await materializeCachedGithubSource({
+              cloneUrl: parsedUrl.url,
+              ref: requestedRef || undefined,
+              stagingDir,
+            })
+            gitProvenance = resolveGitProvenance(stagingDir, body.type, requestedRef)
+          } catch (err) {
             rmSync(stagingDir, { recursive: true, force: true })
-            auditInstallRejected('subpath_missing', body.source, { subpath: parsedUrl.subpath })
-            return Response.json({
-              ok: false,
-              error: `subpath "${parsedUrl.subpath}" not found in repository`,
-            }, { status: 400 })
+            const message = err instanceof Error ? err.message : String(err)
+            auditInstallRejected('git_clone_failed', body.source, { ref: requestedRef, error: message })
+            return Response.json({ ok: false, error: message }, { status: 400 })
           }
-          if (!candidateReal.startsWith(stagingReal + sep) && candidateReal !== stagingReal) {
-            rmSync(stagingDir, { recursive: true, force: true })
-            auditInstallRejected('subpath_traversal', body.source, { subpath: parsedUrl.subpath })
-            return Response.json({
-              ok: false,
-              error: `subpath "${parsedUrl.subpath}" escapes the cloned repository`,
-            }, { status: 400 })
+
+          if (parsedUrl.subpath) {
+            // `parseGithubSource` already rejects `..` segments and leading
+            // slashes, so this `join` cannot escape `stagingDir`. Belt + suspenders:
+            // re-confirm containment before reading files from it.
+            const candidate = join(stagingDir, parsedUrl.subpath)
+            const stagingReal = realpathSync(stagingDir)
+            let candidateReal: string
+            try {
+              candidateReal = realpathSync(candidate)
+            } catch {
+              rmSync(stagingDir, { recursive: true, force: true })
+              auditInstallRejected('subpath_missing', body.source, { subpath: parsedUrl.subpath })
+              return Response.json({
+                ok: false,
+                error: `subpath "${parsedUrl.subpath}" not found in repository`,
+              }, { status: 400 })
+            }
+            if (!candidateReal.startsWith(stagingReal + sep) && candidateReal !== stagingReal) {
+              rmSync(stagingDir, { recursive: true, force: true })
+              auditInstallRejected('subpath_traversal', body.source, { subpath: parsedUrl.subpath })
+              return Response.json({
+                ok: false,
+                error: `subpath "${parsedUrl.subpath}" escapes the cloned repository`,
+              }, { status: 400 })
+            }
+            effectivePluginDir = candidateReal
           }
-          effectivePluginDir = candidateReal
         }
       }
 
@@ -672,18 +710,23 @@ export async function post(req: Request, _url: URL): Promise<Response> {
       // artifacts ready on next boot. Failures here are fatal for the
       // install request — shipping an installed-but-unbuilt plugin would
       // crash startup instead of surfacing the error to the user now.
-      try {
-        await buildUserPlugin(targetDir, { trustExistingDist: body.type === 'github' })
-      } catch (buildErr) {
-        // Build failed — clean up the installed files so the install
-        // appears atomic from the user's perspective.
-        rmSync(targetDir, { recursive: true, force: true })
-        const message = buildErr instanceof Error ? buildErr.message : String(buildErr)
-        log.error('Plugin install build step failed', buildErr as Error, { id })
-        return Response.json({
-          ok: false,
-          error: `Installed "${id}" but failed to build it: ${message}`,
-        }, { status: 500 })
+      //
+      // A Whiskin artifact install is already built (dist/ shipped + verified),
+      // so the build step is skipped entirely.
+      if (!installedFromArtifact) {
+        try {
+          await buildUserPlugin(targetDir, { trustExistingDist: body.type === 'github' })
+        } catch (buildErr) {
+          // Build failed — clean up the installed files so the install
+          // appears atomic from the user's perspective.
+          rmSync(targetDir, { recursive: true, force: true })
+          const message = buildErr instanceof Error ? buildErr.message : String(buildErr)
+          log.error('Plugin install build step failed', buildErr as Error, { id })
+          return Response.json({
+            ok: false,
+            error: `Installed "${id}" but failed to build it: ${message}`,
+          }, { status: 500 })
+        }
       }
 
       // For local installs, record the resolved absolute source path so the

--- a/src/core/whiskin/download.ts
+++ b/src/core/whiskin/download.ts
@@ -14,6 +14,8 @@ import { get as httpGet, type IncomingMessage } from 'http'
 import { get as httpsGet } from 'https'
 
 const MAX_REDIRECTS = 5
+/** Per-request inactivity timeout — a slow/unreachable host must not hang an install. */
+const REQUEST_TIMEOUT_MS = 30_000
 
 /**
  * Issue a GET and follow redirects (301/302/303/307/308) up to MAX_REDIRECTS,
@@ -50,6 +52,9 @@ function fetchFinal(url: string, redirectsLeft = MAX_REDIRECTS): Promise<Incomin
       resolve(res)
     })
     req.on('error', reject)
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`timed out after ${REQUEST_TIMEOUT_MS}ms fetching ${url}`))
+    })
   })
 }
 

--- a/tests/plugins/lifecycle/install-artifact.test.ts
+++ b/tests/plugins/lifecycle/install-artifact.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Install via a published Whiskin artifact through the REST handler (Phase 6
+ * wiring). A `github:` source resolves a published artifact, downloads it,
+ * verifies the checksum, safe-extracts it, and installs it — no git clone, no
+ * build. Only `github-resolver` is mocked (to point at a hermetic host);
+ * download/verify/extract run for real.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from 'bun:test'
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-install-artifact-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+// Point the github resolver at the hermetic host; derive pluginId from subpath
+// like the real implementation. `currentOrigin` is set once the host is up.
+let currentOrigin = ''
+mock.module('../../../src/core/whiskin/github-resolver', () => ({
+  githubArtifactSource: (source: string) => {
+    const { httpIndexResolver } = require('../../../src/core/whiskin/resolver')
+    const subpath = source.split('#')[1] ?? ''
+    const pluginId = subpath.split('/').filter(Boolean).pop()
+    return { resolver: httpIndexResolver(currentOrigin, 'github'), pluginId, baseUrl: currentOrigin }
+  },
+}))
+
+import { post as installPOST } from '../../../packages/host/src/api/plugins/install'
+import { readPluginLockfile } from '../../../packages/core/src/plugins/lockfile'
+import { startArtifactServer, type ArtifactServer } from '../../fixtures/whiskin-artifact-server'
+import { assemblePluginArtifact, indexFromEntries } from '../../../src/core/whiskin/publish'
+import { writeArtifactsIndex, NEUTRAL_PLATFORM, INDEX_FILENAME } from '../../../src/core/whiskin/artifacts-index'
+
+let host: ArtifactServer | null = null
+const releaseDir = join(testDir, 'release')
+const ARTIFACT_FILE = `foo-1.0.0-${NEUTRAL_PLATFORM}.tar.gz`
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/plugins/install', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+/** Build + publish a fresh "foo" artifact into the served release dir. */
+async function publishFoo(): Promise<void> {
+  const built = join(testDir, 'built-foo')
+  rmSync(built, { recursive: true, force: true })
+  mkdirSync(join(built, 'dist'), { recursive: true })
+  writeFileSync(
+    join(built, 'bakin-plugin.json'),
+    JSON.stringify({
+      id: 'foo',
+      name: 'Foo',
+      version: '1.0.0',
+      bakin: '>=1.0.0',
+      description: 'Foo artifact-install fixture',
+      entry: { server: 'index.ts' },
+      permissions: [],
+    }),
+  )
+  writeFileSync(join(built, 'dist', 'index.js'), 'module.exports = {}\n')
+
+  rmSync(releaseDir, { recursive: true, force: true })
+  mkdirSync(releaseDir, { recursive: true })
+  const result = await assemblePluginArtifact({
+    builtDir: built,
+    pluginId: 'foo',
+    pluginVersion: '1.0.0',
+    bakinVersion: '0.0.1-rc.15',
+    bakinRange: '>=1.0.0',
+    platform: NEUTRAL_PLATFORM,
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    artifactUrl: `${currentOrigin}/${ARTIFACT_FILE}`,
+    outDir: releaseDir,
+    builtAt: '2026-06-04T00:00:00.000Z',
+  })
+  writeArtifactsIndex(join(releaseDir, INDEX_FILENAME), indexFromEntries([result.indexEntry]))
+}
+
+beforeAll(async () => {
+  mkdirSync(testDir, { recursive: true })
+  host = await startArtifactServer(releaseDir)
+  currentOrigin = host.origin
+})
+
+afterAll(async () => {
+  if (host) await host.stop()
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(async () => {
+  rmSync(join(testDir, 'plugins'), { recursive: true, force: true })
+  await publishFoo()
+})
+
+describe('install via published artifact (REST handler)', () => {
+  it('installs a github plugin from a published artifact — no git, no build', async () => {
+    const res = await installPOST(
+      makeRequest({ source: 'github:markhayden/bakin-bits-official#plugins/foo', type: 'github' }),
+      new URL('http://localhost/api/plugins/install'),
+    )
+    const json = (await res.json()) as { ok?: boolean; id?: string; error?: string }
+    expect(res.status).toBe(200)
+    expect(json.ok).toBe(true)
+    expect(json.id).toBe('foo')
+
+    // Landed from the artifact: dist shipped + provenance present (not a build).
+    expect(existsSync(join(testDir, 'plugins', 'foo', 'dist', 'index.js'))).toBe(true)
+    expect(existsSync(join(testDir, 'plugins', 'foo', '.whiskin', 'build.json'))).toBe(true)
+    // No staging or artifact-tarball leftovers.
+    expect(existsSync(join(testDir, 'plugins', 'foo', '.whiskin-artifact.tar.gz'))).toBe(false)
+
+    // Recorded in the lockfile as a github install.
+    const entry = readPluginLockfile().plugins['foo']
+    expect(entry).toBeDefined()
+    expect(entry.version).toBe('1.0.0')
+    expect(entry.type).toBe('github')
+  })
+
+  it('rejects a tampered artifact with a hard failure (no silent source fallback)', async () => {
+    // Corrupt the served artifact after the index recorded its checksum.
+    writeFileSync(join(testDir, 'release', `foo-1.0.0-${NEUTRAL_PLATFORM}.tar.gz`), 'tampered')
+    const res = await installPOST(
+      makeRequest({ source: 'github:markhayden/bakin-bits-official#plugins/foo', type: 'github' }),
+      new URL('http://localhost/api/plugins/install'),
+    )
+    const json = (await res.json()) as { ok?: boolean; error?: string }
+    expect(json.ok).toBe(false)
+    expect(existsSync(join(testDir, 'plugins', 'foo'))).toBe(false)
+  })
+})


### PR DESCRIPTION
The final consumer piece. `bakin plugins install github:owner/repo#subpath` now
prefers a published Whiskin artifact (toolchain-free — no git, no build, no bun
on the consumer) and falls back to the existing git-clone + build only when no
artifact exists.

## What changed

In the install REST handler's github branch (for a `#subpath` source):
1. Resolve the artifact via the github-release resolver (`releases/latest/download`
   or `releases/download/<tag>`).
2. If found → download → **verify checksum** → safe-extract into staging → skip
   the build (already built + verified).
3. If not found / no published index → fall back to the existing git-clone +
   build path, untouched.

The shared **consent preflight/commit token flow**, atomic copy, lockfile write,
and live activation are all unchanged — the artifact path reuses them. A
verify/extract failure *after* a match is a **hard error**: we never silently
build a tampered artifact's source. Non-github / no-subpath sources are
unaffected.

Plus: a 30s request timeout on the download helper so a slow/unreachable host
can't hang an install (every github install now hits the index first).

## Verified

- New integration test through the REST handler: a github source installs via a
  served artifact (asserts no git/build, dist + provenance present, lockfile
  entry) and a tampered artifact is rejected with no silent source fallback.
- Full repo suite: **4467 pass / 0 fail** (431 files). typecheck clean.

## With this, the full pipeline is live end-to-end

`bakin plugins publish` (producer) → GitHub release → `bakin plugins install
github:…` (consumer, toolchain-free). Remaining: bits CI to cut real releases,
then the deferred phases (build-flip, startup verifier P9, agent convergence
P11, browser lazy-load/hot-reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)