### PR TITLE
refactor(server): extract search-startup + startup-recovery (safe server.ts slices)

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -184,6 +184,7 @@ function suppressPrettyInfo(entry: LogEntry): boolean {
     'search-query',
     'search-reconcile',
     'search-cleanup',
+    'search-startup',
     'hot-reload-coordinator',
     'mcporter',
     'dispatch',

--- a/server.ts
+++ b/server.ts
@@ -48,6 +48,7 @@ import { getCachedOrBuild } from './packages/host/src/api/docs-runtime'
 import type { buildOpenApiDocument } from './packages/host/src/api/docs-runtime'
 import { collectOpenApiSources as collectTypedOpenApiSources } from './packages/host/src/api/openapi-sources'
 import { migrateIfNeeded } from './src/core/search-migration'
+import { bootSearch } from './src/core/search-startup'
 import * as agents from './src/core/agents'
 import * as doctor from './src/core/doctor'
 import { handleMcpRequest } from './src/core/mcp-server'
@@ -118,7 +119,6 @@ const BAKIN_VERSION = APP_VERSION
 
 const port = Number(process.env.PORT || 3737)
 const CONTENT_DIR = getContentDir()
-const SEARCH_STARTUP_RETRY_MS = 5000
 
 // Singleton lock BEFORE any side effect (dirs, plugins, watcher, antfly,
 // dispatch). Two server processes against one content dir each ran their
@@ -142,55 +142,6 @@ const SEARCH_STARTUP_RETRY_MS = 5000
  */
 function collectOpenApiSources(): Parameters<typeof buildOpenApiDocument>[0] {
   return collectTypedOpenApiSources(pluginRegistry.getAllPluginRoutes())
-}
-
-type SearchMigrationResult = Awaited<ReturnType<typeof migrateIfNeeded>>
-
-async function runSearchStartupBootstrap(
-  migration: SearchMigrationResult,
-  opts: { retry?: boolean } = {},
-): Promise<boolean> {
-  const {
-    createRegisteredTables,
-    reindexContentTypes,
-    runPendingReconciles,
-  } = await import('./src/core/search-registry')
-
-  const tableSetup = await createRegisteredTables()
-  if (tableSetup.failures.length > 0) {
-    const message = opts.retry
-      ? 'Deferred search table setup still failing; startup reconcile and reindex remain paused'
-      : 'Search table setup incomplete; pausing startup reconcile and reindex until tables are ready'
-    log.warn(message, { failures: tableSetup.failures })
-    return false
-  }
-
-  // Drain any startup reconciles enqueued by registerFileBackedContentType.
-  // Tables exist by this point so reconcile scans hit real data. Failures
-  // are logged inside the helper and do not block startup.
-  await runPendingReconciles()
-
-  // If the schema migration dropped tables, kick off a full background
-  // reindex so the freshly-recreated tables get populated with content.
-  // Fire-and-forget: Bakin is usable immediately with empty tables;
-  // indexing completes in the background and streams progress over SSE.
-  if (migration.migrated) {
-    const message = opts.retry
-      ? 'Running deferred full reindex after schema migration'
-      : 'Running full reindex after schema migration'
-    log.info(message, {
-      from: migration.from,
-      to: migration.to,
-    })
-    reindexContentTypes().then((results) => {
-      const total = results.reduce((sum: number, r) => sum + (r.indexed || 0), 0)
-      log.info('Schema migration reindex complete', { tables: results.length, total })
-    }).catch((err) => {
-      log.error('Schema migration reindex failed', err)
-    })
-  }
-
-  return true
 }
 
 // Ensure required directories exist
@@ -237,14 +188,7 @@ const eventBus = new BakinEventBus(broadcast)
   // and we trigger a full reindex after plugins are ready.
   const migration = await migrateIfNeeded()
 
-  const searchBootstrapReady = await runSearchStartupBootstrap(migration)
-  if (!searchBootstrapReady) {
-    setTimeout(() => {
-      runSearchStartupBootstrap(migration, { retry: true }).catch((err) => {
-        log.warn('Deferred search startup retry failed', err)
-      })
-    }, SEARCH_STARTUP_RETRY_MS)
-  }
+  await bootSearch(migration)
 
   // Start periodic orphan cleanup for search indexes
   const { startCleanupTimer } = await import('./src/core/search-cleanup')

--- a/server.ts
+++ b/server.ts
@@ -35,10 +35,7 @@ import { handleJsonPost, jsonResponse } from './src/core/middleware'
 import { writeCrossPluginSearchResponse } from './src/core/api-search-handler'
 import * as watcher from './src/core/watcher'
 import * as dispatch from './src/core/dispatch'
-import * as watchdog from './src/core/watchdog'
-import { runRestartRecovery } from './src/core/restart-recovery'
-import { markPriorBootRunsLost } from './src/core/execution-ledger'
-import { backfillMissingCompletionRows } from './src/core/task-service'
+import { runStartupRecovery } from './src/core/server/startup-recovery'
 import { getBootId } from './src/core/boot-id'
 import { acquireServerLock, formatBindFailureHelp } from './src/core/server-lock'
 import { registerShutdownHandlers, triggerShutdown } from './src/core/lifecycle'
@@ -50,7 +47,6 @@ import { collectOpenApiSources as collectTypedOpenApiSources } from './packages/
 import { migrateIfNeeded } from './src/core/search-migration'
 import { bootSearch } from './src/core/search-startup'
 import * as agents from './src/core/agents'
-import * as doctor from './src/core/doctor'
 import { handleMcpRequest } from './src/core/mcp-server'
 import * as mcporter from './src/core/mcporter'
 import { trackResponse } from './src/core/rest-tracking'
@@ -709,55 +705,7 @@ const eventBus = new BakinEventBus(broadcast)
       log.info(`Full logs: ${logPath}`, { path: logPath })
     }
 
-    void (async () => {
-      // Startup sweep BEFORE restart recovery: runs left 'running' by a
-      // crashed/previous process are marked lost, or their stale claims
-      // would suppress every legitimate re-dispatch below.
-      try {
-        const swept = markPriorBootRunsLost(getBootId())
-        if (swept > 0) log.info('Startup sweep: marked prior-boot runs lost', { swept })
-      } catch (err) {
-        log.error('Startup run sweep failed — stale claims may suppress dispatch until resolved', err)
-      }
-
-      // Ledger heal: done tasks without a completions row (pre-ledger
-      // history, or rows lost to since-fixed leak paths) get synthetic rows
-      // so "row ⟺ done" holds for every reader. Idempotent — a failure
-      // must not block boot, it just retries next start.
-      try {
-        const healed = backfillMissingCompletionRows()
-        if (healed > 0) log.info('Completion backfill: synthetic rows recorded for done tasks', { healed })
-      } catch (err) {
-        log.error('Completion backfill failed', err)
-      }
-
-      let recovered = 0
-      try {
-        const result = await runRestartRecovery(CONTENT_DIR)
-        recovered = result.recovered
-      } catch (err) {
-        log.error('Restart recovery failed', err)
-      } finally {
-        dispatch.start(CONTENT_DIR, port)
-        watchdog.start(CONTENT_DIR)
-      }
-
-      try {
-        if (recovered > 0) {
-          await dispatch.dispatchTasks(CONTENT_DIR, port)
-        }
-      } catch (err) {
-        log.error('Post-recovery dispatch failed', err)
-      } finally {
-        doctor.start(CONTENT_DIR, process.cwd())
-      }
-
-      if (process.env.BAKIN_SEED_USAGE === '1') {
-        import('./dev/imitation-crab/usage-seed')
-          .then(m => m.seedMockUsage())
-          .catch(err => log.warn('Mock usage seed failed', err))
-      }
-    })()
+    void runStartupRecovery(CONTENT_DIR, port)
   })
 
   // Hot-reload coordinator (Phase 2 P2.C8). Enabled by `bakin dev`

--- a/src/core/search-startup.ts
+++ b/src/core/search-startup.ts
@@ -1,0 +1,79 @@
+/**
+ * Search boot logic, extracted from server.ts so it sits beside search-migration.ts
+ * / search-registry.ts and can be unit-tested with mocked registries.
+ *
+ * `bootSearch` runs the one-shot bootstrap and, if table setup isn't ready yet,
+ * schedules a single deferred retry. `runSearchStartupBootstrap` is the bootstrap
+ * itself (table creation → reconcile drain → post-migration reindex).
+ */
+import { createLogger } from './logger'
+import { migrateIfNeeded } from './search-migration'
+
+const log = createLogger('search-startup')
+
+export type SearchMigrationResult = Awaited<ReturnType<typeof migrateIfNeeded>>
+
+export const SEARCH_STARTUP_RETRY_MS = 5000
+
+export async function runSearchStartupBootstrap(
+  migration: SearchMigrationResult,
+  opts: { retry?: boolean } = {},
+): Promise<boolean> {
+  const {
+    createRegisteredTables,
+    reindexContentTypes,
+    runPendingReconciles,
+  } = await import('./search-registry')
+
+  const tableSetup = await createRegisteredTables()
+  if (tableSetup.failures.length > 0) {
+    const message = opts.retry
+      ? 'Deferred search table setup still failing; startup reconcile and reindex remain paused'
+      : 'Search table setup incomplete; pausing startup reconcile and reindex until tables are ready'
+    log.warn(message, { failures: tableSetup.failures })
+    return false
+  }
+
+  // Drain any startup reconciles enqueued by registerFileBackedContentType.
+  // Tables exist by this point so reconcile scans hit real data. Failures
+  // are logged inside the helper and do not block startup.
+  await runPendingReconciles()
+
+  // If the schema migration dropped tables, kick off a full background
+  // reindex so the freshly-recreated tables get populated with content.
+  // Fire-and-forget: Bakin is usable immediately with empty tables;
+  // indexing completes in the background and streams progress over SSE.
+  if (migration.migrated) {
+    const message = opts.retry
+      ? 'Running deferred full reindex after schema migration'
+      : 'Running full reindex after schema migration'
+    log.info(message, {
+      from: migration.from,
+      to: migration.to,
+    })
+    reindexContentTypes().then((results) => {
+      const total = results.reduce((sum: number, r) => sum + (r.indexed || 0), 0)
+      log.info('Schema migration reindex complete', { tables: results.length, total })
+    }).catch((err) => {
+      log.error('Schema migration reindex failed', err)
+    })
+  }
+
+  return true
+}
+
+/**
+ * Run the search bootstrap once; if table setup isn't ready, schedule a single
+ * deferred retry SEARCH_STARTUP_RETRY_MS later. Fire-and-forget — never throws
+ * into the boot path.
+ */
+export async function bootSearch(migration: SearchMigrationResult): Promise<void> {
+  const ready = await runSearchStartupBootstrap(migration)
+  if (!ready) {
+    setTimeout(() => {
+      runSearchStartupBootstrap(migration, { retry: true }).catch((err) => {
+        log.warn('Deferred search startup retry failed', err)
+      })
+    }, SEARCH_STARTUP_RETRY_MS)
+  }
+}

--- a/src/core/server/startup-recovery.ts
+++ b/src/core/server/startup-recovery.ts
@@ -1,0 +1,75 @@
+/**
+ * Post-listen startup recovery — the ordered ledger/recovery sequence that runs
+ * once the HTTP server is accepting traffic. Extracted from server.ts so its
+ * invariants live in one reviewable place.
+ *
+ * Ordering contracts (must not change):
+ *   1. Startup sweep (mark prior-boot runs lost) runs BEFORE restart recovery —
+ *      otherwise stale 'running' claims suppress every legitimate re-dispatch.
+ *   2. dispatch.start + watchdog.start run in a `finally` so they start even if
+ *      restart recovery throws.
+ *   3. doctor.start runs in a `finally` after the post-recovery dispatch.
+ *
+ * Fire-and-forget from the listen callback (`void runStartupRecovery(...)`);
+ * every step swallows its own errors so boot is never blocked.
+ */
+import { createLogger } from '../logger'
+import { getBootId } from '../boot-id'
+import { markPriorBootRunsLost } from '../execution-ledger'
+import { backfillMissingCompletionRows } from '../task-service'
+import { runRestartRecovery } from '../restart-recovery'
+import * as dispatch from '../dispatch'
+import * as watchdog from '../watchdog'
+import * as doctor from '../doctor'
+
+const log = createLogger('startup-recovery')
+
+export async function runStartupRecovery(contentDir: string, port: number): Promise<void> {
+  // Startup sweep BEFORE restart recovery: runs left 'running' by a
+  // crashed/previous process are marked lost, or their stale claims
+  // would suppress every legitimate re-dispatch below.
+  try {
+    const swept = markPriorBootRunsLost(getBootId())
+    if (swept > 0) log.info('Startup sweep: marked prior-boot runs lost', { swept })
+  } catch (err) {
+    log.error('Startup run sweep failed — stale claims may suppress dispatch until resolved', err)
+  }
+
+  // Ledger heal: done tasks without a completions row (pre-ledger history, or
+  // rows lost to since-fixed leak paths) get synthetic rows so "row ⟺ done"
+  // holds for every reader. Idempotent — a failure must not block boot, it
+  // just retries next start.
+  try {
+    const healed = backfillMissingCompletionRows()
+    if (healed > 0) log.info('Completion backfill: synthetic rows recorded for done tasks', { healed })
+  } catch (err) {
+    log.error('Completion backfill failed', err)
+  }
+
+  let recovered = 0
+  try {
+    const result = await runRestartRecovery(contentDir)
+    recovered = result.recovered
+  } catch (err) {
+    log.error('Restart recovery failed', err)
+  } finally {
+    dispatch.start(contentDir, port)
+    watchdog.start(contentDir)
+  }
+
+  try {
+    if (recovered > 0) {
+      await dispatch.dispatchTasks(contentDir, port)
+    }
+  } catch (err) {
+    log.error('Post-recovery dispatch failed', err)
+  } finally {
+    doctor.start(contentDir, process.cwd())
+  }
+
+  if (process.env.BAKIN_SEED_USAGE === '1') {
+    import('../../../dev/imitation-crab/usage-seed')
+      .then(m => m.seedMockUsage())
+      .catch(err => log.warn('Mock usage seed failed', err))
+  }
+}


### PR DESCRIPTION
The **safe slices** of the `server.ts` split. The full split is high-risk — module-graph
contamination (`registerCorePlugins`/`setEmbeddedAssets` must stay in the compile entry), strict
boot-ordering contracts, deliberate graph-pruning dynamic imports, and exact route-precedence
reproduction — so I'm peeling off the self-contained, verifiable pieces first and leaving the
dangerous router/boot seams for a dedicated effort.

`server.ts`: **833 → 727**.

## Slice 1 — search boot → `src/core/search-startup.ts`
`runSearchStartupBootstrap` + the `SEARCH_STARTUP_RETRY_MS` deferred-retry wiring move beside
`search-migration.ts` / `search-registry.ts`. `server.ts` now calls `await bootSearch(migration)`.

## Slice 2 — startup recovery → `src/core/server/startup-recovery.ts`
The post-listen recovery IIFE (sweep → completion backfill → restart recovery → dispatch.start +
watchdog.start in a `finally` → post-recovery dispatchTasks → doctor.start in a `finally` →
`BAKIN_SEED_USAGE`) moves into `runStartupRecovery(contentDir, port)`. Every ordering invariant is
preserved verbatim; the dev usage-seed import stays dynamic. `watchdog`/`doctor` namespace imports
drop out of `server.ts`.

## Verification (incl. the rig)
- typecheck + lint clean; full suite **5105/0**; full 3-target binary build.
- **Isolated-home boot smokes** of the built binary for each slice: the server boots, the search
  tables register through `bootSearch`, and the recovery sequence runs through `runStartupRecovery`
  (**Dispatch / Watchdog / Doctor all started in order**). The only log noise is environmental (empty
  `OPENCLAW_HOME` → schedule cron can't run; Antfly transient shard-scan on fresh empty tables).

More safe slices remain (the un-migrated inline handlers → Web-handler files) before the risky
router/boot seams; noted in `tasks/plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
