### PR TITLE
refactor(workflows): dedupe start validation into one ctx-injected module (#510)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -39,7 +39,6 @@ import {
 } from './lib/source-registry'
 import { isWorkflowDisabled, setWorkflowDisabled } from './lib/availability'
 import {
-  createInstance,
   loadInstance,
   saveInstance,
   getCurrentStep,
@@ -65,6 +64,7 @@ import {
   workflowSkillDriftForDefinition,
 } from './lib/template-list'
 import { formatStepContext } from './lib/step-format'
+import { createValidatedInstance } from './lib/start-validation'
 import { createLogger } from '../../src/core/logger'
 import { getContentDir } from '../../src/core/content-dir'
 import { getTask, updateTask } from '../../src/core/task-store'
@@ -80,7 +80,7 @@ import {
 } from './lib/notifications'
 import { approvalRefFromRecord, findPendingApprovalForGate, getApprovalRecord } from './lib/approval-store'
 import { rehydratePendingApprovals } from './lib/approval-rehydration'
-import type { WorkflowDefinition, WorkflowInstance, NestedWorkflowStep } from './types'
+import type { WorkflowDefinition, WorkflowInstance } from './types'
 
 const log = createLogger('workflows')
 let unsubscribeApprovalResponses: (() => void) | null = null
@@ -152,97 +152,6 @@ function buildGateAuditPayload(
     durationMs: decision?.durationMs,
     ...(reason !== undefined ? { reason } : {}),
   }
-}
-
-async function getRuntimeAgentNames(): Promise<Set<string>> {
-  if (!pluginCtx) return new Set()
-  const agents = await pluginCtx.runtime.agents.list()
-  const names = new Set<string>()
-  for (const agent of agents) {
-    names.add(agent.id)
-    names.add(agent.name)
-  }
-  return names
-}
-
-function collectNestedWorkflowIds(def: WorkflowDefinition, out: Set<string>): void {
-  for (const step of def.steps) {
-    if (step.type === 'workflow') {
-      out.add((step as NestedWorkflowStep).workflow_id)
-    }
-  }
-}
-
-async function validateWorkflowForStart(
-  workflowId: string,
-  assignee: string | undefined,
-  contentDir?: string,
-  runtimeAgents?: Set<string>,
-): Promise<string[]> {
-  const errors: string[] = []
-  const knownAgents = runtimeAgents ?? await getRuntimeAgentNames()
-  const knownWorkflowIds = new Set(listDefinitions(contentDir).map((entry) => entry.name))
-  const visited = new Set<string>()
-
-  // Recurse through nested workflows, validating each definition and detecting
-  // nesting cycles. The REST /instances/start path previously skipped this —
-  // only the hook/exec-tool paths recursed — so a cyclic or invalid nested
-  // workflow could be started via REST. This matches the strong validator.
-  const visit = (id: string, path: string[]): void => {
-    const workflowIdError = validateWorkflowId(id)
-    if (workflowIdError) {
-      errors.push(`Workflow "${id}": ${workflowIdError}`)
-      return
-    }
-    if (path.includes(id)) {
-      errors.push(`Workflow nesting cycle detected: ${[...path, id].join(' -> ')}`)
-      return
-    }
-    if (visited.has(id)) return
-    visited.add(id)
-
-    const def = loadDefinition(id, contentDir)
-    if (!def) {
-      errors.push(`Workflow definition not found: ${id}`)
-      return
-    }
-
-    errors.push(...validateDefinition(def, {
-      definitionId: id,
-      source: def.source,
-      contentDir,
-      knownWorkflowIds,
-      runtimeAgents: knownAgents,
-      assignee,
-      requireResolvedAgents: true,
-    }).map((message) => `Workflow "${id}": ${message}`))
-
-    const nestedIds = new Set<string>()
-    collectNestedWorkflowIds(def, nestedIds)
-    for (const nestedId of nestedIds) visit(nestedId, [...path, id])
-  }
-
-  visit(workflowId, [])
-
-  if (assignee && !knownAgents.has(assignee)) {
-    errors.push(`Assignee "${assignee}" is not a known runtime agent`)
-  }
-  return errors
-}
-
-async function createValidatedInstance(
-  taskId: string,
-  workflowId: string,
-  assignee: string | undefined,
-  contentDir?: string,
-  parentContext?: Record<string, unknown>,
-) {
-  const knownAgents = await getRuntimeAgentNames()
-  const errors = await validateWorkflowForStart(workflowId, assignee, contentDir, knownAgents)
-  if (errors.length > 0) {
-    throw new Error(errors.join('; '))
-  }
-  return createInstance(taskId, workflowId, contentDir, assignee, parentContext, knownAgents)
 }
 
 // ---------------------------------------------------------------------------
@@ -1086,7 +995,7 @@ function populateWorkflowRoutes(arr: any[]): void {
         assignee = getTask(taskId)?.agent
       } catch { /* best effort */ }
 
-      const instance = await createValidatedInstance(taskId, workflowId, assignee)
+      const instance = await createValidatedInstance(pluginCtx, taskId, workflowId, assignee)
 
       // Ensure the task's workflowId is persisted in Bakin task metadata
       try {
@@ -1308,89 +1217,6 @@ const workflowsPlugin: BakinPlugin = definePlugin({
     setGateNotificationSettings(gateNotificationSettings)
     const activeGateSettings = () => getGateNotificationSettings() ?? gateNotificationSettings
 
-    const getRuntimeAgentNames = async (): Promise<Set<string>> => {
-      const agents = await ctx.runtime.agents.list()
-      const names = new Set<string>()
-      for (const agent of agents) {
-        names.add(agent.id)
-        names.add(agent.name)
-      }
-      return names
-    }
-
-    const collectNestedWorkflowIds = (def: WorkflowDefinition, out: Set<string>): void => {
-      for (const step of def.steps) {
-        if (step.type === 'workflow') {
-          out.add((step as NestedWorkflowStep).workflow_id)
-        }
-      }
-    }
-
-    const validateWorkflowForStart = async (
-      workflowId: string,
-      assignee: string | undefined,
-      contentDir?: string,
-      runtimeAgents?: Set<string>,
-    ): Promise<string[]> => {
-      const errors: string[] = []
-      const knownAgents = runtimeAgents ?? await getRuntimeAgentNames()
-      const knownWorkflowIds = new Set(listDefinitions(contentDir).map((entry) => entry.name))
-      const visited = new Set<string>()
-
-      const visit = (id: string, path: string[]): void => {
-        const workflowIdError = validateWorkflowId(id)
-        if (workflowIdError) {
-          errors.push(`Workflow "${id}": ${workflowIdError}`)
-          return
-        }
-        if (path.includes(id)) {
-          errors.push(`Workflow nesting cycle detected: ${[...path, id].join(' -> ')}`)
-          return
-        }
-        if (visited.has(id)) return
-        visited.add(id)
-
-        const def = loadDefinition(id, contentDir)
-        if (!def) {
-          errors.push(`Workflow definition not found: ${id}`)
-          return
-        }
-
-        errors.push(...validateDefinition(def, {
-          definitionId: id,
-          source: def.source,
-          contentDir,
-          knownWorkflowIds,
-          runtimeAgents: knownAgents,
-          assignee,
-          requireResolvedAgents: true,
-        }).map((message) => `Workflow "${id}": ${message}`))
-
-        const nestedIds = new Set<string>()
-        collectNestedWorkflowIds(def, nestedIds)
-        for (const nestedId of nestedIds) visit(nestedId, [...path, id])
-      }
-
-      visit(workflowId, [])
-
-      return errors
-    }
-
-    const createValidatedInstance = async (
-      taskId: string,
-      workflowId: string,
-      assignee: string | undefined,
-      contentDir?: string,
-      parentContext?: Record<string, unknown>,
-    ) => {
-      const knownAgents = await getRuntimeAgentNames()
-      const errors = await validateWorkflowForStart(workflowId, assignee, contentDir, knownAgents)
-      if (errors.length > 0) {
-        throw new Error(errors.join('; '))
-      }
-      return createInstance(taskId, workflowId, contentDir, assignee, parentContext, knownAgents)
-    }
-
     const approvalRehydration = await rehydratePendingApprovals({
       runtime: ctx.runtime,
       channel: activeGateSettings().approvalChannel || 'general',
@@ -1507,7 +1333,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
 
     ctx.hooks.register('workflows.loadInstance', (d: Record<string, unknown>) => loadInstance(d.taskId as string, d.contentDir as string | undefined), { label: 'Load workflow instance.', summary: 'Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.saveInstance', (d: Record<string, unknown>) => saveInstance(d.instance as Parameters<typeof saveInstance>[0], d.contentDir as string | undefined), { label: 'Save workflow instance.', summary: 'Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.createInstance', (d: Record<string, unknown>) => createValidatedInstance(d.taskId as string, d.workflowId as string, d.assignee as string | undefined, d.contentDir as string | undefined, d.parentContext as Record<string, unknown> | undefined), { label: 'Create workflow instance.', summary: 'Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.', hookKind: 'rpc' })
+    ctx.hooks.register('workflows.createInstance', (d: Record<string, unknown>) => createValidatedInstance(ctx, d.taskId as string, d.workflowId as string, d.assignee as string | undefined, d.contentDir as string | undefined, d.parentContext as Record<string, unknown> | undefined), { label: 'Create workflow instance.', summary: 'Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.', hookKind: 'rpc' })
     ctx.hooks.register('workflows.approveGate', (d: Record<string, unknown>) => approveGate(d.taskId as string, d.stepId as string, {
       approver: d.approver as ApprovalActor | undefined,
       contentDir: d.contentDir as string | undefined,
@@ -1628,7 +1454,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
             assignee = getTask(taskId)?.agent
           } catch { /* best effort */ }
 
-          const instance = await createValidatedInstance(taskId, workflowId, assignee)
+          const instance = await createValidatedInstance(ctx, taskId, workflowId, assignee)
 
           try {
             await updateTask(taskId, { workflowId })

--- a/plugins/workflows/lib/start-validation.ts
+++ b/plugins/workflows/lib/start-validation.ts
@@ -1,0 +1,112 @@
+/**
+ * Workflow Start Validation
+ *
+ * The single recursive workflow-start validator shared by REST, hooks, and
+ * exec tools. Previously this logic was duplicated three ways (a module-scope
+ * copy reading the `pluginCtx` global for routes, and an activate-scope copy
+ * closing over `ctx` for hooks/exec-tools) — and the two had diverged: only
+ * the route copy carried the top-level assignee-known check. This module is
+ * the canonical superset: recursive nested-workflow validation + cycle
+ * detection + the explicit assignee check, applied to every start path.
+ *
+ * The runtime-agent dependency is injected as a `ctx` (anything exposing
+ * `runtime.agents.list()`); a null ctx degrades to an empty agent set, matching
+ * the old module-scope guard.
+ */
+import type { PluginContext } from '@bakin/core/plugin-types'
+import type { WorkflowDefinition, NestedWorkflowStep } from '../types'
+import { listDefinitions, loadDefinition, validateDefinition, validateWorkflowId } from './parser'
+import { createInstance } from './runtime'
+
+export async function getRuntimeAgentNames(ctx: PluginContext | null): Promise<Set<string>> {
+  if (!ctx) return new Set()
+  const agents = await ctx.runtime.agents.list()
+  const names = new Set<string>()
+  for (const agent of agents) {
+    names.add(agent.id)
+    names.add(agent.name)
+  }
+  return names
+}
+
+function collectNestedWorkflowIds(def: WorkflowDefinition, out: Set<string>): void {
+  for (const step of def.steps) {
+    if (step.type === 'workflow') {
+      out.add((step as NestedWorkflowStep).workflow_id)
+    }
+  }
+}
+
+export async function validateWorkflowForStart(
+  ctx: PluginContext | null,
+  workflowId: string,
+  assignee: string | undefined,
+  contentDir?: string,
+  runtimeAgents?: Set<string>,
+): Promise<string[]> {
+  const errors: string[] = []
+  const knownAgents = runtimeAgents ?? await getRuntimeAgentNames(ctx)
+  const knownWorkflowIds = new Set(listDefinitions(contentDir).map((entry) => entry.name))
+  const visited = new Set<string>()
+
+  // Recurse through nested workflows, validating each definition and detecting
+  // nesting cycles. The REST /instances/start path previously skipped this —
+  // only the hook/exec-tool paths recursed — so a cyclic or invalid nested
+  // workflow could be started via REST. This matches the strong validator.
+  const visit = (id: string, path: string[]): void => {
+    const workflowIdError = validateWorkflowId(id)
+    if (workflowIdError) {
+      errors.push(`Workflow "${id}": ${workflowIdError}`)
+      return
+    }
+    if (path.includes(id)) {
+      errors.push(`Workflow nesting cycle detected: ${[...path, id].join(' -> ')}`)
+      return
+    }
+    if (visited.has(id)) return
+    visited.add(id)
+
+    const def = loadDefinition(id, contentDir)
+    if (!def) {
+      errors.push(`Workflow definition not found: ${id}`)
+      return
+    }
+
+    errors.push(...validateDefinition(def, {
+      definitionId: id,
+      source: def.source,
+      contentDir,
+      knownWorkflowIds,
+      runtimeAgents: knownAgents,
+      assignee,
+      requireResolvedAgents: true,
+    }).map((message) => `Workflow "${id}": ${message}`))
+
+    const nestedIds = new Set<string>()
+    collectNestedWorkflowIds(def, nestedIds)
+    for (const nestedId of nestedIds) visit(nestedId, [...path, id])
+  }
+
+  visit(workflowId, [])
+
+  if (assignee && !knownAgents.has(assignee)) {
+    errors.push(`Assignee "${assignee}" is not a known runtime agent`)
+  }
+  return errors
+}
+
+export async function createValidatedInstance(
+  ctx: PluginContext | null,
+  taskId: string,
+  workflowId: string,
+  assignee: string | undefined,
+  contentDir?: string,
+  parentContext?: Record<string, unknown>,
+) {
+  const knownAgents = await getRuntimeAgentNames(ctx)
+  const errors = await validateWorkflowForStart(ctx, workflowId, assignee, contentDir, knownAgents)
+  if (errors.length > 0) {
+    throw new Error(errors.join('; '))
+  }
+  return createInstance(taskId, workflowId, contentDir, assignee, parentContext, knownAgents)
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -197,11 +197,22 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     collectWorkflowSkillRefs/countSteps — pure definition+drift aggregation). 2,146 → ~1,950. No pluginCtx
     coupling, no module-load concerns. Verified: typecheck/lint/workflows suite 419-0/full-suite 5123-0/binary
     build/isolated-home boot smoke (Workflows Ready; GET /definitions [buildTemplateList path] + /node-types → 200).
-  - ☐ Phase B (DEFERRED, behavior-touching): `lib/start-validation.ts` — dedupe the two
-    validateWorkflowForStart/createValidatedInstance/getRuntimeAgentNames/collectNestedWorkflowIds copies into one
-    ctx-injected module (the #510 dedup; both copies are already the strong recursive form so it's a true dedup,
-    net behavior identical — keep the REST cycle-rejection regression test green). Then `lib/search-sync.ts` +
-    the pluginCtx→ctx-accessor surgery + route extraction (`routes/{definitions,gates,instances}.ts`), exec-tools,
-    register-hooks, channel-approvals — each its own focused PR with a boot smoke. The decideGate 6-block collapse
-    + stdJsonResponses const + typed defineRoute[] arrays stay deferred redesigns (not required for the split).
+  - ☑ Phase B — the #510 validator dedup: `lib/start-validation.ts` collapses the two copies of
+    getRuntimeAgentNames/collectNestedWorkflowIds/validateWorkflowForStart/createValidatedInstance (a module-scope
+    set reading the `pluginCtx` global for routes + an activate-scope set closing over `ctx` for hooks/exec-tools)
+    into ONE ctx-injected module. The two copies had DIVERGED — only the route copy carried the trailing
+    `assignee not a known runtime agent` superset check — so the unified validator keeps the superset (REST already
+    enforced it; hooks/exec-tools now do too, the intentional tightening toward one strong validator). The runtime-
+    agent dep is injected as a `PluginContext | null` (null → empty agent set, matching the old module-scope guard);
+    routes pass the `pluginCtx` global, hooks/exec-tools pass `ctx`. index.ts now imports only `createValidatedInstance`
+    and dropped its now-unused `createInstance` import. Regression: new gate-hooks test proves the createInstance
+    HOOK rejects a nested-workflow cycle (parity with the existing REST cycle test) — i.e. all three start paths
+    share the recursive validator. 2,146(pre-A) → ~1,760. Verified: typecheck/lint/workflows suite 420-0/full-suite
+    5124-0/binary build/boot smoke (POST /instances/start → 400 from createValidatedInstance, not 5xx).
+  - ☐ Phase C (DEFERRED, behavior-touching): `lib/search-sync.ts` + the pluginCtx→ctx-accessor surgery + route
+    extraction (`routes/{definitions,gates,instances}.ts`), exec-tools, register-hooks, channel-approvals — each its
+    own focused PR with a boot smoke. **OPEN DECISION for Mark:** route extraction REQUIRES replacing the mutable
+    `pluginCtx` module global (still read by indexInstance + one route at index.ts ~120/520) with the appendix's
+    shared-ctx-accessor design — confirm before taking it, or stop the split here. The decideGate 6-block collapse +
+    stdJsonResponses const + typed defineRoute[] arrays stay deferred redesigns (not required for the split).
 - Remaining: workflow-canvas-editor (1,803), models-page (1,205), schedule/index (1,443) + test splits.

--- a/tests/plugins/workflows/gate-hooks.test.ts
+++ b/tests/plugins/workflows/gate-hooks.test.ts
@@ -249,6 +249,40 @@ describe('workflows gate hooks', () => {
     expect((missingStep.errors as string[])[0]).toContain('not a gate')
   })
 
+  it('workflows.createInstance routes through the unified recursive start validator (#510)', async () => {
+    // #510 dedup: REST, the createInstance hook, and the start exec tool now
+    // share ONE strong recursive validator. Proven here on the hook path by
+    // rejecting a nested-workflow cycle (parity with the REST cycle test in
+    // routes.test.ts) — cycle detection is agent-independent, so it isolates
+    // the wiring rather than the empty-mock agent set.
+    writeFileSync(join(defsDir, 'cycle-a.yaml'), `name: Cycle A
+description: A
+version: 1
+steps:
+  - id: nest-b
+    type: workflow
+    label: Run B
+    workflow_id: cycle-b
+`)
+    writeFileSync(join(defsDir, 'cycle-b.yaml'), `name: Cycle B
+description: B
+version: 1
+steps:
+  - id: nest-a
+    type: workflow
+    label: Run A
+    workflow_id: cycle-a
+`)
+    const hooks = await activateWithHooks()
+    await expect(
+      hooks.get('workflows.createInstance')!({
+        taskId: 'task-cycle-hook',
+        workflowId: 'cycle-a',
+        contentDir: testDir,
+      }),
+    ).rejects.toThrow('cycle detected')
+  })
+
   it('workflows.reopenFromStep reopens the same workflow instance', async () => {
     const hooks = await activateWithHooks()
     createPendingGate('task-reopen-hook')


### PR DESCRIPTION
## What

Resolves the **#510 validator dedup**. `index.ts` carried the workflow-start validator **three ways**:

- a **module-scope** copy reading the `pluginCtx` global — used by the REST route closures (which run at module-load and can't see `ctx`)
- an **activate-scope** copy closing over `ctx` — used by the `workflows.createInstance` hook + the start exec tool

…each with its own `getRuntimeAgentNames` / `collectNestedWorkflowIds` / `validateWorkflowForStart` / `createValidatedInstance`.

The two had **quietly diverged**: only the route copy carried the trailing `Assignee "x" is not a known runtime agent` superset check.

This collapses both into **`lib/start-validation.ts`** — one recursive validator with the runtime-agent dependency injected as a `PluginContext | null` (null → empty agent set, matching the old module-scope guard). Routes pass the `pluginCtx` global; hooks/exec-tools pass `ctx`.

## Behavior

The unified validator **keeps the superset** assignee check. So:
- **REST** keeps its exact behavior (already recursive + assignee check)
- **Hook / exec-tool** starts now also apply the assignee-known check — the intended tightening to one strong validator, which is the whole point of #510 (eliminate the three-way divergence so it can't drift again)

`index.ts` drops to a single `createValidatedInstance` import (the other three functions are now internal to the module) and sheds its now-unused `createInstance` import. Net: ~1,760 lines (from 2,146 pre-split).

## Regression test

New `gate-hooks` test asserts the `workflows.createInstance` **hook** rejects a nested-workflow cycle — parity with the existing REST cycle test in `routes.test.ts` — proving all three start paths share the one recursive validator.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (changed/new files)
- ✅ workflows plugin suite — **420/0** (+1)
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — Workflows Ready; `GET /definitions` → 200; `POST /instances/start` with a bogus workflowId → **400** from `createValidatedInstance` (the moved path), not 5xx

## Note on the rest of the `index.ts` split

The remaining route/search/gate extractions (Phase C) require replacing the mutable `pluginCtx` module global with a shared ctx-accessor — a behavior-adjacent change I've flagged in `tasks/plan.md` for an explicit go/no-go before taking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)