### PR TITLE
fix(workflows): cycle-detect nested workflows on the REST start path (#3)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -259,6 +259,14 @@ async function getRuntimeAgentNames(): Promise<Set<string>> {
   return names
 }
 
+function collectNestedWorkflowIds(def: WorkflowDefinition, out: Set<string>): void {
+  for (const step of def.steps) {
+    if (step.type === 'workflow') {
+      out.add((step as NestedWorkflowStep).workflow_id)
+    }
+  }
+}
+
 async function validateWorkflowForStart(
   workflowId: string,
   assignee: string | undefined,
@@ -266,27 +274,50 @@ async function validateWorkflowForStart(
   runtimeAgents?: Set<string>,
 ): Promise<string[]> {
   const errors: string[] = []
-  const workflowIdError = validateWorkflowId(workflowId)
-  if (workflowIdError) {
-    errors.push(workflowIdError)
-    return errors
-  }
-  const def = loadDefinition(workflowId, contentDir)
-  if (!def) {
-    errors.push(`Unknown workflow id: ${workflowId}`)
-    return errors
-  }
   const knownAgents = runtimeAgents ?? await getRuntimeAgentNames()
   const knownWorkflowIds = new Set(listDefinitions(contentDir).map((entry) => entry.name))
-  errors.push(...validateDefinition(def, {
-    definitionId: workflowId,
-    source: def.source,
-    contentDir,
-    knownWorkflowIds,
-    runtimeAgents: knownAgents,
-    assignee,
-    requireResolvedAgents: true,
-  }))
+  const visited = new Set<string>()
+
+  // Recurse through nested workflows, validating each definition and detecting
+  // nesting cycles. The REST /instances/start path previously skipped this —
+  // only the hook/exec-tool paths recursed — so a cyclic or invalid nested
+  // workflow could be started via REST. This matches the strong validator.
+  const visit = (id: string, path: string[]): void => {
+    const workflowIdError = validateWorkflowId(id)
+    if (workflowIdError) {
+      errors.push(`Workflow "${id}": ${workflowIdError}`)
+      return
+    }
+    if (path.includes(id)) {
+      errors.push(`Workflow nesting cycle detected: ${[...path, id].join(' -> ')}`)
+      return
+    }
+    if (visited.has(id)) return
+    visited.add(id)
+
+    const def = loadDefinition(id, contentDir)
+    if (!def) {
+      errors.push(`Workflow definition not found: ${id}`)
+      return
+    }
+
+    errors.push(...validateDefinition(def, {
+      definitionId: id,
+      source: def.source,
+      contentDir,
+      knownWorkflowIds,
+      runtimeAgents: knownAgents,
+      assignee,
+      requireResolvedAgents: true,
+    }).map((message) => `Workflow "${id}": ${message}`))
+
+    const nestedIds = new Set<string>()
+    collectNestedWorkflowIds(def, nestedIds)
+    for (const nestedId of nestedIds) visit(nestedId, [...path, id])
+  }
+
+  visit(workflowId, [])
+
   if (assignee && !knownAgents.has(assignee)) {
     errors.push(`Assignee "${assignee}" is not a known runtime agent`)
   }

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -25,6 +25,16 @@ The big splits (dispatch singleton, plugin-registry, runtime) are fragile and se
 rig to E2E-verify behavior — they're sequenced after the search work and may be split into focused PRs
 (mirroring WS4's part-1/part-2 cadence).
 
+## Incidental correctness bug #3 (workflow start-validation) — ☑
+
+The REST `POST /instances/start` path used a weak `validateWorkflowForStart` that only validated the
+top-level definition — no nested-workflow recursion or cycle detection — while the hook + exec-tool
+paths used a strong recursive validator. So a cyclic/invalid nested workflow could be started via REST.
+Upgraded the module-level validator to the strong recursive form (per-def validation + path-tracking
+cycle detection) while keeping its explicit assignee-param check (a true superset). Regression test:
+REST start with a mutually-nested cycle → 400 "cycle detected". (The local strong copy remains a
+pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
+
 ## Status
 
 - **search.fix — ☑ pluginTables wrong-table bug.** Team registers a direct primary (`agents`, indexed

--- a/tests/plugins/workflows/routes.test.ts
+++ b/tests/plugins/workflows/routes.test.ts
@@ -345,4 +345,39 @@ describe('Workflows Plugin — workflow skill drift routes', () => {
       rmSync(collidingTempPath, { recursive: true, force: true })
     }
   })
+
+  describe('POST /instances/start validation', () => {
+    it('rejects starting a workflow with a nested-workflow cycle (REST parity with the hook path)', async () => {
+      const defsDir = join(testDir, 'workflows', 'definitions')
+      mkdirSync(defsDir, { recursive: true })
+      writeFileSync(join(defsDir, 'cycle-a.yaml'), `
+name: Cycle A
+description: cyclic A
+version: 1
+steps:
+  - id: run-b
+    type: workflow
+    label: Run B
+    workflow_id: cycle-b
+`)
+      writeFileSync(join(defsDir, 'cycle-b.yaml'), `
+name: Cycle B
+description: cyclic B
+version: 1
+steps:
+  - id: run-a
+    type: workflow
+    label: Run A
+    workflow_id: cycle-a
+`)
+
+      const route = findRoute(activated.routes, 'POST', '/instances/start')!
+      const { status, body } = await callRoute(route, activated.ctx, {
+        body: { taskId: 'task-cycle', workflowId: 'cycle-a' },
+      })
+
+      expect(status).toBeGreaterThanOrEqual(400)
+      expect(JSON.stringify(body)).toContain('cycle detected')
+    })
+  })
 })


### PR DESCRIPTION
Audit incidental correctness bug **#3** — the workflow start-validation divergence.

## The bug
REST `POST /instances/start` used a weak `validateWorkflowForStart` that validated only the
top-level definition — **no nested-workflow recursion or cycle detection** — while the hook
(`workflows.createInstance`) and exec-tool paths used a strong recursive validator. So a workflow
with a nesting cycle (A nests B, B nests A) or an invalid nested definition could be **started via
REST** even though the other two entry points rejected it.

## The fix
Upgrade the module-level `validateWorkflowForStart` to the strong recursive form — `visit()` each
nested workflow with path tracking, validate every definition, and report
`Workflow nesting cycle detected: ...` — while **keeping its explicit assignee-param check** (so the
new validator is a true superset of the old behavior, not a swap). The REST path now matches the
hook/exec-tool paths.

## Verification
- Regression test: REST `/instances/start` with a mutually-nested cycle → `400` "cycle detected".
- typecheck + lint clean; workflow tests **419/0**; full suite **5106/0**; full 3-target binary build.

The local strong copy inside `activate()` remains a pre-existing duplicate (it closes over a local
`getRuntimeAgentNames`); collapsing the two is `workflows/index.ts`-split (WS6) territory — noted in
`tasks/plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
