### PR TITLE
feat(images): reference/context images + shim parity + post-live-test hardening (#418 #379 #380)

### DIFF
--- a/.claude/knowledge/assets-versioning.md
+++ b/.claude/knowledge/assets-versioning.md
@@ -161,9 +161,21 @@ return `assetId`. **None of them write tags** — the old machine stamps
 `source`/`generation` and polluted the folder namespace; `import` passes the
 caller's tags through untouched. **Billed calls are idempotent** via `idempotency.ts` (in-flight
 dedup + ~5min TTL result cache, keyed by `{taskId, op, source, promptHash,
-provider, model, w, h, quality}`) — prevents the client-timeout double-bill
-without adding a retry. No `sourcePath` on edit (import loose files first); no
-`savePromptPacket` (the prompt lives per-version in the manifest).
+provider, model, w, h, quality, references}`) — prevents the client-timeout
+double-bill without adding a retry. No `sourcePath` on edit (import loose files
+first); no `savePromptPacket` (the prompt lives per-version in the manifest).
+
+**`generation` provenance (per-version):** `provider`/`model`/`surface`/
+`routeSource`, plus optional `quality` and `references`.
+- `quality` is recorded **only on the shim path** (OpenClaw has no quality
+  flag); native generations omit it. The schema field is optional; the
+  asset-reuse match treats a missing quality as native-normal (#379).
+- `references` (#418) is `Array<{assetId, version}>` — the reference/context
+  images that conditioned the generation. Raw-path references passed to the image
+  tools are auto-imported (source-path dedup) so every entry is a tracked asset.
+  The asset **detail page renders a "References" row** of clickable chips linking
+  to each referenced asset. References also participate in the idempotency key
+  (same prompt + different references ≠ duplicate).
 
 ## save-by-source upsert
 

--- a/.claude/knowledge/images-plugin.md
+++ b/.claude/knowledge/images-plugin.md
@@ -22,7 +22,12 @@ credential-ownership rules.
   model, surface profile, dimensions, and quality.
 - `bakin_exec_images_generate`: generates through a runtime image provider or
   native direct adapter and saves the result into Assets with generation
-  metadata.
+  metadata. Accepts `referenceImages` (#418) — managed assetIds and/or local
+  file paths (mix freely, max 4) that condition the generation. A
+  reference-bearing generate is a NEW asset (use `_edit` to revise an existing
+  one in place).
+- `bakin_exec_images_edit`: edits a managed asset (new version on the same
+  asset); `referenceImages` supplies extra context images alongside the base.
 - `bakin_exec_images_import`: imports a local image file into Assets.
 - `bakin_exec_images_export`: creates resized/cropped/format-converted variants
   for a target surface profile.
@@ -59,6 +64,30 @@ Serving-path diagnostics ("how"): generation results carry
 Provider support is adapter-based, not raw generic HTTP. Add new providers by
 adding a runtime adapter provider route, or (for the direct shim) a provider
 entry in the shared module plus route tests and generation metadata coverage.
+
+## Reference images, quality, and capability gating (#418 / #379)
+
+- **Reference images** are resolved at the Bakin layer: assetIds → current
+  version via `ctx.assets.resolveVersionFile`; raw paths are auto-imported into
+  Assets (source-path dedup) so every reference becomes a tracked asset. Cap is
+  `MAX_REFERENCE_IMAGES = 4`. Native `infer image generate` has no file input, so
+  reference generates are routed through `infer image edit --file …`; edit
+  appends references after the base. Lineage is stamped into
+  `generation.references` (`assetId@version`) and folds into the idempotency key
+  so same-prompt/different-refs is not a duplicate.
+- **Native-only**: references require the runtime path. If the route resolves to
+  the direct shim (`servedBy: 'shim'`), the call fails loudly **before billing** —
+  the shim has no image-input path.
+- **Capability gate**: the selected model must declare the `reference-images`
+  capability (read from the curated static descriptor, which is preferred over
+  runtime-synthesized capabilities — those would clobber the static flag; see
+  #381). A model without it fails loudly before billing.
+- **Quality** is a shim-only concept — OpenClaw's CLI has no quality flag. The
+  asset sidecar records `generation.quality` only on the shim path; native
+  generations omit it. The shim rejects (pre-billing) any option it can't honor
+  (`count>1`, `aspectRatio`, `resolution`, `background`, non-png format).
+- **Asset discovery**: `bakin_exec_assets_list` takes an optional `tags` filter
+  (AND semantics) — the agent's clean way to "look in a folder" (folders = tags).
 
 ## Workflows And Skills
 

--- a/.claude/knowledge/media-generation-adapter-architecture.md
+++ b/.claude/knowledge/media-generation-adapter-architecture.md
@@ -4,10 +4,11 @@ Status: **Shipped (Phases 1–2); kept as the architecture reference.** Landed:
 capability-contract tightening (dropped `outputPath`), shim namespace settled
 (`@bakin/core/media`), the Bakin-owned provider secret store (env → store,
 atomic `0600`, validated provider ids), the `/api/secrets` write API, and the
-image-scoped Provider Keys settings tab. Open follow-ups are tracked on
-GitHub: #378 (all-domains credential inventory), #379 (path parity), #380
-(shared mime/provider tables), #381 (image model catalog drift). The Hermes
-adapter validates the abstraction when a 2nd runtime is built.
+image-scoped Provider Keys settings tab. **#380 (shared mime/provider tables),
+#379 (path parity), and #418 (reference images) have landed** — see §Follow-ups
+landed below. Open follow-ups: #378 (all-domains credential inventory), #381
+(image model catalog drift). The Hermes adapter validates the abstraction when a
+2nd runtime is built.
 Scope: image generation today; the template generalizes to video / audio / any
 provider-backed media modality and to runtimes beyond OpenClaw.
 
@@ -279,3 +280,35 @@ Tracked, not MVP-blocking:
   (`@bakin/core/media/secret-store`), keyed per provider (shared across
   modalities); the future dashboard editing rides the existing settings
   renderer via a new "secret" field type.
+
+## Follow-ups landed (#380 / #379 / #418)
+
+- **#380 — single source of truth for format/credential tables.**
+  `packages/core/src/media/image-format.ts` (a pure module, also exported as the
+  `@bakin/core/media/image-format` subpath so it's client-bundle-safe) owns the
+  canonical image `mime ↔ ext` map (`extensionForImageMime`,
+  `IMAGE_EXTENSION_TO_MIME`) and the provider→env-var table
+  (`IMAGE_PROVIDER_ENV_VARS`). The shim's `extForMime`/`resolveDirectImageKey`,
+  the images plugin's provider `envVars`, and the assets `EXTENSION_TO_MIME`
+  image rows all consume it. A test asserts the images manifest `secrets` ⊆ the
+  table. Fixed the latent `image/gif → .jpg` mistyping.
+
+- **#379 — shim guardrail + truthful quality.** The shim now carries the full
+  generation option surface and **throws before the billed call** on anything it
+  can't honor (`count>1`, `aspectRatio`, `resolution`, `background`, non-png
+  `outputFormat`) — no silent drops. OpenClaw has **no quality flag** (verified
+  against `openclaw/openclaw` `src/cli/capability-cli.ts`), so `quality` is a
+  shim-only concept: the asset sidecar records `generation.quality` only on the
+  shim path; native generations omit it (schema field is now optional). The
+  asset-reuse match treats a missing quality as native-normal.
+
+- **#418 — reference/context images.** `referenceImages` (managed assetIds
+  and/or raw paths; raw paths auto-imported with source-path dedup; cap 4) thread
+  through `RuntimeImageGenerateInput`. The native `infer image generate` has no
+  `--file`, so a generate carrying references is routed through the **edit-style
+  invocation** (`infer image edit --file …`); edit appends references after the
+  base. References are **native-only** — the shim rejects them loudly before
+  billing. Gated on the curated static model's `reference-images` capability
+  (preferred over runtime-synthesized capabilities, which would clobber it — see
+  #381). Lineage is recorded in `generation.references` (`assetId@version`) and
+  participates in the idempotency key.

--- a/.claude/specs/image-references-and-shim-parity.md
+++ b/.claude/specs/image-references-and-shim-parity.md
@@ -1,0 +1,296 @@
+---
+title: "Image reference/context images + media-shim parity"
+status: draft
+issues: [380, 379, 418]
+supersedes_notes: "Closes the three 'Known limitations' deferred from the retired media-generation-adapter-architecture spec."
+---
+
+# Image reference/context images + media-shim parity
+
+## 1. Objective
+
+Make Bakin's image generation materially better by letting agents condition
+generation/edit on **reference images**, and close two latent correctness gaps
+in the media-generation path discovered during the adapter review.
+
+Single user, single machine (Mac mini + OpenClaw). **No backwards-compat /
+shims for old data** — clean, truthful, single-source-of-truth code is the
+priority. Three GitHub issues, one PR, three checkpointed commits.
+
+Target "user": an AI agent calling the images MCP tools
+(`bakin_exec_images_generate` / `_edit`), and the human reading the resulting
+asset in the dashboard.
+
+### Ground truth established from the real OpenClaw CLI (`openclaw/openclaw`)
+
+Verified against `src/cli/capability-cli.ts` + `docs/cli/infer.md` (open source):
+
+- `infer image generate` flags: `--prompt --model --count --size --aspect-ratio
+  --resolution --output-format --background --openai-background --timeout-ms
+  --output --json`. **No `--file`. No `--quality`.**
+- `infer image edit` is identical **plus a required, repeatable `--file`**
+  (collects an array). This is the only generate-style command that takes input
+  images.
+- Therefore: **reference-image generation is impossible on `generate`** and must
+  route through the `edit` command; **`quality` does not exist** in OpenClaw and
+  can only mean anything on the direct-HTTP shim.
+
+## 2. Scope: three issues, one PR
+
+| Commit | Issue | Summary |
+| --- | --- | --- |
+| 1 | #380 | Single source of truth for image mime↔ext + provider→env-var, consumed by shim **and** images plugin. |
+| 2 | #379 | (a) Shim hard-fails on options it can't honor; (b) `quality` recorded only when actually applied (shim path). |
+| 3 | #418 | Reference/context images in generate + extra references in edit, with lineage + idempotency + capability gating + UI. |
+
+Dependency order: #380 (foundation) → #379 (forwarding discipline) →
+#418 (feature on top).
+
+---
+
+## 3. Feature detail + acceptance criteria
+
+### Commit 1 — #380: shared mime/ext + provider→env-var tables
+
+**Problem.** `direct-image-provider.ts` (core) re-encodes a mime→ext table
+(`extForMime`) and provider→env-var names (`resolveDirectImageKey`) that the
+images plugin also owns (`IMAGE_PROVIDERS[].envVars`, `bakin-plugin.json`
+`secrets`, and `plugins/assets/lib/constants.ts` mime map). Core must not import
+plugin code, so the tables drift independently.
+
+**Design.** New `packages/core/src/media/image-format.ts` is the single source of
+truth for:
+- image **mime ↔ extension** (png/jpeg/webp/gif): `extensionForImageMime(mime)`
+  + the reverse map.
+- **provider → env-var names**: `IMAGE_PROVIDER_ENV_VARS` table +
+  `resolveDirectImageKey` reads from it.
+
+Consumers import from core:
+- `direct-image-provider.ts` — `extForMime` → `extensionForImageMime`;
+  `resolveDirectImageKey` uses the shared env-var table.
+- `plugins/images/lib/providers.ts` — `IMAGE_PROVIDERS[].envVars` derives from the
+  shared table (no hand-typed env names).
+- `plugins/assets/lib/constants.ts` — its **image rows** of `EXTENSION_TO_MIME`
+  compose the core image map (assets keeps audio/video/doc rows + asset-type
+  classification, which are not media-gen concerns).
+- `plugins/images/bakin-plugin.json` `secrets` — validated against the shared
+  table by a test (drift guard), not hand-synced.
+
+**Acceptance.**
+- One image mime/ext mapping and one provider→env-var table in core.
+- Adding a provider/format/env-var is a one-place edit.
+- A test asserts `bakin-plugin.json` `secrets` ⊆ the shared env-var table.
+
+### Commit 2 — #379: shim guardrail + truthful quality
+
+**(a) Shim hard-fails on unsupported options.**
+`DirectImageRequest` gains the full option surface the native path carries
+(`count`, `aspectRatio`, `resolution`, `background`, `outputFormat`).
+`generateDirectImage` validates **before** the billed HTTP call and throws a
+clear error for anything it can't honor:
+- `count` > 1 → throw (single-image endpoints).
+- `aspectRatio` / `resolution` / `background` present → throw (not wired).
+- `outputFormat` ∉ shim-supported set → throw.
+
+Rationale: image generation is billed + non-idempotent; failing before spend
+beats a wrong-but-charged image. **Zero user impact today** — no Bakin code path
+passes these options; this is a guardrail that converts a future silent drop
+into an immediate clear failure.
+
+**(b) Quality is recorded only when applied.**
+OpenClaw has no quality knob; `quality` is honored only by the shim
+(`qualityForOpenAI`). Today the asset sidecar records the requested tier even on
+native generates that ignored it — a fiction.
+- `GenerationSchema.quality`: `z.string()` → `z.string().optional()`.
+- `tools.ts persistImageResult`: include `quality` in `generation` **only when
+  `routeSource === 'shim'`**; omit on native.
+- `versionMatchesRequest` / reuse-match: treat "no recorded quality" as the
+  native normal state (don't fail a reuse match because native omitted it).
+
+**Acceptance.**
+- Shim throws (pre-billing) on count>1/aspectRatio/resolution/background/bad
+  format; tests cover each.
+- Native-path generated assets have no `generation.quality`; shim-path ones do.
+- Existing manifests with `quality` still parse (optional field).
+
+### Commit 3 — #418: reference/context images
+
+**Tool contract (both `generate` and `edit`).**
+New optional `referenceImages: string[]`. Each entry auto-classified:
+- matches the assetId validator (`isValidAssetId`) → resolve current version via
+  `ctx.assets.resolveVersionFile`.
+- else → treat as a file path, `existsSync`-checked, then **auto-imported into
+  Assets** (source-path dedup: reuse the existing asset if that path/content is
+  already managed, else import once) so it becomes a tracked assetId. A fresh
+  Discord attachment thus becomes a navigable asset, not a loose path.
+- Unresolvable entry → fail loudly (no silent drop).
+- Cap: `MAX_REFERENCE_IMAGES = 4` (style/logo/product workflows); exceeding →
+  clear error. Constant lives with the tool, easy to bump.
+
+After resolution, **every reference is a managed `assetId@version`** — there is no
+raw-path branch downstream. This uniformity simplifies lineage, idempotency, and
+the UI.
+
+**Threading.**
+- `RuntimeImageGenerateInput` gains `referenceImages?: string[]` (file paths;
+  Bakin resolves assetIds → paths before the adapter call).
+- `RuntimeImageEditInput.files` already exists; extra references **append after**
+  the base asset's current version (base stays `files[0]`).
+- OpenClaw adapter `images.generate`: if `referenceImages` present, route to the
+  **`image edit`** command with `file: referenceImages` (generate has no
+  `--file`). Otherwise unchanged.
+- OpenClaw adapter `images.edit`: `files = [baseCurrentVersion, ...references]`.
+
+**Shim path.** Native-only. If a request carries `referenceImages` and the route
+resolves to the shim, **throw before billing**
+("reference images require the native runtime; <provider> is served via the
+direct shim"). Shim reference support is an explicit future follow-up.
+
+**Capability gating.** Gate on the selected model's `reference-images`
+capability flag (from the provider descriptor); if absent, throw a clear error
+naming the model **before billing** — finally making the declared flag real.
+Runtime-only discovered models lack the flag and are refused until #381 makes
+runtime capability discovery trustworthy (documented dependency).
+
+**Lineage (provenance — answers "associate assets with calls in practice").**
+`GenerationSchema` gains optional `references` (uniform, since raw paths are
+auto-imported):
+```ts
+references?: Array<{ assetId: string; version: number }>
+```
+Recorded at `persistImageResult` for both generate and edit. OpenClaw never
+knows these are assets; Bakin owns the persist step and stamps the resolved
+`assetId@version` identity.
+
+**Idempotency.** `ImageCallKey` + `versionMatchesRequest` fold in a stable
+**reference fingerprint** = sorted join of `assetId@version`. Same prompt +
+different references ⇒ different key ⇒ not a duplicate; same prompt + same
+references ⇒ dedupes as before.
+
+**UI.** Asset detail page renders a **References** row when
+`generation.references` is present: every ref is a clickable asset chip
+(navigate to that asset). Uses existing `ProvenanceChips`/versioned detail
+patterns.
+
+**Asset discovery (Story 3 enabler).** Add an optional `tags: string[]` filter to
+the `bakin_exec_assets_list` MCP tool (the list service already supports
+tag-aware listing for the UI). Makes "look in our brand-assets folder" a single
+clean lookup instead of list-all-and-filter-client-side.
+
+**Acceptance.**
+- `generate` + `edit` accept `referenceImages` (assetIds and/or paths, mixed).
+- Native generate-with-references routes through `image edit` with the refs as
+  `--file`s; edit appends refs after the base.
+- Shim + references → loud pre-billing error.
+- Model without `reference-images` capability → loud pre-billing error naming the
+  model.
+- Lineage persisted in `generation.references`; visible + navigable in asset
+  detail.
+- Idempotency: same prompt/different refs not deduped; same prompt/same refs
+  deduped.
+- The previously-dead `reference-images` capability is now exercised.
+
+---
+
+## 4. Files touched
+
+**Core**
+- `packages/core/src/media/image-format.ts` (new) — mime/ext + env-var SoT.
+- `packages/core/src/media/direct-image-provider.ts` — import shared tables;
+  add option guardrail; (no reference support — rejects via plugin layer).
+- `packages/core/src/adapters/runtime/concepts.ts` — `referenceImages?` on
+  `RuntimeImageGenerateInput`.
+- `packages/core/src/media/index.ts` — export new module (verify barrel).
+
+**Adapter**
+- `packages/adapter-openclaw/src/runtime.ts` — generate routes to `edit` when
+  references present; edit appends references; (no quality flag — confirmed
+  absent).
+
+**Plugins**
+- `plugins/assets/lib/manifest.ts` — `quality` optional; add `references` to
+  `GenerationSchema`.
+- `plugins/assets/lib/constants.ts` — image mime rows compose core map.
+- `plugins/assets/components/versioned/*` — References row on detail page.
+- `plugins/images/index.ts` — `referenceImages` in `generateShape`/`editShape`;
+  tool descriptions clarify edit (= new version of same asset) vs generate-with-
+  references (= new sibling asset) so agents pick the right one.
+- `plugins/images/lib/tools.ts` — resolve/classify/cap references (auto-import
+  raw paths via source-path dedup); thread to runtime; record lineage;
+  quality-only-when-applied; reference fingerprint in idempotency + reuse-match.
+- `plugins/images/lib/providers.ts` — env-vars from shared table; capability gate
+  helper.
+- `plugins/images/bakin-plugin.json` — (unchanged values; covered by drift test).
+- `plugins/assets/index.ts` — optional `tags: string[]` filter on
+  `bakin_exec_assets_list`.
+
+**Docs**
+- `.claude/knowledge/media-generation-adapter-architecture.md` — shared tables,
+  shim guardrail, quality-shim-only, references-native-only.
+- `.claude/knowledge/images-plugin.md` — reference images, capability gate,
+  quality semantics.
+- `.claude/knowledge/assets-versioning.md` — `generation.references`, quality
+  optional, References UI.
+- README.md — verified: no image-generation section; **no change**.
+
+## 5. Code style / constraints
+
+- TypeScript strict; no `any` across module boundaries.
+- Zod at boundaries (tool inputs, manifest).
+- Adapter boundary intact: plugins never import provider HTTP; references
+  resolved at the Bakin layer, paths handed to the runtime capability.
+- No fabricated CLI flags, no fabricated model metadata.
+- `const` over `let`; kebab-case files; functional preference.
+- No silent drops anywhere — every unsupported request fails loudly **before
+  billing**.
+
+## 6. Testing strategy (TDD per commit)
+
+All tests mock content-dir (both facades) + OpenClaw home per CLAUDE.md.
+
+- **#380** `tests/plugins/images/providers.test.ts` (+ a small core media test):
+  env-vars come from shared table; `bakin-plugin.json` secrets ⊆ table.
+- **#379** `tests/core/media/direct-image-provider.test.ts`: each unsupported
+  option throws before any fetch. `tests/plugins/images/tools.test.ts`: native
+  result omits `generation.quality`; shim result includes it; reuse-match works
+  across the asymmetry.
+- **#418** `tests/adapter-openclaw/runtime-images.test.ts`: generate-with-refs
+  invokes `image edit` with `--file`s; edit appends refs after base; no
+  `--quality` ever emitted. `tests/plugins/images/tools.test.ts`: assetId + path
+  resolution, cap enforcement, capability-gate rejection, shim+refs rejection,
+  lineage recorded. `tests/plugins/images/idempotency*.test.ts`: reference
+  fingerprint changes the key; identical refs dedupe.
+
+## 7. Boundaries
+
+**Always:** fail loudly before billing; single source of truth; truthful
+sidecars; keep the adapter boundary clean; update `.claude/knowledge` docs for
+every change.
+
+**Ask first:** any change that would touch the search schema
+(`SCHEMA_VERSION` bump) — current plan deliberately avoids it
+(references/quality are not search fields). Any expansion to shim reference
+support or full shim option implementation.
+
+**Never:** guess OpenClaw flags or model ids; add backwards-compat shims for old
+manifests; silently drop a requested option; record metadata a generation didn't
+actually apply; let core import plugin code.
+
+## 8. Out of scope (documented, not done here)
+
+- #381 (image model catalog drift) — referenced as the trust dependency for
+  runtime-discovered capability flags. Gating uses static descriptors, which are
+  correct today.
+- Shim reference-image support (direct OpenAI edits / Gemini inlineData).
+- Full shim implementation of count/aspectRatio/background/outputFormat.
+
+## 9. Commit strategy (rollback checkpoints)
+
+1. `refactor(media): single source of truth for image mime/ext + provider env vars (#380)`
+2. `fix(media): shim rejects unsupported options + record quality only when applied (#379)`
+3. `feat(images): reference/context images in generate and edit (#418)`
+   — may split into 3a (interface+adapter+tools), 3b (lineage+idempotency),
+   3c (asset-detail References UI) if 3 grows large.
+
+Each commit builds, type-checks, and passes its tests independently — every
+commit is a clean rollback point.

--- a/.claude/specs/image-references-and-shim-parity.plan.md
+++ b/.claude/specs/image-references-and-shim-parity.plan.md
@@ -1,0 +1,287 @@
+---
+title: "Implementation plan — image references + shim parity"
+spec: ./image-references-and-shim-parity.md
+issues: [380, 379, 418]
+status: ready-for-review
+---
+
+# Plan — image references + media-shim parity
+
+Companion to `image-references-and-shim-parity.md`. One PR, three checkpointed
+commits in dependency order. Each commit builds, type-checks, and passes its
+tests independently — every checkpoint is a clean rollback point.
+
+## Dependency graph
+
+```
+COMMIT 1 (#380 foundation)
+  T1.1 core media-format module ──┬─→ T1.2 shim imports it
+                                  ├─→ T1.3 images providers env-vars from it
+                                  ├─→ T1.4 assets constants compose image rows
+                                  └─→ T1.5 tests (table + secrets drift)
+            │
+            ▼ checkpoint A → commit 1
+COMMIT 2 (#379 parity)
+  T2.1 shim option guardrail (throws pre-billing)        [edits shim again → after T1.2]
+  T2.2 GenerationSchema.quality → optional ──→ T2.3 quality recorded only on shim
+                                                  └─→ T2.4 tests
+            │
+            ▼ checkpoint B → commit 2
+COMMIT 3 (#418 feature)
+  T3.1 interfaces (RuntimeImageGenerateInput.referenceImages, generation.references, client types)
+        ├─→ T3.2 adapter: generate→edit routing + edit appends refs
+        └─→ T3.3 plugin tools: resolve/auto-import/cap/gate/shim-reject/lineage/idempotency
+                   (depends on T2.3 — same persist fn; and T3.1)
+  T3.4 assets_list tags filter            [independent — can land any time in commit 3]
+  T3.5 References UI row                   [depends on T3.1 client types]
+  T3.6 tests (tools, idempotency, adapter routing, tags filter)
+            │
+            ▼ checkpoint C → commit 3  (optional split 3a/3b/3c)
+PHASE 4 (docs — not a code commit gate, lands in commit 3 or a 4th doc commit)
+  T4.1 knowledge docs ×3   T4.2 README verify (expected no-op)
+```
+
+Vertical-slice principle: each task carries one complete path (data → logic →
+test), not a horizontal layer. T3.2 and T3.3 are the two halves of the feature
+that must both land for references to work end-to-end; T3.6 proves the whole
+slice.
+
+---
+
+## COMMIT 1 — #380: single source of truth for image format + provider env
+
+### T1.1 — Core media-format module
+- **File:** `packages/core/src/media/image-format.ts` (new); export from
+  `packages/core/src/media/index.ts`.
+- **Do:** image `mime ↔ extension` map (png/jpeg/webp/gif) +
+  `extensionForImageMime(mime): string`; `IMAGE_PROVIDER_ENV_VARS:
+  Record<DirectImageProviderId, string[]>` (`openai → [OPENAI_API_KEY]`,
+  `google → [GEMINI_API_KEY, GOOGLE_AI_API_KEY]`).
+- **Accept:** pure module, no node-only imports beyond types; both maps + helper
+  exported and typed.
+- **Verify:** `bun test tests/core/media/image-format.test.ts --isolate` (new).
+
+### T1.2 — Shim consumes the shared tables
+- **File:** `packages/core/src/media/direct-image-provider.ts`.
+- **Do:** delete local `extForMime`; use `extensionForImageMime`. Rewrite
+  `resolveDirectImageKey` to read env names from `IMAGE_PROVIDER_ENV_VARS`.
+- **Accept:** no behavior change; no duplicated tables remain in the shim.
+- **Verify:** `bun test tests/core/media/direct-image-provider.test.ts --isolate`.
+
+### T1.3 — Images providers env-vars from the table
+- **File:** `plugins/images/lib/providers.ts`.
+- **Do:** `IMAGE_PROVIDERS[].envVars` sourced from `IMAGE_PROVIDER_ENV_VARS`
+  (no hand-typed env names).
+- **Accept:** `providerReadinessFromEnv` behavior unchanged; env names come from
+  one place.
+- **Verify:** `bun test tests/plugins/images/providers.test.ts --isolate`.
+
+### T1.4 — Assets constants compose the core image rows
+- **File:** `plugins/assets/lib/constants.ts`.
+- **Do:** image rows of `EXTENSION_TO_MIME` derive from the core image map
+  (audio/video/doc rows + asset-type classification stay local — not media-gen
+  concerns). No image-row duplication.
+- **Accept:** `getMimeType` returns identical results for all current types.
+- **Verify:** existing assets constants/serve tests stay green.
+
+### T1.5 — Drift-guard tests
+- **Files:** new `tests/core/media/image-format.test.ts`;
+  extend `tests/plugins/images/providers.test.ts`.
+- **Do:** assert mime↔ext round-trips; assert `bakin-plugin.json` `secrets` ⊆
+  flattened `IMAGE_PROVIDER_ENV_VARS` (the future-rename guard from #380).
+- **Accept:** both pass; deliberately breaking a table fails the secrets test.
+
+> **Checkpoint A:** `bun run typecheck` (or `tsc --noEmit` path) + the four
+> targeted test files green + `bun run build` smoke. **Commit 1.**
+
+---
+
+## COMMIT 2 — #379: shim guardrail + truthful quality
+
+### T2.1 — Shim hard-fails on unsupported options
+- **File:** `packages/core/src/media/direct-image-provider.ts`.
+- **Do:** extend `DirectImageRequest` with `count?/aspectRatio?/resolution?/
+  background?/outputFormat?`. In `generateDirectImage`, **before any fetch**,
+  throw a clear `Error` when: `count` > 1; `aspectRatio`/`resolution`/
+  `background` set; `outputFormat` ∉ supported set. Message names the offending
+  option + "direct-image shim".
+- **Accept:** unsupported option → throw, no network call; supported single-PNG
+  path unchanged.
+- **Verify:** `tests/core/media/direct-image-provider.test.ts` — one case per
+  option asserts throw + that `fetch` was never called (mock fetch).
+
+### T2.2 — Quality field becomes optional
+- **File:** `plugins/assets/lib/manifest.ts`.
+- **Do:** `GenerationSchema.quality: z.string()` → `.optional()`.
+- **Accept:** old manifests with `quality` still parse; new ones may omit it.
+- **Verify:** manifest parse test with and without quality.
+
+### T2.3 — Record quality only when applied (shim path)
+- **File:** `plugins/images/lib/tools.ts`.
+- **Do:** in `persistImageResult`, include `generation.quality` only when
+  `routeSource === 'shim'`. Update `versionMatchesRequest` + reuse helpers so a
+  native version (no quality) still matches a native re-request (don't compare
+  quality when neither side recorded it).
+- **Accept:** native generate → asset has no `generation.quality`; shim generate
+  → has it; reuse/idempotency intact on both.
+- **Verify:** `tests/plugins/images/tools.test.ts` — native-omits / shim-includes
+  / reuse-match-native cases.
+
+### T2.4 — Tests (folded into T2.1–T2.3 above)
+
+> **Checkpoint B:** typecheck + `tests/core/media/*` +
+> `tests/plugins/images/{tools,idempotency,idempotency-durable}.test.ts` green +
+> build smoke. **Commit 2.**
+
+---
+
+## COMMIT 3 — #418: reference/context images
+
+### T3.1 — Interfaces & schema
+- **Files:** `packages/core/src/adapters/runtime/concepts.ts`;
+  `plugins/assets/lib/manifest.ts`; `plugins/assets/components/versioned/types.ts`.
+- **Do:** add `referenceImages?: string[]` to `RuntimeImageGenerateInput`
+  (resolved **file paths** by the time the adapter sees them). Add optional
+  `references?: Array<{ assetId: string; version: number }>` to
+  `GenerationSchema`. Mirror `references` in the client `types.ts` generation
+  shape.
+- **Accept:** types compile; schema parses with/without references.
+- **Verify:** `bun run typecheck`; manifest parse test.
+
+### T3.2 — OpenClaw adapter routing
+- **File:** `packages/adapter-openclaw/src/runtime.ts`.
+- **Do:** in `images.generate`, when `input.referenceImages?.length`, dispatch to
+  the **edit** invocation (`runImageInference('edit', { ...input, files:
+  referenceImages })`) since `infer image generate` has no `--file`. In
+  `images.edit`, build `files = [base, ...references]` (base stays first). Never
+  emit `--quality` (confirmed absent).
+- **Accept:** refs present on generate → `infer image edit --file …` args; edit
+  with extra refs → multiple `--file` in order.
+- **Verify:** `tests/adapter-openclaw/runtime-images.test.ts` — assert the exec
+  argv (mocked exec) for both paths; assert no `--quality` ever.
+
+### T3.3 — Plugin tools (resolve, gate, lineage, idempotency)
+- **Files:** `plugins/images/index.ts`, `plugins/images/lib/tools.ts`,
+  `plugins/images/lib/providers.ts`, `plugins/images/lib/idempotency.ts`.
+- **Do:**
+  - `referenceImages: z.array(z.string()).optional()` on generate + edit shapes;
+    tool descriptions clarify edit (new version) vs reference-generate (new
+    sibling).
+  - New resolve step: classify each entry (`isValidAssetId` → resolve current
+    version; else file path → `existsSync` → **auto-import** via source-path
+    dedup → assetId). Cap at `MAX_REFERENCE_IMAGES = 4`, else throw. Unresolvable
+    → throw.
+  - Capability gate: selected model must declare `reference-images`; else throw
+    naming the model (before billing).
+  - Shim guard: if references present and route resolves to shim, throw
+    ("reference images require the native runtime").
+  - Pass resolved paths to `runtime.images.generate/edit`; record
+    `generation.references = [{assetId, version}…]` in `persistImageResult`.
+  - Idempotency: add `references` fingerprint (sorted `assetId@version` join) to
+    `ImageCallKey` + `imageCallSignature` + `versionMatchesRequest`.
+- **Accept:** all six behaviors above hold; same-prompt-different-refs not
+  deduped; same-prompt-same-refs deduped.
+- **Verify:** `tests/plugins/images/{tools,idempotency}.test.ts`.
+
+### T3.4 — `assets_list` tags filter
+- **Files:** `plugins/assets/lib/asset-service.ts` (`listAssets` filter gains
+  `tags?: string[]`, AND-match against normalized manifest tags);
+  `plugins/assets/index.ts` (`bakin_exec_assets_list` param + passthrough).
+- **Accept:** `list({ tags: ['brand'] })` returns only assets tagged `brand`;
+  no tags → unchanged.
+- **Verify:** `tests/plugins/assets/*` list test (add tags case).
+
+### T3.5 — References UI row
+- **File:** `plugins/assets/components/versioned/VersionedAssetDetail.tsx`
+  (+ `atoms.tsx` if a small `ReferenceChips` atom helps).
+- **Do:** when `previewVer.generation?.references?.length`, render a
+  **References** row: each ref a clickable chip → `/assets/<refAssetId>` with a
+  thumb. Follows existing detail/provenance styling.
+- **Accept:** detail page shows navigable reference chips; absent when none.
+- **Verify:** manual (`bun run dev:mock`) + a light render assertion if a
+  component test harness exists for versioned detail.
+
+### T3.6 — Test sweep (folded into T3.2–T3.5)
+
+> **Checkpoint C:** full `bun run test` + `bun run build` + typecheck green.
+> **Commit 3** (split into 3a interfaces+adapter+tools / 3b idempotency+lineage /
+> 3c tags+UI only if the diff gets unwieldy).
+
+---
+
+## PHASE 4 — Docs (lands within commit 3 or a trailing `docs:` commit)
+
+### T4.1 — Knowledge docs
+- `.claude/knowledge/media-generation-adapter-architecture.md` — shared tables,
+  shim option guardrail, quality-shim-only, references-native-only.
+- `.claude/knowledge/images-plugin.md` — `referenceImages`, capability gate,
+  quality semantics, auto-import-of-raw-refs, `assets_list` tags filter.
+- `.claude/knowledge/assets-versioning.md` — `generation.references`, quality
+  optional, References UI row.
+
+### T4.2 — README
+- Verify no image-generation section exists (confirmed during spec). **Expected
+  no change**; note in PR if so.
+
+---
+
+## Commit strategy (rollback checkpoints)
+
+1. `refactor(media): single source of truth for image mime/ext + provider env vars (#380)`
+2. `fix(media): shim rejects unsupported options + record quality only when applied (#379)`
+3. `feat(images): reference/context images in generate and edit (#418)`
+   - (optional) `3a feat(images): thread referenceImages through adapter + tools`
+   - (optional) `3b feat(images): reference lineage + idempotency fingerprint`
+   - (optional) `3c feat(assets): references UI + assets_list tags filter`
++ optional `docs(images): document references, shim guardrail, quality semantics`
+
+Branch off `main` (e.g. `feat/image-reference-images`). PR after checkpoint C +
+docs.
+
+## Risk & rollback notes
+
+- **No search-schema change** (references/quality aren't search fields) → no
+  `SCHEMA_VERSION` bump, no reindex. If that changes, STOP and ask (spec
+  boundary).
+- **Manifest schema is parse-time, not migrated** — optional fields are
+  back/forward compatible by construction; old manifests parse unchanged.
+- **Auto-import side effect**: a raw-path reference creates/upserts an asset.
+  Source-path dedup prevents proliferation; verify in T3.3 tests.
+- **Billing safety**: every new failure mode (cap, gate, shim+refs, shim
+  options) throws **before** the runtime/provider call. A test for each asserts
+  no exec/fetch on rejection.
+- Each commit is independently revertible; reverting commit 3 leaves #380/#379
+  intact and valid.
+
+---
+
+## Task checklist (todo)
+
+**Commit 1 — #380**
+- [ ] T1.1 core `image-format.ts` (mime/ext + env-var table)
+- [ ] T1.2 shim imports shared tables
+- [ ] T1.3 images providers env-vars from table
+- [ ] T1.4 assets constants compose image rows
+- [ ] T1.5 drift-guard tests (round-trip + secrets ⊆ table)
+- [ ] Checkpoint A → commit 1
+
+**Commit 2 — #379**
+- [ ] T2.1 shim hard-fails on unsupported options (pre-billing)
+- [ ] T2.2 `GenerationSchema.quality` optional
+- [ ] T2.3 record quality only on shim path + reuse-match fix
+- [ ] T2.4 tests (per-option throw, native-omits/shim-includes)
+- [ ] Checkpoint B → commit 2
+
+**Commit 3 — #418**
+- [ ] T3.1 interfaces + schema + client types
+- [ ] T3.2 adapter generate→edit routing + edit appends refs
+- [ ] T3.3 plugin tools: resolve/auto-import/cap/gate/shim-reject/lineage/idempotency
+- [ ] T3.4 `assets_list` tags filter
+- [ ] T3.5 References UI row (clickable chips)
+- [ ] T3.6 test sweep
+- [ ] Checkpoint C → commit 3
+
+**Phase 4 — docs**
+- [ ] T4.1 update 3 knowledge docs
+- [ ] T4.2 verify README (expected no-op)
+- [ ] Final: full `bun run test` + build + typecheck; open PR

--- a/.claude/specs/post-480-hardening.md
+++ b/.claude/specs/post-480-hardening.md
@@ -209,7 +209,40 @@ Channel Delivery Discipline section), `generate-image` workflow skill, and
 the bits companion PR (pixel AGENTS.md policy + skill mechanics, within the
 350-word budget).
 
-## 9. Out of Scope (ticketed/follow-up)
+## 9. Round 3 — third live test (task 627ee59e, penguin screenshot, 2026-06-10)
+
+Versioning held where the agent used edit (deliverable got v1→v2). Two
+identity leaks minted duplicates; both closed deterministically:
+
+### R4 — `feat(assets)`: store-path reflection + same-task content dedupe
+- **Duplicate reference:** pixel passed a reference as a file path INTO the
+  asset store (`…/store/<id>/v1.png`) instead of the assetId; source-path
+  dedup keyed on the original `media/inbound` path, so a clone was minted —
+  with `source.path` pointing inside another asset's directory.
+  Fix: `resolveStoreFile()` maps store-internal paths (version files and
+  thumbs) back to `assetId@version`; `upsertFromSource` returns that identity
+  (`changed: false`) instead of cloning, and `resolveReferences` reflects the
+  path into proper lineage (a thumb path resolves to the real version file).
+- **Duplicate deliverable:** pixel copied the finished render to
+  `workspace/tmp/…` and re-saved it via `bakin_exec_assets_save` (following
+  the OUTPUT DISCIPLINE rule literally) — new path, new asset (op upload).
+  Fix: when an upsert would CREATE an asset and the input carries a taskId,
+  byte-identical content against any version of the same task's same-type
+  assets (size prefilter + sha256) returns the existing identity instead.
+  Deliberately task-scoped: reusing an image on a different task remains a
+  new asset.
+- Considered and rejected: a task-level "one asset unless declared" rule —
+  needs intent inference and fights legit multi-deliverable tasks; the
+  iteration guard (R1) already owns the intent layer, these close the
+  identity layer (same file, new clothes).
+
+### R5 — guidance: never re-save managed assets, references by assetId
+asset-rules + OUTPUT DISCIPLINE managed blocks, bakin skill, generate-image
+workflow skill (both repos): image tool results are already managed assets —
+report the assetId, never copy-and-resave; references go by assetId once
+imported, never by file path.
+
+## 10. Out of Scope (ticketed/follow-up)
 
 - `ctx.assets.upsertFromSource` on `AssetsAPI` (architecture nit from review — pre-existing pattern).
 - References UI chip linking to the recorded (not current) version — pre-existing URL-state gap.

--- a/.claude/specs/post-480-hardening.md
+++ b/.claude/specs/post-480-hardening.md
@@ -1,0 +1,166 @@
+# Post-#480 Hardening — Duplicate-Worker Guards, Reference Adoption, Feed Transparency
+
+**Status:** Approved (Mark, 2026-06-09)
+**Branch:** `feat/image-reference-images` — extends open PR #480; update the PR description to cover the new scope.
+**Companion change:** `bakin-bits-official` repo (separate PR there) — pixel agent content. Never edit `~/.openclaw` directly.
+
+## 1. Objective
+
+The first live test of PR #480 (task `d1b213a5`, 2026-06-10) succeeded but exposed three failure classes:
+
+1. **Duplicate worker:** `main` created + dispatched a task, then `bakin_exec_team_message`d the assignee about it 7s later. The unthreaded message landed in pixel's main session, which did the whole job in parallel with the dispatched run — two billed generates, two assets. Every existing guard (ledger, idempotency) sits *downstream* of this and correctly didn't fire.
+2. **Zero feature adoption:** neither session passed `referenceImages` — no agent-facing guidance surface (managed blocks, workflow skill, OpenClaw bakin skill) mentions it; only the raw MCP tool description does. The `media://` reference URI in the task description cost ~70s of discovery friction.
+3. **Opaque transparency:** the feed showed raw `task.completion_suppressed` / `task.dispatch_failure_ignored` event names at exactly the moments the user was most confused.
+
+Plus: the #480 code review found the #379 shim guardrail is unreachable from the production call path, and several hygiene nits.
+
+Target user: Mark (single operator) watching the Live Activity feed; agents (OpenClaw sessions) consuming Bakin tools and guidance. The product value proposition is transparency into the process — every fix here either prevents silent duplicate work or explains system behavior in human terms.
+
+## 2. Work Items, Commits, Acceptance Criteria
+
+Dependency-ordered, one commit each unless noted. Conventional commits with scope.
+
+### C1 — `fix(media): forward full option surface through shim fallback + reject size`
+*Items 3 + review finding 2.*
+
+- `packages/adapter-openclaw/src/runtime.ts` (`generateImageViaShim`, ~926-940): forward `count`, `aspectRatio`, `resolution`, `background`, `outputFormat` from `RuntimeImageGenerateInput` into the `DirectImageRequest` so `assertShimCanHonor` actually executes in production.
+- `packages/core/src/media/direct-image-provider.ts`: add `size` to `DirectImageRequest` and to the rejected set in `assertShimCanHonor` (reject, don't parse — shim callers must use width/height).
+
+**Acceptance:**
+- A shim-routed generate with `outputFormat: 'webp'` (or `count: 2`, `aspectRatio`, `resolution`, `background`, `size`) throws before any billed call; test asserts no fetch fired.
+- A shim-routed generate with `outputFormat: 'png'` and no unsupported options still succeeds (existing honored-path test stays green).
+
+### C2 — `fix(images): review hygiene — edit-base dedupe, wider shim gate, drift doc, missing tests`
+*Item 10.*
+
+- `plugins/images/lib/tools.ts`: `editImage` rejects (or silently dedupes — pick reject, clearer) a `referenceImages` entry equal to the base `assetId`; reference gate widens from `servedBy === 'shim'` to `servedBy !== 'runtime'` so unconfigured providers get the pre-flight message.
+- `plugins/images/lib/idempotency.ts`: comment documenting the accepted fingerprint-drift edge (reference version advancing between timeout and retry → different signature → re-bill; accepted: inputs genuinely changed).
+- Tests: unresolvable assetId reference ("Reference asset not found"), mixed assetId + raw-path reference list.
+
+**Acceptance:** new tests pass; gate-widening has a test (unconfigured provider + references → clear error, no exec/fetch).
+
+### C3 — `feat(images): resolve runtime media:// URIs as reference images`
+*Item 6.*
+
+- `packages/core/src/adapters/runtime/concepts.ts`: optional `resolveMediaUri(uri: string): Promise<string | null>` on the runtime adapter concept (null = unresolvable).
+- `packages/adapter-openclaw/src/runtime.ts`: implement — `media://<rel>` maps under `getOpenClawPath('media', <rel>)` with traversal guard (resolved path must stay under the media root); existence-checked; null otherwise. `media://` knowledge stays adapter-private.
+- `plugins/images/lib/tools.ts` (`resolveReferences`): entries matching `^media://` are resolved via `ctx.runtime.resolveMediaUri` *before* the existing existsSync/auto-import path, so a resolved reference becomes a tracked asset with `taskId` linkage exactly like a raw path. Adapter without the method, or null resolution → clear pre-billing error.
+
+**Acceptance:**
+- `referenceImages: ['media://inbound/x.png']` with the file present under the (mocked) OpenClaw home resolves, auto-imports, records lineage.
+- Missing file / unsupported adapter → error before any billed call (no exec/fetch asserted).
+- Traversal attempt (`media://../secrets`) → error.
+- Tests mock both content-dir resolvers AND OpenClaw home per CLAUDE.md.
+
+### C4 — `feat(team): refuse team messages that would spawn a duplicate task worker`
+*Item 1. The headline guard.*
+
+- `plugins/tasks/index.ts` (activate): register hook `tasks.live-run` → handler takes `{ taskId }`, returns `{ runId, agent, startedAt } | null` via the execution-ledger facade (`getLiveRun`). Plugin→plugin stays on HookRegistry per CLAUDE.md.
+- `plugins/team/index.ts` (`bakin_exec_team_message` handler): extract task-id-shaped tokens (`/\b[0-9a-f]{8}\b/g`) from the message; for each, invoke `tasks.live-run`. If a live run exists **and its agent is the message target**, hard-refuse: return `{ ok: false, error }` naming the task, runId, run age, and the alternatives (task comment via `bakin_exec_log`, or wait). Emit audit event `team.message_blocked` with `{ agentId, taskId, runId }` so the save is visible in Live Activity.
+- Ledger-unavailable: per the fail-closed convention this guard *blocks* the send for matched task tokens (consistent with execution-ledger semantics); messages with no task-shaped tokens are unaffected.
+
+**Acceptance:**
+- Message naming a task with a live run for the target agent → refused, audited, runtime `sendMessageToAgent` NOT called (asserted).
+- Message naming a task whose live run belongs to a *different* agent → delivered.
+- Message naming a completed/settled task → delivered.
+- Message with no task tokens → delivered, no hook invocation needed.
+
+### C5 — `feat(tasks): live-run visibility in tasks_get + dispatch-notified copy in tasks_create`
+*Items 2 + 8.*
+
+- `bakin_exec_tasks_get`: result gains `liveRun: { runId, agent, startedAt } | null` (same ledger facade).
+- `bakin_exec_tasks_create`: when creation auto-dispatched, append to the result message: dispatch already notified `<agent>` — do **not** send them a separate message about this task.
+
+**Acceptance:** tasks_get on a task with a running ledger row returns the liveRun block; on a settled task returns null. tasks_create result contains the copy only when a dispatch actually fired.
+
+### C6 — `feat(core): human-readable summaries for suppressed/ignored task events`
+*Item 7.*
+
+- `src/core/task-service.ts:163` (`task.completion_suppressed`): add `summary` to the audit data, e.g. `"Ignored a duplicate completion — <firstAgent> already completed this task via <firstChannel>."`
+- `src/core/dispatch.ts:750` (`task.dispatch_failure_ignored`): add `summary`, e.g. `"A session error arrived after the task had already moved to <column> — no action needed."`
+- Feed rendering (`packages/host/src/components/layout/layout-shell.tsx` + wherever activity items derive titles): prefer `data.summary`/`data.label` over the raw event name; raw name stays as the secondary line (current behavior preserved as fallback). Emit-time copy, not a client-side event→string map: the summary travels with the audit row into JSONL, SSE, and search.
+
+**Acceptance:** unit test that both emit sites include `summary`; existing audit consumers unaffected (additive data field, no schema bump).
+
+### C7 — `docs(agents): teach referenceImages + attachment-import across guidance surfaces`
+*Items 4 + 5 + 2(rules half). Bakin-repo guidance surfaces only.*
+
+- `src/core/agent-rules/managed-blocks.ts`:
+  - Media-delegation section: `referenceImages` exists on generate/edit (assetIds, local paths, or `media://` URIs after C3; max 4; native runtime only); rule of thumb — *when the brief says "like this image," pass the image as a reference; don't transcribe it into prose*.
+  - Tool Reference: add a `referenceImages=` example line to the `images_generate` mcporter command.
+  - Hard rules / dependency section: creating a task dispatches it — never also message the assignee about it; for channel-message tasks with attachments, import the attachment (`bakin_exec_images_import taskId=…`) and put the assetId in the task description.
+- `skill/SKILL.md` (source of the OpenClaw `bakin` skill): same teachings, skill-appropriate brevity.
+- `plugins/images/defaults/workflow-skills/generate-image.md`: reference mechanics (when to use, parameter forms, native-only constraint).
+
+**Acceptance:** `grep -ri referenceImages` hits all three surfaces; managed-blocks tests (if any assert content) updated; doctor projection unchanged mechanically (content-only edit).
+
+### Companion (bakin-bits-official, separate PR in that repo)
+*Items 9 + 4(bits half).*
+
+- `agents/pixel/workspace/AGENTS.md`: style-guide instruction tightened — append only for series/brand/recurring work (skip one-offs), dedupe before append (same surface + materially-same cues = skip), cap ~10 entries per surface (prune oldest). Add referenceImages to the Generate vs Edit policy ("a provided source image to *imitate* → pass as referenceImages on generate; a source to *revise* → edit").
+- `agents/pixel/workflow-skills/generate-image.md`: mirror the bakin-repo skill update.
+
+**Acceptance:** content review only; `package-contract.test.ts` in bits still passes.
+
+## 3. Commands
+
+- Full suite: `bun run test` (CI parity). Single file: `bun test tests/path/foo.test.ts --isolate`.
+- Typecheck: `bunx tsc --noEmit` (pre-existing astro/fixture errors are known-ignorable).
+- Plugin build sanity: `bun scripts/build-plugins.ts`.
+- No binary build (CI owns it). No server restart needed for managed-blocks content (doctor projects it).
+
+## 4. Project Structure (touched)
+
+```
+packages/adapter-openclaw/src/runtime.ts        C1, C3
+packages/core/src/media/direct-image-provider.ts C1
+packages/core/src/adapters/runtime/concepts.ts   C3
+plugins/images/lib/tools.ts                      C2, C3
+plugins/images/lib/idempotency.ts                C2 (comment only)
+plugins/images/defaults/workflow-skills/generate-image.md C7
+plugins/team/index.ts                            C4
+plugins/tasks/index.ts                           C4 (hook), C5
+src/core/task-service.ts                         C6
+src/core/dispatch.ts                             C6
+packages/host/src/components/layout/layout-shell.tsx (+ activity item renderer) C6
+src/core/agent-rules/managed-blocks.ts           C7
+skill/SKILL.md                                   C7
+tests/**                                         per commit
+../bakin-bits-official/agents/pixel/**           companion
+```
+
+## 5. Code Style
+
+Per CLAUDE.md: strict TS, Zod at boundaries, `createLogger`, no empty catches, kebab-case files, import order. Error classification by `kind`, never message text. New hook follows `{pluginId}.{operation}` naming (`tasks.live-run`, audit event `team.message_blocked`).
+
+## 6. Testing Strategy
+
+- Every test file mocks **both** content-dir resolvers and OpenClaw home; `getBakinPaths` mocks include `db`; ledger-touching tests use the in-memory execution-ledger fake (`tests/core/task-service.test.ts` pattern) or call `closeDb()` before cleanup.
+- Plugin tests use `tests/plugins/test-helpers.ts` (`activatePlugin`, `callRoute`, `callTool`).
+- Billed-call safety tests assert no `exec`/`fetch` fired on every new rejection path (C1, C2, C3) — same pattern as #480's existing tests.
+- C4 needs a team-plugin test harness with a mocked runtime (`sendMessageToAgent` spy) + mocked hook registry or a real tasks-plugin activation alongside.
+- Run full suite before each commit (`bun run test`); each commit is an independent rollback point.
+
+## 7. Boundaries
+
+**Always:**
+- All new failure modes throw **before** any billed provider call.
+- `media://` semantics stay inside `packages/adapter-openclaw`; the images plugin sees only "the runtime can resolve runtime URIs".
+- Guidance edits for agents go to bakin-bits-official or bakin-repo sources — **never** `~/.openclaw`.
+- Audit additions are additive data fields — no search `SCHEMA_VERSION` bump, no manifest migration.
+
+**Ask first:**
+- Any change to ledger schema or completion semantics (none planned — the ledger behaved correctly).
+- Widening the team-message guard beyond exact task-token matches (e.g. fuzzy "are they busy" heuristics) — out of scope.
+
+**Never:**
+- Edit `~/.openclaw` or `~/.bakin` content as part of this work.
+- Add a parallel stat/tracking system (usage recorder is the single recorder).
+- Dedupe billed generates with different prompts at the idempotency layer — the upstream guard (C4) is the fix.
+- Block or alter ledger completion-suppression behavior — narration only (C6).
+
+## 8. Out of Scope (ticketed/follow-up)
+
+- `ctx.assets.upsertFromSource` on `AssetsAPI` (architecture nit from review — pre-existing pattern).
+- References UI chip linking to the recorded (not current) version — pre-existing URL-state gap.
+- Style guides as a managed product feature.

--- a/.claude/specs/post-480-hardening.md
+++ b/.claude/specs/post-480-hardening.md
@@ -55,15 +55,19 @@ Dependency-ordered, one commit each unless noted. Conventional commits with scop
 ### C4 — `feat(team): refuse team messages that would spawn a duplicate task worker`
 *Item 1. The headline guard.*
 
-- `plugins/tasks/index.ts` (activate): register hook `tasks.live-run` → handler takes `{ taskId }`, returns `{ runId, agent, startedAt } | null` via the execution-ledger facade (`getLiveRun`). Plugin→plugin stays on HookRegistry per CLAUDE.md.
-- `plugins/team/index.ts` (`bakin_exec_team_message` handler): extract task-id-shaped tokens (`/\b[0-9a-f]{8}\b/g`) from the message; for each, invoke `tasks.live-run`. If a live run exists **and its agent is the message target**, hard-refuse: return `{ ok: false, error }` naming the task, runId, run age, and the alternatives (task comment via `bakin_exec_log`, or wait). Emit audit event `team.message_blocked` with `{ agentId, taskId, runId }` so the save is visible in Live Activity.
-- Ledger-unavailable: per the fail-closed convention this guard *blocks* the send for matched task tokens (consistent with execution-ledger semantics); messages with no task-shaped tokens are unaffected.
+- *(As implemented — refined from the original hook sketch: the execution
+  ledger is core, not a plugin, so the HookRegistry rule doesn't apply;
+  `plugins/team` imports the `src/core/execution-ledger` facade directly,
+  matching its existing `src/core/agents` import.)*
+- `plugins/team/index.ts` (`bakin_exec_team_message` handler): extract ALL distinct task-id-shaped tokens (`/\b[0-9a-f]{8}\b/g`, no cap) from the message; for each, `getLiveRun(taskId)`. If a live run exists **and its agent is the message target**, hard-refuse: return `{ ok: false, error }` naming the task, runId, run age, and the alternatives (task comment via `bakin_exec_log`, or wait). Emit audit event `team.message_blocked` with `{ agentId, taskId, runId }` so the save is visible in Live Activity (humanized by the audit-message mapper, see C6).
+- Ledger-unavailable: fail CLOSED for task-bearing messages — `LedgerUnavailableError` is caught (`instanceof`, never message text) and returned as a structured refusal explaining the ledger is down; token-free messages deliver unaffected.
 
 **Acceptance:**
 - Message naming a task with a live run for the target agent → refused, audited, runtime `sendMessageToAgent` NOT called (asserted).
 - Message naming a task whose live run belongs to a *different* agent → delivered.
 - Message naming a completed/settled task → delivered.
-- Message with no task tokens → delivered, no hook invocation needed.
+- Message with no task tokens → delivered.
+- Ledger unavailable + task-bearing message → structured refusal, send NOT called (asserted); token-free message still delivers.
 
 ### C5 — `feat(tasks): live-run visibility in tasks_get + dispatch-notified copy in tasks_create`
 *Items 2 + 8.*
@@ -76,11 +80,20 @@ Dependency-ordered, one commit each unless noted. Conventional commits with scop
 ### C6 — `feat(core): human-readable summaries for suppressed/ignored task events`
 *Item 7.*
 
-- `src/core/task-service.ts:163` (`task.completion_suppressed`): add `summary` to the audit data, e.g. `"Ignored a duplicate completion — <firstAgent> already completed this task via <firstChannel>."`
-- `src/core/dispatch.ts:750` (`task.dispatch_failure_ignored`): add `summary`, e.g. `"A session error arrived after the task had already moved to <column> — no action needed."`
-- Feed rendering (`packages/host/src/components/layout/layout-shell.tsx` + wherever activity items derive titles): prefer `data.summary`/`data.label` over the raw event name; raw name stays as the secondary line (current behavior preserved as fallback). Emit-time copy, not a client-side event→string map: the summary travels with the audit row into JSONL, SSE, and search.
+- *(As implemented — refined from the original emit-time-`summary` sketch:
+  the feed already has a canonical humanization point, `mapAuditMessage` in
+  `src/lib/map-audit-message.ts`, used by both the activity API and the SSE
+  hook; these events rendered raw only because no case existed for them.
+  Per-event cases there match how every other event renders. Trade-off
+  accepted: the human copy is derived at read time and does not land in
+  `audit.jsonl`/search rows — the raw data fields it derives from do.)*
+- `src/lib/map-audit-message.ts`: cases for `task.completion_suppressed`,
+  `task.dispatch_failure_ignored`, and `team.message_blocked` (C4's own
+  event must not render raw either).
+- `src/core/task-service.ts:163`: `task.completion_suppressed` emit data
+  gains `title` so the copy can name the task.
 
-**Acceptance:** unit test that both emit sites include `summary`; existing audit consumers unaffected (additive data field, no schema bump).
+**Acceptance:** mapper unit tests assert the exact copy for all three events (including missing-optional-field variants); existing audit consumers unaffected (the only emit change is the additive `title` field, no schema bump).
 
 ### C7 — `docs(agents): teach referenceImages + attachment-import across guidance surfaces`
 *Items 4 + 5 + 2(rules half). Bakin-repo guidance surfaces only.*
@@ -131,7 +144,7 @@ tests/**                                         per commit
 
 ## 5. Code Style
 
-Per CLAUDE.md: strict TS, Zod at boundaries, `createLogger`, no empty catches, kebab-case files, import order. Error classification by `kind`, never message text. New hook follows `{pluginId}.{operation}` naming (`tasks.live-run`, audit event `team.message_blocked`).
+Per CLAUDE.md: strict TS, Zod at boundaries, `createLogger`, no empty catches, kebab-case files, import order. Error classification by `kind`/`instanceof`, never message text. New audit event: `team.message_blocked`.
 
 ## 6. Testing Strategy
 

--- a/.claude/specs/post-480-hardening.md
+++ b/.claude/specs/post-480-hardening.md
@@ -172,7 +172,44 @@ Per CLAUDE.md: strict TS, Zod at boundaries, `createLogger`, no empty catches, k
 - Dedupe billed generates with different prompts at the idempotency layer — the upstream guard (C4) is the fix.
 - Block or alter ledger completion-suppression behavior — narration only (C6).
 
-## 8. Out of Scope (ticketed/follow-up)
+## 8. Round 2 — second live test (task 6abc2131, 2026-06-10)
+
+The guard + guidance worked (single dispatch, references used, QA loop ran).
+Three remaining failure classes, fixed on the same branch:
+
+### R1 — `feat(images)`: reference tag + iteration-as-version
+- Auto-imported references get `tags: ['reference']` (filterable in the
+  assets view; also distinguishes reference material from deliverables).
+- **Iteration trap:** pixel's correction pass referenced its own first pass
+  and minted a sibling asset. Fix (Mark-approved design): `versionOf` on
+  `images_generate` appends the render as a new version (op `'generate'`,
+  participates in the idempotency key via `source`, target validated
+  pre-billing, rejected on edit); a generate referencing the agent's own
+  same-task GENERATED output without `versionOf` is refused with a teaching
+  error; `allowNewAsset=true` is the explicit companion-image escape hatch.
+  Imported same-task references never trip the guard.
+
+### R2 — `feat(channels)`: deliver-once guard on post_channel
+- The same asset was posted to Discord twice (main's monitor loop + the
+  completion reply; different captions, so the existing signature TTL cache
+  could not catch it — and the posts were runtime-native, bypassing Bakin).
+- Deterministic half: `post_channel` records successful asset deliveries in
+  the durable ledger (`channel-post:<taskId>:<channel>:<assetId>`) and
+  refuses a re-delivery regardless of caption; `repost=true` is the explicit
+  escape hatch; failed deliveries never burn the slot.
+- Guidance half (the part that actually bit): orchestrator rules — finished
+  assets go to channels exactly once, via `post_channel` with
+  `imageAssetId` + `taskId` (never pasted natively); only as the
+  reply/handoff for the originating request; monitoring a task is never a
+  posting trigger.
+
+### R3 — guidance: iterate-as-version across all surfaces
+managed-blocks media-delegation + Tool Reference, `skill/SKILL.md` (incl. a
+Channel Delivery Discipline section), `generate-image` workflow skill, and
+the bits companion PR (pixel AGENTS.md policy + skill mechanics, within the
+350-word budget).
+
+## 9. Out of Scope (ticketed/follow-up)
 
 - `ctx.assets.upsertFromSource` on `AssetsAPI` (architecture nit from review — pre-existing pattern).
 - References UI chip linking to the recorded (not current) version — pre-existing URL-state gap.

--- a/.claude/specs/post-480-hardening.md
+++ b/.claude/specs/post-480-hardening.md
@@ -247,3 +247,14 @@ imported, never by file path.
 - `ctx.assets.upsertFromSource` on `AssetsAPI` (architecture nit from review — pre-existing pattern).
 - References UI chip linking to the recorded (not current) version — pre-existing URL-state gap.
 - Style guides as a managed product feature.
+- Accepted residuals from the final review (documented, low-risk):
+  `resolveStoreFile` prefix match is byte-case-sensitive (APFS case-variant
+  paths bypass reflection) and lexical (symlinks not followed) — agents echo
+  canonical tool-result paths; export paths (`exports/<name>`) don't reflect
+  to the parent asset; the deliver-once ledger check is check-then-act
+  (concurrent different-caption posts can race — observed incident was
+  sequential); the iteration guard keys off the CURRENT version's op, so an
+  imported-then-edited asset referenced via store path trips it
+  (`allowNewAsset` covers); same-prompt re-roll into `versionOf` is swallowed
+  as reuse (tweak the prompt for a pure RNG re-roll — consistent with edit
+  idempotency).

--- a/.claude/specs/post-480-hardening.plan.md
+++ b/.claude/specs/post-480-hardening.plan.md
@@ -1,0 +1,254 @@
+---
+title: "Implementation plan — post-#480 hardening"
+spec: ./post-480-hardening.md
+issues: [480]
+status: ready-for-review
+---
+
+# Plan — post-#480 hardening
+
+Companion to `post-480-hardening.md`. Seven commits appended to
+`feat/image-reference-images` (PR #480), dependency-ordered; each commit
+builds, type-checks, and passes its tests independently. Plus one companion
+PR in `../bakin-bits-official` (content only).
+
+## Dependency graph
+
+```
+C1 fix(media): shim forwards options + rejects size
+  T1.1 DirectImageRequest.size + assertShimCanHonor rejects it (test-first)
+  T1.2 generateImageViaShim forwards count/aspectRatio/resolution/background/outputFormat/size
+  T1.3 tests: each option → throws pre-billing on shim route, no fetch; honored path green
+        ▼ checkpoint A → commit 1
+C2 fix(images): review hygiene                       [touches tools.ts before C3 does]
+  T2.1 editImage rejects reference === base assetId (test-first)
+  T2.2 reference gate: servedBy !== 'runtime' (test-first)
+  T2.3 idempotency.ts drift comment (doc only)
+  T2.4 tests: unresolvable assetId ref; mixed assetId+path list
+        ▼ checkpoint B → commit 2
+C3 feat(images): media:// reference URIs             [touches tools.ts + adapter after C1/C2]
+  T3.1 concepts.ts: optional resolveMediaUri on AgentRuntimeAdapter
+  T3.2 adapter-openclaw impl (media root mapping + traversal guard + existsSync)
+  T3.3 tools.ts resolveReferences: media:// branch → resolve → existing auto-import path
+  T3.4 tests: resolve+import+lineage / missing / unsupported adapter / traversal — all pre-billing
+        ▼ checkpoint C → commit 3
+C4 feat(team): duplicate-worker guard                [independent of C1–C3]
+  T4.1 task-token extraction + getLiveRun check + hard refuse + team.message_blocked audit
+  T4.2 tests: refused+audited+send-not-called / other-agent delivered / settled delivered / no-tokens delivered
+        ▼ checkpoint D → commit 4
+C5 feat(tasks): liveRun in tasks_get + create copy   [shares ledger read with C4]
+  T5.1 tasks_get result.liveRun (test-first)
+  T5.2 tasks_create dispatch-notified copy in notice (test-first)
+        ▼ checkpoint E → commit 5
+C6 feat(core): humanized suppressed/ignored events   [independent]
+  T6.1 map-audit-message.ts cases ×2 (test-first) + title added to completion_suppressed emit data
+        ▼ checkpoint F → commit 6
+C7 docs(agents): guidance updates                    [after C3 so media:// is real]
+  T7.1 managed-blocks.ts (media-delegation + Tool Reference + hard rules)
+  T7.2 skill/SKILL.md
+  T7.3 plugins/images/defaults/workflow-skills/generate-image.md
+        ▼ checkpoint G → commit 7 → push, update PR #480 description
+COMPANION (bakin-bits-official, separate PR)
+  T8.1 agents/pixel/workspace/AGENTS.md (style-guide policy + referenceImages in Generate-vs-Edit)
+  T8.2 agents/pixel/workflow-skills/generate-image.md (mirror T7.3)
+```
+
+Plan-level refinements vs the spec (rationale, not scope change):
+
+1. **C4 uses a direct core-facade import, not a hook.** The spec sketched a
+   `tasks.live-run` hook, but the execution ledger is core, not a plugin —
+   the HookRegistry rule governs *plugin↔plugin* calls. `plugins/team/index.ts`
+   already imports `src/core/agents` directly (line 32); importing
+   `src/core/execution-ledger`'s `getLiveRun` is the same established pattern,
+   with no new registration surface. C5 reads the same facade from
+   `plugins/tasks`.
+2. **C6 uses the existing humanization point.** The feed's main line is
+   `mapAuditMessage(entry.event, data)` (`src/lib/map-audit-message.ts`,
+   called from `packages/host/src/api/activity.ts:39`); raw event names render
+   only because the mapper has no case for these events. Add two cases there
+   (client+server-safe lib, no schema change) instead of the spec's emit-time
+   `summary` field. One emit-site change remains: `task.completion_suppressed`
+   gains `title` in its data so the copy can name the task.
+
+---
+
+## Tasks
+
+### C1 — `fix(media): forward full option surface through shim fallback + reject size`
+
+**T1.1** `packages/core/src/media/direct-image-provider.ts`: add `size?: string`
+to `DirectImageRequest` (same "carried to reject" block, lines 31-35) and a
+rejection in `assertShimCanHonor` ("pass width/height instead").
+Test-first in `tests/core/media/direct-image-provider.test.ts`.
+
+**T1.2** `packages/adapter-openclaw/src/runtime.ts` `generateImageViaShim`
+(~933): spread `count/aspectRatio/resolution/background/outputFormat/size`
+from `RuntimeImageGenerateInput` into the `generateDirectImage` call.
+Only defined fields (exactOptionalPropertyTypes-safe spreads as in #480).
+
+**T1.3** `tests/adapter-openclaw/runtime-images.test.ts`: shim-routed generate
+with each unsupported option throws before any provider call (mock
+`generateDirectImage`... no — mock fetch/exec and assert neither fired, same
+pattern as existing shim tests); honored path (`outputFormat:'png'`, no
+options) still succeeds.
+
+**Verify:** `bun test tests/core/media/direct-image-provider.test.ts tests/adapter-openclaw/runtime-images.test.ts --isolate` → commit.
+
+### C2 — `fix(images): review hygiene`
+
+**T2.1** `plugins/images/lib/tools.ts` `editImage` (~458): if
+`params.referenceImages?.includes(params.assetId)` → fail with "reference
+equals the asset being edited — references add *other* context images".
+
+**T2.2** Same file, `resolveReferences` (~202): `servedBy !== 'runtime'` →
+error names the actual `servedBy` value ("served via the direct shim" /
+"provider not configured").
+
+**T2.3** `plugins/images/lib/idempotency.ts` (~40): comment block on the
+accepted drift edge (reference version advances between client timeout and
+retry → new fingerprint → re-bill; accepted because the inputs genuinely
+changed).
+
+**T2.4** `tests/plugins/images/tools.test.ts`: unresolvable assetId reference
+→ "Reference asset not found", no billed call; mixed assetId+raw-path list
+resolves both and records both lineage entries; T2.1/T2.2 cases.
+
+**Verify:** `bun test tests/plugins/images/tools.test.ts --isolate` → commit.
+
+### C3 — `feat(images): resolve runtime media:// URIs as reference images`
+
+**T3.1** `packages/core/src/adapters/runtime/concepts.ts`: on
+`AgentRuntimeAdapter`, `resolveMediaUri?(uri: string): Promise<string | null>`
+— doc comment: runtime-private URI scheme → absolute local path, null when
+unresolvable; never throws for not-found.
+
+**T3.2** `packages/adapter-openclaw/src/runtime.ts`: implement —
+`media://<rel>` → `getOpenClawPath('media', <rel>)`; guard:
+`resolve()`d path must start with the media root (reject traversal), must
+exist. Non-`media://` schemes → null.
+
+**T3.3** `plugins/images/lib/tools.ts` `resolveReferences`: before the
+assetId/path branch, entries matching `/^media:\/\//` resolve via
+`ctx.runtime.resolveMediaUri`; missing method → error "the active runtime
+cannot resolve media:// URIs"; null → error "Reference media URI not found".
+The resolved path then flows through the **existing** raw-path auto-import
+(asset gets `taskId` linkage + lineage like any path reference).
+
+**T3.4** Tests: plugin side in `tools.test.ts` (mock ctx.runtime with/without
+the method); adapter side in `runtime-images.test.ts` or a focused file —
+happy path under mocked OpenClaw home, traversal rejection, missing file.
+All failures asserted pre-billing (no exec/fetch). CLAUDE.md mocks: both
+content-dir resolvers + OpenClaw home; env vars set before imports.
+
+**Risk:** the optional method must also be absent-safe for the Imitation Crab
+mock (`dev/imitation-crab`) — optional means no mock change required; verify
+`bun run dev:mock` type-checks (covered by `tsc --noEmit`).
+
+**Verify:** images + adapter test files, `bunx tsc --noEmit` (only
+pre-existing errors), `bun scripts/build-plugins.ts` → commit.
+
+### C4 — `feat(team): refuse team messages that would spawn a duplicate task worker`
+
+**T4.1** `plugins/team/index.ts` `bakin_exec_team_message` handler (~1896):
+extract candidate ids `message.match(/\b[0-9a-f]{8}\b/g)` (dedup, cap ~10);
+for each, `getLiveRun(taskId)` (import from `../../src/core/execution-ledger`,
+matching the file's existing `src/core/agents` import). If a live run's
+`agent` equals the target `agentId` → return
+`{ ok: false, error: '<agent> is already working task <id> (run <runId>, started <relative>). Sending this message would start a duplicate worker in their main session. Add a task comment (bakin_exec_log) or wait for completion.' }`,
+`appendAudit(…, 'team.message_blocked', sender, { agentId, taskId, runId })`,
+and do NOT call `sendMessageToAgent`. Ledger-unavailable: `getLiveRun`'s
+guard already fails closed — a throw surfaces as a refused send for
+task-bearing messages only.
+
+**T4.2** New `tests/plugins/team/message-guard.test.ts` (pattern:
+`tests/plugins/team/exec-tools.test.ts` + the in-memory execution-ledger mock
+from `tests/core/task-service.test.ts`): four acceptance cases from the spec;
+spy on the runtime messaging mock to assert non-delivery.
+
+**Verify:** `bun test tests/plugins/team/message-guard.test.ts tests/plugins/team/exec-tools.test.ts --isolate` → commit.
+
+### C5 — `feat(tasks): live-run visibility + dispatch-notified copy`
+
+**T5.1** `plugins/tasks/index.ts` `bakin_exec_tasks_get` handler (~721): after
+enrichment, `liveRun: getLiveRun(taskId)` mapped to
+`{ runId, agent, startedAt } | null` (ledger row → ISO timestamp).
+
+**T5.2** Same file, `bakin_exec_tasks_create` (~777): when `parentId || assignee`
+triggered dispatch, push notice: `'Assigned to <assignee> — dispatch will
+notify them with the full task. Do NOT send them a separate message about
+this task; that starts a duplicate worker.'` (joins the existing `notices`).
+
+**T5.3** Tests in `tests/plugins/tasks/` (reuse integration/exec patterns +
+ledger mock): liveRun present while running, null when settled; create-notice
+present with assignee, absent without.
+
+**Verify:** affected tasks test files → commit.
+
+### C6 — `feat(core): humanized suppressed/ignored feed events`
+
+**T6.1** `src/lib/map-audit-message.ts`: cases —
+`task.completion_suppressed` → `Ignored a duplicate completion — ${data.firstAgent} already completed this task via ${data.firstChannel}.`
+`task.dispatch_failure_ignored` → `Session error arrived after "${data.title}" was already ${data.column} — no action needed.`
+**T6.2** `src/core/task-service.ts:163`: add `title` to the emit data (read
+from the task snapshot already in scope).
+**T6.3** Test: extend/create the mapper test (`tests/` location matching
+existing lib tests) asserting both strings.
+
+**Verify:** mapper test + `bun test tests/core/task-service.test.ts --isolate` → commit.
+
+### C7 — `docs(agents): teach referenceImages + attachment-import`
+
+**T7.1** `src/core/agent-rules/managed-blocks.ts`:
+- media-delegation: referenceImages on generate/edit — assetIds, local paths,
+  or `media://` URIs; max 4; native runtime only; *"brief says 'like this
+  image' → pass the image as referenceImages, don't transcribe it into prose."*
+- Tool Reference: `referenceImages='["<assetId|path|media://uri>"]'` example
+  line on the images_generate command.
+- hard-rules/dispatch guidance: creating a task dispatches it — never also
+  message the assignee about it; channel-message tasks with attachments →
+  `bakin_exec_images_import taskId=… filePath=…` and reference the assetId in
+  the description.
+**T7.2** `skill/SKILL.md`: same teachings, brief.
+**T7.3** `plugins/images/defaults/workflow-skills/generate-image.md`:
+reference mechanics section.
+**T7.4** If managed-blocks content is asserted by tests
+(`grep -rn managed-blocks tests/`), update them.
+
+**Verify:** grep all three surfaces for `referenceImages`; full suite
+`bun run test`; push; update PR #480 title/description for the new scope.
+
+### COMPANION — bakin-bits-official PR
+
+**T8.1** `agents/pixel/workspace/AGENTS.md`: style-guide policy (series/brand
+only, dedupe same surface+cues, cap ~10/surface prune-oldest) +
+referenceImages in Generate-vs-Edit policy (imitate → reference on generate;
+revise → edit).
+**T8.2** `agents/pixel/workflow-skills/generate-image.md`: mirror T7.3.
+**Verify:** `cd ../bakin-bits-official && bun test` (package-contract), new
+branch + PR there.
+
+---
+
+## Verification cadence
+
+- Per checkpoint: the listed focused test files (`--isolate`) + the commit.
+- Before C7's commit (last code already in): `bun run test` full suite +
+  `bunx tsc --noEmit` + `bun scripts/build-plugins.ts`.
+- Each commit message: conventional, scoped, body references the live-test
+  incident (task d1b213a5) where it motivated the change.
+
+## Risks / watch-list
+
+1. **C4 false positives:** an 8-hex token that coincidentally matches a live
+   task of the target agent blocks an unrelated message. Accepted: collision
+   requires both the token match *and* a live run for that exact agent; the
+   error tells the sender exactly how to proceed.
+2. **C3 type ripple:** `resolveMediaUri` is optional, so adapter mocks and
+   Imitation Crab need no change — `tsc --noEmit` is the guard.
+3. **C2 gate widening** changes an error string the #480 tests assert —
+   update `tools.test.ts:451`-area assertions in the same commit.
+4. **C5 ledger reads in tests:** any test touching `getLiveRun` needs the
+   `db` key in `getBakinPaths` mocks or the in-memory ledger fake.
+5. **C7 managed-blocks drift:** doctor re-projects managed sections; content
+   edits are mechanically safe but `bakin check agent-assets` consumers in
+   tests may pin strings — T7.4 covers.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -913,8 +913,12 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       if (!match) return null
       const root = resolve(getOpenClawPath('media'))
       const candidate = resolve(root, match[1])
-      if (candidate !== root && !candidate.startsWith(root + sep)) return null
-      return existsSync(candidate) ? candidate : null
+      if (!candidate.startsWith(root + sep)) return null
+      try {
+        return statSync(candidate).isFile() ? candidate : null
+      } catch {
+        return null // missing file — "not found" is a value here, not an error
+      }
     },
   }
 

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -874,6 +874,13 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       return value
     },
     generate: async (input: RuntimeImageGenerateInput): Promise<RuntimeImageGenerationResult> => {
+      // Native `infer image generate` has no file input, so a generate carrying
+      // reference images is served by the edit-style invocation (#418). The shim
+      // can't do references — the plugin rejects that combination upstream.
+      if (input.referenceImages?.length) {
+        const editInput: RuntimeImageEditInput = { ...input, files: input.referenceImages }
+        return tagRuntimeServed(await this.runImageInference('edit', editInput))
+      }
       if (await this.canServeImageNatively(input)) {
         return tagRuntimeServed(await this.runImageInference('generate', input))
       }

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -901,6 +901,23 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
     },
   }
 
+  media = {
+    /**
+     * Resolve an OpenClaw `media://<rel>` URI (how the runtime addresses
+     * channel attachments, e.g. media://inbound/<file>) to its absolute path
+     * under the OpenClaw home's media root. Null for other schemes, missing
+     * files, or anything escaping the media root.
+     */
+    resolveUri: async (uri: string): Promise<string | null> => {
+      const match = /^media:\/\/(.+)$/.exec(uri)
+      if (!match) return null
+      const root = resolve(getOpenClawPath('media'))
+      const candidate = resolve(root, match[1])
+      if (candidate !== root && !candidate.startsWith(root + sep)) return null
+      return existsSync(candidate) ? candidate : null
+    },
+  }
+
   private async cachedImageProviders(): Promise<RuntimeImageProvider[]> {
     const cached = this.imageProvidersCache
     if (cached && Date.now() - cached.at < OPENCLAW_IMAGE_PROVIDERS_TTL_MS) return cached.value

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -938,6 +938,15 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
       height: input.height ?? 1024,
       quality: imageQualityFromMetadata(input.metadata),
       apiKey: resolved.apiKey,
+      // Forward the full generation option surface so the shim's guardrail
+      // (assertShimCanHonor) sees what it can't honor and rejects BEFORE the
+      // billed call — omitting these re-opens the silent drop #379 closed.
+      ...(input.count !== undefined ? { count: input.count } : {}),
+      ...(input.aspectRatio !== undefined ? { aspectRatio: input.aspectRatio } : {}),
+      ...(input.resolution !== undefined ? { resolution: input.resolution } : {}),
+      ...(input.background !== undefined ? { background: input.background } : {}),
+      ...(input.outputFormat !== undefined ? { outputFormat: input.outputFormat } : {}),
+      ...(input.size !== undefined ? { size: input.size } : {}),
     })
     return {
       images: [{

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "./adapters/runtime/concepts": "./src/adapters/runtime/concepts.ts",
     "./adapters/runtime/testing": "./src/adapters/runtime/testing.ts",
     "./media": "./src/media/index.ts",
+    "./media/image-format": "./src/media/image-format.ts",
     "./adapters/search": "./src/adapters/search/index.ts",
     "./adapters/search/concepts": "./src/adapters/search/concepts.ts",
     "./adapters/search/testing": "./src/adapters/search/testing.ts",

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -530,6 +530,17 @@ export interface AgentRuntimeAdapter {
 
   images?: RuntimeImagesAccess
 
+  /**
+   * Access to the runtime's private media store (e.g. channel attachments).
+   * `resolveUri` maps a runtime-private URI (OpenClaw's `media://…`) to an
+   * absolute local file path; null for unknown schemes or missing files —
+   * never throws for not-found. Optional: runtimes without a media store
+   * omit it, and callers must treat absence as "cannot resolve".
+   */
+  media?: {
+    resolveUri(uri: string): Promise<string | null>
+  }
+
   cron: {
     list(): Promise<CronJob[]>
     get(id: string): Promise<CronJob | null>

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -364,6 +364,13 @@ export interface RuntimeImageGenerateInput {
   resolution?: string
   outputFormat?: RuntimeImageOutputFormat
   background?: RuntimeImageBackground
+  /**
+   * Reference/context image file paths conditioning the generation. The caller
+   * (Bakin) resolves managed asset ids to concrete paths before the adapter
+   * sees them. Native generation has no file input, so a generate carrying
+   * references is routed through the edit-style invocation (#418).
+   */
+  referenceImages?: string[]
   timeoutMs?: number
   metadata?: RuntimeMetadata
 }

--- a/packages/core/src/media/direct-image-provider.ts
+++ b/packages/core/src/media/direct-image-provider.ts
@@ -15,8 +15,7 @@
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-
-export type DirectImageProviderId = 'openai' | 'google'
+import { IMAGE_PROVIDER_ENV_VARS, extensionForImageMime, type DirectImageProviderId } from './image-format'
 
 export interface DirectImageRequest {
   provider: DirectImageProviderId
@@ -49,17 +48,15 @@ export function resolveDirectImageKey(
   provider: DirectImageProviderId,
   env: Record<string, string | undefined> = process.env,
 ): string | null {
-  if (provider === 'openai') return env.OPENAI_API_KEY || null
-  return env.GEMINI_API_KEY || env.GOOGLE_AI_API_KEY || null
-}
-
-function extForMime(mimeType: string): string {
-  return mimeType.includes('png') ? 'png' : mimeType.includes('webp') ? 'webp' : 'jpg'
+  for (const name of IMAGE_PROVIDER_ENV_VARS[provider]) {
+    if (env[name]) return env[name] as string
+  }
+  return null
 }
 
 function writeTempImage(prefix: string, mimeType: string, bytes: Buffer): string {
   const dir = mkdtempSync(join(tmpdir(), 'bakin-images-'))
-  const filePath = join(dir, `${prefix}.${extForMime(mimeType)}`)
+  const filePath = join(dir, `${prefix}.${extensionForImageMime(mimeType)}`)
   writeFileSync(filePath, bytes)
   return filePath
 }

--- a/packages/core/src/media/direct-image-provider.ts
+++ b/packages/core/src/media/direct-image-provider.ts
@@ -33,6 +33,7 @@ export interface DirectImageRequest {
   resolution?: string
   background?: string
   outputFormat?: string
+  size?: string
 }
 
 /** Formats the shim can actually produce (providers default to PNG; the shim
@@ -60,6 +61,9 @@ function assertShimCanHonor(request: DirectImageRequest): void {
   }
   if (request.outputFormat && !SHIM_SUPPORTED_OUTPUT_FORMATS.has(request.outputFormat)) {
     throw new Error(`direct-image shim cannot honor outputFormat "${request.outputFormat}" (supported: png)`)
+  }
+  if (request.size) {
+    throw new Error(`direct-image shim cannot honor size (requested ${request.size}); pass width/height instead`)
   }
 }
 

--- a/packages/core/src/media/direct-image-provider.ts
+++ b/packages/core/src/media/direct-image-provider.ts
@@ -25,6 +25,42 @@ export interface DirectImageRequest {
   height: number
   quality: 'draft' | 'standard' | 'premium'
   apiKey: string
+  // Generation options the native path forwards but the shim cannot honor.
+  // Carried so the shim can reject them loudly (see assertShimCanHonor) rather
+  // than silently dropping them — the divergence #379 was filed to close.
+  count?: number
+  aspectRatio?: string
+  resolution?: string
+  background?: string
+  outputFormat?: string
+}
+
+/** Formats the shim can actually produce (providers default to PNG; the shim
+ *  doesn't transcode). Anything else is rejected rather than mislabeled. */
+const SHIM_SUPPORTED_OUTPUT_FORMATS = new Set(['png'])
+
+/**
+ * The shim talks to the providers' single-image generation endpoints and does
+ * not forward sizing/format options. Reject any option it can't honor BEFORE
+ * the billed call so a future caller gets an immediate, precise error instead
+ * of a silently-wrong (but charged) image.
+ */
+function assertShimCanHonor(request: DirectImageRequest): void {
+  if (typeof request.count === 'number' && request.count > 1) {
+    throw new Error(`direct-image shim cannot honor count > 1 (requested ${request.count})`)
+  }
+  if (request.aspectRatio) {
+    throw new Error(`direct-image shim cannot honor aspectRatio (requested ${request.aspectRatio}); pass width/height instead`)
+  }
+  if (request.resolution) {
+    throw new Error(`direct-image shim cannot honor resolution (requested ${request.resolution})`)
+  }
+  if (request.background) {
+    throw new Error(`direct-image shim cannot honor background (requested ${request.background})`)
+  }
+  if (request.outputFormat && !SHIM_SUPPORTED_OUTPUT_FORMATS.has(request.outputFormat)) {
+    throw new Error(`direct-image shim cannot honor outputFormat "${request.outputFormat}" (supported: png)`)
+  }
 }
 
 export interface DirectImageResult {
@@ -184,5 +220,6 @@ async function generateGemini(request: DirectImageRequest): Promise<DirectImageR
  * surfaces to the caller to re-trigger explicitly.
  */
 export async function generateDirectImage(request: DirectImageRequest): Promise<DirectImageResult> {
+  assertShimCanHonor(request)
   return request.provider === 'openai' ? generateOpenAI(request) : generateGemini(request)
 }

--- a/packages/core/src/media/image-format.ts
+++ b/packages/core/src/media/image-format.ts
@@ -1,0 +1,58 @@
+/**
+ * Single source of truth for image-format mappings shared across the core↔plugin
+ * boundary (#380).
+ *
+ * Two small tables previously drifted: the direct-image shim re-encoded a
+ * mime→extension map (`extForMime`) and the provider→env-var names, while the
+ * images/assets plugins owned their own copies. Core must not import plugin code,
+ * so this PURE module (no node imports — safe in the browser bundle) is the one
+ * place both sides consume. Adding a format or a provider credential is a
+ * one-place edit.
+ */
+
+export type DirectImageProviderId = 'openai' | 'google'
+
+/** Canonical image extension → mime. The image rows of the assets plugin's
+ *  broader `EXTENSION_TO_MIME` compose from this so they can never disagree. */
+export const IMAGE_EXTENSION_TO_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+}
+
+/** Preferred mime → extension (controls the jpg-vs-jpeg choice for image/jpeg). */
+const MIME_TO_EXTENSION: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/bmp': 'bmp',
+  'image/x-icon': 'ico',
+}
+
+/**
+ * Bare file extension (no dot) for a provider-returned image mime. Strips mime
+ * parameters and casing. Unknown mimes fall back to `png` (the common
+ * provider-output format) rather than silently mistyping — fixing the prior
+ * `image/gif → .jpg` bug that #380 was filed for.
+ */
+export function extensionForImageMime(mimeType: string): string {
+  const normalized = mimeType.split(';')[0]?.trim().toLowerCase() ?? ''
+  return MIME_TO_EXTENSION[normalized] ?? 'png'
+}
+
+/**
+ * Provider → credential env-var names, in resolution order (first present wins).
+ * Consumed by the shim's `resolveDirectImageKey`, the images plugin's provider
+ * readiness, and validated against the images manifest `secrets`.
+ */
+export const IMAGE_PROVIDER_ENV_VARS: Record<DirectImageProviderId, string[]> = {
+  openai: ['OPENAI_API_KEY'],
+  google: ['GEMINI_API_KEY', 'GOOGLE_AI_API_KEY'],
+}

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -8,5 +8,6 @@
  *
  * See .claude/knowledge/media-generation-adapter-architecture.md.
  */
+export * from './image-format'
 export * from './direct-image-provider'
 export * from './secret-store'

--- a/packages/core/src/media/secret-store.ts
+++ b/packages/core/src/media/secret-store.ts
@@ -19,7 +19,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, renameSync, rmSync } from 'fs'
 import { dirname, join } from 'path'
 import { getContentDir } from '../content-dir'
-import { resolveDirectImageKey, type DirectImageProviderId } from './direct-image-provider'
+import { resolveDirectImageKey } from './direct-image-provider'
+import { type DirectImageProviderId } from './image-format'
 
 interface ProviderSecret {
   apiKey?: string

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -549,7 +549,8 @@ export interface AssetGenerationInfo {
   provider: string
   model: string
   surface: string
-  quality: string
+  /** Honored only on the shim path; native generations omit it (#379). */
+  quality?: string
   routeSource: string
   routeReason?: string
 }

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -553,6 +553,8 @@ export interface AssetGenerationInfo {
   quality?: string
   routeSource: string
   routeReason?: string
+  /** Reference/context images that conditioned this generation (#418). */
+  references?: Array<{ assetId: string; version: number }>
 }
 
 /** Create a new versioned asset (v1) from a source file. */

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -872,6 +872,8 @@ export interface AssetGenerationInfo {
   quality?: string
   routeSource: string
   routeReason?: string
+  /** Reference/context images that conditioned this generation (#418). */
+  references?: Array<{ assetId: string; version: number }>
 }
 
 /** Create a new versioned asset (v1) from a source file. */

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -868,7 +868,8 @@ export interface AssetGenerationInfo {
   provider: string
   model: string
   surface: string
-  quality: string
+  /** Honored only on the shim path; native generations omit it (#379). */
+  quality?: string
   routeSource: string
   routeReason?: string
 }

--- a/plugins/assets/components/versioned/VersionedAssetDetail.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetDetail.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate, Link } from '@tanstack/react-router'
 import { Badge, Button } from '@makinbakin/sdk/ui'
 import { ArrowLeft, Download, Pencil, Trash2, Upload, Loader2, X } from 'lucide-react'
-import { AssetMetaSummary } from './atoms'
+import { AssetMetaSummary, AssetThumb } from './atoms'
 import { AssetEditDrawer } from './AssetEditDrawer'
 import { AssetPreview } from './AssetPreview'
 import { VersionRow } from './VersionRow'
@@ -191,6 +191,28 @@ export function VersionedAssetDetail() {
         onOpenChange={setEditOpen}
         onSaved={fetchManifest}
       />
+
+      {/* References — assets that conditioned this generation (#418) */}
+      {previewVer.generation?.references && previewVer.generation.references.length > 0 && (
+        <div className="mb-4">
+          <h2 className="mb-1.5 text-xs font-semibold uppercase text-muted-foreground">References</h2>
+          <div className="flex flex-wrap gap-2" data-testid="references">
+            {previewVer.generation.references.map(ref => (
+              <Link
+                key={`${ref.assetId}@${ref.version}`}
+                to="/assets/$assetId"
+                params={{ assetId: ref.assetId }}
+                className="flex items-center gap-2 rounded-md border border-border px-2 py-1 text-xs hover:bg-white/5"
+              >
+                <span className="size-8 shrink-0 overflow-hidden rounded">
+                  <AssetThumb assetId={ref.assetId} type="images" version={ref.version} className="h-full w-full object-cover" />
+                </span>
+                <span className="text-muted-foreground">{ref.assetId} <span className="opacity-60">v{ref.version}</span></span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Exports */}
       {manifest.exports.length > 0 && (

--- a/plugins/assets/components/versioned/types.ts
+++ b/plugins/assets/components/versioned/types.ts
@@ -39,6 +39,8 @@ export interface AssetGenerationInfo {
   quality?: string
   routeSource: string
   routeReason?: string
+  /** Reference/context images that conditioned this generation (#418). */
+  references?: Array<{ assetId: string; version: number }>
 }
 
 export interface AssetVersion {

--- a/plugins/assets/components/versioned/types.ts
+++ b/plugins/assets/components/versioned/types.ts
@@ -35,7 +35,8 @@ export interface AssetGenerationInfo {
   provider: string
   model: string
   surface: string
-  quality: string
+  /** Honored only on the shim path; native generations omit it (#379). */
+  quality?: string
   routeSource: string
   routeReason?: string
 }

--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -502,15 +502,17 @@ const assetsPlugin: BakinPlugin = definePlugin({
     ctx.registerExecTool({
       name: 'bakin_exec_assets_list',
       label: 'Listed assets',
-      description: 'List managed assets (one entry per asset, current-version view). Optional type and task filters.',
+      description: 'List managed assets (one entry per asset, current-version view). Optional type, task, and tag filters. Tags are the UI "folders" — pass tags to list a folder, e.g. ["brand"].',
       parameters: {
         type: z.enum(ASSET_TYPES).optional().describe('Filter by asset type'),
         taskId: z.string().optional().describe('Filter to assets linked to this task id'),
+        tags: z.array(z.string()).optional().describe('Filter to assets carrying ALL of these tags (the UI "folders").'),
       },
       handler: async (params: Record<string, unknown>) => {
-        const filter: { type?: AssetType; taskId?: string } = {}
+        const filter: { type?: AssetType; taskId?: string; tags?: string[] } = {}
         if (params.type) filter.type = params.type as AssetType
         if (typeof params.taskId === 'string' && params.taskId.length > 0) filter.taskId = params.taskId
+        if (Array.isArray(params.tags) && params.tags.length > 0) filter.tags = params.tags as string[]
         const assets = listVersionedAssets(Object.keys(filter).length ? filter : undefined)
         return { ok: true, count: assets.length, assets }
       },

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -11,13 +11,13 @@
  * same spine.
  */
 import { mkdirSync, copyFileSync, existsSync, readdirSync, statSync, renameSync, rmSync, readFileSync } from 'node:fs'
-import { join, extname } from 'node:path'
+import { join, extname, resolve, sep } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { getContentDir } from '../../../src/core/content-dir'
 import { createLogger } from '../../../src/core/logger'
 import { getMimeType, type AssetType } from './constants'
-import { generateAssetId, assetDirRelPath, yearMonthFromAssetId } from './asset-id'
+import { generateAssetId, assetDirRelPath, yearMonthFromAssetId, isValidAssetId } from './asset-id'
 import { normalizeTags } from './tags'
 import { withAssetLock } from './asset-lock'
 import { getManifestCached } from './manifest-cache'
@@ -740,10 +740,70 @@ export async function upsertFromSource(sourcePath: string, input: AssetCreateInp
   return withAssetLock(`source:${sourcePath}`, () => upsertFromSourceInner(sourcePath, input))
 }
 
+/**
+ * Map an absolute path INSIDE the asset store back to the asset identity it
+ * belongs to. Recognizes per-version files (`v{n}.{ext}`) and their thumbs;
+ * `absPath` in the result is always the REAL version file (never the thumb).
+ * Null for anything outside the store or store-internal non-version files
+ * (manifest.json, exports/).
+ */
+export function resolveStoreFile(absPath: string): { assetId: string; version: number; absPath: string } | null {
+  const storeRoot = resolve(getContentDir(), 'assets', 'store')
+  const resolved = resolve(absPath)
+  if (!resolved.startsWith(storeRoot + sep)) return null
+  const segments = resolved.slice(storeRoot.length + 1).split(sep)
+  if (segments.length !== 3) return null // exports/<name> and deeper are derived, not versions
+  const [, assetId, file] = segments
+  if (!isValidAssetId(assetId)) return null
+  const manifest = getAsset(assetId)
+  if (!manifest) return null
+  const version = manifest.versions.find((v) => v.file === file || v.thumb === file)
+  if (!version) return null
+  return { assetId, version: version.version, absPath: join(getContentDir(), assetDirRelPath(assetId)!, version.file) }
+}
+
+/** Find an asset version on the SAME task whose bytes equal the file at sourcePath. */
+function findSameTaskContentMatch(sourcePath: string, taskId: string, type: AssetType): { assetId: string; version: number } | null {
+  let size: number
+  try {
+    size = statSync(sourcePath).size
+  } catch {
+    return null
+  }
+  const sourceHash = sha256File(sourcePath)
+  if (!sourceHash) return null
+  for (const summary of listAssets({ taskId, type })) {
+    const manifest = getAsset(summary.assetId)
+    const dirRel = assetDirRelPath(summary.assetId)
+    if (!manifest || !dirRel) continue
+    for (const version of manifest.versions) {
+      if (version.size !== size) continue
+      if (sha256File(join(getContentDir(), dirRel, version.file)) === sourceHash) {
+        return { assetId: summary.assetId, version: version.version }
+      }
+    }
+  }
+  return null
+}
+
 async function upsertFromSourceInner(sourcePath: string, input: AssetCreateInput): Promise<{ assetId: string; version: number; changed: boolean }> {
+  // Reflection: a path INSIDE the asset store is already managed — return its
+  // identity instead of cloning it (live incident: a reference passed as
+  // .../store/<id>/v1.png minted a duplicate asset pointing into the store).
+  const managed = resolveStoreFile(sourcePath)
+  if (managed) return { assetId: managed.assetId, version: managed.version, changed: false }
+
   const source = input.source ?? { kind: 'workspace-file' as const, path: sourcePath }
   const existingId = findBySourcePath(sourcePath)
   if (!existingId) {
+    // Same-task content dedupe: the same bytes under a fresh path (an agent
+    // copying its finished render to workspace/tmp and re-saving) is the SAME
+    // deliverable, not a new asset. Scoped to one task — reusing an image on
+    // a different task is legitimately a new asset.
+    if (input.taskId) {
+      const match = findSameTaskContentMatch(sourcePath, input.taskId, input.type)
+      if (match) return { ...match, changed: false }
+    }
     const created = await createAsset({ ...input, source })
     return { assetId: created.assetId, version: created.version, changed: true }
   }

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -264,10 +264,12 @@ export function getAssetSummary(assetId: string): AssetSummary | null {
 }
 
 /** List assets (one summary per asset, current-version view), newest first. */
-export function listAssets(filter?: { type?: AssetType; taskId?: string | null }): AssetSummary[] {
+export function listAssets(filter?: { type?: AssetType; taskId?: string | null; tags?: string[] }): AssetSummary[] {
   const contentDir = getContentDir()
   const storeRoot = join(contentDir, 'assets', 'store')
   if (!existsSync(storeRoot)) return []
+  // AND semantics: an asset must carry every requested tag (normalized) to match.
+  const wantTags = filter?.tags && filter.tags.length > 0 ? normalizeTags(filter.tags) : null
   const summaries: AssetSummary[] = []
   for (const month of readdirSync(storeRoot)) {
     const monthDir = join(storeRoot, month)
@@ -284,6 +286,10 @@ export function listAssets(filter?: { type?: AssetType; taskId?: string | null }
       if (!manifest) continue
       if (filter?.type && manifest.type !== filter.type) continue
       if (filter?.taskId !== undefined && manifest.taskId !== filter.taskId) continue
+      if (wantTags) {
+        const have = new Set(manifest.tags)
+        if (!wantTags.every(tag => have.has(tag))) continue
+      }
       summaries.push(toSummary(manifest))
     }
   }

--- a/plugins/assets/lib/constants.ts
+++ b/plugins/assets/lib/constants.ts
@@ -1,6 +1,13 @@
 /**
  * Asset type constants and MIME type mappings.
+ *
+ * The image rows of `EXTENSION_TO_MIME` compose from the canonical
+ * `IMAGE_EXTENSION_TO_MIME` in `@bakin/core/media/image-format` (#380) — a pure
+ * module (no node imports) so this file stays safe in the client bundle. Adding
+ * an image format is a one-place edit in core; audio/video/doc rows + asset-type
+ * classification stay here (not media-generation concerns).
  */
+import { IMAGE_EXTENSION_TO_MIME } from '@bakin/core/media/image-format'
 
 export const ASSET_TYPES = ['text', 'images', 'video', 'audio', 'plans', 'research', 'pdf', 'data', 'other'] as const
 export type AssetType = typeof ASSET_TYPES[number]
@@ -49,15 +56,8 @@ export const EXTENSION_TO_MIME: Record<string, string> = {
   '.md': 'text/markdown',
   '.txt': 'text/plain',
   '.rtf': 'application/rtf',
-  // Images
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-  '.svg': 'image/svg+xml',
-  '.bmp': 'image/bmp',
-  '.ico': 'image/x-icon',
+  // Images — single source of truth in @bakin/core/media/image-format (#380)
+  ...IMAGE_EXTENSION_TO_MIME,
   // Video
   '.mp4': 'video/mp4',
   '.mov': 'video/quicktime',

--- a/plugins/assets/lib/manifest.ts
+++ b/plugins/assets/lib/manifest.ts
@@ -22,7 +22,10 @@ const GenerationSchema = z.object({
   provider: z.string(),
   model: z.string(),
   surface: z.string(),
-  quality: z.string(),
+  // Optional: quality is honored only on the direct-provider shim path. The
+  // native runtime (OpenClaw) has no quality knob, so native generations omit
+  // it rather than record a tier they never applied (#379).
+  quality: z.string().optional(),
   routeSource: z.string(),
   routeReason: z.string().optional(),
 })

--- a/plugins/assets/lib/manifest.ts
+++ b/plugins/assets/lib/manifest.ts
@@ -28,6 +28,13 @@ const GenerationSchema = z.object({
   quality: z.string().optional(),
   routeSource: z.string(),
   routeReason: z.string().optional(),
+  // Reference/context images that conditioned this generation, by managed
+  // asset identity (#418). Lineage Bakin owns at the persist step — the runtime
+  // only ever saw opaque file paths.
+  references: z.array(z.object({
+    assetId: z.string(),
+    version: z.number().int().positive(),
+  })).optional(),
 })
 
 export const AssetVersionSchema = z.object({

--- a/plugins/images/defaults/workflow-skills/generate-image.md
+++ b/plugins/images/defaults/workflow-skills/generate-image.md
@@ -50,6 +50,7 @@ Iteration (correction passes, re-rolls, quality loops):
 - Iterating on your own output appends a VERSION of the same asset — never a sibling asset. Revise conditioned on the current image with `bakin_exec_images_edit`; re-roll fresh (optionally with references) with `bakin_exec_images_generate` + `versionOf=<assetId>`.
 - The tool enforces this: a generate that references your own same-task output without `versionOf` is refused. `allowNewAsset=true` exists only for a deliberately separate companion image (same style, different scene) — never for corrections.
 - Deliver ONE assetId at the end; reviewers browse the version history on that asset.
+- The tool result IS the managed asset — never copy the render to a workspace file and re-save it via `bakin_exec_assets_save`, and pass references by assetId once imported, never by file path. (Both are deduped server-side, but don't rely on the net.)
 
 Timeouts and retries:
 

--- a/plugins/images/defaults/workflow-skills/generate-image.md
+++ b/plugins/images/defaults/workflow-skills/generate-image.md
@@ -38,6 +38,13 @@ managed versioned asset.
 3. Verify the tool returned `ok: true`.
 4. Submit the tool's returned `assetId`, `version`, provider, model, surface, width, height, and promptHash.
 
+Reference images:
+
+- When the brief provides a reference ("like this image", "match this style", an attached file), pass the image itself via `referenceImages` — do NOT transcribe what you see into the prompt. Entries can be managed assetIds, local file paths, or the runtime's `media://` attachment URIs (max 4, mixed forms allowed).
+- References require a native runtime model whose capabilities include `reference-images` (check `bakin_exec_images_recommend` / `bakin_exec_images_profiles`); the call fails cleanly before billing otherwise.
+- Raw paths and `media://` URIs are auto-imported as tracked assets linked to the task, and the generated asset records its reference lineage — the References row on the asset page is your provenance.
+- To revise an existing managed asset, use `bakin_exec_images_edit` with its `assetId` instead; `referenceImages` there supplies extra context images, never the asset being edited.
+
 Timeouts and retries:
 
 - If the generation call times out or the transport result is ambiguous, first call `bakin_exec_assets_list` with the same task id and `type: "images"`.

--- a/plugins/images/defaults/workflow-skills/generate-image.md
+++ b/plugins/images/defaults/workflow-skills/generate-image.md
@@ -45,6 +45,12 @@ Reference images:
 - Raw paths and `media://` URIs are auto-imported as tracked assets linked to the task, and the generated asset records its reference lineage — the References row on the asset page is your provenance.
 - To revise an existing managed asset, use `bakin_exec_images_edit` with its `assetId` instead; `referenceImages` there supplies extra context images, never the asset being edited.
 
+Iteration (correction passes, re-rolls, quality loops):
+
+- Iterating on your own output appends a VERSION of the same asset — never a sibling asset. Revise conditioned on the current image with `bakin_exec_images_edit`; re-roll fresh (optionally with references) with `bakin_exec_images_generate` + `versionOf=<assetId>`.
+- The tool enforces this: a generate that references your own same-task output without `versionOf` is refused. `allowNewAsset=true` exists only for a deliberately separate companion image (same style, different scene) — never for corrections.
+- Deliver ONE assetId at the end; reviewers browse the version history on that asset.
+
 Timeouts and retries:
 
 - If the generation call times out or the transport result is ambiguous, first call `bakin_exec_assets_list` with the same task id and `type: "images"`.

--- a/plugins/images/index.ts
+++ b/plugins/images/index.ts
@@ -48,7 +48,8 @@ const generateShape = {
   model: z.string().optional().describe('Provider model id, such as gpt-image-2 or gemini-3.1-flash-image-preview.'),
   width: z.number().int().positive().optional().describe('Optional custom width. Defaults from surface profile.'),
   height: z.number().int().positive().optional().describe('Optional custom height. Defaults from surface profile.'),
-  quality: imageQualityEnum.optional().describe('Generation quality tier.'),
+  quality: imageQualityEnum.optional().describe('Generation quality tier (honored only on the direct-provider path).'),
+  referenceImages: z.array(z.string()).optional().describe('Reference/context images to condition the generation: managed assetIds and/or local file paths (mix freely; max 4). Loose paths are auto-imported as assets. Requires a model with the reference-images capability on the native runtime.'),
 }
 
 const editShape = {
@@ -60,7 +61,8 @@ const editShape = {
   model: z.string().optional().describe('Provider model id.'),
   width: z.number().int().positive().optional().describe('Optional custom width.'),
   height: z.number().int().positive().optional().describe('Optional custom height.'),
-  quality: imageQualityEnum.optional().describe('Edit quality tier.'),
+  quality: imageQualityEnum.optional().describe('Edit quality tier (honored only on the direct-provider path).'),
+  referenceImages: z.array(z.string()).optional().describe('Additional reference/context images alongside the edited asset: managed assetIds and/or local file paths (max 4). Loose paths are auto-imported. Requires a model with the reference-images capability.'),
 }
 
 const importShape = {
@@ -203,14 +205,14 @@ const imagesPlugin = definePlugin({
     })
     ctx.registerExecTool({
       name: 'bakin_exec_images_generate',
-      description: 'Generate an image through a configured runtime image provider, save it as a new managed asset (v1), and return its assetId.',
+      description: 'Generate an image through a configured runtime image provider, save it as a NEW managed asset (v1), and return its assetId. Pass referenceImages to create a new image conditioned on existing assets/files (e.g. "in the style of these"); to revise an existing asset in place use bakin_exec_images_edit instead.',
       label: 'Generated an image',
       parameters: generateShape,
       handler: async (params, agent) => generateImage(ctx, params as never, agent),
     })
     ctx.registerExecTool({
       name: 'bakin_exec_images_edit',
-      description: 'Edit a managed image asset (by assetId) through the runtime image provider — edits the current version, appends a new version, and returns the assetId.',
+      description: 'Edit a managed image asset (by assetId) through the runtime image provider — edits the current version, appends a NEW VERSION to that same asset, and returns the assetId. Pass referenceImages to supply extra context images alongside the edited asset.',
       label: 'Edited an image',
       parameters: editShape,
       handler: async (params, agent) => editImage(ctx, params as never, agent),

--- a/plugins/images/index.ts
+++ b/plugins/images/index.ts
@@ -49,7 +49,9 @@ const generateShape = {
   width: z.number().int().positive().optional().describe('Optional custom width. Defaults from surface profile.'),
   height: z.number().int().positive().optional().describe('Optional custom height. Defaults from surface profile.'),
   quality: imageQualityEnum.optional().describe('Generation quality tier (honored only on the direct-provider path).'),
-  referenceImages: z.array(z.string()).optional().describe('Reference/context images to condition the generation: managed assetIds and/or local file paths (mix freely; max 4). Loose paths are auto-imported as assets. Requires a model with the reference-images capability on the native runtime.'),
+  referenceImages: z.array(z.string()).optional().describe('Reference/context images to condition the generation: managed assetIds, local file paths, and/or media:// attachment URIs (mix freely; max 4). Loose paths and media URIs are auto-imported as assets. Requires a model with the reference-images capability on the native runtime.'),
+  versionOf: z.string().optional().describe('Iteration/re-roll: append the render as a new VERSION of this existing asset instead of minting a new asset. Use this whenever you regenerate or correct your own prior output for the same deliverable.'),
+  allowNewAsset: z.boolean().optional().describe('Set true ONLY when a generate that references your own same-task output is a deliberately separate companion image (e.g. same style, different scene) — not an iteration.'),
 }
 
 const editShape = {

--- a/plugins/images/lib/idempotency.ts
+++ b/plugins/images/lib/idempotency.ts
@@ -32,6 +32,9 @@ export interface ImageCallKey {
   width: number
   height: number
   quality: string
+  /** Order-stable fingerprint of reference images (assetId@version, sorted);
+   *  '' when none. Same prompt + different references must not dedupe (#418). */
+  references: string
 }
 
 export function imageCallSignature(key: ImageCallKey): string {
@@ -46,6 +49,7 @@ export function imageCallSignature(key: ImageCallKey): string {
     key.width,
     key.height,
     key.quality,
+    key.references,
   ])
   return createHash('sha256').update(canonical).digest('hex')
 }

--- a/plugins/images/lib/idempotency.ts
+++ b/plugins/images/lib/idempotency.ts
@@ -33,7 +33,16 @@ export interface ImageCallKey {
   height: number
   quality: string
   /** Order-stable fingerprint of reference images (assetId@version, sorted);
-   *  '' when none. Same prompt + different references must not dedupe (#418). */
+   *  '' when none. Same prompt + different references must not dedupe (#418).
+   *
+   *  Accepted drift edge: the fingerprint binds each reference to its version
+   *  AT CALL TIME. If a referenced asset gains a version (or a loose file's
+   *  bytes change) between a client timeout and its retry, the retry's
+   *  signature differs → ledger miss → a second billed call. Accepted because
+   *  the inputs genuinely changed — the retry is a different generation, not
+   *  a replay — and the window requires a concurrent edit on a single-user
+   *  box. Do NOT "fix" by dropping versions from the fingerprint: that would
+   *  wrongly dedupe a deliberate regenerate-against-the-new-version. */
   references: string
 }
 

--- a/plugins/images/lib/providers.ts
+++ b/plugins/images/lib/providers.ts
@@ -1,13 +1,13 @@
 import type { PluginContext } from '@bakin/core/plugin-types'
 import type { RuntimeImageProvider } from '@bakin/core/adapters/runtime'
-import { listStoredProviders } from '@bakin/core/media'
+import { IMAGE_PROVIDER_ENV_VARS, listStoredProviders } from '@bakin/core/media'
 import type { ImageModelDescriptor, ImagePluginSettings, ImageProviderDescriptor, ImageProviderReadiness } from '../types'
 
 export const IMAGE_PROVIDERS: ImageProviderDescriptor[] = [
   {
     id: 'openai',
     label: 'OpenAI',
-    envVars: ['OPENAI_API_KEY'],
+    envVars: IMAGE_PROVIDER_ENV_VARS.openai,
     models: [
       {
         id: 'gpt-image-2',
@@ -50,7 +50,7 @@ export const IMAGE_PROVIDERS: ImageProviderDescriptor[] = [
   {
     id: 'google',
     label: 'Google Gemini',
-    envVars: ['GEMINI_API_KEY', 'GOOGLE_AI_API_KEY'],
+    envVars: IMAGE_PROVIDER_ENV_VARS.google,
     models: [
       {
         id: 'gemini-3.1-flash-image-preview',

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -203,8 +203,10 @@ async function persistImageResult(
     provider: req.route.provider,
     model: req.route.model,
     surface: req.dims.surface,
-    quality: req.quality,
     routeSource,
+    // Quality is honored only on the shim path; the native runtime has no
+    // quality knob, so don't record a tier it never applied (#379).
+    ...(routeSource === 'shim' ? { quality: req.quality } : {}),
   }
 
   const ref = opts.create
@@ -242,12 +244,17 @@ async function persistImageResult(
 
 function versionMatchesRequest(version: AssetVersion | undefined, req: PreparedImageRequest, promptHash: string, tool: string): boolean {
   if (!version) return false
+  // Quality only participates when it was actually recorded (shim path). A
+  // native version omits quality, so comparing it would wrongly miss the reuse
+  // for an otherwise-identical native re-request (#379).
+  const qualityMatches = version.generation?.quality === undefined
+    || version.generation.quality === req.quality
   return version.tool === tool
     && version.promptHash === promptHash
     && version.generation?.provider === req.route.provider
     && version.generation?.model === req.route.model
     && version.generation?.surface === req.dims.surface
-    && version.generation?.quality === req.quality
+    && qualityMatches
 }
 
 function reusableGenerateResult(params: ImagesGenerateParams, req: PreparedImageRequest, promptHash: string): ExecToolResult | null {

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -387,6 +387,14 @@ function reusableGenerateResult(params: ImagesGenerateParams, req: PreparedImage
   return null
 }
 
+/** Reuse check for a versionOf re-roll: only the target asset's current version counts. */
+function reusableVersionOfResult(assetId: string, req: PreparedImageRequest, promptHash: string): ExecToolResult | null {
+  const manifest = getAsset(assetId)
+  const current = currentVersion(manifest)
+  if (!current || !versionMatchesRequest(current, req, promptHash, 'bakin_exec_images_generate')) return null
+  return imageToolResultFromVersion(assetId, current, req, { reused: true, idempotency: 'asset' })
+}
+
 function reusableEditResult(assetId: string, req: PreparedImageRequest, promptHash: string): ExecToolResult | null {
   const manifest = getAsset(assetId)
   const current = currentVersion(manifest)
@@ -427,9 +435,15 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
 
   // Iteration lands as a VERSION, not a sibling asset (live-test incident:
   // a correction pass referencing the first pass minted a second asset).
+  if (params.versionOf && params.allowNewAsset) {
+    return fail('versionOf and allowNewAsset contradict — versionOf appends a version of an existing asset, allowNewAsset declares a separate companion asset. Pass exactly one.')
+  }
   if (params.versionOf) {
-    const target = await ctx.assets.resolveVersionFile(params.versionOf)
-    if (!target) return fail(`versionOf asset not found: ${params.versionOf}`)
+    const targetManifest = getAsset(params.versionOf)
+    if (!targetManifest) return fail(`versionOf asset not found: ${params.versionOf}`)
+    if (targetManifest.type !== 'images') {
+      return fail(`versionOf must target an images asset; ${params.versionOf} is type '${targetManifest.type}'`)
+    }
   } else if (!params.allowNewAsset) {
     // Guard the iteration trap: referencing your own generated output from
     // THIS task without declaring intent. Imported reference material (op
@@ -447,7 +461,11 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
   }
 
   const promptHash = hashPrompt(req.prompt)
-  const reused = reusableGenerateResult(params, req, promptHash)
+  // With versionOf, reuse is scoped to the TARGET asset only — a matching
+  // sibling must not hijack an explicit re-roll into a different asset.
+  const reused = params.versionOf
+    ? reusableVersionOfResult(params.versionOf, req, promptHash)
+    : reusableGenerateResult(params, req, promptHash)
   if (reused) return reused
 
   // The runtime capability owns transport: native when it can, the shared

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -32,6 +32,10 @@ export interface ImagesGenerateParams {
   quality?: 'draft' | 'standard' | 'premium'
   /** Managed assetIds and/or file paths used as reference/context images (#418). */
   referenceImages?: string[]
+  /** Append the render as a new VERSION of this asset (iteration/re-roll) instead of minting a new asset. */
+  versionOf?: string
+  /** Explicit intent: this generate references own same-task output but is a deliberately separate companion asset. */
+  allowNewAsset?: boolean
 }
 
 export interface ImagesImportParams {
@@ -232,6 +236,9 @@ async function resolveReferences(
         sourceFilePath: entry, type: 'images', agent, taskId: params.taskId,
         op: 'import', tool: 'bakin_exec_images_import',
         description: basename(entry), source: { kind: 'import', path: entry },
+        // Tagged so the assets view can filter reference material out of
+        // deliverables (and the self-iteration guard can tell them apart).
+        tags: ['reference'],
       })
       paths.push(entry)
       lineage.push({ assetId: up.assetId, version: up.version })
@@ -276,7 +283,7 @@ async function persistImageResult(
   ctx: PluginContext,
   params: ImagesGenerateParams,
   agent: string,
-  opts: { req: PreparedImageRequest; result: RuntimeImageGenerationResult; tool: string } & ({ create: true } | { create: false; assetId: string }),
+  opts: { req: PreparedImageRequest; result: RuntimeImageGenerationResult; tool: string } & ({ create: true } | { create: false; assetId: string; op?: 'edit' | 'generate' }),
 ): Promise<ExecToolResult> {
   const { req, result, tool } = opts
   const image = result.images[0]
@@ -313,7 +320,7 @@ async function persistImageResult(
         source: { kind: 'generated', path: null }, generation,
       })
     : await ctx.assets.addVersion(opts.assetId, {
-        sourceFilePath: image.filePath, op: 'edit', tool,
+        sourceFilePath: image.filePath, op: opts.op ?? 'edit', tool,
         prompt: req.prompt, promptHash, description,
         generation,
       })
@@ -408,6 +415,28 @@ function imageToolResultFromVersion(
 export async function generateImage(ctx: PluginContext, params: ImagesGenerateParams, agent: string): Promise<ExecToolResult> {
   const req = await prepareImageRequest(ctx, params, agent)
   if ('error' in req) return fail(req.error)
+
+  // Iteration lands as a VERSION, not a sibling asset (live-test incident:
+  // a correction pass referencing the first pass minted a second asset).
+  if (params.versionOf) {
+    const target = await ctx.assets.resolveVersionFile(params.versionOf)
+    if (!target) return fail(`versionOf asset not found: ${params.versionOf}`)
+  } else if (!params.allowNewAsset) {
+    // Guard the iteration trap: referencing your own generated output from
+    // THIS task without declaring intent. Imported reference material (op
+    // import/upload) on the same task is the normal flow and never trips this.
+    for (const ref of req.references.lineage) {
+      const manifest = getAsset(ref.assetId)
+      const current = currentVersion(manifest)
+      if (!manifest || !current) continue
+      if (manifest.taskId === params.taskId && (current.op === 'generate' || current.op === 'edit')) {
+        return fail(
+          `Reference ${ref.assetId} is your own output on this task. If this is an iteration/correction of that deliverable, pass versionOf="${ref.assetId}" so the render appends a new VERSION (one asset, stable id). If it is a deliberately separate companion image, pass allowNewAsset=true.`,
+        )
+      }
+    }
+  }
+
   const promptHash = hashPrompt(req.prompt)
   const reused = reusableGenerateResult(params, req, promptHash)
   if (reused) return reused
@@ -419,9 +448,10 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
 
   // Idempotent: a client (mcporter) timeout that retries this identical billed
   // call must not bill twice. Reference identity participates so the same prompt
-  // with different references is not treated as a duplicate (#418).
+  // with different references is not treated as a duplicate (#418); versionOf
+  // participates so a re-roll into an asset is distinct from a fresh generate.
   const key: ImageCallKey = {
-    taskId: params.taskId, op: 'generate', source: null,
+    taskId: params.taskId, op: 'generate', source: params.versionOf ?? null,
     promptHash, provider: req.route.provider, model: req.route.model,
     width: req.dims.width, height: req.dims.height, quality: req.quality,
     references: req.references.fingerprint,
@@ -433,7 +463,10 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
         width: req.dims.width, height: req.dims.height, outputFormat: 'png', metadata: { quality: req.quality },
         ...(req.references.paths.length ? { referenceImages: req.references.paths } : {}),
       })
-      return await persistImageResult(ctx, params, agent, { req, result, tool: 'bakin_exec_images_generate', create: true })
+      const persist = params.versionOf
+        ? { req, result, tool: 'bakin_exec_images_generate', create: false as const, assetId: params.versionOf, op: 'generate' as const }
+        : { req, result, tool: 'bakin_exec_images_generate', create: true as const }
+      return await persistImageResult(ctx, params, agent, persist)
     } catch (err) {
       return fail(`Image generation failed: ${errorMessage(err)}`)
     }
@@ -442,6 +475,7 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
 
 export async function editImage(ctx: PluginContext, params: ImagesEditParams, agent: string): Promise<ExecToolResult> {
   if (!params.assetId) return fail('edit requires a managed assetId')
+  if (params.versionOf) return fail('versionOf is a generate parameter — edit already appends a new version to assetId')
   if (params.referenceImages?.includes(params.assetId)) {
     return fail(`Reference ${params.assetId} equals the asset being edited — the edit already includes its current version; references add OTHER context images`)
   }

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -451,6 +451,11 @@ export async function editImage(ctx: PluginContext, params: ImagesEditParams, ag
 
   const req = await prepareImageRequest(ctx, params, agent)
   if ('error' in req) return fail(req.error)
+  // Re-check after resolution: a raw path or media:// reference whose
+  // auto-import deduped to the base asset would send the base file twice.
+  if (req.references.lineage.some(ref => ref.assetId === params.assetId)) {
+    return fail(`Reference resolves to the asset being edited (${params.assetId}) — the edit already includes its current version; references add OTHER context images`)
+  }
   const promptHash = hashPrompt(req.prompt)
   const reused = reusableEditResult(params.assetId, req, promptHash)
   if (reused) return reused

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -199,8 +199,9 @@ async function resolveReferences(
   if (!modelDesc?.capabilities.includes('reference-images')) {
     return { error: `Model does not support reference images: ${route.provider}/${route.model}` }
   }
-  if (readyProvider?.servedBy === 'shim') {
-    return { error: `Reference images require the native runtime; ${route.provider} is served via the direct shim` }
+  if (readyProvider?.servedBy !== 'runtime') {
+    const via = readyProvider?.servedBy === 'shim' ? 'served via the direct shim' : 'not natively configured'
+    return { error: `Reference images require the native runtime; ${route.provider} is ${via}` }
   }
 
   const paths: string[] = []
@@ -429,6 +430,9 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
 
 export async function editImage(ctx: PluginContext, params: ImagesEditParams, agent: string): Promise<ExecToolResult> {
   if (!params.assetId) return fail('edit requires a managed assetId')
+  if (params.referenceImages?.includes(params.assetId)) {
+    return fail(`Reference ${params.assetId} equals the asset being edited — the edit already includes its current version; references add OTHER context images`)
+  }
   // Source is the current version of the managed asset.
   const source = await ctx.assets.resolveVersionFile(params.assetId)
   if (!source) return fail(`Asset not found: ${params.assetId}`)

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -206,7 +206,19 @@ async function resolveReferences(
 
   const paths: string[] = []
   const lineage: Array<{ assetId: string; version: number }> = []
-  for (const entry of entries) {
+  for (const rawEntry of entries) {
+    // Runtime-private media URIs (e.g. a Discord attachment OpenClaw stored as
+    // media://inbound/…) resolve to a local path adapter-side, then flow
+    // through the same auto-import as any raw path — tracked, task-linked.
+    let entry = rawEntry
+    if (/^media:\/\//.test(rawEntry)) {
+      if (!ctx.runtime.media?.resolveUri) {
+        return { error: `The active runtime cannot resolve media:// URIs (reference ${rawEntry}); pass an assetId or local path instead` }
+      }
+      const resolved = await ctx.runtime.media.resolveUri(rawEntry)
+      if (!resolved) return { error: `Reference media URI not found: ${rawEntry}` }
+      entry = resolved
+    }
     if (isValidAssetId(entry)) {
       const ref = await ctx.assets.resolveVersionFile(entry)
       if (!ref) return { error: `Reference asset not found: ${entry}` }

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -3,9 +3,10 @@ import { existsSync } from 'node:fs'
 import { basename } from 'node:path'
 import type { ExecToolResult, PluginContext } from '@bakin/core/plugin-types'
 import type { RuntimeImageGenerationResult } from '@bakin/core/adapters/runtime'
-import { getAsset, listAssets } from '../../assets/lib/asset-service'
+import { getAsset, listAssets, upsertFromSource } from '../../assets/lib/asset-service'
+import { isValidAssetId } from '../../assets/lib/asset-id'
 import type { AssetManifest, AssetVersion } from '../../assets/lib/manifest'
-import type { ImageProviderId } from '../types'
+import type { ImageProviderId, ImageProviderReadiness } from '../types'
 import { effectiveImageSettings, getImageProvider, providerReadiness } from './providers'
 import { resolveImageRoute } from './routing'
 import { getImageProfile } from './platform-profiles'
@@ -13,6 +14,9 @@ import { runBilledImageCall, type ImageCallKey } from './idempotency'
 
 /** Largest edge we send to a provider / feed into sharp, to bound cost. */
 const MAX_IMAGE_EDGE = 2048
+/** Upper bound on reference/context images per call (#418). Providers cap input
+ *  images; keep it conservative and bump here if a workflow needs more. */
+const MAX_REFERENCE_IMAGES = 4
 type Sharp = typeof import('sharp')
 let sharpModule: Promise<Sharp | null> | null = null
 
@@ -26,6 +30,8 @@ export interface ImagesGenerateParams {
   width?: number
   height?: number
   quality?: 'draft' | 'standard' | 'premium'
+  /** Managed assetIds and/or file paths used as reference/context images (#418). */
+  referenceImages?: string[]
 }
 
 export interface ImagesImportParams {
@@ -145,15 +151,85 @@ export async function importImage(ctx: PluginContext, params: ImagesImportParams
   }
 }
 
+/** Reference/context images resolved to concrete paths + their managed lineage. */
+interface ResolvedReferences {
+  /** Concrete file paths handed to the runtime capability. */
+  paths: string[]
+  /** Managed identity recorded in generation provenance + the dedupe key. */
+  lineage: Array<{ assetId: string; version: number }>
+  /** Order-stable fingerprint of the reference set (assetId@version, sorted). */
+  fingerprint: string
+}
+
+const EMPTY_REFERENCES: ResolvedReferences = { paths: [], lineage: [], fingerprint: '' }
+
 interface PreparedImageRequest {
   prompt: string
   dims: { surface: string; width: number; height: number }
   route: { provider: ImageProviderId; model: string }
   quality: 'draft' | 'standard' | 'premium'
+  references: ResolvedReferences
 }
 
-/** Shared prologue for generate + edit: compile prompt, resolve surface + route, validate routability. */
-async function prepareImageRequest(ctx: PluginContext, params: ImagesGenerateParams): Promise<PreparedImageRequest | { error: string }> {
+/**
+ * Resolve reference images for a generate/edit (#418). AssetIds resolve to their
+ * current version; raw paths are auto-imported (source-path dedup) so every
+ * reference becomes a tracked, navigable asset. Gates BEFORE billing on the
+ * count cap, the model's `reference-images` capability, and the serving path
+ * (references require the native runtime — the direct shim can't take inputs).
+ */
+async function resolveReferences(
+  ctx: PluginContext,
+  params: ImagesGenerateParams,
+  agent: string,
+  route: { provider: ImageProviderId; model: string },
+  readyProvider: ImageProviderReadiness | undefined,
+): Promise<ResolvedReferences | { error: string }> {
+  const entries = params.referenceImages ?? []
+  if (entries.length === 0) return EMPTY_REFERENCES
+  if (entries.length > MAX_REFERENCE_IMAGES) {
+    return { error: `Too many reference images: ${entries.length} (max ${MAX_REFERENCE_IMAGES})` }
+  }
+
+  // Prefer the curated static descriptor for capabilities — runtime-discovered
+  // capabilities are best-effort and would otherwise clobber the static
+  // reference-images flag in the merge (see #381 capability-drift).
+  const modelDesc = getImageProvider(route.provider)?.models.find(model => model.id === route.model)
+    ?? readyProvider?.models.find(model => model.id === route.model)
+  if (!modelDesc?.capabilities.includes('reference-images')) {
+    return { error: `Model does not support reference images: ${route.provider}/${route.model}` }
+  }
+  if (readyProvider?.servedBy === 'shim') {
+    return { error: `Reference images require the native runtime; ${route.provider} is served via the direct shim` }
+  }
+
+  const paths: string[] = []
+  const lineage: Array<{ assetId: string; version: number }> = []
+  for (const entry of entries) {
+    if (isValidAssetId(entry)) {
+      const ref = await ctx.assets.resolveVersionFile(entry)
+      if (!ref) return { error: `Reference asset not found: ${entry}` }
+      paths.push(ref.absPath)
+      lineage.push({ assetId: entry, version: ref.version })
+    } else {
+      if (!existsSync(entry)) return { error: `Reference file not found: ${entry}` }
+      // Auto-import the loose file so the reference is tracked provenance, not a
+      // path+hash that can't be browsed later. Source-path dedup avoids dupes.
+      const up = await upsertFromSource(entry, {
+        sourceFilePath: entry, type: 'images', agent, taskId: params.taskId,
+        op: 'import', tool: 'bakin_exec_images_import',
+        description: basename(entry), source: { kind: 'import', path: entry },
+      })
+      paths.push(entry)
+      lineage.push({ assetId: up.assetId, version: up.version })
+    }
+  }
+  const fingerprint = lineage.map(ref => `${ref.assetId}@${ref.version}`).sort().join(',')
+  return { paths, lineage, fingerprint }
+}
+
+/** Shared prologue for generate + edit: compile prompt, resolve surface + route, validate routability + references. */
+async function prepareImageRequest(ctx: PluginContext, params: ImagesGenerateParams, agent: string): Promise<PreparedImageRequest | { error: string }> {
   const prompt = compilePrompt(params)
   if (!prompt) return { error: 'prompt or promptPacket is required' }
   const settings = effectiveImageSettings(ctx)
@@ -171,7 +247,10 @@ async function prepareImageRequest(ctx: PluginContext, params: ImagesGeneratePar
     || readyProvider?.models.some(model => model.id === route.model && model.status === 'routable')
   if (!knownModel) return { error: `Image model is not routable: ${route.provider}/${route.model}` }
 
-  return { prompt, dims, route, quality: params.quality ?? settings.quality }
+  const references = await resolveReferences(ctx, params, agent, route, readyProvider)
+  if ('error' in references) return references
+
+  return { prompt, dims, route, quality: params.quality ?? settings.quality, references }
 }
 
 /**
@@ -207,6 +286,8 @@ async function persistImageResult(
     // Quality is honored only on the shim path; the native runtime has no
     // quality knob, so don't record a tier it never applied (#379).
     ...(routeSource === 'shim' ? { quality: req.quality } : {}),
+    // Reference lineage — which managed assets conditioned this generation (#418).
+    ...(req.references.lineage.length ? { references: req.references.lineage } : {}),
   }
 
   const ref = opts.create
@@ -242,6 +323,11 @@ async function persistImageResult(
   }
 }
 
+function referencesFingerprint(version: AssetVersion | undefined): string {
+  const refs = version?.generation?.references ?? []
+  return refs.map(ref => `${ref.assetId}@${ref.version}`).sort().join(',')
+}
+
 function versionMatchesRequest(version: AssetVersion | undefined, req: PreparedImageRequest, promptHash: string, tool: string): boolean {
   if (!version) return false
   // Quality only participates when it was actually recorded (shim path). A
@@ -249,12 +335,15 @@ function versionMatchesRequest(version: AssetVersion | undefined, req: PreparedI
   // for an otherwise-identical native re-request (#379).
   const qualityMatches = version.generation?.quality === undefined
     || version.generation.quality === req.quality
+  // Same prompt with different references is NOT a duplicate (#418).
+  const referencesMatch = referencesFingerprint(version) === req.references.fingerprint
   return version.tool === tool
     && version.promptHash === promptHash
     && version.generation?.provider === req.route.provider
     && version.generation?.model === req.route.model
     && version.generation?.surface === req.dims.surface
     && qualityMatches
+    && referencesMatch
 }
 
 function reusableGenerateResult(params: ImagesGenerateParams, req: PreparedImageRequest, promptHash: string): ExecToolResult | null {
@@ -304,7 +393,7 @@ function imageToolResultFromVersion(
 }
 
 export async function generateImage(ctx: PluginContext, params: ImagesGenerateParams, agent: string): Promise<ExecToolResult> {
-  const req = await prepareImageRequest(ctx, params)
+  const req = await prepareImageRequest(ctx, params, agent)
   if ('error' in req) return fail(req.error)
   const promptHash = hashPrompt(req.prompt)
   const reused = reusableGenerateResult(params, req, promptHash)
@@ -316,17 +405,20 @@ export async function generateImage(ctx: PluginContext, params: ImagesGeneratePa
   const runGenerate = ctx.runtime.images.generate
 
   // Idempotent: a client (mcporter) timeout that retries this identical billed
-  // call must not bill twice.
+  // call must not bill twice. Reference identity participates so the same prompt
+  // with different references is not treated as a duplicate (#418).
   const key: ImageCallKey = {
     taskId: params.taskId, op: 'generate', source: null,
     promptHash, provider: req.route.provider, model: req.route.model,
     width: req.dims.width, height: req.dims.height, quality: req.quality,
+    references: req.references.fingerprint,
   }
   return runBilledImageCall(key, async () => {
     try {
       const result = await runGenerate({
         prompt: req.prompt, provider: req.route.provider, model: req.route.model,
         width: req.dims.width, height: req.dims.height, outputFormat: 'png', metadata: { quality: req.quality },
+        ...(req.references.paths.length ? { referenceImages: req.references.paths } : {}),
       })
       return await persistImageResult(ctx, params, agent, { req, result, tool: 'bakin_exec_images_generate', create: true })
     } catch (err) {
@@ -341,7 +433,7 @@ export async function editImage(ctx: PluginContext, params: ImagesEditParams, ag
   const source = await ctx.assets.resolveVersionFile(params.assetId)
   if (!source) return fail(`Asset not found: ${params.assetId}`)
 
-  const req = await prepareImageRequest(ctx, params)
+  const req = await prepareImageRequest(ctx, params, agent)
   if ('error' in req) return fail(req.error)
   const promptHash = hashPrompt(req.prompt)
   const reused = reusableEditResult(params.assetId, req, promptHash)
@@ -355,13 +447,15 @@ export async function editImage(ctx: PluginContext, params: ImagesEditParams, ag
     taskId: params.taskId, op: 'edit', source: params.assetId,
     promptHash, provider: req.route.provider, model: req.route.model,
     width: req.dims.width, height: req.dims.height, quality: req.quality,
+    references: req.references.fingerprint,
   }
   return runBilledImageCall(key, async () => {
     try {
+      // The base (current version) stays first; extra references append after it.
       const result = await runEdit({
         prompt: req.prompt, provider: req.route.provider, model: req.route.model,
         width: req.dims.width, height: req.dims.height, outputFormat: 'png',
-        files: [source.absPath], metadata: { quality: req.quality },
+        files: [source.absPath, ...req.references.paths], metadata: { quality: req.quality },
       })
       return await persistImageResult(ctx, params, agent, { req, result, tool: 'bakin_exec_images_edit', create: false, assetId: params.assetId })
     } catch (err) {

--- a/plugins/images/lib/tools.ts
+++ b/plugins/images/lib/tools.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs'
 import { basename } from 'node:path'
 import type { ExecToolResult, PluginContext } from '@bakin/core/plugin-types'
 import type { RuntimeImageGenerationResult } from '@bakin/core/adapters/runtime'
-import { getAsset, listAssets, upsertFromSource } from '../../assets/lib/asset-service'
+import { getAsset, listAssets, upsertFromSource, resolveStoreFile } from '../../assets/lib/asset-service'
 import { isValidAssetId } from '../../assets/lib/asset-id'
 import type { AssetManifest, AssetVersion } from '../../assets/lib/manifest'
 import type { ImageProviderId, ImageProviderReadiness } from '../types'
@@ -222,6 +222,15 @@ async function resolveReferences(
       const resolved = await ctx.runtime.media.resolveUri(rawEntry)
       if (!resolved) return { error: `Reference media URI not found: ${rawEntry}` }
       entry = resolved
+    }
+    // A path INSIDE the asset store is already managed — reflect it to its
+    // identity (and to the real version file when given a thumb) instead of
+    // letting auto-import clone it.
+    const managed = resolveStoreFile(entry)
+    if (managed) {
+      paths.push(managed.absPath)
+      lineage.push({ assetId: managed.assetId, version: managed.version })
+      continue
     }
     if (isValidAssetId(entry)) {
       const ref = await ctx.assets.resolveVersionFile(entry)

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -26,7 +26,7 @@ import {
   triggerDispatch,
 } from '../../src/core/task-service'
 import { createLogger } from '../../src/core/logger'
-import { hasCompletion } from '../../src/core/execution-ledger'
+import { getLiveRun, hasCompletion } from '../../src/core/execution-ledger'
 import { readTaskRuns } from './lib/runs-reader'
 import { getContentDir } from '../../packages/core/src/content-dir'
 import {
@@ -730,7 +730,15 @@ const tasksPlugin: BakinPlugin = definePlugin({
           // still work if an installed plugin's extension is unavailable.
         }
 
-        return { ok: true, ...enriched }
+        // Surface the in-flight run so a session that received the task
+        // through a side channel can see another worker already owns it
+        // (live-test incident: a duplicate worker had no way to know).
+        const live = getLiveRun(params.taskId as string)
+        const liveRun = live
+          ? { runId: live.runId, agent: live.agent, startedAt: new Date(live.startedAt).toISOString() }
+          : null
+
+        return { ok: true, ...enriched, liveRun }
       },
     })
 
@@ -778,6 +786,12 @@ const tasksPlugin: BakinPlugin = definePlugin({
           indexTask(ctx, result.id).catch(() => {})
 
           const notices: string[] = []
+          if (assignee) {
+            // Creation IS the briefing: dispatch sends the assignee the full
+            // task. A separate team message about it lands in their main
+            // session and starts a duplicate worker (live-test incident).
+            notices.push(`Task assigned — dispatch will notify ${assignee} with the full task; do NOT send them a separate message about it.`)
+          }
           if (!parentId && !result.workflowId && !skipWorkflowReason) {
             notices.push('No workflow attached. Consider providing workflowId next time — use bakin_exec_workflows_list to see options.')
           }

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -733,6 +733,9 @@ const tasksPlugin: BakinPlugin = definePlugin({
         // Surface the in-flight run so a session that received the task
         // through a side channel can see another worker already owns it
         // (live-test incident: a duplicate worker had no way to know).
+        // Deliberately NOT wrapped: a ledger failure must fail this read
+        // rather than report liveRun:null — "nobody owns this" is exactly
+        // the wrong answer to give a would-be duplicate worker.
         const live = getLiveRun(params.taskId as string)
         const liveRun = live
           ? { runId: live.runId, agent: live.agent, startedAt: new Date(live.startedAt).toISOString() }

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -30,7 +30,7 @@ import { startAgent, stopAgent } from '../../src/lib/agents'
 import { getSettings, resetSettingsCache } from '../../src/core/settings'
 import { syncConfig as syncMcporter } from '../../src/core/mcporter'
 import { sendMessageToAgent } from '../../src/core/agents'
-import { getLiveRun } from '../../src/core/execution-ledger'
+import { getLiveRun, LedgerUnavailableError } from '../../src/core/execution-ledger'
 import { appendAudit } from '../../src/core/audit'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
 import { getStatsByMs } from '../../src/core/usage'
@@ -1902,9 +1902,22 @@ const teamPlugin: BakinPlugin = definePlugin({
         // already running would land unthreaded in their main session and
         // spawn a parallel worker (live-test incident, task d1b213a5). Refuse
         // hard — the dispatched run is the worker; comments go on the task.
-        const taskTokens = [...new Set(message.match(/\b[0-9a-f]{8}\b/g) ?? [])].slice(0, 10)
+        const taskTokens = [...new Set(message.match(/\b[0-9a-f]{8}\b/g) ?? [])]
         for (const taskId of taskTokens) {
-          const live = getLiveRun(taskId)
+          let live: ReturnType<typeof getLiveRun>
+          try {
+            live = getLiveRun(taskId)
+          } catch (err) {
+            // Fail CLOSED: without the ledger we cannot rule out a live run,
+            // and the cost of a duplicate worker is a double bill.
+            if (err instanceof LedgerUnavailableError) {
+              return {
+                ok: false as const,
+                error: `Cannot verify whether ${agentId} is already working task ${taskId} (execution ledger unavailable) — refusing to risk a duplicate worker. Add a task comment via bakin_exec_log, or retry once the ledger is healthy.`,
+              }
+            }
+            throw err
+          }
           if (live && live.agent === agentId) {
             const ageSeconds = Math.max(0, Math.round((Date.now() - live.startedAt) / 1000))
             appendAudit(getContentDir(), 'team.message_blocked', agent, {

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -30,6 +30,8 @@ import { startAgent, stopAgent } from '../../src/lib/agents'
 import { getSettings, resetSettingsCache } from '../../src/core/settings'
 import { syncConfig as syncMcporter } from '../../src/core/mcporter'
 import { sendMessageToAgent } from '../../src/core/agents'
+import { getLiveRun } from '../../src/core/execution-ledger'
+import { appendAudit } from '../../src/core/audit'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
 import { getStatsByMs } from '../../src/core/usage'
 import { retrieveAgentPackageLessons } from '../../src/core/agent-packages/lesson-retrieval'
@@ -1891,10 +1893,30 @@ const teamPlugin: BakinPlugin = definePlugin({
       description: 'Send a message to an agent via the active runtime.',
       parameters: {
         agentId: z.string().describe('Agent ID'),
-        message: z.string().describe('Message to send'),
+        message: z.string().describe('Message to send. Do NOT use this to brief an agent about a task they were just assigned — dispatch already notified them, and a second message starts a duplicate worker in their main session.'),
       },
-      handler: async (params: Record<string, unknown>) => {
-        const result = await sendMessageToAgent(params.agentId as string, params.message as string)
+      handler: async (params: Record<string, unknown>, agent: string) => {
+        const agentId = params.agentId as string
+        const message = params.message as string
+        // Duplicate-worker guard: a message naming a task the TARGET agent is
+        // already running would land unthreaded in their main session and
+        // spawn a parallel worker (live-test incident, task d1b213a5). Refuse
+        // hard — the dispatched run is the worker; comments go on the task.
+        const taskTokens = [...new Set(message.match(/\b[0-9a-f]{8}\b/g) ?? [])].slice(0, 10)
+        for (const taskId of taskTokens) {
+          const live = getLiveRun(taskId)
+          if (live && live.agent === agentId) {
+            const ageSeconds = Math.max(0, Math.round((Date.now() - live.startedAt) / 1000))
+            appendAudit(getContentDir(), 'team.message_blocked', agent, {
+              agentId, taskId, runId: live.runId,
+            })
+            return {
+              ok: false as const,
+              error: `${agentId} is already working task ${taskId} (run ${live.runId}, started ${ageSeconds}s ago). Sending this message would start a duplicate worker in their main session. Add a task comment via bakin_exec_log instead, or wait for the run to finish.`,
+            }
+          }
+        }
+        const result = await sendMessageToAgent(agentId, message)
         return result
       },
     })

--- a/scripts/lib/post-channel.ts
+++ b/scripts/lib/post-channel.ts
@@ -6,6 +6,7 @@ import { createHash } from 'crypto'
 import { existsSync } from 'fs'
 import { basename, extname } from 'path'
 import { getAppServices } from '@/core/app-services'
+import { getIdempotent, putIdempotent } from '@/core/execution-ledger'
 import { resolveRuntimeChannelRef } from '@/core/channel-aliases'
 import { assertWorkflowToolAllowed } from '@/core/workflow-tool-authorization'
 import { resolveFile } from '@bakin/assets/lib/asset-service'
@@ -22,6 +23,8 @@ export interface PostChannelParams {
   videoAssetId?: string
   embed?: Record<string, unknown>
   taskId?: string
+  /** Explicit intent to send a second copy of an already-delivered asset. */
+  repost?: boolean
 }
 
 /**
@@ -69,6 +72,27 @@ export async function postChannel(
   }
   const { content, imageAssetId, videoAssetId, embed, taskId } = params
 
+  // A deliverable goes to a channel ONCE per task (live-test incident: the
+  // same asset posted twice with different captions — monitor post + completion
+  // reply). Durable in the ledger so it survives restarts; caption differences
+  // don't matter, the asset IS the deliverable. repost=true is the explicit
+  // escape hatch; only successful deliveries below record a row.
+  const deliveredAssetIds = [imageAssetId, videoAssetId].filter((id): id is string => Boolean(id))
+  const deliveryKeys = taskId
+    ? deliveredAssetIds.map(assetId => `channel-post:${taskId}:${channel}:${assetId}`)
+    : []
+  if (!params.repost) {
+    for (const key of deliveryKeys) {
+      const prior = getIdempotent(key)
+      if (prior) {
+        const at = (prior.result as { at?: string } | null)?.at
+        return fail(
+          `Asset already delivered to ${displayChannel(channel)} for task ${taskId}${at ? ` at ${at}` : ''}. A deliverable goes out once — if a second copy is genuinely intended, pass repost=true.`,
+        )
+      }
+    }
+  }
+
   const files = [
     filePayload(imageAssetId, resolveAssetAbsPath(imageAssetId)),
     filePayload(videoAssetId, resolveAssetAbsPath(videoAssetId)),
@@ -99,6 +123,11 @@ export async function postChannel(
     // an agent retry caused by a client timeout or ambiguous adapter failure
     // does not emit a second copy of the same message.
     postCompleted.set(signature, { result, expiresAt: Date.now() + POST_IDEMPOTENCY_TTL_MS })
+    if (result.ok) {
+      for (const key of deliveryKeys) {
+        putIdempotent(key, 'channel.post', { at: new Date().toISOString() })
+      }
+    }
     return result
   } finally {
     if (postInflight.get(signature) === promise) postInflight.delete(signature)
@@ -165,6 +194,7 @@ function postSignature(input: PostChannelParams & { channel: string; files: Arra
     embed: input.embed ?? null,
     files: input.files,
     imageAssetId: input.imageAssetId ?? null,
+    repost: input.repost ?? false,
     taskId: input.taskId ?? null,
     testMode: isTestMode(),
     videoAssetId: input.videoAssetId ?? null,
@@ -260,6 +290,7 @@ addExecTool({
     videoAssetId: z.string().optional().describe('Asset id of a video to attach (current version is sent).'),
     embed: z.record(z.string(), z.unknown()).optional().describe('Optional rich metadata for adapters that support it'),
     taskId: z.string().optional().describe('Task ID for audit trail'),
+    repost: z.boolean().optional().describe('An attached asset is delivered to a channel once per task; set true ONLY when a second copy is genuinely intended.'),
   },
   handler: async (params: Record<string, unknown>, agent: string, ctx) => {
     return postChannel({ ...params, agent } as PostChannelParams, ctx?.runtime)

--- a/scripts/lib/post-channel.ts
+++ b/scripts/lib/post-channel.ts
@@ -6,7 +6,8 @@ import { createHash } from 'crypto'
 import { existsSync } from 'fs'
 import { basename, extname } from 'path'
 import { getAppServices } from '@/core/app-services'
-import { getIdempotent, putIdempotent } from '@/core/execution-ledger'
+import { getIdempotent, putIdempotent, LedgerUnavailableError } from '@/core/execution-ledger'
+import { createLogger } from '@/core/logger'
 import { resolveRuntimeChannelRef } from '@/core/channel-aliases'
 import { assertWorkflowToolAllowed } from '@/core/workflow-tool-authorization'
 import { resolveFile } from '@bakin/assets/lib/asset-service'
@@ -39,6 +40,7 @@ function resolveAssetAbsPath(assetId: string | undefined): string | null {
 
 // When BAKIN_CHANNEL_TEST_MODE=1 (or "true"), all posts are routed to
 // the testing-ground channel regardless of what the caller requested.
+const log = createLogger('post-channel')
 const TEST_CHANNEL = 'testing-ground'
 const POST_IDEMPOTENCY_TTL_MS = 5 * 60 * 1000
 export const CHANNEL_POST_CHUNK_LIMIT = 1900
@@ -72,32 +74,14 @@ export async function postChannel(
   }
   const { content, imageAssetId, videoAssetId, embed, taskId } = params
 
-  // A deliverable goes to a channel ONCE per task (live-test incident: the
-  // same asset posted twice with different captions — monitor post + completion
-  // reply). Durable in the ledger so it survives restarts; caption differences
-  // don't matter, the asset IS the deliverable. repost=true is the explicit
-  // escape hatch; only successful deliveries below record a row.
-  const deliveredAssetIds = [imageAssetId, videoAssetId].filter((id): id is string => Boolean(id))
-  const deliveryKeys = taskId
-    ? deliveredAssetIds.map(assetId => `channel-post:${taskId}:${channel}:${assetId}`)
-    : []
-  if (!params.repost) {
-    for (const key of deliveryKeys) {
-      const prior = getIdempotent(key)
-      if (prior) {
-        const at = (prior.result as { at?: string } | null)?.at
-        return fail(
-          `Asset already delivered to ${displayChannel(channel)} for task ${taskId}${at ? ` at ${at}` : ''}. A deliverable goes out once — if a second copy is genuinely intended, pass repost=true.`,
-        )
-      }
-    }
-  }
-
   const files = [
     filePayload(imageAssetId, resolveAssetAbsPath(imageAssetId)),
     filePayload(videoAssetId, resolveAssetAbsPath(videoAssetId)),
   ].filter((file): file is { name: string; path: string } => Boolean(file))
 
+  // Identical-retry dedup runs FIRST: a verbatim retry of a post we already
+  // sent (mcporter timeout — the caller never saw the success) must return
+  // the cached result, never a refusal whose error text invites repost=true.
   const signature = postSignature({ ...params, channel, files })
   const existing = postInflight.get(signature)
   if (existing) return existing
@@ -105,6 +89,39 @@ export async function postChannel(
   if (cached) {
     if (cached.expiresAt > Date.now()) return { ...cached.result, deduped: true }
     postCompleted.delete(signature)
+  }
+
+  // A deliverable goes to a channel ONCE per task (live-test incident: the
+  // same asset posted twice with DIFFERENT captions — monitor post + completion
+  // reply, which the signature cache above cannot catch). Durable in the
+  // ledger so it survives restarts; the asset IS the deliverable. repost=true
+  // is the explicit escape hatch; only successful deliveries record a row.
+  // Best-effort against concurrent different-caption posts (check-then-act);
+  // the observed incident was sequential.
+  const deliveredAssetIds = [imageAssetId, videoAssetId].filter((id): id is string => Boolean(id))
+  const deliveryKeys = taskId
+    ? deliveredAssetIds.map(assetId => `channel-post:${taskId}:${channel}:${assetId}`)
+    : []
+  if (!params.repost) {
+    for (const key of deliveryKeys) {
+      let prior
+      try {
+        prior = getIdempotent(key)
+      } catch (err) {
+        // Fail closed with an explanation: without the ledger we cannot rule
+        // out a prior delivery, and external sends are non-idempotent.
+        if (err instanceof LedgerUnavailableError) {
+          return fail(`Cannot verify whether this asset was already delivered (execution ledger unavailable) — refusing to risk a duplicate post. Retry once the ledger is healthy.`)
+        }
+        throw err
+      }
+      if (prior) {
+        const at = (prior.result as { at?: string } | null)?.at
+        return fail(
+          `Asset already delivered to ${displayChannel(channel)} for task ${taskId}${at ? ` at ${at}` : ''}. A deliverable goes out once — if a second copy is genuinely intended, pass repost=true.`,
+        )
+      }
+    }
   }
 
   const promise = deliverChannelPost(runtime, {
@@ -125,7 +142,14 @@ export async function postChannel(
     postCompleted.set(signature, { result, expiresAt: Date.now() + POST_IDEMPOTENCY_TTL_MS })
     if (result.ok) {
       for (const key of deliveryKeys) {
-        putIdempotent(key, 'channel.post', { at: new Date().toISOString() })
+        try {
+          putIdempotent(key, 'channel.post', { at: new Date().toISOString() })
+        } catch (err) {
+          // The message already went out — failing the call now would read as
+          // "post failed" and provoke a retry. Log; the TTL cache still
+          // covers verbatim retries for the next few minutes.
+          log.warn('Failed to record channel delivery in the ledger', { key, error: err instanceof Error ? err.message : String(err) })
+        }
       }
     }
     return result

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -66,6 +66,7 @@ Use these current tool names for the common paths:
 - Workflows: `bakin_exec_workflows_list`, `bakin_exec_workflows_get_definition`, `bakin_exec_workflows_start`, `bakin_exec_get_step`, `bakin_exec_submit_step`, `bakin_exec_check_gates`
 - Team: `bakin_exec_team_list`, `bakin_exec_team_profile`, `bakin_exec_team_status`, `bakin_exec_team_message`
 - Assets: `bakin_exec_assets_save`, `bakin_exec_assets_list`, `bakin_exec_assets_get`
+- Images: `bakin_exec_images_generate`, `bakin_exec_images_edit` (both accept `referenceImages`), `bakin_exec_images_import`, `bakin_exec_images_recommend`
 - Channels: `bakin_exec_post_channel`
 - Paths: `bakin_exec_get_paths`
 - Health: `bakin_exec_health_status`, `bakin_exec_health_doctor`
@@ -81,6 +82,11 @@ Before `bakin_exec_tasks_create`:
 2. Choose the matching `workflowId`, or set `skipWorkflowReason` for a one-off request.
 3. Include `parentId` when this is a subtask of an existing task.
 4. Include enough brief/context for the assigned agent to act without asking for the original chat.
+5. If the request carries an attached image, import it against the new task (`bakin_exec_images_import`) and put the returned assetId in the description — the assignee can pass it straight to `referenceImages`. The attachment's `media://` URI also works as a `referenceImages` entry directly.
+
+After `bakin_exec_tasks_create`: STOP. Dispatch delivers the full task to the assignee — do NOT also `bakin_exec_team_message` them about it. That message lands in their main session and starts a duplicate worker (Bakin refuses it when the task's run is detectable). Use `bakin_exec_log` for follow-up context.
+
+When a brief says "like this image" / "based on the attached reference", the generating agent should pass the image itself via `referenceImages` on `bakin_exec_images_generate` (assetIds, local paths, or `media://` URIs, max 4, native runtime models only) — not describe it in prose.
 
 Example shape:
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -90,6 +90,8 @@ When a brief says "like this image" / "based on the attached reference", the gen
 
 Iterating on your own output appends a VERSION, never a new asset: revise with `bakin_exec_images_edit`, or re-roll fresh with `bakin_exec_images_generate` + `versionOf=<assetId>`. One assetId per deliverable, n versions.
 
+Image tool results are already managed assets — never copy one to a workspace file and re-save it via `bakin_exec_assets_save`; report the assetId you already hold. Pass references by assetId once imported, never by file path.
+
 ## Channel Delivery Discipline
 
 A finished asset goes to a channel EXACTLY ONCE, via `bakin_exec_post_channel` with `imageAssetId`/`videoAssetId` + `taskId` — never pasted natively into a channel reply (native posts bypass the audit trail and the once-per-channel guard). Post it only as the reply/handoff for the originating request; progress updates never attach the deliverable, and spotting a finished asset while monitoring a task is not a trigger to post it. The tool refuses a second delivery of the same asset to the same channel for the same task; `repost=true` exists only for a genuinely intended second copy.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -88,6 +88,12 @@ After `bakin_exec_tasks_create`: STOP. Dispatch delivers the full task to the as
 
 When a brief says "like this image" / "based on the attached reference", the generating agent should pass the image itself via `referenceImages` on `bakin_exec_images_generate` (assetIds, local paths, or `media://` URIs, max 4, native runtime models only) — not describe it in prose.
 
+Iterating on your own output appends a VERSION, never a new asset: revise with `bakin_exec_images_edit`, or re-roll fresh with `bakin_exec_images_generate` + `versionOf=<assetId>`. One assetId per deliverable, n versions.
+
+## Channel Delivery Discipline
+
+A finished asset goes to a channel EXACTLY ONCE, via `bakin_exec_post_channel` with `imageAssetId`/`videoAssetId` + `taskId` — never pasted natively into a channel reply (native posts bypass the audit trail and the once-per-channel guard). Post it only as the reply/handoff for the originating request; progress updates never attach the deliverable, and spotting a finished asset while monitoring a task is not a trigger to post it. The tool refuses a second delivery of the same asset to the same channel for the same task; `repost=true` exists only for a genuinely intended second copy.
+
 Example shape:
 
 ```bash

--- a/src/core/agent-rules/managed-blocks.ts
+++ b/src/core/agent-rules/managed-blocks.ts
@@ -63,6 +63,7 @@ These rules govern AGENT_NAME_PLACEHOLDER as orchestrator of the Bakin multi-age
 - Channel attachments become task assets. When a request arrives with an attached image, create the task, then import the attachment against it (\`bakin_exec_images_import taskId=<id> filePath=<path>\`) and reference the returned assetId in the task description — the reference is then visible on the task and directly usable via \`referenceImages\`. The attachment's \`media://\` URI also works directly as a \`referenceImages\` entry.
 - Multi-deliverable requests must be structured, never freeform. Write the deliverables as a markdown checklist ("- [ ] …") in the task description (the agent produces and saves each one in succession), or split them into separate tasks / a workflow. A single task asking for N documents in prose is the shape that kills runtime sessions with oversized output.
 - Deliverables live in assets, not chat. Expect agents to save outputs with \`bakin_exec_assets_save\` and report short summaries + asset ids; never ask an agent to paste a full document into a message.
+- Deliver a finished asset to a channel EXACTLY ONCE, via \`bakin_exec_post_channel\` with \`imageAssetId\`/\`videoAssetId\` + \`taskId\` (never paste media natively into a channel reply — native posts bypass the audit trail and the once-per-channel guard). Post it only as the reply/handoff for the originating request. Progress updates never attach the deliverable, and noticing a finished asset while monitoring a task is NOT a trigger to post it.
 - Use workflows when they apply. Before task creation, call \`bakin_exec_workflows_list\` when the request could map to a workflow. Pass \`workflowId\`, or include \`skipWorkflowReason\` for a one-off request.
 - Workflow tasks are hands-off. Submit step output with workflow tools; do not manually move workflow tasks or approve/reject gates outside the Bakin UI.
 - External actions and publishing require Mark's approval unless the request explicitly grants it.
@@ -443,7 +444,7 @@ Then exit — you will be automatically re-dispatched when their task completes.
 
 > Auto-managed by \`bakin doctor\`. Do not edit this block manually.\n`
 
-      content += `\n**IMAGES:** Default to the core images plugin tools for image work — **prefer \`bakin_exec_images_generate\`** over the runtime's built-in image generation. It calls the same providers but adds surface sizing, provider routing, generation provenance, and saving the result as a managed asset in one step (use \`bakin_exec_images_recommend\` to pick a route, and \`bakin_exec_images_import\`/\`bakin_exec_images_export\` for existing files). **When the brief says "like this image" or provides a reference, pass the image itself via \`referenceImages\`** — managed assetIds, local paths, or the runtime's \`media://\` attachment URIs, up to 4, native runtime models only — instead of transcribing what you see into the prompt. Raw paths and media URIs are auto-imported as tracked assets, and the generation records its reference lineage. When invoking image generation or editing through mcporter, pass \`--timeout 600000\`. Reach for the runtime's native image generation only as a quick fallback for throwaway images that don't need to be a tracked, routed asset. Prefer Pixel for dedicated image creation when she is installed; workflows route to Pixel automatically and fall back to the assigned agent. Always return the managed asset \`assetId\`, not a filesystem path or filename.\n`
+      content += `\n**IMAGES:** Default to the core images plugin tools for image work — **prefer \`bakin_exec_images_generate\`** over the runtime's built-in image generation. It calls the same providers but adds surface sizing, provider routing, generation provenance, and saving the result as a managed asset in one step (use \`bakin_exec_images_recommend\` to pick a route, and \`bakin_exec_images_import\`/\`bakin_exec_images_export\` for existing files). **When the brief says "like this image" or provides a reference, pass the image itself via \`referenceImages\`** — managed assetIds, local paths, or the runtime's \`media://\` attachment URIs, up to 4, native runtime models only — instead of transcribing what you see into the prompt. Raw paths and media URIs are auto-imported as tracked assets, and the generation records its reference lineage. **Iterating on your own output appends a VERSION, never a new asset:** revise with \`bakin_exec_images_edit\`, or re-roll fresh with \`bakin_exec_images_generate versionOf=<assetId>\` — one assetId per deliverable, n versions. When invoking image generation or editing through mcporter, pass \`--timeout 600000\`. Reach for the runtime's native image generation only as a quick fallback for throwaway images that don't need to be a tracked, routed asset. Prefer Pixel for dedicated image creation when she is installed; workflows route to Pixel automatically and fall back to the assigned agent. Always return the managed asset \`assetId\`, not a filesystem path or filename.\n`
 
       if (!canVideo) {
         content += `\n**VIDEO:** You cannot generate video. Ever. Not with Runway, not with any other tool. All video generation goes through Rolo. Create a Rolo task via \`mcporter call bakin-${agentId}.bakin_exec_tasks_create\` and wait.\n`
@@ -584,11 +585,14 @@ mcporter call bakin-${agentId}.bakin_exec_images_generate taskId=<taskId> prompt
 # Same, conditioned on reference images (assetIds, local paths, or media:// URIs — max 4)
 mcporter call bakin-${agentId}.bakin_exec_images_generate --args '{"taskId":"<taskId>","prompt":"<text>","surface":"<surface>","referenceImages":["<assetId|path|media://inbound/file.png>"]}'
 
+# Iteration/re-roll of your own prior output — appends a new VERSION of that asset
+mcporter call bakin-${agentId}.bakin_exec_images_generate --args '{"taskId":"<taskId>","prompt":"<corrected prompt>","surface":"<surface>","versionOf":"<assetId>"}'
+
 # Check workflow gate statuses
 mcporter call bakin-${agentId}.bakin_exec_check_gates taskId=<taskId>
 
 # Post to a runtime channel (with optional attachment) — only when instructed
-mcporter call bakin-${agentId}.bakin_exec_post_channel channel="<name>" content="<message>" taskId=<taskId>
+mcporter call bakin-${agentId}.bakin_exec_post_channel channel="<name>" content="<message>" imageAssetId=<assetId> taskId=<taskId>
 
 # Task lifecycle
 mcporter call bakin-${agentId}.bakin_exec_tasks_get taskId=<taskId>

--- a/src/core/agent-rules/managed-blocks.ts
+++ b/src/core/agent-rules/managed-blocks.ts
@@ -59,6 +59,8 @@ These rules govern AGENT_NAME_PLACEHOLDER as orchestrator of the Bakin multi-age
 - Do not log casual chat, quick answers, acknowledgements, or reactions as tasks.
 - AGENT_NAME_PLACEHOLDER delegates. Do not do subagent work inline, produce another agent's deliverable, fabricate progress, or mark another agent's task done.
 - Create one clear task per agent per deliverable. Let the assigned agent decompose follow-up work.
+- Creating a task IS the briefing. Dispatch sends the assignee the full task automatically — never also send them a team message about it. That message lands in their main session and starts a duplicate worker doing the same job twice (Bakin refuses such messages when it can detect them).
+- Channel attachments become task assets. When a request arrives with an attached image, create the task, then import the attachment against it (\`bakin_exec_images_import taskId=<id> filePath=<path>\`) and reference the returned assetId in the task description — the reference is then visible on the task and directly usable via \`referenceImages\`. The attachment's \`media://\` URI also works directly as a \`referenceImages\` entry.
 - Multi-deliverable requests must be structured, never freeform. Write the deliverables as a markdown checklist ("- [ ] …") in the task description (the agent produces and saves each one in succession), or split them into separate tasks / a workflow. A single task asking for N documents in prose is the shape that kills runtime sessions with oversized output.
 - Deliverables live in assets, not chat. Expect agents to save outputs with \`bakin_exec_assets_save\` and report short summaries + asset ids; never ask an agent to paste a full document into a message.
 - Use workflows when they apply. Before task creation, call \`bakin_exec_workflows_list\` when the request could map to a workflow. Pass \`workflowId\`, or include \`skipWorkflowReason\` for a one-off request.
@@ -406,6 +408,7 @@ mcporter call bakin-${agentId}.bakin_exec_get_paths
 > Auto-managed by \`bakin doctor\`. Do not edit this block manually.
 
 - **NEVER use runtime-native agent commands to spawn or message other agents directly.** Always create a Bakin task via \`mcporter call bakin-${agentId}.bakin_exec_tasks_create title="<task>" assignee="<agent>"\` instead. Direct spawning bypasses the pipeline.
+- **NEVER message an agent about a task they were just assigned.** Dispatch already delivered the full task to them; a separate \`bakin_exec_team_message\` about it lands in their main session and starts a DUPLICATE worker doing the same job twice. Add a task comment (\`bakin_exec_log\`) instead.
 - **NEVER modify task state directly.** Use Bakin tools via mcporter only.
 - **NEVER post to runtime channels without explicit instruction.** Content goes through Mark's review first.
 - **NEVER hardcode file paths.** Always discover paths via \`mcporter call bakin-${agentId}.bakin_exec_get_paths\`. Hardcoded paths break when the content directory moves.
@@ -440,7 +443,7 @@ Then exit — you will be automatically re-dispatched when their task completes.
 
 > Auto-managed by \`bakin doctor\`. Do not edit this block manually.\n`
 
-      content += `\n**IMAGES:** Default to the core images plugin tools for image work — **prefer \`bakin_exec_images_generate\`** over the runtime's built-in image generation. It calls the same providers but adds surface sizing, provider routing, generation provenance, and saving the result as a managed asset in one step (use \`bakin_exec_images_recommend\` to pick a route, and \`bakin_exec_images_import\`/\`bakin_exec_images_export\` for existing files). When invoking image generation or editing through mcporter, pass \`--timeout 600000\`. Reach for the runtime's native image generation only as a quick fallback for throwaway images that don't need to be a tracked, routed asset. Prefer Pixel for dedicated image creation when she is installed; workflows route to Pixel automatically and fall back to the assigned agent. Always return the managed asset \`assetId\`, not a filesystem path or filename.\n`
+      content += `\n**IMAGES:** Default to the core images plugin tools for image work — **prefer \`bakin_exec_images_generate\`** over the runtime's built-in image generation. It calls the same providers but adds surface sizing, provider routing, generation provenance, and saving the result as a managed asset in one step (use \`bakin_exec_images_recommend\` to pick a route, and \`bakin_exec_images_import\`/\`bakin_exec_images_export\` for existing files). **When the brief says "like this image" or provides a reference, pass the image itself via \`referenceImages\`** — managed assetIds, local paths, or the runtime's \`media://\` attachment URIs, up to 4, native runtime models only — instead of transcribing what you see into the prompt. Raw paths and media URIs are auto-imported as tracked assets, and the generation records its reference lineage. When invoking image generation or editing through mcporter, pass \`--timeout 600000\`. Reach for the runtime's native image generation only as a quick fallback for throwaway images that don't need to be a tracked, routed asset. Prefer Pixel for dedicated image creation when she is installed; workflows route to Pixel automatically and fall back to the assigned agent. Always return the managed asset \`assetId\`, not a filesystem path or filename.\n`
 
       if (!canVideo) {
         content += `\n**VIDEO:** You cannot generate video. Ever. Not with Runway, not with any other tool. All video generation goes through Rolo. Create a Rolo task via \`mcporter call bakin-${agentId}.bakin_exec_tasks_create\` and wait.\n`
@@ -577,6 +580,9 @@ mcporter call bakin-${agentId}.bakin_exec_assets_open assetId=<assetId>
 # Recommend and generate an image through the core images plugin
 mcporter call bakin-${agentId}.bakin_exec_images_recommend surface=<surface> objective="<goal>"
 mcporter call bakin-${agentId}.bakin_exec_images_generate taskId=<taskId> prompt="<text>" surface=<surface> provider=auto
+
+# Same, conditioned on reference images (assetIds, local paths, or media:// URIs — max 4)
+mcporter call bakin-${agentId}.bakin_exec_images_generate --args '{"taskId":"<taskId>","prompt":"<text>","surface":"<surface>","referenceImages":["<assetId|path|media://inbound/file.png>"]}'
 
 # Check workflow gate statuses
 mcporter call bakin-${agentId}.bakin_exec_check_gates taskId=<taskId>

--- a/src/core/agent-rules/managed-blocks.ts
+++ b/src/core/agent-rules/managed-blocks.ts
@@ -535,7 +535,8 @@ All created content (images, video, audio, text, plans, data) MUST go to the ass
    - \`agent\` (required, string — NOT \`author\`), \`taskId\` (required, string or null), \`created\` (required, ISO 8601 — NOT \`createdAt\`)
    - Optional: \`tool\`, \`description\`, \`tags\` (string[]), \`originalFilename\`
    - Do NOT add custom fields (e.g. \`prompt\`, \`resolution\`)
-5. **Version with timestamps:** \`20260323-hero-image.png\` for revisions.`,
+5. **Version with timestamps:** \`20260323-hero-image.png\` for revisions.
+6. **\`bakin_exec_images_*\` results are ALREADY managed assets.** Never copy a generated/edited image to a workspace file and re-save it via \`bakin_exec_assets_save\` — you already hold its \`assetId\`; report that. Pass references by \`assetId\` once imported, never by file path.`,
   },
 
   {
@@ -564,7 +565,7 @@ Log via \`mcporter call bakin-${agentId}.bakin_exec_tasks_log_progress taskId=<t
 ### Output Discipline — oversized chat output kills your session
 
 The runtime cannot deliver large completions. Hard rules:
-- Any deliverable or output larger than ~8KB MUST be written to a workspace file and saved as an asset BEFORE you continue (\`bakin_exec_assets_save\`)
+- Any deliverable or output larger than ~8KB MUST be written to a workspace file and saved as an asset BEFORE you continue (\`bakin_exec_assets_save\`) — UNLESS it is already a managed asset (anything \`bakin_exec_images_*\` returned an assetId for): report that assetId, never re-save it
 - Multiple deliverables = a checklist. Produce them ONE AT A TIME: write the file → save it as an asset → log progress → start the next. NEVER draft several deliverables in a single response.
 - Keep every chat/completion message short: status, decisions, and asset ids — never deliverable content.
 - Numerous independent deliverables → split into subtasks (see the Dependency Pattern section) instead of doing them all in one turn. In a workflow step, save large output as an asset and reference the asset id in your submitted step output.

--- a/src/core/task-service.ts
+++ b/src/core/task-service.ts
@@ -162,6 +162,7 @@ export async function moveTaskWithEffects(
     if (!completion.recorded) {
       appendAudit(getContentDir(), 'task.completion_suppressed', agent, {
         id: taskId,
+        title: taskBeforeMove?.title,
         firstCompletedAt: completion.existing.completedAt,
         firstAgent: completion.existing.agent,
         firstChannel: completion.existing.channel,

--- a/src/lib/map-audit-message.ts
+++ b/src/lib/map-audit-message.ts
@@ -23,6 +23,8 @@ export function mapAuditMessage(event: string, data: Record<string, unknown>): s
       return `Ignored a duplicate completion${data.title ? ` of "${data.title}"` : ''} — ${data.firstAgent || 'another run'} had already completed this task${data.firstChannel ? ` via ${data.firstChannel}` : ''}.`
     case 'task.dispatch_failure_ignored':
       return `A session error arrived after "${data.title || data.id}" had already moved to ${data.column || 'done'} — no action needed.`
+    case 'team.message_blocked':
+      return `Blocked a message to ${data.agentId} — they are already running task ${data.taskId}.`
     case 'system.init': return 'Bakin started'
     case 'system.dispatch_error': return `Dispatch failed: ${data.error || 'unknown error'}`
     case 'workflow.step_dispatched': return `Step "${data.label || 'unknown'}" dispatched to ${data.agent || 'agent'}`

--- a/src/lib/map-audit-message.ts
+++ b/src/lib/map-audit-message.ts
@@ -17,6 +17,12 @@ export function mapAuditMessage(event: string, data: Record<string, unknown>): s
       return `Dispatch failed: ${data.error || 'unknown error'}`
     }
     case 'task.updated': return `Updated: ${data.title}`
+    // Ledger-suppression events fire exactly when the user is most confused —
+    // explain the system behaved correctly instead of echoing the event name.
+    case 'task.completion_suppressed':
+      return `Ignored a duplicate completion${data.title ? ` of "${data.title}"` : ''} — ${data.firstAgent || 'another run'} had already completed this task${data.firstChannel ? ` via ${data.firstChannel}` : ''}.`
+    case 'task.dispatch_failure_ignored':
+      return `A session error arrived after "${data.title || data.id}" had already moved to ${data.column || 'done'} — no action needed.`
     case 'system.init': return 'Bakin started'
     case 'system.dispatch_error': return `Dispatch failed: ${data.error || 'unknown error'}`
     case 'workflow.step_dispatched': return `Step "${data.label || 'unknown'}" dispatched to ${data.agent || 'agent'}`

--- a/tests/adapter-openclaw/media-uri.test.ts
+++ b/tests/adapter-openclaw/media-uri.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, describe, expect, it, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+// The adapter's home module reads OPENCLAW_HOME on resolution — set BOTH env
+// vars before any app imports so nothing can touch ~/.openclaw or ~/.bakin.
+const testDir = join(tmpdir(), `bakin-test-media-uri-${Date.now()}-${randomUUID()}`)
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+process.env.BAKIN_HOME = testDir
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+})
+mock.module('../../src/core/content-dir', contentDirMock)
+mock.module('../../packages/core/src/content-dir', contentDirMock)
+
+import { createOpenClawRuntimeAdapter } from '@bakin/adapter-openclaw'
+
+describe('OpenClaw media:// URI resolution', () => {
+  const mediaRoot = join(testDir, 'openclaw', 'media')
+  mkdirSync(join(mediaRoot, 'inbound'), { recursive: true })
+  const attachment = join(mediaRoot, 'inbound', 'cat-reference.png')
+  writeFileSync(attachment, 'cat-bytes')
+  const runtime = createOpenClawRuntimeAdapter({ settings: {} })
+
+  afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+  it('resolves media://inbound/<file> to the absolute path under the media root', async () => {
+    await expect(runtime.media!.resolveUri('media://inbound/cat-reference.png')).resolves.toBe(attachment)
+  })
+
+  it('returns null for a missing file', async () => {
+    await expect(runtime.media!.resolveUri('media://inbound/nope.png')).resolves.toBeNull()
+  })
+
+  it('returns null for other URI schemes', async () => {
+    await expect(runtime.media!.resolveUri('https://example.com/x.png')).resolves.toBeNull()
+    await expect(runtime.media!.resolveUri('/etc/passwd')).resolves.toBeNull()
+  })
+
+  it('rejects traversal out of the media root', async () => {
+    // A real file outside the media root must not be reachable.
+    writeFileSync(join(testDir, 'openclaw', 'secret.txt'), 'secret')
+    await expect(runtime.media!.resolveUri('media://../secret.txt')).resolves.toBeNull()
+    await expect(runtime.media!.resolveUri('media://inbound/../../secret.txt')).resolves.toBeNull()
+  })
+})

--- a/tests/adapter-openclaw/media-uri.test.ts
+++ b/tests/adapter-openclaw/media-uri.test.ts
@@ -16,6 +16,9 @@ const contentDirMock = () => ({
 })
 mock.module('../../src/core/content-dir', contentDirMock)
 mock.module('../../packages/core/src/content-dir', contentDirMock)
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
 
 import { createOpenClawRuntimeAdapter } from '@bakin/adapter-openclaw'
 
@@ -39,6 +42,11 @@ describe('OpenClaw media:// URI resolution', () => {
   it('returns null for other URI schemes', async () => {
     await expect(runtime.media!.resolveUri('https://example.com/x.png')).resolves.toBeNull()
     await expect(runtime.media!.resolveUri('/etc/passwd')).resolves.toBeNull()
+  })
+
+  it('returns null for a directory (only files are valid references)', async () => {
+    await expect(runtime.media!.resolveUri('media://inbound')).resolves.toBeNull()
+    await expect(runtime.media!.resolveUri('media://.')).resolves.toBeNull()
   })
 
   it('rejects traversal out of the media root', async () => {

--- a/tests/adapter-openclaw/runtime-images.test.ts
+++ b/tests/adapter-openclaw/runtime-images.test.ts
@@ -196,6 +196,36 @@ echo "{}"
     expect(readFileSync(callsFile, 'utf-8')).not.toContain('generate')
   })
 
+  it.each([
+    ['count > 1', { count: 2 }],
+    ['aspectRatio', { aspectRatio: '16:9' }],
+    ['resolution', { resolution: '4K' }],
+    ['background', { background: 'transparent' as const }],
+    ['outputFormat webp', { outputFormat: 'webp' as const }],
+    ['size', { size: '1024x1536' }],
+  ])('shim fallback rejects %s before billing instead of silently dropping it (#379)', async (_label, extra) => {
+    process.env.OPENAI_API_KEY = 'shim-key'
+    // Mocked so a broken guard fails on the call count, never on real network.
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ b64_json: Buffer.from('img').toString('base64') }] }),
+    } as unknown as Response)
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: openclaw } })
+
+    // gpt-image-1.5 is not in the mock binary's advertised set → shim route.
+    await expect(runtime.images!.generate({
+      prompt: 'Premium hero',
+      provider: 'openai',
+      model: 'gpt-image-1.5',
+      width: 1024,
+      height: 1024,
+      ...extra,
+    })).rejects.toThrow(/shim cannot honor/)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it('labels the credential source as bakin-store when the key comes from the store', async () => {
     delete process.env.OPENAI_API_KEY
     setStoredProviderKey('openai', 'stored-key')

--- a/tests/adapter-openclaw/runtime-images.test.ts
+++ b/tests/adapter-openclaw/runtime-images.test.ts
@@ -47,7 +47,7 @@ printf 'MCPORTER_CALL_TIMEOUT=%s\\n' "$MCPORTER_CALL_TIMEOUT" >> "${callsFile}"
 echo "{}"
 exit 0
 fi
-if [ "$1" = "infer" ] && [ "$2" = "image" ] && [ "$3" = "generate" ]; then
+if [ "$1" = "infer" ] && [ "$2" = "image" ] && { [ "$3" = "generate" ] || [ "$3" = "edit" ]; }; then
 out=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--output" ]; then
@@ -139,6 +139,35 @@ echo "{}"
     expect(existsSync(result.images[0]!.filePath)).toBe(true)
     expect(readFileSync(callsFile, 'utf-8')).toContain('openai/gpt-image-2')
     expect(readFileSync(callsFile, 'utf-8')).toContain('1024x1024')
+    // OpenClaw has no quality flag; the adapter must never emit one (#379).
+    expect(readFileSync(callsFile, 'utf-8')).not.toContain('--quality')
+  })
+
+  it('routes a reference-image generate through infer image edit with one --file per reference (#418)', async () => {
+    const refA = join(testDir, 'ref-a.png')
+    const refB = join(testDir, 'ref-b.png')
+    writeFileSync(refA, 'a')
+    writeFileSync(refB, 'b')
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter({ settings: { binaryPath: openclaw } })
+
+    const result = await runtime.images!.generate({
+      prompt: 'On-brand social image',
+      provider: 'openai',
+      model: 'gpt-image-2',
+      width: 1024,
+      height: 1024,
+      outputFormat: 'png',
+      referenceImages: [refA, refB],
+    })
+
+    const calls = readFileSync(callsFile, 'utf-8')
+    const argv = calls.split('\n')
+    // Generate has no --file; references force the edit-style invocation.
+    expect(argv.slice(0, 3)).toEqual(['infer', 'image', 'edit'])
+    expect(calls).toContain(`--file\n${refA}`)
+    expect(calls).toContain(`--file\n${refB}`)
+    expect(existsSync(result.images[0]!.filePath)).toBe(true)
   })
 
   it('falls back to the direct shim when OpenClaw cannot serve the model natively', async () => {

--- a/tests/core/media/direct-image-provider.test.ts
+++ b/tests/core/media/direct-image-provider.test.ts
@@ -67,6 +67,41 @@ describe('direct-image-provider', () => {
       expect(result.mimeType).toBe('image/png')
     })
 
+    describe('rejects options it cannot honor, before billing (#379)', () => {
+      const base = {
+        provider: 'openai' as const,
+        model: 'gpt-image-2',
+        prompt: 'x',
+        width: 1024,
+        height: 1024,
+        quality: 'standard' as const,
+        apiKey: 'key',
+      }
+
+      it.each([
+        ['count > 1', { count: 2 }],
+        ['aspectRatio', { aspectRatio: '16:9' }],
+        ['resolution', { resolution: '4K' }],
+        ['background', { background: 'transparent' as const }],
+        ['outputFormat webp', { outputFormat: 'webp' as const }],
+      ])('throws on %s without making a provider call', async (_label, extra) => {
+        const fetchSpy = spyOn(globalThis, 'fetch')
+        await expect(generateDirectImage({ ...base, ...extra })).rejects.toThrow()
+        expect(fetchSpy).not.toHaveBeenCalled()
+      })
+
+      it('allows the honored single-png path (count 1, outputFormat png)', async () => {
+        const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: [{ b64_json: Buffer.from('img').toString('base64') }] }),
+        } as unknown as Response)
+        await expect(
+          generateDirectImage({ ...base, count: 1, outputFormat: 'png' }),
+        ).resolves.toBeDefined()
+        expect(fetchSpy).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it('never retries a failed generation (no double-bill), even on a 5xx', async () => {
       // Generation is non-idempotent and billed — a transient-looking failure
       // must NOT trigger a second paid call. fetch is invoked exactly once.

--- a/tests/core/media/direct-image-provider.test.ts
+++ b/tests/core/media/direct-image-provider.test.ts
@@ -1,4 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The module under test never touches the content dir (it writes to OS tmpdir),
+// but mock the resolvers anyway so a future import can't leak into ~/.bakin/.
+const testDir = join(tmpdir(), `bakin-test-direct-image-${Date.now()}`)
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+
 import {
   generateDirectImage,
   isDirectImageProvider,
@@ -84,6 +97,7 @@ describe('direct-image-provider', () => {
         ['resolution', { resolution: '4K' }],
         ['background', { background: 'transparent' as const }],
         ['outputFormat webp', { outputFormat: 'webp' as const }],
+        ['size', { size: '1024x1536' }],
       ])('throws on %s without making a provider call', async (_label, extra) => {
         const fetchSpy = spyOn(globalThis, 'fetch')
         await expect(generateDirectImage({ ...base, ...extra })).rejects.toThrow()

--- a/tests/core/media/image-format.test.ts
+++ b/tests/core/media/image-format.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  IMAGE_EXTENSION_TO_MIME,
+  IMAGE_PROVIDER_ENV_VARS,
+  extensionForImageMime,
+} from '../../../packages/core/src/media/image-format'
+
+describe('image-format (shared mime/ext + provider env-var source of truth)', () => {
+  describe('extensionForImageMime', () => {
+    it('maps canonical image mimes to extensions (gif is no longer mistyped as jpg)', () => {
+      expect(extensionForImageMime('image/png')).toBe('png')
+      expect(extensionForImageMime('image/jpeg')).toBe('jpg')
+      expect(extensionForImageMime('image/webp')).toBe('webp')
+      expect(extensionForImageMime('image/gif')).toBe('gif')
+    })
+
+    it('ignores mime parameters (charset, etc.) and casing', () => {
+      expect(extensionForImageMime('image/PNG; charset=binary')).toBe('png')
+      expect(extensionForImageMime('IMAGE/WEBP')).toBe('webp')
+    })
+
+    it('falls back to png for an unrecognized image mime', () => {
+      expect(extensionForImageMime('image/unknown-xyz')).toBe('png')
+    })
+  })
+
+  describe('IMAGE_EXTENSION_TO_MIME', () => {
+    it('is the single source for image ext→mime', () => {
+      expect(IMAGE_EXTENSION_TO_MIME['.png']).toBe('image/png')
+      expect(IMAGE_EXTENSION_TO_MIME['.jpg']).toBe('image/jpeg')
+      expect(IMAGE_EXTENSION_TO_MIME['.jpeg']).toBe('image/jpeg')
+      expect(IMAGE_EXTENSION_TO_MIME['.webp']).toBe('image/webp')
+      expect(IMAGE_EXTENSION_TO_MIME['.gif']).toBe('image/gif')
+    })
+  })
+
+  describe('IMAGE_PROVIDER_ENV_VARS', () => {
+    it('declares each provider’s credential env-var names exactly once', () => {
+      expect(IMAGE_PROVIDER_ENV_VARS.openai).toEqual(['OPENAI_API_KEY'])
+      expect(IMAGE_PROVIDER_ENV_VARS.google).toEqual(['GEMINI_API_KEY', 'GOOGLE_AI_API_KEY'])
+    })
+  })
+})

--- a/tests/lib/map-audit-message.test.ts
+++ b/tests/lib/map-audit-message.test.ts
@@ -35,6 +35,12 @@ describe('mapAuditMessage', () => {
     })).toBe('Ignored a duplicate completion — pixel had already completed this task.')
   })
 
+  it('explains team.message_blocked — the duplicate-worker save must not render raw', () => {
+    expect(mapAuditMessage('team.message_blocked', {
+      agentId: 'pixel', taskId: 'd1b213a5', runId: 'task:d1b213a5:d1',
+    })).toBe('Blocked a message to pixel — they are already running task d1b213a5.')
+  })
+
   it('explains task.dispatch_failure_ignored as a non-event', () => {
     expect(mapAuditMessage('task.dispatch_failure_ignored', {
       id: 'd1b213a5', title: 'Create reference-style gray cat image', column: 'done',

--- a/tests/lib/map-audit-message.test.ts
+++ b/tests/lib/map-audit-message.test.ts
@@ -20,6 +20,28 @@ describe('mapAuditMessage', () => {
     expect(mapAuditMessage('system.init', {})).toBe('Bakin started')
   })
 
+  // Internal ledger events fire exactly when the user is most confused —
+  // they must explain themselves instead of rendering raw event names.
+  it('explains task.completion_suppressed using the first-completion data', () => {
+    expect(mapAuditMessage('task.completion_suppressed', {
+      id: 'd1b213a5', title: 'Create reference-style gray cat image',
+      firstAgent: 'pixel', firstChannel: 'mcp', firstCompletedAt: 1781063978406,
+    })).toBe('Ignored a duplicate completion of "Create reference-style gray cat image" — pixel had already completed this task via mcp.')
+  })
+
+  it('explains task.completion_suppressed without optional fields', () => {
+    expect(mapAuditMessage('task.completion_suppressed', {
+      id: 'd1b213a5', firstAgent: 'pixel', firstChannel: null,
+    })).toBe('Ignored a duplicate completion — pixel had already completed this task.')
+  })
+
+  it('explains task.dispatch_failure_ignored as a non-event', () => {
+    expect(mapAuditMessage('task.dispatch_failure_ignored', {
+      id: 'd1b213a5', title: 'Create reference-style gray cat image', column: 'done',
+      error: 'OpenClaw session error before reporting completion (completion: 0KB)',
+    })).toBe('A session error arrived after "Create reference-style gray cat image" had already moved to done — no action needed.')
+  })
+
   it('maps model provider dispatch failures to a compact readable message', () => {
     expect(mapAuditMessage('task.dispatch_failed', {
       category: 'model_provider_unavailable',

--- a/tests/plugins/assets/asset-service.test.ts
+++ b/tests/plugins/assets/asset-service.test.ts
@@ -5,7 +5,7 @@
  */
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { mkdirSync, writeFileSync, rmSync, existsSync, readdirSync } from 'node:fs'
+import { mkdirSync, writeFileSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 
 const testDir = join(tmpdir(), `bakin-asset-svc-${Date.now()}-${randomUUID()}`)
@@ -17,7 +17,7 @@ import sharp from 'sharp'
 import { generateAssetId, yearMonthFromAssetId, isValidAssetId, assetDirRelPath } from '../../../plugins/assets/lib/asset-id'
 import { withAssetLock } from '../../../plugins/assets/lib/asset-lock'
 import { readManifest, writeManifestAtomic, type AssetManifest } from '../../../plugins/assets/lib/manifest'
-import { createAsset, getAsset, resolveFile, assetExists, listAssets } from '../../../plugins/assets/lib/asset-service'
+import { createAsset, getAsset, resolveFile, assetExists, listAssets, resolveStoreFile, upsertFromSource } from '../../../plugins/assets/lib/asset-service'
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 const srcDir = join(testDir, 'src')
@@ -147,5 +147,77 @@ describe('asset-service create + read', () => {
     // AND: must carry every requested tag.
     expect(listAssets({ tags: ['brand', 'hero'] }).length).toBe(1)
     expect(listAssets({ tags: ['brand', 'missing'] }).length).toBe(0)
+  })
+})
+
+describe('store-path reflection + same-task content dedupe (penguin-test fixes)', () => {
+  it('resolveStoreFile maps a store version file (and its thumb) back to assetId@version', async () => {
+    const { assetId } = await createAsset({
+      sourceFilePath: join(srcDir, 'pic.png'), type: 'images', agent: 'pixel', taskId: 'task-reflect',
+      slug: 'reflect', op: 'import',
+    })
+    const dirAbs = join(testDir, assetDirRelPath(assetId)!)
+    const hit = resolveStoreFile(join(dirAbs, 'v1.png'))
+    expect(hit).toMatchObject({ assetId, version: 1 })
+    expect(hit!.absPath.endsWith('v1.png')).toBe(true)
+    // A thumb path resolves to the same version, with absPath = the REAL file.
+    expect(resolveStoreFile(join(dirAbs, 'v1.thumb.jpg'))).toMatchObject({ assetId, version: 1 })
+    expect(resolveStoreFile(join(dirAbs, 'v1.thumb.jpg'))!.absPath.endsWith('v1.png')).toBe(true)
+    // Non-store paths and store-internal non-version files do not resolve.
+    expect(resolveStoreFile(join(srcDir, 'pic.png'))).toBeNull()
+    expect(resolveStoreFile(join(dirAbs, 'manifest.json'))).toBeNull()
+  })
+
+  it('upsertFromSource of a store-internal path returns the existing identity — never a duplicate', async () => {
+    const { assetId } = await createAsset({
+      sourceFilePath: join(srcDir, 'pic.png'), type: 'images', agent: 'pixel', taskId: 'task-noclone',
+      slug: 'original', op: 'import',
+    })
+    const storePath = join(testDir, assetDirRelPath(assetId)!, 'v1.png')
+    const before = listAssets().length
+
+    const up = await upsertFromSource(storePath, {
+      sourceFilePath: storePath, type: 'images', agent: 'pixel', taskId: 'task-noclone',
+      op: 'import', description: 'v1.png', source: { kind: 'import', path: storePath },
+    })
+
+    expect(up).toMatchObject({ assetId, version: 1, changed: false })
+    expect(listAssets().length).toBe(before)
+  })
+
+  it('upsertFromSource dedupes byte-identical content on the SAME task (new path, same bytes)', async () => {
+    const original = await createAsset({
+      sourceFilePath: join(srcDir, 'pic.png'), type: 'images', agent: 'pixel', taskId: 'task-bytes',
+      slug: 'deliverable', op: 'generate',
+    })
+    // The agent copies the finished render to a fresh workspace path and re-saves it.
+    const copyPath = join(srcDir, 'final-copy.png')
+    writeFileSync(copyPath, readFileSync(join(testDir, assetDirRelPath(original.assetId)!, 'v1.png')))
+    const before = listAssets().length
+
+    const up = await upsertFromSource(copyPath, {
+      sourceFilePath: copyPath, type: 'images', agent: 'pixel', taskId: 'task-bytes',
+      op: 'upload', description: 'final copy', source: { kind: 'workspace-file', path: copyPath },
+    })
+
+    expect(up).toMatchObject({ assetId: original.assetId, version: 1, changed: false })
+    expect(listAssets().length).toBe(before)
+  })
+
+  it('does NOT dedupe identical bytes across DIFFERENT tasks', async () => {
+    const original = await createAsset({
+      sourceFilePath: join(srcDir, 'pic.png'), type: 'images', agent: 'pixel', taskId: 'task-a',
+      slug: 'a-img', op: 'generate',
+    })
+    const copyPath = join(srcDir, 'cross-task.png')
+    writeFileSync(copyPath, readFileSync(join(testDir, assetDirRelPath(original.assetId)!, 'v1.png')))
+
+    const up = await upsertFromSource(copyPath, {
+      sourceFilePath: copyPath, type: 'images', agent: 'pixel', taskId: 'task-b',
+      op: 'upload', description: 'reuse on another task', source: { kind: 'workspace-file', path: copyPath },
+    })
+
+    expect(up.assetId).not.toBe(original.assetId)
+    expect(up.changed).toBe(true)
   })
 })

--- a/tests/plugins/assets/asset-service.test.ts
+++ b/tests/plugins/assets/asset-service.test.ts
@@ -134,4 +134,18 @@ describe('asset-service create + read', () => {
     expect(listAssets({ type: 'images' }).every((a) => a.type === 'images')).toBe(true)
     expect(listAssets({ taskId: 'task-1' }).every((a) => a.taskId === 'task-1')).toBe(true)
   })
+
+  it('filters by tag with AND semantics (the UI "folders", #418)', async () => {
+    await createAsset({
+      sourceFilePath: join(srcDir, 'pic.png'), type: 'images', agent: 'pixel', taskId: 'task-brand',
+      slug: 'brand-hero', op: 'generate', tags: ['Brand', 'hero'],
+    })
+    // Single tag, normalized (Brand → brand).
+    const brand = listAssets({ tags: ['brand'] })
+    expect(brand.length).toBe(1)
+    expect(brand[0].tags).toEqual(expect.arrayContaining(['brand', 'hero']))
+    // AND: must carry every requested tag.
+    expect(listAssets({ tags: ['brand', 'hero'] }).length).toBe(1)
+    expect(listAssets({ tags: ['brand', 'missing'] }).length).toBe(0)
+  })
 })

--- a/tests/plugins/images/idempotency-durable.test.ts
+++ b/tests/plugins/images/idempotency-durable.test.ts
@@ -47,6 +47,7 @@ function makeKey(overrides: Partial<ImageCallKey> = {}): ImageCallKey {
     width: 1024,
     height: 1024,
     quality: 'high',
+    references: '',
     ...overrides,
   }
 }

--- a/tests/plugins/images/idempotency.test.ts
+++ b/tests/plugins/images/idempotency.test.ts
@@ -20,6 +20,7 @@ const baseKey: ImageCallKey = {
   width: 1024,
   height: 1536,
   quality: 'standard',
+  references: '',
 }
 
 const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms))
@@ -37,6 +38,16 @@ describe('imageCallSignature', () => {
     expect(imageCallSignature({ ...baseKey, width: 512 })).not.toBe(sig)
     expect(imageCallSignature({ ...baseKey, source: 'a.png' })).not.toBe(sig)
     expect(imageCallSignature({ ...baseKey, taskId: 'task-2' })).not.toBe(sig)
+  })
+
+  it('same prompt with different references is not a duplicate (#418)', () => {
+    const withRefs = imageCallSignature({ ...baseKey, references: '20260601-a@1' })
+    const otherRefs = imageCallSignature({ ...baseKey, references: '20260601-b@2' })
+    const noRefs = imageCallSignature({ ...baseKey, references: '' })
+    expect(withRefs).not.toBe(noRefs)
+    expect(withRefs).not.toBe(otherRefs)
+    // Identical reference sets dedupe as before.
+    expect(imageCallSignature({ ...baseKey, references: '20260601-a@1' })).toBe(withRefs)
   })
 })
 

--- a/tests/plugins/images/providers.test.ts
+++ b/tests/plugins/images/providers.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { rmSync } from 'fs'
+import { readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import type { PluginContext } from '@bakin/core/plugin-types'
+import { IMAGE_PROVIDER_ENV_VARS } from '@bakin/core/media'
 import { resetContentDir } from '../../../src/core/content-dir'
 import { DEFAULT_IMAGE_SETTINGS, listImageProviders, providerReadiness, providerReadinessFromEnv } from '../../../plugins/images/lib/providers'
 
@@ -125,5 +126,23 @@ describe('image providers', () => {
       quality: 'standard',
     })
     expect(DEFAULT_IMAGE_SETTINGS.fallbackOrder.length).toBeGreaterThan(1)
+  })
+
+  describe('credential env-var source of truth (#380)', () => {
+    it('sources provider envVars from the shared core table', () => {
+      const byId = new Map(listImageProviders().map(provider => [provider.id, provider]))
+      expect(byId.get('openai')?.envVars).toEqual(IMAGE_PROVIDER_ENV_VARS.openai)
+      expect(byId.get('google')?.envVars).toEqual(IMAGE_PROVIDER_ENV_VARS.google)
+    })
+
+    it('declares no manifest secret that is absent from the shared table (rename guard)', () => {
+      const manifest = JSON.parse(
+        readFileSync(join(import.meta.dir, '../../../plugins/images/bakin-plugin.json'), 'utf8'),
+      ) as { secrets?: Array<{ name: string }> }
+      const known = new Set(Object.values(IMAGE_PROVIDER_ENV_VARS).flat())
+      for (const secret of manifest.secrets ?? []) {
+        expect(known.has(secret.name)).toBe(true)
+      }
+    })
   })
 })

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -581,5 +581,71 @@ describe('images tools', () => {
       expect(refs).toContainEqual({ assetId: refId, version: 2 })
       expect(refs!.some(ref => ref.assetId !== refId && /^\d{8}-/.test(ref.assetId))).toBe(true)
     })
+
+    it('resolves a media:// reference through the runtime and auto-imports it', async () => {
+      const outFile = join(testDir, 'media-gen.png')
+      writeFileSync(outFile, 'img')
+      const mediaAbs = join(testDir, 'inbound-cat.png')
+      writeFileSync(mediaAbs, 'cat-bytes')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const resolveUri = mock(async (uri: string) => uri === 'media://inbound/cat.png' ? mediaAbs : null)
+      const { ctx, created } = makeContext(
+        { runtime: { media: { resolveUri }, images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'a cat like this', taskId: 'task-media', provider: 'openai',
+        model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: ['media://inbound/cat.png'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(resolveUri).toHaveBeenCalledWith('media://inbound/cat.png')
+      expect(generate).toHaveBeenCalledWith(expect.objectContaining({ referenceImages: [mediaAbs] }))
+      // The resolved file is auto-imported: lineage carries a minted assetId.
+      const refs = (created[0].generation as { references?: Array<{ assetId: string }> }).references
+      expect(refs).toHaveLength(1)
+      expect(refs![0].assetId).toMatch(/^\d{8}-/)
+    })
+
+    it('rejects a media:// reference when the runtime cannot resolve media URIs, before billing', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-media-unsupported', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', referenceImages: ['media://inbound/cat.png'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/cannot resolve media:\/\/ URIs/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unresolvable media:// reference, before billing', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const resolveUri = mock(async () => null)
+      const { ctx } = makeContext(
+        { runtime: { media: { resolveUri }, images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-media-missing', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', referenceImages: ['media://inbound/gone.png'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/reference media URI not found/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -758,6 +758,45 @@ describe('images tools', () => {
       expect(refs!.some(ref => ref.assetId !== refId && /^\d{8}-/.test(ref.assetId))).toBe(true)
     })
 
+    it('a reference passed as a store-internal PATH maps to the existing asset — never a duplicate import', async () => {
+      // Penguin-test incident: pixel passed .../store/<id>/v1.png instead of
+      // the assetId and minted a clone of the already-imported reference.
+      const srcFile = join(testDir, 'screenshot.png')
+      writeFileSync(srcFile, 'screenshot-bytes')
+      const { createAsset, listAssets: listReal } = await import('../../../plugins/assets/lib/asset-service')
+      const { assetDirRelPath } = await import('../../../plugins/assets/lib/asset-id')
+      const imported = await createAsset({
+        sourceFilePath: srcFile, type: 'images', agent: 'pixel', taskId: 'task-storepath',
+        slug: 'screenshot', op: 'import', tool: 'bakin_exec_images_import',
+        description: 'screenshot', source: { kind: 'import', path: srcFile }, tags: ['reference'],
+      })
+      const storePath = join(testDir, assetDirRelPath(imported.assetId)!, 'v1.png')
+      const outFile = join(testDir, 'penguinized.png')
+      writeFileSync(outFile, 'render')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+      const assetCountBefore = listReal().length
+
+      const result = await generateImage(ctx, {
+        prompt: 'replace thumbnails with penguins', taskId: 'task-storepath',
+        provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: [storePath],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(generate).toHaveBeenCalledWith(expect.objectContaining({ referenceImages: [storePath] }))
+      expect(created[0].generation).toMatchObject({ references: [{ assetId: imported.assetId, version: 1 }] })
+      // No clone minted in the real store.
+      expect(listReal().length).toBe(assetCountBefore)
+    })
+
     it('resolves a media:// reference through the runtime and auto-imports it', async () => {
       const outFile = join(testDir, 'media-gen.png')
       writeFileSync(outFile, 'img')

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -321,4 +321,147 @@ describe('images tools', () => {
     expect(exported[0]).toMatchObject({ assetId: '20260528-source-a1b2c3d4' })
     expect(exported[0].input).toMatchObject({ surface: 'open-graph', format: 'jpg', width: 1200, height: 630 })
   })
+
+  describe('reference images (#418)', () => {
+    // A runtime-configured provider yields servedBy: 'runtime' so the native
+    // reference path is exercised (the default harness has no runtime provider →
+    // servedBy 'shim', which references are not allowed on).
+    const runtimeProvider = () => mock(async () => [
+      { id: 'openai', label: 'OpenAI', configured: true, selected: true, defaultModel: 'gpt-image-2', models: ['gpt-image-2'] },
+    ])
+
+    it('generates conditioned on a reference asset and records lineage', async () => {
+      const outFile = join(testDir, 'ref-generated.png')
+      writeFileSync(outFile, 'img')
+      const refAbs = join(testDir, 'horse.png')
+      writeFileSync(refAbs, 'horse')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: refAbs, mimeType: 'image/png', version: 3 },
+      )
+      const refId = '20260601-horse-aaaabbbb'
+
+      const result = await generateImage(ctx, {
+        prompt: 'a charming horse in space', taskId: 'task-ref', provider: 'openai',
+        model: 'gpt-image-2', surface: 'instagram-feed-portrait', referenceImages: [refId],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(generate).toHaveBeenCalledWith(expect.objectContaining({ referenceImages: [refAbs] }))
+      expect(created[0].generation).toMatchObject({ references: [{ assetId: refId, version: 3 }] })
+    })
+
+    it('auto-imports a raw-path reference into a managed asset', async () => {
+      const outFile = join(testDir, 'gen.png')
+      writeFileSync(outFile, 'img')
+      const refPath = join(testDir, 'loose-logo.png')
+      writeFileSync(refPath, 'logo-bytes')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created } = makeContext({ runtime: { images: { providers: runtimeProvider(), generate } } } as never, null)
+
+      const result = await generateImage(ctx, {
+        prompt: 'brand thing', taskId: 'task-import', provider: 'openai',
+        model: 'gpt-image-2', surface: 'instagram-feed-portrait', referenceImages: [refPath],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(generate).toHaveBeenCalledWith(expect.objectContaining({ referenceImages: [refPath] }))
+      const refs = (created[0].generation as { references?: Array<{ assetId: string }> }).references
+      expect(refs).toHaveLength(1)
+      expect(refs![0].assetId).toMatch(/^\d{8}-/) // a freshly minted managed assetId
+    })
+
+    it('rejects references served via the shim, before billing', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: mock(async () => []), generate } } } as never,
+        { absPath: join(testDir, 'x.png'), mimeType: 'image/png', version: 1 },
+      )
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-shimref', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', referenceImages: ['20260601-horse-aaaabbbb'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/native runtime/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('rejects references when the model lacks the reference-images capability', async () => {
+      // A runtime-only provider/model synthesizes capabilities without reference-images.
+      const providers = mock(async () => [
+        { id: 'replicate', label: 'Replicate', configured: true, selected: true, defaultModel: 'flux', models: ['flux'] },
+      ])
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers, generate } } } as never,
+        { absPath: join(testDir, 'x.png'), mimeType: 'image/png', version: 1 },
+      )
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-cap', provider: 'replicate', model: 'flux',
+        surface: 'instagram-feed-portrait', referenceImages: ['20260601-horse-aaaabbbb'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/does not support reference images/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('rejects more than the max reference images, before billing', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: join(testDir, 'x.png'), mimeType: 'image/png', version: 1 },
+      )
+      const refs = [1, 2, 3, 4, 5].map(n => `2026060${n}-ref-aaaabbbb`)
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-cap2', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', referenceImages: refs,
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/too many reference images/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('appends references after the base file on edit', async () => {
+      const outFile = join(testDir, 'edited.png')
+      writeFileSync(outFile, 'img')
+      const baseAbs = join(testDir, 'base.png')
+      writeFileSync(baseAbs, 'base')
+      const refAbs = join(testDir, 'ref.png')
+      writeFileSync(refAbs, 'ref')
+      const edit = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      // resolveVersionFile is called for both the base asset AND the reference
+      // assetId; the mock returns the same ref, so assert the base path comes first.
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), edit } } } as never,
+        { absPath: baseAbs, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await editImage(ctx, {
+        assetId: '20260601-logo-aaaabbbb', prompt: 'match this', taskId: 'task-edit-ref',
+        provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: ['20260601-swatch-ccccdddd'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      const editArgs = (edit.mock.calls[0] as unknown[])[0] as { files: string[] }
+      expect(editArgs.files[0]).toBe(baseAbs) // base stays first
+      expect(editArgs.files).toHaveLength(2)
+    })
+  })
 })

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -501,6 +501,12 @@ describe('images tools', () => {
       writeFileSync(outFile, 'img')
       const baseAbs = join(testDir, 'pass1.png')
       writeFileSync(baseAbs, 'pass1')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const target = await createAsset({
+        sourceFilePath: baseAbs, type: 'images', agent: 'pixel', taskId: 'task-reroll',
+        slug: 'horse-image', op: 'generate', tool: 'bakin_exec_images_generate',
+        description: 'first pass', source: { kind: 'generated', path: null },
+      })
       const generate = mock(async () => ({
         provider: 'openai', model: 'gpt-image-2',
         images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
@@ -514,15 +520,100 @@ describe('images tools', () => {
       const result = await generateImage(ctx, {
         prompt: 'clearer side profile, same dusty world', taskId: 'task-reroll',
         provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
-        versionOf: '20260601-horse-aaaabbbb',
+        versionOf: target.assetId,
       }, 'pixel')
 
       expect(result.ok).toBe(true)
       expect(result.version).toBe(2)
       expect(created).toHaveLength(0)
       expect(versioned).toHaveLength(1)
-      expect(versioned[0].assetId).toBe('20260601-horse-aaaabbbb')
+      expect(versioned[0].assetId).toBe(target.assetId)
       expect(versioned[0].input.op).toBe('generate')
+    })
+
+    it('versionOf must target an images asset, before billing', async () => {
+      const notePath = join(testDir, 'note.md')
+      writeFileSync(notePath, '# notes')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const textAsset = await createAsset({
+        sourceFilePath: notePath, type: 'text', agent: 'pixel', taskId: 'task-type',
+        slug: 'notes', op: 'upload', description: 'notes',
+      })
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: notePath, mimeType: 'text/markdown', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-type', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', versionOf: textAsset.assetId,
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/versionOf must target an images asset/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('rejects the contradictory versionOf + allowNewAsset combination', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-contradict', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', versionOf: '20260601-h-aaaabbbb', allowNewAsset: true,
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/versionOf and allowNewAsset/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('versionOf is never hijacked by a matching SIBLING asset in the reuse check', async () => {
+      // A sibling on the same task whose current version matches the request
+      // must not swallow an explicit versionOf re-roll as "reused".
+      const prompt = 'identical prompt for both'
+      const siblingFile = join(testDir, 'sibling.png')
+      writeFileSync(siblingFile, 'sibling')
+      const targetFile = join(testDir, 'target.png')
+      writeFileSync(targetFile, 'target')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const sibling = await createAsset({
+        sourceFilePath: siblingFile, type: 'images', agent: 'pixel', taskId: 'task-hijack',
+        slug: 'sibling', op: 'generate', tool: 'bakin_exec_images_generate',
+        prompt, promptHash: promptHash(prompt), description: 'sibling',
+        source: { kind: 'generated', path: null },
+        generation: { provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait', routeSource: 'runtime' },
+      })
+      const target = await createAsset({
+        sourceFilePath: targetFile, type: 'images', agent: 'pixel', taskId: 'task-hijack',
+        slug: 'target', op: 'generate', tool: 'bakin_exec_images_generate',
+        description: 'target', source: { kind: 'generated', path: null },
+      })
+      const outFile = join(testDir, 'hijack-out.png')
+      writeFileSync(outFile, 'render')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, versioned } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: targetFile, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt, taskId: 'task-hijack', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', versionOf: target.assetId,
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(result.assetId).not.toBe(sibling.assetId)
+      expect(versioned).toHaveLength(1)
+      expect(versioned[0].assetId).toBe(target.assetId)
     })
 
     it('versionOf fails cleanly when the target asset does not exist, before billing', async () => {

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -491,5 +491,95 @@ describe('images tools', () => {
       expect(editArgs.files[0]).toBe(baseAbs) // base stays first
       expect(editArgs.files).toHaveLength(2)
     })
+
+    it('rejects an edit whose reference equals the asset being edited, before billing', async () => {
+      const edit = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), edit } } } as never,
+        { absPath: join(testDir, 'base.png'), mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await editImage(ctx, {
+        assetId: '20260601-logo-aaaabbbb', prompt: 'tweak', taskId: 'task-self-ref',
+        provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: ['20260601-logo-aaaabbbb'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/equals the asset being edited/i)
+      expect(edit).not.toHaveBeenCalled()
+    })
+
+    it('rejects references on an unconfigured provider with a clear pre-flight error', async () => {
+      // No runtime config and no Bakin key → servedBy 'unconfigured'. The gate
+      // must give the pre-flight message, not a later opaque CLI failure.
+      delete process.env.OPENAI_API_KEY
+      delete process.env.GEMINI_API_KEY
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: mock(async () => []), generate } } } as never,
+        { absPath: join(testDir, 'x.png'), mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-unconf', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', referenceImages: ['20260601-horse-aaaabbbb'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/native runtime/i)
+      expect(result.error).toMatch(/not natively configured/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unresolvable assetId reference, before billing', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      // sourceRef null → resolveVersionFile finds nothing for the reference id.
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-missing-ref', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', referenceImages: ['20260601-ghost-aaaabbbb'],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/reference asset not found/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('resolves a mixed assetId + raw-path reference list and records both in lineage', async () => {
+      const outFile = join(testDir, 'mixed-gen.png')
+      writeFileSync(outFile, 'img')
+      const refAbs = join(testDir, 'managed-ref.png')
+      writeFileSync(refAbs, 'managed')
+      const loosePath = join(testDir, 'loose-ref.png')
+      writeFileSync(loosePath, 'loose')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: refAbs, mimeType: 'image/png', version: 2 },
+      )
+      const refId = '20260601-swatch-ccccdddd'
+
+      const result = await generateImage(ctx, {
+        prompt: 'brand collage', taskId: 'task-mixed', provider: 'openai',
+        model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: [refId, loosePath],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(generate).toHaveBeenCalledWith(expect.objectContaining({ referenceImages: [refAbs, loosePath] }))
+      const refs = (created[0].generation as { references?: Array<{ assetId: string; version: number }> }).references
+      expect(refs).toHaveLength(2)
+      expect(refs).toContainEqual({ assetId: refId, version: 2 })
+      expect(refs!.some(ref => ref.assetId !== refId && /^\d{8}-/.test(ref.assetId))).toBe(true)
+    })
   })
 })

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -91,6 +91,8 @@ describe('images tools', () => {
     expect(generate).toHaveBeenCalledWith(expect.objectContaining({ provider: 'google', model: 'gemini-3.1-flash-image-preview', width: 1080, height: 1920 }))
     expect(created[0]).toMatchObject({ sourceFilePath: runtimeFile, type: 'images', op: 'generate', tool: 'bakin_exec_images_generate' })
     expect(created[0].generation).toMatchObject({ provider: 'google', model: 'gemini-3.1-flash-image-preview', surface: 'instagram-story', routeSource: 'runtime' })
+    // Native path has no quality knob — don't record a tier it never applied (#379).
+    expect((created[0].generation as Record<string, unknown>).quality).toBeUndefined()
     expect((created[0].source as { kind: string }).kind).toBe('generated')
     // No machine tags: provenance lives in generation/op, tags are the user's namespace.
     expect(created[0].tags).toBeUndefined()
@@ -106,12 +108,14 @@ describe('images tools', () => {
     }))
     const { ctx, created } = makeContext({ runtime: { images: { providers: mock(async () => []), generate } } as never })
 
-    const result = await generateImage(ctx, { prompt: 'Premium hero', taskId: 'task-shim', provider: 'openai', model: 'gpt-image-1.5', surface: 'blog-hero' }, 'pixel')
+    const result = await generateImage(ctx, { prompt: 'Premium hero', taskId: 'task-shim', provider: 'openai', model: 'gpt-image-1.5', surface: 'blog-hero', quality: 'premium' }, 'pixel')
 
     expect(result.ok).toBe(true)
     expect(result.routeSource).toBe('shim')
     expect(result.credentialSource).toBe('bakin-env')
     expect(created[0].generation).toMatchObject({ routeSource: 'shim' })
+    // Shim path honors quality, so it IS recorded (#379).
+    expect((created[0].generation as Record<string, unknown>).quality).toBe('premium')
   })
 
   it('clamps oversized custom dimensions proportionally before generating', async () => {

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -177,6 +177,34 @@ describe('images tools', () => {
     expect(generate).not.toHaveBeenCalled()
   })
 
+  it('reuses a native generated asset that recorded no quality, on an identical retry (#379)', async () => {
+    const prompt = 'A lighthouse at dusk, long exposure.'
+    const file = join(testDir, 'native-generated.png')
+    writeFileSync(file, 'img')
+    const existing = await createAsset({
+      sourceFilePath: file, type: 'images', agent: 'pixel', taskId: 'task-native-retry',
+      slug: 'instagram-feed-portrait-image', op: 'generate', tool: 'bakin_exec_images_generate',
+      prompt, promptHash: promptHash(prompt), description: prompt,
+      source: { kind: 'generated', path: null },
+      // Native generation: quality deliberately absent (the runtime never applied one).
+      generation: { provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait', routeSource: 'runtime' },
+    })
+    const generate = mock(async () => { throw new Error('provider should not be called') })
+    const { ctx } = makeContext({ runtime: { images: { providers: mock(async () => []), generate } } as never })
+
+    // The retry still carries a quality tier (from settings/default); the
+    // reuse-match must treat the stored asset's missing quality as native-normal.
+    const result = await generateImage(ctx, {
+      prompt, taskId: 'task-native-retry', provider: 'openai', model: 'gpt-image-2',
+      surface: 'instagram-feed-portrait', quality: 'premium',
+    }, 'pixel')
+
+    expect(result.ok).toBe(true)
+    expect(result.assetId).toBe(existing.assetId)
+    expect(result.reused).toBe(true)
+    expect(generate).not.toHaveBeenCalled()
+  })
+
   it('fails clearly when the active runtime has no image capability', async () => {
     const { ctx } = makeContext()
     const result = await generateImage(ctx, { prompt: 'x', taskId: 'task-none', provider: 'openai', model: 'gpt-image-2', surface: 'blog-hero' }, 'pixel')

--- a/tests/plugins/images/tools.test.ts
+++ b/tests/plugins/images/tools.test.ts
@@ -406,6 +406,10 @@ describe('images tools', () => {
       const refs = (created[0].generation as { references?: Array<{ assetId: string }> }).references
       expect(refs).toHaveLength(1)
       expect(refs![0].assetId).toMatch(/^\d{8}-/) // a freshly minted managed assetId
+      // Auto-imported references are tagged so the assets view can filter them
+      // out from deliverables.
+      const { getAsset } = await import('../../../plugins/assets/lib/asset-service')
+      expect(getAsset(refs![0].assetId)?.tags).toContain('reference')
     })
 
     it('rejects references served via the shim, before billing', async () => {
@@ -490,6 +494,178 @@ describe('images tools', () => {
       const editArgs = (edit.mock.calls[0] as unknown[])[0] as { files: string[] }
       expect(editArgs.files[0]).toBe(baseAbs) // base stays first
       expect(editArgs.files).toHaveLength(2)
+    })
+
+    it('versionOf appends the render as a new version of an existing asset (op: generate)', async () => {
+      const outFile = join(testDir, 'reroll.png')
+      writeFileSync(outFile, 'img')
+      const baseAbs = join(testDir, 'pass1.png')
+      writeFileSync(baseAbs, 'pass1')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created, versioned } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: baseAbs, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'clearer side profile, same dusty world', taskId: 'task-reroll',
+        provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        versionOf: '20260601-horse-aaaabbbb',
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(result.version).toBe(2)
+      expect(created).toHaveLength(0)
+      expect(versioned).toHaveLength(1)
+      expect(versioned[0].assetId).toBe('20260601-horse-aaaabbbb')
+      expect(versioned[0].input.op).toBe('generate')
+    })
+
+    it('versionOf fails cleanly when the target asset does not exist, before billing', async () => {
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        null,
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'x', taskId: 'task-reroll-missing', provider: 'openai', model: 'gpt-image-2',
+        surface: 'instagram-feed-portrait', versionOf: '20260601-ghost-aaaabbbb',
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/versionOf asset not found/i)
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('refuses generate referencing the agent OWN same-task output without versionOf — the iteration trap', async () => {
+      // Seed a REAL generated asset on this task (pixel's first pass).
+      const passFile = join(testDir, 'first-pass.png')
+      writeFileSync(passFile, 'first-pass')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const firstPass = await createAsset({
+        sourceFilePath: passFile, type: 'images', agent: 'pixel', taskId: 'task-iter',
+        slug: 'horse-image', op: 'generate', tool: 'bakin_exec_images_generate',
+        description: 'first pass', source: { kind: 'generated', path: null },
+      })
+
+      const generate = mock(async () => { throw new Error('should not bill') })
+      const { ctx } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: passFile, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'correction pass: clearer side profile', taskId: 'task-iter',
+        provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: [firstPass.assetId],
+      }, 'pixel')
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toMatch(/your own output on this task/i)
+      expect(result.error).toContain('versionOf')
+      expect(result.error).toContain('allowNewAsset')
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('allows the iteration when versionOf targets the referenced first pass', async () => {
+      const passFile = join(testDir, 'first-pass-v.png')
+      writeFileSync(passFile, 'first-pass')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const firstPass = await createAsset({
+        sourceFilePath: passFile, type: 'images', agent: 'pixel', taskId: 'task-iter2',
+        slug: 'horse-image', op: 'generate', tool: 'bakin_exec_images_generate',
+        description: 'first pass', source: { kind: 'generated', path: null },
+      })
+      const outFile = join(testDir, 'second-pass.png')
+      writeFileSync(outFile, 'second')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, versioned } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: passFile, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'correction pass', taskId: 'task-iter2', provider: 'openai',
+        model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: [firstPass.assetId], versionOf: firstPass.assetId,
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(versioned).toHaveLength(1)
+      expect(versioned[0].assetId).toBe(firstPass.assetId)
+    })
+
+    it('allows a deliberate companion image via allowNewAsset', async () => {
+      const passFile = join(testDir, 'first-pass-c.png')
+      writeFileSync(passFile, 'first-pass')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const firstPass = await createAsset({
+        sourceFilePath: passFile, type: 'images', agent: 'pixel', taskId: 'task-set',
+        slug: 'horse-image', op: 'generate', tool: 'bakin_exec_images_generate',
+        description: 'first of a set', source: { kind: 'generated', path: null },
+      })
+      const outFile = join(testDir, 'companion.png')
+      writeFileSync(outFile, 'companion')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: passFile, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'same style, different scene: grazing at dawn', taskId: 'task-set',
+        provider: 'openai', model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: [firstPass.assetId], allowNewAsset: true,
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(created).toHaveLength(1)
+    })
+
+    it('does NOT trip the iteration guard for an imported same-task reference', async () => {
+      // main imported Mark's attachment against this task — referencing it is
+      // the normal flow, not iteration.
+      const refFile = join(testDir, 'attachment.png')
+      writeFileSync(refFile, 'attachment')
+      const { createAsset } = await import('../../../plugins/assets/lib/asset-service')
+      const imported = await createAsset({
+        sourceFilePath: refFile, type: 'images', agent: 'main', taskId: 'task-attach',
+        slug: 'reference', op: 'import', tool: 'bakin_exec_images_import',
+        description: 'attachment', source: { kind: 'import', path: refFile }, tags: ['reference'],
+      })
+      const outFile = join(testDir, 'from-attachment.png')
+      writeFileSync(outFile, 'render')
+      const generate = mock(async () => ({
+        provider: 'openai', model: 'gpt-image-2',
+        images: [{ filePath: outFile, mimeType: 'image/png', width: 1024, height: 1024 }],
+        metadata: { servedBy: 'runtime' },
+      }))
+      const { ctx, created } = makeContext(
+        { runtime: { images: { providers: runtimeProvider(), generate } } } as never,
+        { absPath: refFile, mimeType: 'image/png', version: 1 },
+      )
+
+      const result = await generateImage(ctx, {
+        prompt: 'a horse like this', taskId: 'task-attach', provider: 'openai',
+        model: 'gpt-image-2', surface: 'instagram-feed-portrait',
+        referenceImages: [imported.assetId],
+      }, 'pixel')
+
+      expect(result.ok).toBe(true)
+      expect(created).toHaveLength(1)
     })
 
     it('rejects an edit whose reference equals the asset being edited, before billing', async () => {

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -56,6 +56,8 @@ mock.module('../../../src/lib/content-files', () => ({
 const completionsFake = new Map<string, { taskId: string; runId: string | null; agent: string; channel: string | null; completedAt: number }>()
 // Seedable per-task runs for the run-history route (the route maps these via runs-reader).
 let mockTaskRuns: Record<string, Array<Record<string, unknown>>> = {}
+// Seedable live runs for the tasks_get liveRun block.
+let mockLiveRuns: Record<string, { runId: string; agent: string; startedAt: number }> = {}
 const ledgerMock = () => ({
   recordCompletion: (taskId: string, input: { runId?: string; agent: string; channel?: string }) => {
     const existing = completionsFake.get(taskId)
@@ -65,7 +67,10 @@ const ledgerMock = () => ({
   },
   hasCompletion: (taskId: string) => completionsFake.has(taskId),
   deleteCompletion: (taskId: string) => completionsFake.delete(taskId),
-  getLiveRun: () => null,
+  getLiveRun: (taskId: string) => {
+    const run = mockLiveRuns[taskId]
+    return run ? { ...run, taskId, status: 'running' } : null
+  },
   bumpHeartbeatByTask: () => {},
   listRunsByTask: (taskId: string, limit = 50) => (mockTaskRuns[taskId] ?? []).slice(0, limit),
 })
@@ -149,6 +154,7 @@ afterAll(() => {
 beforeEach(() => {
   mock.clearAllMocks()
   mockTaskRuns = {}
+  mockLiveRuns = {}
   // bun:test's clearAllMocks only clears call history; reset implementations
   // so a previous test's mockRejectedValue doesn't leak into the next.
   for (const m of [
@@ -1077,9 +1083,57 @@ describe('bakin_exec_tasks_get', () => {
   })
 })
 
+describe('bakin_exec_tasks_get liveRun visibility', () => {
+  it('includes the live run while one is in flight, so duplicate sessions can self-detect', async () => {
+    mockGetTaskDetails.mockResolvedValue({ task: { id: 'd1b213a5', title: 'Cat image' }, column: 'inProgress' })
+    mockLiveRuns['d1b213a5'] = { runId: 'task:d1b213a5:d1', agent: 'pixel', startedAt: 1781063794175 }
+
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_get')!
+    const result = await callTool(tool, { taskId: 'd1b213a5' })
+
+    expect(result.ok).toBe(true)
+    expect(result.liveRun).toEqual({
+      runId: 'task:d1b213a5:d1',
+      agent: 'pixel',
+      startedAt: new Date(1781063794175).toISOString(),
+    })
+  })
+
+  it('returns liveRun null when no run is in flight', async () => {
+    mockGetTaskDetails.mockResolvedValue({ task: { id: 'abc', title: 'Done thing' }, column: 'done' })
+
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_get')!
+    const result = await callTool(tool, { taskId: 'abc' })
+
+    expect(result.ok).toBe(true)
+    expect(result.liveRun).toBeNull()
+  })
+})
+
 // ─── bakin_exec_tasks_create ───────────────────────────────────────────────
 
 describe('bakin_exec_tasks_create', () => {
+  it('tells the creator that dispatch notifies the assignee — no separate message needed', async () => {
+    mockCreateTaskWithEffects.mockResolvedValue({ id: 'new-t', workflowId: 'wf-1' })
+
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_create')!
+    const result = await callTool(tool, { title: 'New Task', assignee: 'pixel', workflowId: 'wf-1' }, 'main')
+
+    expect(result.ok).toBe(true)
+    expect(result.notice).toContain('dispatch will notify pixel')
+    expect(result.notice).toContain('do NOT send them a separate message')
+  })
+
+  it('omits the dispatch copy when nothing was dispatched', async () => {
+    mockCreateTaskWithEffects.mockResolvedValue({ id: 'new-t3', workflowId: 'wf-1' })
+
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_create')!
+    const result = await callTool(tool, { title: 'Unassigned Task', workflowId: 'wf-1' }, 'main')
+
+    expect(result.ok).toBe(true)
+    expect(result.notice ?? '').not.toContain('separate message')
+  })
+
   it('creates a task with workflow', async () => {
     mockCreateTaskWithEffects.mockResolvedValue({ id: 'new-t', workflowId: 'wf-1' })
 

--- a/tests/plugins/team/message-guard.test.ts
+++ b/tests/plugins/team/message-guard.test.ts
@@ -1,0 +1,139 @@
+/**
+ * bakin_exec_team_message duplicate-worker guard.
+ *
+ * Live-test incident (task d1b213a5): main created+dispatched a task, then
+ * team-messaged the assignee about it — the unthreaded message landed in the
+ * agent's main session, which did the whole job a second time (two billed
+ * generates). The guard hard-refuses a message that references a task the
+ * TARGET agent is already running, and audits the block.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-team-msg-guard-${Date.now()}`)
+
+// ES imports are hoisted above mock.module — set env so home guards do not trip.
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = testDir + '-openclaw'
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+mock.module('../../../src/core/watcher', () => ({
+  registerSyncHook: mock(),
+  registerUnlinkHook: mock(),
+}))
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+mock.module('../../../src/core/mcporter', () => ({
+  syncConfig: mock(() => []),
+}))
+
+// In-memory ledger fake — tests control which task has a live run.
+const liveRuns = new Map<string, { runId: string; agent: string; startedAt: number }>()
+mock.module('../../../src/core/execution-ledger', () => ({
+  getLiveRun: (taskId: string) => {
+    const run = liveRuns.get(taskId)
+    return run ? { runId: run.runId, taskId, agent: run.agent, startedAt: run.startedAt, status: 'running' } : null
+  },
+}))
+
+const sendMessageToAgent = mock(async () => ({ ok: true, reply: 'delivered' }))
+mock.module('../../../src/core/agents', () => ({ sendMessageToAgent }))
+
+const audits: Array<{ event: string; agent: string; data: Record<string, unknown> }> = []
+mock.module('../../../src/core/audit', () => ({
+  appendAudit: (_dir: string, event: string, agent: string, data: Record<string, unknown>) => {
+    audits.push({ event, agent, data })
+  },
+}))
+
+import { activatePlugin, findTool, callTool } from '../test-helpers'
+const teamPlugin = (await import('../../../plugins/team/index')).default as typeof import('../../../plugins/team/index').default
+import type { ActivatedPlugin } from '../test-helpers'
+
+let activated: ActivatedPlugin
+
+beforeAll(async () => {
+  mkdirSync(join(testDir, 'plugin-settings'), { recursive: true })
+  writeFileSync(join(testDir, 'plugin-settings', 'team.json'), JSON.stringify({ displaySettings: {}, teams: [] }))
+  activated = await activatePlugin(teamPlugin, testDir)
+})
+
+beforeEach(() => {
+  liveRuns.clear()
+  audits.length = 0
+  sendMessageToAgent.mockClear()
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('bakin_exec_team_message duplicate-worker guard', () => {
+  const tool = () => findTool(activated.execTools, 'bakin_exec_team_message')!
+
+  it('refuses a message referencing a task the target agent is already running, and audits', async () => {
+    liveRuns.set('d1b213a5', { runId: 'task:d1b213a5:d1', agent: 'pixel', startedAt: Date.now() - 40_000 })
+
+    const result = await callTool(tool(), {
+      agentId: 'pixel',
+      message: 'Task d1b213a5 is assigned to you: create the cat image and report back.',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/already working task d1b213a5/i)
+    expect(result.error).toMatch(/duplicate worker/i)
+    expect(sendMessageToAgent).not.toHaveBeenCalled()
+    expect(audits).toContainEqual(expect.objectContaining({
+      event: 'team.message_blocked',
+      data: expect.objectContaining({ agentId: 'pixel', taskId: 'd1b213a5', runId: 'task:d1b213a5:d1' }),
+    }))
+  })
+
+  it('delivers when the referenced live run belongs to a different agent', async () => {
+    liveRuns.set('d1b213a5', { runId: 'task:d1b213a5:d1', agent: 'pixel', startedAt: Date.now() })
+
+    const result = await callTool(tool(), {
+      agentId: 'rolo',
+      message: 'FYI pixel is on d1b213a5 — please prep the video for after.',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sendMessageToAgent).toHaveBeenCalledTimes(1)
+    expect(audits).toHaveLength(0)
+  })
+
+  it('delivers when the referenced task has no live run (settled/unknown)', async () => {
+    const result = await callTool(tool(), {
+      agentId: 'pixel',
+      message: 'Nice work on d1b213a5 — the client loved it.',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sendMessageToAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it('delivers a message with no task-shaped tokens untouched', async () => {
+    const result = await callTool(tool(), {
+      agentId: 'pixel',
+      message: 'Quick check-in: how is the style guide shaping up?',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sendMessageToAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/plugins/team/message-guard.test.ts
+++ b/tests/plugins/team/message-guard.test.ts
@@ -42,10 +42,15 @@ mock.module('../../../src/core/mcporter', () => ({
   syncConfig: mock(() => []),
 }))
 
-// In-memory ledger fake — tests control which task has a live run.
+// In-memory ledger fake — tests control which task has a live run, and can
+// simulate ledger unavailability (the guard must fail CLOSED).
+class FakeLedgerUnavailableError extends Error {}
 const liveRuns = new Map<string, { runId: string; agent: string; startedAt: number }>()
+let ledgerDown = false
 mock.module('../../../src/core/execution-ledger', () => ({
+  LedgerUnavailableError: FakeLedgerUnavailableError,
   getLiveRun: (taskId: string) => {
+    if (ledgerDown) throw new FakeLedgerUnavailableError('ledger op failed: getLiveRun')
     const run = liveRuns.get(taskId)
     return run ? { runId: run.runId, taskId, agent: run.agent, startedAt: run.startedAt, status: 'running' } : null
   },
@@ -75,6 +80,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   liveRuns.clear()
+  ledgerDown = false
   audits.length = 0
   sendMessageToAgent.mockClear()
 })
@@ -135,5 +141,45 @@ describe('bakin_exec_team_message duplicate-worker guard', () => {
 
     expect(result.ok).toBe(true)
     expect(sendMessageToAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails CLOSED with a structured refusal when the ledger is unavailable', async () => {
+    ledgerDown = true
+
+    const result = await callTool(tool(), {
+      agentId: 'pixel',
+      message: 'Heads up on d1b213a5 — please double-check the output.',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/cannot verify/i)
+    expect(result.error).toMatch(/duplicate worker/i)
+    expect(sendMessageToAgent).not.toHaveBeenCalled()
+  })
+
+  it('still delivers token-free messages while the ledger is unavailable', async () => {
+    ledgerDown = true
+
+    const result = await callTool(tool(), {
+      agentId: 'pixel',
+      message: 'No task talk here, just saying hi.',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sendMessageToAgent).toHaveBeenCalledTimes(1)
+  })
+
+  it('checks every distinct token, not just the first ten', async () => {
+    // 11 distinct hex tokens; the live-run task is the last one.
+    const decoys = Array.from({ length: 10 }, (_, i) => `aaaa000${i}`)
+    liveRuns.set('d1b213a5', { runId: 'task:d1b213a5:d1', agent: 'pixel', startedAt: Date.now() })
+
+    const result = await callTool(tool(), {
+      agentId: 'pixel',
+      message: `Context hashes: ${decoys.join(' ')} — and please start on d1b213a5 now.`,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(sendMessageToAgent).not.toHaveBeenCalled()
   })
 })

--- a/tests/scripts/post-channel.test.ts
+++ b/tests/scripts/post-channel.test.ts
@@ -305,6 +305,23 @@ describe('postChannel', () => {
     expect(deliverContent).toHaveBeenCalledTimes(1)
   })
 
+  it('an IDENTICAL retry of a successful asset post is deduped, not refused', async () => {
+    // The mcporter-timeout contract: the caller never saw the success and
+    // retries verbatim — that must return the cached result, not a refusal
+    // whose error text invites repost=true (and a real double-send).
+    const params = {
+      channel: 'general', content: 'final render attached', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }
+    const first = await postChannel(params, runtime)
+    const second = await postChannel(params, runtime)
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(true)
+    expect(second.deduped).toBe(true)
+    expect(deliverContent).toHaveBeenCalledTimes(1)
+  })
+
   it('repost=true deliberately sends a second copy', async () => {
     await postChannel({
       channel: 'general', content: 'first', agent: 'main',

--- a/tests/scripts/post-channel.test.ts
+++ b/tests/scripts/post-channel.test.ts
@@ -35,6 +35,15 @@ const settingsMock = {
 mock.module('@/core/settings', () => settingsMock)
 mock.module('../../src/core/settings', () => settingsMock)
 
+// In-memory durable delivery ledger (asset-level once-per-channel dedupe).
+const idempotencyRows = new Map<string, { result: unknown }>()
+const ledgerMock = {
+  getIdempotent: (key: string) => idempotencyRows.get(key) ?? null,
+  putIdempotent: (key: string, _kind: string, result: unknown) => { idempotencyRows.set(key, { result }) },
+}
+mock.module('@/core/execution-ledger', () => ledgerMock)
+mock.module('../../src/core/execution-ledger', () => ledgerMock)
+
 let mockWorkflowAuthorizationError: Error | null = null
 const mockAssertWorkflowToolAllowed = mock(async (..._args: unknown[]) => {
   if (mockWorkflowAuthorizationError) throw mockWorkflowAuthorizationError
@@ -67,6 +76,7 @@ describe('postChannel', () => {
     mockNotificationTarget = ''
     mockChannelAliases = { general: 'discord:channel-123', 'testing-ground': 'discord:test-channel' }
     mockContentDir = tmpdir()
+    idempotencyRows.clear()
     resetPostChannelIdempotencyForTests()
   })
 
@@ -274,6 +284,79 @@ describe('postChannel', () => {
     expect(first.ok).toBe(true)
     expect(second.ok).toBe(true)
     expect(deliverContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses re-delivering the same asset to the same channel for the same task — even with a new caption', async () => {
+    // The live-test double-post: main posted the deliverable from its monitor
+    // loop, then again as the completion reply. Different captions, same asset.
+    const first = await postChannel({
+      channel: 'general', content: "Pixel's corrected side-view version:", agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+    const second = await postChannel({
+      channel: 'general', content: 'One more option for #testing-ground: full side-view rear.', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(false)
+    expect(second.error).toMatch(/already delivered/i)
+    expect(second.error).toContain('repost=true')
+    expect(deliverContent).toHaveBeenCalledTimes(1)
+  })
+
+  it('repost=true deliberately sends a second copy', async () => {
+    await postChannel({
+      channel: 'general', content: 'first', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+    const second = await postChannel({
+      channel: 'general', content: 'again, on request', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5', repost: true,
+    }, runtime)
+
+    expect(second.ok).toBe(true)
+    expect(deliverContent).toHaveBeenCalledTimes(2)
+  })
+
+  it('the same asset may go to a DIFFERENT channel without repost', async () => {
+    await postChannel({
+      channel: 'general', content: 'to general', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+    const second = await postChannel({
+      channel: 'testing-ground', content: 'to testing', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+
+    expect(second.ok).toBe(true)
+    expect(deliverContent).toHaveBeenCalledTimes(2)
+  })
+
+  it('text-only posts are never asset-deduped', async () => {
+    const first = await postChannel({ channel: 'general', content: 'status one', agent: 'main', taskId: 'task-horse' }, runtime)
+    const second = await postChannel({ channel: 'general', content: 'status two', agent: 'main', taskId: 'task-horse' }, runtime)
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(true)
+    expect(deliverContent).toHaveBeenCalledTimes(2)
+  })
+
+  it('a failed delivery does not burn the once-per-channel slot', async () => {
+    deliverContent.mockRejectedValueOnce(new Error('channel offline'))
+
+    const first = await postChannel({
+      channel: 'general', content: 'attempt', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+    const second = await postChannel({
+      channel: 'general', content: 'retry after outage', agent: 'main',
+      taskId: 'task-horse', imageAssetId: '20260610-horse-947652b5',
+    }, runtime)
+
+    expect(first.ok).toBe(false)
+    expect(second.ok).toBe(true)
+    expect(deliverContent).toHaveBeenCalledTimes(2)
   })
 
   it('returns a failed exec result when workflow policy denies posting', async () => {


### PR DESCRIPTION
Closes #418, #379, #380.

Three tightly-coupled image-asset tickets plus a post-live-test hardening pass, dependency-ordered commits (each an independent rollback point). Specs + plans in `.claude/specs/image-references-and-shim-parity{,.plan}.md` and `.claude/specs/post-480-hardening{,.plan}.md`.

## Part 1 — original scope (#380 #379 #418)

### #380 — single source of truth for image format/credential tables
`packages/core/src/media/image-format.ts` (pure, client-safe subpath) owns the canonical image `mime ↔ ext` map and provider→env-var table; shim, images plugin, and assets rows consume it. Fixes the latent `image/gif → .jpg` mistyping.

### #379 — shim guardrail + truthful quality
The shim carries the full generation option surface and **throws before the billed call** on anything it can't honor. OpenClaw has no quality flag (verified against the open-source CLI), so `quality` is recorded only on the shim path; native-quality reuse matches accordingly.

### #418 — reference/context images
`referenceImages` (managed assetIds and/or local paths, max 4) on generate + edit. Native `infer image generate` has no `--file`, so reference-bearing generates route through the edit-style invocation. Native-only, capability-gated on the curated `reference-images` flag, lineage recorded in `generation.references` + rendered as a clickable References row, folded into the idempotency key. `bakin_exec_assets_list` gains a `tags` filter.

## Part 2 — post-live-test hardening

The first live test (task `d1b213a5`, 2026-06-10) succeeded but exposed three failure classes; full forensic triage in the spec. Fixes:

- **`fix(media)`** — the #379 guardrail was unreachable in production: the shim fallback never forwarded `count/aspectRatio/resolution/background/outputFormat`. Now forwarded; `size` carried + rejected too. Every rejection asserted pre-billing.
- **`fix(images)`** — review hygiene: edit-base-as-reference rejected, reference gate widened to `servedBy !== 'runtime'` (unconfigured providers get the clear pre-flight error), fingerprint-drift edge documented, untested reference branches covered.
- **`feat(images)`** — `referenceImages` accepts the runtime's `media://` attachment URIs (the live test burned ~70s rediscovering a Discord attachment's local path). Optional `media.resolveUri` on the adapter concept; scheme knowledge stays adapter-private; traversal-guarded; resolved references auto-import as task-linked assets.
- **`feat(team)`** — **duplicate-worker guard.** Root cause of the live test's double-billing: main created+dispatched a task, then team-messaged the assignee about it; the unthreaded message spawned a parallel worker in the agent's main session (two billed generates, two assets — every existing guard sits downstream of that fork). `team_message` now hard-refuses messages naming a task the target agent has a live ledger run for, with audit event `team.message_blocked`.
- **`feat(tasks)`** — `tasks_get` returns `liveRun { runId, agent, startedAt }` so duplicate sessions/humans can see a task is owned; `tasks_create` tells the creator dispatch already notified the assignee.
- **`feat(core)`** — `task.completion_suppressed` / `task.dispatch_failure_ignored` render human explanations in Live Activity instead of raw event names.
- **`docs(agents)`** — referenceImages taught in every guidance surface (managed blocks, bakin skill, generate-image workflow skill) — the live test had **zero** adoption because only the raw tool schema mentioned it; orchestrator rules now mandate attachment-import at task creation and forbid messaging assignees of dispatched tasks.

Companion content PR: markhayden/bakin-bits-official#66 (pixel's imitate-vs-revise policy + bounded style guide).

## Safety invariants
- Every failure mode throws **before** any billed provider call — each with a test asserting no exec/fetch fired.
- No search-schema change; audit additions are additive data fields; manifest changes optional/parse-time.
- Coordination facts only in the ledger; `media://` semantics never leave the adapter.

## Tests
Full suite **4833 pass / 0 fail** (467 files). New coverage: shim option forwarding (per-option, pre-billing), media:// resolution (happy/missing/unsupported/traversal), duplicate-worker guard (4 acceptance cases), liveRun visibility, create-notice, humanized event copy, reference edge cases.

## Not done (intentional)
- Full binary build skipped (CI owns it).
- References UI render typed/built but not visually verified against a real OpenClaw.
- Live-run guard matches explicit task-id tokens only — no fuzzy intent detection by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Part 3 — round-2 fixes (second live test, task `6abc2131`)

The guard + guidance from Part 2 held (single dispatch, references used, autonomous QA loop). Three remaining classes, fixed:

- **`feat(images)`** — auto-imported references are tagged `reference` (filterable); **iteration lands as a version, not a sibling asset**: `versionOf` on generate appends a re-roll as a new version (op `generate`, idempotency-aware, pre-billing validation), and a generate referencing the agent's own same-task generated output without it is refused with a teaching error (`allowNewAsset=true` = explicit companion-image escape hatch; imported same-task references never trip it).
- **`feat(channels)`** — **an asset is delivered to a channel once per task**: durable ledger rows make `post_channel` refuse caption-different re-deliveries (the double-post incident); `repost=true` is the explicit escape hatch; failed deliveries never burn the slot.
- **`docs(agents)`** — orchestrator delivery discipline (deliverables via `post_channel` with `imageAssetId`+`taskId`, exactly once, never native channel pastes, monitoring ≠ posting trigger) + iterate-as-version across every guidance surface.

Full suite **4858 pass / 0 fail**. Companion bits PR updated: markhayden/bakin-bits-official#66.


## Part 4 — round-3 fixes (penguin-screenshot test, task `627ee59e`)

Versioning held (deliverable got v1→v2 via edit); two **identity leaks** still minted duplicate assets. Both closed deterministically in `feat(assets)`:

- **Store-path reflection** — a reference passed as a file path *into* the asset store (`…/store/<id>/v1.png` instead of the assetId) no longer clones: `resolveStoreFile()` maps store-internal paths (incl. thumbs → real version file) back to `assetId@version`; `upsertFromSource` returns that identity and `resolveReferences` records proper lineage.
- **Same-task content dedupe** — re-saving the finished render from a fresh workspace path (`assets_save` after copying to `workspace/tmp/`) returns the existing asset/version instead of minting (size + sha256 match against the same task's same-type versions; deliberately task-scoped).
- **`docs(agents)`** — the OUTPUT DISCIPLINE rule that *caused* the re-save now carves out the exception: image tool results are already managed assets; report the assetId, never copy-and-resave; references by assetId, never file paths.

Full suite **4863 pass / 0 fail**. Companion bits PR updated.
