### PR TITLE
feat(health): session-store retention check (#435)

### DIFF
--- a/.claude/knowledge/doctor-and-health-checks.md
+++ b/.claude/knowledge/doctor-and-health-checks.md
@@ -54,6 +54,7 @@ The orchestrator is intentionally trivial — it has no opinion about what's bei
 | `plugins/health/lib/system-checks/service.ts` | `service` |
 | `plugins/health/lib/system-checks/mcporter.ts` | `mcporter` |
 | `plugins/health/lib/system-checks/runtime.ts` | `runtime` |
+| `plugins/health/lib/system-checks/session-store.ts` | `session-store` |
 | `plugins/health/lib/system-checks/channel-aliases.ts` | `channel-aliases` |
 | `plugins/health/lib/system-checks/restart-recovery.ts` | `restart-recovery` |
 | `plugins/health/lib/system-checks/channel-approvals.ts` | `channel-approvals` |

--- a/.claude/knowledge/session-forensics.md
+++ b/.claude/knowledge/session-forensics.md
@@ -95,8 +95,17 @@ gives every dispatch attempt a fresh, deterministic provider session:
 - the gateway idempotency key `bakin:<threadId>` is stable per logical turn.
 
 Session-store (`sessions.json`) reads are mtime-cached in the adapter since
-per-dispatch sessions accumulate entries. OpenClaw-side retention of old
-sessions is an upstream concern (rig validation item).
+per-dispatch sessions accumulate entries. OpenClaw-side retention exists as
+of 2026.6.5 (#435 close-out): `session.maintenance` defaults to
+`mode: enforce`, `pruneAfter: 30d`, `maxEntries: 500`, and maintenance runs
+on session-store **writes** and via `openclaw sessions cleanup --enforce` —
+never on gateway startup/reads. Unreferenced transcript/trajectory artifacts
+are only GC'd past a 30-day cutoff, and disk-budget eviction requires
+opting into `session.maintenance.maxDiskBytes`. The health plugin's
+`session-store` doctor check (`plugins/health/lib/system-checks/
+session-store.ts`, fed by the read-only `runtime.sessions.storeStats()`
+adapter capability) is the early warning when accumulation outruns
+maintenance.
 
 ## Observability
 

--- a/.claude/specs/session-store-retention-check-plan.md
+++ b/.claude/specs/session-store-retention-check-plan.md
@@ -1,0 +1,134 @@
+# Plan — Session-Store Retention Check (#435 close-out)
+
+Spec: `session-store-retention-check.md`. Branch:
+`feat/session-store-retention-check` off `main`.
+
+Verified integration points (read during planning):
+
+- Concept interface: `packages/core/src/adapters/runtime/concepts.ts:507`
+  (`sessions: { list, get }`); `RuntimeSession` at `:239`.
+- OpenClaw adapter stub: `packages/adapter-openclaw/src/runtime.ts:808`
+  (`sessions = { list: async () => [], get: async () => null }`); home
+  resolution via `getOpenClawHome()` from `./home`.
+- Testing adapter: `packages/core/src/adapters/runtime/testing.ts:83` —
+  leave `storeStats` omitted (exercises the absence path by default).
+- Check registration: `plugins/health/index.ts` ~`:514` — register
+  `session-store` after the `runtime` check, `run: () =>
+  checkSessionStore(ctx.runtime)`.
+- Tests live at `tests/adapter-openclaw/` (adapter) and
+  `tests/plugins/health/` (new `session-store.test.ts`).
+- Docs: `.claude/knowledge/adapter-architecture.md:77` lists concept names
+  only (no method enumeration) → **no change needed there**; spec §5
+  conditional resolves to "skip".
+
+## Task 1 — Adapter capability `sessions.storeStats()` ✅ Commit 1
+
+**Slice:** type + OpenClaw implementation + tests. Inert (no consumer).
+
+1. `concepts.ts`: add `RuntimeSessionStoreStats` interface
+   (`agentId/storeEntries/fileCount/diskBytes`) + optional
+   `storeStats?(): Promise<RuntimeSessionStoreStats[]>` on `sessions`,
+   doc-commented per spec §3.1. Export the type from the adapter barrel
+   (`packages/core/src/adapters/runtime/index.ts`) if types are re-exported
+   there (check at build time).
+2. `packages/adapter-openclaw/src/runtime.ts`: implement `storeStats` on the
+   `sessions` object — `readdir(<home>/agents)`, per agent stat every file
+   in `sessions/` (skip agents without the dir), sum bytes, count files,
+   `storeEntries` = key count of parsed `sessions.json` (missing/malformed →
+   0, log at debug, never throw).
+3. Tests `tests/adapter-openclaw/runtime-session-stats.test.ts`: temp
+   `OPENCLAW_HOME` set **before imports** (CLAUDE.md rule), fixtures for
+   multi-agent, missing dir, empty store, malformed store. Cleanup in
+   `afterAll`. Mock logger.
+
+**Acceptance:** tests green via
+`bun test tests/adapter-openclaw/runtime-session-stats.test.ts --isolate`;
+`bun run typecheck` (or `tsc` equivalent in repo scripts) clean.
+**Verify live:** quick `bun -e` against real home comparing one agent's
+`diskBytes` to `du -sk` (read-only).
+
+**Commit:** `feat(core): add optional sessions.storeStats to runtime adapter`
+
+## Task 2 — Health check `session-store` ✅ Commit 2
+
+**Slice:** check + registration + tests. Depends on Task 1.
+
+1. `plugins/health/lib/system-checks/session-store.ts`:
+   `checkSessionStore(runtime: Pick<AgentRuntimeAdapter, 'sessions'>)`.
+   Constants: `SESSION_STORE_WARN_BYTES` (500MB), `SESSION_STORE_ERROR_BYTES`
+   (1GB), `SESSION_STORE_ORPHAN_RATIO` (10), `SESSION_STORE_ORPHAN_MIN_FILES`
+   (100). Semantics per spec §3.2: absent capability → single ok ("stats not
+   available for this runtime"); throw → single error result (logged); all
+   healthy → single ok summary (agent count + total bytes); else one result
+   per offending agent with sizes, counts, and the remediation message
+   (`openclaw sessions cleanup --enforce`, `session.maintenance.maxDiskBytes`).
+   `autoFixable: false` everywhere.
+2. Register in `plugins/health/index.ts` after `runtime`:
+   `{ id: 'session-store', name: 'Runtime session-store growth', run: ... }`.
+3. Tests `tests/plugins/health/session-store.test.ts` (pure-function, fake
+   runtime objects — no fs): ok path, byte warn, byte error, orphan warn,
+   ratio suppressed under min-files, absent capability, stats throwing,
+   multiple offenders → multiple results.
+
+**Acceptance:** new tests green; `bun run test` full suite green;
+**verify live:** restart-free check via `bakin doctor` or
+`bun test` is not enough — run the doctor once on this machine and confirm
+`session-store` fires WARN for `main` (24× ratio). Capture output for the
+issue comment. Also run `bun run dev:mock` doctor path once to confirm the
+absence → ok branch.
+
+**Commit:** `feat(health): add session-store growth check`
+
+## Task 3 — Docs ✅ Commit 3
+
+1. `.claude/knowledge/session-forensics.md` (~line 97): replace the
+   "upstream concern (rig validation item)" paragraph with verified
+   2026.6.5 behavior (maintenance on writes + CLI, defaults, no startup
+   pruning, disk budget opt-in) + pointer to the `session-store` doctor
+   check.
+2. `.claude/knowledge/doctor-and-health-checks.md`: add
+   `plugins/health/lib/system-checks/session-store.ts` | `session-store`
+   to the system-checks table.
+3. Spec + this plan checked in (already written; included in this commit).
+
+**Acceptance:** grep shows no remaining "upstream concern" retention note;
+README confirmed untouched-by-design.
+
+**Commit:** `docs(knowledge): record verified OpenClaw session retention behavior`
+
+## Task 4 — Machine remediation + issue close-out (ops, no commit)
+
+Depends on Task 2's live WARN capture.
+
+1. Record before: `du -sh ~/.openclaw/agents/*/sessions`, dry-run cleanup
+   JSON, doctor WARN text.
+2. `openclaw sessions cleanup --enforce --all-agents`.
+3. `openclaw config set session.maintenance.maxDiskBytes 536870912`
+   (+ `openclaw config get session.maintenance` to confirm; gateway restart
+   only if OpenClaw requires it to pick up config — check `openclaw doctor`).
+4. Re-run doctor; record after-state (size WARN cleared; orphan-ratio WARN
+   may persist for <30d artifacts — expected, note it).
+5. Comment on #435: upstream findings, check id, before/after; close issue.
+6. Merge PR (single PR containing commits 1–3, conventional title
+   `feat(health): session-store retention check (#435)`).
+
+**Acceptance criteria for the whole effort:** spec §7 items 1–6.
+
+## Checkpoints / rollback
+
+- After each commit the tree is green and shippable; commits 1–3 are
+  independently revertible in reverse order (3: docs only; 2: doctor loses
+  the check, capability stays inert; 1: removes the unused capability).
+- Remediation is reversible only in config (`openclaw config unset
+  session.maintenance.maxDiskBytes`); deleted artifacts are gone — which is
+  the point, and they're >30d-old unreferenced transcripts handled by
+  OpenClaw's own GC rules.
+
+## Risks
+
+- **Adapter walk cost:** ~1.8k files statted per doctor cycle for `main` —
+  microseconds-to-low-ms territory, doctor is cron-cadence; acceptable.
+- **OpenClaw config set side effects:** `openclaw.json` is rewritten by its
+  own CLI (it already maintains `.bak` rotations). Bakin never touches it.
+- **Threshold judgment:** constants are deliberate first guesses; one-line
+  edits if reality disagrees.

--- a/.claude/specs/session-store-retention-check.md
+++ b/.claude/specs/session-store-retention-check.md
@@ -1,0 +1,203 @@
+# Session-Store Retention Check (#435 close-out)
+
+**Issue:** https://github.com/markhayden/bakin/issues/435
+**Status:** Spec approved — see companion `session-store-retention-check-plan.md`
+**Date:** 2026-06-11
+
+## 1. Objective
+
+Close out the remaining scope of #435 (OpenClaw session retention) now that
+upstream has shipped built-in session-store maintenance. Three deliverables:
+
+1. **Doctor early-warning check** — a read-only health check that watches
+   per-agent session-store growth and fires before unbounded accumulation
+   becomes a problem.
+2. **Docs** — update knowledge docs that still describe retention as an
+   open upstream concern; record the verified upstream behavior.
+3. **Machine remediation** (ops, not code) — run OpenClaw's own cleanup and
+   set a disk budget so the gateway self-maintains; use the before/after as
+   live validation of the new check.
+
+## 2. Verified Findings (2026-06-11, OpenClaw 2026.6.5 (5181e4f), this machine)
+
+The issue's "raise upstream" action is **moot** — upstream shipped retention:
+
+- `openclaw sessions cleanup` exists: store maintenance with `--dry-run`,
+  `--enforce`, `--all-agents`, `--fix-missing`, `--fix-dm-scope`,
+  `--active-key` protection.
+- `session.maintenance` config: `mode` (default **enforce**), `pruneAfter`
+  (default **30d**), `maxEntries` (default **500**), optional `maxDiskBytes`
+  with `highWaterBytes` (default 80% of max). Docs:
+  https://docs.openclaw.ai/reference/session-management-compaction
+- Maintenance fires on session-store **writes** and via the manual CLI —
+  **not** on gateway startup or reads.
+- **Gap observed live:** without `maxDiskBytes` configured (`diskBudget:
+  null` on this machine), there is no disk-budget eviction and unreferenced
+  artifacts (transcripts/trajectories no longer referenced by the store) are
+  only GC'd when cleanup actually runs, and only past a 30-day cutoff.
+  Observed: `main` sessions dir at **321MB / 1,812 files** with only **74**
+  live store entries; dry-run cleanup would free ~90MB (389 files) today.
+
+Conclusion: upstream maintenance exists but is not self-sufficient on this
+machine's configuration → an early-warning doctor check is the right
+Bakin-side guard, plus a one-time ops remediation.
+
+## 3. Design
+
+### 3.1 Adapter capability — `runtime.sessions.storeStats()`
+
+Extend the `sessions` concept on `AgentRuntimeAdapter`
+(`packages/core/src/adapters/runtime/concepts.ts:507`) with an **optional**
+method (same optionality pattern as `media?` / `images?`):
+
+```ts
+sessions: {
+  list(agentId?: string): Promise<RuntimeSession[]>
+  get(sessionId: string): Promise<RuntimeSession | null>
+  /**
+   * Per-agent session-store disk stats. Optional: runtimes without a
+   * file-backed session store omit it; callers treat absence as
+   * "stats unavailable" (skip, never error).
+   */
+  storeStats?(): Promise<RuntimeSessionStoreStats[]>
+}
+```
+
+```ts
+interface RuntimeSessionStoreStats {
+  agentId: string
+  storeEntries: number   // live entries in sessions.json
+  fileCount: number      // files in the sessions dir (incl. sessions.json)
+  diskBytes: number      // total bytes of the sessions dir
+}
+```
+
+OpenClaw implementation (`packages/adapter-openclaw/src/runtime.ts`):
+enumerate `<openclawHome>/agents/*/sessions/`, stat files, count
+`sessions.json` entries (`Object.keys(parse(...)).length`; tolerate missing
+or malformed stores → `storeEntries: 0`). Read-only; no OpenClaw CLI calls,
+no mutation, respects `getOpenClawHome()` resolution. Agents without a
+sessions dir are skipped.
+
+The mock runtime (Imitation Crab) and the testing adapter omit
+`storeStats` — absence is a supported state.
+
+### 3.2 Health check — `runtime.session-store`
+
+New file `plugins/health/lib/system-checks/session-store.ts`, registered by
+the health plugin alongside the existing `runtime` check. Pure function over
+`RuntimeSessionStoreStats[]` (stats-fetching injected, matching
+`checkRuntime(runtime: Pick<...>)` style).
+
+Per-agent evaluation, hardcoded named constants:
+
+| Constant | Value | Fires |
+|---|---|---|
+| `SESSION_STORE_WARN_BYTES` | 500 MB | `warn` when an agent's sessions dir exceeds it |
+| `SESSION_STORE_ERROR_BYTES` | 1 GB | `error` |
+| `SESSION_STORE_ORPHAN_RATIO` | 10× | `warn` when `fileCount / max(storeEntries, 1)` exceeds it AND `fileCount` is non-trivial (≥ `SESSION_STORE_ORPHAN_MIN_FILES` = 100) |
+
+- One `HealthCheckResult` summarizing all agents when everything is healthy
+  (`status: 'ok'`); one result per offending agent otherwise, message naming
+  the agent, size, file/entry counts, and the fix:
+  `openclaw sessions cleanup --enforce` + configure
+  `session.maintenance.maxDiskBytes`.
+- `storeStats` absent on the active runtime → single `ok` result,
+  "session-store stats not available for this runtime" (not a warning —
+  mock/dev runtimes are healthy states).
+- `autoFixable: false` — remediation mutates runtime-owned data; Bakin
+  surfaces, the user (or the gateway itself) fixes. This preserves the
+  adapter boundary: Bakin never writes under `~/.openclaw`.
+
+### 3.3 Machine remediation (ops runbook, performed as part of this work)
+
+After the check ships and its WARN against current state is captured:
+
+1. `openclaw sessions cleanup --enforce --all-agents` (frees ~90MB today).
+2. `openclaw config set session.maintenance.maxDiskBytes 536870912` (512MB
+   per agent store) so the gateway's write-triggered high-water eviction is
+   active going forward. Uses OpenClaw's own CLI exclusively.
+3. Re-run the doctor check; confirm the size signal improves and record
+   before/after in the issue close-out comment.
+
+Note: orphan-ratio may still warn immediately after cleanup (artifacts <30d
+old are retained by upstream GC). That is expected and documented in the
+check message; the disk-budget eviction handles it over time.
+
+## 4. Testing Strategy
+
+- **Adapter:** unit tests for the OpenClaw `storeStats()` against a temp
+  OpenClaw home (env-var + `@bakin/adapter-openclaw/home` mock per
+  CLAUDE.md testing rules — set `OPENCLAW_HOME` before imports). Cases:
+  multiple agents, missing sessions dir, empty/malformed `sessions.json`.
+- **Check:** pure-function tests over synthetic stats — ok path, byte warn,
+  byte error, orphan-ratio warn, ratio guard below min-files, absent
+  capability, stats call throwing (→ single `error` result, logged).
+- **Both content-dir resolvers + logger mocked** in any test touching the
+  filesystem; temp dirs cleaned in `afterAll`.
+- Full suite via `bun run test`; new files individually via
+  `bun test <file> --isolate`.
+
+## 5. Docs Impact
+
+- `.claude/knowledge/session-forensics.md` — replace the "OpenClaw-side
+  retention … is an upstream concern (rig validation item)" note with the
+  verified upstream behavior + pointer to the new check.
+- `.claude/knowledge/doctor-and-health-checks.md` — add
+  `session-store.ts` to the system-checks table.
+- `.claude/knowledge/adapter-architecture.md` — only if it enumerates the
+  `sessions` concept surface (verify during build; add `storeStats?` if so).
+- README.md — not impacted (no user-facing surface change beyond a doctor
+  check; doctor checks aren't enumerated there).
+- Issue #435 — close-out comment with verified findings, check id, and
+  remediation before/after; then close.
+
+## 6. Boundaries
+
+**Always:**
+- Adapter boundary: provider paths only inside `packages/adapter-openclaw/`;
+  the check consumes `AppServices.runtime` capability only.
+- Read-only with respect to `~/.openclaw` in all Bakin code paths.
+- Strict TS, named constants, `createLogger`, no empty catches.
+
+**Ask first:**
+- Any change to `session.maintenance` values other than the agreed
+  `maxDiskBytes=512MB`.
+- Any deletion beyond what `openclaw sessions cleanup --enforce` itself
+  performs.
+
+**Never:**
+- Bakin code writing/deleting under `~/.openclaw`.
+- Auto-fix that mutates runtime session data.
+- Parsing OpenClaw CLI output in the health check (the adapter walks the
+  filesystem; no subprocess per doctor cycle).
+- Backwards-compat shims — `storeStats` is optional by design, not for
+  compat theater.
+
+## 7. Acceptance Criteria
+
+1. `getAppServices().runtime.sessions.storeStats()` returns accurate
+   per-agent stats on this machine (spot-checked against `du`/`ls`).
+2. Doctor lists `session-store` under the health plugin; firing semantics
+   match §3.2 (verified by tests + one live run showing the day-one WARN).
+3. Mock runtime (`bun run dev:mock`) doctor run shows the `ok`
+   "not available" path, not an error.
+4. Full test suite green; no test touches real `~/.bakin` or `~/.openclaw`.
+5. Machine remediated per §3.3 with before/after recorded on #435; issue
+   closed.
+6. Docs updated per §5.
+
+## 8. Commit Strategy (checkpoints)
+
+Branch `feat/session-store-retention-check`; detailed task-level plan in the
+companion plan doc. Natural rollback points:
+
+1. `feat(core): add optional sessions.storeStats to runtime adapter` —
+   concept type + OpenClaw implementation + adapter tests. Standalone:
+   nothing consumes it yet; revert = delete capability.
+2. `feat(health): add session-store growth check` — check + registration +
+   tests. Revert = doctor loses one check; adapter capability remains inert.
+3. `docs(knowledge): record verified OpenClaw session retention behavior` —
+   knowledge-doc updates + spec/plan docs. Pure docs.
+
+Remediation (§3.3) is machine ops, not a commit.

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -22,6 +22,7 @@ import type {
   RuntimeImageProvider,
   RuntimeMetadata,
   RuntimeMemorySearchResult,
+  RuntimeSessionStoreStats,
   RuntimeSkill,
   UpdateCronJobInput,
   WorkspaceFile,
@@ -808,6 +809,35 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   sessions = {
     list: async () => [],
     get: async () => null,
+    storeStats: async (): Promise<RuntimeSessionStoreStats[]> => {
+      const agentsDir = getOpenClawPath('agents')
+      if (!existsSync(agentsDir)) return []
+      const stats: RuntimeSessionStoreStats[] = []
+      for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue
+        const sessionsDir = join(agentsDir, entry.name, 'sessions')
+        if (!existsSync(sessionsDir)) continue
+        let fileCount = 0
+        let diskBytes = 0
+        for (const file of readdirSync(sessionsDir, { withFileTypes: true })) {
+          if (!file.isFile()) continue
+          fileCount += 1
+          diskBytes += statSync(join(sessionsDir, file.name)).size
+        }
+        let storeEntries = 0
+        try {
+          const store: unknown = JSON.parse(readFileSync(join(sessionsDir, 'sessions.json'), 'utf-8'))
+          if (store && typeof store === 'object') storeEntries = Object.keys(store).length
+        } catch (err) {
+          this.logger.debug('Session store missing or unparsable while collecting stats', {
+            agentId: entry.name,
+            error: String(err),
+          })
+        }
+        stats.push({ agentId: entry.name, storeEntries, fileCount, diskBytes })
+      }
+      return stats
+    },
   }
 
   memory = {

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -817,13 +817,23 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
         if (!entry.isDirectory()) continue
         const sessionsDir = join(agentsDir, entry.name, 'sessions')
         if (!existsSync(sessionsDir)) continue
+        // Top-level files are session artifacts (transcripts, the store
+        // itself); subtrees like skills-prompts/ are cache disk pressure
+        // only and must not skew the orphan file count.
         let fileCount = 0
         let diskBytes = 0
-        for (const file of readdirSync(sessionsDir, { withFileTypes: true })) {
-          if (!file.isFile()) continue
-          fileCount += 1
-          diskBytes += statSync(join(sessionsDir, file.name)).size
+        const walk = (dir: string, topLevel: boolean) => {
+          for (const file of readdirSync(dir, { withFileTypes: true })) {
+            const path = join(dir, file.name)
+            if (file.isDirectory()) {
+              walk(path, false)
+            } else if (file.isFile()) {
+              if (topLevel) fileCount += 1
+              diskBytes += statSync(path).size
+            }
+          }
         }
+        walk(sessionsDir, true)
         let storeEntries = 0
         try {
           const store: unknown = JSON.parse(readFileSync(join(sessionsDir, 'sessions.json'), 'utf-8'))

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -249,9 +249,13 @@ export interface RuntimeSessionStoreStats {
   agentId: string
   /** Live entries in the runtime's session store for this agent. */
   storeEntries: number
-  /** Files in the agent's sessions directory, including the store itself. */
+  /**
+   * Top-level files in the agent's sessions directory (session artifacts,
+   * including the store itself) — cache subtrees are excluded so the
+   * orphaned-artifact ratio stays meaningful.
+   */
   fileCount: number
-  /** Total bytes of the agent's sessions directory. */
+  /** Total bytes of the agent's sessions directory, subtrees included. */
   diskBytes: number
 }
 

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -245,6 +245,16 @@ export interface RuntimeSession {
   metadata?: RuntimeMetadata
 }
 
+export interface RuntimeSessionStoreStats {
+  agentId: string
+  /** Live entries in the runtime's session store for this agent. */
+  storeEntries: number
+  /** Files in the agent's sessions directory, including the store itself. */
+  fileCount: number
+  /** Total bytes of the agent's sessions directory. */
+  diskBytes: number
+}
+
 export interface RuntimeMemoryTier {
   id: string
   label: string
@@ -507,6 +517,12 @@ export interface AgentRuntimeAdapter {
   sessions: {
     list(agentId?: string): Promise<RuntimeSession[]>
     get(sessionId: string): Promise<RuntimeSession | null>
+    /**
+     * Per-agent session-store disk stats. Optional: runtimes without a
+     * file-backed session store omit it, and callers must treat absence
+     * as "stats unavailable" — skip, never error.
+     */
+    storeStats?(): Promise<RuntimeSessionStoreStats[]>
   }
 
   memory: {

--- a/packages/core/src/adapters/runtime/index.ts
+++ b/packages/core/src/adapters/runtime/index.ts
@@ -75,6 +75,7 @@ export type {
   RuntimePermissionPatch,
   RawCronSnapshot,
   RuntimeSession,
+  RuntimeSessionStoreStats,
   RuntimeSkill,
   ToolResult,
   UpdateCronJobInput,

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -23,6 +23,7 @@ import { checkContentDir } from './lib/system-checks/content-dir'
 import { checkService } from './lib/system-checks/service'
 import { checkMcporter, mcporterRepair } from './lib/system-checks/mcporter'
 import { checkRuntime } from './lib/system-checks/runtime'
+import { checkSessionStore } from './lib/system-checks/session-store'
 import { checkChannelApprovals } from './lib/system-checks/channel-approvals'
 import { checkChannelAliases } from './lib/system-checks/channel-aliases'
 import { checkRestartRecovery } from './lib/system-checks/restart-recovery'
@@ -515,6 +516,11 @@ const healthPlugin: BakinPlugin = definePlugin({
       id: 'runtime',
       name: 'Runtime reachability',
       run: () => checkRuntime(ctx.runtime),
+    })
+    ctx.registerHealthCheck({
+      id: 'session-store',
+      name: 'Runtime session-store growth',
+      run: () => checkSessionStore(ctx.runtime),
     })
     ctx.registerHealthCheck({
       id: 'channel-approvals',

--- a/plugins/health/lib/system-checks/session-store.ts
+++ b/plugins/health/lib/system-checks/session-store.ts
@@ -1,0 +1,70 @@
+/**
+ * System check — runtime session-store growth (#435).
+ *
+ * OpenClaw's built-in maintenance (session.maintenance) prunes store
+ * entries on writes, but unreferenced transcript/trajectory artifacts only
+ * get GC'd by explicit cleanup runs or a configured disk budget. This check
+ * is the early warning when accumulation outruns maintenance. Read-only:
+ * remediation mutates runtime-owned data, so it is never auto-fixed.
+ */
+import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
+import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+
+// First-guess thresholds, sized against observed reality on 2026-06-11
+// (main at 321MB / 1,812 files / 74 entries — a 24x orphan ratio).
+export const SESSION_STORE_WARN_BYTES = 500 * 1024 * 1024
+export const SESSION_STORE_ERROR_BYTES = 1024 * 1024 * 1024
+export const SESSION_STORE_ORPHAN_RATIO = 10
+export const SESSION_STORE_ORPHAN_MIN_FILES = 100
+
+const REMEDIATION =
+  'Run `openclaw sessions cleanup --enforce` and consider setting `session.maintenance.maxDiskBytes` so the gateway self-maintains.'
+
+function formatMb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}
+
+export async function checkSessionStore(
+  runtime: Pick<AgentRuntimeAdapter, 'sessions'>,
+): Promise<HealthCheckResult[]> {
+  const check = 'session-store'
+  if (!runtime.sessions.storeStats) {
+    return [{ check, status: 'ok', message: 'Session-store stats not available for this runtime', autoFixable: false }]
+  }
+
+  let stats
+  try {
+    stats = await runtime.sessions.storeStats()
+  } catch (err) {
+    return [{ check, status: 'error', message: `Session-store stats failed: ${err}`, autoFixable: false }]
+  }
+
+  const results: HealthCheckResult[] = []
+  for (const agent of stats) {
+    const orphanRatio = agent.fileCount / Math.max(agent.storeEntries, 1)
+    const detail = `${agent.agentId}: ${formatMb(agent.diskBytes)}, ${agent.fileCount} files, ${agent.storeEntries} store entries`
+    if (agent.diskBytes > SESSION_STORE_ERROR_BYTES) {
+      results.push({ check, status: 'error', message: `Session store oversized — ${detail}. ${REMEDIATION}`, autoFixable: false })
+    } else if (agent.diskBytes > SESSION_STORE_WARN_BYTES) {
+      results.push({ check, status: 'warn', message: `Session store growing — ${detail}. ${REMEDIATION}`, autoFixable: false })
+    } else if (agent.fileCount >= SESSION_STORE_ORPHAN_MIN_FILES && orphanRatio > SESSION_STORE_ORPHAN_RATIO) {
+      results.push({
+        check,
+        status: 'warn',
+        message: `Orphaned session artifacts accumulating — ${detail} (${orphanRatio.toFixed(0)}x files per entry). ${REMEDIATION}`,
+        autoFixable: false,
+      })
+    }
+  }
+
+  if (results.length === 0) {
+    const totalBytes = stats.reduce((sum, s) => sum + s.diskBytes, 0)
+    return [{
+      check,
+      status: 'ok',
+      message: `Session stores healthy across ${stats.length} agents (${formatMb(totalBytes)} total)`,
+      autoFixable: false,
+    }]
+  }
+  return results
+}

--- a/tests/adapter-openclaw/runtime-session-stats.test.ts
+++ b/tests/adapter-openclaw/runtime-session-stats.test.ts
@@ -104,6 +104,22 @@ describe('OpenClaw runtime sessions.storeStats', () => {
     expect(broken?.fileCount).toBe(2)
   })
 
+  it('counts nested subtree bytes but only top-level files toward fileCount', async () => {
+    // Real stores carry skills-prompts/sha256/** caches: they are disk
+    // pressure (diskBytes) but not session artifacts (fileCount).
+    seedAgent('main', { store: '{}', artifacts: { 'a.jsonl': 'x'.repeat(10) } })
+    const nested = join(testDir, 'agents', 'main', 'sessions', 'skills-prompts', 'sha256')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(nested, 'cache.txt'), 'z'.repeat(40), 'utf-8')
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const main = ((await runtime.sessions.storeStats?.()) ?? []).find((s) => s.agentId === 'main')
+
+    expect(main?.fileCount).toBe(2) // sessions.json + a.jsonl only
+    expect(main?.diskBytes).toBe(2 + 10 + 40) // store + artifact + nested cache
+  })
+
   it('returns an empty list when no agents dir exists', async () => {
     const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
     const runtime = createOpenClawRuntimeAdapter()

--- a/tests/adapter-openclaw/runtime-session-stats.test.ts
+++ b/tests/adapter-openclaw/runtime-session-stats.test.ts
@@ -1,0 +1,112 @@
+/**
+ * sessions.storeStats() — read-only per-agent session-store disk stats.
+ *
+ * Feeds the health plugin's `session-store` growth check (#435). The walk
+ * must never throw: agents without a sessions dir are skipped, and a
+ * missing or malformed sessions.json reports storeEntries=0 while the
+ * dir's files still count toward fileCount/diskBytes.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const contentDir = mkdtempSync(join(tmpdir(), 'bakin-session-stats-content-'))
+mock.module('../../src/core/content-dir', () => ({
+  getContentDir: () => contentDir,
+  getBakinPaths: () => ({ root: contentDir, db: join(contentDir, 'bakin.db') }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => contentDir,
+  getBakinPaths: () => ({ root: contentDir, db: join(contentDir, 'bakin.db') }),
+}))
+afterAll(() => rmSync(contentDir, { recursive: true, force: true }))
+
+describe('OpenClaw runtime sessions.storeStats', () => {
+  let testDir: string
+  let originalOpenClawHome: string | undefined
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'bakin-openclaw-session-stats-test-'))
+    originalOpenClawHome = process.env.OPENCLAW_HOME
+    process.env.OPENCLAW_HOME = testDir
+  })
+
+  afterEach(() => {
+    if (originalOpenClawHome === undefined) delete process.env.OPENCLAW_HOME
+    else process.env.OPENCLAW_HOME = originalOpenClawHome
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  function seedAgent(agentId: string, opts: { store?: string; artifacts?: Record<string, string>; sessionsDir?: boolean }) {
+    const agentDir = join(testDir, 'agents', agentId)
+    mkdirSync(agentDir, { recursive: true })
+    if (opts.sessionsDir === false) return
+    const sessionsDir = join(agentDir, 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    if (opts.store !== undefined) writeFileSync(join(sessionsDir, 'sessions.json'), opts.store, 'utf-8')
+    for (const [name, content] of Object.entries(opts.artifacts ?? {})) {
+      writeFileSync(join(sessionsDir, name), content, 'utf-8')
+    }
+  }
+
+  it('reports entries, file count, and disk bytes per agent', async () => {
+    seedAgent('main', {
+      store: JSON.stringify({
+        'agent:main:explicit:a': { sessionId: 'a' },
+        'agent:main:explicit:b': { sessionId: 'b' },
+      }),
+      artifacts: { 'a.jsonl': 'x'.repeat(100), 'b.jsonl': 'y'.repeat(50), 'orphan.jsonl': 'z'.repeat(25) },
+    })
+    seedAgent('scout', { store: '{}' })
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const stats = (await runtime.sessions.storeStats?.()) ?? []
+
+    const main = stats.find((s) => s.agentId === 'main')
+    expect(main).toBeDefined()
+    expect(main?.storeEntries).toBe(2)
+    expect(main?.fileCount).toBe(4) // sessions.json + 3 artifacts
+    const expectedBytes =
+      JSON.stringify({ 'agent:main:explicit:a': { sessionId: 'a' }, 'agent:main:explicit:b': { sessionId: 'b' } }).length + 175
+    expect(main?.diskBytes).toBe(expectedBytes)
+
+    const scout = stats.find((s) => s.agentId === 'scout')
+    expect(scout?.storeEntries).toBe(0)
+    expect(scout?.fileCount).toBe(1)
+  })
+
+  it('skips agents without a sessions dir and tolerates a missing store', async () => {
+    seedAgent('no-sessions', { sessionsDir: false })
+    seedAgent('no-store', { artifacts: { 'stray.jsonl': 'abc' } })
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const stats = (await runtime.sessions.storeStats?.()) ?? []
+
+    expect(stats.find((s) => s.agentId === 'no-sessions')).toBeUndefined()
+    const noStore = stats.find((s) => s.agentId === 'no-store')
+    expect(noStore?.storeEntries).toBe(0)
+    expect(noStore?.fileCount).toBe(1)
+    expect(noStore?.diskBytes).toBe(3)
+  })
+
+  it('reports storeEntries=0 for a malformed store without throwing', async () => {
+    seedAgent('broken', { store: '{not json', artifacts: { 's.jsonl': '1234' } })
+
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    const stats = (await runtime.sessions.storeStats?.()) ?? []
+
+    const broken = stats.find((s) => s.agentId === 'broken')
+    expect(broken?.storeEntries).toBe(0)
+    expect(broken?.fileCount).toBe(2)
+  })
+
+  it('returns an empty list when no agents dir exists', async () => {
+    const { createOpenClawRuntimeAdapter } = await import('@bakin/adapter-openclaw')
+    const runtime = createOpenClawRuntimeAdapter()
+    expect((await runtime.sessions.storeStats?.()) ?? []).toEqual([])
+  })
+})

--- a/tests/plugins/health/session-store.test.ts
+++ b/tests/plugins/health/session-store.test.ts
@@ -1,0 +1,134 @@
+/**
+ * `session-store` system check — early warning on runtime session-store
+ * growth (#435). Pure-function tests over synthetic adapter stats; no
+ * filesystem. Mocks below satisfy the global test-isolation rules even
+ * though nothing here should touch storage.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-health-session-store-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = pathJoin(testDir, 'openclaw')
+
+import { describe, it, expect, afterAll, mock } from 'bun:test'
+import { rmSync } from 'fs'
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: pathJoin(testDir, 'bakin.db') }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: pathJoin(testDir, 'bakin.db') }),
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+}))
+
+import {
+  checkSessionStore,
+  SESSION_STORE_WARN_BYTES,
+  SESSION_STORE_ERROR_BYTES,
+  SESSION_STORE_ORPHAN_RATIO,
+  SESSION_STORE_ORPHAN_MIN_FILES,
+} from '../../../plugins/health/lib/system-checks/session-store'
+import type { RuntimeSessionStoreStats } from '@bakin/core/adapters/runtime'
+
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+const MB = 1024 * 1024
+
+function runtimeWith(stats: RuntimeSessionStoreStats[]) {
+  return { sessions: { list: async () => [], get: async () => null, storeStats: async () => stats } }
+}
+
+function healthy(agentId: string): RuntimeSessionStoreStats {
+  return { agentId, storeEntries: 20, fileCount: 60, diskBytes: 10 * MB }
+}
+
+describe('session-store system check', () => {
+  it('returns a single ok summary when all agents are within bounds', async () => {
+    const results = await checkSessionStore(runtimeWith([healthy('main'), healthy('scout')]))
+    expect(results).toHaveLength(1)
+    expect(results[0]?.status).toBe('ok')
+    expect(results[0]?.check).toBe('session-store')
+  })
+
+  it('warns when an agent dir exceeds the warn byte threshold', async () => {
+    const results = await checkSessionStore(
+      runtimeWith([healthy('scout'), { agentId: 'main', storeEntries: 50, fileCount: 80, diskBytes: SESSION_STORE_WARN_BYTES + 1 }]),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0]?.status).toBe('warn')
+    expect(results[0]?.message).toContain('main')
+    expect(results[0]?.message).toContain('openclaw sessions cleanup --enforce')
+    expect(results[0]?.autoFixable).toBe(false)
+  })
+
+  it('errors when an agent dir exceeds the error byte threshold', async () => {
+    const results = await checkSessionStore(
+      runtimeWith([{ agentId: 'main', storeEntries: 50, fileCount: 80, diskBytes: SESSION_STORE_ERROR_BYTES + 1 }]),
+    )
+    expect(results[0]?.status).toBe('error')
+  })
+
+  it('warns on orphaned-artifact buildup (file count far above store entries)', async () => {
+    const stats = {
+      agentId: 'main',
+      storeEntries: 10,
+      fileCount: 10 * SESSION_STORE_ORPHAN_RATIO + 1,
+      diskBytes: 10 * MB,
+    }
+    const results = await checkSessionStore(runtimeWith([stats]))
+    expect(results[0]?.status).toBe('warn')
+    expect(results[0]?.message).toContain('session.maintenance.maxDiskBytes')
+  })
+
+  it('suppresses the orphan ratio below the minimum file count', async () => {
+    const stats = { agentId: 'tiny', storeEntries: 1, fileCount: SESSION_STORE_ORPHAN_MIN_FILES - 1, diskBytes: MB }
+    const results = await checkSessionStore(runtimeWith([stats]))
+    expect(results[0]?.status).toBe('ok')
+  })
+
+  it('treats zero store entries as a denominator of one', async () => {
+    const stats = { agentId: 'main', storeEntries: 0, fileCount: SESSION_STORE_ORPHAN_MIN_FILES + 1, diskBytes: MB }
+    const results = await checkSessionStore(runtimeWith([stats]))
+    expect(results[0]?.status).toBe('warn')
+  })
+
+  it('reports one result per offending agent', async () => {
+    const results = await checkSessionStore(
+      runtimeWith([
+        { agentId: 'a', storeEntries: 5, fileCount: 10, diskBytes: SESSION_STORE_WARN_BYTES + 1 },
+        { agentId: 'b', storeEntries: 5, fileCount: 10, diskBytes: SESSION_STORE_ERROR_BYTES + 1 },
+        healthy('c'),
+      ]),
+    )
+    expect(results).toHaveLength(2)
+    expect(results.map((r) => r.status).sort()).toEqual(['error', 'warn'])
+  })
+
+  it('returns ok when the runtime does not expose storeStats', async () => {
+    const results = await checkSessionStore({ sessions: { list: async () => [], get: async () => null } })
+    expect(results).toHaveLength(1)
+    expect(results[0]?.status).toBe('ok')
+    expect(results[0]?.message).toContain('not available')
+  })
+
+  it('returns a single error result when storeStats throws', async () => {
+    const runtime = {
+      sessions: {
+        list: async () => [],
+        get: async () => null,
+        storeStats: async (): Promise<RuntimeSessionStoreStats[]> => {
+          throw new Error('boom')
+        },
+      },
+    }
+    const results = await checkSessionStore(runtime)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.status).toBe('error')
+  })
+})

--- a/tests/plugins/health/session-store.test.ts
+++ b/tests/plugins/health/session-store.test.ts
@@ -110,6 +110,12 @@ describe('session-store system check', () => {
     expect(results.map((r) => r.status).sort()).toEqual(['error', 'warn'])
   })
 
+  it('returns ok for an empty stats list (no agents with session stores)', async () => {
+    const results = await checkSessionStore(runtimeWith([]))
+    expect(results).toHaveLength(1)
+    expect(results[0]?.status).toBe('ok')
+  })
+
   it('returns ok when the runtime does not expose storeStats', async () => {
     const results = await checkSessionStore({ sessions: { list: async () => [], get: async () => null } })
     expect(results).toHaveLength(1)


### PR DESCRIPTION
Closes the remaining scope of #435 (session retention) now that OpenClaw 2026.6.5 ships built-in session-store maintenance.

## What changed
- **`runtime.sessions.storeStats()`** — optional read-only adapter capability returning per-agent session-store stats (live store entries, top-level artifact file count, recursive disk bytes). OpenClaw implementation walks `<home>/agents/*/sessions`; runtimes without a file-backed store omit it.
- **`session-store` doctor check** (health plugin) — warns at 500MB / errors at 1GB per agent, plus an orphaned-artifact signal at 10× files-per-store-entry (min 100 files). `autoFixable: false`; the message points at `openclaw sessions cleanup --enforce` + `session.maintenance.maxDiskBytes`. Verified live: fired the expected WARN on `main` (321MB, 24× ratio) day one.
- **Docs** — session-forensics retention note now records the verified upstream behavior; doctor system-checks table gains the new row; spec + plan checked in under `.claude/specs/`.

## Verified on this machine (OpenClaw 2026.6.5)
- `session.maintenance` defaults: `mode: enforce`, `pruneAfter: 30d`, `maxEntries: 500`; runs on store writes + manual CLI, never on startup. Disk-budget eviction is opt-in via `maxDiskBytes`.
- Remediation performed: `openclaw sessions cleanup --enforce --all-agents` freed 91.5MB (400 artifacts) from `main`; `session.maintenance.maxDiskBytes=512MB` set and gateway restarted.

## Tests
15 new tests (5 adapter, 10 check); full suite 4,993 pass / 0 fail.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)