### PR TITLE
fix(dev): stop orphaning the antfly child on dev-loop shutdown and EADDRINUSE

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -491,8 +491,22 @@ function registerShutdown(): void {
   const cleanup = () => {
     if (tailwindChild && !tailwindChild.killed) tailwindChild.kill('SIGTERM')
   }
-  process.on('SIGINT', () => { cleanup(); process.exit(0) })
-  process.on('SIGTERM', () => { cleanup(); process.exit(0) })
+  // These handlers are registered BEFORE server.ts loads, so they run first
+  // on a signal. Once the server's lifecycle owns shutdown
+  // (src/core/lifecycle.ts sets the global below), calling process.exit here
+  // would preempt its async cleanup and orphan the antfly child on 3738
+  // (#459) — kill tailwind only and let the lifecycle handler (registered
+  // later on the same signal) finish the job and exit. Checked via
+  // globalThis, not an import: pulling in lifecycle.ts from here would load
+  // the whole server module graph on an early Ctrl-C during the build phase.
+  const lifecycleOwnsShutdown = () =>
+    (globalThis as Record<string, unknown>).__bakinLifecycleOwnsShutdown === true
+  const onSignal = () => {
+    cleanup()
+    if (!lifecycleOwnsShutdown()) process.exit(0)
+  }
+  process.on('SIGINT', onSignal)
+  process.on('SIGTERM', onSignal)
   process.on('exit', cleanup)
 }
 

--- a/server.ts
+++ b/server.ts
@@ -730,6 +730,26 @@ const eventBus = new BakinEventBus(broadcast)
   const dispatchState = dispatch.loadDispatchState(CONTENT_DIR)
   dispatchState.serverStart = Date.now()
 
+  // Without this, an EADDRINUSE 'error' event throws as an uncaught
+  // exception — by now antfly is already spawned and the watcher is running,
+  // and the crash bypasses the lifecycle shutdown, orphaning the child
+  // (#459). Fail loudly with remediation and take the graceful path instead.
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      log.error(
+        `Port ${port} is already in use - another Bakin (or a half-dead dev generation) is holding it. ` +
+        `Find it with: lsof -nP -iTCP:${port} -sTCP:LISTEN`,
+        err,
+      )
+    } else {
+      log.error('HTTP server error', err)
+    }
+    // Route through the lifecycle shutdown (registered above) so children
+    // and watchers come down cleanly; exitCode survives into its exit call.
+    process.exitCode = 1
+    process.kill(process.pid, 'SIGTERM')
+  })
+
   server.listen(port, '0.0.0.0', () => {
     log.info(`Bakin ready on http://localhost:${port}`)
     log.info(`Listening on 0.0.0.0:${port} (Tailscale: http://100.91.112.69:${port})`)

--- a/src/core/lifecycle.ts
+++ b/src/core/lifecycle.ts
@@ -16,9 +16,20 @@ const log = createLogger('lifecycle')
 
 let shutdownInProgress = false
 
+/**
+ * True once the lifecycle owns SIGINT/SIGTERM. scripts/dev.ts registers its
+ * own (earlier) signal handlers for the pre-server boot window; they consult
+ * this to know they must NOT call process.exit and preempt the async
+ * shutdown below — doing so orphaned the antfly child every time (#459).
+ */
+export function lifecycleOwnsShutdown(): boolean {
+  return (globalThis as Record<string, unknown>).__bakinLifecycleOwnsShutdown === true
+}
+
 /** Tests use this between cases — bun:test has no vi.resetModules equivalent. */
 export function _resetShutdownStateForTests(): void {
   shutdownInProgress = false
+  delete (globalThis as Record<string, unknown>).__bakinLifecycleOwnsShutdown
 }
 
 export function registerShutdownHandlers(server: Server, contentDir: string): void {
@@ -56,12 +67,15 @@ export function registerShutdownHandlers(server: Server, contentDir: string): vo
     // Give time for final writes
     setTimeout(() => {
       log.info('Shutdown complete')
-      process.exit(0)
+      // Honor a pre-set failure code (e.g. EADDRINUSE at listen time, #459)
+      // instead of stamping success over it.
+      process.exit(typeof process.exitCode === 'number' ? process.exitCode : 0)
     }, 1000)
   }
 
   process.on('SIGTERM', () => shutdown('SIGTERM'))
   process.on('SIGINT', () => shutdown('SIGINT'))
+  ;(globalThis as Record<string, unknown>).__bakinLifecycleOwnsShutdown = true
 
   log.info('Shutdown handlers registered')
 }

--- a/tests/core/lifecycle.test.ts
+++ b/tests/core/lifecycle.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import type { Server } from 'http'
+
+const testDir = join(tmpdir(), `bakin-test-lifecycle-${Date.now()}`)
+mock.module('../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir }),
+}))
 
 mock.module('@bakin/core/main-agent', () => ({
   getMainAgentId: () => 'main',
@@ -148,5 +160,31 @@ describe('lifecycle', () => {
     await processListeners['SIGTERM']()
     await processListeners['SIGTERM']()
     expect(mockShutdownAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks shutdown ownership so dev.ts defers instead of preempting (#459)', async () => {
+    // scripts/dev.ts's earlier-registered signal handlers consult this flag;
+    // when set they must NOT call process.exit, or the async shutdown above
+    // never runs and the antfly child is orphaned.
+    const mod = await import('../../src/core/lifecycle')
+    expect(mod.lifecycleOwnsShutdown()).toBe(false)
+    registerShutdownHandlers(mockServer(), '/tmp/test')
+    expect(mod.lifecycleOwnsShutdown()).toBe(true)
+    expect((globalThis as Record<string, unknown>).__bakinLifecycleOwnsShutdown).toBe(true)
+  })
+
+  it('honors a pre-set failure exitCode instead of stamping success (#459)', async () => {
+    // EADDRINUSE handling sets process.exitCode = 1 before routing through
+    // the graceful shutdown — the final exit must carry it.
+    const previousExitCode = process.exitCode
+    process.exitCode = 1
+    try {
+      registerShutdownHandlers(mockServer(), '/tmp/test')
+      await processListeners['SIGTERM']()
+      vi.advanceTimersByTime(1100)
+      expect(process.exit).toHaveBeenCalledWith(1)
+    } finally {
+      process.exitCode = previousExitCode
+    }
   })
 })


### PR DESCRIPTION
Closes #459.

Two dev-loop defects that minted orphaned antfly processes across `bun run dev` generations (full diagnosis in the issue):

1. **`scripts/dev.ts` signal handlers preempted the lifecycle shutdown.** They're registered before `server.ts` loads and called `process.exit(0)` — signal listeners run in registration order, so `src/core/lifecycle.ts`'s async shutdown (the only path that stops the antfly child) never executed. The dev handler now defers once the lifecycle owns shutdown, via a `globalThis` flag set by `registerShutdownHandlers()` — deliberately checked without importing lifecycle, so an early Ctrl-C during the build phase doesn't drag in the server module graph.

2. **Unhandled `EADDRINUSE` crashed after full boot, skipping cleanup.** `server.listen()` had no `'error'` listener; a squatted 3737 threw an uncaught exception *after* antfly was spawned and the watcher started. Now: clear error naming the port + `lsof` remediation, then self-SIGTERM through the lifecycle shutdown, exiting 1 (lifecycle's final `process.exit` honors a pre-set `process.exitCode`).

**Verified end-to-end** (isolated `BAKIN_HOME`, two servers on one port): second server exits 1 with the named remediation and `Shutdown complete`; first keeps serving and exits cleanly on SIGTERM.

Related but intentionally NOT here (they live on the migration branch / PR #457, since that's where the adapter and the `~/.bakin/antfly` dir are owned):
- watcher ignore for the private antfly data dir (the Bun-native deadlock that made processes unkillable by SIGTERM)
- sync `process.on('exit')` net in the adapter that kills the antfly child on any JS-level exit

Suite: 4658 pass / 0 fail; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)