### PR TITLE
refactor(dispatch): dedup the regular fire-path (prepareAndFireRegularDispatch)

### DIFF
--- a/src/core/dispatch-cycle.ts
+++ b/src/core/dispatch-cycle.ts
@@ -9,10 +9,9 @@ import { appendAudit } from './audit'
 import { getSettings } from './settings'
 import { getAppServices } from './app-services'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
-import { loseRun, type ClaimNextRunResult } from './execution-ledger'
+import { loseRun } from './execution-ledger'
 import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
 import { blockTask as blockStoredTask } from './task-store'
-import { buildTaskLessonQuery } from './agent-packages/lesson-retrieval'
 import type { DispatchRosterAgent } from './dispatch-types'
 import {
   withStateLock,
@@ -24,9 +23,8 @@ import {
   trimDispatched,
 } from './dispatch-state'
 import { readDispatchColumns, isTaskDispatchEligible, addTaskLog, moveTaskToInProgress, tryAddTaskLog } from './dispatch-board'
-import { buildDispatchLessonBlock, buildDispatchAssetBlock } from './dispatch-context-blocks'
-import { buildDispatchMessage, buildDecompositionMessage } from './dispatch-prompts'
-import { concurrencyGate, deferForBudget, claimDispatchRun, auditDispatchSuppressed, fireDispatchTurn } from './dispatch-turns'
+import { concurrencyGate, deferForBudget, fireDispatchTurn } from './dispatch-turns'
+import { prepareRegularDispatch } from './dispatch-prepare'
 import { dispatchWorkflowTask } from './dispatch-workflow'
 
 const log = createLogger('dispatch-cycle')
@@ -203,67 +201,37 @@ export async function dispatchTasks(contentDir: string, port: number): Promise<v
         continue
       }
 
-      // Per-task guard: one bad task (store hiccup, hook failure) must not
-      // abort the cycle — collected intents and other tasks still dispatch.
-      let claim: ClaimNextRunResult | null = null
-      try {
-        // Claim FIRST — the ledger run row is the lock; everything after it
-        // is a side effect. A duplicate (overlapping cycle, racing kick,
-        // second process) fails here before any move or send.
-        claim = claimDispatchRun(task.id, targetAgent)
-        if (!claim.claimed) {
-          auditDispatchSuppressed(contentDir, task, targetAgent, claim.liveRunId, 'cycle')
-          continue
-        }
-
-        const lessonBlock = await buildDispatchLessonBlock({
-          contentDir,
-          taskId: task.id,
-          title: task.title,
-          agentId: targetAgent,
-          query: buildTaskLessonQuery(task),
-        })
-        const assetsBlock = await buildDispatchAssetBlock(task.id)
-        const recovery = failure?.sessionDeath
-        const message = recovery?.stage === 'decomposition'
-          ? buildDecompositionMessage(task, targetAgent, recovery)
-          : buildDispatchMessage(task, targetAgent, contentDir, mainAgentId, lessonBlock, {}, recovery, runtimeRoster, assetsBlock)
-        const initialLogCount = task.log?.length ?? 0
-
-        // Move to inProgress BEFORE sending message to eliminate race condition
-        // where fast agents complete before dispatch moves the task
-        await moveTaskToInProgress(task.id, targetAgent)
-
-        const threadId = claim.runId
-        dispatchedSet.add(task.id)
-        // The internal todo→inProgress move is folded into task.dispatched —
-        // one audit row per dispatch, carrying the transition.
-        appendAudit(contentDir, 'task.dispatched', targetAgent, { id: task.id, title: task.title, threadId, from: 'todo', to: 'inProgress' })
-        log.info('Task dispatched', { id: task.id, title: task.title, agent: targetAgent, threadId })
-        pendingTurns.push({
-          marker: task.id,
-          task,
-          targetAgent,
-          threadId,
-          message,
-          contentDir,
-          port,
-          initialLogCount,
-          logPrefix: 'Dispatch failed',
-          dispatchKind: 'regular',
-          // A task carrying a sessionDeath record is a recovery re-dispatch
-          // even on the main cycle (e.g. the ladder's immediate re-dispatch
-          // was lost to a restart or budget-deferred). Route it to the
-          // 'recovery' origin just like dispatchSingleTask(...,'recovery').
-          isRecovery: !!recovery,
-        })
-        pendingByAgent.set(targetAgent, (pendingByAgent.get(targetAgent) ?? 0) + 1)
-      } catch (err) {
-        log.error(`Failed to prepare dispatch for task "${task.title}"`, err, { id: task.id })
-        // A claim whose turn will never fire must be released, or the task
-        // is locked until the watchdog/boot sweep notices.
-        if (claim?.claimed) loseRun(claim.runId, 'dispatch-prep-failed')
+      // Shared prepare: claim → build → move → audit (see prepareRegularDispatch).
+      // A prep failure here must not abort the cycle — collected intents and
+      // other tasks still dispatch. The two-phase fire (collect now, save
+      // once, fire all) is the cycle's own concern, so we COLLECT the returned
+      // turn rather than firing it — and record no per-turn onSettled usage
+      // (deliberate; see dispatch-prepare's header).
+      const prepared = await prepareRegularDispatch({
+        task,
+        targetAgent,
+        contentDir,
+        port,
+        mainAgentId,
+        runtimeRoster,
+        recovery: failure?.sessionDeath,
+        continuation: {},
+        logPrefix: 'Dispatch failed',
+        // A task carrying a sessionDeath record is a recovery re-dispatch even
+        // on the main cycle (e.g. the ladder's immediate re-dispatch was lost
+        // to a restart or budget-deferred). Route it to the 'recovery' origin
+        // just like dispatchSingleTask(...,'recovery').
+        isRecovery: !!failure?.sessionDeath,
+        path: 'cycle',
+      })
+      if (prepared.status === 'suppressed') continue
+      if (prepared.status === 'prep-failed') {
+        log.error(`Failed to prepare dispatch for task "${task.title}"`, prepared.error, { id: task.id })
+        continue
       }
+      dispatchedSet.add(task.id)
+      pendingTurns.push(prepared.turn)
+      pendingByAgent.set(targetAgent, (pendingByAgent.get(targetAgent) ?? 0) + 1)
     }
 
     state.lastRun = Date.now()

--- a/src/core/dispatch-prepare.ts
+++ b/src/core/dispatch-prepare.ts
@@ -1,0 +1,137 @@
+/**
+ * The shared per-task fire preparation for REGULAR (non-workflow) dispatch:
+ * the claim → lesson → assets → message → move → audit sequence that the
+ * periodic cycle (`dispatchTasks`) and immediate single dispatch
+ * (`dispatchSingleTask`) previously ran as two near-identical ~30-line copies.
+ *
+ * The ledger claim is the extraction boundary. Concurrency + budget gating
+ * stays in the callers on purpose — their deferral semantics differ (the cycle
+ * reserves slots for collected-but-unfired turns and defers silently; single
+ * logs a recovery-deferral and reserves nothing). Everything from the claim
+ * onward is identical and lives here.
+ *
+ * The result carries the `fireDispatchTurn` payload WITHOUT `onSettled`, so
+ * each caller keeps its own fire shape:
+ *   - the cycle COLLECTS the payload for its two-phase flow (one batched state
+ *     save, then fire all) and records no per-turn `onSettled` usage;
+ *   - single fires immediately and attaches the `onSettled` dispatch
+ *     duration/status usage entry.
+ * That usage-recording asymmetry is PRESERVED deliberately: `meterAgentTurn`
+ * (inside `fireDispatchTurn`) already records the token/cost usage entry for
+ * EVERY turn on BOTH paths, so the cost metering has no gap. The extra
+ * `name:'dispatch'` duration entry is single-only telemetry, and unifying it
+ * would change the live usage feed — a separate, feed-affecting decision that
+ * does not belong in a behavior-neutral dedup.
+ */
+import { createLogger } from './logger'
+import { appendAudit } from './audit'
+import { loseRun } from './execution-ledger'
+import { buildTaskLessonQuery } from './agent-packages/lesson-retrieval'
+import type { DispatchTask, DispatchRosterAgent, DispatchContinuationContext, SessionDeathState } from './dispatch-types'
+import { buildDispatchLessonBlock, buildDispatchAssetBlock } from './dispatch-context-blocks'
+import { buildDispatchMessage, buildDecompositionMessage } from './dispatch-prompts'
+import { moveTaskToInProgress } from './dispatch-board'
+import { claimDispatchRun, auditDispatchSuppressed, fireDispatchTurn } from './dispatch-turns'
+
+const log = createLogger('dispatch-prepare')
+
+/** The fireDispatchTurn payload minus onSettled — the caller owns the fire. */
+export type PreparedTurn = Omit<Parameters<typeof fireDispatchTurn>[0], 'onSettled'>
+
+export type PrepareRegularDispatchResult =
+  | { status: 'ready'; turn: PreparedTurn }
+  | { status: 'suppressed' }
+  | { status: 'prep-failed'; error: unknown }
+
+/**
+ * Claim a run, build the dispatch message, move the task to inProgress, and
+ * audit `task.dispatched` — the shared regular-dispatch preparation. The
+ * caller must have already cleared the concurrency + budget gates.
+ *
+ * Claim FIRST: the ledger run row is the lock; everything after it is a side
+ * effect, so a duplicate (overlapping cycle, racing kick, second process)
+ * fails at the claim before any build/move/send. On a suppressed claim this
+ * audits `task.dispatch_suppressed` and returns `suppressed`. On a build/move
+ * failure it releases the claim (`loseRun`) — so the caller never leaks a
+ * claim that would lock the task until the watchdog/boot sweep — and returns
+ * `prep-failed`. On success it returns the `fireDispatchTurn` payload for the
+ * caller to collect (cycle) or fire (single).
+ */
+export async function prepareRegularDispatch(input: {
+  task: DispatchTask
+  targetAgent: string
+  contentDir: string
+  port: number
+  mainAgentId: string
+  runtimeRoster: DispatchRosterAgent[]
+  /** The session-death record driving a recovery re-dispatch, if any. */
+  recovery: SessionDeathState | undefined
+  /** Dependency/subtask continuation context ({} for the periodic cycle). */
+  continuation: DispatchContinuationContext
+  /** Log label the fired turn uses on failure. */
+  logPrefix: string
+  /** Route the turn to the 'recovery' origin policy. */
+  isRecovery: boolean
+  /** Which path is dispatching — used only for the suppressed-claim audit. */
+  path: 'cycle' | 'single'
+}): Promise<PrepareRegularDispatchResult> {
+  const { task, targetAgent, contentDir, port, mainAgentId, runtimeRoster, recovery, continuation, logPrefix, isRecovery, path } = input
+
+  // Claim FIRST — the ledger row is the lock (see fn doc).
+  const claim = claimDispatchRun(task.id, targetAgent)
+  if (!claim.claimed) {
+    auditDispatchSuppressed(contentDir, task, targetAgent, claim.liveRunId, path)
+    return { status: 'suppressed' }
+  }
+
+  try {
+    const lessonBlock = await buildDispatchLessonBlock({
+      contentDir,
+      taskId: task.id,
+      title: task.title,
+      agentId: targetAgent,
+      query: buildTaskLessonQuery(task),
+    })
+    const assetsBlock = await buildDispatchAssetBlock(task.id)
+    const message = recovery?.stage === 'decomposition'
+      ? buildDecompositionMessage(task, targetAgent, recovery)
+      : buildDispatchMessage(task, targetAgent, contentDir, mainAgentId, lessonBlock, continuation, recovery, runtimeRoster, assetsBlock)
+    const initialLogCount = task.log?.length ?? 0
+
+    // Move to inProgress BEFORE the turn fires to eliminate the race where a
+    // fast agent completes before dispatch moves the task.
+    await moveTaskToInProgress(task.id, targetAgent)
+
+    const threadId = claim.runId
+    // The internal todo→inProgress move is folded into task.dispatched — one
+    // audit row per dispatch, carrying the transition.
+    appendAudit(contentDir, 'task.dispatched', targetAgent, { id: task.id, title: task.title, threadId, from: 'todo', to: 'inProgress' })
+    log.info('Task dispatched', { id: task.id, title: task.title, agent: targetAgent, threadId, path })
+
+    return {
+      status: 'ready',
+      turn: {
+        marker: task.id,
+        task,
+        targetAgent,
+        threadId,
+        message,
+        contentDir,
+        port,
+        initialLogCount,
+        logPrefix,
+        dispatchKind: 'regular',
+        isRecovery,
+      },
+    }
+  } catch (error) {
+    // A claim whose turn will never fire must be released, or the task is
+    // locked until the watchdog/boot sweep notices it.
+    try {
+      loseRun(claim.runId, 'dispatch-prep-failed')
+    } catch (releaseErr) {
+      log.error('Failed to release claim after prep failure', releaseErr, { threadId: claim.runId })
+    }
+    return { status: 'prep-failed', error }
+  }
+}

--- a/src/core/dispatch-single.ts
+++ b/src/core/dispatch-single.ts
@@ -10,7 +10,6 @@ import { getSettings } from './settings'
 import { getAppServices } from './app-services'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { loseRun } from './execution-ledger'
-import { buildTaskLessonQuery } from './agent-packages/lesson-retrieval'
 import type { DispatchContinuationContext, DispatchRosterAgent } from './dispatch-types'
 import {
   withStateLock,
@@ -21,10 +20,9 @@ import {
   trimDispatched,
 } from './dispatch-state'
 import { readDispatchColumns, isTaskDispatchEligible, addTaskLog, moveTaskToInProgress, tryAddTaskLog } from './dispatch-board'
-import { buildDispatchLessonBlock, buildDispatchAssetBlock } from './dispatch-context-blocks'
-import { buildDispatchMessage, buildDecompositionMessage } from './dispatch-prompts'
 import { formatDispatchError } from './dispatch-failures'
-import { concurrencyGate, deferForBudget, claimDispatchRun, auditDispatchSuppressed, fireDispatchTurn } from './dispatch-turns'
+import { concurrencyGate, deferForBudget, fireDispatchTurn } from './dispatch-turns'
+import { prepareRegularDispatch } from './dispatch-prepare'
 import { dispatchWorkflowTask } from './dispatch-workflow'
 
 const log = createLogger('dispatch-single')
@@ -155,73 +153,57 @@ export async function dispatchSingleTask(
       return
     }
 
-    const lessonBlock = await buildDispatchLessonBlock({
-      contentDir,
-      taskId: task.id,
-      title: task.title,
-      agentId: targetAgent,
-      query: buildTaskLessonQuery(task),
-    })
-    const assetsBlock = await buildDispatchAssetBlock(task.id)
-    const recovery = failure?.sessionDeath
-    const message = recovery?.stage === 'decomposition'
-      ? buildDecompositionMessage(task, targetAgent, recovery)
-      : buildDispatchMessage(task, targetAgent, contentDir, mainAgentId, lessonBlock, continuation, recovery, runtimeRoster, assetsBlock)
-    const dispatchStart = Date.now()
-    const initialLogCount = task.log?.length ?? 0
-
     // Spend ceiling — defer (leave in todo) when a budget cap is hit.
     if (await deferForBudget(targetAgent, contentDir)) {
       log.debug('Single-task dispatch deferred by budget gate', { id: task.id, agent: targetAgent, source })
       return
     }
 
-    // Claim first — the ledger row is the lock (a kick racing the cycle or
-    // another process fails here, before any side effect).
-    const claim = claimDispatchRun(task.id, targetAgent)
-    if (!claim.claimed) {
-      auditDispatchSuppressed(contentDir, task, targetAgent, claim.liveRunId, 'single')
-      return
-    }
+    // Shared prepare: claim → build → move → audit (see prepareRegularDispatch).
+    const dispatchStart = Date.now()
+    const prepared = await prepareRegularDispatch({
+      task,
+      targetAgent,
+      contentDir,
+      port,
+      mainAgentId,
+      runtimeRoster,
+      recovery: failure?.sessionDeath,
+      continuation,
+      logPrefix: 'Immediate dispatch failed',
+      isRecovery: source === 'recovery',
+      path: 'single',
+    })
+    if (prepared.status === 'suppressed') return
+    // A prep failure propagates out of dispatchSingleTask (its callers — kick,
+    // continuation, ladder — handle/log it); the claim was already released.
+    if (prepared.status === 'prep-failed') throw prepared.error
 
-    const threadId = claim.runId
+    const turn = prepared.turn
     try {
-      // Move to inProgress BEFORE sending message to eliminate race condition
-      await moveTaskToInProgress(task.id, targetAgent)
-
+      // Single dispatch persists its dispatched marker per call (the cycle
+      // batches one save for its whole collection). The claim + move are
+      // already durable; this records the advisory bookkeeping.
       state.dispatched.push(task.id)
       trimDispatched(state, settings.dispatch.maxDispatched)
       saveDispatchState(contentDir, state)
     } catch (err) {
       // A claim whose turn will never fire must be released, or the task is
-      // locked until the watchdog/boot sweep notices (mirrors the cycle's
-      // per-task guard).
+      // locked until the watchdog/boot sweep notices.
       try {
-        loseRun(threadId, 'dispatch-prep-failed')
+        loseRun(turn.threadId, 'dispatch-prep-failed')
       } catch (releaseErr) {
-        log.error('Failed to release claim after prep failure', releaseErr, { threadId })
+        log.error('Failed to release claim after state-save failure', releaseErr, { threadId: turn.threadId })
       }
       throw err
     }
 
-    // Internal move folded into task.dispatched — one audit row per dispatch.
-    appendAudit(contentDir, 'task.dispatched', targetAgent, { id: task.id, title: task.title, threadId, from: 'todo', to: 'inProgress' })
     if (source !== 'continuation') {
       appendAudit(contentDir, 'task.kicked', source, { id: task.id, title: task.title })
     }
-    log.info('Single-task dispatch', { id: task.id, title: task.title, agent: targetAgent, source, threadId })
+    log.info('Single-task dispatch', { id: task.id, title: task.title, agent: targetAgent, source, threadId: turn.threadId })
     fireDispatchTurn({
-      marker: task.id,
-      task,
-      targetAgent,
-      threadId,
-      message,
-      contentDir,
-      port,
-      initialLogCount,
-      logPrefix: 'Immediate dispatch failed',
-      dispatchKind: 'regular',
-      isRecovery: source === 'recovery',
+      ...turn,
       onSettled: (outcome, err) => {
         recordUsage({
           kind: 'agent',

--- a/src/core/dispatch-state.ts
+++ b/src/core/dispatch-state.ts
@@ -13,7 +13,7 @@
  * are a cross-package contract (packages/core/src/execution/ledger.ts reads the
  * file directly for its seq-watermark migration) — do not rename or reshape.
  */
-import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, renameSync, existsSync } from 'fs'
 import { join } from 'path'
 import { createLogger } from './logger'
 import type { DispatchState, FailureRecord } from './dispatch-types'
@@ -86,7 +86,17 @@ export function loadDispatchState(contentDir: string): DispatchState {
 }
 
 export function saveDispatchState(contentDir: string, state: DispatchState): void {
-  writeFileSync(getStateFile(contentDir), JSON.stringify(state, null, 2), 'utf-8')
+  // Atomic write: a torn .dispatch-state.json (process killed mid-write) fails
+  // loadDispatchState's JSON.parse and resets ALL dispatch bookkeeping
+  // (dispatched markers + failure records). Write a sibling temp then rename —
+  // rename is atomic on the same filesystem, so a reader (or the ledger's
+  // seq-watermark migration) sees either the old file or the complete new one,
+  // never a partial. The pid suffix avoids collision if a second process ever
+  // races (the server lock refuses that, but defense-in-depth is cheap).
+  const target = getStateFile(contentDir)
+  const tmp = `${target}.${process.pid}.tmp`
+  writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf-8')
+  renameSync(tmp, target)
 }
 
 export async function clearDispatchMarker(contentDir: string, taskId: string): Promise<void> {


### PR DESCRIPTION
Follow-up to #514. The handoff (`tasks/dispatch-phase-b-handoff.md`) flagged one dispatch remainder after the fire-path split: the ~120 lines copy-pasted between `dispatchTasks` (cycle) and `dispatchSingleTask`. Unlike #514 this is **behavior-touching**, so it's its own commit with the deliberate decisions called out below, and the **live exactly-once hammer is its merge gate**.

## What changed
Extracted the duplicated `claim → lesson → assets → message → move → audit` sequence into `src/core/dispatch-prepare.ts` (`prepareRegularDispatch`). Both callers now share one copy (−113 dup lines from the callers; logic lives once in a ~75-line helper).

The **ledger claim is the extraction boundary**. Concurrency + budget gating stays in the callers because their deferral semantics differ (the cycle reserves slots for collected-but-unfired turns and defers silently; single logs a recovery-deferral and reserves nothing). The helper returns the `fireDispatchTurn` payload **without `onSettled`**, so each caller keeps its fire shape: the cycle **collects** for its two-phase batched-save flow; single **fires** immediately.

## Deliberate decisions
- **Usage recording PRESERVED, not unified.** `meterAgentTurn` (inside `fireDispatchTurn`) already records the token/cost usage entry for *every* turn on *both* paths — so there is **no metering gap**. The single-only `name:'dispatch'` duration entry is telemetry; unifying it would change the live usage feed, a separate decision kept out of a behavior-neutral dedup (per the `usage.ts` "single recorder" caution).
- **Single's internal order normalized to the cycle's** (`budget → claim → build`; `task.dispatched` audited before the per-call state save). Behavior-neutral for exactly-once — the claim is the lock. Minor: single's `onSettled` duration now includes message-build time (negligible vs a multi-second turn).
- **Build/move failure now claims-then-releases** (`loseRun`) on both paths (single previously built before claiming) — a harmless lost-row on the rare prep failure, consistent with the cycle.
- **`saveDispatchState` now writes atomically** (temp + rename) — the handoff's deferred item; a torn `.dispatch-state.json` from a mid-write crash can no longer reset dispatch bookkeeping.

## Verification
- typecheck + lint clean; **full suite 5106/0**; all 96 dispatch tests green.
- `prepareRegularDispatch` is exercised by the existing dispatch integration tests — both callers route through it (the 96 green tests cover the ready + suppressed paths, incl. the session-death ladder and concurrency caps).

## ⚠️ Merge gate: the LIVE run
Behavior-touching fire-path change → the bare-metal live-OpenClaw **exactly-once hammer** in `tasks/dispatch-phase-b-handoff.md` is the authoritative gate (single / burst / session-death ladder / watchdog / restart / workflow / soak — each checked for exactly-once via the ledger + audit). Running it now; will post results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)