### PR TITLE
refactor(server): migrate /api/version + /api/docs to Web-handler files

### DIFF
--- a/packages/host/src/api/docs.ts
+++ b/packages/host/src/api/docs.ts
@@ -1,0 +1,11 @@
+/**
+ * GET /api/docs — legacy `{ routes }` shape. Stable contract for CLI consumers
+ * (`bakin plugins list`, `bakin docs`) until the OpenAPI surface becomes canonical.
+ */
+import { getAllRoutes } from '@/core/api-docs'
+
+export async function get(_req: Request, _url: URL): Promise<Response> {
+  void _req
+  void _url
+  return Response.json({ routes: getAllRoutes() })
+}

--- a/packages/host/src/api/version.ts
+++ b/packages/host/src/api/version.ts
@@ -1,0 +1,10 @@
+/**
+ * GET /api/version — the running Bakin version. Stable contract used by the CLI.
+ */
+import { APP_VERSION } from '@bakin/core/constants'
+
+export async function get(_req: Request, _url: URL): Promise<Response> {
+  void _req
+  void _url
+  return Response.json({ version: APP_VERSION })
+}

--- a/server.ts
+++ b/server.ts
@@ -40,7 +40,7 @@ import { getBootId } from './src/core/boot-id'
 import { acquireServerLock, formatBindFailureHelp } from './src/core/server-lock'
 import { registerShutdownHandlers, triggerShutdown } from './src/core/lifecycle'
 import { checkAndContinueDependents } from './src/core/continuation'
-import { getAllRoutes, generateDocs } from './src/core/api-docs'
+import { generateDocs } from './src/core/api-docs'
 import { getCachedOrBuild } from './packages/host/src/api/docs-runtime'
 import type { buildOpenApiDocument } from './packages/host/src/api/docs-runtime'
 import { collectOpenApiSources as collectTypedOpenApiSources } from './packages/host/src/api/openapi-sources'
@@ -81,6 +81,8 @@ import * as assetsRoute from './packages/host/src/api/assets/[...path]'
 import * as pluginCatchAllRoute from './packages/host/src/api/plugins/[pluginId]/[[...path]]'
 import * as pluginsManifestRoute from './packages/host/src/api/plugins/manifest'
 import * as pluginsAssetsRoute from './packages/host/src/api/plugins/assets'
+import * as versionRoute from './packages/host/src/api/version'
+import * as docsRoute from './packages/host/src/api/docs'
 import * as updateStatusRoute from './packages/host/src/api/update/status'
 import * as updateApplyRoute from './packages/host/src/api/update/apply'
 import { handleDevSse } from './packages/host/src/api/dev/events'
@@ -97,10 +99,6 @@ import { EMBEDDED_ASSETS_STATIC } from './packages/host/src/api/_embedded-assets
 setEmbeddedAssets(EMBEDDED_ASSETS_STATIC)
 
 const log = createLogger('server')
-
-import { APP_VERSION } from './packages/core/src/constants'
-
-const BAKIN_VERSION = APP_VERSION
 
 // Parse argv and run one-shot subcommands (`version`, `stop`, `status`,
 // `plugins ...`, `update`, `--help`) before touching the filesystem.
@@ -252,7 +250,7 @@ const eventBus = new BakinEventBus(broadcast)
 
     // Version endpoint
     if (url.pathname === '/api/version' && req.method === 'GET') {
-      jsonResponse(res, 200, { version: BAKIN_VERSION })
+      dispatchWebHandler(req, res, versionRoute.get)
       return
     }
 
@@ -270,7 +268,7 @@ const eventBus = new BakinEventBus(broadcast)
     // the new OpenAPI surface becomes the canonical endpoint and the
     // CLI migrates over.
     if (url.pathname === '/api/docs' && req.method === 'GET') {
-      jsonResponse(res, 200, { routes: getAllRoutes() })
+      dispatchWebHandler(req, res, docsRoute.get)
       return
     }
 


### PR DESCRIPTION
**Stacked on #511** (base = `refactor/server-search-startup`). Continues the `server.ts` decomposition.

Moves two trivial, side-effect-free read handlers out of the `createServer` if-chain into Web-handler
files matching the 30+ already-migrated siblings:
- `packages/host/src/api/version.ts` — `GET /api/version`
- `packages/host/src/api/docs.ts` — `GET /api/docs` (the legacy `{ routes }` shape)

The router branches now dispatch through `dispatchWebHandler` like everything else; **precedence is
unchanged** (this is not the declarative-table refactor — the if-chain structure stays). Drops the
now-dead `BAKIN_VERSION`/`APP_VERSION` + `getAllRoutes` wiring from `server.ts`.

These two have zero `server.ts`-runtime dependencies. The dependency-bearing inline handlers
(`/api/openapi` needs port + pluginRegistry; reindex/settings/agents/dispatch) and the risky
route-table refactor remain for a focused effort.

## Verification
typecheck + lint clean; api/docs tests **131/0**; full suite **5105/0**; full binary build; boot
smoke — both endpoints respond through the new handlers (`/api/version` → version; `/api/docs` →
`{routes:[...]}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
