### PR TITLE
refactor(workflows): extract step-format + template-list from index (phase A)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -29,8 +29,6 @@ import {
 } from './lib/health-checks'
 import {
   repairWorkflowSkillDrift,
-  scanWorkflowSkillDrift,
-  type WorkflowSkillDriftReport,
 } from './lib/workflow-skill-drift'
 import {
   isReadOnly,
@@ -39,7 +37,7 @@ import {
   getShadowedSource,
   type DefinitionSource,
 } from './lib/source-registry'
-import { isWorkflowDisabled, readDisabledWorkflowIds, setWorkflowDisabled } from './lib/availability'
+import { isWorkflowDisabled, setWorkflowDisabled } from './lib/availability'
 import {
   createInstance,
   loadInstance,
@@ -60,6 +58,13 @@ import {
   type WorkflowToolUseAction,
 } from './lib/runtime'
 import { matchWorkflow } from './lib/matcher'
+import {
+  buildTemplateList,
+  resolveSubWorkflows,
+  workflowSkillDriftBySkill,
+  workflowSkillDriftForDefinition,
+} from './lib/template-list'
+import { formatStepContext } from './lib/step-format'
 import { createLogger } from '../../src/core/logger'
 import { getContentDir } from '../../src/core/content-dir'
 import { getTask, updateTask } from '../../src/core/task-store'
@@ -75,7 +80,7 @@ import {
 } from './lib/notifications'
 import { approvalRefFromRecord, findPendingApprovalForGate, getApprovalRecord } from './lib/approval-store'
 import { rehydratePendingApprovals } from './lib/approval-rehydration'
-import type { WorkflowTemplate, WorkflowDefinition, WorkflowInstance, NestedWorkflowStep, WorkflowSkillDriftSummary } from './types'
+import type { WorkflowDefinition, WorkflowInstance, NestedWorkflowStep } from './types'
 
 const log = createLogger('workflows')
 let unsubscribeApprovalResponses: (() => void) | null = null
@@ -97,105 +102,6 @@ function activeGateSettings(): GateNotificationSettings {
 }
 
 // ─── Module-scope helpers ────────────────────────────────────────────────
-
-function resolveSubWorkflows(steps: WorkflowDefinition['steps'], subWorkflows: Record<string, WorkflowDefinition>): void {
-  for (const step of steps) {
-    if (step.type === 'workflow') {
-      const nested = step as NestedWorkflowStep
-      if (nested.workflow_id && !subWorkflows[nested.workflow_id]) {
-        const subDef = loadDefinition(nested.workflow_id)
-        if (subDef) {
-          subWorkflows[nested.workflow_id] = subDef
-          resolveSubWorkflows(subDef.steps, subWorkflows)
-        }
-      }
-    }
-  }
-}
-
-function buildTemplateList(options: { includeDisabled?: boolean } = {}): { templates: WorkflowTemplate[]; subWorkflows: Record<string, WorkflowDefinition> } {
-  const defs = listDefinitions()
-  const disabledWorkflowIds = readDisabledWorkflowIds()
-  const subWorkflows: Record<string, WorkflowDefinition> = {}
-  const driftBySkill = workflowSkillDriftBySkill()
-  const templates: WorkflowTemplate[] = defs.flatMap(d => {
-    const disabled = d.source !== 'user' && disabledWorkflowIds.has(d.name)
-    const shadowedSource = d.source === 'user' ? getShadowedSource(d.name) : undefined
-    if (disabled && !options.includeDisabled) return []
-    resolveSubWorkflows(d.definition.steps, subWorkflows)
-    return [{
-      name: d.definition.name,
-      filename: d.name,
-      description: d.definition.description,
-      stepCount: countSteps(d.definition.steps),
-      definition: d.definition,
-      source: d.source,
-      pluginId: d.pluginId,
-      packageId: d.packageId,
-      disabled,
-      shadowedSource,
-      skillDrift: workflowSkillDriftForDefinition(d.definition, driftBySkill, subWorkflows),
-    }]
-  })
-  return { templates, subWorkflows }
-}
-
-function workflowSkillDriftBySkill(): Map<string, WorkflowSkillDriftReport> {
-  return new Map(scanWorkflowSkillDrift(getContentDir()).map(report => [report.skillName, report]))
-}
-
-function workflowSkillDriftForDefinition(
-  definition: WorkflowDefinition,
-  driftBySkill: Map<string, WorkflowSkillDriftReport>,
-  subWorkflows: Record<string, WorkflowDefinition> = {},
-): WorkflowSkillDriftSummary | undefined {
-  const byStep: Record<string, string[]> = {}
-  const reports = new Map<string, WorkflowSkillDriftReport>()
-  for (const ref of collectWorkflowSkillRefs(definition.steps, subWorkflows)) {
-    const report = driftBySkill.get(ref.skill)
-    if (!report) continue
-    reports.set(report.skillName, report)
-    byStep[ref.stepId] = [...(byStep[ref.stepId] ?? []), ref.skill]
-  }
-  const uniqueReports = Array.from(reports.values())
-  if (uniqueReports.length === 0) return undefined
-  return {
-    count: uniqueReports.length,
-    repairableCount: uniqueReports.filter(report => report.repairable).length,
-    skills: uniqueReports.map(report => report.skillName),
-    reports: uniqueReports,
-    byStep,
-  }
-}
-
-function collectWorkflowSkillRefs(
-  steps: WorkflowDefinition['steps'],
-  subWorkflows: Record<string, WorkflowDefinition> = {},
-  idPrefix = '',
-  workflowStack = new Set<string>(),
-): Array<{ stepId: string; skill: string }> {
-  const refs: Array<{ stepId: string; skill: string }> = []
-  for (const step of steps) {
-    const stepId = idPrefix ? `${idPrefix}__${step.id}` : step.id
-    const skill = (step as { skill?: unknown }).skill
-    if (typeof skill === 'string' && skill.length > 0) {
-      refs.push({ stepId, skill })
-    }
-    if (step.type === 'parallel') {
-      refs.push(...collectWorkflowSkillRefs(step.steps, subWorkflows, idPrefix, workflowStack))
-    }
-    if (step.type === 'workflow') {
-      const workflowId = (step as NestedWorkflowStep).workflow_id
-      const nested = workflowId ? subWorkflows[workflowId] : undefined
-      if (nested && !workflowStack.has(workflowId)) {
-        const nextStack = new Set(workflowStack)
-        nextStack.add(workflowId)
-        refs.push(...collectWorkflowSkillRefs(nested.steps, subWorkflows, stepId, nextStack))
-      }
-    }
-  }
-  return refs
-}
 
 function instanceToSearchDoc(inst: WorkflowInstance): Record<string, unknown> {
   const def = loadDefinition(inst.workflowId)
@@ -343,118 +249,10 @@ async function createValidatedInstance(
 // Human-readable step context formatter (migrated from scripts/lib/get-step.ts)
 // ---------------------------------------------------------------------------
 
-function formatSchema(schema: Record<string, unknown>, indent = 0): string {
-  const prefix = '  '.repeat(indent)
-  const lines: string[] = []
-  const properties = (schema.properties || schema.fields || schema) as Record<string, Record<string, unknown>>
-  const required = new Set<string>((schema.required as string[]) || [])
-
-  for (const [key, def] of Object.entries(properties)) {
-    if (key === 'type' || key === 'required' || key === 'properties' || key === 'fields') continue
-    const type = (def?.type as string) || 'unknown'
-    const desc = (def?.description as string) || ''
-    const req = required.has(key) ? ', required' : ''
-    lines.push(`${prefix}- ${key} (${type}${req})${desc ? ': ' + desc : ''}`)
-    if (type === 'object' && (def.properties || def.fields)) {
-      lines.push(formatSchema(def as Record<string, unknown>, indent + 1))
-    }
-  }
-  return lines.join('\n')
-}
-
-function formatStepContext(step: Record<string, unknown>): string {
-  if (step.status === 'pending_approval') {
-    const sections: string[] = []
-    sections.push(`STEP: ${step.stepId ?? '(gate)'}`)
-    sections.push('STATUS: pending_approval')
-    if (step.label) sections.push(`LABEL: ${step.label}`)
-    sections.push('')
-    sections.push('WAITING FOR HUMAN APPROVAL')
-    sections.push('No agent action is required until this gate is approved or rejected.')
-    sections.push('Use bakin_exec_check_gates for the current approval status.')
-    return sections.join('\n')
-  }
-
-  if (step.status === 'complete') {
-    return [
-      'STATUS: complete',
-      'WORKFLOW COMPLETE',
-      'No further workflow step is active for this task.',
-    ].join('\n')
-  }
-
-  const sections: string[] = []
-  sections.push(`STEP: ${step.stepId}`)
-  sections.push(`STATUS: ${step.status}`)
-  if (step.label) sections.push(`LABEL: ${step.label}`)
-  if (step.agent) sections.push(`AGENT: ${step.agent}`)
-
-  if (step.instructions) {
-    sections.push('')
-    sections.push('INSTRUCTIONS:')
-    sections.push(step.instructions as string)
-  }
-
-  if (step.priorStepOutput) {
-    sections.push('')
-    sections.push('PRIOR STEP OUTPUT:')
-    sections.push(typeof step.priorStepOutput === 'string' ? step.priorStepOutput : JSON.stringify(step.priorStepOutput, null, 2))
-  } else if (!step.stepOutputs || Object.keys(step.stepOutputs as Record<string, unknown>).length === 0) {
-    sections.push('')
-    sections.push('PRIOR STEP OUTPUT:')
-    sections.push('(none — this is the first step)')
-  }
-
-  const stepOutputs = step.stepOutputs as Record<string, unknown> | undefined
-  if (stepOutputs && Object.keys(stepOutputs).length > 0) {
-    sections.push('')
-    sections.push('ALL PRIOR STEP OUTPUTS:')
-    for (const [stepId, output] of Object.entries(stepOutputs)) {
-      sections.push(`  [${stepId}]:`)
-      sections.push('  ' + JSON.stringify(output, null, 2).replace(/\n/g, '\n  '))
-    }
-  }
-
-  if (step.output_schema) {
-    sections.push('')
-    sections.push('REQUIRED OUTPUT SCHEMA:')
-    sections.push(formatSchema(step.output_schema as Record<string, unknown>))
-  }
-
-  if (step.rejectionReason) {
-    sections.push('')
-    sections.push('REJECTION CONTEXT:')
-    sections.push(step.rejectionReason as string)
-    if (step.previousOutput) {
-      sections.push('')
-      sections.push('YOUR PREVIOUS OUTPUT (needs revision):')
-      sections.push(JSON.stringify(step.previousOutput, null, 2))
-    }
-  } else {
-    sections.push('')
-    sections.push('REJECTION CONTEXT:')
-    sections.push('(none — first attempt)')
-  }
-
-  return sections.join('\n')
-}
-
 /** Fire-and-forget dispatch trigger so the next workflow step's agent starts immediately. */
 function triggerDispatch() {
   const port = Number(process.env.PORT || 3737)
   fetch(`http://localhost:${port}/api/dispatch`, { method: 'POST' }).catch(() => {})
-}
-
-function countSteps(steps: { type: string; steps?: unknown[] }[]): number {
-  let count = 0
-  for (const step of steps) {
-    if (step.type === 'parallel' && Array.isArray(step.steps)) {
-      count += step.steps.length
-    } else {
-      count++
-    }
-  }
-  return count
 }
 
 /** Convert a workflow definition to a search document. */

--- a/plugins/workflows/lib/step-format.ts
+++ b/plugins/workflows/lib/step-format.ts
@@ -1,0 +1,102 @@
+/**
+ * Workflow Step Formatting (presentation-for-agents)
+ *
+ * Pure JSON-schema-to-text and step-context-to-text formatters used when
+ * presenting a workflow step to an agent. No IO, no module state.
+ */
+
+export function formatSchema(schema: Record<string, unknown>, indent = 0): string {
+  const prefix = '  '.repeat(indent)
+  const lines: string[] = []
+  const properties = (schema.properties || schema.fields || schema) as Record<string, Record<string, unknown>>
+  const required = new Set<string>((schema.required as string[]) || [])
+
+  for (const [key, def] of Object.entries(properties)) {
+    if (key === 'type' || key === 'required' || key === 'properties' || key === 'fields') continue
+    const type = (def?.type as string) || 'unknown'
+    const desc = (def?.description as string) || ''
+    const req = required.has(key) ? ', required' : ''
+    lines.push(`${prefix}- ${key} (${type}${req})${desc ? ': ' + desc : ''}`)
+    if (type === 'object' && (def.properties || def.fields)) {
+      lines.push(formatSchema(def as Record<string, unknown>, indent + 1))
+    }
+  }
+  return lines.join('\n')
+}
+
+export function formatStepContext(step: Record<string, unknown>): string {
+  if (step.status === 'pending_approval') {
+    const sections: string[] = []
+    sections.push(`STEP: ${step.stepId ?? '(gate)'}`)
+    sections.push('STATUS: pending_approval')
+    if (step.label) sections.push(`LABEL: ${step.label}`)
+    sections.push('')
+    sections.push('WAITING FOR HUMAN APPROVAL')
+    sections.push('No agent action is required until this gate is approved or rejected.')
+    sections.push('Use bakin_exec_check_gates for the current approval status.')
+    return sections.join('\n')
+  }
+
+  if (step.status === 'complete') {
+    return [
+      'STATUS: complete',
+      'WORKFLOW COMPLETE',
+      'No further workflow step is active for this task.',
+    ].join('\n')
+  }
+
+  const sections: string[] = []
+  sections.push(`STEP: ${step.stepId}`)
+  sections.push(`STATUS: ${step.status}`)
+  if (step.label) sections.push(`LABEL: ${step.label}`)
+  if (step.agent) sections.push(`AGENT: ${step.agent}`)
+
+  if (step.instructions) {
+    sections.push('')
+    sections.push('INSTRUCTIONS:')
+    sections.push(step.instructions as string)
+  }
+
+  if (step.priorStepOutput) {
+    sections.push('')
+    sections.push('PRIOR STEP OUTPUT:')
+    sections.push(typeof step.priorStepOutput === 'string' ? step.priorStepOutput : JSON.stringify(step.priorStepOutput, null, 2))
+  } else if (!step.stepOutputs || Object.keys(step.stepOutputs as Record<string, unknown>).length === 0) {
+    sections.push('')
+    sections.push('PRIOR STEP OUTPUT:')
+    sections.push('(none — this is the first step)')
+  }
+
+  const stepOutputs = step.stepOutputs as Record<string, unknown> | undefined
+  if (stepOutputs && Object.keys(stepOutputs).length > 0) {
+    sections.push('')
+    sections.push('ALL PRIOR STEP OUTPUTS:')
+    for (const [stepId, output] of Object.entries(stepOutputs)) {
+      sections.push(`  [${stepId}]:`)
+      sections.push('  ' + JSON.stringify(output, null, 2).replace(/\n/g, '\n  '))
+    }
+  }
+
+  if (step.output_schema) {
+    sections.push('')
+    sections.push('REQUIRED OUTPUT SCHEMA:')
+    sections.push(formatSchema(step.output_schema as Record<string, unknown>))
+  }
+
+  if (step.rejectionReason) {
+    sections.push('')
+    sections.push('REJECTION CONTEXT:')
+    sections.push(step.rejectionReason as string)
+    if (step.previousOutput) {
+      sections.push('')
+      sections.push('YOUR PREVIOUS OUTPUT (needs revision):')
+      sections.push(JSON.stringify(step.previousOutput, null, 2))
+    }
+  } else {
+    sections.push('')
+    sections.push('REJECTION CONTEXT:')
+    sections.push('(none — first attempt)')
+  }
+
+  return sections.join('\n')
+}

--- a/plugins/workflows/lib/template-list.ts
+++ b/plugins/workflows/lib/template-list.ts
@@ -1,0 +1,129 @@
+/**
+ * Workflow Template List (definition + drift aggregation)
+ *
+ * Pure aggregation over workflow definitions: resolves nested sub-workflows,
+ * builds the template list with per-definition skill-drift summaries, and
+ * counts steps. Used by both routes and exec tools. No module state.
+ */
+import type {
+  WorkflowTemplate,
+  WorkflowDefinition,
+  NestedWorkflowStep,
+  WorkflowSkillDriftSummary,
+} from '../types'
+import { listDefinitions, loadDefinition } from './parser'
+import { readDisabledWorkflowIds } from './availability'
+import { getShadowedSource } from './source-registry'
+import { scanWorkflowSkillDrift, type WorkflowSkillDriftReport } from './workflow-skill-drift'
+import { getContentDir } from './content-dir'
+
+export function resolveSubWorkflows(steps: WorkflowDefinition['steps'], subWorkflows: Record<string, WorkflowDefinition>): void {
+  for (const step of steps) {
+    if (step.type === 'workflow') {
+      const nested = step as NestedWorkflowStep
+      if (nested.workflow_id && !subWorkflows[nested.workflow_id]) {
+        const subDef = loadDefinition(nested.workflow_id)
+        if (subDef) {
+          subWorkflows[nested.workflow_id] = subDef
+          resolveSubWorkflows(subDef.steps, subWorkflows)
+        }
+      }
+    }
+  }
+}
+
+export function buildTemplateList(options: { includeDisabled?: boolean } = {}): { templates: WorkflowTemplate[]; subWorkflows: Record<string, WorkflowDefinition> } {
+  const defs = listDefinitions()
+  const disabledWorkflowIds = readDisabledWorkflowIds()
+  const subWorkflows: Record<string, WorkflowDefinition> = {}
+  const driftBySkill = workflowSkillDriftBySkill()
+  const templates: WorkflowTemplate[] = defs.flatMap(d => {
+    const disabled = d.source !== 'user' && disabledWorkflowIds.has(d.name)
+    const shadowedSource = d.source === 'user' ? getShadowedSource(d.name) : undefined
+    if (disabled && !options.includeDisabled) return []
+    resolveSubWorkflows(d.definition.steps, subWorkflows)
+    return [{
+      name: d.definition.name,
+      filename: d.name,
+      description: d.definition.description,
+      stepCount: countSteps(d.definition.steps),
+      definition: d.definition,
+      source: d.source,
+      pluginId: d.pluginId,
+      packageId: d.packageId,
+      disabled,
+      shadowedSource,
+      skillDrift: workflowSkillDriftForDefinition(d.definition, driftBySkill, subWorkflows),
+    }]
+  })
+  return { templates, subWorkflows }
+}
+
+export function workflowSkillDriftBySkill(): Map<string, WorkflowSkillDriftReport> {
+  return new Map(scanWorkflowSkillDrift(getContentDir()).map(report => [report.skillName, report]))
+}
+
+export function workflowSkillDriftForDefinition(
+  definition: WorkflowDefinition,
+  driftBySkill: Map<string, WorkflowSkillDriftReport>,
+  subWorkflows: Record<string, WorkflowDefinition> = {},
+): WorkflowSkillDriftSummary | undefined {
+  const byStep: Record<string, string[]> = {}
+  const reports = new Map<string, WorkflowSkillDriftReport>()
+  for (const ref of collectWorkflowSkillRefs(definition.steps, subWorkflows)) {
+    const report = driftBySkill.get(ref.skill)
+    if (!report) continue
+    reports.set(report.skillName, report)
+    byStep[ref.stepId] = [...(byStep[ref.stepId] ?? []), ref.skill]
+  }
+  const uniqueReports = Array.from(reports.values())
+  if (uniqueReports.length === 0) return undefined
+  return {
+    count: uniqueReports.length,
+    repairableCount: uniqueReports.filter(report => report.repairable).length,
+    skills: uniqueReports.map(report => report.skillName),
+    reports: uniqueReports,
+    byStep,
+  }
+}
+
+function collectWorkflowSkillRefs(
+  steps: WorkflowDefinition['steps'],
+  subWorkflows: Record<string, WorkflowDefinition> = {},
+  idPrefix = '',
+  workflowStack = new Set<string>(),
+): Array<{ stepId: string; skill: string }> {
+  const refs: Array<{ stepId: string; skill: string }> = []
+  for (const step of steps) {
+    const stepId = idPrefix ? `${idPrefix}__${step.id}` : step.id
+    const skill = (step as { skill?: unknown }).skill
+    if (typeof skill === 'string' && skill.length > 0) {
+      refs.push({ stepId, skill })
+    }
+    if (step.type === 'parallel') {
+      refs.push(...collectWorkflowSkillRefs(step.steps, subWorkflows, idPrefix, workflowStack))
+    }
+    if (step.type === 'workflow') {
+      const workflowId = (step as NestedWorkflowStep).workflow_id
+      const nested = workflowId ? subWorkflows[workflowId] : undefined
+      if (nested && !workflowStack.has(workflowId)) {
+        const nextStack = new Set(workflowStack)
+        nextStack.add(workflowId)
+        refs.push(...collectWorkflowSkillRefs(nested.steps, subWorkflows, stepId, nextStack))
+      }
+    }
+  }
+  return refs
+}
+
+export function countSteps(steps: { type: string; steps?: unknown[] }[]): number {
+  let count = 0
+  for (const step of steps) {
+    if (step.type === 'parallel' && Array.isArray(step.steps)) {
+      count += step.steps.length
+    } else {
+      count++
+    }
+  }
+  return count
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -186,5 +186,22 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   contentDir-param drop, require→import, discriminated getCurrentStep union) NOT taken — noted for follow-up.
   Verified: typecheck/lint/workflows suite 419-0/full-suite 5123-0/binary build/isolated-home boot smoke (workflows
   activates + Ready; GET /definitions + /instances → 200; schedule ENOENT is the environmental openclaw-cron miss).
-- Remaining: workflows/index (2,146), workflow-canvas-editor (1,803), models-page
-  (1,205), schedule/index (1,443) + test splits. Includes the workflows validator dedup flagged in #510.
+- workflows/index — ◧ **split by RISK** (2,146; the cluster's most entangled plugin file: module-load side
+  effects — populateWorkflowRoutes runs at import; a mutable `pluginCtx` module global written in activate and
+  read by route closures; and the triple-scope duplicate-helper pattern — module-scope copies feed the route
+  closures while activate-scope copies feed hooks/exec-tools). The meaningful route/search/validation/gate
+  extractions are inseparable from deduping those copies + replacing the pluginCtx global with ctx injection
+  (behavior-touching, per the appendix), so it's tiered like dispatch/plugin-registry rather than one mega-PR.
+  - ☑ Phase A (pure, zero behavior change): `lib/step-format.ts` (formatSchema/formatStepContext — pure
+    presentation-for-agents) + `lib/template-list.ts` (resolveSubWorkflows/buildTemplateList/workflowSkillDrift*/
+    collectWorkflowSkillRefs/countSteps — pure definition+drift aggregation). 2,146 → ~1,950. No pluginCtx
+    coupling, no module-load concerns. Verified: typecheck/lint/workflows suite 419-0/full-suite 5123-0/binary
+    build/isolated-home boot smoke (Workflows Ready; GET /definitions [buildTemplateList path] + /node-types → 200).
+  - ☐ Phase B (DEFERRED, behavior-touching): `lib/start-validation.ts` — dedupe the two
+    validateWorkflowForStart/createValidatedInstance/getRuntimeAgentNames/collectNestedWorkflowIds copies into one
+    ctx-injected module (the #510 dedup; both copies are already the strong recursive form so it's a true dedup,
+    net behavior identical — keep the REST cycle-rejection regression test green). Then `lib/search-sync.ts` +
+    the pluginCtx→ctx-accessor surgery + route extraction (`routes/{definitions,gates,instances}.ts`), exec-tools,
+    register-hooks, channel-approvals — each its own focused PR with a boot smoke. The decideGate 6-block collapse
+    + stdJsonResponses const + typed defineRoute[] arrays stay deferred redesigns (not required for the split).
+- Remaining: workflow-canvas-editor (1,803), models-page (1,205), schedule/index (1,443) + test splits.


### PR DESCRIPTION
## What

First, deliberately-**pure** slice of the `plugins/workflows/index.ts` split (2,146 lines — the workflows cluster's most entangled file). Extracts two groups of module-scope helpers with **zero `pluginCtx` coupling and zero module-load concerns**:

| Module | Contents |
|---|---|
| `lib/step-format.ts` | `formatSchema`, `formatStepContext` — pure presentation-for-agents formatting |
| `lib/template-list.ts` | `resolveSubWorkflows`, `buildTemplateList`, `workflowSkillDriftBySkill`/`ForDefinition`, `collectWorkflowSkillRefs`, `countSteps` — pure definition + skill-drift aggregation |

`index.ts` drops from **2,146 → ~1,950** and imports both modules back. No behavior change.

## Why tiered (not one PR)

`index.ts` carries module-load side effects (`populateWorkflowRoutes` runs at import), a **mutable `pluginCtx` module global** written in `activate` and read by route closures, and the **triple-scope duplicate-helper pattern** (module-scope copies feed the route closures; activate-scope copies feed hooks/exec-tools). The meaningful route/search/validation/gate extractions are *inseparable* from deduping those copies and replacing `pluginCtx` with ctx injection — both behavior-touching, exactly as the appendix flags. So this is tiered like the dispatch / plugin-registry splits rather than landed as one mega-PR. This PR is the safe, pure first tier; the follow-up phases (including the #510 validator dedup) are laid out in `tasks/plan.md`.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (all 3 changed/new files)
- ✅ workflows plugin suite — **419/0**
- ✅ full suite — **5123/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — Workflows activates + Ready; `GET /definitions` (the `buildTemplateList` path) and `GET /node-types` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)