### PR TITLE
fix(team): client-side routing + team page polish

### DIFF
--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -31,7 +31,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'soul', label: 'Soul' },
   { id: 'memory', label: 'Memory' },
   { id: 'heartbeat', label: 'Heartbeat' },
-  { id: 'rules', label: 'Rules' },
+  { id: 'rules', label: 'AGENTS.md' },
   { id: 'tools', label: 'Tools' },
   { id: 'skills', label: 'Skills' },
   { id: 'lessons', label: 'Lessons' },

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -203,15 +203,24 @@ export function TeamDetail({ teamId }: { teamId: string }) {
         </CardHeader>
         <CardContent className="space-y-2">
           <p className="text-xs text-muted-foreground">
-            {isGlobal
-              ? 'Reaches every agent’s AGENTS.md via Bakin blocks on sync.'
-              : 'Reaches every member’s AGENTS.md via Bakin blocks on sync.'}
+            Standing instructions for {isGlobal ? 'every agent' : `every ${team?.label ?? teamId} member`} —
+            write them once here instead of editing each agent. On <span className="font-medium text-foreground">Sync</span>,
+            Bakin composes this into each agent's AGENTS.md managed block; their own notes outside the block are never touched.
           </p>
+          {(content ?? '').trim() === '' && (
+            <p className="text-xs text-muted-foreground">
+              Good fits: house rules, tone, conventions, escalation. Personalize with{' '}
+              <code className="text-[11px]">{'{{agentName}}'}</code>, <code className="text-[11px]">{'{{agentId}}'}</code>,{' '}
+              <code className="text-[11px]">{'{{mainAgentName}}'}</code>.
+            </p>
+          )}
           <Textarea
             value={content ?? ''}
             onChange={(e) => { setContent(e.target.value); setDirty(true) }}
             className="min-h-96 font-mono text-xs"
-            placeholder={isGlobal ? '# House rules for every agent…' : `# Rules for the ${team?.label ?? teamId} team…`}
+            placeholder={isGlobal
+              ? `# House rules\n\n- Keep replies short and direct.\n- {{agentName}} reports blockers to {{mainAgentName}} immediately.`
+              : `# ${team?.label ?? teamId} team rules\n\n- Follow the team style guide.\n- Hand finished work back by assetId, never file paths.`}
             aria-label="Shared context content"
           />
           <div className="flex items-center gap-2">

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -223,12 +223,12 @@ export function TeamDetail({ teamId }: { teamId: string }) {
               : `# ${team?.label ?? teamId} team rules\n\n- Follow the team style guide.\n- Hand finished work back by assetId, never file paths.`}
             aria-label="Shared context content"
           />
-          <div className="flex items-center gap-2">
+          <div className="flex items-center justify-end gap-2">
+            {saveError && <span className="text-xs text-red-400">{saveError}</span>}
+            {dirty && <span className="text-xs text-yellow-500">Unsaved changes — members go stale after save until synced.</span>}
             <Button size="sm" onClick={save} disabled={!dirty || saving}>
               {saving ? 'Saving…' : 'Save'}
             </Button>
-            {dirty && <span className="text-xs text-yellow-500">Unsaved changes — members go stale after save until synced.</span>}
-            {saveError && <span className="text-xs text-red-400">{saveError}</span>}
           </div>
         </CardContent>
       </Card>

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -210,8 +210,7 @@ export function TeamDetail({ teamId }: { teamId: string }) {
           <Textarea
             value={content ?? ''}
             onChange={(e) => { setContent(e.target.value); setDirty(true) }}
-            rows={24}
-            className="font-mono text-xs"
+            className="min-h-96 font-mono text-xs"
             placeholder={isGlobal ? '# House rules for every agent…' : `# Rules for the ${team?.label ?? teamId} team…`}
             aria-label="Shared context content"
           />

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -210,7 +210,7 @@ export function TeamDetail({ teamId }: { teamId: string }) {
           <Textarea
             value={content ?? ''}
             onChange={(e) => { setContent(e.target.value); setDirty(true) }}
-            rows={12}
+            rows={24}
             className="font-mono text-xs"
             placeholder={isGlobal ? '# House rules for every agent…' : `# Rules for the ${team?.label ?? teamId} team…`}
             aria-label="Shared context content"

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -204,8 +204,8 @@ export function TeamDetail({ teamId }: { teamId: string }) {
         <CardContent className="space-y-2">
           <p className="text-xs text-muted-foreground">
             {isGlobal
-              ? 'Reaches EVERY agent’s AGENTS.md managed block on sync. Content inside a bakin:managed block (role files) is Bakin-owned and re-asserted automatically.'
-              : 'Reaches every member’s AGENTS.md managed block on sync.'}
+              ? 'Reaches every agent’s AGENTS.md via Bakin blocks on sync.'
+              : 'Reaches every member’s AGENTS.md via Bakin blocks on sync.'}
           </p>
           <Textarea
             value={content ?? ''}

--- a/plugins/team/components/team-grid.tsx
+++ b/plugins/team/components/team-grid.tsx
@@ -169,16 +169,21 @@ interface SectionNodeData extends Record<string, unknown> {
 
 function SectionNode({ data }: NodeProps) {
   const { label, teamId, hasContext } = data as SectionNodeData
+  const router = useRouter()
   return (
     <div className="flex items-center justify-center gap-1 px-4">
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0" />
-      <a
-        href={teamId ? `/team/teams/${encodeURIComponent(teamId)}` : '/team'}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          if (teamId) router.push(`/team/teams/${encodeURIComponent(teamId)}`)
+        }}
         className="text-[10px] font-semibold uppercase tracking-widest text-zinc-500 whitespace-nowrap hover:text-zinc-300 hover:underline"
         title={hasContext ? 'Team carries shared context — click to view' : 'Open team page'}
       >
         {label}
-      </a>
+      </button>
       {hasContext && (
         <ScrollText className="size-3 text-info" aria-label={`${label} has shared context rules`} />
       )}

--- a/plugins/team/components/team-manager.tsx
+++ b/plugins/team/components/team-manager.tsx
@@ -12,10 +12,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@makinbakin/sdk/ui"
-import { useAgentStore } from '@makinbakin/sdk/hooks'
+import { useAgentStore, useRouter } from '@makinbakin/sdk/hooks'
 import type { OrgTeam } from '../types'
 
 export function TeamManager() {
+  const router = useRouter()
   const teams = useAgentStore((s) => s.teams)
   const agents = useAgentStore((s) => s.agents)
   const reload = useAgentStore((s) => s.load)
@@ -103,7 +104,7 @@ export function TeamManager() {
         <div className="space-y-3">
           <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3">
             <div className="flex-1 min-w-0">
-              <a href="/team/teams/global" className="text-sm font-semibold hover:underline">Global</a>
+              <button type="button" onClick={() => router.push('/team/teams/global')} className="text-sm font-semibold hover:underline text-left">Global</button>
               <div className="text-xs text-muted-foreground">Shared context for every agent</div>
             </div>
             <code className="text-[10px] text-muted-foreground font-mono">global</code>
@@ -115,9 +116,9 @@ export function TeamManager() {
                 className="flex items-center gap-3 rounded-lg border border-border bg-card p-3"
               >
                 <div className="flex-1 min-w-0">
-                  <a href={`/team/teams/${encodeURIComponent(team.id)}`} className="text-sm font-semibold hover:underline">
+                  <button type="button" onClick={() => router.push(`/team/teams/${encodeURIComponent(team.id)}`)} className="text-sm font-semibold hover:underline text-left">
                     {team.label}
-                  </a>
+                  </button>
                   <div className="text-xs text-muted-foreground">
                     Reports to{' '}
                     <select

--- a/tests/plugins/team/agent-detail-tabs.test.tsx
+++ b/tests/plugins/team/agent-detail-tabs.test.tsx
@@ -144,7 +144,7 @@ describe('AgentDetail — tab URL contract', () => {
   it('writes the tab back to the URL when a tab is clicked', async () => {
     queryState.tab = 'overview'
     render(<AgentDetail agentId="explorer" />)
-    const rulesBtn = await waitFor(() => screen.getByRole('button', { name: 'Rules' }))
+    const rulesBtn = await waitFor(() => screen.getByRole('button', { name: 'AGENTS.md' }))
     fireEvent.click(rulesBtn)
     expect(setTabSpy).toHaveBeenCalledWith('rules')
   })


### PR DESCRIPTION
Post-merge fixes for the #401 UI surfaces, found while using them live:

- **Client-side routing for team links** (the major one): team-manager drawer rows, the Global entry, and graph section labels used plain `<a href>` — every click forced a full app re-bootstrap ("Loading plugins…", reads as a hang over Tailscale). Now `router.push` everywhere; verified live.
- **AGENTS.md tab**: the agent-detail "Rules" tab was the only one whose label didn't match its file, and under the layered-context model it actively misled. Renamed to AGENTS.md.
- **Shared-context editor**: onboarding copy (what it is, where it flows on Sync, never-touches-agent-notes guarantee), a what-to-write hint + personalization tokens shown only while empty, concrete example placeholders, doubled editor height (min-h-96 — `rows` is a no-op under the SDK Textarea's `field-sizing: content`), Save right-aligned, tightened helper copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)