### PR TITLE
fix(cli): WS4 part 2 — no-arg→help parity, update no-op message, confirm-prompt dedup

### DIFF
--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -3756,6 +3756,18 @@ export async function main(): Promise<void> {
         else console.log(APP_VERSION)
         break
 
+      case 'update':
+        // Self-update is implemented only in the compiled binary (handled in
+        // src/core/cli.ts before delegation reaches here). This source/npm entry
+        // can't replace its own executable — guide the user instead of erroring.
+        console.log(
+          'Self-update is only available in the compiled `bakin` binary (run `bakin update`).\n' +
+          'This source/npm invocation does not self-update — update via your install method:\n' +
+          '  • Homebrew:        brew upgrade bakin\n' +
+          '  • Source checkout: git pull',
+        )
+        break
+
       case 'status':
         await cmdStatus()
         break

--- a/cli/bakin.ts
+++ b/cli/bakin.ts
@@ -1883,8 +1883,9 @@ async function printDoctorRepairVerifyTui(requestId: string, result: Record<stri
   return renderInkReport(() => import('../src/core/cli/ui/doctor-repair'), (m) => m.DoctorRepairVerifyReport, { requestId, result })
 }
 
-async function confirmPrompt(message: string): Promise<boolean> {
-  if (!process.stdin.isTTY) return false
+// Shared readline y/N core. Callers own their own pre-guards (isTTY / count
+// checks) so each keeps its exact behavior; only the readline boilerplate is shared.
+async function promptYesNo(message: string): Promise<boolean> {
   const readline = await import('node:readline/promises')
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
   try {
@@ -1895,28 +1896,19 @@ async function confirmPrompt(message: string): Promise<boolean> {
   }
 }
 
+async function confirmPrompt(message: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false
+  return promptYesNo(message)
+}
+
 async function confirmDoctorRepair(plan: CliDoctorRepairPlan): Promise<boolean> {
   if (plan.summary.safeItems === 0) return false
-  const readline = await import('node:readline/promises')
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
-  try {
-    const answer = await rl.question(`\nApply ${plan.summary.safeItems} safe repair item${plan.summary.safeItems === 1 ? '' : 's'}? [y/N] `)
-    return /^(y|yes)$/i.test(answer.trim())
-  } finally {
-    rl.close()
-  }
+  return promptYesNo(`Apply ${plan.summary.safeItems} safe repair item${plan.summary.safeItems === 1 ? '' : 's'}?`)
 }
 
 async function confirmDoctorDelegate(unresolved: CliDoctorRepairPlan['diagnostics']): Promise<boolean> {
   if (unresolved.length === 0) return false
-  const readline = await import('node:readline/promises')
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
-  try {
-    const answer = await rl.question(`\nCreate a delegated repair task for ${unresolved.length} finding${unresolved.length === 1 ? '' : 's'}? [y/N] `)
-    return /^(y|yes)$/i.test(answer.trim())
-  } finally {
-    rl.close()
-  }
+  return promptYesNo(`Create a delegated repair task for ${unresolved.length} finding${unresolved.length === 1 ? '' : 's'}?`)
 }
 
 async function cmdDoctorFix(options: { json: boolean; yes: boolean; isTTY: boolean }): Promise<void> {

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -274,8 +274,9 @@ export async function dispatchCli(argv: string[]): Promise<CliResult> {
   }
 
   const args = argv.slice(2)
-  // No-arg invocation is `start` — the compiled binary's primary job.
-  const cmd = args[0] ?? 'start'
+  // No-arg invocation shows help — parity with the source CLI (cli/bakin.ts).
+  // Starting the server is the explicit `bakin start`.
+  const cmd = args[0] ?? 'help'
 
   if (cmd === '--help' || cmd === '-h' || cmd === 'help') {
     return { startServer: false, exitCode: await cmdHelp() }

--- a/src/core/cli/parser.ts
+++ b/src/core/cli/parser.ts
@@ -78,10 +78,12 @@ export function parseCliInvocation(argv: string[]): ParsedCliInvocation {
   }
 
   if (args.length === 0) {
+    // No-arg invocation shows help (parity with the live dispatchers in
+    // src/core/cli.ts and cli/bakin.ts); starting the server is explicit `start`.
     return {
       global: parsed.options,
       args,
-      commandName: 'start',
+      commandName: 'help',
       commandArgs: [],
       commandFound: true,
       passthrough: parsed.passthrough,

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -114,13 +114,24 @@ materially); note the consolidated client + the fixed divergences.
   typed-error improvement deferred (moved verbatim).
 - B4 — ☑ extracted 8 pure output helpers → src/cli/output.ts. Exit helpers + emit() + confirm
   unification deferred (entangled / behavior-sensitive).
-- B5 — ☐ **(next focused unit — large + fragile)** command modules + slim router + emit() dispatcher
-  + confirm unification + no-arg/update/help-registry divergence fixes. Touches exit-code plumbing,
-  dynamic-import contracts; behavior-changing parts want the dockerized-rig E2E before merge.
+- B5.1 — ☑ behavioral divergence fixes: no-arg → help (binary + parser, parity with source CLI);
+  `update` → no-op guidance message on the source CLI (was an unknown-command error). User-chosen
+  behavior (Mark, 2026-06-15: "default to help and no-op with message").
+- B5.2 — ☑ collapsed the 3 confirm-prompt copies onto one promptYesNo readline core (each caller
+  keeps its own guard; behavior-identical).
+- B5.3 — ☐ **(next focused unit — fragile, wants E2E)** the command-module split (extract per-scope
+  cmd modules, move the top static server-core imports into them, slim cli/bakin.ts to a router) +
+  the emit() isTTY/plain/json dispatcher (~95 sites) + help-registry-driven dispatch. Touches the
+  binary entry's exit-code plumbing + dynamic-import contracts; the behavior-changing parts want the
+  dockerized-rig E2E before merge.
 - B6 — ☐ wire/retire the stalled runner/parser/options/result framework.
 - B7 — ☐ test splits (tty-cli-harness + readonly-commands.test split).
 - docs — ☐
 
-### Checkpoint (2026-06-15): B1–B4 are a coherent, low-risk, fully-verified chunk (pure
-extractions + dedup + the BAKIN_URL bug fix). B5+ are higher-risk. Suggested split: ship B1–B4 as
-"WS4 part 1" and tackle B5 as a fresh focused effort (mirrors the WS3 → WS3b split).
+### Checkpoints (2026-06-15)
+- Part 1 (B1–B4): shipped + merged (PR #503) — readonly split, renderInkReport, http client +
+  BAKIN_URL fix, output helpers.
+- Part 2 (B5.1–B5.2): the safe, fully-verified slice of B5 — the user-chosen divergence fixes + the
+  confirm-prompt dedup. Shipping as its own PR.
+- Part 3 (B5.3 + B6 + B7 + docs): the command-module split / emit() dispatcher / framework / test
+  splits — the fragile, E2E-wanting remainder. Next focused effort.

--- a/tests/cli/parser.test.ts
+++ b/tests/cli/parser.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'bun:test'
 import { parseCliInvocation } from '../../src/core/cli/parser'
 
 describe('parseCliInvocation', () => {
-  it('defaults no-arg invocation to start', () => {
+  it('defaults no-arg invocation to help', () => {
     expect(parseCliInvocation(['node', 'bakin'])).toMatchObject({
-      commandName: 'start',
+      commandName: 'help',
       commandArgs: [],
       commandFound: true,
     })

--- a/tests/cli/readonly-commands.test.ts
+++ b/tests/cli/readonly-commands.test.ts
@@ -79,6 +79,17 @@ describe('read-only CLI TTY commands', () => {
     expect(errorOutput()).toBe('')
   })
 
+  it('prints a no-op guidance message for `update` on the source CLI', async () => {
+    process.argv = ['bun', 'cli/bakin.ts', 'update']
+
+    const { main } = await import('../../cli/bakin')
+    await main()
+
+    expect(output()).toContain('Self-update is only available in the compiled')
+    expect(output()).toContain('brew upgrade bakin')
+    expect(errorOutput()).toBe('')
+  })
+
   it('accepts help as a source CLI alias for the shared TUI help', async () => {
     process.exit = ((code?: number) => {
       throw new Error(`exit:${code ?? 0}`)


### PR DESCRIPTION
WS4 part 2 — the safe, fully-verified slice of B5: the behavioral divergence fixes you chose plus a
confirm-prompt dedup. The large/fragile remainder of B5 (command-module split + `emit()` dispatcher)
lands as a focused part 3 that wants the dockerized-rig E2E.

Spec: `.claude/specs/audit-2026-06/REPORT.md`. Plan: `tasks/plan.md`.

## What's in it

- **No-arg → help parity.** The binary dispatcher (`src/core/cli.ts`) defaulted a bare `bakin` to
  `start`; the source CLI defaulted to help. Both now default to **help** — starting the server is the
  explicit `bakin start`. The unused parser framework is updated to match the convention. (No test
  asserted binary no-arg → start; `start`/`serve` remain explicit.)
- **`bakin update` no-op on the source/npm entry.** It previously fell through to an "unknown command"
  error (self-update is implemented only in the compiled binary). It now prints a no-op guidance
  message pointing at the install method (brew / git) instead of erroring.
- **Confirm-prompt dedup.** `confirmPrompt` / `confirmDoctorRepair` / `confirmDoctorDelegate` each
  re-rolled the same `node:readline/promises` y/N boilerplate; collapsed onto one `promptYesNo` core.
  Each caller keeps its own pre-guard verbatim (the doctor prompts deliberately lack the isTTY guard),
  so behavior is identical.

## Verification
- `bun run typecheck` + `bun run lint` clean.
- `bun test tests/cli/ --isolate`: **253 pass / 0 fail** (added a test for the `update` message; updated
  the parser no-arg test to expect help).
- `bun run build`: full 3-target binary compiled (the no-arg change is in the binary dispatcher);
  build-stamp files reverted.

## Deferred to part 3 (next focused effort, wants E2E)
The command-module split (extract per-scope `cmd` modules, move the top static server-core imports into
them, slim `cli/bakin.ts` to a router), the `emit({tui,plain,json})` dispatcher (~95 isTTY sites), and
help-registry-driven dispatch — they touch the binary entry's exit-code plumbing + dynamic-import
contracts, so the behavior-changing parts should land with the dockerized-rig E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
