### PR TITLE
Fix deterministic Discord digest delivery

### DIFF
--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -548,8 +548,8 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       for (const channel of args.channels) {
         const ref = splitChannelRef(channel, args.message.metadata)
         const files = metadataFiles(args.message.metadata)
-        await this.exec(openClawMessageSendArgs(ref, args.message, files))
-        deliveries.push({ channelId: channel, ref: `message:${Date.now()}`, renderedAt })
+        const stdout = await this.exec(openClawMessageSendArgs(ref, args.message, files))
+        deliveries.push({ channelId: channel, ref: deliveryRefFromOpenClawOutput(stdout) ?? `message:${Date.now()}`, renderedAt })
       }
       return { deliveries }
     },
@@ -1649,7 +1649,51 @@ function openClawMessageSendArgs(
   if (body) args.push('--message', body)
   if (message.threadId) args.push('--thread-id', message.threadId)
   for (const file of files) args.push('--media', file.path)
+  args.push('--json')
   return args
+}
+
+function deliveryRefFromOpenClawOutput(stdout: string): string | null {
+  const value = parseOpenClawDeliveryOutput(stdout)
+  const id = firstStringAtPaths(value, [
+    ['messageId'],
+    ['message_id'],
+    ['id'],
+    ['message', 'id'],
+    ['result', 'messageId'],
+    ['result', 'message_id'],
+    ['result', 'id'],
+    ['result', 'message', 'id'],
+    ['delivery', 'messageId'],
+    ['delivery', 'message_id'],
+    ['delivery', 'id'],
+    ['delivery', 'message', 'id'],
+  ])
+  return id ? `message:${id}` : null
+}
+
+function parseOpenClawDeliveryOutput(stdout: string): Record<string, unknown> | null {
+  const text = stdout.trim()
+  if (!text) return null
+  return parseJsonObject(text)
+    ?? parseJsonObject(text.split('\n').reverse().find(part => part.trim().startsWith('{') && part.trim().endsWith('}')) ?? '')
+}
+
+function firstStringAtPaths(value: unknown, paths: string[][]): string | null {
+  for (const path of paths) {
+    const found = stringAtPath(value, path)
+    if (found) return found
+  }
+  return null
+}
+
+function stringAtPath(value: unknown, path: string[]): string | null {
+  let current = value
+  for (const key of path) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return null
+    current = (current as Record<string, unknown>)[key]
+  }
+  return typeof current === 'string' && current.trim() ? current.trim() : null
 }
 
 function readChannelInfos(): ChannelInfo[] {

--- a/scripts/lib/post-channel.ts
+++ b/scripts/lib/post-channel.ts
@@ -38,6 +38,7 @@ function resolveAssetAbsPath(assetId: string | undefined): string | null {
 // the testing-ground channel regardless of what the caller requested.
 const TEST_CHANNEL = 'testing-ground'
 const POST_IDEMPOTENCY_TTL_MS = 5 * 60 * 1000
+export const CHANNEL_POST_CHUNK_LIMIT = 1900
 const postInflight = new Map<string, Promise<ExecToolResult>>()
 const postCompleted = new Map<string, { result: ExecToolResult; expiresAt: number }>()
 
@@ -117,26 +118,34 @@ async function deliverChannelPost(
   },
 ): Promise<ExecToolResult> {
   try {
-    const result = await runtime.channels.deliverContent({
-      channels: [input.channel],
-      content: {
-        title: 'Channel post',
-        body: input.content,
-        files: input.files,
-        metadata: {
-          agent: input.agent,
-          taskId: input.taskId,
-          embed: input.embed,
-          requestedChannel: input.requestedChannel,
-          resolvedChannel: input.channel,
-          ...(isTestMode() && input.channel !== normalizeChannelTarget(input.requestedChannel) ? { testMode: true } : {}),
+    const chunks = chunkChannelPostContent(input.content)
+    const deliveries = []
+    for (let i = 0; i < chunks.length; i += 1) {
+      const result = await runtime.channels.deliverContent({
+        channels: [input.channel],
+        content: {
+          title: '',
+          body: chunks[i],
+          files: i === 0 ? input.files : [],
+          metadata: {
+            agent: input.agent,
+            taskId: input.taskId,
+            embed: input.embed,
+            requestedChannel: input.requestedChannel,
+            resolvedChannel: input.channel,
+            chunkIndex: i + 1,
+            chunkCount: chunks.length,
+            ...(isTestMode() && input.channel !== normalizeChannelTarget(input.requestedChannel) ? { testMode: true } : {}),
+          },
         },
-      },
-    })
+      })
+      deliveries.push(...result.deliveries)
+    }
 
     return succeed({
-      deliveries: result.deliveries,
+      deliveries,
       channel: displayChannel(input.channel),
+      chunkCount: chunks.length,
       taskId: input.taskId,
       ...(isTestMode() && input.channel !== normalizeChannelTarget(input.requestedChannel) ? {
         testMode: true,
@@ -161,6 +170,47 @@ function postSignature(input: PostChannelParams & { channel: string; files: Arra
     videoAssetId: input.videoAssetId ?? null,
   })
   return createHash('sha256').update(canonical).digest('hex')
+}
+
+export function chunkChannelPostContent(content: string, limit = CHANNEL_POST_CHUNK_LIMIT): string[] {
+  const normalized = content || ''
+  if (normalized.length <= limit) return [normalized]
+
+  const rawChunks = splitTextIntoChunks(normalized, limit - chunkPrefix(99, 99).length)
+  const count = rawChunks.length
+  const prefixWidth = String(count).length
+  const bodyLimit = limit - chunkPrefix(count, count, prefixWidth).length
+  const chunks = rawChunks.some(chunk => chunk.length > bodyLimit)
+    ? splitTextIntoChunks(normalized, bodyLimit)
+    : rawChunks
+
+  return chunks.map((chunk, index) => `${chunkPrefix(index + 1, chunks.length, String(chunks.length).length)}${chunk}`)
+}
+
+function chunkPrefix(index: number, count: number, width = String(count).length): string {
+  return `[${String(index).padStart(width, '0')}/${count}] `
+}
+
+function splitTextIntoChunks(text: string, limit: number): string[] {
+  if (limit < 32) throw new Error('Channel post chunk limit is too small')
+  const chunks: string[] = []
+  let remaining = text
+  while (remaining.length > limit) {
+    const index = findChunkBreak(remaining, limit)
+    chunks.push(remaining.slice(0, index).trimEnd())
+    remaining = remaining.slice(index).trimStart()
+  }
+  chunks.push(remaining)
+  return chunks
+}
+
+function findChunkBreak(text: string, limit: number): number {
+  const search = text.slice(0, limit + 1)
+  for (const marker of ['\n\n', '\n', '. ', '; ', ', ', ' ']) {
+    const index = search.lastIndexOf(marker)
+    if (index >= Math.floor(limit * 0.55)) return index + marker.length
+  }
+  return limit
 }
 
 function stableJson(value: unknown): string {

--- a/tests/adapter-openclaw/runtime-channels.test.ts
+++ b/tests/adapter-openclaw/runtime-channels.test.ts
@@ -11,7 +11,7 @@ function installOpenClawCliRecorder(testDir: string): { binaryPath: string; call
     '#!/usr/bin/env bun',
     'import { appendFileSync } from "fs"',
     'appendFileSync(process.env.OPENCLAW_CLI_LOG!, JSON.stringify(process.argv.slice(2)) + "\\n")',
-    'process.stdout.write(JSON.stringify({ ok: true }))',
+    'process.stdout.write(JSON.stringify({ ok: true, messageId: "discord-message-123" }))',
     '',
   ].join('\n'), 'utf-8')
   chmodSync(shimPath, 0o755)
@@ -123,7 +123,7 @@ describe('OpenClaw runtime channels', () => {
       },
     })
 
-    expect(result.deliveries).toEqual([expect.objectContaining({ channelId: 'discord' })])
+    expect(result.deliveries).toEqual([expect.objectContaining({ channelId: 'discord', ref: 'message:discord-message-123' })])
     expect(calls).toHaveLength(0)
     expect(recorder.calls()).toEqual([[
       'message',
@@ -134,6 +134,7 @@ describe('OpenClaw runtime channels', () => {
       'Launch post\n\nShip it.',
       '--media',
       '/tmp/hero.png',
+      '--json',
     ]])
   })
 
@@ -163,6 +164,7 @@ describe('OpenClaw runtime channels', () => {
       'Workflow publish failed\n\nChannel delivery failed.',
       '--thread-id',
       'thread-123',
+      '--json',
     ]])
   })
 

--- a/tests/scripts/post-channel.test.ts
+++ b/tests/scripts/post-channel.test.ts
@@ -46,7 +46,7 @@ mock.module('../../src/core/workflow-tool-authorization', () => ({
   assertWorkflowToolAllowed: (...args: unknown[]) => mockAssertWorkflowToolAllowed(...args),
 }))
 
-import { postChannel, resetPostChannelIdempotencyForTests } from '../../scripts/lib/post-channel'
+import { CHANNEL_POST_CHUNK_LIMIT, chunkChannelPostContent, postChannel, resetPostChannelIdempotencyForTests } from '../../scripts/lib/post-channel'
 
 describe('postChannel', () => {
   const originalEnv = { ...process.env }
@@ -91,18 +91,84 @@ describe('postChannel', () => {
     expect(call).toEqual({
       channels: ['discord:channel-123'],
       content: {
-        title: 'Channel post',
+        title: '',
         body: 'test message',
         files: [],
         metadata: {
           agent: 'chef',
           taskId: 'task-123',
           embed: undefined,
+          chunkCount: 1,
+          chunkIndex: 1,
           requestedChannel: '#general',
           resolvedChannel: 'discord:channel-123',
         },
       },
     })
+  })
+
+  it('keeps near-threshold payloads as one unwrapped delivery', async () => {
+    const content = `Runtime Roundup\n\n${'A'.repeat(1500)}\n\nLinks\n${'B'.repeat(250)}`
+
+    const result = await postChannel({
+      channel: '#general',
+      content,
+      agent: 'chef',
+      taskId: 'task-123',
+    }, runtime)
+
+    expect(result.ok).toBe(true)
+    expect(result.chunkCount).toBe(1)
+    expect(deliverContent).toHaveBeenCalledTimes(1)
+    const [call] = deliverContent.mock.calls[0] as unknown as [Record<string, unknown> & { content: { body: string; title: string } }]
+    expect(call.content.title).toBe('')
+    expect(call.content.body).toBe(content)
+    expect(call.content.body.startsWith('Channel post')).toBe(false)
+    expect(call.content.body.length).toBeLessThanOrEqual(CHANNEL_POST_CHUNK_LIMIT)
+  })
+
+  it('splits long payloads deterministically with ordered chunk prefixes', async () => {
+    const content = [
+      '**Runtime Roundup**',
+      `OpenClaw ${'alpha '.repeat(180)}`,
+      `Hermes ${'beta '.repeat(180)}`,
+      `DeerFlow ${'gamma '.repeat(180)}`,
+      `Links ${'delta '.repeat(180)}`,
+    ].join('\n\n')
+
+    const result = await postChannel({
+      channel: '#general',
+      content,
+      agent: 'chef',
+      taskId: 'task-123',
+    }, runtime)
+
+    expect(result.ok).toBe(true)
+    expect(result.chunkCount).toBe(3)
+    expect(deliverContent).toHaveBeenCalledTimes(3)
+    const bodies = deliverContent.mock.calls.map(call => {
+      const [arg] = call as unknown as [Record<string, unknown> & { content: { body: string; title: string; files: unknown[]; metadata: Record<string, unknown> } }]
+      expect(arg.content.title).toBe('')
+      expect(arg.content.body.length).toBeLessThanOrEqual(CHANNEL_POST_CHUNK_LIMIT)
+      return arg.content.body
+    })
+    expect(bodies[0]?.startsWith('[1/3] ')).toBe(true)
+    expect(bodies[1]?.startsWith('[2/3] ')).toBe(true)
+    expect(bodies[2]?.startsWith('[3/3] ')).toBe(true)
+    expect(bodies.join('\n')).toContain('OpenClaw')
+    expect(bodies.join('\n')).toContain('DeerFlow')
+    expect(bodies.join('\n')).not.toContain('Channel post')
+  })
+
+  it('exposes deterministic chunks for harness-style regression checks', () => {
+    const oneChunk = chunkChannelPostContent('x'.repeat(1800))
+    const twoChunks = chunkChannelPostContent(`${'one '.repeat(450)}\n\n${'two '.repeat(450)}`)
+
+    expect(oneChunk).toHaveLength(1)
+    expect(oneChunk[0]?.startsWith('[1/1]')).toBe(false)
+    expect(twoChunks.length).toBeGreaterThan(1)
+    expect(twoChunks.every(chunk => chunk.length <= CHANNEL_POST_CHUNK_LIMIT)).toBe(true)
+    expect(twoChunks[0]?.startsWith('[1/')).toBe(true)
   })
 
   it('fails before runtime delivery when a bare channel has no alias or runtime channel match', async () => {


### PR DESCRIPTION
## Summary
- make bakin_exec_post_channel split long channel posts deterministically under a 1900-character limit with ordered chunk prefixes
- stop adding the visible "Channel post" wrapper title to normal channel-post content
- request JSON receipts from OpenClaw message sends and record provider message IDs when available

## Verification
- npm exec --yes --package bun@1.3.13 -- bun run typecheck
- npm exec --yes --package bun@1.3.13 -- bun test tests/scripts/post-channel.test.ts tests/adapter-openclaw/runtime-channels.test.ts
- npm exec --yes --package bun@1.3.13 -- bunx eslint scripts/lib/post-channel.ts packages/adapter-openclaw/src/runtime.ts tests/scripts/post-channel.test.ts tests/adapter-openclaw/runtime-channels.test.ts