### PR TITLE
feat(plugins): P9 startup artifact verifier + needs-update surfacing

### DIFF
--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -27,6 +27,7 @@ import { readPluginLockfile, type PluginLockEntry } from '@bakin/core/plugins/lo
 import { startStartupSpan, type StartupDiagnosticLogger } from '@/core/startup-diagnostics'
 import { PLUGIN_CLIENT_EXTERNALS, PLUGIN_SERVER_EXTERNALS } from '@/core/whiskin/externals'
 import { validatePluginImports, NON_RUNTIME_DIRS, type PluginPackageJson } from '@/core/whiskin/import-scan'
+import { verifyInstalledArtifact } from '@/core/whiskin/verify'
 
 // Single source for the externals contract — see src/core/whiskin/externals.ts.
 const CLIENT_EXTERNAL = PLUGIN_CLIENT_EXTERNALS
@@ -382,6 +383,25 @@ export async function buildAllUserPlugins(
     if (name.startsWith('.')) continue
     const pluginDir = join(userPluginsDir, name)
     if (!existsSync(join(pluginDir, 'bakin-plugin.json'))) continue
+
+    // Whiskin artifact installs carry provenance; verify host compatibility
+    // before activating. An incompatible artifact (host moved past the externals
+    // contract it was built for) is needs-update, not a silent activation.
+    // Plugins without provenance (legacy/local/dev) take the unchanged path.
+    const verification = verifyInstalledArtifact(pluginDir)
+    if (verification.status === 'needs-update') {
+      log.warn?.(
+        `Plugin "${name}" needs update — ${verification.reason}. Skipping activation; reinstall to fetch a compatible artifact.`,
+      )
+      continue
+    }
+    if (verification.status === 'invalid') {
+      log.warn?.(
+        `Plugin "${name}" has invalid Whiskin provenance — ${verification.reason}. Skipping activation.`,
+      )
+      continue
+    }
+
     try {
       const trustExistingDist = lockedPlugins[name]?.type === 'github' && lockedPlugins[name]?.linked !== true
       await buildUserPlugin(pluginDir, { trustExistingDist, diagnosticsLog: log, pluginId: name })

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -29,6 +29,7 @@ import { checkRestartRecovery } from './lib/system-checks/restart-recovery'
 import { checkSearchAdapter } from './lib/system-checks/search'
 import { checkAndSyncSkill, syncSkillRepair } from './lib/system-checks/sync-skill'
 import { checkPluginAssets } from './lib/system-checks/plugin-assets'
+import { checkPluginArtifacts } from './lib/system-checks/plugin-artifacts'
 import { applyManagedBlocksForRuntime } from '../../src/core/agent-rules/managed-blocks'
 
 type RegistryAccessor = () => Array<Record<string, unknown>>
@@ -597,6 +598,11 @@ const healthPlugin: BakinPlugin = definePlugin({
       id: 'plugin-assets',
       name: 'Plugin-shipped runtime skills install state',
       run: () => checkPluginAssets(),
+    })
+    ctx.registerHealthCheck({
+      id: 'plugin-artifacts',
+      name: 'Installed plugin artifact compatibility',
+      run: () => Promise.resolve(checkPluginArtifacts()),
     })
     ctx.registerHealthCheck({
       id: 'plugin-registry',

--- a/plugins/health/lib/system-checks/plugin-artifacts.ts
+++ b/plugins/health/lib/system-checks/plugin-artifacts.ts
@@ -1,0 +1,52 @@
+/**
+ * System check — installed Whiskin plugin artifacts. Surfaces plugins whose
+ * provenance no longer matches this host (needs-update after a Bakin upgrade)
+ * or is invalid, so a plugin that startup skipped isn't silently missing. The
+ * repair is to reinstall (fetch a compatible published artifact); never
+ * auto-fixed.
+ */
+import { existsSync, readdirSync, type Dirent } from 'fs'
+import { join } from 'path'
+import { getContentDir } from '../../../../src/core/content-dir'
+import { verifyInstalledArtifact } from '../../../../src/core/whiskin/verify'
+import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+
+const CHECK = 'plugin-artifacts'
+
+export function checkPluginArtifacts(): HealthCheckResult[] {
+  const pluginsDir = join(getContentDir(), 'plugins')
+  if (!existsSync(pluginsDir)) {
+    return [{ check: CHECK, status: 'ok', message: 'No installed plugins.', autoFixable: false }]
+  }
+
+  let entries: Dirent[]
+  try {
+    entries = readdirSync(pluginsDir, { withFileTypes: true }) as Dirent[]
+  } catch (err) {
+    return [{ check: CHECK, status: 'warn', message: `Could not read plugins dir: ${err}`, autoFixable: false }]
+  }
+
+  const problems: string[] = []
+  for (const entry of entries) {
+    const name = String(entry.name)
+    if (!entry.isDirectory() || name.startsWith('.')) continue
+    const verification = verifyInstalledArtifact(join(pluginsDir, name))
+    if (verification.status === 'needs-update') {
+      problems.push(`${name}: needs update (${verification.reason})`)
+    } else if (verification.status === 'invalid') {
+      problems.push(`${name}: invalid provenance (${verification.reason})`)
+    }
+  }
+
+  if (problems.length === 0) {
+    return [{ check: CHECK, status: 'ok', message: 'All installed plugin artifacts are compatible.', autoFixable: false }]
+  }
+  return [{
+    check: CHECK,
+    status: 'warn',
+    message:
+      `${problems.length} plugin artifact(s) inactive — reinstall to fetch a compatible build. ` +
+      problems.join('; '),
+    autoFixable: false,
+  }]
+}

--- a/src/core/whiskin/verify.ts
+++ b/src/core/whiskin/verify.ts
@@ -1,0 +1,55 @@
+/**
+ * Startup verification of an installed Whiskin artifact (Phase 9).
+ *
+ * At boot, instead of blindly trusting an installed plugin's dist/, we verify
+ * the `.whiskin/build.json` provenance:
+ *   - no provenance → legacy/local/dev plugin; not our concern (unchanged path).
+ *   - provenance present + externals contract matches → safe to activate.
+ *   - provenance present but externals contract DOESN'T match → the host has
+ *     moved past what the artifact was built for (e.g. a React/SDK bump). Mark
+ *     it needs-update rather than activating a plugin that will break at
+ *     runtime; the repair is to refetch a compatible published artifact.
+ *
+ * This is the host-upgrade safety the spec calls for: consumers never rebuild,
+ * so an incompatible artifact becomes needs-update, not a silent activation.
+ */
+import { existsSync } from 'fs'
+import { join } from 'path'
+import {
+  PROVENANCE_FILENAME,
+  isExternalsContractCompatible,
+  readProvenance,
+  type WhiskinBuildProvenance,
+} from './provenance'
+import { EXTERNALS_CONTRACT } from './externals'
+
+export type ArtifactVerification =
+  | { status: 'non-whiskin' }
+  | { status: 'compatible'; provenance: WhiskinBuildProvenance }
+  | { status: 'needs-update'; reason: string; provenance: WhiskinBuildProvenance }
+  | { status: 'invalid'; reason: string }
+
+/**
+ * Verify the installed plugin at `pluginDir`. Pure (reads `.whiskin/build.json`
+ * only); never throws — a corrupt record returns `invalid`.
+ */
+export function verifyInstalledArtifact(pluginDir: string): ArtifactVerification {
+  const provPath = join(pluginDir, '.whiskin', PROVENANCE_FILENAME)
+  if (!existsSync(provPath)) return { status: 'non-whiskin' }
+
+  let provenance: WhiskinBuildProvenance
+  try {
+    provenance = readProvenance(provPath)
+  } catch (err) {
+    return { status: 'invalid', reason: err instanceof Error ? err.message : String(err) }
+  }
+
+  if (!isExternalsContractCompatible(provenance)) {
+    return {
+      status: 'needs-update',
+      reason: `built for externals contract "${provenance.externalsContract}", but this host provides "${EXTERNALS_CONTRACT}"`,
+      provenance,
+    }
+  }
+  return { status: 'compatible', provenance }
+}

--- a/tests/core/whiskin/verify.test.ts
+++ b/tests/core/whiskin/verify.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Startup artifact verification (Phase 9). Pure over a temp plugin dir.
+ * Mandatory isolation mocks per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskin-verify-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { verifyInstalledArtifact } from '../../../src/core/whiskin/verify'
+import { writeProvenance, WHISKIN_PROVENANCE_VERSION, type WhiskinBuildProvenance } from '../../../src/core/whiskin/provenance'
+import { EXTERNALS_CONTRACT } from '../../../src/core/whiskin/externals'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+function pluginDir(provenance?: Partial<WhiskinBuildProvenance> | 'corrupt'): string {
+  const dir = join(tmpdir(), `whiskin-verify-plugin-${Date.now()}-${randomUUID()}`)
+  mkdirSync(join(dir, 'dist'), { recursive: true })
+  dirs.push(dir)
+  if (provenance === 'corrupt') {
+    mkdirSync(join(dir, '.whiskin'), { recursive: true })
+    writeFileSync(join(dir, '.whiskin', 'build.json'), 'not json{')
+  } else if (provenance) {
+    const full: WhiskinBuildProvenance = {
+      version: WHISKIN_PROVENANCE_VERSION,
+      pluginId: 'foo',
+      pluginVersion: '1.0.0',
+      bakinVersion: '0.0.1-rc.15',
+      bakinRange: '>=0.0.1-rc.1',
+      whiskinVersion: '1',
+      buildBackend: 'system-bun',
+      platform: 'neutral',
+      sourceCommitSha: '',
+      sourceTreeSha: 'a'.repeat(64),
+      manifestSha: 'b'.repeat(64),
+      externalsContract: EXTERNALS_CONTRACT,
+      approvedInstallScripts: [],
+      outputs: { serverEntry: 'dist/index.js' },
+      builtAt: '2026-06-04T00:00:00.000Z',
+      ...provenance,
+    }
+    mkdirSync(join(dir, '.whiskin'), { recursive: true })
+    writeProvenance(join(dir, '.whiskin', 'build.json'), full)
+  }
+  return dir
+}
+
+describe('verifyInstalledArtifact', () => {
+  it('returns non-whiskin when there is no .whiskin/build.json', () => {
+    expect(verifyInstalledArtifact(pluginDir()).status).toBe('non-whiskin')
+  })
+
+  it('returns compatible when the externals contract matches the host', () => {
+    const v = verifyInstalledArtifact(pluginDir({}))
+    expect(v.status).toBe('compatible')
+  })
+
+  it('returns needs-update when the externals contract does not match', () => {
+    const v = verifyInstalledArtifact(pluginDir({ externalsContract: 'react18-old-vX' }))
+    expect(v.status).toBe('needs-update')
+    if (v.status === 'needs-update') expect(v.reason).toContain('react18-old-vX')
+  })
+
+  it('returns invalid for a corrupt provenance record', () => {
+    expect(verifyInstalledArtifact(pluginDir('corrupt')).status).toBe('invalid')
+  })
+})

--- a/tests/plugins/health/plugin-artifacts.test.ts
+++ b/tests/plugins/health/plugin-artifacts.test.ts
@@ -1,0 +1,87 @@
+/**
+ * plugin-artifacts health check (P9 surfacing). Scans installed plugins for
+ * needs-update / invalid Whiskin provenance.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-plugin-artifacts-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = pathJoin(testDir, 'openclaw')
+
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { checkPluginArtifacts } from '../../../plugins/health/lib/system-checks/plugin-artifacts'
+import { writeProvenance, WHISKIN_PROVENANCE_VERSION, type WhiskinBuildProvenance } from '../../../src/core/whiskin/provenance'
+import { EXTERNALS_CONTRACT } from '../../../src/core/whiskin/externals'
+
+function installPlugin(id: string, externalsContract: string): void {
+  const dir = join(testDir, 'plugins', id)
+  mkdirSync(join(dir, '.whiskin'), { recursive: true })
+  mkdirSync(join(dir, 'dist'), { recursive: true })
+  writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({ id, version: '1.0.0' }))
+  const prov: WhiskinBuildProvenance = {
+    version: WHISKIN_PROVENANCE_VERSION,
+    pluginId: id,
+    pluginVersion: '1.0.0',
+    bakinVersion: '0.0.1-rc.15',
+    bakinRange: '>=0.0.1-rc.1',
+    whiskinVersion: '1',
+    buildBackend: 'system-bun',
+    platform: 'neutral',
+    sourceCommitSha: '',
+    sourceTreeSha: 'a'.repeat(64),
+    manifestSha: 'b'.repeat(64),
+    externalsContract,
+    approvedInstallScripts: [],
+    outputs: { serverEntry: 'dist/index.js' },
+    builtAt: '2026-06-04T00:00:00.000Z',
+  }
+  writeProvenance(join(dir, '.whiskin', 'build.json'), prov)
+}
+
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+beforeEach(() => {
+  rmSync(join(testDir, 'plugins'), { recursive: true, force: true })
+  mkdirSync(join(testDir, 'plugins'), { recursive: true })
+})
+
+describe('checkPluginArtifacts', () => {
+  it('is ok when no plugins are installed', () => {
+    rmSync(join(testDir, 'plugins'), { recursive: true, force: true })
+    expect(checkPluginArtifacts()[0].status).toBe('ok')
+  })
+
+  it('is ok when all installed artifacts are compatible', () => {
+    installPlugin('foo', EXTERNALS_CONTRACT)
+    expect(checkPluginArtifacts()[0].status).toBe('ok')
+  })
+
+  it('warns about a needs-update artifact (incompatible externals contract)', () => {
+    installPlugin('foo', EXTERNALS_CONTRACT)
+    installPlugin('stale', 'react18-old-vX')
+    const r = checkPluginArtifacts()[0]
+    expect(r.status).toBe('warn')
+    expect(r.message).toContain('stale')
+    expect(r.message).toContain('needs update')
+  })
+})


### PR DESCRIPTION
P9 — startup verifies installed Whiskin artifacts instead of blindly trusting
dist/, with host-upgrade safety.

- `verifyInstalledArtifact(pluginDir)` reads `.whiskin/build.json` and reports
  compatible / needs-update (externals contract no longer matches the host) /
  invalid / non-whiskin.
- `buildAllUserPlugins` skips activation for needs-update / invalid artifacts
  with a clear warning — consumers never rebuild, so an incompatible artifact
  becomes needs-update, not a silent activation that breaks at runtime.
- Legacy/local/dev plugins have no provenance → `non-whiskin` → existing path
  unchanged; nothing pre-Whiskin breaks.
- `plugin-artifacts` health check surfaces needs-update/invalid plugins in
  doctor/health (repair = reinstall a compatible artifact).

Verified: typecheck clean; verify + health + startup/build suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)