### PR TITLE
refactor(team): extract runtime-agents + agent-lessons helpers from index

### DIFF
--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -15,25 +15,22 @@ import {
   openSync,
   readFileSync,
   readSync,
-  readdirSync,
-  statSync,
   unlinkSync,
   writeFileSync,
 } from 'fs'
-import { basename, dirname, join, relative } from 'path'
+import { dirname, join } from 'path'
 import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { defineRoute, definePlugin } from '@bakin/core/routing'
 import type { PluginContextLite } from '@bakin/core/routing'
 import { createLogger } from '../../src/core/logger'
 import { readHeartbeats } from '../../src/lib/content-files'
 import { getContentDir, getBakinPaths } from '../../packages/core/src/content-dir'
-import { resolveAgentAvatar, serveAvatar, detectImageExtension } from '@bakin/core/agents/avatar'
+import { serveAvatar, detectImageExtension } from '@bakin/core/agents/avatar'
 import { removeInstalledBy } from '@bakin/core/agent-packages/markers'
 import {
   readPluginSettings as readStoredPluginSettings,
   writePluginSettings as writeStoredPluginSettings,
 } from '@bakin/core/plugins/settings-store'
-import { parseLessonFrontmatter as parseLessonFm } from '@bakin/core/format/frontmatter'
 import { startAgent, stopAgent } from '../../src/lib/agents'
 import { getSettings, resetSettingsCache } from '../../src/core/settings'
 import { syncConfig as syncMcporter } from '../../src/core/mcporter'
@@ -43,18 +40,38 @@ import { appendAudit } from '../../src/core/audit'
 import { getAllAgentUsage } from '../../src/core/agent-usage'
 import { getStatsByMs } from '../../src/core/usage'
 import { retrieveAgentPackageLessons } from '../../src/core/agent-packages/lesson-retrieval'
-import { getRuntimeMainAgentId, type AgentRuntimeAdapter, type RuntimeAgent } from '@bakin/core/adapters/runtime'
+import { getRuntimeMainAgentId, type AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
 import { readLatestSessionTranscript } from './lib/session-reader'
 import { agentSyncRepair, checkAgentRoster, checkPersonas, checkAgentSync, personaRepair } from './lib/health-checks'
+import {
+  agentToMeta,
+  listRuntimeAgentMetas,
+  getRuntimeAgentIds,
+  getRuntimeAgentModel,
+  getRuntimeAgentProfile,
+  createRuntimeAgent,
+  addToRuntimeAllowlists,
+  removeFromRuntimeAllowlists,
+  removeRuntimeAgent,
+  updateRuntimeAgentIdentity,
+  setRuntimeSubagentPermissions,
+  listRuntimeSkills,
+  readRuntimeSkillFile,
+  listRuntimeMemoryFiles,
+  readRuntimeMemoryFile,
+  readRuntimeHeartbeatRaw,
+} from './lib/runtime-agents'
+import {
+  agentLessonFileToId,
+  agentLessonKeyToFilePath,
+  agentLessonFileToDoc,
+  agentLessonReindexAll,
+} from './lib/agent-lessons'
 import type {
-  AgentMeta,
-  AgentProfile,
   AgentWithStatus,
   AgentDisplaySettingsMap,
   HeartbeatData,
-  HeartbeatRaw,
   OrgTeam,
-  SkillSummary,
   TeamPluginSettings,
 } from './types'
 
@@ -157,283 +174,6 @@ async function mergeDisplayDefaults(runtime: AgentRuntimeAdapter, overrides: Age
   return result
 }
 
-interface IdentityFields {
-  name?: string
-  emoji?: string
-  role?: string
-  vibe?: string
-  primaryFunction?: string
-  defaultMode?: string
-}
-
-interface CreateAgentInput extends IdentityFields {
-  id: string
-  name: string
-  model?: string
-  soul?: string
-  tools?: string
-}
-
-function metadataString(agent: RuntimeAgent, key: string): string | undefined {
-  const value = agent.metadata?.[key]
-  return typeof value === 'string' && value.length > 0 ? value : undefined
-}
-
-function metadataStringArray(agent: RuntimeAgent, key: string): string[] | null {
-  const value = agent.metadata?.[key]
-  return Array.isArray(value) && value.every((entry) => typeof entry === 'string') ? value : null
-}
-
-function agentToMeta(agent: RuntimeAgent): AgentMeta {
-  const headshot = resolveAgentAvatar(agent.id) ? `/api/plugins/team/${agent.id}/avatar` : ''
-
-  return {
-    id: agent.id,
-    name: agent.name || agent.id,
-    emoji: metadataString(agent, 'emoji') ?? '',
-    role: agent.role ?? metadataString(agent, 'role') ?? '',
-    headshot,
-  }
-}
-
-async function listRuntimeAgentMetas(runtime: AgentRuntimeAdapter): Promise<AgentMeta[]> {
-  return (await runtime.agents.list()).map(agentToMeta)
-}
-
-async function getRuntimeAgentIds(runtime: AgentRuntimeAdapter): Promise<string[]> {
-  return (await runtime.agents.list()).map((agent) => agent.id)
-}
-
-async function getRuntimeAgentModel(runtime: AgentRuntimeAdapter, agent: RuntimeAgent): Promise<string> {
-  if (agent.model) return agent.model
-  const config = await runtime.config.get<{
-    agents?: { defaults?: { model?: { primary?: string } } }
-  }>()
-  return config.agents?.defaults?.model?.primary ?? 'unknown'
-}
-
-async function readRuntimeWorkspaceText(
-  runtime: AgentRuntimeAdapter,
-  agentId: string,
-  path: string,
-): Promise<string | null> {
-  return (await runtime.agents.readWorkspaceFile(agentId, path))?.content ?? null
-}
-
-async function getRuntimeAgentProfile(runtime: AgentRuntimeAdapter, agentId: string): Promise<AgentProfile | null> {
-  const agent = await runtime.agents.get(agentId)
-  if (!agent) return null
-  const meta = agentToMeta(agent)
-  const model = await getRuntimeAgentModel(runtime, agent)
-  return {
-    ...meta,
-    model,
-    workspacePath: metadataString(agent, 'workspacePath') ?? '',
-    soul: await readRuntimeWorkspaceText(runtime, agent.id, 'SOUL.md'),
-    identity: await readRuntimeWorkspaceText(runtime, agent.id, 'IDENTITY.md'),
-    rules: await readRuntimeWorkspaceText(runtime, agent.id, 'AGENTS.md'),
-    tools: await readRuntimeWorkspaceText(runtime, agent.id, 'TOOLS.md'),
-    heartbeatMd: await readRuntimeWorkspaceText(runtime, agent.id, 'HEARTBEAT.md'),
-    subagentPerms: metadataStringArray(agent, 'subagentAllowAgents'),
-  }
-}
-
-function synthesizeIdentityMd(fields: IdentityFields): string {
-  const lines = ['# IDENTITY.md', '']
-  const entries: [string, string | undefined][] = [
-    ['Name', fields.name],
-    ['Role', fields.role],
-    ['Emoji', fields.emoji],
-    ['Vibe', fields.vibe],
-    ['Primary Function', fields.primaryFunction],
-    ['Default Mode', fields.defaultMode],
-  ]
-  for (const [label, value] of entries) {
-    if (value) lines.push(`- **${label}:** ${value}`)
-  }
-  lines.push('')
-  return lines.join('\n')
-}
-
-function parseIdentityMd(content: string): Record<string, string> {
-  const fields: Record<string, string> = {}
-  const regex = /^[-*]\s*\*\*(.+?):\*\*\s*(.+)/gm
-  let match
-  while ((match = regex.exec(content)) !== null) {
-    fields[match[1]] = match[2].trim()
-  }
-  return fields
-}
-
-async function createRuntimeAgent(
-  runtime: AgentRuntimeAdapter,
-  input: CreateAgentInput,
-): Promise<{ id: string; workspace: string }> {
-  const agent = await runtime.agents.create({
-    id: input.id,
-    name: input.name,
-    role: input.role,
-    model: input.model,
-    metadata: {
-      emoji: input.emoji,
-      role: input.role,
-      vibe: input.vibe,
-      primaryFunction: input.primaryFunction,
-      defaultMode: input.defaultMode,
-    },
-  })
-
-  await runtime.agents.writeWorkspaceFile(input.id, {
-    path: 'IDENTITY.md',
-    content: synthesizeIdentityMd(input),
-  })
-  if (input.soul) {
-    await runtime.agents.writeWorkspaceFile(input.id, { path: 'SOUL.md', content: input.soul })
-  }
-  if (input.tools) {
-    await runtime.agents.writeWorkspaceFile(input.id, { path: 'TOOLS.md', content: input.tools })
-  }
-
-  return { id: input.id, workspace: metadataString(agent, 'workspacePath') ?? '' }
-}
-
-async function addToRuntimeAllowlists(
-  runtime: AgentRuntimeAdapter,
-  newAgentId: string,
-  dispatchable: 'all' | 'main' | string[],
-): Promise<void> {
-  const mainAgentId = await getRuntimeMainAgentId(runtime)
-  if (dispatchable === 'main') {
-    await runtime.agents.updateAllowlist(mainAgentId, { add: [newAgentId] })
-    return
-  }
-
-  const agents = await runtime.agents.list()
-  if (dispatchable === 'all') {
-    await Promise.all(
-      agents
-        .filter((agent) => agent.id !== newAgentId)
-        .map((agent) => runtime.agents.updateAllowlist(agent.id, { add: [newAgentId] })),
-    )
-    return
-  }
-
-  const targetIds = new Set(dispatchable)
-  targetIds.add(mainAgentId)
-  targetIds.delete(newAgentId)
-  await Promise.all(Array.from(targetIds).map((agentId) => runtime.agents.updateAllowlist(agentId, { add: [newAgentId] })))
-}
-
-async function removeFromRuntimeAllowlists(runtime: AgentRuntimeAdapter, agentId: string): Promise<void> {
-  const agents = await runtime.agents.list()
-  await Promise.all(agents.map((agent) => runtime.agents.updateAllowlist(agent.id, { remove: [agentId] })))
-}
-
-async function removeRuntimeAgent(runtime: AgentRuntimeAdapter, agentId: string): Promise<boolean> {
-  if (!(await runtime.agents.get(agentId))) return false
-  await runtime.agents.remove(agentId)
-  return true
-}
-
-async function updateRuntimeAgentIdentity(
-  runtime: AgentRuntimeAdapter,
-  agentId: string,
-  fields: IdentityFields & { soul?: string; tools?: string },
-): Promise<string[]> {
-  const agent = await runtime.agents.get(agentId)
-  if (!agent) throw new Error(`Agent "${agentId}" not found in roster`)
-
-  const updated: string[] = []
-  if (fields.name || fields.emoji || fields.role || fields.vibe || fields.primaryFunction || fields.defaultMode) {
-    await runtime.agents.update(agentId, {
-      name: fields.name,
-      role: fields.role,
-      metadata: {
-        ...(agent.metadata ?? {}),
-        ...(fields.emoji ? { emoji: fields.emoji } : {}),
-        ...(fields.role ? { role: fields.role } : {}),
-        ...(fields.vibe ? { vibe: fields.vibe } : {}),
-        ...(fields.primaryFunction ? { primaryFunction: fields.primaryFunction } : {}),
-        ...(fields.defaultMode ? { defaultMode: fields.defaultMode } : {}),
-      },
-    })
-    if (fields.name) updated.push('name')
-    if (fields.emoji) updated.push('emoji')
-  }
-
-  const structuredFields = ['role', 'vibe', 'primaryFunction', 'defaultMode'] as const
-  const hasStructuredUpdate = structuredFields.some((field) => fields[field])
-  if (hasStructuredUpdate || fields.name || fields.emoji) {
-    const existing = await readRuntimeWorkspaceText(runtime, agentId, 'IDENTITY.md')
-    const parsed = existing ? parseIdentityMd(existing) : {}
-    const merged: IdentityFields = {
-      name: fields.name ?? parsed['Name'],
-      emoji: fields.emoji ?? parsed['Emoji'],
-      role: fields.role ?? parsed['Role'],
-      vibe: fields.vibe ?? parsed['Vibe'],
-      primaryFunction: fields.primaryFunction ?? parsed['Primary Function'],
-      defaultMode: fields.defaultMode ?? parsed['Default Mode'],
-    }
-    await runtime.agents.writeWorkspaceFile(agentId, { path: 'IDENTITY.md', content: synthesizeIdentityMd(merged) })
-    for (const field of structuredFields) {
-      if (fields[field]) updated.push(field)
-    }
-  }
-
-  if (fields.soul) {
-    await runtime.agents.writeWorkspaceFile(agentId, { path: 'SOUL.md', content: fields.soul })
-    updated.push('soul')
-  }
-  if (fields.tools) {
-    await runtime.agents.writeWorkspaceFile(agentId, { path: 'TOOLS.md', content: fields.tools })
-    updated.push('tools')
-  }
-
-  return updated
-}
-
-async function setRuntimeSubagentPermissions(
-  runtime: AgentRuntimeAdapter,
-  agentId: string,
-  allowAgents: string[],
-): Promise<void> {
-  if (allowAgents.includes(agentId)) {
-    throw new Error(`Agent "${agentId}" cannot dispatch to itself`)
-  }
-  await runtime.agents.updateAllowlist(agentId, { replace: allowAgents })
-}
-
-async function listRuntimeSkills(runtime: AgentRuntimeAdapter, agentId: string): Promise<SkillSummary[]> {
-  return (await runtime.skills.list(agentId)).map((skill) => ({
-    id: skill.name,
-    name: skill.name,
-    hasSkillMd: typeof skill.metadata?.hasSkillMd === 'boolean'
-      ? skill.metadata.hasSkillMd
-      : Boolean(skill.instructions || skill.path),
-  }))
-}
-
-async function readRuntimeSkillFile(runtime: AgentRuntimeAdapter, agentId: string, skillId: string): Promise<string | null> {
-  return (await runtime.skills.get(skillId, agentId))?.instructions ?? null
-}
-
-async function listRuntimeMemoryFiles(runtime: AgentRuntimeAdapter, agentId: string): Promise<string[]> {
-  return (await runtime.memory.listEntries('workspace-memory', { agentId }))
-    .map((entry) => basename(entry.path ?? entry.id))
-    .sort()
-    .reverse()
-}
-
-async function readRuntimeMemoryFile(runtime: AgentRuntimeAdapter, agentId: string, date: string): Promise<string | null> {
-  const entry = await runtime.memory.getEntry('workspace-memory', date, { agentId })
-  if (entry) return entry.content
-  return readRuntimeWorkspaceText(runtime, agentId, `memory/${date}`)
-}
-
-async function readRuntimeHeartbeatRaw(runtime: AgentRuntimeAdapter, agentId: string): Promise<HeartbeatRaw | null> {
-  const heartbeat = await runtime.agents.readWorkspaceFile(agentId, 'HEARTBEAT.md')
-  return heartbeat ? { content: heartbeat.content, lastUpdated: heartbeat.updatedAt ?? null } : null
-}
 
 // ─── Status Resolution ───────────────────────────────────────────────────────
 
@@ -569,144 +309,6 @@ async function getOrgStructure(runtime: AgentRuntimeAdapter) {
 
 /** Module-level hook for batch-indexing agents — set during activate() */
 let batchIndexAgents: () => Promise<void> = async () => {}
-
-// ─── Agent-lessons indexing helpers ────────────────────────────────────────
-
-/**
- * Decompose a packages/agents/<dir>@<version>/lessons/<lesson>.md path
- * into the parts needed to build a search id + doc. Returns null on a
- * non-conforming path (the watcher passes us anything that matches the
- * glob; we trust the glob for happy-path inputs but defensively handle
- * the edge cases).
- */
-interface LessonFileParts {
-  packageId: string
-  version: string
-  lessonId: string
-  agentId: string
-}
-
-function parseLessonFilePath(rel: string): LessonFileParts | null {
-  // rel example: 'packages/agents/pixel@0.1.0/lessons/style.md'
-  const segments = rel.split('/')
-  if (segments.length < 5) return null
-  if (segments[0] !== 'packages' || segments[1] !== 'agents') return null
-  if (segments[3] !== 'lessons') return null
-  const dirName = segments[2]
-  const lessonFile = segments[4]
-  if (!lessonFile.endsWith('.md')) return null
-  const at = dirName.lastIndexOf('@')
-  if (at === -1) return null
-  const packageId = dirName.slice(0, at)
-  const version = dirName.slice(at + 1)
-  const lessonId = lessonFile.replace(/\.md$/i, '')
-  // For kind:"agent" packages the package id IS the agent id; this matches
-  // the projection convention in src/core/agent-packages/projector.ts.
-  return { packageId, version, agentId: packageId, lessonId }
-}
-
-function agentLessonFileToId(rel: string): string {
-  const parts = parseLessonFilePath(rel)
-  if (!parts) return rel.replace(/[^a-zA-Z0-9_]+/g, '_')
-  return `${parts.packageId}@${parts.version}/${parts.lessonId}`
-}
-
-function agentLessonKeyToFilePath(key: string): string | null {
-  const slash = key.indexOf('/')
-  if (slash === -1) return null
-  const dirPart = key.slice(0, slash)
-  const lesson = key.slice(slash + 1)
-  return join(getContentDir(), 'packages', 'agents', dirPart, 'lessons', `${lesson}.md`)
-}
-
-interface LessonDoc extends Record<string, unknown> {
-  title: string
-  body: string
-  package_id: string
-  agent_id: string
-  lesson_id: string
-  tags: string[]
-  default_enabled: 'true' | 'false'
-  updated_at: string
-}
-
-function parseLessonFrontmatter(raw: string): {
-  title: string
-  body: string
-  tags: string[]
-  defaultEnabled: boolean
-} {
-  const { title, body, tags, defaultEnabled } = parseLessonFm(raw)
-  return { title: title ?? '', body, tags, defaultEnabled }
-}
-
-async function agentLessonFileToDoc(rel: string): Promise<LessonDoc | null> {
-  const parts = parseLessonFilePath(rel)
-  if (!parts) return null
-  const abs = join(getContentDir(), rel)
-  if (!existsSync(abs)) return null
-  let raw: string
-  try {
-    raw = readFileSync(abs, 'utf-8')
-  } catch {
-    return null
-  }
-  const { title, body, tags, defaultEnabled } = parseLessonFrontmatter(raw)
-  return {
-    title: title || parts.lessonId,
-    body,
-    package_id: parts.packageId,
-    agent_id: parts.agentId,
-    lesson_id: parts.lessonId,
-    tags,
-    default_enabled: defaultEnabled ? 'true' : 'false',
-    updated_at: new Date().toISOString(),
-  }
-}
-
-/**
- * Walk every installed agent package's lessons/ dir and yield
- * (key, doc) pairs for the search index reindexer.
- */
-function* agentLessonReindexAll(): Generator<{ key: string; doc: LessonDoc }> {
-  const root = join(getContentDir(), 'packages', 'agents')
-  if (!existsSync(root)) return
-  for (const dirent of readdirSync(root, { withFileTypes: true })) {
-    if (!dirent.isDirectory()) continue
-    const lessonsDir = join(root, dirent.name, 'lessons')
-    if (!existsSync(lessonsDir)) continue
-    let stat
-    try { stat = statSync(lessonsDir) } catch { continue }
-    if (!stat.isDirectory()) continue
-    for (const file of readdirSync(lessonsDir)) {
-      if (!file.endsWith('.md')) continue
-      const rel = relative(getContentDir(), join(lessonsDir, file))
-      const parts = parseLessonFilePath(rel)
-      if (!parts) continue
-      const raw = readFileSync(join(lessonsDir, file), 'utf-8')
-      const { title, body, tags, defaultEnabled } = parseLessonFrontmatter(raw)
-      const key = `${parts.packageId}@${parts.version}/${parts.lessonId}`
-      yield {
-        key,
-        doc: {
-          title: title || parts.lessonId,
-          body,
-          package_id: parts.packageId,
-          agent_id: parts.agentId,
-          lesson_id: parts.lessonId,
-          tags,
-          default_enabled: defaultEnabled ? 'true' : 'false',
-          updated_at: new Date().toISOString(),
-        },
-      }
-    }
-  }
-}
-
-// Reference imports so unused-import linting doesn't fire when the
-// helpers above don't exercise every utility on every code path.
-void basename
-void dirname
 
 // ─── Plugin context handle (set during activate, used by module-scope helpers) ─
 

--- a/plugins/team/lib/agent-lessons.ts
+++ b/plugins/team/lib/agent-lessons.ts
@@ -1,0 +1,139 @@
+/**
+ * Agent-package lesson file helpers for the team plugin.
+ *
+ * Extracted from index.ts. Pure path parsing + filesystem reads over the
+ * installed agent-package lessons tree (`~/.bakin/packages/agents/<id>@<ver>/
+ * lessons/*.md`) — used by team's lesson search-index content type (the
+ * `bakin_agent-lessons` table) and its reindex generator. No plugin-context
+ * dependency.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+import { join, relative } from 'path'
+
+import { parseLessonFrontmatter as parseLessonFm } from '@bakin/core/format/frontmatter'
+
+import { getContentDir } from '../../../packages/core/src/content-dir'
+
+interface LessonFileParts {
+  packageId: string
+  version: string
+  lessonId: string
+  agentId: string
+}
+
+export function parseLessonFilePath(rel: string): LessonFileParts | null {
+  // rel example: 'packages/agents/pixel@0.1.0/lessons/style.md'
+  const segments = rel.split('/')
+  if (segments.length < 5) return null
+  if (segments[0] !== 'packages' || segments[1] !== 'agents') return null
+  if (segments[3] !== 'lessons') return null
+  const dirName = segments[2]
+  const lessonFile = segments[4]
+  if (!lessonFile.endsWith('.md')) return null
+  const at = dirName.lastIndexOf('@')
+  if (at === -1) return null
+  const packageId = dirName.slice(0, at)
+  const version = dirName.slice(at + 1)
+  const lessonId = lessonFile.replace(/\.md$/i, '')
+  // For kind:"agent" packages the package id IS the agent id; this matches
+  // the projection convention in src/core/agent-packages/projector.ts.
+  return { packageId, version, agentId: packageId, lessonId }
+}
+
+export function agentLessonFileToId(rel: string): string {
+  const parts = parseLessonFilePath(rel)
+  if (!parts) return rel.replace(/[^a-zA-Z0-9_]+/g, '_')
+  return `${parts.packageId}@${parts.version}/${parts.lessonId}`
+}
+
+export function agentLessonKeyToFilePath(key: string): string | null {
+  const slash = key.indexOf('/')
+  if (slash === -1) return null
+  const dirPart = key.slice(0, slash)
+  const lesson = key.slice(slash + 1)
+  return join(getContentDir(), 'packages', 'agents', dirPart, 'lessons', `${lesson}.md`)
+}
+
+export interface LessonDoc extends Record<string, unknown> {
+  title: string
+  body: string
+  package_id: string
+  agent_id: string
+  lesson_id: string
+  tags: string[]
+  default_enabled: 'true' | 'false'
+  updated_at: string
+}
+
+export function parseLessonFrontmatter(raw: string): {
+  title: string
+  body: string
+  tags: string[]
+  defaultEnabled: boolean
+} {
+  const { title, body, tags, defaultEnabled } = parseLessonFm(raw)
+  return { title: title ?? '', body, tags, defaultEnabled }
+}
+
+export async function agentLessonFileToDoc(rel: string): Promise<LessonDoc | null> {
+  const parts = parseLessonFilePath(rel)
+  if (!parts) return null
+  const abs = join(getContentDir(), rel)
+  if (!existsSync(abs)) return null
+  let raw: string
+  try {
+    raw = readFileSync(abs, 'utf-8')
+  } catch {
+    return null
+  }
+  const { title, body, tags, defaultEnabled } = parseLessonFrontmatter(raw)
+  return {
+    title: title || parts.lessonId,
+    body,
+    package_id: parts.packageId,
+    agent_id: parts.agentId,
+    lesson_id: parts.lessonId,
+    tags,
+    default_enabled: defaultEnabled ? 'true' : 'false',
+    updated_at: new Date().toISOString(),
+  }
+}
+
+/**
+ * Walk every installed agent package's lessons/ dir and yield
+ * (key, doc) pairs for the search index reindexer.
+ */
+export function* agentLessonReindexAll(): Generator<{ key: string; doc: LessonDoc }> {
+  const root = join(getContentDir(), 'packages', 'agents')
+  if (!existsSync(root)) return
+  for (const dirent of readdirSync(root, { withFileTypes: true })) {
+    if (!dirent.isDirectory()) continue
+    const lessonsDir = join(root, dirent.name, 'lessons')
+    if (!existsSync(lessonsDir)) continue
+    let stat
+    try { stat = statSync(lessonsDir) } catch { continue }
+    if (!stat.isDirectory()) continue
+    for (const file of readdirSync(lessonsDir)) {
+      if (!file.endsWith('.md')) continue
+      const rel = relative(getContentDir(), join(lessonsDir, file))
+      const parts = parseLessonFilePath(rel)
+      if (!parts) continue
+      const raw = readFileSync(join(lessonsDir, file), 'utf-8')
+      const { title, body, tags, defaultEnabled } = parseLessonFrontmatter(raw)
+      const key = `${parts.packageId}@${parts.version}/${parts.lessonId}`
+      yield {
+        key,
+        doc: {
+          title: title || parts.lessonId,
+          body,
+          package_id: parts.packageId,
+          agent_id: parts.agentId,
+          lesson_id: parts.lessonId,
+          tags,
+          default_enabled: defaultEnabled ? 'true' : 'false',
+          updated_at: new Date().toISOString(),
+        },
+      }
+    }
+  }
+}

--- a/plugins/team/lib/runtime-agents.ts
+++ b/plugins/team/lib/runtime-agents.ts
@@ -1,0 +1,298 @@
+/**
+ * Runtime-adapter agent helpers for the team plugin.
+ *
+ * Extracted from index.ts. Every function takes the `AgentRuntimeAdapter`
+ * explicitly (or is a pure identity-markdown transform), so this module has no
+ * dependency on the plugin's module-level context — it's a thin, testable
+ * wrapper layer over the runtime's agent/skills/memory surface that the team
+ * REST routes and activate() call into.
+ */
+import { basename } from 'path'
+
+import { resolveAgentAvatar } from '@bakin/core/agents/avatar'
+import { getRuntimeMainAgentId, type AgentRuntimeAdapter, type RuntimeAgent } from '@bakin/core/adapters/runtime'
+
+import type {
+  AgentMeta,
+  AgentProfile,
+  HeartbeatRaw,
+  SkillSummary,
+} from '../types'
+
+export interface IdentityFields {
+  name?: string
+  emoji?: string
+  role?: string
+  vibe?: string
+  primaryFunction?: string
+  defaultMode?: string
+}
+
+export interface CreateAgentInput extends IdentityFields {
+  id: string
+  name: string
+  model?: string
+  soul?: string
+  tools?: string
+}
+
+function metadataString(agent: RuntimeAgent, key: string): string | undefined {
+  const value = agent.metadata?.[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function metadataStringArray(agent: RuntimeAgent, key: string): string[] | null {
+  const value = agent.metadata?.[key]
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string') ? value : null
+}
+
+export function agentToMeta(agent: RuntimeAgent): AgentMeta {
+  const headshot = resolveAgentAvatar(agent.id) ? `/api/plugins/team/${agent.id}/avatar` : ''
+
+  return {
+    id: agent.id,
+    name: agent.name || agent.id,
+    emoji: metadataString(agent, 'emoji') ?? '',
+    role: agent.role ?? metadataString(agent, 'role') ?? '',
+    headshot,
+  }
+}
+
+export async function listRuntimeAgentMetas(runtime: AgentRuntimeAdapter): Promise<AgentMeta[]> {
+  return (await runtime.agents.list()).map(agentToMeta)
+}
+
+export async function getRuntimeAgentIds(runtime: AgentRuntimeAdapter): Promise<string[]> {
+  return (await runtime.agents.list()).map((agent) => agent.id)
+}
+
+export async function getRuntimeAgentModel(runtime: AgentRuntimeAdapter, agent: RuntimeAgent): Promise<string> {
+  if (agent.model) return agent.model
+  const config = await runtime.config.get<{
+    agents?: { defaults?: { model?: { primary?: string } } }
+  }>()
+  return config.agents?.defaults?.model?.primary ?? 'unknown'
+}
+
+async function readRuntimeWorkspaceText(
+  runtime: AgentRuntimeAdapter,
+  agentId: string,
+  path: string,
+): Promise<string | null> {
+  return (await runtime.agents.readWorkspaceFile(agentId, path))?.content ?? null
+}
+
+export async function getRuntimeAgentProfile(runtime: AgentRuntimeAdapter, agentId: string): Promise<AgentProfile | null> {
+  const agent = await runtime.agents.get(agentId)
+  if (!agent) return null
+  const meta = agentToMeta(agent)
+  const model = await getRuntimeAgentModel(runtime, agent)
+  return {
+    ...meta,
+    model,
+    workspacePath: metadataString(agent, 'workspacePath') ?? '',
+    soul: await readRuntimeWorkspaceText(runtime, agent.id, 'SOUL.md'),
+    identity: await readRuntimeWorkspaceText(runtime, agent.id, 'IDENTITY.md'),
+    rules: await readRuntimeWorkspaceText(runtime, agent.id, 'AGENTS.md'),
+    tools: await readRuntimeWorkspaceText(runtime, agent.id, 'TOOLS.md'),
+    heartbeatMd: await readRuntimeWorkspaceText(runtime, agent.id, 'HEARTBEAT.md'),
+    subagentPerms: metadataStringArray(agent, 'subagentAllowAgents'),
+  }
+}
+
+function synthesizeIdentityMd(fields: IdentityFields): string {
+  const lines = ['# IDENTITY.md', '']
+  const entries: [string, string | undefined][] = [
+    ['Name', fields.name],
+    ['Role', fields.role],
+    ['Emoji', fields.emoji],
+    ['Vibe', fields.vibe],
+    ['Primary Function', fields.primaryFunction],
+    ['Default Mode', fields.defaultMode],
+  ]
+  for (const [label, value] of entries) {
+    if (value) lines.push(`- **${label}:** ${value}`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+function parseIdentityMd(content: string): Record<string, string> {
+  const fields: Record<string, string> = {}
+  const regex = /^[-*]\s*\*\*(.+?):\*\*\s*(.+)/gm
+  let match
+  while ((match = regex.exec(content)) !== null) {
+    fields[match[1]] = match[2].trim()
+  }
+  return fields
+}
+
+export async function createRuntimeAgent(
+  runtime: AgentRuntimeAdapter,
+  input: CreateAgentInput,
+): Promise<{ id: string; workspace: string }> {
+  const agent = await runtime.agents.create({
+    id: input.id,
+    name: input.name,
+    role: input.role,
+    model: input.model,
+    metadata: {
+      emoji: input.emoji,
+      role: input.role,
+      vibe: input.vibe,
+      primaryFunction: input.primaryFunction,
+      defaultMode: input.defaultMode,
+    },
+  })
+
+  await runtime.agents.writeWorkspaceFile(input.id, {
+    path: 'IDENTITY.md',
+    content: synthesizeIdentityMd(input),
+  })
+  if (input.soul) {
+    await runtime.agents.writeWorkspaceFile(input.id, { path: 'SOUL.md', content: input.soul })
+  }
+  if (input.tools) {
+    await runtime.agents.writeWorkspaceFile(input.id, { path: 'TOOLS.md', content: input.tools })
+  }
+
+  return { id: input.id, workspace: metadataString(agent, 'workspacePath') ?? '' }
+}
+
+export async function addToRuntimeAllowlists(
+  runtime: AgentRuntimeAdapter,
+  newAgentId: string,
+  dispatchable: 'all' | 'main' | string[],
+): Promise<void> {
+  const mainAgentId = await getRuntimeMainAgentId(runtime)
+  if (dispatchable === 'main') {
+    await runtime.agents.updateAllowlist(mainAgentId, { add: [newAgentId] })
+    return
+  }
+
+  const agents = await runtime.agents.list()
+  if (dispatchable === 'all') {
+    await Promise.all(
+      agents
+        .filter((agent) => agent.id !== newAgentId)
+        .map((agent) => runtime.agents.updateAllowlist(agent.id, { add: [newAgentId] })),
+    )
+    return
+  }
+
+  const targetIds = new Set(dispatchable)
+  targetIds.add(mainAgentId)
+  targetIds.delete(newAgentId)
+  await Promise.all(Array.from(targetIds).map((agentId) => runtime.agents.updateAllowlist(agentId, { add: [newAgentId] })))
+}
+
+export async function removeFromRuntimeAllowlists(runtime: AgentRuntimeAdapter, agentId: string): Promise<void> {
+  const agents = await runtime.agents.list()
+  await Promise.all(agents.map((agent) => runtime.agents.updateAllowlist(agent.id, { remove: [agentId] })))
+}
+
+export async function removeRuntimeAgent(runtime: AgentRuntimeAdapter, agentId: string): Promise<boolean> {
+  if (!(await runtime.agents.get(agentId))) return false
+  await runtime.agents.remove(agentId)
+  return true
+}
+
+export async function updateRuntimeAgentIdentity(
+  runtime: AgentRuntimeAdapter,
+  agentId: string,
+  fields: IdentityFields & { soul?: string; tools?: string },
+): Promise<string[]> {
+  const agent = await runtime.agents.get(agentId)
+  if (!agent) throw new Error(`Agent "${agentId}" not found in roster`)
+
+  const updated: string[] = []
+  if (fields.name || fields.emoji || fields.role || fields.vibe || fields.primaryFunction || fields.defaultMode) {
+    await runtime.agents.update(agentId, {
+      name: fields.name,
+      role: fields.role,
+      metadata: {
+        ...(agent.metadata ?? {}),
+        ...(fields.emoji ? { emoji: fields.emoji } : {}),
+        ...(fields.role ? { role: fields.role } : {}),
+        ...(fields.vibe ? { vibe: fields.vibe } : {}),
+        ...(fields.primaryFunction ? { primaryFunction: fields.primaryFunction } : {}),
+        ...(fields.defaultMode ? { defaultMode: fields.defaultMode } : {}),
+      },
+    })
+    if (fields.name) updated.push('name')
+    if (fields.emoji) updated.push('emoji')
+  }
+
+  const structuredFields = ['role', 'vibe', 'primaryFunction', 'defaultMode'] as const
+  const hasStructuredUpdate = structuredFields.some((field) => fields[field])
+  if (hasStructuredUpdate || fields.name || fields.emoji) {
+    const existing = await readRuntimeWorkspaceText(runtime, agentId, 'IDENTITY.md')
+    const parsed = existing ? parseIdentityMd(existing) : {}
+    const merged: IdentityFields = {
+      name: fields.name ?? parsed['Name'],
+      emoji: fields.emoji ?? parsed['Emoji'],
+      role: fields.role ?? parsed['Role'],
+      vibe: fields.vibe ?? parsed['Vibe'],
+      primaryFunction: fields.primaryFunction ?? parsed['Primary Function'],
+      defaultMode: fields.defaultMode ?? parsed['Default Mode'],
+    }
+    await runtime.agents.writeWorkspaceFile(agentId, { path: 'IDENTITY.md', content: synthesizeIdentityMd(merged) })
+    for (const field of structuredFields) {
+      if (fields[field]) updated.push(field)
+    }
+  }
+
+  if (fields.soul) {
+    await runtime.agents.writeWorkspaceFile(agentId, { path: 'SOUL.md', content: fields.soul })
+    updated.push('soul')
+  }
+  if (fields.tools) {
+    await runtime.agents.writeWorkspaceFile(agentId, { path: 'TOOLS.md', content: fields.tools })
+    updated.push('tools')
+  }
+
+  return updated
+}
+
+export async function setRuntimeSubagentPermissions(
+  runtime: AgentRuntimeAdapter,
+  agentId: string,
+  allowAgents: string[],
+): Promise<void> {
+  if (allowAgents.includes(agentId)) {
+    throw new Error(`Agent "${agentId}" cannot dispatch to itself`)
+  }
+  await runtime.agents.updateAllowlist(agentId, { replace: allowAgents })
+}
+
+export async function listRuntimeSkills(runtime: AgentRuntimeAdapter, agentId: string): Promise<SkillSummary[]> {
+  return (await runtime.skills.list(agentId)).map((skill) => ({
+    id: skill.name,
+    name: skill.name,
+    hasSkillMd: typeof skill.metadata?.hasSkillMd === 'boolean'
+      ? skill.metadata.hasSkillMd
+      : Boolean(skill.instructions || skill.path),
+  }))
+}
+
+export async function readRuntimeSkillFile(runtime: AgentRuntimeAdapter, agentId: string, skillId: string): Promise<string | null> {
+  return (await runtime.skills.get(skillId, agentId))?.instructions ?? null
+}
+
+export async function listRuntimeMemoryFiles(runtime: AgentRuntimeAdapter, agentId: string): Promise<string[]> {
+  return (await runtime.memory.listEntries('workspace-memory', { agentId }))
+    .map((entry) => basename(entry.path ?? entry.id))
+    .sort()
+    .reverse()
+}
+
+export async function readRuntimeMemoryFile(runtime: AgentRuntimeAdapter, agentId: string, date: string): Promise<string | null> {
+  const entry = await runtime.memory.getEntry('workspace-memory', date, { agentId })
+  if (entry) return entry.content
+  return readRuntimeWorkspaceText(runtime, agentId, `memory/${date}`)
+}
+
+export async function readRuntimeHeartbeatRaw(runtime: AgentRuntimeAdapter, agentId: string): Promise<HeartbeatRaw | null> {
+  const heartbeat = await runtime.agents.readWorkspaceFile(agentId, 'HEARTBEAT.md')
+  return heartbeat ? { content: heartbeat.content, lastUpdated: heartbeat.updatedAt ?? null } : null
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -128,8 +128,16 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   (10 plugins) + host `build.ts` smoke.
 - Remaining WS7: shared dir-walker.
 
-## WS6 — plugin god-files (not started)
+## WS6 — plugin god-files
 
-team/index (2,312), workflows/index (2,146) + lib/runtime (1,633), workflow-canvas-editor (1,803),
-models-page (1,205), health-page (1,155), schedule/index (1,443), tasks/index (1,089), asset-service (835)
-+ test splits. Includes the workflows validator dedup flagged in #510.
+- team/index — ◧ **Phase A done.** Extracted two cohesive lib modules from the 2,312-line index:
+  `lib/runtime-agents.ts` (the ~270-line runtime-adapter agent wrapper layer — every fn takes the adapter
+  explicitly, zero module-ctx coupling) and `lib/agent-lessons.ts` (the agent-package lesson path-parse +
+  fs-read helpers for the `bakin_agent-lessons` content type). index.ts 2,312 → 1,914; no behavior change
+  (pure relocation of param-based/pure helpers; routes + activate untouched). Verified: typecheck/lint/team
+  suite 183-0/full-suite/binary build. DEFERRED (Phase B): extract the ~970-line `populateTeamRoutes` into
+  `lib/routes/*` (the bulk; route handlers take ctx as a param so it's tractable) + the status-resolution
+  group (`staleSettingsCtx`/`resolveAgentStatus`/`getOrgStructure`).
+- Remaining: workflows/index (2,146) + lib/runtime (1,633), workflow-canvas-editor (1,803), models-page
+  (1,205), health-page (1,155), schedule/index (1,443), tasks/index (1,089), asset-service (835) + test
+  splits. Includes the workflows validator dedup flagged in #510.


### PR DESCRIPTION
## What

Phase A of the `team/index.ts` split (WS6 — plugin god-files). The 2,312-line team server entry sheds two cohesive helper groups into `lib/` modules, following the existing `team/lib/` idiom (`session-reader`, `build-graph`, `health-checks`).

| Module | Contents |
|---|---|
| `lib/runtime-agents.ts` | ~270-line runtime-adapter agent wrapper layer — `agentToMeta`, list/get/create/remove/update agents, allowlist add/remove, subagent permissions, skills, memory files, heartbeat, IDENTITY.md synth/parse |
| `lib/agent-lessons.ts` | agent-package lesson path parsing + fs reads for the `bakin_agent-lessons` search content type (parse path, file→id, key→path, frontmatter, file→doc, reindex generator) |

**Why these two first:** every function in `runtime-agents` takes the `AgentRuntimeAdapter` explicitly (or is a pure identity-markdown transform), and `agent-lessons` is pure path/fs work — so **neither has any module-level context coupling**. They're the cleanest, lowest-risk extractions, and `agent-lessons` already has a dedicated test (`agent-lessons-search.test.ts`).

`index.ts`: **2,312 → 1,914 lines.** Pure relocation — `populateTeamRoutes` and `activate()` are untouched. The route handlers already take `ctx` as a parameter, so they simply import the helpers now instead of calling module-scope functions.

## Deferred (follow-up)

- Extract the **~970-line `populateTeamRoutes`** into `lib/routes/*` — the real bulk; tractable because handlers take `ctx` as a param.
- The status-resolution group (`staleSettingsCtx` / `resolveAgentStatus` / `getOrgStructure`).

## Verification

- `bun run typecheck` + `eslint` clean
- team suite (`tests/plugins/team/`) **183/0**
- full suite **5123/0**
- `bun run build` (binary)
- isolated-home boot smoke: **Team activates cleanly** through the refactored path (`Plugin loaded: Team v1.0.0`, team `onReady` fires, all plugins ready)

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
