### PR TITLE
fix(cli): sync migration prompt 409 handling + agent-sync check off-server

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1604,7 +1604,10 @@ async function cmdAgentPackagesSync(agentId: string | undefined, flags: AgentsCm
   else if (flags.reclaim?.length) body.reclaim = flags.reclaim
 
   const syncOne = async (id: string): Promise<unknown> => {
-    let result = await apiPost(`/api/agent-packages/${encodeURIComponent(id)}/sync`, body) as Record<string, unknown>
+    // apiPostJson (not apiPost) — the 409 migrationRequired response is a
+    // structured payload we branch on, not a transport error to throw.
+    const first = await apiPostJson(`/api/agent-packages/${encodeURIComponent(id)}/sync`, body)
+    let result = first.data as Record<string, unknown>
     if (result.migrationRequired) {
       const confirmed = flags.yes || await confirmPrompt(
         `Package for "${id}" predates block-based projection. Run the one-time migration?\n` +
@@ -1616,7 +1619,8 @@ async function cmdAgentPackagesSync(agentId: string | undefined, flags: AgentsCm
       }
       const migration = await apiPost('/api/agent-packages/migrate', {}) as Record<string, unknown>
       if (!migration.ok) return migration
-      result = await apiPost(`/api/agent-packages/${encodeURIComponent(id)}/sync`, body) as Record<string, unknown>
+      const second = await apiPostJson(`/api/agent-packages/${encodeURIComponent(id)}/sync`, body)
+      result = second.data as Record<string, unknown>
     }
     return result
   }

--- a/src/core/onboarding/agent-sync.ts
+++ b/src/core/onboarding/agent-sync.ts
@@ -16,6 +16,7 @@
  * so the two views never disagree.
  */
 import { createLogger } from '../logger'
+import { createAppServices, maybeGetAppServices } from '../app-services'
 import { scanAgentSync, type SyncScanReport } from '../agent-packages/sync-scanner'
 import { syncAllAgents } from '../agent-packages/sync'
 import { refreshRoleContextBlocks } from '../team-context'
@@ -36,9 +37,21 @@ function summarize(report: SyncScanReport): { errors: number; warns: number; par
   }
 }
 
+/**
+ * The scanner talks to the runtime adapter. In the server process AppServices
+ * already exist; the CLI's `bakin check/install agent-sync` path runs in its
+ * own process and must create them first (same pattern as the credentials +
+ * openclaw-integration components).
+ */
+async function ensureAppServices(): Promise<void> {
+  if (maybeGetAppServices()) return
+  await createAppServices()
+}
+
 async function check(): Promise<CheckResult> {
   let report: SyncScanReport
   try {
+    await ensureAppServices()
     report = await scanAgentSync()
   } catch (err) {
     return {
@@ -73,6 +86,7 @@ async function check(): Promise<CheckResult> {
 
 async function install(_opts: OnboardingOptions): Promise<InstallResult> {
   const start = Date.now()
+  await ensureAppServices()
   const before = await scanAgentSync()
 
   if (before.findings.length === 0) {


### PR DESCRIPTION
Two real-world findings from the Phase E live migration of #401 — both paths worked in tests (mocked fetch / in-process services) but not in the real CLI process. Details in the commit message. The live migration itself completed successfully with these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)