### PR TITLE
fix(dev): stop dev.ts signal handlers preempting lifecycle shutdown (#459)

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -99,7 +99,7 @@ The dev-client bundle itself is disk-only — written to `packages/host/public/_
 
 - **Build phase (sole listener):** the dev handler kills the tailwind child and owns `process.exit(0)` — Ctrl+C during the prestart builds exits promptly.
 - **After server boot:** `lifecycle.registerShutdownHandlers()` has added its own listener on the same signals. The dev handler detects this via `process.listenerCount(signal) > 1`, kills tailwind, and falls through — the lifecycle listener then runs the full graceful chain (plugins → dispatch/watchdog/doctor → watcher → `search.shutdown()` which stops the antfly child → SSE → HTTP → audit → ledger → server lock) and owns the exit. The dev handler must NEVER call `process.exit` here: that preempts the chain and orphans antfly on its port (#459 defect 1).
-- **Second signal (escape hatch):** a repeated SIGINT/SIGTERM while a graceful shutdown is hung logs a warning and force-exits 130.
+- **Second signal (escape hatch):** a repeated SIGINT/SIGTERM while a graceful shutdown is hung logs a warning and force-exits (130 for SIGINT, 143 for SIGTERM).
 - A `process.on('exit')` hook kills tailwind on every JS-level exit path regardless of who calls `process.exit`.
 
 Known gap: a signal landing after antfly is spawned but before `registerShutdownHandlers()` (end of `server.ts` `main()`) exits via the dev path and can orphan antfly — accepted in the spec; the adapter-side sync exit hook on the antfly-zig branch (PR #457) covers it. Separate pre-existing leak: killing the tailwind `bunx` wrapper can orphan the underlying node `tailwindcss` process (grandchild not in the wrapper's signal path).

--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -93,6 +93,17 @@ Three env-checks ensure `BAKIN_DEV` never leaks into the compiled binary:
 
 The dev-client bundle itself is disk-only — written to `packages/host/public/__bakin-dev/client.js`, gitignored, naturally excluded from `scripts/generate-embedded-assets.ts` (which only descends into explicitly-walked subdirectories under `public/`). It can never ship in a compiled binary.
 
+## Shutdown ordering (#459)
+
+`scripts/dev.ts` registers SIGINT/SIGTERM handlers **before** `await import('../server')`, and signal listeners run in registration order — so the dev handler always fires first. The rules live in `scripts/dev-shutdown.ts` (`registerDevShutdown`, DI-tested in `tests/scripts/dev-shutdown.test.ts`):
+
+- **Build phase (sole listener):** the dev handler kills the tailwind child and owns `process.exit(0)` — Ctrl+C during the prestart builds exits promptly.
+- **After server boot:** `lifecycle.registerShutdownHandlers()` has added its own listener on the same signals. The dev handler detects this via `process.listenerCount(signal) > 1`, kills tailwind, and falls through — the lifecycle listener then runs the full graceful chain (plugins → dispatch/watchdog/doctor → watcher → `search.shutdown()` which stops the antfly child → SSE → HTTP → audit → ledger → server lock) and owns the exit. The dev handler must NEVER call `process.exit` here: that preempts the chain and orphans antfly on its port (#459 defect 1).
+- **Second signal (escape hatch):** a repeated SIGINT/SIGTERM while a graceful shutdown is hung logs a warning and force-exits 130.
+- A `process.on('exit')` hook kills tailwind on every JS-level exit path regardless of who calls `process.exit`.
+
+Known gap: a signal landing after antfly is spawned but before `registerShutdownHandlers()` (end of `server.ts` `main()`) exits via the dev path and can orphan antfly — accepted in the spec; the adapter-side sync exit hook on the antfly-zig branch (PR #457) covers it. Separate pre-existing leak: killing the tailwind `bunx` wrapper can orphan the underlying node `tailwindcss` process (grandchild not in the wrapper's signal path).
+
 ## Imitation Crab
 
 `bun run dev:mock` starts the OpenClaw-compatible mock under

--- a/.claude/specs/dev-shutdown-signal-ordering-plan.md
+++ b/.claude/specs/dev-shutdown-signal-ordering-plan.md
@@ -1,0 +1,87 @@
+# Plan: Dev Shutdown Signal Ordering (#459, defect 1)
+
+## Context
+
+Killing `bun run dev` orphans the antfly child on `:3738`. Root cause: `scripts/dev.ts` `registerShutdown()` (scripts/dev.ts:490-497) registers SIGINT/SIGTERM handlers **before** `await import('../server')`, and those handlers call `process.exit(0)` synchronously. Signal listeners run in registration order, so the real async shutdown chain in `src/core/lifecycle.ts:89-96` (plugins → dispatch/watchdog/doctor → watcher → `search.shutdown()` which stops antfly → SSE → HTTP → audit → ledger → server lock) never executes. Overlapping half-dead generations then cause phantom UI behavior.
+
+This is the last open defect on issue #459 — defect 2 (EADDRINUSE) + the singleton lock merged in PR #465; the adapter `process.on('exit')` antfly kill + watcher ignore belong to PR #457 (still open, must not be duplicated).
+
+Spec: `.claude/specs/dev-shutdown-signal-ordering.md` (approved). Confirmed design decisions:
+1. **listenerCount detection** — dev handler always kills tailwind; only calls `process.exit(0)` when `process.listenerCount(signal) <= 1` (i.e. lifecycle handlers not yet registered — build phase). Otherwise falls through so lifecycle's later-registered listener runs the full chain.
+2. **Second-signal escape hatch** — repeated SIGINT/SIGTERM (shared counter) logs a warning and `process.exit(130)` so a hung graceful shutdown is never unkillable.
+3. **DI extraction for testability** — new `scripts/dev-shutdown.ts` with injected process-like object, following the `scripts/dev-log-classifier.ts` → `tests/scripts/dev-log-classifier.test.ts` pattern (dev.ts has top-level side effects and can't be imported in tests).
+
+No changes to `src/core/lifecycle.ts`, `server.ts`, or `packages/adapter-antfly/`.
+
+## Tasks
+
+### Task 1 — `scripts/dev-shutdown.ts` + unit tests (commit 1)
+
+New module:
+
+```ts
+export interface DevShutdownDeps {
+  proc: Pick<NodeJS.Process, 'on' | 'listenerCount' | 'exit'>
+  killTailwind: () => void
+  warn: (message: string) => void
+}
+
+export function registerDevShutdown(deps: DevShutdownDeps): void
+```
+
+Behavior:
+- Registers SIGINT + SIGTERM handlers and an `exit` handler (`killTailwind`) on `deps.proc`.
+- On first signal: `killTailwind()`; then `if (proc.listenerCount(signal) <= 1) proc.exit(0)` — else fall through (lifecycle owns exit).
+- On second signal (shared count across both signals): `warn(...)` + `proc.exit(130)`.
+
+TDD: write `tests/scripts/dev-shutdown.test.ts` first against a fake proc (EventEmitter-based; never emit real signals on the test process). Cases:
+1. Solo listener → tailwind killed, `exit(0)`.
+2. Second listener present on the signal → tailwind killed, NO exit call.
+3. Second signal (SIGINT then SIGINT, and SIGINT then SIGTERM) → warn + `exit(130)`.
+4. `exit` event handler registered → killTailwind invoked.
+
+Pure logic module, no app imports → no content-dir/OpenClaw mocks needed (matches other tests in `tests/scripts/`).
+
+Verify: `bun test tests/scripts/dev-shutdown.test.ts --isolate` green.
+
+Commit: `feat(dev): add dev-shutdown module deferring to lifecycle handlers` — pure addition, dev.ts untouched, safe rollback point.
+
+### Task 2 — wire `scripts/dev.ts` (commit 2)
+
+Replace `registerShutdown()` (scripts/dev.ts:490-497) with a call to `registerDevShutdown({ proc: process, killTailwind, warn: (m) => devLog('warn', 'dev', m) })`, where `killTailwind` is the existing tailwind kill (`if (tailwindChild && !tailwindChild.killed) tailwindChild.kill('SIGTERM')`). Import per repo import-order convention (relative, alongside `./dev-build-one-plugin`). Keep the call at the top of `main()`.
+
+Verify: `bun run test` (full suite) green; typecheck via the suite/build.
+
+Commit: `fix(dev): stop preempting lifecycle shutdown on SIGINT/SIGTERM (#459)` — the behavior change, isolated.
+
+### Task 3 — manual end-to-end verification (checkpoint, no commit)
+
+Acceptance criteria from the spec, against real `bun run dev`:
+1. Wait for ready → `kill -TERM <pid>` → lifecycle shutdown logs appear, exit 0, `lsof -nP -iTCP:3738 -sTCP:LISTEN` empty (antfly stopped), `lsof -nP -iTCP:3737 -sTCP:LISTEN` empty.
+2. Ctrl+C/SIGINT during initial build phase → prompt exit, tailwind child gone.
+3. (Best-effort) second signal during graceful shutdown → warn + exit 130.
+
+Note: requires the real `~/.bakin` dev environment on this machine (dev.ts runs the server in-process; this is the machine's normal dev loop).
+
+### Task 4 — docs (commit 3)
+
+- Add a short **Shutdown** section to `.claude/knowledge/dev-loop.md`: dev handler owns exit only during the build phase; defers to lifecycle once `registerShutdownHandlers()` runs; second signal forces exit 130; tailwind killed on every JS exit via the `exit` hook; antfly stop happens inside lifecycle's `search.shutdown()`.
+- Copy the approved plan to `.claude/specs/dev-shutdown-signal-ordering-plan.md` per repo spec/plan convention.
+- README / CLAUDE.md: no changes needed (internal dev tooling; CLAUDE.md already links dev-loop.md).
+
+Commit: `docs(dev): document dev-loop shutdown semantics`
+
+### Task 5 — review + ship
+
+- `/agent-skills:test` pass for coverage check, then five-axis review of the diff.
+- Push branch `fix/dev-shutdown-signal-ordering`, open PR referencing #459 (closes the remaining defect; note PR #465 shipped the server half).
+
+## Dependency order
+
+Task 1 → Task 2 → Task 3 (verify) → Task 4 → Task 5. Strictly linear; each commit is a rollback checkpoint.
+
+## Verification summary
+
+- Unit: `bun test tests/scripts/dev-shutdown.test.ts --isolate`
+- Suite: `bun run test`
+- Manual: issue repro (SIGTERM after ready → port 3738 free; SIGINT during builds; double-signal force exit)

--- a/.claude/specs/dev-shutdown-signal-ordering.md
+++ b/.claude/specs/dev-shutdown-signal-ordering.md
@@ -1,0 +1,55 @@
+# Dev Shutdown Signal Ordering (#459, defect 1)
+
+**Issue:** [#459](https://github.com/markhayden/bakin/issues/459) — Dev loop leaves orphaned processes.
+**Scope:** Defect 1 only. Defect 2 (unhandled EADDRINUSE) and the server singleton lock shipped in PR #465. The adapter-side `process.on('exit')` antfly kill and the `antfly/` watcher ignore belong to PR #457 (antfly-zig migration, still open) and MUST NOT be duplicated here.
+
+## Objective
+
+Killing `bun run dev` with SIGINT/SIGTERM must run the server's full graceful-shutdown chain (`src/core/lifecycle.ts` — plugins → dispatch/watchdog/doctor → watcher → `search.shutdown()` → SSE → HTTP → audit → ledger → server lock) so the antfly child on `:3738` is stopped, not orphaned.
+
+### Root cause
+
+`scripts/dev.ts` `registerShutdown()` registers SIGINT/SIGTERM handlers **before** `await import('../server')`. Node/Bun run signal listeners in registration order; dev.ts's handler calls `process.exit(0)` synchronously, so `lifecycle.ts`'s async `shutdown()` (registered later on the same signals) never executes. The antfly child survives parent death and squats `127.0.0.1:3738`; overlapping half-dead generations produce phantom UI behavior.
+
+## Design (decisions confirmed 2026-06-11)
+
+1. **Detection — `listenerCount` check.** Inside the dev signal handler: kill tailwind, then `if (process.listenerCount(signal) <= 1) process.exit(0)`. Before server boot completes, dev.ts is the only listener and owns the exit (builds phase, Ctrl+C must still work). After `lifecycle.registerShutdownHandlers()` runs, the count is 2 and dev.ts falls through — the lifecycle listener runs the full graceful chain and exits. Self-contained in dev.ts; no lifecycle.ts changes; verified only these two registrants exist in the `bun run dev` process (imitation-crab and `cli/bakin.ts` handlers are separate processes).
+
+2. **Escape hatch — second signal forces exit.** A repeated SIGINT/SIGTERM (shared counter across both signals) logs a warning and calls `process.exit(130)` immediately. Without it, a hung graceful chain (stalled plugin `shutdownAll()`, wedged antfly kill) makes `bun run dev` unkillable at the terminal — strictly worse UX than today's instant exit. The force path does NOT touch antfly directly (dev.ts importing the adapter would violate the adapter boundary); in the pathological hung case antfly may orphan — no worse than current behavior, and PR #457's exit hook covers it.
+
+3. **Testability — extract with dependency injection.** New `scripts/dev-shutdown.ts` exporting `registerDevShutdown(deps)` where `deps` injects a process-like object (`on`/`listenerCount`/`exit`), a `killTailwind` callback, and a `warn` logger. `dev.ts` calls it with the real `process`. Tests use a fake emitter — emitting real SIGINT on the test process would kill the runner. Matches the established `scripts/dev-log-classifier.ts` → `tests/scripts/dev-log-classifier.test.ts` extraction pattern.
+
+4. **The `process.on('exit')` tailwind cleanup stays** — it covers every JS-level exit path regardless of who calls `process.exit`.
+
+## Acceptance criteria
+
+1. `bun run dev`, wait for ready, `kill -TERM <pid>` → server logs the lifecycle shutdown chain, process exits 0, and `lsof -nP -iTCP:3738 -sTCP:LISTEN` is empty (antfly stopped). Same for Ctrl+C (SIGINT).
+2. SIGINT during the initial build phase (before the server import) still exits promptly and kills the tailwind child.
+3. A second SIGINT/SIGTERM while a graceful shutdown is in flight forces exit 130 with a logged warning.
+4. Unit tests in `tests/scripts/dev-shutdown.test.ts` cover: solo-listener exit(0); defer when a second listener is present; tailwind killed on both paths; second-signal force exit(130); `exit`-hook cleanup registration.
+5. Full suite (`bun run test`) passes.
+
+## Out of scope / known gaps
+
+- **Boot-window gap:** a signal arriving after antfly is spawned but before `registerShutdownHandlers()` (end of `server.ts` `main()`) exits via dev.ts's own path and can orphan antfly. Accepted by the issue; PR #457's sync adapter exit hook is the cover. No server.ts changes here.
+- **Defect 3 (watcher deadlock):** no JS handler can run in a deadlocked process; fixed on the #457 branch (`shouldIgnoreContentWatcherPath` ignores `antfly/`).
+- No changes to `src/core/lifecycle.ts`, `server.ts`, or `packages/adapter-antfly/`.
+
+## Testing strategy
+
+- TDD: write `tests/scripts/dev-shutdown.test.ts` against the new module first, then wire `scripts/dev.ts`.
+- Pure logic module — no filesystem, no content-dir mocks needed (no app imports). Logger is injected, not the app logger.
+- Manual verification: the repro from the issue (acceptance criteria 1–3) against a real `bun run dev`.
+
+## Commit strategy (rollback checkpoints)
+
+Branch `fix/dev-shutdown-signal-ordering` off `main`:
+
+1. `feat(dev): add dev-shutdown module deferring to lifecycle handlers` — new `scripts/dev-shutdown.ts` + `tests/scripts/dev-shutdown.test.ts`. Pure addition; dev.ts untouched; safe to revert.
+2. `fix(dev): stop preempting lifecycle shutdown on SIGINT/SIGTERM (#459)` — `scripts/dev.ts` replaces `registerShutdown()` with `registerDevShutdown(...)`. The behavior change, isolated for rollback.
+3. `docs(dev): document dev-loop shutdown semantics` — add a Shutdown section to `.claude/knowledge/dev-loop.md`.
+
+## Documentation impact
+
+- `.claude/knowledge/dev-loop.md`: new short section on shutdown ordering (dev handler defers to lifecycle once registered; second signal forces exit).
+- README / CLAUDE.md: unaffected (internal dev tooling; CLAUDE.md already points at dev-loop.md).

--- a/scripts/dev-shutdown.ts
+++ b/scripts/dev-shutdown.ts
@@ -38,14 +38,16 @@ export function registerDevShutdown({ proc, killTailwind, warn }: DevShutdownDep
     signalCount++
     if (signalCount > 1) {
       warn(`second ${signal} during shutdown — forcing exit`)
-      proc.exit(130)
+      proc.exit(signal === 'SIGINT' ? 130 : 143)
       return
     }
     killTailwind()
     // Sole listener → build phase, the server hasn't registered its
     // lifecycle handlers yet: we own the exit. Otherwise the lifecycle
     // listener (registered later on this same signal) runs next and
-    // owns the full graceful shutdown + exit.
+    // owns the full graceful shutdown + exit. Invariant: only dev.ts and
+    // lifecycle.ts register these signals in this process — a stray third
+    // listener degrades the build-phase Ctrl+C to the second-signal path.
     if (proc.listenerCount(signal) <= 1) proc.exit(0)
   }
 

--- a/scripts/dev-shutdown.ts
+++ b/scripts/dev-shutdown.ts
@@ -1,0 +1,55 @@
+/**
+ * Dev-loop shutdown signal handling (#459 defect 1).
+ *
+ * scripts/dev.ts registers its SIGINT/SIGTERM handlers BEFORE importing
+ * server.ts, and signal listeners run in registration order. The old
+ * handler called process.exit(0) synchronously, which preempted the
+ * lifecycle shutdown chain (src/core/lifecycle.ts) registered later on
+ * the same signals — orphaning the antfly child on :3738.
+ *
+ * The rule here: the dev handler always owns the tailwind child, but only
+ * owns the EXIT while it is the sole signal listener (the build phase,
+ * before server boot). Once lifecycle.registerShutdownHandlers() has added
+ * its listener, the dev handler falls through and lets the lifecycle chain
+ * (plugins → dispatch → watcher → search.shutdown()/antfly → …) run and
+ * exit. A second signal is the operator escape hatch for a hung graceful
+ * shutdown: warn and force-exit 130.
+ *
+ * Extracted from dev.ts with the process object injected so tests can
+ * drive it with a fake — emitting real signals would kill the test runner.
+ */
+
+export interface DevShutdownProc {
+  on(event: string, listener: (...args: unknown[]) => void): unknown
+  listenerCount(event: string): number
+  exit(code?: number): void
+}
+
+export interface DevShutdownDeps {
+  proc: DevShutdownProc
+  killTailwind: () => void
+  warn: (message: string) => void
+}
+
+export function registerDevShutdown({ proc, killTailwind, warn }: DevShutdownDeps): void {
+  let signalCount = 0
+
+  const onSignal = (signal: 'SIGINT' | 'SIGTERM') => {
+    signalCount++
+    if (signalCount > 1) {
+      warn(`second ${signal} during shutdown — forcing exit`)
+      proc.exit(130)
+      return
+    }
+    killTailwind()
+    // Sole listener → build phase, the server hasn't registered its
+    // lifecycle handlers yet: we own the exit. Otherwise the lifecycle
+    // listener (registered later on this same signal) runs next and
+    // owns the full graceful shutdown + exit.
+    if (proc.listenerCount(signal) <= 1) proc.exit(0)
+  }
+
+  proc.on('SIGINT', () => onSignal('SIGINT'))
+  proc.on('SIGTERM', () => onSignal('SIGTERM'))
+  proc.on('exit', killTailwind)
+}

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -60,6 +60,7 @@ import chokidar from 'chokidar'
 import { broadcastDev, type DevEvent, type DevScope } from '../packages/host/src/api/dev/events'
 import { buildOnePlugin } from './dev-build-one-plugin'
 import { isBenignTailwindLine } from './dev-log-classifier'
+import { registerDevShutdown } from './dev-shutdown'
 
 const REPO_ROOT = resolve(import.meta.dir, '..')
 const PLUGINS_DIR = join(REPO_ROOT, 'plugins')
@@ -487,13 +488,18 @@ function startCssWatcher(): void {
 
 // ---------- Shutdown ----------------------------------------------------
 
+// Signal handling lives in dev-shutdown.ts: we register before server.ts
+// imports, so we must NOT call process.exit once lifecycle.ts's handlers
+// exist on the same signals — that preempted the graceful chain and
+// orphaned the antfly child (#459 defect 1).
 function registerShutdown(): void {
-  const cleanup = () => {
-    if (tailwindChild && !tailwindChild.killed) tailwindChild.kill('SIGTERM')
-  }
-  process.on('SIGINT', () => { cleanup(); process.exit(0) })
-  process.on('SIGTERM', () => { cleanup(); process.exit(0) })
-  process.on('exit', cleanup)
+  registerDevShutdown({
+    proc: process,
+    killTailwind: () => {
+      if (tailwindChild && !tailwindChild.killed) tailwindChild.kill('SIGTERM')
+    },
+    warn: (message) => devLog('warn', 'dev', message),
+  })
 }
 
 // ---------- Main --------------------------------------------------------

--- a/tests/scripts/dev-shutdown.test.ts
+++ b/tests/scripts/dev-shutdown.test.ts
@@ -6,8 +6,9 @@
  * Uses a fake process object: emitting real signals on the test process
  * would kill the runner.
  */
-import { describe, expect, test } from 'bun:test'
 import { EventEmitter } from 'node:events'
+
+import { describe, expect, test } from 'bun:test'
 
 import { registerDevShutdown } from '../../scripts/dev-shutdown'
 
@@ -82,20 +83,23 @@ describe('registerDevShutdown', () => {
     expect(h.warnings[0]).toContain('SIGINT')
   })
 
-  test('second signal (mixed signals) forces exit 130', () => {
+  test('second signal (mixed signals) forces exit with the second signal code', () => {
     const h = setup()
     h.proc.on('SIGINT', () => {})
     h.proc.on('SIGTERM', () => {})
     h.proc.emit('SIGINT')
     h.proc.emit('SIGTERM')
-    expect(h.proc.exitCalls).toEqual([130])
+    expect(h.proc.exitCalls).toEqual([143])
   })
 
-  test('tailwind is killed only once across first signal + exit hook', () => {
+  test('signal then exit event calls killTailwind twice — dedup is the caller\'s job', () => {
+    // The module does not dedupe; scripts/dev.ts guards with
+    // `!tailwindChild.killed` so the double call is harmless there.
     const h = setup()
     h.proc.on('SIGTERM', () => {})
     h.proc.emit('SIGTERM')
-    expect(h.tailwindKills).toBe(1)
+    h.proc.emit('exit')
+    expect(h.tailwindKills).toBe(2)
   })
 
   test('exit event kills tailwind (covers every JS exit path)', () => {

--- a/tests/scripts/dev-shutdown.test.ts
+++ b/tests/scripts/dev-shutdown.test.ts
@@ -59,6 +59,18 @@ describe('registerDevShutdown', () => {
     expect(h.proc.exitCalls).toEqual([])
   })
 
+  test('lifecycle listener registered later still runs on the signal (#459 regression)', () => {
+    const h = setup()
+    let lifecycleRan = false
+    // Mirrors lifecycle.registerShutdownHandlers(): registered after
+    // dev.ts on the same signal — listener order means dev runs first
+    // and must not exit, or this never executes.
+    h.proc.on('SIGTERM', () => { lifecycleRan = true })
+    h.proc.emit('SIGTERM')
+    expect(lifecycleRan).toBe(true)
+    expect(h.proc.exitCalls).toEqual([])
+  })
+
   test('second signal (same signal) forces exit 130 with a warning', () => {
     const h = setup()
     h.proc.on('SIGINT', () => {})
@@ -67,6 +79,7 @@ describe('registerDevShutdown', () => {
     h.proc.emit('SIGINT')
     expect(h.proc.exitCalls).toEqual([130])
     expect(h.warnings.length).toBe(1)
+    expect(h.warnings[0]).toContain('SIGINT')
   })
 
   test('second signal (mixed signals) forces exit 130', () => {

--- a/tests/scripts/dev-shutdown.test.ts
+++ b/tests/scripts/dev-shutdown.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for scripts/dev-shutdown.ts — the dev-loop signal handling
+ * that defers to lifecycle.ts's graceful shutdown once the server has
+ * registered its own SIGINT/SIGTERM listeners (#459 defect 1).
+ *
+ * Uses a fake process object: emitting real signals on the test process
+ * would kill the runner.
+ */
+import { describe, expect, test } from 'bun:test'
+import { EventEmitter } from 'node:events'
+
+import { registerDevShutdown } from '../../scripts/dev-shutdown'
+
+class FakeProc extends EventEmitter {
+  exitCalls: number[] = []
+
+  exit(code?: number): void {
+    this.exitCalls.push(code ?? 0)
+  }
+}
+
+interface Harness {
+  proc: FakeProc
+  tailwindKills: number
+  warnings: string[]
+}
+
+function setup(): Harness {
+  const harness: Harness = { proc: new FakeProc(), tailwindKills: 0, warnings: [] }
+  registerDevShutdown({
+    proc: harness.proc,
+    killTailwind: () => { harness.tailwindKills++ },
+    warn: (message) => { harness.warnings.push(message) },
+  })
+  return harness
+}
+
+describe('registerDevShutdown', () => {
+  test('solo listener (build phase): kills tailwind and exits 0', () => {
+    const h = setup()
+    h.proc.emit('SIGTERM')
+    expect(h.tailwindKills).toBe(1)
+    expect(h.proc.exitCalls).toEqual([0])
+  })
+
+  test('solo listener: SIGINT also exits 0', () => {
+    const h = setup()
+    h.proc.emit('SIGINT')
+    expect(h.proc.exitCalls).toEqual([0])
+  })
+
+  test('lifecycle listener present: kills tailwind but does NOT exit', () => {
+    const h = setup()
+    // lifecycle.registerShutdownHandlers() registers after dev.ts,
+    // on the same signals — mirror that ordering.
+    h.proc.on('SIGTERM', () => {})
+    h.proc.emit('SIGTERM')
+    expect(h.tailwindKills).toBe(1)
+    expect(h.proc.exitCalls).toEqual([])
+  })
+
+  test('second signal (same signal) forces exit 130 with a warning', () => {
+    const h = setup()
+    h.proc.on('SIGINT', () => {})
+    h.proc.emit('SIGINT')
+    expect(h.proc.exitCalls).toEqual([])
+    h.proc.emit('SIGINT')
+    expect(h.proc.exitCalls).toEqual([130])
+    expect(h.warnings.length).toBe(1)
+  })
+
+  test('second signal (mixed signals) forces exit 130', () => {
+    const h = setup()
+    h.proc.on('SIGINT', () => {})
+    h.proc.on('SIGTERM', () => {})
+    h.proc.emit('SIGINT')
+    h.proc.emit('SIGTERM')
+    expect(h.proc.exitCalls).toEqual([130])
+  })
+
+  test('tailwind is killed only once across first signal + exit hook', () => {
+    const h = setup()
+    h.proc.on('SIGTERM', () => {})
+    h.proc.emit('SIGTERM')
+    expect(h.tailwindKills).toBe(1)
+  })
+
+  test('exit event kills tailwind (covers every JS exit path)', () => {
+    const h = setup()
+    h.proc.emit('exit')
+    expect(h.tailwindKills).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #459 (defect 1 — the last open half; defect 2 + the singleton lock shipped in #465).

`scripts/dev.ts` registers SIGINT/SIGTERM handlers before `await import('../server')`, and signal listeners run in registration order — so its synchronous `process.exit(0)` preempted `lifecycle.ts`'s graceful chain (plugins → dispatch → watcher → `search.shutdown()` → SSE → HTTP → ledger → server lock). The antfly child survived parent death and squatted its port; overlapping half-dead generations produced phantom UI behavior.

## Changes

- **New `scripts/dev-shutdown.ts`** (`registerDevShutdown`, DI for testability): always kills the tailwind child, but only owns `process.exit(0)` while it is the **sole** listener on the signal (build phase, via `listenerCount`). Once `lifecycle.registerShutdownHandlers()` registers on the same signals, the dev handler falls through and the lifecycle listener runs the full graceful chain and owns the exit.
- **Escape hatch:** a second SIGINT/SIGTERM during a hung shutdown warns and force-exits (130/143) — `bun run dev` is never unkillable at the terminal.
- **Tests:** `tests/scripts/dev-shutdown.test.ts` (8 cases, fake proc — real signals would kill the runner), including a regression test asserting the later-registered lifecycle listener actually runs.
- **Docs:** Shutdown-ordering section in `.claude/knowledge/dev-loop.md`; spec + plan under `.claude/specs/`.

Out of scope (owned by #457, not duplicated here): the adapter-side sync exit hook, the `antfly/` watcher ignore, and the boot-window gap before handler registration. Also surfaced but untouched: a pre-existing leak where killing the tailwind `bunx` wrapper orphans the underlying node `tailwindcss` grandchild (documented in dev-loop.md).

## Verification

- `bun run dev` → ready → `kill -TERM` → full lifecycle chain logged ("Stopping Antfly server..." → "Antfly stopped"), antfly child dead, ports 3737/3738 free
- SIGINT during the build phase → prompt exit, nothing leaked
- Double SIGTERM during shutdown → warning logged, process dead ~46ms later (vs the 1s graceful timer), confirmed force path via missing "Shutdown complete" in server.log
- Full suite: 4986 pass / 0 fail; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)