### PR TITLE
refactor(assets): extract asset-media + asset-trash from asset-service

### DIFF
--- a/plugins/assets/index.ts
+++ b/plugins/assets/index.ts
@@ -19,10 +19,13 @@ import { handleTagsRename, handleTagsRemove, handleTagsApply } from './routes/ta
 import { isValidAssetId } from './lib/asset-id'
 import {
   getAsset, upsertFromSource, resolveFile as resolveVersionedFile,
-  listAssets as listVersionedAssets, deleteAsset as deleteVersionedAsset,
+  listAssets as listVersionedAssets,
   relink as relinkVersioned, retype as retypeVersioned,
-  listTrashedAssets, emptyAssetTrash, permanentlyDeleteTrashed, restoreAsset as restoreVersionedAsset,
 } from './lib/asset-service'
+import {
+  deleteAsset as deleteVersionedAsset,
+  listTrashedAssets, emptyAssetTrash, permanentlyDeleteTrashed, restoreAsset as restoreVersionedAsset,
+} from './lib/asset-trash'
 import { listAssetIdsByTask, taskAssetIndexRemove, taskAssetIndexUpsert } from './lib/task-asset-index'
 import { versionedAssetPath, buildVersionedAssetSearchDoc } from './lib/search-doc'
 import { ASSET_TYPES, type AssetType } from './lib/constants'

--- a/plugins/assets/lib/asset-id.ts
+++ b/plugins/assets/lib/asset-id.ts
@@ -6,6 +6,9 @@
  * storage shard key, derived by construction — no resolver, no map. The slug is
  * frozen at creation (it is an id, not a title; the manifest carries live meaning).
  */
+import { join } from 'node:path'
+
+import { getContentDir } from '../../../src/core/content-dir'
 import { slugify, generateId8 } from './filename-id'
 
 const ASSET_ID_RE = /^(\d{4})(\d{2})(\d{2})-.+-[0-9a-f]{8}$/i
@@ -54,4 +57,10 @@ export function assetDirRelPath(assetId: string): string | null {
   if (!isValidAssetId(assetId)) return null
   const ym = yearMonthFromAssetId(assetId)
   return ym ? `assets/store/${ym}/${assetId}` : null
+}
+
+/** Absolute directory path for an assetId under the content dir, or null if invalid. */
+export function assetDirAbs(assetId: string): string | null {
+  const rel = assetDirRelPath(assetId)
+  return rel ? join(getContentDir(), rel) : null
 }

--- a/plugins/assets/lib/asset-media.ts
+++ b/plugins/assets/lib/asset-media.ts
@@ -1,0 +1,68 @@
+/**
+ * Image media helpers for the asset service: lazy `sharp` loading, image
+ * dimension probing, and thumbnail generation (sharp, with an ffmpeg fallback).
+ *
+ * Extracted from asset-service.ts. This is the only module-level mutable state
+ * in the asset service (the `sharpModule` promise cache), so isolating it keeps
+ * the create/read/mutation paths free of side effects. `sharp` is loaded lazily
+ * and tolerated-absent — image metadata/export degrade to null rather than
+ * failing the asset operation.
+ */
+import { existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+
+import { createLogger } from '../../../src/core/logger'
+
+const log = createLogger('asset-service')
+
+type Sharp = typeof import('sharp')
+let sharpModule: Promise<Sharp | null> | null = null
+
+export async function loadSharp(): Promise<Sharp | null> {
+  sharpModule ??= import('sharp')
+    .then((mod): Sharp => (mod as unknown as { default?: Sharp }).default ?? (mod as unknown as Sharp))
+    .catch((err) => {
+      log.warn('sharp unavailable; image metadata/export support disabled', { error: err instanceof Error ? err.message : String(err) })
+      return null
+    })
+  return sharpModule
+}
+
+export async function imageDimensions(filePath: string): Promise<{ width: number | null; height: number | null }> {
+  try {
+    const sharp = await loadSharp()
+    if (!sharp) return { width: null, height: null }
+    const meta = await sharp(filePath).metadata()
+    return { width: meta.width ?? null, height: meta.height ?? null }
+  } catch {
+    return { width: null, height: null }
+  }
+}
+
+export async function generateThumbnail(inputPath: string, outputPath: string, widthPx = 400): Promise<boolean> {
+  const sharp = await loadSharp()
+  if (sharp) {
+    try {
+      await sharp(inputPath)
+        .resize({ width: widthPx, withoutEnlargement: true })
+        .jpeg({ quality: 82 })
+        .toFile(outputPath)
+      return existsSync(outputPath)
+    } catch (err) {
+      log.warn('sharp thumbnail generation failed; trying ffmpeg fallback', { error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  try {
+    // argv form (no shell) — paths/extensions are derived from client filenames,
+    // so a shell string would expand $(...)/backticks in a crafted name.
+    const r = spawnSync(
+      'ffmpeg',
+      ['-i', inputPath, '-vf', `scale=${widthPx}:-1`, '-q:v', '5', '-y', outputPath],
+      { stdio: 'pipe', timeout: 30_000 },
+    )
+    return r.status === 0 && existsSync(outputPath)
+  } catch {
+    return false
+  }
+}

--- a/plugins/assets/lib/asset-service.ts
+++ b/plugins/assets/lib/asset-service.ts
@@ -10,18 +10,17 @@
  * Type-agnostic: images are the first consumer, but any asset type uses the
  * same spine.
  */
-import { mkdirSync, copyFileSync, existsSync, readdirSync, statSync, renameSync, rmSync, readFileSync } from 'node:fs'
+import { mkdirSync, copyFileSync, existsSync, readdirSync, statSync, rmSync, readFileSync } from 'node:fs'
 import { join, extname, resolve, sep } from 'node:path'
-import { spawnSync } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { getContentDir } from '../../../src/core/content-dir'
 import { createLogger } from '../../../src/core/logger'
 import { getMimeType, type AssetType } from './constants'
-import { generateAssetId, assetDirRelPath, yearMonthFromAssetId, isValidAssetId } from './asset-id'
+import { generateAssetId, assetDirRelPath, assetDirAbs, yearMonthFromAssetId, isValidAssetId } from './asset-id'
 import { normalizeTags } from './tags'
 import { withAssetLock } from './asset-lock'
 import { getManifestCached } from './manifest-cache'
-import { taskAssetIndexRemove, taskAssetIndexUpsert } from './task-asset-index'
+import { loadSharp, imageDimensions, generateThumbnail } from './asset-media'
 import {
   readManifest,
   writeManifestAtomic,
@@ -33,8 +32,6 @@ import {
 } from './manifest'
 
 const log = createLogger('asset-service')
-type Sharp = typeof import('sharp')
-let sharpModule: Promise<Sharp | null> | null = null
 
 export interface AssetCreateInput {
   /** Absolute path to the source file to copy in as v1. */
@@ -84,55 +81,6 @@ function extOf(filePath: string): string {
 
 function nowIso(): string {
   return new Date().toISOString()
-}
-
-async function loadSharp(): Promise<Sharp | null> {
-  sharpModule ??= import('sharp')
-    .then((mod): Sharp => (mod as unknown as { default?: Sharp }).default ?? (mod as unknown as Sharp))
-    .catch((err) => {
-      log.warn('sharp unavailable; image metadata/export support disabled', { error: err instanceof Error ? err.message : String(err) })
-      return null
-    })
-  return sharpModule
-}
-
-async function imageDimensions(filePath: string): Promise<{ width: number | null; height: number | null }> {
-  try {
-    const sharp = await loadSharp()
-    if (!sharp) return { width: null, height: null }
-    const meta = await sharp(filePath).metadata()
-    return { width: meta.width ?? null, height: meta.height ?? null }
-  } catch {
-    return { width: null, height: null }
-  }
-}
-
-async function generateThumbnail(inputPath: string, outputPath: string, widthPx = 400): Promise<boolean> {
-  const sharp = await loadSharp()
-  if (sharp) {
-    try {
-      await sharp(inputPath)
-        .resize({ width: widthPx, withoutEnlargement: true })
-        .jpeg({ quality: 82 })
-        .toFile(outputPath)
-      return existsSync(outputPath)
-    } catch (err) {
-      log.warn('sharp thumbnail generation failed; trying ffmpeg fallback', { error: err instanceof Error ? err.message : String(err) })
-    }
-  }
-
-  try {
-    // argv form (no shell) — paths/extensions are derived from client filenames,
-    // so a shell string would expand $(...)/backticks in a crafted name.
-    const r = spawnSync(
-      'ffmpeg',
-      ['-i', inputPath, '-vf', `scale=${widthPx}:-1`, '-q:v', '5', '-y', outputPath],
-      { stdio: 'pipe', timeout: 30_000 },
-    )
-    return r.status === 0 && existsSync(outputPath)
-  } catch {
-    return false
-  }
 }
 
 /** Allocate a fresh, collision-free assetId directory. */
@@ -299,11 +247,6 @@ export function listAssets(filter?: { type?: AssetType; taskId?: string | null; 
 // ---------------------------------------------------------------------------
 // Mutations — all serialized behind the per-asset lock + atomic manifest write.
 // ---------------------------------------------------------------------------
-
-function assetDirAbs(assetId: string): string | null {
-  const rel = assetDirRelPath(assetId)
-  return rel ? join(getContentDir(), rel) : null
-}
 
 /**
  * Asset-level description mirrors the current version's. Tags deliberately do
@@ -598,103 +541,6 @@ export async function retype(assetId: string, type: AssetType): Promise<AssetMan
     manifest.updated = nowIso()
     writeManifestAtomic(dirAbs, manifest)
     return manifest
-  })
-}
-
-const TRASH_SEPARATOR = '__deleted-'
-
-/** Trash the whole asset directory (recoverable via restoreAsset). */
-export async function deleteAsset(assetId: string): Promise<{ trashName: string }> {
-  return withAssetLock(assetId, async () => {
-    const dirAbs = assetDirAbs(assetId)
-    if (!dirAbs || !existsSync(dirAbs)) throw new Error(`Asset not found: ${assetId}`)
-    const trashRoot = join(getContentDir(), 'assets', '.trash')
-    mkdirSync(trashRoot, { recursive: true })
-    const trashName = `${assetId}${TRASH_SEPARATOR}${Date.now()}`
-    renameSync(dirAbs, join(trashRoot, trashName))
-    // Trash bypasses the manifest-write choke point — evict explicitly.
-    taskAssetIndexRemove(assetId)
-    return { trashName }
-  })
-}
-
-export interface TrashedAssetInfo {
-  trashName: string
-  assetId: string
-  type: string
-  agent: string
-  deletedAt: number
-  versionCount: number
-  description: string
-}
-
-const TRASH_SUFFIX_RE = new RegExp(`(.+)${TRASH_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)$`)
-
-/** List trashed versioned assets (directories under .trash/). */
-export function listTrashedAssets(): TrashedAssetInfo[] {
-  const trashRoot = join(getContentDir(), 'assets', '.trash')
-  if (!existsSync(trashRoot)) return []
-  const out: TrashedAssetInfo[] = []
-  for (const entry of readdirSync(trashRoot)) {
-    const m = TRASH_SUFFIX_RE.exec(entry)
-    if (!m) continue
-    const dir = join(trashRoot, entry)
-    try { if (!statSync(dir).isDirectory()) continue } catch { continue }
-    const manifest = readManifest(dir)
-    out.push({
-      trashName: entry,
-      assetId: m[1],
-      type: manifest?.type ?? 'other',
-      agent: manifest?.agent ?? 'unknown',
-      deletedAt: Number(m[2]),
-      versionCount: manifest?.versions.length ?? 0,
-      description: manifest?.description ?? '',
-    })
-  }
-  return out.sort((a, b) => b.deletedAt - a.deletedAt)
-}
-
-/** Permanently delete one trashed asset directory. */
-export function permanentlyDeleteTrashed(trashName: string): boolean {
-  if (!trashName || trashName.includes('/') || trashName.includes('..')) return false
-  const dir = join(getContentDir(), 'assets', '.trash', trashName)
-  if (!existsSync(dir)) return false
-  rmSync(dir, { recursive: true, force: true })
-  return true
-}
-
-/** Empty the whole asset trash. Returns the count removed. */
-export function emptyAssetTrash(): number {
-  const trashRoot = join(getContentDir(), 'assets', '.trash')
-  if (!existsSync(trashRoot)) return 0
-  const entries = readdirSync(trashRoot)
-  let n = 0
-  for (const entry of entries) {
-    try { rmSync(join(trashRoot, entry), { recursive: true, force: true }); n++ } catch { /* skip */ }
-  }
-  return n
-}
-
-/** Restore a trashed asset directory back into the store. */
-export async function restoreAsset(trashName: string): Promise<{ assetId: string }> {
-  // Reject path-traversal in the trash entry name (matches permanentlyDeleteTrashed).
-  if (!trashName || trashName.includes('/') || trashName.includes('\\') || trashName.includes('..')) {
-    throw new Error(`Invalid trash name: ${trashName}`)
-  }
-  const assetId = trashName.split(TRASH_SEPARATOR)[0]
-  const rel = assetDirRelPath(assetId)
-  if (!rel) throw new Error(`Cannot restore — invalid assetId in: ${trashName}`)
-  return withAssetLock(assetId, async () => {
-    const trashPath = join(getContentDir(), 'assets', '.trash', trashName)
-    if (!existsSync(trashPath)) throw new Error(`Trashed asset not found: ${trashName}`)
-    const destAbs = join(getContentDir(), rel)
-    if (existsSync(destAbs)) throw new Error(`Cannot restore — an asset already exists at ${assetId}`)
-    mkdirSync(join(destAbs, '..'), { recursive: true })
-    renameSync(trashPath, destAbs)
-    // Restore bypasses the manifest-write choke point — relink explicitly.
-    const restored = readManifest(destAbs)
-    if (restored) taskAssetIndexUpsert(restored.assetId, restored.taskId ?? null)
-    return { assetId }
   })
 }
 

--- a/plugins/assets/lib/asset-trash.ts
+++ b/plugins/assets/lib/asset-trash.ts
@@ -1,0 +1,115 @@
+/**
+ * Asset trash: soft-delete (move the asset directory under `assets/.trash/`),
+ * list/restore/permanently-delete.
+ *
+ * Extracted from asset-service.ts. Self-contained — depends only on asset-id
+ * (dir resolution), asset-lock (per-asset mutex), manifest (read), and the
+ * task-asset index. Trash operations deliberately bypass the manifest-write
+ * choke point (a rename, not a write), so they evict/relink the task-asset
+ * index explicitly (the `taskAssetIndexRemove`/`taskAssetIndexUpsert` calls).
+ */
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { getContentDir } from '../../../src/core/content-dir'
+import { assetDirAbs, assetDirRelPath } from './asset-id'
+import { withAssetLock } from './asset-lock'
+import { readManifest } from './manifest'
+import { taskAssetIndexRemove, taskAssetIndexUpsert } from './task-asset-index'
+
+const TRASH_SEPARATOR = '__deleted-'
+
+/** Trash the whole asset directory (recoverable via restoreAsset). */
+export async function deleteAsset(assetId: string): Promise<{ trashName: string }> {
+  return withAssetLock(assetId, async () => {
+    const dirAbs = assetDirAbs(assetId)
+    if (!dirAbs || !existsSync(dirAbs)) throw new Error(`Asset not found: ${assetId}`)
+    const trashRoot = join(getContentDir(), 'assets', '.trash')
+    mkdirSync(trashRoot, { recursive: true })
+    const trashName = `${assetId}${TRASH_SEPARATOR}${Date.now()}`
+    renameSync(dirAbs, join(trashRoot, trashName))
+    // Trash bypasses the manifest-write choke point — evict explicitly.
+    taskAssetIndexRemove(assetId)
+    return { trashName }
+  })
+}
+
+export interface TrashedAssetInfo {
+  trashName: string
+  assetId: string
+  type: string
+  agent: string
+  deletedAt: number
+  versionCount: number
+  description: string
+}
+
+const TRASH_SUFFIX_RE = new RegExp(`(.+)${TRASH_SEPARATOR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)$`)
+
+/** List trashed versioned assets (directories under .trash/). */
+export function listTrashedAssets(): TrashedAssetInfo[] {
+  const trashRoot = join(getContentDir(), 'assets', '.trash')
+  if (!existsSync(trashRoot)) return []
+  const out: TrashedAssetInfo[] = []
+  for (const entry of readdirSync(trashRoot)) {
+    const m = TRASH_SUFFIX_RE.exec(entry)
+    if (!m) continue
+    const dir = join(trashRoot, entry)
+    try { if (!statSync(dir).isDirectory()) continue } catch { continue }
+    const manifest = readManifest(dir)
+    out.push({
+      trashName: entry,
+      assetId: m[1],
+      type: manifest?.type ?? 'other',
+      agent: manifest?.agent ?? 'unknown',
+      deletedAt: Number(m[2]),
+      versionCount: manifest?.versions.length ?? 0,
+      description: manifest?.description ?? '',
+    })
+  }
+  return out.sort((a, b) => b.deletedAt - a.deletedAt)
+}
+
+/** Permanently delete one trashed asset directory. */
+export function permanentlyDeleteTrashed(trashName: string): boolean {
+  if (!trashName || trashName.includes('/') || trashName.includes('..')) return false
+  const dir = join(getContentDir(), 'assets', '.trash', trashName)
+  if (!existsSync(dir)) return false
+  rmSync(dir, { recursive: true, force: true })
+  return true
+}
+
+/** Empty the whole asset trash. Returns the count removed. */
+export function emptyAssetTrash(): number {
+  const trashRoot = join(getContentDir(), 'assets', '.trash')
+  if (!existsSync(trashRoot)) return 0
+  const entries = readdirSync(trashRoot)
+  let n = 0
+  for (const entry of entries) {
+    try { rmSync(join(trashRoot, entry), { recursive: true, force: true }); n++ } catch { /* skip */ }
+  }
+  return n
+}
+
+/** Restore a trashed asset directory back into the store. */
+export async function restoreAsset(trashName: string): Promise<{ assetId: string }> {
+  // Reject path-traversal in the trash entry name (matches permanentlyDeleteTrashed).
+  if (!trashName || trashName.includes('/') || trashName.includes('\\') || trashName.includes('..')) {
+    throw new Error(`Invalid trash name: ${trashName}`)
+  }
+  const assetId = trashName.split(TRASH_SEPARATOR)[0]
+  const rel = assetDirRelPath(assetId)
+  if (!rel) throw new Error(`Cannot restore — invalid assetId in: ${trashName}`)
+  return withAssetLock(assetId, async () => {
+    const trashPath = join(getContentDir(), 'assets', '.trash', trashName)
+    if (!existsSync(trashPath)) throw new Error(`Trashed asset not found: ${trashName}`)
+    const destAbs = join(getContentDir(), rel)
+    if (existsSync(destAbs)) throw new Error(`Cannot restore — an asset already exists at ${assetId}`)
+    mkdirSync(join(destAbs, '..'), { recursive: true })
+    renameSync(trashPath, destAbs)
+    // Restore bypasses the manifest-write choke point — relink explicitly.
+    const restored = readManifest(destAbs)
+    if (restored) taskAssetIndexUpsert(restored.assetId, restored.taskId ?? null)
+    return { assetId }
+  })
+}

--- a/plugins/assets/routes/versioned.ts
+++ b/plugins/assets/routes/versioned.ts
@@ -8,9 +8,12 @@ import { basename, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import {
-  listAssets, getAsset, promoteVersion, deleteVersion, deleteAsset, addExport, relink,
-  addVersion, updateMetadata, listTrashedAssets, restoreAsset, permanentlyDeleteTrashed, emptyAssetTrash,
+  listAssets, getAsset, promoteVersion, deleteVersion, addExport, relink,
+  addVersion, updateMetadata,
 } from '../lib/asset-service'
+import {
+  deleteAsset, listTrashedAssets, restoreAsset, permanentlyDeleteTrashed, emptyAssetTrash,
+} from '../lib/asset-trash'
 import type { AssetType } from '../lib/constants'
 
 function errMsg(err: unknown): string {

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -152,6 +152,15 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   taken here — noted for follow-up. Verified: typecheck/lint/tasks suite 206-0/full-suite/binary build/boot smoke.
   DEFERRED: the ~370-line exec-tools block → `lib/exec-tools.ts` (registerTaskExecTools) + `lib/maintenance.ts`,
   which slims activate() to the thin-index shape.
+- asset-service — ◧ **media + trash extracted** (835 → 682). `lib/asset-media.ts` (lazy sharp loader +
+  imageDimensions + generateThumbnail — the only module-level mutable state, the sharpModule cache) and
+  `lib/asset-trash.ts` (soft-delete/list/restore/purge — self-contained, deliberately bypasses the
+  manifest-write choke point so it evicts/relinks the task-asset index explicitly). `assetDirAbs` moved to
+  its natural home `asset-id.ts` (both service + trash import it — no cycle). The 2 route/index consumers +
+  4 test files repointed to `asset-trash`; the two fragile importers (plugin-context-services dynamic import,
+  post-channel path-alias) use only create/read fns and are untouched. Verified: typecheck/lint/assets suite
+  242-0/full-suite/binary build. DEFERRED: asset-mutations + asset-upsert split + the optional redesigns
+  (mutateManifest combinator, iterateStoreManifests walker, images-plugin sharp-dedup).
 - Remaining: workflows/index (2,146) + lib/runtime (1,633), workflow-canvas-editor (1,803), models-page
-  (1,205), health-page (1,155), schedule/index (1,443), asset-service (835) + test splits. Includes the
-  workflows validator dedup flagged in #510.
+  (1,205), health-page (1,155), schedule/index (1,443) + test splits. Includes the workflows validator
+  dedup flagged in #510.

--- a/tests/plugins/assets/asset-lifecycle.test.ts
+++ b/tests/plugins/assets/asset-lifecycle.test.ts
@@ -17,8 +17,9 @@ import sharp from 'sharp'
 import { assetDirRelPath } from '../../../plugins/assets/lib/asset-id'
 import {
   createAsset, getAsset, addVersion, promoteVersion, deleteVersion,
-  addExport, relink, retype, deleteAsset, restoreAsset,
+  addExport, relink, retype,
 } from '../../../plugins/assets/lib/asset-service'
+import { deleteAsset, restoreAsset } from '../../../plugins/assets/lib/asset-trash'
 
 const srcDir = join(testDir, 'src')
 const png = (name: string, r: number) =>

--- a/tests/plugins/assets/list-by-task-hook.test.ts
+++ b/tests/plugins/assets/list-by-task-hook.test.ts
@@ -43,7 +43,8 @@ mock.module('../../../src/core/watcher', () => ({
 }))
 
 import assetsPlugin from '@bakin/assets'
-import { createAsset, relink, deleteAsset } from '@bakin/assets/lib/asset-service'
+import { createAsset, relink } from '@bakin/assets/lib/asset-service'
+import { deleteAsset } from '@bakin/assets/lib/asset-trash'
 
 type ListHandler = (data: Record<string, unknown>) => Array<{ assetId: string; description: string; type: string }> | Promise<Array<{ assetId: string; description: string; type: string }>>
 

--- a/tests/plugins/assets/manifest-cache.test.ts
+++ b/tests/plugins/assets/manifest-cache.test.ts
@@ -43,8 +43,9 @@ import { writeManifestAtomic, type AssetManifest } from '../../../plugins/assets
 import { __resetManifestCache } from '../../../plugins/assets/lib/manifest-cache'
 import {
   createAsset, getAsset, listAssets, addVersion, promoteVersion, relink,
-  deleteAsset, restoreAsset, findBySourcePath,
+  findBySourcePath,
 } from '../../../plugins/assets/lib/asset-service'
+import { deleteAsset, restoreAsset } from '../../../plugins/assets/lib/asset-trash'
 import { resolveAssetServe } from '../../../plugins/assets/lib/serve'
 
 const srcDir = join(testDir, 'src')

--- a/tests/plugins/assets/tag-ops.test.ts
+++ b/tests/plugins/assets/tag-ops.test.ts
@@ -14,8 +14,9 @@ process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
 import sharp from 'sharp'
 import {
-  createAsset, getAsset, deleteAsset, renameTagGlobal, removeTagGlobal, applyTags,
+  createAsset, getAsset, renameTagGlobal, removeTagGlobal, applyTags,
 } from '../../../plugins/assets/lib/asset-service'
+import { deleteAsset } from '../../../plugins/assets/lib/asset-trash'
 import { assetDirRelPath } from '../../../plugins/assets/lib/asset-id'
 import { handleTagsRename, handleTagsRemove, handleTagsApply } from '../../../plugins/assets/routes/tags'
 


### PR DESCRIPTION
## What

WS6 god-file split, following the audit's `APPENDIX-cohesion.md` seam map. Two self-contained, **cycle-free** modules move out of the 835-line `asset-service.ts`.

| Module | Contents |
|---|---|
| `lib/asset-media.ts` | lazy `sharp` loader + `imageDimensions` + `generateThumbnail` (ffmpeg fallback) — **the only module-level mutable state** in the asset service (the `sharpModule` promise cache) |
| `lib/asset-trash.ts` | soft-delete (`deleteAsset`) + list/restore/permanently-delete/empty — depends only on asset-id, asset-lock, manifest, task-asset index |

`assetDirAbs` moves to its natural home `asset-id.ts` (pure `assetId → dir` resolution); both `asset-service` (mutations) and `asset-trash` import it there — **no cycle**, since `asset-service` never imports `asset-trash`.

The 3 media helpers were module-private, so no public surface change. Trash ops deliberately bypass the manifest-write choke point (a rename, not a write), so their explicit task-asset-index evict/relink calls travel with them.

**Importers updated:** the two trash consumers (`plugins/assets/index.ts`, `routes/versioned.ts`) and 4 test files repoint to `asset-trash`. The two fragile non-TS-caught importers the audit flagged — `plugin-context-services.ts` (string-literal dynamic import) and `post-channel.ts` (path-alias) — use only create/read functions and are **untouched**.

`asset-service.ts`: **835 → 682 lines.** Pure relocation.

**Deferred:** the `asset-mutations` + `asset-upsert` split and the optional redesigns (mutateManifest combinator, iterateStoreManifests walker, deduping the images-plugin sharp copy against the new `asset-media`).

## Verification

- `bun run typecheck` + `eslint` clean
- assets suite (`tests/plugins/assets/`) **242/0** — lifecycle/manifest-cache/tag-ops/list-by-task all exercise the moved trash + media code
- full suite **5123/0**
- `bun run build` (binary)
- isolated-home boot smoke: Assets activates; `GET /api/plugins/assets/trash` + `/versioned` both **200**

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
