### PR TITLE
fix(lint): exempt the storage core from the bun:sqlite import ban

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -172,6 +172,18 @@ const eslintConfig = defineConfig([
       "no-restricted-imports": ["error", adapterBoundaryImportRestrictions],
     },
   },
+  // The shared storage core is the SOLE bun:sqlite importer (enforced by
+  // tests/architecture/adapter-boundary.test.ts). Re-apply the adapter
+  // boundary minus the bun:sqlite path for this one file.
+  {
+    files: ["packages/core/src/storage/db.ts"],
+    rules: {
+      "no-restricted-imports": ["error", {
+        paths: adapterBoundaryImportRestrictions.paths.filter((p) => p.name !== "bun:sqlite"),
+        patterns: adapterBoundaryImportRestrictions.patterns,
+      }],
+    },
+  },
   // Plugin isolation: every plugin talks to Bakin's shell and to other
   // plugins exclusively through @makinbakin/sdk/*. Direct imports from another
   // plugin's internals or from Bakin's src/ components/hooks are banned so


### PR DESCRIPTION
## Summary

Release lint is failing on main:

```
packages/core/src/storage/db.ts
  14:1  error  'bun:sqlite' import is restricted ...  no-restricted-imports
```

`packages/core/src/storage/db.ts` is the **designated** sole `bun:sqlite` importer — that ownership is already enforced by `tests/architecture/adapter-boundary.test.ts` — but the eslint adapter-boundary rule never got the matching exemption when the execution ledger landed in #465.

## Fix

Adds a scoped override for `packages/core/src/storage/db.ts` that re-applies the full adapter-boundary restriction set **minus only the `bun:sqlite` path**. The file remains subject to every other restriction (adapter packages, `@antfly/sdk`, etc.).

## Verification

- `bun run lint` passes clean
- Probe test: a stray `bun:sqlite` import in `src/core/` still fails lint — the exemption is surgical to the one file

Unblocks the v0.0.1-rc.17 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)