### PR TITLE
fix(rig): cron-CLI operator scopes + stale host agentDir on reused state

### DIFF
--- a/.claude/knowledge/dockerized-openclaw-rig.md
+++ b/.claude/knowledge/dockerized-openclaw-rig.md
@@ -53,12 +53,26 @@ These cost real debugging; don't re-derive them.
      makes `agents add` look failed, and the adapter falls back to writing a **host**
      workspace path that breaks in-container dispatch (`EACCES mkdir /Users`).
   Reference clients: OpenClaw's own `packages/gateway-client` + `clippy/src/lib/device-identity.ts`.
+- **Operator scopes must include `operator.admin` + `operator.pairing`** — OpenClaw
+  2026.5.28's `cron add/list` CLI requests them on top of read/write; with only the
+  old read/write pair every cron command dies on "scope upgrade pending approval"
+  (the same pairing chicken-egg as above, #467). `OPERATOR_SCOPES` in
+  `device-approve.ts` carries all four, and `ensureApprovedDevice` reconciles
+  REUSED rig state in place (`widenDeviceScopes` unions into `scopes`,
+  `approvedScopes`, `tokens.operator.scopes`; keypair/token untouched) — no
+  `instance reset`, no lost Codex auth. Runs before the gateway starts.
 - **host ↔ container paths** — the `openclaw-shim` translates the host openclaw-home
   prefix → `/home/node/.openclaw` in CLI args, so path-passing commands (agents add)
-  target the container. Stored config paths (agent workspaces) are the gap the
-  `plugins.allow` fix closes.
+  target the container. Stored config paths are the other half: `plugins.allow`
+  prevents the bad host-path write at the source, and `instance up` normalizes any
+  already-stored host `agentDir`/`workspace` values back to the container home
+  (`agent-paths.ts`, runs pre-gateway; symptom of stale paths: dispatch fails with
+  `EACCES: mkdir '/Users'`, #467).
 - **`BAKIN_URL`** = the container's callback URL (`host.docker.internal:3737`); the
   host-run Bakin CLI uses `localhost:3737` instead (`instance run`/`shell` override it).
+  The per-agent mcporter `bakin-<agent>` configs **bake this URL in at `up` time** —
+  running Bakin on a non-default port for testing means rewiring those configs in the
+  container (and reverting after); a plain server restart on 3737 needs nothing.
 
 ## Secret handling
 

--- a/scripts/instance.ts
+++ b/scripts/instance.ts
@@ -13,7 +13,7 @@
  *   sandbox   Bakin runs inside the container (clean Linux box).
  */
 import { randomUUID } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { mkdir, readdir, rm } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
@@ -75,6 +75,8 @@ function makeDeps(paths: InstancePaths): LifecycleDeps {
     ensureDevice: () => {
       ensureApprovedDevice(paths.openclawHome, Date.now(), `bakin-dev-${randomUUID()}`)
     },
+    readTextFile: (path) => readFileSync(path, 'utf-8'),
+    writeTextFile: (path, content) => { writeFileSync(path, content) },
     sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
     log: (message) => console.log(`▸ ${message}`),
     env: process.env,

--- a/scripts/instance/agent-paths.ts
+++ b/scripts/instance/agent-paths.ts
@@ -1,0 +1,65 @@
+/**
+ * Normalize stored agent paths in openclaw.json to the container home.
+ *
+ * Reused rig state can carry HOST paths in agent config (a previous run's
+ * `agents add` wrote pre-translation values) — in-container dispatch then
+ * fails with EACCES mkdir '/Users'. The openclaw-shim translates CLI args at
+ * call time; this is the stored-config counterpart, applied on `instance up`
+ * before the gateway starts (#467, same family as the plugins.allow fix).
+ *
+ * Boundary: dev-rig module, exempt from provider-boundary rules.
+ */
+
+export const CONTAINER_OPENCLAW_HOME = '/home/node/.openclaw'
+
+type JsonObject = Record<string, unknown>
+
+function translate(value: unknown, hostOpenclawHome: string): { value: unknown; changed: boolean } {
+  if (typeof value === 'string' && value.startsWith(hostOpenclawHome)) {
+    return { value: CONTAINER_OPENCLAW_HOME + value.slice(hostOpenclawHome.length), changed: true }
+  }
+  return { value, changed: false }
+}
+
+/**
+ * Pure: returns a deep-cloned config with `agents.defaults.workspace` and
+ * `agents.list[*].{workspace,agentDir}` host-home prefixes rewritten to the
+ * container home. Only the exact host openclaw-home prefix matches —
+ * unrelated absolute paths are never touched.
+ */
+export function normalizeAgentPaths(
+  config: JsonObject,
+  hostOpenclawHome: string,
+): { config: JsonObject; changed: boolean } {
+  const next = structuredClone(config)
+  let changed = false
+
+  const agents = next.agents as JsonObject | undefined
+  if (!agents || typeof agents !== 'object') return { config: next, changed }
+
+  const defaults = agents.defaults as JsonObject | undefined
+  if (defaults && typeof defaults === 'object') {
+    const result = translate(defaults.workspace, hostOpenclawHome)
+    if (result.changed) {
+      defaults.workspace = result.value
+      changed = true
+    }
+  }
+
+  const list = agents.list
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      if (!entry || typeof entry !== 'object') continue
+      const agent = entry as JsonObject
+      for (const key of ['workspace', 'agentDir'] as const) {
+        const result = translate(agent[key], hostOpenclawHome)
+        if (result.changed) {
+          agent[key] = result.value
+          changed = true
+        }
+      }
+    }
+  }
+
+  return { config: next, changed }
+}

--- a/scripts/instance/device-approve.ts
+++ b/scripts/instance/device-approve.ts
@@ -11,10 +11,13 @@
  * Boundary: dev-rig module, exempt from provider-boundary rules.
  */
 import { createHash, generateKeyPairSync } from 'node:crypto'
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-const OPERATOR_SCOPES = ['operator.read', 'operator.write']
+// OpenClaw 2026.5.28's cron CLI requests operator.admin + operator.pairing on
+// top of read/write — without them every `cron add/list` dies on "scope
+// upgrade pending approval" (the documented pairing chicken-and-egg, #467).
+const OPERATOR_SCOPES = ['operator.read', 'operator.write', 'operator.admin', 'operator.pairing']
 
 function base64url(bytes: Buffer): string {
   return bytes.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
@@ -86,14 +89,91 @@ export function buildApprovedDeviceState(kp: DeviceKeypair, token: string, nowMs
   return { identity, deviceAuth, paired }
 }
 
+type ScopedRecord = Record<string, unknown>
+
+function unionScopes(target: unknown, scopes: readonly string[]): { value: string[]; changed: boolean } {
+  const existing = Array.isArray(target) ? target.filter((s): s is string => typeof s === 'string') : []
+  const value = [...existing]
+  let changed = false
+  for (const scope of scopes) {
+    if (!value.includes(scope)) {
+      value.push(scope)
+      changed = true
+    }
+  }
+  return { value, changed }
+}
+
 /**
- * Ensure the openclaw home has a pre-approved Bakin device. No-op if an
- * identity already exists (don't clobber a working pairing).
+ * Union the required operator scopes into existing device state. Pure —
+ * keypair and token are untouched. Reused rig state predates the wider
+ * scope list, and an `instance reset` to regenerate it would lose Codex
+ * auth; widening in place avoids both.
+ */
+export function widenDeviceScopes(
+  paired: Record<string, ScopedRecord>,
+  deviceAuth: ScopedRecord,
+  scopes: readonly string[] = OPERATOR_SCOPES,
+): { paired: Record<string, ScopedRecord>; deviceAuth: ScopedRecord; changed: boolean } {
+  let changed = false
+  const nextPaired = structuredClone(paired)
+  for (const record of Object.values(nextPaired)) {
+    for (const key of ['scopes', 'approvedScopes'] as const) {
+      const result = unionScopes(record[key], scopes)
+      if (result.changed) {
+        record[key] = result.value
+        changed = true
+      }
+    }
+    const operatorToken = (record.tokens as Record<string, ScopedRecord> | undefined)?.operator
+    if (operatorToken) {
+      const result = unionScopes(operatorToken.scopes, scopes)
+      if (result.changed) {
+        operatorToken.scopes = result.value
+        changed = true
+      }
+    }
+  }
+  const nextAuth = structuredClone(deviceAuth)
+  const authToken = (nextAuth.tokens as Record<string, ScopedRecord> | undefined)?.operator
+  if (authToken) {
+    const result = unionScopes(authToken.scopes, scopes)
+    if (result.changed) {
+      authToken.scopes = result.value
+      changed = true
+    }
+  }
+  return { paired: nextPaired, deviceAuth: nextAuth, changed }
+}
+
+/**
+ * Ensure the openclaw home has a pre-approved Bakin device. When an identity
+ * already exists, the pairing is kept (never clobbered) but its scopes are
+ * reconciled against OPERATOR_SCOPES — `up` runs this before the gateway
+ * starts, so widened scopes are read on the next gateway boot.
  */
 export function ensureApprovedDevice(openclawHome: string, nowMs: number, token: string): boolean {
   const identityDir = join(openclawHome, 'identity')
   const devicesDir = join(openclawHome, 'devices')
-  if (existsSync(join(identityDir, 'device.json'))) return false
+  if (existsSync(join(identityDir, 'device.json'))) {
+    try {
+      const pairedPath = join(devicesDir, 'paired.json')
+      const authPath = join(identityDir, 'device-auth.json')
+      if (existsSync(pairedPath) && existsSync(authPath)) {
+        const paired = JSON.parse(readFileSync(pairedPath, 'utf-8')) as Record<string, ScopedRecord>
+        const deviceAuth = JSON.parse(readFileSync(authPath, 'utf-8')) as ScopedRecord
+        const widened = widenDeviceScopes(paired, deviceAuth)
+        if (widened.changed) {
+          writeFileSync(pairedPath, JSON.stringify(widened.paired, null, 2))
+          writeFileSync(authPath, JSON.stringify(widened.deviceAuth, null, 2))
+          console.log('[device-approve] widened operator scopes on existing rig state')
+        }
+      }
+    } catch (err) {
+      console.warn(`[device-approve] scope reconcile skipped: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    return false
+  }
 
   mkdirSync(identityDir, { recursive: true })
   mkdirSync(devicesDir, { recursive: true })

--- a/scripts/instance/lifecycle.ts
+++ b/scripts/instance/lifecycle.ts
@@ -17,6 +17,7 @@ import {
   codexLoginArgs,
   type OpenClawExec,
 } from './codex'
+import { normalizeAgentPaths } from './agent-paths'
 import { mcporterBakinUrlBase, mcporterConfigJson, mcporterWriteArgs, parseAgentIds } from './mcporter'
 import { buildConfigCommands } from './openclaw-config'
 import { parseSecretsTemplate, redactSecrets, resolveSecrets } from './op-resolve'
@@ -40,6 +41,8 @@ export interface LifecycleDeps {
   exists: (path: string) => boolean
   /** Pre-approve Bakin's gateway device so operator.write is granted (no-op if already set up). */
   ensureDevice: () => void
+  readTextFile: (path: string) => string
+  writeTextFile: (path: string, content: string) => void
   sleep: (ms: number) => Promise<void>
   log: (message: string) => void
   env: Record<string, string | undefined>
@@ -214,6 +217,25 @@ export async function up(
       if (result.code !== 0) {
         throw new Error(`OpenClaw config init failed (${command.join(' ')}): ${result.stderr.trim() || `exit ${result.code}`}`)
       }
+    }
+  }
+
+  // Reused rig state may hold HOST agent paths (stored pre-translation by a
+  // previous run's `agents add`) — in-container dispatch then fails with
+  // EACCES mkdir '/Users'. Rewrite them to the container home BEFORE the
+  // gateway starts so it reads normalized config on boot (the stored-config
+  // counterpart of the openclaw-shim's CLI arg translation, #467).
+  const openclawConfigPath = join(paths.openclawHome, 'openclaw.json')
+  if (deps.exists(openclawConfigPath)) {
+    try {
+      const parsed = JSON.parse(deps.readTextFile(openclawConfigPath)) as Record<string, unknown>
+      const normalized = normalizeAgentPaths(parsed, paths.openclawHome)
+      if (normalized.changed) {
+        deps.log('normalizing stored agent paths to the container home…')
+        deps.writeTextFile(openclawConfigPath, JSON.stringify(normalized.config, null, 2))
+      }
+    } catch (err) {
+      deps.log(`agent-path normalization skipped (unreadable openclaw.json): ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 

--- a/tests/scripts/instance/agent-paths.test.ts
+++ b/tests/scripts/instance/agent-paths.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test'
+
+import { CONTAINER_OPENCLAW_HOME, normalizeAgentPaths } from '../../../scripts/instance/agent-paths'
+
+const HOST_HOME = '/Users/mark/repo/dev/openclaw-home'
+
+describe('normalizeAgentPaths', () => {
+  it('rewrites host-prefixed defaults.workspace and per-agent workspace/agentDir', () => {
+    const config = {
+      agents: {
+        defaults: { workspace: `${HOST_HOME}/workspace` },
+        list: [
+          {
+            id: 'main',
+            workspace: `${HOST_HOME}/workspace`,
+            agentDir: `${HOST_HOME}/agents/main/agent`,
+            model: { primary: 'openai/gpt-5.5' },
+          },
+        ],
+      },
+      gateway: { bind: 'lan' },
+    }
+
+    const result = normalizeAgentPaths(config, HOST_HOME)
+    expect(result.changed).toBe(true)
+    const agents = result.config.agents as {
+      defaults: { workspace: string }
+      list: Array<{ id: string; workspace: string; agentDir: string; model: unknown }>
+    }
+    expect(agents.defaults.workspace).toBe(`${CONTAINER_OPENCLAW_HOME}/workspace`)
+    expect(agents.list[0]!.workspace).toBe(`${CONTAINER_OPENCLAW_HOME}/workspace`)
+    expect(agents.list[0]!.agentDir).toBe(`${CONTAINER_OPENCLAW_HOME}/agents/main/agent`)
+    // unrelated fields untouched
+    expect(agents.list[0]!.model).toEqual({ primary: 'openai/gpt-5.5' })
+    expect((result.config.gateway as { bind: string }).bind).toBe('lan')
+    // input is not mutated
+    expect(config.agents.list[0]!.agentDir).toBe(`${HOST_HOME}/agents/main/agent`)
+  })
+
+  it('no-ops on container-form paths', () => {
+    const config = {
+      agents: {
+        defaults: { workspace: `${CONTAINER_OPENCLAW_HOME}/workspace` },
+        list: [{ id: 'main', agentDir: `${CONTAINER_OPENCLAW_HOME}/agents/main/agent` }],
+      },
+    }
+    const result = normalizeAgentPaths(config, HOST_HOME)
+    expect(result.changed).toBe(false)
+    expect(result.config).toEqual(config)
+  })
+
+  it('matches only the host openclaw-home prefix, not arbitrary absolute paths', () => {
+    const config = {
+      agents: {
+        list: [{ id: 'main', workspace: '/opt/some/other/workspace' }],
+      },
+    }
+    const result = normalizeAgentPaths(config, HOST_HOME)
+    expect(result.changed).toBe(false)
+    expect((result.config.agents as { list: Array<{ workspace: string }> }).list[0]!.workspace)
+      .toBe('/opt/some/other/workspace')
+  })
+
+  it('tolerates missing agents/list/defaults and non-string values', () => {
+    expect(normalizeAgentPaths({}, HOST_HOME).changed).toBe(false)
+    expect(normalizeAgentPaths({ agents: {} }, HOST_HOME).changed).toBe(false)
+    expect(normalizeAgentPaths({ agents: { list: [{ agentDir: 42 }] } }, HOST_HOME).changed).toBe(false)
+  })
+})

--- a/tests/scripts/instance/device-approve.test.ts
+++ b/tests/scripts/instance/device-approve.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
 
-import { buildApprovedDeviceState, generateDeviceKeypair } from '../../../scripts/instance/device-approve'
+import { buildApprovedDeviceState, ensureApprovedDevice, generateDeviceKeypair, widenDeviceScopes } from '../../../scripts/instance/device-approve'
+
+// OpenClaw 2026.5.28's cron CLI requests admin + pairing on top of read/write.
+const ALL_SCOPES = ['operator.admin', 'operator.pairing', 'operator.read', 'operator.write']
+const NARROW_SCOPES = ['operator.read', 'operator.write']
 
 describe('generateDeviceKeypair', () => {
   it('produces an ed25519 keypair with a sha256-hex deviceId and 32-byte raw pubkey', () => {
@@ -20,17 +27,19 @@ describe('buildApprovedDeviceState', () => {
     publicKeyRawBase64Url: 'rawpub',
   }
 
-  it('pre-approves the device with operator.write + Bakin metadata', () => {
+  it('pre-approves the device with the full operator scope set + Bakin metadata', () => {
     const { identity, deviceAuth, paired } = buildApprovedDeviceState(kp, 'tok-1', 1000)
     expect(identity.deviceId).toBe('dev123')
     expect(deviceAuth.tokens.operator.token).toBe('tok-1')
-    expect(deviceAuth.tokens.operator.scopes).toContain('operator.write')
+    expect([...deviceAuth.tokens.operator.scopes].sort()).toEqual(ALL_SCOPES)
 
     const dev = paired.dev123
     expect(dev.clientId).toBe('gateway-client')
     expect(dev.clientMode).toBe('backend')
     expect(dev.publicKey).toBe('rawpub')
-    expect(dev.approvedScopes).toEqual(['operator.read', 'operator.write'])
+    expect([...dev.scopes].sort()).toEqual(ALL_SCOPES)
+    expect([...dev.approvedScopes].sort()).toEqual(ALL_SCOPES)
+    expect([...dev.tokens.operator.scopes].sort()).toEqual(ALL_SCOPES)
     expect(dev.tokens.operator.token).toBe('tok-1')
   })
 
@@ -38,5 +47,85 @@ describe('buildApprovedDeviceState', () => {
     const dev = buildApprovedDeviceState(kp, 't', 1).paired.dev123 as Record<string, unknown>
     expect('platform' in dev).toBe(false)
     expect('deviceFamily' in dev).toBe(false)
+  })
+})
+
+describe('widenDeviceScopes', () => {
+  function narrowState() {
+    const { deviceAuth, paired } = buildApprovedDeviceState(
+      { deviceId: 'dev123', publicKeyPem: 'PUB', privateKeyPem: 'PRIV', publicKeyRawBase64Url: 'rawpub' },
+      'tok-1', 1000,
+    )
+    const p = JSON.parse(JSON.stringify(paired)) as Record<string, Record<string, unknown>>
+    const a = JSON.parse(JSON.stringify(deviceAuth)) as Record<string, unknown>
+    p.dev123.scopes = [...NARROW_SCOPES]
+    p.dev123.approvedScopes = [...NARROW_SCOPES]
+    ;(p.dev123.tokens as Record<string, Record<string, unknown>>).operator.scopes = [...NARROW_SCOPES]
+    ;(a.tokens as Record<string, Record<string, unknown>>).operator.scopes = [...NARROW_SCOPES]
+    return { paired: p, deviceAuth: a }
+  }
+
+  it('unions the required scopes into all three encodings, preserving token', () => {
+    const { paired, deviceAuth } = narrowState()
+    const result = widenDeviceScopes(paired, deviceAuth)
+    expect(result.changed).toBe(true)
+
+    const dev = result.paired.dev123 as Record<string, unknown>
+    expect([...(dev.scopes as string[])].sort()).toEqual(ALL_SCOPES)
+    expect([...(dev.approvedScopes as string[])].sort()).toEqual(ALL_SCOPES)
+    const devTok = (dev.tokens as Record<string, Record<string, unknown>>).operator
+    expect([...(devTok.scopes as string[])].sort()).toEqual(ALL_SCOPES)
+    expect(devTok.token).toBe('tok-1')
+    const authTok = (result.deviceAuth.tokens as Record<string, Record<string, unknown>>).operator
+    expect([...(authTok.scopes as string[])].sort()).toEqual(ALL_SCOPES)
+    expect(authTok.token).toBe('tok-1')
+  })
+
+  it('reports changed=false when scopes are already a superset', () => {
+    const { paired, deviceAuth } = narrowState()
+    const once = widenDeviceScopes(paired, deviceAuth)
+    const twice = widenDeviceScopes(
+      once.paired as Record<string, Record<string, unknown>>,
+      once.deviceAuth,
+    )
+    expect(twice.changed).toBe(false)
+  })
+})
+
+describe('ensureApprovedDevice scope reconcile', () => {
+  it('widens narrow scopes in reused rig state without touching keypair or token', () => {
+    const home = mkdtempSync(join(tmpdir(), 'bakin-rig-device-test-'))
+    try {
+      expect(ensureApprovedDevice(home, 1000, 'tok-1')).toBe(true)
+
+      // Simulate pre-#467 state: narrow the persisted scopes by hand
+      const pairedPath = join(home, 'devices', 'paired.json')
+      const authPath = join(home, 'identity', 'device-auth.json')
+      const paired = JSON.parse(readFileSync(pairedPath, 'utf-8'))
+      const id = Object.keys(paired)[0]!
+      paired[id].scopes = [...NARROW_SCOPES]
+      paired[id].approvedScopes = [...NARROW_SCOPES]
+      paired[id].tokens.operator.scopes = [...NARROW_SCOPES]
+      writeFileSync(pairedPath, JSON.stringify(paired, null, 2))
+      const auth = JSON.parse(readFileSync(authPath, 'utf-8'))
+      auth.tokens.operator.scopes = [...NARROW_SCOPES]
+      writeFileSync(authPath, JSON.stringify(auth, null, 2))
+      const identityBefore = readFileSync(join(home, 'identity', 'device.json'), 'utf-8')
+
+      // Reused state: returns false (not created) but reconciles scopes
+      expect(ensureApprovedDevice(home, 2000, 'tok-ignored')).toBe(false)
+
+      const widened = JSON.parse(readFileSync(pairedPath, 'utf-8'))
+      expect([...widened[id].approvedScopes].sort()).toEqual(ALL_SCOPES)
+      expect([...widened[id].scopes].sort()).toEqual(ALL_SCOPES)
+      expect([...widened[id].tokens.operator.scopes].sort()).toEqual(ALL_SCOPES)
+      expect(widened[id].tokens.operator.token).toBe('tok-1') // original token kept
+      const authWidened = JSON.parse(readFileSync(authPath, 'utf-8'))
+      expect([...authWidened.tokens.operator.scopes].sort()).toEqual(ALL_SCOPES)
+      // identity (keypair) untouched
+      expect(readFileSync(join(home, 'identity', 'device.json'), 'utf-8')).toBe(identityBefore)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 })

--- a/tests/scripts/instance/lifecycle.test.ts
+++ b/tests/scripts/instance/lifecycle.test.ts
@@ -33,10 +33,12 @@ function fakeDeps(over: Partial<{
   results: (argv: string[]) => RunResult
   env: Record<string, string | undefined>
   exists: boolean
+  configText: string
 }> = {}) {
   const calls: string[][] = []
   const wiped: string[] = []
   const mkdirs: string[] = []
+  const writes: Array<{ path: string; content: string; beforeCallCount: number }> = []
   const runner: CommandRunner = {
     async run(argv) {
       calls.push(argv)
@@ -53,11 +55,13 @@ function fakeDeps(over: Partial<{
     mkdirp: async (p) => { mkdirs.push(p) },
     exists: () => over.exists ?? true, // default: config already present (init skipped)
     ensureDevice: () => {},
+    readTextFile: () => over.configText ?? '{}',
+    writeTextFile: (path, content) => { writes.push({ path, content, beforeCallCount: calls.length }) },
     sleep: async () => {},
     log: () => {},
     env: over.env ?? { OP_SERVICE_ACCOUNT_TOKEN: 'tok' },
   }
-  return { deps, calls, wiped, mkdirs }
+  return { deps, calls, wiped, mkdirs, writes }
 }
 
 describe('compose argv builders', () => {
@@ -168,6 +172,47 @@ describe('up — native', () => {
     const upIdx = order.findIndex((c) => c.includes('up -d'))
     expect(initIdx).toBeGreaterThanOrEqual(0)
     expect(upIdx).toBeGreaterThan(initIdx)
+  })
+})
+
+describe('up — agent-path normalization', () => {
+  const HOST_HOME = '/tmp/fake-repo/dev/openclaw-home'
+
+  it('rewrites stored host agent paths to the container home before the gateway starts', async () => {
+    const { paths, plan } = planFor(['up'])
+    const config = {
+      agents: {
+        list: [{ id: 'main', agentDir: `${HOST_HOME}/agents/main/agent`, workspace: `${HOST_HOME}/workspace` }],
+      },
+    }
+    const { deps, calls, writes } = fakeDeps({ exists: true, configText: JSON.stringify(config) })
+    await up(plan, paths, 'BRAVE_API_KEY=op://V/brave/cred', deps)
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]!.path).toBe(`${HOST_HOME}/openclaw.json`)
+    const written = JSON.parse(writes[0]!.content) as typeof config
+    expect(written.agents.list[0]!.agentDir).toBe('/home/node/.openclaw/agents/main/agent')
+    expect(written.agents.list[0]!.workspace).toBe('/home/node/.openclaw/workspace')
+
+    // rewrite happens before docker compose up (gateway reads config on start)
+    const upIdx = calls.findIndex((c) => c.join(' ').includes('up -d'))
+    expect(upIdx).toBeGreaterThanOrEqual(0)
+    expect(writes[0]!.beforeCallCount).toBeLessThanOrEqual(upIdx)
+  })
+
+  it('writes nothing when stored paths are already container-form', async () => {
+    const { paths, plan } = planFor(['up'])
+    const config = { agents: { list: [{ id: 'main', agentDir: '/home/node/.openclaw/agents/main/agent' }] } }
+    const { deps, writes } = fakeDeps({ exists: true, configText: JSON.stringify(config) })
+    await up(plan, paths, 'BRAVE_API_KEY=op://V/brave/cred', deps)
+    expect(writes).toHaveLength(0)
+  })
+
+  it('skips normalization on fresh state (no openclaw.json)', async () => {
+    const { paths, plan } = planFor(['up'])
+    const { deps, writes } = fakeDeps({ exists: false })
+    await up(plan, paths, 'BRAVE_API_KEY=op://V/brave/cred', deps)
+    expect(writes).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
Fixes #467.

## What

Two rig defects hit live during the execution-safety gold-standard e2e (2026-06-06), both previously worked around by hand-editing container state:

1. **Device scopes too narrow** — OpenClaw 2026.5.28's \`cron add/list\` CLI requests \`operator.admin\` + \`operator.pairing\`; the rig pre-approved only read/write, so every cron command died on "scope upgrade pending approval".
2. **Stale host \`agentDir\`** — reused rig state carried host paths (\`/Users/...\`) in agent config; in-container dispatch failed with \`EACCES: mkdir '/Users'\`.

## How

1. **704bfd9c** — \`OPERATOR_SCOPES\` carries all four scopes, and — because the failure scenario is *reused* state that \`ensureApprovedDevice\` previously skipped — its existing-identity branch now reconciles in place via the pure \`widenDeviceScopes\` (union into \`scopes\`/\`approvedScopes\`/\`tokens.operator.scopes\`; keypair and token untouched, so no \`instance reset\` and no lost Codex auth). Runs before the gateway starts.
2. **fd992ffe** — new pure \`normalizeAgentPaths\` rewrites the host openclaw-home prefix (only that prefix) to \`/home/node/.openclaw\` across \`agents.defaults.workspace\` and \`agents.list[*].{workspace,agentDir}\`; wired into \`up\` after config bootstrap, before gateway start, write-only-when-changed. The stored-config counterpart of the openclaw-shim's CLI arg translation.
3. **docs** — rig knowledge hard-won list gains the scope requirement + reconcile, the agentDir normalization (with its EACCES symptom), and the mcporter \`BAKIN_URL\`-baked-at-\`up\`-time gotcha for non-default ports.

## Testing

TDD: scope-widening and normalization tests written RED-first (fresh-state full scope set, reused-state reconcile preserving keypair/token + idempotence; pure path translation cases; lifecycle ordering — rewrite lands before \`docker compose up\`, fresh state skips). Full suite green: 4908 pass / 0 fail. Dev-rig only — nothing here ships in the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)