### PR TITLE
perf(host): lazy browser plugin loading via declarative manifests (Whiskit P1)

### DIFF
--- a/.claude/knowledge/plugin-system.md
+++ b/.claude/knowledge/plugin-system.md
@@ -65,17 +65,30 @@ HTTP server begins accepting traffic
 On shutdown (SIGTERM): pluginRegistry.shutdownAll() →
   calls plugin.onShutdown() in reverse order
 
-Browser boot (packages/host/src/main.tsx)
+Browser boot (packages/host/src/main.tsx) — LAZY since Whiskit P1
     ↓
 ReactDOM renders <PluginHost><Shell/></PluginHost>
     ↓
 PluginHost.useEffect:
-  1. fetch('/api/plugins/manifest')
-  2. Promise.all(manifest.plugins.map(loadPluginClient))
-  3. loadPluginClient = dynamic import of /api/plugins/<id>/assets/client.js
-  4. Each plugin's client.js runs registerPlugin({...}) as a side effect
-  5. setReady(true) → shell re-renders, pulls nav items + slots from registry
+  1. fetch('/api/plugins/manifest') — includes contributes.{nav,routes,slots,eager}
+  2. applyManifestMetadata: setManifestNav per plugin (sidebar renders from
+     manifest JSON) + configureLazyPlugins (slot/route → owning plugin index)
+  3. Import ONLY eager plugins: contributes.eager (tasks, health — nav-badge
+     providers) or legacy clients with no declarative metadata
+  4. setReady(true) → shell renders; sidebar nav is complete already
+  5. Lazy plugins import on first demand: <Slot> render of a declared slot, or
+     the plugin route catch-all matching a declared route pattern. Load states
+     (idle/loading/loaded/error) live in the SDK lazy store; failed imports
+     render inline errors with retry. After every client import a drift check
+     compares runtime registrations vs manifest declarations and console.warns.
+  6. Each plugin's client.js runs registerPlugin({...}) as a side effect.
+     Runtime navItems override manifest nav while registered (conditional-nav
+     escape hatch); unregisterPlugin never clears manifest nav.
 ```
+
+The CI twin of the runtime drift check is `tests/plugins/manifest-drift.test.tsx`
+— it imports every clientful core plugin and fails on declaration drift, and
+pins the eager list (tasks + health only).
 
 ## Startup Diagnostics
 
@@ -791,23 +804,33 @@ On mount:
 
 ```
 1. GET /api/plugins/manifest
-   → { plugins: [{ id, name, version, clientEntry }, ...] }
+   → { plugins: [{ id, name, version, clientEntry, contributes }, ...] }
    → clientEntry = "/api/plugins/<id>/assets/client.js"
-2. Promise.all(plugins.map(p => import(p.clientEntry)))
-3. Each dynamic import evaluates the plugin's client.js, which runs
-   `registerPlugin({...})` as a module side-effect.
-4. `assertReactInstance(pluginId, module.React)` — optional runtime
+2. applyManifestMetadata: setManifestNav(id, contributes.nav) per plugin
+   (sidebar nav exists before any client loads, survives unregisterPlugin)
+   + configureLazyPlugins({ slotOwners, routeOwners }) from
+   contributes.slots / contributes.routes.
+3. Import ONLY eager plugins — contributes.eager: true, or clients with no
+   declarative nav/routes/slots (legacy backward compat).
+4. setReady(true) → the shell renders with the full sidebar.
+5. Lazy demand: <Slot> calls requestSlotPlugins(name) on render; the
+   plugin route catch-all calls requestRoutePlugins(pathname). The host's
+   loader (setLazyPluginLoader) imports the owning plugin's client.js;
+   its registerPlugin({...}) side effect fills the registry and consumers
+   re-render. Load state per plugin: idle → loading → loaded | error
+   (error → inline fallback with retry via retryPluginLoad).
+6. `assertReactInstance(pluginId, module.React)` — optional runtime
    check that catches plugins that accidentally bundled their own
    React (broken hooks). Plugins aren't required to export React;
    the lack of an export is a non-event.
-5. setReady(true) → the shell re-renders. AppSidebar reads
-   `getAllNavItems()`; slot consumers re-evaluate.
+7. After every client import, checkPluginDrift (drift-check.ts) compares
+   runtime registrations against contributes.{nav,routes,slots} and
+   console.warns on mismatch.
 ```
 
 Failures in one plugin are logged and skipped — they never block the
-others. While plugins are loading, the sidebar is briefly empty and
-slots return `null` for uncontributed names. Acceptable for a
-single-user LAN app on cold boot.
+others. Slot entries and lazily-routed pages are wrapped in per-plugin
+error boundaries so a crashing component can't take down the shell.
 
 Binary mode is identical at the loader level: the same
 `/api/plugins/<id>/assets/client.js` URL, just served from embedded

--- a/docs/src/content/docs/extending/plugins/client-ui.md
+++ b/docs/src/content/docs/extending/plugins/client-ui.md
@@ -35,9 +35,15 @@ registerPlugin({
 ```
 <!-- /docs:snippet -->
 
+## Lazy Loading
+
+The shell does not import every plugin's client bundle at boot. Declare your client's contributions in `bakin-plugin.json` — `contributes.nav` (sidebar items as JSON), `contributes.routes` (the patterns you pass to `registerPlugin({ routes })`), and `contributes.slots` (the slot names you fill) — and Bakin renders your nav immediately while loading `client.js` only on first navigation into one of your routes or first render of one of your slots.
+
+Keep the manifest declarations and the `registerPlugin()` call in sync: Bakin runs a drift check after every client load and warns on mismatch. Clients that must run at boot (badge providers, conditional nav) set `contributes.eager: true` and may keep registering `navItems` at runtime — runtime nav overrides manifest nav while the plugin is registered. A client with no declarative metadata loads eagerly (legacy behavior).
+
 ## Navigation
 
-Navigation items should be stable and specific to the plugin. Use lucide icon names. Include `order` only when the plugin has a strong placement requirement.
+Navigation items should be stable and specific to the plugin. Use lucide icon names. Include `order` only when the plugin has a strong placement requirement. Prefer declaring nav in `bakin-plugin.json` `contributes.nav` (same NavItem shape, JSON) so it renders before your client loads; pass `navItems` to `registerPlugin()` only when nav must be computed at runtime.
 
 <div class="table-light-full table-label">
 
@@ -116,7 +122,7 @@ registerPlugin({
 })
 ```
 
-Patterns support exact paths and dynamic segments in `:id`, `[id]`, or `$id` form. If a route is visible in navigation, also declare it in `bakin-plugin.json` `contributes.clientRoutes`.
+Patterns support exact paths and dynamic segments in `:id`, `[id]`, or `$id` form. Declare every registered pattern in `bakin-plugin.json` `contributes.routes` so direct navigation lazy-loads your client; if a route is visible in navigation, also declare it in `contributes.clientRoutes` for docs generation.
 
 ## Page Slots
 

--- a/docs/src/content/docs/extending/plugins/manifest.md
+++ b/docs/src/content/docs/extending/plugins/manifest.md
@@ -120,10 +120,20 @@ The signature covers canonical JSON for `bakin-plugin.json` with the top-level `
 | `cliCommands[]` | `name`, `usage`, `summary`, `dispatch` |
 | `settings[]` | `key`, `summary` |
 | `docs` | `slug` |
+| `nav[]` | NavItem JSON: `id`, `label` (plus `icon`, `href`, `order`, `children`, ...) |
+| `routes[]` | route `path` pattern matching a `registerPlugin({ routes })` key |
+| `slots[]` | slot names the client fills via `registerPlugin({ slots })` |
+| `eager` | boolean — load the client at boot instead of on first demand |
 
 </div>
 
 API route paths are plugin-relative. A route declared as `/hello` is exposed under `/api/plugins/{pluginId}/hello`. Do not declare `/api/...` paths in a plugin manifest.
+
+### Declarative client metadata (lazy loading)
+
+`nav`, `routes`, and `slots` describe the client bundle's contributions so the shell can render the sidebar and route the first navigation **before** the bundle loads. A plugin that declares any of them is lazy by default: its `client.js` imports on the first render of a declared slot or navigation into a declared route pattern. Declarations must exactly match what `client.tsx` registers at runtime — Bakin warns on drift after every client load.
+
+Set `"eager": true` for clients that must run at boot — background components in the `nav-badge-providers` slot, conditional nav, or other module-load side effects. A client entry with none of `nav`/`routes`/`slots` is treated as eager for backward compatibility.
 
 Exec tool names must use the plugin-owned MCP namespace: `bakin_exec_{pluginId}_{action}`. The manifest declaration and runtime `ctx.registerExecTool()` call must agree. Bakin rejects undeclared tools, duplicate tool names, and user plugin tools that register outside their own plugin prefix.
 

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -32,9 +32,25 @@ The main entry. Re-exports the plugin contract types (`./types`) plus the high-t
 | `subscribeNavBadges` | Subscribe to nav-badge mutations (separate channel from `subscribeRegistry`). |
 | `getPluginRoute` | Look up a specific client route by plugin id + path. |
 | `getPluginRoutes` | Get all registered client routes (across all plugins). |
+| `setManifestNav` | Seed a plugin's declarative nav from its manifest (host-side; survives unregisterPlugin). |
+| `getManifestNav` | Read the manifest nav currently seeded for a plugin (drift validation). |
 | `ClientRouteEntry` | — |
 | `MatchedPluginRoute` | — |
 | `PluginRegistration` | — |
+| `configureLazyPlugins` | Install the manifest-derived slot/route ownership index for lazy loading (host-side). |
+| `setLazyPluginLoader` | Install the demand loader that imports a plugin's client bundle (host-side). |
+| `setPluginLoadState` | Report a plugin client's load progress: idle → loading → loaded \| error (host-side). |
+| `getPluginLoadState` | Current load state for a plugin client. Unknown plugins report 'idle'. |
+| `getPluginLoadError` | Last load error message for a plugin whose state is 'error', if any. |
+| `getSlotOwners` | Plugins whose manifests declare the given slot in `contributes.slots`. |
+| `getRouteOwners` | Plugins whose manifest `contributes.routes` patterns match a pathname. |
+| `requestSlotPlugins` | Ask the host to lazy-load every idle plugin that fills the named slot. |
+| `requestRoutePlugins` | Ask the host to lazy-load every idle plugin whose route patterns match the pathname. |
+| `retryPluginLoad` | Reset a failed plugin to idle and re-request its client bundle. |
+| `getLazyPluginsVersion` | Monotonic lazy-store version for useSyncExternalStore consumers. |
+| `subscribeLazyPlugins` | Subscribe to lazy-plugin store mutations. Returns an unsubscribe fn. |
+| `LazyPluginIndex` | — |
+| `PluginLoadState` | — |
 | `defineRoute` | Define a plugin HTTP route with typed input/output schemas. |
 | `defineCoreRoute` | Define a core (non-plugin) HTTP route. |
 | `definePlugin` | Compose a plugin's routes into a single definition for the server. |
@@ -201,6 +217,7 @@ Source: `packages/sdk/src/slots/index.tsx`.
 | --- | --- |
 | `registerSlot` | Register a component for a named slot. Lower `order` renders first; entries |
 | `getSlotEntries` | Read the registered entries for a slot. Exported for tooling / tests. |
+| `getSlotNamesOwnedBy` | Slot names that currently have at least one entry owned by the given |
 | `clearSlotsOwnedBy` | Remove every slot entry owned by the given plugin. Used by |
 | `Slot` | Render all components registered for the named slot, in order. Extra props |
 
@@ -295,6 +312,10 @@ The full contributions block in `bakin-plugin.json` — everything a plugin adds
 | `cliCommands?` | `CliCommandContribution[]` | CLI commands the plugin contributes to the `bakin` binary. |
 | `settings?` | `SettingsContribution[]` | Settings keys this plugin owns in the settings UI. |
 | `docs?` | `DocsContribution` | Optional docs page slug. |
+| `nav?` | `NavItem[]` | Declarative sidebar nav items. Rendered from manifest JSON before the |
+| `routes?` | `ClientRoutePatternContribution[]` | Client route patterns the plugin's client registers via |
+| `slots?` | `string[]` | Slot names the plugin's client fills via `registerPlugin({ slots })` |
+| `eager?` | `boolean` | Load the client bundle at boot instead of on first demand. The escape |
 
 #### `ExecToolDefinition`
 
@@ -575,6 +596,12 @@ The `bakin.config.ts` shape — root configuration for a Bakin installation.
 | --- | --- |
 | `PluginEntry` | A plugin entry in `bakin.config.ts`. |
 
+### Other
+
+| Type | Description |
+| --- | --- |
+| `ClientRoutePatternContribution` | Manifest declaration of one client route *pattern* the plugin's client |
+
 ## `@makinbakin/sdk/utils`
 
 Source: `packages/sdk/src/utils/index.ts`.
@@ -655,5 +682,5 @@ Source: `packages/sdk/src/routing/index.ts`.
 | `DefinePluginInput` | — |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 3, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jun 5, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -2,8 +2,10 @@ import type {
   ApiRouteContribution,
   CliCommandContribution,
   ClientRouteContribution,
+  ClientRoutePatternContribution,
   ExecToolContribution,
   HttpMethod,
+  NavItem,
   PluginContributions,
   PluginManifest,
   PluginManifestSignature,
@@ -197,6 +199,77 @@ function parseClientRoute(raw: unknown, index: number): ClientRouteContribution 
   }
 }
 
+const NAV_BADGE_TONES = new Set(['error', 'attention', 'info', 'success'])
+
+function parseNavItem(raw: unknown, label: string): NavItem {
+  if (!isRecord(raw)) throw new PluginManifestError(`${label} must be an object`)
+  const item: NavItem = {
+    id: stringField(raw, 'id', { required: true })!,
+    label: stringField(raw, 'label', { required: true })!,
+  }
+  const icon = stringField(raw, 'icon')
+  if (icon !== undefined) item.icon = icon
+  const href = stringField(raw, 'href')
+  if (href !== undefined) {
+    if (!href.startsWith('/') || href.startsWith('/api/') || href.includes('..')) {
+      throw new PluginManifestError(`${label}.href "${href}" must be an app path starting with "/" (not /api/, no "..")`)
+    }
+    item.href = href
+  }
+  if (raw.order !== undefined) {
+    if (typeof raw.order !== 'number' || !Number.isFinite(raw.order)) {
+      throw new PluginManifestError(`${label}.order must be a finite number`)
+    }
+    item.order = raw.order
+  }
+  if (raw.alwaysExpanded !== undefined) {
+    if (typeof raw.alwaysExpanded !== 'boolean') {
+      throw new PluginManifestError(`${label}.alwaysExpanded must be a boolean`)
+    }
+    item.alwaysExpanded = raw.alwaysExpanded
+  }
+  if (raw.badge !== undefined) {
+    if (!isRecord(raw.badge)) throw new PluginManifestError(`${label}.badge must be an object`)
+    const badge: NavItem['badge'] = {}
+    if (raw.badge.count !== undefined) {
+      if (typeof raw.badge.count !== 'number' || !Number.isFinite(raw.badge.count)) {
+        throw new PluginManifestError(`${label}.badge.count must be a finite number`)
+      }
+      badge.count = raw.badge.count
+    }
+    if (raw.badge.tone !== undefined) {
+      if (typeof raw.badge.tone !== 'string' || !NAV_BADGE_TONES.has(raw.badge.tone)) {
+        throw new PluginManifestError(`${label}.badge.tone must be one of: ${[...NAV_BADGE_TONES].join(', ')}`)
+      }
+      badge.tone = raw.badge.tone as NonNullable<NavItem['badge']>['tone']
+    }
+    item.badge = badge
+  }
+  if (raw.children !== undefined) {
+    if (!Array.isArray(raw.children)) throw new PluginManifestError(`${label}.children must be an array`)
+    item.children = raw.children.map((child, childIndex) => parseNavItem(child, `${label}.children[${childIndex}]`))
+  }
+  return item
+}
+
+function parseRoutePattern(raw: unknown, index: number): ClientRoutePatternContribution {
+  if (!isRecord(raw)) throw new PluginManifestError(`contributes.routes[${index}] must be an object`)
+  const path = stringField(raw, 'path', { required: true })!
+  if (!path.startsWith('/')) {
+    throw new PluginManifestError(`contributes.routes[${index}].path "${path}" must start with "/"`)
+  }
+  if (path.startsWith('/api/')) {
+    throw new PluginManifestError(`contributes.routes[${index}].path "${path}" must not be an API path`)
+  }
+  if (path.includes('..')) {
+    throw new PluginManifestError(`contributes.routes[${index}].path "${path}" must not contain ".."`)
+  }
+  return {
+    path,
+    summary: stringField(raw, 'summary'),
+  }
+}
+
 function parseExecTool(raw: unknown, index: number): ExecToolContribution {
   if (!isRecord(raw)) throw new PluginManifestError(`contributes.execTools[${index}] must be an object`)
   return {
@@ -281,6 +354,49 @@ function parseContributions(input: unknown): PluginContributions | undefined {
   if (input.docs !== undefined) {
     if (!isRecord(input.docs)) throw new PluginManifestError('contributes.docs must be an object')
     out.docs = { slug: stringField(input.docs, 'slug', { required: true })! }
+  }
+  if (input.nav !== undefined) {
+    if (!Array.isArray(input.nav)) throw new PluginManifestError('contributes.nav must be an array')
+    const seenNavIds = new Set<string>()
+    out.nav = input.nav.map((item, index) => parseNavItem(item, `contributes.nav[${index}]`))
+    const collectIds = (items: NavItem[]): void => {
+      for (const item of items) {
+        if (seenNavIds.has(item.id)) {
+          throw new PluginManifestError(`contributes.nav declares duplicate nav item id "${item.id}"`)
+        }
+        seenNavIds.add(item.id)
+        if (item.children) collectIds(item.children)
+      }
+    }
+    collectIds(out.nav)
+  }
+  if (input.routes !== undefined) {
+    if (!Array.isArray(input.routes)) throw new PluginManifestError('contributes.routes must be an array')
+    out.routes = input.routes.map(parseRoutePattern)
+    const seenPaths = new Set<string>()
+    for (const route of out.routes) {
+      if (seenPaths.has(route.path)) {
+        throw new PluginManifestError(`contributes.routes declares duplicate path "${route.path}"`)
+      }
+      seenPaths.add(route.path)
+    }
+  }
+  if (input.slots !== undefined) {
+    if (!Array.isArray(input.slots)) throw new PluginManifestError('contributes.slots must be an array of strings')
+    const slots: string[] = []
+    for (const slot of input.slots) {
+      if (typeof slot !== 'string' || slot.length === 0) {
+        throw new PluginManifestError('contributes.slots must contain only non-empty strings')
+      }
+      if (!slots.includes(slot)) slots.push(slot)
+    }
+    out.slots = slots
+  }
+  if (input.eager !== undefined) {
+    if (typeof input.eager !== 'boolean') {
+      throw new PluginManifestError('contributes.eager must be a boolean')
+    }
+    out.eager = input.eager
   }
 
   return out

--- a/packages/host/src/plugin-host/PluginHost.tsx
+++ b/packages/host/src/plugin-host/PluginHost.tsx
@@ -405,11 +405,16 @@ async function performHotSwap(id: string, clientEntry: string, version: string, 
   // Re-apply declarative metadata so manifest edits (nav, slot/route
   // ownership) land with the swap, not just code changes.
   if (manifest) applyManifestMetadata(manifest)
-  // Lazy plugin whose client never loaded: nothing to swap. The refreshed
-  // manifest carries the new clientVersion, so the next demand imports the
-  // new bundle. Record the URL so repeat SSE events for the same build
-  // stay deduped.
-  if (getPluginLoadState(id) === 'idle') {
+  // A declaratively-lazy plugin whose client never loaded has nothing to
+  // swap: the refreshed manifest carries the new clientVersion, so the next
+  // demand imports the new bundle. Record the URL so repeat SSE events for
+  // the same build stay deduped. Legacy/eager plugins (and ids outside the
+  // manifest, as the hot-swap tests use) keep the old always-import path.
+  const isUnloadedLazy = plugin !== undefined
+    && isLoadablePlugin(plugin)
+    && !isEagerPlugin(plugin)
+    && getPluginLoadState(id) === 'idle'
+  if (isUnloadedLazy) {
     appliedHotSwapUrls.set(id, importUrl)
     return
   }

--- a/packages/host/src/plugin-host/PluginHost.tsx
+++ b/packages/host/src/plugin-host/PluginHost.tsx
@@ -1,17 +1,24 @@
 /**
- * PluginHost — boots plugins at runtime.
+ * PluginHost — boots plugins at runtime, lazily.
  *
  * On mount:
  *   1. Fetches /api/plugins/manifest (TF1) to get each plugin's client
- *      bundle URL.
- *   2. Dynamic-imports every clientEntry in parallel. Each plugin's
- *      client.mjs runs `registerPlugin({...})` / `registerSlot(...)` as a
- *      side effect — no exports are read.
- *   3. Optionally calls `assertReactInstance(pluginId, pluginReact)` on
- *      each loaded module to catch plugins that bundled their own React
- *      (broken hooks).
- *   4. Flips a `ready` flag to re-render the shell with nav items + slots
- *      populated from the registry.
+ *      bundle URL + declarative `contributes.{nav,routes,slots,eager}`.
+ *   2. Seeds the sidebar from manifest nav (`setManifestNav`) and installs
+ *      the lazy ownership index (`configureLazyPlugins`) — all before any
+ *      client bundle loads.
+ *   3. Dynamic-imports ONLY eager plugins: `contributes.eager: true`
+ *      (background providers like nav-badge-providers) and legacy plugins
+ *      with a client but no declarative metadata (backward compat). Each
+ *      plugin's client.mjs runs `registerPlugin({...})` as a side effect —
+ *      no exports are read.
+ *   4. Flips a `ready` flag to render the shell. Every other plugin's
+ *      client loads on first demand: a `<Slot>` it owns rendering, or
+ *      navigation into one of its manifest route patterns (the plugin
+ *      route catch-all calls `requestRoutePlugins`).
+ *   5. After every client import, a drift check compares the runtime
+ *      registrations against the manifest declarations and warns on
+ *      mismatch (the lazy contract is only as good as the manifest).
  *
  * Re-render on registry change: consumers (<Slot>, <AppSidebar>) subscribe
  * to `getRegistryVersion()` via `useSyncExternalStore` themselves — a
@@ -22,13 +29,24 @@
  * Dev hot-swap bridge: when the dev-client script is present in the
  * document, PluginHost exposes `window.__bakinHotSwapPlugin(id, clientEntry,
  * version)` so scripts/dev.ts can trigger a per-plugin remount without a
- * full page reload. Production builds never ship the dev client, so the
- * window handle stays undefined there.
+ * full page reload. Hot-swapping a plugin whose client never loaded is a
+ * metadata-only refresh — the new bundle is picked up by the next demand.
+ * Production builds never ship the dev client, so the window handle stays
+ * undefined there.
  */
 import { useEffect, useState, type ReactNode } from 'react'
-import { unregisterPlugin } from '@makinbakin/sdk'
+import {
+  configureLazyPlugins,
+  getPluginLoadState,
+  setLazyPluginLoader,
+  setManifestNav,
+  setPluginLoadState,
+  unregisterPlugin,
+  type PluginContributions,
+} from '@makinbakin/sdk'
 import { Slot } from '@makinbakin/sdk/slots'
 import { assertReactInstance } from '../lib/react-identity'
+import { checkPluginDrift } from './drift-check'
 import {
   installVersionMismatchDetector,
   VERSION_MISMATCH_EVENT,
@@ -43,6 +61,7 @@ interface ManifestPlugin {
   clientVersion?: string
   clientCss?: string
   status?: 'active' | 'failed'
+  contributes?: PluginContributions
 }
 
 interface Manifest {
@@ -208,6 +227,88 @@ function swapPluginCss(plugin: ManifestPlugin, version: string): void {
   }
 }
 
+/**
+ * True if the manifest declares any of the metadata that makes lazy
+ * loading possible. Plugins with a client but none of it are legacy-shaped
+ * and load eagerly (old behavior) until migrated.
+ */
+function hasDeclarativeClientMetadata(plugin: ManifestPlugin): boolean {
+  const c = plugin.contributes
+  return Boolean(c?.nav?.length || c?.routes?.length || c?.slots?.length)
+}
+
+function isLoadablePlugin(plugin: ManifestPlugin): boolean {
+  return plugin.status !== 'failed' && Boolean(plugin.clientEntry)
+}
+
+/** Eager = explicit `contributes.eager` escape hatch, or legacy shape. */
+function isEagerPlugin(plugin: ManifestPlugin): boolean {
+  if (!isLoadablePlugin(plugin)) return false
+  return plugin.contributes?.eager === true || !hasDeclarativeClientMetadata(plugin)
+}
+
+// Plugin ids whose manifest nav we've seeded — so a plugin removed from the
+// manifest (dev uninstall + hot reload) gets its sidebar entry cleared on
+// the next refresh instead of lingering forever.
+const seededManifestNavIds = new Set<string>()
+
+/**
+ * Apply a fresh manifest's declarative metadata: sidebar nav + the lazy
+ * slot/route ownership index. Runs on boot and after every manifest
+ * refresh (hot-swap, version mismatch) so metadata edits land without the
+ * client bundle reloading.
+ */
+function applyManifestMetadata(manifest: Manifest): void {
+  const slotOwners = new Map<string, string[]>()
+  const routeOwners: Array<{ pattern: string; pluginId: string }> = []
+  const presentIds = new Set<string>()
+
+  for (const plugin of manifest.plugins) {
+    presentIds.add(plugin.id)
+    const loadable = isLoadablePlugin(plugin)
+    setManifestNav(plugin.id, loadable ? plugin.contributes?.nav ?? null : null)
+    if (loadable && plugin.contributes?.nav?.length) seededManifestNavIds.add(plugin.id)
+    if (!loadable) continue
+    for (const slot of plugin.contributes?.slots ?? []) {
+      const owners = slotOwners.get(slot) ?? []
+      owners.push(plugin.id)
+      slotOwners.set(slot, owners)
+    }
+    for (const route of plugin.contributes?.routes ?? []) {
+      routeOwners.push({ pattern: route.path, pluginId: plugin.id })
+    }
+  }
+
+  for (const id of seededManifestNavIds) {
+    if (presentIds.has(id)) continue
+    setManifestNav(id, null)
+    seededManifestNavIds.delete(id)
+  }
+
+  configureLazyPlugins({ slotOwners, routeOwners })
+}
+
+/**
+ * Compare a freshly-loaded client's runtime registrations against its
+ * manifest declarations. Drift means lazy loading misbehaves (routes that
+ * 404 until an unrelated demand, nav that only exists after load), so the
+ * warnings are unconditional — this is an authoring bug, not noise.
+ */
+function runDriftCheck(plugin: ManifestPlugin): void {
+  const warnings = checkPluginDrift(plugin.id, plugin.contributes)
+  for (const warning of warnings) {
+    console.warn(`[bakin] plugin "${plugin.id}" manifest drift: ${warning}`)
+  }
+  if (warnings.length > 0) {
+    debugPluginStartup('pluginHost.driftCheck', {
+      pluginId: plugin.id,
+      status: 'drift',
+      count: warnings.length,
+      warnings,
+    })
+  }
+}
+
 async function loadPluginClient(plugin: ManifestPlugin): Promise<void> {
   if (plugin.status === 'failed' || !plugin.clientEntry) {
     debugPluginStartup('pluginHost.clientImport', {
@@ -218,6 +319,9 @@ async function loadPluginClient(plugin: ManifestPlugin): Promise<void> {
     })
     return
   }
+  // Mark loading synchronously (before the first await) so a second demand
+  // arriving in the same tick can't double-import the bundle.
+  setPluginLoadState(plugin.id, 'loading')
   const cssStartedAt = nowMs()
   injectPluginCss(plugin)
   if (plugin.clientCss) {
@@ -239,14 +343,19 @@ async function loadPluginClient(plugin: ManifestPlugin): Promise<void> {
     if (mod.React) {
       assertReactInstance(plugin.id, mod.React as typeof import('react'))
     }
+    setPluginLoadState(plugin.id, 'loaded')
     debugPluginStartup('pluginHost.clientImport', {
       pluginId: plugin.id,
       status: 'ok',
       durationMs: roundedMs(nowMs() - startedAt),
     })
+    runDriftCheck(plugin)
   } catch (err) {
-    // One bad plugin shouldn't prevent the rest from loading. Log + skip.
+    // One bad plugin shouldn't prevent the rest from loading. Log + skip;
+    // the error state surfaces through <Slot> / catch-all fallbacks, which
+    // offer a retry.
     console.error(`[bakin] Plugin ${plugin.id} failed to load from ${importUrl}:`, err)
+    setPluginLoadState(plugin.id, 'error', err instanceof Error ? err.message : String(err))
     debugPluginStartup('pluginHost.clientImport', {
       pluginId: plugin.id,
       status: 'error',
@@ -293,10 +402,29 @@ async function refreshManifest(): Promise<Manifest | null> {
 async function performHotSwap(id: string, clientEntry: string, version: string, importUrl: string): Promise<void> {
   const manifest = await refreshManifest()
   const plugin = manifest?.plugins.find((p) => p.id === id)
+  // Re-apply declarative metadata so manifest edits (nav, slot/route
+  // ownership) land with the swap, not just code changes.
+  if (manifest) applyManifestMetadata(manifest)
+  // Lazy plugin whose client never loaded: nothing to swap. The refreshed
+  // manifest carries the new clientVersion, so the next demand imports the
+  // new bundle. Record the URL so repeat SSE events for the same build
+  // stay deduped.
+  if (getPluginLoadState(id) === 'idle') {
+    appliedHotSwapUrls.set(id, importUrl)
+    return
+  }
   unregisterPlugin(id)
   if (plugin) swapPluginCss(plugin, version)
-  await import(/* @vite-ignore */ importUrl)
+  setPluginLoadState(id, 'loading')
+  try {
+    await import(/* @vite-ignore */ importUrl)
+  } catch (err) {
+    setPluginLoadState(id, 'error', err instanceof Error ? err.message : String(err))
+    throw err
+  }
+  setPluginLoadState(id, 'loaded')
   appliedHotSwapUrls.set(id, importUrl)
+  if (plugin) runDriftCheck(plugin)
 }
 
 async function hotSwapPlugin(id: string, clientEntry: string, version: string): Promise<void> {
@@ -330,6 +458,7 @@ async function bootPluginClients(): Promise<PluginBootResult> {
   const startedAt = nowMs()
   let status: 'ok' | 'error' = 'ok'
   let count = 0
+  let lazyCount = 0
   try {
     const manifest = await refreshManifest()
     if (!manifest) {
@@ -337,8 +466,13 @@ async function bootPluginClients(): Promise<PluginBootResult> {
       status = 'error'
       return { status, count }
     }
-    count = manifest.plugins.length
-    await Promise.all(manifest.plugins.map(loadPluginClient))
+    // Declarative metadata first: sidebar nav + lazy ownership index exist
+    // before (and regardless of) any client bundle loading.
+    applyManifestMetadata(manifest)
+    const eagerPlugins = manifest.plugins.filter(isEagerPlugin)
+    count = eagerPlugins.length
+    lazyCount = manifest.plugins.filter((p) => isLoadablePlugin(p) && !isEagerPlugin(p)).length
+    await Promise.all(eagerPlugins.map(loadPluginClient))
   } catch (err) {
     status = 'error'
     console.error('[bakin] Plugin host boot failed:', err)
@@ -348,6 +482,7 @@ async function bootPluginClients(): Promise<PluginBootResult> {
       status,
       durationMs: roundedMs(endedAt - startedAt),
       count,
+      lazyCount,
     })
     logStartupResourceSummary(startedAt, endedAt)
   }
@@ -406,6 +541,19 @@ export function PluginHost({ children }: { children: ReactNode }) {
       cancelled = true
       releasePluginBoot()
     }
+  }, [])
+
+  // Install the lazy demand loader: <Slot> and the plugin route catch-all
+  // request a plugin id on first render of something it owns; we resolve it
+  // against the latest manifest and import its client bundle. The lazy
+  // store filters non-idle plugins, so this never double-imports.
+  useEffect(() => {
+    setLazyPluginLoader((pluginId) => {
+      const plugin = latestManifest?.plugins.find((p) => p.id === pluginId)
+      if (!plugin) return
+      void loadPluginClient(plugin)
+    })
+    return () => setLazyPluginLoader(null)
   }, [])
 
   // Expose the hot-swap handle to the dev client. Keyed on the script

--- a/packages/host/src/plugin-host/drift-check.ts
+++ b/packages/host/src/plugin-host/drift-check.ts
@@ -1,0 +1,98 @@
+/**
+ * Drift validation for declarative plugin manifests (lazy loading).
+ *
+ * A lazily-loaded plugin's sidebar nav, route ownership, and slot ownership
+ * come from `bakin-plugin.json` `contributes.{nav,routes,slots}` — but the
+ * actual registrations happen when its client bundle finally executes
+ * `registerPlugin`. If the two drift apart, symptoms are subtle (a route
+ * that 404s until some unrelated slot loads the client, nav that vanishes
+ * after hot-swap), so the host checks every loaded client against its
+ * manifest and warns loudly.
+ *
+ * Runs as a startup diagnostic after each client import (eager or lazy).
+ * The CI-side twin lives in tests/plugins/manifest-drift.test.tsx, which
+ * imports every core plugin's client and applies the same comparison.
+ */
+import {
+  getManifestNav,
+  getPluginNavItems,
+  getPluginRoutes,
+  type NavItem,
+  type PluginContributions,
+} from '@makinbakin/sdk'
+import { getSlotNamesOwnedBy } from '@makinbakin/sdk/slots'
+
+/**
+ * Compare a loaded plugin's runtime registrations against its declarative
+ * manifest metadata. Returns human-readable drift warnings; empty when in
+ * sync. Plugins with no declarative client metadata (legacy, eager-loaded)
+ * are exempt — they have nothing to drift from.
+ */
+export function checkPluginDrift(
+  pluginId: string,
+  contributes: PluginContributions | undefined,
+): string[] {
+  const declaredNav = contributes?.nav
+  const declaredRoutes = contributes?.routes
+  const declaredSlots = contributes?.slots
+  if (!declaredNav && !declaredRoutes && !declaredSlots) return []
+
+  const warnings: string[] = []
+
+  // --- nav ---------------------------------------------------------------
+  // A migrated plugin's client passes no navItems (manifest nav renders the
+  // sidebar). Runtime navItems override manifest nav — that's the
+  // conditional-nav escape hatch — but silently diverging from declared nav
+  // is an authoring bug worth surfacing.
+  const runtimeNav = getPluginNavItems(pluginId)
+  if (runtimeNav.length > 0) {
+    const manifestNav = getManifestNav(pluginId)
+    if (manifestNav.length === 0) {
+      warnings.push(
+        `registers navItems at runtime but declares no contributes.nav — its sidebar entry won't exist until the client loads, defeating lazy loading`,
+      )
+    } else if (!navEquals(manifestNav, runtimeNav)) {
+      warnings.push(
+        `runtime navItems differ from contributes.nav (runtime wins while registered; remove contributes.nav if the override is intentional)`,
+      )
+    }
+  }
+
+  // --- routes ------------------------------------------------------------
+  const runtimeRoutePaths = new Set(getPluginRoutes(pluginId).map((r) => r.path))
+  const declaredRoutePaths = new Set((declaredRoutes ?? []).map((r) => r.path))
+  for (const path of declaredRoutePaths) {
+    if (!runtimeRoutePaths.has(path)) {
+      warnings.push(`contributes.routes declares "${path}" but the client never registered it`)
+    }
+  }
+  for (const path of runtimeRoutePaths) {
+    if (!declaredRoutePaths.has(path)) {
+      warnings.push(
+        `client registers route "${path}" missing from contributes.routes — direct navigation there won't trigger a lazy load`,
+      )
+    }
+  }
+
+  // --- slots -------------------------------------------------------------
+  const runtimeSlots = new Set(getSlotNamesOwnedBy(pluginId))
+  const declaredSlotNames = new Set(declaredSlots ?? [])
+  for (const name of declaredSlotNames) {
+    if (!runtimeSlots.has(name)) {
+      warnings.push(`contributes.slots declares "${name}" but the client never registered it`)
+    }
+  }
+  for (const name of runtimeSlots) {
+    if (!declaredSlotNames.has(name)) {
+      warnings.push(
+        `client registers slot "${name}" missing from contributes.slots — rendering that slot won't trigger a lazy load`,
+      )
+    }
+  }
+
+  return warnings
+}
+
+function navEquals(a: ReadonlyArray<NavItem>, b: ReadonlyArray<NavItem>): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}

--- a/packages/host/src/routes/plugin-catchall.tsx
+++ b/packages/host/src/routes/plugin-catchall.tsx
@@ -5,22 +5,111 @@
  * claimed by installed plugins through `registerPlugin({ routes })`, which
  * lets extracted plugins render real pages without Bakin adding one route
  * file per plugin page.
+ *
+ * Lazy loading: navigating here is a demand signal. If no runtime route
+ * matches yet but a plugin's manifest `contributes.routes` claims the path,
+ * we request its client bundle and render a loading state until the
+ * module's `registerPlugin` side effect fills the registry. A failed
+ * import renders an inline error with retry instead of a false 404.
  */
 import { createRoute, useLocation } from '@tanstack/react-router'
-import { useSyncExternalStore } from 'react'
+import { Component, useEffect, useSyncExternalStore, type ReactNode } from 'react'
 import {
+  getLazyPluginsVersion,
+  getPluginLoadError,
+  getPluginLoadState,
   getPluginRoute,
   getRegistryVersion,
+  getRouteOwners,
+  requestRoutePlugins,
+  retryPluginLoad,
+  subscribeLazyPlugins,
   subscribeRegistry,
 } from '@makinbakin/sdk'
 import { Route as RootRoute } from './__root'
 
+/** Boundary so a crashing lazily-loaded page can't white-screen the shell. */
+class PluginPageBoundary extends Component<
+  { pluginId: string; pathname: string; children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null }
+
+  static getDerivedStateFromError(error: Error): { error: Error } {
+    return { error }
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error(`[bakin] plugin "${this.props.pluginId}" page crashed at ${this.props.pathname}:`, error)
+  }
+
+  componentDidUpdate(prevProps: { pathname: string }): void {
+    // Navigating away resets the boundary so the next page renders fresh.
+    if (prevProps.pathname !== this.props.pathname && this.state.error) {
+      this.setState({ error: null })
+    }
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div className="p-6 text-sm text-destructive" role="alert">
+          Plugin &quot;{this.props.pluginId}&quot; failed to render this page.
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+function PluginLoadingPage() {
+  return (
+    <div className="flex h-full items-center justify-center" role="status" aria-live="polite">
+      <span className="size-6 animate-spin rounded-full border-[3px] border-[#ff4d94]/20 border-t-[#ff4d94]" aria-hidden="true" />
+      <span className="sr-only">Loading plugin</span>
+    </div>
+  )
+}
+
+function PluginLoadErrorPage({ pluginIds }: { pluginIds: string[] }) {
+  const detail = getPluginLoadError(pluginIds[0])
+  return (
+    <div className="flex flex-col items-start gap-3 p-6 text-sm" role="alert">
+      <span className="text-destructive">
+        {pluginIds.length === 1 ? `Plugin "${pluginIds[0]}" failed to load` : `Plugins ${pluginIds.map((id) => `"${id}"`).join(', ')} failed to load`}
+        {detail ? ` — ${detail}` : ''}
+      </span>
+      <button
+        type="button"
+        className="rounded border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+        onClick={() => pluginIds.forEach(retryPluginLoad)}
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
 function PluginCatchAllPage() {
   useSyncExternalStore(subscribeRegistry, getRegistryVersion, getRegistryVersion)
+  useSyncExternalStore(subscribeLazyPlugins, getLazyPluginsVersion, getLazyPluginsVersion)
   const location = useLocation()
+
+  useEffect(() => {
+    requestRoutePlugins(location.pathname)
+  }, [location.pathname])
+
   const match = getPluginRoute(location.pathname)
 
   if (!match) {
+    const owners = getRouteOwners(location.pathname)
+    if (owners.length > 0) {
+      const failed = owners.filter((id) => getPluginLoadState(id) === 'error')
+      if (failed.length > 0) return <PluginLoadErrorPage pluginIds={[...failed]} />
+      // idle (demand fires in the effect above) or loading — either way the
+      // registry fills in when the client's registerPlugin runs.
+      return <PluginLoadingPage />
+    }
     return (
       <div className="p-6 text-sm text-muted-foreground">
         Page not found.
@@ -28,13 +117,15 @@ function PluginCatchAllPage() {
     )
   }
 
-  const Component = match.component
+  const Page = match.component
   return (
-    <Component
-      params={match.params}
-      pathname={location.pathname}
-      {...match.params}
-    />
+    <PluginPageBoundary pluginId={match.pluginId} pathname={location.pathname}>
+      <Page
+        params={match.params}
+        pathname={location.pathname}
+        {...match.params}
+      />
+    </PluginPageBoundary>
   )
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -52,7 +52,28 @@ export { subscribeNavBadges } from './register'
 export { getPluginRoute } from './register'
 /** Get all registered client routes (across all plugins). */
 export { getPluginRoutes } from './register'
+/** Seed a plugin's declarative nav from its manifest (host-side; survives unregisterPlugin). */
+export { setManifestNav } from './register'
+/** Read the manifest nav currently seeded for a plugin (drift validation). */
+export { getManifestNav } from './register'
 export type { ClientRouteEntry, MatchedPluginRoute, NavItem, PluginRegistration } from './register'
+
+/** Lazy plugin-client loading: ownership index + load-state store (host-side wiring). */
+export {
+  configureLazyPlugins,
+  setLazyPluginLoader,
+  setPluginLoadState,
+  getPluginLoadState,
+  getPluginLoadError,
+  getSlotOwners,
+  getRouteOwners,
+  requestSlotPlugins,
+  requestRoutePlugins,
+  retryPluginLoad,
+  getLazyPluginsVersion,
+  subscribeLazyPlugins,
+} from './lazy'
+export type { LazyPluginIndex, PluginLoadState } from './lazy'
 
 /** Define a plugin HTTP route with typed input/output schemas. */
 export { defineRoute } from './routing'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -58,21 +58,30 @@ export { setManifestNav } from './register'
 export { getManifestNav } from './register'
 export type { ClientRouteEntry, MatchedPluginRoute, NavItem, PluginRegistration } from './register'
 
-/** Lazy plugin-client loading: ownership index + load-state store (host-side wiring). */
-export {
-  configureLazyPlugins,
-  setLazyPluginLoader,
-  setPluginLoadState,
-  getPluginLoadState,
-  getPluginLoadError,
-  getSlotOwners,
-  getRouteOwners,
-  requestSlotPlugins,
-  requestRoutePlugins,
-  retryPluginLoad,
-  getLazyPluginsVersion,
-  subscribeLazyPlugins,
-} from './lazy'
+/** Install the manifest-derived slot/route ownership index for lazy loading (host-side). */
+export { configureLazyPlugins } from './lazy'
+/** Install the demand loader that imports a plugin's client bundle (host-side). */
+export { setLazyPluginLoader } from './lazy'
+/** Report a plugin client's load progress: idle → loading → loaded | error (host-side). */
+export { setPluginLoadState } from './lazy'
+/** Current load state for a plugin client. Unknown plugins report 'idle'. */
+export { getPluginLoadState } from './lazy'
+/** Last load error message for a plugin whose state is 'error', if any. */
+export { getPluginLoadError } from './lazy'
+/** Plugins whose manifests declare the given slot in `contributes.slots`. */
+export { getSlotOwners } from './lazy'
+/** Plugins whose manifest `contributes.routes` patterns match a pathname. */
+export { getRouteOwners } from './lazy'
+/** Ask the host to lazy-load every idle plugin that fills the named slot. */
+export { requestSlotPlugins } from './lazy'
+/** Ask the host to lazy-load every idle plugin whose route patterns match the pathname. */
+export { requestRoutePlugins } from './lazy'
+/** Reset a failed plugin to idle and re-request its client bundle. */
+export { retryPluginLoad } from './lazy'
+/** Monotonic lazy-store version for useSyncExternalStore consumers. */
+export { getLazyPluginsVersion } from './lazy'
+/** Subscribe to lazy-plugin store mutations. Returns an unsubscribe fn. */
+export { subscribeLazyPlugins } from './lazy'
 export type { LazyPluginIndex, PluginLoadState } from './lazy'
 
 /** Define a plugin HTTP route with typed input/output schemas. */

--- a/packages/sdk/src/lazy.ts
+++ b/packages/sdk/src/lazy.ts
@@ -1,0 +1,180 @@
+'use client'
+
+/**
+ * Lazy plugin-client loading — the SDK side.
+ *
+ * With declarative manifests (`contributes.nav/routes/slots`), the host no
+ * longer imports every plugin's client bundle at boot. Instead it:
+ *
+ *   1. calls `configureLazyPlugins()` with an ownership index built from the
+ *      manifest — which plugin fills which slot, which plugin owns which
+ *      client route pattern;
+ *   2. installs a loader via `setLazyPluginLoader()` that dynamic-imports a
+ *      plugin's client.js on demand.
+ *
+ * Demand comes from two render-time surfaces:
+ *   - `<Slot>` calls `requestSlotPlugins(name)` when it renders — if an
+ *     owning plugin's client hasn't loaded yet, the loader fires and the
+ *     slot re-renders when `registerPlugin` runs as the module's side effect;
+ *   - the host's plugin route catch-all calls `requestRoutePlugins(pathname)`.
+ *
+ * Load state per plugin (`idle → loading → loaded | error`) lives in a
+ * browser-global store (HMR-safe, same pattern as the client registry) so
+ * `<Slot>` and the catch-all can render loading/error fallbacks and offer a
+ * retry without the shell crashing on a failed import.
+ */
+
+import { matchRoutePattern } from './register'
+
+export type PluginLoadState = 'idle' | 'loading' | 'loaded' | 'error'
+
+interface LazyPluginStore {
+  /** slot name → pluginIds whose manifests declare it in `contributes.slots`. */
+  ownersBySlot: Map<string, string[]>
+  /** Manifest route patterns (`contributes.routes`) → owning pluginId. */
+  routeOwners: Array<{ pattern: string; pluginId: string }>
+  states: Map<string, PluginLoadState>
+  /** Last load error message per plugin (set alongside state 'error'). */
+  errors: Map<string, string>
+  loader: ((pluginId: string) => void) | null
+  version: number
+  listeners: Set<() => void>
+}
+
+function getStore(): LazyPluginStore {
+  const g = globalThis as Record<string, unknown>
+  if (!g.__bakinLazyPluginStore) {
+    g.__bakinLazyPluginStore = {
+      ownersBySlot: new Map<string, string[]>(),
+      routeOwners: [],
+      states: new Map<string, PluginLoadState>(),
+      errors: new Map<string, string>(),
+      loader: null,
+      version: 0,
+      listeners: new Set<() => void>(),
+    } satisfies LazyPluginStore
+  }
+  return g.__bakinLazyPluginStore as LazyPluginStore
+}
+
+function bump(): void {
+  const store = getStore()
+  store.version++
+  for (const l of store.listeners) {
+    try { l() } catch (err) { console.error('[bakin] lazy-plugin listener threw:', err) }
+  }
+}
+
+export interface LazyPluginIndex {
+  /** slot name → owning pluginIds (from each manifest's `contributes.slots`). */
+  slotOwners: ReadonlyMap<string, string[]>
+  /** Route pattern → owning pluginId (from `contributes.routes`). */
+  routeOwners: ReadonlyArray<{ pattern: string; pluginId: string }>
+}
+
+/**
+ * Install the manifest-derived ownership index. Called by the host on boot
+ * and after every manifest refresh (hot-swap). Replaces the previous index;
+ * load states are preserved.
+ */
+export function configureLazyPlugins(index: LazyPluginIndex): void {
+  const store = getStore()
+  store.ownersBySlot = new Map(index.slotOwners)
+  store.routeOwners = [...index.routeOwners]
+  bump()
+}
+
+/**
+ * Install the demand loader. The host's loader dynamic-imports the plugin's
+ * client bundle and reports progress through `setPluginLoadState`. Pass
+ * `null` to uninstall (tests). Without a loader, demand requests are no-ops.
+ */
+export function setLazyPluginLoader(loader: ((pluginId: string) => void) | null): void {
+  getStore().loader = loader
+}
+
+/** Report a plugin client's load progress. Host-side use. */
+export function setPluginLoadState(pluginId: string, state: PluginLoadState, error?: string): void {
+  const store = getStore()
+  if (store.states.get(pluginId) === state && store.errors.get(pluginId) === error) return
+  store.states.set(pluginId, state)
+  if (state === 'error' && error) store.errors.set(pluginId, error)
+  else store.errors.delete(pluginId)
+  bump()
+}
+
+/** Current load state for a plugin client. Unknown plugins report 'idle'. */
+export function getPluginLoadState(pluginId: string): PluginLoadState {
+  return getStore().states.get(pluginId) ?? 'idle'
+}
+
+/** Last load error message for a plugin whose state is 'error', if any. */
+export function getPluginLoadError(pluginId: string): string | undefined {
+  return getStore().errors.get(pluginId)
+}
+
+/** Plugins whose manifests declare the given slot in `contributes.slots`. */
+export function getSlotOwners(name: string): ReadonlyArray<string> {
+  return getStore().ownersBySlot.get(name) ?? []
+}
+
+/**
+ * Plugins whose manifest `contributes.routes` patterns match the pathname.
+ */
+export function getRouteOwners(pathname: string): ReadonlyArray<string> {
+  const owners: string[] = []
+  for (const { pattern, pluginId } of getStore().routeOwners) {
+    if (matchRoutePattern(pattern, pathname) && !owners.includes(pluginId)) {
+      owners.push(pluginId)
+    }
+  }
+  return owners
+}
+
+function demand(pluginIds: ReadonlyArray<string>): void {
+  const store = getStore()
+  if (!store.loader) return
+  for (const pluginId of pluginIds) {
+    if ((store.states.get(pluginId) ?? 'idle') !== 'idle') continue
+    store.loader(pluginId)
+  }
+}
+
+/**
+ * Ask the host to load every idle plugin that fills the named slot.
+ * Called by `<Slot>` on render (via effect). Safe to call repeatedly —
+ * non-idle plugins are skipped.
+ */
+export function requestSlotPlugins(name: string): void {
+  demand(getSlotOwners(name))
+}
+
+/**
+ * Ask the host to load every idle plugin whose manifest route patterns
+ * match the pathname. Called by the host's plugin route catch-all.
+ */
+export function requestRoutePlugins(pathname: string): void {
+  demand(getRouteOwners(pathname))
+}
+
+/** Reset a failed plugin to idle and re-request it. Used by error fallbacks. */
+export function retryPluginLoad(pluginId: string): void {
+  const store = getStore()
+  if (store.states.get(pluginId) !== 'error') return
+  store.states.set(pluginId, 'idle')
+  store.errors.delete(pluginId)
+  bump()
+  demand([pluginId])
+}
+
+/** Monotonic version for useSyncExternalStore consumers. */
+export function getLazyPluginsVersion(): number {
+  return getStore().version
+}
+
+/** Subscribe to lazy-plugin store mutations. Returns an unsubscribe fn. */
+export function subscribeLazyPlugins(listener: () => void): () => void {
+  const store = getStore()
+  store.listeners.add(listener)
+  return () => { store.listeners.delete(listener) }
+}

--- a/packages/sdk/src/register.ts
+++ b/packages/sdk/src/register.ts
@@ -50,6 +50,14 @@ interface ClientRouteEntry {
 
 interface ClientRegistry {
   navByPlugin: Map<string, NavItem[]>
+  // Declarative nav from each plugin's bakin-plugin.json `contributes.nav`,
+  // seeded by the host from the manifest BEFORE any client bundle loads.
+  // Kept on a separate map so `unregisterPlugin` (hot-swap teardown) never
+  // drops manifest nav — a lazily-loaded plugin keeps its sidebar entry
+  // whether or not its client has executed. Runtime nav (`navByPlugin`)
+  // overrides a plugin's manifest nav when both exist — the conditional-nav
+  // escape hatch.
+  manifestNavByPlugin: Map<string, NavItem[]>
   routesByPlugin: Map<string, ClientRouteEntry[]>
   cleanupByPlugin: Map<string, Array<() => void>>
   navItemsSnapshot: NavItem[]
@@ -65,6 +73,10 @@ interface ClientRegistry {
 
 function buildNavItemsSnapshot(registry: ClientRegistry): NavItem[] {
   const items: NavItem[] = []
+  for (const [pluginId, navItems] of registry.manifestNavByPlugin.entries()) {
+    if (registry.navByPlugin.has(pluginId)) continue // runtime nav overrides
+    items.push(...navItems)
+  }
   for (const navItems of registry.navByPlugin.values()) {
     items.push(...navItems)
   }
@@ -76,6 +88,7 @@ function getRegistry(): ClientRegistry {
   if (!g.__bakinClientRegistry) {
     g.__bakinClientRegistry = {
       navByPlugin: new Map<string, NavItem[]>(),
+      manifestNavByPlugin: new Map<string, NavItem[]>(),
       routesByPlugin: new Map<string, ClientRouteEntry[]>(),
       cleanupByPlugin: new Map<string, Array<() => void>>(),
       navItemsSnapshot: [],
@@ -87,6 +100,9 @@ function getRegistry(): ClientRegistry {
     } as ClientRegistry
   }
   const registry = g.__bakinClientRegistry as ClientRegistry
+  // Hydrate manifest-nav if the registry pre-dates this addition (HMR retains
+  // the singleton across reloads, so older shapes can show up).
+  if (!registry.manifestNavByPlugin) registry.manifestNavByPlugin = new Map()
   if (!Array.isArray(registry.navItemsSnapshot)) {
     registry.navItemsSnapshot = buildNavItemsSnapshot(registry)
   }
@@ -200,6 +216,40 @@ export function registerPluginCleanup(id: string, fn: () => void): void {
 }
 
 /**
+ * Seed (or replace) a plugin's declarative nav from its manifest
+ * `contributes.nav`. Called by the host's PluginHost after every manifest
+ * fetch — including hot-swap refreshes — so the sidebar renders before any
+ * client bundle loads. Pass `null` (or an empty array) to clear.
+ *
+ * Manifest nav lives on its own map: `unregisterPlugin` never touches it,
+ * and a plugin that registers `navItems` at runtime overrides its manifest
+ * nav while registered (the conditional-nav escape hatch).
+ */
+export function setManifestNav(pluginId: string, navItems: NavItem[] | null): void {
+  const registry = getRegistry()
+  if (!navItems || navItems.length === 0) {
+    if (!registry.manifestNavByPlugin.delete(pluginId)) return
+    bumpVersion()
+    return
+  }
+  // Manifest refreshes re-seed every plugin on every fetch; skip the version
+  // bump (and the nav re-render it forces) when nothing actually changed.
+  const prev = registry.manifestNavByPlugin.get(pluginId)
+  if (prev && JSON.stringify(prev) === JSON.stringify(navItems)) return
+  registry.manifestNavByPlugin.set(pluginId, navItems)
+  bumpVersion()
+}
+
+/**
+ * The declarative manifest nav currently seeded for a plugin (empty if none).
+ * Used by the drift validation check to compare manifest nav against what a
+ * loaded client registered at runtime.
+ */
+export function getManifestNav(pluginId: string): ReadonlyArray<NavItem> {
+  return getRegistry().manifestNavByPlugin.get(pluginId) ?? []
+}
+
+/**
  * Monotonic counter bumped on every register / unregister. Used with
  * React's `useSyncExternalStore` (via `subscribeRegistry`) so the shell
  * re-renders nav + slots when plugins come or go at runtime.
@@ -304,7 +354,11 @@ function normalizePattern(pattern: string): string[] {
   return pattern.split('/').filter(Boolean)
 }
 
-function matchRoutePattern(pattern: string, pathname: string): { params: Record<string, string>; score: number } | null {
+/**
+ * Match a route pattern (`/projects/[id]`, `/x/:id`, `/y/$id`) against a
+ * concrete pathname. Internal SDK helper shared with the lazy-loading index.
+ */
+export function matchRoutePattern(pattern: string, pathname: string): { params: Record<string, string>; score: number } | null {
   const patternSegments = normalizePattern(pattern)
   const pathSegments = normalizePattern(pathname)
   if (patternSegments.length !== pathSegments.length) return null

--- a/packages/sdk/src/slots/index.tsx
+++ b/packages/sdk/src/slots/index.tsx
@@ -74,6 +74,19 @@ export function getSlotEntries(name: string): ReadonlyArray<SlotEntry> {
 }
 
 /**
+ * Slot names that currently have at least one entry owned by the given
+ * plugin. Used by the host's drift validation check to compare runtime
+ * slot registrations against the manifest's `contributes.slots`.
+ */
+export function getSlotNamesOwnedBy(pluginId: string): string[] {
+  const names: string[] = []
+  for (const [name, entries] of getRegistry().entries()) {
+    if (entries.some((e) => e.owner === pluginId)) names.push(name)
+  }
+  return names
+}
+
+/**
  * Remove every slot entry owned by the given plugin. Used by
  * `unregisterPlugin` during v2 hot-swap. Entries without an `owner`
  * (test registrations, pre-v2 legacy registrations) survive — callers

--- a/packages/sdk/src/slots/index.tsx
+++ b/packages/sdk/src/slots/index.tsx
@@ -22,8 +22,17 @@
  * Test-only helpers are not exported — tests use the public unregister path.
  */
 
-import { useSyncExternalStore, type ComponentType, type JSX } from 'react'
+import { Component, useEffect, useSyncExternalStore, type ComponentType, type JSX, type ReactNode } from 'react'
 import { subscribeRegistry, getRegistryVersion } from '../register'
+import {
+  getLazyPluginsVersion,
+  getPluginLoadError,
+  getPluginLoadState,
+  getSlotOwners,
+  requestSlotPlugins,
+  retryPluginLoad,
+  subscribeLazyPlugins,
+} from '../lazy'
 
 interface SlotEntry {
   component: ComponentType<Record<string, unknown>>
@@ -85,9 +94,70 @@ interface SlotProps {
 }
 
 /**
+ * Per-entry error boundary so one plugin's crashing slot component (or a
+ * component from a half-loaded lazy bundle) can't unmount the shell or the
+ * other entries rendered in the same slot.
+ */
+class SlotEntryBoundary extends Component<
+  { owner?: string; slotName: string; children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null }
+
+  static getDerivedStateFromError(error: Error): { error: Error } {
+    return { error }
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error(
+      `[bakin] slot "${this.props.slotName}" entry${this.props.owner ? ` from plugin "${this.props.owner}"` : ''} crashed:`,
+      error,
+    )
+  }
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive" role="alert">
+          {this.props.owner ? `Plugin "${this.props.owner}"` : 'A plugin'} failed to render this section.
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+/** Fallback shown in place of slot content when an owning plugin's client bundle failed to load. */
+function SlotLoadError({ slotName, pluginIds }: { slotName: string; pluginIds: string[] }): JSX.Element {
+  return (
+    <div className="flex flex-col items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive" role="alert">
+      <span>
+        {pluginIds.length === 1 ? `Plugin "${pluginIds[0]}" failed to load` : `Plugins ${pluginIds.map((id) => `"${id}"`).join(', ')} failed to load`}
+        {getPluginLoadError(pluginIds[0]) ? ` — ${getPluginLoadError(pluginIds[0])}` : ''}
+      </span>
+      <button
+        type="button"
+        className="rounded border border-destructive/40 px-2 py-1 text-xs hover:bg-destructive/20"
+        onClick={() => pluginIds.forEach(retryPluginLoad)}
+        aria-label={`Retry loading ${slotName}`}
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+/**
  * Render all components registered for the named slot, in order. Extra props
  * are passed through to every registered component unchanged. Returns `null`
  * if nothing is registered.
+ *
+ * Lazy loading: rendering a slot is a demand signal — if a manifest declares
+ * an owner for this slot whose client bundle hasn't loaded yet, the host's
+ * loader fires and the slot re-renders once `registerPlugin` runs. While an
+ * owner is loading the slot renders nothing (page slots resolve in one
+ * paint on the LAN); if an owner's bundle failed to import, an inline error
+ * with a retry button renders instead of silent emptiness.
  */
 export function Slot({ name, ...props }: SlotProps): JSX.Element | null {
   // Subscribe to registry mutations so hot-swap (v2) re-renders the
@@ -95,13 +165,27 @@ export function Slot({ name, ...props }: SlotProps): JSX.Element | null {
   // useSyncExternalStore re-renders PluginHost itself but consumers
   // below (<Slot>, <AppSidebar>) keep reading the pre-swap registry.
   useSyncExternalStore(subscribeRegistry, getRegistryVersion, getRegistryVersion)
+  // Lazy load-state subscription: re-render when an owning plugin's client
+  // starts/finishes loading so the loading/error fallbacks stay current.
+  useSyncExternalStore(subscribeLazyPlugins, getLazyPluginsVersion, getLazyPluginsVersion)
+  useEffect(() => {
+    requestSlotPlugins(name)
+  }, [name])
   const entries = getSlotEntries(name)
-  if (entries.length === 0) return null
+  if (entries.length === 0) {
+    const failed = getSlotOwners(name).filter((id) => getPluginLoadState(id) === 'error')
+    if (failed.length > 0) return <SlotLoadError slotName={name} pluginIds={[...failed]} />
+    return null
+  }
   return (
     <>
       {entries.map((entry, i) => {
         const C = entry.component
-        return <C key={`${name}-${i}`} {...props} />
+        return (
+          <SlotEntryBoundary key={`${name}-${i}`} owner={entry.owner} slotName={name}>
+            <C {...props} />
+          </SlotEntryBoundary>
+        )
       })}
     </>
   )

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -153,6 +153,19 @@ export interface ClientRouteContribution {
   slot?: string
 }
 
+/**
+ * Manifest declaration of one client route *pattern* the plugin's client
+ * registers via `registerPlugin({ routes })`. Unlike `clientRoutes` (concrete
+ * documentation paths), these patterns must exactly match the keys passed to
+ * `registerPlugin({ routes })` — including dynamic segments (`/projects/[id]`)
+ * — so the host knows which plugin owns a path before its client has loaded.
+ */
+export interface ClientRoutePatternContribution {
+  /** Route pattern, e.g. `/projects/[id]`. Supports `[id]`, `:id`, `$id` segments. */
+  path: string
+  summary?: string
+}
+
 /** Manifest declaration of an MCP exec tool the plugin exposes. */
 export interface ExecToolContribution {
   name: string
@@ -207,6 +220,34 @@ export interface PluginContributions {
   settings?: SettingsContribution[]
   /** Optional docs page slug. */
   docs?: DocsContribution
+  /**
+   * Declarative sidebar nav items. Rendered from manifest JSON before the
+   * plugin's client bundle loads — this is what makes lazy loading possible.
+   * A plugin that also passes `navItems` to `registerPlugin` at runtime
+   * overrides its manifest nav (the conditional-nav escape hatch); the two
+   * are compared by the drift validation check.
+   */
+  nav?: NavItem[]
+  /**
+   * Client route patterns the plugin's client registers via
+   * `registerPlugin({ routes })`. Must exactly match the registered keys —
+   * the host uses these to lazy-load the client on first navigation.
+   */
+  routes?: ClientRoutePatternContribution[]
+  /**
+   * Slot names the plugin's client fills via `registerPlugin({ slots })`
+   * (e.g. `page:/tasks`, `task-assets`). The host lazy-loads the client the
+   * first time one of these slots renders.
+   */
+  slots?: string[]
+  /**
+   * Load the client bundle at boot instead of on first demand. The escape
+   * hatch for plugins with background providers (`nav-badge-providers`),
+   * conditional nav, or other module-load side effects the shell needs
+   * immediately. Plugins with a client but no declarative `nav`/`routes`/
+   * `slots` metadata are treated as eager for backward compatibility.
+   */
+  eager?: boolean
 }
 
 /** Optional Ed25519 signature block proving manifest authenticity. */

--- a/plugins/assets/bakin-plugin.json
+++ b/plugins/assets/bakin-plugin.json
@@ -157,6 +157,20 @@
     ],
     "docs": {
       "slug": "using/assets"
-    }
+    },
+    "nav": [
+      {
+        "id": "assets",
+        "label": "Assets",
+        "icon": "FolderOpen",
+        "href": "/assets",
+        "order": 20
+      }
+    ],
+    "slots": [
+      "task-assets",
+      "page:/assets",
+      "page:/assets/:assetId"
+    ]
   }
 }

--- a/plugins/assets/client.tsx
+++ b/plugins/assets/client.tsx
@@ -1,20 +1,17 @@
 /**
  * Assets plugin — client entry point.
- * Registers nav items and client-side slot contributions via registerPlugin.
+ * Registers client-side slot contributions via registerPlugin. Nav is
+ * declared in bakin-plugin.json `contributes.nav`; slots are mirrored in
+ * `contributes.slots` so the host lazy-loads this client on first render
+ * of any of them.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { TaskAssets } from './components/task-assets'
 import { VersionedAssetGrid } from './components/versioned/VersionedAssetGrid'
 import { VersionedAssetDetail } from './components/versioned/VersionedAssetDetail'
 
-const navItems: NavItem[] = [
-  { id: 'assets', label: 'Assets', icon: 'FolderOpen', href: '/assets', order: 20 },
-]
-
 registerPlugin({
   id: 'assets',
-  navItems,
   slots: {
     // Task-scoped asset gallery — consumed by tasks detail dialog. Shows all
     // assets linked to a task plus an Add button. User plugins can override

--- a/plugins/health/bakin-plugin.json
+++ b/plugins/health/bakin-plugin.json
@@ -83,6 +83,20 @@
     ],
     "docs": {
       "slug": "using/health"
-    }
+    },
+    "nav": [
+      {
+        "id": "health",
+        "label": "Health",
+        "icon": "Activity",
+        "href": "/health",
+        "order": 85
+      }
+    ],
+    "slots": [
+      "page:/health",
+      "nav-badge-providers"
+    ],
+    "eager": true
   }
 }

--- a/plugins/health/client.tsx
+++ b/plugins/health/client.tsx
@@ -1,18 +1,15 @@
 /**
  * Health plugin — client entry point.
+ * Nav is declared in bakin-plugin.json `contributes.nav`; slots are mirrored
+ * in `contributes.slots`. Eager (`contributes.eager`) because the nav badge
+ * provider must run at boot.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { HealthPage } from './components/health-page'
 import { HealthBadgeProvider } from './components/health-badge-provider'
 
-const navItems: NavItem[] = [
-  { id: 'health', label: 'Health', icon: 'Activity', href: '/health', order: 85 },
-]
-
 registerPlugin({
   id: 'health',
-  navItems,
   slots: {
     'page:/health': HealthPage,
     // Background runner that keeps the Health nav badge (failing-check

--- a/plugins/memory/bakin-plugin.json
+++ b/plugins/memory/bakin-plugin.json
@@ -131,6 +131,18 @@
     ],
     "docs": {
       "slug": "using/memory"
-    }
+    },
+    "nav": [
+      {
+        "id": "memory",
+        "label": "Memory",
+        "icon": "Brain",
+        "href": "/memory",
+        "order": 50
+      }
+    ],
+    "slots": [
+      "page:/memory"
+    ]
   }
 }

--- a/plugins/memory/client.tsx
+++ b/plugins/memory/client.tsx
@@ -1,17 +1,13 @@
 /**
  * Memory plugin — client entry point.
+ * Nav is declared in bakin-plugin.json `contributes.nav`; slots are mirrored
+ * in `contributes.slots` so the host lazy-loads this client on first render.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { MemoryShell } from './components/memory-shell'
-
-const navItems: NavItem[] = [
-  { id: 'memory', label: 'Memory', icon: 'Brain', href: '/memory', order: 50 },
-]
 
 registerPlugin({
   id: 'memory',
-  navItems,
   slots: {
     'page:/memory': MemoryShell,
   },

--- a/plugins/models/bakin-plugin.json
+++ b/plugins/models/bakin-plugin.json
@@ -103,6 +103,18 @@
     ],
     "docs": {
       "slug": "using/models"
-    }
+    },
+    "nav": [
+      {
+        "id": "models",
+        "label": "Models",
+        "icon": "Cpu",
+        "href": "/models",
+        "order": 70
+      }
+    ],
+    "slots": [
+      "page:/models"
+    ]
   }
 }

--- a/plugins/models/client.tsx
+++ b/plugins/models/client.tsx
@@ -1,17 +1,13 @@
 /**
  * Models plugin — client entry point.
+ * Nav is declared in bakin-plugin.json `contributes.nav`; slots are mirrored
+ * in `contributes.slots` so the host lazy-loads this client on first render.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { ModelsPage } from './components/models-page'
-
-const navItems: NavItem[] = [
-  { id: 'models', label: 'Models', icon: 'Cpu', href: '/models', order: 70 },
-]
 
 registerPlugin({
   id: 'models',
-  navItems,
   slots: {
     'page:/models': ModelsPage,
   },

--- a/plugins/schedule/bakin-plugin.json
+++ b/plugins/schedule/bakin-plugin.json
@@ -156,6 +156,18 @@
     ],
     "docs": {
       "slug": "using/schedule"
-    }
+    },
+    "nav": [
+      {
+        "id": "schedule",
+        "label": "Schedule",
+        "icon": "AlarmClock",
+        "href": "/schedule",
+        "order": 22
+      }
+    ],
+    "slots": [
+      "page:/schedule"
+    ]
   }
 }

--- a/plugins/schedule/client.tsx
+++ b/plugins/schedule/client.tsx
@@ -1,17 +1,13 @@
 /**
  * Schedule plugin — client entry point.
+ * Nav is declared in bakin-plugin.json `contributes.nav`; slots are mirrored
+ * in `contributes.slots` so the host lazy-loads this client on first render.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { SchedulePage } from './components/schedule-page'
-
-const navItems: NavItem[] = [
-  { id: 'schedule', label: 'Schedule', icon: 'AlarmClock', href: '/schedule', order: 22 },
-]
 
 registerPlugin({
   id: 'schedule',
-  navItems,
   slots: {
     'page:/schedule': SchedulePage,
   },

--- a/plugins/tasks/bakin-plugin.json
+++ b/plugins/tasks/bakin-plugin.json
@@ -207,6 +207,20 @@
     ],
     "docs": {
       "slug": "using/tasks"
-    }
+    },
+    "nav": [
+      {
+        "id": "tasks",
+        "label": "Tasks",
+        "icon": "CheckSquare",
+        "href": "/tasks",
+        "order": 10
+      }
+    ],
+    "slots": [
+      "page:/tasks",
+      "nav-badge-providers"
+    ],
+    "eager": true
   }
 }

--- a/plugins/tasks/client.tsx
+++ b/plugins/tasks/client.tsx
@@ -1,19 +1,16 @@
 /**
  * Tasks plugin — client entry point.
- * Registers nav items and client-side slot contributions via registerPlugin.
+ * Registers client-side slot contributions via registerPlugin. Nav is
+ * declared in bakin-plugin.json `contributes.nav`; slots are mirrored in
+ * `contributes.slots`. Eager (`contributes.eager`) because the nav badge
+ * provider must run at boot.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { KanbanBoard } from './components/kanban-board'
 import { TasksBadgeProvider } from './components/tasks-badge-provider'
 
-const navItems: NavItem[] = [
-  { id: 'tasks', label: 'Tasks', icon: 'CheckSquare', href: '/tasks', order: 10 },
-]
-
 registerPlugin({
   id: 'tasks',
-  navItems,
   slots: {
     'page:/tasks': KanbanBoard,
     // Background runner that keeps the Tasks nav badge (blocked/review) in

--- a/plugins/team/bakin-plugin.json
+++ b/plugins/team/bakin-plugin.json
@@ -290,6 +290,19 @@
     ],
     "docs": {
       "slug": "using/team"
-    }
+    },
+    "nav": [
+      {
+        "id": "team",
+        "label": "Team",
+        "icon": "Users",
+        "href": "/team",
+        "order": 60
+      }
+    ],
+    "slots": [
+      "page:/team",
+      "page:/team/[id]"
+    ]
   }
 }

--- a/plugins/team/client.tsx
+++ b/plugins/team/client.tsx
@@ -1,18 +1,14 @@
 /**
  * Team plugin — client entry point.
+ * Nav is declared in bakin-plugin.json `contributes.nav`; slots are mirrored
+ * in `contributes.slots` so the host lazy-loads this client on first render.
  */
 import { registerPlugin } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 import { TeamGrid } from './components/team-grid'
 import { AgentDetail } from './components/agent-detail'
 
-const navItems: NavItem[] = [
-  { id: 'team', label: 'Team', icon: 'Users', href: '/team', order: 60 },
-]
-
 registerPlugin({
   id: 'team',
-  navItems,
   slots: {
     'page:/team': TeamGrid,
     'page:/team/[id]': AgentDetail,

--- a/plugins/workflows/bakin-plugin.json
+++ b/plugins/workflows/bakin-plugin.json
@@ -189,6 +189,21 @@
     ],
     "docs": {
       "slug": "using/workflows"
-    }
+    },
+    "nav": [
+      {
+        "id": "workflows",
+        "label": "Workflows",
+        "icon": "Workflow",
+        "href": "/workflows",
+        "order": 40
+      }
+    ],
+    "slots": [
+      "page:/workflows",
+      "page:/workflows/[id]",
+      "page:/workflows/new",
+      "page:/workflows/[id]/edit"
+    ]
   }
 }

--- a/plugins/workflows/client.tsx
+++ b/plugins/workflows/client.tsx
@@ -1,7 +1,10 @@
 /**
  * Workflows plugin — client entry point
  *
- * - `registerPlugin` contributes nav items and page slots.
+ * - `registerPlugin` contributes page slots. Nav is declared in
+ *   bakin-plugin.json `contributes.nav`; slots are mirrored in
+ *   `contributes.slots` so the host lazy-loads this client (the heaviest
+ *   core bundle — xyflow) on first render of a workflows page.
  * - `registerNodeRenderer` wires each xyflow node kind to its visual
  *   component. Kinds are globally unique — built-ins use their bare name
  *   (`agent`, `gate`, `parallel`, `output`, `workflow`, `createTask`, `trigger`,
@@ -9,7 +12,6 @@
  *   `{pluginId}.{kind}`.
  */
 import { registerPlugin, registerPluginCleanup } from '@makinbakin/sdk'
-import type { NavItem } from '@makinbakin/sdk'
 
 import { TriggerNode } from './components/nodes/trigger-node'
 import { AgentNode } from './components/nodes/agent-node'
@@ -29,13 +31,8 @@ import {
 } from './lib/node-renderer-registry'
 import { unregisterPluginDefinitions } from './lib/source-registry'
 
-const navItems: NavItem[] = [
-  { id: 'workflows', label: 'Workflows', icon: 'Workflow', href: '/workflows', order: 40 },
-]
-
 registerPlugin({
   id: 'workflows',
-  navItems,
   slots: {
     'page:/workflows': WorkflowsPage,
     'page:/workflows/[id]': WorkflowDetail,

--- a/tests/components/plugin-host.test.tsx
+++ b/tests/components/plugin-host.test.tsx
@@ -54,7 +54,15 @@ mock.module('../../packages/core/src/content-dir', () => {
 })
 
 import { PluginHost } from '../../packages/host/src/plugin-host/PluginHost'
-import { registerPlugin, unregisterPlugin } from '@makinbakin/sdk'
+import {
+  configureLazyPlugins,
+  getAllNavItems,
+  getPluginLoadState,
+  registerPlugin,
+  setManifestNav,
+  setPluginLoadState,
+  unregisterPlugin,
+} from '@makinbakin/sdk'
 import { Slot } from '@makinbakin/sdk/slots'
 
 function SlotPage() {
@@ -108,7 +116,12 @@ beforeEach(() => {
 
 afterEach(() => {
   removeDevScriptTag()
-  for (const id of USED_IDS) unregisterPlugin(id)
+  for (const id of USED_IDS) {
+    unregisterPlugin(id)
+    setManifestNav(id, null)
+    setPluginLoadState(id, 'idle')
+  }
+  configureLazyPlugins({ slotOwners: new Map(), routeOwners: [] })
   delete (window as unknown as { __bakinHotSwapPlugin?: unknown }).__bakinHotSwapPlugin
   delete (window as unknown as { __bakinStartupSpans?: unknown }).__bakinStartupSpans
   delete (globalThis as Record<string, unknown>).__bakinHotSwapRegister
@@ -463,6 +476,191 @@ describe('Slot — re-renders on registry change', () => {
       expect(nodes.length).toBe(1)
       expect(nodes[0].textContent).toBe('rendered-from-x-v2')
     })
+  })
+})
+
+describe('PluginHost — lazy boot from declarative manifests', () => {
+  function writeRegisteringModule(dir: string, pluginId: string, slotName: string): string {
+    const modulePath = join(dir, `${pluginId}-client.mjs`)
+    writeFileSync(modulePath, [
+      `globalThis.__bakinHotSwapImportCount = (globalThis.__bakinHotSwapImportCount ?? 0) + 1`,
+      `globalThis.__bakinHotSwapRegister('${pluginId}', '${slotName}')`,
+      '',
+    ].join('\n'))
+    return pathToFileURL(modulePath).href
+  }
+
+  function stubManifestFetch(plugins: unknown[]) {
+    vi.stubGlobal('fetch', mock(async (url: string) => {
+      if (url === '/api/plugins/manifest') {
+        return new Response(JSON.stringify({ plugins }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      return new Response('not found', { status: 404 })
+    }))
+  }
+
+  it('seeds sidebar nav from contributes.nav without importing the client', async () => {
+    const moduleDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-host-lazy-'))
+    try {
+      ;(globalThis as Record<string, unknown>).__bakinHotSwapRegister = (id: string, slotName: string) => {
+        registerPlugin({ id, slots: { [slotName]: SlotPage } })
+      }
+      const clientEntry = writeRegisteringModule(moduleDir, 'x', 'page:/probe')
+      stubManifestFetch([{
+        id: 'x',
+        name: 'X',
+        version: '1.0.0',
+        clientEntry,
+        clientVersion: 'lazy-1',
+        status: 'active',
+        contributes: {
+          nav: [{ id: 'x-nav', label: 'X', href: '/x', order: 7 }],
+          slots: ['page:/probe'],
+        },
+      }])
+
+      render(
+        <PluginHost>
+          <div data-testid="shell" />
+        </PluginHost>,
+      )
+      await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
+
+      // Nav is live from the manifest; the client module never imported.
+      expect(getAllNavItems().map((i) => i.id)).toContain('x-nav')
+      expect((globalThis as Record<string, unknown>).__bakinHotSwapImportCount).toBeUndefined()
+      expect(getPluginLoadState('x')).toBe('idle')
+    } finally {
+      rmSync(moduleDir, { recursive: true, force: true })
+    }
+  })
+
+  it('imports a lazy client on first render of a declared slot', async () => {
+    const moduleDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-host-lazy-'))
+    try {
+      ;(globalThis as Record<string, unknown>).__bakinHotSwapRegister = (id: string, slotName: string) => {
+        registerPlugin({ id, slots: { [slotName]: SlotPage } })
+      }
+      const clientEntry = writeRegisteringModule(moduleDir, 'x', 'page:/probe')
+      stubManifestFetch([{
+        id: 'x',
+        name: 'X',
+        version: '1.0.0',
+        clientEntry,
+        clientVersion: 'lazy-2',
+        status: 'active',
+        contributes: { slots: ['page:/probe'] },
+      }])
+
+      render(
+        <PluginHost>
+          <ProbeTree />
+        </PluginHost>,
+      )
+      // The probe tree renders <Slot name="page:/probe" /> immediately —
+      // that render is the demand that imports the client.
+      await waitFor(() => expect(screen.queryByTestId('slot-content')?.textContent)
+        .toBe('rendered-from-x'), { timeout: 5000 })
+      expect((globalThis as Record<string, unknown>).__bakinHotSwapImportCount).toBe(1)
+      expect(getPluginLoadState('x')).toBe('loaded')
+    } finally {
+      rmSync(moduleDir, { recursive: true, force: true })
+    }
+  })
+
+  it('imports eager-flagged and legacy (no metadata) clients at boot', async () => {
+    const moduleDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-host-eager-'))
+    try {
+      ;(globalThis as Record<string, unknown>).__bakinHotSwapRegister = (id: string, slotName: string) => {
+        registerPlugin({ id, slots: { [slotName]: SlotPage } })
+      }
+      stubManifestFetch([
+        {
+          id: 'x',
+          name: 'X (eager flag)',
+          version: '1.0.0',
+          clientEntry: writeRegisteringModule(moduleDir, 'x', 'page:/x-eager'),
+          clientVersion: 'eager-1',
+          status: 'active',
+          contributes: { slots: ['page:/x-eager'], eager: true },
+        },
+        {
+          id: 'y',
+          name: 'Y (legacy shape)',
+          version: '1.0.0',
+          clientEntry: writeRegisteringModule(moduleDir, 'y', 'page:/y-legacy'),
+          clientVersion: 'legacy-1',
+          status: 'active',
+        },
+      ])
+
+      render(
+        <PluginHost>
+          <div />
+        </PluginHost>,
+      )
+      await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull(), { timeout: 5000 })
+
+      await waitFor(() => {
+        expect(getPluginLoadState('x')).toBe('loaded')
+        expect(getPluginLoadState('y')).toBe('loaded')
+      })
+      expect((globalThis as Record<string, unknown>).__bakinHotSwapImportCount).toBe(2)
+    } finally {
+      rmSync(moduleDir, { recursive: true, force: true })
+    }
+  })
+
+  it('hot-swapping a never-loaded lazy plugin refreshes metadata without importing', async () => {
+    const consoleDebug = spyOn(console, 'debug').mockImplementation(() => {})
+    injectDevScriptTag()
+    const moduleDir = mkdtempSync(join(tmpdir(), 'bakin-plugin-host-lazyswap-'))
+    try {
+      ;(globalThis as Record<string, unknown>).__bakinHotSwapRegister = (id: string, slotName: string) => {
+        registerPlugin({ id, slots: { [slotName]: SlotPage } })
+      }
+      const clientEntry = writeRegisteringModule(moduleDir, 'x', 'page:/probe')
+      stubManifestFetch([{
+        id: 'x',
+        name: 'X',
+        version: '1.0.0',
+        clientEntry,
+        clientVersion: 'swap-2',
+        status: 'active',
+        contributes: {
+          nav: [{ id: 'x-nav', label: 'X v2', href: '/x' }],
+          slots: ['page:/probe'],
+        },
+      }])
+
+      render(
+        <PluginHost>
+          <div />
+        </PluginHost>,
+      )
+      await waitFor(() => expect(screen.queryByText('Loading plugins')).toBeNull())
+
+      const handle = (window as unknown as {
+        __bakinHotSwapPlugin?: (...a: unknown[]) => Promise<void>
+      }).__bakinHotSwapPlugin
+      expect(typeof handle).toBe('function')
+
+      await act(async () => {
+        await handle!('x', clientEntry, 'swap-2')
+      })
+
+      // Metadata refreshed (nav re-seeded from the new manifest) but the
+      // client bundle was never imported — it stays lazy.
+      expect(getAllNavItems().map((i) => i.label)).toContain('X v2')
+      expect((globalThis as Record<string, unknown>).__bakinHotSwapImportCount).toBeUndefined()
+      expect(getPluginLoadState('x')).toBe('idle')
+    } finally {
+      consoleDebug.mockRestore()
+      rmSync(moduleDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/core/plugin-manifest.test.ts
+++ b/tests/core/plugin-manifest.test.ts
@@ -1,4 +1,25 @@
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
+
+// Per CLAUDE.md — defensive content-dir mocks even for pure parser tests.
+mock.module('../../src/core/content-dir', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-plugin-manifest-noop')
+  return {
+    getContentDir: () => base,
+    getBakinPaths: () => ({ root: base }),
+  }
+})
+mock.module('../../packages/core/src/content-dir', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-plugin-manifest-noop')
+  return {
+    getContentDir: () => base,
+    getBakinPaths: () => ({ root: base }),
+  }
+})
+
 import {
   PluginManifestError,
   parsePluginManifest,
@@ -220,5 +241,118 @@ describe('plugin manifest schema', () => {
 
   it('reports invalid JSON through readPluginManifestJson', () => {
     expect(() => readPluginManifestJson('{ nope')).toThrow(/Invalid bakin-plugin\.json/)
+  })
+})
+
+describe('plugin manifest declarative client contributions (lazy loading)', () => {
+  it('parses contributes.nav / routes / slots / eager', () => {
+    const manifest = parsePluginManifest({
+      ...baseManifest,
+      contributes: {
+        nav: [
+          {
+            id: 'messaging',
+            label: 'Messaging',
+            icon: 'MessageSquare',
+            href: '/messaging',
+            order: 25,
+            alwaysExpanded: true,
+            badge: { tone: 'info' },
+            children: [
+              { id: 'messaging-calendar', label: 'Calendar', icon: 'CalendarDays', href: '/messaging/calendar' },
+            ],
+          },
+        ],
+        routes: [
+          { path: '/messaging', summary: 'Messaging index' },
+          { path: '/messaging/plans/[id]' },
+        ],
+        slots: ['nav-badge-providers', 'page:/messaging'],
+        eager: true,
+      },
+    })
+
+    expect(manifest.contributes?.nav).toEqual([
+      {
+        id: 'messaging',
+        label: 'Messaging',
+        icon: 'MessageSquare',
+        href: '/messaging',
+        order: 25,
+        alwaysExpanded: true,
+        badge: { tone: 'info' },
+        children: [
+          { id: 'messaging-calendar', label: 'Calendar', icon: 'CalendarDays', href: '/messaging/calendar' },
+        ],
+      },
+    ])
+    expect(manifest.contributes?.routes).toEqual([
+      { path: '/messaging', summary: 'Messaging index' },
+      { path: '/messaging/plans/[id]', summary: undefined },
+    ])
+    expect(manifest.contributes?.slots).toEqual(['nav-badge-providers', 'page:/messaging'])
+    expect(manifest.contributes?.eager).toBe(true)
+  })
+
+  it('rejects nav items missing id or label', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { nav: [{ label: 'No id', href: '/x' }] },
+    })).toThrow(/missing required field "id"/)
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { nav: [{ id: 'x', href: '/x' }] },
+    })).toThrow(/missing required field "label"/)
+  })
+
+  it('rejects nav hrefs that are not app paths', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { nav: [{ id: 'x', label: 'X', href: '/api/plugins/x' }] },
+    })).toThrow(/must be an app path/)
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { nav: [{ id: 'x', label: 'X', href: 'relative' }] },
+    })).toThrow(/must be an app path/)
+  })
+
+  it('rejects duplicate nav ids across nesting levels', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: {
+        nav: [
+          { id: 'x', label: 'X', children: [{ id: 'x', label: 'X again' }] },
+        ],
+      },
+    })).toThrow(/duplicate nav item id "x"/)
+  })
+
+  it('rejects invalid badge tones in nav items', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { nav: [{ id: 'x', label: 'X', badge: { tone: 'loud' } }] },
+    })).toThrow(/badge\.tone must be one of/)
+  })
+
+  it('rejects route patterns under /api and duplicates', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { routes: [{ path: '/api/messaging' }] },
+    })).toThrow(/must not be an API path/)
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { routes: [{ path: '/messaging' }, { path: '/messaging' }] },
+    })).toThrow(/duplicate path "\/messaging"/)
+  })
+
+  it('rejects non-string slot entries and non-boolean eager', () => {
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { slots: ['page:/x', 7] },
+    })).toThrow(/only non-empty strings/)
+    expect(() => parsePluginManifest({
+      ...baseManifest,
+      contributes: { eager: 'yes' },
+    })).toThrow(/eager must be a boolean/)
   })
 })

--- a/tests/plugins/manifest-drift.test.tsx
+++ b/tests/plugins/manifest-drift.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+/**
+ * Manifest drift validation — the CI half of the lazy-loading drift check.
+ *
+ * Every clientful core plugin declares its nav/slots (and any routes) in
+ * bakin-plugin.json `contributes.*`. The host trusts those declarations to
+ * render the sidebar and decide when to lazy-load each client bundle — so
+ * a declaration that doesn't match what `client.tsx` actually registers
+ * breaks lazy loading in ways that only surface at runtime (sidebar
+ * entries that dead-end, slots that never demand their plugin).
+ *
+ * This test imports each core plugin's client (running its registerPlugin
+ * side effect) and applies the same `checkPluginDrift` comparison the host
+ * runs as a startup diagnostic. Any drift fails CI with the host's own
+ * warning text.
+ */
+import { afterAll, describe, expect, it, mock } from 'bun:test'
+
+// Per CLAUDE.md — defensive resolver mocks. Client modules are browser-side
+// React and must never touch ~/.bakin/ or ~/.openclaw/, but a transitive
+// import could.
+mock.module('../../src/core/content-dir', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-manifest-drift-noop')
+  return {
+    getContentDir: () => base,
+    getBakinPaths: () => ({ root: base }),
+  }
+})
+mock.module('../../packages/core/src/content-dir', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-manifest-drift-noop')
+  return {
+    getContentDir: () => base,
+    getBakinPaths: () => ({ root: base }),
+  }
+})
+mock.module('@bakin/adapter-openclaw/home', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-manifest-drift-noop', 'openclaw')
+  return {
+    getOpenClawHome: () => base,
+    getOpenClawPath: (...parts: string[]) => join(base, ...parts),
+    resetOpenClawHome: () => {},
+  }
+})
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+import { setManifestNav, unregisterPlugin } from '@makinbakin/sdk'
+import { readPluginManifestJson } from '../../packages/core/src/plugins/manifest'
+import { checkPluginDrift } from '../../packages/host/src/plugin-host/drift-check'
+
+// Every core plugin that ships a client.tsx. git + images are server-only.
+const CLIENTFUL_CORE_PLUGINS = [
+  'assets',
+  'health',
+  'memory',
+  'models',
+  'schedule',
+  'tasks',
+  'team',
+  'workflows',
+] as const
+
+afterAll(() => {
+  for (const id of CLIENTFUL_CORE_PLUGINS) {
+    unregisterPlugin(id)
+    setManifestNav(id, null)
+  }
+})
+
+describe('core plugin manifest drift (lazy-loading contract)', () => {
+  for (const pluginId of CLIENTFUL_CORE_PLUGINS) {
+    it(`${pluginId}: client registrations match contributes.{nav,routes,slots}`, () => {
+      const { readFileSync } = require('fs') as typeof import('fs')
+      const manifest = readPluginManifestJson(
+        readFileSync(`${process.cwd()}/plugins/${pluginId}/bakin-plugin.json`, 'utf-8'),
+      )
+
+      // Declarative metadata is mandatory for clientful core plugins — a
+      // client with none would silently fall back to eager loading.
+      expect(manifest.contributes?.nav?.length ?? 0).toBeGreaterThan(0)
+      expect(manifest.contributes?.slots?.length ?? 0).toBeGreaterThan(0)
+
+      // Import runs registerPlugin as a side effect (same as the browser).
+      require(`../../plugins/${pluginId}/client`)
+      setManifestNav(pluginId, manifest.contributes?.nav ?? null)
+
+      expect(checkPluginDrift(pluginId, manifest.contributes)).toEqual([])
+    })
+  }
+
+  it('eager escape hatch stays limited to badge-provider plugins', () => {
+    const { readFileSync } = require('fs') as typeof import('fs')
+    const eager = CLIENTFUL_CORE_PLUGINS.filter((id) => {
+      const manifest = readPluginManifestJson(
+        readFileSync(`${process.cwd()}/plugins/${id}/bakin-plugin.json`, 'utf-8'),
+      )
+      return manifest.contributes?.eager === true
+    })
+    // tasks + health run nav-badge providers that must mount at boot.
+    // Growing this list shrinks the lazy-loading win — do it deliberately.
+    expect(eager.sort()).toEqual(['health', 'tasks'])
+  })
+})

--- a/tests/sdk/lazy.test.tsx
+++ b/tests/sdk/lazy.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for @makinbakin/sdk lazy plugin loading — the manifest-nav channel
+ * (`setManifestNav`) and the lazy load-state store (`configureLazyPlugins`,
+ * demand requests, retry, Slot integration).
+ *
+ * Both stores are browser-global, so each test cleans up the ids it used.
+ */
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+
+// Defensive content-dir mocks per CLAUDE.md test-isolation rules.
+mock.module('../../src/core/content-dir', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-sdk-lazy-noop')
+  return {
+    getContentDir: () => base,
+    getBakinPaths: () => ({ root: base }),
+  }
+})
+mock.module('../../packages/core/src/content-dir', () => {
+  const { join } = require('path') as typeof import('path')
+  const { tmpdir } = require('os') as typeof import('os')
+  const base = join(tmpdir(), 'bakin-test-sdk-lazy-noop')
+  return {
+    getContentDir: () => base,
+    getBakinPaths: () => ({ root: base }),
+  }
+})
+
+import {
+  configureLazyPlugins,
+  getAllNavItems,
+  getManifestNav,
+  getNavItemsSnapshot,
+  getPluginLoadError,
+  getPluginLoadState,
+  getRouteOwners,
+  getSlotOwners,
+  registerPlugin,
+  requestRoutePlugins,
+  requestSlotPlugins,
+  retryPluginLoad,
+  setLazyPluginLoader,
+  setManifestNav,
+  setPluginLoadState,
+  unregisterPlugin,
+} from '@makinbakin/sdk'
+import { Slot } from '@makinbakin/sdk/slots'
+
+const USED_IDS = ['lz-a', 'lz-b']
+
+afterEach(() => {
+  for (const id of USED_IDS) {
+    unregisterPlugin(id)
+    setManifestNav(id, null)
+    setPluginLoadState(id, 'idle')
+  }
+  configureLazyPlugins({ slotOwners: new Map(), routeOwners: [] })
+  setLazyPluginLoader(null)
+  cleanup()
+})
+
+describe('setManifestNav — declarative nav channel', () => {
+  it('seeds nav items that appear in the merged snapshot', () => {
+    setManifestNav('lz-a', [{ id: 'lz-a-nav', label: 'Lazy A', href: '/lz-a', order: 5 }])
+    expect(getAllNavItems().map((i) => i.id)).toContain('lz-a-nav')
+    expect(getManifestNav('lz-a')).toHaveLength(1)
+  })
+
+  it('survives unregisterPlugin (hot-swap teardown)', () => {
+    setManifestNav('lz-a', [{ id: 'lz-a-nav', label: 'Lazy A', href: '/lz-a' }])
+    registerPlugin({ id: 'lz-a', slots: {} })
+    unregisterPlugin('lz-a')
+    expect(getAllNavItems().map((i) => i.id)).toContain('lz-a-nav')
+  })
+
+  it('is overridden by runtime navItems while registered (escape hatch)', () => {
+    setManifestNav('lz-a', [{ id: 'lz-a-manifest', label: 'Manifest', href: '/lz-a' }])
+    registerPlugin({
+      id: 'lz-a',
+      navItems: [{ id: 'lz-a-runtime', label: 'Runtime', href: '/lz-a' }],
+    })
+    const ids = getAllNavItems().map((i) => i.id)
+    expect(ids).toContain('lz-a-runtime')
+    expect(ids).not.toContain('lz-a-manifest')
+
+    // Teardown restores the manifest nav.
+    unregisterPlugin('lz-a')
+    expect(getAllNavItems().map((i) => i.id)).toContain('lz-a-manifest')
+  })
+
+  it('clears via null and skips version churn on identical re-seed', () => {
+    setManifestNav('lz-a', [{ id: 'lz-a-nav', label: 'Lazy A', href: '/lz-a' }])
+    const snapshot = getNavItemsSnapshot()
+    setManifestNav('lz-a', [{ id: 'lz-a-nav', label: 'Lazy A', href: '/lz-a' }])
+    expect(getNavItemsSnapshot()).toBe(snapshot) // identity stable — no bump
+    setManifestNav('lz-a', null)
+    expect(getAllNavItems().map((i) => i.id)).not.toContain('lz-a-nav')
+  })
+})
+
+describe('lazy plugin store — ownership + demand', () => {
+  it('routes slot demand to the installed loader for idle owners only', () => {
+    const loaded: string[] = []
+    configureLazyPlugins({
+      slotOwners: new Map([['page:/lz-a', ['lz-a']], ['shared-slot', ['lz-a', 'lz-b']]]),
+      routeOwners: [],
+    })
+    setLazyPluginLoader((id) => {
+      loaded.push(id)
+      setPluginLoadState(id, 'loading')
+    })
+
+    requestSlotPlugins('page:/lz-a')
+    expect(loaded).toEqual(['lz-a'])
+
+    // lz-a is now loading — only lz-b is still idle.
+    requestSlotPlugins('shared-slot')
+    expect(loaded).toEqual(['lz-a', 'lz-b'])
+
+    // Nothing is idle anymore; repeat demand is a no-op.
+    requestSlotPlugins('shared-slot')
+    expect(loaded).toEqual(['lz-a', 'lz-b'])
+  })
+
+  it('matches route owners against dynamic patterns', () => {
+    configureLazyPlugins({
+      slotOwners: new Map(),
+      routeOwners: [
+        { pattern: '/lz-a', pluginId: 'lz-a' },
+        { pattern: '/lz-a/[id]', pluginId: 'lz-a' },
+        { pattern: '/lz-b/:id/edit', pluginId: 'lz-b' },
+      ],
+    })
+    expect(getRouteOwners('/lz-a')).toEqual(['lz-a'])
+    expect(getRouteOwners('/lz-a/42')).toEqual(['lz-a'])
+    expect(getRouteOwners('/lz-b/7/edit')).toEqual(['lz-b'])
+    expect(getRouteOwners('/elsewhere')).toEqual([])
+
+    const loaded: string[] = []
+    setLazyPluginLoader((id) => {
+      loaded.push(id)
+      setPluginLoadState(id, 'loading')
+    })
+    requestRoutePlugins('/lz-a/42')
+    expect(loaded).toEqual(['lz-a'])
+  })
+
+  it('tracks load state + error message, and retryPluginLoad re-demands', () => {
+    configureLazyPlugins({ slotOwners: new Map([['page:/lz-a', ['lz-a']]]), routeOwners: [] })
+    const loads: string[] = []
+    setLazyPluginLoader((id) => {
+      loads.push(id)
+      setPluginLoadState(id, 'loading')
+    })
+
+    requestSlotPlugins('page:/lz-a')
+    expect(getPluginLoadState('lz-a')).toBe('loading')
+    setPluginLoadState('lz-a', 'error', 'import failed')
+    expect(getPluginLoadError('lz-a')).toBe('import failed')
+
+    retryPluginLoad('lz-a')
+    expect(loads).toEqual(['lz-a', 'lz-a'])
+    expect(getPluginLoadError('lz-a')).toBeUndefined()
+
+    // retry on a non-errored plugin is a no-op
+    setPluginLoadState('lz-a', 'loaded')
+    retryPluginLoad('lz-a')
+    expect(loads).toEqual(['lz-a', 'lz-a'])
+  })
+
+  it('demand without a loader is a safe no-op', () => {
+    configureLazyPlugins({ slotOwners: new Map([['page:/lz-a', ['lz-a']]]), routeOwners: [] })
+    expect(() => requestSlotPlugins('page:/lz-a')).not.toThrow()
+    expect(getPluginLoadState('lz-a')).toBe('idle')
+    expect(getSlotOwners('page:/lz-a')).toEqual(['lz-a'])
+  })
+})
+
+describe('Slot — lazy integration', () => {
+  it('rendering a slot demands its idle owners', async () => {
+    configureLazyPlugins({ slotOwners: new Map([['page:/lz-a', ['lz-a']]]), routeOwners: [] })
+    const loaded: string[] = []
+    setLazyPluginLoader((id) => {
+      loaded.push(id)
+      setPluginLoadState(id, 'loading')
+    })
+
+    render(<Slot name="page:/lz-a" />)
+    await waitFor(() => expect(loaded).toEqual(['lz-a']))
+  })
+
+  it('shows an error fallback with retry when an owner fails to load', async () => {
+    configureLazyPlugins({ slotOwners: new Map([['page:/lz-a', ['lz-a']]]), routeOwners: [] })
+    const loads: string[] = []
+    setLazyPluginLoader((id) => {
+      loads.push(id)
+      setPluginLoadState(id, 'loading')
+    })
+
+    render(<Slot name="page:/lz-a" />)
+    await waitFor(() => expect(loads).toEqual(['lz-a']))
+
+    act(() => { setPluginLoadState('lz-a', 'error', 'boom') })
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('"lz-a" failed to load'))
+    expect(screen.getByRole('alert').textContent).toContain('boom')
+
+    // Retry → loader fires again → content registers → fallback gone.
+    act(() => { screen.getByRole('button', { name: /retry/i }).click() })
+    expect(loads).toEqual(['lz-a', 'lz-a'])
+    act(() => {
+      registerPlugin({ id: 'lz-a', slots: { 'page:/lz-a': () => <span data-testid="lz-content">loaded</span> } })
+      setPluginLoadState('lz-a', 'loaded')
+    })
+    await waitFor(() => expect(screen.getByTestId('lz-content')).toBeDefined())
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('isolates a crashing slot entry behind a per-entry boundary', async () => {
+    const consoleError = mock(() => {})
+    const originalError = console.error
+    console.error = consoleError
+    try {
+      function Crashing(): never {
+        throw new Error('plugin render crash')
+      }
+      registerPlugin({ id: 'lz-a', slots: { 'shared-slot': Crashing } })
+      registerPlugin({ id: 'lz-b', slots: { 'shared-slot': () => <span data-testid="lz-b-ok">ok</span> } })
+
+      render(<Slot name="shared-slot" />)
+      await waitFor(() => expect(screen.getByTestId('lz-b-ok')).toBeDefined())
+      expect(screen.getByRole('alert').textContent).toContain('"lz-a" failed to render')
+    } finally {
+      console.error = originalError
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Kills the user-visible "Loading plugins" delay. The shell no longer imports every plugin's client bundle at boot — it renders the sidebar from manifest JSON and loads each `client.js` on first navigation into the plugin's routes or first render of one of its slots.

Implements approach **(a) declarative manifest metadata** from `.claude/specs/whiskit-plugin-builder-plan.md` Phase 1. No code-splitting — import-map / hot-reload machinery untouched.

### Manifest schema (`@makinbakin/sdk` contract change)

`bakin-plugin.json` `contributes` gains four keys:
- `nav` — sidebar NavItems as JSON, rendered before the client loads
- `routes` — client route patterns matching `registerPlugin({ routes })` keys (lazy-load on direct navigation, via the plugin route catch-all)
- `slots` — slot names the client fills (lazy-load on first `<Slot>` render)
- `eager` — escape hatch for clients that must run at boot

Backward compatible: a client with none of the above loads eagerly (old behavior), and `registerPlugin({ navItems })` still works — runtime nav overrides manifest nav (conditional-nav escape hatch).

### SDK runtime

- `setManifestNav` — manifest nav on a separate registry channel that survives `unregisterPlugin` (hot-swap teardown)
- Lazy store: slot/route ownership index + per-plugin `idle → loading → loaded | error` states; `<Slot>` and the catch-all are the demand surfaces
- Plugin-local error boundaries: failed lazy imports render inline errors with retry; crashing slot/page components can't take down the shell

### Drift validation

- Startup diagnostic: after every client import, runtime registrations are compared against `contributes.{nav,routes,slots}`; mismatches warn loudly
- CI gate: `tests/plugins/manifest-drift.test.tsx` imports every core client and fails on drift; also pins the eager list to `tasks` + `health`

### Core plugin migration

All 8 clientful core plugins move to declarative manifests. `tasks` + `health` stay eager (nav-badge providers must mount at boot); **assets, memory, models, schedule, team, workflows** (the heaviest bundle — xyflow) are now lazy.

### Dev loop

Hot-swap and version-mismatch behavior preserved. Swapping a manifest-declared lazy plugin whose client never loaded is metadata-only — the next demand imports the new bundle.

## Verification

- `bun run test` — 4508 pass / 0 fail; `bun run typecheck` clean; `bun run docs:check` green
- Manual (isolated instance, Playwright, plugin diagnostics on):
  - cold boot imports exactly 2 clients (`tasks`, `health`); 5 lazy; sidebar fully rendered from manifest nav; health badge live
  - sidebar click on Models → demand import → page renders
  - cold direct-load `/workflows` and deep link `/team/<id>` → demand import → pages render
  - zero drift warnings; failed plugin (schedule, env-induced) cleanly excluded from nav

## Coordination

The SDK contract ships in the published `@makinbakin/sdk`; companion PR moves `bakin-bits-official` messaging (+`eager` for its badge provider) and projects to the declarative shape, followed by plugin releases. Backward compat means existing installs keep working eagerly until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)