### PR TITLE
fix(dev): spawn pinned local tailwind bin directly, not bunx @latest

### DIFF
--- a/.claude/knowledge/dev-loop.md
+++ b/.claude/knowledge/dev-loop.md
@@ -49,7 +49,7 @@ scripts/dev.ts (process.env.BAKIN_DEV = '1', BAKIN_DEV_HOTRELOAD = '1')
     │     • `bakin dev --no-color` sets NO_COLOR=1
     ├── Initial prestart build (css, vendors, plugins, host-shell)
     ├── Bun.build(dev-client.ts → public/__bakin-dev/client.js)
-    ├── Spawn bunx @tailwindcss/cli --watch=always   (child process)
+    ├── Spawn bun node_modules/.bin/tailwindcss --watch=always   (child process)
     ├── chokidar watchers:
     │     • packages/host/src/**         → rebuild shell → dev:reload
     │     • plugins/<id>/<devWatch>       → rebuildOnePlugin(id) → dev:hot-swap
@@ -102,7 +102,9 @@ The dev-client bundle itself is disk-only — written to `packages/host/public/_
 - **Second signal (escape hatch):** a repeated SIGINT/SIGTERM while a graceful shutdown is hung logs a warning and force-exits (130 for SIGINT, 143 for SIGTERM).
 - A `process.on('exit')` hook kills tailwind on every JS-level exit path regardless of who calls `process.exit`.
 
-Known gap: a signal landing after antfly is spawned but before `registerShutdownHandlers()` (end of `server.ts` `main()`) exits via the dev path and can orphan antfly — accepted in the spec; the adapter-side sync exit hook on the antfly-zig branch (PR #457) covers it. Separate pre-existing leak: killing the tailwind `bunx` wrapper can orphan the underlying node `tailwindcss` process (grandchild not in the wrapper's signal path).
+Known gap: a signal landing after antfly is spawned but before `registerShutdownHandlers()` (end of `server.ts` `main()`) exits via the dev path and can orphan antfly — accepted in the spec; the adapter-side sync exit hook on the antfly-zig branch (PR #457) covers it.
+
+The tailwind child is spawned as the lockfile-pinned `node_modules/.bin/tailwindcss` directly under bun — the child pid IS the tailwind process, so `kill('SIGTERM')` reaches it. It was previously spawned via `bunx`, which inserted a wrapper chain (volta-shim → bunx → node) that ate the signal and orphaned the node `--watch` grandchild, and downloaded floating `@tailwindcss/cli@latest` instead of the pinned devDependency. Comment-only CSS edits may not rewrite the output file (identical result, mtime unchanged) — use an output-changing rule when verifying the watch pipeline.
 
 ## Imitation Crab
 

--- a/.claude/specs/tailwind-direct-spawn-plan.md
+++ b/.claude/specs/tailwind-direct-spawn-plan.md
@@ -1,6 +1,6 @@
 # Plan: Tailwind Direct Spawn
 
-Spec: `.claude/specs/tailwind-direct-spawn.md` (approved 2026-06-12). Small two-commit change; tasks are strictly linear.
+Spec: `.claude/specs/tailwind-direct-spawn.md` (approved 2026-06-11). Small two-commit change; tasks are strictly linear.
 
 ## Task 1 — the fix (commit 1)
 

--- a/.claude/specs/tailwind-direct-spawn-plan.md
+++ b/.claude/specs/tailwind-direct-spawn-plan.md
@@ -1,0 +1,37 @@
+# Plan: Tailwind Direct Spawn
+
+Spec: `.claude/specs/tailwind-direct-spawn.md` (approved 2026-06-12). Small two-commit change; tasks are strictly linear.
+
+## Task 1 — the fix (commit 1)
+
+**Files:** `scripts/dev.ts` (`startTailwindWatch()`, ~line 215), `package.json` (`build:css`, line 18).
+
+- `dev.ts`: add `const TAILWIND_BIN = join(REPO_ROOT, 'node_modules/.bin/tailwindcss')` near the other path constants; change the spawn from `nodeSpawn('bunx', ['@tailwindcss/cli', '-i', …, '-o', …, '--watch=always'], …)` to `nodeSpawn('bun', [TAILWIND_BIN, '-i', …, '-o', …, '--watch=always'], …)`. Stdio wiring, log classification, exit listener all unchanged.
+- `package.json`: `"build:css": "tailwindcss -i ./packages/host/src/globals.css -o ./packages/host/public/globals.css"` (node_modules/.bin is on PATH in package scripts).
+- Include the spec + this plan file.
+
+**Verify:** typecheck clean; `bun run build:css` exits 0 and writes `packages/host/public/globals.css`; full suite green.
+
+**Commit:** `fix(dev): spawn pinned local tailwind bin directly, not bunx @latest`
+
+## Task 2 — manual end-to-end verification (checkpoint, no commit)
+
+1. Ports 3737/3738 free → `bun run dev` → ready.
+2. `ps` tree: exactly one tailwind process, direct child of the dev pid; no node grandchild, no bunx/volta wrapper; `pgrep -fl "tailwindcss@latest|bunx-"` finds nothing new.
+3. `kill -TERM <dev pid>` → graceful chain runs → `pgrep -fl tailwindcss` empty; no orphans; revert any `_embedded-assets-static.ts` churn from the dev boot (known build-stamp trap).
+
+## Task 3 — docs (commit 2)
+
+- `.claude/knowledge/dev-loop.md` line 52: diagram line → `Spawn bun node_modules/.bin/tailwindcss --watch=always (child process)`.
+- Same file, § Shutdown ordering: rewrite the "Separate pre-existing leak" sentence — leak fixed by direct spawn; keep one line of history for context.
+- Only doc touch point (grep-verified across README/CLAUDE/CONTRIBUTING/docs).
+
+**Commit:** `docs(dev): update dev-loop tailwind spawn + leak notes`
+
+## Task 4 — ship
+
+Code review of the diff, push `fix/tailwind-direct-spawn`, PR (no issue — straight to PR per spec), context in PR body.
+
+## Verification summary
+
+No new unit tests (spawn configuration, no logic surface — per spec). Gates: typecheck, `bun run build:css`, full suite, manual repro above.

--- a/.claude/specs/tailwind-direct-spawn.md
+++ b/.claude/specs/tailwind-direct-spawn.md
@@ -1,0 +1,46 @@
+# Tailwind Direct Spawn — fix watch-process leak + version drift
+
+**Tracking:** No issue (confirmed straight-to-PR); discovered during #459 verification, noted in `.claude/knowledge/dev-loop.md` § Shutdown ordering.
+
+## Objective
+
+Killing the dev loop must not orphan the tailwind watch process, and tailwind must run the lockfile-pinned version.
+
+### Root causes (verified live 2026-06-11)
+
+1. **Leak:** `scripts/dev.ts` `startTailwindWatch()` spawns `bunx @tailwindcss/cli … --watch=always`. On this machine the chain is volta-shim → bunx → **node grandchild** (the CLI's `#!/usr/bin/env node` shebang). `tailwindChild.kill('SIGTERM')` hits only the wrapper; the node grandchild reparents to launchd and watches files forever. Observed twice during #459 verification (pids 91436, 91590, ppid 1).
+2. **Version drift:** the bunx temp dir was `bunx-501-@tailwindcss/cli@latest` — bunx downloaded floating **@latest** instead of using the repo's pinned devDependency `@tailwindcss/cli@^4.2.4` (present at `node_modules/.bin/tailwindcss` → `../@tailwindcss/cli/dist/index.mjs`).
+
+## Design (decisions confirmed 2026-06-12)
+
+1. **`scripts/dev.ts`:** spawn the local bin directly under bun — `nodeSpawn('bun', [join(REPO_ROOT, 'node_modules/.bin/tailwindcss'), '-i', …, '-o', …, '--watch=always'], …)`. The child pid IS the tailwind process: SIGTERM kills it, no grandchild, no wrapper resolution at boot, version comes from the lockfile. Verified: `bun node_modules/.bin/tailwindcss --help` runs v4.2.4 clean (bun executes the .mjs directly, shebang ignored). Everything else (stdio piping, log classification, `--watch=always` for closed stdin, exit listener, `.killed` guard) unchanged.
+2. **`package.json` `build:css`:** switch `bunx @tailwindcss/cli …` → `tailwindcss …` — package scripts have `node_modules/.bin` on PATH, so this unambiguously resolves to the pinned version. One-shot command (no leak), fixed for drift + consistency.
+3. **No issue filed** — PR carries the context.
+
+## Acceptance criteria
+
+1. `bun run dev` → ready: exactly one tailwind process, a **direct child** of the dev process (no node grandchild, no bunx/volta wrapper).
+2. `kill -TERM <dev pid>` → graceful shutdown → `pgrep -fl tailwindcss` empty.
+3. CSS pipeline still works: tailwind watch emits, `build:css` produces `packages/host/public/globals.css` with the pinned v4.2.4.
+4. Full suite (`bun run test`) passes; typecheck clean.
+
+## Out of scope
+
+- No changes to `scripts/dev-shutdown.ts` (just shipped in #491; its caller-side `.killed` guard already handles double-kill).
+- No process-group machinery — tailwind v4's CLI spawns no workers of its own.
+
+## Testing strategy
+
+- This is spawn configuration, not logic — no meaningful unit test surface; do NOT add brittle tests that grep package.json. Manual verification per acceptance criteria + full-suite regression.
+
+## Commit strategy (rollback checkpoints)
+
+Branch `fix/tailwind-direct-spawn` off `main`:
+
+1. `fix(dev): spawn pinned local tailwind bin directly, not bunx @latest` — `scripts/dev.ts` + `package.json` (`build:css`) + this spec.
+2. `docs(dev): update dev-loop tailwind spawn + leak notes` — amend `.claude/knowledge/dev-loop.md` (architecture diagram line "Spawn bunx @tailwindcss/cli" and the § Shutdown ordering known-leak note → fixed).
+
+## Documentation impact
+
+- `.claude/knowledge/dev-loop.md`: two touch points (diagram + leak note).
+- README / CLAUDE.md / CONTRIBUTING.md: verify no `bunx @tailwindcss` references; no other impact expected.

--- a/.claude/specs/tailwind-direct-spawn.md
+++ b/.claude/specs/tailwind-direct-spawn.md
@@ -11,7 +11,7 @@ Killing the dev loop must not orphan the tailwind watch process, and tailwind mu
 1. **Leak:** `scripts/dev.ts` `startTailwindWatch()` spawns `bunx @tailwindcss/cli … --watch=always`. On this machine the chain is volta-shim → bunx → **node grandchild** (the CLI's `#!/usr/bin/env node` shebang). `tailwindChild.kill('SIGTERM')` hits only the wrapper; the node grandchild reparents to launchd and watches files forever. Observed twice during #459 verification (pids 91436, 91590, ppid 1).
 2. **Version drift:** the bunx temp dir was `bunx-501-@tailwindcss/cli@latest` — bunx downloaded floating **@latest** instead of using the repo's pinned devDependency `@tailwindcss/cli@^4.2.4` (present at `node_modules/.bin/tailwindcss` → `../@tailwindcss/cli/dist/index.mjs`).
 
-## Design (decisions confirmed 2026-06-12)
+## Design (decisions confirmed 2026-06-11)
 
 1. **`scripts/dev.ts`:** spawn the local bin directly under bun — `nodeSpawn('bun', [join(REPO_ROOT, 'node_modules/.bin/tailwindcss'), '-i', …, '-o', …, '--watch=always'], …)`. The child pid IS the tailwind process: SIGTERM kills it, no grandchild, no wrapper resolution at boot, version comes from the lockfile. Verified: `bun node_modules/.bin/tailwindcss --help` runs v4.2.4 clean (bun executes the .mjs directly, shebang ignored). Everything else (stdio piping, log classification, `--watch=always` for closed stdin, exit listener, `.killed` guard) unchanged.
 2. **`package.json` `build:css`:** switch `bunx @tailwindcss/cli …` → `tailwindcss …` — package scripts have `node_modules/.bin` on PATH, so this unambiguously resolves to the pinned version. One-shot command (no leak), fixed for drift + consistency.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "bun run build:css && bun run build:vendors && bun run build:plugins && bun run build:host-shell && bun run build:assert-production-assets && bun run build:binary",
     "release": "bun run scripts/prep-release.ts",
     "build:host": "bun run build:css && bun run build:vendors && bun run build:host-shell",
-    "build:css": "bunx @tailwindcss/cli -i ./packages/host/src/globals.css -o ./packages/host/public/globals.css",
+    "build:css": "tailwindcss -i ./packages/host/src/globals.css -o ./packages/host/public/globals.css",
     "build:host-shell": "bun run packages/host/build.ts",
     "build:vendors": "bun run scripts/build-vendors.ts",
     "build:plugins": "bun run scripts/build-plugins.ts",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -66,6 +66,7 @@ const REPO_ROOT = resolve(import.meta.dir, '..')
 const PLUGINS_DIR = join(REPO_ROOT, 'plugins')
 const DEV_CLIENT_ENTRY = join(REPO_ROOT, 'packages/host/src/dev-client/client.ts')
 const DEV_CLIENT_OUTDIR = join(REPO_ROOT, 'packages/host/public/__bakin-dev')
+const TAILWIND_BIN = join(REPO_ROOT, 'node_modules/.bin/tailwindcss')
 
 const CORE_PLUGINS = [
   'tasks', 'team', 'workflows', 'assets',
@@ -218,10 +219,14 @@ function startTailwindWatch(): void {
   // --watch=always keeps the watcher alive when stdin is closed (we use
   // stdio:'ignore' for stdin). Plain --watch exits on stdin close and
   // silently stops emitting output.
+  // Spawn the lockfile-pinned local bin directly under bun: the child pid
+  // IS the tailwind process, so kill('SIGTERM') reaches it. bunx added a
+  // wrapper chain that ate the signal (orphaned node grandchild) and
+  // downloaded floating @tailwindcss/cli@latest instead of the devDep.
   tailwindChild = nodeSpawn(
-    'bunx',
+    'bun',
     [
-      '@tailwindcss/cli',
+      TAILWIND_BIN,
       '-i', './packages/host/src/globals.css',
       '-o', './packages/host/public/globals.css',
       '--watch=always',


### PR DESCRIPTION
## Summary

Fixes the dev-loop tailwind leak surfaced during #459 verification (documented as a known gap in `dev-loop.md` by #491) — straight to PR, no issue, per kickoff decision.

Two defects, one root cause:

- **Leak:** `nodeSpawn('bunx', ['@tailwindcss/cli', …, '--watch=always'])` produced a volta-shim → bunx → **node grandchild** chain. `tailwindChild.kill('SIGTERM')` hit only the wrapper; the node `--watch` process reparented to launchd and watched files forever (observed twice, pids 91436/91590).
- **Version drift:** bunx downloaded floating `@tailwindcss/cli@latest` at every dev boot, ignoring the pinned `^4.2.4` devDependency.

## Changes

- `scripts/dev.ts`: spawn the lockfile-pinned `node_modules/.bin/tailwindcss` directly under `bun` — the child pid IS the tailwind process, so SIGTERM reaches it. No wrapper resolution at boot.
- `package.json` `build:css`: `bunx @tailwindcss/cli` → bare `tailwindcss` (node_modules/.bin is on package-script PATH). CI workflows run `bun install --frozen-lockfile` first, so both pipelines resolve the pinned version.
- Docs: `dev-loop.md` diagram + leak note updated; spec/plan under `.claude/specs/`.

No new unit tests — spawn configuration with no logic surface (spec rules out brittle package.json-grep tests).

## Verification

- `bun run dev` → exactly one tailwind process, **direct child** of the dev pid (no node grandchild, no bunx/volta wrapper)
- Output-changing CSS edit → rebuild + `css updated` dev event fired (edit + revert); note: comment-only edits produce identical output and skip the rewrite (documented gotcha)
- `kill -TERM` → graceful chain ran, **zero tailwind/bunx survivors**, port freed
- `bun run build:css` → v4.2.4 (pinned), exits 0
- Full suite 4986 pass / 0 fail; typecheck clean
- Code review: approve; supply-chain posture improves (no runtime download of `@latest`)

Follow-up candidates (out of scope): prune now-dead bunx download-chatter patterns from `dev-log-classifier.ts`; optional `existsSync(TAILWIND_BIN)` guard with a "run bun install" hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)