### PR TITLE
fix: audit incidental correctness bugs — dev images watch, dead server write, schedule pause drift

### DIFF
--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -1201,7 +1201,10 @@ const schedulePlugin: BakinPlugin = definePlugin({
           case 'pause':
             meta.paused = true
             meta.pauseReason = 'manual'
-            if (params.pauseUntil) meta.pauseUntil = params.pauseUntil as string
+            // Unconditional, matching the REST pause route: a fresh pause without a
+            // date clears any stale auto-resume from a prior pause (was a conditional
+            // assignment here that left the old pauseUntil in place).
+            meta.pauseUntil = params.pauseUntil as string | undefined
             meta.enabled = false
             break
           case 'resume':

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -69,7 +69,7 @@ const DEV_CLIENT_OUTDIR = join(REPO_ROOT, 'packages/host/public/__bakin-dev')
 const TAILWIND_BIN = join(REPO_ROOT, 'node_modules/.bin/tailwindcss')
 
 const CORE_PLUGINS = [
-  'tasks', 'team', 'workflows', 'assets',
+  'tasks', 'team', 'workflows', 'assets', 'images',
   'schedule', 'memory', 'models', 'health',
   'git',
 ]

--- a/server.ts
+++ b/server.ts
@@ -744,10 +744,6 @@ const eventBus = new BakinEventBus(broadcast)
   // Register graceful shutdown
   registerShutdownHandlers(server, CONTENT_DIR)
 
-  // Write initial dispatch state
-  const dispatchState = dispatch.loadDispatchState(CONTENT_DIR)
-  dispatchState.serverStart = Date.now()
-
   // A bind failure (another generation or process squatting the port) used
   // to throw uncaught AFTER the watcher/antfly side effects started,
   // orphaning children (#459). Route it through the graceful-shutdown chain

--- a/tests/plugins/schedule/routes.test.ts
+++ b/tests/plugins/schedule/routes.test.ts
@@ -1397,6 +1397,17 @@ describe('schedule exec tools', () => {
       expect(meta!.pauseUntil).toBe('2026-05-01T00:00:00Z')
     })
 
+    it('clears a stale pauseUntil when re-paused without a date (parity with the REST route)', async () => {
+      upsertJob(makeMeta({ jobId: 'job-stale', paused: true, pauseUntil: '2026-05-01T00:00:00Z' }))
+
+      const tool = findTool(plugin.execTools, 'bakin_exec_schedule_pause')!
+      await callTool(tool, { jobId: 'job-stale', action: 'pause' })
+
+      const meta = getJob('job-stale')
+      expect(meta!.paused).toBe(true)
+      expect(meta!.pauseUntil).toBeUndefined()
+    })
+
     it('resumes a job and clears all state', async () => {
       upsertJob(makeMeta({
         jobId: 'job-r',


### PR DESCRIPTION
The audit's Phase-0 report listed seven "notable correctness bugs found incidentally — deserving
early fixes." Two (BAKIN_URL #5, npm `update` #6) were fixed during WS4. This PR clears three more
that are small, real, and verifiable without the dockerized rig.

## Fixes

- **#2 — dev loop ignored the `images` plugin.** `scripts/dev.ts` `CORE_PLUGINS` omitted `images`
  (one of the 10 core plugins; it's in the canonical embed set `src/lib/plugin-static-imports.ts`),
  so edits to `plugins/images` never triggered a rebuild. Added it.
- **#7 — dead dispatch-state write in server boot.** `server.ts` loaded the dispatch state, set
  `serverStart` on the returned object, and never saved or read it (`loadDispatchState` is a pure
  read). Removed the dead load + assignment + misleading comment.
- **#4 — schedule `pause` exec-tool drift.** `bakin_exec_schedule_pause` assigned `pauseUntil`
  conditionally, so re-pausing a job that had a prior auto-resume date — without a new one — left the
  stale date and the job would auto-resume unexpectedly. The REST route already assigns it
  unconditionally; aligned the exec tool. Regression test added.

## Deferred (with rationale)

- **#1 — search-registry `pluginTables` 1:1 wrong-table writes** (team registers two content types,
  so `ctx.search.index()` for agents lands in the agent-lessons table). Verified real and impactful,
  but it touches **four** resolution sites (the pluginId→table resolver plus the file-backed sync
  hook, unlink hook, and startup reconcile), and every minimal patch is registration-order-fragile or
  breaks an edge case (a file-backed-only plugin that also direct-indexes). The correct fix is a
  table-scoped / per-content-type API — which is exactly the job of WS5's search-registry split
  (the file is restructured into 4 modules there) and wants Antfly integration to E2E-verify. Left
  for WS5 per the audit's own "fix during WS5's search-registry split (or pull forward)" note.

## Verification
`bun run test` **5104 / 0**; typecheck + lint clean; full 3-target binary build for the server.ts +
schedule changes (build-stamp reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
