### PR TITLE
feat(schedule): run visibility — ledger-backed run history + skip audit

### DIFF
--- a/.claude/knowledge/bakin-owned-scheduler.md
+++ b/.claude/knowledge/bakin-owned-scheduler.md
@@ -25,6 +25,12 @@ The fix: **Bakin owns scheduling for Bakin schedules.** OpenClaw cron is no long
 
 The crons the runtime/agents create for themselves are surfaced **read-only**. `lib/jobs-reader.ts` unions two sources: runtime crons (`cron.list()`) and store-owned Bakin schedules (synthesized from the stored schedule when they have no runtime cron). Mutating a non-Bakin job (PUT / pause / skip / delete, route + exec tool) is rejected with 403 / `ok:false` and guidance to **adopt** it first. `adopt` copies the expr into a Bakin schedule and removes the native cron; `restore-native` puts it back. The reader never auto-deletes a Bakin record (a read must not mutate the store) — only genuinely-orphaned non-Bakin sidecar entries are swept.
 
+## Run history & skip visibility
+
+The ledger's `cron_fires` table is the durable per-fire record (`(job_id, run_id)` PK, `disposition` ∈ `pending|created|skipped|seeded`, `task_id`, and `skip_reason` — added in migration v2). Because Bakin schedules have no OpenClaw cron runs, the job-drawer run history reads the **ledger**, not the runtime adapter: `lib/runs-reader.ts` routes by ownership — a Bakin job → `listCronFires(jobId, limit)` mapped to `RunEntry` (created→`success`+taskId, skipped→`skipped`+`skippedReason`, pending→`pending`); a native cron → `cron.listRuns`. (Pre-cutover the drawer read `cron.listRuns` for everything, so Bakin jobs showed empty history — this is the fix.)
+
+Skips are **visible**: every `skipFire()` in `runClaimedFire` (overlap / paused / skip-count / auto-paused) records the reason to `cron_fires.skip_reason` *and* emits a `schedule.fire_skipped` activity-audit event, so an overrunning or paused schedule shows up on the feed instead of silently dropping beats. The default `allowOverlap: false` already serializes a job (a fire whose prior task is still in an active column is skipped, not piled on) — this just makes that serialization observable. Heal-time consume of an orphaned claim records `skip_reason: 'job-removed'` (no feed event).
+
 ## Migration / repair command
 
 `schedule-cutover` doctor check (`lib/health-checks.ts`): flags any Bakin schedule still backed by an OpenClaw cron job (incomplete cutover → rogue-fire risk). Its repair runs the same idempotent `migrateBakinSchedulesOffOpenClawCron`. So `bakin check schedule-cutover` / `bakin install schedule-cutover` is the end-user migration command for when OpenClaw was unreachable at boot.
@@ -45,5 +51,6 @@ The cron→task **bridge webhook** + shared secret, the **reconcile-poll** (`rec
 
 - `plugins/schedule/lib/{cron-eval,scheduler,cutover,prompt-guard,sidecar,jobs-reader,health-checks}.ts`
 - `plugins/schedule/index.ts` — routes, exec tools, `activate()` wiring, read-only guards
-- Ledger: `packages/core/src/execution/ledger.ts` (`cron_fires`), facade `src/core/execution-ledger.ts`
+- Ledger: `packages/core/src/execution/ledger.ts` (`cron_fires` + `skip_reason`, `listCronFires`), facade `src/core/execution-ledger.ts`
+- Run history: `plugins/schedule/lib/runs-reader.ts` (ownership routing), `components/run-history.tsx`, client type `src/hooks/use-schedule.ts` (`RunEntry`)
 - Tests: `tests/plugins/schedule/*` (engine + catch-up are fake-clock; cutover/health/routes are mocked)

--- a/dev/imitation-crab/fixtures/jobs.json
+++ b/dev/imitation-crab/fixtures/jobs.json
@@ -8,6 +8,7 @@
       "enabled": true,
       "delivery": { "mode": "none" },
       "payload": { "message": "bakin:schedule:daily-brief" },
+      "toolsAllow": ["web_search", "message", "file_read"],
       "createdAt": "2026-03-15T12:00:00Z"
     },
     {
@@ -17,7 +18,18 @@
       "enabled": true,
       "delivery": { "mode": "none" },
       "payload": { "message": "bakin:schedule:weekly-review" },
+      "toolsAllow": ["web_search", "message"],
       "createdAt": "2026-03-15T12:00:00Z"
+    },
+    {
+      "id": "social-metrics",
+      "name": "Social Metrics Collector",
+      "schedule": { "kind": "cron", "expr": "0 8 * * *", "tz": "America/Denver" },
+      "enabled": true,
+      "delivery": { "mode": "announce" },
+      "payload": { "message": "bakin:schedule:social-metrics" },
+      "toolsAllow": ["web_search", "message", "shell"],
+      "createdAt": "2026-03-25T09:00:00Z"
     },
     {
       "id": "content-pipeline",
@@ -27,51 +39,6 @@
       "delivery": { "mode": "none" },
       "payload": { "message": "bakin:schedule:content-pipeline" },
       "createdAt": "2026-03-20T08:00:00Z"
-    },
-    {
-      "id": "recipe-photo-check",
-      "name": "Recipe Photo Audit",
-      "schedule": { "kind": "every", "expr": "12h" },
-      "enabled": true,
-      "delivery": { "mode": "none" },
-      "payload": { "message": "bakin:schedule:recipe-photo-check" },
-      "createdAt": "2026-03-22T10:00:00Z"
-    },
-    {
-      "id": "social-metrics",
-      "name": "Social Metrics Collector",
-      "schedule": { "kind": "cron", "expr": "0 8 * * *", "tz": "America/Denver" },
-      "enabled": true,
-      "delivery": { "mode": "announce" },
-      "payload": { "message": "bakin:schedule:social-metrics" },
-      "createdAt": "2026-03-25T09:00:00Z"
-    },
-    {
-      "id": "menu-price-sync",
-      "name": "Menu Price Sync",
-      "schedule": { "kind": "cron", "expr": "0 6 * * 1", "tz": "America/Denver" },
-      "enabled": true,
-      "delivery": { "mode": "none" },
-      "payload": { "message": "bakin:schedule:menu-price-sync" },
-      "createdAt": "2026-03-28T07:00:00Z"
-    },
-    {
-      "id": "blog-seo-scan",
-      "name": "Blog SEO Scanner",
-      "schedule": { "kind": "cron", "expr": "0 2 * * 3", "tz": "America/Denver" },
-      "enabled": true,
-      "delivery": { "mode": "none" },
-      "payload": { "message": "bakin:schedule:blog-seo-scan" },
-      "createdAt": "2026-04-01T08:00:00Z"
-    },
-    {
-      "id": "ingredient-restock",
-      "name": "Ingredient Restock Alert",
-      "schedule": { "kind": "every", "expr": "6h" },
-      "enabled": false,
-      "delivery": { "mode": "none" },
-      "payload": { "message": "bakin:schedule:ingredient-restock" },
-      "createdAt": "2026-04-02T10:00:00Z"
     }
   ]
 }

--- a/dev/imitation-crab/seed.ts
+++ b/dev/imitation-crab/seed.ts
@@ -5,7 +5,9 @@
 import { existsSync, mkdirSync, cpSync, readFileSync, writeFileSync, rmSync, symlinkSync, appendFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
-import { initBakinHome } from '../../packages/core/src/content-dir'
+import { initBakinHome, resetContentDir } from '../../packages/core/src/content-dir'
+import { claimCronFire, attachCronTask, markCronFireSkipped } from '../../src/core/execution-ledger'
+import { closeDb } from '../../packages/core/src/storage/db'
 import { getMockHome } from './env'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -24,6 +26,11 @@ export function seed(force = false): void {
   if (force) {
     rmSync(mockHome, { recursive: true, force: true })
   }
+
+  // Resolve every Bakin path (and the execution ledger db) to the mock home for
+  // the rest of this seed — never to real ~/.bakin. Set BEFORE any ledger write.
+  process.env.BAKIN_HOME = mockHome
+  resetContentDir()
 
   console.log(`[seed] Creating ${mockHome}`)
 
@@ -70,6 +77,10 @@ export function seed(force = false): void {
   // Seed Bakin-owned task-store data.
   seedTasks(mockHome)
 
+  // Seed Bakin-owned schedules + their ledger fire history (run-history UI).
+  seedSchedules(mockHome)
+  seedScheduleFires()
+
   // Create a sample gateway log for today
   seedGatewayLog()
 
@@ -110,6 +121,107 @@ function seedTasks(mockHome: string): void {
   }
 
   console.log(`[seed] Bakin task store seeded (${tasks.length} tasks)`)
+}
+
+// IDs reused by seedScheduleFires so the run history is internally consistent.
+const SCHED = {
+  standup: 'sch_demo_standup',
+  hourly: 'sch_demo_hourly',
+  weekly: 'sch_demo_weekly',
+} as const
+
+function seedSchedules(mockHome: string): void {
+  const now = new Date().toISOString()
+  // createdAt = now so startup catch-up won't fire historical occurrences into
+  // `blocked` on every boot (it skips occurrences predating createdAt). The
+  // seeded cron_fires below provide the visible history; live ticks go forward.
+  const base = {
+    isBakinJob: true as const,
+    source: 'bakin' as const,
+    owner: 'main',
+    requireTriage: false,
+    maxFailures: 3,
+    consecutiveFailures: 0,
+    tz: 'America/Denver',
+    createdAt: now,
+    updatedAt: now,
+  }
+  const jobs = {
+    [SCHED.standup]: {
+      ...base,
+      jobId: SCHED.standup,
+      displayName: 'Morning Standup',
+      agentId: 'main',
+      taskPrompt: 'Summarize what each agent is working on today.',
+      taskTitle: 'Standup {date}',
+      schedule: { kind: 'cron', expr: '0 9 * * *' },
+      enabled: true,
+      allowOverlap: false,
+      lastTaskId: 'task-td-001',
+    },
+    [SCHED.hourly]: {
+      ...base,
+      jobId: SCHED.hourly,
+      displayName: 'Hourly Inbox Sync',
+      agentId: 'rolo',
+      taskPrompt: 'Pull new inbox items and triage them.',
+      taskTitle: 'Inbox sync {date}',
+      schedule: { kind: 'cron', expr: '0 * * * *' },
+      enabled: true,
+      allowOverlap: false, // overruns serialize → overlap skips (seeded below)
+      lastTaskId: 'task-ip-001',
+    },
+    [SCHED.weekly]: {
+      ...base,
+      jobId: SCHED.weekly,
+      displayName: 'Weekly Report (paused)',
+      agentId: 'rolo',
+      taskPrompt: 'Compile the weekly engagement report.',
+      taskTitle: 'Weekly report {date}',
+      schedule: { kind: 'cron', expr: '0 8 * * 1' },
+      enabled: false,
+      paused: true,
+      pauseReason: 'manual',
+      allowOverlap: false,
+    },
+  }
+  const dir = join(mockHome, 'schedule')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'sidecar.json'), JSON.stringify({ version: 1, jobs }, null, 2) + '\n', 'utf-8')
+  console.log(`[seed] Bakin schedules seeded (${Object.keys(jobs).length} jobs)`)
+}
+
+/**
+ * Seed cron_fires history so the run-history UI shows real fires + skips with
+ * reasons. Targets the mock home's bakin.db (BAKIN_HOME was pinned above).
+ */
+function seedScheduleFires(): void {
+  const HOUR = 3_600_000
+  const now = Date.now()
+  // Each entry: minutes-ago → a created (with task) or skipped (with reason) fire.
+  type Fire = { job: string; agoH: number; task?: string; skip?: string }
+  const fires: Fire[] = [
+    { job: SCHED.standup, agoH: 49, task: 'task-td-001' },
+    { job: SCHED.standup, agoH: 25, task: 'task-td-002' },
+    { job: SCHED.standup, agoH: 1, task: 'task-td-003' },
+    { job: SCHED.hourly, agoH: 4, task: 'task-ip-001' },
+    { job: SCHED.hourly, agoH: 3, skip: 'overlap' }, // prior run still active
+    { job: SCHED.hourly, agoH: 2, task: 'task-ip-002' },
+    { job: SCHED.hourly, agoH: 1, skip: 'overlap' },
+    { job: SCHED.weekly, agoH: 168, task: 'task-bl-001' },
+    { job: SCHED.weekly, agoH: 0.5, skip: 'paused' }, // fired while paused
+  ]
+  for (const f of fires) {
+    const firedAt = now - f.agoH * HOUR
+    const occurrence = new Date(firedAt).toISOString()
+    const runId = `${f.job}:${occurrence}`
+    const claim = claimCronFire(f.job, runId, firedAt, 'pending', firedAt)
+    if (!claim.claimed) continue
+    if (f.skip) markCronFireSkipped(f.job, runId, f.skip)
+    else if (f.task) attachCronTask(f.job, runId, f.task)
+  }
+  closeDb() // release the handle; the spawned server opens its own connection
+  console.log(`[seed] Schedule run history seeded (${fires.length} fires)`)
 }
 
 function seedGatewayLog(): void {

--- a/packages/core/src/execution/ledger.ts
+++ b/packages/core/src/execution/ledger.ts
@@ -120,6 +120,15 @@ const MIGRATIONS = [
       )
     },
   },
+  {
+    // Persist WHY a fire was skipped (overlap / paused / skip-count / auto-paused)
+    // so the per-schedule run history can show it without log-spelunking. The
+    // disposition stays the coordination fact; skip_reason is the human label.
+    version: 2,
+    up: (db: Db) => {
+      db.exec('ALTER TABLE cron_fires ADD COLUMN skip_reason TEXT')
+    },
+  },
 ]
 
 /** Open the db with this module's schema applied. Every verb goes through here. */
@@ -433,6 +442,7 @@ export interface CronFireRow {
   claimedAt: number
   taskId: string | null
   disposition: 'pending' | 'created' | 'skipped' | 'seeded'
+  skipReason: string | null
 }
 
 interface RawCronFireRow {
@@ -442,6 +452,7 @@ interface RawCronFireRow {
   claimed_at: number
   task_id: string | null
   disposition: CronFireRow['disposition']
+  skip_reason: string | null
 }
 
 function toCronFireRow(raw: RawCronFireRow): CronFireRow {
@@ -452,6 +463,7 @@ function toCronFireRow(raw: RawCronFireRow): CronFireRow {
     claimedAt: raw.claimed_at,
     taskId: raw.task_id,
     disposition: raw.disposition,
+    skipReason: raw.skip_reason ?? null,
   }
 }
 
@@ -506,12 +518,25 @@ export function attachCronTask(jobId: string, runId: string, taskId: string): vo
   })
 }
 
-/** A deliberately skipped fire (paused / skip-N / no-overlap) — consumed, never healed. */
-export function markCronFireSkipped(jobId: string, runId: string): void {
+/** A deliberately skipped fire (paused / skip-N / no-overlap) — consumed, never
+ *  healed. `reason` is the human label surfaced in the run history. */
+export function markCronFireSkipped(jobId: string, runId: string, reason?: string): void {
   guard(`markCronFireSkipped(${jobId}, ${runId})`, () => {
     ledger()
-      .prepare('UPDATE cron_fires SET disposition = \'skipped\' WHERE job_id = ? AND run_id = ?')
-      .run(jobId, runId)
+      .prepare('UPDATE cron_fires SET disposition = \'skipped\', skip_reason = ? WHERE job_id = ? AND run_id = ?')
+      .run(reason ?? null, jobId, runId)
+  })
+}
+
+/** A job's fires, newest logical-fire-time first — backs the run-history UI. */
+export function listCronFires(jobId: string, limit = 50): CronFireRow[] {
+  return guard(`listCronFires(${jobId})`, () => {
+    return ledger()
+      .prepare<RawCronFireRow, [string, number]>(
+        'SELECT * FROM cron_fires WHERE job_id = ? ORDER BY fired_at DESC LIMIT ?',
+      )
+      .all(jobId, limit)
+      .map(toCronFireRow)
   })
 }
 

--- a/plugins/schedule/components/job-row.tsx
+++ b/plugins/schedule/components/job-row.tsx
@@ -122,7 +122,7 @@ export function JobRow({
           >
             <MoreHorizontal className="size-4" />
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="min-w-36" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
+          <DropdownMenuContent align="end" className="w-auto min-w-36 whitespace-nowrap" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
             <DropdownMenuItem onClick={onRunNow}>
               <Play className="size-3.5 mr-2" /> Run Now
             </DropdownMenuItem>

--- a/plugins/schedule/components/run-history.tsx
+++ b/plugins/schedule/components/run-history.tsx
@@ -47,11 +47,16 @@ export function RunHistory({ jobId }: { jobId: string }) {
                 ? 'bg-green-500/10 text-green-400 border-green-500/20'
                 : run.status === 'skipped'
                 ? 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20'
+                : run.status === 'pending'
+                ? 'bg-amber-500/10 text-amber-400 border-amber-500/20'
                 : 'bg-red-500/10 text-red-400 border-red-500/20'
             }
           >
             {run.status}
           </Badge>
+          {run.status === 'skipped' && run.skippedReason && (
+            <span className="text-xs text-muted-foreground">{run.skippedReason}</span>
+          )}
           {run.taskId && (
             <span className="text-xs text-muted-foreground font-mono">{run.taskId.slice(0, 8)}</span>
           )}

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -352,7 +352,9 @@ type SkipReason = 'paused' | 'skip-count' | 'auto-paused' | 'overlap'
  *  silently dropping beats. */
 function skipFire(jobId: string, runId: string, reason: SkipReason): ProcessRunResult {
   markCronFireSkipped(jobId, runId, reason)
-  pluginCtx?.activity.audit('schedule.fire_skipped', 'system', { jobId, runId, reason })
+  // activity.audit prepends the plugin id → observable event is `schedule.fire_skipped`
+  // (matches fire_suppressed/fire_healed/task_created — bare operation, no manual prefix).
+  pluginCtx?.activity.audit('fire_skipped', 'system', { jobId, runId, reason })
   return { status: 200, body: { ok: true, skipped: reason } }
 }
 

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -345,7 +345,9 @@ function storedTaskExists(taskId: string): boolean {
   }
 }
 
-type SkipReason = 'paused' | 'skip-count' | 'auto-paused' | 'overlap'
+// Every reason a fire can be skipped. 'job-removed' is the only one set outside
+// skipFire() — the healer consumes an orphaned claim with no live ctx to audit.
+type SkipReason = 'paused' | 'skip-count' | 'auto-paused' | 'overlap' | 'job-removed'
 
 /** Record a skipped fire (ledger disposition + reason) AND surface it on the
  *  activity feed, so an overrunning or paused schedule shows up instead of

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -345,6 +345,17 @@ function storedTaskExists(taskId: string): boolean {
   }
 }
 
+type SkipReason = 'paused' | 'skip-count' | 'auto-paused' | 'overlap'
+
+/** Record a skipped fire (ledger disposition + reason) AND surface it on the
+ *  activity feed, so an overrunning or paused schedule shows up instead of
+ *  silently dropping beats. */
+function skipFire(jobId: string, runId: string, reason: SkipReason): ProcessRunResult {
+  markCronFireSkipped(jobId, runId, reason)
+  pluginCtx?.activity.audit('schedule.fire_skipped', 'system', { jobId, runId, reason })
+  return { status: 200, body: { ok: true, skipped: reason } }
+}
+
 async function runClaimedFire(
   meta: BakinJobMeta,
   jobId: string,
@@ -356,16 +367,14 @@ async function runClaimedFire(
   // Check pause state
   const pauseState = isPaused(meta)
   if (pauseState.paused) {
-    markCronFireSkipped(jobId, runId) // consumed — never healed into a task
     upsertJob(meta) // persist any auto-resume changes
-    return { status: 200, body: { ok: true, skipped: 'paused' } }
+    return skipFire(jobId, runId, 'paused') // consumed — never healed into a task
   }
 
   // Check skip-next-N
   if (shouldSkip(meta)) {
-    markCronFireSkipped(jobId, runId)
     upsertJob(meta)
-    return { status: 200, body: { ok: true, skipped: 'skip-count' } }
+    return skipFire(jobId, runId, 'skip-count')
   }
 
   // Check failure auto-pause
@@ -373,9 +382,8 @@ async function runClaimedFire(
     meta.paused = true
     meta.pauseReason = 'auto-failures'
     meta.enabled = false // mirror manual pause: skip at the scheduler gate, no claim churn
-    markCronFireSkipped(jobId, runId)
     upsertJob(meta)
-    return { status: 200, body: { ok: true, skipped: 'auto-paused' } }
+    return skipFire(jobId, runId, 'auto-paused')
   }
 
   // Both the overlap guard and last-task-outcome tracking inspect the board;
@@ -395,8 +403,7 @@ async function runClaimedFire(
     for (const col of activeColumns) {
       const tasks = board.columns[col] ?? []
       if (tasks.some(t => t.id === meta.lastTaskId)) {
-        markCronFireSkipped(jobId, runId)
-        return { status: 200, body: { ok: true, skipped: 'overlap' } }
+        return skipFire(jobId, runId, 'overlap')
       }
     }
   }
@@ -411,9 +418,8 @@ async function runClaimedFire(
       if (blocked.some(t => t.id === meta.lastTaskId)) {
         const autoPaused = recordFailure(meta)
         if (autoPaused) {
-          markCronFireSkipped(jobId, runId)
           upsertJob(meta)
-          return { status: 200, body: { ok: true, skipped: 'auto-paused' } }
+          return skipFire(jobId, runId, 'auto-paused')
         }
       }
     }
@@ -516,7 +522,7 @@ async function healPendingCronClaims(): Promise<void> {
     const meta = getJob(claim.jobId)
     if (!meta?.isBakinJob) {
       // Job deleted/unmanaged since the claim — consume it.
-      markCronFireSkipped(claim.jobId, claim.runId)
+      markCronFireSkipped(claim.jobId, claim.runId, 'job-removed')
       continue
     }
     const result = await runClaimedFire(meta, claim.jobId, claim.runId)

--- a/plugins/schedule/lib/runs-reader.ts
+++ b/plugins/schedule/lib/runs-reader.ts
@@ -44,6 +44,10 @@ function readLedgerRuns(jobId: string, limit: number): RunEntry[] {
 }
 
 export function cronFireToEntry(fire: CronFireRow): RunEntry {
+  // A cron_fires row records the FIRE outcome (did the schedule create/skip a
+  // task), not the task's terminal result — so 'success' = "a task was created".
+  // RunEntry's 'failure' status is only reachable via the native-cron adapter
+  // path (runtimeRunToEntry); ledger fires are never red.
   const status: RunEntry['status'] =
     fire.disposition === 'skipped' ? 'skipped' : fire.disposition === 'pending' ? 'pending' : 'success' // created | seeded
   return {

--- a/plugins/schedule/lib/runs-reader.ts
+++ b/plugins/schedule/lib/runs-reader.ts
@@ -1,8 +1,15 @@
 /**
- * Reads cron run history from the active runtime adapter.
+ * Reads per-job run history.
+ *
+ * Bakin-owned schedules no longer have runtime cron runs — their fire history
+ * lives in the execution ledger's cron_fires table (each occurrence's claim +
+ * disposition). Native (unmanaged) runtime crons still report through the
+ * adapter. We route by ownership so both surfaces show real history.
  */
 import type { AgentRuntimeAdapter, CronRun } from '@bakin/core/adapters/runtime'
 import { createLogger } from '../../../src/core/logger'
+import { listCronFires, type CronFireRow } from '../../../src/core/execution-ledger'
+import { getJob } from './sidecar'
 import type { RunEntry } from '../types'
 
 const log = createLogger('schedule:runs')
@@ -11,6 +18,7 @@ type RuntimeCronRunReader = Pick<AgentRuntimeAdapter['cron'], 'listRuns'>
 
 /** Read run history for a specific job. Returns newest-first. */
 export async function readRuns(cron: RuntimeCronRunReader, jobId: string, limit = 50): Promise<RunEntry[]> {
+  if (getJob(jobId)?.isBakinJob) return readLedgerRuns(jobId, limit)
   try {
     return (await cron.listRuns(jobId)).slice(0, limit).map(runtimeRunToEntry)
   } catch (err) {
@@ -23,6 +31,29 @@ export async function readRuns(cron: RuntimeCronRunReader, jobId: string, limit 
 export async function getLastRun(cron: RuntimeCronRunReader, jobId: string): Promise<RunEntry | null> {
   const runs = await readRuns(cron, jobId, 1)
   return runs[0] ?? null
+}
+
+/** Bakin schedule fire history from the execution ledger (newest-first). */
+function readLedgerRuns(jobId: string, limit: number): RunEntry[] {
+  try {
+    return listCronFires(jobId, limit).map(cronFireToEntry)
+  } catch (err) {
+    log.warn('Failed to read run history from ledger', err, { jobId })
+    return []
+  }
+}
+
+export function cronFireToEntry(fire: CronFireRow): RunEntry {
+  const status: RunEntry['status'] =
+    fire.disposition === 'skipped' ? 'skipped' : fire.disposition === 'pending' ? 'pending' : 'success' // created | seeded
+  return {
+    runId: fire.runId,
+    jobId: fire.jobId,
+    timestamp: new Date(fire.firedAt).toISOString(),
+    status,
+    taskId: fire.taskId ?? undefined,
+    skippedReason: fire.skipReason ?? undefined,
+  }
 }
 
 export function runtimeRunToEntry(run: CronRun): RunEntry {

--- a/plugins/schedule/types.ts
+++ b/plugins/schedule/types.ts
@@ -149,7 +149,7 @@ export interface RunEntry {
   runId: string
   jobId: string
   timestamp: string
-  status: 'success' | 'failure' | 'skipped'
+  status: 'success' | 'failure' | 'skipped' | 'pending'
   duration?: number
   error?: string
   taskId?: string // Bakin task created by this run

--- a/src/core/execution-ledger.ts
+++ b/src/core/execution-ledger.ts
@@ -17,6 +17,7 @@ export {
   getCronFire,
   attachCronTask,
   markCronFireSkipped,
+  listCronFires,
   findHealableCronClaims,
   recordCompletion,
   hasCompletion,

--- a/src/hooks/use-schedule.ts
+++ b/src/hooks/use-schedule.ts
@@ -40,9 +40,10 @@ export interface ScheduleJob {
 export interface RunEntry {
   runId: string
   timestamp: string
-  status: 'success' | 'failure' | 'skipped'
+  status: 'success' | 'failure' | 'skipped' | 'pending'
   taskId?: string
   error?: string
+  skippedReason?: string // why a 'skipped' fire was skipped (overlap/paused/skip-count/auto-paused)
 }
 
 interface UseScheduleOptions {

--- a/tasks/plan-run-visibility.md
+++ b/tasks/plan-run-visibility.md
@@ -1,0 +1,52 @@
+# Schedule run visibility — plan
+
+Make schedule fires/skips visible. Two user asks: (1) live audit on skipped fires,
+(2) ledger-backed per-schedule run history in the job drawer (also fixes a cutover
+regression: the drawer's run history reads OpenClaw cron runs, which are now empty
+for Bakin-owned schedules).
+
+The skip *reason* is currently discarded — `markCronFireSkipped` flattens every
+skip to `disposition='skipped'`. `cron_fires` is the per-fire durable record keyed
+by `(jobId, runId)`, so the reason's natural home is a `skip_reason` column there.
+That makes the run-history a single clean ledger read.
+
+## Slice A — ledger: persist skip reason + list fires  (commit 1)
+- Migration v2: `ALTER TABLE cron_fires ADD COLUMN skip_reason TEXT`.
+- `markCronFireSkipped(jobId, runId, reason?)` writes the reason.
+- `CronFireRow` gains `skipReason: string | null`.
+- New read verb `listCronFires(jobId, limit)` — newest-first by `fired_at`.
+- Facade re-exports in `src/core/execution-ledger.ts`.
+- **AC:** mark→read round-trips the reason; `listCronFires` returns a job's fires
+  newest-first, bounded by limit; migration is idempotent on an existing db.
+- **Test:** `tests/core/execution-ledger.test.ts`.
+
+## Slice B — fire path: emit `schedule.fire_skipped` + carry reason  (commit 2)
+- `skipFire(jobId, runId, reason)` helper in `plugins/schedule/index.ts`:
+  `markCronFireSkipped(jobId, runId, reason)` + `pluginCtx.activity.audit(
+  'schedule.fire_skipped', 'system', { jobId, runId, reason })` + return body.
+- Replace the 5 skip return sites (paused, skip-count, auto-paused×2, overlap),
+  keeping each site's existing `upsertJob(meta)` where present.
+- **AC:** a paused fire and an overlap skip each emit one `schedule.fire_skipped`
+  with the right `reason`; ledger row carries that reason; no change to create path.
+- **Test:** `tests/plugins/schedule/cron-dedup.test.ts` (already captures audit).
+
+## Slice C — run history reads the ledger for Bakin jobs + UI  (commit 3)
+- `runs-reader.ts`: `readRuns`/`getLastRun` route by ownership — Bakin job →
+  `listCronFires` mapped to `RunEntry` (created→success+taskId, skipped→skipped+
+  skippedReason, pending→running); native job → existing `cron.listRuns`.
+- Route `/:jobId/runs` + `getLastRun` callers pass the job (not just `cron`).
+- `run-history.tsx`: render `skippedReason` next to a skipped badge.
+- **AC:** a Bakin job with fires shows them in the drawer (was empty post-cutover);
+  skipped rows show the reason; native crons still read the runtime adapter.
+- **Test:** `tests/plugins/schedule/routes.test.ts`.
+
+## Verify (before "done")
+- `bun run test`, `bun run build`, `bun run docs:check`.
+- Update `.claude/knowledge/bakin-owned-scheduler.md` (run-history source + skip
+  visibility) and the schedule plugin's `bakin-plugin.json` route docs if needed.
+- Gold-standard E2E in the isolated docker rig.
+
+## Commit / rollback
+One commit per slice (A→B→C), each independently green. Slice A is additive
+(nullable column + new verb) so B/C can land later; B is independent of C. Any
+slice can be reverted alone. Branch: `feat/schedule-run-visibility`.

--- a/tests/core/execution-ledger.test.ts
+++ b/tests/core/execution-ledger.test.ts
@@ -47,9 +47,11 @@ import {
   currentSeq,
   setSeqWatermark,
   claimCronFire,
+  getCronFire,
   attachCronTask,
   markCronFireSkipped,
   findHealableCronClaims,
+  listCronFires,
   recordCompletion,
   hasCompletion,
   getCompletion,
@@ -249,6 +251,37 @@ describe('cron_fires — claim before create', () => {
   it('same runId across different jobs is independent', () => {
     expect(claimCronFire('jobA', 'shared-run').claimed).toBe(true)
     expect(claimCronFire('jobB', 'shared-run').claimed).toBe(true)
+  })
+
+  it('records the skip reason and round-trips it on read', () => {
+    claimCronFire('job-skip', 'run-overlap', Date.now())
+    markCronFireSkipped('job-skip', 'run-overlap', 'overlap')
+    expect(getCronFire('job-skip', 'run-overlap')?.skipReason).toBe('overlap')
+    // a reason-less skip leaves the column null (back-compat with bare callers)
+    claimCronFire('job-skip', 'run-bare', Date.now())
+    markCronFireSkipped('job-skip', 'run-bare')
+    expect(getCronFire('job-skip', 'run-bare')?.skipReason).toBeNull()
+  })
+})
+
+describe('listCronFires — per-job history, newest first', () => {
+  it('returns a job\'s fires newest-first with disposition + reason, bounded by limit', () => {
+    const base = Date.now()
+    claimCronFire('hist', 'r1', base - 30_000)
+    attachCronTask('hist', 'r1', 'task-1')
+    claimCronFire('hist', 'r2', base - 20_000)
+    markCronFireSkipped('hist', 'r2', 'paused')
+    claimCronFire('hist', 'r3', base - 10_000) // stays pending
+    claimCronFire('other', 'x1', base - 5_000) // different job — excluded
+
+    const all = listCronFires('hist', 50)
+    expect(all.map((f) => f.runId)).toEqual(['r3', 'r2', 'r1']) // newest fired_at first
+    expect(all.find((f) => f.runId === 'r1')?.disposition).toBe('created')
+    expect(all.find((f) => f.runId === 'r1')?.taskId).toBe('task-1')
+    expect(all.find((f) => f.runId === 'r2')?.skipReason).toBe('paused')
+
+    expect(listCronFires('hist', 2).map((f) => f.runId)).toEqual(['r3', 'r2']) // limit honored
+    expect(listCronFires('nope', 50)).toEqual([])
   })
 })
 

--- a/tests/plugins/schedule/cron-dedup.test.ts
+++ b/tests/plugins/schedule/cron-dedup.test.ts
@@ -235,6 +235,33 @@ describe('cron fire dedup (claim before create)', () => {
     expect(mockCreateTask).toHaveBeenCalledTimes(2)
   })
 
+  it('emits schedule.fire_skipped with the reason when a paused job fires', async () => {
+    upsertJob(makeMeta({ paused: true, pauseReason: 'manual' }))
+    const payload = { jobId: 'release-notes', runId: 'run-paused-audit', timestamp: '2026-06-06T07:00:00Z' }
+    const result = await fireScheduledRunFromPayload(payload)
+
+    expect(result.body.skipped).toBe('paused')
+    const ev = auditEvents.filter((e) => e.event === 'schedule.fire_skipped')
+    expect(ev).toHaveLength(1)
+    expect(ev[0].data.reason).toBe('paused')
+    expect(ev[0].data.runId).toBe('run-paused-audit')
+    expect(getCronFire('release-notes', 'run-paused-audit')?.skipReason).toBe('paused')
+  })
+
+  it('emits schedule.fire_skipped with reason "overlap" when the prior task is still active', async () => {
+    upsertJob(makeMeta({ allowOverlap: false, lastTaskId: 'task-active' }))
+    emptyBoard.columns.todo.push({ id: 'task-active' } as never)
+    const payload = { jobId: 'release-notes', runId: 'run-overlap-audit', timestamp: '2026-06-06T07:00:00Z' }
+    const result = await fireScheduledRunFromPayload(payload)
+
+    expect(result.body.skipped).toBe('overlap')
+    const ev = auditEvents.filter((e) => e.event === 'schedule.fire_skipped')
+    expect(ev).toHaveLength(1)
+    expect(ev[0].data.reason).toBe('overlap')
+    expect(getCronFire('release-notes', 'run-overlap-audit')?.skipReason).toBe('overlap')
+    expect(mockCreateTask).not.toHaveBeenCalled()
+  })
+
   it('Prove-It (#472): a post-create effect failure does not duplicate the task on heal', async () => {
     upsertJob(makeMeta())
     // Simulate createTaskWithEffects writing the row, then a post-create effect

--- a/tests/plugins/schedule/cron-dedup.test.ts
+++ b/tests/plugins/schedule/cron-dedup.test.ts
@@ -241,7 +241,7 @@ describe('cron fire dedup (claim before create)', () => {
     const result = await fireScheduledRunFromPayload(payload)
 
     expect(result.body.skipped).toBe('paused')
-    const ev = auditEvents.filter((e) => e.event === 'schedule.fire_skipped')
+    const ev = auditEvents.filter((e) => e.event === 'fire_skipped')
     expect(ev).toHaveLength(1)
     expect(ev[0].data.reason).toBe('paused')
     expect(ev[0].data.runId).toBe('run-paused-audit')
@@ -255,7 +255,7 @@ describe('cron fire dedup (claim before create)', () => {
     const result = await fireScheduledRunFromPayload(payload)
 
     expect(result.body.skipped).toBe('overlap')
-    const ev = auditEvents.filter((e) => e.event === 'schedule.fire_skipped')
+    const ev = auditEvents.filter((e) => e.event === 'fire_skipped')
     expect(ev).toHaveLength(1)
     expect(ev[0].data.reason).toBe('overlap')
     expect(getCronFire('release-notes', 'run-overlap-audit')?.skipReason).toBe('overlap')

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -257,7 +257,8 @@ mock.module('@bakin/schedule/lib/cron-parser', () => ({
 import { activatePlugin, findRoute, findTool, callRoute, callTool, callSearchRoute } from '../test-helpers'
 const schedulePlugin = (await import('@bakin/schedule/index')).default
 import { upsertJob, getJob } from '@bakin/schedule/lib/sidecar'
-import { getCronFire } from '../../../src/core/execution-ledger'
+import { getCronFire, claimCronFire, attachCronTask, markCronFireSkipped } from '../../../src/core/execution-ledger'
+import { closeDb } from '../../../packages/core/src/storage/db'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -328,6 +329,7 @@ beforeEach(() => {
 })
 
 afterAll(() => {
+  closeDb() // release the ledger handle before deleting its inode (SQLITE_IOERR_VNODE)
   rmSync(testDir, { recursive: true, force: true })
 })
 
@@ -1036,6 +1038,25 @@ describe('schedule routes', () => {
       expect(runs[0].runId).toBe('r1')
     })
 
+    it('reads a Bakin job\'s fire history from the ledger (fires + skips), newest-first', async () => {
+      // Bakin schedules have no runtime cron runs post-cutover — history is in the ledger.
+      upsertJob(makeMeta({ jobId: 'job-ledger', isBakinJob: true }))
+      const base = Date.parse('2026-03-30T09:00:00Z')
+      claimCronFire('job-ledger', 'run-a', base)
+      attachCronTask('job-ledger', 'run-a', 'task-aaaaaaaa')
+      claimCronFire('job-ledger', 'run-b', base + 60_000)
+      markCronFireSkipped('job-ledger', 'run-b', 'overlap')
+
+      const route = findRoute(plugin.routes, 'GET', '/:jobId/runs')!
+      const { status, body } = await callRoute(route, plugin.ctx, { searchParams: { jobId: 'job-ledger' } })
+
+      expect(status).toBe(200)
+      const runs = body.runs as RunEntry[]
+      expect(runs.map(r => r.runId)).toEqual(['run-b', 'run-a']) // newest fired_at first
+      expect(runs.find(r => r.runId === 'run-a')).toMatchObject({ status: 'success', taskId: 'task-aaaaaaaa' })
+      expect(runs.find(r => r.runId === 'run-b')).toMatchObject({ status: 'skipped', skippedReason: 'overlap' })
+    })
+
     it.skip('returns 400 when jobId is missing — legacy: routing requires :jobId in path', () => {})
 
     it('returns empty array when no runs exist', async () => {
@@ -1506,9 +1527,10 @@ describe('schedule exec tools', () => {
       expect(job.lastRun).toBeNull()
     })
 
-    it('includes lastRun when available', async () => {
+    it('includes lastRun from the ledger for a Bakin job', async () => {
       upsertJob(makeMeta({ jobId: 'job-get-run' }))
-      lastRunOverride = { runId: 'r99', jobId: 'job-get-run', timestamp: '2026-03-31T09:00:00Z', status: 'success' }
+      claimCronFire('job-get-run', 'r99', Date.parse('2026-03-31T09:00:00Z'))
+      attachCronTask('job-get-run', 'r99', 'task-r99')
 
       const tool = findTool(plugin.execTools, 'bakin_exec_schedule_get')!
       const result = await callTool(tool, { jobId: 'job-get-run' })
@@ -1516,6 +1538,8 @@ describe('schedule exec tools', () => {
       const job = result.job as Record<string, unknown>
       const lastRun = job.lastRun as RunEntry
       expect(lastRun.runId).toBe('r99')
+      expect(lastRun.status).toBe('success')
+      expect(lastRun.taskId).toBe('task-r99')
     })
 
     it('returns error when jobId is missing', async () => {


### PR DESCRIPTION
## Why

Follow-on to the Bakin-owned scheduler (#473). Two visibility gaps remained:

1. **Skips were silent.** When `runClaimedFire` skips a fire (overlap / paused / skip-count / auto-paused) it only flipped the ledger disposition to `skipped` — no feed event, and the *reason* was discarded. An overrunning every-5-min job serializes correctly (`allowOverlap: false` = skip_if_active) but dropped its overlapping beats invisibly.
2. **Run history was empty for Bakin jobs (cutover regression).** The job-drawer run history read `cron.listRuns` from the OpenClaw adapter. Post-cutover, Bakin schedules have no OpenClaw cron runs — so every Bakin job showed *no history*, even though `cron_fires` had the full record.

This makes both visible, with the skip *reason* living where it belongs: a `skip_reason` column on `cron_fires` (the per-fire durable record), so run history is a single clean ledger read.

## What

- **Ledger** (`packages/core/src/execution/ledger.ts`): migration v2 adds `cron_fires.skip_reason` (additive, idempotent); `markCronFireSkipped(jobId, runId, reason?)` records it; new `listCronFires(jobId, limit)` read verb (newest-first). Facade re-export in `src/core/execution-ledger.ts`.
- **Fire path** (`plugins/schedule/index.ts`): a `skipFire()` helper records the reason **and** emits a `schedule.fire_skipped` activity-audit event at every skip site (behaviour-preserving refactor — each site keeps its prior `upsertJob` side effect).
- **Run history** (`plugins/schedule/lib/runs-reader.ts`): `readRuns`/`getLastRun` route by ownership — Bakin job → `cron_fires` (created→success+taskId, skipped→skipped+reason, pending→pending); native cron → the runtime adapter as before. `run-history.tsx` shows the skip reason; `RunEntry` extended in both its definitions (`plugins/schedule/types.ts` + `src/hooks/use-schedule.ts`).
- **Mock coverage** (`dev/imitation-crab/`): seeds Bakin schedules + `cron_fires` history into the mock home so the new UI is exercisable under `dev:mock` (leak-safe — `BAKIN_HOME` pinned to the mock home before any ledger write; real `~/.bakin` verified untouched). Native-cron fixture trimmed 8→4 with `toolsAllow` so the list isn't a wall of "Missing cron tools" warnings.
- **UI fix** (`job-row.tsx`): the list-view actions menu was pinned to the trigger width (`w-(--anchor-width)`) and clipped/wrapped "Adopt into Bakin"; `w-auto` lets it size to its longest item.

## Verification

- `bun run test` (4763 pass), `typecheck`, `lint`, `docs:check` all green. A real-ledger integration test drives the actual `/:jobId/runs` handler end-to-end (Bakin → ledger, native → adapter).
- **Gold-standard docker E2E** (isolated rig): migration v2 applies on a real server boot; a live Bakin job's `/runs` returns ledger fires (regression fixed); a real overlap skip surfaced as `status: skipped, skippedReason: overlap`; the `schedule.fire_skipped` event fired live.
  - The E2E **caught a bug the unit test missed**: `activity.audit` prepends the plugin id, so `'schedule.fire_skipped'` emitted `schedule.schedule.fire_skipped`. Fixed to the bare `'fire_skipped'`.
- **Code review**: independent reviewer approved, no critical/important issues. Two clarity follow-ups applied — `'job-removed'` folded into the `SkipReason` union (single source of truth), and `cronFireToEntry` documents that `success` = "a task was created" (the `failure` status is native-adapter-only). Possible follow-up: join the completion ledger to reflect real task outcomes in run history.

## Related

- #461 (per-job concurrencyPolicy/catchUpPolicy) closed as parked — `skip_if_active` is already the default; now that run history makes skips observable, that knob has something to act on. Paperclip blueprint captured on the issue.
- #463 (per-*task* dispatch-attempt history from the `runs` table) remains a separate ticket — different surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)