### PR TITLE
refactor(dispatch): extract pure error classification to dispatch-failures.ts

### DIFF
--- a/src/core/dispatch-failures.ts
+++ b/src/core/dispatch-failures.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure dispatch error classification over the adapter's typed RuntimeError /
+ * RuntimeTurnError. Zero dispatch state — extracted from dispatch.ts so the
+ * classification can be reasoned about (and tested) in isolation. Classification
+ * is on `err.kind` only; the structural-signal fallbacks never inspect message text.
+ */
+import { RuntimeError, RuntimeTurnError } from '@bakin/core/adapters/runtime'
+
+const MAX_ERR_LEN = 500
+
+/** Truncate a raw error string so a runaway provider response can't balloon the audit/log. */
+export function formatDispatchError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err)
+  return raw.length > MAX_ERR_LEN ? `${raw.slice(0, MAX_ERR_LEN)}… (truncated)` : raw
+}
+
+export type DispatchFailureKind = 'transient' | 'structural'
+
+export type DispatchFailureReasonCode =
+  | 'provider_cooldown'
+  | 'auth_profile_unavailable'
+  | 'dispatch_timeout'
+  | 'transport_failure'
+  | 'runtime_adapter_failure'
+  | 'runtime_turn_died'
+  | 'runtime_dispatch_failed'
+
+export interface DispatchFailureDetail {
+  category: 'model_provider_unavailable' | 'runtime_unavailable'
+  reasonCode: DispatchFailureReasonCode
+  summary: string
+  specificReason: string
+  retryable: boolean
+  provider?: string
+  model?: string
+  cooldownReason?: string
+  rawError: string
+}
+
+const TRANSIENT_CODES = new Set([
+  'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'UND_ERR_SOCKET', 'EPIPE',
+])
+
+// Split dispatch failures into:
+//   - transient: transport failures (socket drop, disconnect, fetch error)
+//     that should clear within a cycle. Use the short cooldown.
+//   - structural: the runtime answered and said no, or timed out outright.
+//     Use the long cooldown.
+//
+// Adapters throw typed RuntimeErrors — classification is on `kind` only.
+// The structural-signal fallback below (TypeError / AbortError / cause.code)
+// exists for non-RuntimeError errors from mock adapters or unexpected paths;
+// it never inspects error message text. Default to 'structural' on unknown
+// errors: treating an unknown failure as a real outage is the safer side.
+// Note: ANY TypeError classifies transient (broader than fetch failures) —
+// a code-bug TypeError retries on the short cooldown but is bounded by
+// maxRetries, which actually blocks it for review faster than structural.
+export function classifyDispatchError(err: unknown): DispatchFailureKind {
+  if (err instanceof RuntimeError) {
+    return err.kind === 'transport' ? 'transient' : 'structural'
+  }
+  if (err instanceof TypeError) return 'transient'
+  const cause = (err as { cause?: { code?: string } })?.cause
+  if (cause?.code && TRANSIENT_CODES.has(cause.code)) return 'transient'
+  if (err instanceof Error && err.name === 'AbortError') return 'transient'
+  return 'structural'
+}
+
+export function classifyDispatchFailureDetail(err: unknown): DispatchFailureDetail {
+  const rawError = formatDispatchError(err)
+
+  if (err instanceof RuntimeError) {
+    switch (err.kind) {
+      case 'provider_cooldown': {
+        const info = err.providerInfo ?? {}
+        return {
+          category: 'model_provider_unavailable',
+          reasonCode: info.authProfileUnavailable ? 'auth_profile_unavailable' : 'provider_cooldown',
+          summary: 'Dispatch failed: model provider unavailable',
+          specificReason: info.authProfileUnavailable
+            ? 'Auth profile unavailable'
+            : 'Provider in cooldown after timeout',
+          retryable: true,
+          ...(info.provider ? { provider: info.provider } : {}),
+          ...(info.model ? { model: info.model } : {}),
+          ...(info.cooldownReason ? { cooldownReason: info.cooldownReason } : {}),
+          rawError,
+        }
+      }
+      case 'timeout':
+        return {
+          category: 'runtime_unavailable',
+          reasonCode: 'dispatch_timeout',
+          summary: 'Dispatch failed: runtime dispatch timed out',
+          specificReason: 'Runtime dispatch timed out',
+          retryable: true,
+          rawError,
+        }
+      case 'transport':
+        return {
+          category: 'runtime_unavailable',
+          reasonCode: 'transport_failure',
+          summary: 'Dispatch failed: runtime transport unavailable',
+          specificReason: 'Runtime transport failure',
+          retryable: true,
+          rawError,
+        }
+      case 'session_death':
+        return {
+          category: 'runtime_unavailable',
+          reasonCode: 'runtime_turn_died',
+          summary: 'Dispatch failed: runtime session died before completion',
+          specificReason: err instanceof RuntimeTurnError
+            ? (err.diagnosis.detail ?? err.message)
+            : err.message,
+          retryable: false,
+          rawError,
+        }
+      case 'runtime_failed':
+        return {
+          category: 'runtime_unavailable',
+          reasonCode: 'runtime_adapter_failure',
+          summary: 'Dispatch failed: runtime adapter failure',
+          specificReason: 'Runtime adapter failure',
+          retryable: true,
+          rawError,
+        }
+    }
+  }
+
+  if (err instanceof TypeError || (err instanceof Error && err.name === 'AbortError')) {
+    return {
+      category: 'runtime_unavailable',
+      reasonCode: 'transport_failure',
+      summary: 'Dispatch failed: runtime transport unavailable',
+      specificReason: 'Runtime transport failure',
+      retryable: true,
+      rawError,
+    }
+  }
+
+  return {
+    category: 'runtime_unavailable',
+    reasonCode: 'runtime_dispatch_failed',
+    summary: 'Dispatch failed: runtime dispatch failed before task completion',
+    specificReason: 'Runtime dispatch failed before task completion',
+    retryable: true,
+    rawError,
+  }
+}
+
+export function formatSanitizedRuntimeFailure(err: unknown): string {
+  if (err instanceof RuntimeTurnError) {
+    return err.diagnosis.detail ?? err.message
+  }
+  if (err instanceof RuntimeError) {
+    switch (err.kind) {
+      case 'timeout': return 'runtime gateway request timed out'
+      case 'transport': return 'runtime transport failure'
+      case 'provider_cooldown': return 'model provider unavailable'
+      case 'session_death': return err.message
+      case 'runtime_failed': return 'runtime adapter failure'
+    }
+  }
+  if (err instanceof Error && err.name === 'AbortError') return 'runtime transport request aborted'
+  return 'runtime dispatch failed before task completion'
+}

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -9,7 +9,7 @@ import { getSettings } from './settings'
 import { appendAudit } from './audit'
 import { recordUsage } from './usage'
 import { getAppServices } from './app-services'
-import { getRuntimeMainAgentId, RuntimeError, RuntimeTurnError, type MessageResult } from '@bakin/core/adapters/runtime'
+import { getRuntimeMainAgentId, RuntimeTurnError, type MessageResult } from '@bakin/core/adapters/runtime'
 import { claimNextRun, currentSeq, loseRun, settleRun, spendTotal, type ClaimNextRunResult } from './execution-ledger'
 import { meterAgentTurn } from './agent-cost'
 import { resolveTurnModel, type ResolvedTurn, type RoutingConfig } from './model-routing'
@@ -28,6 +28,17 @@ import {
   readTaskboard,
   updateTask as updateStoredTask,
 } from './task-store'
+import {
+  formatDispatchError,
+  classifyDispatchError,
+  classifyDispatchFailureDetail,
+  formatSanitizedRuntimeFailure,
+  type DispatchFailureKind,
+} from './dispatch-failures'
+
+// Re-export the pure failure-classification surface so `@/core/dispatch`
+// consumers (and the dispatch-error-classification test) keep their import path.
+export { classifyDispatchError, classifyDispatchFailureDetail, formatSanitizedRuntimeFailure }
 
 const log = createLogger('dispatch')
 const hooks = () => getHookRegistry()
@@ -202,11 +213,6 @@ function auditDispatchSuppressed(contentDir: string, task: { id: string; title: 
 // the dispatch catch handlers. Bound the blast radius — a runaway adapter
 // response (HTML error page, stack trace, accidental secret echo) should
 // not balloon the audit file or the task drawer.
-const MAX_ERR_LEN = 500
-function formatDispatchError(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err)
-  return raw.length > MAX_ERR_LEN ? `${raw.slice(0, MAX_ERR_LEN)}… (truncated)` : raw
-}
 
 // Formatted lesson blocks cached per (agentId, query). The query embeds
 // title/description/step instructions, so a workflow step change naturally
@@ -276,28 +282,6 @@ export async function buildDispatchLessonBlock(input: {
     })
     return ''
   }
-}
-
-type DispatchFailureKind = 'transient' | 'structural'
-type DispatchFailureReasonCode =
-  | 'provider_cooldown'
-  | 'auth_profile_unavailable'
-  | 'dispatch_timeout'
-  | 'transport_failure'
-  | 'runtime_adapter_failure'
-  | 'runtime_turn_died'
-  | 'runtime_dispatch_failed'
-
-interface DispatchFailureDetail {
-  category: 'model_provider_unavailable' | 'runtime_unavailable'
-  reasonCode: DispatchFailureReasonCode
-  summary: string
-  specificReason: string
-  retryable: boolean
-  provider?: string
-  model?: string
-  cooldownReason?: string
-  rawError: string
 }
 
 /** Diagnosis evidence persisted across ladder rungs (salvagedText stripped). */
@@ -450,118 +434,6 @@ async function moveTaskToInProgress(taskId: string, agent: string): Promise<void
   await updateStoredTask(taskId, { column: 'inProgress', agent })
 }
 
-const TRANSIENT_CODES = new Set([
-  'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'UND_ERR_SOCKET', 'EPIPE',
-])
-
-// Split dispatch failures into:
-//   - transient: transport failures (socket drop, disconnect, fetch error)
-//     that should clear within a cycle. Use the short cooldown.
-//   - structural: the runtime answered and said no, or timed out outright.
-//     Use the long cooldown.
-//
-// Adapters throw typed RuntimeErrors — classification is on `kind` only.
-// The structural-signal fallback below (TypeError / AbortError / cause.code)
-// exists for non-RuntimeError errors from mock adapters or unexpected paths;
-// it never inspects error message text. Default to 'structural' on unknown
-// errors: treating an unknown failure as a real outage is the safer side.
-// Note: ANY TypeError classifies transient (broader than fetch failures) —
-// a code-bug TypeError retries on the short cooldown but is bounded by
-// maxRetries, which actually blocks it for review faster than structural.
-export function classifyDispatchError(err: unknown): DispatchFailureKind {
-  if (err instanceof RuntimeError) {
-    return err.kind === 'transport' ? 'transient' : 'structural'
-  }
-  if (err instanceof TypeError) return 'transient'
-  const cause = (err as { cause?: { code?: string } })?.cause
-  if (cause?.code && TRANSIENT_CODES.has(cause.code)) return 'transient'
-  if (err instanceof Error && err.name === 'AbortError') return 'transient'
-  return 'structural'
-}
-
-export function classifyDispatchFailureDetail(err: unknown): DispatchFailureDetail {
-  const rawError = formatDispatchError(err)
-
-  if (err instanceof RuntimeError) {
-    switch (err.kind) {
-      case 'provider_cooldown': {
-        const info = err.providerInfo ?? {}
-        return {
-          category: 'model_provider_unavailable',
-          reasonCode: info.authProfileUnavailable ? 'auth_profile_unavailable' : 'provider_cooldown',
-          summary: 'Dispatch failed: model provider unavailable',
-          specificReason: info.authProfileUnavailable
-            ? 'Auth profile unavailable'
-            : 'Provider in cooldown after timeout',
-          retryable: true,
-          ...(info.provider ? { provider: info.provider } : {}),
-          ...(info.model ? { model: info.model } : {}),
-          ...(info.cooldownReason ? { cooldownReason: info.cooldownReason } : {}),
-          rawError,
-        }
-      }
-      case 'timeout':
-        return {
-          category: 'runtime_unavailable',
-          reasonCode: 'dispatch_timeout',
-          summary: 'Dispatch failed: runtime dispatch timed out',
-          specificReason: 'Runtime dispatch timed out',
-          retryable: true,
-          rawError,
-        }
-      case 'transport':
-        return {
-          category: 'runtime_unavailable',
-          reasonCode: 'transport_failure',
-          summary: 'Dispatch failed: runtime transport unavailable',
-          specificReason: 'Runtime transport failure',
-          retryable: true,
-          rawError,
-        }
-      case 'session_death':
-        return {
-          category: 'runtime_unavailable',
-          reasonCode: 'runtime_turn_died',
-          summary: 'Dispatch failed: runtime session died before completion',
-          specificReason: err instanceof RuntimeTurnError
-            ? (err.diagnosis.detail ?? err.message)
-            : err.message,
-          retryable: false,
-          rawError,
-        }
-      case 'runtime_failed':
-        return {
-          category: 'runtime_unavailable',
-          reasonCode: 'runtime_adapter_failure',
-          summary: 'Dispatch failed: runtime adapter failure',
-          specificReason: 'Runtime adapter failure',
-          retryable: true,
-          rawError,
-        }
-    }
-  }
-
-  if (err instanceof TypeError || (err instanceof Error && err.name === 'AbortError')) {
-    return {
-      category: 'runtime_unavailable',
-      reasonCode: 'transport_failure',
-      summary: 'Dispatch failed: runtime transport unavailable',
-      specificReason: 'Runtime transport failure',
-      retryable: true,
-      rawError,
-    }
-  }
-
-  return {
-    category: 'runtime_unavailable',
-    reasonCode: 'runtime_dispatch_failed',
-    summary: 'Dispatch failed: runtime dispatch failed before task completion',
-    specificReason: 'Runtime dispatch failed before task completion',
-    retryable: true,
-    rawError,
-  }
-}
-
 let dispatching = false
 let dispatchStartedAt = 0
 let dispatchTimer: NodeJS.Timeout | null = null
@@ -631,23 +503,6 @@ async function tryAddTaskLog(taskId: string, author: string, message: string, da
   } catch (err) {
     log.warn('Failed to append dispatch reconciliation task log', err, { id: taskId })
   }
-}
-
-export function formatSanitizedRuntimeFailure(err: unknown): string {
-  if (err instanceof RuntimeTurnError) {
-    return err.diagnosis.detail ?? err.message
-  }
-  if (err instanceof RuntimeError) {
-    switch (err.kind) {
-      case 'timeout': return 'runtime gateway request timed out'
-      case 'transport': return 'runtime transport failure'
-      case 'provider_cooldown': return 'model provider unavailable'
-      case 'session_death': return err.message
-      case 'runtime_failed': return 'runtime adapter failure'
-    }
-  }
-  if (err instanceof Error && err.name === 'AbortError') return 'runtime transport request aborted'
-  return 'runtime dispatch failed before task completion'
 }
 
 function shouldBlockAfterDispatchFailure(

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -57,4 +57,18 @@ rig to E2E-verify behavior — they're sequenced after the search work and may b
   hashes. Consolidating changes output for one caller and invalidates stored sourceTreeSha values
   (spurious "source changed" on existing installs); needs a deliberate canonical-pick + one-time reset,
   best done with the full upgrade.ts split + a migration step.
-- dispatch.split — ☐   plugin-registry.split — ☐   server.split — ☐   upgrade.split (remaining) — ☐   runtime.split — ☐
+- dispatch.split — ◧ **split by RISK, not all at once** (dispatch is the audit's most dangerous file:
+  6 module-level singletons where a misplaced one silently breaks the .dispatch-state.json mutex →
+  duplicate fires; an import cycle (handleSessionDeath ⇄ dispatchSingleTask) needing DI surgery; a
+  cross-package ledger contract on the state file).
+  - ☑ Pure module #1: `dispatch-failures.ts` (error classification over RuntimeError/RuntimeTurnError —
+    zero state, zero fire-path). dispatch.ts 2,240 → 2,096, re-exports the public classify* surface so
+    `@/core/dispatch` consumers + the test are unchanged. typecheck/lint/61-dispatch-tests/full-suite/binary green.
+  - ☐ Pure module #2/#3: prompts (entangled — buildCorrectiveSection needs SessionDeathState; sharedExecutionToolDocs
+    is shared with the workflow builder) and board reads. Doable after the state types are extracted.
+  - ☐ **DANGEROUS modules (dedicated effort, heavy rig dispatch-E2E):** state.ts (the stateQueue mutex),
+    turns.ts (inFlightTurns/pendingLadderRedispatches/fireDispatchTurn), session-death.ts (the cycle),
+    cycle.ts (dispatching/timer + dispatchTasks fire loop), single.ts (dispatchSingleTask). Plus the
+    behavior-touching dedup (prepareAndFireRegularDispatch) — separate from the relocation.
+- plugin-registry.split — ☐ (high-value sub-item: extract the hook-registry-singleton — breaks a live
+  import cycle; the APPENDIX's "highest-value seam")   server.split — ☐   upgrade.split (remaining) — ☐   runtime.split — ☐


### PR DESCRIPTION
The first, safe step of the `dispatch.ts` split — extracted by **risk**, not all at once.

`dispatch.ts` is the audit's single most dangerous file: 6 module-level singletons (a misplaced one
silently breaks the `.dispatch-state.json` mutex → duplicate task fires), an import cycle
(`handleSessionDeath ⇄ dispatchSingleTask`) that needs dependency-injection surgery, and a
cross-package ledger contract on the state file. So the pure, zero-state modules come out first; the
fire-path / singleton / cycle modules are left for a dedicated effort with heavy rig dispatch-E2E.

## This PR
Moves the error-classification layer into `src/core/dispatch-failures.ts`:
`formatDispatchError`, `classifyDispatchError`, `classifyDispatchFailureDetail`,
`formatSanitizedRuntimeFailure`, and their types. All pure functions over the adapter's typed
`RuntimeError`/`RuntimeTurnError` — zero dispatch state, zero fire-path. `dispatch.ts` re-exports the
public `classify*` surface, so every `@/core/dispatch` consumer and the
`dispatch-error-classification` test keep their import path unchanged. `dispatch.ts`: 2,240 → 2,096.

## Verification
typecheck + lint clean; dispatch tests **61/0** (incl. the error-classification suite through the
re-export); full suite **5105/0**; full 3-target binary build. No fire-path behavior touched, so no
rig E2E needed here (that's reserved for the dangerous modules).

Next (documented in `tasks/plan.md`): the remaining pure modules (prompts/board — mildly entangled
with the state types) and then the dangerous fire-path/singleton/cycle modules as a focused effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
