### PR TITLE
refactor(plugins): delete dead checkUpgradeAvailable

### DIFF
--- a/src/core/plugins/upgrade.ts
+++ b/src/core/plugins/upgrade.ts
@@ -353,37 +353,6 @@ async function probeOne(entry: PluginLockEntry, id: string): Promise<UpgradeAvai
 }
 
 /**
- * Check whether an upgrade is available for an installed plugin and persist
- * the freshness markers (`lastChecked` + `remoteHeadSha`/`sourceTreeSha`)
- * into the lockfile. Used by `bakin plugins list --check` for single-plugin
- * checks. Concurrent callers should prefer `runChecks` to avoid races.
- *
- * Network/fs errors are caught and returned in the `error` field so one
- * plugin's failure doesn't blank the whole list.
- */
-export async function checkUpgradeAvailable(id: string): Promise<UpgradeAvailability> {
-  const entry = readPluginLockfile().plugins[id]
-  if (!entry) {
-    return {
-      id,
-      upgradeAvailable: false,
-      lastChecked: new Date().toISOString(),
-      error: 'no lockfile entry',
-    }
-  }
-  const result = await probeOne(entry, id)
-  // Single-plugin path still serializes via one read-modify-write call —
-  // safe because there's no parallelism here.
-  if (!result.error) {
-    const patch: Partial<PluginLockEntry> = { lastChecked: result.lastChecked }
-    if (result.remoteHeadSha) patch.remoteHeadSha = result.remoteHeadSha
-    if (result.sourceTreeSha) patch.lastSourceTreeSha = result.sourceTreeSha
-    writePluginLockfile(updatePlugin(readPluginLockfile(), id, patch))
-  }
-  return result
-}
-
-/**
  * Run the `--check` probe for many plugins in parallel and write the
  * lockfile ONCE with all updates. The previous shape (each probe
  * read-modify-writes the lockfile) raced under Promise.all and silently

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -46,4 +46,12 @@ rig to E2E-verify behavior — they're sequenced after the search work and may b
   import cycles, logger allowlist names, 12 test-file import paths, server.ts dynamic-import strings).
   Also fold in the smaller cleanups: transform() $inc/$push type-narrow, pendingReconciles swap idiom (×3),
   crossTableSearch self-recursion, dead getSearchAdapter export.
-- dispatch.split — ☐   plugin-registry.split — ☐   server.split — ☐   upgrade.split — ☐   runtime.split — ☐
+- upgrade.cleanup — ☑ deleted dead `checkUpgradeAvailable` (zero callers; superseded by `runChecks`;
+  stale doc claimed `--check` used it). **Hasher consolidation DEFERRED (behavior-sensitive):** the
+  "two directory hashers" — `computeSourceTreeSha` (upgrade.ts: skips node_modules/dist/.git, hashes
+  concatenated rel+bytes) and `hashSourceTree` (whiskit/source-hash.ts: skips NON_RUNTIME_DIRS+dotfiles,
+  hashes joined rel+filehash lines) — have DIFFERENT skip-sets and formulas, so they produce different
+  hashes. Consolidating changes output for one caller and invalidates stored sourceTreeSha values
+  (spurious "source changed" on existing installs); needs a deliberate canonical-pick + one-time reset,
+  best done with the full upgrade.ts split + a migration step.
+- dispatch.split — ☐   plugin-registry.split — ☐   server.split — ☐   upgrade.split (remaining) — ☐   runtime.split — ☐


### PR DESCRIPTION
A small, verified WS5 dead-code removal.

`checkUpgradeAvailable` (the single-plugin upgrade probe) has **zero callers** — `runChecks`
(the parallel, race-safe multi-plugin probe) superseded it, and its doc comment claiming
`bakin plugins list --check` uses it was stale. Deleted; the shared helpers it used
(`probeOne`, `readPluginLockfile`, `writePluginLockfile`, `updatePlugin`, `UpgradeAvailability`)
are all still used by `runChecks` and untouched.

**Deferred (documented in `tasks/plan.md`):** the audit's "consolidate the two directory
hashers." `computeSourceTreeSha` (upgrade.ts — skips node_modules/dist/.git, hashes concatenated
rel+bytes) and `hashSourceTree` (whiskit/source-hash.ts — skips NON_RUNTIME_DIRS+dotfiles, hashes
joined rel+filehash lines) have **different skip-sets and formulas**, so consolidating changes hash
output and invalidates stored `sourceTreeSha` values (spurious "source changed" on existing
installs). That's a behavior-sensitive migration, not a clean dedup — it belongs with the full
upgrade.ts split plus a one-time reset.

Verified: typecheck + lint clean; lifecycle tests 244/0; full 3-target binary build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
