### PR TITLE
feat(tasks): reflect real task outcome (not just dispatch outcome) in run history

### DIFF
--- a/.claude/knowledge/execution-ledger.md
+++ b/.claude/knowledge/execution-ledger.md
@@ -72,7 +72,7 @@ exactly preserving legacy threadId semantics.
 | Boot | `server.ts` before restart recovery | `markPriorBootRunsLost(bootId)` |
 | Money ops | `plugins/images` `runBilledImageCall` | `getIdempotent`, `putIdempotent` |
 | Edit safety | `plugins/tasks` `taskEditGuard` | `hasCompletion` |
-| Run history (read-only) | `plugins/tasks` task drawer via `GET /:taskId/runs` (per-task attempts + task outcome: `readTaskOutcome` joins the completions row with the task column — completion wins, else blocked/archived/done(legacy)/in_progress, #476); `plugins/schedule` job drawer (per-schedule fires) | `listRunsByTask`, `getCompletion`, `listCronFires` |
+| Run history (read-only) | `plugins/tasks` task drawer via `GET /:taskId/runs` (per-task attempts + task outcome: `readTaskOutcome` joins the completions row with the task column — completion wins, else blocked/archived/done(legacy)/in_progress; the column fallback is gated on dispatch history so unknown ids never trigger the task store's shard walk, #476); `plugins/schedule` job drawer (per-schedule fires) | `listRunsByTask`, `getCompletion`, `listCronFires` |
 | Cleanup | `task-store.deleteTask` (advisory) | `purgeTaskRows` (cron_fires kept — they dedupe the job, not the task) |
 
 ## Semantics

--- a/.claude/knowledge/execution-ledger.md
+++ b/.claude/knowledge/execution-ledger.md
@@ -72,7 +72,7 @@ exactly preserving legacy threadId semantics.
 | Boot | `server.ts` before restart recovery | `markPriorBootRunsLost(bootId)` |
 | Money ops | `plugins/images` `runBilledImageCall` | `getIdempotent`, `putIdempotent` |
 | Edit safety | `plugins/tasks` `taskEditGuard` | `hasCompletion` |
-| Run history (read-only) | `plugins/tasks` task drawer via `GET /:taskId/runs` (per-task attempts); `plugins/schedule` job drawer (per-schedule fires) | `listRunsByTask`, `listCronFires` |
+| Run history (read-only) | `plugins/tasks` task drawer via `GET /:taskId/runs` (per-task attempts + task outcome: `readTaskOutcome` joins the completions row with the task column — completion wins, else blocked/archived/done(legacy)/in_progress, #476); `plugins/schedule` job drawer (per-schedule fires) | `listRunsByTask`, `getCompletion`, `listCronFires` |
 | Cleanup | `task-store.deleteTask` (advisory) | `purgeTaskRows` (cron_fires kept — they dedupe the job, not the task) |
 
 ## Semantics

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,153 +1,152 @@
-# SPEC — Schedule: blocked tasks must not suppress real fires
+# SPEC — Tasks: reflect real task outcome in Run History
 
-> Status: draft for approval · Owner: Mark · Date: 2026-06-08
+> Status: draft for approval · Owner: Mark · Date: 2026-06-09
+> Issue: [#476](https://github.com/markhayden/bakin/issues/476) · Follow-on to #463 / PR #475
 
 ## 1. Objective
 
-A stalled `blocked` task currently behaves as if a run is still "in flight," which
-silently suppresses a job's next genuine scheduled fire. Fix the scheduler so a
-`blocked` last-task is treated as *needs human triage*, not *currently running*:
-the next real fire proceeds, the job's health (auto-pause) is not falsely
-penalized by triage blocks, and catch-up tasks are labeled with the date they
-were *supposed* to run.
+The Run History timeline in the task drawer shows each run's dispatch status from
+the ledger `runs` table. `settled` means *the agent's turn ended cleanly*, not
+that the task succeeded — so a green `settled` badge on a task that later
+blocked or stalled reads as a false success.
 
-Target environment: single-user, self-hosted Bakin on a Mac mini. No
-backwards-compat or shims. Priority: reduce tech debt; keep it clean and clear.
+Fix: surface the task's terminal outcome (from the completion ledger + task
+column) alongside the dispatch history, and stop using green for `settled`.
 
-## 2. Background — confirmed root cause
+Target environment: single-user, self-hosted Bakin. No backwards-compat or
+shims — the API response shape may change freely. Priority: reduce tech debt;
+keep it clean and clear.
 
-Triage on the production machine established the chain (not a timezone bug, not a
-failing default):
+### Acceptance criteria (from the issue)
 
-1. Schedule **cutover** ran, then startup **catch-up** created the previous
-   period's missed fires directly in `blocked` (`blockedReason: "missed schedule
-   window"`). These tasks **never dispatch** (empty log, no execution).
-2. **Cascade (the real bug):** at the real fire time, the live scheduler skipped
-   the fire as `overlap` because the `blocked` task still existed — so the genuine
-   run was silently suppressed until the user hand-moved the task to `todo`.
-3. **Cosmetic:** catch-up task titles used `new Date()` (today) instead of the
-   occurrence date, so a stale prior-day run masqueraded as "today's" run.
+1. Run history visibly distinguishes "the agent's turn settled" from "the task
+   succeeded / failed / blocked".
+2. Read-only; reuses the completion ledger + task column. No new audit query
+   surface, no new write verbs, no schema changes.
+3. A `settled` run on a task that's still in progress no longer reads as a
+   success.
 
-Relevant code, all in `plugins/schedule/index.ts`:
-- Overlap guard: `runClaimedFire` lines **404–413** — `activeColumns` includes `'blocked'`.
-- Failure tracking: lines **416–428** — any `blocked` last-task calls `recordFailure()`.
-- Title/date: line **433** — `const now = new Date()` used for `templateVars.date`.
-- Fire callback: line **558** — receives the occurrence as `_occurrence` and **discards it**, so `runClaimedFire` never gets the occurrence.
+## 2. Design decisions (interview-resolved)
 
-## 3. Scope
+| Decision | Resolution |
+|---|---|
+| Scope | Tasks plugin only. The schedule plugin's `cronFireToEntry` surface is out of scope (follow-up issue if ever needed). |
+| Data shape | Sibling object: `GET /api/plugins/tasks/:taskId/runs` returns `{ runs, outcome }`. Outcome is task-level state — it is **not** stamped onto run entries. |
+| Derivation location | Server-side, in `plugins/tasks/lib/runs-reader.ts` (`readTaskOutcome`). One tested place owns the semantics; UI stays a dumb renderer. |
+| Outcome semantics | Completion row wins: completion exists → `done` (even if since archived). Else by column: `blocked` → `blocked`, `archived` → `archived` (abandoned), `done` → `done` (legacy task with no row), anything else → `in_progress`. |
+| UI shape | Outcome badge on the Run History **header** line. Per-run `settled` badge recolored green → neutral blue; green becomes exclusively "task done". `lost` stays red, `running` amber, `superseded` zinc. Outcome colors: done → green, blocked → red, in_progress → amber, archived → zinc. |
+| Empty state | Unchanged: component renders nothing when a task has zero runs (no outcome badge either). |
 
-**In scope**
-- Overlap guard no longer treats `blocked` as active.
-- Failure/auto-pause tracking ignores *triage* blocks; still counts *dispatch-failure* blocks.
-- Catch-up task title/date derived from the **occurrence**, not creation time.
-- Tests + knowledge-doc update.
+### Outcome derivation (normative)
 
-**Out of scope (non-goals)**
-- The cutover/migration path itself (one-time, already resolved).
-- Whether catch-up creates a `blocked` triage task at all (the catch-up *window*
-  policy stays as-is — it remains the legitimate "here's a stale run, triage it"
-  signal).
-- Auto-cleanup/auto-archive of stale blocked triage tasks.
-- Any change to dispatch-side block paths (`src/core/dispatch.ts`).
+```
+getCompletion(taskId) row exists ──→ done (completedAt, agent from row)
+else column = blocked            ──→ blocked
+else column = archived           ──→ archived   (never completed)
+else column = done               ──→ done       (legacy; no completedAt/agent)
+else                             ──→ in_progress
+```
 
-## 4. Functional requirements & acceptance criteria
+Unknown task (no board entry, no completion): `outcome` is omitted — the route
+already returns an empty runs list for unknown tasks and must not start
+erroring.
 
-### FR1 — Overlap guard excludes `blocked`
-`activeColumns` becomes `['todo', 'inProgress', 'review']`.
+### Types
 
-- **AC1.1** Last task in `blocked` → the next fire is **created/dispatched** (not skipped as `overlap`).
-- **AC1.2** Last task in `inProgress`, `review`, or `todo` → fire is still skipped as `overlap` (unchanged).
-- **AC1.3** `allowOverlap: true` continues to bypass the guard entirely (unchanged).
+```ts
+/** Task-level terminal outcome, derived from completion ledger + column. */
+export interface TaskOutcome {
+  state: 'done' | 'blocked' | 'archived' | 'in_progress'
+  /** Set when state === 'done' and a completion row exists. */
+  completedAt?: string // ISO
+  /** Agent that recorded the completion, when known. */
+  agent?: string
+}
+```
 
-### FR2 — Triage blocks are not failures
-The literal `'missed schedule window'` is extracted to an exported constant
-(e.g. `MISSED_WINDOW_REASON`) owned by the schedule plugin and reused at the
-creation site. The outcome check (416–428) classifies the `blocked` last-task by
-`blockedReason`:
+Declared in `plugins/tasks/types.ts`, mirrored in
+`src/hooks/use-task-run-history.ts` (existing keep-in-sync pattern for
+`TaskRunEntry`). The hook returns `{ runs, outcome, loading }`.
 
-- **AC2.1** Last task blocked with reason === `MISSED_WINDOW_REASON` → **no**
-  `recordFailure`, no auto-pause contribution (it's a notification).
-- **AC2.2** Last task blocked with any other reason (dispatch failures:
-  `"Agent run ended before reporting completion…"`, `"Dispatch failed N times…"`)
-  → `recordFailure` as today (can auto-pause after `maxFailures`).
-- **AC2.3** Last task in `done`/`archived` → `recordSuccess` (unchanged).
-- **AC2.4** Discrimination is by an owned constant compared against the task's
-  `blockedReason`, **not** brittle substring matching of external error text.
+## 3. Touched files (project structure)
 
-### FR3 — Catch-up tasks labeled by occurrence date
-Thread the occurrence through the fire callback into `runClaimedFire`; use it for
-`templateVars.date` and the default title. Manual fires (no occurrence) fall back
-to their existing `firedAt`/now.
+| File | Change |
+|---|---|
+| `plugins/tasks/lib/runs-reader.ts` | Add `readTaskOutcome(taskId): TaskOutcome \| undefined` using `getCompletion` (from `src/core/execution-ledger`, already exported) + `getTaskWithColumn` (from `src/core/task-store`). |
+| `plugins/tasks/types.ts` | Add `TaskOutcome`. |
+| `plugins/tasks/index.ts` | `/:taskId/runs` handler returns `{ runs, outcome }`. |
+| `src/hooks/use-task-run-history.ts` | Mirror `TaskOutcome`; expose `outcome` from the hook. |
+| `plugins/tasks/components/task-run-history.tsx` | Header outcome badge; recolor `settled` to blue. |
+| `tests/plugins/tasks/*` | Coverage for derivation + route shape (see §5). |
+| `.claude/knowledge/execution-ledger.md` | Update the read-only consumers table (run-history row) to note the outcome join on `completions`. |
 
-- **AC3.1** A catch-up task for an occurrence on day *D* has a title/`date` of *D*,
-  not the (later) creation day.
-- **AC3.2** A normal on-time fire is unchanged (occurrence ≈ now).
-- **AC3.3** `runClaimedFire` no longer reads wall-clock `new Date()` for the label;
-  the occurrence (or explicit manual `firedAt`) is the single source.
+No new source files except possibly a dedicated test file. No `packages/core`
+changes (`getCompletion` already exists). No README impact (verified — no
+run-history mention). No SDK/vendor/build changes.
 
-### FR4 — End-to-end regression (the cascade)
-- **AC4.1** Given a `blocked` triage task as the job's last task, when the next
-  occurrence fires, a new task is created and dispatched, and the job's
-  `consecutiveFailures` is unchanged (not incremented).
+## 4. Commands & code style
 
-## 5. Implementation approach
+- Dev: `bun run dev` (plugin HMR covers the component; server-side changes to
+  `runs-reader.ts`/`index.ts` need a manual server restart).
+- Full suite: `bun run test`. Single file: `bun test tests/plugins/tasks/<f>.test.ts --isolate`.
+- Conventions per CLAUDE.md: strict TS (no `any` across boundaries), Zod at
+  API boundaries, `const` over `let`, kebab-case files, import order
+  (builtins → external → SDK → `@/*` → relative).
+- Commits: conventional with scope (see §6).
 
-Behavior change is confined to `plugins/schedule/index.ts` plus the fire callback
-passing the occurrence. The `SchedulerDeps.fire` signature already carries
-`occurrence`, so only the callback body and `runClaimedFire` signature change.
+## 5. Testing strategy
 
-1. Export `MISSED_WINDOW_REASON = 'missed schedule window'`; use it at line 561
-   and in the outcome check.
-2. `runClaimedFire(meta, jobId, runId, opts)` gains an `occurrence?: Date` (or a
-   `firedAtMs`) input; `templateVars.date`/title derive from it; default to now
-   for manual fires.
-3. Fire callback (≈558) passes the real `occurrence` instead of `_occurrence`.
-4. Overlap `activeColumns` → drop `'blocked'`.
-5. Outcome check → skip `recordFailure` when `blockedReason === MISSED_WINDOW_REASON`.
+Per CLAUDE.md testing rules: mock **both** content-dir resolvers, OpenClaw
+home, logger, watcher; temp dirs + `afterAll` cleanup; `closeDb()` before
+`rmSync` if the real ledger is exercised; use `tests/plugins/test-helpers.ts`
+for route tests.
 
-Keep functions pure where practical; no new dependencies.
+Unit — `readTaskOutcome` derivation (table-driven over the normative rules):
+1. Completion row exists, column done → `done` with `completedAt` + `agent`.
+2. Completion row exists, column archived → `done` (completion wins).
+3. No completion, column blocked → `blocked`.
+4. No completion, column archived → `archived`.
+5. No completion, column done (legacy) → `done`, no `completedAt`.
+6. No completion, column inProgress/todo/backlog/review → `in_progress`.
+7. Unknown task → `undefined`.
 
-## 6. Code style
-Per `CLAUDE.md`: TypeScript strict, no `any` across boundaries, `const` over
-`let`, `UPPER_SNAKE_CASE` for the new constant, existing import order, conventional
-commits with `fix(schedule):` / `refactor(schedule):` scopes.
+Route — `GET /:taskId/runs` returns `{ runs, outcome }`; unknown task returns
+`{ runs: [] }` without error.
 
-## 7. Commands
-- Test (file): `bun test tests/plugins/schedule/<file>.test.ts --isolate`
-- Full suite: `bun run test`
-- `bun run typecheck` · `bun run lint`
-- Manual: `bun run dev:mock`
+Existing tests in `tests/plugins/tasks/routes.test.ts` asserting the runs
+response must keep passing (updated only if they pin the exact response keys).
 
-## 8. Testing strategy
-TDD (Prove-It): write failing tests first. Use `tests/plugins/schedule/` with the
-isolated mock context helpers (`activatePlugin`, `callRoute`) and the mandatory
-content-dir / OpenClaw-home mocks (per `CLAUDE.md` testing rules).
+## 6. Commit strategy (rollback checkpoints)
 
-- **overlap**: blocked last-task → fire proceeds (AC1.1); inProgress/review/todo → skipped (AC1.2); allowOverlap bypass (AC1.3).
-- **failure tracking**: triage block → no recordFailure (AC2.1); dispatch-failure block → recordFailure (AC2.2); done → recordSuccess (AC2.3).
-- **date label**: catch-up task titled by occurrence date (AC3.1); on-time unchanged (AC3.2).
-- **regression**: cascade scenario end-to-end (AC4.1).
+Branch: `feat/task-outcome-run-history`. Each commit builds + tests green —
+natural rollback points:
 
-Run: `bun test tests/plugins/schedule/ --isolate`, then full `bun run test`.
+1. `feat(tasks): add readTaskOutcome derivation over completions + column`
+   — runs-reader + types + unit tests. Pure addition; nothing consumes it yet.
+2. `feat(tasks): return task outcome from the runs route`
+   — route + route tests + hook mirror. API now serves `{ runs, outcome }`;
+   UI unchanged and tolerant of the extra key.
+3. `feat(tasks): show task outcome in run history header, demote settled to blue`
+   — component change, the user-visible payoff.
+4. `docs(ledger): note run-history outcome join in execution-ledger knowledge`
+   — knowledge doc update (can fold into 2 if trivial).
 
-## 9. Boundaries
-- **Always:** mock both content-dir resolvers + OpenClaw home in tests; keep the
-  fix confined to `plugins/schedule/`; update `.claude/knowledge/bakin-owned-scheduler.md`.
-- **Ask first:** any change that would alter `src/core/dispatch.ts` block paths,
-  the catch-up window policy, or task-store semantics.
-- **Never:** classify blocks by external error-message text; write to real
-  `~/.bakin`/`~/.openclaw` from tests; add backwards-compat shims.
+Reverting 3 leaves a useful API; reverting 2–3 leaves a harmless helper.
 
-## 10. Commit checkpoints (carried into /plan)
-1. `refactor(schedule): extract MISSED_WINDOW_REASON constant` (no behavior change).
-2. `fix(schedule): exclude blocked from overlap guard` + tests (FR1).
-3. `fix(schedule): don't count triage blocks toward auto-pause` + tests (FR2).
-4. `fix(schedule): label catch-up tasks by occurrence date` + tests (FR3, FR4).
-5. `docs(schedule): update bakin-owned-scheduler knowledge for blocked semantics`.
+## 7. Boundaries
 
-Each checkpoint is independently revertable.
+**Always:**
+- Read-only against the ledger — only `getCompletion`; never write verbs.
+- Respect the adapter boundary: everything stays in `plugins/tasks` +
+  existing `src/core` facades.
+- Outcome derivation stays server-side in one function.
 
-## 11. Docs impacted
-- `.claude/knowledge/bakin-owned-scheduler.md` — overlap ignores `blocked`, triage
-  blocks don't penalize health, catch-up labels by occurrence.
-- `README.md` / `CLAUDE.md` — not expected to change (verify during build).
+**Ask first:**
+- Any change to ledger schema or verbs (should be unnecessary).
+- Any change to the schedule plugin (out of scope).
+
+**Never:**
+- Backwards-compat shims for the old response shape (single-user machine).
+- New audit-log queries for outcome (issue explicitly excludes this).
+- Per-run outcome stamping.
+- Fabricating outcome states beyond the four derived ones.

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -30,7 +30,7 @@ export { useRunHistory } from '@/hooks/use-schedule'
 export type { ScheduleJob, RunEntry } from '@/hooks/use-schedule'
 /** Fetch dispatch run history for a task. */
 export { useTaskRunHistory } from '@/hooks/use-task-run-history'
-export type { TaskRunEntry } from '@/hooks/use-task-run-history'
+export type { TaskOutcome, TaskRunEntry } from '@/hooks/use-task-run-history'
 /** Hybrid full-text + semantic search across plugins with facet filtering. */
 export { useSearch } from '@/hooks/use-search'
 /** Re-rank a local list to match the order returned by a search query. */

--- a/plugins/tasks/components/task-run-history.tsx
+++ b/plugins/tasks/components/task-run-history.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { useTaskRunHistory, type TaskRunEntry } from "@makinbakin/sdk/hooks"
+import { useTaskRunHistory, type TaskOutcome, type TaskRunEntry } from "@makinbakin/sdk/hooks"
 import { Badge, Separator } from "@makinbakin/sdk/ui"
 import { ChevronRight } from 'lucide-react'
 
@@ -26,11 +26,27 @@ function formatDuration(ms?: number): string | null {
   return `${Math.floor(s / 60)}m ${s % 60}s`
 }
 
+// `settled` is blue, not green — a settled turn is not a succeeded task (#476);
+// green is reserved for the task-done outcome badge.
 const STATUS_CLASS: Record<TaskRunEntry['status'], string> = {
-  settled: 'bg-green-500/10 text-green-400 border-green-500/20',
+  settled: 'bg-blue-500/10 text-blue-400 border-blue-500/20',
   superseded: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
   lost: 'bg-red-500/10 text-red-400 border-red-500/20',
   running: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+}
+
+const OUTCOME_CLASS: Record<TaskOutcome['state'], string> = {
+  done: 'bg-green-500/10 text-green-400 border-green-500/20',
+  blocked: 'bg-red-500/10 text-red-400 border-red-500/20',
+  in_progress: 'bg-amber-500/10 text-amber-400 border-amber-500/20',
+  archived: 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20',
+}
+
+const OUTCOME_LABEL: Record<TaskOutcome['state'], string> = {
+  done: 'done',
+  blocked: 'blocked',
+  in_progress: 'in progress',
+  archived: 'archived',
 }
 
 /**
@@ -40,7 +56,7 @@ const STATUS_CLASS: Record<TaskRunEntry['status'], string> = {
  * task has no runs.
  */
 export function TaskRunHistory({ taskId }: { taskId: string }) {
-  const { runs, loading } = useTaskRunHistory(taskId)
+  const { runs, outcome, loading } = useTaskRunHistory(taskId)
   const [open, setOpen] = useState(true)
 
   if (loading || runs.length === 0) return null
@@ -59,6 +75,14 @@ export function TaskRunHistory({ taskId }: { taskId: string }) {
         >
           <h3 className="text-[11px] text-muted-foreground uppercase tracking-wider">Run History</h3>
           <span className="text-[11px] text-muted-foreground/70">{summary}</span>
+          {outcome && (
+            <>
+              <Badge variant="outline" className={OUTCOME_CLASS[outcome.state]}>{OUTCOME_LABEL[outcome.state]}</Badge>
+              {outcome.completedAt && (
+                <span className="text-[11px] text-muted-foreground/70">{relativeTime(outcome.completedAt)}</span>
+              )}
+            </>
+          )}
           <ChevronRight className={`size-3 text-muted-foreground ml-auto transition-transform ${open ? 'rotate-90' : ''}`} />
         </button>
         {open && (

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -321,10 +321,10 @@ const routes = [
     responses: { 200: z.object({}).passthrough() },
     handler: async (_req, _ctx, { params, query }) => {
       // Unknown task → empty list, never an error (a not-yet-dispatched task has no runs).
-      return Response.json({
-        runs: readTaskRuns(params.taskId, query.limit ?? 50),
-        outcome: readTaskOutcome(params.taskId),
-      })
+      // Column fallback is gated on dispatch history so unknown ids can't trigger
+      // the task store's full shard walk on every request.
+      const runs = readTaskRuns(params.taskId, query.limit ?? 50)
+      return Response.json({ runs, outcome: readTaskOutcome(params.taskId, runs.length > 0) })
     },
   }),
 

--- a/plugins/tasks/index.ts
+++ b/plugins/tasks/index.ts
@@ -27,7 +27,7 @@ import {
 } from '../../src/core/task-service'
 import { createLogger } from '../../src/core/logger'
 import { hasCompletion } from '../../src/core/execution-ledger'
-import { readTaskRuns } from './lib/runs-reader'
+import { readTaskOutcome, readTaskRuns } from './lib/runs-reader'
 import { getContentDir } from '../../packages/core/src/content-dir'
 import {
   checkSessionDeathIncidents,
@@ -321,7 +321,10 @@ const routes = [
     responses: { 200: z.object({}).passthrough() },
     handler: async (_req, _ctx, { params, query }) => {
       // Unknown task → empty list, never an error (a not-yet-dispatched task has no runs).
-      return Response.json({ runs: readTaskRuns(params.taskId, query.limit ?? 50) })
+      return Response.json({
+        runs: readTaskRuns(params.taskId, query.limit ?? 50),
+        outcome: readTaskOutcome(params.taskId),
+      })
     },
   }),
 

--- a/plugins/tasks/lib/runs-reader.ts
+++ b/plugins/tasks/lib/runs-reader.ts
@@ -17,8 +17,13 @@ export function readTaskRuns(taskId: string, limit = 50): TaskRunEntry[] {
  * A completions row wins (it always implies the board reached done — archiving
  * a done task keeps it); otherwise the current column decides. Unknown task →
  * undefined.
+ *
+ * The completion check is a cheap indexed lookup and always runs. The column
+ * fallback hits the task store, where an unknown id falls through to an
+ * uncached full shard walk — callers that can't vouch for the task (e.g. the
+ * runs route with zero dispatch history) pass columnFallback=false to skip it.
  */
-export function readTaskOutcome(taskId: string): TaskOutcome | undefined {
+export function readTaskOutcome(taskId: string, columnFallback = true): TaskOutcome | undefined {
   const completion = getCompletion(taskId)
   if (completion) {
     return {
@@ -27,6 +32,7 @@ export function readTaskOutcome(taskId: string): TaskOutcome | undefined {
       agent: completion.agent,
     }
   }
+  if (!columnFallback) return undefined
   const entry = getTaskWithColumn(taskId)
   if (!entry) return undefined
   switch (entry.column) {

--- a/plugins/tasks/lib/runs-reader.ts
+++ b/plugins/tasks/lib/runs-reader.ts
@@ -3,12 +3,42 @@
  * and maps it to the UI-facing TaskRunEntry. Read-only; mirrors the schedule
  * plugin's runs-reader pattern.
  */
-import { listRunsByTask, type RunRow } from '../../../src/core/execution-ledger'
-import type { TaskRunEntry } from '../types'
+import { getCompletion, listRunsByTask, type RunRow } from '../../../src/core/execution-ledger'
+import { getTaskWithColumn } from '../../../src/core/task-store'
+import type { TaskOutcome, TaskRunEntry } from '../types'
 
 /** A task's dispatch attempts, newest-first. */
 export function readTaskRuns(taskId: string, limit = 50): TaskRunEntry[] {
   return listRunsByTask(taskId, limit).map(runRowToEntry)
+}
+
+/**
+ * The task's terminal outcome, distinct from any run's dispatch status (#476).
+ * A completions row wins (it always implies the board reached done — archiving
+ * a done task keeps it); otherwise the current column decides. Unknown task →
+ * undefined.
+ */
+export function readTaskOutcome(taskId: string): TaskOutcome | undefined {
+  const completion = getCompletion(taskId)
+  if (completion) {
+    return {
+      state: 'done',
+      completedAt: new Date(completion.completedAt).toISOString(),
+      agent: completion.agent,
+    }
+  }
+  const entry = getTaskWithColumn(taskId)
+  if (!entry) return undefined
+  switch (entry.column) {
+    case 'blocked':
+      return { state: 'blocked' }
+    case 'archived':
+      return { state: 'archived' }
+    case 'done': // legacy done task without a completions row
+      return { state: 'done' }
+    default:
+      return { state: 'in_progress' }
+  }
 }
 
 export function runRowToEntry(run: RunRow): TaskRunEntry {

--- a/plugins/tasks/types.ts
+++ b/plugins/tasks/types.ts
@@ -52,6 +52,16 @@ export interface TaskBoard {
 
 export type ColumnId = keyof TaskColumns
 
+/** Task-level terminal outcome, derived from the completion ledger + task column.
+ *  Mirrored client-side in src/hooks/use-task-run-history.ts — keep in sync. */
+export interface TaskOutcome {
+  state: 'done' | 'blocked' | 'archived' | 'in_progress'
+  /** Set when state === 'done' and a completion row exists. */
+  completedAt?: string // ISO
+  /** Agent that recorded the completion, when known. */
+  agent?: string
+}
+
 /** One dispatch attempt for a task, from the execution ledger's `runs` table.
  *  Mirrored client-side in src/hooks/use-task-run-history.ts — keep in sync. */
 export interface TaskRunEntry {

--- a/src/hooks/use-task-run-history.ts
+++ b/src/hooks/use-task-run-history.ts
@@ -2,6 +2,15 @@
 
 import { useState, useEffect } from 'react'
 
+/** Task-level terminal outcome (mirrors plugins/tasks TaskOutcome). */
+export interface TaskOutcome {
+  state: 'done' | 'blocked' | 'archived' | 'in_progress'
+  /** Set when state === 'done' and a completion row exists. */
+  completedAt?: string // ISO
+  /** Agent that recorded the completion, when known. */
+  agent?: string
+}
+
 /** One dispatch attempt for a task (mirrors plugins/tasks TaskRunEntry). */
 export interface TaskRunEntry {
   runId: string
@@ -15,25 +24,30 @@ export interface TaskRunEntry {
   durationMs?: number
 }
 
-/** Fetch a task's dispatch run history (newest-first) from the execution ledger. */
+/** Fetch a task's dispatch run history (newest-first) + task outcome from the execution ledger. */
 export function useTaskRunHistory(taskId: string | null, limit = 50) {
   const [runs, setRuns] = useState<TaskRunEntry[]>([])
+  const [outcome, setOutcome] = useState<TaskOutcome | undefined>(undefined)
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (!taskId) {
       setRuns([])
+      setOutcome(undefined)
       return
     }
     setLoading(true)
     fetch(`/api/plugins/tasks/${taskId}/runs?limit=${limit}`)
       .then(res => (res.ok ? res.json() : null))
       .then(data => {
-        if (data) setRuns(data.runs || [])
+        if (data) {
+          setRuns(data.runs || [])
+          setOutcome(data.outcome)
+        }
       })
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [taskId, limit])
 
-  return { runs, loading }
+  return { runs, outcome, loading }
 }

--- a/tasks/plan-bakin-owned-scheduler.md
+++ b/tasks/plan-bakin-owned-scheduler.md
@@ -1,0 +1,195 @@
+# PLAN — Bakin-Owned Scheduler
+
+> Derived from `SPEC.md`. Plan-mode artifact: ordering, vertical slices, acceptance + verification, checkpoints, and the commit/rollback strategy.
+> Branch: `feat/bakin-owned-scheduler` off `main`. One commit per task; each task ends green (suite + lint).
+
+## Dependency graph
+
+```
+cron-eval (T1) ─────────────┐
+                            ├─► scheduler engine (T3) ─► SWITCH: cutover+routes+activate (T4) ─► remove reconcile/bridge (T5)
+schedule-store model (T2) ──┘                                        │
+                                                                     ├─► catch-up / missed-fire → todo|blocked (T6)
+                                                                     ├─► legacy-repair + seeding removal (T7)
+                                                                     ├─► adapter Bakin-cron payload removal (T8)
+                                                                     ├─► runtime-cron read-only split + UI (T9) ─► next-run column (T10)
+                                                                     ├─► orphan-cron doctor check (T11)
+                                                                     ├─► delivery-error surfacing (T12)  [adapter+core+UI; independent]
+                                                                     └─► prompt-guard (T13)
+docs alignment (T14) — last
+```
+
+Critical path: **T1/T2 → T3 → T4** (the switch that fixes the double-fire) → everything else fans out.
+T12 (delivery-error surfacing) is independent and could be done any time after T4; sequenced into the visibility phase.
+
+## Slicing principle
+
+Each task is a vertical slice that compiles, tests, and commits on its own. The risky moment — Bakin starting to fire while OpenClaw still fires — is collapsed into a **single atomic task (T4)**: it stops creating OpenClaw crons, deletes existing Bakin-owned OpenClaw crons (cutover), neutralizes the reconcile path, and activates the engine together. No intermediate double-fire window.
+
+---
+
+## Phase 0 — Engine primitives (no behavior change)
+
+### T1 — `cron-eval.ts`: isolate cron-parser
+- **Build:** `plugins/schedule/lib/cron-eval.ts` wrapping `cron-parser` (already in `package.json:75`). API: `nextRun(expr, tz, after)`, `occurrencesBetween(expr, tz, from, to)`, `isValidExpr(expr)`. All tz-aware via the job's `tz`.
+- **Acceptance:** pure module, `cron-parser` imported nowhere else in the plugin.
+- **Verify:** `bun test tests/plugins/schedule/cron-eval.test.ts --isolate` — next-run/occurrences correctness, a DST-boundary case, invalid-expr handling.
+- **Commit:** `feat(schedule): add cron-eval module isolating cron-parser`
+
+### T2 — Schedule store model
+- **Build:** rename `lib/sidecar.ts` → `lib/schedule-store.ts`. Extend `BakinJobMeta` (`types.ts`) with `schedule: { kind: 'cron'|'every'|'at'; expr: string }` and `enabled: boolean`. Bakin-owned id minting (no OpenClaw-derived id). Zod parse on read.
+- **Acceptance:** store CRUD round-trips the new fields; existing fields untouched; readers updated to the new module path.
+- **Verify:** `bun test tests/plugins/schedule/schedule-store.test.ts --isolate`; full suite green (additive change).
+- **Commit:** `refactor(schedule): make sidecar the canonical schedule store (schedule expr + enabled)`
+
+> **CHECKPOINT A** — engine primitives + store model in place, no behavior change. Rollback point: revert to here keeps the old OpenClaw-cron path fully working.
+
+---
+
+## Phase 1 — The switch (fixes the double-fire)
+
+### T3 — Scheduler engine (built, not yet activated)
+- **Build:** `plugins/schedule/lib/scheduler.ts`. `Scheduler` with injected clock `now: () => number`. `tick()` iterates enabled store jobs, computes occurrences in `(now - window, now]` via cron-eval, mints `runId = \`${jobId}:${occurrenceEpochUTC}\``, calls `claimCronFire`; on fresh claim → `runClaimedFire(...)`. Reuses existing pause/skip/overlap/failure logic and `healPendingCronClaims`. Not wired into `activate()` yet (or wired but gated off `schedule` being unset, so a no-op).
+- **Acceptance:** with a fake clock, a due occurrence fires once; re-ticking the same minute creates no second task; pause/skip/overlap honored.
+- **Verify:** `bun test tests/plugins/schedule/scheduler.test.ts --isolate` (fake clock, no real timers).
+- **Commit:** `feat(schedule): add Bakin scheduler engine (fake-clock testable)`
+
+### T4 — SWITCH: cutover + routes + activate (atomic)
+- **Build (one commit):**
+  - `lib/cutover.ts`: a single idempotent `migrateBakinSchedulesOffOpenClawCron()` — for each Bakin job, read its current OpenClaw cron expr/tz (via `cron.get`) into the store's `schedule`, then `cron.remove` the OpenClaw job. Skip if already migrated / no runtime job. **Called automatically on activate** (closes the upgrade gap: the new scheduler only fires jobs whose store has a `schedule` expr, so migration must populate it before the reconcile-poll is gone — otherwise an un-migrated job would rogue-fire via OpenClaw with no Bakin task). The **same function is reused by the doctor auto-fix in T11** as the bulletproof repair path when OpenClaw was unreachable at activate.
+  - Create/update routes + exec tools (`index.ts:139,141,251,954,1013,1111,1433,1490`) write the store and **stop calling `cron.create/update`** for Bakin schedules.
+  - Pause/resume (`index.ts:1211,1222,1231,1524,1533,1542`) flip the store `enabled`/`paused` flag instead of `cron.update({enabled})`.
+  - Activate the scheduler in `activate()`; **remove the reconcile-poll** (`startReconciler`, `reconcileScheduleRuns`) wiring so the old path no longer creates tasks.
+- **Acceptance:** creating a Bakin schedule writes no OpenClaw cron job; an existing job is migrated + its OpenClaw cron removed; a due schedule fires exactly once (Bakin), zero OpenClaw fires.
+- **Verify:** `bun test tests/plugins/schedule/ --isolate` incl. an extended exactly-once test (reuse `cron-dedup.test.ts`); manual: create schedule via route in test → assert mock OpenClaw `jobs.json` unchanged.
+- **Commit:** `feat(schedule): fire schedules from Bakin's own scheduler; cut over off OpenClaw cron`
+
+### T5 — Remove bridge webhook + reconcile remnants
+- **Build:** delete `handleBridge`, `processScheduledRun` (bridge entry), `getOrCreateBridgeSecret`, the bridge route, `seedCronFireLedgerFromSidecar` call sites that only served the old path; remove `bridgeEnabled`/`bridgeSecret` settings; add `catchUpWindowMinutes`/`tickIntervalSeconds` settings. Keep `runClaimedFire`, `claimCronFire`, `healPendingCronClaims`.
+- **Acceptance:** no references to the bridge remain; settings schema updated; suite green.
+- **Verify:** `grep -rn "bridge\|reconcileScheduleRuns" plugins/schedule` clean; full suite.
+- **Commit:** `refactor(schedule): remove bridge webhook + reconcile-poll (dead after cutover)`
+
+> **CHECKPOINT B** — **double-fire eliminated.** Bakin fires exactly once; OpenClaw fires no Bakin schedules. This is the milestone that resolves the reported bug. Rollback point.
+
+---
+
+## Phase 2 — Downtime handling
+
+### T6 — Catch-up / missed-fire → todo | blocked
+- **Build:** startup catch-up in scheduler: compute missed occurrences since the catch-up horizon; take the **most recent** per job → fire to `todo` if within `catchUpWindowMinutes`, else `createTaskWithEffects({ column: 'blocked', blockedReason: 'missed-window', ... })`; `markCronFireSkipped` the older occurrences. Tiny core addition: `createTaskWithEffects` accepts `blockedReason` passthrough (`src/core/task-service.ts` — small, flagged as the one core touch).
+- **Acceptance:** AC#4 in SPEC — recent→todo, stale→blocked w/ reason, long outage coalesces to one, window boundary exact.
+- **Verify:** Prove-It test `tests/plugins/schedule/catch-up.test.ts --isolate` (fake clock; just-inside vs just-outside window; 3-day outage → 1 task).
+- **Commit:** `feat(schedule): catch-up policy with safety window (todo within window, blocked when stale)`
+
+> **CHECKPOINT C** — downtime handling correct and visible.
+
+---
+
+## Phase 3 — Dead-code removal
+
+### T7 — Remove legacy main-session-wake repair + seeding
+- **Build:** delete `needsBakinCronWakeRepair`, `repairMainSessionBakinCronPayloads`, `runLegacyCronRepair`, `scheduleLegacyCronRepairRetry`, `checkLegacyBakinCronPayloads`, `legacyCronWakeRepair`, related constants/timers, and `seedCronFireLedgerFromSidecar` (the legacy `processedRunIds` migration — no longer relevant under the new model).
+- **Acceptance:** no legacy-repair references; suite green.
+- **Verify:** `grep -rn "needsBakinCronWakeRepair\|legacyCronRepair\|seedCronFireLedger" plugins/schedule` clean.
+- **Commit:** `refactor(schedule): drop legacy main-session-wake repair + sidecar seeding`
+
+### T8 — Adapter cleanup (strip Bakin-cron special-casing)
+- **Build:** in `packages/adapter-openclaw/src/runtime.ts` remove `isBakinCron`, `cronPayloadForCommand`, the bakin branch of `appendCronPayloadArgs`, and the `bakinSchedule` toolsAllow special-casing. **Keep** generic `cron.list/get/listRuns/create/update/remove` (create/update lose only the Bakin branch; `remove` needed by cutover; `list`/`listRuns` needed for read-only). Verify no non-schedule callers depend on the removed bits.
+- **Acceptance:** adapter has no `bakin:`/`bakinSchedule` awareness; `tests/adapter-openclaw/runtime-cron.test.ts` updated to drop Bakin-cron cases.
+- **Verify:** `bun test tests/adapter-openclaw/ --isolate`; `grep -rn "bakinSchedule\|isBakinCron\|cronPayloadForCommand" packages/adapter-openclaw` clean.
+- **Commit:** `refactor(adapter-openclaw): remove Bakin-specific cron payload shaping`
+
+> **CHECKPOINT D** — ~500 lines of cross-process wrangling gone; adapter generic again; suite green.
+
+---
+
+## Phase 4 — Visibility (the user's adjacent asks)
+
+### T9 — Runtime-cron read-only surfacing
+- **Build:** `jobs-reader.ts` splits into **owned** (Bakin store) vs **runtime** (adapter `cron.list`, read-only). UI (`schedule-page.tsx`, `job-list.tsx`, `job-row.tsx`) renders two groups; mutation routes reject runtime-cron ids with a clear error.
+- **Acceptance:** AC#5 — native crons read-only; Bakin schedules editable; mutating a runtime id is rejected.
+- **Verify:** `bun test tests/plugins/schedule/jobs-reader.test.ts --isolate`; route test asserts rejection.
+- **Commit:** `feat(schedule): surface OpenClaw native crons read-only alongside Bakin schedules`
+
+### T10 — Next-run column
+- **Build:** compute next-run per Bakin schedule via cron-eval in jobs-reader; render column in UI.
+- **Acceptance:** next-run shown and correct for cron + tz.
+- **Verify:** unit test on the computed field; UI smoke via `bun run dev:mock`.
+- **Commit:** `feat(schedule): show computed next-run per schedule`
+
+### T11 — Orphan-cron doctor check (= the end-user migration command)
+- **Build:** `health-checks.ts` adds a check: any Bakin store schedule that still has a matching OpenClaw cron job (via `cron.list`) → warn (incomplete cutover / rogue-fire risk). **Auto-fix calls the shared `migrateBakinSchedulesOffOpenClawCron()` from T4** (import expr if missing, then remove the orphan) — so this is the canonical end-user migration/repair path via `bakin check schedule-cutover` / `bakin install schedule-cutover`, identical logic to the automatic on-activate cutover.
+- **Acceptance:** AC#6 — flags orphan; ok when clean; auto-fix completes the migration (job still scheduled in Bakin, OpenClaw cron gone); idempotent.
+- **Verify:** `bun test tests/plugins/schedule/health-checks.test.ts --isolate` (orphan present → fixed → clean on re-run).
+- **Commit:** `feat(schedule): doctor check + repair for orphaned OpenClaw crons behind Bakin schedules`
+
+### T12 — Delivery-error surfacing (adapter + core + UI)
+- **Build:** OpenClaw adapter propagates channel-delivery failures (e.g. "Invalid Form Body") as a typed event/audit; core audit/SSE carries it; `activity-feed.tsx` + task log render it. Link to the originating task where available.
+- **Acceptance:** AC#7 — a delivery failure appears in the activity feed and on the task.
+- **Verify:** `bun test` with a mock adapter emitting a delivery failure → audit + task-log assertions.
+- **Commit:** `feat(delivery): surface channel-delivery failures in activity feed and task log`
+
+### T13 — Schedule prompt danger-zone guard
+- **Build:** `lib/prompt-guard.ts` — on create/edit, warn when a schedule prompt risks the channel transport danger zone (e.g. "do not split" + high char cap). Surface in `job-form.tsx`.
+- **Acceptance:** AC#8 — danger-zone prompt warns; safe prompt does not.
+- **Verify:** `bun test tests/plugins/schedule/prompt-guard.test.ts --isolate`.
+- **Commit:** `feat(schedule): warn on schedule prompts that risk the channel transport danger zone`
+
+> **CHECKPOINT E** — all visibility features in; suite green.
+
+---
+
+## Phase 5 — Docs & close-out
+
+### T14 — Docs alignment
+- **Build:** update `CLAUDE.md` (re-draw the cron ownership boundary: *runtime owns crons it/agents create; Bakin owns scheduling of Bakin tasks*); `.claude/knowledge/` schedule/cron deep-dive + `adapter-architecture.md` note; schedule plugin README/authoring if impacted. Record the out-of-scope follow-ups (prompt content edit, stale doc job-id).
+- **Acceptance:** docs match the shipped behavior; no stale references to bridge/reconcile/OpenClaw-cron-for-Bakin.
+- **Verify:** manual read; `grep` for stale terms across docs.
+- **Commit:** `docs(schedule): document Bakin-owned scheduling + re-draw cron ownership boundary`
+
+> **CHECKPOINT F** — full `bun run test` + lint + `bun run build` green. Ready for `/agent-skills:test` coverage pass and `/agent-skills:review`.
+
+---
+
+## Phase 6 — Gold-standard E2E validation (MUST pass before "complete")
+
+### T15 — Bulletproof E2E against the dockerized OpenClaw rig
+Real OpenClaw in Docker, not the mock — `bun run instance up` / `instance dev` (`scripts/instance.ts`, `.claude/knowledge/dockerized-openclaw-rig.md`). Does **not** touch `~/.openclaw` or `~/.bakin`. This is the acceptance gate; the work is not complete until every check passes.
+
+- **Scenarios (each asserted against real runtime state — `cron/jobs.json`, cron run logs, the task board, channel/delivery records):**
+  1. **No OpenClaw cron created:** create a Bakin schedule → assert the rig's `cron/jobs.json` gains **no** `bakin:schedule:*` entry.
+  2. **Exactly-once fire:** drive a schedule to its fire minute → exactly one Bakin task; **zero** OpenClaw-originated agent turns; no duplicate channel post. (This is the original bug — must be provably gone.)
+  3. **Upgrade migration (gap-free):** seed the rig with a *legacy* Bakin-owned OpenClaw cron (agentTurn payload, like today's Daily Scramble) → start the new server → assert auto-cutover imported the expr into the store, removed the OpenClaw cron, and the next fire is single-path Bakin with no rogue turn.
+  4. **Doctor repair:** simulate OpenClaw unreachable at activate (leave an orphan cron) → `bakin check schedule-cutover` flags it → `bakin install schedule-cutover` completes migration → re-check clean.
+  5. **Downtime catch-up:** stop the server across a fire time, restart within the window → fires to `todo`; restart outside the window → lands in `blocked` (`missed-window`); long outage → one coalesced task.
+  6. **Pause/skip/overlap:** verified end-to-end against the rig (no fire while paused; skip-N honored; overlap guard blocks concurrent task).
+  7. **Read-only surfacing:** create a *native* OpenClaw cron directly in the rig → appears read-only in the schedule view; mutation attempt rejected; Bakin schedules remain editable.
+  8. **Delivery-error visibility:** induce a channel-delivery failure → appears in the activity feed + on the task.
+  9. **Idempotency/durability:** restart the server twice → no re-fire of past occurrences, no duplicate migration, no orphan.
+- **Acceptance:** all 9 scenarios pass against real OpenClaw; `cron/jobs.json` holds no Bakin entries; the original double-post is unreproducible across repeated runs.
+- **Verify:** scripted E2E run on the rig (capture transcript/artifacts); document results in the PR.
+- **Commit:** `test(schedule): gold-standard E2E validation against dockerized OpenClaw rig`
+
+> **CHECKPOINT G — DONE.** Bug provably gone end-to-end on real OpenClaw; migration (auto + doctor) verified; visibility verified. Only now is the work "complete."
+
+---
+
+## Commit / rollback strategy
+
+- **Branch:** `feat/bakin-owned-scheduler` off `main`. PR at the end (per repo norm — squash-merge style history shows merge PRs).
+- **One commit per task**, conventional + scoped (messages above). Every commit is green (suite + lint) so any commit is a safe `git revert` / reset point.
+- **Checkpoints A–F are the rollback anchors:**
+  - **A** — safe baseline; old path intact.
+  - **B** — the bug is fixed; if anything later regresses, reset to B keeps the double-fire fix with old dead code still present (acceptable interim).
+  - **D** — clean architecture; the natural "good state" if visibility work needs to pause.
+  - **F** — ship-ready.
+- **Riskiest commit is T4** (the switch). It is self-contained and reversible: `git revert` of T4 restores OpenClaw-cron firing (T5+ not yet applied at that point, so reconcile/bridge still exist). Validate T4 hard before proceeding.
+- **No shims / no dual-run:** per project rule, we do not keep both fire paths alive across commits — T4 switches atomically. The "rollback" mechanism is git, not a runtime flag.
+- **Build-stamp trap:** do **not** `git add -A` after a local `bun run build` (it rewrites a tracked version-stamp file). Stage explicit paths per commit.
+
+## Risks & mitigations
+- **Missed fires / DST** (new surface): concentrated tests in T1 (DST) + T6 (window/coalesce, Prove-It). Mitigated by cron-parser handling tz/DST and Bakin already being the always-on singleton.
+- **Cutover correctness** (T4): idempotent; reads expr from OpenClaw before deleting; doctor check (T11) catches any orphan left behind.
+- **One core touch** (`createTaskWithEffects` `blockedReason`, T6): minimal, additive; flagged for review.
+- **Delivery-error scope creep** (T12): bounded to propagate+render an existing failure; no change to delivery logic itself.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,195 +1,168 @@
-# PLAN — Bakin-Owned Scheduler
+# PLAN — Task Outcome in Run History (#476)
 
 > Derived from `SPEC.md`. Plan-mode artifact: ordering, vertical slices, acceptance + verification, checkpoints, and the commit/rollback strategy.
-> Branch: `feat/bakin-owned-scheduler` off `main`. One commit per task; each task ends green (suite + lint).
+> Branch: `feat/task-outcome-run-history` off `main`. One commit per task; each task ends green (full suite).
+> Prior plan archived at `tasks/plan-bakin-owned-scheduler.md`.
 
 ## Dependency graph
 
 ```
-cron-eval (T1) ─────────────┐
-                            ├─► scheduler engine (T3) ─► SWITCH: cutover+routes+activate (T4) ─► remove reconcile/bridge (T5)
-schedule-store model (T2) ──┘                                        │
-                                                                     ├─► catch-up / missed-fire → todo|blocked (T6)
-                                                                     ├─► legacy-repair + seeding removal (T7)
-                                                                     ├─► adapter Bakin-cron payload removal (T8)
-                                                                     ├─► runtime-cron read-only split + UI (T9) ─► next-run column (T10)
-                                                                     ├─► orphan-cron doctor check (T11)
-                                                                     ├─► delivery-error surfacing (T12)  [adapter+core+UI; independent]
-                                                                     └─► prompt-guard (T13)
-docs alignment (T14) — last
+T1 readTaskOutcome + TaskOutcome type (+unit tests)
+ │
+ ├─► T2 route returns { runs, outcome } + hook/SDK mirror (+route tests)
+ │        │
+ │        └─► T3 UI: header outcome badge + settled→blue (+component test)
+ │
+ └─► T4 docs: execution-ledger.md consumers table   (independent after T1)
 ```
 
-Critical path: **T1/T2 → T3 → T4** (the switch that fixes the double-fire) → everything else fans out.
-T12 (delivery-error surfacing) is independent and could be done any time after T4; sequenced into the visibility phase.
+Critical path: T1 → T2 → T3. T4 can land any time after T1; sequenced last.
 
 ## Slicing principle
 
-Each task is a vertical slice that compiles, tests, and commits on its own. The risky moment — Bakin starting to fire while OpenClaw still fires — is collapsed into a **single atomic task (T4)**: it stops creating OpenClaw crons, deletes existing Bakin-owned OpenClaw crons (cutover), neutralizes the reconcile path, and activates the engine together. No intermediate double-fire window.
+Each task is a vertical slice that compiles, tests, and commits on its own.
+T1 is a pure addition (nothing consumes it); T2 changes the API contract while
+the UI remains tolerant (it ignores unknown keys); T3 is the user-visible
+payoff. Reverting T3 leaves a useful API; reverting T2–T3 leaves a harmless
+helper.
 
 ---
 
-## Phase 0 — Engine primitives (no behavior change)
+## T1 — `readTaskOutcome` derivation + `TaskOutcome` type
 
-### T1 — `cron-eval.ts`: isolate cron-parser
-- **Build:** `plugins/schedule/lib/cron-eval.ts` wrapping `cron-parser` (already in `package.json:75`). API: `nextRun(expr, tz, after)`, `occurrencesBetween(expr, tz, from, to)`, `isValidExpr(expr)`. All tz-aware via the job's `tz`.
-- **Acceptance:** pure module, `cron-parser` imported nowhere else in the plugin.
-- **Verify:** `bun test tests/plugins/schedule/cron-eval.test.ts --isolate` — next-run/occurrences correctness, a DST-boundary case, invalid-expr handling.
-- **Commit:** `feat(schedule): add cron-eval module isolating cron-parser`
+**Files:** `plugins/tasks/lib/runs-reader.ts`, `plugins/tasks/types.ts`,
+`tests/plugins/tasks/runs-reader.test.ts` (new; mirrors
+`tests/plugins/schedule/runs-reader.test.ts` placement).
 
-### T2 — Schedule store model
-- **Build:** rename `lib/sidecar.ts` → `lib/schedule-store.ts`. Extend `BakinJobMeta` (`types.ts`) with `schedule: { kind: 'cron'|'every'|'at'; expr: string }` and `enabled: boolean`. Bakin-owned id minting (no OpenClaw-derived id). Zod parse on read.
-- **Acceptance:** store CRUD round-trips the new fields; existing fields untouched; readers updated to the new module path.
-- **Verify:** `bun test tests/plugins/schedule/schedule-store.test.ts --isolate`; full suite green (additive change).
-- **Commit:** `refactor(schedule): make sidecar the canonical schedule store (schedule expr + enabled)`
+**Change:**
+- `TaskOutcome` interface in `plugins/tasks/types.ts` (per SPEC §2 Types).
+- `readTaskOutcome(taskId: string): TaskOutcome | undefined` in
+  `runs-reader.ts`:
+  - `getCompletion(taskId)` via the existing relative import path
+    (`../../../src/core/execution-ledger`).
+  - `getTaskWithColumn(taskId)` from `../../../src/core/task-store`.
+  - Normative derivation (SPEC §2): completion row → `done` with
+    `completedAt` (ISO) + `agent`; else column `blocked`/`archived` →
+    same-named state; column `done` → `done` without completion fields;
+    other columns → `in_progress`; unknown task (no row, no board entry)
+    → `undefined`.
 
-> **CHECKPOINT A** — engine primitives + store model in place, no behavior change. Rollback point: revert to here keeps the old OpenClaw-cron path fully working.
+**Tests (table-driven, mock `src/core/execution-ledger` + `src/core/task-store`
+via BOTH the relative and `@/` specifiers, plus logger; no real ledger):**
+1. completion + column done → `done` with `completedAt`/`agent`
+2. completion + column archived → `done` (completion wins)
+3. no completion + blocked → `blocked`
+4. no completion + archived → `archived`
+5. no completion + done (legacy) → `done`, no `completedAt`
+6. no completion + each of inProgress/todo/backlog/review → `in_progress`
+7. unknown task → `undefined`
 
----
-
-## Phase 1 — The switch (fixes the double-fire)
-
-### T3 — Scheduler engine (built, not yet activated)
-- **Build:** `plugins/schedule/lib/scheduler.ts`. `Scheduler` with injected clock `now: () => number`. `tick()` iterates enabled store jobs, computes occurrences in `(now - window, now]` via cron-eval, mints `runId = \`${jobId}:${occurrenceEpochUTC}\``, calls `claimCronFire`; on fresh claim → `runClaimedFire(...)`. Reuses existing pause/skip/overlap/failure logic and `healPendingCronClaims`. Not wired into `activate()` yet (or wired but gated off `schedule` being unset, so a no-op).
-- **Acceptance:** with a fake clock, a due occurrence fires once; re-ticking the same minute creates no second task; pause/skip/overlap honored.
-- **Verify:** `bun test tests/plugins/schedule/scheduler.test.ts --isolate` (fake clock, no real timers).
-- **Commit:** `feat(schedule): add Bakin scheduler engine (fake-clock testable)`
-
-### T4 — SWITCH: cutover + routes + activate (atomic)
-- **Build (one commit):**
-  - `lib/cutover.ts`: a single idempotent `migrateBakinSchedulesOffOpenClawCron()` — for each Bakin job, read its current OpenClaw cron expr/tz (via `cron.get`) into the store's `schedule`, then `cron.remove` the OpenClaw job. Skip if already migrated / no runtime job. **Called automatically on activate** (closes the upgrade gap: the new scheduler only fires jobs whose store has a `schedule` expr, so migration must populate it before the reconcile-poll is gone — otherwise an un-migrated job would rogue-fire via OpenClaw with no Bakin task). The **same function is reused by the doctor auto-fix in T11** as the bulletproof repair path when OpenClaw was unreachable at activate.
-  - Create/update routes + exec tools (`index.ts:139,141,251,954,1013,1111,1433,1490`) write the store and **stop calling `cron.create/update`** for Bakin schedules.
-  - Pause/resume (`index.ts:1211,1222,1231,1524,1533,1542`) flip the store `enabled`/`paused` flag instead of `cron.update({enabled})`.
-  - Activate the scheduler in `activate()`; **remove the reconcile-poll** (`startReconciler`, `reconcileScheduleRuns`) wiring so the old path no longer creates tasks.
-- **Acceptance:** creating a Bakin schedule writes no OpenClaw cron job; an existing job is migrated + its OpenClaw cron removed; a due schedule fires exactly once (Bakin), zero OpenClaw fires.
-- **Verify:** `bun test tests/plugins/schedule/ --isolate` incl. an extended exactly-once test (reuse `cron-dedup.test.ts`); manual: create schedule via route in test → assert mock OpenClaw `jobs.json` unchanged.
-- **Commit:** `feat(schedule): fire schedules from Bakin's own scheduler; cut over off OpenClaw cron`
-
-### T5 — Remove bridge webhook + reconcile remnants
-- **Build:** delete `handleBridge`, `processScheduledRun` (bridge entry), `getOrCreateBridgeSecret`, the bridge route, `seedCronFireLedgerFromSidecar` call sites that only served the old path; remove `bridgeEnabled`/`bridgeSecret` settings; add `catchUpWindowMinutes`/`tickIntervalSeconds` settings. Keep `runClaimedFire`, `claimCronFire`, `healPendingCronClaims`.
-- **Acceptance:** no references to the bridge remain; settings schema updated; suite green.
-- **Verify:** `grep -rn "bridge\|reconcileScheduleRuns" plugins/schedule` clean; full suite.
-- **Commit:** `refactor(schedule): remove bridge webhook + reconcile-poll (dead after cutover)`
-
-> **CHECKPOINT B** — **double-fire eliminated.** Bakin fires exactly once; OpenClaw fires no Bakin schedules. This is the milestone that resolves the reported bug. Rollback point.
+**Acceptance:** all 7 derivation cases pass; no behavior change anywhere else.
+**Verify:** `bun test tests/plugins/tasks/runs-reader.test.ts --isolate`, then
+`bun run test` green.
+**Commit:** `feat(tasks): add readTaskOutcome derivation over completions + column`
 
 ---
 
-## Phase 2 — Downtime handling
+## T2 — Route returns `{ runs, outcome }` + client mirror
 
-### T6 — Catch-up / missed-fire → todo | blocked
-- **Build:** startup catch-up in scheduler: compute missed occurrences since the catch-up horizon; take the **most recent** per job → fire to `todo` if within `catchUpWindowMinutes`, else `createTaskWithEffects({ column: 'blocked', blockedReason: 'missed-window', ... })`; `markCronFireSkipped` the older occurrences. Tiny core addition: `createTaskWithEffects` accepts `blockedReason` passthrough (`src/core/task-service.ts` — small, flagged as the one core touch).
-- **Acceptance:** AC#4 in SPEC — recent→todo, stale→blocked w/ reason, long outage coalesces to one, window boundary exact.
-- **Verify:** Prove-It test `tests/plugins/schedule/catch-up.test.ts --isolate` (fake clock; just-inside vs just-outside window; 3-day outage → 1 task).
-- **Commit:** `feat(schedule): catch-up policy with safety window (todo within window, blocked when stale)`
+**Files:** `plugins/tasks/index.ts` (`/:taskId/runs` handler),
+`src/hooks/use-task-run-history.ts`, `packages/sdk/src/hooks/index.ts`,
+`tests/plugins/tasks/routes.test.ts`.
 
-> **CHECKPOINT C** — downtime handling correct and visible.
+**Change:**
+- Handler: `Response.json({ runs: readTaskRuns(...), outcome: readTaskOutcome(params.taskId) })`.
+  `outcome: undefined` serializes to an absent key — unknown tasks keep
+  returning `{ runs: [] }` with status 200.
+- Hook: mirror `TaskOutcome` (keep-in-sync comment, same as `TaskRunEntry`),
+  add `outcome` state, return `{ runs, outcome, loading }`.
+- SDK: `export type { TaskOutcome }` beside the existing `TaskRunEntry`
+  re-export (`packages/sdk/src/hooks/index.ts:33`).
 
----
+**Tests (extend `routes.test.ts`):**
+- Existing ledger fake gains `getCompletion` (reads `completionsFake`); the
+  `@/core/task-store` mock gains `getTaskWithColumn` — and the same mock is
+  registered for the relative specifier `../../../src/core/task-store` (the
+  ledger mock already does both; missing one is a leak surface).
+- Runs + completion seeded → body has `outcome.state === 'done'` with
+  `completedAt`/`agent`; runs + no completion + column blocked → `blocked`;
+  unknown task → `runs: []`, no `outcome` key, status 200.
+- Existing run-history assertions keep passing untouched (they don't pin
+  response keys).
 
-## Phase 3 — Dead-code removal
+**Acceptance:** API serves the sibling outcome object per SPEC; empty-task
+behavior unchanged.
+**Verify:** `bun test tests/plugins/tasks/routes.test.ts --isolate`, then
+`bun run test` green.
+**Commit:** `feat(tasks): return task outcome from the runs route`
 
-### T7 — Remove legacy main-session-wake repair + seeding
-- **Build:** delete `needsBakinCronWakeRepair`, `repairMainSessionBakinCronPayloads`, `runLegacyCronRepair`, `scheduleLegacyCronRepairRetry`, `checkLegacyBakinCronPayloads`, `legacyCronWakeRepair`, related constants/timers, and `seedCronFireLedgerFromSidecar` (the legacy `processedRunIds` migration — no longer relevant under the new model).
-- **Acceptance:** no legacy-repair references; suite green.
-- **Verify:** `grep -rn "needsBakinCronWakeRepair\|legacyCronRepair\|seedCronFireLedger" plugins/schedule` clean.
-- **Commit:** `refactor(schedule): drop legacy main-session-wake repair + sidecar seeding`
-
-### T8 — Adapter cleanup (strip Bakin-cron special-casing)
-- **Build:** in `packages/adapter-openclaw/src/runtime.ts` remove `isBakinCron`, `cronPayloadForCommand`, the bakin branch of `appendCronPayloadArgs`, and the `bakinSchedule` toolsAllow special-casing. **Keep** generic `cron.list/get/listRuns/create/update/remove` (create/update lose only the Bakin branch; `remove` needed by cutover; `list`/`listRuns` needed for read-only). Verify no non-schedule callers depend on the removed bits.
-- **Acceptance:** adapter has no `bakin:`/`bakinSchedule` awareness; `tests/adapter-openclaw/runtime-cron.test.ts` updated to drop Bakin-cron cases.
-- **Verify:** `bun test tests/adapter-openclaw/ --isolate`; `grep -rn "bakinSchedule\|isBakinCron\|cronPayloadForCommand" packages/adapter-openclaw` clean.
-- **Commit:** `refactor(adapter-openclaw): remove Bakin-specific cron payload shaping`
-
-> **CHECKPOINT D** — ~500 lines of cross-process wrangling gone; adapter generic again; suite green.
-
----
-
-## Phase 4 — Visibility (the user's adjacent asks)
-
-### T9 — Runtime-cron read-only surfacing
-- **Build:** `jobs-reader.ts` splits into **owned** (Bakin store) vs **runtime** (adapter `cron.list`, read-only). UI (`schedule-page.tsx`, `job-list.tsx`, `job-row.tsx`) renders two groups; mutation routes reject runtime-cron ids with a clear error.
-- **Acceptance:** AC#5 — native crons read-only; Bakin schedules editable; mutating a runtime id is rejected.
-- **Verify:** `bun test tests/plugins/schedule/jobs-reader.test.ts --isolate`; route test asserts rejection.
-- **Commit:** `feat(schedule): surface OpenClaw native crons read-only alongside Bakin schedules`
-
-### T10 — Next-run column
-- **Build:** compute next-run per Bakin schedule via cron-eval in jobs-reader; render column in UI.
-- **Acceptance:** next-run shown and correct for cron + tz.
-- **Verify:** unit test on the computed field; UI smoke via `bun run dev:mock`.
-- **Commit:** `feat(schedule): show computed next-run per schedule`
-
-### T11 — Orphan-cron doctor check (= the end-user migration command)
-- **Build:** `health-checks.ts` adds a check: any Bakin store schedule that still has a matching OpenClaw cron job (via `cron.list`) → warn (incomplete cutover / rogue-fire risk). **Auto-fix calls the shared `migrateBakinSchedulesOffOpenClawCron()` from T4** (import expr if missing, then remove the orphan) — so this is the canonical end-user migration/repair path via `bakin check schedule-cutover` / `bakin install schedule-cutover`, identical logic to the automatic on-activate cutover.
-- **Acceptance:** AC#6 — flags orphan; ok when clean; auto-fix completes the migration (job still scheduled in Bakin, OpenClaw cron gone); idempotent.
-- **Verify:** `bun test tests/plugins/schedule/health-checks.test.ts --isolate` (orphan present → fixed → clean on re-run).
-- **Commit:** `feat(schedule): doctor check + repair for orphaned OpenClaw crons behind Bakin schedules`
-
-### T12 — Delivery-error surfacing (adapter + core + UI)
-- **Build:** OpenClaw adapter propagates channel-delivery failures (e.g. "Invalid Form Body") as a typed event/audit; core audit/SSE carries it; `activity-feed.tsx` + task log render it. Link to the originating task where available.
-- **Acceptance:** AC#7 — a delivery failure appears in the activity feed and on the task.
-- **Verify:** `bun test` with a mock adapter emitting a delivery failure → audit + task-log assertions.
-- **Commit:** `feat(delivery): surface channel-delivery failures in activity feed and task log`
-
-### T13 — Schedule prompt danger-zone guard
-- **Build:** `lib/prompt-guard.ts` — on create/edit, warn when a schedule prompt risks the channel transport danger zone (e.g. "do not split" + high char cap). Surface in `job-form.tsx`.
-- **Acceptance:** AC#8 — danger-zone prompt warns; safe prompt does not.
-- **Verify:** `bun test tests/plugins/schedule/prompt-guard.test.ts --isolate`.
-- **Commit:** `feat(schedule): warn on schedule prompts that risk the channel transport danger zone`
-
-> **CHECKPOINT E** — all visibility features in; suite green.
+— **CHECKPOINT A** — API contract complete and tested; UI untouched. Safe
+rollback point: reverting everything after this still leaves a correct API.
 
 ---
 
-## Phase 5 — Docs & close-out
+## T3 — UI: header outcome badge + demote settled green → blue
 
-### T14 — Docs alignment
-- **Build:** update `CLAUDE.md` (re-draw the cron ownership boundary: *runtime owns crons it/agents create; Bakin owns scheduling of Bakin tasks*); `.claude/knowledge/` schedule/cron deep-dive + `adapter-architecture.md` note; schedule plugin README/authoring if impacted. Record the out-of-scope follow-ups (prompt content edit, stale doc job-id).
-- **Acceptance:** docs match the shipped behavior; no stale references to bridge/reconcile/OpenClaw-cron-for-Bakin.
-- **Verify:** manual read; `grep` for stale terms across docs.
-- **Commit:** `docs(schedule): document Bakin-owned scheduling + re-draw cron ownership boundary`
+**Files:** `plugins/tasks/components/task-run-history.tsx`,
+`tests/plugins/tasks/task-run-history.test.tsx` (new; follows
+`task-card.test.tsx` component-test pattern).
 
-> **CHECKPOINT F** — full `bun run test` + lint + `bun run build` green. Ready for `/agent-skills:test` coverage pass and `/agent-skills:review`.
+**Change (per SPEC UI mock):**
+- Consume `outcome` from `useTaskRunHistory`.
+- Header line gains an outcome badge after the summary text:
+  done → green (`✓ done` + relative completedAt when present), blocked → red,
+  in_progress → amber, archived → zinc. Label text: `done` / `blocked` /
+  `in progress` / `archived` (display form of the enum).
+- `STATUS_CLASS.settled` green → blue (`bg-blue-500/10 text-blue-400
+  border-blue-500/20`); `lost`/`running`/`superseded` unchanged.
+- No-runs early return unchanged (outcome never renders without runs).
 
----
+**Tests:**
+- Header shows the outcome badge per state (done/blocked/in_progress);
+  settled badge no longer carries green classes; zero runs renders nothing
+  even when outcome would be `done`.
 
-## Phase 6 — Gold-standard E2E validation (MUST pass before "complete")
+**Acceptance:** acceptance criteria 1 & 3 of the issue — a settled run on an
+in-progress task shows blue `settled` + amber `in progress`; green appears
+only for task-done.
+**Verify:** component test green; full `bun run test`; visual spot-check via
+`bun run dev:mock` (imitation-crab seeds run-history data).
+**Commit:** `feat(tasks): show task outcome in run history header, demote settled to blue`
 
-### T15 — Bulletproof E2E against the dockerized OpenClaw rig
-Real OpenClaw in Docker, not the mock — `bun run instance up` / `instance dev` (`scripts/instance.ts`, `.claude/knowledge/dockerized-openclaw-rig.md`). Does **not** touch `~/.openclaw` or `~/.bakin`. This is the acceptance gate; the work is not complete until every check passes.
-
-- **Scenarios (each asserted against real runtime state — `cron/jobs.json`, cron run logs, the task board, channel/delivery records):**
-  1. **No OpenClaw cron created:** create a Bakin schedule → assert the rig's `cron/jobs.json` gains **no** `bakin:schedule:*` entry.
-  2. **Exactly-once fire:** drive a schedule to its fire minute → exactly one Bakin task; **zero** OpenClaw-originated agent turns; no duplicate channel post. (This is the original bug — must be provably gone.)
-  3. **Upgrade migration (gap-free):** seed the rig with a *legacy* Bakin-owned OpenClaw cron (agentTurn payload, like today's Daily Scramble) → start the new server → assert auto-cutover imported the expr into the store, removed the OpenClaw cron, and the next fire is single-path Bakin with no rogue turn.
-  4. **Doctor repair:** simulate OpenClaw unreachable at activate (leave an orphan cron) → `bakin check schedule-cutover` flags it → `bakin install schedule-cutover` completes migration → re-check clean.
-  5. **Downtime catch-up:** stop the server across a fire time, restart within the window → fires to `todo`; restart outside the window → lands in `blocked` (`missed-window`); long outage → one coalesced task.
-  6. **Pause/skip/overlap:** verified end-to-end against the rig (no fire while paused; skip-N honored; overlap guard blocks concurrent task).
-  7. **Read-only surfacing:** create a *native* OpenClaw cron directly in the rig → appears read-only in the schedule view; mutation attempt rejected; Bakin schedules remain editable.
-  8. **Delivery-error visibility:** induce a channel-delivery failure → appears in the activity feed + on the task.
-  9. **Idempotency/durability:** restart the server twice → no re-fire of past occurrences, no duplicate migration, no orphan.
-- **Acceptance:** all 9 scenarios pass against real OpenClaw; `cron/jobs.json` holds no Bakin entries; the original double-post is unreproducible across repeated runs.
-- **Verify:** scripted E2E run on the rig (capture transcript/artifacts); document results in the PR.
-- **Commit:** `test(schedule): gold-standard E2E validation against dockerized OpenClaw rig`
-
-> **CHECKPOINT G — DONE.** Bug provably gone end-to-end on real OpenClaw; migration (auto + doctor) verified; visibility verified. Only now is the work "complete."
+— **CHECKPOINT B** — feature complete and user-visible; full suite green.
 
 ---
 
-## Commit / rollback strategy
+## T4 — Docs: knowledge alignment
 
-- **Branch:** `feat/bakin-owned-scheduler` off `main`. PR at the end (per repo norm — squash-merge style history shows merge PRs).
-- **One commit per task**, conventional + scoped (messages above). Every commit is green (suite + lint) so any commit is a safe `git revert` / reset point.
-- **Checkpoints A–F are the rollback anchors:**
-  - **A** — safe baseline; old path intact.
-  - **B** — the bug is fixed; if anything later regresses, reset to B keeps the double-fire fix with old dead code still present (acceptable interim).
-  - **D** — clean architecture; the natural "good state" if visibility work needs to pause.
-  - **F** — ship-ready.
-- **Riskiest commit is T4** (the switch). It is self-contained and reversible: `git revert` of T4 restores OpenClaw-cron firing (T5+ not yet applied at that point, so reconcile/bridge still exist). Validate T4 hard before proceeding.
-- **No shims / no dual-run:** per project rule, we do not keep both fire paths alive across commits — T4 switches atomically. The "rollback" mechanism is git, not a runtime flag.
-- **Build-stamp trap:** do **not** `git add -A` after a local `bun run build` (it rewrites a tracked version-stamp file). Stage explicit paths per commit.
+**Files:** `.claude/knowledge/execution-ledger.md` (consumers table, the
+"Run history (read-only)" row) — note the tasks drawer now joins
+`getCompletion` + task column into a task-outcome line. Sweep for other stale
+mentions (`grep -rn "runs-reader\|run history" .claude/knowledge/`):
+`shared-ui-patterns.md` references the schedule drawer only — untouched
+unless wording drifts. README verified unaffected (no run-history mention).
 
-## Risks & mitigations
-- **Missed fires / DST** (new surface): concentrated tests in T1 (DST) + T6 (window/coalesce, Prove-It). Mitigated by cron-parser handling tz/DST and Bakin already being the always-on singleton.
-- **Cutover correctness** (T4): idempotent; reads expr from OpenClaw before deleting; doctor check (T11) catches any orphan left behind.
-- **One core touch** (`createTaskWithEffects` `blockedReason`, T6): minimal, additive; flagged for review.
-- **Delivery-error scope creep** (T12): bounded to propagate+render an existing failure; no change to delivery logic itself.
+**Acceptance:** knowledge docs describe the outcome join accurately; no other
+doc contradicts the new behavior.
+**Verify:** re-read the touched doc section; `bun run test` still green
+(docs-only).
+**Commit:** `docs(ledger): note run-history outcome join in execution-ledger knowledge`
+
+---
+
+## Final gate (before PR)
+
+- Full suite: `bun run test` green.
+- `SPEC.md` + `tasks/plan.md` + `tasks/todo.md` committed on the branch
+  (first commit, or alongside T1).
+- Never `git add -A` after a local build (generated-version build-stamp trap).
+- PR references #476; body maps commits to the rollback ladder.
+
+## Rollback strategy
+
+| Revert | Leaves |
+|---|---|
+| T4 | feature intact, docs stale (re-do docs) |
+| T3 | correct `{ runs, outcome }` API, old UI |
+| T3+T2 | unused-but-tested helper, zero surface change |
+| all | clean main |

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -158,6 +158,25 @@ doc contradicts the new behavior.
 - Never `git add -A` after a local build (generated-version build-stamp trap).
 - PR references #476; body maps commits to the rollback ladder.
 
+## Docker gold-standard verification (isolated mode) — PASSED 2026-06-09
+
+Run against a real OpenClaw container + live Bakin server (`instance up/dev
+--mode isolated`), driving the user stories end-to-end via CLI + API:
+
+| Story | Result |
+|---|---|
+| Agent turn settles, task still open | ✅ run `settled/turn ok` while `outcome: in_progress` — the false-success read is gone |
+| Block after settled run | ✅ `outcome: blocked`, run badge stays `settled` |
+| Human completes (log + move to done) | ✅ `outcome: done` + `completedAt` + `agent` from the completions row |
+| Archive after done | ✅ outcome stays `done` (completion wins) |
+| Agent completes via MCP (`bakin_exec_tasks_complete`) | ✅ `outcome: done` with agent attribution |
+| Unknown task | ✅ `{"runs":[]}`, no outcome key, HTTP 200 |
+| Served UI bundle | ✅ `/api/plugins/tasks/assets/client.js` maps `settled` → blue, `done` outcome → green, "in progress" label present |
+
+Incidental finds (pre-existing board guards, working as designed): blocked →
+done is an invalid transition (must pass through todo), and moves to done
+require at least one log entry.
+
 ## Rollback strategy
 
 | Revert | Leaves |

--- a/tasks/todo-bakin-owned-scheduler.md
+++ b/tasks/todo-bakin-owned-scheduler.md
@@ -1,0 +1,47 @@
+# TODO — Bakin-Owned Scheduler
+
+Branch: `feat/bakin-owned-scheduler` off `main`. One commit per task; each ends green. See `tasks/plan.md` for detail.
+
+## Phase 0 — Engine primitives
+- [x] **T1** `cron-eval.ts` isolating cron-parser (+ tests: next-run, occurrences, DST, invalid expr) — `feat(schedule): add cron-eval module isolating cron-parser` ✅ 8615138a
+- [x] **T2** schedule store model: `schedule` expr + `enabled`, Bakin-owned id (+tests; file rename deferred) — `refactor(schedule): make the sidecar the canonical schedule store` ✅ f5808d7c
+- [x] **— CHECKPOINT A** — primitives in place, no behavior change, full suite green (4741 pass)
+
+## Phase 1 — The switch (fixes the double-fire)
+- [x] **T3** scheduler engine, fake-clock testable, not yet activated — `feat(schedule): add the Bakin scheduler engine` ✅ 904e4fc7
+- [ ] **T4** SWITCH — re-sliced into 3 independently-green commits (reader rewrite + 2 health checks must move in; discovered the reader's stale-sidecar cleanup would delete every Bakin job post-cutover, and scheduleSyncRepair could re-create OpenClaw crons):
+  - [x] **T4a** `lib/cutover.ts` idempotent migration fn (+tests) — `feat(schedule): add idempotent cutover migration off OpenClaw cron` ✅ 79a8c9f9
+  - [x] **T4b** `jobs-reader` unions store-only Bakin jobs + drop the storage-mutating stale-delete (+tests) — `refactor(schedule): surface store-owned schedules in the merged reader` ✅ 5bee2f49
+  - [x] **T4c** atomic flip: create/update/pause/run_now/adopt/ensureBakinJob write the store (no OpenClaw cron) + activate runs cutover + startScheduler + drop reconcile-start + removed legacy-wake cluster (T7 absorbed) + 2 health checks + test updates — `feat(schedule): fire schedules from Bakin's own scheduler; cut over off OpenClaw cron` ✅ dba04986
+- [x] **— CHECKPOINT B** — double-fire eliminated; one fire path; full suite 4757 pass ✅
+- [x] **T5** remove bridge webhook + secret + reconcile remnants; settings (`catchUpWindowMinutes`+`tickIntervalSeconds` in UI); heal folded into scheduler tick — `refactor(schedule): remove dead bridge webhook + reconcile-poll machinery` ✅ 5f90bbe0
+- [ ] **— CHECKPOINT B** — double-fire eliminated; one fire path; OpenClaw fires no Bakin schedules ✅ core bug fixed
+
+## Phase 2 — Downtime handling
+- [x] **T6** catch-up: most-recent missed → todo within window / blocked when stale, coalesce older; `createTaskWithEffects`+`updateTask` gain `blockedReason` (core touch) — `feat(schedule): catch-up policy with a safety window` ✅ fe19d797
+- [x] **— CHECKPOINT C** — downtime handling correct + visible
+
+## Phase 3 — Dead-code removal
+- [~] **T7** legacy main-session-wake repair cluster + its 2 health checks — **absorbed into T4c** (lint forced their removal once activate stopped calling them). Remaining for T5: bridge webhook + `reconcileScheduleRuns` + `seedCronFireLedgerFromSidecar`.
+- [x] **T8** adapter: strip Bakin-cron payload shaping (keep generic CRUD/list/runs) — `refactor(adapter-openclaw): remove Bakin-specific cron payload shaping` ✅ b119d63f
+- [x] **— CHECKPOINT D** — wrangling gone; adapter generic; full suite 4737 pass
+
+## Phase 4 — Visibility
+- [x] **T9** runtime-cron read-only (reader already unions both; added 403 mutation guards on PUT/pause/skip/delete route+exec) — `feat(schedule): next-run column + read-only guards for native crons` ✅ 40e33a0f
+- [x] **T10** next-run column (reader computes via cron-eval.nextRun; row + drawer) — same commit ✅ 40e33a0f
+- [x] **T11** schedule-cutover doctor check + repair = end-user migration command (`bakin check/install schedule-cutover`, shares the cutover fn) — `feat(schedule): doctor check + repair for schedules not cut over` ✅ 5357d7fc
+- [~] **T12** delivery-error surfacing — **DEFERRED** (decide together). Turn-killing delivery failures already surface via dispatch audit; the incident's *recovered/repaired* failures (agent posts via its message tool INSIDE OpenClaw) need trajectory tool-error introspection — a separate, larger session-forensics effort, not observable at Bakin's `channels.sendMessage` (only the watchdog calls that). T13's prompt-guard already attacks the root cause.
+- [x] **T13** schedule prompt danger-zone guard (live form warning + API warnings) — `feat(schedule): warn on prompts that risk the transport danger zone` ✅ 2b68443c
+- [x] **— CHECKPOINT E** — visibility shipped (T9/T10/T11/T13); T12 deferred w/ rationale; suite green
+
+## Phase 5 — Docs & close-out
+- [x] **T14** docs: CLAUDE.md boundary re-draw + new `.claude/knowledge/bakin-owned-scheduler.md` + adapter/dispatch/ledger refresh + SPEC/tasks committed — `docs(schedule): document Bakin-owned scheduling` ✅ 95bbe4c4
+- [x] **— CHECKPOINT F** — full lint + test green (running final confirmation); ready for live E2E
+
+## Phase 6 — Gold-standard E2E (MUST pass before "complete")
+- [ ] **T15** bulletproof E2E vs dockerized OpenClaw rig — **runbook ready: `tasks/t15-e2e-runbook.md`** (9 scenarios). RUN TOGETHER with the user against `bun run instance up`.
+- [ ] **— CHECKPOINT G — DONE** — bug provably gone E2E on real OpenClaw; migration (auto + doctor) + visibility verified
+
+## Out of scope (follow-ups for the user)
+- [ ] Agent workspace prompt edit: 9am `<1900, do not split` → align to the safe `<900, split deliberately` shape (Bakin adds the *warning* in T13; content edit is yours)
+- [ ] Fix stale job-id in `workspace/docs/bakin-daily-release-summary.md:5`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,4 +15,6 @@ Branch: `feat/task-outcome-run-history` off `main`. One commit per task; each en
 - [x] **T4** `.claude/knowledge/execution-ledger.md` consumers-table update + stale-mention sweep (no other doc references the runs response or badge colors; README unaffected) — `docs(ledger): note run-history outcome join in execution-ledger knowledge`
 
 ## Final gate
-- [ ] `bun run test` green; PR references #476 with rollback ladder
+- [x] Coverage audit: archived-badge component test added; all 4 outcome states covered at unit + component level
+- [x] `bun run test` green (4801 pass / 0 fail), typecheck + lint clean
+- [ ] PR references #476 with rollback ladder

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17,4 +17,5 @@ Branch: `feat/task-outcome-run-history` off `main`. One commit per task; each en
 ## Final gate
 - [x] Coverage audit: archived-badge component test added; all 4 outcome states covered at unit + component level
 - [x] `bun run test` green (4801 pass / 0 fail), typecheck + lint clean
+- [x] Docker gold-standard E2E (isolated rig, real OpenClaw): 6 user stories + served-bundle check all passed — see plan.md
 - [ ] PR references #476 with rollback ladder

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,47 +1,18 @@
-# TODO — Bakin-Owned Scheduler
+# TODO — Task Outcome in Run History (#476)
 
-Branch: `feat/bakin-owned-scheduler` off `main`. One commit per task; each ends green. See `tasks/plan.md` for detail.
+Branch: `feat/task-outcome-run-history` off `main`. One commit per task; each ends green. See `tasks/plan.md` for detail.
 
-## Phase 0 — Engine primitives
-- [x] **T1** `cron-eval.ts` isolating cron-parser (+ tests: next-run, occurrences, DST, invalid expr) — `feat(schedule): add cron-eval module isolating cron-parser` ✅ 8615138a
-- [x] **T2** schedule store model: `schedule` expr + `enabled`, Bakin-owned id (+tests; file rename deferred) — `refactor(schedule): make the sidecar the canonical schedule store` ✅ f5808d7c
-- [x] **— CHECKPOINT A** — primitives in place, no behavior change, full suite green (4741 pass)
+## Phase 1 — Server derivation
+- [ ] **T1** `readTaskOutcome` + `TaskOutcome` type + table-driven unit tests (7 derivation cases) — `feat(tasks): add readTaskOutcome derivation over completions + column`
+- [ ] **T2** runs route returns `{ runs, outcome }` + hook mirror + SDK type re-export + route tests (mock task-store via BOTH specifiers) — `feat(tasks): return task outcome from the runs route`
+- [ ] **— CHECKPOINT A** — API contract complete, full suite green
 
-## Phase 1 — The switch (fixes the double-fire)
-- [x] **T3** scheduler engine, fake-clock testable, not yet activated — `feat(schedule): add the Bakin scheduler engine` ✅ 904e4fc7
-- [ ] **T4** SWITCH — re-sliced into 3 independently-green commits (reader rewrite + 2 health checks must move in; discovered the reader's stale-sidecar cleanup would delete every Bakin job post-cutover, and scheduleSyncRepair could re-create OpenClaw crons):
-  - [x] **T4a** `lib/cutover.ts` idempotent migration fn (+tests) — `feat(schedule): add idempotent cutover migration off OpenClaw cron` ✅ 79a8c9f9
-  - [x] **T4b** `jobs-reader` unions store-only Bakin jobs + drop the storage-mutating stale-delete (+tests) — `refactor(schedule): surface store-owned schedules in the merged reader` ✅ 5bee2f49
-  - [x] **T4c** atomic flip: create/update/pause/run_now/adopt/ensureBakinJob write the store (no OpenClaw cron) + activate runs cutover + startScheduler + drop reconcile-start + removed legacy-wake cluster (T7 absorbed) + 2 health checks + test updates — `feat(schedule): fire schedules from Bakin's own scheduler; cut over off OpenClaw cron` ✅ dba04986
-- [x] **— CHECKPOINT B** — double-fire eliminated; one fire path; full suite 4757 pass ✅
-- [x] **T5** remove bridge webhook + secret + reconcile remnants; settings (`catchUpWindowMinutes`+`tickIntervalSeconds` in UI); heal folded into scheduler tick — `refactor(schedule): remove dead bridge webhook + reconcile-poll machinery` ✅ 5f90bbe0
-- [ ] **— CHECKPOINT B** — double-fire eliminated; one fire path; OpenClaw fires no Bakin schedules ✅ core bug fixed
+## Phase 2 — UI
+- [ ] **T3** header outcome badge + settled green→blue + component test — `feat(tasks): show task outcome in run history header, demote settled to blue`
+- [ ] **— CHECKPOINT B** — feature complete, full suite green, visual spot-check (`bun run dev:mock`)
 
-## Phase 2 — Downtime handling
-- [x] **T6** catch-up: most-recent missed → todo within window / blocked when stale, coalesce older; `createTaskWithEffects`+`updateTask` gain `blockedReason` (core touch) — `feat(schedule): catch-up policy with a safety window` ✅ fe19d797
-- [x] **— CHECKPOINT C** — downtime handling correct + visible
+## Phase 3 — Docs
+- [ ] **T4** `.claude/knowledge/execution-ledger.md` consumers-table update + stale-mention sweep — `docs(ledger): note run-history outcome join in execution-ledger knowledge`
 
-## Phase 3 — Dead-code removal
-- [~] **T7** legacy main-session-wake repair cluster + its 2 health checks — **absorbed into T4c** (lint forced their removal once activate stopped calling them). Remaining for T5: bridge webhook + `reconcileScheduleRuns` + `seedCronFireLedgerFromSidecar`.
-- [x] **T8** adapter: strip Bakin-cron payload shaping (keep generic CRUD/list/runs) — `refactor(adapter-openclaw): remove Bakin-specific cron payload shaping` ✅ b119d63f
-- [x] **— CHECKPOINT D** — wrangling gone; adapter generic; full suite 4737 pass
-
-## Phase 4 — Visibility
-- [x] **T9** runtime-cron read-only (reader already unions both; added 403 mutation guards on PUT/pause/skip/delete route+exec) — `feat(schedule): next-run column + read-only guards for native crons` ✅ 40e33a0f
-- [x] **T10** next-run column (reader computes via cron-eval.nextRun; row + drawer) — same commit ✅ 40e33a0f
-- [x] **T11** schedule-cutover doctor check + repair = end-user migration command (`bakin check/install schedule-cutover`, shares the cutover fn) — `feat(schedule): doctor check + repair for schedules not cut over` ✅ 5357d7fc
-- [~] **T12** delivery-error surfacing — **DEFERRED** (decide together). Turn-killing delivery failures already surface via dispatch audit; the incident's *recovered/repaired* failures (agent posts via its message tool INSIDE OpenClaw) need trajectory tool-error introspection — a separate, larger session-forensics effort, not observable at Bakin's `channels.sendMessage` (only the watchdog calls that). T13's prompt-guard already attacks the root cause.
-- [x] **T13** schedule prompt danger-zone guard (live form warning + API warnings) — `feat(schedule): warn on prompts that risk the transport danger zone` ✅ 2b68443c
-- [x] **— CHECKPOINT E** — visibility shipped (T9/T10/T11/T13); T12 deferred w/ rationale; suite green
-
-## Phase 5 — Docs & close-out
-- [x] **T14** docs: CLAUDE.md boundary re-draw + new `.claude/knowledge/bakin-owned-scheduler.md` + adapter/dispatch/ledger refresh + SPEC/tasks committed — `docs(schedule): document Bakin-owned scheduling` ✅ 95bbe4c4
-- [x] **— CHECKPOINT F** — full lint + test green (running final confirmation); ready for live E2E
-
-## Phase 6 — Gold-standard E2E (MUST pass before "complete")
-- [ ] **T15** bulletproof E2E vs dockerized OpenClaw rig — **runbook ready: `tasks/t15-e2e-runbook.md`** (9 scenarios). RUN TOGETHER with the user against `bun run instance up`.
-- [ ] **— CHECKPOINT G — DONE** — bug provably gone E2E on real OpenClaw; migration (auto + doctor) + visibility verified
-
-## Out of scope (follow-ups for the user)
-- [ ] Agent workspace prompt edit: 9am `<1900, do not split` → align to the safe `<900, split deliberately` shape (Bakin adds the *warning* in T13; content edit is yours)
-- [ ] Fix stale job-id in `workspace/docs/bakin-daily-release-summary.md:5`
+## Final gate
+- [ ] `bun run test` green; PR references #476 with rollback ladder

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,16 +3,16 @@
 Branch: `feat/task-outcome-run-history` off `main`. One commit per task; each ends green. See `tasks/plan.md` for detail.
 
 ## Phase 1 — Server derivation
-- [ ] **T1** `readTaskOutcome` + `TaskOutcome` type + table-driven unit tests (7 derivation cases) — `feat(tasks): add readTaskOutcome derivation over completions + column`
-- [ ] **T2** runs route returns `{ runs, outcome }` + hook mirror + SDK type re-export + route tests (mock task-store via BOTH specifiers) — `feat(tasks): return task outcome from the runs route`
-- [ ] **— CHECKPOINT A** — API contract complete, full suite green
+- [x] **T1** `readTaskOutcome` + `TaskOutcome` type + table-driven unit tests (7 derivation cases) — `feat(tasks): add readTaskOutcome derivation over completions + column` ✅ e4b6e3b5
+- [x] **T2** runs route returns `{ runs, outcome }` + hook mirror + SDK type re-export + route tests (mock task-store via BOTH specifiers) — `feat(tasks): return task outcome from the runs route` ✅ 8f454d94
+- [x] **— CHECKPOINT A** — API contract complete, full suite green (4803 pass)
 
 ## Phase 2 — UI
-- [ ] **T3** header outcome badge + settled green→blue + component test — `feat(tasks): show task outcome in run history header, demote settled to blue`
-- [ ] **— CHECKPOINT B** — feature complete, full suite green, visual spot-check (`bun run dev:mock`)
+- [x] **T3** header outcome badge + settled green→blue + component test — `feat(tasks): show task outcome in run history header, demote settled to blue` ✅ 0c95cf9d
+- [x] **— CHECKPOINT B** — feature complete, full suite green (4809 pass), plugins build clean
 
 ## Phase 3 — Docs
-- [ ] **T4** `.claude/knowledge/execution-ledger.md` consumers-table update + stale-mention sweep — `docs(ledger): note run-history outcome join in execution-ledger knowledge`
+- [x] **T4** `.claude/knowledge/execution-ledger.md` consumers-table update + stale-mention sweep (no other doc references the runs response or badge colors; README unaffected) — `docs(ledger): note run-history outcome join in execution-ledger knowledge`
 
 ## Final gate
 - [ ] `bun run test` green; PR references #476 with rollback ladder

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -64,6 +64,7 @@ const ledgerMock = () => ({
     return { recorded: true as const }
   },
   hasCompletion: (taskId: string) => completionsFake.has(taskId),
+  getCompletion: (taskId: string) => completionsFake.get(taskId) ?? null,
   deleteCompletion: (taskId: string) => completionsFake.delete(taskId),
   getLiveRun: () => null,
   bumpHeartbeatByTask: () => {},
@@ -89,8 +90,11 @@ const mockSetDependency = mock()
 const mockClearDependency = mock()
 const mockReorderTasks = mock()
 const mockGetTask = mock()
+const mockGetTaskWithColumn = mock(
+  (_id: string): { task: Record<string, unknown>; column: string } | null => null,
+)
 
-mock.module('@/core/task-store', () => ({
+const taskStoreMock = () => ({
   readTaskboard: (...args: unknown[]) => mockReadTaskboard(...args),
   createTask: (...args: unknown[]) => mockCreateTask(...args),
   deleteTask: (...args: unknown[]) => mockDeleteTask(...args),
@@ -103,9 +107,13 @@ mock.module('@/core/task-store', () => ({
   clearDependency: (...args: unknown[]) => mockClearDependency(...args),
   reorderTasks: (...args: unknown[]) => mockReorderTasks(...args),
   getTask: (...args: unknown[]) => mockGetTask(...args),
+  getTaskWithColumn: (...args: unknown[]) => mockGetTaskWithColumn(...(args as [string])),
   autoArchiveDoneTasks: mock().mockReturnValue(0),
   archiveOldTasks: mock().mockReturnValue(0),
-}))
+})
+// Both specifiers — runs-reader imports task-store relatively (same trap as the ledger mock).
+mock.module('@/core/task-store', taskStoreMock)
+mock.module('../../../src/core/task-store', taskStoreMock)
 
 // Mock task-service functions
 const mockMoveTaskWithEffects = mock()

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -419,6 +419,23 @@ describe('GET /:taskId/runs — dispatch run history', () => {
     expect(body.runs).toEqual([])
     expect('outcome' in body).toBe(false)
   })
+
+  it('never touches the task store for a task with no runs (unknown ids would trigger a full shard walk)', async () => {
+    const route = findRoute(activated.routes, 'GET', '/:taskId/runs')!
+    await callRoute(route, activated.ctx, { searchParams: { taskId: 'ghost' } })
+    expect(mockGetTaskWithColumn).not.toHaveBeenCalled()
+  })
+
+  it('still reports done for a completed task with no runs (completion lookup is cheap and ungated)', async () => {
+    const completedAt = 1_700_000_500_000
+    completionsFake.set('done-no-runs', { taskId: 'done-no-runs', runId: null, agent: 'pixel', channel: null, completedAt })
+
+    const route = findRoute(activated.routes, 'GET', '/:taskId/runs')!
+    const { body } = await callRoute(route, activated.ctx, { searchParams: { taskId: 'done-no-runs' } })
+
+    expect(body.outcome).toMatchObject({ state: 'done' })
+    expect(mockGetTaskWithColumn).not.toHaveBeenCalled()
+  })
 })
 
 // ─── POST / — Create Task ──────────────────────────────────────────────────

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -165,8 +165,9 @@ beforeEach(() => {
     mockSetDependency, mockClearDependency, mockReorderTasks, mockGetTask,
     mockMoveTaskWithEffects, mockBlockTaskWithEffects, mockCreateTaskWithEffects,
     mockReportComplete, mockSetDependencyWithEffects, mockGetTaskDetails,
-    mockLogProgress, mockTriggerDispatch,
+    mockLogProgress, mockTriggerDispatch, mockGetTaskWithColumn,
   ]) m.mockReset()
+  mockGetTaskWithColumn.mockReturnValue(null)
   completionsFake.clear()
   // Handlers destructure the completion-gate result from these two.
   mockMoveTaskWithEffects.mockResolvedValue({ alreadyComplete: false })
@@ -377,6 +378,46 @@ describe('GET /:taskId/runs — dispatch run history', () => {
     const { status, body } = await callRoute(route, activated.ctx, { searchParams: { taskId: 'no-runs' } })
     expect(status).toBe(200)
     expect(body.runs).toEqual([])
+  })
+
+  it('includes a done outcome from the completion ledger alongside the runs', async () => {
+    const completedAt = 1_700_000_500_000
+    completionsFake.set('task-done', { taskId: 'task-done', runId: 'task:task-done:d1', agent: 'pixel', channel: null, completedAt })
+    mockTaskRuns['task-done'] = [{
+      runId: 'task:task-done:d1', taskId: 'task-done', seq: 1, agent: 'pixel', status: 'settled',
+      startedAt: completedAt - 1000, settledAt: completedAt, settleReason: 'turn-ok',
+    }]
+
+    const route = findRoute(activated.routes, 'GET', '/:taskId/runs')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { taskId: 'task-done' } })
+
+    expect(status).toBe(200)
+    expect(body.outcome).toEqual({
+      state: 'done',
+      completedAt: new Date(completedAt).toISOString(),
+      agent: 'pixel',
+    })
+  })
+
+  it('derives the outcome from the task column when no completion exists', async () => {
+    mockGetTaskWithColumn.mockReturnValue({ task: { id: 'task-blocked' }, column: 'blocked' })
+    mockTaskRuns['task-blocked'] = [{
+      runId: 'task:task-blocked:d1', taskId: 'task-blocked', seq: 1, agent: 'pixel', status: 'settled',
+      startedAt: 1_700_000_000_000, settledAt: 1_700_000_001_000, settleReason: 'turn-ok',
+    }]
+
+    const route = findRoute(activated.routes, 'GET', '/:taskId/runs')!
+    const { body } = await callRoute(route, activated.ctx, { searchParams: { taskId: 'task-blocked' } })
+
+    expect(body.outcome).toEqual({ state: 'blocked' })
+  })
+
+  it('omits the outcome key for an unknown task', async () => {
+    const route = findRoute(activated.routes, 'GET', '/:taskId/runs')!
+    const { status, body } = await callRoute(route, activated.ctx, { searchParams: { taskId: 'ghost' } })
+    expect(status).toBe(200)
+    expect(body.runs).toEqual([])
+    expect('outcome' in body).toBe(false)
   })
 })
 

--- a/tests/plugins/tasks/runs-reader.test.ts
+++ b/tests/plugins/tasks/runs-reader.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the tasks runs-reader outcome derivation (#476).
+ * readTaskOutcome joins the completion ledger with the task column —
+ * completion row wins; otherwise the column maps to the outcome state.
+ */
+import { describe, it, expect, mock } from 'bun:test'
+import { mkdtempSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+process.env.BAKIN_HOME = mkdtempSync(join(tmpdir(), 'bakin-test-home-'))
+
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+// In-memory fakes — this test exercises derivation, not ledger/store semantics.
+const completions = new Map<string, { taskId: string; runId: string | null; agent: string; channel: string | null; completedAt: number }>()
+const board = new Map<string, { task: { id: string; title: string }; column: string }>()
+
+const ledgerMock = () => ({
+  getCompletion: (taskId: string) => completions.get(taskId) ?? null,
+  listRunsByTask: () => [],
+})
+mock.module('@/core/execution-ledger', ledgerMock)
+mock.module('../../../src/core/execution-ledger', ledgerMock)
+
+const storeMock = () => ({
+  getTaskWithColumn: (id: string) => board.get(id) ?? null,
+})
+mock.module('@/core/task-store', storeMock)
+mock.module('../../../src/core/task-store', storeMock)
+
+const { readTaskOutcome } = await import('@bakin/tasks/lib/runs-reader')
+
+const COMPLETED_AT = Date.UTC(2026, 5, 8, 12, 0, 0)
+
+function seed(taskId: string, opts: { column?: string; completed?: boolean }) {
+  completions.delete(taskId)
+  board.delete(taskId)
+  if (opts.completed) {
+    completions.set(taskId, { taskId, runId: `task:${taskId}:d1`, agent: 'pixel', channel: null, completedAt: COMPLETED_AT })
+  }
+  if (opts.column) {
+    board.set(taskId, { task: { id: taskId, title: 'T' }, column: opts.column })
+  }
+}
+
+describe('tasks/runs-reader readTaskOutcome', () => {
+  it('completion row + column done → done with completedAt and agent', () => {
+    seed('t1', { column: 'done', completed: true })
+    expect(readTaskOutcome('t1')).toEqual({
+      state: 'done',
+      completedAt: new Date(COMPLETED_AT).toISOString(),
+      agent: 'pixel',
+    })
+  })
+
+  it('completion row wins over a later archive', () => {
+    seed('t2', { column: 'archived', completed: true })
+    expect(readTaskOutcome('t2')?.state).toBe('done')
+    expect(readTaskOutcome('t2')?.completedAt).toBe(new Date(COMPLETED_AT).toISOString())
+  })
+
+  it('no completion + column blocked → blocked', () => {
+    seed('t3', { column: 'blocked' })
+    expect(readTaskOutcome('t3')).toEqual({ state: 'blocked' })
+  })
+
+  it('no completion + column archived → archived (never completed)', () => {
+    seed('t4', { column: 'archived' })
+    expect(readTaskOutcome('t4')).toEqual({ state: 'archived' })
+  })
+
+  it('no completion + column done → done without completion fields (legacy)', () => {
+    seed('t5', { column: 'done' })
+    expect(readTaskOutcome('t5')).toEqual({ state: 'done' })
+  })
+
+  it.each(['inProgress', 'todo', 'backlog', 'review'])(
+    'no completion + column %s → in_progress',
+    (column) => {
+      seed('t6', { column })
+      expect(readTaskOutcome('t6')).toEqual({ state: 'in_progress' })
+    },
+  )
+
+  it('unknown task (no completion, no board entry) → undefined', () => {
+    seed('t7', {})
+    expect(readTaskOutcome('t7')).toBeUndefined()
+  })
+})

--- a/tests/plugins/tasks/runs-reader.test.ts
+++ b/tests/plugins/tasks/runs-reader.test.ts
@@ -3,12 +3,14 @@
  * readTaskOutcome joins the completion ledger with the task column —
  * completion row wins; otherwise the column maps to the outcome state.
  */
-import { describe, it, expect, mock } from 'bun:test'
-import { mkdtempSync } from 'fs'
+import { describe, it, expect, mock, afterAll } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
-process.env.BAKIN_HOME = mkdtempSync(join(tmpdir(), 'bakin-test-home-'))
+const testHome = mkdtempSync(join(tmpdir(), 'bakin-test-home-'))
+process.env.BAKIN_HOME = testHome
+afterAll(() => rmSync(testHome, { recursive: true, force: true }))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({
@@ -93,5 +95,15 @@ describe('tasks/runs-reader readTaskOutcome', () => {
   it('unknown task (no completion, no board entry) → undefined', () => {
     seed('t7', {})
     expect(readTaskOutcome('t7')).toBeUndefined()
+  })
+
+  it('columnFallback=false: completion still wins without touching the board', () => {
+    seed('t8', { completed: true })
+    expect(readTaskOutcome('t8', false)?.state).toBe('done')
+  })
+
+  it('columnFallback=false: no completion → undefined even when a board entry exists', () => {
+    seed('t9', { column: 'blocked' })
+    expect(readTaskOutcome('t9', false)).toBeUndefined()
   })
 })

--- a/tests/plugins/tasks/task-edit-safety.test.ts
+++ b/tests/plugins/tasks/task-edit-safety.test.ts
@@ -61,6 +61,7 @@ const mockAssignTask = mock(async (id: string) => bump(id))
 mock.module('@/core/task-store', () => ({
   readTaskboard: mock(() => ({ columns: {} })),
   getTask: mock((id: string) => tasks.get(id) ?? null),
+  getTaskWithColumn: mock(() => null),
   updateTask: mockUpdateTask,
   assignTask: mockAssignTask,
   deleteTask: mock(async () => {}),

--- a/tests/plugins/tasks/task-run-history.test.tsx
+++ b/tests/plugins/tasks/task-run-history.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+/**
+ * TaskRunHistory outcome rendering (#476): the header carries the task-level
+ * outcome badge, the per-run `settled` badge is blue (green is reserved for
+ * task done), and the section still renders nothing without runs.
+ */
+import { describe, expect, it, mock, beforeEach } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-task-run-history-${Date.now()}`)
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
+
+// Inert — the component never touches the store/ledger (it renders hook data),
+// but the isolation rules want the surface closed.
+mock.module('../../../src/core/task-store', () => ({
+  getTaskWithColumn: () => null,
+}))
+mock.module('../../../src/core/execution-ledger', () => ({
+  getCompletion: () => null,
+  listRunsByTask: () => [],
+}))
+
+interface HookResult {
+  runs: Array<Record<string, unknown>>
+  outcome?: { state: string; completedAt?: string; agent?: string }
+  loading: boolean
+}
+let hookResult: HookResult = { runs: [], loading: false }
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useTaskRunHistory: () => hookResult,
+}))
+mock.module('@makinbakin/sdk/ui', () => ({
+  Badge: ({ children, className }: { children?: unknown; className?: string }) => (
+    <span data-testid="badge" className={className}>{children as never}</span>
+  ),
+  Separator: () => <hr />,
+}))
+
+const { TaskRunHistory } = await import('../../../plugins/tasks/components/task-run-history')
+
+function run(over: Record<string, unknown> = {}) {
+  return {
+    runId: 'task:t1:d1',
+    taskId: 't1',
+    seq: 1,
+    agent: 'pixel',
+    status: 'settled',
+    startedAt: '2026-06-08T12:00:00.000Z',
+    settledAt: '2026-06-08T12:01:00.000Z',
+    durationMs: 60000,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  hookResult = { runs: [], loading: false }
+})
+
+describe('TaskRunHistory task outcome', () => {
+  it('shows a done outcome badge in the header', () => {
+    hookResult = { runs: [run()], outcome: { state: 'done', completedAt: '2026-06-08T12:01:00.000Z', agent: 'pixel' }, loading: false }
+    render(<TaskRunHistory taskId="t1" />)
+    expect(screen.getByText('done')).toBeDefined()
+  })
+
+  it('shows an in-progress outcome so a settled run does not read as success', () => {
+    hookResult = { runs: [run()], outcome: { state: 'in_progress' }, loading: false }
+    render(<TaskRunHistory taskId="t1" />)
+    expect(screen.getByText('in progress')).toBeDefined()
+  })
+
+  it('shows a blocked outcome badge', () => {
+    hookResult = { runs: [run()], outcome: { state: 'blocked' }, loading: false }
+    render(<TaskRunHistory taskId="t1" />)
+    expect(screen.getByText('blocked')).toBeDefined()
+  })
+
+  it('renders the settled badge blue, never green', () => {
+    hookResult = { runs: [run()], outcome: { state: 'in_progress' }, loading: false }
+    render(<TaskRunHistory taskId="t1" />)
+    const settled = screen.getByText('settled')
+    expect(settled.className).toContain('blue')
+    expect(settled.className).not.toContain('green')
+  })
+
+  it('reserves green for the done outcome badge', () => {
+    hookResult = { runs: [run()], outcome: { state: 'done', completedAt: '2026-06-08T12:01:00.000Z' }, loading: false }
+    render(<TaskRunHistory taskId="t1" />)
+    expect(screen.getByText('done').className).toContain('green')
+  })
+
+  it('renders nothing without runs, even when an outcome exists', () => {
+    hookResult = { runs: [], outcome: { state: 'done' }, loading: false }
+    const { container } = render(<TaskRunHistory taskId="t1" />)
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/tests/plugins/tasks/task-run-history.test.tsx
+++ b/tests/plugins/tasks/task-run-history.test.tsx
@@ -86,6 +86,12 @@ describe('TaskRunHistory task outcome', () => {
     expect(screen.getByText('blocked')).toBeDefined()
   })
 
+  it('shows an archived outcome badge', () => {
+    hookResult = { runs: [run()], outcome: { state: 'archived' }, loading: false }
+    render(<TaskRunHistory taskId="t1" />)
+    expect(screen.getByText('archived')).toBeDefined()
+  })
+
   it('renders the settled badge blue, never green', () => {
     hookResult = { runs: [run()], outcome: { state: 'in_progress' }, loading: false }
     render(<TaskRunHistory taskId="t1" />)


### PR DESCRIPTION
Closes #476. Follow-on to #463 / #475.

## What

The Run History timeline showed each run's dispatch status, and a green `settled` badge read as "this task succeeded" — but settled only means *the agent's turn ended cleanly*. This PR surfaces the task's terminal outcome beside the dispatch history and reserves green for actual success:

- **`readTaskOutcome(taskId)`** (`plugins/tasks/lib/runs-reader.ts`) joins the existing `getCompletion` ledger verb with the task column. Completion row wins → `done` (even after archive — a completions row always implies the board reached done); else column maps to `blocked` / `archived` / `done` (legacy, no row) / `in_progress`. Unknown task → no outcome.
- **`GET /:taskId/runs`** now returns `{ runs, outcome }` — outcome is a sibling task-level object, never stamped per run. Hook mirrors it; SDK re-exports `TaskOutcome`.
- **UI:** the Run History header carries the outcome badge (done green + completion time, blocked red, in progress amber, archived zinc), and the per-run `settled` badge went green → **blue**. Green now exclusively means the task reached Done.

Read-only against the ledger; no schema changes, no new write verbs, no audit coupling.

## Commit ladder (rollback checkpoints)

Each commit lands green; revert from the top down:

| Commit | Leaves behind |
|---|---|
| `docs(tasks): record docker gold-standard e2e verification` | — |
| `test(tasks): cover the archived outcome badge` | — |
| `docs(ledger): note run-history outcome join` | feature intact |
| `feat(tasks): show task outcome in run history header…` | correct `{ runs, outcome }` API, old UI |
| `feat(tasks): return task outcome from the runs route` | unused tested helper, zero surface change |
| `feat(tasks): add readTaskOutcome derivation…` | clean main |

## Test plan

- **Unit:** 10 table-driven cases over the derivation (completion-wins, archive-after-done, legacy done, all four in-progress columns, unknown task).
- **Route:** `{ runs, outcome }` contract incl. outcome-key omission for unknown tasks.
- **Component:** all four badge states, settled-is-blue/never-green assertion, empty-state guard.
- **Full suite:** 4801 pass / 0 fail; typecheck + lint clean; plugins build clean.
- **Docker gold-standard E2E (isolated rig, real OpenClaw):** settled-turn-while-open shows `in_progress`; block/complete/archive transitions; agent MCP completion attribution; unknown-task contract; served bundle maps `settled`→blue, `done`→green. Record in `tasks/plan.md`.

Incidental finds during E2E (pre-existing guards, working as designed): `blocked → done` is an invalid transition, and done requires a log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)