### PR TITLE
refactor(docs): delete dead legacy OpenAPI generator (-227 lines)

### DIFF
--- a/scripts/docs/generate.ts
+++ b/scripts/docs/generate.ts
@@ -6,18 +6,15 @@ import {
   getApiRoutes,
   getCliCommands,
   externalSourceRoots,
-  listPluginManifests,
   relativeSource,
   renderExecToolsSnippet,
   sourceFiles,
 } from './source-scan'
-import type { ApiRouteContribution } from './source-scan'
 import { dirname, join } from 'node:path'
 import { APP_VERSION } from '../../packages/core/src/constants'
 import { DEFAULT_SETTINGS } from '../../packages/core/src/settings'
 import { CLI_COMMANDS } from '../../src/core/cli/registry'
 import { getAllRoutes } from '../../src/core/api-docs'
-import type { RouteDoc } from '../../src/core/api-docs'
 import { PERMISSION_DESCRIPTIONS, PermissionSchema } from '../../packages/core/src/plugins/permissions'
 
 const repoRoot = new URL('../..', import.meta.url).pathname
@@ -1176,97 +1173,10 @@ function renderCliReference(): string {
 	  return lines.join('\n')
 	}
 
-type OpenApiSchema = Record<string, unknown>
 type OpenApiOperation = Record<string, unknown>
-
-function methodOrder(method: string): number {
-  return ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'].indexOf(method)
-}
 
 function tagOrder(tag: string): string {
   return tag === 'Core' ? '00 Core' : `10 ${tag}`
-}
-
-function openApiPath(path: string): string {
-  return path.replace(/:([A-Za-z0-9_]+)/g, '{$1}')
-}
-
-function operationIdFor(scope: string, method: string, path: string): string {
-  const slug = path
-    .replace(/^\/+/, '')
-    .replace(/:([A-Za-z0-9_]+)/g, 'by-$1')
-    .replace(/[^A-Za-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  return [scope, method.toLowerCase(), slug || 'root']
-    .join('-')
-    .replace(/-+/g, '-')
-}
-
-function pathParameters(path: string, declared: ApiRouteContribution['parameters'] = []): NonNullable<ApiRouteContribution['parameters']> {
-  const declaredByName = new Map(declared.map(param => [`${param.in}:${param.name}`, param]))
-  const params: NonNullable<ApiRouteContribution['parameters']> = []
-  for (const match of path.matchAll(/:([A-Za-z0-9_]+)/g)) {
-    const name = match[1]
-    params.push({
-      name,
-      in: 'path',
-      required: true,
-      schema: { type: 'string' },
-      ...declaredByName.get(`path:${name}`),
-    })
-  }
-  for (const param of declared) {
-    if (param.in !== 'path' || !params.some(existing => existing.name === param.name)) {
-      params.push(param)
-    }
-  }
-  return params
-}
-
-function schemaOrObject(schema: unknown): OpenApiSchema {
-  if (schema && typeof schema === 'object' && !Array.isArray(schema)) return schema as OpenApiSchema
-  return { type: 'object', additionalProperties: true }
-}
-
-function schemaForParamHint(hint: string): OpenApiSchema {
-  const optional = hint.endsWith('?')
-  const normalized = optional ? hint.slice(0, -1) : hint
-  if (normalized.includes('|')) {
-    return { type: 'string', enum: normalized.split('|').filter(Boolean) }
-  }
-  if (normalized === 'boolean') return { type: 'boolean' }
-  if (normalized === 'number') return { type: 'number' }
-  if (normalized === 'integer') return { type: 'integer' }
-  if (normalized === 'object') return { type: 'object', additionalProperties: true }
-  return { type: 'string' }
-}
-
-function schemaFromParamsHint(params?: string): OpenApiSchema | undefined {
-  const trimmed = params?.trim()
-  if (!trimmed || !trimmed.startsWith('{') || !trimmed.endsWith('}')) return undefined
-
-  const properties: Record<string, OpenApiSchema> = {}
-  const required: string[] = []
-  for (const match of trimmed.matchAll(/"([^"]+)"\s*:\s*"([^"]+)"/g)) {
-    const [, name, hint] = match
-    properties[name] = schemaForParamHint(hint)
-    if (!hint.endsWith('?')) required.push(name)
-  }
-  if (Object.keys(properties).length === 0) return undefined
-  return {
-    type: 'object',
-    properties,
-    ...(required.length ? { required } : {}),
-    additionalProperties: false,
-  }
-}
-
-function openApiContent(contentType: string, schema: unknown, example?: unknown): Record<string, unknown> {
-  const content: Record<string, unknown> = {
-    schema: schemaOrObject(schema),
-  }
-  if (example !== undefined) content.example = example
-  return { [contentType]: content }
 }
 
 function isGenericObjectSchema(schema: unknown): boolean {
@@ -1329,143 +1239,6 @@ function curlForOperation(method: string, path: string, operation: OpenApiOperat
     lines.push(`  --data '${JSON.stringify(sample)}'`)
   }
   return lines.join(' \\\n')
-}
-
-function openApiResponses(route: ApiRouteContribution | RouteDoc): Record<string, unknown> {
-  const declared = 'responses' in route ? route.responses : undefined
-  if (declared && Object.keys(declared).length > 0) {
-    return Object.fromEntries(Object.entries(declared).map(([status, response]) => {
-      const out: Record<string, unknown> = { description: response.description }
-      if (response.schema || response.example !== undefined) {
-        out.content = openApiContent(response.contentType ?? 'application/json', response.schema, response.example)
-      }
-      return [status, out]
-    }))
-  }
-  return {
-    200: {
-      description: 'Successful response.',
-      content: openApiContent('application/json', { type: 'object', additionalProperties: true }),
-    },
-    default: {
-      description: 'Error response.',
-      content: openApiContent('application/json', {
-        type: 'object',
-        properties: {
-          error: { type: 'string' },
-        },
-        additionalProperties: true,
-      }),
-    },
-  }
-}
-
-function defaultRequestBody(route: ApiRouteContribution | RouteDoc): Record<string, unknown> | undefined {
-  if (['GET', 'DELETE'].includes(route.method)) return undefined
-  return {
-    description: 'JSON request body. See route handler and examples for accepted fields until this route declares a specific request schema.',
-    required: true,
-    content: openApiContent('application/json', { type: 'object', additionalProperties: true }),
-  }
-}
-
-function routeOperation(route: ApiRouteContribution | RouteDoc, scope: string, fullPath: string, tag: string): OpenApiOperation {
-  const parameters = pathParameters(route.path, 'parameters' in route ? route.parameters : undefined).map(param => {
-    const out: Record<string, unknown> = {
-      name: param.name,
-      in: param.in,
-      required: param.in === 'path' ? true : param.required ?? false,
-      schema: schemaOrObject(param.schema ?? { type: 'string' }),
-    }
-    if (param.description) out.description = param.description
-    if (param.example !== undefined) out.example = param.example
-    return out
-  })
-  const operation: OpenApiOperation = {
-    operationId: ('operationId' in route && route.operationId) ? route.operationId : operationIdFor(scope, route.method, route.path),
-    tags: ('tags' in route && route.tags?.length) ? route.tags : [tag],
-    summary: route.summary,
-    responses: openApiResponses(route),
-    'x-bakin-visibility': route.visibility ?? 'public',
-    'x-bakin-stability': route.stability ?? 'stable',
-  }
-  if (route.description) operation.description = route.description
-  if (parameters.length) operation.parameters = parameters
-  const requestBody = 'requestBody' in route ? route.requestBody : undefined
-  if (requestBody) {
-    operation.requestBody = {
-      description: requestBody.description,
-      required: requestBody.required ?? !['GET', 'DELETE'].includes(route.method),
-      content: openApiContent(requestBody.contentType ?? 'application/json', requestBody.schema, requestBody.example),
-    }
-  } else if ('params' in route && route.params && !route.params.startsWith('?')) {
-    const paramsSchema = schemaFromParamsHint(route.params)
-    operation.requestBody = {
-      description: route.params,
-      required: !['GET', 'DELETE'].includes(route.method),
-      content: openApiContent('application/json', paramsSchema ?? { type: 'object', additionalProperties: true }),
-    }
-  } else {
-    const body = defaultRequestBody(route)
-    if (body) operation.requestBody = body
-  }
-  if (route.permissions?.length) operation.security = [{ pluginPermissions: route.permissions }]
-  operation['x-bakin-full-path'] = fullPath
-  return operation
-}
-
-function allApiDocRoutes(): Array<{ scope: string; tag: string; fullPath: string; route: ApiRouteContribution | RouteDoc; manifestDescription?: string }> {
-  const coreRoutes = getAllRoutes()
-    .filter(r => r.pluginId === 'core')
-    .map(route => ({ scope: 'core', tag: 'Core', fullPath: route.fullPath, route }))
-  const pluginRoutes = listPluginManifests()
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .flatMap(manifest => getApiRoutes(manifest.id).map(route => ({
-      scope: manifest.id,
-      tag: manifest.name,
-      fullPath: `/api/plugins/${manifest.id}${route.path}`,
-      route,
-      manifestDescription: manifest.description,
-    })))
-  return [...coreRoutes, ...pluginRoutes].sort((a, b) =>
-    tagOrder(a.tag).localeCompare(tagOrder(b.tag)) ||
-    a.fullPath.localeCompare(b.fullPath) ||
-    methodOrder(a.route.method) - methodOrder(b.route.method),
-  )
-}
-
-function _buildOpenApiDocument(): Record<string, unknown> {
-  const paths: Record<string, Record<string, unknown>> = {}
-  const tags = new Map<string, string | undefined>()
-  for (const entry of allApiDocRoutes()) {
-    tags.set(entry.tag, entry.manifestDescription)
-    const path = openApiPath(entry.fullPath)
-    paths[path] ??= {}
-    paths[path][entry.route.method.toLowerCase()] = routeOperation(entry.route, entry.scope, entry.fullPath, entry.tag)
-  }
-  return {
-    openapi: '3.1.0',
-    info: {
-      title: 'Bakin API',
-      version: APP_VERSION,
-      description: 'Generated OpenAPI contract for Bakin core and official plugin HTTP routes.',
-    },
-    servers: [
-      { url: 'http://localhost:3737', description: 'Local Bakin server' },
-    ],
-    tags: [...tags.entries()].map(([name, description]) => ({ name, ...(description ? { description } : {}) })),
-    paths,
-    components: {
-      securitySchemes: {
-        pluginPermissions: {
-          type: 'apiKey',
-          in: 'header',
-          name: 'X-Bakin-Plugin-Permission',
-          description: 'Documents plugin permission requirements. The local runtime currently enforces route access through Bakin plugin registration and runtime policy.',
-        },
-      },
-    },
-  }
 }
 
 function renderApiReference(groups: Map<string, Array<{ operationId: string; curl: string }>>): string {

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -89,8 +89,24 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     docker create-task smoke (fire-core runs, no wiring crash). **LIVE exactly-once gate:** the bare-metal
     OpenClaw stress plan in `tasks/dispatch-phase-b-handoff.md` (burst concurrency / session-death ladder /
     restart recovery / soak, all checked for exactly-once via ledger+audit) is the authoritative sign-off.
-  - ☐ **Behavior-touching dedup (separate):** `prepareAndFireRegularDispatch` (the ~120-line
-    dispatchTasks/dispatchSingleTask copy-paste) + the `saveDispatchState` atomic-write — own commit,
-    re-run the full live hammer after.
-- plugin-registry.split — ☐ (high-value sub-item: extract the hook-registry-singleton — breaks a live
-  import cycle; the APPENDIX's "highest-value seam")   server.split — ☐   upgrade.split (remaining) — ☐   runtime.split — ☐
+  - ☑ Behavior-touching dedup: `prepareRegularDispatch` (the dispatchTasks/dispatchSingleTask
+    copy-paste) — done by Mark (#516), live-verified. dispatch.ts split is now COMPLETE end-to-end
+    (Phase A #513 + Phase B fire-core #514 + dedup #516).
+- plugin-registry.split — ☐ (the hook-registry-singleton seam is ALREADY done — WS2/#499; remaining =
+  topo-sort/activation-pipeline dedup + move out of src/lib)   server.split — ☐ (router-table + boot.ts;
+  search-startup/recovery already extracted)   runtime.split — ☐ (adapter, 3,188 lines)
+
+## WS7 — tooling
+
+- docs-generate.split — ◧ IN PROGRESS: `scripts/docs/generate.ts` (2,585) → ~12 lib/ modules + a thin
+  invocation-only entry; delete the dead legacy OpenAPI generator (~215 lines). Pure relocation, byte-for-byte
+  output preserved (gate: `docs:check` + the post-`docs:generate` diff is date-stamp-only). Escaper-consolidation
+  / plugin-list-derivation / CLI-metadata redesigns DEFERRED (output-risk).
+- Remaining WS7: externals contract (build.ts/dev.ts import PLUGIN_CLIENT_EXTERNALS), single CORE_PLUGINS list
+  consolidation (images already added to dev.ts), shared dir-walker.
+
+## WS6 — plugin god-files (not started)
+
+team/index (2,312), workflows/index (2,146) + lib/runtime (1,633), workflow-canvas-editor (1,803),
+models-page (1,205), health-page (1,155), schedule/index (1,443), tasks/index (1,089), asset-service (835)
++ test splits. Includes the workflows validator dedup flagged in #510.


### PR DESCRIPTION
WS7 — first slice of the `scripts/docs/generate.ts` cleanup.

Deletes the **dead legacy OpenAPI generator** from `generate.ts`: `_buildOpenApiDocument` and its
exclusive helper cluster (`allApiDocRoutes`, the standalone `methodOrder` fn, `openApiPath`,
`operationIdFor`, `pathParameters`, `schemaOrObject`, `schemaForParamHint`, `schemaFromParamsHint`,
`openApiContent`, `openApiResponses`, `defaultRequestBody`, `routeOperation`) + the `OpenApiSchema`
type + 3 orphaned imports — **~227 lines**, all verified to have zero live callers. It was superseded
by the typed-route orchestration block (its own comment already said so). The live OpenAPI helpers
(`OpenApiOperation`, `tagOrder`, `isGenericObjectSchema`, `sampleOpenApiValue`, `firstOpenApiContent`,
`curlForOperation`) are kept.

`generate.ts`: 2,585 → 2,358.

## Verification
- **Output-neutral, proven byte-for-byte:** generated tree with the deletion vs with main's generator
  → `diff -rq` is EMPTY across all generated files (`.generated`, the seven mdx/md pages,
  `public/openapi.json`, `public/llms`). (The committed `docs/` are stale, so the gate is
  generate-before == generate-after, not diff-vs-committed.)
- `bun run typecheck` + `bunx eslint scripts/docs/` clean; `docs:validate` (42 pages) +
  `docs:validate:routes` pass. `generate.ts` is a dev/CI script with no test/runtime importers.

## Follow-up
The 12-module relocation of the rest of `generate.ts` (per `APPENDIX-cohesion.md`) is a separate,
pure-mechanical change — best done in-context with per-module commits, gated by the same
generate-before==generate-after snapshot diff. (Also carries the `tasks/plan.md` status correction:
the dispatch split incl. the #516 dedup is now complete.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
