### PR TITLE
refactor(core): split plugin-registry helpers + unify duplicate topo-sorts

### DIFF
--- a/src/lib/plugin-activation-audit.ts
+++ b/src/lib/plugin-activation-audit.ts
@@ -1,0 +1,69 @@
+/**
+ * Plugin activation audit (#142 layer 1).
+ *
+ * Extracted from plugin-registry.ts. On every plugin activation, log the
+ * plugin's requested permissions to ~/.bakin/audit.jsonl AND an info-level
+ * log line, so `jq 'select(.event=="plugin.activate")'` over the audit trail
+ * shows the full surface the user authorized.
+ *
+ * Permission-read failures are tolerated (records empty permissions) —
+ * install/upgrade already validate; a malformed manifest at boot shouldn't
+ * block the server.
+ */
+import { existsSync, readFileSync } from 'fs'
+
+import type { BakinPlugin } from '@bakin/core/plugin-types'
+import type { PluginManifest as PublicPluginManifest } from '@makinbakin/sdk/types'
+
+import { parseManifestPermissions } from '../../packages/core/src/plugins/permissions'
+import { readPluginLockfile } from '../../packages/core/src/plugins/lockfile'
+import { getContentDir } from '../core/content-dir'
+import { createLogger } from '../core/logger'
+import { appendAudit } from '../core/audit'
+
+const log = createLogger('plugin-registry')
+
+export function logPluginActivation(args: {
+  plugin: BakinPlugin
+  source: 'core' | 'user'
+  manifestPath?: string
+  manifest?: PublicPluginManifest
+}): void {
+  const { plugin, source, manifestPath, manifest: embeddedManifest } = args
+  let permissions: string[] = []
+  let resolvedSource: 'core' | 'github' | 'local' = source === 'core' ? 'core' : 'local'
+
+  if (embeddedManifest) {
+    permissions = parseManifestPermissions(embeddedManifest.permissions)
+  } else if (manifestPath && existsSync(manifestPath)) {
+    try {
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>
+      permissions = parseManifestPermissions(manifest.permissions)
+    } catch {
+      // Already validated at install/upgrade — silently keep permissions empty.
+    }
+  }
+
+  if (source === 'user') {
+    try {
+      const entry = readPluginLockfile().plugins[plugin.id]
+      if (entry?.type === 'github') resolvedSource = 'github'
+      else if (entry?.type === 'local') resolvedSource = 'local'
+    } catch {
+      // lockfile read failure — leave as 'local'
+    }
+  }
+
+  log.info('plugin activated', {
+    pluginId: plugin.id,
+    version: plugin.version,
+    permissions,
+    source: resolvedSource,
+  })
+  appendAudit(getContentDir(), 'plugin.activate', 'system', {
+    pluginId: plugin.id,
+    version: plugin.version,
+    permissions,
+    source: resolvedSource,
+  }, 'system')
+}

--- a/src/lib/plugin-console-capture.ts
+++ b/src/lib/plugin-console-capture.ts
@@ -1,0 +1,138 @@
+/**
+ * Plugin console capture + plugin-scoped logging.
+ *
+ * Extracted from plugin-registry.ts. User plugins activate inside
+ * `withCapturedPluginConsole`, which patches `console.*` so a plugin's stray
+ * `console.log` is routed through the structured logger tagged with its id
+ * instead of leaking raw to stdout. `createPluginScopedLogger` is the
+ * structured logger handed to each plugin's `ctx.log`.
+ *
+ * The capture context is `AsyncLocalStorage`-backed so the patch only affects
+ * console calls made within a given plugin's activation, not unrelated async
+ * work interleaved on the event loop.
+ */
+import { AsyncLocalStorage } from 'async_hooks'
+import { inspect } from 'util'
+
+import { createLogger } from '../core/logger'
+
+const log = createLogger('plugin-registry')
+
+type CapturedConsoleLevel = 'debug' | 'error' | 'info' | 'warn'
+type CapturedConsoleMethod = CapturedConsoleLevel | 'log'
+interface CapturedConsoleContext {
+  pluginId: string
+}
+
+const capturedConsoleContext = new AsyncLocalStorage<CapturedConsoleContext | undefined>()
+
+function withoutCapturedPluginConsole<T>(action: () => T): T {
+  return capturedConsoleContext.run(undefined, action)
+}
+
+function stripPluginConsolePrefix(pluginId: string, message: string): string {
+  const escaped = pluginId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return message.replace(new RegExp(`^\\[${escaped}\\]\\s*`), '')
+}
+
+function formatPluginConsoleArgs(pluginId: string, args: unknown[]): string {
+  return stripPluginConsolePrefix(
+    pluginId,
+    args.map((arg) => {
+      if (typeof arg === 'string') return arg
+      return inspect(arg, { breakLength: Infinity, colors: false, compact: true, depth: 5 })
+    }).join(' '),
+  ).trim()
+}
+
+export async function withCapturedPluginConsole<T>(pluginId: string, action: () => Promise<T> | T): Promise<T> {
+  const original: Record<CapturedConsoleMethod, (...args: unknown[]) => void> = {
+    debug: console.debug.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+  }
+
+  const restore = () => {
+    console.debug = original.debug as typeof console.debug
+    console.error = original.error as typeof console.error
+    console.info = original.info as typeof console.info
+    console.log = original.log as typeof console.log
+    console.warn = original.warn as typeof console.warn
+  }
+
+  const install = () => {
+    console.debug = ((...args: unknown[]) => emit('debug', 'debug', args)) as typeof console.debug
+    console.error = ((...args: unknown[]) => emit('error', 'error', args)) as typeof console.error
+    console.info = ((...args: unknown[]) => emit('info', 'info', args)) as typeof console.info
+    console.log = ((...args: unknown[]) => emit('info', 'log', args)) as typeof console.log
+    console.warn = ((...args: unknown[]) => emit('warn', 'warn', args)) as typeof console.warn
+  }
+
+  const emit = (level: CapturedConsoleLevel, method: CapturedConsoleMethod, args: unknown[]) => {
+    const context = capturedConsoleContext.getStore()
+    if (!context) {
+      original[method](...args)
+      return
+    }
+
+    const message = formatPluginConsoleArgs(context.pluginId, args)
+    if (!message) return
+
+    // createLogger writes through console.*. Clear the plugin context while
+    // forwarding so the rendered logger line is not captured recursively.
+    withoutCapturedPluginConsole(() => {
+      const data = { source: 'plugin', pluginId: context.pluginId, console: true }
+      if (level === 'debug') log.debug(message, data)
+      else if (level === 'error') log.error(message, data)
+      else if (level === 'warn') log.warn(message, data)
+      else log.info(message, data)
+    })
+  }
+
+  install()
+  try {
+    return await capturedConsoleContext.run({ pluginId }, action)
+  } finally {
+    restore()
+  }
+}
+
+function withPluginLogData(pluginId: string, data?: unknown): Record<string, unknown> {
+  return {
+    ...(data && typeof data === 'object' && !Array.isArray(data) ? data as Record<string, unknown> : {}),
+    source: 'plugin',
+    pluginId,
+  }
+}
+
+export function createPluginScopedLogger(pluginId: string) {
+  const pluginLog = createLogger(`plugin:${pluginId}`)
+  return {
+    debug: (message: string, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => pluginLog.debug(message, withPluginLogData(pluginId, data)))
+    },
+    info: (message: string, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => pluginLog.info(message, withPluginLogData(pluginId, data)))
+    },
+    warn: (message: string, errorOrData?: unknown, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => {
+        if (errorOrData instanceof Error || typeof errorOrData === 'string') {
+          pluginLog.warn(message, errorOrData, withPluginLogData(pluginId, data))
+        } else {
+          pluginLog.warn(message, withPluginLogData(pluginId, errorOrData))
+        }
+      })
+    },
+    error: (message: string, errorOrData?: unknown, data?: Record<string, unknown>) => {
+      withoutCapturedPluginConsole(() => {
+        if (errorOrData instanceof Error || typeof errorOrData === 'string') {
+          pluginLog.error(message, errorOrData, withPluginLogData(pluginId, data))
+        } else {
+          pluginLog.error(message, withPluginLogData(pluginId, errorOrData))
+        }
+      })
+    },
+  }
+}

--- a/src/lib/plugin-registry-types.ts
+++ b/src/lib/plugin-registry-types.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared types for the server-side plugin registry.
+ *
+ * Extracted from plugin-registry.ts (the public barrel) so the registry
+ * implementation, the topological sort, and the activation helpers can share
+ * one definition without the file owning every concern. plugin-registry.ts
+ * re-exports `CorePluginRegistration` to keep its public surface unchanged.
+ */
+import type {
+  BakinPlugin,
+  PluginContext,
+  NavItem,
+  APIRoute,
+  UISlotRegistration,
+} from '@bakin/core/plugin-types'
+import type { PluginManifest as PublicPluginManifest } from '@makinbakin/sdk/types'
+
+/**
+ * One entry in the static core-plugin table that `server.ts` registers via
+ * `registerCorePlugins` on startup — this is what lets `bun build --compile`
+ * trace each plugin's module graph from the entry point.
+ */
+export interface CorePluginRegistration {
+  plugin: BakinPlugin
+  manifest: PublicPluginManifest
+}
+
+export interface PluginState {
+  plugin: BakinPlugin
+  manifest?: PublicPluginManifest
+  source: 'core' | 'user'
+  description: string
+  navItems: NavItem[]
+  routes: APIRoute[]
+  slots: UISlotRegistration[]
+  watchPatterns: string[]
+  /** Namespaced workflow node kinds registered via ctx.registerNodeType. */
+  nodeKinds: string[]
+  /** Namespaced notification channel ids registered via ctx.registerNotificationChannel. */
+  channelIds: string[]
+  /** Namespaced health check ids registered via ctx.registerHealthCheck. */
+  healthCheckIds: string[]
+  /** Cached PluginContext — handed to onUninstall during plugin remove (#119). */
+  ctx?: PluginContext
+}
+
+export interface PluginFailureState {
+  id: string
+  name: string
+  version: string
+  description: string
+  source: 'built-in' | 'user'
+  errorCode: 'manifest_invalid' | 'missing_dependency' | 'dependency_cycle' | 'dependency_failed' | 'activation_failed'
+  errorMessage: string
+  missingDependencies?: string[]
+}
+
+export interface PluginLoadEntry {
+  path: string
+  id: string
+  deps: string[]
+  manifest?: PublicPluginManifest
+}

--- a/src/lib/plugin-registry.ts
+++ b/src/lib/plugin-registry.ts
@@ -2,7 +2,6 @@
  * Server-side plugin registry singleton.
  * Loads plugins, stores their registrations, and provides lookups.
  */
-import { AsyncLocalStorage } from 'async_hooks'
 import {
   existsSync,
   readFileSync,
@@ -10,7 +9,6 @@ import {
   statSync,
 } from 'fs'
 import { join } from 'path'
-import { inspect } from 'util'
 import type {
   BakinConfig,
   BakinPlugin,
@@ -47,13 +45,11 @@ import { addExecTool, removeExecToolsByPlugin } from '../core/exec-tools/registr
 import { runMigrations } from '../core/migrations'
 import { getContentDir } from '../core/content-dir'
 import { createLogger } from '../core/logger'
-import { appendAudit } from '../core/audit'
 import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
 import { getPluginSkills as skillRegistry, clearPluginSkills, removePluginSkillsByPlugin } from '@bakin/core/skills/plugin-skill-registry'
 import { getContentTypes, purgeContentType } from '../core/search-registry'
 import { loadPluginSkills } from './plugin-skill-loader'
 import { setCorePluginCheck, readPluginLockfile } from '../../packages/core/src/plugins/lockfile'
-import { parseManifestPermissions } from '../../packages/core/src/plugins/permissions'
 import {
   PluginManifestError,
   readPluginManifestJson,
@@ -62,6 +58,19 @@ import { getAppServices } from '../core/app-services'
 import type { PluginManifest as PublicPluginManifest } from '@makinbakin/sdk/types'
 import { buildPluginContext, type PluginContextRegistrars } from './plugin-context-factory'
 import { startStartupSpan } from '../core/startup-diagnostics'
+import type {
+  CorePluginRegistration,
+  PluginState,
+  PluginFailureState,
+  PluginLoadEntry,
+} from './plugin-registry-types'
+import { withCapturedPluginConsole, createPluginScopedLogger } from './plugin-console-capture'
+import { logPluginActivation } from './plugin-activation-audit'
+import { topologicalSortPlugins } from './plugin-topo-sort'
+
+// Re-exported so `@/lib/plugin-registry` consumers (server.ts) keep their
+// import path for the static core-plugin table's element type.
+export type { CorePluginRegistration } from './plugin-registry-types'
 
 /**
  * Optional static core-plugin table. Set from server.ts on startup so
@@ -72,11 +81,6 @@ import { startStartupSpan } from '../core/startup-diagnostics'
  *
  * Shape: { 'plugins/team': { plugin: BakinPluginInstance, manifest }, ... }
  */
-export interface CorePluginRegistration {
-  plugin: BakinPlugin
-  manifest: PublicPluginManifest
-}
-
 let corePluginTable: Readonly<Record<string, CorePluginRegistration>> = {}
 export function registerCorePlugins(table: Readonly<Record<string, CorePluginRegistration>>): void {
   for (const { plugin } of Object.values(corePluginTable)) {
@@ -96,124 +100,9 @@ export function registerCorePlugins(table: Readonly<Record<string, CorePluginReg
 }
 
 const log = createLogger('plugin-registry')
-type CapturedConsoleLevel = 'debug' | 'error' | 'info' | 'warn'
-type CapturedConsoleMethod = CapturedConsoleLevel | 'log'
-interface CapturedConsoleContext {
-  pluginId: string
-}
 
-const capturedConsoleContext = new AsyncLocalStorage<CapturedConsoleContext | undefined>()
-
-function withoutCapturedPluginConsole<T>(action: () => T): T {
-  return capturedConsoleContext.run(undefined, action)
-}
-
-function stripPluginConsolePrefix(pluginId: string, message: string): string {
-  const escaped = pluginId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return message.replace(new RegExp(`^\\[${escaped}\\]\\s*`), '')
-}
-
-function formatPluginConsoleArgs(pluginId: string, args: unknown[]): string {
-  return stripPluginConsolePrefix(
-    pluginId,
-    args.map((arg) => {
-      if (typeof arg === 'string') return arg
-      return inspect(arg, { breakLength: Infinity, colors: false, compact: true, depth: 5 })
-    }).join(' '),
-  ).trim()
-}
-
-async function withCapturedPluginConsole<T>(pluginId: string, action: () => Promise<T> | T): Promise<T> {
-  const original: Record<CapturedConsoleMethod, (...args: unknown[]) => void> = {
-    debug: console.debug.bind(console),
-    error: console.error.bind(console),
-    info: console.info.bind(console),
-    log: console.log.bind(console),
-    warn: console.warn.bind(console),
-  }
-
-  const restore = () => {
-    console.debug = original.debug as typeof console.debug
-    console.error = original.error as typeof console.error
-    console.info = original.info as typeof console.info
-    console.log = original.log as typeof console.log
-    console.warn = original.warn as typeof console.warn
-  }
-
-  const install = () => {
-    console.debug = ((...args: unknown[]) => emit('debug', 'debug', args)) as typeof console.debug
-    console.error = ((...args: unknown[]) => emit('error', 'error', args)) as typeof console.error
-    console.info = ((...args: unknown[]) => emit('info', 'info', args)) as typeof console.info
-    console.log = ((...args: unknown[]) => emit('info', 'log', args)) as typeof console.log
-    console.warn = ((...args: unknown[]) => emit('warn', 'warn', args)) as typeof console.warn
-  }
-
-  const emit = (level: CapturedConsoleLevel, method: CapturedConsoleMethod, args: unknown[]) => {
-    const context = capturedConsoleContext.getStore()
-    if (!context) {
-      original[method](...args)
-      return
-    }
-
-    const message = formatPluginConsoleArgs(context.pluginId, args)
-    if (!message) return
-
-    // createLogger writes through console.*. Clear the plugin context while
-    // forwarding so the rendered logger line is not captured recursively.
-    withoutCapturedPluginConsole(() => {
-      const data = { source: 'plugin', pluginId: context.pluginId, console: true }
-      if (level === 'debug') log.debug(message, data)
-      else if (level === 'error') log.error(message, data)
-      else if (level === 'warn') log.warn(message, data)
-      else log.info(message, data)
-    })
-  }
-
-  install()
-  try {
-    return await capturedConsoleContext.run({ pluginId }, action)
-  } finally {
-    restore()
-  }
-}
-
-function withPluginLogData(pluginId: string, data?: unknown): Record<string, unknown> {
-  return {
-    ...(data && typeof data === 'object' && !Array.isArray(data) ? data as Record<string, unknown> : {}),
-    source: 'plugin',
-    pluginId,
-  }
-}
-
-function createPluginScopedLogger(pluginId: string) {
-  const pluginLog = createLogger(`plugin:${pluginId}`)
-  return {
-    debug: (message: string, data?: Record<string, unknown>) => {
-      withoutCapturedPluginConsole(() => pluginLog.debug(message, withPluginLogData(pluginId, data)))
-    },
-    info: (message: string, data?: Record<string, unknown>) => {
-      withoutCapturedPluginConsole(() => pluginLog.info(message, withPluginLogData(pluginId, data)))
-    },
-    warn: (message: string, errorOrData?: unknown, data?: Record<string, unknown>) => {
-      withoutCapturedPluginConsole(() => {
-        if (errorOrData instanceof Error || typeof errorOrData === 'string') {
-          pluginLog.warn(message, errorOrData, withPluginLogData(pluginId, data))
-        } else {
-          pluginLog.warn(message, withPluginLogData(pluginId, errorOrData))
-        }
-      })
-    },
-    error: (message: string, errorOrData?: unknown, data?: Record<string, unknown>) => {
-      withoutCapturedPluginConsole(() => {
-        if (errorOrData instanceof Error || typeof errorOrData === 'string') {
-          pluginLog.error(message, errorOrData, withPluginLogData(pluginId, data))
-        } else {
-          pluginLog.error(message, withPluginLogData(pluginId, errorOrData))
-        }
-      })
-    },
-  }
-}
+// Plugin console capture + plugin-scoped logging now live in
+// ./plugin-console-capture (withCapturedPluginConsole / createPluginScopedLogger).
 
 function resolveAppServices(services?: AppServices): AppServices {
   return services ?? getAppServices()
@@ -256,95 +145,10 @@ export function isCorePlugin(pluginId: string): boolean {
 // setter at boot.
 setCorePluginCheck(isCorePlugin)
 
-/**
- * #142 layer 1 — log a plugin's requested permissions on activation.
- * Appends to ~/.bakin/audit.jsonl AND emits an info-level log line.
- *
- * Permission failures are tolerated here (returns []) — install/upgrade
- * already validate; a malformed manifest at boot shouldn't block the
- * server. The audit entry just records `(requests: ?)` in that case.
- */
-function logPluginActivation(args: {
-  plugin: BakinPlugin
-  source: 'core' | 'user'
-  manifestPath?: string
-  manifest?: PublicPluginManifest
-}): void {
-  const { plugin, source, manifestPath, manifest: embeddedManifest } = args
-  let permissions: string[] = []
-  let resolvedSource: 'core' | 'github' | 'local' = source === 'core' ? 'core' : 'local'
-
-  if (embeddedManifest) {
-    permissions = parseManifestPermissions(embeddedManifest.permissions)
-  } else if (manifestPath && existsSync(manifestPath)) {
-    try {
-      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as Record<string, unknown>
-      permissions = parseManifestPermissions(manifest.permissions)
-    } catch {
-      // Already validated at install/upgrade — silently keep permissions empty.
-    }
-  }
-
-  if (source === 'user') {
-    try {
-      const entry = readPluginLockfile().plugins[plugin.id]
-      if (entry?.type === 'github') resolvedSource = 'github'
-      else if (entry?.type === 'local') resolvedSource = 'local'
-    } catch {
-      // lockfile read failure — leave as 'local'
-    }
-  }
-
-  log.info('plugin activated', {
-    pluginId: plugin.id,
-    version: plugin.version,
-    permissions,
-    source: resolvedSource,
-  })
-  appendAudit(getContentDir(), 'plugin.activate', 'system', {
-    pluginId: plugin.id,
-    version: plugin.version,
-    permissions,
-    source: resolvedSource,
-  }, 'system')
-}
-
-interface PluginState {
-  plugin: BakinPlugin
-  manifest?: PublicPluginManifest
-  source: 'core' | 'user'
-  description: string
-  navItems: NavItem[]
-  routes: APIRoute[]
-  slots: UISlotRegistration[]
-  watchPatterns: string[]
-  /** Namespaced workflow node kinds registered via ctx.registerNodeType. */
-  nodeKinds: string[]
-  /** Namespaced notification channel ids registered via ctx.registerNotificationChannel. */
-  channelIds: string[]
-  /** Namespaced health check ids registered via ctx.registerHealthCheck. */
-  healthCheckIds: string[]
-  /** Cached PluginContext — handed to onUninstall during plugin remove (#119). */
-  ctx?: PluginContext
-}
-
-interface PluginFailureState {
-  id: string
-  name: string
-  version: string
-  description: string
-  source: 'built-in' | 'user'
-  errorCode: 'manifest_invalid' | 'missing_dependency' | 'dependency_cycle' | 'dependency_failed' | 'activation_failed'
-  errorMessage: string
-  missingDependencies?: string[]
-}
-
-interface PluginLoadEntry {
-  path: string
-  id: string
-  deps: string[]
-  manifest?: PublicPluginManifest
-}
+// logPluginActivation (#142 layer 1 — audit a plugin's requested permissions on
+// activation) now lives in ./plugin-activation-audit.
+// PluginState / PluginFailureState / PluginLoadEntry now live in
+// ./plugin-registry-types.
 
 /** Slug a workflow definition `name` into a stable id when no `id` is supplied. */
 function slugifyWorkflowId(name: string): string {
@@ -459,117 +263,35 @@ class PluginRegistryImpl {
     }
   }
 
+  /**
+   * Core-plugin activation order. A missing dependency FAILS the dependent
+   * (core deps must all be present), and a detected cycle is logged.
+   */
   private topologicalSort(entries: PluginLoadEntry[]): PluginLoadEntry[] {
-    const byId = new Map(entries.map(e => [e.id, e]))
-    const inDegree = new Map<string, number>()
-    const dependents = new Map<string, string[]>()
-
-    for (const e of entries) {
-      inDegree.set(e.id, 0)
-      dependents.set(e.id, [])
-    }
-
-    for (const e of entries) {
-      for (const dep of e.deps) {
-        if (!byId.has(dep)) {
-          this.markPluginFailed({
-            id: e.id,
-            name: e.manifest?.name ?? e.id,
-            version: e.manifest?.version ?? '0.0.0',
-            description: e.manifest?.description ?? '',
-            source: 'built-in',
-            errorCode: 'missing_dependency',
-            errorMessage: `Missing dependency: ${dep}`,
-            missingDependencies: [dep],
-          })
-          continue
-        }
-        inDegree.set(e.id, (inDegree.get(e.id) || 0) + 1)
-        dependents.get(dep)!.push(e.id)
-      }
-    }
-
-    // Start with nodes that have no dependencies
-    const queue = entries.filter(e => inDegree.get(e.id) === 0).map(e => e.id)
-    const result: PluginLoadEntry[] = []
-
-    while (queue.length > 0) {
-      const id = queue.shift()!
-      result.push(byId.get(id)!)
-      for (const dep of dependents.get(id) || []) {
-        const deg = (inDegree.get(dep) || 1) - 1
-        inDegree.set(dep, deg)
-        if (deg === 0) queue.push(dep)
-      }
-    }
-
-    // Detect cycles — any entries not in result have circular deps
-    if (result.length < entries.length) {
-      const missing = entries.filter(e => !result.find(r => r.id === e.id))
-      const cycle = missing.map(e => e.id).join(' ↔ ')
-      log.error(`Circular plugin dependencies detected: ${cycle}`)
-      for (const entry of missing) {
-        this.markPluginFailed({
-          id: entry.id,
-          name: entry.manifest?.name ?? entry.id,
-          version: entry.manifest?.version ?? '0.0.0',
-          description: entry.manifest?.description ?? '',
-          source: 'built-in',
-          errorCode: 'dependency_cycle',
-          errorMessage: `Circular plugin dependency detected: ${cycle}`,
-        })
-      }
-    }
-
-    return result.filter(entry => !this.failedPlugins.has(entry.id))
+    return topologicalSortPlugins(
+      entries,
+      { source: 'built-in', failOnMissingDep: true, logCycle: true },
+      {
+        markFailed: (failure) => this.markPluginFailed(failure),
+        isFailed: (id) => this.failedPlugins.has(id),
+      },
+    )
   }
 
+  /**
+   * User-plugin activation order. loadUserPlugins has already pruned missing
+   * dependencies (passing only intra-user deps), so a missing edge is skipped
+   * silently here; only cycles fail.
+   */
   private topologicalSortUserPlugins(entries: PluginLoadEntry[]): PluginLoadEntry[] {
-    const byId = new Map(entries.map(e => [e.id, e]))
-    const inDegree = new Map<string, number>()
-    const dependents = new Map<string, string[]>()
-
-    for (const entry of entries) {
-      inDegree.set(entry.id, 0)
-      dependents.set(entry.id, [])
-    }
-    for (const entry of entries) {
-      for (const dep of entry.deps) {
-        if (!byId.has(dep)) continue
-        inDegree.set(entry.id, (inDegree.get(entry.id) ?? 0) + 1)
-        dependents.get(dep)!.push(entry.id)
-      }
-    }
-
-    const queue = entries.filter(entry => inDegree.get(entry.id) === 0).map(entry => entry.id)
-    const result: PluginLoadEntry[] = []
-    while (queue.length > 0) {
-      const id = queue.shift()!
-      result.push(byId.get(id)!)
-      for (const dependent of dependents.get(id) ?? []) {
-        const next = (inDegree.get(dependent) ?? 1) - 1
-        inDegree.set(dependent, next)
-        if (next === 0) queue.push(dependent)
-      }
-    }
-
-    if (result.length < entries.length) {
-      const cycleEntries = entries.filter(entry => !result.some(sorted => sorted.id === entry.id))
-      const cycle = cycleEntries.map(entry => entry.id).join(' ↔ ')
-      for (const entry of cycleEntries) {
-        this.markPluginFailed({
-          id: entry.id,
-          name: entry.manifest?.name ?? entry.id,
-          version: entry.manifest?.version ?? '0.0.0',
-          description: entry.manifest?.description ?? '',
-          source: 'user',
-          errorCode: 'dependency_cycle',
-          errorMessage: `Circular plugin dependency detected: ${cycle}`,
-        })
-      }
-    }
-
-    return result
+    return topologicalSortPlugins(
+      entries,
+      { source: 'user', failOnMissingDep: false, logCycle: false },
+      {
+        markFailed: (failure) => this.markPluginFailed(failure),
+        isFailed: (id) => this.failedPlugins.has(id),
+      },
+    )
   }
 
   private markPluginFailed(failure: PluginFailureState): void {

--- a/src/lib/plugin-topo-sort.ts
+++ b/src/lib/plugin-topo-sort.ts
@@ -1,0 +1,104 @@
+/**
+ * Dependency-ordered plugin activation sort (Kahn's algorithm).
+ *
+ * One implementation for both the core-plugin and user-plugin passes — they
+ * previously carried two near-identical copies (`topologicalSort` /
+ * `topologicalSortUserPlugins`) that drifted in three ways, all captured here
+ * as options:
+ *   - `source`        — the failure record's source ('built-in' vs 'user').
+ *   - `failOnMissingDep` — core fails an entry whose dependency isn't present;
+ *     the user pass pre-filters missing deps in loadUserPlugins, so it skips
+ *     the edge silently (false).
+ *   - `logCycle`      — core logs a top-level error on a detected cycle.
+ *
+ * The result is always filtered against `isFailed` so entries this sort marked
+ * failed (missing dep) don't reach activation. Cycle-failed entries never make
+ * it into the result (Kahn's leaves them out), so the filter is a no-op for the
+ * user pass — preserving its original behavior exactly.
+ */
+import { createLogger } from '../core/logger'
+import type { PluginFailureState, PluginLoadEntry } from './plugin-registry-types'
+
+const log = createLogger('plugin-registry')
+
+export interface TopoSortOptions {
+  source: 'built-in' | 'user'
+  failOnMissingDep: boolean
+  logCycle: boolean
+}
+
+export interface TopoSortHooks {
+  markFailed: (failure: PluginFailureState) => void
+  isFailed: (id: string) => boolean
+}
+
+export function topologicalSortPlugins(
+  entries: PluginLoadEntry[],
+  opts: TopoSortOptions,
+  hooks: TopoSortHooks,
+): PluginLoadEntry[] {
+  const byId = new Map(entries.map(e => [e.id, e]))
+  const inDegree = new Map<string, number>()
+  const dependents = new Map<string, string[]>()
+
+  for (const e of entries) {
+    inDegree.set(e.id, 0)
+    dependents.set(e.id, [])
+  }
+
+  for (const e of entries) {
+    for (const dep of e.deps) {
+      if (!byId.has(dep)) {
+        if (opts.failOnMissingDep) {
+          hooks.markFailed({
+            id: e.id,
+            name: e.manifest?.name ?? e.id,
+            version: e.manifest?.version ?? '0.0.0',
+            description: e.manifest?.description ?? '',
+            source: opts.source,
+            errorCode: 'missing_dependency',
+            errorMessage: `Missing dependency: ${dep}`,
+            missingDependencies: [dep],
+          })
+        }
+        continue
+      }
+      inDegree.set(e.id, (inDegree.get(e.id) ?? 0) + 1)
+      dependents.get(dep)!.push(e.id)
+    }
+  }
+
+  // Start with nodes that have no dependencies.
+  const queue = entries.filter(e => inDegree.get(e.id) === 0).map(e => e.id)
+  const result: PluginLoadEntry[] = []
+
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    result.push(byId.get(id)!)
+    for (const dep of dependents.get(id) ?? []) {
+      const deg = (inDegree.get(dep) ?? 1) - 1
+      inDegree.set(dep, deg)
+      if (deg === 0) queue.push(dep)
+    }
+  }
+
+  // Detect cycles — any entries not in result have circular deps.
+  if (result.length < entries.length) {
+    const missing = entries.filter(e => !result.some(r => r.id === e.id))
+    const cycle = missing.map(e => e.id).join(' ↔ ')
+    if (opts.logCycle) log.error(`Circular plugin dependencies detected: ${cycle}`)
+    for (const entry of missing) {
+      hooks.markFailed({
+        id: entry.id,
+        name: entry.manifest?.name ?? entry.id,
+        version: entry.manifest?.version ?? '0.0.0',
+        description: entry.manifest?.description ?? '',
+        source: opts.source,
+        errorCode: 'dependency_cycle',
+        errorMessage: `Circular plugin dependency detected: ${cycle}`,
+      })
+    }
+  }
+
+  return result.filter(entry => !hooks.isFailed(entry.id))
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -92,9 +92,25 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   - ☑ Behavior-touching dedup: `prepareRegularDispatch` (the dispatchTasks/dispatchSingleTask
     copy-paste) — done by Mark (#516), live-verified. dispatch.ts split is now COMPLETE end-to-end
     (Phase A #513 + Phase B fire-core #514 + dedup #516).
-- plugin-registry.split — ☐ (the hook-registry-singleton seam is ALREADY done — WS2/#499; remaining =
-  topo-sort/activation-pipeline dedup + move out of src/lib)   server.split — ☐ (router-table + boot.ts;
-  search-startup/recovery already extracted)   runtime.split — ☐ (adapter, 3,188 lines)
+- plugin-registry.split — ◧ **split by RISK** (boot-critical; the hook-registry-singleton seam was already
+  done — WS2/#499). Barrel-preserving: `src/lib/plugin-registry.ts` stays the public module (55 importers +
+  ~40 test `mock.module` overlays target that path), pulling extracted helpers from siblings.
+  - ☑ Phase A: extracted `plugin-registry-types.ts` (PluginState/FailureState/LoadEntry/CorePluginRegistration),
+    `plugin-console-capture.ts` (withCapturedPluginConsole + createPluginScopedLogger), `plugin-activation-audit.ts`
+    (logPluginActivation), and **unified the two duplicate topo-sorts** into `plugin-topo-sort.ts` — one Kahn's
+    impl parameterized by `{source, failOnMissingDep, logCycle}` (the only 3 ways the core/user copies differed);
+    always-filter is a no-op for the user pass (cycle entries already excluded), preserving its behavior exactly.
+    plugin-registry.ts 1,512 → ~1,000. Public surface unchanged (re-exports CorePluginRegistration). Verified:
+    typecheck/lint/registry-test 52-0/full-suite 5115-0/binary build + isolated-home boot smoke (9 plugins activate
+    in correct topo order through the refactored loadPlugin→buildContext path; the 1 failure is schedule's
+    openclaw-cron ENOENT, environmental). New direct unit test for the unified sort (6-0).
+  - ☐ Phase B (DEFERRED, behavior-touching): unify the two activation pipelines (`loadPlugin` /
+    `activateUserPluginEntry` share a ~60-line tail but diverge on import mechanism, console-capture wrapping,
+    migrations, core/user id bookkeeping, and logPluginActivation ordering — merging normalizes boot-path
+    ordering, so it gets its own commit + boot smoke, mirroring the dispatch dedup cadence). Plus the physical
+    **move out of src/lib** (churns 55 importers + 40 mock paths — mechanical, separate).
+- server.split — ☐ (router-table + boot.ts; search-startup/recovery already extracted; HOLD until the dispatch
+  live-test passes — it stresses the same boot/router surface)   runtime.split — ☐ (adapter, 3,188 lines)
 
 ## WS7 — tooling
 

--- a/tests/core/plugin-topo-sort.test.ts
+++ b/tests/core/plugin-topo-sort.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Direct unit tests for the unified plugin topological sort.
+ *
+ * This free function replaced two near-identical class methods
+ * (`topologicalSort` / `topologicalSortUserPlugins`). The registry test covers
+ * both paths end-to-end; these tests pin the parameterized differences in
+ * isolation so the dedup can't silently regress one mode:
+ *   - failOnMissingDep (core fails the dependent; user skips the edge)
+ *   - source (the failure record's source field)
+ *
+ * The third option, logCycle, only controls a cosmetic top-level log line whose
+ * sink is captured at module load (before mock.module can intercept it), so it
+ * isn't asserted here — the registry test + boot smoke exercise it in practice.
+ */
+import { describe, it, expect } from 'bun:test'
+
+// Pure graph function; never touches storage. Defensive content-dir mocks keep
+// the isolation rule satisfied so a future import can't leak into ~/.bakin/.
+import { mock } from 'bun:test'
+mock.module('../../src/core/content-dir', () => ({ getContentDir: () => '/tmp/bakin-topo-test' }))
+mock.module('../../packages/core/src/content-dir', () => ({ getContentDir: () => '/tmp/bakin-topo-test' }))
+
+import { topologicalSortPlugins } from '../../src/lib/plugin-topo-sort'
+import type { PluginFailureState, PluginLoadEntry } from '../../src/lib/plugin-registry-types'
+
+function entry(id: string, deps: string[] = []): PluginLoadEntry {
+  return { id, path: `plugins/${id}`, deps }
+}
+
+/** Drives the sort with a real failed-set so isFailed reflects markFailed. */
+function run(entries: PluginLoadEntry[], opts: { source: 'built-in' | 'user'; failOnMissingDep: boolean; logCycle: boolean }) {
+  const failed = new Map<string, PluginFailureState>()
+  const sorted = topologicalSortPlugins(entries, opts, {
+    markFailed: (f) => failed.set(f.id, f),
+    isFailed: (id) => failed.has(id),
+  })
+  return { sorted: sorted.map((e) => e.id), failed }
+}
+
+const CORE = { source: 'built-in' as const, failOnMissingDep: true, logCycle: true }
+const USER = { source: 'user' as const, failOnMissingDep: false, logCycle: false }
+
+describe('topologicalSortPlugins', () => {
+  it('preserves order when there are no dependencies', () => {
+    const { sorted } = run([entry('a'), entry('b'), entry('c')], CORE)
+    expect(sorted).toEqual(['a', 'b', 'c'])
+  })
+
+  it('orders a dependent after its dependency', () => {
+    const { sorted } = run([entry('b', ['a']), entry('a')], CORE)
+    expect(sorted.indexOf('a')).toBeLessThan(sorted.indexOf('b'))
+  })
+
+  it('core pass: a missing dependency fails the dependent (source built-in)', () => {
+    const { sorted, failed } = run([entry('a', ['ghost'])], CORE)
+    expect(sorted).toEqual([]) // failed entry filtered out of activation
+    expect(failed.get('a')?.errorCode).toBe('missing_dependency')
+    expect(failed.get('a')?.source).toBe('built-in')
+  })
+
+  it('user pass: a missing dependency is skipped silently, not failed', () => {
+    const { sorted, failed } = run([entry('a', ['ghost'])], USER)
+    expect(sorted).toEqual(['a']) // edge skipped, entry still activates
+    expect(failed.has('a')).toBe(false)
+  })
+
+  it('core pass: detects a cycle and fails the involved entries (source built-in)', () => {
+    const { sorted, failed } = run([entry('a', ['b']), entry('b', ['a'])], CORE)
+    expect(sorted).toEqual([])
+    expect(failed.get('a')?.errorCode).toBe('dependency_cycle')
+    expect(failed.get('b')?.source).toBe('built-in')
+  })
+
+  it('user pass: detects a cycle and fails the involved entries (source user)', () => {
+    const { sorted, failed } = run([entry('a', ['b']), entry('b', ['a'])], USER)
+    expect(sorted).toEqual([])
+    expect(failed.get('a')?.errorCode).toBe('dependency_cycle')
+    expect(failed.get('b')?.source).toBe('user')
+  })
+})


### PR DESCRIPTION
## What

Phase A of the `plugin-registry.ts` split (WS5 of the audit). The 1,512-line file becomes a barrel + cohesive sibling modules, and the two audit-flagged **duplicate topological sorts** are unified into one.

This is **barrel-preserving**: `src/lib/plugin-registry.ts` stays the public module (it keeps the `PluginRegistryImpl` class, the globalThis singleton, and every export). That matters because **55 source files import it and ~40 test files `mock.module` that exact path** — moving the file would churn all of them. The implementation moves out; the import path doesn't.

## Modules extracted

| Module | Contents |
|---|---|
| `plugin-registry-types.ts` | `PluginState`, `PluginFailureState`, `PluginLoadEntry`, `CorePluginRegistration` |
| `plugin-console-capture.ts` | `withCapturedPluginConsole` + `createPluginScopedLogger` (the `AsyncLocalStorage` console-capture machinery) |
| `plugin-activation-audit.ts` | `logPluginActivation` (#142 layer 1 permission audit) |
| `plugin-topo-sort.ts` | **One** Kahn's-algorithm sort replacing the two near-identical copies |

## The dedup

`topologicalSort` (core) and `topologicalSortUserPlugins` (user) were the same algorithm differing in exactly three ways, now options:
- `source` — the failure record's `'built-in' | 'user'`.
- `failOnMissingDep` — core fails a dependent whose dep is absent; the user pass pre-filters missing deps in `loadUserPlugins`, so it skips the edge silently.
- `logCycle` — only the core pass logs a top-level cycle error.

The unified function always filters the result against `isFailed`. For the user pass this is a **no-op** (cycle entries never enter the result via Kahn's, and it doesn't fail missing deps), so its behavior is preserved exactly.

`plugin-registry.ts`: **1,512 → ~1,000 lines.** No behavior change.

## Deferred (own follow-up, behavior-touching)

- **Unify the two activation pipelines** (`loadPlugin` / `activateUserPluginEntry`). They share a ~60-line tail but diverge on import mechanism, console-capture wrapping, migrations, core/user id bookkeeping, and `logPluginActivation` ordering — merging normalizes boot-path ordering, so it gets its own commit + boot smoke (mirroring the dispatch-dedup cadence).
- **Physical move out of `src/lib`** — mechanical, but churns 55 importers + 40 mock paths; separate.

## Verification

- `bun run typecheck` + `eslint` clean
- registry test (`tests/core/plugin-registry.test.ts`) **52/0** — exercises the real activation pipeline + both topo paths + cycle/missing-dep failure states
- full suite **5115/0**
- `bun run build` (binary) + **isolated-home boot smoke**: 9 plugins activate in correct dependency order (`team → tasks → memory → assets → health → git → models → workflows → schedule → images`) through the refactored `loadPlugin → buildContext` path; the one failure is `schedule`'s `openclaw cron list` ENOENT (no openclaw binary on PATH here — environmental, would fail identically on main)
- new direct unit test for the unified sort: **6/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
