### PR TITLE
Layered context UI: health repair, team pages, graph badges — #401 PR 2/2

### DIFF
--- a/packages/host/src/router.ts
+++ b/packages/host/src/router.ts
@@ -11,6 +11,7 @@ import { Route as IndexRoute } from './routes/index'
 import { Route as TasksRoute } from './routes/tasks'
 import { Route as TeamIndexRoute } from './routes/team.index'
 import { Route as TeamIdRoute } from './routes/team.$id'
+import { Route as TeamTeamsRoute } from './routes/team.teams.$teamId'
 import { Route as WorkflowsIndexRoute } from './routes/workflows.index'
 import { Route as WorkflowsNewRoute } from './routes/workflows.new'
 import { Route as WorkflowsIdIndexRoute } from './routes/workflows.$id.index'
@@ -28,6 +29,7 @@ const routeTree = RootRoute.addChildren([
   IndexRoute,
   TasksRoute,
   TeamIndexRoute,
+  TeamTeamsRoute,
   TeamIdRoute,
   WorkflowsIndexRoute,
   WorkflowsNewRoute,

--- a/packages/host/src/routes/team.teams.$teamId.tsx
+++ b/packages/host/src/routes/team.teams.$teamId.tsx
@@ -1,0 +1,28 @@
+/**
+ * /team/teams/$teamId — team detail route (layered-context spec, C11).
+ *
+ * Static `teams` segment outranks the `/team/$id` agent-detail param route
+ * in TanStack matching, so team pages never collide with agent ids. The
+ * pseudo-team id `global` renders the global context page.
+ */
+import { createRoute } from '@tanstack/react-router'
+import { Slot } from '@makinbakin/sdk/slots'
+import { Suspense } from 'react'
+import { Route as RootRoute } from './__root'
+
+function TeamDetailPage() {
+  const { teamId } = Route.useParams()
+  return (
+    <div className="p-6 flex flex-col h-full min-h-0">
+      <Suspense fallback={null}>
+        <Slot name="page:/team/teams/[teamId]" teamId={teamId} />
+      </Suspense>
+    </div>
+  )
+}
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/team/teams/$teamId',
+  component: TeamDetailPage,
+})

--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -18,7 +18,8 @@ import {
 } from "@makinbakin/sdk/ui"
 import { PluginHeader } from "@makinbakin/sdk/components"
 import { UnderlineTabs } from "@makinbakin/sdk/components"
-import { Search, CircleCheck, Clock, AlertCircle } from 'lucide-react'
+import { Search, CircleCheck, Clock, AlertCircle, Wrench } from 'lucide-react'
+import { RepairDialog } from './repair-dialog'
 import type { HealthCheckResult } from '@makinbakin/sdk'
 
 const PLUGIN_CHECK_INTERVAL_MS = 60 * 60 * 1000
@@ -438,6 +439,7 @@ function AgentUsagePanel({ feed }: { feed: UsageFeedData | null }) {
 
 export function HealthPage() {
   const [data, setData] = useState<HealthSummary | null>(null)
+  const [repairOpen, setRepairOpen] = useState(false)
   const [registry, setRegistry] = useState<RegistryData | null>(null)
   const [pluginManifest, setPluginManifest] = useState<PluginManifestData | null>(null)
   const [pluginChecking, setPluginChecking] = useState(false)
@@ -1084,7 +1086,7 @@ export function HealthPage() {
                   </span>
                 )}
               </span>
-              <div className="flex gap-2 text-xs">
+              <div className="flex items-center gap-2 text-xs">
                 <Badge className={STATUS_STYLES.ok}>
                   {doctor.summary.total - doctor.summary.errors - doctor.summary.warnings} ok
                 </Badge>
@@ -1093,6 +1095,11 @@ export function HealthPage() {
                 )}
                 {doctor.summary.errors > 0 && (
                   <Badge className={STATUS_STYLES.error}>{doctor.summary.errors} error</Badge>
+                )}
+                {doctor.summary.warnings + doctor.summary.errors > 0 && (
+                  <Button size="sm" variant="outline" className="h-6 gap-1 px-2 text-xs" onClick={() => setRepairOpen(true)}>
+                    <Wrench className="size-3" /> Repair…
+                  </Button>
                 )}
               </div>
             </CardTitle>
@@ -1118,6 +1125,8 @@ export function HealthPage() {
           </CardContent>
         </Card>
       )}
+
+      <RepairDialog open={repairOpen} onOpenChange={setRepairOpen} onApplied={() => { void fetchData() }} />
 
       {/* Server info footer */}
       {server && (

--- a/plugins/health/components/repair-dialog.tsx
+++ b/plugins/health/components/repair-dialog.tsx
@@ -1,0 +1,257 @@
+'use client'
+
+/**
+ * Generic doctor repair flow (layered-context spec, C10) — the first repair
+ * affordance in the Health UI. Works for ANY check whose handler offers
+ * repairs, not just agent-sync:
+ *
+ *   plan (GET /doctor/repair/plan) → per-item review with safety labels →
+ *   explicit selection (safe items pre-checked; manual/destructive items
+ *   require individually ticking their confirmation box) →
+ *   apply (POST /doctor/repair/apply { accepted, itemIds, allowDestructive })
+ *   → results + verification.
+ *
+ * Destructive consent is structural: the apply engine refuses non-safe items
+ * unless the caller passed explicit itemIds + allowDestructive, which this
+ * dialog only sends for items the user ticked one-by-one.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@makinbakin/sdk/ui'
+import { AlertTriangle, CircleCheck, Wrench } from 'lucide-react'
+
+interface RepairChange {
+  kind: string
+  target: string
+  action: string
+  description: string
+}
+
+interface RepairPlanItem {
+  id: string
+  checkId: string
+  healthCheckId: string
+  checkName: string
+  title: string
+  reason: string
+  safety: 'safe' | 'manual' | 'destructive'
+  requiresConfirmation: boolean
+  changes: RepairChange[]
+}
+
+interface RepairPlanReport {
+  items: RepairPlanItem[]
+  errors: Array<{ healthCheckId: string; message: string }>
+  summary: { totalItems: number; safeItems: number }
+}
+
+interface RepairApplyResult {
+  id: string
+  checkId: string
+  status: 'applied' | 'skipped' | 'failed'
+  message: string
+}
+
+interface RepairApplyReport {
+  status: 'confirmation_required' | 'applied'
+  applied: RepairApplyResult[]
+  skipped: RepairApplyResult[]
+  errors: Array<{ healthCheckId: string; message: string }>
+  verification: Array<{ check: string; status: string; message: string }>
+}
+
+const SAFETY_STYLES: Record<RepairPlanItem['safety'], string> = {
+  safe: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+  manual: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  destructive: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+}
+
+export function RepairDialog({ open, onOpenChange, onApplied }: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onApplied?: () => void
+}) {
+  const [plan, setPlan] = useState<RepairPlanReport | null>(null)
+  const [planning, setPlanning] = useState(false)
+  const [planError, setPlanError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [applying, setApplying] = useState(false)
+  const [result, setResult] = useState<RepairApplyReport | null>(null)
+  const [applyError, setApplyError] = useState<string | null>(null)
+
+  const loadPlan = useCallback(async () => {
+    setPlanning(true)
+    setPlanError(null)
+    setResult(null)
+    try {
+      const res = await fetch('/api/plugins/health/doctor/repair/plan')
+      if (!res.ok) throw new Error(`plan failed (${res.status})`)
+      const report = await res.json() as RepairPlanReport
+      setPlan(report)
+      // Safe items are pre-selected; anything requiring confirmation starts
+      // unticked — consent is per item, never implied.
+      setSelected(new Set(report.items.filter((i) => i.safety === 'safe' && !i.requiresConfirmation).map((i) => i.id)))
+    } catch (err) {
+      setPlanError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPlanning(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) void loadPlan()
+  }, [open, loadPlan])
+
+  const destructiveSelected = useMemo(
+    () => plan?.items.some((i) => selected.has(i.id) && i.safety !== 'safe') ?? false,
+    [plan, selected],
+  )
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const apply = async () => {
+    if (!plan || selected.size === 0) return
+    setApplying(true)
+    setApplyError(null)
+    try {
+      const res = await fetch('/api/plugins/health/doctor/repair/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          accepted: true,
+          itemIds: [...selected],
+          allowDestructive: destructiveSelected,
+        }),
+      })
+      const report = await res.json() as RepairApplyReport
+      if (!res.ok && (report as unknown as { error?: string }).error) {
+        throw new Error((report as unknown as { error: string }).error)
+      }
+      setResult(report)
+      onApplied?.()
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Wrench className="size-4" /> Repair
+          </DialogTitle>
+          <DialogDescription>
+            Review the planned repairs. Safe items are pre-selected; anything
+            marked manual or destructive needs its own checkbox ticked.
+          </DialogDescription>
+        </DialogHeader>
+
+        {planning && <p className="text-sm text-muted-foreground">Planning repairs…</p>}
+        {planError && <p className="text-sm text-red-400">{planError}</p>}
+
+        {!planning && plan && !result && (
+          <div className="space-y-3 max-h-96 overflow-y-auto">
+            {plan.items.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                Nothing repairable right now — remaining findings need manual attention.
+              </p>
+            )}
+            {plan.items.map((item) => (
+              <label
+                key={item.id}
+                className={`flex items-start gap-3 rounded-md border p-3 cursor-pointer ${item.safety === 'destructive' ? 'border-red-300 dark:border-red-900' : 'border-border'}`}
+              >
+                <input
+                  type="checkbox"
+                  className="mt-1"
+                  checked={selected.has(item.id)}
+                  onChange={() => toggle(item.id)}
+                  aria-label={`Select repair: ${item.title}`}
+                />
+                <span className="space-y-1 text-sm">
+                  <span className="flex items-center gap-2 font-medium">
+                    {item.title}
+                    <Badge className={`${SAFETY_STYLES[item.safety]} text-[10px] px-1.5`}>{item.safety}</Badge>
+                  </span>
+                  <span className="block text-muted-foreground">{item.reason}</span>
+                  {item.changes.map((change, i) => (
+                    <span key={i} className="block text-xs text-muted-foreground">
+                      → {change.action} {change.target}: {change.description}
+                    </span>
+                  ))}
+                  {item.safety === 'destructive' && (
+                    <span className="flex items-center gap-1 text-xs text-red-500">
+                      <AlertTriangle className="size-3" /> Overwrites content — tick to confirm explicitly.
+                    </span>
+                  )}
+                </span>
+              </label>
+            ))}
+            {plan.errors.length > 0 && (
+              <p className="text-xs text-yellow-500">
+                {plan.errors.length} check(s) failed to plan: {plan.errors.map((e) => e.healthCheckId).join(', ')}
+              </p>
+            )}
+          </div>
+        )}
+
+        {result && (
+          <div className="space-y-2 max-h-96 overflow-y-auto text-sm">
+            {[...result.applied, ...result.skipped].map((r) => (
+              <div key={r.id} className="flex items-start gap-2">
+                {r.status === 'applied'
+                  ? <CircleCheck className="size-4 shrink-0 text-green-500 mt-0.5" />
+                  : <AlertTriangle className="size-4 shrink-0 text-yellow-500 mt-0.5" />}
+                <span><span className="font-medium">{r.id}</span> — {r.status}: {r.message}</span>
+              </div>
+            ))}
+            {result.errors.map((e, i) => (
+              <p key={i} className="text-red-400 text-xs">{e.healthCheckId}: {e.message}</p>
+            ))}
+            {result.verification.length > 0 && (
+              <p className="text-xs text-muted-foreground">
+                Verification: {result.verification.filter((v) => v.status === 'ok' || v.status === 'fixed').length}/{result.verification.length} checks clean after repair.
+              </p>
+            )}
+          </div>
+        )}
+        {applyError && <p className="text-sm text-red-400">{applyError}</p>}
+
+        <DialogFooter>
+          {!result ? (
+            <>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+              <Button
+                onClick={apply}
+                disabled={applying || selected.size === 0}
+                variant={destructiveSelected ? 'destructive' : 'default'}
+              >
+                {applying ? 'Applying…' : destructiveSelected ? `Apply ${selected.size} (incl. destructive)` : `Apply ${selected.size} repair${selected.size === 1 ? '' : 's'}`}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={() => onOpenChange(false)}>Done</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -138,6 +138,7 @@ const doctorResponse = z.object({
 const doctorRepairApplyBody = z.object({
   accepted: z.boolean(),
   itemIds: z.array(z.string()).optional(),
+  allowDestructive: z.boolean().optional(),
 })
 
 const acceptedBody = z.object({
@@ -323,6 +324,7 @@ const routes = [
           projectRoot: process.cwd(),
           accepted: body.accepted,
           itemIds: body.itemIds,
+          allowDestructive: body.allowDestructive,
         })
         return Response.json(report, {
           status: report.status === 'confirmation_required' ? 409 : 200,

--- a/plugins/team/bakin-plugin.json
+++ b/plugins/team/bakin-plugin.json
@@ -322,7 +322,8 @@
     ],
     "slots": [
       "page:/team",
-      "page:/team/[id]"
+      "page:/team/[id]",
+      "page:/team/teams/[teamId]"
     ]
   }
 }

--- a/plugins/team/client.tsx
+++ b/plugins/team/client.tsx
@@ -6,11 +6,13 @@
 import { registerPlugin } from '@makinbakin/sdk'
 import { TeamGrid } from './components/team-grid'
 import { AgentDetail } from './components/agent-detail'
+import { TeamDetail } from './components/team-detail'
 
 registerPlugin({
   id: 'team',
   slots: {
     'page:/team': TeamGrid,
     'page:/team/[id]': AgentDetail,
+    'page:/team/teams/[teamId]': TeamDetail,
   },
 })

--- a/plugins/team/components/package-card.tsx
+++ b/plugins/team/components/package-card.tsx
@@ -131,21 +131,35 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
   const updateAvailable = Boolean(packageState?.updateStatus?.upgradeAvailable || state === 'update-available')
   const displayState = updateAvailable ? 'update-available' : state
 
-  async function updatePackage(refreshTemplate: boolean) {
+  async function syncPackage() {
     setActionBusy(true)
     setActionError(null)
     setActionMessage(null)
     try {
-      const res = await fetch(`/api/agent-packages/${encodeURIComponent(agentId)}/update`, {
+      const res = await fetch(`/api/agent-packages/${encodeURIComponent(agentId)}/sync`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refreshTemplate }),
+        body: JSON.stringify({}),
       })
       const body = await res.json().catch(() => ({}))
-      if (!res.ok || body?.ok === false) {
-        throw new Error(typeof body?.error === 'string' ? body.error : 'Agent package update failed.')
+      if (res.status === 409 && body?.migrationRequired) {
+        throw new Error('One-time block migration required — run `bakin agents sync` and confirm, or use the Health page Repair flow.')
       }
-      setActionMessage(refreshTemplate ? 'Package templates reseeded.' : 'Package updated while preserving workspace changes.')
+      if (!res.ok || body?.ok === false) {
+        throw new Error(typeof body?.error === 'string' ? body.error : 'Agent sync failed.')
+      }
+      const receipt = body.receipt ?? {}
+      const recomposed = (receipt.blocks ?? []).filter((b: { action: string }) => b.action === 'recomposed').map((b: { file: string }) => b.file)
+      const skipped = receipt.skipped ?? []
+      const parts = [
+        receipt.package?.changed
+          ? `Updated ${receipt.package.versionBefore} → ${receipt.package.versionAfter}.`
+          : 'Already at the latest source.',
+        recomposed.length > 0 ? `Recomposed: ${recomposed.join(', ')}.` : 'All blocks current.',
+        skipped.length > 0 ? `${skipped.length} user-edited file(s) preserved (reclaim to overwrite).` : null,
+        `Verification: ${receipt.verification?.status ?? 'unknown'}.`,
+      ].filter(Boolean)
+      setActionMessage(parts.join(' '))
       await refreshPackageStates()
     } catch (err) {
       setActionError(err instanceof Error ? err.message : String(err))
@@ -214,19 +228,19 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <PackageStateBadge state={displayState} packageId={packageState?.packageId} />
         <div className="flex items-center gap-1.5">
-          {hasPackage && updateAvailable && (
+          {hasPackage && (
             <Button
               size="sm"
-              variant="info"
+              variant={updateAvailable ? 'info' : 'outline'}
               onClick={() => {
                 setActionError(null)
                 setActionMessage(null)
                 setUpdateOpen(true)
               }}
-              aria-label="Upgrade agent package"
+              aria-label={updateAvailable ? 'Upgrade agent package' : 'Sync agent package'}
             >
               <RefreshCw className="size-3 mr-1.5" />
-              Upgrade
+              {updateAvailable ? 'Upgrade' : 'Sync'}
             </Button>
           )}
           {hasPackage && (
@@ -306,9 +320,9 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
       <Dialog open={updateOpen} onOpenChange={setUpdateOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Upgrade {packageState?.packageId ?? agentId}</DialogTitle>
+            <DialogTitle>Sync {packageState?.packageId ?? agentId}</DialogTitle>
             <DialogDescription>
-              Bakin will pull the latest package source for {agentId}. Update keeps workspace files and user edits in place. Full rewrite reseeds package template files; files protected by `.userEdited` stay protected.
+              Bakin pulls the latest package source for {agentId}, recomposes the managed blocks (context layers + template + lessons), re-projects skills and assets, verifies the result, and writes a receipt. Content outside the managed blocks is never touched; `.userEdited` skills/assets are skipped with a reclaim hint.
             </DialogDescription>
           </DialogHeader>
           {packageState?.updateStatus && (
@@ -349,11 +363,8 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
             <Button variant="outline" onClick={() => setUpdateOpen(false)}>
               Close
             </Button>
-            <Button variant="info" disabled={actionBusy || Boolean(actionMessage)} onClick={() => updatePackage(false)}>
-              Update package
-            </Button>
-            <Button variant="warning" disabled={actionBusy || Boolean(actionMessage)} onClick={() => updatePackage(true)}>
-              Full rewrite
+            <Button variant="info" disabled={actionBusy || Boolean(actionMessage)} onClick={() => syncPackage()}>
+              Sync agent
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+/**
+ * Team detail page (layered-context spec, C11) — the home of the shared-rules
+ * confidence loop. Renders for a real OrgTeam OR the `global` pseudo-team
+ * ("the team everyone's on"):
+ *
+ *   - header: name, color, member avatars
+ *   - shared context editor: the team's (or global) context file with the
+ *     two-zone ownership made visible — user content edits in place; the
+ *     Bakin-managed block (role files only) is never editable here
+ *   - members with per-agent sync state (from the last receipts/doctor data)
+ *   - "Sync team" → POST /teams/:teamId/sync (global: syncs every agent via
+ *     the per-agent route) → combined receipt summary
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter } from '@makinbakin/sdk/hooks'
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  Textarea,
+} from '@makinbakin/sdk/ui'
+import { PluginHeader } from '@makinbakin/sdk/components'
+import { ArrowLeft, CircleCheck, Globe, RefreshCw, TriangleAlert, Users } from 'lucide-react'
+
+interface TeamInfo {
+  id: string
+  label: string
+  color?: string
+}
+
+interface MemberMeta {
+  id: string
+  name: string
+  emoji?: string
+}
+
+interface SyncResultRow {
+  agentId: string
+  receipt?: {
+    verification?: { status: string; findings?: Array<{ message: string }> }
+    blocks?: Array<{ file: string; action: string }>
+    skipped?: Array<{ target: string; hint?: string }>
+  }
+  error?: string
+}
+
+const GLOBAL_TEAM: TeamInfo = { id: 'global', label: 'Global' }
+
+export function TeamDetail({ teamId }: { teamId: string }) {
+  const router = useRouter()
+  const isGlobal = teamId === 'global'
+
+  const [team, setTeam] = useState<TeamInfo | null>(isGlobal ? GLOBAL_TEAM : null)
+  const [members, setMembers] = useState<MemberMeta[] | null>(null)
+  const [content, setContent] = useState<string | null>(null)
+  const [contentPath, setContentPath] = useState<string | null>(null)
+  const [dirty, setDirty] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [syncing, setSyncing] = useState(false)
+  const [syncResults, setSyncResults] = useState<SyncResultRow[] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const contextUrl = isGlobal
+    ? '/api/plugins/team/context/global'
+    : `/api/plugins/team/context/team?id=${encodeURIComponent(teamId)}`
+
+  const load = useCallback(async () => {
+    try {
+      if (isGlobal) {
+        const agentsRes = await fetch('/api/plugins/team/')
+        const agentsJson = await agentsRes.json()
+        const list = Array.isArray(agentsJson) ? agentsJson : agentsJson.agents ?? []
+        setMembers(list.map((a: MemberMeta) => ({ id: a.id, name: a.name ?? a.id, emoji: (a as { emoji?: string }).emoji })))
+      } else {
+        const res = await fetch(`/api/plugins/team/teams/${encodeURIComponent(teamId)}/members`)
+        if (!res.ok) throw new Error(`Team "${teamId}" not found`)
+        const json = await res.json()
+        setTeam(json.team)
+        setMembers((json.members ?? []).map((a: MemberMeta) => ({ id: a.id, name: a.name ?? a.id, emoji: (a as { emoji?: string }).emoji })))
+      }
+
+      const ctxRes = await fetch(contextUrl)
+      const ctxJson = await ctxRes.json()
+      if (ctxJson.ok) {
+        setContent(ctxJson.content ?? '')
+        setContentPath(ctxJson.path ?? null)
+      }
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err))
+    }
+  }, [contextUrl, isGlobal, teamId])
+
+  useEffect(() => { void load() }, [load])
+
+  const save = async () => {
+    if (content === null) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const res = await fetch(contextUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      })
+      const json = await res.json()
+      if (!json.ok) throw new Error(json.error ?? `save failed (${res.status})`)
+      setContent(json.content ?? content)
+      setDirty(false)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const syncTeam = async () => {
+    setSyncing(true)
+    setSyncResults(null)
+    try {
+      if (isGlobal) {
+        // Global pseudo-team: sync every agent via the per-agent route.
+        const rows: SyncResultRow[] = []
+        for (const member of members ?? []) {
+          try {
+            const res = await fetch(`/api/agent-packages/${encodeURIComponent(member.id)}/sync`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({}),
+            })
+            const json = await res.json()
+            rows.push(json.ok ? { agentId: member.id, receipt: json.receipt } : { agentId: member.id, error: json.error ?? `sync failed (${res.status})` })
+          } catch (err) {
+            rows.push({ agentId: member.id, error: err instanceof Error ? err.message : String(err) })
+          }
+        }
+        setSyncResults(rows)
+      } else {
+        const res = await fetch(`/api/plugins/team/teams/${encodeURIComponent(teamId)}/sync`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        })
+        const json = await res.json()
+        if (!json.ok) throw new Error(json.error ?? `sync failed (${res.status})`)
+        setSyncResults(json.results ?? [])
+      }
+    } catch (err) {
+      setSyncResults([{ agentId: '(team)', error: err instanceof Error ? err.message : String(err) }])
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  const resultByAgent = useMemo(
+    () => new Map((syncResults ?? []).map((r) => [r.agentId, r])),
+    [syncResults],
+  )
+
+  if (loadError) {
+    return <p className="text-sm text-red-400">{loadError}</p>
+  }
+
+  if (!members) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="sm" className="gap-1" onClick={() => router.push('/team')}>
+            <ArrowLeft className="size-4" /> Team
+          </Button>
+          {isGlobal
+            ? <Globe className="size-5 text-muted-foreground" />
+            : <Users className="size-5" style={team?.color ? { color: team.color } : undefined} />}
+          <PluginHeader title={team?.label ?? teamId} count={members.length} />
+        </div>
+        <Button onClick={syncTeam} disabled={syncing} className="gap-1">
+          <RefreshCw className={`size-4 ${syncing ? 'animate-spin' : ''}`} />
+          {syncing ? 'Syncing…' : isGlobal ? 'Sync all agents' : 'Sync team'}
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-baseline justify-between text-base">
+            <span>Shared context</span>
+            {contentPath && <span className="text-xs font-normal text-muted-foreground">{contentPath}</span>}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-xs text-muted-foreground">
+            {isGlobal
+              ? 'Reaches EVERY agent’s AGENTS.md managed block on sync. Content inside a bakin:managed block (role files) is Bakin-owned and re-asserted automatically.'
+              : 'Reaches every member’s AGENTS.md managed block on sync.'}
+          </p>
+          <Textarea
+            value={content ?? ''}
+            onChange={(e) => { setContent(e.target.value); setDirty(true) }}
+            rows={12}
+            className="font-mono text-xs"
+            placeholder={isGlobal ? '# House rules for every agent…' : `# Rules for the ${team?.label ?? teamId} team…`}
+            aria-label="Shared context content"
+          />
+          <div className="flex items-center gap-2">
+            <Button size="sm" onClick={save} disabled={!dirty || saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+            {dirty && <span className="text-xs text-yellow-500">Unsaved changes — members go stale after save until synced.</span>}
+            {saveError && <span className="text-xs text-red-400">{saveError}</span>}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Members</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {members.length === 0 && <p className="text-sm text-muted-foreground">No members assigned yet.</p>}
+            {members.map((member) => {
+              const result = resultByAgent.get(member.id)
+              return (
+                <div key={member.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
+                  <button
+                    type="button"
+                    className="flex items-center gap-2 hover:underline"
+                    onClick={() => router.push(`/team/${member.id}`)}
+                  >
+                    <span>{member.emoji ?? '🤖'}</span>
+                    <span className="font-medium">{member.name}</span>
+                    <span className="text-muted-foreground text-xs">{member.id}</span>
+                  </button>
+                  {result && (
+                    result.error ? (
+                      <Badge className="bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300 gap-1">
+                        <TriangleAlert className="size-3" /> {result.error.slice(0, 60)}
+                      </Badge>
+                    ) : (
+                      <Badge className={result.receipt?.verification?.status === 'ok'
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300 gap-1'
+                        : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300 gap-1'}>
+                        <CircleCheck className="size-3" />
+                        {result.receipt?.verification?.status === 'ok' ? 'synced' : 'issues'}
+                        {(result.receipt?.blocks ?? []).filter((b) => b.action === 'recomposed').length > 0 &&
+                          ` · ${(result.receipt?.blocks ?? []).filter((b) => b.action === 'recomposed').length} block(s)`}
+                      </Badge>
+                    )
+                  )}
+                </div>
+              )
+            })}
+          </div>
+          {syncResults && syncResults.some((r) => (r.receipt?.skipped?.length ?? 0) > 0) && (
+            <div className="mt-3 space-y-1 text-xs text-yellow-600 dark:text-yellow-400">
+              {syncResults.flatMap((r) => (r.receipt?.skipped ?? []).map((skip, i) => (
+                <p key={`${r.agentId}-${i}`}>
+                  Skipped (user-edited; preserved): {skip.target}{skip.hint ? ` — ${skip.hint}` : ''}
+                </p>
+              )))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useMemo, useCallback, useState } from 'react'
+import { useMemo, useCallback, useState, useEffect } from 'react'
 import { useRouter } from '@makinbakin/sdk/hooks'
-import { Plus, Users, Settings2, Loader2 } from 'lucide-react'
+import { Plus, Users, Settings2, Loader2, ScrollText } from 'lucide-react'
 import {
   ReactFlow,
   Background,
@@ -163,16 +163,25 @@ export function AgentCardNode({ data }: NodeProps) {
 
 interface SectionNodeData extends Record<string, unknown> {
   label: string
+  teamId?: string
+  hasContext?: boolean
 }
 
 function SectionNode({ data }: NodeProps) {
-  const { label } = data as SectionNodeData
+  const { label, teamId, hasContext } = data as SectionNodeData
   return (
-    <div className="flex items-center justify-center px-4">
+    <div className="flex items-center justify-center gap-1 px-4">
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0" />
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 whitespace-nowrap">
+      <a
+        href={teamId ? `/team/teams/${encodeURIComponent(teamId)}` : '/team'}
+        className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 whitespace-nowrap hover:text-zinc-300 hover:underline"
+        title={hasContext ? 'Team carries shared context — click to view' : 'Open team page'}
+      >
         {label}
-      </span>
+      </a>
+      {hasContext && (
+        <ScrollText className="size-3 text-info" aria-label={`${label} has shared context rules`} />
+      )}
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0" />
     </div>
   )
@@ -196,6 +205,23 @@ export function TeamGrid() {
   const reload = useAgentStore((s) => s.load)
   const [showCreate, setShowCreate] = useState(false)
   const [showTeams, setShowTeams] = useState(false)
+  const [teamsWithContext, setTeamsWithContext] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/api/plugins/team/context')
+        const json = await res.json()
+        if (cancelled || !json.ok) return
+        const ids = (json.teams ?? [])
+          .filter((t: { content: string | null }) => (t.content ?? '').trim().length > 0)
+          .map((t: { teamId: string }) => t.teamId)
+        setTeamsWithContext(new Set(ids))
+      } catch { /* badge is best-effort */ }
+    })()
+    return () => { cancelled = true }
+  }, [])
   const runtimeStatus = useRuntimeStatus()
   const [submitting, setSubmitting] = useState(false)
   const [pendingCreate, setPendingCreate] = useState<{ data: AgentFormData; avatarFile: File | null } | null>(null)
@@ -210,7 +236,7 @@ export function TeamGrid() {
 
   const { nodes, edges } = useMemo(
     () => loaded
-      ? buildGraph({ agents: agentsWithStatus, teams, displaySettings, mainAgentId })
+      ? buildGraph({ agents: agentsWithStatus, teams, displaySettings, mainAgentId, teamsWithContext })
       : { nodes: [], edges: [] },
     [agentsWithStatus, teams, displaySettings, mainAgentId, loaded],
   )

--- a/plugins/team/components/team-manager.tsx
+++ b/plugins/team/components/team-manager.tsx
@@ -101,6 +101,13 @@ export function TeamManager() {
         />
       ) : (
         <div className="space-y-3">
+          <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
+            <div className="flex-1 min-w-0">
+              <a href="/team/teams/global" className="text-sm font-semibold hover:underline">Global</a>
+              <div className="text-xs text-muted-foreground">Shared context for every agent</div>
+            </div>
+            <code className="text-[10px] text-muted-foreground font-mono">global</code>
+          </div>
           {teams.map((team) => {
             return (
               <div
@@ -108,7 +115,9 @@ export function TeamManager() {
                 className="flex items-center gap-3 rounded-lg border border-border bg-card p-3"
               >
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm font-semibold">{team.label}</div>
+                  <a href={`/team/teams/${encodeURIComponent(team.id)}`} className="text-sm font-semibold hover:underline">
+                    {team.label}
+                  </a>
                   <div className="text-xs text-muted-foreground">
                     Reports to{' '}
                     <select

--- a/plugins/team/lib/build-graph.ts
+++ b/plugins/team/lib/build-graph.ts
@@ -40,6 +40,8 @@ export interface BuildGraphInput {
   displaySettings: AgentDisplaySettingsMap
   /** Canonical main/orchestrator agent id. Null when the roster is broken. */
   mainAgentId: string | null
+  /** Team ids whose shared context file has content (rules badge on the section node). */
+  teamsWithContext?: Set<string>
 }
 
 export interface BuildGraphResult {
@@ -85,7 +87,7 @@ function resolveReporter(
  * inputs and you'll get identical output.
  */
 export function buildGraph(input: BuildGraphInput): BuildGraphResult {
-  const { agents, teams, displaySettings, mainAgentId } = input
+  const { agents, teams, displaySettings, mainAgentId, teamsWithContext } = input
   const nodes: Node[] = []
   const edges: Edge[] = []
   const agentMap = new Map(agents.map((a) => [a.id, a]))
@@ -217,7 +219,7 @@ export function buildGraph(input: BuildGraphInput): BuildGraphResult {
         id: `section-${team.id}`,
         type: 'section',
         position: { x: centerX - SECTION_W / 2, y: sectionY },
-        data: { label: team.label },
+        data: { label: team.label, teamId: team.id, hasContext: teamsWithContext?.has(team.id) ?? false },
       })
       edges.push({
         id: `${reporterId}->section-${team.id}`,

--- a/src/core/doctor-repair.ts
+++ b/src/core/doctor-repair.ts
@@ -72,6 +72,13 @@ export interface DoctorRepairOptions {
 export interface DoctorRepairApplyOptions extends DoctorRepairOptions {
   accepted: boolean
   itemIds?: string[]
+  /**
+   * Apply non-safe (manual/destructive) items too. Honored ONLY when the
+   * caller explicitly selected items via `itemIds` — a blanket apply can
+   * never sweep destructive repairs in. The UI's per-item confirmation
+   * checkboxes are the consent surface for this flag.
+   */
+  allowDestructive?: boolean
 }
 
 function errorMessage(err: unknown): string {
@@ -195,8 +202,9 @@ export async function applyDoctorRepair(options: DoctorRepairApplyOptions): Prom
     }
   }
 
-  const safeItems = selectedItems.filter(item => item.safety === 'safe')
-  const blockedItems = selectedItems.filter(item => item.safety !== 'safe')
+  const destructiveAllowed = options.allowDestructive === true && !!options.itemIds
+  const safeItems = selectedItems.filter(item => item.safety === 'safe' || destructiveAllowed)
+  const blockedItems = selectedItems.filter(item => item.safety !== 'safe' && !destructiveAllowed)
   const skipped: HealthRepairApplyResult[] = blockedItems.map(item => ({
     id: item.id,
     checkId: item.checkId,

--- a/tests/plugins/health/repair-dialog.test.tsx
+++ b/tests/plugins/health/repair-dialog.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for the generic doctor repair dialog (layered-context spec, C10).
+ *
+ * Coverage:
+ *   - plan fetch on open; safe items pre-selected, destructive items not
+ *   - apply posts explicit itemIds; allowDestructive only when a
+ *     destructive item was ticked by hand
+ *   - results render applied/skipped + verification summary
+ */
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+
+// Pure-UI test (all fetches mocked) — content-dir/OpenClaw mocks are the
+// CLAUDE.md-mandated belt-and-suspenders so no transitive import can ever
+// touch real ~/.bakin or ~/.openclaw.
+const testDir = join(tmpdir(), `bakin-test-repair-dialog-${Date.now()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { RepairDialog } from '../../../plugins/health/components/repair-dialog'
+
+const PLAN = {
+  items: [
+    {
+      id: 'team.agent-sync.local',
+      checkId: 'agent-sync',
+      healthCheckId: 'team.agent-sync',
+      checkName: 'Agent sync',
+      title: 'Sync agents locally',
+      reason: '2 stale blocks',
+      safety: 'safe',
+      requiresConfirmation: false,
+      changes: [{ kind: 'runtime', target: 'pixel', action: 'update', description: 'Recompose blocks' }],
+    },
+    {
+      id: 'team.agent-sync.migrate',
+      checkId: 'agent-sync',
+      healthCheckId: 'team.agent-sync',
+      checkName: 'Agent sync',
+      title: 'Run the one-time block migration',
+      reason: 'Legacy package shapes',
+      safety: 'destructive',
+      requiresConfirmation: true,
+      changes: [{ kind: 'runtime', target: 'pixel', action: 'update', description: 'Overwrite workspace files' }],
+    },
+  ],
+  errors: [],
+  summary: { totalItems: 2, safeItems: 1 },
+}
+
+const APPLY = {
+  status: 'applied',
+  applied: [
+    { id: 'team.agent-sync.local', checkId: 'agent-sync', status: 'applied', message: 'Synced 2 agents locally.' },
+  ],
+  skipped: [],
+  errors: [],
+  verification: [{ check: 'agent-sync', status: 'ok', message: 'in sync' }],
+}
+
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = []
+
+beforeEach(() => {
+  cleanup()
+  fetchCalls = []
+  global.fetch = mock(async (url: RequestInfo | URL, init?: RequestInit) => {
+    fetchCalls.push({ url: String(url), init })
+    if (String(url).endsWith('/repair/plan')) {
+      return { ok: true, json: async () => PLAN } as Response
+    }
+    if (String(url).endsWith('/repair/apply')) {
+      return { ok: true, json: async () => APPLY } as Response
+    }
+    return { ok: false, json: async () => ({}) } as Response
+  }) as unknown as typeof global.fetch
+})
+
+describe('RepairDialog', () => {
+  it('plans on open with safe items pre-selected and destructive items unticked', async () => {
+    render(<RepairDialog open onOpenChange={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Sync agents locally')).toBeDefined())
+
+    const safeBox = screen.getByLabelText('Select repair: Sync agents locally') as HTMLInputElement
+    const destructiveBox = screen.getByLabelText('Select repair: Run the one-time block migration') as HTMLInputElement
+    expect(safeBox.checked).toBe(true)
+    expect(destructiveBox.checked).toBe(false)
+    expect(screen.getByText('destructive')).toBeDefined()
+  })
+
+  it('applies selected safe items without allowDestructive', async () => {
+    render(<RepairDialog open onOpenChange={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Sync agents locally')).toBeDefined())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply 1 repair' }))
+    await waitFor(() => expect(screen.getByText(/Synced 2 agents locally/)).toBeDefined())
+
+    const applyCall = fetchCalls.find((c) => c.url.endsWith('/repair/apply'))!
+    const body = JSON.parse(String(applyCall.init?.body))
+    expect(body).toEqual({ accepted: true, itemIds: ['team.agent-sync.local'], allowDestructive: false })
+    expect(screen.getByText(/Verification: 1\/1 checks clean/)).toBeDefined()
+  })
+
+  it('sends allowDestructive only after the destructive item is ticked by hand', async () => {
+    const onApplied = mock(() => {})
+    render(<RepairDialog open onOpenChange={() => {}} onApplied={onApplied} />)
+    await waitFor(() => expect(screen.getByText('Run the one-time block migration')).toBeDefined())
+
+    fireEvent.click(screen.getByLabelText('Select repair: Run the one-time block migration'))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply 2 (incl. destructive)' }))
+    await waitFor(() => expect(fetchCalls.some((c) => c.url.endsWith('/repair/apply'))).toBe(true))
+
+    const body = JSON.parse(String(fetchCalls.find((c) => c.url.endsWith('/repair/apply'))!.init?.body))
+    expect(body.allowDestructive).toBe(true)
+    expect(new Set(body.itemIds)).toEqual(new Set(['team.agent-sync.local', 'team.agent-sync.migrate']))
+    await waitFor(() => expect(onApplied).toHaveBeenCalled())
+  })
+})

--- a/tests/plugins/team/agent-detail-package-card.test.tsx
+++ b/tests/plugins/team/agent-detail-package-card.test.tsx
@@ -334,22 +334,21 @@ describe('PackageCard — update and remove actions', () => {
     return fetchMock
   }
 
-  it('opens update modal and sends update-package payload', async () => {
+  it('opens the sync modal and posts to the sync route', async () => {
     const fetchMock = setupActionFetch()
 
     render(<PackageCardBody agentId="pixel" packageState={UPDATE_ROW} />)
 
     expect(screen.getByText('update available')).toBeDefined()
     fireEvent.click(screen.getByRole('button', { name: 'Upgrade agent package' }))
-    expect(screen.getByRole('heading', { name: 'Upgrade pixel' })).toBeDefined()
+    expect(screen.getByRole('heading', { name: 'Sync pixel' })).toBeDefined()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Update package' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Sync agent' }))
 
     await waitFor(() => {
       expect(fetchMock.mock.calls.some((call) => (
-        call[0] === '/api/agent-packages/pixel/update'
+        call[0] === '/api/agent-packages/pixel/sync'
         && (call[1] as RequestInit | undefined)?.method === 'POST'
-        && String((call[1] as RequestInit | undefined)?.body).includes('"refreshTemplate":false')
       ))).toBe(true)
     })
   })

--- a/tests/plugins/team/team-detail.test.tsx
+++ b/tests/plugins/team/team-detail.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for the team detail page (layered-context spec, C11).
+ *
+ * Coverage:
+ *   - loads members + shared context for a real team
+ *   - saving context PUTs to the team context route
+ *   - "Sync team" posts to /teams/:id/sync and renders per-member results
+ *     including user-edited skips
+ *   - global pseudo-team loads the roster + global context file
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-team-detail-${Date.now()}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@tanstack/react-router', () => ({
+  useNavigate: () => mock(),
+  useLocation: () => ({ pathname: '/team/teams/media', searchStr: '', search: {} }),
+  useParams: () => ({ teamId: 'media' }),
+}))
+
+import { TeamDetail } from '../../../plugins/team/components/team-detail'
+
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = []
+
+const MEMBERS = {
+  team: { id: 'media', label: 'Media', color: '#fff' },
+  members: [
+    { id: 'pixel', name: 'Pixel', emoji: '🎨' },
+    { id: 'rolo', name: 'Rolo', emoji: '🎬' },
+  ],
+}
+
+const SYNC_RESULTS = {
+  ok: true,
+  teamId: 'media',
+  results: [
+    {
+      agentId: 'pixel',
+      receipt: {
+        verification: { status: 'ok', findings: [] },
+        blocks: [{ file: 'AGENTS.md', action: 'recomposed' }],
+        skipped: [],
+      },
+    },
+    {
+      agentId: 'rolo',
+      receipt: {
+        verification: { status: 'ok', findings: [] },
+        blocks: [],
+        skipped: [{ target: 'runtime:agent-skill:rolo:video-gen', hint: 'bakin agents sync rolo --reclaim …' }],
+      },
+    },
+  ],
+}
+
+function installFetch() {
+  fetchCalls = []
+  global.fetch = mock(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url)
+    fetchCalls.push({ url: u, init })
+    if (u.endsWith('/teams/media/members')) return { ok: true, json: async () => MEMBERS } as Response
+    if (u.includes('/context/team?id=media') && (!init || init.method === undefined)) {
+      return { ok: true, json: async () => ({ ok: true, path: '/x/media.md', content: '# Media Team' }) } as Response
+    }
+    if (u.includes('/context/team?id=media') && init?.method === 'PUT') {
+      return { ok: true, json: async () => ({ ok: true, path: '/x/media.md', content: JSON.parse(String(init.body)).content }) } as Response
+    }
+    if (u.endsWith('/teams/media/sync')) return { ok: true, json: async () => SYNC_RESULTS } as Response
+    if (u.endsWith('/context/global')) return { ok: true, json: async () => ({ ok: true, path: '/x/global.md', content: '' }) } as Response
+    if (u === '/api/plugins/team/') return { ok: true, json: async () => [{ id: 'main', name: 'Roscoe' }, { id: 'pixel', name: 'Pixel' }] } as Response
+    return { ok: false, json: async () => ({}) } as Response
+  }) as unknown as typeof global.fetch
+}
+
+beforeEach(() => {
+  cleanup()
+  installFetch()
+})
+
+afterEach(() => cleanup())
+afterAll(() => {})
+
+describe('TeamDetail', () => {
+  it('loads members and the shared context file', async () => {
+    render(<TeamDetail teamId="media" />)
+    await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+    expect(screen.getByText('Rolo')).toBeDefined()
+    const editor = screen.getByLabelText('Shared context content') as HTMLTextAreaElement
+    expect(editor.value).toBe('# Media Team')
+    expect(screen.getByText('/x/media.md')).toBeDefined()
+  })
+
+  it('saves edited context via PUT', async () => {
+    render(<TeamDetail teamId="media" />)
+    await waitFor(() => expect(screen.getByLabelText('Shared context content')).toBeDefined())
+
+    fireEvent.change(screen.getByLabelText('Shared context content'), { target: { value: '# Media Team v2' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      const put = fetchCalls.find((c) => c.init?.method === 'PUT')
+      expect(put).toBeDefined()
+      expect(JSON.parse(String(put!.init!.body)).content).toBe('# Media Team v2')
+    })
+  })
+
+  it('syncs the team and shows per-member results incl. user-edited skips', async () => {
+    render(<TeamDetail teamId="media" />)
+    await waitFor(() => expect(screen.getByText('Pixel')).toBeDefined())
+
+    fireEvent.click(screen.getByRole('button', { name: /Sync team/ }))
+    await waitFor(() => expect(fetchCalls.some((c) => c.url.endsWith('/teams/media/sync'))).toBe(true))
+
+    await waitFor(() => expect(screen.getByText(/1 block\(s\)/)).toBeDefined())
+    expect(screen.getByText(/Skipped \(user-edited; preserved\)/)).toBeDefined()
+  })
+
+  it('renders the global pseudo-team from the roster + global.md', async () => {
+    render(<TeamDetail teamId="global" />)
+    await waitFor(() => expect(screen.getByText('Roscoe')).toBeDefined())
+    expect(screen.getByRole('button', { name: /Sync all agents/ })).toBeDefined()
+    expect(fetchCalls.some((c) => c.url.endsWith('/context/global'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

UI half of #401 (stacked on #486):

- **Health page** gets its first repair affordance: Repair… on the Diagnostics card → plan modal with safety labels and per-item checkboxes (safe pre-selected; destructive items — the block migration — must be ticked individually) → apply → results + verification. Engine gains `allowDestructive`, honored only with explicit item selection.
- **Team detail pages** (`/team/teams/:teamId`): shared-context editor, members with sync results, "Sync team" with combined receipts including user-edited skips + reclaim hints. **Global** renders as a pseudo-team over the whole roster (global.md).
- **Agent detail**: package card syncs (always available), renders receipt summaries, surfaces migration-required with next steps.
- **Org graph**: team section nodes link to detail pages and carry a rules badge when the team ships shared context.

## Verification

Full suite green (4939 tests), build green; component tests cover the repair dialog consent mechanics and the team-detail load/save/sync/receipt loop per the approved user stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)