### PR TITLE
fix(health,workflows): plugin-assets off-server init + registry-aware skill check

### DIFF
--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -16,6 +16,8 @@ import { readTaskboard } from '../../../src/core/task-store'
 import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 
 import { listDefinitions } from './parser'
+import { getAgentPackageSkills } from './agent-package-skill-registry'
+import { getPluginSkills } from '../../../src/lib/plugin-registry'
 import { listInstances } from './runtime'
 import {
   repairWorkflowSkillDrift,
@@ -182,18 +184,28 @@ export async function checkWorkflowDefinitions(contentDir: string): Promise<Heal
   const results: HealthCheckResult[] = []
   const skillsDir = join(contentDir, 'workflows', 'skills')
 
+  // Mirror the skill-loader's resolution tiers: a skill "exists" when a user
+  // file is on disk OR an agent package / plugin registered it. Checking the
+  // file alone false-positives whenever a packaged skill has no local shadow.
+  const registered = new Set([
+    ...getAgentPackageSkills().keys(),
+    ...getPluginSkills().keys(),
+  ])
+  const skillExists = (name: string): boolean =>
+    existsSync(join(skillsDir, `${name}.md`)) || registered.has(name)
+
   try {
     const defs = listDefinitions(contentDir)
     for (const { name, definition } of defs) {
       for (const step of definition.steps) {
         const skillName = (step as { skill?: string }).skill
-        if (skillName && !existsSync(join(skillsDir, `${skillName}.md`))) {
+        if (skillName && !skillExists(skillName)) {
           results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" references skill "${skillName}" which does not exist`))
         }
         // Check parallel children too
         if ((step as { type?: string }).type === 'parallel' && 'steps' in step) {
           for (const child of (step as { steps: Array<{ id: string; skill?: string }> }).steps) {
-            if (child.skill && !existsSync(join(skillsDir, `${child.skill}.md`))) {
+            if (child.skill && !skillExists(child.skill)) {
               results.push(warn('workflow-definitions', `Workflow "${name}" parallel step "${child.id}" references skill "${child.skill}" which does not exist`))
             }
           }

--- a/src/core/onboarding/plugin-assets.ts
+++ b/src/core/onboarding/plugin-assets.ts
@@ -25,7 +25,7 @@ import {
   readdirSync,
 } from 'fs'
 import { join } from 'path'
-import { getAppServices } from '../app-services'
+import { createAppServices, getAppServices, maybeGetAppServices } from '../app-services'
 import { createLogger } from '../logger'
 import type { RuntimeSkill } from '@bakin/core/adapters/runtime'
 import {
@@ -264,7 +264,20 @@ function discoverPlugins(): PluginEntry[] {
   return plugins
 }
 
+
+/**
+ * The scanner talks to the runtime adapter. In the server process AppServices
+ * already exist; the CLI's `bakin check/install plugin-assets` path runs in
+ * its own process and must create them first (same pattern as agent-sync +
+ * credentials components).
+ */
+async function ensureAppServices(): Promise<void> {
+  if (maybeGetAppServices()) return
+  await createAppServices()
+}
+
 async function check(): Promise<CheckResult> {
+  await ensureAppServices()
   const plugins = discoverPlugins()
   const report = await scanPluginAssets(plugins)
   const pending = report.missing.length + report.drifted.length
@@ -300,6 +313,7 @@ async function check(): Promise<CheckResult> {
 }
 
 async function install(_opts: OnboardingOptions): Promise<InstallResult> {
+  await ensureAppServices()
   const start = Date.now()
   const plugins = discoverPlugins()
   const report = await installPluginAssets(plugins)

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -252,6 +252,34 @@ steps:
     const results = await checkWorkflowDefinitions(testDir)
     expect(results.some(r => r.status === 'warn' && r.message.includes('missing-skill'))).toBe(true)
   })
+
+  it('resolves skills registered by agent packages (no local file shadow needed)', async () => {
+    const { registerAgentPackageSkill, unregisterAgentPackageSkills } = await import('../../../plugins/workflows/lib/agent-package-skill-registry')
+    registerAgentPackageSkill('pixel', 'packaged-skill', {
+      name: 'packaged-skill',
+      description: 'from the pixel package',
+      instructions: 'body',
+    } as never)
+    try {
+      writeFileSync(
+        join(definitionsDir, 'packaged-flow.yaml'),
+        `name: Packaged flow
+description: test
+version: 1
+steps:
+  - id: s1
+    label: Step 1
+    type: agent
+    agent: main
+    skill: packaged-skill
+`,
+      )
+      const results = await checkWorkflowDefinitions(testDir)
+      expect(results.some(r => r.message.includes('packaged-skill'))).toBe(false)
+    } finally {
+      unregisterAgentPackageSkills('pixel')
+    }
+  })
 })
 
 describe('checkStaleWorkflowInstances', () => {


### PR DESCRIPTION
Follow-up to #490 (this commit landed on that branch moments after it merged). Two pre-existing issues surfaced by the #401 live run:

- `bakin check/install plugin-assets` hit 'AppServices have not been initialized' in the CLI process — same lazy-init treatment as the agent-sync component in #490.
- `checkWorkflowDefinitions` only looked for skill FILES under `~/.bakin/workflows/skills/`, false-positively flagging workflows whose skills resolve through the agent-package or plugin registries (exactly what happens once a stale local shadow is removed). The check now mirrors the skill-loader's resolution tiers, with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)