### PR TITLE
Session-death hardening follow-up: three recovery-flow fixes from the live rig ladder smoke

### DIFF
--- a/.claude/knowledge/dockerized-openclaw-rig.md
+++ b/.claude/knowledge/dockerized-openclaw-rig.md
@@ -77,3 +77,19 @@ gitignored `dev/openclaw-home/` until `reset`. Both are documented in
 Cross-agent dispatch is wired + verified, but relies on the rig pre-approving the
 device + `plugins.allow`. The clean re-auth path (`--fresh`) re-triggers interactive
 Codex OAuth. Native vs sandbox differ only in where Bakin runs; both can dispatch.
+
+**Asset-save path gap (native/isolated modes):** the agent runs in the container
+and writes deliverables under `/home/node/.openclaw/workspace/…`, but
+`bakin_exec_assets_save` executes host-side and can't read container paths — the
+agent will (correctly) block the task with a path explanation. Production is
+unaffected (Bakin + OpenClaw share one filesystem on the Mac mini). Observed
+live during the 2026-06-04 ladder smoke; if rig-level asset saving is ever
+needed, mount the workspace or translate paths like the openclaw-shim does.
+
+## Validation campaign
+
+`bun run scripts/instance/validate.ts` (rig up first) runs the session-death
+hardening validation: gateway sanity, real-turn e2e + forensics against live
+trajectories, same/cross-agent concurrency probes, benchmarks, a
+gateway-restart failure drill, and a session-retention probe. See
+`.claude/knowledge/session-forensics.md` for the system it validates.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -1272,7 +1272,15 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     opts: OpenClawAgentTurnOptions,
   ): { kind: 'recovered'; content: string } | { kind: 'death'; error: RuntimeTurnError } | null {
     if (!trajectoryFile) return null
-    if (err.kind !== 'timeout' && err.kind !== 'transport') return null
+    // timeout/transport: the frame never arrived. runtime_failed: an error
+    // FRAME arrived — but a graceful gateway shutdown mid-turn sends one
+    // while ALSO writing session.ended(error) to the trajectory (observed
+    // live on the rig), and the frame can beat the fail-fast watcher. The
+    // on-disk evidence is authoritative either way; per-attempt offset
+    // scoping means a pre-run rejection (e.g. param validation) simply has
+    // no events after the offset → null → the original error stands.
+    // provider_cooldown stays excluded: the turn was never accepted.
+    if (err.kind !== 'timeout' && err.kind !== 'transport' && err.kind !== 'runtime_failed') return null
 
     const outcome = inspectTrajectoryRun({
       trajectoryFile,

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -739,7 +739,17 @@ async function reconcileRejectedDispatch(input: {
   const kind = classifyDispatchError(input.err)
   const detail = classifyDispatchFailureDetail(input.err)
   const attempt = (prev?.count || 0) + 1
-  input.state.failedDispatches[input.task.id] = { lastAttempt: Date.now(), count: attempt, kind }
+  // Preserve any in-flight recovery-ladder state: a transport failure
+  // between ladder rungs (e.g. the corrective re-dispatch fired while the
+  // gateway was still rebooting after the death) must not wipe the stage —
+  // otherwise the ladder restarts from scratch and the corrective prompt
+  // is lost. Found live during the rig ladder smoke.
+  input.state.failedDispatches[input.task.id] = {
+    lastAttempt: Date.now(),
+    count: attempt,
+    kind,
+    ...(prev?.sessionDeath ? { sessionDeath: prev.sessionDeath } : {}),
+  }
 
   if (snapshot?.column === 'inProgress') {
     try {
@@ -848,13 +858,31 @@ function fireDispatchTurn(opts: {
   // turn's slot shouldn't free until its outcome has been recorded.
   const settled = sendDispatchMessage(opts.targetAgent, opts.message, opts.threadId)
     .then(async () => {
+      let completedDecomposition = false
       await withStateLock(() => {
         const state = loadDispatchState(opts.contentDir)
-        if (state.failedDispatches?.[opts.task.id]) {
-          delete state.failedDispatches[opts.task.id]
+        const record = state.failedDispatches?.[opts.task.id]
+        if (record) {
+          completedDecomposition = record.sessionDeath?.stage === 'decomposition'
+          delete state.failedDispatches![opts.task.id]
           saveDispatchState(opts.contentDir, state)
         }
       })
+      // A successful DECOMPOSITION turn ends with the agent creating the
+      // subtask chain and STOPPING (no tasks_complete, by design) — which
+      // leaves the parent inProgress, where continuation skips it when the
+      // chain finishes (found live on the rig: the parent idled until
+      // watchdog recovery). Park it in todo; the dependsOn gate the agent
+      // set holds it there until the chain completes, then continuation
+      // re-dispatches it for final assembly.
+      if (completedDecomposition && findDispatchTaskSnapshot(opts.task.id)?.column === 'inProgress') {
+        try {
+          await moveStoredTask(opts.task.id, 'todo', 'inProgress')
+          await tryAddTaskLog(opts.task.id, 'system', 'Decomposition complete — parked in Todo until the subtask chain finishes (dependency gate), then re-dispatched for final assembly.')
+        } catch (err) {
+          log.warn('Failed to park decomposed parent in todo', err, { id: opts.task.id })
+        }
+      }
       opts.onSettled?.('ok')
     })
     .catch(async (err) => {

--- a/tests/adapter-openclaw/runtime-stream.test.ts
+++ b/tests/adapter-openclaw/runtime-stream.test.ts
@@ -356,6 +356,46 @@ describe('OpenClaw runtime Gateway chat', () => {
     }
   })
 
+  it('post-mortem covers runtime_failed: a gateway error FRAME with a dead session on disk yields the diagnosis', async () => {
+    // Live-rig finding: a graceful gateway shutdown mid-turn sends an error
+    // frame (kind runtime_failed) AND writes session.ended(error) to the
+    // trajectory. The frame races the fail-fast watcher; when the frame
+    // wins, post-mortem must still convert it into the diagnosed death.
+    const { RuntimeTurnError } = await import('../../packages/core/src/adapters/runtime')
+
+    FakeWebSocket.onRequest = (frame, ws) => {
+      if (frame.method !== 'agent') return
+      const sessionId = frame.params.sessionId as string
+      const dir = join(testDir, 'agents', 'pixel', 'sessions')
+      mkdirSync(dir, { recursive: true })
+      const lines = [
+        { type: 'session.started', data: {} },
+        { type: 'turn.client_closed', data: {} }, // new event type seen live — must be tolerated
+        { type: 'model.completed', data: { timedOut: false, assistantTexts: ['partial work'] } },
+        { type: 'session.ended', data: { status: 'error', timedOut: false } },
+      ].map((e, i) => JSON.stringify({
+        traceSchema: 'openclaw-trajectory', schemaVersion: 1, traceId: sessionId,
+        type: e.type, ts: new Date(0).toISOString(), seq: i + 1, sessionId, runId: 'run-1', data: e.data,
+      }))
+      writeFileSync(join(dir, `${sessionId}.trajectory.jsonl`), lines.join('\n') + '\n')
+      // Error frame arrives immediately — beats the 200ms watcher poll.
+      ws.emitMessage({ type: 'res', id: frame.id, ok: false, error: { message: 'gateway shutting down', code: 'unavailable' } })
+    }
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+
+    try {
+      await runtime.messaging.send({ agentId: 'pixel', content: 'do work', threadId: 'task:t-frame:d1' })
+      throw new Error('expected send to reject')
+    } catch (err) {
+      expect(err).toBeInstanceOf(RuntimeTurnError)
+      const diagnosis = (err as InstanceType<typeof RuntimeTurnError>).diagnosis
+      expect(diagnosis.sessionStatus).toBe('error')
+      expect(diagnosis.salvagedText).toBe('partial work')
+    }
+  })
+
   it('fail-fast success arm: a lost final frame on a SUCCESSFUL run recovers after the grace window, not after 630s', async () => {
     FakeWebSocket.onRequest = (frame, ws) => {
       if (frame.method !== 'agent') return

--- a/tests/core/dispatch-session-death.test.ts
+++ b/tests/core/dispatch-session-death.test.ts
@@ -74,12 +74,38 @@ function setColumns(c: Partial<Columns>): void {
 const mockStoreBlockTask = mock(async (..._args: unknown[]) => undefined)
 const mockStoreAddTaskLog = mock(async (..._args: unknown[]) => undefined)
 const mockStoreMoveTask = mock(async (..._args: unknown[]) => undefined)
+
+// Stateful column mock: dispatch moves tasks between columns (todo →
+// inProgress at fire, back on recovery, todo-park after decomposition) and
+// reads the board back via snapshots — a static mock would lie to the
+// settle-time guards.
+function relocate(taskId: string, to: keyof Columns): void {
+  for (const column of Object.keys(currentColumns) as Array<keyof Columns>) {
+    const list = currentColumns[column] as Array<{ id: string }>
+    const idx = list.findIndex((t) => t.id === taskId)
+    if (idx >= 0) {
+      const [task] = list.splice(idx, 1)
+      ;(currentColumns[to] as Array<{ id: string }>).push(task!)
+      return
+    }
+  }
+}
+
 const taskStoreMock = {
   readTaskboard: mock(() => ({ columns: currentColumns })),
   addTaskLog: (...args: unknown[]) => mockStoreAddTaskLog(...args),
-  updateTask: mock(async () => undefined),
-  moveTask: (...args: unknown[]) => mockStoreMoveTask(...args),
-  blockTask: (...args: unknown[]) => mockStoreBlockTask(...args),
+  updateTask: mock(async (taskId: string, patch: { column?: string }) => {
+    if (patch?.column) relocate(taskId, patch.column as keyof Columns)
+    return undefined
+  }),
+  moveTask: (...args: unknown[]) => {
+    relocate(args[0] as string, args[1] as keyof Columns)
+    return mockStoreMoveTask(...args)
+  },
+  blockTask: (...args: unknown[]) => {
+    relocate(args[0] as string, 'blocked')
+    return mockStoreBlockTask(...args)
+  },
 }
 mock.module('../../src/core/task-store', () => taskStoreMock)
 mock.module('@/core/task-store', () => taskStoreMock)
@@ -319,6 +345,46 @@ describe('recovery ladder — interplay with generic failures', () => {
     const second = mockRuntimeSend.mock.calls[1]?.[0] as Record<string, unknown>
     expect(second.content).toContain('PREVIOUS ATTEMPT FAILED')
     expect(second.content).not.toContain('salvaged as asset')
+  })
+
+  it('a successful DECOMPOSITION turn parks the parent in todo so continuation can re-dispatch it', async () => {
+    // Live-rig finding: the decomposition turn ends with "create subtasks,
+    // then STOP" (no tasks_complete), leaving the parent inProgress — where
+    // continuation skips it when the subtask chain completes, stranding it
+    // until watchdog recovery. The settle-success handler must move a
+    // decomposition parent back to todo (the dependsOn gate holds it there).
+    setColumns({ todo: [{ id: 't-480', title: 'Decomposing task', agent: 'jessica' }] })
+    mockRuntimeSend.mockRejectedValueOnce(deathError())
+    mockRuntimeSend.mockRejectedValueOnce(deathError())
+    // third send = the decomposition turn → succeeds (default resolve)
+
+    await dispatchTasks(tempDir, 3737)
+      await awaitDispatchIdle()
+    await wait(300)
+
+    expect(auditCalls('task.decomposition_dispatched').length).toBe(1)
+    // The decomposition turn's success must bounce the parent to todo.
+    const moveCalls = mockStoreMoveTask.mock.calls.filter((c) => c[0] === 't-480' && c[1] === 'todo')
+    expect(moveCalls.length).toBeGreaterThanOrEqual(1)
+    expect(readState().failedDispatches['t-480']).toBeUndefined()
+  })
+
+  it('a transport failure between ladder rungs PRESERVES the ladder state (gateway rebooting mid-recovery)', async () => {
+    // Real-rig scenario: death 1 → immediate corrective re-dispatch fires
+    // while the gateway is still restarting → transport failure. The generic
+    // cooldown record must not wipe sessionDeath, or the ladder restarts
+    // from scratch and the corrective prompt is lost.
+    setColumns({ todo: [{ id: 't-470', title: 'Gateway rebooting', agent: 'jessica' }] })
+    mockRuntimeSend.mockRejectedValueOnce(deathError())
+    mockRuntimeSend.mockRejectedValueOnce(new RuntimeError('OpenClaw chat gateway is not connected', { kind: 'transport' }))
+
+    await dispatchTasks(tempDir, 3737)
+      await awaitDispatchIdle()
+    await wait(150)
+
+    const record = readState().failedDispatches['t-470']
+    expect(record.kind).toBe('transient') // the transport failure is recorded…
+    expect(record.sessionDeath).toMatchObject({ stage: 'corrective', deaths: 1 }) // …but the ladder survives
   })
 
   it('a successful corrective attempt clears the ladder state', async () => {


### PR DESCRIPTION
Follow-up to #438 (merged): the manual full-stack ladder smoke + validation campaign ran after the merge and caught three recovery-flow gaps; these two commits landed on the branch post-merge.

## Fixes (each with tests; found live on the dockerized rig)
1. **Post-mortem covers `runtime_failed`** — a graceful gateway shutdown mid-turn sends an error FRAME while also writing `session.ended(error)` to the trajectory; when the frame beat the fail-fast watcher, the death surfaced as a generic adapter failure and the ladder never engaged. On-disk evidence is now authoritative for runtime_failed too (per-attempt offset scoping keeps pre-run rejections unaffected). Also tolerates the `turn.client_closed` event observed live.
2. **Ladder state survives transport failures between rungs** — the immediate corrective re-dispatch often fires while the gateway is still rebooting; the resulting transport failure's cooldown record was overwriting `failedDispatches` without `sessionDeath`, restarting the ladder and losing the corrective prompt.
3. **Successful decomposition parks the parent in `todo`** — the decomposition turn ends with the agent stopping (no tasks_complete, by design), leaving the parent `inProgress` where continuation skips dependents — stranding it until watchdog recovery (~30 min). The settle handler now bounces it to `todo`, where the agent-set `dependsOn` gate holds it until the chain completes.

Plus a rig knowledge-doc note (asset-save path gap, validation campaign pointer) and a stateful column mock for the ladder tests.

## Live verification (task `58d81aa3`)
Full lifecycle on the real stack: death 1 → corrective (state preserved through a transport failure) → death 2 → decomposition → real agent created + chained a subtask via MCP → parent parked in todo → child completed → `task.continuation` → parent re-dispatched → **done**. Also verified live: `maxTurnsPerAgent=2` fires two same-agent turns 72ms apart, both complete; Bakin-restart-mid-turn recovers + re-dispatches in a fresh d2 session; the `session-death-incidents` doctor check WARNs with the real incident list.

Suite: 4,413 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)