### PR TITLE
Assets usability pass: tag folders, metadata editing, tile sizing

### DIFF
--- a/.claude/knowledge/assets-versioning.md
+++ b/.claude/knowledge/assets-versioning.md
@@ -23,9 +23,17 @@ the `assetId`, never a filename.
 - **Versions are linear, append-only, stable-numbered with gaps allowed.**
   `currentVersion` is a free pointer (can point at any version). `parentVersion`
   records lineage. Never renumber.
-- **Display fields** (`description`, `tags`) **mirror the current version**, so
-  promote/delete losslessly restore the right card/search content. Per-version
-  `description`/`tags` are stored on each version for this.
+- **`description` mirrors the current version** (stored per-version), so
+  promote/delete losslessly restore the right card/search content. **`tags` are
+  asset-level ONLY** — a pure organizational namespace ("folders" in the UI)
+  that `addVersion`/`promoteVersion`/`deleteVersion` never touch. Versions
+  carry no tags field (old manifests' version tags are stripped on parse; no
+  migration). Machine provenance never goes into tags — it lives structurally
+  in `op`/`source`/`generation`.
+- **Tag normalization** (`lib/tags.ts` — trim, lowercase, whitespace→hyphen,
+  dedupe) is applied by **every** tag-writing path: `updateMetadata`, global
+  ops, bulk apply, `createAsset`, upload, `assets_save`. One source of truth;
+  routes never bypass it.
 - **Exports are derived artifacts, not versions** — idempotent per surface (one
   export per surface; re-export overwrites).
 - Markdown/text assets ride the same spine; "markdown out of v1" only meant no
@@ -44,9 +52,15 @@ the `assetId`, never a filename.
   (guards the version-number race). Different assets stay concurrent.
 - `asset-service.ts` — `createAsset` / `addVersion` / `promoteVersion` /
   `deleteVersion` (auto-fallback, can't-delete-last) / `addExport` / `relink` /
-  `retype` / `deleteAsset` + `restoreAsset` / `getAsset` / `resolveFile` /
-  `listAssets` / `findBySourcePath` / `upsertFromSource`. All mutations: lock →
-  mutate → atomic write.
+  `retype` / `updateMetadata` (description write-through + tags replace) /
+  `renameTagGlobal` + `removeTagGlobal` (store-wide sweeps; **trash skipped** —
+  a restore may resurrect a stale tag, fixable with one edit) / `applyTags`
+  (bulk; unknown ids reported, not fatal) / `deleteAsset` + `restoreAsset` /
+  `getAsset` / `resolveFile` / `listAssets` / `findBySourcePath` /
+  `upsertFromSource` (caller tags **union** into asset tags on version-upsert).
+  All mutations: lock → mutate → atomic write.
+- `tags.ts` — `normalizeTag` / `normalizeTags`, shared by server mutations AND
+  the client TagInput (pure module, no node imports).
 - `serve.ts` — `resolveAssetServe(segments)` for the HTTP serving route.
 - `search-doc.ts` — `versionedAssetPath` + `buildVersionedAssetSearchDoc`.
 
@@ -106,7 +120,11 @@ GET    /api/assets/<assetId>/export/<name>  # export bytes
 Host route `packages/host/src/api/assets/[...path].ts` resolves via the
 `assets.resolveServe` hook; ETag keyed on `assetId:currentVersion` (busts on
 promote/edit). Plugin mutation routes under `/api/plugins/assets/versioned/*`
-(`plugins/assets/routes/versioned.ts`).
+(`plugins/assets/routes/versioned.ts`), including
+`PATCH /versioned/:assetId/metadata` (description and/or tags). Global tag ops
+under `/api/plugins/assets/tags/*` (`routes/tags.ts`):
+`POST /tags/rename {from,to}`, `POST /tags/remove {tag}`,
+`POST /tags/apply {assetIds, add?, remove?}`.
 
 ## Search
 
@@ -114,6 +132,17 @@ One `bakin_assets` row **per asset, keyed by `assetId`**, built from the current
 version. `manifest.json` is the indexed unit + reindex trigger: the watcher's
 `onSync` reindexes on manifest write, `onUnlink` removes on manifest delete.
 Version/thumb/export files never get their own row.
+
+Doc fields beyond the basics: `tags` (comma-joined text, searchable + embedded)
+plus `tags_facet` (keyword **array** — text fields can't produce per-tag terms
+buckets); generation provenance as `surface` (searchable + in the embedding
+templates — "instagram" matches `instagram-feed-portrait`) and
+`provider`/`model` (**facet-only**, deliberately kept out of embeddings so they
+don't flatten similarity across generated assets). Facets:
+`asset_type, agent, tool, tags_facet, provider, model`. Any future schema/index
+change here needs a `SCHEMA_VERSION` bump in `src/core/search-migration.ts`
+(existing tables are never altered in place — boot does drop → recreate →
+reindex; v3 added these fields).
 
 ## Live updates
 
@@ -127,7 +156,10 @@ fetch per tab, removals fold a trash refetch into the same flush.
 
 `generate` → `createAsset` (v1); `edit(assetId)` → `addVersion` on the current
 version; `export(assetId)` → `addExport`; `import`/upload → `createAsset`. Tools
-return `assetId`. **Billed calls are idempotent** via `idempotency.ts` (in-flight
+return `assetId`. **None of them write tags** — the old machine stamps
+(`generated`/`edited`/`imported`/surface/provider/model) duplicated `op`/
+`source`/`generation` and polluted the folder namespace; `import` passes the
+caller's tags through untouched. **Billed calls are idempotent** via `idempotency.ts` (in-flight
 dedup + ~5min TTL result cache, keyed by `{taskId, op, source, promptHash,
 provider, model, w, h, quality}`) — prevents the client-timeout double-bill
 without adding a retry. No `sourcePath` on edit (import loose files first); no
@@ -149,3 +181,14 @@ badge, navigate, live refresh) and the detail route (`VersionedAssetDetail`,
 host route `assets.$assetId.tsx` → `page:/assets/:assetId` slot): current
 preview + exports + version timeline (promote / delete-version) + delete-scope
 dialog. Client types in `components/versioned/types.ts` (no server imports).
+
+Index views (`?view=` URL-backed): `grid` (auto-fill tiles, 250px min) /
+`list` / `tags` (**Folders** — `TagFolderGrid`: assets grouped per tag,
+multi-tag assets in every matching folder, pinned Untagged bucket, recency
+sort, kebab rename/delete wired to the global tag routes) / `trash`. Tag
+filtering: `Tags` FacetFilter (`?tags=a,b`; `__untagged__` sentinel from
+`tag-filter.ts`) with a `Folders / <tag> ✕` breadcrumb back to `?view=tags`.
+Metadata editing: `AssetEditDrawer` (BakinDrawer; description + `TagInput`
+chips with suggestions) opens from card hover pencil, list-row action, and the
+detail Edit button → PATCH metadata. Bulk tagging: Select mode in grid/list +
+floating bar → `POST /tags/apply`.

--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -69,7 +69,7 @@ Browser:
     packages/host/public/index.html  (_static.ts injects dev-client script
                                        before </body> when BAKIN_DEV=1)
         │
-        ├── /assets/main.js   (shell bundle)
+        ├── /_app/main.js     (shell bundle)
         ├── /vendor/*.js       (react, tanstack-router, @bakin/sdk/*)
         ├── /__bakin-dev/client.js   (dev client — dev-only, disk-only)
         └── /api/plugins/<id>/assets/client.js   (each plugin's bundle)

--- a/.claude/knowledge/repo-architecture.md
+++ b/.claude/knowledge/repo-architecture.md
@@ -293,7 +293,8 @@ Browser →  HTTP request → Bakin (server.ts)
     /mcp               → handleMcpRequest            (SSE + Streamable HTTP)
     /api/plugins/<id>/<path> → plugin catch-all router
     /vendor/*          → static handler (from public/vendor or embedded)
-    /assets/*          → plugin asset router
+    /_app/*            → host shell bundle (packages/host/dist; NOT /assets —
+                         that's the assets plugin's page namespace)
     (anything else)    → serveHostClient = SPA fallback (index.html)
   ↓
   index.html loads vendor/*.js + main.js

--- a/.claude/knowledge/url-state-deep-linking.md
+++ b/.claude/knowledge/url-state-deep-linking.md
@@ -85,6 +85,26 @@ registerPlugin({
 - Empty array is default for multi-select — omit from URL when empty
 - Param names should be consistent across plugins (e.g., `q` for search everywhere, `view` for view mode)
 
+## Multi-param updates: never call two setters in one tick
+
+Each `useQueryState`/`useQueryArrayState` setter snapshots the **pre-update**
+search params and calls `router.replace` — two setters in the same handler
+clobber each other (the second nav drops the first's param). And `replace`
+creates no history entry, so browser back can't undo the navigation.
+
+For any interaction that updates multiple params (e.g. the assets folder
+click: `view` + `tags`), build ONE URL and `router.push` it — one atomic
+update, one history entry. Pattern (`VersionedAssetGrid.tsx` `pushParams`):
+
+```tsx
+const params = new URLSearchParams(searchParams.toString())
+// set/delete every param, honoring defaults-omitted
+router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+```
+
+Rule of thumb: `replace` for filter tweaks within a view; `push` for
+navigation-like transitions the user expects back to undo.
+
 ## FacetFilter Component
 
 Located at `src/components/facet-filter.tsx`. Shared multi-select filter component using Popover + Command.

--- a/.claude/specs/assets-usability-plan.md
+++ b/.claude/specs/assets-usability-plan.md
@@ -1,0 +1,108 @@
+# Assets Usability Pass — Implementation Plan
+
+Spec: `.claude/specs/assets-usability.md` (user-approved, F1–F8). On approval, this plan is also saved to `.claude/specs/assets-usability-plan.md` per repo convention.
+
+## Context
+
+The assets plugin is write-only for the user: agents create assets with descriptions/tags, but no UI or API exists to edit them; tags can't be filtered, grouped, or changed; the tile grid squishes cards (`grid-cols-2 sm:3 md:4 lg:5`). The spec settles the design: tags become a **pure asset-level organizational namespace** (folders) that survives agent edits/promotes; description keeps write-through-to-current-version semantics; a drawer edits metadata; a folders view + tag facet + bulk tagging make the index navigable at scale.
+
+**Critical code facts grounding this plan** (all verified by reading):
+- `plugins/assets/lib/asset-service.ts:303` — `mirrorDisplay()` copies current version's `description`+`tags` to asset level; called from `addVersion`/`promoteVersion`/`deleteVersion`.
+- `plugins/images/lib/tools.ts:212,217` — stamps machine tags `['generated'|'edited', surface, provider, model]`; same data already structured in `generation {provider, model, surface, quality}` + `op`.
+- `upsertFromSourceInner` (asset-service.ts:666) passes `tags` into `addVersion` — must change to asset-level union under F8.
+- Routes: declarative `defineRoute` table in `plugins/assets/index.ts:62-186`; handlers in `plugins/assets/routes/versioned.ts`. Mutations audit via `ctx.activity.audit(...)`.
+- Search: `registerFileBackedContentType` in index.ts:210 — `tags: {type:'text'}` comma-joined (search-doc.ts:51); facets need `keyword` type per `.claude/knowledge/search-plugin-guide.md`; embedding template `{{description}} {{tags}} {{file_name}} {{content}}`.
+- Grid: `VersionedAssetGrid.tsx` (395 lines) — views `grid|list|trash` via `useQueryState('view')`, type facet via `useQueryArrayState('type')` + client-side filter (line 245); card click navigates to detail.
+- SDK components: `BakinDrawer` (src/components/bakin-drawer.tsx — open/onOpenChange/title/actions/dirty props), `FacetFilter` (src/components/facet-filter.tsx — label/options/selected/onChange/counts), `Dialog`, `Badge`, `Input`, `Textarea`. No TagInput exists anywhere.
+- Tests: `tests/plugins/assets/` — 19 files, env-var-first temp-dir isolation pattern (`BAKIN_HOME`+`OPENCLAW_HOME` set before imports). **12 of them reference tags**; `asset-lifecycle.test.ts` explicitly asserts the OLD mirror behavior (`expect(m.tags).toEqual(['two'])` after addVersion) and must be updated in the F8 task.
+- Knowledge doc: `.claude/knowledge/assets-versioning.md:26-28` documents the mirror invariant — must be rewritten.
+
+## Branch & Commit Strategy
+
+One branch `feat/assets-usability` off `main`, PR at the end. **Ten commits, each a green checkpoint** (typecheck via `bun run build` types + `bun run test` pass before every commit) so any regression rolls back to the nearest checkpoint with `git revert`/`reset`. Server is data-compatible at every commit (old manifests always parse — Zod strips the removed version-tags key; no migration).
+
+| # | Commit (conventional) | Contents |
+|---|---|---|
+| 1 | `fix(assets): content-driven tile grid with 250px min card width` | F1 only — one-line grid class change. Trivial, instant rollback anchor. |
+| 2 | `refactor(assets)!: tags become asset-level only, decoupled from version mirror` | F8 server core: schema, service, images tools, existing-test updates. The foundation everything else builds on. |
+| 3 | `feat(assets): tag normalization + metadata update API` | normalizeTags lib + `updateMetadata` service + PATCH route + creation-path normalization + tests. |
+| 4 | `feat(assets): global tag rename/remove + bulk apply API` | F4/F7 server: service fns + 3 routes + tests. |
+| 5 | `feat(assets): index generation provenance for search; tags facet` | F6: search-doc fields + registration schema/facets + tests. |
+| 6 | `feat(assets): tags facet filter + folder breadcrumb in grid/list` | F5 UI + breadcrumb. |
+| 7 | `feat(assets): asset metadata edit drawer with tag input` | F3 UI: TagInput + AssetEditDrawer + affordances on card/row/detail. |
+| 8 | `feat(assets): folders view grouping assets by tag` | F2 UI: TagFolderGrid + rename/delete dialogs wired to commit-4 routes. |
+| 9 | `feat(assets): bulk multi-select tagging` | F7 UI: selection mode + action bar. |
+| 10 | `docs(assets): update knowledge docs for tag namespace + editing` | assets-versioning.md rewrite of invariant + new routes; search docs if schema changed; README check. |
+
+Commits 2–5 are server-side (manual server restart to verify); 6–9 are client-side (HMR via `bun run dev`). 1 is independent; 5 is independent of 3–4; 6 depends on 2 only (filtering is client-side); 7 depends on 3; 8 depends on 4+6; 9 depends on 4+7.
+
+## Tasks
+
+### T1 — Tile min-width (commit 1)
+`VersionedAssetGrid.tsx:387`: `grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5` → `grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]`.
+**Accept:** cards never narrower than 250px; row count adapts to viewport. **Verify:** `bun run dev`, resize window; existing tests green.
+
+### T2 — Tags decoupling (commit 2) — the foundation
+1. `plugins/assets/lib/manifest.ts`: delete `tags` from `AssetVersionSchema`; update the lines-39-41 comment (description-only mirror).
+2. `asset-service.ts`: `mirrorDisplay` → description only (rename comment); `AssetVersionInput` drops `tags`; `addVersion` no longer writes version tags; `createAsset` keeps `input.tags` → `manifest.tags` only (not on v1 version object); `upsertFromSourceInner` stops passing tags to `addVersion` (the union lands in T3 — see below). Do **not** widen `addVersion`'s signature with a merge param.
+3. `plugins/images/lib/tools.ts`: delete the `tags:` arguments at **all three** sites — `:136` (`importImage`'s `params.tags ?? ['imported']` default → `params.tags ?? undefined`; `op: 'import'` already records provenance), `:212` (generate), `:217` (edit).
+4. Test fallout (exhaustive — vetted by adversarial review; commit must be green):
+   - `tests/plugins/assets/asset-lifecycle.test.ts:49,58` — invert the mirror-tags assertions (tags survive addVersion/promote).
+   - `tests/plugins/images/tools.test.ts:145,255` — hard-assert the machine-tag arrays; remove those expectations.
+   - `tests/plugins/assets/manifest-cache.test.ts:219` — freeze-guard asserts on `versions[0].tags` which ceases to exist (would pass as TypeError for the wrong reason); retarget to a surviving version field.
+   - Files that merely *construct* version-level tags in raw JSON fixtures (`versioned-exec-tools`, `health-checks`, `clipboard-purge`, `serve`, `asset-service`, `manifest-cache:193`) need **no edit** — Zod strips unknown keys on parse. Don't churn them.
+   - `search-doc.test.ts:52` + `upload.test.ts:134` survive because createAsset/upload keep routing tags to asset level — they become regression guards; keep as-is.
+   - Add new guards: user tags intact after addVersion (with + without input tags), promote changes description but never tags, generate/edit/import produce zero machine tags.
+**Accept:** version objects carry no tags; asset tags survive addVersion/promote/delete-version; old manifests with version tags still parse (Zod strips). **Verify:** `bun run test tests/plugins/assets/ tests/plugins/images/ --isolate` green; full suite green.
+
+### T3 — Normalization + metadata PATCH (commit 3)
+1. New `plugins/assets/lib/tags.ts`: `normalizeTags(tags: string[]): string[]` — trim, lowercase, collapse internal whitespace to `-`, drop empties, dedupe (order-preserving).
+2. `asset-service.ts`: `updateMetadata(assetId, { description?, tags? })` — per-asset lock; description: `.slice(0,200)`, write-through to asset-level + current version; tags: `normalizeTags` → asset-level only; bump `updated`; `writeManifestAtomic`. Apply `normalizeTags` in `createAsset` + upload route's tag parsing (`routes/upload.ts:47`).
+3. **Upsert union** (deferred from T2): in `upsertFromSourceInner`, after `addVersion` returns and when `input.tags` was provided, call `updateMetadata(existingId, { tags: union(manifest.tags, input.tags) })`. Lock-correct (source lock + per-asset lock use different keys, no deadlock); two writes is fine — the watcher coalesces and only the final manifest is indexed. Keeps `addVersion`'s API clean.
+3. New handler in `routes/versioned.ts` (or `routes/tags.ts`): `PATCH /versioned/:assetId/metadata`, Zod body `{ description?: string, tags?: string[] }` (reject empty body), 404 unknown asset; audit `asset.metadata_updated`. Register via `defineRoute` in index.ts.
+**Accept/Verify:** new test file `tests/plugins/assets/metadata-route.test.ts` — write-through description (older versions untouched, cap), tags asset-level only, normalization (`"Hello World"`→`hello-world`, dedupe), 400/404, manifest re-read from disk; promote-after-edit restores that version's description but not tags.
+
+### T4 — Global tag ops + bulk apply (commit 4)
+1. `asset-service.ts`: `renameTagGlobal(from, to)` (normalize `to`; sweep `listAssets()`, per-asset lock + atomic write only for assets carrying `from`; merge-dedupe; returns count), `removeTagGlobal(tag)` (same sweep), `applyTags(assetIds, {add, remove})` (per-asset; unknown ids collected, not fatal).
+2. New `plugins/assets/routes/tags.ts`: `POST /tags/rename {from,to}`, `POST /tags/remove {tag}`, `POST /tags/apply {assetIds, add?, remove?}` — Zod bodies, audits (`assets.tag.renamed` / `assets.tag.removed` / `assets.tags.applied`). Register in index.ts. Trash is naturally skipped (`listAssets` only walks `store/`).
+**Accept/Verify:** `tests/plugins/assets/tag-ops.test.ts` — multi-asset sweep, merge on rename collision, non-carrying assets' manifests untouched (compare mtime/serialized bytes), apply add+remove + per-asset results, trash dir untouched.
+
+### T5 — Search provenance + tags facet (commit 5)
+1. `search-doc.ts`: add `surface: current.generation?.surface ?? ''` (text, searchable+embedded), `provider`/`model` (keyword) — empty strings when no generation.
+2. index.ts registration: schema adds `surface {text}`, `provider {keyword}`, `model {keyword}`; `searchableFields` += `surface`; both `embeddingTemplate`s += `{{surface}}`; `facets` += `provider`, `model`.
+3. **Tags facet (F6):** the comma-joined `text` field CANNOT facet — a terms aggregation on it yields one bucket with the whole `"a, b"` string (adapter maps facets to terms aggs, `packages/adapter-antfly/src/search.ts:532`; `text` → analyzed, `search.ts:501`). Add a dedicated `tags_facet: { type: 'array' }` field (adapter maps `array → ['keyword']`, `search.ts:506`) populated with the normalized tag array, and facet on it. **Caveat:** no array-valued field exists anywhere in the repo yet, so antfly's array-terms-bucketing is unverified — spike it first against a dev Antfly; if buckets don't split per element, ship F6 as provider/model facets only and file the tags-facet follow-up. The grid's Tags FacetFilter (T6) is client-side and unaffected either way.
+4. **Schema migration (mandatory, not optional):** existing tables are never altered — `tables.create` no-ops when the table exists (`search.ts:215`). Bump `SCHEMA_VERSION` 2 → 3 in `src/core/search-migration.ts:35` (+ version-history comment) so boot does drop → recreate-with-new-schema → reindex. `bakin reindex` alone pushes docs into the OLD schema and the new fields never materialize.
+**Accept/Verify:** update `search-doc.test.ts` + `multimodal-indexing.test.ts`; new assertions: doc carries surface/provider/model (+ tags_facet array); absent generation → empty fields; Antfly disabled → no-ops. Migration verified by booting dev server against a pre-existing index.
+
+### T6 — Tags facet filter + breadcrumb (commit 6)
+`VersionedAssetGrid.tsx`: `useQueryArrayState('tags')`; tag options + counts derived from loaded summaries (`__untagged__` sentinel entry labeled "Untagged"); second `FacetFilter` next to Type; client-side filter extends line 245 (`__untagged__` matches `tags.length===0`); breadcrumb row when tags filter active — `Folders / <tag(s)> ✕` linking `view=tags` / clearing filter.
+**Accept/Verify:** URL-backed (`?tags=a,b` deep-links), works in grid+list, search+type filters compose. Manual dev check; component behavior covered by E2E-ish manual pass (matches existing repo practice — grid has no unit tests).
+*(Noted UX gap, deliberately out of scope: `AssetMetaSummary` tag badges on cards stay non-clickable — filtering goes through the facet. Revisit if it chafes.)*
+
+### T7 — Edit drawer (commit 7)
+1. New `TagInput.tsx` (plugin-local): badge chips with ✕, text input with suggestion popover (filtered existing tags from summaries), Enter adds freeform; client-side preview of normalization (server is authority).
+2. New `AssetEditDrawer.tsx`: `BakinDrawer` (use `dirty` prop), Description `Textarea` + TagInput; Save → `PATCH /versioned/:id/metadata`; error display; close on success (SSE refetch reconciles).
+3. Affordances: hover pencil on `AssetCard` (stopPropagation vs card onClick), action on `AssetListRow`, Edit button in `VersionedAssetDetail.tsx` header.
+**Accept/Verify:** edit from all three entry points round-trips; Esc/backdrop close respects dirty state. Manual dev pass.
+
+### T8 — Folders view (commit 8)
+`VIEW_OPTIONS` += `{ key: 'tags', label: 'Folders', Icon: Folder }`. New `TagFolderGrid.tsx`: group summaries by tag (multi-membership), Untagged pinned first, folders sorted by max(updated) desc; folder card = up-to-4 thumb collage (`AssetThumb`) + name + count; click → `setView('grid')` + `setTags([tag])`; kebab → Rename (input dialog) / Delete (confirm dialog) → commit-4 routes → SSE refetch.
+**Accept/Verify:** folder click lands in filtered grid with breadcrumb back; rename merges; delete clears folder; empty store edge (no tags → just Untagged or empty state). Manual dev pass.
+
+### T9 — Bulk tagging (commit 9)
+Selection mode in `VersionedAssetGrid.tsx` (header "Select" toggle; checkboxes on cards/rows; ephemeral state); floating action bar (N selected): TagInput + "Add tags" → `POST /tags/apply`; clear-selection; exit on view change.
+**Accept/Verify:** tags land on all selected (SSE refetch shows); selection survives filtering but not view switch. Manual dev pass.
+
+### T10 — Docs (commit 10)
+- `.claude/knowledge/assets-versioning.md`: rewrite mirror invariant (description-only), document tag namespace rule, new routes, normalization, global ops + trash caveat, no machine tags.
+- `.claude/knowledge/search-system.md` / `search-plugin-guide.md`: only if T5 changed registration patterns worth documenting.
+- `README.md`: verified — no assets-feature enumeration exists; no change expected.
+**Verify:** docs match shipped behavior; grep for stale "mirror the current version" phrasing repo-wide (it also appears in code comments updated in T2).
+
+## End-to-End Verification (before PR)
+
+1. `bun run test` — full suite green.
+2. `bun run build` — typecheck + binary build green.
+3. Manual `bun run dev` pass: resize grid (F1) → tag two assets via drawer (F3) → folders view shows them (F2) → click folder → breadcrumb back → rename folder (F4) → bulk-tag three assets (F7) → agent-style addVersion (upload new version on detail page) and confirm tags survive (F8) → search an asset by surface term (F5/F6, if Antfly enabled).
+4. Optional Playwright spot-check of grid min-width + drawer flow.
+5. PR `feat/assets-usability` → main with summary referencing the spec.

--- a/.claude/specs/assets-usability.md
+++ b/.claude/specs/assets-usability.md
@@ -1,0 +1,118 @@
+# Assets Plugin Usability Pass — tiles, tag folders, metadata editing
+
+Make the assets index navigable at scale: fix squished tile cards, turn tags into a first-class "folder" concept, and give the user a way to edit asset metadata (description + tags) that has never existed. Single-user machine; priority is reducing tech debt — no backwards compatibility, no shims.
+
+## Objective
+
+Today the assets plugin is write-only from the user's perspective: agents create assets with descriptions and tags, but there is **zero UI or API** to edit them (`plugins/assets/index.ts` routes cover promote/delete/relink/export/upload only). Tags exist in the manifest and search index but can't be filtered on, grouped by, or changed. The tile grid uses fixed column counts (`grid-cols-2 sm:3 md:4 lg:5`) that squish cards below usable size before wrapping.
+
+This pass delivers:
+1. **F1 — Tile min-width:** content-driven grid, 250px minimum card width.
+2. **F2 — Folders view:** a new view mode at the assets index grouping assets by tag, folder-click navigates into a tag-filtered grid with a breadcrumb back.
+3. **F3 — Metadata edit drawer:** edit description + tags from grid cards, list rows, and the detail page.
+4. **F4 — Global tag ops:** rename/delete a tag across all assets from the folders view.
+5. **F5 — Tags facet filter:** URL-backed multi-select Tags filter in grid/list views.
+6. **F6 — Search facet:** register tags as an Antfly search facet.
+7. **F7 — Bulk tagging:** multi-select assets in grid/list → add tags to all selected.
+8. **F8 — Tag/version decoupling:** tags become a pure asset-level organizational namespace that survives agent edits and promotes (see Design v2).
+
+## Design — settled 2026-06-05 (interview + evidence-based revision)
+
+### v2 revision: tags decoupled from the version mirror
+
+The original write-through plan died on contact with the code: `addVersion` sets the new version's tags to `input.tags ?? []` and `mirrorDisplay()` copies them to asset level — and `plugins/images/lib/tools.ts:217` stamps `['edited', surface, provider, model]` on **every agent edit**. Under the mirror invariant, a user's `hello-world` folder tag would be wiped the next time an agent touched the image, and promote would shuffle folder membership. Additionally those machine tags are pure duplication: per-version `op` + `generation { provider, model, surface, quality }` already record the same provenance structurally.
+
+**Resolution (user-approved):**
+- `asset.tags` is the single organizational namespace. `mirrorDisplay` mirrors **description only**. `addVersion` and `promoteVersion` never alter asset tags.
+- **`tags` is deleted from `AssetVersionSchema`** — it has no remaining consumer. Zod strips the stale key from existing manifests on parse; the next write drops it. No migration, nothing reads it.
+- The images tools **stop stamping machine tags** (`'generated'`, `'edited'`, surface, provider, model) — provenance already lives in `op`/`tool`/`generation`. Existing machine-tag folders are cleaned up manually via F4 global delete (~5 clicks; tiny asset population, no migration code).
+- Creation paths route organizational tags to asset level: `createAsset`/`upload`/`bakin_exec_assets_save` take `tags` → `asset.tags` (normalized). When `assets_save` upserts a **new version** of an existing asset and the caller passed tags, they are **unioned** into `asset.tags` (agents add organization, never wipe the user's).
+- Description keeps the original write-through decision: editing it updates asset-level + current version; promote/delete still restore per-version descriptions. That invariant remains correct for content-descriptive text.
+
+### Decisions
+
+| Decision | Choice |
+|---|---|
+| Tags model | Asset-level only (F8 above). Version schema loses `tags`; machine stamps removed at the source. |
+| Description edit semantics | **Write-through to current version** (asset-level + current version's `description`), keeping the mirror invariant for description. Apply the existing 200-char cap (`.slice(0, 200)`) — same as version writes. |
+| Folder-click navigation | **Filter the existing grid.** Clicking a folder navigates to `?view=grid&tags=<tag>`. No dedicated folder page — the folders view is a visual entry point into the same tag-filter backbone (F5). One mental model, deep-linkable. |
+| Breadcrumb / back | When a tags filter is active in grid/list, show a breadcrumb row (`Folders / <tag> ✕`) linking back to `?view=tags` and clearing the filter. Browser back also works since all state is URL-backed. |
+| Edit access pattern | **Right-side `BakinDrawer`** (SDK component) with Description textarea + TagInput. Opened from a hover edit affordance on grid cards, an action on list rows, and an Edit button on the detail page. |
+| Tag input behavior | Combobox: type-to-filter suggestions from all existing tags (derived client-side from loaded summaries — no new endpoint), Enter creates freeform. |
+| Tag normalization | Server-side in **every path that writes tags** (PATCH, global ops, bulk apply, createAsset, upload, assets_save): trim, lowercase, collapse internal whitespace to hyphens (`"Hello World"` → `"hello-world"`), dedupe, drop empties. Single shared `normalizeTag()` — one source of truth. |
+| Global tag ops | Folder card kebab menu: **Rename** (re-tags every asset carrying it; merge+dedupe if target exists) and **Delete** (removes the tag from all assets; assets untouched). Only `asset.tags` exists now, so these are simple single-field sweeps. |
+| Trash policy | Global tag ops **skip `.trash/`** (consistent with `listAssets`). A restored asset may resurrect a stale tag — acceptable at this scale; fix is one drawer edit. Documented, not handled. |
+| Untagged assets | Pinned **"Untagged"** pseudo-folder in folders view; clicking filters to tagless assets (`?view=grid&tags=__untagged__` or equivalent sentinel). Nothing is invisible in this view. |
+| Folder sort & card | Folders sorted by most-recently-updated asset within them (Untagged pinned first). Folder card: thumbnail collage of up to 4 recent assets + tag name + asset count. |
+| Multi-tag membership | An asset with N tags appears in all N folders. Tags are labels, not exclusive containers. |
+| Title field | **None added.** `description` keeps doubling as the displayed title. No schema migration. |
+| Folders data source | Computed **entirely client-side** from the existing `/versioned` list response (summaries already carry `tags`, `updated`, `hasThumb`). No new list endpoint. |
+| Search provenance fields | With machine tags gone, the search doc indexes the current version's `generation` provenance directly: **`surface` in searchable text + embedding template** (real semantic value — "instagram" matches `instagram-feed-portrait`); **`provider` + `model` as filterable facet fields** (not embedded — supports "everything made with gpt-image-2" auditing without polluting embeddings). |
+| Bulk tagging UX | Selection mode in grid/list (header toggle or hover checkbox); floating action bar when N > 0: "Add tags to N assets" (TagInput) + clear selection. Selection is ephemeral component state, not URL. The bulk endpoint supports add **and** remove; UI ships add-only (per-subset removal is covered by per-asset edit + global delete). |
+| Out of scope | Drag-asset-onto-folder. Separate title field. Editing agent/taskId from the drawer (relink already exists). Tag colors. Agent-facing metadata-edit exec tool (assets_save already carries tags; revisit if agents need post-hoc editing). |
+
+## API
+
+All under `/api/plugins/assets/`, registered in `plugins/assets/index.ts`, implemented in `plugins/assets/routes/`. Every mutation goes through `writeManifestAtomic` under the per-asset lock and is picked up by the content watcher → `asset.changed` SSE → grid refetch. Zod-validated bodies.
+
+| Route | Method | Body | Behavior |
+|---|---|---|---|
+| `/versioned/:assetId/metadata` | PATCH | `{ description?: string, tags?: string[] }` | Description: write-through (asset-level + current version, 200-char cap). Tags: replace `asset.tags` (normalized). Returns updated manifest. 404 unknown asset, 400 invalid body. |
+| `/tags/rename` | POST | `{ from: string, to: string }` | Every asset with `from` in `asset.tags`: replace with normalized `to`, dedupe (merge). Skips trash. Returns `{ updated: number }`. |
+| `/tags/remove` | POST | `{ tag: string }` | Remove `tag` from `asset.tags` of every asset. Skips trash. Returns `{ updated: number }`. |
+| `/tags/apply` | POST | `{ assetIds: string[], add?: string[], remove?: string[] }` | Per asset: add/remove on `asset.tags` (normalized, deduped). Returns per-asset results; unknown assetIds reported, don't abort the rest. |
+
+Tag mutation core lives in `plugins/assets/lib/asset-service.ts` (`updateMetadata`, `renameTagGlobal`, `removeTagGlobal`, `applyTags`) next to the existing `promoteVersion`/`relink` mutations; `normalizeTag` in a small shared module used by all writers.
+
+## UI
+
+All in `plugins/assets/components/`, imports from `@makinbakin/sdk` / `@makinbakin/sdk/components` only.
+
+- **Grid sizing (F1):** `VersionedAssetGrid.tsx:387` — replace fixed `grid-cols-*` with `repeat(auto-fill, minmax(250px, 1fr))` (Tailwind arbitrary value). Applies to the tiled (grid) view only.
+- **Folders view (F2):** add `{ key: 'tags', label: 'Folders' }` to `VIEW_OPTIONS` (view state already URL-backed via `useQueryState('view')`). New `TagFolderGrid.tsx` renders folder cards from the in-memory summaries; kebab menu hosts Rename/Delete (F4) with confirm dialogs (SDK `Dialog`).
+- **Tags filter (F5):** SDK `FacetFilter` next to the existing Type filter, options derived from loaded summaries, backed by `useQueryArrayState('tags')`. Client-side filtering, same as the type filter. Breadcrumb row renders when the tags filter is active.
+- **Edit drawer (F3):** new `AssetEditDrawer.tsx` (SDK `BakinDrawer` + `Textarea` + new `TagInput.tsx`). Optimistic close on successful PATCH; SSE refetch reconciles. TagInput is plugin-local for now — promote to SDK only when a second consumer appears.
+- **Bulk select (F7):** selection state in `VersionedAssetGrid.tsx`; action bar component; reuses `TagInput`; calls `/tags/apply`.
+
+## Affected Files
+
+- `plugins/assets/lib/manifest.ts` — **remove `tags` from `AssetVersionSchema`**; no other schema change
+- `plugins/assets/lib/asset-service.ts` — metadata/tag mutations; `mirrorDisplay` mirrors description only; creation/version inputs drop version tags, route organizational tags to asset level
+- `plugins/images/lib/tools.ts` — stop stamping machine tags (provenance stays in `op`/`generation`)
+- `plugins/assets/routes/versioned.ts` + new `plugins/assets/routes/tags.ts` — new routes
+- `plugins/assets/routes/upload.ts` — tags → asset level, normalized
+- `plugins/assets/index.ts` — route registration; `assets_save` tag handling (union on upsert-version); tags facet in search registration (F6)
+- `plugins/assets/lib/search-doc.ts` — tags facet field if Antfly needs a keyword-typed field; add `surface` (searchable + embedded) and `provider`/`model` (facets) from current version's `generation` (check `.claude/knowledge/search-plugin-guide.md`)
+- `plugins/assets/components/versioned/VersionedAssetGrid.tsx` — grid sizing, folders view wiring, tags facet, breadcrumb, selection mode
+- `plugins/assets/components/versioned/TagFolderGrid.tsx` — **new**
+- `plugins/assets/components/versioned/AssetEditDrawer.tsx` — **new**
+- `plugins/assets/components/versioned/TagInput.tsx` — **new**
+- `plugins/assets/components/versioned/VersionedAssetDetail.tsx` — Edit button → drawer
+- `tests/plugins/assets-*.test.ts` — new route/service tests
+- `.claude/knowledge/assets-versioning.md` — tags-as-asset-level-namespace rule, metadata mutation contract, normalization, global tag ops, trash caveat
+- `README.md` — only if it enumerates assets features (verify during build)
+
+## Testing Strategy
+
+Route/service-level tests under `tests/`, following CLAUDE.md testing rules verbatim (temp-dir `BAKIN_HOME`, mock both content-dir paths + OpenClaw home, mock logger/watcher, `afterAll` cleanup, `--isolate`):
+
+- **PATCH metadata:** description updates asset-level AND current version (older versions untouched, 200-char cap); tags replace asset-level only; normalization applied (`"Hello World"` → `"hello-world"`, dedupe, empty-drop); 404/400 paths; manifest re-read from disk to assert atomic write.
+- **Decoupling invariants (the regression guards for F8):** after tagging an asset, `addVersion` (with and without input tags) leaves user tags intact; `promoteVersion` changes description but never tags; image generate/edit produce **no** machine tags.
+- **Rename:** sweeps all assets carrying the tag; merge+dedupe when target already present; non-carrying assets untouched (manifest byte-identical); trash untouched.
+- **Remove:** same sweep/skip assertions.
+- **Apply (bulk):** add+remove across a set; per-asset result reporting; unknown assetId doesn't abort the rest.
+- **Creation normalization:** upload/assets_save/createAsset normalize tags; assets_save upsert-version unions tags into asset level.
+- **Search doc:** built doc carries `surface` in searchable/embedded text and `provider`/`model` as facet fields; absent `generation` (uploads) yields empty fields, not errors.
+- UI verified manually via `bun run dev` (+ Playwright/devtools spot-check of grid min-width and drawer flow if warranted in the test phase).
+
+## Boundaries
+
+- **Always:** mutate manifests only via `writeManifestAtomic` under the per-asset lock; normalize tags through the single shared helper in every writing path; keep all filter/view state URL-backed (`useQueryState`/`useQueryArrayState`); emit nothing manually — the watcher owns `asset.changed`.
+- **Ask first:** any further manifest schema change beyond removing version `tags`; promoting TagInput into the SDK; new endpoints beyond the four listed.
+- **Never:** per-file sidecars or parallel tag stores (tags live in `asset.tags` in the manifest, period); backwards-compat shims; bypassing Zod validation on route bodies; touching `~/.bakin/` from tests.
+
+## Commands
+
+- Dev: `bun run dev` (HMR for plugin client code; server route changes need manual restart)
+- Tests: `bun run test` (full), `bun test tests/plugins/<file>.test.ts --isolate` (single)
+- Typecheck/build sanity: `bun run build` before ship

--- a/docs/src/content/docs/using/assets.md
+++ b/docs/src/content/docs/using/assets.md
@@ -11,7 +11,19 @@ Your agents are hoarders, in the good way. Every image they ship, every plan the
   <img src="/docs/media/screenshots/using-assets--library.webp" alt="The assets library: one card per asset, with a version-count badge on assets that have history." loading="lazy">
 </figure>
 
-The library shows **one card per asset**. An asset that has been revised shows a `v3 · 3 versions` badge in the corner; the card always renders the *current* version. Click any card to open its [detail page](#the-detail-page) — preview, full version history, and exports.
+The library shows **one card per asset**. An asset that has been revised shows a `v3 · 3 versions` badge in the corner; the card always renders the *current* version. Click any card to open its [detail page](#the-detail-page) — preview, full version history, and exports. Hover a card (or list row) for a pencil that opens the [edit drawer](#editing-metadata-and-tags).
+
+Four views, all URL-backed: **Grid** (tiles, never narrower than 250px), **List**, **Folders**, and **Trash**. Filter by **Type** or **Tags** (an *Untagged* option keeps tagless assets reachable); filters deep-link via `?type=` / `?tags=`.
+
+### Folders (tags as organization)
+
+Tags double as folders. The **Folders** view groups the library by tag — each folder card shows a collage of its most recent assets and a count; an asset with three tags appears in all three folders. Clicking a folder lands you in the grid filtered to that tag, with a `Folders / <tag>` breadcrumb back. From a folder's `⋮` menu you can **Rename** the tag across every asset that carries it (merging if the target name exists) or **Delete** it everywhere (the assets themselves are untouched). Folders sort by their most recently updated asset; *Untagged* is pinned first.
+
+### Editing metadata and tags
+
+The edit drawer (hover pencil on any card or row, or **Edit** on the detail page) edits an asset's **description** and **tags**. Tags normalize on save (`Hello World` → `hello-world`) and the input suggests existing tags so near-duplicate folders don't accumulate. To tag many assets at once, hit **Select** in grid or list view, click assets to select them, and use the floating bar to apply tags to the whole selection.
+
+Tags are **asset-level organization** — they survive agent edits, new versions, and promotes. Descriptions ride with versions: editing one updates the current version, and promoting an older version restores *its* description.
 
 Search is semantic and reaches text and pixels at the same time. Type "italian food" and you'll get recipes for carbonara, photos of pasta the visual index spotted on sight, research notes on regional cooking, video clips of pizza-making. None of those need to literally say "italian" to surface. One query, the whole library. Search indexes the **current version** of each asset.
 
@@ -59,7 +71,7 @@ Agents call `bakin_exec_assets_save` with a source file. The key behavior: **re-
 
 Clicking a card opens `/assets/<assetId>` — the home for everything version-related:
 
-- **Current preview** of the asset, plus its description, agent, task, and tags (these mirror the current version).
+- **Current preview** of the asset, plus its description, agent, task, and tags. The description mirrors the current version (promote restores that version's description); tags are asset-level and never change with versions. **Edit** opens the metadata drawer.
 - **Exports**: derived, surface-sized deliverables (e.g. an `open-graph.jpg` cropped from a chosen version). Exports are *not* versions — they're published artifacts that download directly.
 - **Version history**: every version newest-first, each showing its op (generate/edit/upload), prompt, and provenance (provider · model · route · surface). Two actions per version:
   - **Make current** — promote any older version back to current. No files change; the card, search, and default export source all follow the pointer.
@@ -85,7 +97,7 @@ Editing a text asset's content saves a **new version** — the history captures 
   .trash/                                      # soft-deleted assets (whole directories)
 ```
 
-The `manifest.json` is the single source of truth — there are no per-file sidecars. It holds asset-level metadata (`type`, `agent`, `taskId`, `currentVersion`, mirrored `description`/`tags`) plus the full `versions[]` and `exports[]`. Writes are atomic; mutations are serialized per asset.
+The `manifest.json` is the single source of truth — there are no per-file sidecars. It holds asset-level metadata (`type`, `agent`, `taskId`, `currentVersion`, the mirrored `description`, and the asset-level `tags`) plus the full `versions[]` and `exports[]`. Writes are atomic; mutations are serialized per asset.
 
 ## Addressing
 
@@ -104,10 +116,10 @@ ETags are keyed on `assetId:currentVersion`, so promoting or editing busts the b
 
 Assets register with the search system as a file-backed content type, table `bakin_assets` — **one row per asset, keyed by `assetId`**, built from the current version. The `manifest.json` is both the indexed unit and the reindex trigger: any mutation rewrites it and re-indexes that one row. Indexed across two Antfly indexes:
 
-- **Text**: description, tags, and extracted content (PDF text, markdown, plain text, JSON, CSV, YAML).
+- **Text**: description, tags, generation surface (so "instagram" finds `instagram-feed-portrait` images), and extracted content (PDF text, markdown, plain text, JSON, CSV, YAML).
 - **Visual** (raster images only): a CLIP embedding of the current version's image.
 
-Facets for filtering: `asset_type`, `agent`, `tool`. Cross-table search reaches assets, tasks, projects, memory, and everything else in one query. If anything looks stale, reindex from the [Health](/docs/using/health/) page.
+Facets for filtering: `asset_type`, `agent`, `tool`, `tags_facet`, `provider`, `model` — so "everything made with gpt-image-2" is one facet away. Cross-table search reaches assets, tasks, projects, memory, and everything else in one query. If anything looks stale, reindex from the [Health](/docs/using/health/) page.
 
 ## Trash and recovery
 

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -571,7 +571,10 @@ export interface AssetCreateInput {
   generation?: AssetGenerationInfo | null
 }
 
-/** Append a new version to an existing asset. */
+/**
+ * Append a new version to an existing asset. Note: no `tags` — tags are an
+ * asset-level organizational namespace that versioning never touches.
+ */
 export interface AssetVersionCreateInput {
   sourceFilePath: string
   op?: 'edit' | 'generate' | 'upload' | 'import'
@@ -579,7 +582,6 @@ export interface AssetVersionCreateInput {
   prompt?: string | null
   promptHash?: string | null
   description?: string
-  tags?: string[]
   generation?: AssetGenerationInfo | null
 }
 

--- a/packages/host/public/index.html
+++ b/packages/host/public/index.html
@@ -84,6 +84,6 @@
         </div>
       </div>
     </div>
-    <script type="module" src="/assets/main.js"></script>
+    <script type="module" src="/_app/main.js"></script>
   </body>
 </html>

--- a/packages/host/src/api/_embedded-assets-static.ts
+++ b/packages/host/src/api/_embedded-assets-static.ts
@@ -15,7 +15,7 @@
  * to route handlers.
  */
 
-import asset_assets_main_js from '../../dist/main.js' with { type: 'file' }
+import asset_app_main_js from '../../dist/main.js' with { type: 'file' }
 import asset_index_html from '../../public/index.html' with { type: 'file' }
 import asset_bakin_logo_svg from '../../public/bakin-logo.svg' with { type: 'file' }
 import asset_bakin_hop_svg from '../../public/bakin-hop.svg' with { type: 'file' }
@@ -51,7 +51,7 @@ import asset_data_curated_agents_json from '../data/curated-agents.json' with { 
  *  handlers request (including leading slash). Both core static assets
  *  and core plugin dist outputs live in this single map. */
 export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
-  ['/assets/main.js', asset_assets_main_js],
+  ['/_app/main.js', asset_app_main_js],
   ['/index.html', asset_index_html],
   ['/bakin-logo.svg', asset_bakin_logo_svg],
   ['/bakin-hop.svg', asset_bakin_hop_svg],

--- a/packages/host/src/api/_static.ts
+++ b/packages/host/src/api/_static.ts
@@ -2,7 +2,10 @@
  * Static asset + SPA fallback server for the Bakin host bundle.
  *
  * Serves:
- *   /assets/<name>    → packages/host/dist/<name>  (main.js, main.css, *.map)
+ *   /_app/<name>      → packages/host/dist/<name>  (main.js, main.css, *.map)
+ *                       (NOT /assets/* — that's the assets plugin's page
+ *                       namespace; client routes like /assets/<assetId> must
+ *                       reach the SPA fallback on hard refresh)
  *   /vendor/<name>    → packages/host/public/vendor/<name>  (react, sdk, etc.)
  *   /globals.css      → packages/host/public/globals.css
  *   /favicon.ico      → packages/host/public/favicon.ico (404 ok if absent)
@@ -162,8 +165,8 @@ export async function serveHostClient(req: IncomingMessage, res: ServerResponse,
   if (await sendEmbedded(req, res, pathname)) return true
 
   // Disk fallback for dev — mirrors the old resolution logic.
-  if (pathname.startsWith('/assets/')) {
-    const rel = pathname.slice('/assets/'.length)
+  if (pathname.startsWith('/_app/')) {
+    const rel = pathname.slice('/_app/'.length)
     if (await sendDiskFile(req, res, join(DIST_DIR, rel))) return true
     res.writeHead(404, { 'Content-Type': 'text/plain' })
     res.end('Not found')

--- a/packages/host/src/plugin-host/PluginHost.tsx
+++ b/packages/host/src/plugin-host/PluginHost.tsx
@@ -141,7 +141,7 @@ function startupResourceLabel(name: string): string {
     const path = url.pathname
     const pluginAsset = path.match(/^\/api\/plugins\/([^/]+)\/assets\/([^/]+)$/)
     if (pluginAsset) return `plugin:${pluginAsset[1]}:${pluginAsset[2]}`
-    if (path.startsWith('/assets/')) return `app:${path.split('/').pop() ?? 'asset'}`
+    if (path.startsWith('/_app/')) return `app:${path.split('/').pop() ?? 'asset'}`
     if (path.startsWith('/node_modules/')) return 'node_modules'
     if (path.startsWith('/src/')) return 'src'
     if (path.startsWith('/packages/')) return 'packages'

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -890,7 +890,10 @@ export interface AssetCreateInput {
   generation?: AssetGenerationInfo | null
 }
 
-/** Append a new version to an existing asset. */
+/**
+ * Append a new version to an existing asset. Note: no `tags` — tags are an
+ * asset-level organizational namespace that versioning never touches.
+ */
 export interface AssetVersionCreateInput {
   sourceFilePath: string
   op?: 'edit' | 'generate' | 'upload' | 'import'
@@ -898,7 +901,6 @@ export interface AssetVersionCreateInput {
   prompt?: string | null
   promptHash?: string | null
   description?: string
-  tags?: string[]
   generation?: AssetGenerationInfo | null
 }
 

--- a/plugins/assets/components/versioned/AssetEditDrawer.tsx
+++ b/plugins/assets/components/versioned/AssetEditDrawer.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button, Label, Textarea } from '@makinbakin/sdk/ui'
+import { BakinDrawer } from '@makinbakin/sdk/components'
+import { Loader2 } from 'lucide-react'
+import { TagInput } from './TagInput'
+import { VERSIONED_API } from './asset-urls'
+import type { VersionedAssetSummary } from './types'
+
+/**
+ * Right-side drawer for editing user-facing asset metadata (description +
+ * tags) via PATCH /versioned/:assetId/metadata. Description writes through to
+ * the current version server-side; tags are the asset-level namespace.
+ * Suggestions come from the caller's loaded summaries, or are fetched once
+ * when not provided (detail page).
+ */
+export function AssetEditDrawer({ assetId, initialDescription, initialTags, suggestions, open, onOpenChange, onSaved }: {
+  assetId: string
+  initialDescription: string
+  initialTags: string[]
+  /** Existing tags across all assets; fetched from the list endpoint when omitted. */
+  suggestions?: string[]
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSaved?: () => void
+}) {
+  const [description, setDescription] = useState(initialDescription)
+  const [tags, setTags] = useState<string[]>(initialTags)
+  const [fetchedSuggestions, setFetchedSuggestions] = useState<string[] | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Re-seed form state each time the drawer opens (possibly for a new asset).
+  useEffect(() => {
+    if (open) {
+      setDescription(initialDescription)
+      setTags(initialTags)
+      setError(null)
+    }
+  }, [open, assetId, initialDescription, initialTags])
+
+  useEffect(() => {
+    if (!open || suggestions !== undefined || fetchedSuggestions !== null) return
+    fetch(VERSIONED_API)
+      .then(r => r.ok ? r.json() : { assets: [] })
+      .then((d: { assets?: VersionedAssetSummary[] }) => {
+        const all = new Set<string>()
+        for (const a of d.assets ?? []) for (const t of a.tags ?? []) all.add(t)
+        setFetchedSuggestions([...all].sort())
+      })
+      .catch(() => setFetchedSuggestions([]))
+  }, [open, suggestions, fetchedSuggestions])
+
+  const dirty = description !== initialDescription || tags.join('\n') !== initialTags.join('\n')
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`${VERSIONED_API}/${encodeURIComponent(assetId)}/metadata`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description, tags }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(body.error || `Save failed (${res.status})`)
+      }
+      onSaved?.()
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <BakinDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit asset"
+      description={assetId}
+      storageKey="asset-edit"
+      defaultWidth={420}
+      dirty={dirty && !saving}
+      actions={
+        <Button size="sm" onClick={save} disabled={saving || !dirty} data-testid="asset-edit-save">
+          {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-4 p-4" data-testid="asset-edit-drawer">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="asset-edit-description">Description</Label>
+          <Textarea
+            id="asset-edit-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={200}
+            rows={3}
+            placeholder="What is this asset?"
+            data-testid="asset-edit-description"
+          />
+          <span className="text-right text-[11px] text-muted-foreground">{description.length}/200</span>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label>Tags</Label>
+          <TagInput value={tags} onChange={setTags} suggestions={suggestions ?? fetchedSuggestions ?? []} />
+          <span className="text-[11px] text-muted-foreground">Tags group assets into folders. Enter adds; type to reuse existing tags.</span>
+        </div>
+        {error && <p className="text-xs text-destructive" data-testid="asset-edit-error">{error}</p>}
+      </div>
+    </BakinDrawer>
+  )
+}

--- a/plugins/assets/components/versioned/AssetEditDrawer.tsx
+++ b/plugins/assets/components/versioned/AssetEditDrawer.tsx
@@ -83,17 +83,14 @@ export function AssetEditDrawer({ assetId, initialDescription, initialTags, sugg
       title="Edit asset"
       description={assetId}
       storageKey="asset-edit"
-      defaultWidth={420}
+      defaultWidth={480}
       dirty={dirty && !saving}
-      actions={
-        <Button size="sm" onClick={save} disabled={saving || !dirty} data-testid="asset-edit-save">
-          {saving ? <Loader2 className="size-4 animate-spin" /> : null}
-          {saving ? 'Saving…' : 'Save'}
-        </Button>
-      }
     >
-      <div className="flex flex-col gap-4 p-4" data-testid="asset-edit-drawer">
-        <div className="flex flex-col gap-1.5">
+      {/* Matches the AgentForm drawer conventions: BakinDrawer owns the
+          padding (px-7 py-6); fields are space-y-1.5 Label+control+help;
+          footer buttons live in the body, right-aligned. */}
+      <div className="flex flex-col gap-5" data-testid="asset-edit-drawer">
+        <div className="space-y-1.5">
           <Label htmlFor="asset-edit-description">Description</Label>
           <Textarea
             id="asset-edit-description"
@@ -104,14 +101,28 @@ export function AssetEditDrawer({ assetId, initialDescription, initialTags, sugg
             placeholder="What is this asset?"
             data-testid="asset-edit-description"
           />
-          <span className="text-right text-[11px] text-muted-foreground">{description.length}/200</span>
+          <p className="text-xs text-muted-foreground text-right">{description.length}/200</p>
         </div>
-        <div className="flex flex-col gap-1.5">
-          <Label>Tags</Label>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="asset-edit-tags">Tags</Label>
           <TagInput value={tags} onChange={setTags} suggestions={suggestions ?? fetchedSuggestions ?? []} />
-          <span className="text-[11px] text-muted-foreground">Tags group assets into folders. Enter adds; type to reuse existing tags.</span>
+          <p className="text-xs text-muted-foreground">
+            Tags group assets into folders. Enter adds; type to reuse existing tags.
+          </p>
         </div>
+
         {error && <p className="text-xs text-destructive" data-testid="asset-edit-error">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={save} disabled={saving || !dirty} data-testid="asset-edit-save">
+            {saving && <Loader2 className="size-3.5 animate-spin mr-1.5" />}
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
       </div>
     </BakinDrawer>
   )

--- a/plugins/assets/components/versioned/TagFolderGrid.tsx
+++ b/plugins/assets/components/versioned/TagFolderGrid.tsx
@@ -100,12 +100,17 @@ function FolderCard({ folder, onOpen, onRename, onDelete }: {
  * most-recently-updated asset. Rename/Delete fan out via the global tag
  * routes; the SSE refetch reconciles the grid.
  */
-export function TagFolderGrid({ assets, onOpenFolder, onChanged }: {
+export function TagFolderGrid({ assets, filter = '', onOpenFolder, onChanged }: {
   assets: VersionedAssetSummary[]
+  /** Lowercased folder-name filter from the header search box. */
+  filter?: string
   onOpenFolder: (tag: string) => void
   onChanged: () => void
 }) {
-  const folders = useMemo(() => buildFolders(assets), [assets])
+  const folders = useMemo(() => {
+    const all = buildFolders(assets)
+    return filter ? all.filter(f => f.label.toLowerCase().includes(filter)) : all
+  }, [assets, filter])
   const [renaming, setRenaming] = useState<string | null>(null)
   const [renameTo, setRenameTo] = useState('')
   const [deleting, setDeleting] = useState<string | null>(null)
@@ -133,12 +138,18 @@ export function TagFolderGrid({ assets, onOpenFolder, onChanged }: {
   }
 
   if (folders.length === 0) {
-    return <div className="p-8 text-sm text-muted-foreground" data-testid="folders-empty">No assets yet — tags you add will appear here as folders.</div>
+    return (
+      <div className="p-8 text-sm text-muted-foreground" data-testid="folders-empty">
+        {filter ? 'No folders match your filter.' : 'No assets yet — tags you add will appear here as folders.'}
+      </div>
+    )
   }
 
   return (
     <>
-      <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]" data-testid="tag-folders">
+      {/* mt-4: the grid/list views get header spacing from the filters row,
+          which the folders view doesn't render. */}
+      <div className="mt-4 grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]" data-testid="tag-folders">
         {folders.map(folder => (
           <FolderCard
             key={folder.tag}

--- a/plugins/assets/components/versioned/TagFolderGrid.tsx
+++ b/plugins/assets/components/versioned/TagFolderGrid.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import {
+  Badge, Button, Input,
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem,
+} from '@makinbakin/sdk/ui'
+import { FolderOpen, MoreVertical, Pencil, Trash2, Loader2 } from 'lucide-react'
+import { AssetThumb } from './atoms'
+import { TAGS_API } from './asset-urls'
+import { UNTAGGED } from './tag-filter'
+import type { VersionedAssetSummary } from './types'
+
+interface Folder {
+  tag: string
+  label: string
+  assets: VersionedAssetSummary[] // newest-updated first
+}
+
+/** Group summaries into tag folders: Untagged pinned, rest by recency. */
+function buildFolders(assets: VersionedAssetSummary[]): Folder[] {
+  const byTag = new Map<string, VersionedAssetSummary[]>()
+  const untagged: VersionedAssetSummary[] = []
+  for (const a of assets) {
+    if ((a.tags ?? []).length === 0) untagged.push(a)
+    for (const t of a.tags ?? []) {
+      const list = byTag.get(t) ?? []
+      list.push(a)
+      byTag.set(t, list)
+    }
+  }
+  const newestFirst = (list: VersionedAssetSummary[]) => [...list].sort((x, y) => y.updated.localeCompare(x.updated))
+  const folders: Folder[] = [...byTag.entries()]
+    .map(([tag, list]) => ({ tag, label: tag, assets: newestFirst(list) }))
+    .sort((x, y) => y.assets[0].updated.localeCompare(x.assets[0].updated))
+  if (untagged.length > 0) folders.unshift({ tag: UNTAGGED, label: 'Untagged', assets: newestFirst(untagged) })
+  return folders
+}
+
+function FolderCard({ folder, onOpen, onRename, onDelete }: {
+  folder: Folder
+  onOpen: () => void
+  onRename: () => void
+  onDelete: () => void
+}) {
+  const thumbs = folder.assets.slice(0, 4)
+  const real = folder.tag !== UNTAGGED
+  return (
+    <div
+      onClick={onOpen}
+      className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card transition-all duration-150 hover:-translate-y-0.5 hover:border-[rgba(255,255,255,0.15)]"
+      data-testid={`tag-folder-${folder.tag}`}
+    >
+      <div className="relative grid aspect-square grid-cols-2 grid-rows-2 gap-px overflow-hidden bg-zinc-900/50">
+        {thumbs.map(a => (
+          <div key={a.assetId} className="overflow-hidden">
+            <AssetThumb assetId={a.assetId} type={a.type} version={a.currentVersion} hasThumb={a.hasThumb} />
+          </div>
+        ))}
+        {/* Pad the collage so a 1–3 asset folder still reads as a 2x2 grid. */}
+        {Array.from({ length: Math.max(0, 4 - thumbs.length) }, (_, i) => (
+          <div key={`pad-${i}`} className="bg-zinc-900/30" />
+        ))}
+        {real && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              onClick={(e) => e.stopPropagation()}
+              className="absolute right-1.5 top-1.5 z-10 rounded bg-black/60 p-1.5 text-zinc-300 opacity-0 transition-opacity hover:text-white group-hover:opacity-100 data-[state=open]:opacity-100"
+              aria-label={`Folder actions for ${folder.label}`}
+              data-testid={`folder-menu-${folder.tag}`}
+            >
+              <MoreVertical className="size-3.5" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+              <DropdownMenuItem onClick={onRename} data-testid={`folder-rename-${folder.tag}`}>
+                <Pencil className="size-3.5" /> Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onDelete} className="text-red-400 focus:text-red-300" data-testid={`folder-delete-${folder.tag}`}>
+                <Trash2 className="size-3.5" /> Delete tag
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+      <div className="flex items-center gap-2 p-3">
+        <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+        <span className="truncate text-sm font-medium text-foreground" title={folder.label}>{folder.label}</span>
+        <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]" data-testid={`folder-count-${folder.tag}`}>
+          {folder.assets.length}
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Folders view — assets grouped by tag (multi-tag assets appear in every
+ * matching folder). Untagged is pinned first; real folders sort by their
+ * most-recently-updated asset. Rename/Delete fan out via the global tag
+ * routes; the SSE refetch reconciles the grid.
+ */
+export function TagFolderGrid({ assets, onOpenFolder, onChanged }: {
+  assets: VersionedAssetSummary[]
+  onOpenFolder: (tag: string) => void
+  onChanged: () => void
+}) {
+  const folders = useMemo(() => buildFolders(assets), [assets])
+  const [renaming, setRenaming] = useState<string | null>(null)
+  const [renameTo, setRenameTo] = useState('')
+  const [deleting, setDeleting] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const run = async (path: string, body: unknown, close: () => void) => {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`${TAGS_API}${path}`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(data.error || `Request failed (${res.status})`)
+      }
+      close()
+      onChanged()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (folders.length === 0) {
+    return <div className="p-8 text-sm text-muted-foreground" data-testid="folders-empty">No assets yet — tags you add will appear here as folders.</div>
+  }
+
+  return (
+    <>
+      <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]" data-testid="tag-folders">
+        {folders.map(folder => (
+          <FolderCard
+            key={folder.tag}
+            folder={folder}
+            onOpen={() => onOpenFolder(folder.tag)}
+            onRename={() => { setRenameTo(folder.tag); setError(null); setRenaming(folder.tag) }}
+            onDelete={() => { setError(null); setDeleting(folder.tag) }}
+          />
+        ))}
+      </div>
+
+      {/* Rename dialog */}
+      <Dialog open={renaming !== null} onOpenChange={(open) => { if (!open) setRenaming(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename tag</DialogTitle>
+            <DialogDescription>Renames “{renaming}” on every asset that carries it. Merges if the target tag already exists.</DialogDescription>
+          </DialogHeader>
+          <Input
+            value={renameTo}
+            onChange={(e) => setRenameTo(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && renaming) run('/rename', { from: renaming, to: renameTo }, () => setRenaming(null)) }}
+            autoFocus
+            data-testid="folder-rename-input"
+          />
+          {error && renaming !== null && <p className="text-xs text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRenaming(null)}>Cancel</Button>
+            <Button
+              onClick={() => renaming && run('/rename', { from: renaming, to: renameTo }, () => setRenaming(null))}
+              disabled={busy || !renameTo.trim() || renameTo.trim() === renaming}
+              data-testid="folder-rename-confirm"
+            >
+              {busy ? <Loader2 className="size-4 animate-spin" /> : null} Rename
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete dialog */}
+      <Dialog open={deleting !== null} onOpenChange={(open) => { if (!open) setDeleting(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete tag</DialogTitle>
+            <DialogDescription>Removes “{deleting}” from every asset that carries it. The assets themselves are untouched.</DialogDescription>
+          </DialogHeader>
+          {error && deleting !== null && <p className="text-xs text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleting(null)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleting && run('/remove', { tag: deleting }, () => setDeleting(null))}
+              disabled={busy}
+              data-testid="folder-delete-confirm"
+            >
+              {busy ? <Loader2 className="size-4 animate-spin" /> : null} Delete tag
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/plugins/assets/components/versioned/TagInput.tsx
+++ b/plugins/assets/components/versioned/TagInput.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { Badge, Input } from '@makinbakin/sdk/ui'
+import { X } from 'lucide-react'
+import { normalizeTag } from '../../lib/tags'
+
+/**
+ * Tag chip editor: badges with remove, a text input that suggests existing
+ * tags while typing, Enter/comma adds freeform. Normalization mirrors the
+ * server's normalizeTags (which remains the authority on save).
+ */
+export function TagInput({ value, onChange, suggestions = [], placeholder = 'Add tag…' }: {
+  value: string[]
+  onChange: (tags: string[]) => void
+  suggestions?: string[]
+  placeholder?: string
+}) {
+  const [draft, setDraft] = useState('')
+  const [focused, setFocused] = useState(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  const matches = useMemo(() => {
+    const n = normalizeTag(draft)
+    return suggestions
+      .filter(s => !value.includes(s) && (n === '' || s.includes(n)))
+      .slice(0, 8)
+  }, [draft, suggestions, value])
+
+  const add = (raw: string) => {
+    const tag = normalizeTag(raw)
+    if (tag && !value.includes(tag)) onChange([...value, tag])
+    setDraft('')
+    inputRef.current?.focus()
+  }
+  const remove = (tag: string) => onChange(value.filter(t => t !== tag))
+
+  return (
+    <div className="relative" data-testid="tag-input">
+      <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-border bg-transparent px-2 py-1.5">
+        {value.map(tag => (
+          <Badge key={tag} variant="secondary" className="gap-1 pr-1 text-xs font-normal" data-testid={`tag-chip-${tag}`}>
+            {tag}
+            <button onClick={() => remove(tag)} aria-label={`Remove tag ${tag}`} className="rounded-full p-0.5 hover:bg-muted">
+              <X className="size-3" />
+            </button>
+          </Badge>
+        ))}
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 150) /* allow suggestion click */}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ',') {
+              e.preventDefault()
+              add(draft)
+            } else if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+              remove(value[value.length - 1])
+            }
+          }}
+          placeholder={value.length === 0 ? placeholder : ''}
+          className="h-6 min-w-24 flex-1 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+          data-testid="tag-input-field"
+        />
+      </div>
+      {focused && matches.length > 0 && (
+        <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-48 overflow-auto rounded-md border border-border bg-popover py-1 shadow-md" data-testid="tag-suggestions">
+          {matches.map(s => (
+            <button
+              key={s}
+              onMouseDown={(e) => { e.preventDefault(); add(s) }}
+              className="block w-full px-2.5 py-1 text-left text-sm text-popover-foreground hover:bg-accent"
+              data-testid={`tag-suggestion-${s}`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/assets/components/versioned/VersionedAssetDetail.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetDetail.tsx
@@ -181,7 +181,7 @@ export function VersionedAssetDetail() {
         />
       </div>
 
-      <div className="mb-4"><AssetMetaSummary agent={manifest.agent} created={manifest.created} taskId={manifest.taskId} tags={manifest.tags} /></div>
+      <div className="mb-4"><AssetMetaSummary agent={manifest.agent} created={manifest.created} taskId={manifest.taskId} tags={manifest.tags} maxTags={Infinity} /></div>
 
       <AssetEditDrawer
         assetId={manifest.assetId}

--- a/plugins/assets/components/versioned/VersionedAssetDetail.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetDetail.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate, Link } from '@tanstack/react-router'
 import { Badge, Button } from '@makinbakin/sdk/ui'
-import { ArrowLeft, Download, Trash2, Upload, Loader2, X } from 'lucide-react'
+import { ArrowLeft, Download, Pencil, Trash2, Upload, Loader2, X } from 'lucide-react'
 import { AssetMetaSummary } from './atoms'
+import { AssetEditDrawer } from './AssetEditDrawer'
 import { AssetPreview } from './AssetPreview'
 import { VersionRow } from './VersionRow'
 import { assetVersionUrl, assetExportUrl, VERSIONED_API } from './asset-urls'
@@ -22,6 +23,7 @@ export function VersionedAssetDetail() {
   const [addingVersion, setAddingVersion] = useState(false)
   const [versionError, setVersionError] = useState<string | null>(null)
   const [lightbox, setLightbox] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
   const [selectedVersion, setSelectedVersion] = useState<number | null>(null)
   const versionInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -153,6 +155,9 @@ export function VersionedAssetDetail() {
         <Button size="sm" variant="ghost" onClick={() => navigate({ to: '/assets' })}><ArrowLeft className="size-4 mr-1" /> Assets</Button>
         <h1 className="truncate text-base font-semibold" title={manifest.assetId}>{manifest.description || manifest.assetId}</h1>
         <Badge variant="secondary" className="ml-auto" data-testid="version-count">{manifest.versions.length} version{manifest.versions.length === 1 ? '' : 's'}</Badge>
+        <Button size="sm" variant="outline" onClick={() => setEditOpen(true)} data-testid="edit-asset">
+          <Pencil className="size-4 mr-1" /> Edit
+        </Button>
         <Button size="sm" variant="outline" onClick={() => versionInputRef.current?.click()} disabled={addingVersion} data-testid="add-version">
           {addingVersion ? <Loader2 className="size-4 animate-spin mr-1" /> : <Upload className="size-4 mr-1" />}
           {addingVersion ? 'Uploading…' : 'Add version'}
@@ -177,6 +182,15 @@ export function VersionedAssetDetail() {
       </div>
 
       <div className="mb-4"><AssetMetaSummary agent={manifest.agent} created={manifest.created} taskId={manifest.taskId} tags={manifest.tags} /></div>
+
+      <AssetEditDrawer
+        assetId={manifest.assetId}
+        initialDescription={manifest.description}
+        initialTags={manifest.tags ?? []}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        onSaved={fetchManifest}
+      />
 
       {/* Exports */}
       {manifest.exports.length > 0 && (

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
 import { useNavigate } from '@tanstack/react-router'
-import { useQueryState, useQueryArrayState, useSearch, useDebug } from '@makinbakin/sdk/hooks'
+import { useQueryState, useQueryArrayState, useSearch, useDebug, useRouter, usePathname, useSearchParams } from '@makinbakin/sdk/hooks'
 import { Button } from '@makinbakin/sdk/ui'
 import { PluginHeader, FacetFilter } from '@makinbakin/sdk/components'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
@@ -149,6 +149,26 @@ export function VersionedAssetGrid() {
   const [view, setView] = useQueryState('view', 'grid')
   const [typeFilter, setTypeFilter] = useQueryArrayState('type')
   const [tagFilter, setTagFilter] = useQueryArrayState('tags')
+
+  // Folder navigation updates view AND tags in ONE history entry. Two
+  // sequential useQueryState setters would clobber each other (both snapshot
+  // the pre-update params), and their replace() leaves no entry for browser
+  // back. push() makes folder → filtered-grid → back work like real folders.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const pushParams = useCallback((updates: Record<string, string | null>) => {
+    const params = new URLSearchParams(searchParams.toString())
+    for (const [key, val] of Object.entries(updates)) {
+      if (val === null || val === '') params.delete(key)
+      else params.set(key, val)
+    }
+    const qs = params.toString()
+    router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+  }, [router, pathname, searchParams])
+  // view=grid is the URL default — omit the param entirely when navigating to it.
+  const openFolder = useCallback((tag: string) => pushParams({ view: null, tags: tag }), [pushParams])
+  const goToFolders = useCallback(() => pushParams({ view: 'tags', tags: null }), [pushParams])
 
   const [assets, setAssets] = useState<VersionedAssetSummary[]>([])
   const [trash, setTrash] = useState<TrashedAssetSummary[]>([])
@@ -449,7 +469,7 @@ export function VersionedAssetGrid() {
       {view !== 'trash' && view !== 'tags' && tagFilter.length > 0 && (
         <div className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="tag-breadcrumb">
           <button
-            onClick={() => { setTagFilter([]); setView('tags') }}
+            onClick={goToFolders}
             className="flex items-center gap-1 rounded px-1 py-0.5 transition-colors hover:text-foreground"
             data-testid="breadcrumb-folders"
           >
@@ -507,7 +527,7 @@ export function VersionedAssetGrid() {
       ) : view === 'tags' ? (
         <TagFolderGrid
           assets={assets}
-          onOpenFolder={(tag) => { setTagFilter([tag]); setView('grid') }}
+          onOpenFolder={openFolder}
           onChanged={fetchAssets}
         />
       ) : displayed.length === 0 ? (

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -384,7 +384,7 @@ export function VersionedAssetGrid() {
           ))}
         </div>
       ) : (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" data-testid="assets-grid">
+        <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]" data-testid="assets-grid">
           {displayed.map(asset => (
             <AssetCard key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} />
           ))}

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -6,9 +6,10 @@ import { useQueryState, useQueryArrayState, useSearch, useDebug } from '@makinba
 import { Button } from '@makinbakin/sdk/ui'
 import { PluginHeader, FacetFilter } from '@makinbakin/sdk/components'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
-import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen } from 'lucide-react'
+import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen, Pencil } from 'lucide-react'
 import { ASSET_TYPES } from '../../lib/constants'
 import { createSseRefetchScheduler } from './sse-refetch'
+import { AssetEditDrawer } from './AssetEditDrawer'
 import { AssetThumb, AssetMetaSummary, AssetTypeIcon } from './atoms'
 import { VERSIONED_API, UPLOAD_API, TRASH_API } from './asset-urls'
 import type { VersionedAssetSummary, TrashedAssetSummary } from './types'
@@ -63,16 +64,24 @@ function ScoreOverlay({ info, className = '' }: { info: AssetScoreInfo; classNam
   )
 }
 
-function AssetCard({ asset, onOpen, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; scoreInfo?: AssetScoreInfo }) {
+function AssetCard({ asset, onOpen, onEdit, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; onEdit: () => void; scoreInfo?: AssetScoreInfo }) {
   return (
     <div
       onClick={onOpen}
-      className="flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card transition-all duration-150 hover:-translate-y-0.5 hover:border-[rgba(255,255,255,0.15)]"
+      className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card transition-all duration-150 hover:-translate-y-0.5 hover:border-[rgba(255,255,255,0.15)]"
       data-testid={`asset-card-${asset.assetId}`}
     >
       <div className="relative aspect-square overflow-hidden bg-zinc-900/50">
         <AssetThumb assetId={asset.assetId} type={asset.type} version={asset.currentVersion} hasThumb={asset.hasThumb} />
-        {scoreInfo && <ScoreOverlay info={scoreInfo} className="absolute right-1.5 top-1.5 z-10" />}
+        <button
+          onClick={(e) => { e.stopPropagation(); onEdit() }}
+          className="absolute right-1.5 top-1.5 z-10 rounded bg-black/60 p-1.5 text-zinc-300 opacity-0 transition-opacity hover:text-white group-hover:opacity-100"
+          aria-label={`Edit ${asset.description || asset.assetId}`}
+          data-testid={`asset-edit-${asset.assetId}`}
+        >
+          <Pencil className="size-3.5" />
+        </button>
+        {scoreInfo && <ScoreOverlay info={scoreInfo} className="absolute left-1.5 top-1.5 z-10" />}
         {asset.versionCount > 1 && (
           <span className="absolute bottom-1.5 left-1.5 rounded bg-black/70 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300" data-testid="version-badge">
             {asset.versionCount} versions
@@ -92,11 +101,11 @@ function AssetCard({ asset, onOpen, scoreInfo }: { asset: VersionedAssetSummary;
   )
 }
 
-function AssetListRow({ asset, onOpen, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; scoreInfo?: AssetScoreInfo }) {
+function AssetListRow({ asset, onOpen, onEdit, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; onEdit: () => void; scoreInfo?: AssetScoreInfo }) {
   return (
-    <button
+    <div
       onClick={onOpen}
-      className="flex w-full items-center gap-3 rounded-md border border-border bg-card px-3 py-2 text-left transition-colors hover:border-[rgba(255,255,255,0.15)]"
+      className="group flex w-full cursor-pointer items-center gap-3 rounded-md border border-border bg-card px-3 py-2 text-left transition-colors hover:border-[rgba(255,255,255,0.15)]"
       data-testid={`asset-row-${asset.assetId}`}
     >
       <div className="size-10 shrink-0 overflow-hidden rounded">
@@ -112,9 +121,17 @@ function AssetListRow({ asset, onOpen, scoreInfo }: { asset: VersionedAssetSumma
         </div>
       </div>
       {scoreInfo && <ScoreOverlay info={scoreInfo} className="shrink-0" />}
+      <button
+        onClick={(e) => { e.stopPropagation(); onEdit() }}
+        className="shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+        aria-label={`Edit ${asset.description || asset.assetId}`}
+        data-testid={`asset-edit-${asset.assetId}`}
+      >
+        <Pencil className="size-3.5" />
+      </button>
       <span className="shrink-0 text-[11px] text-muted-foreground">{formatSize(asset.size)}</span>
       <span className="shrink-0 text-[11px] text-muted-foreground">{formatAge(asset.created)}</span>
-    </button>
+    </div>
   )
 }
 
@@ -129,6 +146,7 @@ export function VersionedAssetGrid() {
 
   const [assets, setAssets] = useState<VersionedAssetSummary[]>([])
   const [trash, setTrash] = useState<TrashedAssetSummary[]>([])
+  const [editing, setEditing] = useState<VersionedAssetSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [uploading, setUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -437,15 +455,27 @@ export function VersionedAssetGrid() {
       ) : view === 'list' ? (
         <div className="flex flex-col gap-1.5" data-testid="assets-list">
           {displayed.map(asset => (
-            <AssetListRow key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} />
+            <AssetListRow key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} onEdit={() => setEditing(asset)} />
           ))}
         </div>
       ) : (
         <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]" data-testid="assets-grid">
           {displayed.map(asset => (
-            <AssetCard key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} />
+            <AssetCard key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} onEdit={() => setEditing(asset)} />
           ))}
         </div>
+      )}
+
+      {editing && (
+        <AssetEditDrawer
+          assetId={editing.assetId}
+          initialDescription={editing.description}
+          initialTags={editing.tags ?? []}
+          suggestions={tagOptions.filter(o => o.value !== UNTAGGED).map(o => o.value)}
+          open={editing !== null}
+          onOpenChange={(open) => { if (!open) setEditing(null) }}
+          onSaved={fetchAssets}
+        />
       )}
     </div>
   )

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -6,14 +6,15 @@ import { useQueryState, useQueryArrayState, useSearch, useDebug } from '@makinba
 import { Button } from '@makinbakin/sdk/ui'
 import { PluginHeader, FacetFilter } from '@makinbakin/sdk/components'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
-import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen, Pencil } from 'lucide-react'
+import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen, Pencil, Check, SquareMousePointer, Tags } from 'lucide-react'
 import { ASSET_TYPES } from '../../lib/constants'
 import { createSseRefetchScheduler } from './sse-refetch'
 import { AssetEditDrawer } from './AssetEditDrawer'
 import { TagFolderGrid } from './TagFolderGrid'
+import { TagInput } from './TagInput'
 import { UNTAGGED, matchesTagFilter } from './tag-filter'
 import { AssetThumb, AssetMetaSummary, AssetTypeIcon } from './atoms'
-import { VERSIONED_API, UPLOAD_API, TRASH_API } from './asset-urls'
+import { VERSIONED_API, UPLOAD_API, TRASH_API, TAGS_API } from './asset-urls'
 import type { VersionedAssetSummary, TrashedAssetSummary } from './types'
 
 type View = 'grid' | 'list' | 'tags' | 'trash'
@@ -59,15 +60,20 @@ function ScoreOverlay({ info, className = '' }: { info: AssetScoreInfo; classNam
   )
 }
 
-function AssetCard({ asset, onOpen, onEdit, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; onEdit: () => void; scoreInfo?: AssetScoreInfo }) {
+function AssetCard({ asset, onOpen, onEdit, selected, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; onEdit: () => void; selected?: boolean; scoreInfo?: AssetScoreInfo }) {
   return (
     <div
       onClick={onOpen}
-      className="group flex cursor-pointer flex-col overflow-hidden rounded-lg border border-border bg-card transition-all duration-150 hover:-translate-y-0.5 hover:border-[rgba(255,255,255,0.15)]"
+      className={`group flex cursor-pointer flex-col overflow-hidden rounded-lg border bg-card transition-all duration-150 hover:-translate-y-0.5 ${selected ? 'border-emerald-500/70 ring-1 ring-emerald-500/50' : 'border-border hover:border-[rgba(255,255,255,0.15)]'}`}
       data-testid={`asset-card-${asset.assetId}`}
     >
       <div className="relative aspect-square overflow-hidden bg-zinc-900/50">
         <AssetThumb assetId={asset.assetId} type={asset.type} version={asset.currentVersion} hasThumb={asset.hasThumb} />
+        {selected !== undefined && (
+          <span className={`absolute left-1.5 top-1.5 z-10 flex size-5 items-center justify-center rounded border ${selected ? 'border-emerald-500 bg-emerald-500 text-black' : 'border-zinc-500 bg-black/60'}`} data-testid={`asset-selected-${asset.assetId}`}>
+            {selected && <Check className="size-3.5" />}
+          </span>
+        )}
         <button
           onClick={(e) => { e.stopPropagation(); onEdit() }}
           className="absolute right-1.5 top-1.5 z-10 rounded bg-black/60 p-1.5 text-zinc-300 opacity-0 transition-opacity hover:text-white group-hover:opacity-100"
@@ -96,13 +102,18 @@ function AssetCard({ asset, onOpen, onEdit, scoreInfo }: { asset: VersionedAsset
   )
 }
 
-function AssetListRow({ asset, onOpen, onEdit, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; onEdit: () => void; scoreInfo?: AssetScoreInfo }) {
+function AssetListRow({ asset, onOpen, onEdit, selected, scoreInfo }: { asset: VersionedAssetSummary; onOpen: () => void; onEdit: () => void; selected?: boolean; scoreInfo?: AssetScoreInfo }) {
   return (
     <div
       onClick={onOpen}
-      className="group flex w-full cursor-pointer items-center gap-3 rounded-md border border-border bg-card px-3 py-2 text-left transition-colors hover:border-[rgba(255,255,255,0.15)]"
+      className={`group flex w-full cursor-pointer items-center gap-3 rounded-md border bg-card px-3 py-2 text-left transition-colors ${selected ? 'border-emerald-500/70 ring-1 ring-emerald-500/50' : 'border-border hover:border-[rgba(255,255,255,0.15)]'}`}
       data-testid={`asset-row-${asset.assetId}`}
     >
+      {selected !== undefined && (
+        <span className={`flex size-4.5 shrink-0 items-center justify-center rounded border ${selected ? 'border-emerald-500 bg-emerald-500 text-black' : 'border-zinc-500'}`} data-testid={`asset-selected-${asset.assetId}`}>
+          {selected && <Check className="size-3" />}
+        </span>
+      )}
       <div className="size-10 shrink-0 overflow-hidden rounded">
         <AssetThumb assetId={asset.assetId} type={asset.type} version={asset.currentVersion} hasThumb={asset.hasThumb} />
       </div>
@@ -142,6 +153,26 @@ export function VersionedAssetGrid() {
   const [assets, setAssets] = useState<VersionedAssetSummary[]>([])
   const [trash, setTrash] = useState<TrashedAssetSummary[]>([])
   const [editing, setEditing] = useState<VersionedAssetSummary | null>(null)
+
+  // Bulk selection — ephemeral (not URL-backed), exits on view change.
+  const [selectMode, setSelectMode] = useState(false)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [bulkTags, setBulkTags] = useState<string[]>([])
+  const [bulkBusy, setBulkBusy] = useState(false)
+  const [bulkError, setBulkError] = useState<string | null>(null)
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false)
+    setSelected(new Set())
+    setBulkTags([])
+    setBulkError(null)
+  }, [])
+  useEffect(() => { exitSelectMode() }, [view, exitSelectMode])
+  const toggleSelected = (assetId: string) => setSelected(prev => {
+    const next = new Set(prev)
+    if (next.has(assetId)) next.delete(assetId)
+    else next.add(assetId)
+    return next
+  })
   const [loading, setLoading] = useState(true)
   const [uploading, setUploading] = useState(false)
   const [uploadError, setUploadError] = useState<string | null>(null)
@@ -332,6 +363,11 @@ export function VersionedAssetGrid() {
   const actions = (
     <div className="flex items-center gap-2">
       {pending && <Loader2 className="size-4 animate-spin text-muted-foreground" data-testid="search-spinner" />}
+      {(view === 'grid' || view === 'list') && (
+        <Button size="sm" variant={selectMode ? 'secondary' : 'outline'} onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))} data-testid="toggle-select-mode">
+          <SquareMousePointer className="size-4" /> {selectMode ? 'Done' : 'Select'}
+        </Button>
+      )}
       <Button size="sm" onClick={openPicker} disabled={uploading} data-testid="add-asset">
         {uploading ? <Loader2 className="size-4 animate-spin" /> : <Upload className="size-4" />}
         {uploading ? 'Uploading…' : 'Add asset'}
@@ -339,6 +375,29 @@ export function VersionedAssetGrid() {
       {viewToggle}
     </div>
   )
+
+  const applyBulkTags = async () => {
+    if (bulkTags.length === 0 || selected.size === 0) return
+    setBulkBusy(true)
+    setBulkError(null)
+    try {
+      const res = await fetch(`${TAGS_API}/apply`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ assetIds: [...selected], add: bulkTags }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(body.error || `Tagging failed (${res.status})`)
+      }
+      exitSelectMode()
+      setSelectMode(true) // stay in select mode for the next batch
+      fetchAssets()
+    } catch (err) {
+      setBulkError(err instanceof Error ? err.message : 'Tagging failed')
+    } finally {
+      setBulkBusy(false)
+    }
+  }
 
   if (loading) return <div className="p-8 text-sm text-muted-foreground">Loading assets…</div>
 
@@ -456,14 +515,44 @@ export function VersionedAssetGrid() {
       ) : view === 'list' ? (
         <div className="flex flex-col gap-1.5" data-testid="assets-list">
           {displayed.map(asset => (
-            <AssetListRow key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} onEdit={() => setEditing(asset)} />
+            <AssetListRow
+              key={asset.assetId}
+              asset={asset}
+              scoreInfo={scoreFor(asset.assetId)}
+              selected={selectMode ? selected.has(asset.assetId) : undefined}
+              onOpen={() => (selectMode ? toggleSelected(asset.assetId) : navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } }))}
+              onEdit={() => setEditing(asset)}
+            />
           ))}
         </div>
       ) : (
         <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(250px,1fr))]" data-testid="assets-grid">
           {displayed.map(asset => (
-            <AssetCard key={asset.assetId} asset={asset} scoreInfo={scoreFor(asset.assetId)} onOpen={() => navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } })} onEdit={() => setEditing(asset)} />
+            <AssetCard
+              key={asset.assetId}
+              asset={asset}
+              scoreInfo={scoreFor(asset.assetId)}
+              selected={selectMode ? selected.has(asset.assetId) : undefined}
+              onOpen={() => (selectMode ? toggleSelected(asset.assetId) : navigate({ to: '/assets/$assetId', params: { assetId: asset.assetId } }))}
+              onEdit={() => setEditing(asset)}
+            />
           ))}
+        </div>
+      )}
+
+      {/* Floating bulk-tag bar while assets are selected. */}
+      {selectMode && selected.size > 0 && (
+        <div className="fixed bottom-4 left-1/2 z-40 flex w-[min(560px,calc(100vw-2rem))] -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 shadow-lg backdrop-blur" data-testid="bulk-tag-bar">
+          <Tags className="size-4 shrink-0 text-muted-foreground" />
+          <span className="shrink-0 text-xs text-muted-foreground" data-testid="bulk-selected-count">{selected.size} selected</span>
+          <div className="min-w-0 flex-1">
+            <TagInput value={bulkTags} onChange={setBulkTags} suggestions={tagOptions.filter(o => o.value !== UNTAGGED).map(o => o.value)} placeholder="Add tags…" />
+          </div>
+          <Button size="sm" onClick={applyBulkTags} disabled={bulkBusy || bulkTags.length === 0} data-testid="bulk-apply-tags">
+            {bulkBusy ? <Loader2 className="size-4 animate-spin" /> : null} Tag {selected.size}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setSelected(new Set())} data-testid="bulk-clear-selection">Clear</Button>
+          {bulkError && <p className="text-xs text-destructive">{bulkError}</p>}
         </div>
       )}
 

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -10,15 +10,18 @@ import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, Lis
 import { ASSET_TYPES } from '../../lib/constants'
 import { createSseRefetchScheduler } from './sse-refetch'
 import { AssetEditDrawer } from './AssetEditDrawer'
+import { TagFolderGrid } from './TagFolderGrid'
+import { UNTAGGED, matchesTagFilter } from './tag-filter'
 import { AssetThumb, AssetMetaSummary, AssetTypeIcon } from './atoms'
 import { VERSIONED_API, UPLOAD_API, TRASH_API } from './asset-urls'
 import type { VersionedAssetSummary, TrashedAssetSummary } from './types'
 
-type View = 'grid' | 'list' | 'trash'
+type View = 'grid' | 'list' | 'tags' | 'trash'
 
 const VIEW_OPTIONS: Array<{ key: View; label: string; Icon: typeof LayoutGrid }> = [
   { key: 'grid', label: 'Grid', Icon: LayoutGrid },
   { key: 'list', label: 'List', Icon: List },
+  { key: 'tags', label: 'Folders', Icon: FolderOpen },
   { key: 'trash', label: 'Trash', Icon: Trash2 },
 ]
 
@@ -30,14 +33,6 @@ const TYPE_OPTIONS = ASSET_TYPES.map((value) => ({
   icon: <AssetTypeIcon type={value} className="size-3.5" />,
 }))
 
-/** Sentinel tag-filter value matching assets with no tags at all. */
-export const UNTAGGED = '__untagged__'
-
-/** Does an asset match the active tag filter (any-of; UNTAGGED = tagless)? */
-export function matchesTagFilter(tags: string[], filter: string[]): boolean {
-  if (filter.length === 0) return true
-  return filter.some((f) => (f === UNTAGGED ? tags.length === 0 : tags.includes(f)))
-}
 
 /** Per-result Antfly relevance breakdown. */
 export interface AssetScoreInfo { score: number; indexScores?: Record<string, number> }
@@ -375,15 +370,15 @@ export function VersionedAssetGrid() {
       {fileInput}
       <PluginHeader
         title="Assets"
-        count={view === 'trash' ? trash.length : displayed.length}
+        count={view === 'trash' ? trash.length : view === 'tags' ? tagOptions.length : displayed.length}
         actions={actions}
-        search={view === 'trash' ? undefined : { value: q, onChange: setQ, placeholder: 'Search assets…' }}
+        search={view === 'trash' || view === 'tags' ? undefined : { value: q, onChange: setQ, placeholder: 'Search assets…' }}
       />
 
       {uploadError && <p className="mb-2 text-xs text-destructive">{uploadError}</p>}
       {linkTo && view !== 'trash' && <p className="mb-2 text-xs text-muted-foreground">New uploads will be linked to this task.</p>}
 
-      {view !== 'trash' && (
+      {view !== 'trash' && view !== 'tags' && (
         <div className="mb-3 mt-3 flex items-center gap-2" data-testid="asset-filters">
           <ListFilter className="size-3.5 shrink-0 text-muted-foreground" />
           <FacetFilter label="Type" options={TYPE_OPTIONS} selected={typeFilter} onChange={setTypeFilter} counts={typeCounts} />
@@ -392,7 +387,7 @@ export function VersionedAssetGrid() {
       )}
 
       {/* Breadcrumb back to the folders view while a tag filter is active. */}
-      {view !== 'trash' && tagFilter.length > 0 && (
+      {view !== 'trash' && view !== 'tags' && tagFilter.length > 0 && (
         <div className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="tag-breadcrumb">
           <button
             onClick={() => { setTagFilter([]); setView('tags') }}
@@ -450,6 +445,12 @@ export function VersionedAssetGrid() {
             ))}
           </div>
         )
+      ) : view === 'tags' ? (
+        <TagFolderGrid
+          assets={assets}
+          onOpenFolder={(tag) => { setTagFilter([tag]); setView('grid') }}
+          onChanged={fetchAssets}
+        />
       ) : displayed.length === 0 ? (
         <div className="p-8 text-sm text-muted-foreground" data-testid="assets-no-match">No assets match your filters.</div>
       ) : view === 'list' ? (

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -6,7 +6,7 @@ import { useQueryState, useQueryArrayState, useSearch, useDebug, useRouter, useP
 import { Button } from '@makinbakin/sdk/ui'
 import { PluginHeader, FacetFilter } from '@makinbakin/sdk/components'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
-import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen, Pencil, Check, SquareMousePointer, Tags } from 'lucide-react'
+import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen, Pencil, Check, SquareMousePointer, Tags, ArrowLeft } from 'lucide-react'
 import { ASSET_TYPES } from '../../lib/constants'
 import { createSseRefetchScheduler } from './sse-refetch'
 import { AssetEditDrawer } from './AssetEditDrawer'
@@ -236,8 +236,9 @@ export function VersionedAssetGrid() {
   // explicit restore/empty/permanent-delete actions, which refetch directly).
   useEffect(() => { if (view === 'trash') fetchTrash() }, [view, fetchTrash])
 
-  // Drive the search hook from the URL query.
-  useEffect(() => { search.search(q) }, [q]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Drive the search hook from the URL query. The folders view repurposes the
+  // same box as a client-side folder-name filter — no Antfly round-trip.
+  useEffect(() => { if (view !== 'tags') search.search(q) }, [q, view]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const es = new EventSource('/api/events')
@@ -321,6 +322,13 @@ export function VersionedAssetGrid() {
     return (tagCounts[UNTAGGED] ?? 0) > 0 ? [{ value: UNTAGGED, label: 'Untagged' }, ...tags] : tags
   }, [tagCounts])
 
+  // Folder-name filter for the folders view (header search box, client-side).
+  const folderFilter = view === 'tags' ? q.trim().toLowerCase() : ''
+  const folderCount = useMemo(
+    () => tagOptions.filter(o => !folderFilter || o.label.toLowerCase().includes(folderFilter)).length,
+    [tagOptions, folderFilter],
+  )
+
   const scoreMap = useMemo(
     () => new Map<string, AssetScoreInfo>(search.results.map(r => [r.id, { score: r.score, indexScores: r.indexScores }])),
     [search.results],
@@ -330,7 +338,9 @@ export function VersionedAssetGrid() {
   // A search is "pending" while the request is in flight OR the last completed
   // search query doesn't yet match the current input (covers the debounce gap).
   // Used to show a spinner and suppress the "no match" flash before results land.
-  const searching = q.trim().length > 0
+  // Folders view never searches (folder-name filter is client-side) — without
+  // the view guard the stale meta.query would pin the spinner on forever.
+  const searching = q.trim().length > 0 && view !== 'tags'
   const pending = searching && (search.loading || (search.meta?.query ?? '') !== q.trim())
 
   const filtered = useMemo(() => {
@@ -449,9 +459,11 @@ export function VersionedAssetGrid() {
       {fileInput}
       <PluginHeader
         title="Assets"
-        count={view === 'trash' ? trash.length : view === 'tags' ? tagOptions.length : displayed.length}
+        count={view === 'trash' ? trash.length : view === 'tags' ? folderCount : displayed.length}
         actions={actions}
-        search={view === 'trash' || view === 'tags' ? undefined : { value: q, onChange: setQ, placeholder: 'Search assets…' }}
+        search={view === 'trash' ? undefined : view === 'tags'
+          ? { value: q, onChange: setQ, placeholder: 'Filter folders…' }
+          : { value: q, onChange: setQ, placeholder: 'Search assets…' }}
       />
 
       {uploadError && <p className="mb-2 text-xs text-destructive">{uploadError}</p>}
@@ -465,7 +477,9 @@ export function VersionedAssetGrid() {
         </div>
       )}
 
-      {/* Breadcrumb back to the folders view while a tag filter is active. */}
+      {/* Breadcrumb back to the folders view while a tag filter is active.
+          Clearing the filter happens via the Tags facet; the breadcrumb is
+          purely a "go back" affordance. */}
       {view !== 'trash' && view !== 'tags' && tagFilter.length > 0 && (
         <div className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="tag-breadcrumb">
           <button
@@ -473,20 +487,12 @@ export function VersionedAssetGrid() {
             className="flex items-center gap-1 rounded px-1 py-0.5 transition-colors hover:text-foreground"
             data-testid="breadcrumb-folders"
           >
-            <FolderOpen className="size-3.5" /> Folders
+            <ArrowLeft className="size-3.5" /> Folders
           </button>
           <span>/</span>
           <span className="font-medium text-foreground">
             {tagFilter.map(t => (t === UNTAGGED ? 'Untagged' : t)).join(', ')}
           </span>
-          <button
-            onClick={() => setTagFilter([])}
-            className="ml-0.5 rounded p-0.5 transition-colors hover:text-foreground"
-            aria-label="Clear tag filter"
-            data-testid="clear-tag-filter"
-          >
-            <X className="size-3.5" />
-          </button>
         </div>
       )}
 
@@ -527,6 +533,7 @@ export function VersionedAssetGrid() {
       ) : view === 'tags' ? (
         <TagFolderGrid
           assets={assets}
+          filter={folderFilter}
           onOpenFolder={openFolder}
           onChanged={fetchAssets}
         />

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -6,7 +6,7 @@ import { useQueryState, useQueryArrayState, useSearch, useDebug } from '@makinba
 import { Button } from '@makinbakin/sdk/ui'
 import { PluginHeader, FacetFilter } from '@makinbakin/sdk/components'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
-import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter } from 'lucide-react'
+import { ImagePlus, Upload, Loader2, LayoutGrid, List, Trash2, RotateCcw, X, ListFilter, FolderOpen } from 'lucide-react'
 import { ASSET_TYPES } from '../../lib/constants'
 import { createSseRefetchScheduler } from './sse-refetch'
 import { AssetThumb, AssetMetaSummary, AssetTypeIcon } from './atoms'
@@ -28,6 +28,15 @@ const TYPE_OPTIONS = ASSET_TYPES.map((value) => ({
   label: value === 'pdf' ? 'PDF' : value.charAt(0).toUpperCase() + value.slice(1),
   icon: <AssetTypeIcon type={value} className="size-3.5" />,
 }))
+
+/** Sentinel tag-filter value matching assets with no tags at all. */
+export const UNTAGGED = '__untagged__'
+
+/** Does an asset match the active tag filter (any-of; UNTAGGED = tagless)? */
+export function matchesTagFilter(tags: string[], filter: string[]): boolean {
+  if (filter.length === 0) return true
+  return filter.some((f) => (f === UNTAGGED ? tags.length === 0 : tags.includes(f)))
+}
 
 /** Per-result Antfly relevance breakdown. */
 export interface AssetScoreInfo { score: number; indexScores?: Record<string, number> }
@@ -116,6 +125,7 @@ export function VersionedAssetGrid() {
   const [q, setQ] = useQueryState('q', '')
   const [view, setView] = useQueryState('view', 'grid')
   const [typeFilter, setTypeFilter] = useQueryArrayState('type')
+  const [tagFilter, setTagFilter] = useQueryArrayState('tags')
 
   const [assets, setAssets] = useState<VersionedAssetSummary[]>([])
   const [trash, setTrash] = useState<TrashedAssetSummary[]>([])
@@ -229,6 +239,24 @@ export function VersionedAssetGrid() {
     return c
   }, [assets])
 
+  // Tag facet options derive from the loaded summaries (no extra endpoint);
+  // the pinned Untagged sentinel keeps tagless assets reachable.
+  const tagCounts = useMemo(() => {
+    const c: Record<string, number> = {}
+    for (const a of assets) {
+      if ((a.tags ?? []).length === 0) c[UNTAGGED] = (c[UNTAGGED] ?? 0) + 1
+      for (const t of a.tags ?? []) c[t] = (c[t] ?? 0) + 1
+    }
+    return c
+  }, [assets])
+
+  const tagOptions = useMemo(() => {
+    const tags = Object.keys(tagCounts).filter(t => t !== UNTAGGED)
+      .sort((a, b) => (tagCounts[b] ?? 0) - (tagCounts[a] ?? 0) || a.localeCompare(b))
+      .map(value => ({ value, label: value }))
+    return (tagCounts[UNTAGGED] ?? 0) > 0 ? [{ value: UNTAGGED, label: 'Untagged' }, ...tags] : tags
+  }, [tagCounts])
+
   const scoreMap = useMemo(
     () => new Map<string, AssetScoreInfo>(search.results.map(r => [r.id, { score: r.score, indexScores: r.indexScores }])),
     [search.results],
@@ -242,7 +270,10 @@ export function VersionedAssetGrid() {
   const pending = searching && (search.loading || (search.meta?.query ?? '') !== q.trim())
 
   const filtered = useMemo(() => {
-    let list = assets.filter(a => typeFilter.length === 0 || typeFilter.includes(a.type))
+    let list = assets.filter(a =>
+      (typeFilter.length === 0 || typeFilter.includes(a.type)) &&
+      matchesTagFilter(a.tags ?? [], tagFilter),
+    )
     if (q.trim()) {
       // Restrict to search matches, ordered by relevance (reuse scoreMap).
       list = list
@@ -250,7 +281,7 @@ export function VersionedAssetGrid() {
         .sort((a, b) => (scoreMap.get(b.assetId)?.score ?? 0) - (scoreMap.get(a.assetId)?.score ?? 0))
     }
     return list
-  }, [assets, typeFilter, q, scoreMap])
+  }, [assets, typeFilter, tagFilter, q, scoreMap])
 
   // Keep the last settled list on screen while a search is pending — the
   // results only change once the request completes (no flicker / takeover).
@@ -338,6 +369,32 @@ export function VersionedAssetGrid() {
         <div className="mb-3 mt-3 flex items-center gap-2" data-testid="asset-filters">
           <ListFilter className="size-3.5 shrink-0 text-muted-foreground" />
           <FacetFilter label="Type" options={TYPE_OPTIONS} selected={typeFilter} onChange={setTypeFilter} counts={typeCounts} />
+          <FacetFilter label="Tags" options={tagOptions} selected={tagFilter} onChange={setTagFilter} counts={tagCounts} />
+        </div>
+      )}
+
+      {/* Breadcrumb back to the folders view while a tag filter is active. */}
+      {view !== 'trash' && tagFilter.length > 0 && (
+        <div className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground" data-testid="tag-breadcrumb">
+          <button
+            onClick={() => { setTagFilter([]); setView('tags') }}
+            className="flex items-center gap-1 rounded px-1 py-0.5 transition-colors hover:text-foreground"
+            data-testid="breadcrumb-folders"
+          >
+            <FolderOpen className="size-3.5" /> Folders
+          </button>
+          <span>/</span>
+          <span className="font-medium text-foreground">
+            {tagFilter.map(t => (t === UNTAGGED ? 'Untagged' : t)).join(', ')}
+          </span>
+          <button
+            onClick={() => setTagFilter([])}
+            className="ml-0.5 rounded p-0.5 transition-colors hover:text-foreground"
+            aria-label="Clear tag filter"
+            data-testid="clear-tag-filter"
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
       )}
 

--- a/plugins/assets/components/versioned/asset-urls.ts
+++ b/plugins/assets/components/versioned/asset-urls.ts
@@ -30,3 +30,6 @@ export const UPLOAD_API = '/api/plugins/assets/upload'
 
 /** Trash endpoint — list / restore / permanent-delete / empty. */
 export const TRASH_API = '/api/plugins/assets/trash'
+
+/** Global tag operations — rename / remove / bulk apply. */
+export const TAGS_API = '/api/plugins/assets/tags'

--- a/plugins/assets/components/versioned/atoms.tsx
+++ b/plugins/assets/components/versioned/atoms.tsx
@@ -58,12 +58,18 @@ export function AssetThumb({ assetId, type, version, hasThumb, className }: {
   )
 }
 
-/** Agent · age · taskId · tags row. Shared by card, modal, detail header. */
-export function AssetMetaSummary({ agent, created, taskId, tags }: {
+/**
+ * Agent · age · taskId · tags row. Shared by card, modal, detail header.
+ * `maxTags` caps the badges (cards stay compact, "+N" shows the rest);
+ * the detail view passes Infinity — truncating there hid freshly added
+ * tags behind the overflow counter.
+ */
+export function AssetMetaSummary({ agent, created, taskId, tags, maxTags = 4 }: {
   agent: string
   created: string
   taskId: string | null
   tags: string[]
+  maxTags?: number
 }) {
   return (
     <div className="flex flex-col gap-1.5">
@@ -86,10 +92,12 @@ export function AssetMetaSummary({ agent, created, taskId, tags }: {
       </div>
       {tags.length > 0 && (
         <div className="flex flex-wrap gap-1">
-          {tags.slice(0, 4).map(tag => (
+          {/* Most-recent tags win the cap — tags append chronologically, so a
+              freshly added tag must be visible, not hidden behind "+N". */}
+          {tags.slice(-maxTags).map(tag => (
             <Badge key={tag} variant="secondary" className="text-[9px] h-4 px-1.5">{tag}</Badge>
           ))}
-          {tags.length > 4 && <span className="text-[9px] text-muted-foreground">+{tags.length - 4}</span>}
+          {tags.length > maxTags && <span className="text-[9px] text-muted-foreground">+{tags.length - maxTags}</span>}
         </div>
       )}
     </div>

--- a/plugins/assets/components/versioned/tag-filter.ts
+++ b/plugins/assets/components/versioned/tag-filter.ts
@@ -1,0 +1,10 @@
+/** Shared tag-filter helpers for the grid, folders view, and breadcrumb. */
+
+/** Sentinel tag-filter value matching assets with no tags at all. */
+export const UNTAGGED = '__untagged__'
+
+/** Does an asset match the active tag filter (any-of; UNTAGGED = tagless)? */
+export function matchesTagFilter(tags: string[], filter: string[]): boolean {
+  if (filter.length === 0) return true
+  return filter.some((f) => (f === UNTAGGED ? tags.length === 0 : tags.includes(f)))
+}

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -260,11 +260,19 @@ const assetsPlugin: BakinPlugin = definePlugin({
       schema: {
         description: { type: 'text' },
         tags: { type: 'text' },
+        // Keyword array mirror of `tags` for per-tag facet buckets (text
+        // fields can't facet; arrays index per-element).
+        tags_facet: { type: 'array' },
         agent: { type: 'keyword' },
         task_id: { type: 'keyword' },
         asset_type: { type: 'keyword' },
         file_name: { type: 'text' },
         tool: { type: 'keyword' },
+        // Generation provenance (from the current version's `generation`).
+        // surface is searchable text; provider/model are facet-only.
+        surface: { type: 'text' },
+        provider: { type: 'keyword' },
+        model: { type: 'keyword' },
         updated_at: { type: 'datetime' },
         // `content` is populated server-side by extractAssetContent:
         // plain text for .md/.txt/.json/.csv/.yaml, pdf-parse output for
@@ -277,7 +285,7 @@ const assetsPlugin: BakinPlugin = definePlugin({
         // The search adapter owns provider-specific media dereferencing.
         image_url: { type: 'keyword' },
       },
-      searchableFields: ['description', 'tags', 'file_name', 'content'],
+      searchableFields: ['description', 'tags', 'file_name', 'surface', 'content'],
       // Intentionally no `rerankField`. bakin_assets is a multimodal table
       // (PDF body text in `content`, image pixels in the visual index,
       // metadata in description/tags/file_name) and the cross-encoder
@@ -288,12 +296,12 @@ const assetsPlugin: BakinPlugin = definePlugin({
       // the full rationale and the queries that surfaced the problem.
       // Unused when `indexes` is set, but the type requires it. Kept as the
       // equivalent template for the default-index synthesis path.
-      embeddingTemplate: '{{description}} {{tags}} {{file_name}} {{content}}',
+      embeddingTemplate: '{{description}} {{tags}} {{file_name}} {{surface}} {{content}}',
       indexes: [
         {
           name: 'assets_text',
           embedderRef: 'default',
-          embeddingTemplate: '{{description}} {{tags}} {{file_name}} {{content}}',
+          embeddingTemplate: '{{description}} {{tags}} {{file_name}} {{surface}} {{content}}',
           chunker: { enabled: true, targetTokens: 200, overlapTokens: 25 },
         },
         {
@@ -302,7 +310,7 @@ const assetsPlugin: BakinPlugin = definePlugin({
           mediaUrlField: 'image_url',
         },
       ],
-      facets: ['asset_type', 'agent', 'tool'],
+      facets: ['asset_type', 'agent', 'tool', 'tags_facet', 'provider', 'model'],
       // An asset is a directory under assets/store/<ym>/<assetId>/ whose
       // manifest.json is the single indexed unit (keyed by assetId). Version,
       // thumbnail, and export files never get their own search doc. onSync /

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -12,7 +12,7 @@ import { resolveAssetServe } from './lib/serve'
 import {
   handleVersionedList, handleVersionedGet, handleVersionedPromote,
   handleVersionedDeleteVersion, handleVersionedDeleteAsset, handleVersionedExport,
-  handleVersionedRelink, handleVersionedAddVersion,
+  handleVersionedRelink, handleVersionedAddVersion, handleVersionedUpdateMetadata,
   handleTrashList, handleTrashRestore, handleTrashPermanentDelete, handleTrashEmpty,
 } from './routes/versioned'
 import { isValidAssetId } from './lib/asset-id'
@@ -111,6 +111,18 @@ const routes = [
     params: z.object({ assetId: z.string().min(1) }),
     responses: { 200: okPassthrough, 400: errorResponse },
     handler: async (req) => handleVersionedExport(req),
+  }),
+  defineRoute({
+    path: '/versioned/:assetId/metadata',
+    method: 'PATCH',
+    summary: 'Edit asset description and/or tags',
+    params: z.object({ assetId: z.string().min(1) }),
+    responses: { 200: okPassthrough, 400: errorResponse, 404: errorResponse },
+    handler: async (req, ctx) => {
+      const res = await handleVersionedUpdateMetadata(req)
+      if (res.ok) ctx.activity.audit('asset.metadata_updated', 'user')
+      return res
+    },
   }),
   defineRoute({
     path: '/versioned/:assetId/relink',

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -15,6 +15,7 @@ import {
   handleVersionedRelink, handleVersionedAddVersion, handleVersionedUpdateMetadata,
   handleTrashList, handleTrashRestore, handleTrashPermanentDelete, handleTrashEmpty,
 } from './routes/versioned'
+import { handleTagsRename, handleTagsRemove, handleTagsApply } from './routes/tags'
 import { isValidAssetId } from './lib/asset-id'
 import {
   getAsset, upsertFromSource, resolveFile as resolveVersionedFile,
@@ -149,6 +150,41 @@ const routes = [
     body: { contentType: 'none' },
     responses: { 200: okPassthrough, 400: errorResponse },
     handler: async (req) => handleVersionedDeleteAsset(req),
+  }),
+
+  // Global tag operations — power the folders view + bulk-select tagging.
+  defineRoute({
+    path: '/tags/rename',
+    method: 'POST',
+    summary: 'Rename a tag across all assets',
+    responses: { 200: okPassthrough, 400: errorResponse },
+    handler: async (req, ctx) => {
+      const res = await handleTagsRename(req)
+      if (res.ok) ctx.activity.audit('assets.tag.renamed', 'user')
+      return res
+    },
+  }),
+  defineRoute({
+    path: '/tags/remove',
+    method: 'POST',
+    summary: 'Remove a tag from all assets',
+    responses: { 200: okPassthrough, 400: errorResponse },
+    handler: async (req, ctx) => {
+      const res = await handleTagsRemove(req)
+      if (res.ok) ctx.activity.audit('assets.tag.removed', 'user')
+      return res
+    },
+  }),
+  defineRoute({
+    path: '/tags/apply',
+    method: 'POST',
+    summary: 'Bulk add/remove tags on a set of assets',
+    responses: { 200: okPassthrough, 400: errorResponse },
+    handler: async (req, ctx) => {
+      const res = await handleTagsApply(req)
+      if (res.ok) ctx.activity.audit('assets.tags.applied', 'user')
+      return res
+    },
   }),
 
   // Trash (versioned whole-asset deletions) — restore/permanent-delete/empty.

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -400,6 +400,57 @@ export async function updateMetadata(assetId: string, input: AssetMetadataInput)
   })
 }
 
+/**
+ * Rename a tag across every asset carrying it (merge-dedupe when the target
+ * already exists). Sweeps the live store only — trash is deliberately skipped
+ * (a restored asset may resurrect a stale tag; fix is one metadata edit).
+ */
+export async function renameTagGlobal(from: string, to: string): Promise<{ updated: number }> {
+  const target = normalizeTags([to])[0]
+  if (!from || !target) throw new Error('Both from and to tags are required')
+  let updated = 0
+  for (const summary of listAssets()) {
+    if (!summary.tags.includes(from)) continue
+    await updateMetadata(summary.assetId, { tags: summary.tags.map((t) => (t === from ? target : t)) })
+    updated++
+  }
+  return { updated }
+}
+
+/** Remove a tag from every asset carrying it (assets themselves untouched). Skips trash. */
+export async function removeTagGlobal(tag: string): Promise<{ updated: number }> {
+  if (!tag) throw new Error('tag is required')
+  let updated = 0
+  for (const summary of listAssets()) {
+    if (!summary.tags.includes(tag)) continue
+    await updateMetadata(summary.assetId, { tags: summary.tags.filter((t) => t !== tag) })
+    updated++
+  }
+  return { updated }
+}
+
+/** Bulk add/remove tags on a set of assets. Unknown ids are reported, not fatal. */
+export async function applyTags(
+  assetIds: string[],
+  input: { add?: string[]; remove?: string[] },
+): Promise<{ updated: number; failed: string[] }> {
+  const add = normalizeTags(input.add ?? [])
+  const remove = new Set(normalizeTags(input.remove ?? []))
+  let updated = 0
+  const failed: string[] = []
+  for (const assetId of assetIds) {
+    const manifest = getAsset(assetId)
+    if (!manifest) {
+      failed.push(assetId)
+      continue
+    }
+    const tags = [...manifest.tags.filter((t) => !remove.has(t)), ...add]
+    await updateMetadata(assetId, { tags })
+    updated++
+  }
+  return { updated, failed }
+}
+
 /** Move the current pointer to an existing version (no file changes). */
 export async function promoteVersion(assetId: string, version: number): Promise<AssetManifest> {
   return withAssetLock(assetId, async () => {

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -407,6 +407,9 @@ export async function updateMetadata(assetId: string, input: AssetMetadataInput)
  */
 export async function renameTagGlobal(from: string, to: string): Promise<{ updated: number }> {
   const target = normalizeTags([to])[0]
+  // `from` is deliberately matched verbatim (not normalized): it must equal
+  // what's stored, including legacy pre-normalization tags — rename is the
+  // tool that cleans those up.
   if (!from || !target) throw new Error('Both from and to tags are required')
   let updated = 0
   for (const summary of listAssets()) {
@@ -436,6 +439,9 @@ export async function applyTags(
 ): Promise<{ updated: number; failed: string[] }> {
   const add = normalizeTags(input.add ?? [])
   const remove = new Set(normalizeTags(input.remove ?? []))
+  // Nothing to do → don't rewrite N manifests (each write triggers a
+  // reindex + asset.changed broadcast).
+  if (add.length === 0 && remove.size === 0) return { updated: 0, failed: [] }
   let updated = 0
   const failed: string[] = []
   for (const assetId of assetIds) {

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -18,6 +18,7 @@ import { getContentDir } from '../../../src/core/content-dir'
 import { createLogger } from '../../../src/core/logger'
 import { getMimeType, type AssetType } from './constants'
 import { generateAssetId, assetDirRelPath, yearMonthFromAssetId } from './asset-id'
+import { normalizeTags } from './tags'
 import { withAssetLock } from './asset-lock'
 import { getManifestCached } from './manifest-cache'
 import { taskAssetIndexRemove, taskAssetIndexUpsert } from './task-asset-index'
@@ -195,7 +196,7 @@ export async function createAsset(input: AssetCreateInput): Promise<{ assetId: s
     updated: created,
     currentVersion: 1,
     description: version.description,
-    tags: input.tags ?? [],
+    tags: normalizeTags(input.tags ?? []),
     versions: [version],
     exports: [],
   }
@@ -364,6 +365,38 @@ export async function addVersion(assetId: string, input: AssetVersionInput): Pro
     mirrorDisplay(manifest)
     writeManifestAtomic(dirAbs, manifest)
     return { assetId, version: nextVersion, manifest }
+  })
+}
+
+export interface AssetMetadataInput {
+  description?: string
+  tags?: string[]
+}
+
+/**
+ * Update user-editable metadata. Description writes through to the asset level
+ * AND the current version (200-char cap — same as version writes) so the
+ * mirror invariant holds; tags replace the asset-level namespace (normalized)
+ * and never touch versions.
+ */
+export async function updateMetadata(assetId: string, input: AssetMetadataInput): Promise<AssetManifest> {
+  return withAssetLock(assetId, async () => {
+    const dirAbs = assetDirAbs(assetId)
+    if (!dirAbs) throw new Error(`Invalid assetId: ${assetId}`)
+    const manifest = readManifest(dirAbs)
+    if (!manifest) throw new Error(`Asset not found: ${assetId}`)
+    if (input.description !== undefined) {
+      const description = input.description.slice(0, 200)
+      manifest.description = description
+      const current = manifest.versions.find((v) => v.version === manifest.currentVersion)
+      if (current) current.description = description
+    }
+    if (input.tags !== undefined) {
+      manifest.tags = normalizeTags(input.tags)
+    }
+    manifest.updated = nowIso()
+    writeManifestAtomic(dirAbs, manifest)
+    return manifest
   })
 }
 
@@ -669,5 +702,11 @@ async function upsertFromSourceInner(sourcePath: string, input: AssetCreateInput
     tool: input.tool ?? null,
     description: input.description,
   })
+  // Union caller-provided tags into the asset-level namespace — agents add
+  // organization, never wipe the user's. (Separate locked write; the watcher
+  // coalesces and only the final manifest is indexed.)
+  if (input.tags && input.tags.length > 0) {
+    await updateMetadata(existingId, { tags: [...(next.manifest.tags ?? []), ...input.tags] })
+  }
   return { assetId: next.assetId, version: next.version, changed: true }
 }

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -178,7 +178,6 @@ export async function createAsset(input: AssetCreateInput): Promise<{ assetId: s
     height: dims.height,
     created,
     description: (input.description ?? input.prompt ?? '').slice(0, 200),
-    tags: input.tags ?? [],
     op: input.op ?? 'upload',
     parentVersion: null,
     tool: input.tool ?? null,
@@ -196,7 +195,7 @@ export async function createAsset(input: AssetCreateInput): Promise<{ assetId: s
     updated: created,
     currentVersion: 1,
     description: version.description,
-    tags: version.tags,
+    tags: input.tags ?? [],
     versions: [version],
     exports: [],
   }
@@ -299,12 +298,15 @@ function assetDirAbs(assetId: string): string | null {
   return rel ? join(getContentDir(), rel) : null
 }
 
-/** Asset-level display fields mirror the current version's. */
+/**
+ * Asset-level description mirrors the current version's. Tags deliberately do
+ * NOT mirror — they're an asset-level organizational namespace that must
+ * survive addVersion/promote/deleteVersion.
+ */
 function mirrorDisplay(manifest: AssetManifest): void {
   const current = manifest.versions.find((v) => v.version === manifest.currentVersion)
   if (current) {
     manifest.description = current.description
-    manifest.tags = current.tags
   }
 }
 
@@ -323,7 +325,6 @@ export interface AssetVersionInput {
   prompt?: string | null
   promptHash?: string | null
   description?: string
-  tags?: string[]
   generation?: AssetGeneration | null
 }
 
@@ -353,7 +354,6 @@ export async function addVersion(assetId: string, input: AssetVersionInput): Pro
       version: nextVersion, file, thumb, mimeType: getMimeType(input.sourceFilePath), size: statSync(fileAbs).size,
       width: dims.width, height: dims.height, created,
       description: (input.description ?? input.prompt ?? '').slice(0, 200),
-      tags: input.tags ?? [],
       op: input.op ?? 'edit', parentVersion, tool: input.tool ?? null,
       prompt: input.prompt ?? null, promptHash: input.promptHash ?? null,
       generation: input.generation ?? null,
@@ -668,7 +668,6 @@ async function upsertFromSourceInner(sourcePath: string, input: AssetCreateInput
     op: 'upload',
     tool: input.tool ?? null,
     description: input.description,
-    tags: input.tags,
   })
   return { assetId: next.assetId, version: next.version, changed: true }
 }

--- a/plugins/assets/lib/manifest.ts
+++ b/plugins/assets/lib/manifest.ts
@@ -36,10 +36,12 @@ export const AssetVersionSchema = z.object({
   width: z.number().int().nullable(),
   height: z.number().int().nullable(),
   created: z.string(),
-  // Per-version display fields. Asset-level description/tags mirror the current
-  // version's, so promote/delete losslessly restore the right display.
+  // Per-version display field. Asset-level description mirrors the current
+  // version's, so promote/delete losslessly restore the right display. Tags are
+  // deliberately NOT versioned — they're an asset-level organizational
+  // namespace that must survive addVersion/promote (old manifests' version
+  // tags are stripped by parse).
   description: z.string(),
-  tags: z.array(z.string()),
   op: z.enum(ASSET_OPS),
   parentVersion: z.number().int().positive().nullable(),
   tool: z.string().nullable(),

--- a/plugins/assets/lib/search-doc.ts
+++ b/plugins/assets/lib/search-doc.ts
@@ -49,11 +49,20 @@ export async function buildVersionedAssetSearchDoc(manifest: AssetManifest, asse
   return {
     description: manifest.description || '',
     tags: (manifest.tags || []).join(', '),
+    // Keyword array for per-tag facet buckets (the comma-joined `tags` text
+    // field can't facet — a terms agg would bucket the whole string).
+    tags_facet: manifest.tags || [],
     agent: manifest.agent || '',
     task_id: manifest.taskId || '',
     asset_type: manifest.type,
     file_name: assetId,
     tool: current.tool || '',
+    // Generation provenance: surface is searchable/embedded ("instagram"
+    // matches instagram-feed-portrait); provider/model are facet-only —
+    // embedding them would flatten similarity across generated assets.
+    surface: current.generation?.surface ?? '',
+    provider: current.generation?.provider ?? '',
+    model: current.generation?.model ?? '',
     updated_at: manifest.updated || new Date().toISOString(),
     content,
     image_url: isRaster ? buildAssetFileUrl(relFromAssetsRoot) : '',

--- a/plugins/assets/lib/tags.ts
+++ b/plugins/assets/lib/tags.ts
@@ -1,0 +1,21 @@
+/**
+ * Tag normalization — the single source of truth for every path that writes
+ * tags (metadata PATCH, global tag ops, bulk apply, createAsset, upload,
+ * assets_save). Tags double as the folder namespace in the UI, so consistency
+ * matters: "Hello World" and "hello-world" must be the same folder.
+ */
+
+/** Normalize one tag: trim, lowercase, collapse internal whitespace to hyphens. */
+export function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase().replace(/\s+/g, '-')
+}
+
+/** Normalize a tag list: per-tag normalize, drop empties, dedupe (first-seen order). */
+export function normalizeTags(tags: string[]): string[] {
+  const out: string[] = []
+  for (const raw of tags) {
+    const tag = normalizeTag(raw)
+    if (tag && !out.includes(tag)) out.push(tag)
+  }
+  return out
+}

--- a/plugins/assets/lib/tags.ts
+++ b/plugins/assets/lib/tags.ts
@@ -5,9 +5,15 @@
  * matters: "Hello World" and "hello-world" must be the same folder.
  */
 
-/** Normalize one tag: trim, lowercase, collapse internal whitespace to hyphens. */
+/**
+ * Normalize one tag: trim, lowercase, collapse internal whitespace to hyphens,
+ * then strip everything outside [a-z0-9-]. The charset restriction keeps tags
+ * safe as URL params and search facet tokens (Antfly filter queries
+ * string-interpolate values), and makes the UI's `__untagged__` filter
+ * sentinel structurally uncreatable (underscores are stripped).
+ */
 export function normalizeTag(tag: string): string {
-  return tag.trim().toLowerCase().replace(/\s+/g, '-')
+  return tag.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')
 }
 
 /** Normalize a tag list: per-tag normalize, drop empties, dedupe (first-seen order). */

--- a/plugins/assets/routes/tags.ts
+++ b/plugins/assets/routes/tags.ts
@@ -1,0 +1,51 @@
+/**
+ * HTTP handlers for global tag operations — rename/remove across the whole
+ * store and bulk apply over a set of assets. These power the folders view and
+ * bulk-select tagging; each underlying mutation is an atomic manifest write
+ * the watcher picks up for reindex + the asset.changed SSE event.
+ */
+import { renameTagGlobal, removeTagGlobal, applyTags } from '../lib/asset-service'
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/** POST /tags/rename — rename a tag across all assets carrying it. */
+export async function handleTagsRename(req: Request): Promise<Response> {
+  const body = await req.json().catch(() => ({})) as { from?: unknown; to?: unknown }
+  const from = typeof body.from === 'string' ? body.from.trim() : ''
+  const to = typeof body.to === 'string' ? body.to.trim() : ''
+  if (!from || !to) return Response.json({ error: 'from and to (non-empty strings) required' }, { status: 400 })
+  try {
+    return Response.json({ ok: true, ...(await renameTagGlobal(from, to)) })
+  } catch (err) {
+    return Response.json({ error: errMsg(err) }, { status: 400 })
+  }
+}
+
+/** POST /tags/remove — remove a tag from all assets carrying it. */
+export async function handleTagsRemove(req: Request): Promise<Response> {
+  const body = await req.json().catch(() => ({})) as { tag?: unknown }
+  const tag = typeof body.tag === 'string' ? body.tag.trim() : ''
+  if (!tag) return Response.json({ error: 'tag (non-empty string) required' }, { status: 400 })
+  try {
+    return Response.json({ ok: true, ...(await removeTagGlobal(tag)) })
+  } catch (err) {
+    return Response.json({ error: errMsg(err) }, { status: 400 })
+  }
+}
+
+/** POST /tags/apply — bulk add/remove tags on a set of assets. */
+export async function handleTagsApply(req: Request): Promise<Response> {
+  const body = await req.json().catch(() => ({})) as { assetIds?: unknown; add?: unknown; remove?: unknown }
+  const assetIds = Array.isArray(body.assetIds) && body.assetIds.every((id) => typeof id === 'string') ? body.assetIds as string[] : []
+  const add = Array.isArray(body.add) && body.add.every((t) => typeof t === 'string') ? body.add as string[] : undefined
+  const remove = Array.isArray(body.remove) && body.remove.every((t) => typeof t === 'string') ? body.remove as string[] : undefined
+  if (assetIds.length === 0) return Response.json({ error: 'assetIds (non-empty string[]) required' }, { status: 400 })
+  if (!add?.length && !remove?.length) return Response.json({ error: 'add and/or remove (string[]) required' }, { status: 400 })
+  try {
+    return Response.json({ ok: true, ...(await applyTags(assetIds, { add, remove })) })
+  } catch (err) {
+    return Response.json({ error: errMsg(err) }, { status: 400 })
+  }
+}

--- a/plugins/assets/routes/versioned.ts
+++ b/plugins/assets/routes/versioned.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import {
   listAssets, getAsset, promoteVersion, deleteVersion, deleteAsset, addExport, relink,
-  addVersion, listTrashedAssets, restoreAsset, permanentlyDeleteTrashed, emptyAssetTrash,
+  addVersion, updateMetadata, listTrashedAssets, restoreAsset, permanentlyDeleteTrashed, emptyAssetTrash,
 } from '../lib/asset-service'
 import type { AssetType } from '../lib/constants'
 
@@ -114,6 +114,24 @@ export async function handleVersionedAddVersion(req: Request): Promise<Response>
   } finally {
     try { unlinkSync(tmpPath) } catch { /* best-effort */ }
     try { rmSync(tmpDir, { recursive: true, force: true }) } catch { /* best-effort */ }
+  }
+}
+
+/** PATCH /versioned/:assetId/metadata — edit description (write-through) and/or tags. */
+export async function handleVersionedUpdateMetadata(req: Request): Promise<Response> {
+  const assetId = segmentsAfterVersioned(new URL(req.url))[0] || ''
+  if (!getAsset(assetId)) return Response.json({ error: 'Asset not found' }, { status: 404 })
+  const body = await req.json().catch(() => null) as { description?: unknown; tags?: unknown } | null
+  const description = typeof body?.description === 'string' ? body.description : undefined
+  const tags = Array.isArray(body?.tags) && body.tags.every((t) => typeof t === 'string') ? body.tags as string[] : undefined
+  const malformed = (body?.description !== undefined && description === undefined) || (body?.tags !== undefined && tags === undefined)
+  if (malformed || (description === undefined && tags === undefined)) {
+    return Response.json({ error: 'description (string) and/or tags (string[]) required' }, { status: 400 })
+  }
+  try {
+    return Response.json({ ok: true, asset: await updateMetadata(assetId, { description, tags }) })
+  } catch (err) {
+    return Response.json({ error: errMsg(err) }, { status: 400 })
   }
 }
 

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -132,8 +132,10 @@ export async function importImage(ctx: PluginContext, params: ImagesImportParams
       taskId: params.taskId,
       op: 'import',
       tool: 'bakin_exec_images_import',
+      // No machine-tag default: provenance lives in op/source, tags are the
+      // user's organizational namespace.
       description: (params.description || basename(params.filePath)).slice(0, 200),
-      tags: params.tags ?? ['imported'],
+      tags: params.tags,
       slug: params.description || basename(params.filePath),
       source: { kind: 'import', path: params.filePath },
     })
@@ -209,12 +211,14 @@ async function persistImageResult(
     ? await ctx.assets.createAsset({
         sourceFilePath: image.filePath, type: 'images', agent, taskId: params.taskId,
         slug: `${req.dims.surface}-image`, op: 'generate', tool,
-        prompt: req.prompt, promptHash, description, tags: ['generated', req.dims.surface, req.route.provider, req.route.model],
+        // No machine tags: provenance (surface/provider/model) lives in
+        // `generation` + `op`; tags stay the user's organizational namespace.
+        prompt: req.prompt, promptHash, description,
         source: { kind: 'generated', path: null }, generation,
       })
     : await ctx.assets.addVersion(opts.assetId, {
         sourceFilePath: image.filePath, op: 'edit', tool,
-        prompt: req.prompt, promptHash, description, tags: ['edited', req.dims.surface, req.route.provider, req.route.model],
+        prompt: req.prompt, promptHash, description,
         generation,
       })
 

--- a/scripts/generate-embedded-assets.ts
+++ b/scripts/generate-embedded-assets.ts
@@ -10,7 +10,7 @@
  * unchanged in both modes.
  *
  * The generated map is keyed by the serving URL path the handlers use
- * (e.g. "/assets/main.js", "/globals.css", "/vendor/react.js",
+ * (e.g. "/_app/main.js", "/globals.css", "/vendor/react.js",
  * "/api/plugins/tasks/assets/client.js") so the handlers only need a
  * single lookup.
  *
@@ -91,8 +91,10 @@ export function collectAssets(repoRoot: string): AssetSource[] {
 
   const assets: AssetSource[] = []
 
-  // Host client bundle — served under /assets/*
-  walk(join(repoRoot, 'packages/host/dist'), '/assets', assets)
+  // Host client bundle — served under /_app/* (NOT /assets/* — that's the
+  // assets plugin's page namespace; the old shared prefix made hard refreshes
+  // of /assets/<assetId> 404 instead of reaching the SPA fallback).
+  walk(join(repoRoot, 'packages/host/dist'), '/_app', assets)
 
   // Public static files — served at their path under / (minus /vendor, handled below)
   const publicDir = join(repoRoot, 'packages/host/public')

--- a/src/core/search-migration.ts
+++ b/src/core/search-migration.ts
@@ -17,6 +17,9 @@
  *   2 — multi-index support (assets_text + assets_visual on bakin_assets),
  *       content field populated server-side, default embedder swapped to
  *       BAAI/bge-small-en-v1.5 via Termite.
+ *   3 — bakin_assets gains tags_facet (keyword array for per-tag facet
+ *       buckets) + generation provenance fields (surface searchable/embedded,
+ *       provider/model facet-only); assets embedding template adds {{surface}}.
  *
  * Bump SCHEMA_VERSION whenever a change requires an existing table to
  * be dropped and recreated with new schema, indexes, or embedder config.
@@ -32,7 +35,7 @@ import { createLogger } from './logger'
 const log = createLogger('search-migration')
 
 /** Current in-code schema version. Bump when search tables need a drop+recreate. */
-export const SCHEMA_VERSION = 2
+export const SCHEMA_VERSION = 3
 
 const STATE_FILE_NAME = '.search-state.json'
 const TABLE_PREFIX = 'bakin_'

--- a/tests/api/curated.test.ts
+++ b/tests/api/curated.test.ts
@@ -117,7 +117,7 @@ describe('embedded-assets builder excludes agents/', () => {
     expect(script).not.toContain("'/agents'")
 
     // Positively confirm the explicit walks are still there
-    expect(script).toContain("walk(join(repoRoot, 'packages/host/dist'), '/assets'")
+    expect(script).toContain("walk(join(repoRoot, 'packages/host/dist'), '/_app'")
     expect(script).toContain('walk(distDir')
   })
 })

--- a/tests/api/host-static.test.ts
+++ b/tests/api/host-static.test.ts
@@ -49,7 +49,7 @@ const SAMPLE_HTML = `<!doctype html>
   <head><title>Bakin</title></head>
   <body class="bg-background">
     <div id="root"></div>
-    <script type="module" src="/assets/main.js"></script>
+    <script type="module" src="/_app/main.js"></script>
   </body>
 </html>
 `
@@ -118,8 +118,8 @@ describe('transformIndexHtmlForDev', () => {
     expect(out).toContain('<script type="module" src="/__bakin-dev/client.js"></script>')
     // Script lands before </body>, not after.
     expect(out.indexOf('__bakin-dev')).toBeLessThan(out.indexOf('</body>'))
-    // The original <script src="/assets/main.js"> is still present.
-    expect(out).toContain('/assets/main.js')
+    // The original <script src="/_app/main.js"> is still present.
+    expect(out).toContain('/_app/main.js')
   })
 
   it('no-ops (logs a warning) when </body> is missing', () => {
@@ -135,7 +135,7 @@ describe('host index boot fallback', () => {
     const html = readFileSync(join(process.cwd(), 'packages/host/public/index.html'), 'utf-8')
     expect(html).toContain('class="bakin-boot"')
     expect(html).toContain('Loading app')
-    expect(html.indexOf('class="bakin-boot"')).toBeLessThan(html.indexOf('/assets/main.js'))
+    expect(html.indexOf('class="bakin-boot"')).toBeLessThan(html.indexOf('/_app/main.js'))
   })
 })
 
@@ -180,7 +180,7 @@ describe('cacheControlFor', () => {
 
   it('returns no-store for any 200 response when BAKIN_DEV=1', () => {
     process.env.BAKIN_DEV = '1'
-    expect(cacheControlFor('/assets/main.js', 200)).toBe('no-store')
+    expect(cacheControlFor('/_app/main.js', 200)).toBe('no-store')
     expect(cacheControlFor('/vendor/react.js', 200)).toBe('no-store')
     expect(cacheControlFor('/globals.css', 200)).toBe('no-store')
     expect(cacheControlFor('/index.html', 200)).toBe('no-store')
@@ -189,7 +189,7 @@ describe('cacheControlFor', () => {
   it('returns no-cache for HTML and public, max-age=300 for other 200s when BAKIN_DEV is unset', () => {
     delete process.env.BAKIN_DEV
     expect(cacheControlFor('/index.html', 200)).toBe('no-cache')
-    expect(cacheControlFor('/assets/main.js', 200)).toBe('public, max-age=300')
+    expect(cacheControlFor('/_app/main.js', 200)).toBe('public, max-age=300')
     expect(cacheControlFor('/vendor/react.js', 200)).toBe('public, max-age=300')
   })
 

--- a/tests/plugins/assets/asset-lifecycle.test.ts
+++ b/tests/plugins/assets/asset-lifecycle.test.ts
@@ -39,23 +39,30 @@ afterAll(() => rmSync(testDir, { recursive: true, force: true }))
 describe('addVersion + promote', () => {
   it('appends a version derived from current and advances the pointer', async () => {
     const { assetId } = await freshImageAsset()
-    const r = await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), op: 'edit', description: 'second', tags: ['two'] })
+    const r = await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), op: 'edit', description: 'second' })
     expect(r.version).toBe(2)
     const m = getAsset(assetId)!
     expect(m.currentVersion).toBe(2)
     expect(m.versions.map((v) => v.version)).toEqual([1, 2])
     expect(m.versions[1].parentVersion).toBe(1)
     expect(m.description).toBe('second') // mirrors current
-    expect(m.tags).toEqual(['two'])
+    expect(m.tags).toEqual(['one']) // tags are asset-level — versioning never touches them
   })
 
-  it('promote moves the pointer and restores that version display (mirror)', async () => {
+  it('promote moves the pointer and restores that version description, never tags', async () => {
     const { assetId } = await freshImageAsset()
-    await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), description: 'second', tags: ['two'] })
+    await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), description: 'second' })
     const m = await promoteVersion(assetId, 1)
     expect(m.currentVersion).toBe(1)
     expect(m.description).toBe('first')
     expect(m.tags).toEqual(['one'])
+  })
+
+  it('version objects carry no tags field (asset-level namespace only)', async () => {
+    const { assetId } = await freshImageAsset()
+    await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), description: 'second' })
+    const m = getAsset(assetId)!
+    for (const v of m.versions) expect('tags' in v).toBe(false)
   })
 })
 

--- a/tests/plugins/assets/asset-service.test.ts
+++ b/tests/plugins/assets/asset-service.test.ts
@@ -74,7 +74,7 @@ describe('manifest atomic IO', () => {
     assetId: '20260529-m-aabbccdd', type: 'text', source: { kind: 'upload', path: null },
     agent: 'tester', taskId: null, created: 'c', updated: 'c', currentVersion: 1,
     description: 'd', tags: ['t'],
-    versions: [{ version: 1, file: 'v1.md', thumb: null, mimeType: 'text/markdown', size: 3, width: null, height: null, created: 'c', description: 'd', tags: ['t'], op: 'upload', parentVersion: null, tool: null, prompt: null, promptHash: null, generation: null }],
+    versions: [{ version: 1, file: 'v1.md', thumb: null, mimeType: 'text/markdown', size: 3, width: null, height: null, created: 'c', description: 'd', op: 'upload', parentVersion: null, tool: null, prompt: null, promptHash: null, generation: null }],
     exports: [],
   }
 

--- a/tests/plugins/assets/manifest-cache.test.ts
+++ b/tests/plugins/assets/manifest-cache.test.ts
@@ -190,7 +190,7 @@ describe('eviction + negative reads', () => {
       assetId: ghostId, type: 'text', source: { kind: 'upload', path: null },
       agent: 'tester', taskId: null, created: 'c', updated: 'c', currentVersion: 1,
       description: 'now real', tags: [],
-      versions: [{ version: 1, file: 'v1.md', thumb: null, mimeType: 'text/markdown', size: 1, width: null, height: null, created: 'c', description: 'now real', tags: [], op: 'upload', parentVersion: null, tool: null, prompt: null, promptHash: null, generation: null }],
+      versions: [{ version: 1, file: 'v1.md', thumb: null, mimeType: 'text/markdown', size: 1, width: null, height: null, created: 'c', description: 'now real', op: 'upload', parentVersion: null, tool: null, prompt: null, promptHash: null, generation: null }],
       exports: [],
     }
     writeFileSync(join(dirAbs, 'v1.md'), 'x', 'utf-8')
@@ -216,7 +216,7 @@ describe('test-mode freeze', () => {
     })
     const manifest = getAsset(id)!
     expect(() => { (manifest as AssetManifest).description = 'mutated' }).toThrow()
-    expect(() => { (manifest as AssetManifest).versions[0].tags.push('nope') }).toThrow()
+    expect(() => { (manifest as AssetManifest).versions[0].description = 'nope' }).toThrow()
     expect(getAsset(id)?.description).toBe('do not touch')
   })
 })

--- a/tests/plugins/assets/metadata-route.test.ts
+++ b/tests/plugins/assets/metadata-route.test.ts
@@ -48,6 +48,10 @@ describe('normalizeTags', () => {
   it('preserves first-seen order', () => {
     expect(normalizeTags(['beta', 'Alpha', 'BETA'])).toEqual(['beta', 'alpha'])
   })
+  it('collapses tabs/newlines and passes already-normalized tags through', () => {
+    expect(normalizeTags(['a\tb', 'c\nd', 'already-normal'])).toEqual(['a-b', 'c-d', 'already-normal'])
+    expect(normalizeTags(['hello-world'])).toEqual(['hello-world'])
+  })
 })
 
 describe('updateMetadata', () => {

--- a/tests/plugins/assets/metadata-route.test.ts
+++ b/tests/plugins/assets/metadata-route.test.ts
@@ -52,6 +52,13 @@ describe('normalizeTags', () => {
     expect(normalizeTags(['a\tb', 'c\nd', 'already-normal'])).toEqual(['a-b', 'c-d', 'already-normal'])
     expect(normalizeTags(['hello-world'])).toEqual(['hello-world'])
   })
+  it('strips characters outside [a-z0-9-] — tags stay safe as URL/facet tokens', () => {
+    expect(normalizeTags(['a:b', 'foo)(', 'c.d/e'])).toEqual(['ab', 'foo', 'cde'])
+    expect(normalizeTags(['!!!'])).toEqual([]) // fully-stripped tags drop
+  })
+  it('makes the __untagged__ filter sentinel uncreatable (underscores stripped)', () => {
+    expect(normalizeTags(['__untagged__'])).toEqual(['untagged'])
+  })
 })
 
 describe('updateMetadata', () => {

--- a/tests/plugins/assets/metadata-route.test.ts
+++ b/tests/plugins/assets/metadata-route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Asset metadata editing — normalizeTags, updateMetadata service (description
+ * write-through + asset-level tags), PATCH /versioned/:assetId/metadata route,
+ * and the upsert-from-source tag union. Isolated to a temp BAKIN_HOME.
+ */
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdirSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+
+const testDir = join(tmpdir(), `bakin-metadata-route-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import sharp from 'sharp'
+import { normalizeTags } from '../../../plugins/assets/lib/tags'
+import {
+  createAsset, addVersion, getAsset, promoteVersion, updateMetadata, upsertFromSource,
+} from '../../../plugins/assets/lib/asset-service'
+import { assetDirRelPath } from '../../../plugins/assets/lib/asset-id'
+import { handleVersionedUpdateMetadata } from '../../../plugins/assets/routes/versioned'
+
+const base = 'http://localhost/api/plugins/assets/versioned'
+const patch = (path: string, body?: unknown) =>
+  new Request(`${base}${path}`, { method: 'PATCH', body: body === undefined ? undefined : JSON.stringify(body), headers: { 'Content-Type': 'application/json' } })
+
+const srcDir = join(testDir, 'src')
+const png = (name: string, r: number) =>
+  sharp({ create: { width: 6, height: 6, channels: 3, background: { r, g: 0, b: 0 } } }).png().toFile(join(srcDir, name))
+
+async function freshAsset() {
+  return createAsset({ sourceFilePath: join(srcDir, 'a.png'), type: 'images', agent: 'pixel', taskId: 't1', slug: 'pic', op: 'generate', description: 'first', tags: ['one'] })
+}
+
+beforeAll(async () => {
+  mkdirSync(srcDir, { recursive: true })
+  await png('a.png', 10)
+  await png('b.png', 20)
+})
+
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+describe('normalizeTags', () => {
+  it('trims, lowercases, hyphenates internal whitespace, dedupes, drops empties', () => {
+    expect(normalizeTags(['  Hello World ', 'hello-world', 'A  B', '', '   ', 'X'])).toEqual(['hello-world', 'a-b', 'x'])
+  })
+  it('preserves first-seen order', () => {
+    expect(normalizeTags(['beta', 'Alpha', 'BETA'])).toEqual(['beta', 'alpha'])
+  })
+})
+
+describe('updateMetadata', () => {
+  it('writes description through to asset level AND current version, capped at 200', async () => {
+    const { assetId } = await freshAsset()
+    await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), op: 'edit', description: 'second' })
+    const long = 'x'.repeat(250)
+    const m = await updateMetadata(assetId, { description: long })
+    expect(m.description).toBe('x'.repeat(200))
+    expect(m.versions.find(v => v.version === 2)!.description).toBe('x'.repeat(200))
+    expect(m.versions.find(v => v.version === 1)!.description).toBe('first') // older versions untouched
+  })
+
+  it('replaces tags asset-level only, normalized', async () => {
+    const { assetId } = await freshAsset()
+    const m = await updateMetadata(assetId, { tags: ['Hello World', 'two', 'TWO'] })
+    expect(m.tags).toEqual(['hello-world', 'two'])
+    expect(m.description).toBe('first') // untouched when not provided
+  })
+
+  it('promote after edit restores that version description but never tags', async () => {
+    const { assetId } = await freshAsset()
+    await addVersion(assetId, { sourceFilePath: join(srcDir, 'b.png'), op: 'edit', description: 'second' })
+    await updateMetadata(assetId, { description: 'edited v2', tags: ['kept'] })
+    const m = await promoteVersion(assetId, 1)
+    expect(m.description).toBe('first') // v1's stored description
+    expect(m.tags).toEqual(['kept']) // tags survive promote
+  })
+
+  it('throws for unknown asset', async () => {
+    expect(updateMetadata('20260529-ghost-deadbeef', { tags: ['x'] })).rejects.toThrow()
+  })
+})
+
+describe('PATCH /versioned/:assetId/metadata', () => {
+  it('updates and persists to disk atomically', async () => {
+    const { assetId } = await freshAsset()
+    const res = await handleVersionedUpdateMetadata(patch(`/${assetId}/metadata`, { description: 'new desc', tags: [' Tag One ', 'two'] }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.asset.tags).toEqual(['tag-one', 'two'])
+    // Re-read manifest from disk — not from any cache.
+    const raw = JSON.parse(readFileSync(join(testDir, assetDirRelPath(assetId)!, 'manifest.json'), 'utf-8'))
+    expect(raw.description).toBe('new desc')
+    expect(raw.tags).toEqual(['tag-one', 'two'])
+    expect(raw.versions[0].description).toBe('new desc') // write-through
+  })
+
+  it('400s an empty or invalid body', async () => {
+    const { assetId } = await freshAsset()
+    expect((await handleVersionedUpdateMetadata(patch(`/${assetId}/metadata`, {}))).status).toBe(400)
+    expect((await handleVersionedUpdateMetadata(patch(`/${assetId}/metadata`, { tags: 'not-an-array' }))).status).toBe(400)
+  })
+
+  it('404s an unknown asset', async () => {
+    const res = await handleVersionedUpdateMetadata(patch('/20260529-ghost-deadbeef/metadata', { tags: ['x'] }))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('upsertFromSource tag union', () => {
+  it('unions provided tags into asset tags when versioning existing content', async () => {
+    const sourcePath = join(srcDir, 'evolving.png')
+    await png('evolving.png', 30)
+    const first = await upsertFromSource(sourcePath, {
+      sourceFilePath: sourcePath, type: 'images', agent: 'pixel', taskId: null, op: 'upload', tags: ['Initial Tag'],
+    })
+    expect(getAsset(first.assetId)!.tags).toEqual(['initial-tag'])
+
+    await png('evolving.png', 40) // content changes → new version
+    const second = await upsertFromSource(sourcePath, {
+      sourceFilePath: sourcePath, type: 'images', agent: 'pixel', taskId: null, op: 'upload', tags: ['added'],
+    })
+    expect(second.assetId).toBe(first.assetId)
+    expect(second.changed).toBe(true)
+    expect(getAsset(first.assetId)!.tags).toEqual(['initial-tag', 'added']) // union, not replace
+  })
+
+  it('no-op upsert (unchanged content) still leaves tags intact', async () => {
+    const sourcePath = join(srcDir, 'stable.png')
+    await png('stable.png', 50)
+    const first = await upsertFromSource(sourcePath, {
+      sourceFilePath: sourcePath, type: 'images', agent: 'pixel', taskId: null, op: 'upload', tags: ['keep'],
+    })
+    const again = await upsertFromSource(sourcePath, {
+      sourceFilePath: sourcePath, type: 'images', agent: 'pixel', taskId: null, op: 'upload',
+    })
+    expect(again.changed).toBe(false)
+    expect(getAsset(first.assetId)!.tags).toEqual(['keep'])
+  })
+})

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -68,8 +68,8 @@ afterAll(() => {
 // ===========================================================================
 
 describe('route registration', () => {
-  it('registers all 14 routes', () => {
-    expect(plugin.routes.length).toBe(14)
+  it('registers all 15 routes', () => {
+    expect(plugin.routes.length).toBe(15)
   })
 
   it.each([
@@ -79,6 +79,7 @@ describe('route registration', () => {
     ['POST', '/versioned/:assetId/promote'],
     ['DELETE', '/versioned/:assetId/v/:version'],
     ['POST', '/versioned/:assetId/export'],
+    ['PATCH', '/versioned/:assetId/metadata'],
     ['POST', '/versioned/:assetId/relink'],
     ['POST', '/versioned/:assetId/version'],
     ['DELETE', '/versioned/:assetId'],

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -68,8 +68,8 @@ afterAll(() => {
 // ===========================================================================
 
 describe('route registration', () => {
-  it('registers all 15 routes', () => {
-    expect(plugin.routes.length).toBe(15)
+  it('registers all 18 routes', () => {
+    expect(plugin.routes.length).toBe(18)
   })
 
   it.each([
@@ -83,6 +83,9 @@ describe('route registration', () => {
     ['POST', '/versioned/:assetId/relink'],
     ['POST', '/versioned/:assetId/version'],
     ['DELETE', '/versioned/:assetId'],
+    ['POST', '/tags/rename'],
+    ['POST', '/tags/remove'],
+    ['POST', '/tags/apply'],
     ['GET', '/trash'],
     ['POST', '/trash/:trashName/restore'],
     ['DELETE', '/trash/:trashName'],

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -170,6 +170,27 @@ describe('exec tool: bakin_exec_assets_save', () => {
     expect((result.assetId as string)).toMatch(/^\d{8}-saved-hero-[0-9a-f]{8}$/)
     expect(result.version).toBe(1)
     expect(result.changed).toBe(true)
+
+    // Tags land on the asset (asset-level namespace), normalized.
+    const getTool = findTool(plugin.execTools, 'bakin_exec_assets_get')!
+    const fetched = await callTool(getTool, { assetId: result.assetId }, 'pixel')
+    expect((fetched.asset as { tags: string[] }).tags).toEqual(['test', 'save'])
+  })
+
+  it('normalizes caller tags on save', async () => {
+    const sourceFile = join(testDir, 'source-tagged.png')
+    writeFileSync(sourceFile, 'tagged-bytes')
+
+    const tool = findTool(plugin.execTools, 'bakin_exec_assets_save')!
+    const result = await callTool(tool, {
+      filePath: sourceFile, taskId: 'task-save-002', type: 'images',
+      tags: ['Hello World', 'MIXED case', 'hello-world'],
+    }, 'pixel')
+    expect(result.ok).toBe(true)
+
+    const getTool = findTool(plugin.execTools, 'bakin_exec_assets_get')!
+    const fetched = await callTool(getTool, { assetId: result.assetId }, 'pixel')
+    expect((fetched.asset as { tags: string[] }).tags).toEqual(['hello-world', 'mixed-case'])
   })
 
   it('returns error for nonexistent source file', async () => {

--- a/tests/plugins/assets/search-doc.test.ts
+++ b/tests/plugins/assets/search-doc.test.ts
@@ -50,6 +50,7 @@ describe('buildVersionedAssetSearchDoc', () => {
     expect(doc.asset_type).toBe('images')
     expect(doc.description).toBe('a pic')
     expect(doc.tags).toBe('hero')
+    expect(doc.tags_facet).toEqual(['hero']) // keyword array for faceting
     expect(doc.agent).toBe('pixel')
     expect(doc.task_id).toBe('t1')
     expect(String(doc.image_url)).toContain('store/') // file:// url to current version
@@ -62,5 +63,26 @@ describe('buildVersionedAssetSearchDoc', () => {
     expect(doc.asset_type).toBe('text')
     expect(doc.image_url).toBe('')
     expect(String(doc.content)).toContain('searchable body text')
+  })
+
+  it('carries generation provenance — surface searchable, provider/model facetable', async () => {
+    const { assetId } = await createAsset({
+      sourceFilePath: join(srcDir, 'p.png'), type: 'images', agent: 'pixel', taskId: null, slug: 'gen', op: 'generate',
+      description: 'generated pic', source: { kind: 'generated', path: null },
+      generation: { provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait', quality: 'standard', routeSource: 'runtime' },
+    })
+    const doc = await buildVersionedAssetSearchDoc(getAsset(assetId)!, assetId)
+    expect(doc.surface).toBe('instagram-feed-portrait')
+    expect(doc.provider).toBe('openai')
+    expect(doc.model).toBe('gpt-image-2')
+  })
+
+  it('yields empty provenance fields when the current version has no generation (uploads)', async () => {
+    const { assetId } = await createAsset({ sourceFilePath: join(srcDir, 'doc.md'), type: 'text', agent: 'margo', taskId: null, slug: 'plain', op: 'upload' })
+    const doc = await buildVersionedAssetSearchDoc(getAsset(assetId)!, assetId)
+    expect(doc.surface).toBe('')
+    expect(doc.provider).toBe('')
+    expect(doc.model).toBe('')
+    expect(doc.tags_facet).toEqual([])
   })
 })

--- a/tests/plugins/assets/serve.test.ts
+++ b/tests/plugins/assets/serve.test.ts
@@ -24,8 +24,8 @@ const manifest: AssetManifest = {
   agent: 'pixel', taskId: 't1', created: 'c', updated: 'c', currentVersion: 2,
   description: 'cake', tags: ['x'],
   versions: [
-    { version: 1, file: 'v1.png', thumb: null, mimeType: 'image/png', size: 3, width: 4, height: 4, created: 'c', description: 'p1', tags: [], op: 'generate', parentVersion: null, tool: 't', prompt: 'p1', promptHash: 'h1', generation: null },
-    { version: 2, file: 'v2.png', thumb: 'v2.thumb.jpg', mimeType: 'image/png', size: 3, width: 4, height: 4, created: 'c', description: 'p2', tags: [], op: 'edit', parentVersion: 1, tool: 't', prompt: 'p2', promptHash: 'h2', generation: null },
+    { version: 1, file: 'v1.png', thumb: null, mimeType: 'image/png', size: 3, width: 4, height: 4, created: 'c', description: 'p1', op: 'generate', parentVersion: null, tool: 't', prompt: 'p1', promptHash: 'h1', generation: null },
+    { version: 2, file: 'v2.png', thumb: 'v2.thumb.jpg', mimeType: 'image/png', size: 3, width: 4, height: 4, created: 'c', description: 'p2', op: 'edit', parentVersion: 1, tool: 't', prompt: 'p2', promptHash: 'h2', generation: null },
   ],
   exports: [
     { name: 'open-graph', surface: 'open-graph', format: 'jpg', file: 'exports/open-graph.jpg', width: 1200, height: 630, fromVersion: 2, created: 'c' },

--- a/tests/plugins/assets/tag-filter.test.ts
+++ b/tests/plugins/assets/tag-filter.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure unit tests for the client-side tag-filter helpers (no app modules, no
+ * filesystem — same exception class as the constants tests).
+ */
+import { describe, it, expect } from 'bun:test'
+import { UNTAGGED, matchesTagFilter } from '../../../plugins/assets/components/versioned/tag-filter'
+
+describe('matchesTagFilter', () => {
+  it('matches everything when the filter is empty', () => {
+    expect(matchesTagFilter([], [])).toBe(true)
+    expect(matchesTagFilter(['a'], [])).toBe(true)
+  })
+
+  it('matches any-of across multiple selected tags', () => {
+    expect(matchesTagFilter(['a', 'b'], ['b', 'c'])).toBe(true)
+    expect(matchesTagFilter(['a'], ['b', 'c'])).toBe(false)
+  })
+
+  it('UNTAGGED matches only tagless assets', () => {
+    expect(matchesTagFilter([], [UNTAGGED])).toBe(true)
+    expect(matchesTagFilter(['a'], [UNTAGGED])).toBe(false)
+  })
+
+  it('UNTAGGED composes any-of with real tags', () => {
+    expect(matchesTagFilter([], [UNTAGGED, 'x'])).toBe(true)
+    expect(matchesTagFilter(['x'], [UNTAGGED, 'x'])).toBe(true)
+    expect(matchesTagFilter(['y'], [UNTAGGED, 'x'])).toBe(false)
+  })
+
+  it('never treats the sentinel as a literal tag', () => {
+    // An asset can't legitimately carry the sentinel (normalization would
+    // keep it, but nothing creates it); a tagless filter match must come
+    // from emptiness, not string equality.
+    expect(matchesTagFilter([UNTAGGED], ['some-tag'])).toBe(false)
+  })
+})

--- a/tests/plugins/assets/tag-ops.test.ts
+++ b/tests/plugins/assets/tag-ops.test.ts
@@ -79,6 +79,15 @@ describe('removeTagGlobal', () => {
 })
 
 describe('applyTags', () => {
+  it('no-ops without rewriting manifests when add and remove are empty', async () => {
+    const a = await makeAsset('noop', ['keep'])
+    const manifestPath = join(testDir, assetDirRelPath(a)!, 'manifest.json')
+    const before = readFileSync(manifestPath, 'utf-8')
+    const res = await applyTags([a], {})
+    expect(res).toEqual({ updated: 0, failed: [] })
+    expect(readFileSync(manifestPath, 'utf-8')).toBe(before)
+  })
+
   it('adds and removes across a set, normalized, with per-asset results', async () => {
     const a = await makeAsset('ba', ['x'])
     const b = await makeAsset('bb', [])

--- a/tests/plugins/assets/tag-ops.test.ts
+++ b/tests/plugins/assets/tag-ops.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Global tag operations — renameTagGlobal / removeTagGlobal / applyTags and
+ * their HTTP routes. Isolated to a temp BAKIN_HOME.
+ */
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdirSync, rmSync, readFileSync, statSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+
+const testDir = join(tmpdir(), `bakin-tag-ops-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import sharp from 'sharp'
+import {
+  createAsset, getAsset, deleteAsset, renameTagGlobal, removeTagGlobal, applyTags,
+} from '../../../plugins/assets/lib/asset-service'
+import { assetDirRelPath } from '../../../plugins/assets/lib/asset-id'
+import { handleTagsRename, handleTagsRemove, handleTagsApply } from '../../../plugins/assets/routes/tags'
+
+const base = 'http://localhost/api/plugins/assets/tags'
+const post = (path: string, body: unknown) =>
+  new Request(`${base}${path}`, { method: 'POST', body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } })
+
+const srcDir = join(testDir, 'src')
+
+async function makeAsset(slug: string, tags: string[]) {
+  const { assetId } = await createAsset({
+    sourceFilePath: join(srcDir, 'a.png'), type: 'images', agent: 'pixel', taskId: null, slug, op: 'generate', description: slug, tags,
+  })
+  return assetId
+}
+
+beforeAll(async () => {
+  mkdirSync(srcDir, { recursive: true })
+  await sharp({ create: { width: 6, height: 6, channels: 3, background: { r: 9, g: 0, b: 0 } } }).png().toFile(join(srcDir, 'a.png'))
+})
+
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+describe('renameTagGlobal', () => {
+  it('renames across all carrying assets, merge-dedupes on collision, skips others', async () => {
+    const a = await makeAsset('ra', ['old-name', 'other'])
+    const b = await makeAsset('rb', ['old-name', 'new-name']) // collision → merge
+    const c = await makeAsset('rc', ['unrelated'])
+    const cManifestPath = join(testDir, assetDirRelPath(c)!, 'manifest.json')
+    const cBefore = readFileSync(cManifestPath, 'utf-8')
+    const cMtime = statSync(cManifestPath).mtimeMs
+
+    const { updated } = await renameTagGlobal('old-name', 'New Name')
+    expect(updated).toBe(2)
+    expect(getAsset(a)!.tags).toEqual(['new-name', 'other'])
+    expect(getAsset(b)!.tags).toEqual(['new-name'])
+    expect(getAsset(c)!.tags).toEqual(['unrelated'])
+    expect(readFileSync(cManifestPath, 'utf-8')).toBe(cBefore) // untouched bytes
+    expect(statSync(cManifestPath).mtimeMs).toBe(cMtime)
+  })
+
+  it('does not touch trashed assets', async () => {
+    const t = await makeAsset('rt', ['doomed'])
+    const { trashName } = await deleteAsset(t)
+    const { updated } = await renameTagGlobal('doomed', 'renamed')
+    expect(updated).toBe(0)
+    const raw = JSON.parse(readFileSync(join(testDir, 'assets', '.trash', trashName, 'manifest.json'), 'utf-8'))
+    expect(raw.tags).toEqual(['doomed'])
+  })
+})
+
+describe('removeTagGlobal', () => {
+  it('removes the tag from every carrying asset, leaves assets intact', async () => {
+    const a = await makeAsset('da', ['kill-me', 'keep'])
+    const b = await makeAsset('db', ['keep'])
+    const { updated } = await removeTagGlobal('kill-me')
+    expect(updated).toBe(1)
+    expect(getAsset(a)!.tags).toEqual(['keep'])
+    expect(getAsset(b)!.tags).toEqual(['keep'])
+  })
+})
+
+describe('applyTags', () => {
+  it('adds and removes across a set, normalized, with per-asset results', async () => {
+    const a = await makeAsset('ba', ['x'])
+    const b = await makeAsset('bb', [])
+    const res = await applyTags([a, b, '20260529-ghost-deadbeef'], { add: ['New Tag'], remove: ['x'] })
+    expect(getAsset(a)!.tags).toEqual(['new-tag'])
+    expect(getAsset(b)!.tags).toEqual(['new-tag'])
+    expect(res.updated).toBe(2)
+    expect(res.failed).toEqual(['20260529-ghost-deadbeef']) // unknown id doesn't abort the rest
+  })
+})
+
+describe('tag routes', () => {
+  it('POST /tags/rename validates and renames', async () => {
+    const a = await makeAsset('hra', ['route-old'])
+    const res = await handleTagsRename(post('/rename', { from: 'route-old', to: 'Route New' }))
+    expect(res.status).toBe(200)
+    expect((await res.json()).updated).toBe(1)
+    expect(getAsset(a)!.tags).toEqual(['route-new'])
+    expect((await handleTagsRename(post('/rename', { from: '', to: 'x' }))).status).toBe(400)
+    expect((await handleTagsRename(post('/rename', { from: 'x' }))).status).toBe(400)
+  })
+
+  it('POST /tags/remove validates and removes', async () => {
+    const a = await makeAsset('hda', ['gone'])
+    const res = await handleTagsRemove(post('/remove', { tag: 'gone' }))
+    expect(res.status).toBe(200)
+    expect(getAsset(a)!.tags).toEqual([])
+    expect((await handleTagsRemove(post('/remove', {}))).status).toBe(400)
+  })
+
+  it('POST /tags/apply validates and applies', async () => {
+    const a = await makeAsset('hba', [])
+    const res = await handleTagsApply(post('/apply', { assetIds: [a], add: ['bulk'] }))
+    expect(res.status).toBe(200)
+    expect(getAsset(a)!.tags).toEqual(['bulk'])
+    expect((await handleTagsApply(post('/apply', { assetIds: [], add: ['x'] }))).status).toBe(400)
+    expect((await handleTagsApply(post('/apply', { assetIds: [a] }))).status).toBe(400) // neither add nor remove
+  })
+})

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -92,6 +92,8 @@ describe('images tools', () => {
     expect(created[0]).toMatchObject({ sourceFilePath: runtimeFile, type: 'images', op: 'generate', tool: 'bakin_exec_images_generate' })
     expect(created[0].generation).toMatchObject({ provider: 'google', model: 'gemini-3.1-flash-image-preview', surface: 'instagram-story', routeSource: 'runtime' })
     expect((created[0].source as { kind: string }).kind).toBe('generated')
+    // No machine tags: provenance lives in generation/op, tags are the user's namespace.
+    expect(created[0].tags).toBeUndefined()
   })
 
   it('records the shim serving path and credential source when the adapter gap-fills', async () => {
@@ -229,6 +231,8 @@ describe('images tools', () => {
     expect(versioned[0]).toMatchObject({ assetId: '20260529-src-a1b2c3d4' })
     expect(versioned[0].input).toMatchObject({ sourceFilePath: editedFile, op: 'edit', tool: 'bakin_exec_images_edit' })
     expect(versioned[0].input.generation).toMatchObject({ routeSource: 'runtime' })
+    // Version inputs carry no tags — versioning never touches the asset's tag namespace.
+    expect('tags' in versioned[0].input).toBe(false)
   })
 
   it('reuses the current edited version for an identical edit retry', async () => {
@@ -252,7 +256,6 @@ describe('images tools', () => {
       prompt,
       promptHash: promptHash(prompt),
       description: prompt,
-      tags: ['edited', 'instagram-square', 'google', 'gemini-3.1-flash-image-preview'],
       generation: {
         provider: 'google',
         model: 'gemini-3.1-flash-image-preview',
@@ -300,6 +303,8 @@ describe('images tools', () => {
     expect(result.ok).toBe(true)
     expect(result.assetId).toBe('20260529-img-a1b2c3d4')
     expect(created[0]).toMatchObject({ sourceFilePath: filePath, taskId: 'task-import', type: 'images', op: 'import', tool: 'bakin_exec_images_import' })
+    // No 'imported' machine-tag default — op/source already record provenance.
+    expect(created[0].tags).toBeUndefined()
   })
 
   it('exports an asset to a surface profile (attached export)', async () => {

--- a/tests/scripts/generate-embedded-assets.test.ts
+++ b/tests/scripts/generate-embedded-assets.test.ts
@@ -52,7 +52,7 @@ describe('collectAssets', () => {
   it('collects host, public, vendor, plugin dist, and data assets with serving URL paths', () => {
     const urls = collectAssets(root).map(a => a.urlPath)
 
-    expect(urls).toContain('/assets/main.js')
+    expect(urls).toContain('/_app/main.js')
     expect(urls).toContain('/globals.css')
     expect(urls).toContain('/index.html')
     expect(urls).toContain('/vendor/react.js')
@@ -109,7 +109,7 @@ describe('collectAssets', () => {
     const urls = collectAssets(root).map(a => a.urlPath)
 
     const order = [
-      urls.indexOf('/assets/main.js'),
+      urls.indexOf('/_app/main.js'),
       urls.indexOf('/globals.css'),
       urls.indexOf('/vendor/react.js'),
       urls.indexOf('/api/plugins/alpha/assets/client.js'),
@@ -126,9 +126,9 @@ describe('emitManifest', () => {
     const assets = collectAssets(root)
     const manifest = emitManifest(assets, outFile)
 
-    expect(manifest).toContain("import asset_assets_main_js from '../../dist/main.js' with { type: 'file' }")
+    expect(manifest).toContain("import asset_app_main_js from '../../dist/main.js' with { type: 'file' }")
     expect(manifest).toContain("import asset_api_plugins_alpha_assets_client_js from '../../../../plugins/alpha/dist/client.js' with { type: 'file' }")
-    expect(manifest).toContain("  ['/assets/main.js', asset_assets_main_js],")
+    expect(manifest).toContain("  ['/_app/main.js', asset_app_main_js],")
     expect(manifest).toContain(`export const EMBEDDED_ASSET_COUNT = ${assets.length}`)
     expect(manifest).toContain('export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string>')
   })


### PR DESCRIPTION
## Summary

Makes the assets index navigable at scale. Spec: `.claude/specs/assets-usability.md`; plan: `.claude/specs/assets-usability-plan.md` (interview-driven, adversarially vetted).

**Tags become a pure asset-level organizational namespace ("folders"):**
- `AssetVersionSchema` loses `tags` (old manifests parse fine — Zod strips); `mirrorDisplay` mirrors description only; `addVersion`/`promote` never touch tags
- Images tools stop stamping machine tags (`generated`/`edited`/`imported`/surface/provider/model) — that provenance already lives structurally in `op`/`source`/`generation`
- `normalizeTags` (trim, lowercase, ws→hyphen, charset `[a-z0-9-]`, dedupe) applied by every tag-writing path

**New API:** `PATCH /versioned/:assetId/metadata` (description write-through + tags), `POST /tags/{rename,remove,apply}` (global rename/delete, bulk tagging) — all atomic manifest writes, audited, watcher-emitted SSE.

**New UI:** Folders view (tag-grouped collage cards, Untagged bucket, recency sort, rename/delete kebab, folder-name filter), edit drawer (card hover / list row / detail), Tags facet filter + back breadcrumb (URL-backed, deep-linkable), bulk multi-select tagging, 250px min tile width.

**Search:** `surface` searchable+embedded; `provider`/`model`/`tags_facet` facets; `SCHEMA_VERSION` 2→3 (boot drops + recreates + reindexes).

**Infra fix:** host shell bundle moved `/assets/*` → `/_app/*` — hard refresh of `/assets/<assetId>` previously hard-404'd instead of reaching the SPA fallback (pre-existing namespace collision).

## Test plan
- Full suite green (4666 tests / 0 fail), typecheck clean, production binary build + asset assertions pass
- New suites: `metadata-route`, `tag-ops`, `tag-filter`; regression guards: tags survive addVersion/promote, zero machine tags from generate/edit/import, `/_app` rename
- Manually verified: drawer save/live refresh, folder → filtered grid → browser back, hard refresh of detail route
- Post-merge: first boot runs the v3 search migration (drop/recreate/reindex); verify tags facet buckets split per-tag against live Antfly

🤖 Generated with [Claude Code](https://claude.com/claude-code)