### PR TITLE
refactor(build): single source for core-plugin ids + client externals

### DIFF
--- a/packages/host/build.ts
+++ b/packages/host/build.ts
@@ -11,6 +11,8 @@
  */
 import { rmSync } from 'node:fs'
 
+import { PLUGIN_CLIENT_EXTERNALS } from '../../src/core/whiskit/externals'
+
 const production = process.env.BAKIN_DEV !== '1'
 
 // Always start from a clean dist so stale TC1 outputs don't linger.
@@ -33,24 +35,9 @@ await Bun.build({
   },
   // TD1: externalize React + SDK package aliases so plugins and shell share instances
   // at runtime via the browser import map emitted in TD3. TD2 produces the
-  // vendor bundles that the import map points at.
-  external: [
-    'react',
-    'react-dom',
-    'react-dom/client',
-    'react/jsx-runtime',
-    'react/jsx-dev-runtime',
-    '@tanstack/react-router',
-    '@makinbakin/sdk',
-    '@makinbakin/sdk/ui',
-    '@makinbakin/sdk/hooks',
-    '@makinbakin/sdk/components',
-    '@makinbakin/sdk/slots',
-    '@makinbakin/sdk/types',
-    '@makinbakin/sdk/utils',
-    '@makinbakin/sdk/metadata',
-    '@makinbakin/sdk/routing',
-  ],
+  // vendor bundles that the import map points at. Single source for the contract —
+  // see src/core/whiskit/externals.ts (matches the plugin client bundles exactly).
+  external: [...PLUGIN_CLIENT_EXTERNALS],
 })
 
 console.log('packages/host: built')

--- a/scripts/build-plugins.ts
+++ b/scripts/build-plugins.ts
@@ -15,12 +15,10 @@
  */
 import { buildOnePlugin } from './dev-build-one-plugin'
 import { PLUGIN_CLIENT_EXTERNALS } from '../src/core/whiskit/externals'
+import { CORE_PLUGIN_IDS } from '../src/lib/core-plugin-ids'
 
-const CORE_PLUGINS = [
-  'tasks', 'team', 'memory', 'models',
-  'assets', 'images', 'workflows', 'schedule',
-  'health', 'git',
-]
+// Single source for the core plugin set — see src/lib/core-plugin-ids.ts.
+const CORE_PLUGINS = CORE_PLUGIN_IDS
 
 // Single source for the externals contract — see src/core/whiskit/externals.ts.
 const EXTERNAL = PLUGIN_CLIENT_EXTERNALS

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -58,6 +58,8 @@ import { join, resolve } from 'node:path'
 import chokidar from 'chokidar'
 
 import { broadcastDev, type DevEvent, type DevScope } from '../packages/host/src/api/dev/events'
+import { PLUGIN_CLIENT_EXTERNALS } from '../src/core/whiskit/externals'
+import { CORE_PLUGIN_IDS } from '../src/lib/core-plugin-ids'
 import { buildOnePlugin } from './dev-build-one-plugin'
 import { isBenignTailwindLine } from './dev-log-classifier'
 import { registerDevShutdown } from './dev-shutdown'
@@ -68,21 +70,11 @@ const DEV_CLIENT_ENTRY = join(REPO_ROOT, 'packages/host/src/dev-client/client.ts
 const DEV_CLIENT_OUTDIR = join(REPO_ROOT, 'packages/host/public/__bakin-dev')
 const TAILWIND_BIN = join(REPO_ROOT, 'node_modules/.bin/tailwindcss')
 
-const CORE_PLUGINS = [
-  'tasks', 'team', 'workflows', 'assets', 'images',
-  'schedule', 'memory', 'models', 'health',
-  'git',
-]
+// Single source for the core plugin set — see src/lib/core-plugin-ids.ts.
+const CORE_PLUGINS = CORE_PLUGIN_IDS
 
-const EXTERNAL = [
-  'react', 'react-dom', 'react-dom/client',
-  'react/jsx-runtime', 'react/jsx-dev-runtime',
-  '@tanstack/react-router',
-  '@makinbakin/sdk', '@makinbakin/sdk/ui', '@makinbakin/sdk/hooks',
-  '@makinbakin/sdk/components', '@makinbakin/sdk/slots',
-  '@makinbakin/sdk/types', '@makinbakin/sdk/utils',
-  '@makinbakin/sdk/metadata', '@makinbakin/sdk/routing',
-]
+// Single source for the externals contract — see src/core/whiskit/externals.ts.
+const EXTERNAL = PLUGIN_CLIENT_EXTERNALS
 
 const DEFAULT_PLUGIN_DEV_WATCH = [
   'client.tsx', 'components/**', 'lib/**', '*.ts',

--- a/src/lib/core-plugin-ids.ts
+++ b/src/lib/core-plugin-ids.ts
@@ -1,0 +1,29 @@
+/**
+ * The canonical list of core plugin ids — the 10 plugins under `plugins/<id>/`.
+ *
+ * Single source of truth for the build/dev scripts that need to iterate the
+ * core plugin set (`scripts/build-plugins.ts`, `scripts/dev.ts`). These lists
+ * were previously hand-maintained copies in each script with DIFFERENT orderings;
+ * when `images` was added it had to be threaded into every copy by hand and a
+ * miss silently dropped a plugin from one build path. Owning the list once kills
+ * that drift.
+ *
+ * This is a deliberately lightweight module (a plain string array, no imports)
+ * so build scripts can pull the id list without loading the heavy
+ * `CORE_PLUGIN_IMPORTS` map (which statically imports every plugin module).
+ * An architecture test (`tests/architecture/core-plugin-ids.test.ts`) asserts
+ * this list stays in lockstep with the keys of that map — the actual set the
+ * binary embeds — so the two can never diverge.
+ */
+export const CORE_PLUGIN_IDS: readonly string[] = [
+  'team',
+  'tasks',
+  'memory',
+  'models',
+  'assets',
+  'images',
+  'workflows',
+  'schedule',
+  'health',
+  'git',
+]

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -102,8 +102,15 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   invocation-only entry; delete the dead legacy OpenAPI generator (~215 lines). Pure relocation, byte-for-byte
   output preserved (gate: `docs:check` + the post-`docs:generate` diff is date-stamp-only). Escaper-consolidation
   / plugin-list-derivation / CLI-metadata redesigns DEFERRED (output-risk).
-- Remaining WS7: externals contract (build.ts/dev.ts import PLUGIN_CLIENT_EXTERNALS), single CORE_PLUGINS list
-  consolidation (images already added to dev.ts), shared dir-walker.
+- externals + CORE_PLUGINS consolidation — ☑ New `src/lib/core-plugin-ids.ts` is the single canonical
+  core-plugin id list; `scripts/build-plugins.ts` + `scripts/dev.ts` import it (the two hand-maintained,
+  differently-ordered copies — the source of the dropped-`images` class of bug — are gone). `scripts/dev.ts`
+  + `packages/host/build.ts` now import `PLUGIN_CLIENT_EXTERNALS` instead of inlining byte-identical externals
+  arrays. A pure-scanner architecture test (`tests/architecture/core-plugin-ids.test.ts`) pins the canonical
+  list to BOTH the on-disk `plugins/` dirs AND the `CORE_PLUGIN_IMPORTS` embed-map keys, so the single source
+  can't silently drift from the real set. Verified: typecheck/lint/new-test green + full `build-plugins.ts`
+  (10 plugins) + host `build.ts` smoke.
+- Remaining WS7: shared dir-walker.
 
 ## WS6 — plugin god-files (not started)
 

--- a/tests/architecture/core-plugin-ids.test.ts
+++ b/tests/architecture/core-plugin-ids.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Architecture scan guarding the canonical core-plugin id list
+ * (src/lib/core-plugin-ids.ts) against drift.
+ *
+ * The build/dev scripts (scripts/build-plugins.ts, scripts/dev.ts) used to
+ * each carry a hand-maintained copy of this list in a different order; adding
+ * `images` had to be threaded into every copy and a miss silently dropped a
+ * plugin from one build path. They now all import CORE_PLUGIN_IDS — but a
+ * single source is only safe if it can't silently fall out of sync with the
+ * two things that define the REAL core set:
+ *   1. the plugin directories on disk under plugins/
+ *   2. the keys of CORE_PLUGIN_IMPORTS (src/lib/plugin-static-imports.ts) — the
+ *      map the binary statically imports + embeds.
+ * This test fails if any of the three diverge.
+ *
+ * Pure scanner: imports the zero-dependency CORE_PLUGIN_IDS list and reads the
+ * other two sources as text/dir — imports no heavy app modules.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join } from 'path'
+
+import { CORE_PLUGIN_IDS } from '../../src/lib/core-plugin-ids'
+
+const ROOT = process.cwd()
+const sorted = (xs: readonly string[]) => [...xs].sort()
+
+describe('canonical core-plugin id list', () => {
+  it('matches the plugin directories on disk under plugins/', () => {
+    const dirs = readdirSync(join(ROOT, 'plugins')).filter((name) =>
+      statSync(join(ROOT, 'plugins', name)).isDirectory(),
+    )
+    expect(sorted(CORE_PLUGIN_IDS)).toEqual(sorted(dirs))
+  })
+
+  it('matches the keys of CORE_PLUGIN_IMPORTS (the embedded set)', () => {
+    // Parse the source for `'plugins/<id>':` keys rather than importing the map,
+    // which would statically pull in every plugin module.
+    const src = readFileSync(join(ROOT, 'src/lib/plugin-static-imports.ts'), 'utf-8')
+    const keys = [...src.matchAll(/['"]plugins\/([a-z0-9-]+)['"]\s*:/g)].map((m) => m[1])
+    expect(keys.length).toBeGreaterThan(0)
+    expect(sorted(CORE_PLUGIN_IDS)).toEqual(sorted(keys))
+  })
+})


### PR DESCRIPTION
## What

WS7 tooling consolidation: kill the duplicated core-plugin id lists and the inlined client-externals arrays in the build/dev scripts.

Before this PR:
- `scripts/build-plugins.ts` and `scripts/dev.ts` each hardcoded the 10 core-plugin ids — **in different orders**. This is exactly the drift surface that previously dropped `images` from one build path when it was added (it had to be threaded into every copy by hand).
- `scripts/dev.ts` and `packages/host/build.ts` each inlined their own copy of the client externals array (react + router + the 9 SDK sub-paths) — **byte-identical** to the existing `PLUGIN_CLIENT_EXTERNALS` contract that `scripts/build-plugins.ts` already imports.

## Changes

- **New `src/lib/core-plugin-ids.ts`** — the canonical core-plugin id list. Deliberately zero-dependency (a plain string array, no imports) so build scripts can pull the list without loading the heavy `CORE_PLUGIN_IMPORTS` map (which statically imports every plugin module).
- `scripts/build-plugins.ts` + `scripts/dev.ts` now import `CORE_PLUGIN_IDS`; the two hand-maintained copies are deleted.
- `scripts/dev.ts` + `packages/host/build.ts` now import `PLUGIN_CLIENT_EXTERNALS` from `src/core/whiskit/externals.ts` instead of inlining the arrays.
- **New pure-scanner architecture test** (`tests/architecture/core-plugin-ids.test.ts`) pins `CORE_PLUGIN_IDS` to BOTH the on-disk `plugins/` dirs AND the `CORE_PLUGIN_IMPORTS` embed-map keys — so the single source can never silently drift from the real embedded set. Imports only the zero-dependency list; reads the other two sources as text/dir (no heavy app imports).

## Verification

- `bun run typecheck` clean
- `eslint` clean on all changed files
- new architecture test: 2 pass / 0 fail
- full `bun scripts/build-plugins.ts` — all 10 plugins built (now in the single canonical order)
- host `bun packages/host/build.ts` — shell built with the externalized SDK/React surface

No behavior change — pure build-tooling dedup. `dist/` artifacts are gitignored (no churn); the full-compile build-stamp files were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
