### PR TITLE
fix(tests): anchor boot-diag mock resource entries to live performance.now()

### DIFF
--- a/tests/components/plugin-host.test.tsx
+++ b/tests/components/plugin-host.test.tsx
@@ -203,6 +203,12 @@ describe('PluginHost — boot', () => {
     }))
     const consoleDebug = spyOn(console, 'debug').mockImplementation(() => {})
     const originalGetEntriesByType = window.performance.getEntriesByType
+    // Anchor mock entries to live performance.now(): the resource-summary
+    // filter compares entry times against real boot timestamps, and bun runs
+    // the whole suite in one process — absolute times (startTime: 0,
+    // responseEnd: 100_000) fall outside the boot window once the process has
+    // been up >100s, silently dropping the resourceSummary span.
+    const bootBase = performance.now()
     Object.defineProperty(window.performance, 'getEntriesByType', {
       configurable: true,
       value: mock((type: string) => type === 'resource'
@@ -210,8 +216,8 @@ describe('PluginHost — boot', () => {
             {
               name: 'http://localhost/api/plugins/x/assets/client.js?v=diag',
               initiatorType: 'script',
-              startTime: 0,
-              responseEnd: 100_000,
+              startTime: bootBase,
+              responseEnd: bootBase + 100_000,
               duration: 123.45,
               transferSize: 2048,
               encodedBodySize: 1024,
@@ -220,8 +226,8 @@ describe('PluginHost — boot', () => {
             {
               name: 'http://localhost/node_modules/.vite/deps/react.js',
               initiatorType: 'script',
-              startTime: 0,
-              responseEnd: 100_000,
+              startTime: bootBase,
+              responseEnd: bootBase + 100_000,
               duration: 20,
               transferSize: 512,
               encodedBodySize: 256,


### PR DESCRIPTION
## Summary

The release pipeline failed on `PluginHost — boot > emits browser plugin boot diagnostics when explicitly enabled` — the same test #446 already patched with `waitFor` headroom. It was never a timeout.

## Root cause

`logStartupResourceSummary` filters performance entries against the real boot window:

```ts
return responseEnd >= startedAt - 5 && entry.startTime <= endedAt + 5
```

The test mocked entries at absolute times (`startTime: 0`, `responseEnd: 100_000`), but `startedAt`/`endedAt` come from live `performance.now()`. Bun runs the full suite in **one process**, so once the suite has been running >100 seconds before this file executes, the mock entries fall outside the boot window, the `resourceSummary` span is silently dropped (`resources.length === 0` early-return), and the assertion fails. The CI run took 297s — a suite-position flake, not a timing flake.

## Fix

Anchor the mock entries to `performance.now()` captured at test time (`bootBase` / `bootBase + 100_000`) so they always overlap the boot window regardless of process uptime.

## Verification

Reproduced deterministically with a preload shim adding 150s of fake uptime (`performance.now = () => realNow() + 150_000`):

- **Before:** fails at the `resourceSummary` assertion — same failure as CI
- **After:** passes with the shim, and passes in a normal run

Unblocks the v0.0.1-rc.17 release (again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)