### PR TITLE
test(host): fix flaky PluginHost boot-diagnostics timeout

### DIFF
--- a/tests/components/plugin-host.test.tsx
+++ b/tests/components/plugin-host.test.tsx
@@ -224,7 +224,10 @@ describe('PluginHost — boot', () => {
           <ProbeTree />
         </PluginHost>,
       )
-      await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
+      // This is the one boot test that does a real dynamic import() of a file://
+      // module, so boot can cross waitFor's default 1000ms under full-suite load
+      // (the other boot tests use empty manifests). Give it headroom.
+      await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull(), { timeout: 5000 })
 
       expect(consoleDebug).toHaveBeenCalledWith('[bakin] startup span', expect.objectContaining({
         category: 'startup',


### PR DESCRIPTION
CI flaked on `PluginHost — boot > emits browser plugin boot diagnostics when explicitly enabled` (failed at **1007.99ms**, just over testing-library's default 1000ms `waitFor`).

**Not a regression** — the test passes 3/3 in isolation (~2s). It's the only boot test that does a *real* dynamic `import()` of a file:// module (the others use empty manifests), so under full-suite contention (278s, many parallel files) boot occasionally crosses the 1000ms default.

Fix: bump that single boot-wait `waitFor` to a 5000ms timeout. **No production code change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)