### PR TITLE
Cache asset manifests: stat-validated read cache + grid SSE debounce (#392)

### DIFF
--- a/.claude/knowledge/assets-versioning.md
+++ b/.claude/knowledge/assets-versioning.md
@@ -35,8 +35,11 @@ the `assetId`, never a filename.
 
 - `asset-id.ts` — generate/validate assetId, shard derivation.
 - `manifest.ts` — Zod `AssetManifest` schema + **atomic** read/write (temp+rename;
-  tolerant reads). The manifest is read on every serve AND is the search reindex
+  tolerant reads). The manifest backs every serve AND is the search reindex
   trigger, so torn writes must never be observable.
+- `manifest-cache.ts` — stat-validated read cache (see below). Read paths go
+  through `getManifestCached`; mutations and `.trash/` reads call `readManifest`
+  directly.
 - `asset-lock.ts` — per-`assetId` async mutex serializing all manifest mutations
   (guards the version-number race). Different assets stay concurrent.
 - `asset-service.ts` — `createAsset` / `addVersion` / `promoteVersion` /
@@ -46,6 +49,34 @@ the `assetId`, never a filename.
   mutate → atomic write.
 - `serve.ts` — `resolveAssetServe(segments)` for the HTTP serving route.
 - `search-doc.ts` — `versionedAssetPath` + `buildVersionedAssetSearchDoc`.
+
+## Manifest read cache (#392)
+
+`lib/manifest-cache.ts` — in-memory `assetId → manifest`, **validated against
+one `statSync` of `manifest.json` on every read** (token: `ino + size +
+mtimeMs`). Match → cached manifest; mismatch → re-parse + refill; stat failure
+→ evict + null. Because `writeManifestAtomic` is temp-file + rename, the inode
+changes on every write — the token discriminates even same-millisecond writes
+and restored timestamps. Drops list/serve parse cost from O(total assets) to
+O(changed) while reads stay ground-truth: **no invalidation wiring, no watcher
+dependency, no staleness by construction.** Contract details:
+
+- **Fill ordering is stat → read → cache (pre-read token).** A write landing
+  between stat and read costs one redundant re-parse later, never staleness.
+  Don't "optimize" this order.
+- **Mutations bypass the cache** (fresh `readManifest` under the asset lock) so
+  a stale entry can never be persisted back to disk. `.trash/` reads also
+  bypass (watcher-excluded, would never revalidate sensibly).
+- Positive-only (404 probes insert nothing), unbounded (~KB/manifest), lazy
+  fill. Cached manifests are **shared references, deep-frozen under
+  `NODE_ENV=test`** — a consumer mutating one throws in the suite.
+- `resolveFileFromManifest(manifest, version?)` resolves version files from an
+  already-loaded manifest; `serve.ts` uses it so one request = one stat, not
+  two parses. `resolveFile(assetId)` keeps the old signature on top of it.
+- **Caching rule of thumb (repo-wide):** stat-validate when an authoritative
+  file exists to validate against (this cache; adapter `sessionStoreCache`);
+  write-through + watcher backstop only for *derived* indexes with no backing
+  file (`task-asset-index`). Don't write-through what you can stat.
 
 ## Cross-plugin API (`ctx.assets`)
 
@@ -88,7 +119,9 @@ Version/thumb/export files never get their own row.
 
 Every mutation rewrites the manifest → the watcher emits `asset.changed`
 (`asset.removed` on delete) over `/api/events`. The grid + detail route refetch
-on these events.
+on these events. The grid coalesces event bursts through a 300ms trailing
+debounce (`components/versioned/sse-refetch.ts`): N rapid mutations → one list
+fetch per tab, removals fold a trash refetch into the same flush.
 
 ## Image tools (`plugins/images/lib/tools.ts`)
 

--- a/.claude/specs/asset-manifest-cache-plan.md
+++ b/.claude/specs/asset-manifest-cache-plan.md
@@ -1,0 +1,79 @@
+# Plan — Asset Manifest Cache (#392)
+
+Spec: `.claude/specs/asset-manifest-cache.md`. Branch: `perf/asset-manifest-cache` off `main`.
+
+## Dependency graph
+
+```
+T1 (RED tests) ──► T2 (cache module + read paths) ──► CHECKPOINT A ──► T4 (docs)
+                                                   └► T3 (grid debounce) ──► CHECKPOINT A
+CHECKPOINT A ──► T5 (manual gold-standard e2e) ──► T6 (PR)
+```
+
+T3 is independent of T1/T2 (client-only) but lands after so the e2e pass exercises both together. Vertical slices: T2 is one complete server path (cache → every read route → proof tests green); T3 one complete client path.
+
+## Tasks
+
+### T1 — RED parse-count + freshness specs — commit 1: `test(assets): parse-count + freshness specs for manifest cache (RED)`
+
+New `tests/plugins/assets/manifest-cache.test.ts` (standard temp-dir + dual content-dir mocks + logger/watcher mocks, `--isolate`), using `spyOn(fs, 'readFileSync')` op-counting (idiom: `tests/core/task-store-index.test.ts:155`). Specs encode spec criteria 1–5:
+
+1. Repeated `listAssets` over an unchanged store: manifest `readFileSync` count is N on first call, **0 on subsequent calls**
+2. Second `resolveAssetServe(['<id>','thumb'])` for same asset: **0 manifest reads** (also covers the double-read tidy: first call ≤1 read)
+3. Freshness via every mutation path: `addVersion`, `promoteVersion`, `relink`, `deleteAsset`, `restoreAsset` → immediate read reflects change
+4. External hand-rewrite of `manifest.json` (no watcher running) → immediate read reflects it
+5. Same-`mtimeMs` double-write (force with `utimesSync` after second write) → both observed (ino discriminates)
+6. Eviction: trashed/deleted asset reads null + no entry; unknown assetId inserts nothing
+7. Test-mode freeze: mutating a returned manifest throws
+
+**AC:** specs 1, 2, 5, 7 FAIL on current code (red); 3, 4, 6 pass (current behavior — they pin the no-regression contract). Committed with `it.todo`-free failing state? No — failing tests can't land green. **Resolution:** commit 1 contains the test file with the not-yet-passing specs marked `it.skip` + a `// RED: unskip in commit 2` marker; commit 2 unskips. Suite stays green at every checkpoint while preserving RED-first evidence in history.
+**Verify:** `bun test tests/plugins/assets/manifest-cache.test.ts --isolate` — skipped specs counted, others green; full suite untouched.
+
+### T2 — Cache module + read-path swap — commit 2: `perf(assets): mtime-validated manifest cache behind asset-service read paths`
+
+1. **`plugins/assets/lib/manifest-cache.ts`** (new, ~50 lines): `getManifestCached(assetId, assetDirAbs)` — `statSync` (try/catch; failure → evict, null) → token compare (`ino`,`size`,`mtimeMs`) → hit: return cached; miss: `readManifest`, fill positive-only **with pre-read token**, `NODE_ENV=test` → deep-`Object.freeze` before storing. `__resetManifestCache()` export. One-way import from `./manifest`.
+2. **`asset-service.ts` read paths:** `getAsset` delegates to `getManifestCached`; `listAssets` + `findBySourcePath` swap their inner `readManifest(join(monthDir, assetId))` for the cached get (dir walk unchanged). Mutations/trash/`listTrashedAssets` keep `readManifest` verbatim.
+3. **Serve double-read tidy:** extract internal `resolveFileFromManifest(manifest, assetId, version?)`; `resolveFile` (public signature unchanged — 3 external consumers) = `getAsset` + that helper; `serve.resolveAssetServe` calls the helper with the manifest it already holds.
+4. Unskip T1's RED specs.
+
+**AC:** all manifest-cache specs green; existing `asset-service.test.ts`, `serve.test.ts`, `versioned-routes.test.ts`, `versioned-exec-tools.test.ts`, `clipboard-purge.test.ts`, integration `assets-serve-route.test.ts` pass **unmodified** (zero-behavior-change proof); no new exports from asset-service; `manifest.ts`/`index.ts` diff-clean.
+**Verify:** `bun run test` full suite; `git diff --stat` confirms file scope matches spec's affected-files list.
+
+### CHECKPOINT A — after T2+T3: full suite + `bun run build` green; review diff against spec boundaries (anything touched outside the affected-files list = stop and reassess).
+
+### T3 — Grid SSE debounce — commit 3: `perf(assets): debounce VersionedAssetGrid SSE refetch`
+
+In `VersionedAssetGrid.tsx` SSE handler: single trailing ~300ms timer coalescing `asset.changed`→`fetchAssets` and `asset.removed`→`fetchAssets`+`fetchTrash` (removed events set a flag so the flush includes trash); timer ref cleared on unmount alongside `es.close()`. Direct-action fetches (upload/restore/trash ops) untouched. Component test (pattern: `asset-thumb.test.tsx`): burst of N synthetic SSE events within window → exactly 1 list fetch; unmount mid-window → no fetch, no act warnings.
+
+**AC:** new component test green; existing grid behavior tests pass.
+**Verify:** `bun test tests/plugins/assets/ --isolate`; manual spot-check deferred to T5.
+
+### T4 — Docs — commit 4: `docs(assets): assets-versioning knowledge update (cache contract + caching rule of thumb)`
+
+`.claude/knowledge/assets-versioning.md`: short "Manifest read cache" section — token validation contract, stat-before-read rule, what bypasses it, and the repo rule of thumb (*mtime-validate when an authoritative file exists; write-through only for derived indexes* — `sessionStoreCache` vs `task-asset-index`). Check `.claude/knowledge/plugin-system.md` + `search-system.md` for stale claims about per-read manifest parsing (line-level scan, expect no changes). README/CLAUDE.md: no impact (no commands/architecture surface changed) — confirm by scan.
+
+**AC:** knowledge doc reflects the shipped design; no doc claims contradict code.
+
+### T5 — Manual gold-standard e2e (dockerized rig + Playwright)
+
+`bun run instance dev` (disposable home). Script:
+1. Seed several versioned assets (upload via UI + `bun run mock:seed`-equivalent rig seeding as available)
+2. Grid load: thumbnails render, counts right
+3. Full lifecycle via UI: upload → add version → promote → delete version → trash asset → restore — each step's UI updates live (SSE), detail view correct
+4. Real-agent loop: dispatch a task instructing the agent to `bakin_exec_assets_save` the same evolving file several times quickly → grid shows coalesced refresh (not N stampedes), versions accumulate on ONE asset
+5. External-edit self-heal: hand-edit a manifest's description in the rig home → refetch/navigate shows new value (no restart, no watcher dependency)
+6. Server log: zero errors/warnings attributable to assets
+7. Light perf sanity: time `/api/plugins/assets/versioned` cold vs warm (expect warm ≤ cold; no regression)
+
+**AC:** all 7 pass, findings written into the PR body (the #452 verification-bar format).
+
+### T6 — PR
+
+`gh pr create` → main. Body: spec/plan links, per-commit map, verification evidence (suite, build, e2e transcript), **observed follow-up note:** `plugins/images/lib/tools.ts:6` imports `../../assets/lib/asset-service` directly (pre-existing hook-boundary violation — not fixed here; file an issue).
+
+## Risks & mitigations
+
+- **Freeze breaks a hidden mutator** → spec's "ask first" boundary; the full-suite run in T2 is the detector (freeze active under `NODE_ENV=test`).
+- **`statSync` ino semantics in test temp-dirs (tmpfs/docker)** — APFS + Docker linux fs both provide stable inos; spec 5's forced-mtime test proves the discriminator works on the actual fs.
+- **Existing tests that assert exact fs op counts on asset paths** (if any exist from #452) could see counts change → T2 AC requires existing tests pass *unmodified*; if one legitimately encodes the old double-read, updating it is allowed but must be called out in the commit body.
+```

--- a/.claude/specs/asset-manifest-cache.md
+++ b/.claude/specs/asset-manifest-cache.md
@@ -1,0 +1,93 @@
+# Asset Manifest Cache (#392) — mtime-validated MVP
+
+Closes [#392](https://github.com/markhayden/bakin/issues/392) — cache asset manifests to avoid O(N) re-parse on every list/serve request.
+
+## Objective
+
+Asset reads re-parse `manifest.json` (readFileSync + JSON.parse + Zod, ~100µs each, all synchronous) on every request. `listAssets()` parses **every** asset's manifest per call (grid list route, `bakin_exec_assets_list`, clipboard purge); `resolveAssetServe()` parses per byte/thumb/export request — twice, via `getAsset` + `resolveFile`; `findBySourcePath()` (every `bakin_exec_assets_save`) walks all manifests; the `assets.listByTask` hook (#452) calls `getAsset` per linked asset every dispatch cycle. The grid refetches the full list on every `asset.changed` SSE event with no debounce.
+
+Add a small **mtime-validated** in-memory cache so parse cost drops from O(total assets) to O(changed assets) per read, and debounce the grid's SSE refetch. Pure perf/tech-debt work: **zero observable behavior change** — reads always reflect disk.
+
+Single-user machine. No backwards compatibility, no shims, no config flags, no observability machinery.
+
+## Design — settled 2026-06-05 (interview + double-check)
+
+**Validation-token cache, not an invalidation cache.** Entries are `assetId → { token, manifest }` where `token = { ino, size, mtimeMs }` from one `statSync` of `manifest.json`. Every read stats the file: token match → return cached manifest; mismatch/stat-failure → re-parse/evict. Correctness is checked against disk at read time, **never maintained by discipline** — no write-through, no watcher wiring, no choke-point coupling, no trash/restore special-casing, no onSync ordering constraints. Mutations, `manifest.ts`, and `index.ts` need zero changes.
+
+### Why not the issue's proposed watcher-invalidated cache (considered alternatives)
+
+- **Write-through + watcher backstop** (issue text; #452's `task-asset-index` pattern): faster steady state (zero syscalls on hit) but creates a permanent invariant — every future manifest-writing/renaming path must remember the cache — plus a watcher-liveness dependency (missed event = stale forever, phantom assets) and a two-tier consistency model. `task-asset-index` *needs* write-through because a derived taskId→assetIds index has no file to validate against. Manifests do.
+- **Repo rule of thumb this establishes:** *mtime-validate when an authoritative file exists to stat (`sessionStoreCache` precedent); write-through only for derived indexes with no backing file (`task-asset-index`).* Goes in the knowledge doc.
+- Cost accepted: one ~10µs stat per asset per list call (vs ~100µs+ parse). At 1k assets: ~10ms vs ~150ms event-loop block. If ever insufficient (~10k assets), write-through can be added inside the module without touching callers.
+
+### Decisions
+
+| Decision | Choice |
+|---|---|
+| Validation token | `ino + size + mtimeMs` from one `statSync`. `writeManifestAtomic` is temp-file + rename, so **ino changes on every write** — immune to same-millisecond writes, restored old timestamps, delete-recreate. |
+| Fill ordering | **stat → read → cache with the pre-read token.** Token-at-or-before-content means the worst race outcome is one redundant re-parse, never staleness. Stat-after-read could mask an interleaved write. |
+| Stat failure | Evict entry, return null (covers trash, external delete; no dead-entry growth). |
+| Read coverage | All store reads route through the cached get-or-fill: `getAsset`, `listAssets`, `getAssetSummary`, `resolveFile`, `findBySourcePath`. `serve.resolveAssetServe` passes its manifest into the version-resolution step (kills the existing double read — 3-line tidy). |
+| Stays uncached | Mutations (read disk fresh under `withAssetLock` — unchanged code); `.trash/` reads; health-check/doctor reads (occasional, direct parse is correct there). |
+| Entry policy | Positive-only (never cache null — no growth from 404 URL probes), unbounded Map (~KB per manifest; an LRU smaller than the store would thrash under `listAssets`). |
+| Fill strategy | Lazy. First `listAssets` warms the store; no eager scan. |
+| Cached-object safety | Shared references. `Object.freeze` entries **in test mode only** (`NODE_ENV=test`) so any future consumer mutation throws in the suite instead of corrupting silently. No consumer mutates today (audited: routes serialize, images tools read-only). |
+| Concurrency | Get-or-fill is fully synchronous (no awaits inside) — no interleaving on Bun's single thread. Mutations stay behind the per-asset lock, untouched. |
+| Grid SSE refetch | ~300ms trailing debounce coalescing `asset.changed`/`asset.removed` bursts (shared timer also covering `fetchTrash`); timer cleaned up on unmount. Direct user actions (upload/restore) keep their immediate fetches. |
+| Multi-process consumers | `scripts/lib/post-channel.ts` et al. get a per-process cache validating against shared disk — always correct, no coordination. |
+| Test isolation | `__resetManifestCache()` test-only export (hygiene). mtime validation self-corrects across content-dir swaps (different path → different ino → refill), so **no audit of existing tests is required.** |
+
+## Module Contract — `plugins/assets/lib/manifest-cache.ts` (new, ~50 lines)
+
+```ts
+/** Stat-validated read: returns the cached manifest iff manifest.json's
+ *  ino+size+mtimeMs match; otherwise re-reads via readManifest, refills
+ *  (positive-only), and returns fresh. Stat failure evicts and returns null. */
+getManifestCached(assetId: string, assetDirAbs: string): AssetManifest | null
+
+/** @internal Test-only. */
+__resetManifestCache(): void
+```
+
+Imports `readManifest` + type from `./manifest` (one-way; manifest.ts never imports back). `asset-service.ts` read paths swap `readManifest(dir)` → `getManifestCached(assetId, dir)`; mutation paths keep `readManifest` as-is.
+
+## Affected Files
+
+- `plugins/assets/lib/manifest-cache.ts` — **new**
+- `plugins/assets/lib/asset-service.ts` — read paths only (`getAsset`, `listAssets`, `findBySourcePath`); mutations untouched
+- `plugins/assets/lib/serve.ts` — pass resolved manifest through to version resolution (remove double read)
+- `plugins/assets/components/versioned/VersionedAssetGrid.tsx` — debounced SSE refetch
+- `.claude/knowledge/assets-versioning.md` — cache contract + the mtime-vs-write-through rule of thumb
+- Tests: new `tests/plugins/assets/manifest-cache.test.ts`; targeted additions to `asset-service.test.ts` / `serve.test.ts` / grid test
+
+**Explicitly untouched:** `manifest.ts`, `plugins/assets/index.ts`, all mutation functions, trash/restore, health checks, legacy filename paths.
+
+## Acceptance Criteria
+
+1. **Parse-count proof (RED-first, fs-spy style like #452):** repeated `listAssets` calls re-parse nothing when manifests are unchanged (stats only); second serve resolve for the same asset performs zero manifest file reads.
+2. **Freshness without events:** mutate via any path (`addVersion`/`promote`/`relink`/`deleteAsset`/`restoreAsset`) → immediate read reflects it (token mismatch → re-parse). **External hand-rewrite of manifest.json → immediate read reflects it** — no watcher involvement anywhere.
+3. **Same-millisecond writes:** two `writeManifestAtomic` calls with identical mtimeMs (forced) are both observed (ino discriminates).
+4. **Eviction:** trashed/externally-deleted asset → read returns null, entry evicted; unknown assetIds insert nothing.
+5. **Test-mode freeze:** mutating a returned manifest throws under `NODE_ENV=test`.
+6. **Grid coalescing:** burst of SSE events within the window → exactly one list fetch; timer cleanup on unmount.
+7. Full suite green (`bun run test`), `bun run build` green.
+8. **Manual gold-standard e2e** (dockerized rig `bun run instance dev` + Playwright): grid load with thumbnails; upload → add-version → promote → trash → restore round-trip with live UI updates; real-agent `bakin_exec_assets_save` loop showing coalesced refresh; hand-edit a manifest in the rig home → next read/UI reflects it; zero errors in server log.
+
+## Testing Strategy
+
+Per CLAUDE.md rules: mock both content-dir resolvers + OpenClaw home into temp dirs, mock logger/watcher, `--isolate`, cleanup in `afterAll`. `__resetManifestCache()` in setups. Parse-count assertions via fs spies on `readFileSync` filtered to manifest paths (#452's op-count pattern). Grid debounce via the existing component-test pattern (`asset-thumb.test.tsx`).
+
+## Commit Strategy (natural rollback checkpoints)
+
+Dependency-ordered; each commit leaves the suite green and is independently revertible:
+
+1. `test(assets): parse-count + freshness specs for manifest cache (RED)` — failing specs encoding criteria 1–4 against current behavior
+2. `perf(assets): mtime-validated manifest cache behind asset-service read paths` — module + read-path swap + serve double-read tidy; turns commit 1 green. Reverting restores plain disk reads with no residue.
+3. `perf(assets): debounce VersionedAssetGrid SSE refetch` — client-side, fully independent
+4. `docs(assets): assets-versioning knowledge update (cache contract + caching rule of thumb)`
+
+## Boundaries
+
+- **Always:** stat-before-read fill ordering; positive-only entries; mutations read disk fresh.
+- **Never:** cache `.trash/` reads; watcher/event wiring for the cache; stat-tracking machinery; touching `manifest.ts`/`index.ts`/mutation paths; fixing the `plugins/images` → `assets/lib` direct-import boundary violation here (pre-existing — file as observed follow-up in the PR, like #452's `.meta.json` note).
+- **Ask first:** if implementation reveals a consumer mutating a cached manifest (would force clone-on-read), or if the serve tidy turns out to require reshaping `resolveFile`'s public signature beyond an optional parameter.

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -8,6 +8,7 @@ import { PluginHeader, FacetFilter } from '@makinbakin/sdk/components'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
 import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter } from 'lucide-react'
 import { ASSET_TYPES } from '../../lib/constants'
+import { createSseRefetchScheduler } from './sse-refetch'
 import { AssetThumb, AssetMetaSummary, AssetTypeIcon } from './atoms'
 import { VERSIONED_API, UPLOAD_API, TRASH_API } from './asset-urls'
 import type { VersionedAssetSummary, TrashedAssetSummary } from './types'
@@ -166,15 +167,19 @@ export function VersionedAssetGrid() {
 
   useEffect(() => {
     const es = new EventSource('/api/events')
+    // Coalesce event bursts (agent edit loops) into one refetch per window —
+    // direct user actions (upload/restore/trash ops) keep their immediate
+    // fetches elsewhere in this component.
+    const refetch = createSseRefetchScheduler(fetchAssets, fetchTrash)
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data)
         if (data.type !== 'plugin-event') return
-        if (data.event === 'asset.changed') fetchAssets()
-        else if (data.event === 'asset.removed') { fetchAssets(); fetchTrash() }
+        if (data.event === 'asset.changed') refetch.schedule(false)
+        else if (data.event === 'asset.removed') refetch.schedule(true)
       } catch { /* ignore non-JSON */ }
     }
-    return () => es.close()
+    return () => { refetch.cancel(); es.close() }
   }, [fetchAssets, fetchTrash])
 
   // ─── Upload ──────────────────────────────────────────────────────────

--- a/plugins/assets/components/versioned/sse-refetch.ts
+++ b/plugins/assets/components/versioned/sse-refetch.ts
@@ -1,0 +1,45 @@
+/**
+ * Trailing-debounce scheduler for SSE-driven grid refetches (#392).
+ *
+ * An agent mutating assets in a loop fires one `asset.changed` per write;
+ * without coalescing every connected tab refetches the full list per event.
+ * A burst of schedule() calls inside the window collapses to ONE flush after
+ * the burst settles. `asset.removed` events flag the trash list into the same
+ * flush. cancel() (unmount) drops any pending flush.
+ */
+export const SSE_REFETCH_DEBOUNCE_MS = 300
+
+export interface SseRefetchScheduler {
+  /** Coalesce a refetch; `withTrash` folds a trash refetch into the flush. */
+  schedule: (withTrash: boolean) => void
+  /** Drop any pending flush (component unmount). */
+  cancel: () => void
+}
+
+export function createSseRefetchScheduler(
+  fetchAssets: () => void,
+  fetchTrash: () => void,
+  debounceMs: number = SSE_REFETCH_DEBOUNCE_MS,
+): SseRefetchScheduler {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let includeTrash = false
+
+  return {
+    schedule(withTrash: boolean) {
+      includeTrash ||= withTrash
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        const withTrashNow = includeTrash
+        includeTrash = false
+        fetchAssets()
+        if (withTrashNow) fetchTrash()
+      }, debounceMs)
+    },
+    cancel() {
+      if (timer) clearTimeout(timer)
+      timer = null
+      includeTrash = false
+    },
+  }
+}

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -19,6 +19,7 @@ import { createLogger } from '../../../src/core/logger'
 import { getMimeType, type AssetType } from './constants'
 import { generateAssetId, assetDirRelPath, yearMonthFromAssetId } from './asset-id'
 import { withAssetLock } from './asset-lock'
+import { getManifestCached } from './manifest-cache'
 import { taskAssetIndexRemove, taskAssetIndexUpsert } from './task-asset-index'
 import {
   readManifest,
@@ -203,22 +204,20 @@ export async function createAsset(input: AssetCreateInput): Promise<{ assetId: s
   return { assetId, version: 1, manifest }
 }
 
-/** Read an asset's manifest, or null if missing/invalid. */
+/** Read an asset's manifest (stat-validated cache), or null if missing/invalid. */
 export function getAsset(assetId: string): AssetManifest | null {
   const rel = assetDirRelPath(assetId)
   if (!rel) return null
-  return readManifest(join(getContentDir(), rel))
+  return getManifestCached(assetId, join(getContentDir(), rel))
 }
 
 export function assetExists(assetId: string): boolean {
   return getAsset(assetId) !== null
 }
 
-/** Resolve an asset version (current by default) to an on-disk file reference. */
-export function resolveFile(assetId: string, version?: number): AssetFileRef | null {
-  const manifest = getAsset(assetId)
-  if (!manifest) return null
-  const rel = assetDirRelPath(assetId)
+/** Resolve a version from an already-loaded manifest (no further manifest reads). */
+export function resolveFileFromManifest(manifest: AssetManifest, version?: number): AssetFileRef | null {
+  const rel = assetDirRelPath(manifest.assetId)
   if (!rel) return null
   const target = version ?? manifest.currentVersion
   const ver = manifest.versions.find((v) => v.version === target)
@@ -229,6 +228,12 @@ export function resolveFile(assetId: string, version?: number): AssetFileRef | n
     size: ver.size,
     version: target,
   }
+}
+
+/** Resolve an asset version (current by default) to an on-disk file reference. */
+export function resolveFile(assetId: string, version?: number): AssetFileRef | null {
+  const manifest = getAsset(assetId)
+  return manifest ? resolveFileFromManifest(manifest, version) : null
 }
 
 function toSummary(manifest: AssetManifest): AssetSummary {
@@ -275,7 +280,7 @@ export function listAssets(filter?: { type?: AssetType; taskId?: string | null }
     }
     for (const assetId of entries) {
       if (!yearMonthFromAssetId(assetId)) continue // skip non-asset dirs/files
-      const manifest = readManifest(join(monthDir, assetId))
+      const manifest = getManifestCached(assetId, join(monthDir, assetId))
       if (!manifest) continue
       if (filter?.type && manifest.type !== filter.type) continue
       if (filter?.taskId !== undefined && manifest.taskId !== filter.taskId) continue
@@ -620,7 +625,7 @@ export function findBySourcePath(sourcePath: string): string | null {
     }
     for (const assetId of entries) {
       if (!yearMonthFromAssetId(assetId)) continue
-      const manifest = readManifest(join(monthDir, assetId))
+      const manifest = getManifestCached(assetId, join(monthDir, assetId))
       if (manifest?.source?.path === sourcePath) return assetId
     }
   }

--- a/plugins/assets/lib/manifest-cache.ts
+++ b/plugins/assets/lib/manifest-cache.ts
@@ -1,0 +1,16 @@
+/**
+ * Manifest read cache (#392) — stub.
+ *
+ * Pass-through placeholder so the RED specs in
+ * tests/plugins/assets/manifest-cache.test.ts can land first; the
+ * mtime-validated implementation replaces this in the next commit.
+ */
+import { readManifest, type AssetManifest } from './manifest'
+
+/** Read an asset's manifest (uncached stub). */
+export function getManifestCached(_assetId: string, assetDirAbs: string): AssetManifest | null {
+  return readManifest(assetDirAbs)
+}
+
+/** @internal Test-only. */
+export function __resetManifestCache(): void {}

--- a/plugins/assets/lib/manifest-cache.ts
+++ b/plugins/assets/lib/manifest-cache.ts
@@ -1,16 +1,77 @@
 /**
- * Manifest read cache (#392) — stub.
+ * Manifest read cache (#392) — stat-validated, never stale by construction.
  *
- * Pass-through placeholder so the RED specs in
- * tests/plugins/assets/manifest-cache.test.ts can land first; the
- * mtime-validated implementation replaces this in the next commit.
+ * Entries are validated against one statSync of manifest.json on EVERY read:
+ * token match (ino + size + mtimeMs) → cached manifest; mismatch → re-parse
+ * and refill; stat failure → evict and return null. `writeManifestAtomic` is
+ * temp-file + rename, so the inode changes on every write — the token
+ * discriminates even same-millisecond writes, restored old timestamps, and
+ * delete-recreate. No invalidation wiring exists or is needed: correctness is
+ * checked against disk at read time, never maintained by discipline. Mutations
+ * and `.trash/` reads bypass this module entirely (see asset-service).
+ *
+ * Token is captured BEFORE the read (stat → read → fill): a write landing
+ * between the two leaves an old token on new content, costing one redundant
+ * re-parse on the next read — never staleness. Entries are positive-only
+ * (misses are not cached, so 404 probes insert nothing) and unbounded
+ * (~KB per manifest; an LRU smaller than the store would thrash under
+ * listAssets). Cached manifests are shared references — frozen under test so
+ * any future consumer mutation throws in the suite instead of silently
+ * corrupting reads in production.
  */
-import { readManifest, type AssetManifest } from './manifest'
+import { statSync } from 'node:fs'
+import { join } from 'node:path'
+import { readManifest, MANIFEST_FILENAME, type AssetManifest } from './manifest'
 
-/** Read an asset's manifest (uncached stub). */
-export function getManifestCached(_assetId: string, assetDirAbs: string): AssetManifest | null {
-  return readManifest(assetDirAbs)
+interface CacheEntry {
+  ino: number
+  size: number
+  mtimeMs: number
+  manifest: AssetManifest
 }
 
-/** @internal Test-only. */
-export function __resetManifestCache(): void {}
+const cache = new Map<string, CacheEntry>()
+
+// Matches the logger's test detection: bun test sets NODE_ENV=test.
+const FREEZE = process.env.NODE_ENV === 'test' || process.env.VITEST !== undefined
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object') {
+    for (const key of Object.keys(value)) deepFreeze((value as Record<string, unknown>)[key])
+    Object.freeze(value)
+  }
+  return value
+}
+
+/**
+ * Stat-validated read of an asset's manifest: cached when the on-disk token
+ * matches, freshly parsed otherwise, null (and evicted) when missing/invalid.
+ */
+export function getManifestCached(assetId: string, assetDirAbs: string): AssetManifest | null {
+  let st: { ino: number; size: number; mtimeMs: number }
+  try {
+    st = statSync(join(assetDirAbs, MANIFEST_FILENAME))
+  } catch {
+    cache.delete(assetId)
+    return null
+  }
+
+  const hit = cache.get(assetId)
+  if (hit && hit.ino === st.ino && hit.size === st.size && hit.mtimeMs === st.mtimeMs) {
+    return hit.manifest
+  }
+
+  const manifest = readManifest(assetDirAbs)
+  if (!manifest) {
+    cache.delete(assetId)
+    return null
+  }
+  if (FREEZE) deepFreeze(manifest)
+  cache.set(assetId, { ino: st.ino, size: st.size, mtimeMs: st.mtimeMs, manifest })
+  return manifest
+}
+
+/** @internal Test-only: drop all entries. */
+export function __resetManifestCache(): void {
+  cache.clear()
+}

--- a/plugins/assets/lib/serve.ts
+++ b/plugins/assets/lib/serve.ts
@@ -16,7 +16,7 @@ import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import { getContentDir } from '../../../src/core/content-dir'
 import { isValidAssetId, assetDirRelPath } from './asset-id'
-import { getAsset, resolveFile } from './asset-service'
+import { getAsset, resolveFileFromManifest } from './asset-service'
 import type { AssetManifest } from './manifest'
 
 export type AssetServeResult =
@@ -51,7 +51,7 @@ export function resolveAssetServe(segments: string[]): AssetServeResult {
 
   // [assetId] → current
   if (rest.length === 0) {
-    const ref = resolveFile(assetId)
+    const ref = resolveFileFromManifest(manifest)
     if (!ref) return notFound()
     return { match: true, found: true, absPath: ref.absPath, mimeType: ref.mimeType, cacheKey: `${assetId}:v${ref.version}` }
   }
@@ -66,7 +66,7 @@ export function resolveAssetServe(segments: string[]): AssetServeResult {
     const n = Number(rest[1])
     if (!Number.isInteger(n) || n < 1) return notFound()
     if (rest.length === 2) {
-      const ref = resolveFile(assetId, n)
+      const ref = resolveFileFromManifest(manifest, n)
       if (!ref) return notFound()
       return { match: true, found: true, absPath: ref.absPath, mimeType: ref.mimeType, cacheKey: `${assetId}:v${n}` }
     }

--- a/tests/plugins/assets/manifest-cache.test.ts
+++ b/tests/plugins/assets/manifest-cache.test.ts
@@ -50,7 +50,7 @@ import { resolveAssetServe } from '../../../plugins/assets/lib/serve'
 const srcDir = join(testDir, 'src')
 
 /** Count readFileSync calls that target a manifest.json. */
-function manifestReads(spy: ReturnType<typeof spyOn>): number {
+function manifestReads(spy: { mock: { calls: unknown[][] } }): number {
   return spy.mock.calls.filter((c) => String(c[0]).endsWith('manifest.json')).length
 }
 

--- a/tests/plugins/assets/manifest-cache.test.ts
+++ b/tests/plugins/assets/manifest-cache.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Manifest read cache (#392): parse-count proofs, freshness without watcher
+ * events, the ino discriminator for same-mtime writes, eviction, and the
+ * test-mode freeze. Isolated to a temp BAKIN_HOME so it never touches ~/.bakin.
+ *
+ * RED-first: specs marked `it.skip` encode the cached behavior and fail on
+ * pre-cache code — they are unskipped in the commit that lands the cache.
+ * Unskipped specs pin current behavior the cache must not regress.
+ */
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdirSync, writeFileSync, rmSync, statSync, utimesSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+
+const testDir = join(tmpdir(), `bakin-manifest-cache-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, spyOn, mock } from 'bun:test'
+import * as fs from 'node:fs'
+
+// Belt-and-braces isolation per CLAUDE.md: env vars above cover module-load
+// reads; these mocks pin every content-dir resolution to the temp dir.
+const bakinPaths = () => {
+  const assets = join(testDir, 'assets')
+  return {
+    home: testDir, memoryLog: join(testDir, 'MEMORY-LOG.md'), audit: join(testDir, 'audit.jsonl'),
+    assets, 'assets.store': join(assets, 'store'), 'assets.inbox': join(assets, 'inbox'), 'assets.trash': join(assets, '.trash'),
+    agents: join(testDir, 'agents'), personas: join(testDir, 'team', 'personas'), team: join(testDir, 'team'),
+    heartbeats: join(testDir, 'heartbeats'), inbox: join(testDir, 'inbox'), tasks: join(testDir, 'tasks'),
+    workflows: join(testDir, 'workflows'), settings: join(testDir, 'settings.json'), logs: join(testDir, 'logs'),
+  }
+}
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: bakinPaths }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: () => testDir, getBakinPaths: bakinPaths }))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+import { assetDirRelPath } from '../../../plugins/assets/lib/asset-id'
+import { writeManifestAtomic, type AssetManifest } from '../../../plugins/assets/lib/manifest'
+import { __resetManifestCache } from '../../../plugins/assets/lib/manifest-cache'
+import {
+  createAsset, getAsset, listAssets, addVersion, promoteVersion, relink,
+  deleteAsset, restoreAsset, findBySourcePath,
+} from '../../../plugins/assets/lib/asset-service'
+import { resolveAssetServe } from '../../../plugins/assets/lib/serve'
+
+const srcDir = join(testDir, 'src')
+
+/** Count readFileSync calls that target a manifest.json. */
+function manifestReads(spy: ReturnType<typeof spyOn>): number {
+  return spy.mock.calls.filter((c) => String(c[0]).endsWith('manifest.json')).length
+}
+
+function makeSource(name: string, content: string): string {
+  const p = join(srcDir, name)
+  writeFileSync(p, content, 'utf-8')
+  return p
+}
+
+async function makeAsset(name: string, content: string, taskId: string | null = null): Promise<string> {
+  const { assetId } = await createAsset({
+    sourceFilePath: makeSource(name, content), type: 'text', agent: 'tester', taskId,
+  })
+  return assetId
+}
+
+beforeAll(() => mkdirSync(srcDir, { recursive: true }))
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+beforeEach(() => __resetManifestCache())
+
+describe('parse counts (cache hits read zero manifests)', () => {
+  // RED: unskip in the commit that lands the cache (#392)
+  it.skip('listAssets parses each manifest once, then zero on unchanged repeat calls', async () => {
+    const ids = [await makeAsset('a.md', 'a'), await makeAsset('b.md', 'b'), await makeAsset('c.md', 'c')]
+    __resetManifestCache()
+
+    const spy = spyOn(fs, 'readFileSync')
+    spy.mockClear()
+    const first = listAssets()
+    expect(first.map((s) => s.assetId).sort()).toEqual([...ids].sort())
+    expect(manifestReads(spy)).toBe(ids.length)
+
+    spy.mockClear()
+    const second = listAssets()
+    expect(second).toEqual(first)
+    expect(manifestReads(spy)).toBe(0)
+    spy.mockRestore()
+  })
+
+  // RED: unskip in the commit that lands the cache (#392)
+  it.skip('serve resolves with at most one parse cold and zero warm', async () => {
+    const id = await makeAsset('serve.md', 'serve me')
+    __resetManifestCache()
+
+    const spy = spyOn(fs, 'readFileSync')
+    spy.mockClear()
+    const cold = resolveAssetServe([id])
+    expect(cold).toMatchObject({ match: true, found: true })
+    expect(manifestReads(spy)).toBeLessThanOrEqual(1)
+
+    spy.mockClear()
+    const warm = resolveAssetServe([id])
+    expect(warm).toEqual(cold)
+    expect(manifestReads(spy)).toBe(0)
+    spy.mockRestore()
+  })
+
+  // RED: unskip in the commit that lands the cache (#392)
+  it.skip('findBySourcePath parses nothing on a warm cache', async () => {
+    const src = makeSource('find-me.md', 'find')
+    const { assetId } = await createAsset({ sourceFilePath: src, type: 'text', agent: 'tester', taskId: null })
+    __resetManifestCache()
+    listAssets() // warm
+
+    const spy = spyOn(fs, 'readFileSync')
+    spy.mockClear()
+    expect(findBySourcePath(src)).toBeNull() // created via upload source (path null)
+    expect(getAsset(assetId)?.assetId).toBe(assetId)
+    expect(manifestReads(spy)).toBe(0)
+    spy.mockRestore()
+  })
+})
+
+describe('freshness without watcher events', () => {
+  it('every mutation path is immediately visible through reads', async () => {
+    const id = await makeAsset('mut.md', 'v1 content', 'task-1')
+    listAssets() // warm cache
+
+    await addVersion(id, { sourceFilePath: makeSource('mut-v2.md', 'v2 content') })
+    expect(getAsset(id)?.versions.length).toBe(2)
+    expect(getAsset(id)?.currentVersion).toBe(2)
+
+    await promoteVersion(id, 1)
+    expect(getAsset(id)?.currentVersion).toBe(1)
+    expect(listAssets().find((s) => s.assetId === id)?.currentVersion).toBe(1)
+
+    await relink(id, 'task-2')
+    expect(getAsset(id)?.taskId).toBe('task-2')
+
+    const { trashName } = await deleteAsset(id)
+    expect(getAsset(id)).toBeNull()
+    expect(listAssets().some((s) => s.assetId === id)).toBe(false)
+
+    await restoreAsset(trashName)
+    expect(getAsset(id)?.taskId).toBe('task-2')
+    expect(listAssets().some((s) => s.assetId === id)).toBe(true)
+  })
+
+  it('an external manifest rewrite is immediately visible (no watcher running)', async () => {
+    const id = await makeAsset('ext.md', 'original')
+    const manifest = getAsset(id)! // warm the cache with the original
+    const dirAbs = join(testDir, assetDirRelPath(id)!)
+
+    const edited: AssetManifest = JSON.parse(JSON.stringify(manifest))
+    edited.description = 'hand-edited externally'
+    writeManifestAtomic(dirAbs, edited)
+
+    expect(getAsset(id)?.description).toBe('hand-edited externally')
+  })
+
+  it('observes a second write even when forced to the identical mtime (ino discriminates)', async () => {
+    const id = await makeAsset('mtime.md', 'first')
+    const dirAbs = join(testDir, assetDirRelPath(id)!)
+    const manifestPath = join(dirAbs, 'manifest.json')
+
+    const before = getAsset(id)! // fill cache
+    const st = statSync(manifestPath)
+
+    const edited: AssetManifest = JSON.parse(JSON.stringify(before))
+    edited.description = 'second write, same mtime'
+    writeManifestAtomic(dirAbs, edited)
+    // Force the new file back to the exact pre-write timestamps: only the
+    // inode (fresh temp file per atomic write) can tell the versions apart.
+    utimesSync(manifestPath, st.atime, st.mtime)
+
+    expect(getAsset(id)?.description).toBe('second write, same mtime')
+  })
+})
+
+describe('eviction + negative reads', () => {
+  it('never caches a negative: a miss followed by creation is immediately visible', async () => {
+    const ghostId = '20260101-ghost-aabbccdd'
+    expect(getAsset(ghostId)).toBeNull()
+    expect(getAsset(ghostId)).toBeNull() // repeat miss, still null, no crash
+
+    // Materialize the exact id that just missed; it must appear immediately.
+    const dirAbs = join(testDir, assetDirRelPath(ghostId)!)
+    mkdirSync(dirAbs, { recursive: true })
+    const manifest: AssetManifest = {
+      assetId: ghostId, type: 'text', source: { kind: 'upload', path: null },
+      agent: 'tester', taskId: null, created: 'c', updated: 'c', currentVersion: 1,
+      description: 'now real', tags: [],
+      versions: [{ version: 1, file: 'v1.md', thumb: null, mimeType: 'text/markdown', size: 1, width: null, height: null, created: 'c', description: 'now real', tags: [], op: 'upload', parentVersion: null, tool: null, prompt: null, promptHash: null, generation: null }],
+      exports: [],
+    }
+    writeFileSync(join(dirAbs, 'v1.md'), 'x', 'utf-8')
+    writeManifestAtomic(dirAbs, manifest)
+
+    expect(getAsset(ghostId)?.description).toBe('now real')
+  })
+
+  it('a trashed asset reads null immediately (entry evicted, not stale)', async () => {
+    const id = await makeAsset('evict.md', 'soon gone')
+    getAsset(id) // warm
+    await deleteAsset(id)
+    expect(getAsset(id)).toBeNull()
+    expect(resolveAssetServe([id])).toMatchObject({ match: true, found: false })
+  })
+})
+
+describe('test-mode freeze', () => {
+  // RED: unskip in the commit that lands the cache (#392)
+  it.skip('cached manifests are frozen under NODE_ENV=test — consumer mutation throws', async () => {
+    const id = await makeAsset('frozen.md', 'do not touch')
+    const manifest = getAsset(id)!
+    expect(() => { (manifest as AssetManifest).description = 'mutated' }).toThrow()
+    expect(() => { (manifest as AssetManifest).versions[0].tags.push('nope') }).toThrow()
+    expect(getAsset(id)?.description).toBe('do not touch')
+  })
+})

--- a/tests/plugins/assets/manifest-cache.test.ts
+++ b/tests/plugins/assets/manifest-cache.test.ts
@@ -72,8 +72,7 @@ afterAll(() => rmSync(testDir, { recursive: true, force: true }))
 beforeEach(() => __resetManifestCache())
 
 describe('parse counts (cache hits read zero manifests)', () => {
-  // RED: unskip in the commit that lands the cache (#392)
-  it.skip('listAssets parses each manifest once, then zero on unchanged repeat calls', async () => {
+  it('listAssets parses each manifest once, then zero on unchanged repeat calls', async () => {
     const ids = [await makeAsset('a.md', 'a'), await makeAsset('b.md', 'b'), await makeAsset('c.md', 'c')]
     __resetManifestCache()
 
@@ -90,8 +89,7 @@ describe('parse counts (cache hits read zero manifests)', () => {
     spy.mockRestore()
   })
 
-  // RED: unskip in the commit that lands the cache (#392)
-  it.skip('serve resolves with at most one parse cold and zero warm', async () => {
+  it('serve resolves with at most one parse cold and zero warm', async () => {
     const id = await makeAsset('serve.md', 'serve me')
     __resetManifestCache()
 
@@ -108,8 +106,7 @@ describe('parse counts (cache hits read zero manifests)', () => {
     spy.mockRestore()
   })
 
-  // RED: unskip in the commit that lands the cache (#392)
-  it.skip('findBySourcePath parses nothing on a warm cache', async () => {
+  it('findBySourcePath parses nothing on a warm cache', async () => {
     const src = makeSource('find-me.md', 'find')
     const { assetId } = await createAsset({ sourceFilePath: src, type: 'text', agent: 'tester', taskId: null })
     __resetManifestCache()
@@ -212,9 +209,11 @@ describe('eviction + negative reads', () => {
 })
 
 describe('test-mode freeze', () => {
-  // RED: unskip in the commit that lands the cache (#392)
-  it.skip('cached manifests are frozen under NODE_ENV=test — consumer mutation throws', async () => {
-    const id = await makeAsset('frozen.md', 'do not touch')
+  it('cached manifests are frozen under NODE_ENV=test — consumer mutation throws', async () => {
+    const { assetId: id } = await createAsset({
+      sourceFilePath: makeSource('frozen.md', 'content'), type: 'text', agent: 'tester',
+      taskId: null, description: 'do not touch',
+    })
     const manifest = getAsset(id)!
     expect(() => { (manifest as AssetManifest).description = 'mutated' }).toThrow()
     expect(() => { (manifest as AssetManifest).versions[0].tags.push('nope') }).toThrow()

--- a/tests/plugins/assets/sse-refetch.test.ts
+++ b/tests/plugins/assets/sse-refetch.test.ts
@@ -1,0 +1,62 @@
+/**
+ * SSE refetch coalescing (#392): a burst of asset.changed/asset.removed
+ * events inside the debounce window flushes exactly one list fetch (plus one
+ * trash fetch iff any event in the burst was a removal); cancel() drops a
+ * pending flush. Pure timer logic — no DOM, no EventSource.
+ */
+import { describe, it, expect, mock } from 'bun:test'
+
+// The scheduler is a pure timer helper with an empty import graph, but every
+// tests/plugins/** file pins the content-dir resolvers per CLAUDE.md so a
+// future import can't silently reach ~/.bakin.
+const noDir = () => { throw new Error('sse-refetch test must not touch the content dir') }
+mock.module('../../../src/core/content-dir', () => ({ getContentDir: noDir, getBakinPaths: noDir }))
+mock.module('../../../packages/core/src/content-dir', () => ({ getContentDir: noDir, getBakinPaths: noDir }))
+
+import { createSseRefetchScheduler } from '../../../plugins/assets/components/versioned/sse-refetch'
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+const WINDOW = 20
+
+function harness() {
+  let assets = 0
+  let trash = 0
+  const s = createSseRefetchScheduler(() => { assets++ }, () => { trash++ }, WINDOW)
+  return { s, counts: () => ({ assets, trash }) }
+}
+
+describe('createSseRefetchScheduler', () => {
+  it('coalesces a burst into exactly one assets fetch', async () => {
+    const { s, counts } = harness()
+    for (let i = 0; i < 10; i++) s.schedule(false)
+    expect(counts()).toEqual({ assets: 0, trash: 0 }) // trailing: nothing yet
+    await delay(WINDOW * 3)
+    expect(counts()).toEqual({ assets: 1, trash: 0 })
+  })
+
+  it('folds a removal anywhere in the burst into one trash fetch', async () => {
+    const { s, counts } = harness()
+    s.schedule(false)
+    s.schedule(true) // removal mid-burst
+    s.schedule(false) // trailing change must not drop the trash flag
+    await delay(WINDOW * 3)
+    expect(counts()).toEqual({ assets: 1, trash: 1 })
+  })
+
+  it('separate bursts flush separately, trash flag resets between them', async () => {
+    const { s, counts } = harness()
+    s.schedule(true)
+    await delay(WINDOW * 3)
+    s.schedule(false)
+    await delay(WINDOW * 3)
+    expect(counts()).toEqual({ assets: 2, trash: 1 })
+  })
+
+  it('cancel() drops the pending flush (unmount mid-window)', async () => {
+    const { s, counts } = harness()
+    s.schedule(true)
+    s.cancel()
+    await delay(WINDOW * 3)
+    expect(counts()).toEqual({ assets: 0, trash: 0 })
+  })
+})


### PR DESCRIPTION
Closes #392.

Spec: `.claude/specs/asset-manifest-cache.md` · Plan: `.claude/specs/asset-manifest-cache-plan.md`

## Design — deliberate deviation from the issue text

The issue proposed a watcher-invalidated cache. We shipped a **stat-validated** one instead (settled in spec interview): entries are `assetId → manifest` validated against one `statSync` of `manifest.json` on every read (token: `ino + size + mtimeMs` — the atomic temp+rename write means a fresh inode per write, so even same-millisecond writes are discriminated). Reads stay ground-truth from disk with **zero invalidation wiring, no watcher dependency, and no staleness by construction** — no standing invariant for future manifest-writing code to remember. `manifest.ts`, `index.ts`, all mutation paths, and trash/restore are untouched.

Rule of thumb this establishes (now in `.claude/knowledge/assets-versioning.md`): *stat-validate when an authoritative file exists to validate against (this cache, adapter `sessionStoreCache`); write-through + watcher backstop only for derived indexes with no backing file (`task-asset-index`, #452).*

## Commits (each independently revertible)

1. `test(assets)` — RED parse-count + freshness specs (fs-spy op-counting; failing specs verified red against a pass-through stub, skip-marked to keep the suite green)
2. `perf(assets)` — the cache + read-path swap (`getAsset`/`listAssets`/`findBySourcePath`) + `resolveFileFromManifest` (kills serve's double parse; `resolveFile` signature unchanged); unskips the RED specs
3. `perf(assets)` — grid SSE refetch debounce (300ms trailing, removals fold a trash refetch into the flush, cancel on unmount; scheduler extracted + unit-tested)
4. `docs(assets)` — knowledge update

Cache properties: positive-only (404 probes insert nothing), unbounded (~KB/manifest), lazy fill, stat→read→fill ordering (a racing write costs one redundant re-parse, never staleness), entries deep-frozen under `NODE_ENV=test` so any consumer mutation throws in the suite.

## Verification

- Full suite **4596 pass / 0 fail** (446 files); existing asset tests pass **unmodified** with the freeze active (zero-behavior-change proof). `bun run build` green (all three binaries).
- **Manual gold-standard e2e** against the live dev instance on this machine (real `~/.bakin`; the dockerized rig was the planned venue but Docker isn't installed here — and the rig couldn't have run the agent save-loop anyway per its documented container-path gap):
  - Grid + thumbnails render through the cache; warm list reads ~0.6–1.0ms, thumb serves ~0.5–0.7ms
  - Full lifecycle via UI/API: upload → add v2 → promote v1 → trash → restore — every step immediately visible on the next read, restore preserved versions + pointer; live grid updates over SSE without reload
  - **Coalescing:** 10 mutations fired in 98ms → exactly **1** SSE-driven list refetch in the browser network log (was 1:1 per event before)
  - **Self-heal:** hand-edited a manifest on disk (in-place rewrite — same inode; size/mtime caught it) → immediately visible on the next API read and in the UI
  - Zero browser console errors; zero attributable server-log errors (pre-existing Antfly `file:// S3 credential` warnings date to May 18)

## Observed while in there (not touched — follow-ups)

- `plugins/images/lib/tools.ts:6` imports `../../assets/lib/asset-service` directly — pre-existing violation of the hooks-only cross-plugin rule. Harmless today (single server module graph via `plugin-static-imports.ts`) but worth an issue.
- Dev-rig note: a restarted dev server can race the dying Antfly child of its predecessor ("Antfly already running" → skips spawn → search dead until next restart). Hit during e2e setup; second clean restart resolved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)