### PR TITLE
refactor(dispatch): extract safe modules — Phase A (types/prompts/board/context-blocks)

### DIFF
--- a/src/core/dispatch-board.ts
+++ b/src/core/dispatch-board.ts
@@ -1,0 +1,102 @@
+/**
+ * Taskboard reads + dispatch-eligibility policy + the thin task-store wrappers
+ * the dispatch fire-path uses. Pure reads/policy — no dispatch state, no mutex,
+ * no fire-path. Extracted from dispatch.ts.
+ */
+import { createLogger } from './logger'
+import {
+  addTaskLog as appendTaskLog,
+  readTaskboard,
+  updateTask as updateStoredTask,
+} from './task-store'
+import type {
+  DispatchColumns,
+  DispatchEligibility,
+  DispatchEligibilityContext,
+  DispatchTask,
+  DispatchTaskSnapshot,
+} from './dispatch-types'
+
+const log = createLogger('dispatch')
+
+export function emptyDispatchColumns(): DispatchColumns {
+  return {
+    backlog: [],
+    todo: [],
+    inProgress: [],
+    review: [],
+    done: [],
+    blocked: [],
+    archived: [],
+  }
+}
+
+export async function readDispatchColumns(): Promise<DispatchColumns> {
+  const board = readTaskboard() as unknown as { columns: Partial<DispatchColumns> }
+  return { ...emptyDispatchColumns(), ...(board?.columns ?? {}) }
+}
+
+export function isTaskDispatchEligible(
+  task: DispatchTask,
+  context: DispatchEligibilityContext,
+): DispatchEligibility {
+  if (task.availableAt) {
+    const availableMs = Date.parse(task.availableAt)
+    if (!Number.isNaN(availableMs) && availableMs > context.nowMs) {
+      return { eligible: false, reason: 'scheduled' }
+    }
+  }
+
+  let danglingDependency: string | undefined
+  if (task.dependsOn && !context.completedTaskIds.has(task.dependsOn)) {
+    const targetExists = context.knownTaskIds ? context.knownTaskIds.has(task.dependsOn) : true
+    if (targetExists) {
+      return { eligible: false, reason: 'dependency' }
+    }
+    danglingDependency = task.dependsOn
+  }
+
+  if (task.agent && !context.runtimeAgentIds.has(task.agent)) {
+    return { eligible: false, reason: 'agent' }
+  }
+
+  return { eligible: true, ...(danglingDependency ? { danglingDependency } : {}) }
+}
+
+export async function addTaskLog(taskId: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
+  if (data) await appendTaskLog(taskId, author, message, data)
+  else await appendTaskLog(taskId, author, message)
+}
+
+export async function moveTaskToInProgress(taskId: string, agent: string): Promise<void> {
+  await updateStoredTask(taskId, { column: 'inProgress', agent })
+}
+
+export function findDispatchTaskSnapshot(taskId: string): DispatchTaskSnapshot | null {
+  const { columns } = readTaskboard() as unknown as { columns: DispatchColumns }
+  for (const column of Object.keys(emptyDispatchColumns()) as Array<keyof DispatchColumns>) {
+    const task = columns[column]?.find(t => t.id === taskId)
+    if (task) return { column, task }
+  }
+  return null
+}
+
+export function taskAlreadyLeftActiveWork(column: keyof DispatchColumns): boolean {
+  return column === 'done' || column === 'blocked' || column === 'review' || column === 'archived'
+}
+
+export async function tryAddTaskLog(taskId: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
+  try {
+    if (data) await addTaskLog(taskId, author, message, data)
+    else await addTaskLog(taskId, author, message)
+  } catch (err) {
+    log.warn('Failed to append dispatch reconciliation task log', err, { id: taskId })
+  }
+}
+
+export function shouldBlockAfterDispatchFailure(
+  snapshot: DispatchTaskSnapshot,
+  initialLogCount: number,
+): boolean {
+  return (snapshot.task.log?.length ?? 0) > initialLogCount
+}

--- a/src/core/dispatch-context-blocks.ts
+++ b/src/core/dispatch-context-blocks.ts
@@ -1,0 +1,110 @@
+/**
+ * Async prompt-context builders that hit external systems (agent-package
+ * lessons via retrieval, attached assets via the assets hook). Owns the
+ * lessonBlockCache. Extracted from dispatch.ts — distinct from the synchronous
+ * prompt string assembly in dispatch-prompts.ts because these are async,
+ * cached, and audit-emitting.
+ */
+import { createLogger } from './logger'
+import { getSettings } from './settings'
+import { appendAudit } from './audit'
+import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
+import {
+  formatLessonsForDispatch,
+  retrieveAgentPackageLessons,
+} from './agent-packages/lesson-retrieval'
+import { formatDispatchError } from './dispatch-failures'
+
+const log = createLogger('dispatch')
+const hooks = () => getHookRegistry()
+
+// Formatted lesson blocks cached per (agentId, query). The query embeds
+// title/description/step instructions, so a workflow step change naturally
+// misses while inProgress re-dispatches of the same step hit — no separate
+// stepId bookkeeping needed. Bounded + TTL'd; empty blocks are cached too so
+// lesson-less agents don't re-query every dispatch.
+const LESSON_BLOCK_CACHE_TTL_MS = 5 * 60_000
+const LESSON_BLOCK_CACHE_MAX = 200
+const lessonBlockCache = new Map<string, { block: string; expires: number }>()
+
+/** @internal Test-only. */
+export function __resetLessonBlockCache(): void {
+  lessonBlockCache.clear()
+}
+
+/** @internal Exported for testing. */
+export async function buildDispatchLessonBlock(input: {
+  contentDir: string
+  taskId: string
+  title: string
+  agentId: string
+  query: string
+}): Promise<string> {
+  const cacheKey = JSON.stringify([input.agentId, input.query])
+  const hit = lessonBlockCache.get(cacheKey)
+  if (hit && hit.expires > Date.now()) return hit.block
+
+  try {
+    const settings = getSettings().agentPackages?.lessonsRetrieval
+    const result = await retrieveAgentPackageLessons({
+      contentDir: input.contentDir,
+      agentId: input.agentId,
+      query: input.query,
+      settings,
+      requireDispatchInjection: true,
+    })
+    const block = formatLessonsForDispatch(
+      result.lessons,
+      settings?.maxCharacters,
+    )
+    lessonBlockCache.set(cacheKey, { block, expires: Date.now() + LESSON_BLOCK_CACHE_TTL_MS })
+    while (lessonBlockCache.size > LESSON_BLOCK_CACHE_MAX) {
+      const oldest = lessonBlockCache.keys().next().value
+      if (oldest === undefined) break
+      lessonBlockCache.delete(oldest)
+    }
+    if (result.lessons.length > 0) {
+      appendAudit(input.contentDir, 'agent_pkg.lessons_retrieved', input.agentId, {
+        taskId: input.taskId,
+        title: input.title,
+        packageId: result.packageId,
+        lessons: result.lessons.map((lesson) => ({
+          lessonId: lesson.lessonId,
+          title: lesson.title,
+          score: lesson.score,
+        })),
+      })
+    }
+    return block
+  } catch (err) {
+    const error = formatDispatchError(err)
+    log.warn('Dispatch lesson retrieval failed', { taskId: input.taskId, agentId: input.agentId, error })
+    appendAudit(input.contentDir, 'agent_pkg.lessons_retrieval_failed', input.agentId, {
+      taskId: input.taskId,
+      title: input.title,
+      error,
+    })
+    return ''
+  }
+}
+
+/**
+ * Resolve a task's attached assets via the assets.listByTask hook and render
+ * the dispatch block. Async (hook invoke), so call sites compute it before
+ * the synchronous message builders and pass the result in. Returns '' when
+ * the task has no assets or the assets plugin is unavailable.
+ */
+export async function buildDispatchAssetBlock(taskId: string): Promise<string> {
+  try {
+    const assets = await hooks().invoke<Array<{ assetId: string; description?: string; type: string }>>(
+      'assets.listByTask',
+      { taskId },
+    ) ?? []
+    if (assets.length === 0) return ''
+    const lines = assets.map((a) => `- ${a.assetId}${a.description ? ` — ${a.description}` : ''}`)
+    return `\n\n## Attached Assets\nThis task has ${assets.length} linked asset(s). Review them for context before starting:\n${lines.join('\n')}\nOpen with bakin_exec_assets_open using the assetId to read the current content + metadata. AssetIds are stable identity — do not store raw disk paths.`
+  } catch {
+    // Assets plugin not activated (tests, minimal installs) — no block.
+    return ''
+  }
+}

--- a/src/core/dispatch-prompts.ts
+++ b/src/core/dispatch-prompts.ts
@@ -1,0 +1,210 @@
+/**
+ * Synchronous dispatch prompt assembly. Pure string builders extracted from
+ * dispatch.ts — no dispatch state, no I/O. Async/cached context blocks
+ * (lessons, assets) live in dispatch-context-blocks.ts and are passed in here
+ * as already-resolved strings.
+ */
+import { join } from 'path'
+import type {
+  DispatchContinuationContext,
+  DispatchRosterAgent,
+  SessionDeathState,
+} from './dispatch-types'
+
+const IMAGE_MCPORTER_TIMEOUT_MS = 600000
+
+export function mcporterHelpers(agentName: string) {
+  const server = `bakin-${agentName}`
+  return {
+    server,
+    mc: (tool: string, args: string) => `mcporter call ${server}.${tool} ${args}`,
+    mcImage: (tool: string, args: string) => `mcporter call ${server}.${tool} --timeout ${IMAGE_MCPORTER_TIMEOUT_MS} ${args}`,
+  }
+}
+
+/**
+ * Shared execution-tool documentation — single source so the regular and
+ * workflow prompt builders cannot drift. Intentional differences (e.g.
+ * channel posting only for output steps) are explicit parameters.
+ */
+export function sharedExecutionToolDocs(agentName: string, taskId: string, opts: { allowChannelPost: boolean }): string[] {
+  const { mc, mcImage } = mcporterHelpers(agentName)
+  const lines = [
+    '# Save any file as a managed asset (handles naming + sidecar metadata)',
+    mc('bakin_exec_assets_save', `taskId=${taskId} type=<images|text|video|audio|plans|data|other> filePath="<path>" description="<what it is>"`),
+    '',
+    '# Recommend and generate an image through the core images plugin',
+    mc('bakin_exec_images_recommend', 'surface=instagram-feed-portrait objective="<goal>"'),
+    mcImage('bakin_exec_images_generate', `taskId=${taskId} prompt="<text>" surface=instagram-feed-portrait provider=auto`),
+    '',
+    '# Check workflow gate statuses',
+    mc('bakin_exec_check_gates', `taskId=${taskId}`),
+  ]
+  if (opts.allowChannelPost) {
+    lines.push(
+      '',
+      '# Post to a runtime channel (with optional image/video attachment)',
+      mc('bakin_exec_post_channel', `channel="<name>" content="<message>" taskId=${taskId}`),
+    )
+  }
+  return lines
+}
+
+/**
+ * The prevention half of session-death hardening: a short artifact-first
+ * reminder injected into EVERY dispatch prompt, carrying the taskId-templated
+ * save command. The full rule prose lives in the subagent role-context layer
+ * composed into each agent's AGENTS.md managed block (maintained by
+ * `bakin agents sync` / doctor) — this inline reminder keeps the
+ * safety-critical presence per-dispatch without re-shipping the static
+ * catalog every turn.
+ */
+export function outputDisciplineSection(agentName: string, taskId: string, opts: { subtasksAllowed: boolean }): string[] {
+  const { mc } = mcporterHelpers(agentName)
+  return [
+    '## OUTPUT DISCIPLINE — MANDATORY',
+    '',
+    `Oversized chat output KILLS your runtime session. Deliverables larger than ~8KB go to workspace files, saved as assets ONE AT A TIME: \`${mc('bakin_exec_assets_save', `taskId=${taskId} type=<type> filePath="<path>" description="<what it is>"`)}\``,
+    opts.subtasksAllowed
+      ? 'Keep chat short — status + asset ids only. Numerous independent deliverables → split into subtasks. Full rules: "Bakin Execution Tools" in your AGENTS.md.'
+      : 'Keep chat short — status + asset ids only. Large step output → save as asset, reference the asset id in your submitted output. Full rules: "Bakin Execution Tools" in your AGENTS.md.',
+  ]
+}
+
+/**
+ * Corrective guidance injected at the TOP of a re-dispatch prompt after a
+ * session death (position primacy — the agent must read this before the
+ * task). Explains WHY the previous attempt died and how this one differs.
+ */
+export function buildCorrectiveSection(taskId: string, recovery: SessionDeathState): string {
+  const d = recovery.lastDiagnosis
+  const sizeLabel = d.completionBytes !== undefined
+    ? `~${Math.round(d.completionBytes / 1024)}KB`
+    : 'too much'
+  const salvageLine = recovery.salvagedAssetIds.length > 0
+    ? `\nA partial copy of that output was salvaged as asset ${recovery.salvagedAssetIds.join(', ')} — open it with bakin_exec_assets_open and REUSE it instead of regenerating from scratch.`
+    : ''
+  return `## PREVIOUS ATTEMPT FAILED — READ FIRST
+Your previous attempt on this task died before completion: ${d.detail ?? `the runtime session ended (${d.sessionStatus ?? d.reason})`}. The session was killed because ${sizeLabel} of output was emitted as chat text instead of being written to files — the runtime cannot deliver responses that large.${salvageLine}
+
+Do this attempt differently:
+- Produce deliverables ONE AT A TIME: write each to a workspace file, then immediately save it: bakin_exec_assets_save taskId=${taskId} type=<type> filePath="<path>" description="<what it is>"
+- Log progress after each save, then move to the next deliverable.
+- Keep every chat/completion message SHORT: status + asset ids only. NEVER put deliverable content in chat output.
+
+`
+}
+
+/**
+ * Decomposition dispatch (recovery-ladder rung 2): the agent must NOT do the
+ * work — only split it into chained single-deliverable subtasks. Emitting a
+ * handful of tool calls is a tiny output, the structural opposite of the
+ * failure being recovered from.
+ */
+export function buildDecompositionMessage(
+  task: { id: string; title: string; description?: string },
+  agentName: string,
+  recovery: SessionDeathState,
+): string {
+  const server = `bakin-${agentName}`
+  const mc = (tool: string, args: string) => `mcporter call ${server}.${tool} ${args}`
+  const d = recovery.lastDiagnosis
+  const detailsBlock = task.description ? `\n\nOriginal task details:\n${task.description}` : ''
+  const salvageBlock = recovery.salvagedAssetIds.length > 0
+    ? `\n\nSalvaged partial output from the failed attempts is saved as asset ${recovery.salvagedAssetIds.join(', ')} (open with bakin_exec_assets_open). Use it to determine which deliverables are already partially done and reference it in the subtask descriptions.`
+    : ''
+
+  return `## DECOMPOSITION REQUIRED — DO NOT DO THE WORK
+
+Task "${task.title}" (ID: ${task.id}) has failed ${recovery.deaths} times because the runtime session died mid-attempt${d.oversizedOutput ? ' from oversized chat output' : ''}. Producing everything in one turn does not work. Your ONLY job right now is to split it into subtasks — do NOT produce any deliverable content in this turn.${detailsBlock}${salvageBlock}
+
+Steps:
+1. Identify the distinct deliverables this task requires (a checklist).
+2. Create one subtask per deliverable, in order:
+   \`${mc('bakin_exec_tasks_create', `title="<deliverable>" parentId=${task.id} agent=${agentName} description="Produce <deliverable>. Write it to a file and save it with bakin_exec_assets_save taskId=${task.id} (link assets to the PARENT task so the final review sees them). Keep chat output short."`)}\`
+3. Chain them so they run one at a time: for every subtask after the first, \`${mc('bakin_exec_tasks_set_dependency', 'taskId=<subtask> dependsOn=<previous subtask>')}\`. Then make THIS task wait for the chain: \`${mc('bakin_exec_tasks_set_dependency', `taskId=${task.id} dependsOn=<last subtask>`)}\` — it will re-dispatch automatically for final assembly when the chain completes.
+4. Log what you created: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="Decomposed into N subtasks: <ids>"`)}\`
+5. STOP. Do not start any subtask, do not draft content, do not call tasks_complete.`
+}
+
+/** @internal Exported for testing. */
+export function buildDispatchMessage(
+  task: { id: string; title: string; description?: string; agent?: string; projectId?: string },
+  agentName: string,
+  contentDir: string,
+  mainAgentId = 'main',
+  lessonBlock = '',
+  continuation: DispatchContinuationContext = {},
+  recovery?: SessionDeathState,
+  roster: DispatchRosterAgent[] = [],
+  assetsBlock = '',
+): string {
+  const correctivePrefix = recovery?.stage === 'corrective' ? buildCorrectiveSection(task.id, recovery) : ''
+  const detailsBlock = task.description ? `\n\nDetails:\n${task.description}` : ''
+  const lessonSection = lessonBlock ? `\n\n${lessonBlock}` : ''
+  // Dependency continuations run in a fresh session — the prompt must carry
+  // the completion context the old shared-session resume nudge relied on.
+  const continuationBlock = continuation.completedDependency
+    ? `\n\n## Completed Dependency\nYour dependency task "${continuation.completedDependency.title}" (task ${continuation.completedDependency.id}) is now done. Review its outcome before resuming: \`bakin_exec_tasks_get taskId=${continuation.completedDependency.id}\` shows its log and completion summary, and its saved assets are linked to that task. Continue this task from where it left off.`
+    : ''
+
+  // Project context — lightweight mention if task has a projectId
+  let projectBlock = ''
+  if (task.projectId) {
+    projectBlock = `\n\n**Project:** id ${task.projectId}\nThe project spec may contain detailed requirements. Call bakin_exec_projects_get to read it before starting work.`
+  }
+  const contactsRef = `Reference info is in ${join(contentDir, 'team/CONTACTS.md')}.`
+
+  const { server, mc } = mcporterHelpers(agentName)
+
+  if (!task.agent) {
+    // Roster comes from the live runtime — never a hardcoded agent list
+    // (custom-agent installs broke against baked-in names).
+    const rosterAgents = roster.filter((a) => a.id !== mainAgentId)
+    const rosterText = rosterAgents.length > 0
+      ? ` (${rosterAgents.map((a) => (a.role ? `${a.id}=${a.role}` : a.id)).join(', ')})`
+      : ''
+    return `${correctivePrefix}Triage this task: "${task.title}".${detailsBlock}${continuationBlock}${assetsBlock}${lessonSection}\n\nEither handle it yourself or assign it to the right agent${rosterText} via \`${mc('bakin_exec_tasks_assign', `taskId=${task.id} agent="<agent>"`)}\`. ${contactsRef}\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
+  }
+
+  if (task.agent === mainAgentId) {
+    return `${correctivePrefix}Work on this task: "${task.title}".${detailsBlock}${continuationBlock}${assetsBlock}${lessonSection}\n\n${contactsRef} When done: \`${mc('bakin_exec_tasks_complete', `taskId=${task.id} summary="<what you did>"`)}\`\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
+  }
+
+  return `${correctivePrefix}Work on this task: "${task.title}".${detailsBlock}${continuationBlock}${assetsBlock}${projectBlock}${lessonSection}
+
+## PROGRESS LOGGING — MANDATORY
+
+Log progress at EVERY major step (start, each step, decisions, blockers, completion; at least every 2 minutes). Full logging rules: "Bakin Execution Tools" in your AGENTS.md.
+
+${outputDisciplineSection(agentName, task.id, { subtasksAllowed: true }).join('\n')}
+
+## TASK COMMANDS — via mcporter (server \`${server}\`)
+
+\`\`\`bash
+# Log progress (mandatory, every major step)
+${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<what you did or are doing>"`)}
+
+# Report complete (when finished — includes summary + notifies orchestrator)
+${mc('bakin_exec_tasks_complete', `taskId=${task.id} summary="<what you accomplished>"`)}
+
+# Block task (if stuck or cannot proceed)
+${mc('bakin_exec_tasks_block', `taskId=${task.id} reason="<what went wrong>"`)}
+
+# Create subtask + register dependency (then stop — you'll be re-dispatched)
+${mc('bakin_exec_tasks_create', `title="<subtask>" assignee="<agent>" description="<brief>" parentId=${task.id}`)}
+${mc('bakin_exec_tasks_set_dependency', `taskId=${task.id} dependsOn="<other-task-id>"`)}
+
+# Check your task details
+${mc('bakin_exec_tasks_get', `taskId=${task.id}`)}
+
+${sharedExecutionToolDocs(agentName, task.id, { allowChannelPost: true }).join('\n')}${task.projectId ? `
+
+# Project tools (this task is part of a project)
+${mc('bakin_exec_projects_get', `projectId="${task.projectId}"`)}
+${mc('bakin_exec_projects_mark_item', `projectId="${task.projectId}" taskItemId="<itemId>" checked=true`)}
+${mc('bakin_exec_projects_add_item', `projectId="${task.projectId}" title="<item title>"`)}` : ''}
+\`\`\`
+
+Tool reference + dependency pattern: "Bakin Execution Tools" in your AGENTS.md.`
+}

--- a/src/core/dispatch-types.ts
+++ b/src/core/dispatch-types.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared dispatch types. Pure type/interface declarations extracted from
+ * dispatch.ts so the dispatch modules (prompts, board, context-blocks) and the
+ * fire-path core share one set of definitions without import cycles. No runtime.
+ */
+import type { DispatchFailureKind } from './dispatch-failures'
+
+export type DispatchTask = {
+  id: string
+  title: string
+  agent?: string
+  workflowId?: string
+  description?: string
+  projectId?: string
+  availableAt?: string
+  dependsOn?: string
+  // Origin signals for per-turn model routing (present on the stored task).
+  scheduleJobId?: string
+  parentId?: string | null
+  tags?: string[]
+  log?: Array<{ timestamp: string; message?: string }>
+}
+
+export type DispatchColumns = {
+  backlog: DispatchTask[]
+  todo: DispatchTask[]
+  inProgress: DispatchTask[]
+  review: DispatchTask[]
+  done: DispatchTask[]
+  blocked: DispatchTask[]
+  archived: DispatchTask[]
+}
+
+export type DispatchTaskSnapshot = {
+  column: keyof DispatchColumns
+  task: DispatchTask
+}
+
+export type DispatchEligibilityContext = {
+  nowMs: number
+  runtimeAgentIds: Set<string>
+  completedTaskIds: Set<string>
+  /**
+   * Every task id present on the board, any column. When provided, a
+   * dependsOn pointing at an id that exists nowhere (hard-deleted by
+   * archiveOldTasks) is treated as satisfied instead of stranding the
+   * dependent forever — surfaced via `danglingDependency` so callers log it.
+   */
+  knownTaskIds?: Set<string>
+}
+
+export type DispatchIneligibleReason = 'scheduled' | 'dependency' | 'agent'
+
+export type DispatchEligibility =
+  | { eligible: true; danglingDependency?: string }
+  | { eligible: false; reason: DispatchIneligibleReason }
+
+/** Diagnosis evidence persisted across ladder rungs (salvagedText stripped). */
+export interface SessionDeathDiagnosisLite {
+  reason: string
+  sessionId?: string
+  sessionStatus?: string
+  completionBytes?: number
+  outputTruncated?: boolean
+  oversizedOutput?: boolean
+  lastToolCall?: string
+  detail?: string
+}
+
+/**
+ * Recovery-ladder state for a task whose runtime session died. `stage` is
+ * what the NEXT dispatch of this task must do: 'corrective' injects the
+ * PREVIOUS ATTEMPT FAILED guidance, 'decomposition' replaces the work prompt
+ * with split-into-subtasks instructions. Session deaths are deterministic —
+ * they never enter the generic cooldown/retry loop.
+ */
+export interface SessionDeathState {
+  stage: 'corrective' | 'decomposition'
+  deaths: number
+  lastDiagnosis: SessionDeathDiagnosisLite
+  salvagedAssetIds: string[]
+}
+
+export interface FailureRecord {
+  lastAttempt: number
+  count: number
+  kind: DispatchFailureKind
+  sessionDeath?: SessionDeathState
+}
+
+export interface DispatchState {
+  lastRun: number | null
+  serverStart: number
+  dispatched: string[]
+  failedDispatches: Record<string, FailureRecord>
+  /**
+   * Legacy monotonic per-task dispatch counter. Seq minting moved to the
+   * execution ledger (seq_watermarks seeded from this field once, by the
+   * ledger's v1 migration). Kept read-only in the type so old state files
+   * parse; never written again.
+   */
+  dispatchSeq?: Record<string, number>
+}
+
+export interface DispatchContinuationContext {
+  completedDependency?: { id: string; title: string }
+}
+
+export interface DispatchRosterAgent {
+  id: string
+  role?: string
+}
+
+export interface InFlightTurn {
+  agentId: string
+  taskId: string
+  threadId: string
+  startedAt: number
+  /** Full send + settle chain; resolves when reconciliation has finished. */
+  settled: Promise<void>
+}
+
+export type ConcurrencyGate = 'concurrency_cap' | 'agent_busy' | null

--- a/src/core/dispatch.ts
+++ b/src/core/dispatch.ts
@@ -18,31 +18,79 @@ import { getBootId } from './boot-id'
 import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
 import {
   buildTaskLessonQuery,
-  formatLessonsForDispatch,
-  retrieveAgentPackageLessons,
 } from './agent-packages/lesson-retrieval'
 import {
-  addTaskLog as appendTaskLog,
   blockTask as blockStoredTask,
   moveTask as moveStoredTask,
   readTaskboard,
-  updateTask as updateStoredTask,
 } from './task-store'
 import {
   formatDispatchError,
   classifyDispatchError,
   classifyDispatchFailureDetail,
   formatSanitizedRuntimeFailure,
-  type DispatchFailureKind,
 } from './dispatch-failures'
 
 // Re-export the pure failure-classification surface so `@/core/dispatch`
 // consumers (and the dispatch-error-classification test) keep their import path.
 export { classifyDispatchError, classifyDispatchFailureDetail, formatSanitizedRuntimeFailure }
 
+import type {
+  DispatchTask,
+  DispatchColumns,
+  DispatchEligibility,
+  DispatchIneligibleReason,
+  SessionDeathDiagnosisLite,
+  SessionDeathState,
+  FailureRecord,
+  DispatchState,
+  DispatchContinuationContext,
+  DispatchRosterAgent,
+  InFlightTurn,
+  ConcurrencyGate,
+} from './dispatch-types'
+import {
+  readDispatchColumns,
+  isTaskDispatchEligible,
+  findDispatchTaskSnapshot,
+  taskAlreadyLeftActiveWork,
+  shouldBlockAfterDispatchFailure,
+  addTaskLog,
+  moveTaskToInProgress,
+  tryAddTaskLog,
+} from './dispatch-board'
+import {
+  __resetLessonBlockCache,
+  buildDispatchLessonBlock,
+  buildDispatchAssetBlock,
+} from './dispatch-context-blocks'
+import {
+  mcporterHelpers,
+  sharedExecutionToolDocs,
+  outputDisciplineSection,
+  buildCorrectiveSection,
+  buildDecompositionMessage,
+  buildDispatchMessage,
+} from './dispatch-prompts'
+
+// Re-export the moved public surface so `@/core/dispatch` consumers + tests
+// keep their import paths.
+export type {
+  DispatchEligibility,
+  DispatchIneligibleReason,
+  DispatchContinuationContext,
+  DispatchRosterAgent,
+}
+export {
+  isTaskDispatchEligible,
+  buildDispatchAssetBlock,
+  buildDispatchLessonBlock,
+  __resetLessonBlockCache,
+  buildDispatchMessage,
+}
+
 const log = createLogger('dispatch')
 const hooks = () => getHookRegistry()
-const IMAGE_MCPORTER_TIMEOUT_MS = 600000
 
 /**
  * Task-work sends get a per-dispatch session: a fresh, deterministic
@@ -209,231 +257,6 @@ function auditDispatchSuppressed(contentDir: string, task: { id: string; title: 
   log.warn('Dispatch suppressed — live run already exists', { id: task.id, liveRunId, path })
 }
 
-// Upstream runtime error bodies land in task logs and audit JSONL via
-// the dispatch catch handlers. Bound the blast radius — a runaway adapter
-// response (HTML error page, stack trace, accidental secret echo) should
-// not balloon the audit file or the task drawer.
-
-// Formatted lesson blocks cached per (agentId, query). The query embeds
-// title/description/step instructions, so a workflow step change naturally
-// misses while inProgress re-dispatches of the same step hit — no separate
-// stepId bookkeeping needed. Bounded + TTL'd; empty blocks are cached too so
-// lesson-less agents don't re-query every dispatch.
-const LESSON_BLOCK_CACHE_TTL_MS = 5 * 60_000
-const LESSON_BLOCK_CACHE_MAX = 200
-const lessonBlockCache = new Map<string, { block: string; expires: number }>()
-
-/** @internal Test-only. */
-export function __resetLessonBlockCache(): void {
-  lessonBlockCache.clear()
-}
-
-/** @internal Exported for testing. */
-export async function buildDispatchLessonBlock(input: {
-  contentDir: string
-  taskId: string
-  title: string
-  agentId: string
-  query: string
-}): Promise<string> {
-  const cacheKey = JSON.stringify([input.agentId, input.query])
-  const hit = lessonBlockCache.get(cacheKey)
-  if (hit && hit.expires > Date.now()) return hit.block
-
-  try {
-    const settings = getSettings().agentPackages?.lessonsRetrieval
-    const result = await retrieveAgentPackageLessons({
-      contentDir: input.contentDir,
-      agentId: input.agentId,
-      query: input.query,
-      settings,
-      requireDispatchInjection: true,
-    })
-    const block = formatLessonsForDispatch(
-      result.lessons,
-      settings?.maxCharacters,
-    )
-    lessonBlockCache.set(cacheKey, { block, expires: Date.now() + LESSON_BLOCK_CACHE_TTL_MS })
-    while (lessonBlockCache.size > LESSON_BLOCK_CACHE_MAX) {
-      const oldest = lessonBlockCache.keys().next().value
-      if (oldest === undefined) break
-      lessonBlockCache.delete(oldest)
-    }
-    if (result.lessons.length > 0) {
-      appendAudit(input.contentDir, 'agent_pkg.lessons_retrieved', input.agentId, {
-        taskId: input.taskId,
-        title: input.title,
-        packageId: result.packageId,
-        lessons: result.lessons.map((lesson) => ({
-          lessonId: lesson.lessonId,
-          title: lesson.title,
-          score: lesson.score,
-        })),
-      })
-    }
-    return block
-  } catch (err) {
-    const error = formatDispatchError(err)
-    log.warn('Dispatch lesson retrieval failed', { taskId: input.taskId, agentId: input.agentId, error })
-    appendAudit(input.contentDir, 'agent_pkg.lessons_retrieval_failed', input.agentId, {
-      taskId: input.taskId,
-      title: input.title,
-      error,
-    })
-    return ''
-  }
-}
-
-/** Diagnosis evidence persisted across ladder rungs (salvagedText stripped). */
-interface SessionDeathDiagnosisLite {
-  reason: string
-  sessionId?: string
-  sessionStatus?: string
-  completionBytes?: number
-  outputTruncated?: boolean
-  oversizedOutput?: boolean
-  lastToolCall?: string
-  detail?: string
-}
-
-/**
- * Recovery-ladder state for a task whose runtime session died. `stage` is
- * what the NEXT dispatch of this task must do: 'corrective' injects the
- * PREVIOUS ATTEMPT FAILED guidance, 'decomposition' replaces the work prompt
- * with split-into-subtasks instructions. Session deaths are deterministic —
- * they never enter the generic cooldown/retry loop.
- */
-interface SessionDeathState {
-  stage: 'corrective' | 'decomposition'
-  deaths: number
-  lastDiagnosis: SessionDeathDiagnosisLite
-  salvagedAssetIds: string[]
-}
-
-interface FailureRecord {
-  lastAttempt: number
-  count: number
-  kind: DispatchFailureKind
-  sessionDeath?: SessionDeathState
-}
-
-interface DispatchState {
-  lastRun: number | null
-  serverStart: number
-  dispatched: string[]
-  failedDispatches: Record<string, FailureRecord>
-  /**
-   * Legacy monotonic per-task dispatch counter. Seq minting moved to the
-   * execution ledger (seq_watermarks seeded from this field once, by the
-   * ledger's v1 migration). Kept read-only in the type so old state files
-   * parse; never written again.
-   */
-  dispatchSeq?: Record<string, number>
-}
-
-type DispatchTask = {
-  id: string
-  title: string
-  agent?: string
-  workflowId?: string
-  description?: string
-  projectId?: string
-  availableAt?: string
-  dependsOn?: string
-  // Origin signals for per-turn model routing (present on the stored task).
-  scheduleJobId?: string
-  parentId?: string | null
-  tags?: string[]
-  log?: Array<{ timestamp: string; message?: string }>
-}
-
-type DispatchTaskSnapshot = {
-  column: keyof DispatchColumns
-  task: DispatchTask
-}
-
-type DispatchEligibilityContext = {
-  nowMs: number
-  runtimeAgentIds: Set<string>
-  completedTaskIds: Set<string>
-  /**
-   * Every task id present on the board, any column. When provided, a
-   * dependsOn pointing at an id that exists nowhere (hard-deleted by
-   * archiveOldTasks) is treated as satisfied instead of stranding the
-   * dependent forever — surfaced via `danglingDependency` so callers log it.
-   */
-  knownTaskIds?: Set<string>
-}
-
-export type DispatchIneligibleReason = 'scheduled' | 'dependency' | 'agent'
-
-export type DispatchEligibility =
-  | { eligible: true; danglingDependency?: string }
-  | { eligible: false; reason: DispatchIneligibleReason }
-
-type DispatchColumns = {
-  backlog: DispatchTask[]
-  todo: DispatchTask[]
-  inProgress: DispatchTask[]
-  review: DispatchTask[]
-  done: DispatchTask[]
-  blocked: DispatchTask[]
-  archived: DispatchTask[]
-}
-
-function emptyDispatchColumns(): DispatchColumns {
-  return {
-    backlog: [],
-    todo: [],
-    inProgress: [],
-    review: [],
-    done: [],
-    blocked: [],
-    archived: [],
-  }
-}
-
-async function readDispatchColumns(): Promise<DispatchColumns> {
-  const board = readTaskboard() as unknown as { columns: Partial<DispatchColumns> }
-  return { ...emptyDispatchColumns(), ...(board?.columns ?? {}) }
-}
-
-export function isTaskDispatchEligible(
-  task: DispatchTask,
-  context: DispatchEligibilityContext,
-): DispatchEligibility {
-  if (task.availableAt) {
-    const availableMs = Date.parse(task.availableAt)
-    if (!Number.isNaN(availableMs) && availableMs > context.nowMs) {
-      return { eligible: false, reason: 'scheduled' }
-    }
-  }
-
-  let danglingDependency: string | undefined
-  if (task.dependsOn && !context.completedTaskIds.has(task.dependsOn)) {
-    const targetExists = context.knownTaskIds ? context.knownTaskIds.has(task.dependsOn) : true
-    if (targetExists) {
-      return { eligible: false, reason: 'dependency' }
-    }
-    danglingDependency = task.dependsOn
-  }
-
-  if (task.agent && !context.runtimeAgentIds.has(task.agent)) {
-    return { eligible: false, reason: 'agent' }
-  }
-
-  return { eligible: true, ...(danglingDependency ? { danglingDependency } : {}) }
-}
-
-async function addTaskLog(taskId: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
-  if (data) await appendTaskLog(taskId, author, message, data)
-  else await appendTaskLog(taskId, author, message)
-}
-
-async function moveTaskToInProgress(taskId: string, agent: string): Promise<void> {
-  await updateStoredTask(taskId, { column: 'inProgress', agent })
-}
-
 let dispatching = false
 let dispatchStartedAt = 0
 let dispatchTimer: NodeJS.Timeout | null = null
@@ -481,35 +304,6 @@ function removeDispatchMarkersForTask(
       if (getDispatchMarkerTaskId(marker) === taskId) dispatchedSet.delete(marker)
     }
   }
-}
-
-function findDispatchTaskSnapshot(taskId: string): DispatchTaskSnapshot | null {
-  const { columns } = readTaskboard() as unknown as { columns: DispatchColumns }
-  for (const column of Object.keys(emptyDispatchColumns()) as Array<keyof DispatchColumns>) {
-    const task = columns[column]?.find(t => t.id === taskId)
-    if (task) return { column, task }
-  }
-  return null
-}
-
-function taskAlreadyLeftActiveWork(column: keyof DispatchColumns): boolean {
-  return column === 'done' || column === 'blocked' || column === 'review' || column === 'archived'
-}
-
-async function tryAddTaskLog(taskId: string, author: string, message: string, data?: Record<string, unknown>): Promise<void> {
-  try {
-    if (data) await addTaskLog(taskId, author, message, data)
-    else await addTaskLog(taskId, author, message)
-  } catch (err) {
-    log.warn('Failed to append dispatch reconciliation task log', err, { id: taskId })
-  }
-}
-
-function shouldBlockAfterDispatchFailure(
-  snapshot: DispatchTaskSnapshot,
-  initialLogCount: number,
-): boolean {
-  return (snapshot.task.log?.length ?? 0) > initialLogCount
 }
 
 // How long after a session death before the automatic ladder re-dispatch
@@ -811,15 +605,6 @@ async function reconcileRejectedDispatch(input: {
 // unchanged (in-flight promises die with the process, restart-recovery
 // handles orphaned inProgress tasks via heartbeats).
 
-interface InFlightTurn {
-  agentId: string
-  taskId: string
-  threadId: string
-  startedAt: number
-  /** Full send + settle chain; resolves when reconciliation has finished. */
-  settled: Promise<void>
-}
-
 const inFlightTurns = new Map<string, InFlightTurn>()
 
 export function getInFlightTurnCount(agentId?: string): number {
@@ -830,8 +615,6 @@ export function getInFlightTurnCount(agentId?: string): number {
   }
   return count
 }
-
-export type ConcurrencyGate = 'concurrency_cap' | 'agent_busy' | null
 
 /** Why a dispatch can't fire right now, or null when a slot is free. */
 function concurrencyGate(
@@ -1282,10 +1065,6 @@ export async function clearDispatchMarker(contentDir: string, taskId: string): P
   })
 }
 
-export interface DispatchContinuationContext {
-  completedDependency?: { id: string; title: string }
-}
-
 export async function dispatchSingleTask(
   taskId: string,
   contentDir: string,
@@ -1491,228 +1270,6 @@ export async function dispatchSingleTask(
       },
     })
   })
-}
-
-function mcporterHelpers(agentName: string) {
-  const server = `bakin-${agentName}`
-  return {
-    server,
-    mc: (tool: string, args: string) => `mcporter call ${server}.${tool} ${args}`,
-    mcImage: (tool: string, args: string) => `mcporter call ${server}.${tool} --timeout ${IMAGE_MCPORTER_TIMEOUT_MS} ${args}`,
-  }
-}
-
-/**
- * Shared execution-tool documentation — single source so the regular and
- * workflow prompt builders cannot drift. Intentional differences (e.g.
- * channel posting only for output steps) are explicit parameters.
- */
-function sharedExecutionToolDocs(agentName: string, taskId: string, opts: { allowChannelPost: boolean }): string[] {
-  const { mc, mcImage } = mcporterHelpers(agentName)
-  const lines = [
-    '# Save any file as a managed asset (handles naming + sidecar metadata)',
-    mc('bakin_exec_assets_save', `taskId=${taskId} type=<images|text|video|audio|plans|data|other> filePath="<path>" description="<what it is>"`),
-    '',
-    '# Recommend and generate an image through the core images plugin',
-    mc('bakin_exec_images_recommend', 'surface=instagram-feed-portrait objective="<goal>"'),
-    mcImage('bakin_exec_images_generate', `taskId=${taskId} prompt="<text>" surface=instagram-feed-portrait provider=auto`),
-    '',
-    '# Check workflow gate statuses',
-    mc('bakin_exec_check_gates', `taskId=${taskId}`),
-  ]
-  if (opts.allowChannelPost) {
-    lines.push(
-      '',
-      '# Post to a runtime channel (with optional image/video attachment)',
-      mc('bakin_exec_post_channel', `channel="<name>" content="<message>" taskId=${taskId}`),
-    )
-  }
-  return lines
-}
-
-/**
- * The prevention half of session-death hardening: a short artifact-first
- * reminder injected into EVERY dispatch prompt, carrying the taskId-templated
- * save command. The full rule prose lives in the subagent role-context layer
- * composed into each agent's AGENTS.md managed block (maintained by
- * `bakin agents sync` / doctor) — this inline reminder keeps the
- * safety-critical presence per-dispatch without re-shipping the static
- * catalog every turn.
- */
-function outputDisciplineSection(agentName: string, taskId: string, opts: { subtasksAllowed: boolean }): string[] {
-  const { mc } = mcporterHelpers(agentName)
-  return [
-    '## OUTPUT DISCIPLINE — MANDATORY',
-    '',
-    `Oversized chat output KILLS your runtime session. Deliverables larger than ~8KB go to workspace files, saved as assets ONE AT A TIME: \`${mc('bakin_exec_assets_save', `taskId=${taskId} type=<type> filePath="<path>" description="<what it is>"`)}\``,
-    opts.subtasksAllowed
-      ? 'Keep chat short — status + asset ids only. Numerous independent deliverables → split into subtasks. Full rules: "Bakin Execution Tools" in your AGENTS.md.'
-      : 'Keep chat short — status + asset ids only. Large step output → save as asset, reference the asset id in your submitted output. Full rules: "Bakin Execution Tools" in your AGENTS.md.',
-  ]
-}
-
-/**
- * Corrective guidance injected at the TOP of a re-dispatch prompt after a
- * session death (position primacy — the agent must read this before the
- * task). Explains WHY the previous attempt died and how this one differs.
- */
-function buildCorrectiveSection(taskId: string, recovery: SessionDeathState): string {
-  const d = recovery.lastDiagnosis
-  const sizeLabel = d.completionBytes !== undefined
-    ? `~${Math.round(d.completionBytes / 1024)}KB`
-    : 'too much'
-  const salvageLine = recovery.salvagedAssetIds.length > 0
-    ? `\nA partial copy of that output was salvaged as asset ${recovery.salvagedAssetIds.join(', ')} — open it with bakin_exec_assets_open and REUSE it instead of regenerating from scratch.`
-    : ''
-  return `## PREVIOUS ATTEMPT FAILED — READ FIRST
-Your previous attempt on this task died before completion: ${d.detail ?? `the runtime session ended (${d.sessionStatus ?? d.reason})`}. The session was killed because ${sizeLabel} of output was emitted as chat text instead of being written to files — the runtime cannot deliver responses that large.${salvageLine}
-
-Do this attempt differently:
-- Produce deliverables ONE AT A TIME: write each to a workspace file, then immediately save it: bakin_exec_assets_save taskId=${taskId} type=<type> filePath="<path>" description="<what it is>"
-- Log progress after each save, then move to the next deliverable.
-- Keep every chat/completion message SHORT: status + asset ids only. NEVER put deliverable content in chat output.
-
-`
-}
-
-/**
- * Decomposition dispatch (recovery-ladder rung 2): the agent must NOT do the
- * work — only split it into chained single-deliverable subtasks. Emitting a
- * handful of tool calls is a tiny output, the structural opposite of the
- * failure being recovered from.
- */
-function buildDecompositionMessage(
-  task: { id: string; title: string; description?: string },
-  agentName: string,
-  recovery: SessionDeathState,
-): string {
-  const server = `bakin-${agentName}`
-  const mc = (tool: string, args: string) => `mcporter call ${server}.${tool} ${args}`
-  const d = recovery.lastDiagnosis
-  const detailsBlock = task.description ? `\n\nOriginal task details:\n${task.description}` : ''
-  const salvageBlock = recovery.salvagedAssetIds.length > 0
-    ? `\n\nSalvaged partial output from the failed attempts is saved as asset ${recovery.salvagedAssetIds.join(', ')} (open with bakin_exec_assets_open). Use it to determine which deliverables are already partially done and reference it in the subtask descriptions.`
-    : ''
-
-  return `## DECOMPOSITION REQUIRED — DO NOT DO THE WORK
-
-Task "${task.title}" (ID: ${task.id}) has failed ${recovery.deaths} times because the runtime session died mid-attempt${d.oversizedOutput ? ' from oversized chat output' : ''}. Producing everything in one turn does not work. Your ONLY job right now is to split it into subtasks — do NOT produce any deliverable content in this turn.${detailsBlock}${salvageBlock}
-
-Steps:
-1. Identify the distinct deliverables this task requires (a checklist).
-2. Create one subtask per deliverable, in order:
-   \`${mc('bakin_exec_tasks_create', `title="<deliverable>" parentId=${task.id} agent=${agentName} description="Produce <deliverable>. Write it to a file and save it with bakin_exec_assets_save taskId=${task.id} (link assets to the PARENT task so the final review sees them). Keep chat output short."`)}\`
-3. Chain them so they run one at a time: for every subtask after the first, \`${mc('bakin_exec_tasks_set_dependency', 'taskId=<subtask> dependsOn=<previous subtask>')}\`. Then make THIS task wait for the chain: \`${mc('bakin_exec_tasks_set_dependency', `taskId=${task.id} dependsOn=<last subtask>`)}\` — it will re-dispatch automatically for final assembly when the chain completes.
-4. Log what you created: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="Decomposed into N subtasks: <ids>"`)}\`
-5. STOP. Do not start any subtask, do not draft content, do not call tasks_complete.`
-}
-
-export interface DispatchRosterAgent {
-  id: string
-  role?: string
-}
-
-/**
- * Resolve a task's attached assets via the assets.listByTask hook and render
- * the dispatch block. Async (hook invoke), so call sites compute it before
- * the synchronous message builders and pass the result in. Returns '' when
- * the task has no assets or the assets plugin is unavailable.
- */
-export async function buildDispatchAssetBlock(taskId: string): Promise<string> {
-  try {
-    const assets = await hooks().invoke<Array<{ assetId: string; description?: string; type: string }>>(
-      'assets.listByTask',
-      { taskId },
-    ) ?? []
-    if (assets.length === 0) return ''
-    const lines = assets.map((a) => `- ${a.assetId}${a.description ? ` — ${a.description}` : ''}`)
-    return `\n\n## Attached Assets\nThis task has ${assets.length} linked asset(s). Review them for context before starting:\n${lines.join('\n')}\nOpen with bakin_exec_assets_open using the assetId to read the current content + metadata. AssetIds are stable identity — do not store raw disk paths.`
-  } catch {
-    // Assets plugin not activated (tests, minimal installs) — no block.
-    return ''
-  }
-}
-
-/** @internal Exported for testing. */
-export function buildDispatchMessage(
-  task: { id: string; title: string; description?: string; agent?: string; projectId?: string },
-  agentName: string,
-  contentDir: string,
-  mainAgentId = 'main',
-  lessonBlock = '',
-  continuation: DispatchContinuationContext = {},
-  recovery?: SessionDeathState,
-  roster: DispatchRosterAgent[] = [],
-  assetsBlock = '',
-): string {
-  const correctivePrefix = recovery?.stage === 'corrective' ? buildCorrectiveSection(task.id, recovery) : ''
-  const detailsBlock = task.description ? `\n\nDetails:\n${task.description}` : ''
-  const lessonSection = lessonBlock ? `\n\n${lessonBlock}` : ''
-  // Dependency continuations run in a fresh session — the prompt must carry
-  // the completion context the old shared-session resume nudge relied on.
-  const continuationBlock = continuation.completedDependency
-    ? `\n\n## Completed Dependency\nYour dependency task "${continuation.completedDependency.title}" (task ${continuation.completedDependency.id}) is now done. Review its outcome before resuming: \`bakin_exec_tasks_get taskId=${continuation.completedDependency.id}\` shows its log and completion summary, and its saved assets are linked to that task. Continue this task from where it left off.`
-    : ''
-
-  // Project context — lightweight mention if task has a projectId
-  let projectBlock = ''
-  if (task.projectId) {
-    projectBlock = `\n\n**Project:** id ${task.projectId}\nThe project spec may contain detailed requirements. Call bakin_exec_projects_get to read it before starting work.`
-  }
-  const contactsRef = `Reference info is in ${join(contentDir, 'team/CONTACTS.md')}.`
-
-  const { server, mc } = mcporterHelpers(agentName)
-
-  if (!task.agent) {
-    // Roster comes from the live runtime — never a hardcoded agent list
-    // (custom-agent installs broke against baked-in names).
-    const rosterAgents = roster.filter((a) => a.id !== mainAgentId)
-    const rosterText = rosterAgents.length > 0
-      ? ` (${rosterAgents.map((a) => (a.role ? `${a.id}=${a.role}` : a.id)).join(', ')})`
-      : ''
-    return `${correctivePrefix}Triage this task: "${task.title}".${detailsBlock}${continuationBlock}${assetsBlock}${lessonSection}\n\nEither handle it yourself or assign it to the right agent${rosterText} via \`${mc('bakin_exec_tasks_assign', `taskId=${task.id} agent="<agent>"`)}\`. ${contactsRef}\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
-  }
-
-  if (task.agent === mainAgentId) {
-    return `${correctivePrefix}Work on this task: "${task.title}".${detailsBlock}${continuationBlock}${assetsBlock}${lessonSection}\n\n${contactsRef} When done: \`${mc('bakin_exec_tasks_complete', `taskId=${task.id} summary="<what you did>"`)}\`\n\nLog progress: \`${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<update>"`)}\``
-  }
-
-  return `${correctivePrefix}Work on this task: "${task.title}".${detailsBlock}${continuationBlock}${assetsBlock}${projectBlock}${lessonSection}
-
-## PROGRESS LOGGING — MANDATORY
-
-Log progress at EVERY major step (start, each step, decisions, blockers, completion; at least every 2 minutes). Full logging rules: "Bakin Execution Tools" in your AGENTS.md.
-
-${outputDisciplineSection(agentName, task.id, { subtasksAllowed: true }).join('\n')}
-
-## TASK COMMANDS — via mcporter (server \`${server}\`)
-
-\`\`\`bash
-# Log progress (mandatory, every major step)
-${mc('bakin_exec_tasks_log_progress', `taskId=${task.id} message="<what you did or are doing>"`)}
-
-# Report complete (when finished — includes summary + notifies orchestrator)
-${mc('bakin_exec_tasks_complete', `taskId=${task.id} summary="<what you accomplished>"`)}
-
-# Block task (if stuck or cannot proceed)
-${mc('bakin_exec_tasks_block', `taskId=${task.id} reason="<what went wrong>"`)}
-
-# Create subtask + register dependency (then stop — you'll be re-dispatched)
-${mc('bakin_exec_tasks_create', `title="<subtask>" assignee="<agent>" description="<brief>" parentId=${task.id}`)}
-${mc('bakin_exec_tasks_set_dependency', `taskId=${task.id} dependsOn="<other-task-id>"`)}
-
-# Check your task details
-${mc('bakin_exec_tasks_get', `taskId=${task.id}`)}
-
-${sharedExecutionToolDocs(agentName, task.id, { allowChannelPost: true }).join('\n')}${task.projectId ? `
-
-# Project tools (this task is part of a project)
-${mc('bakin_exec_projects_get', `projectId="${task.projectId}"`)}
-${mc('bakin_exec_projects_mark_item', `projectId="${task.projectId}" taskItemId="<itemId>" checked=true`)}
-${mc('bakin_exec_projects_add_item', `projectId="${task.projectId}" title="<item title>"`)}` : ''}
-\`\`\`
-
-Tool reference + dependency pattern: "Bakin Execution Tools" in your AGENTS.md.`
 }
 
 export function start(contentDir: string, port: number): void {

--- a/tasks/dispatch-phase-b-handoff.md
+++ b/tasks/dispatch-phase-b-handoff.md
@@ -1,0 +1,165 @@
+# Handoff: dispatch.ts Phase B — split the dangerous fire-path core
+
+**For:** Claude on the test machine (live OpenClaw available).
+**Author:** prior session (Phase A author).
+**Spec:** `.claude/specs/audit-2026-06/APPENDIX-cohesion.md` § `src/core/dispatch.ts` (the canonical seam map + risk notes).
+
+This is the **most dangerous refactor in the audit** — `dispatch.ts` is the live, exactly-once
+task-dispatch loop. A subtle mistake here causes **duplicate task fires** or **stuck dispatch** in a
+running system. Treat the verification protocol (§5) as the actual deliverable; the code move is the
+easy part.
+
+---
+
+## 0. Starting state (verify before you begin)
+
+- **PR #513 (Phase A) must be merged.** Confirm `src/core/dispatch.ts` is ~1,652 lines and these
+  siblings already exist: `dispatch-types.ts`, `dispatch-prompts.ts`, `dispatch-board.ts`,
+  `dispatch-context-blocks.ts`, `dispatch-failures.ts`. If not, stop — Phase B builds on them.
+- `git checkout main && git pull` (with #513 merged), then `git checkout -b refactor/dispatch-fire-path`.
+- **Capture a behavioral baseline first** (§5.0) on the UNMODIFIED code, so you can diff Phase B against it.
+- Read the APPENDIX risk notes in full before touching anything.
+
+## 1. What Phase B is
+
+Relocate the remaining fire-path code out of `dispatch.ts` into sibling modules (same pattern Phase A
+used: `dispatch-*.ts` files; `dispatch.ts` imports back + re-exports so `@/core/dispatch` and the
+3 mock-the-path test files are unchanged), preserving behavior **exactly**. Then, as a **separate
+commit after the split verifies**, the `prepareAndFireRegularDispatch` dedup (§6, behavior-touching).
+
+Do NOT do the dedup and the relocation together. Relocation must be a provable no-op.
+
+## 2. Target modules (sibling files; line refs are pre-Phase-A and approximate — find by symbol)
+
+- **`dispatch-state.ts`** — the `.dispatch-state.json` layer. `stateQueue` + `withStateLock`,
+  `getStateFile`/`loadDispatchState`/`saveDispatchState`, `trimDispatched`, dispatch-marker helpers
+  (`getDispatchMarkerTaskId`/`removeDispatchMarkersForTask`), `getFailureRecord`/`cooldownForFailure`,
+  `clearDispatchMarker`. **SOLE owner of the `stateQueue` mutex.** While here, make `saveDispatchState`
+  atomic (temp-then-rename) per the APPENDIX — but do that as its own labeled change, not silently.
+- **`dispatch-turns.ts`** — the concurrent-dispatch engine. `sendDispatchMessage`, `claimDispatchRun`,
+  `auditDispatchSuppressed`, the `InFlightTurn` registry + `getInFlightTurnCount` + `concurrencyGate`,
+  `pendingLadderRedispatches` + `awaitDispatchIdle` + a **new `scheduleLadderRedispatch()` helper**
+  (so the counter is mutated only inside this module), `fireDispatchTurn`, plus the per-turn helpers
+  `resolveDispatchRouting`/`recordTurnCost`/`budgetGate`/`deferForBudget`/`auditBudgetOnce`.
+- **`dispatch-session-death.ts`** — the recovery ladder. `stripSalvage`, `salvageSessionDeathOutput`,
+  `handleSessionDeath`, `reconcileRejectedDispatch`, `shouldBlockAfterDispatchFailure`. **The
+  `dispatchSingleTask` re-dispatch (the setTimeout in `handleSessionDeath`) MUST be injected** (see §3.2).
+- **`dispatch-workflow.ts`** — `dispatchWorkflowTask` + `buildWorkflowDispatchMessage` (each other's
+  only real coupling; keep together).
+- **`dispatch-cycle.ts`** — the periodic cycle. `dispatching`/`dispatchStartedAt`/`dispatchTimer` +
+  `DISPATCH_TIMEOUT_MS`, `dispatchTasks` (the collect-then-fire loop), `start`/`stop`, `getDispatchInfo`.
+- **`dispatch-single.ts`** — `dispatchSingleTask` (kick/subtask/continuation/recovery sources).
+- **`dispatch.ts`** — becomes the thin **barrel**: re-export the full public surface (see §4) from the
+  sibling modules. Keep the existing `export { classifyDispatchError, ... }` and the Phase-A re-exports.
+
+## 3. The hazards (this is where it breaks)
+
+**3.1 The mutex must be a single instance.** Only `dispatch-state.ts` declares `stateQueue` /
+`withStateLock`. EVERY caller (`fireDispatchTurn`'s settle handlers, `dispatchTasks`,
+`dispatchSingleTask`) imports `withStateLock` from `dispatch-state.ts`. If two modules each declare a
+`stateQueue`, the `.dispatch-state.json` lock silently splits and concurrent dispatch double-writes →
+duplicate fires. The settle handlers reload state under `withStateLock` and must share the one lock.
+
+**3.2 The import cycle (session-death ⇄ single).** `handleSessionDeath` schedules `dispatchSingleTask`
+via `setTimeout`; `dispatchSingleTask` → `fireDispatchTurn` → `reconcileRejectedDispatch` →
+`handleSessionDeath`. Break it with a late-bound setter: `dispatch-session-death.ts` exports
+`setRedispatch(fn)` and a module-local `redispatch` var it calls instead of importing
+`dispatchSingleTask` directly. The barrel (`dispatch.ts`) wires it once after all modules load:
+`setRedispatch(dispatchSingleTask)`. (Alternative: pass `dispatchSingleTask` as a param down the call
+chain — messier. The setter is cleaner.) Add a guard so calling `redispatch` before it's wired throws
+a clear error rather than silently no-op'ing.
+
+**3.3 `pendingLadderRedispatches` lives in `dispatch-turns.ts` only.** It's incremented by the ladder
+re-dispatch (today in `handleSessionDeath`) and read by `awaitDispatchIdle`. Move the increment behind
+`scheduleLadderRedispatch()` in `dispatch-turns.ts`; `handleSessionDeath` calls that helper instead of
+touching the counter. If the counter ends up duplicated across modules, `awaitDispatchIdle` drains the
+wrong one and tests/recovery hang or race.
+
+**3.4 Other singletons each in exactly one module:** `dispatching`/`dispatchStartedAt`/`dispatchTimer`
+→ `dispatch-cycle.ts`; `inFlightTurns` → `dispatch-turns.ts`; `lessonBlockCache` already sole-owned by
+`dispatch-context-blocks.ts` (Phase A).
+
+**3.5 Cross-package ledger contract (DO NOT TOUCH).** `packages/core/src/execution/ledger.ts` reads
+`.dispatch-state.json` directly for its seq-watermark migration. The file path and the `dispatchSeq`
+field are a contract — do not rename the file or change its JSON shape.
+
+**3.6 Barrel + mocks.** 3 test files mock the module path (`tests/core/continuation.test.ts` mocks
+BOTH `../../src/core/dispatch` and `@/core/dispatch`; `doctor-delegate.test.ts` and `lifecycle.test.ts`
+mock the relative path). The barrel must stay at `src/core/dispatch.ts`. Internal modules import each
+other **directly** (e.g. `./dispatch-state`), NEVER via the barrel, or you get self-cycles.
+
+**3.7 Consumers that must keep working via the barrel:** `server.ts` namespace-imports the module and
+uses `dispatchTasks`, `getDispatchInfo`, `start`, `loadDispatchState`; watchdog/task-service/etc. import
+named symbols. Grep `from '@/core/dispatch'` and `from '.../dispatch'` and confirm every imported name
+is re-exported.
+
+## 4. Public surface the barrel MUST re-export (grep to confirm none missing)
+
+`start`, `stop`, `dispatchTasks`, `dispatchSingleTask`, `clearDispatchMarker`, `getDispatchInfo`,
+`loadDispatchState`, `isTaskDispatchEligible`, `classifyDispatchError`, `classifyDispatchFailureDetail`,
+`formatSanitizedRuntimeFailure`, `buildDispatchMessage`, `buildDispatchAssetBlock`,
+`buildDispatchLessonBlock`, `__resetLessonBlockCache`, `awaitDispatchIdle`, `getInFlightTurnCount`,
+`budgetGate`, and the types `DispatchEligibility`, `DispatchIneligibleReason`,
+`DispatchContinuationContext`, `DispatchRosterAgent`, `ConcurrencyGate`. (Most types already live in
+`dispatch-types.ts` from Phase A — re-export from there.)
+
+## 5. Verification protocol (the real deliverable)
+
+### 5.0 Baseline (BEFORE any change, on merged-#513 main)
+Run §5.1–5.4 once on the unmodified code and **save the outputs** (ledger row counts, audit event
+sequence, log). Phase B must reproduce these exactly.
+
+### 5.1 Static + suite (after EACH module extraction, not just at the end)
+- `bun run typecheck` clean.
+- `bunx eslint` the touched files clean (trim import-backs that go unused in the barrel).
+- `bun test tests/core/dispatch.test.ts dispatch-error-classification continuation budget task-service
+  restart-recovery watchdog --isolate` green.
+- At the end: full `bun run test` (baseline 5106/0) + `bun run build` (3 binaries; revert the
+  build-stamp files `packages/core/src/generated-version.ts` + `_embedded-assets-static.ts` after).
+
+### 5.2 Live dispatch E2E (the point of this machine — real OpenClaw)
+Use a **throwaway `BAKIN_HOME`** (don't risk the live board) but the **real OpenClaw**:
+```
+BAKIN_HOME=/tmp/phaseb OPENCLAW_HOME=<your live openclaw home> bakin start    # or the built binary
+```
+Then, in another shell (point the CLI at it):
+1. **Single fire, exactly once.** Create a task assigned to a real agent (`bakin tasks create "phase-b smoke" <agent>`). Watch it dispatch and the agent run a turn to completion/settle.
+   - **Ledger check:** open `$BAKIN_HOME/bakin.db` and confirm: exactly ONE run claim for the dispatch attempt (`threadId` = `task:<id>:d<seq>`), exactly ONE completion row, no duplicate-claim rows.
+   - **Audit check:** `$BAKIN_HOME/audit.jsonl` — exactly one `task.dispatched` per attempt; any
+     `*_suppressed` events are legit (a real duplicate would be a bug). The doctor `execution-safety`
+     check (`bakin check execution-safety` if available, or the health page) must be clean.
+2. **Concurrency.** Create several tasks at once across agents. Confirm `settings.dispatch.maxConcurrentTurns` / `maxTurnsPerAgent` are respected and EACH task gets exactly one claim/fire — no double-dispatch under the mutex.
+3. **Session-death → recovery ladder.** Trigger a session death (a task that emits oversized chat output is the natural repro; or kill the agent's turn mid-flight). Confirm the ladder advances **corrective → decomposition → block**, with EXACTLY ONE re-dispatch per rung, `awaitDispatchIdle` drains, and no duplicate fires. This is the cycle/`pendingLadderRedispatches` path — the riskiest part of the split.
+4. **Watchdog supersede.** Let a turn time out; confirm it's superseded (not double-fired).
+5. **Restart recovery.** Stop the server mid-dispatch, restart; confirm the startup sweep marks prior runs lost and re-dispatches each task exactly once (no duplicate from a stale claim).
+
+### 5.3 Diff against baseline
+Every ledger/audit count + the recovery sequence must match the §5.0 baseline. ANY extra fire, missed
+dispatch, or hung `awaitDispatchIdle` = STOP and revert.
+
+## 6. The dedup (separate commit, only after §5 passes clean)
+
+`prepareAndFireRegularDispatch`: extract the ~120 lines copy-pasted between `dispatchTasks` and
+`dispatchSingleTask` — runtime roster + main-agent resolution, `completedTaskIds`/`knownTaskIds` set
+building, eligibility + dangling-dependency logging, failure cooldown/max-retry checks, and the
+claim→lesson→assets→message→move→audit→fire sequence. **This is behavior-touching** — re-run the FULL
+§5.2 live E2E afterward. Note the pre-existing drift the APPENDIX flags: the single path records usage
+via `onSettled`, the workflow-single path records it inline, and the cycle path records none — decide
+to unify or preserve **deliberately** and document the choice. Also fold `buildDecompositionMessage`'s
+local `mc` helper onto `mcporterHelpers` (it re-implements it).
+
+## 7. Rollback / safety
+
+- One commit per module; one commit for the dedup. Revert any single one cleanly.
+- If the live E2E shows a duplicate fire, a missed dispatch, or a recovery hang: **revert and do not
+  ship.** A passing unit suite is necessary but NOT sufficient for this file — the live exactly-once
+  behavior is the gate.
+- PR it as `refactor(dispatch): split fire-path core (Phase B)`; in the body, paste the §5.2 ledger/
+  audit results so the reviewer sees the exactly-once evidence, not just "tests pass".
+
+## 8. Why this is split from Phase A
+
+Phase A (merged, #513) moved only the pure/no-fire-path modules — verifiable by tests + a boot smoke.
+Phase B moves the mutex, the fire loop, the recovery cycle, and the concurrency counters: code where a
+relocation bug doesn't fail a unit test but DOES double-fire a real task. That's why it gets the live
+OpenClaw E2E on real hardware, not just the docker happy-path.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -74,9 +74,13 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   - ☑ Pure module #1: `dispatch-failures.ts` (error classification over RuntimeError/RuntimeTurnError —
     zero state, zero fire-path). dispatch.ts 2,240 → 2,096, re-exports the public classify* surface so
     `@/core/dispatch` consumers + the test are unchanged. typecheck/lint/61-dispatch-tests/full-suite/binary green.
-  - ☐ Pure module #2/#3: prompts (entangled — buildCorrectiveSection needs SessionDeathState; sharedExecutionToolDocs
-    is shared with the workflow builder) and board reads. Doable after the state types are extracted.
-  - ☐ **DANGEROUS modules (dedicated effort, heavy rig dispatch-E2E):** state.ts (the stateQueue mutex),
+  - ☑ Phase A safe modules: `dispatch-types.ts` (14 shared types — the leaf that unblocks the rest),
+    `dispatch-prompts.ts` (pure builders), `dispatch-board.ts` (reads + task-store wrappers),
+    `dispatch-context-blocks.ts` (lessonBlockCache sole owner + lesson/asset blocks). dispatch.ts
+    2,096 → 1,652; re-exports the public surface so consumers + the 3 mock-the-path tests are unchanged;
+    no cycles (modules → dispatch-types only). typecheck/lint/96-tests/full-suite/binary + boot-smoke
+    (Dispatch started clean) green. Fire-path/singleton/cycle core untouched.
+  - ☐ **DANGEROUS modules Phase B (dedicated effort, heavy rig dispatch-E2E):** state.ts (the stateQueue mutex),
     turns.ts (inFlightTurns/pendingLadderRedispatches/fireDispatchTurn), session-death.ts (the cycle),
     cycle.ts (dispatching/timer + dispatchTasks fire loop), single.ts (dispatchSingleTask). Plus the
     behavior-touching dedup (prepareAndFireRegularDispatch) — separate from the relocation.


### PR DESCRIPTION
**Phase A** of finishing the `dispatch.ts` split — the safe, non-fire-path modules.

`dispatch.ts` is the audit's most dangerous file (live exactly-once task dispatch), so the pure
modules come out first and the fire-path / mutex / singleton / cycle core stays **untouched** for a
dedicated Phase B with heavy rig dispatch-E2E.

## Extracted (4 sibling modules, following the merged `dispatch-failures.ts` pattern)
- **`dispatch-types.ts`** (123) — the 14 shared types; a leaf the other modules import from (unblocks
  the rest by breaking type-cycle concerns).
- **`dispatch-prompts.ts`** (210) — pure prompt builders + `IMAGE_MCPORTER_TIMEOUT_MS`.
- **`dispatch-board.ts`** (102) — taskboard reads + policy + the task-store wrappers.
- **`dispatch-context-blocks.ts`** (110) — sole owner of `lessonBlockCache` + lesson/asset blocks.

`dispatch.ts`: **2,096 → 1,652**. Imports back what the core uses and re-exports the public surface,
so every `@/core/dispatch` consumer + the 3 tests that `mock.module` the path are unchanged. No cycles
(new modules import `dispatch-types` only). The fire-path core (`stateQueue` mutex, `fireDispatchTurn`,
`dispatchTasks`/`dispatchSingleTask`, the `handleSessionDeath ⇄ dispatchSingleTask` cycle, the
`dispatching`/`dispatchTimer`/`inFlightTurns`/`pendingLadderRedispatches` singletons) is intact.

## Verification (incl. the rig)
typecheck + lint clean; dispatch/continuation/budget/task-service **96/0**; full suite **5106/0**; full
3-target binary build; **boot smoke** of the built binary — `[dispatch] Dispatch started` cleanly, no
module-load errors from the extracted modules. (Phase A doesn't touch the fire path, so this verifies
wiring; the exactly-once fire-E2E is reserved for Phase B.)

## Next — Phase B (separate, dedicated)
The dangerous core: the `stateQueue` mutex (sole-owner `state.ts`), `turns.ts`
(`fireDispatchTurn`/`inFlightTurns`/`pendingLadderRedispatches`), `session-death.ts` (the cycle, via
DI), `cycle.ts`/`single.ts` (the fire loops), + the `prepareAndFireRegularDispatch` dedup. Gets a
create-task → verify-exactly-once-via-ledger rig E2E before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
