### PR TITLE
refactor(health): extract types + formatters from health-page

### DIFF
--- a/plugins/health/components/health-page.tsx
+++ b/plugins/health/components/health-page.tsx
@@ -21,8 +21,24 @@ import { UnderlineTabs } from "@makinbakin/sdk/components"
 import { formatAge } from "@makinbakin/sdk/utils"
 import { Search, CircleCheck, Clock, AlertCircle, Wrench } from 'lucide-react'
 import { RepairDialog } from './repair-dialog'
-import type { HealthCheckResult } from '@makinbakin/sdk'
 import type { AgentUsage } from '@makinbakin/sdk/types'
+import type {
+  PluginInfo,
+  RegistryData,
+  PluginManifestData,
+  UsageKind,
+  UsageFeedData,
+  HealthSummary,
+} from '../types'
+import {
+  formatUptime,
+  formatTokenCount,
+  formatRuntimeCost,
+  formatDateShort,
+  searchStatsDocumentCount,
+  extractErrorMessage,
+  formatActivity,
+} from '../lib/format'
 
 const PLUGIN_CHECK_INTERVAL_MS = 60 * 60 * 1000
 
@@ -32,146 +48,6 @@ const USAGE_TABS = [
   { id: 'agents', label: 'Agent Usage' },
 ] as const
 
-interface McpSessionInfo {
-  agent: string
-  sessions: number
-  connectedAt: string
-}
-
-interface DoctorData {
-  results: HealthCheckResult[]
-  summary: { total: number; errors: number; warnings: number }
-  cachedAt?: string
-}
-
-interface ServerData {
-  port: number
-  pid: number
-  nodeVersion: string
-  memoryMB: number
-  totalMemoryMB: number
-}
-
-interface PluginInfo {
-  id: string
-  name: string
-  version: string
-  latestVersion?: string | null
-  description: string
-  source: 'built-in' | 'user'
-  routes: number
-  installed?: {
-    version?: string
-    commitSha?: string
-    remoteHeadSha?: string
-    lastChecked?: string
-    newPermissions?: string[]
-  } | null
-  upgradeAvailable?: boolean
-  staleHintDays?: number | null
-}
-
-interface RegistryData {
-  plugins: PluginInfo[]
-}
-
-interface PluginManifestEntry {
-  id: string
-  name: string
-  version: string
-  latestVersion?: string | null
-  source: 'core' | 'github' | 'local'
-  installed: PluginInfo['installed']
-  upgradeAvailable: boolean
-  staleHintDays: number | null
-}
-
-interface PluginManifestData {
-  plugins: PluginManifestEntry[]
-}
-
-
-interface ErrorsByKind {
-  total: number
-  byKind: { mcp: number; rest: number; agent: number }
-}
-
-type UsageKind = 'mcp' | 'rest' | 'agent'
-
-interface UsageEntry {
-  ts: string
-  kind: UsageKind
-  name: string
-  agent: string | null
-  durationMs: number | null
-  status: 'ok' | 'error'
-  meta?: Record<string, unknown>
-}
-
-interface TopByNameRow {
-  name: string
-  count: number
-  errors: number
-  medianDurationMs: number | null
-}
-
-interface ByAgentRow {
-  agent: string
-  count: number
-  errors: number
-  lastActivity: UsageEntry | null
-}
-
-interface UsageFeedData {
-  totals: { count: number; errors: number; errorRate: number }
-  topByName: TopByNameRow[]
-  byAgent: ByAgentRow[]
-  recent: UsageEntry[]
-}
-
-interface HealthSummary {
-  doctor: DoctorData | null
-  errors1h: ErrorsByKind | null
-  activeSessions: McpSessionInfo[] | null
-  upSince: string | null
-  server: ServerData | null
-}
-
-function formatUptime(since: string): string {
-  const ms = Date.now() - new Date(since).getTime()
-  const secs = Math.floor(ms / 1000)
-  if (secs < 60) return `${secs}s`
-  const mins = Math.floor(secs / 60)
-  if (mins < 60) return `${mins}m ${secs % 60}s`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ${mins % 60}m`
-  const days = Math.floor(hrs / 24)
-  return `${days}d ${hrs % 24}h`
-}
-
-function formatTokenCount(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
-  return String(n)
-}
-
-function formatRuntimeCost(value: number | null): string {
-  if (value === null) return 'unavailable'
-  if (value === 0) return '$0.00'
-  if (value < 0.01) return `$${value.toFixed(4)}`
-  return `$${value.toFixed(2)}`
-}
-
-function formatDateShort(date: Date): string {
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-}
-
-function searchStatsDocumentCount(stats: Record<string, unknown> | null | undefined): number {
-  if (!stats) return 0
-  const value = stats.documents ?? stats.num_docs ?? stats.documentCount
-  const count = typeof value === 'number' ? value : Number(value)
-  return Number.isFinite(count) ? count : 0
-}
 
 // ---------------------------------------------------------------------------
 // Horizontal bar chart component (pure CSS, no dependencies)
@@ -252,16 +128,6 @@ const STATUS_STYLES: Record<string, string> = {
 // ---------------------------------------------------------------------------
 // Usage tab panels
 // ---------------------------------------------------------------------------
-
-function extractErrorMessage(entry: UsageEntry): string {
-  const meta = entry.meta ?? {}
-  if (typeof meta.error === 'string' && meta.error.length > 0) return meta.error
-  if (typeof meta.httpStatus === 'number') {
-    const method = typeof meta.method === 'string' ? `${meta.method} ` : ''
-    return `${method}HTTP ${meta.httpStatus}`
-  }
-  return 'Error (no detail)'
-}
 
 function UsageBarsPanel({
   feed,
@@ -365,15 +231,6 @@ function UsageBarsPanel({
       </div>
     </div>
   )
-}
-
-function formatActivity(entry: UsageEntry | null): string {
-  if (!entry) return 'no activity'
-  const ageSec = Math.max(0, Math.round((Date.now() - new Date(entry.ts).getTime()) / 1000))
-  if (ageSec >= 30) return `idle ${ageSec}s`
-  if (entry.kind === 'mcp') return `calling ${entry.name.replace('bakin_exec_', '')} · ${ageSec}s ago`
-  if (entry.kind === 'rest') return `handling ${entry.name} · ${ageSec}s ago`
-  return `${entry.name} · ${ageSec}s ago`
 }
 
 function AgentUsagePanel({ feed }: { feed: UsageFeedData | null }) {

--- a/plugins/health/lib/format.ts
+++ b/plugins/health/lib/format.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure formatters for the health dashboard.
+ *
+ * Extracted from components/health-page.tsx. (formatAge already comes from
+ * @makinbakin/sdk/utils — not duplicated here.)
+ */
+import type { UsageEntry } from '../types'
+
+export function formatUptime(since: string): string {
+  const ms = Date.now() - new Date(since).getTime()
+  const secs = Math.floor(ms / 1000)
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ${secs % 60}s`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ${mins % 60}m`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ${hrs % 24}h`
+}
+
+export function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+export function formatRuntimeCost(value: number | null): string {
+  if (value === null) return 'unavailable'
+  if (value === 0) return '$0.00'
+  if (value < 0.01) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
+}
+
+export function formatDateShort(date: Date): string {
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+export function searchStatsDocumentCount(stats: Record<string, unknown> | null | undefined): number {
+  if (!stats) return 0
+  const value = stats.documents ?? stats.num_docs ?? stats.documentCount
+  const count = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(count) ? count : 0
+}
+
+export function extractErrorMessage(entry: UsageEntry): string {
+  const meta = entry.meta ?? {}
+  if (typeof meta.error === 'string' && meta.error.length > 0) return meta.error
+  if (typeof meta.httpStatus === 'number') {
+    const method = typeof meta.method === 'string' ? `${meta.method} ` : ''
+    return `${method}HTTP ${meta.httpStatus}`
+  }
+  return 'Error (no detail)'
+}
+
+export function formatActivity(entry: UsageEntry | null): string {
+  if (!entry) return 'no activity'
+  const ageSec = Math.max(0, Math.round((Date.now() - new Date(entry.ts).getTime()) / 1000))
+  if (ageSec >= 30) return `idle ${ageSec}s`
+  if (entry.kind === 'mcp') return `calling ${entry.name.replace('bakin_exec_', '')} · ${ageSec}s ago`
+  if (entry.kind === 'rest') return `handling ${entry.name} · ${ageSec}s ago`
+  return `${entry.name} · ${ageSec}s ago`
+}

--- a/plugins/health/types.ts
+++ b/plugins/health/types.ts
@@ -1,0 +1,113 @@
+/**
+ * Wire-format types for the health plugin's dashboard endpoints.
+ *
+ * Extracted from components/health-page.tsx (which previously declared these
+ * inline, the missing-types.ts convention violation the tasks/models plugins
+ * don't have). Both the page component and plugins/health/index.ts can now type
+ * their route payloads against one set of contracts.
+ */
+import type { HealthCheckResult } from '@makinbakin/sdk'
+
+export interface McpSessionInfo {
+  agent: string
+  sessions: number
+  connectedAt: string
+}
+
+export interface DoctorData {
+  results: HealthCheckResult[]
+  summary: { total: number; errors: number; warnings: number }
+  cachedAt?: string
+}
+
+export interface ServerData {
+  port: number
+  pid: number
+  nodeVersion: string
+  memoryMB: number
+  totalMemoryMB: number
+}
+
+export interface PluginInfo {
+  id: string
+  name: string
+  version: string
+  latestVersion?: string | null
+  description: string
+  source: 'built-in' | 'user'
+  routes: number
+  installed?: {
+    version?: string
+    commitSha?: string
+    remoteHeadSha?: string
+    lastChecked?: string
+    newPermissions?: string[]
+  } | null
+  upgradeAvailable?: boolean
+  staleHintDays?: number | null
+}
+
+export interface RegistryData {
+  plugins: PluginInfo[]
+}
+
+export interface PluginManifestEntry {
+  id: string
+  name: string
+  version: string
+  latestVersion?: string | null
+  source: 'core' | 'github' | 'local'
+  installed: PluginInfo['installed']
+  upgradeAvailable: boolean
+  staleHintDays: number | null
+}
+
+export interface PluginManifestData {
+  plugins: PluginManifestEntry[]
+}
+
+export interface ErrorsByKind {
+  total: number
+  byKind: { mcp: number; rest: number; agent: number }
+}
+
+export type UsageKind = 'mcp' | 'rest' | 'agent'
+
+export interface UsageEntry {
+  ts: string
+  kind: UsageKind
+  name: string
+  agent: string | null
+  durationMs: number | null
+  status: 'ok' | 'error'
+  meta?: Record<string, unknown>
+}
+
+export interface TopByNameRow {
+  name: string
+  count: number
+  errors: number
+  medianDurationMs: number | null
+}
+
+export interface ByAgentRow {
+  agent: string
+  count: number
+  errors: number
+  lastActivity: UsageEntry | null
+}
+
+export interface UsageFeedData {
+  totals: { count: number; errors: number; errorRate: number }
+  topByName: TopByNameRow[]
+  byAgent: ByAgentRow[]
+  recent: UsageEntry[]
+}
+
+export interface HealthSummary {
+  doctor: DoctorData | null
+  errors1h: ErrorsByKind | null
+  activeSessions: McpSessionInfo[] | null
+  upSince: string | null
+  server: ServerData | null
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -163,6 +163,12 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   post-channel path-alias) use only create/read fns and are untouched. Verified: typecheck/lint/assets suite
   242-0/full-suite/binary build. DEFERRED: asset-mutations + asset-upsert split + the optional redesigns
   (mutateManifest combinator, iterateStoreManifests walker, images-plugin sharp-dedup).
+- health-page — ◧ **types + formatters extracted** (1,155 → 996). `plugins/health/types.ts` (the 14 wire-format
+  interfaces + UsageKind — fixes the missing-types.ts convention violation; health/index.ts can now type its
+  route payloads against them) and `plugins/health/lib/format.ts` (formatUptime/formatTokenCount/formatRuntimeCost/
+  formatDateShort/searchStatsDocumentCount/extractErrorMessage/formatActivity). formatAge was already on the SDK.
+  Pure relocation (types erased at build; formatters pure). Verified: typecheck/lint/health suite 98-0/full-suite/
+  binary build/boot smoke. DEFERRED: the section-component split (usage/plugins/search/agent-usage sections) +
+  the per-section-fetch redesign + SearchHealthData promotion — the involved React-state work.
 - Remaining: workflows/index (2,146) + lib/runtime (1,633), workflow-canvas-editor (1,803), models-page
-  (1,205), health-page (1,155), schedule/index (1,443) + test splits. Includes the workflows validator
-  dedup flagged in #510.
+  (1,205), schedule/index (1,443) + test splits. Includes the workflows validator dedup flagged in #510.


### PR DESCRIPTION
## What

WS6 client-component split, following the audit's `APPENDIX-cohesion.md` seam map. Two pure, leaf modules move out of the 1,155-line `health-page.tsx`.

| Module | Contents |
|---|---|
| `plugins/health/types.ts` | The 14 wire-format interfaces (McpSessionInfo, DoctorData, ServerData, PluginInfo, RegistryData, PluginManifestEntry/Data, ErrorsByKind, UsageEntry/Kind, TopByNameRow, ByAgentRow, UsageFeedData, HealthSummary) |
| `plugins/health/lib/format.ts` | The pure formatters (formatUptime, formatTokenCount, formatRuntimeCost, formatDateShort, searchStatsDocumentCount, extractErrorMessage, formatActivity) |

`types.ts` fixes the **missing-`types.ts` convention violation** (the tasks/models plugins both have one) — `plugins/health/index.ts` can now type its route payloads against the same contracts. `formatAge` already came from `@makinbakin/sdk/utils`, so no dedup was needed there.

`health-page.tsx`: **1,155 → 996 lines.** Pure relocation — types are erased at build, formatters are pure, and the `HealthPage` export + `client.tsx` slot registration are untouched (`types <- lib/format <- component` is a DAG, no cycles).

**Deferred** (the involved React-state work, per the appendix): the section-component split (usage / plugins / search / agent-usage), the per-section-fetch redesign, and promoting the inline `searchHealth` state type to a named `SearchHealthData`.

## Verification

- `bun run typecheck` + `eslint` clean
- health suite (`tests/plugins/health/`, incl. `health-page.test.tsx`) **98/0**
- full suite **5123/0**
- `bun run build` (binary)
- isolated-home boot smoke: Health activates; `GET /api/plugins/health/summary` → 200; the `client.js` bundle (with the refactored component) → 200

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
