### PR TITLE
feat(plugins): Whiskit shared build backend + publish --build (P2)

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1002,15 +1002,16 @@ async function cmdDiagnosticsStartup(action: string | undefined, args: string[])
 }
 
 /**
- * `bakin plugins publish <builtPluginDir> --out <dir>` — assemble a published
- * artifact from a BUILT plugin directory (Whiskit Phase 4). Purely local: reads
- * the manifest, stamps provenance, tars + checksums the artifact, and writes (or
- * carries forward into) whiskit-artifacts.json. Building the plugin is the
- * producer's step (run before this); `--build` is a future addition.
+ * `bakin plugins publish <pluginDir> --out <dir> [--build]` — assemble a
+ * published artifact from a plugin directory (Whiskit Phase 4). Purely local:
+ * reads the manifest, stamps provenance, tars + checksums the artifact, and
+ * writes (or carries forward into) whiskit-artifacts.json. With `--build`,
+ * the Whiskit build backend compiles the plugin first via the system bun
+ * (Phase 2) — producers no longer need a separate `bun run build` step.
  */
 async function cmdPluginsPublish(
   pluginDir: string,
-  opts: { out: string; baseUrl?: string; platform?: string; json?: boolean },
+  opts: { out: string; baseUrl?: string; platform?: string; json?: boolean; build?: boolean },
 ): Promise<void> {
   const { existsSync } = await import('node:fs')
   const { resolve, join } = await import('node:path')
@@ -1020,7 +1021,7 @@ async function cmdPluginsPublish(
   if (!existsSync(manifestPath)) {
     await exitCommandIssue(`No bakin-plugin.json found in ${abs}`, {
       command: 'bakin plugins publish',
-      usage: 'bakin plugins publish <builtPluginDir> --out <dir> [--base-url <url>] [--platform <p>] [--json]',
+      usage: 'bakin plugins publish <pluginDir> --out <dir> [--build] [--base-url <url>] [--platform <p>] [--json]',
     })
     return
   }
@@ -1039,8 +1040,33 @@ async function cmdPluginsPublish(
     })
     return
   }
+
+  if (opts.build) {
+    const { buildPluginWithSystemBun } = await import('../src/core/whiskit/build')
+    const { WhiskitBuildError } = await import('../src/core/whiskit/types')
+    try {
+      const result = await buildPluginWithSystemBun({
+        pluginDir: abs,
+        pluginId: manifest.id,
+        production: true,
+        installDeps: true,
+      })
+      if (!opts.json) {
+        console.log(`Built ${manifest.id} (server${result.builtClient ? ' + client' : ''}, ${result.durationMs}ms)`)
+      }
+    } catch (err) {
+      const detail = err instanceof WhiskitBuildError
+        ? `[${err.stage}] ${err.message}`
+        : err instanceof Error ? err.message : String(err)
+      await exitCommandIssue(`Build failed: ${detail}`, {
+        command: 'bakin plugins publish',
+      })
+      return
+    }
+  }
+
   if (!existsSync(join(abs, 'dist', 'index.js'))) {
-    await exitCommandIssue(`No dist/index.js in ${abs} — build the plugin before publishing.`, {
+    await exitCommandIssue(`No dist/index.js in ${abs} — build the plugin first or pass --build.`, {
       command: 'bakin plugins publish',
     })
     return
@@ -4284,7 +4310,7 @@ export async function main(): Promise<void> {
             json: parsed.json,
           })
         } else if (sub === 'publish') {
-          const PUBLISH_USAGE = 'bakin plugins publish <builtPluginDir> --out <dir> [--base-url <url>] [--platform <p>] [--json]'
+          const PUBLISH_USAGE = 'bakin plugins publish <pluginDir> --out <dir> [--build] [--base-url <url>] [--platform <p>] [--json]'
           const flags = args.slice(2)
           const dir = flags.find(arg => !arg.startsWith('--'))
           const flagValue = (name: string): string | undefined => {
@@ -4293,7 +4319,7 @@ export async function main(): Promise<void> {
           }
           const out = flagValue('--out')
           if (!dir || !out) {
-            await exitCommandIssue(!dir ? 'Missing <builtPluginDir>.' : 'Missing required --out <dir>.', {
+            await exitCommandIssue(!dir ? 'Missing <pluginDir>.' : 'Missing required --out <dir>.', {
               command: 'bakin plugins publish',
               usage: PUBLISH_USAGE,
             })
@@ -4304,6 +4330,7 @@ export async function main(): Promise<void> {
             baseUrl: flagValue('--base-url'),
             platform: flagValue('--platform'),
             json: flags.includes('--json'),
+            build: flags.includes('--build'),
           })
         } else if (sub === 'export') {
           const flags = args.slice(2)

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -1,5 +1,6 @@
 /**
- * In-binary user-plugin builder (#147 TE13).
+ * In-binary user-plugin builder (#147 TE13) — thin adapter over the Whiskit
+ * shared build backend (Phase 2).
  *
  * Installed user plugins live in `~/.bakin/plugins/<id>/` and may ship
  * with their own dependencies declared in their package.json. Before the
@@ -7,51 +8,31 @@
  * surfaced to the runtime client loader (Phase F, for the client half),
  * each entry needs to be bundled to `dist/` with the shared externals.
  *
- * Shape matches `scripts/build-plugins.ts` (the core-plugin pipeline) so
- * the disk layout is identical for core vs user plugins — the runtime
- * loader doesn't care which bucket a plugin came from.
- *
- * Client externals hold React, @tanstack/react-router, and SDK package aliases
- * so the host shell and plugin share the browser singletons wired by the
- * import map. Server builds bundle the SDK so activation of dist/index.js does
- * not depend on a workspace symlink or a locally installed SDK package.
+ * The compile steps live in `src/core/whiskit/build.ts`: the in-process
+ * `Bun.build()` fast path when running from source (dev hot loop — no
+ * subprocess per save), the system-`bun` backend under the compiled binary.
+ * What stays here is the caller-side policy: freshness/rebuild skip,
+ * trusted prebuilt dist handling, provenance verification at startup, and
+ * the startup-diagnostics spans.
  *
  * Rebuild skip: if every dist output is newer than every source entry,
  * the build is a no-op. This keeps server boot fast when nothing changed.
  */
 import { existsSync, statSync, readdirSync, readFileSync } from 'node:fs'
 import type { Dirent } from 'node:fs'
-import { spawn } from 'node:child_process'
-import { basename, join, resolve } from 'node:path'
+import { basename, join } from 'node:path'
 import { readPluginLockfile, type PluginLockEntry } from '@bakin/core/plugins/lockfile'
 import { startStartupSpan, type StartupDiagnosticLogger } from '@/core/startup-diagnostics'
-import { PLUGIN_CLIENT_EXTERNALS, PLUGIN_SERVER_EXTERNALS } from '@/core/whiskit/externals'
 import { validatePluginImports, NON_RUNTIME_DIRS, type PluginPackageJson } from '@/core/whiskit/import-scan'
+import {
+  buildPluginInProcess,
+  buildPluginWithSystemBun,
+  canBuildInProcess,
+} from '@/core/whiskit/build'
+import { WhiskitBuildError, type WhiskitStageEvent } from '@/core/whiskit/types'
 import { verifyInstalledArtifact } from '@/core/whiskit/verify'
 
-// Single source for the externals contract — see src/core/whiskit/externals.ts.
-const CLIENT_EXTERNAL = PLUGIN_CLIENT_EXTERNALS
-const SERVER_EXTERNAL = PLUGIN_SERVER_EXTERNALS
-
-const REPO_ROOT = resolve(import.meta.dir, '../../../..')
-const SDK_ENTRYPOINTS: Record<string, string> = {
-  '@makinbakin/sdk': join(REPO_ROOT, 'packages/sdk/src/index.ts'),
-  '@makinbakin/sdk/ui': join(REPO_ROOT, 'packages/sdk/src/ui/index.ts'),
-  '@makinbakin/sdk/hooks': join(REPO_ROOT, 'packages/sdk/src/hooks/index.ts'),
-  '@makinbakin/sdk/components': join(REPO_ROOT, 'packages/sdk/src/components/index.ts'),
-  '@makinbakin/sdk/slots': join(REPO_ROOT, 'packages/sdk/src/slots/index.tsx'),
-  '@makinbakin/sdk/types': join(REPO_ROOT, 'packages/sdk/src/types/index.ts'),
-  '@makinbakin/sdk/utils': join(REPO_ROOT, 'packages/sdk/src/utils/index.ts'),
-  '@makinbakin/sdk/metadata': join(REPO_ROOT, 'packages/sdk/src/metadata/index.ts'),
-  '@makinbakin/sdk/routing': join(REPO_ROOT, 'packages/sdk/src/routing/index.ts'),
-}
-
 const JSX_DEV_RUNTIME_RE = /(?:react\/jsx-dev-runtime|\bjsxDEV\b)/
-
-interface RunResult {
-  exitCode: number
-  stderr: string
-}
 
 export interface BuildLogger {
   debug?: (msg: string, meta?: Record<string, unknown>) => void
@@ -78,29 +59,6 @@ function diagnosticsLogger(log?: BuildLogger): StartupDiagnosticLogger | null {
     debug: (message, data) => log.debug?.(message, data),
     warn: (message, data) => log.warn?.(message, data),
   }
-}
-
-/**
- * Portable subprocess runner. Passing the binary through `spawn` with an
- * argv array avoids shell interpolation and path-traversal tricks.
- */
-function runSubprocess(cmd: string, args: string[], cwd?: string): Promise<RunResult> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(cmd, args, {
-      cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-    const stderrChunks: Buffer[] = []
-    proc.stdout?.on('data', () => { /* discard */ })
-    proc.stderr?.on('data', (chunk: Buffer) => { stderrChunks.push(chunk) })
-    proc.once('error', reject)
-    proc.once('close', (code: number | null) => {
-      resolve({
-        exitCode: code ?? 0,
-        stderr: Buffer.concat(stderrChunks).toString('utf-8'),
-      })
-    })
-  })
 }
 
 /**
@@ -177,19 +135,51 @@ function readPackageJson(pluginDir: string): PluginPackageJson {
   }
 }
 
+const STAGE_SPANS: Record<WhiskitStageEvent['stage'], { span: string; errorLabel: string }> = {
+  'install': { span: 'userPlugin.dependencies', errorLabel: 'bun install failed' },
+  'server-build': { span: 'userPlugin.serverBuild', errorLabel: 'server build failed' },
+  'client-build': { span: 'userPlugin.clientBuild', errorLabel: 'client build failed' },
+}
+
+const STAGE_ERROR_LABELS: Record<WhiskitBuildError['stage'], string> = {
+  'resolve-bun': 'system bun not found',
+  'validate': 'import validation failed',
+  'resolve-sdk': 'sdk resolution failed',
+  'install': 'dependency install failed',
+  'server-build': 'server build failed',
+  'client-build': 'client build failed',
+}
+
 /**
- * Build a user plugin's dist/ from its sources.
+ * Replay a backend stage event as a startup span with an accurate duration.
+ * The backend reports after the fact, so the span's clock is replayed via
+ * the `now` override: first read 0, second read the stage's durationMs.
+ */
+function emitStageSpan(
+  diag: StartupDiagnosticLogger,
+  pluginId: string,
+  event: WhiskitStageEvent,
+): void {
+  const { span, errorLabel } = STAGE_SPANS[event.stage]
+  let reads = 0
+  const handle = startStartupSpan(diag, span, {
+    phase: 'user-plugin-build',
+    pluginId,
+    pluginSource: 'user',
+    thresholdMs: 1_000,
+    now: () => (reads++ === 0 ? 0 : event.durationMs),
+  })
+  handle.end(event.status === 'ok' ? { status: 'ok' } : { status: 'error', error: errorLabel })
+}
+
+/**
+ * Build a user plugin's dist/ from its sources via the Whiskit backend.
  *
- * - If `package.json` is present and declares deps, runs `bun install` in
- *   the plugin directory first. Peer deps stay external via the bundler
- *   externals list, so this is mostly for dev deps / rare plugin-owned
- *   npm packages.
+ * - Declared deps install with `bun install --ignore-scripts` (pure-JS
+ *   installs; lifecycle scripts are withheld until the elevated path lands).
  * - When `trustExistingDist` is set and every expected dist output is
  *   present, skips the rebuild. This is used for GitHub-installed plugins
  *   that ship their own build artifacts.
- * - Runs `bun build` on `index.ts` (server) and `client.tsx` (browser, if
- *   present). Both land in `dist/` with `index.js` / `client.js`. The server
- *   bundle is self-contained except for shared runtime singletons.
  * - Skips the build when the dist outputs are newer than every source file.
  */
 export async function buildUserPlugin(
@@ -216,6 +206,8 @@ export async function buildUserPlugin(
     const hasClient = existsSync(clientEntry)
     errorStage = 'invalid package.json'
     const pkg = readPackageJson(pluginDir)
+    // Import contract is enforced every boot — even when dist is fresh and
+    // the compile would be skipped.
     errorStage = 'import validation failed'
     validatePluginImports(pluginDir, pkg)
 
@@ -236,6 +228,9 @@ export async function buildUserPlugin(
         return
       }
       if (trustCompleteDist && hasClient) {
+        // Trusted prebuilt server dist + stale client (jsx-dev artifact):
+        // refresh the client only — server rebuilds on consumer machines
+        // would need SDK sources the machine may not have.
         buildServer = false
       }
 
@@ -248,105 +243,21 @@ export async function buildUserPlugin(
       }
     }
 
-    // Install deps if the plugin has its own package.json + declared deps.
-    if (existsSync(join(pluginDir, 'package.json'))) {
-      const hasDeps =
-        (pkg.dependencies && Object.keys(pkg.dependencies).length > 0) ||
-        (pkg.devDependencies && Object.keys(pkg.devDependencies).length > 0)
-      if (hasDeps) {
-        errorStage = 'dependency install failed'
-        const installSpan = diag ? startStartupSpan(diag, 'userPlugin.dependencies', {
-          phase: 'user-plugin-build',
-          pluginId,
-          pluginSource: 'user',
-          thresholdMs: 1_000,
-        }) : null
-        let installResult: RunResult
-        try {
-          installResult = await runSubprocess('bun', ['install'], pluginDir)
-        } catch (err) {
-          installSpan?.end({ status: 'error', error: 'bun install failed' })
-          throw err
-        }
-        if (installResult.exitCode !== 0) {
-          installSpan?.end({ status: 'error', error: 'bun install failed' })
-          throw new Error(`bun install failed in ${pluginDir}:\n${installResult.stderr}`)
-        }
-        installSpan?.end({ status: 'ok' })
-      }
-    }
-
-    if (buildServer) {
-      const serverBuildConfig = {
-        entrypoints: [serverEntry],
-        outdir: distDir,
-        target: 'bun',
-        format: 'esm',
-        naming: 'index.[ext]',
-        external: SERVER_EXTERNAL,
-        plugins: [{
-          name: 'bakin-sdk-server-resolver',
-          setup(build: any) {
-            build.onResolve({ filter: /^@makinbakin\/sdk(\/.*)?$/ }, (args: { path: string }) => {
-              const path = SDK_ENTRYPOINTS[args.path]
-              if (!path) return
-              return { path }
-            })
-          },
-        }],
-      } as Parameters<typeof Bun.build>[0] & { plugins: Array<unknown> }
-      const serverSpan = diag ? startStartupSpan(diag, 'userPlugin.serverBuild', {
-        phase: 'user-plugin-build',
-        pluginId,
-        pluginSource: 'user',
-        thresholdMs: 1_000,
-      }) : null
-      errorStage = 'server build failed'
-      let serverResult: Awaited<ReturnType<typeof Bun.build>>
-      try {
-        serverResult = await Bun.build(serverBuildConfig)
-      } catch (err) {
-        serverSpan?.end({ status: 'error', error: 'server build failed' })
-        throw err
-      }
-      if (!serverResult.success) {
-        serverSpan?.end({ status: 'error', error: 'server build failed' })
-        throw new Error(`Failed to build server entry for ${pluginDir}:\n${serverResult.logs.join('\n')}`)
-      }
-      serverSpan?.end({ status: 'ok' })
-    }
-
-    if (hasClient) {
-      const clientSpan = diag ? startStartupSpan(diag, 'userPlugin.clientBuild', {
-        phase: 'user-plugin-build',
-        pluginId,
-        pluginSource: 'user',
-        thresholdMs: 1_000,
-      }) : null
-      errorStage = 'client build failed'
-      let clientResult: RunResult
-      try {
-        clientResult = await runSubprocess('bun', [
-          'build', clientEntry,
-          '--outdir', distDir,
-          '--target', 'browser',
-          '--format', 'esm',
-          '--entry-naming', 'client.[ext]',
-          ...(isProductionBuild() ? ['--production'] : []),
-          ...CLIENT_EXTERNAL.flatMap(e => ['--external', e]),
-        ])
-      } catch (err) {
-        clientSpan?.end({ status: 'error', error: 'client build failed' })
-        throw err
-      }
-      if (clientResult.exitCode !== 0) {
-        clientSpan?.end({ status: 'error', error: 'client build failed' })
-        throw new Error(`Failed to build client entry for ${pluginDir}:\n${clientResult.stderr}`)
-      }
-      clientSpan?.end({ status: 'ok' })
-    }
+    errorStage = 'build failed'
+    const build = canBuildInProcess() ? buildPluginInProcess : buildPluginWithSystemBun
+    await build({
+      pluginDir,
+      pluginId,
+      production: isProductionBuild(),
+      installDeps: true,
+      serverBuild: buildServer,
+      onStage: diag ? (event) => emitStageSpan(diag, pluginId, event) : undefined,
+    })
     totalSpan?.end({ status: 'ok', rebuilt: true, hasClient })
   } catch (err) {
+    if (err instanceof WhiskitBuildError) {
+      errorStage = STAGE_ERROR_LABELS[err.stage] ?? errorStage
+    }
     totalSpan?.end({ status: 'error', error: errorStage })
     throw err
   }

--- a/src/core/whiskit/build.ts
+++ b/src/core/whiskit/build.ts
@@ -1,0 +1,340 @@
+/**
+ * Whiskit shared build backend (Phase 2) — one code path that turns a plugin
+ * source dir into `dist/{index.js, client.js}` identically on producer
+ * machines (`bakin plugins publish --build`), consumer machines (install-time
+ * builds under the compiled binary), and CI.
+ *
+ * Externals strategy (must match the proven bits-official build or server
+ * output diverges):
+ *   - CLIENT externalizes React + router + the full SDK surface — the host's
+ *     browser import map provides the singletons.
+ *   - SERVER externalizes React/router only and INLINES the SDK. The plugin's
+ *     runtime import path on a user's machine is `<binary>/dist/index.js`,
+ *     where Node's resolver can't find @makinbakin/sdk. Other deps are also
+ *     bundled (Bun's default) — published artifacts ship dist/ without
+ *     node_modules.
+ *
+ * Two backends, one contract:
+ *   - `buildPluginWithSystemBun` shells out to the system `bun`. The server
+ *     build needs an SDK resolver plugin, which the `bun build` CLI cannot
+ *     express, so it runs a generated script (Bun.build + onResolve) under
+ *     the system bun. Works from a compiled binary.
+ *   - `buildPluginInProcess` calls `Bun.build()` directly — the dev hot-loop
+ *     fast path (no subprocess per save). Only available from a source run.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { PLUGIN_CLIENT_EXTERNALS, PLUGIN_SERVER_EXTERNALS } from './externals'
+import { validatePluginImports, type PluginPackageJson } from './import-scan'
+import { commandFailure, runSystemBun, DEFAULT_BUILD_TIMEOUT_MS } from './command'
+import { WhiskitBuildError, type WhiskitBuildRequest, type WhiskitBuildResult } from './types'
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+
+/** SDK sub-path names ('' is the package root). Mirrors the package exports. */
+const SDK_SUBPATHS = ['', 'ui', 'hooks', 'components', 'slots', 'types', 'utils', 'metadata', 'routing'] as const
+
+export interface SdkResolution {
+  /** Where the SDK came from — recorded in diagnostics. */
+  source: 'env' | 'repo-source' | 'plugin-node-modules'
+  /** Specifier → absolute entry file, fed to the resolver plugin. */
+  entrypoints: Record<string, string>
+}
+
+function specifier(subpath: string): string {
+  return subpath ? `@makinbakin/sdk/${subpath}` : '@makinbakin/sdk'
+}
+
+/**
+ * Build the specifier → file map for an SDK root, probing each sub-path for
+ * the styles we ship: compiled npm package (`index.js`) and repo source
+ * (`index.ts` / `index.tsx`). Returns null when any sub-path is missing —
+ * a partial SDK would produce a bundle that explodes at activation.
+ */
+function sdkEntrypointMap(root: string): Record<string, string> | null {
+  const map: Record<string, string> = {}
+  for (const subpath of SDK_SUBPATHS) {
+    const base = subpath ? join(root, subpath) : root
+    const candidate = ['index.js', 'index.ts', 'index.tsx']
+      .map((name) => join(base, name))
+      .find((path) => existsSync(path))
+    if (!candidate) return null
+    map[specifier(subpath)] = candidate
+  }
+  return map
+}
+
+/**
+ * Locate SDK sources for server-bundle inlining. Resolution ladder:
+ *   1. `BAKIN_SDK_PATH` — explicit root (CI / hermetic builds)
+ *   2. repo source (`packages/sdk/src`) — source runs
+ *   3. the plugin's own `node_modules/@makinbakin/sdk` — consumer machines,
+ *      installed by the plugin's declared devDependency
+ */
+export function resolveSdkEntrypoints(pluginDir: string): SdkResolution {
+  const envRoot = process.env.BAKIN_SDK_PATH
+  if (envRoot && envRoot.trim().length > 0) {
+    const entrypoints = sdkEntrypointMap(envRoot)
+    if (!entrypoints) {
+      throw new WhiskitBuildError(
+        'resolve-sdk',
+        `BAKIN_SDK_PATH (${envRoot}) does not contain a complete @makinbakin/sdk package`,
+      )
+    }
+    return { source: 'env', entrypoints }
+  }
+
+  const repoSdkSrc = join(REPO_ROOT, 'packages', 'sdk', 'src')
+  if (existsSync(join(repoSdkSrc, 'index.ts'))) {
+    const entrypoints = sdkEntrypointMap(repoSdkSrc)
+    if (entrypoints) return { source: 'repo-source', entrypoints }
+  }
+
+  const pluginSdk = join(pluginDir, 'node_modules', '@makinbakin', 'sdk')
+  if (existsSync(join(pluginSdk, 'package.json'))) {
+    const entrypoints = sdkEntrypointMap(pluginSdk)
+    if (entrypoints) return { source: 'plugin-node-modules', entrypoints }
+  }
+
+  throw new WhiskitBuildError(
+    'resolve-sdk',
+    `Cannot locate @makinbakin/sdk sources to inline into the server bundle for ${pluginDir}. ` +
+    `Add "@makinbakin/sdk" to the plugin's devDependencies (and build with deps installed), ` +
+    `or set BAKIN_SDK_PATH to an installed copy of the package.`,
+  )
+}
+
+export function readPluginPackageJson(pluginDir: string): PluginPackageJson {
+  const pkgJsonPath = join(pluginDir, 'package.json')
+  if (!existsSync(pkgJsonPath)) return {}
+  try {
+    return JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as PluginPackageJson
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new WhiskitBuildError('validate', `Invalid package.json in ${pluginDir}: ${err.message}`)
+    }
+    throw err
+  }
+}
+
+function hasDeclaredDeps(pkg: PluginPackageJson): boolean {
+  return (
+    Object.keys(pkg.dependencies ?? {}).length > 0 ||
+    Object.keys(pkg.devDependencies ?? {}).length > 0
+  )
+}
+
+interface ValidatedPlugin {
+  pluginId: string
+  serverEntry: string
+  clientEntry: string | null
+  distDir: string
+  pkg: PluginPackageJson
+}
+
+function validateRequest(req: WhiskitBuildRequest): ValidatedPlugin {
+  const pluginId = req.pluginId ?? basename(req.pluginDir)
+  const serverEntry = join(req.pluginDir, 'index.ts')
+  if (!existsSync(serverEntry)) {
+    throw new WhiskitBuildError('validate', `${serverEntry} not found — every plugin needs a server entry`)
+  }
+  const clientPath = join(req.pluginDir, 'client.tsx')
+  const pkg = readPluginPackageJson(req.pluginDir)
+  try {
+    validatePluginImports(req.pluginDir, pkg)
+  } catch (err) {
+    throw new WhiskitBuildError('validate', err instanceof Error ? err.message : String(err))
+  }
+  return {
+    pluginId,
+    serverEntry,
+    clientEntry: existsSync(clientPath) ? clientPath : null,
+    distDir: join(req.pluginDir, 'dist'),
+    pkg,
+  }
+}
+
+/**
+ * `bun install --ignore-scripts` in the plugin dir. Pure-JS installs only —
+ * lifecycle scripts are withheld until the elevated path lands (Phase 7).
+ */
+async function installDeps(req: WhiskitBuildRequest, plugin: ValidatedPlugin): Promise<boolean> {
+  if (!req.installDeps || !hasDeclaredDeps(plugin.pkg)) return false
+  const result = await runSystemBun(['install', '--ignore-scripts'], {
+    cwd: req.pluginDir,
+    timeoutMs: req.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
+  })
+  if (result.exitCode !== 0) {
+    throw commandFailure('install', `Dependency install for "${plugin.pluginId}"`, result)
+  }
+  return true
+}
+
+/**
+ * The script run under the system bun for server builds. `bun build` (CLI)
+ * has no plugin support, so SDK inlining needs an in-script `Bun.build()`
+ * with an onResolve hook. Config arrives as a JSON file path in argv[2] —
+ * nothing is string-interpolated into code.
+ */
+const SERVER_BUILD_SCRIPT = `
+const config = JSON.parse(await Bun.file(process.argv[2]).text())
+const result = await Bun.build({
+  entrypoints: [config.entry],
+  outdir: config.outdir,
+  target: 'bun',
+  format: 'esm',
+  naming: 'index.[ext]',
+  external: config.externals,
+  plugins: [{
+    name: 'whiskit-sdk-resolver',
+    setup(build) {
+      build.onResolve({ filter: /^@makinbakin\\/sdk(\\/.*)?$/ }, (args) => {
+        const path = config.sdkEntrypoints[args.path]
+        if (!path) return
+        return { path }
+      })
+    },
+  }],
+})
+if (!result.success) {
+  console.error(result.logs.map(String).join('\\n'))
+  process.exit(1)
+}
+`
+
+interface ServerBuildConfig {
+  entry: string
+  outdir: string
+  externals: string[]
+  sdkEntrypoints: Record<string, string>
+}
+
+async function buildServerWithSystemBun(
+  req: WhiskitBuildRequest,
+  plugin: ValidatedPlugin,
+  sdk: SdkResolution,
+): Promise<void> {
+  const scratch = mkdtempSync(join(tmpdir(), 'whiskit-server-build-'))
+  try {
+    const scriptPath = join(scratch, 'build.ts')
+    const configPath = join(scratch, 'config.json')
+    const config: ServerBuildConfig = {
+      entry: plugin.serverEntry,
+      outdir: plugin.distDir,
+      externals: [...PLUGIN_SERVER_EXTERNALS],
+      sdkEntrypoints: sdk.entrypoints,
+    }
+    writeFileSync(scriptPath, SERVER_BUILD_SCRIPT)
+    writeFileSync(configPath, JSON.stringify(config))
+    const result = await runSystemBun([scriptPath, configPath], {
+      cwd: req.pluginDir,
+      timeoutMs: req.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
+    })
+    if (result.exitCode !== 0) {
+      throw commandFailure('server-build', `Server build for "${plugin.pluginId}"`, result)
+    }
+  } finally {
+    rmSync(scratch, { recursive: true, force: true })
+  }
+}
+
+async function buildClientWithSystemBun(req: WhiskitBuildRequest, plugin: ValidatedPlugin): Promise<void> {
+  if (!plugin.clientEntry) return
+  const result = await runSystemBun(
+    [
+      'build', plugin.clientEntry,
+      '--outdir', plugin.distDir,
+      '--target', 'browser',
+      '--format', 'esm',
+      '--entry-naming', 'client.[ext]',
+      ...(req.production ? ['--production'] : []),
+      ...PLUGIN_CLIENT_EXTERNALS.flatMap((e) => ['--external', e]),
+    ],
+    { cwd: req.pluginDir, timeoutMs: req.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS },
+  )
+  if (result.exitCode !== 0) {
+    throw commandFailure('client-build', `Client build for "${plugin.pluginId}"`, result)
+  }
+}
+
+/**
+ * Publish/install-path build: every compile step is a system-`bun`
+ * subprocess, so the same code works from a source run and the compiled
+ * binary.
+ */
+export async function buildPluginWithSystemBun(req: WhiskitBuildRequest): Promise<WhiskitBuildResult> {
+  const startedAt = Date.now()
+  const plugin = validateRequest(req)
+  const installedDeps = await installDeps(req, plugin)
+  const sdk = resolveSdkEntrypoints(req.pluginDir)
+  await buildServerWithSystemBun(req, plugin, sdk)
+  await buildClientWithSystemBun(req, plugin)
+  return {
+    pluginId: plugin.pluginId,
+    builtServer: true,
+    builtClient: plugin.clientEntry !== null,
+    installedDeps,
+    backend: 'system-bun',
+    durationMs: Date.now() - startedAt,
+  }
+}
+
+/**
+ * True when the in-process fast path can work: running from a source tree
+ * (repo SDK sources on disk, not the compiled binary's /$bunfs/ layout).
+ */
+export function canBuildInProcess(): boolean {
+  return existsSync(join(REPO_ROOT, 'packages', 'sdk', 'src', 'index.ts'))
+}
+
+/**
+ * Dev-hot-loop fast path: server compile via in-process `Bun.build()` (no
+ * subprocess per save), client compile via the system bun (the CLI path the
+ * dev loop has always used — browser bundles can't be produced in-process
+ * under `bun --hot` anyway). Source runs only; see `canBuildInProcess`.
+ */
+export async function buildPluginInProcess(req: WhiskitBuildRequest): Promise<WhiskitBuildResult> {
+  const startedAt = Date.now()
+  const plugin = validateRequest(req)
+  const installedDeps = await installDeps(req, plugin)
+  const sdk = resolveSdkEntrypoints(req.pluginDir)
+
+  // The bun-types snapshot predates BuildConfig.plugins — same cast as the
+  // legacy user-plugin-builder used.
+  const serverBuildConfig = {
+    entrypoints: [plugin.serverEntry],
+    outdir: plugin.distDir,
+    target: 'bun',
+    format: 'esm',
+    naming: 'index.[ext]',
+    external: [...PLUGIN_SERVER_EXTERNALS],
+    plugins: [{
+      name: 'whiskit-sdk-resolver',
+      setup(build: { onResolve: (filter: { filter: RegExp }, cb: (args: { path: string }) => { path: string } | undefined) => void }) {
+        build.onResolve({ filter: /^@makinbakin\/sdk(\/.*)?$/ }, (args) => {
+          const path = sdk.entrypoints[args.path]
+          if (!path) return
+          return { path }
+        })
+      },
+    }],
+  } as Parameters<typeof Bun.build>[0] & { plugins: Array<unknown> }
+  const serverResult = await Bun.build(serverBuildConfig)
+  if (!serverResult.success) {
+    throw new WhiskitBuildError(
+      'server-build',
+      `Server build for "${plugin.pluginId}" failed:\n${serverResult.logs.join('\n')}`,
+    )
+  }
+
+  await buildClientWithSystemBun(req, plugin)
+  return {
+    pluginId: plugin.pluginId,
+    builtServer: true,
+    builtClient: plugin.clientEntry !== null,
+    installedDeps,
+    backend: 'in-process',
+    durationMs: Date.now() - startedAt,
+  }
+}

--- a/src/core/whiskit/build.ts
+++ b/src/core/whiskit/build.ts
@@ -165,6 +165,11 @@ async function installDeps(req: WhiskitBuildRequest, plugin: ValidatedPlugin): P
     cwd: req.pluginDir,
     timeoutMs: req.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
   })
+  req.onStage?.({
+    stage: 'install',
+    status: result.exitCode === 0 ? 'ok' : 'error',
+    durationMs: result.durationMs,
+  })
   if (result.exitCode !== 0) {
     throw commandFailure('install', `Dependency install for "${plugin.pluginId}"`, result)
   }
@@ -231,6 +236,11 @@ async function buildServerWithSystemBun(
       cwd: req.pluginDir,
       timeoutMs: req.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
     })
+    req.onStage?.({
+      stage: 'server-build',
+      status: result.exitCode === 0 ? 'ok' : 'error',
+      durationMs: result.durationMs,
+    })
     if (result.exitCode !== 0) {
       throw commandFailure('server-build', `Server build for "${plugin.pluginId}"`, result)
     }
@@ -253,6 +263,11 @@ async function buildClientWithSystemBun(req: WhiskitBuildRequest, plugin: Valida
     ],
     { cwd: req.pluginDir, timeoutMs: req.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS },
   )
+  req.onStage?.({
+    stage: 'client-build',
+    status: result.exitCode === 0 ? 'ok' : 'error',
+    durationMs: result.durationMs,
+  })
   if (result.exitCode !== 0) {
     throw commandFailure('client-build', `Client build for "${plugin.pluginId}"`, result)
   }
@@ -267,12 +282,15 @@ export async function buildPluginWithSystemBun(req: WhiskitBuildRequest): Promis
   const startedAt = Date.now()
   const plugin = validateRequest(req)
   const installedDeps = await installDeps(req, plugin)
-  const sdk = resolveSdkEntrypoints(req.pluginDir)
-  await buildServerWithSystemBun(req, plugin, sdk)
+  const buildServer = req.serverBuild !== false
+  if (buildServer) {
+    const sdk = resolveSdkEntrypoints(req.pluginDir)
+    await buildServerWithSystemBun(req, plugin, sdk)
+  }
   await buildClientWithSystemBun(req, plugin)
   return {
     pluginId: plugin.pluginId,
-    builtServer: true,
+    builtServer: buildServer,
     builtClient: plugin.clientEntry !== null,
     installedDeps,
     backend: 'system-bun',
@@ -298,6 +316,17 @@ export async function buildPluginInProcess(req: WhiskitBuildRequest): Promise<Wh
   const startedAt = Date.now()
   const plugin = validateRequest(req)
   const installedDeps = await installDeps(req, plugin)
+  if (req.serverBuild === false) {
+    await buildClientWithSystemBun(req, plugin)
+    return {
+      pluginId: plugin.pluginId,
+      builtServer: false,
+      builtClient: plugin.clientEntry !== null,
+      installedDeps,
+      backend: 'in-process',
+      durationMs: Date.now() - startedAt,
+    }
+  }
   const sdk = resolveSdkEntrypoints(req.pluginDir)
 
   // The bun-types snapshot predates BuildConfig.plugins — same cast as the
@@ -320,7 +349,19 @@ export async function buildPluginInProcess(req: WhiskitBuildRequest): Promise<Wh
       },
     }],
   } as Parameters<typeof Bun.build>[0] & { plugins: Array<unknown> }
-  const serverResult = await Bun.build(serverBuildConfig)
+  const serverStartedAt = Date.now()
+  let serverResult: Awaited<ReturnType<typeof Bun.build>>
+  try {
+    serverResult = await Bun.build(serverBuildConfig)
+  } catch (err) {
+    req.onStage?.({ stage: 'server-build', status: 'error', durationMs: Date.now() - serverStartedAt })
+    throw err
+  }
+  req.onStage?.({
+    stage: 'server-build',
+    status: serverResult.success ? 'ok' : 'error',
+    durationMs: Date.now() - serverStartedAt,
+  })
   if (!serverResult.success) {
     throw new WhiskitBuildError(
       'server-build',

--- a/src/core/whiskit/command.ts
+++ b/src/core/whiskit/command.ts
@@ -52,7 +52,8 @@ const ENV_ALLOWLIST = [
 export function findSystemBun(): string {
   const override = process.env.BAKIN_BUN_PATH
   if (override && override.trim().length > 0) return override
-  const found = Bun.which('bun')
+  // Bun.which exists at runtime; the repo's bun-types snapshot predates it.
+  const found = (Bun as unknown as { which: (bin: string) => string | null }).which('bun')
   if (!found) {
     throw new WhiskitBuildError(
       'resolve-bun',

--- a/src/core/whiskit/command.ts
+++ b/src/core/whiskit/command.ts
@@ -1,0 +1,169 @@
+/**
+ * Stable system-`bun` runner for the Whiskit build backend (Phase 2).
+ *
+ * Why a subprocess at all: the compiled `bakin` binary cannot rely on its
+ * embedded Bun for plugin builds (in-process `Bun.build()` resolves against
+ * the `/$bunfs/` virtual filesystem, not the user's machine), so every
+ * publish/install build shells out to the system `bun` found on PATH. The
+ * same runner is used from a source checkout so CI and dev machines take
+ * one code path.
+ *
+ * Hardening:
+ *   - argv-array spawn — no shell, no interpolation
+ *   - env allowlist — plugin builds (and their postinstall-adjacent tooling)
+ *     never see Bakin's secrets; only what `bun` needs to resolve + cache
+ *   - wall-clock timeout with SIGKILL — a hung build can't wedge the server
+ *   - capped stdout/stderr capture — a log-spamming build can't balloon memory
+ */
+import { spawn } from 'node:child_process'
+import { WhiskitBuildError, type WhiskitCommandResult } from './types'
+
+export const DEFAULT_BUILD_TIMEOUT_MS = 120_000
+
+/** Cap captured stdout/stderr at 256 KB each — plenty for any real error. */
+const OUTPUT_CAP_BYTES = 256 * 1024
+
+/**
+ * Environment variables a plugin build legitimately needs. Everything else
+ * (API keys, tokens, Bakin internals) is withheld.
+ */
+const ENV_ALLOWLIST = [
+  'PATH',
+  'HOME',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'USER',
+  'LANG',
+  'LC_ALL',
+  'BUN_INSTALL',
+  'BUN_INSTALL_CACHE_DIR',
+  'NPM_CONFIG_REGISTRY',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'SystemRoot', // Windows: child processes fail to start without it
+] as const
+
+/**
+ * Locate the system `bun` executable. `BAKIN_BUN_PATH` overrides for odd
+ * setups (CI containers, hermetic builds); otherwise PATH lookup.
+ */
+export function findSystemBun(): string {
+  const override = process.env.BAKIN_BUN_PATH
+  if (override && override.trim().length > 0) return override
+  const found = Bun.which('bun')
+  if (!found) {
+    throw new WhiskitBuildError(
+      'resolve-bun',
+      'System `bun` not found on PATH. Plugin builds require Bun (https://bun.sh) — install it or set BAKIN_BUN_PATH.',
+    )
+  }
+  return found
+}
+
+function allowlistedEnv(extraEnv?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = { NO_COLOR: '1' }
+  for (const key of ENV_ALLOWLIST) {
+    const value = process.env[key]
+    if (value !== undefined) env[key] = value
+  }
+  return { ...env, ...extraEnv }
+}
+
+export interface RunSystemBunOptions {
+  cwd: string
+  /** Wall-clock limit; the process is SIGKILLed past it. */
+  timeoutMs?: number
+  /** Extra env vars layered over the allowlist (e.g. NODE_ENV). */
+  extraEnv?: Record<string, string>
+}
+
+class CappedCollector {
+  private chunks: Buffer[] = []
+  private size = 0
+  truncated = false
+
+  push(chunk: Buffer): void {
+    if (this.size >= OUTPUT_CAP_BYTES) {
+      this.truncated = true
+      return
+    }
+    const room = OUTPUT_CAP_BYTES - this.size
+    const piece = chunk.byteLength > room ? chunk.subarray(0, room) : chunk
+    if (piece.byteLength < chunk.byteLength) this.truncated = true
+    this.chunks.push(piece)
+    this.size += piece.byteLength
+  }
+
+  toString(): string {
+    const text = Buffer.concat(this.chunks).toString('utf-8')
+    return this.truncated ? `${text}\n… [output truncated]` : text
+  }
+}
+
+/**
+ * Run `bun <args>` with the hardened settings above. Resolves with the
+ * captured result for any exit (including non-zero and timeout) — callers
+ * decide what a failure means for their stage. Rejects only when the
+ * process cannot be spawned at all.
+ */
+export function runSystemBun(args: string[], options: RunSystemBunOptions): Promise<WhiskitCommandResult> {
+  const bun = findSystemBun()
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS
+  const startedAt = Date.now()
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(bun, args, {
+      cwd: options.cwd,
+      env: allowlistedEnv(options.extraEnv),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    const stdout = new CappedCollector()
+    const stderr = new CappedCollector()
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      proc.kill('SIGKILL')
+    }, timeoutMs)
+
+    proc.stdout?.on('data', (chunk: Buffer) => stdout.push(chunk))
+    proc.stderr?.on('data', (chunk: Buffer) => stderr.push(chunk))
+    proc.once('error', (err) => {
+      clearTimeout(timer)
+      reject(new WhiskitBuildError('resolve-bun', `Failed to spawn ${bun}: ${err.message}`))
+    })
+    proc.once('close', (code: number | null) => {
+      clearTimeout(timer)
+      resolve({
+        exitCode: code ?? (timedOut ? 124 : 0),
+        stdout: stdout.toString(),
+        stderr: stderr.toString(),
+        timedOut,
+        durationMs: Date.now() - startedAt,
+      })
+    })
+  })
+}
+
+/**
+ * Shape a failed command into a WhiskitBuildError with a readable, bounded
+ * message: stage + exit reason + the stderr tail (where bun puts its
+ * diagnostics). Never embeds the full environment or argv.
+ */
+export function commandFailure(
+  stage: WhiskitBuildError['stage'],
+  what: string,
+  result: WhiskitCommandResult,
+): WhiskitBuildError {
+  const reason = result.timedOut
+    ? `timed out after ${Math.round(result.durationMs / 1000)}s`
+    : `exited with code ${result.exitCode}`
+  const tail = result.stderr.trim().split('\n').slice(-25).join('\n')
+  return new WhiskitBuildError(
+    stage,
+    `${what} ${reason}${tail ? `:\n${tail}` : ''}`,
+    result.stderr,
+  )
+}

--- a/src/core/whiskit/types.ts
+++ b/src/core/whiskit/types.ts
@@ -42,6 +42,13 @@ export class WhiskitBuildError extends Error {
   }
 }
 
+/** Stage progress event for observability (startup spans, dev overlay). */
+export interface WhiskitStageEvent {
+  stage: 'install' | 'server-build' | 'client-build'
+  status: 'ok' | 'error'
+  durationMs: number
+}
+
 /** A request to build one plugin source dir into dist/. */
 export interface WhiskitBuildRequest {
   pluginDir: string
@@ -57,6 +64,13 @@ export interface WhiskitBuildRequest {
   installDeps?: boolean
   /** Per-subprocess timeout. Defaults to DEFAULT_BUILD_TIMEOUT_MS. */
   timeoutMs?: number
+  /**
+   * Set false to skip the server compile (and its SDK resolution) — used
+   * when a trusted prebuilt server dist only needs its client refreshed.
+   */
+  serverBuild?: boolean
+  /** Optional per-stage observer — callers map these to diagnostics spans. */
+  onStage?: (event: WhiskitStageEvent) => void
 }
 
 export interface WhiskitBuildResult {

--- a/src/core/whiskit/types.ts
+++ b/src/core/whiskit/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types for the Whiskit build backend (Phase 2).
+ *
+ * The backend has one job: turn a plugin source dir into `dist/{index.js,
+ * client.js}` the same way everywhere — `bakin plugins publish --build` on a
+ * producer machine, install-time builds on a consumer machine, and the
+ * source-run dev loop. Build failures carry a `stage` so callers can show
+ * "dependency install failed" instead of a generic stack.
+ */
+
+/** Result of one system-`bun` subprocess run. */
+export interface WhiskitCommandResult {
+  exitCode: number
+  /** Captured stdout, capped at OUTPUT_CAP_BYTES. */
+  stdout: string
+  /** Captured stderr, capped at OUTPUT_CAP_BYTES. */
+  stderr: string
+  /** True when the process was killed by the timeout. */
+  timedOut: boolean
+  durationMs: number
+}
+
+/** Where in the build pipeline a failure happened. */
+export type WhiskitBuildStage =
+  | 'resolve-bun'
+  | 'validate'
+  | 'resolve-sdk'
+  | 'install'
+  | 'server-build'
+  | 'client-build'
+
+export class WhiskitBuildError extends Error {
+  readonly stage: WhiskitBuildStage
+  /** Trimmed stderr tail from the failing subprocess, when there was one. */
+  readonly stderr?: string
+
+  constructor(stage: WhiskitBuildStage, message: string, stderr?: string) {
+    super(message)
+    this.name = 'WhiskitBuildError'
+    this.stage = stage
+    this.stderr = stderr
+  }
+}
+
+/** A request to build one plugin source dir into dist/. */
+export interface WhiskitBuildRequest {
+  pluginDir: string
+  /** Defaults to basename(pluginDir). Used in logs/errors only. */
+  pluginId?: string
+  /** Minify the client bundle (publish/release builds). */
+  production?: boolean
+  /**
+   * Run `bun install --ignore-scripts` first when the plugin declares
+   * dependencies. Publish/install paths want this; the dev hot loop
+   * usually has node_modules already.
+   */
+  installDeps?: boolean
+  /** Per-subprocess timeout. Defaults to DEFAULT_BUILD_TIMEOUT_MS. */
+  timeoutMs?: number
+}
+
+export interface WhiskitBuildResult {
+  pluginId: string
+  builtServer: boolean
+  /** False when the plugin has no client.tsx. */
+  builtClient: boolean
+  /** True when `bun install --ignore-scripts` ran. */
+  installedDeps: boolean
+  /** Which backend compiled the bundles. */
+  backend: 'system-bun' | 'in-process'
+  durationMs: number
+}

--- a/tests/core/whiskit/build.test.ts
+++ b/tests/core/whiskit/build.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Whiskit shared build backend (Phase 2): system-bun builds of a fixture
+ * plugin — SDK inlined into the server bundle, SDK external in the client
+ * bundle, `bun install --ignore-scripts` for declared deps (offline file:
+ * dep), import-contract enforcement, SDK resolution ladder. Real bun
+ * subprocesses, no network. Mandatory isolation mocks per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskit-build-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import {
+  buildPluginInProcess,
+  buildPluginWithSystemBun,
+  canBuildInProcess,
+  resolveSdkEntrypoints,
+} from '../../../src/core/whiskit/build'
+import { WhiskitBuildError } from '../../../src/core/whiskit/types'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  delete process.env.BAKIN_SDK_PATH
+})
+function freshDir(prefix: string): string {
+  const d = join(tmpdir(), `whiskit-${prefix}-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+/** A minimal buildable plugin: server entry imports the SDK, client fills a slot. */
+function seedPlugin(opts: { withClient?: boolean } = {}): string {
+  const dir = freshDir('plugin')
+  writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({
+    id: 'demo', name: 'Demo', version: '0.1.0', bakin: '>=0.0.1',
+    description: 'build fixture', entry: { server: 'index.ts' },
+  }))
+  writeFileSync(join(dir, 'index.ts'), [
+    `import type { NavItem } from '@makinbakin/sdk/types'`,
+    // A runtime SDK import so inlining is observable in the output bundle.
+    `import { getRegistryVersion } from '@makinbakin/sdk'`,
+    `export default {`,
+    `  id: 'demo', name: 'Demo', version: '0.1.0',`,
+    `  nav: [] as NavItem[],`,
+    `  activate() { return getRegistryVersion() },`,
+    `}`,
+    '',
+  ].join('\n'))
+  if (opts.withClient !== false) {
+    writeFileSync(join(dir, 'client.tsx'), [
+      `import { registerPlugin } from '@makinbakin/sdk'`,
+      `registerPlugin({ id: 'demo', slots: {} })`,
+      '',
+    ].join('\n'))
+  }
+  return dir
+}
+
+describe('resolveSdkEntrypoints', () => {
+  it('resolves repo SDK source in a source run', () => {
+    const sdk = resolveSdkEntrypoints(freshDir('nosdk'))
+    expect(sdk.source).toBe('repo-source')
+    expect(sdk.entrypoints['@makinbakin/sdk']).toContain('packages/sdk/src/index.ts')
+    expect(sdk.entrypoints['@makinbakin/sdk/slots']).toContain('slots/index.tsx')
+  })
+
+  it('honors BAKIN_SDK_PATH and rejects incomplete roots', () => {
+    const fake = freshDir('fakesdk')
+    // Complete fake package layout
+    writeFileSync(join(fake, 'index.js'), 'export const x = 1\n')
+    for (const sub of ['ui', 'hooks', 'components', 'slots', 'types', 'utils', 'metadata', 'routing']) {
+      mkdirSync(join(fake, sub), { recursive: true })
+      writeFileSync(join(fake, sub, 'index.js'), 'export const x = 1\n')
+    }
+    process.env.BAKIN_SDK_PATH = fake
+    const sdk = resolveSdkEntrypoints(freshDir('plugindir'))
+    expect(sdk.source).toBe('env')
+    expect(sdk.entrypoints['@makinbakin/sdk/ui']).toBe(join(fake, 'ui', 'index.js'))
+
+    // Incomplete root → hard error, not silent fallback
+    rmSync(join(fake, 'routing'), { recursive: true, force: true })
+    expect(() => resolveSdkEntrypoints(freshDir('plugindir2')))
+      .toThrow(/does not contain a complete @makinbakin\/sdk/)
+  })
+})
+
+describe('buildPluginWithSystemBun', () => {
+  it('inlines the SDK into the server bundle and keeps it external in the client', async () => {
+    const dir = seedPlugin()
+    const result = await buildPluginWithSystemBun({ pluginDir: dir })
+
+    expect(result.backend).toBe('system-bun')
+    expect(result.builtServer).toBe(true)
+    expect(result.builtClient).toBe(true)
+
+    const server = readFileSync(join(dir, 'dist', 'index.js'), 'utf-8')
+    expect(server).not.toContain('from "@makinbakin/sdk"') // inlined
+    expect(server).toContain('getRegistryVersion')          // SDK code present
+
+    const client = readFileSync(join(dir, 'dist', 'client.js'), 'utf-8')
+    expect(client).toContain('@makinbakin/sdk')              // stays external
+  }, 30_000)
+
+  it('builds server-only plugins without a client bundle', async () => {
+    const dir = seedPlugin({ withClient: false })
+    const result = await buildPluginWithSystemBun({ pluginDir: dir })
+    expect(result.builtClient).toBe(false)
+    expect(existsSync(join(dir, 'dist', 'index.js'))).toBe(true)
+    expect(existsSync(join(dir, 'dist', 'client.js'))).toBe(false)
+  }, 30_000)
+
+  it('installs declared deps with --ignore-scripts and bundles them into the server', async () => {
+    // Offline file: dependency with a lifecycle script that must NOT run.
+    const depDir = freshDir('dep')
+    writeFileSync(join(depDir, 'package.json'), JSON.stringify({
+      name: 'demo-dep', version: '1.0.0', main: 'index.js',
+      scripts: { postinstall: `node -e "require('fs').writeFileSync('${join(depDir, 'POSTINSTALL_RAN')}', '1')"` },
+    }))
+    writeFileSync(join(depDir, 'index.js'), 'module.exports = { marker: "demo-dep-marker-value" }\n')
+
+    const dir = seedPlugin({ withClient: false })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: 'demo', version: '0.1.0',
+      dependencies: { 'demo-dep': `file:${depDir}` },
+    }))
+    writeFileSync(join(dir, 'index.ts'), [
+      `import dep from 'demo-dep'`,
+      `export default { id: 'demo', activate() { return dep.marker } }`,
+      '',
+    ].join('\n'))
+
+    const result = await buildPluginWithSystemBun({ pluginDir: dir, installDeps: true })
+    expect(result.installedDeps).toBe(true)
+    const server = readFileSync(join(dir, 'dist', 'index.js'), 'utf-8')
+    expect(server).toContain('demo-dep-marker-value') // dep bundled in
+    expect(existsSync(join(depDir, 'POSTINSTALL_RAN'))).toBe(false) // scripts withheld
+  }, 30_000)
+
+  it('rejects undeclared imports before building anything', async () => {
+    const dir = seedPlugin({ withClient: false })
+    writeFileSync(join(dir, 'index.ts'), [
+      `import _ from 'undeclared-package'`,
+      `export default { id: 'demo', activate() {} }`,
+      '',
+    ].join('\n'))
+    expect(buildPluginWithSystemBun({ pluginDir: dir })).rejects.toThrow(/not declared in package.json/)
+    expect(existsSync(join(dir, 'dist'))).toBe(false)
+  })
+
+  it('surfaces server compile errors as stage-tagged failures with stderr detail', async () => {
+    const dir = seedPlugin({ withClient: false })
+    writeFileSync(join(dir, 'index.ts'), `import { missing } from './does-not-exist'\nexport default missing\n`)
+    try {
+      await buildPluginWithSystemBun({ pluginDir: dir })
+      throw new Error('expected build to fail')
+    } catch (err) {
+      expect(err).toBeInstanceOf(WhiskitBuildError)
+      expect((err as WhiskitBuildError).stage).toBe('server-build')
+      expect((err as WhiskitBuildError).message).toContain('does-not-exist')
+    }
+  }, 30_000)
+})
+
+describe('buildPluginInProcess (dev fast path)', () => {
+  it('is available from a source run', () => {
+    expect(canBuildInProcess()).toBe(true)
+  })
+
+  it('produces the same bundle shape as the system-bun backend', async () => {
+    const dir = seedPlugin()
+    const result = await buildPluginInProcess({ pluginDir: dir })
+    expect(result.backend).toBe('in-process')
+
+    const server = readFileSync(join(dir, 'dist', 'index.js'), 'utf-8')
+    expect(server).not.toContain('from "@makinbakin/sdk"')
+    expect(server).toContain('getRegistryVersion')
+    const client = readFileSync(join(dir, 'dist', 'client.js'), 'utf-8')
+    expect(client).toContain('@makinbakin/sdk')
+  }, 30_000)
+})

--- a/tests/core/whiskit/command.test.ts
+++ b/tests/core/whiskit/command.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Whiskit system-bun runner (Phase 2): argv exec, env allowlist, output
+ * caps, timeout kill, sanitized failures. Uses real `bun -e` subprocesses —
+ * fast, no network. Mandatory isolation mocks per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync } from 'fs'
+
+const mockDir = join(tmpdir(), `whiskit-command-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { commandFailure, findSystemBun, runSystemBun } from '../../../src/core/whiskit/command'
+import { WhiskitBuildError } from '../../../src/core/whiskit/types'
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  delete process.env.BAKIN_BUN_PATH
+  delete process.env.WHISKIT_TEST_SECRET
+})
+function freshDir(): string {
+  const d = join(tmpdir(), `whiskit-cmd-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+describe('findSystemBun', () => {
+  it('honors the BAKIN_BUN_PATH override', () => {
+    process.env.BAKIN_BUN_PATH = '/custom/bin/bun'
+    expect(findSystemBun()).toBe('/custom/bin/bun')
+  })
+
+  it('falls back to PATH lookup', () => {
+    expect(findSystemBun()).toContain('bun')
+  })
+})
+
+describe('runSystemBun', () => {
+  it('runs bun with argv array and captures stdout', async () => {
+    const result = await runSystemBun(['-e', 'console.log("hello-whiskit")'], { cwd: freshDir() })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('hello-whiskit')
+    expect(result.timedOut).toBe(false)
+  })
+
+  it('captures stderr and the non-zero exit code without rejecting', async () => {
+    const result = await runSystemBun(['-e', 'console.error("boom-detail"); process.exit(3)'], { cwd: freshDir() })
+    expect(result.exitCode).toBe(3)
+    expect(result.stderr).toContain('boom-detail')
+  })
+
+  it('withholds non-allowlisted env vars from the subprocess', async () => {
+    process.env.WHISKIT_TEST_SECRET = 'super-secret'
+    const result = await runSystemBun(
+      ['-e', 'console.log(JSON.stringify({ secret: process.env.WHISKIT_TEST_SECRET ?? null, path: !!process.env.PATH }))'],
+      { cwd: freshDir() },
+    )
+    const parsed = JSON.parse(result.stdout.trim()) as { secret: string | null; path: boolean }
+    expect(parsed.secret).toBeNull()
+    expect(parsed.path).toBe(true) // PATH is allowlisted — bun needs it
+  })
+
+  it('layers extraEnv over the allowlist', async () => {
+    const result = await runSystemBun(
+      ['-e', 'console.log(process.env.NODE_ENV)'],
+      { cwd: freshDir(), extraEnv: { NODE_ENV: 'production' } },
+    )
+    expect(result.stdout.trim()).toBe('production')
+  })
+
+  it('kills a hung process at the timeout', async () => {
+    const result = await runSystemBun(
+      ['-e', 'await new Promise(() => {})'],
+      { cwd: freshDir(), timeoutMs: 500 },
+    )
+    expect(result.timedOut).toBe(true)
+    expect(result.durationMs).toBeLessThan(10_000)
+  })
+
+  it('caps runaway output instead of buffering it all', async () => {
+    const result = await runSystemBun(
+      ['-e', 'const line = "x".repeat(1024); for (let i = 0; i < 1024; i++) console.log(line)'],
+      { cwd: freshDir() },
+    )
+    expect(result.stdout.length).toBeLessThan(300 * 1024)
+    expect(result.stdout).toContain('[output truncated]')
+  })
+})
+
+describe('commandFailure', () => {
+  it('builds a bounded, stage-tagged error from a failed result', () => {
+    const err = commandFailure('server-build', 'Server build for "demo"', {
+      exitCode: 1,
+      stdout: '',
+      stderr: Array.from({ length: 60 }, (_, i) => `line-${i}`).join('\n'),
+      timedOut: false,
+      durationMs: 1234,
+    })
+    expect(err).toBeInstanceOf(WhiskitBuildError)
+    expect(err.stage).toBe('server-build')
+    expect(err.message).toContain('exited with code 1')
+    expect(err.message).toContain('line-59') // stderr tail kept
+    expect(err.message).not.toContain('line-0') // head trimmed
+  })
+
+  it('reports timeouts as timeouts', () => {
+    const err = commandFailure('install', 'Dependency install', {
+      exitCode: 124,
+      stdout: '',
+      stderr: '',
+      timedOut: true,
+      durationMs: 120_000,
+    })
+    expect(err.message).toContain('timed out after 120s')
+  })
+})

--- a/tests/core/whiskit/publish-build.test.ts
+++ b/tests/core/whiskit/publish-build.test.ts
@@ -1,0 +1,128 @@
+/**
+ * `bakin plugins publish --build` (Phase 2 wiring): the CLI compiles an
+ * UNBUILT plugin via the Whiskit system-bun backend before assembling the
+ * artifact. Runs the real CLI as a subprocess with isolated homes — purely
+ * local, no server, no network. Mandatory isolation mocks per project rule.
+ */
+import { describe, it, expect, afterEach, mock } from 'bun:test'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+import { randomUUID } from 'crypto'
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { spawnSync } from 'child_process'
+
+const mockDir = join(tmpdir(), `whiskit-publish-build-mock-${Date.now()}-${randomUUID()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => mockDir,
+  getBakinPaths: () => ({}),
+  isUsingBakinHome: () => true,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(mockDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(mockDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+const CLI = join(REPO_ROOT, 'cli', 'bakin.ts')
+
+const dirs: string[] = []
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+function freshDir(prefix: string): string {
+  const d = join(tmpdir(), `whiskit-${prefix}-${Date.now()}-${randomUUID()}`)
+  mkdirSync(d, { recursive: true })
+  dirs.push(d)
+  return d
+}
+
+function seedUnbuiltPlugin(): string {
+  const dir = freshDir('pub-src')
+  writeFileSync(join(dir, 'bakin-plugin.json'), JSON.stringify({
+    id: 'pubdemo', name: 'Pub Demo', version: '0.2.0', bakin: '>=0.0.1',
+    description: 'publish --build fixture', entry: { server: 'index.ts', client: 'client.tsx' },
+  }))
+  writeFileSync(join(dir, 'index.ts'), [
+    `import { getRegistryVersion } from '@makinbakin/sdk'`,
+    `export default { id: 'pubdemo', name: 'Pub Demo', version: '0.2.0', activate() { return getRegistryVersion() } }`,
+    '',
+  ].join('\n'))
+  writeFileSync(join(dir, 'client.tsx'), [
+    `import { registerPlugin } from '@makinbakin/sdk'`,
+    `registerPlugin({ id: 'pubdemo', slots: {} })`,
+    '',
+  ].join('\n'))
+  return dir
+}
+
+function runPublish(pluginDir: string, outDir: string, extra: string[] = []): { exitCode: number; output: string } {
+  const home = freshDir('pub-home')
+  const result = spawnSync('bun', [CLI, 'plugins', 'publish', pluginDir, '--out', outDir, ...extra], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      BAKIN_HOME: home,
+      OPENCLAW_HOME: join(home, 'openclaw'),
+      NO_COLOR: '1',
+    },
+    encoding: 'utf-8',
+    timeout: 120_000,
+  })
+  return {
+    exitCode: result.status ?? -1,
+    output: `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+  }
+}
+
+describe('bakin plugins publish --build', () => {
+  it('builds an unbuilt plugin and assembles a checksummed artifact', () => {
+    const pluginDir = seedUnbuiltPlugin()
+    const outDir = freshDir('pub-out')
+    expect(existsSync(join(pluginDir, 'dist'))).toBe(false)
+
+    const { exitCode, output } = runPublish(pluginDir, outDir, ['--build'])
+    expect(output).toContain('Built pubdemo')
+    expect(output).toContain('Published pubdemo@0.2.0')
+    expect(exitCode).toBe(0)
+
+    // dist produced with the proven externals strategy
+    const server = readFileSync(join(pluginDir, 'dist', 'index.js'), 'utf-8')
+    expect(server).not.toContain('from "@makinbakin/sdk"')
+    const client = readFileSync(join(pluginDir, 'dist', 'client.js'), 'utf-8')
+    expect(client).toContain('@makinbakin/sdk')
+
+    // artifact + sidecar checksum + carried-forward index
+    const artifact = join(outDir, 'pubdemo-0.2.0-neutral.tar.gz')
+    expect(existsSync(artifact)).toBe(true)
+    expect(existsSync(`${artifact}.sha256`)).toBe(true)
+    const index = JSON.parse(readFileSync(join(outDir, 'whiskit-artifacts.json'), 'utf-8')) as {
+      plugins?: Record<string, unknown>
+    }
+    expect(JSON.stringify(index)).toContain('pubdemo')
+  }, 120_000)
+
+  it('still refuses an unbuilt plugin without --build, pointing at the flag', () => {
+    const pluginDir = seedUnbuiltPlugin()
+    const outDir = freshDir('pub-out')
+    const { exitCode, output } = runPublish(pluginDir, outDir)
+    expect(exitCode).not.toBe(0)
+    expect(output).toContain('--build')
+    expect(existsSync(join(outDir, 'pubdemo-0.2.0-neutral.tar.gz'))).toBe(false)
+  }, 120_000)
+
+  it('fails with a stage-tagged error when the source does not compile', () => {
+    const pluginDir = seedUnbuiltPlugin()
+    writeFileSync(join(pluginDir, 'index.ts'), `import { nope } from './missing'\nexport default nope\n`)
+    const outDir = freshDir('pub-out')
+    const { exitCode, output } = runPublish(pluginDir, outDir, ['--build'])
+    expect(exitCode).not.toBe(0)
+    expect(output).toContain('Build failed')
+    expect(output).toContain('server-build')
+  }, 120_000)
+})


### PR DESCRIPTION
## Summary

Whiskit Phase 2 — one build code path that runs identically in CI, on dev machines, and under the compiled binary, then wired into `bakin plugins publish --build`.

### New backend (`src/core/whiskit/{types,command,build}.ts`)

- **`command.ts`** — hardened system-`bun` runner: argv-array spawn (no shell), env allowlist (plugin builds never see Bakin secrets), capped stdout/stderr capture, SIGKILL wall-clock timeout, stage-tagged `WhiskitBuildError`s with a bounded stderr tail.
- **`build.ts`** — `buildPluginWithSystemBun`: import-contract validation → `bun install --ignore-scripts` for declared deps → server build → client build, every compile step a system-bun subprocess so the identical path works from a compiled binary. Server builds inline the SDK via a **generated `Bun.build` script with an onResolve plugin** run under the system bun (the `bun build` CLI can't express resolver plugins) — reproducing the proven bits-official externals strategy exactly: client externalizes React+SDK, server externalizes React/router and inlines SDK + deps.
- **SDK source ladder** for server inlining: `BAKIN_SDK_PATH` → repo `packages/sdk/src` (source runs) → the plugin's own `node_modules/@makinbakin/sdk`; hard error with remedy otherwise.
- **Hot-reload speed guard** — `buildPluginInProcess` keeps the in-process `Bun.build()` fast path for source-run dev (no subprocess per save); `canBuildInProcess()` gates it.

### `buildUserPlugin` → thin adapter

Keeps caller policy (freshness skip, trusted prebuilt dist, provenance verification, startup spans — replayed from backend stage events with accurate durations). Trusted server dist + stale client now refreshes the client only (`serverBuild: false`) — consumer machines never need SDK sources for that path. **Behavior change per the plan:** dependency installs now run `--ignore-scripts` (elevated install-script path deferred to Phase 7).

### `bakin plugins publish --build`

Compiles from clean source (production client) before assembling; unbuilt-without-`--build` errors now point at the flag. The bits `publish.yml` can drop its separate `bun run build` step once this ships.

## Verification

- `bun test --isolate tests/core/whiskit tests/api/plugins-build.test.ts tests/scripts/dev-build-one-plugin.test.ts` — 88 pass
- `bun run test` — 4530 pass / 0 fail; `bun run typecheck` clean
- Functional: `bakin plugins publish <unbuiltDir> --build --out <tmp>` produces dist with the correct externals split + checksummed artifact + carried-forward `whiskit-artifacts.json` (verified manually and as a subprocess regression test)

Plan: `.claude/specs/whiskit-plugin-builder-plan.md` Phase 2. Follows #448 (P1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)