### PR TITLE
fix(search): WS5 — route multi-content plugins by a primary table (pluginTables wrong-table bug)

### DIFF
--- a/.claude/knowledge/search-plugin-guide.md
+++ b/.claude/knowledge/search-plugin-guide.md
@@ -24,10 +24,12 @@ and `filters` to `ctx.search.query()`. The MCP search exec tools (`search_query`
 same backend, so registering a content type also makes the plugin's data
 agent-searchable.
 
-`getTableForPlugin(pluginId)` (formerly `getPluginTable`) throws if a single
-plugin registers more than one content type, since the auto-wired `/search`
-route can't disambiguate. Plugins with multiple content types must register
-their own custom route.
+`getTableForPlugin(pluginId)` (formerly `getPluginTable`) returns the plugin's
+**primary** content-type table (the one registered via `registerContentType`).
+A plugin gets one primary — a second *direct* registration throws early — while
+file-backed content types register as secondary and index into their own table,
+so the auto-wired `/search` route resolves the primary unambiguously even for a
+multi-content plugin (e.g. `team`'s `agents` primary + `agent-lessons` file-backed).
 
 ## Step-by-Step (file-backed plugins)
 

--- a/.claude/knowledge/search-system.md
+++ b/.claude/knowledge/search-system.md
@@ -66,12 +66,15 @@ plugin dispatch path uses `BuildSearchAPIOptions.skipFileBackedWiring`
 to avoid double-wiring file-backed hooks when the API is constructed
 outside the plugin activation phase.
 
-`getTableForPlugin(pluginId)` (formerly `getPluginTable`) returns the
-single registered table name for that plugin and **throws** when one
-plugin has registered more than one content type, so the auto-wired
-`/search` route can't ambiguously resolve a table. Plugins that need
-multiple content types must register a custom route and call
-`ctx.search.query({ table: '...' })` explicitly.
+`getTableForPlugin(pluginId)` (formerly `getPluginTable`) returns the plugin's
+**primary** content-type table — the one a plugin registers via
+`registerContentType` and targets with bare `ctx.search.index/remove/transform/query`,
+and what the auto-wired `/search` route + MCP plugin-param routing resolve to. A plugin
+has exactly one primary (a second *direct* registration throws early); **file-backed
+content types register as secondary** and are indexed into their own table directly, so a
+plugin like `team` can register a direct primary (`agents`) plus a file-backed secondary
+(`agent-lessons`) without the resolver misrouting. `getTableForPlugin` returns the primary
+(or null) and no longer throws on multi-content plugins.
 
 ### Three consistency paths
 

--- a/src/core/search-registry.ts
+++ b/src/core/search-registry.ts
@@ -344,25 +344,15 @@ export function unregisterContentTypesByPlugin(pluginId: string): number {
 }
 
 /**
- * Get the full table name for a plugin. Returns null when the plugin has
- * no registered content type. Throws when a plugin has registered multiple
- * content types — the API/MCP layers assume 1:1 plugin→table, and the spec
- * §5.1d decision reinforces that. This is a defensive guard; no plugin
- * ships more than one content type today.
+ * Get the full table name a plugin's `/search` route and MCP plugin-param
+ * routing resolve to — the plugin's PRIMARY content type. Returns null when the
+ * plugin has registered no content type. A plugin with multiple content types
+ * (one direct primary + secondary file-backed types, e.g. team) resolves to its
+ * primary; it no longer throws (the dispatch layers route to one table per plugin,
+ * and secondary file-backed types are indexed directly, not via this path).
  */
 export function getTableForPlugin(pluginId: string): string | null {
-  const matches: string[] = []
-  for (const [tableName, def] of getRegistry().contentTypes) {
-    if (def.pluginId === pluginId) matches.push(tableName)
-  }
-  if (matches.length === 0) return null
-  if (matches.length > 1) {
-    throw new Error(
-      `Plugin "${pluginId}" has ${matches.length} registered content types (${matches.join(', ')}); expected 1. ` +
-        `The /search and MCP plugin-param routing assumes a single table per plugin.`,
-    )
-  }
-  return matches[0]
+  return getRegistry().pluginTables.get(pluginId) ?? null
 }
 
 /**
@@ -446,20 +436,43 @@ export function buildSearchAPI(pluginId: string, opts?: BuildSearchAPIOptions): 
     })
   }
 
-  const api: SearchAPI = {
-    registerContentType(def: SearchContentTypeDefinition): void {
-      const tableName = fullTableName(def.table)
-      const existing = registry.contentTypes.get(tableName)
-      if (existing && existing.pluginId !== pluginId) {
+  // Register a content type, recording its table as the plugin's PRIMARY when
+  // `primary` is true. The primary table is what bare ctx.search.index/remove/
+  // transform/query target and what getTableForPlugin (and the /search + MCP
+  // routing) resolve to. A plugin has exactly one primary; a second DIRECT
+  // registration is an error. File-backed content types register as secondary
+  // (primary=false) — they index into their own table explicitly (see the wiring
+  // below) and only become the primary as a fallback when a plugin has no direct
+  // content type at all (e.g. a purely file-backed plugin).
+  const registerContentTypeInternal = (def: SearchContentTypeDefinition, primary: boolean): void => {
+    const tableName = fullTableName(def.table)
+    const existing = registry.contentTypes.get(tableName)
+    if (existing && existing.pluginId !== pluginId) {
+      throw new Error(
+        `Search content type table "${tableName}" is already registered by plugin "${existing.pluginId}"; ` +
+        `plugin "${pluginId}" cannot take ownership.`,
+      )
+    }
+    registry.contentTypes.set(tableName, { ...def, pluginId })
+    const currentPrimary = registry.pluginTables.get(pluginId)
+    if (primary) {
+      if (currentPrimary && currentPrimary !== tableName) {
         throw new Error(
-          `Search content type table "${tableName}" is already registered by plugin "${existing.pluginId}"; ` +
-          `plugin "${pluginId}" cannot take ownership.`,
+          `Plugin "${pluginId}" already has a primary search content type "${currentPrimary}"; ` +
+          `"${tableName}" cannot also be primary. Only file-backed content types may be secondary.`,
         )
       }
-      registry.contentTypes.set(tableName, { ...def, pluginId })
       registry.pluginTables.set(pluginId, tableName)
-      log.info(`Content type registered: ${tableName} (plugin: ${pluginId})`)
-      maybeAutoRegisterSearchRoute()
+    } else if (!currentPrimary) {
+      registry.pluginTables.set(pluginId, tableName)
+    }
+    log.info(`Content type registered: ${tableName} (plugin: ${pluginId}${primary ? '' : ', secondary'})`)
+    maybeAutoRegisterSearchRoute()
+  }
+
+  const api: SearchAPI = {
+    registerContentType(def: SearchContentTypeDefinition): void {
+      registerContentTypeInternal(def, true)
     },
 
     registerFileBackedContentType(def: FileBackedContentTypeDefinition): void {
@@ -472,8 +485,9 @@ export function buildSearchAPI(pluginId: string, opts?: BuildSearchAPIOptions): 
       removePendingReconciles(pluginId, tableName)
 
       // Standard registration first — gives us the table, schema, and reindex
-      // generator. Everything below layers watcher hooks + reconcile on top.
-      api.registerContentType(def)
+      // generator. Registered as SECONDARY: file-backed types index into their
+      // own table (below), never via the plugin's primary resolver.
+      registerContentTypeInternal(def, false)
       if (opts?.skipFileBackedWiring) return
 
       const includePatterns = def.filePatterns.map(p => p.pattern)
@@ -504,7 +518,10 @@ export function buildSearchAPI(pluginId: string, opts?: BuildSearchAPIOptions): 
             // file may have been removed between watcher emit and our stat;
             // fall back to "now" so the index entry is at least monotonic.
           }
-          await api.index(key, { ...doc, [MTIME_FIELD]: mtimeMs })
+          // Index into THIS content type's table directly — not via api.index,
+          // which resolves the plugin's primary table (wrong for a secondary
+          // file-backed type on a multi-content plugin like team).
+          await getSearchAdapter().documents.index(tableName, key, { ...doc, [MTIME_FIELD]: mtimeMs })
         } catch (err) {
           log.warn('File-backed sync hook failed', err, { table: tableName, rel })
         }
@@ -521,7 +538,7 @@ export function buildSearchAPI(pluginId: string, opts?: BuildSearchAPIOptions): 
           if (!mapper) return
           const key = mapper.fileToId(rel)
           if (key === null) return
-          await api.remove(key)
+          await getSearchAdapter().documents.remove(tableName, key)
         } catch (err) {
           log.warn('File-backed unlink hook failed', err, { table: tableName, rel })
         }
@@ -688,10 +705,13 @@ async function runPendingReconcilesMatching(predicate: (item: RegistryState['pen
   registry.pendingReconciles.push(...keep)
   for (const { pluginId, def } of items) {
     try {
-      const api = buildSearchAPI(pluginId)
+      // Reconcile into THIS content type's own table directly (a file-backed
+      // type may be a secondary on a multi-content plugin; api.index would
+      // resolve the plugin's primary table instead).
+      const reconcileTable = fullTableName(def.table)
       await performStartupReconcile(def, contentDir, {
-        index: (key, doc) => api.index(key, doc),
-        remove: (key) => api.remove(key),
+        index: (key, doc) => getSearchAdapter().documents.index(reconcileTable, key, doc),
+        remove: (key) => getSearchAdapter().documents.remove(reconcileTable, key),
         scanIndex: async function* (tableName) {
           for await (const { key, document } of getSearchAdapter().scan(tableName)) {
             const mtime = typeof document[MTIME_FIELD] === 'number'

--- a/tasks/plan-ws4-cli.md
+++ b/tasks/plan-ws4-cli.md
@@ -1,0 +1,137 @@
+# Plan: WS4 — refactor/cli (consolidate three CLIs into one)
+
+Spec: `.claude/specs/audit-2026-06/REPORT.md` + `APPENDIX-cohesion.md` (the authoritative
+per-file split plan with verified line ranges). Branch: `refactor/cli` off `main`.
+The audit's biggest single win (~1,500+ lines die). One revertable commit per phase; every
+commit green on `bun run test` + `bun run typecheck`. PR gate adds `bun run build` (the binary
+compiles readonly.tsx via src/core/cli.ts — a full build is mandatory) + lint + docs.
+
+## Current state (recon 2026-06-15, confirmed)
+
+Three CLIs:
+- `src/core/cli.ts` (330) — binary dispatcher. Handles version/update/dev/start/serve directly;
+  delegates the rest to `cli/bakin.ts` by **monkey-patching process.argv + process.exit**
+  (`process.exit(code)` throws `DelegatedCliExit`, caught → exit code). no-arg → `start`.
+- `cli/bakin.ts` (4,632) — npm `bakin` bin (package.json:10) + the delegated source CLI. Owns
+  30+ command groups. `BASE_URL = process.env.BAKIN_URL || http://localhost:${PORT||3737}` (line 53).
+  ~44 byte-identical `printXxxTui` wrappers (lazy `Promise.all([import(ui), import(render-to-string),
+  import(react)])` + console.log), ~95 inline `isTTY` branches. no-arg → help. **No `update` case.**
+- `src/cli/schedule.ts` (237) — 7 schedule command fns, called from cli/bakin.ts. **BUG:**
+  `BASE_URL = http://localhost:${PORT||3737}` (line 7) — ignores `BAKIN_URL`.
+
+Stalled framework (`src/core/cli/{runner,parser,options,result}.ts`, 37/128/96/71 lines) — complete,
+tested, **zero production callers**.
+
+Render layer `src/core/cli/ui/readonly.tsx` (2,808): ~35 all-`unknown` DTO interfaces (14-316),
+~80 helpers (318-1638), 38 exported `*Report` ink components (1639-2808). No module-load side
+effects; one-directional imports (readonly → ./tui → ./style-tokens); ALL consumers load it via
+`import('.../cli/ui/readonly')` (~30 sites in bakin.ts, src/core/cli.ts, src/cli/schedule.ts) +
+`tests/cli/readonly-ui.test.tsx` (imports all 34 components by name).
+
+Load-bearing contracts the split MUST preserve:
+- package.json bin → `./cli/bakin.ts`; binary dispatcher dynamic-imports `'../../cli/bakin'` and
+  destructures `{ main }`; `scripts/instance*.ts` shell out to `bun run cli/bakin.ts`. So cli/bakin.ts
+  stays a file exporting `main()` with its `import.meta.main` guard.
+- Extracted command modules MUST keep calling `process.exit` (not return codes) or the binary's
+  exit-code plumbing + tests (`rejects.toThrow('exit:1')`) break.
+- Heavy deps (react/ink/ui/onboarding/whiskit) are dynamically imported on purpose for cheap binary
+  startup — no new module may statically pull them into the entry import graph.
+- Mutual lazy dep: bakin.ts ↔ src/core/cli.ts — both sides stay dynamic (no static cycle).
+
+## Phases (appendix order; lowest-risk first)
+
+### B1 — split `src/core/cli/ui/readonly.tsx` (2,808 → 11 reports/* + barrel)  ⟵ start here
+Low-risk: no side effects; a barrel at the old path keeps every dynamic-import + readonly-ui.test.tsx
+working unchanged. Move by the appendix line-ranges into `src/core/cli/ui/reports/`:
+`format.ts` (pure formatters+DetailFieldRow), `command-meta.tsx`, `runtime.tsx` (status/dispatch/agents/
+version), `settings.tsx` (+paths +docs), `tasks.tsx`, `workflows.tsx`, `plugins.tsx`, `packages.tsx`,
+`search.tsx` (+reindex), `schedule.tsx`, `trash.tsx`. Replace readonly.tsx with `readonly.ts`
+(`export * from './reports/*'`, types included). All reports import shared formatters from format.ts;
+doctor.tsx/doctor-repair.tsx adopt format.ts's plural/valueText in the same pass (verified dups).
+- **Accept:** typecheck + `tests/cli/readonly-ui.test.tsx` green; **full `bun run build`** (binary
+  compiles it). No DTO retyping yet (keep behavior identical; Zod redesign is a later, optional pass).
+- Commit: `refactor(cli): split readonly.tsx into per-domain report modules + barrel`
+
+### B2 — `renderInkReport` helper; collapse the 45 printXxxTui wrappers
+Add one generic lazy `renderInkReport(load, props)` (in `src/core/cli/ui/`, next to render-to-string)
+preserving lazy loading; replace the ~44 copy-paste wrappers in cli/bakin.ts. Make the eager
+`const USAGE = renderCliUsage(...)` (bakin.ts:3790) lazy. Prerequisite for clean bakin.ts seams.
+- **Accept:** typecheck + tests/cli green; grep shows ≤1 `renderToString(createElement` in bakin.ts.
+- Commit: `refactor(cli): one renderInkReport helper replacing 45 printXxxTui wrappers`
+
+### B3 — extract `src/cli/http.ts` (one BAKIN_URL-aware client)
+BASE_URL + api/apiGet/apiPost/apiPostJson/apiDelete + apiErrorPayload/jsonObject/parseJsonText +
+getCliAgent/getCliRoster. Adopt in cli/bakin.ts AND src/cli/schedule.ts — **fixes the BAKIN_URL bug.**
+Replace `isServerConnectionError` message-text classification with a typed connection error.
+- **Accept:** typecheck + tests/cli + schedule.test green; `BAKIN_URL=... bakin schedule list` hits the override.
+- Commit: `refactor(cli): shared BAKIN_URL-aware http client; fix schedule BAKIN_URL bug`
+
+### B4 — extract `src/cli/output.ts`
+print/printTable, renderInkReport re-home, exit helpers (exitCommandIssue/Usage/UnknownSubcommand/
+CommandFailure), one `confirmPrompt` (collapse the 3 readline copies), statusIcon/formatBytes/daysUntil,
+and an `emit({tui,plain,json})` dispatcher to kill the inline isTTY/plain/json branching.
+- **Accept:** typecheck + tests/cli green.
+- Commit: `refactor(cli): shared output module + emit() dispatcher; collapse isTTY branching`
+
+### B5 — `src/cli/lifecycle.ts` + command modules; slim cli/bakin.ts to a ~200-line router
+Extract lifecycle (waitForServerVersion/cmdStartServer/cmdReboot/cmdStop) + per-scope command modules
+(one file per group); each `case` becomes one line. Move the top-of-file static server-core imports
+(whiskit/settings/import-export) into their command modules. Keep bakin.ts ↔ src/core/cli.ts dynamic.
+Fix divergences: no-arg parity, add `update` to bakin.ts, help-registry-driven dispatch.
+- **Accept:** typecheck + full tests/cli green; `bun run build`; behavioral parity verified.
+- Commits: one per extracted module + one for the divergence fixes.
+
+### B6 — wire or retire the stalled framework (`runner/parser/options/result`)
+Decide during B5: if the slimmed router adopts parser/options/runner, wire them (delete dead bits);
+else delete the framework + its tests as superseded. Document the call.
+- Commit: `refactor(cli): {adopt|retire} the cli command framework`
+
+### B7 — test splits
+Extract `tests/cli/helpers/tty-cli-harness.ts` (the ×10 copy-pasted TTY harness + withTempBakinHome);
+split `readonly-commands.test.ts` (1,432) into `readonly-help-errors.test.ts`, `readonly-logs.test.ts`,
+and per-domain command test files along the source seams; de-chain mega-`it()`s.
+- **Accept:** full suite green; harness shared.
+- Commits: one per split file group.
+
+### Docs
+`.claude/knowledge/repo-architecture.md` + CLAUDE.md "Build, Dev, CLI" section (CLI structure changes
+materially); note the consolidated client + the fixed divergences.
+
+## Risks & mitigations
+- **Binary build** — readonly.tsx compiles into the single-file binary via src/core/cli.ts; every
+  phase touching cli/* runs a full `bun run build` before commit (+ build-stamp trap: revert
+  generated-version.ts + _embedded-assets-static.ts).
+- **Exit-code plumbing** — command modules keep calling `process.exit`; don't convert to return codes.
+- **Dynamic-import graph** — never statically import react/ink/ui/whiskit into the entry; keep the
+  bakin.ts ↔ src/core/cli.ts mutual dep dynamic.
+- **Test mocks** — tests/cli/* mock modules by resolved path + import `{ main }`; extracted code must
+  import the SAME modules (only relative specifiers change).
+
+## Status
+- B1 — ☑ readonly.tsx (2,809) → 11 reports/* modules + barrel. Verified (typecheck/252-isolated/binary).
+- B2 — ☑ renderInkReport helper; collapsed 41 printXxxTui wrappers (−204 net). 4 inline renders left.
+- B3 — ☑ shared src/cli/http.ts client; **fixed schedule BAKIN_URL bug**. isServerConnectionError
+  typed-error improvement deferred (moved verbatim).
+- B4 — ☑ extracted 8 pure output helpers → src/cli/output.ts. Exit helpers + emit() + confirm
+  unification deferred (entangled / behavior-sensitive).
+- B5.1 — ☑ behavioral divergence fixes: no-arg → help (binary + parser, parity with source CLI);
+  `update` → no-op guidance message on the source CLI (was an unknown-command error). User-chosen
+  behavior (Mark, 2026-06-15: "default to help and no-op with message").
+- B5.2 — ☑ collapsed the 3 confirm-prompt copies onto one promptYesNo readline core (each caller
+  keeps its own guard; behavior-identical).
+- B5.3 — ☐ **(next focused unit — fragile, wants E2E)** the command-module split (extract per-scope
+  cmd modules, move the top static server-core imports into them, slim cli/bakin.ts to a router) +
+  the emit() isTTY/plain/json dispatcher (~95 sites) + help-registry-driven dispatch. Touches the
+  binary entry's exit-code plumbing + dynamic-import contracts; the behavior-changing parts want the
+  dockerized-rig E2E before merge.
+- B6 — ☐ wire/retire the stalled runner/parser/options/result framework.
+- B7 — ☐ test splits (tty-cli-harness + readonly-commands.test split).
+- docs — ☐
+
+### Checkpoints (2026-06-15)
+- Part 1 (B1–B4): shipped + merged (PR #503) — readonly split, renderInkReport, http client +
+  BAKIN_URL fix, output helpers.
+- Part 2 (B5.1–B5.2): the safe, fully-verified slice of B5 — the user-chosen divergence fixes + the
+  confirm-prompt dedup. Shipping as its own PR.
+- Part 3 (B5.3 + B6 + B7 + docs): the command-module split / emit() dispatcher / framework / test
+  splits — the fragile, E2E-wanting remainder. Next focused effort.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,137 +1,49 @@
-# Plan: WS4 — refactor/cli (consolidate three CLIs into one)
+# Plan: WS5 — refactor/core-splits
 
-Spec: `.claude/specs/audit-2026-06/REPORT.md` + `APPENDIX-cohesion.md` (the authoritative
-per-file split plan with verified line ranges). Branch: `refactor/cli` off `main`.
-The audit's biggest single win (~1,500+ lines die). One revertable commit per phase; every
-commit green on `bun run test` + `bun run typecheck`. PR gate adds `bun run build` (the binary
-compiles readonly.tsx via src/core/cli.ts — a full build is mandatory) + lint + docs.
+Spec: `.claude/specs/audit-2026-06/REPORT.md` + `APPENDIX-cohesion.md`. Branch: `refactor/core-splits`
+off `main`. The big core/server/adapter files. One revertable commit per finding/file; every commit
+green on `bun run test` + `bun run typecheck` + (for anything in the binary graph) `bun run build`.
 
-## Current state (recon 2026-06-15, confirmed)
+## Items (REPORT §WS5)
 
-Three CLIs:
-- `src/core/cli.ts` (330) — binary dispatcher. Handles version/update/dev/start/serve directly;
-  delegates the rest to `cli/bakin.ts` by **monkey-patching process.argv + process.exit**
-  (`process.exit(code)` throws `DelegatedCliExit`, caught → exit code). no-arg → `start`.
-- `cli/bakin.ts` (4,632) — npm `bakin` bin (package.json:10) + the delegated source CLI. Owns
-  30+ command groups. `BASE_URL = process.env.BAKIN_URL || http://localhost:${PORT||3737}` (line 53).
-  ~44 byte-identical `printXxxTui` wrappers (lazy `Promise.all([import(ui), import(render-to-string),
-  import(react)])` + console.log), ~95 inline `isTTY` branches. no-arg → help. **No `update` case.**
-- `src/cli/schedule.ts` (237) — 7 schedule command fns, called from cli/bakin.ts. **BUG:**
-  `BASE_URL = http://localhost:${PORT||3737}` (line 7) — ignores `BAKIN_URL`.
+- **search-registry.ts** (1,134 → 4 modules) + **fix the pluginTables 1:1 wrong-table bug**.
+- `dispatch.ts` (2,079 → 11; dedupe dispatchTasks/dispatchSingleTask; singleton placement is the risk).
+- `src/lib/plugin-registry.ts` (1,608 → 7; unify dup topo-sorts + activation pipelines; move out of src/lib).
+- `server.ts` (837 → declarative route table + boot/recovery modules; dead dispatch-state write already
+  removed in the incidental-bugs PR #505).
+- `src/core/plugins/upgrade.ts` (926 → 6; delete dead checkUpgradeAvailable; consolidate two dir hashers).
+- `packages/adapter-openclaw/src/runtime.ts` (3,069 → 13 capability factories; dedupe deepMerge).
 
-Stalled framework (`src/core/cli/{runner,parser,options,result}.ts`, 37/128/96/71 lines) — complete,
-tested, **zero production callers**.
+## Sequencing decision
 
-Render layer `src/core/cli/ui/readonly.tsx` (2,808): ~35 all-`unknown` DTO interfaces (14-316),
-~80 helpers (318-1638), 38 exported `*Report` ink components (1639-2808). No module-load side
-effects; one-directional imports (readonly → ./tui → ./style-tokens); ALL consumers load it via
-`import('.../cli/ui/readonly')` (~30 sites in bakin.ts, src/core/cli.ts, src/cli/schedule.ts) +
-`tests/cli/readonly-ui.test.tsx` (imports all 34 components by name).
+The pluginTables fix is the highest-value correctness item and is **fully unit-testable** (it's purely
+about which table name reaches the adapter — a mock adapter verifies routing; Antfly behavior is
+irrelevant). So it's done FIRST as a focused, behavior-isolated change, ahead of the mechanical 4-module
+split (which is pure relocation and lands next, no behavior change).
 
-Load-bearing contracts the split MUST preserve:
-- package.json bin → `./cli/bakin.ts`; binary dispatcher dynamic-imports `'../../cli/bakin'` and
-  destructures `{ main }`; `scripts/instance*.ts` shell out to `bun run cli/bakin.ts`. So cli/bakin.ts
-  stays a file exporting `main()` with its `import.meta.main` guard.
-- Extracted command modules MUST keep calling `process.exit` (not return codes) or the binary's
-  exit-code plumbing + tests (`rejects.toThrow('exit:1')`) break.
-- Heavy deps (react/ink/ui/onboarding/whiskit) are dynamically imported on purpose for cheap binary
-  startup — no new module may statically pull them into the entry import graph.
-- Mutual lazy dep: bakin.ts ↔ src/core/cli.ts — both sides stay dynamic (no static cycle).
-
-## Phases (appendix order; lowest-risk first)
-
-### B1 — split `src/core/cli/ui/readonly.tsx` (2,808 → 11 reports/* + barrel)  ⟵ start here
-Low-risk: no side effects; a barrel at the old path keeps every dynamic-import + readonly-ui.test.tsx
-working unchanged. Move by the appendix line-ranges into `src/core/cli/ui/reports/`:
-`format.ts` (pure formatters+DetailFieldRow), `command-meta.tsx`, `runtime.tsx` (status/dispatch/agents/
-version), `settings.tsx` (+paths +docs), `tasks.tsx`, `workflows.tsx`, `plugins.tsx`, `packages.tsx`,
-`search.tsx` (+reindex), `schedule.tsx`, `trash.tsx`. Replace readonly.tsx with `readonly.ts`
-(`export * from './reports/*'`, types included). All reports import shared formatters from format.ts;
-doctor.tsx/doctor-repair.tsx adopt format.ts's plural/valueText in the same pass (verified dups).
-- **Accept:** typecheck + `tests/cli/readonly-ui.test.tsx` green; **full `bun run build`** (binary
-  compiles it). No DTO retyping yet (keep behavior identical; Zod redesign is a later, optional pass).
-- Commit: `refactor(cli): split readonly.tsx into per-domain report modules + barrel`
-
-### B2 — `renderInkReport` helper; collapse the 45 printXxxTui wrappers
-Add one generic lazy `renderInkReport(load, props)` (in `src/core/cli/ui/`, next to render-to-string)
-preserving lazy loading; replace the ~44 copy-paste wrappers in cli/bakin.ts. Make the eager
-`const USAGE = renderCliUsage(...)` (bakin.ts:3790) lazy. Prerequisite for clean bakin.ts seams.
-- **Accept:** typecheck + tests/cli green; grep shows ≤1 `renderToString(createElement` in bakin.ts.
-- Commit: `refactor(cli): one renderInkReport helper replacing 45 printXxxTui wrappers`
-
-### B3 — extract `src/cli/http.ts` (one BAKIN_URL-aware client)
-BASE_URL + api/apiGet/apiPost/apiPostJson/apiDelete + apiErrorPayload/jsonObject/parseJsonText +
-getCliAgent/getCliRoster. Adopt in cli/bakin.ts AND src/cli/schedule.ts — **fixes the BAKIN_URL bug.**
-Replace `isServerConnectionError` message-text classification with a typed connection error.
-- **Accept:** typecheck + tests/cli + schedule.test green; `BAKIN_URL=... bakin schedule list` hits the override.
-- Commit: `refactor(cli): shared BAKIN_URL-aware http client; fix schedule BAKIN_URL bug`
-
-### B4 — extract `src/cli/output.ts`
-print/printTable, renderInkReport re-home, exit helpers (exitCommandIssue/Usage/UnknownSubcommand/
-CommandFailure), one `confirmPrompt` (collapse the 3 readline copies), statusIcon/formatBytes/daysUntil,
-and an `emit({tui,plain,json})` dispatcher to kill the inline isTTY/plain/json branching.
-- **Accept:** typecheck + tests/cli green.
-- Commit: `refactor(cli): shared output module + emit() dispatcher; collapse isTTY branching`
-
-### B5 — `src/cli/lifecycle.ts` + command modules; slim cli/bakin.ts to a ~200-line router
-Extract lifecycle (waitForServerVersion/cmdStartServer/cmdReboot/cmdStop) + per-scope command modules
-(one file per group); each `case` becomes one line. Move the top-of-file static server-core imports
-(whiskit/settings/import-export) into their command modules. Keep bakin.ts ↔ src/core/cli.ts dynamic.
-Fix divergences: no-arg parity, add `update` to bakin.ts, help-registry-driven dispatch.
-- **Accept:** typecheck + full tests/cli green; `bun run build`; behavioral parity verified.
-- Commits: one per extracted module + one for the divergence fixes.
-
-### B6 — wire or retire the stalled framework (`runner/parser/options/result`)
-Decide during B5: if the slimmed router adopts parser/options/runner, wire them (delete dead bits);
-else delete the framework + its tests as superseded. Document the call.
-- Commit: `refactor(cli): {adopt|retire} the cli command framework`
-
-### B7 — test splits
-Extract `tests/cli/helpers/tty-cli-harness.ts` (the ×10 copy-pasted TTY harness + withTempBakinHome);
-split `readonly-commands.test.ts` (1,432) into `readonly-help-errors.test.ts`, `readonly-logs.test.ts`,
-and per-domain command test files along the source seams; de-chain mega-`it()`s.
-- **Accept:** full suite green; harness shared.
-- Commits: one per split file group.
-
-### Docs
-`.claude/knowledge/repo-architecture.md` + CLAUDE.md "Build, Dev, CLI" section (CLI structure changes
-materially); note the consolidated client + the fixed divergences.
-
-## Risks & mitigations
-- **Binary build** — readonly.tsx compiles into the single-file binary via src/core/cli.ts; every
-  phase touching cli/* runs a full `bun run build` before commit (+ build-stamp trap: revert
-  generated-version.ts + _embedded-assets-static.ts).
-- **Exit-code plumbing** — command modules keep calling `process.exit`; don't convert to return codes.
-- **Dynamic-import graph** — never statically import react/ink/ui/whiskit into the entry; keep the
-  bakin.ts ↔ src/core/cli.ts mutual dep dynamic.
-- **Test mocks** — tests/cli/* mock modules by resolved path + import `{ main }`; extracted code must
-  import the SAME modules (only relative specifiers change).
+The big splits (dispatch singleton, plugin-registry, runtime) are fragile and several want the dockerized
+rig to E2E-verify behavior — they're sequenced after the search work and may be split into focused PRs
+(mirroring WS4's part-1/part-2 cadence).
 
 ## Status
-- B1 — ☑ readonly.tsx (2,809) → 11 reports/* modules + barrel. Verified (typecheck/252-isolated/binary).
-- B2 — ☑ renderInkReport helper; collapsed 41 printXxxTui wrappers (−204 net). 4 inline renders left.
-- B3 — ☑ shared src/cli/http.ts client; **fixed schedule BAKIN_URL bug**. isServerConnectionError
-  typed-error improvement deferred (moved verbatim).
-- B4 — ☑ extracted 8 pure output helpers → src/cli/output.ts. Exit helpers + emit() + confirm
-  unification deferred (entangled / behavior-sensitive).
-- B5.1 — ☑ behavioral divergence fixes: no-arg → help (binary + parser, parity with source CLI);
-  `update` → no-op guidance message on the source CLI (was an unknown-command error). User-chosen
-  behavior (Mark, 2026-06-15: "default to help and no-op with message").
-- B5.2 — ☑ collapsed the 3 confirm-prompt copies onto one promptYesNo readline core (each caller
-  keeps its own guard; behavior-identical).
-- B5.3 — ☐ **(next focused unit — fragile, wants E2E)** the command-module split (extract per-scope
-  cmd modules, move the top static server-core imports into them, slim cli/bakin.ts to a router) +
-  the emit() isTTY/plain/json dispatcher (~95 sites) + help-registry-driven dispatch. Touches the
-  binary entry's exit-code plumbing + dynamic-import contracts; the behavior-changing parts want the
-  dockerized-rig E2E before merge.
-- B6 — ☐ wire/retire the stalled runner/parser/options/result framework.
-- B7 — ☐ test splits (tty-cli-harness + readonly-commands.test split).
-- docs — ☐
 
-### Checkpoints (2026-06-15)
-- Part 1 (B1–B4): shipped + merged (PR #503) — readonly split, renderInkReport, http client +
-  BAKIN_URL fix, output helpers.
-- Part 2 (B5.1–B5.2): the safe, fully-verified slice of B5 — the user-chosen divergence fixes + the
-  confirm-prompt dedup. Shipping as its own PR.
-- Part 3 (B5.3 + B6 + B7 + docs): the command-module split / emit() dispatcher / framework / test
-  splits — the fragile, E2E-wanting remainder. Next focused effort.
+- **search.fix — ☑ pluginTables wrong-table bug.** Team registers a direct primary (`agents`, indexed
+  via `ctx.search.index`) + a file-backed secondary (`agent-lessons`); last-write-wins routed agent docs
+  into the lessons table and made `getTableForPlugin('team')` throw (breaking team's `/search` + MCP).
+  Fix: a "primary table" model — `registerContentType` records the primary (one direct per plugin,
+  enforced; a second throws early), file-backed types register as **secondary** and index/remove/reconcile
+  into their **own** table directly (not the primary resolver); `getTableForPlugin` returns the primary
+  (no longer throws). No public SearchAPI/SDK type change (internal `registerContentTypeInternal`). Regression
+  test added (direct→primary + file-backed→own-table). Chosen over the audit's handle-API option because it
+  fixes the real cases with zero API/two-tier churn; the only residual (a hypothetical plugin with two
+  DIRECT content types) now errors early instead of silently misrouting.
+  - **OPERATIONAL (for Mark):** existing instances have stale agent docs already written to
+    `bakin_agent-lessons` (and missing from `bakin_agent`). After deploying, run a one-time
+    `bakin reindex` (re-runs generators into the correct tables) and purge the mis-routed rows from
+    `bakin_agent-lessons`. The code fix prevents recurrence; it can't retro-move already-written rows.
+- search.split — ☐ search-registry.ts → 4 modules (search-registry / search-plugin-api / search-reindex /
+  search-query) + barrel. Mechanical relocation; hazards in APPENDIX (globalThis HMR state in one module,
+  import cycles, logger allowlist names, 12 test-file import paths, server.ts dynamic-import strings).
+  Also fold in the smaller cleanups: transform() $inc/$push type-narrow, pendingReconciles swap idiom (×3),
+  crossTableSearch self-recursion, dead getSearchAdapter export.
+- dispatch.split — ☐   plugin-registry.split — ☐   server.split — ☐   upgrade.split — ☐   runtime.split — ☐

--- a/tests/core/register-file-backed-content-type.test.ts
+++ b/tests/core/register-file-backed-content-type.test.ts
@@ -124,6 +124,36 @@ describe('registerFileBackedContentType', () => {
     expect((doc as Record<string, unknown>).title).toBe('projects/foo.md')
   })
 
+  it('routes a primary + file-backed secondary to the right tables (team regression)', async () => {
+    // Reproduces the pluginTables 1:1 bug: a plugin (like team) with a direct
+    // primary content type registered FIRST and a file-backed secondary SECOND.
+    // The old last-write-wins resolver sent the primary's direct index() calls
+    // into the secondary's table.
+    const api = buildSearchAPI('team-like')
+    api.registerContentType({
+      table: 'agents',
+      schema: { name: { type: 'text' } },
+      searchableFields: ['name'],
+      embeddingTemplate: '{{name}}',
+      reindex: async function* () {},
+      verifyExists: async () => true,
+    })
+    api.registerFileBackedContentType(makeDef({ table: 'agent-lessons' }))
+
+    // Direct index() resolves to the PRIMARY table, not the last-registered one.
+    await api.index('a1', { name: 'Agent One' })
+    expect(searchHarness.calls.documentsIndex).toHaveBeenCalledWith(
+      'bakin_agents',
+      'a1',
+      expect.objectContaining({ name: 'Agent One' }),
+    )
+
+    // The file-backed sync hook indexes into ITS OWN table (the secondary).
+    searchHarness.calls.documentsIndex.mockClear()
+    await syncHooks[syncHooks.length - 1]('projects/foo.md', 'foo body')
+    expect(searchHarness.calls.documentsIndex.mock.calls[0][0]).toBe('bakin_agent-lessons')
+  })
+
   it('sync hook ignores files outside the pattern scope', async () => {
     const api = buildSearchAPI('projects')
     api.registerFileBackedContentType(makeDef())

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -127,11 +127,14 @@ describe('search-registry', () => {
     expect(getTableForPlugin('nonexistent')).toBeNull()
   })
 
-  it('getTableForPlugin throws if a plugin has multiple content types', () => {
+  it('rejects a second DIRECT (primary) content type for one plugin', () => {
     const api = buildSearchAPI('multi')
     api.registerContentType(makeDef('one'))
-    api.registerContentType(makeDef('two'))
-    expect(() => getTableForPlugin('multi')).toThrow(/multi.*2 registered/)
+    // A plugin gets exactly one primary content type; the second direct
+    // registration fails early rather than silently overwriting the resolver.
+    expect(() => api.registerContentType(makeDef('two'))).toThrow(/already has a primary/)
+    // The first one is still the resolvable table.
+    expect(getTableForPlugin('multi')).toBe('bakin_one')
   })
 
   it('getTableForPlugin returns null when the registry is completely empty', () => {
@@ -141,14 +144,11 @@ describe('search-registry', () => {
     expect(getTableForPlugin('anything')).toBeNull()
   })
 
-  it('getTableForPlugin error message names the conflicting tables', () => {
+  it('the primary-conflict error names the existing primary and the rejected table', () => {
     const api = buildSearchAPI('multi')
     api.registerContentType(makeDef('alpha'))
-    api.registerContentType(makeDef('beta'))
-    // The error must list both bakin_alpha and bakin_beta so an operator
-    // tracking down a misconfiguration can find them without code-diving.
-    expect(() => getTableForPlugin('multi')).toThrow(/bakin_alpha/)
-    expect(() => getTableForPlugin('multi')).toThrow(/bakin_beta/)
+    expect(() => api.registerContentType(makeDef('beta'))).toThrow(/bakin_alpha/)
+    expect(() => api.registerContentType(makeDef('beta'))).toThrow(/bakin_beta/)
   })
 
   it('registerContentType preserves pluginId', () => {


### PR DESCRIPTION
WS5 part 1 — the search-registry correctness fix from the audit's per-file plan, pulled to the front
because it's a real silent-data-corruption bug and is fully unit-testable. The mechanical
`search-registry.ts` → 4-module split (and the larger WS5 splits: dispatch, plugin-registry, runtime)
follow as focused efforts.

Spec: `.claude/specs/audit-2026-06/{REPORT,APPENDIX-cohesion}.md`. Plan: `tasks/plan.md`.

## The bug

The registry tracked one table per plugin with last-write-wins. `team` registers **two** content
types — a direct `agents` type (indexed via `ctx.search.index`, registered first) and a file-backed
`agent-lessons` type (registered second). Last-wins meant:
- every direct `index`/`remove`/`transform` for agents wrote into `bakin_agent-lessons` (wrong table
  *and* schema), and
- `getTableForPlugin('team')` **threw**, breaking team's `/search` route + MCP plugin-param routing.

## The fix — a "primary table" model (no public SearchAPI/SDK type change)

- `registerContentType` records the plugin's **primary** table. Exactly one primary per plugin; a
  second *direct* registration throws early instead of silently overwriting.
- File-backed content types register as **secondary** (via an internal `registerContentTypeInternal`);
  their sync hook, unlink hook, and startup reconcile index/remove into their **own** table directly,
  never via the primary resolver. A file-backed type becomes primary only as a fallback for a purely
  file-backed plugin.
- `getTableForPlugin` returns the primary (or null) and no longer throws; bare
  `ctx.search.index/remove/transform/query` keep resolving the primary.

Chosen over the audit's table-scoped-handle option: fixes the real cases (team + every single-content
plugin) with zero API / two-tier-type churn. The only residual — a hypothetical plugin with two
*direct* content types — now errors at registration rather than misrouting.

## Verification
- Regression test: direct `index()` → primary table; file-backed sync → its own table. Reworked the
  `getTableForPlugin` multi-content tests (now assert the early registration error).
- `bun test` core + team/memory/tasks **893/0**; full suite **5105/0**; typecheck + lint clean; full
  3-target binary build. Knowledge docs updated.

## Operational note (for deploy)
Instances that already ran have agent docs sitting in `bakin_agent-lessons` (and missing from
`bakin_agent`). A one-time `bakin reindex` + purge of the mis-routed rows cleans them up — the code
fix prevents recurrence but can't retro-move already-written rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
