### PR TITLE
refactor(workflows): replace pluginCtx global with accessor + dedupe search-sync (C1)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -35,7 +35,6 @@ import {
   getDefinition as getRegistryDefinition,
   getManagedDefinition,
   getShadowedSource,
-  type DefinitionSource,
 } from './lib/source-registry'
 import { isWorkflowDisabled, setWorkflowDisabled } from './lib/availability'
 import {
@@ -65,6 +64,8 @@ import {
 } from './lib/template-list'
 import { formatStepContext } from './lib/step-format'
 import { createValidatedInstance } from './lib/start-validation'
+import { getWorkflowPluginContext, setWorkflowPluginContext } from './lib/plugin-context'
+import { instanceToSearchDoc, definitionToSearchDoc, indexInstance, indexDefinition } from './lib/search-sync'
 import { createLogger } from '../../src/core/logger'
 import { getContentDir } from '../../src/core/content-dir'
 import { getTask, updateTask } from '../../src/core/task-store'
@@ -85,9 +86,6 @@ import type { WorkflowDefinition, WorkflowInstance } from './types'
 const log = createLogger('workflows')
 let unsubscribeApprovalResponses: (() => void) | null = null
 
-// ─── Module-scope state populated during activate() ──────────────────────
-let pluginCtx: PluginContext | null = null
-
 const passthroughWf = z.object({}).passthrough()
 const errorResponseWf = z.object({ error: z.string() }).passthrough()
 const htmlResponseWf = { contentType: 'text/html' as const }
@@ -102,32 +100,6 @@ function activeGateSettings(): GateNotificationSettings {
 }
 
 // ─── Module-scope helpers ────────────────────────────────────────────────
-
-function instanceToSearchDoc(inst: WorkflowInstance): Record<string, unknown> {
-  const def = loadDefinition(inst.workflowId)
-  const stepsText = def?.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ') || ''
-  return {
-    name: def?.name || inst.workflowId,
-    description: def?.description || '',
-    type: 'instance',
-    status: inst.status,
-    task_id: inst.taskId,
-    steps: stepsText,
-    updated_at: inst.updatedAt || new Date().toISOString(),
-  }
-}
-
-async function indexInstance(taskId: string): Promise<void> {
-  if (!pluginCtx) return
-  try {
-    const inst = loadInstance(taskId)
-    if (inst) {
-      await pluginCtx.search.index(`inst:${taskId}`, instanceToSearchDoc(inst))
-    }
-  } catch (err) {
-    log.warn('Failed to index workflow instance', { taskId, error: err instanceof Error ? err.message : String(err) })
-  }
-}
 
 function getGateDescription(workflowId: string, stepId: string): string | undefined {
   const def = loadDefinition(workflowId)
@@ -162,21 +134,6 @@ function buildGateAuditPayload(
 function triggerDispatch() {
   const port = Number(process.env.PORT || 3737)
   fetch(`http://localhost:${port}/api/dispatch`, { method: 'POST' }).catch(() => {})
-}
-
-/** Convert a workflow definition to a search document. */
-function definitionToSearchDoc(name: string, def: WorkflowDefinition, source?: DefinitionSource): Record<string, unknown> {
-  const stepsText = def.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ')
-  const definitionSource = source ?? (def as WorkflowDefinition & { source?: DefinitionSource }).source
-  return {
-    name: def.name,
-    description: def.description || '',
-    type: 'definition',
-    status: definitionSource !== 'user' && isWorkflowDisabled(name) ? 'disabled' : 'active',
-    task_id: '',
-    steps: stepsText,
-    updated_at: new Date().toISOString(),
-  }
 }
 
 function populateWorkflowRoutes(arr: any[]): void {
@@ -426,10 +383,7 @@ function populateWorkflowRoutes(arr: any[]): void {
 
     setWorkflowDisabled(name, body.disabled)
     try {
-      await pluginCtx?.search.index(
-        `def:${name}`,
-        definitionToSearchDoc(name, effectiveDefinition, effectiveDefinition.source),
-      )
+      await indexDefinition(name, effectiveDefinition, effectiveDefinition.source)
     } catch (err) {
       log.warn('Failed to reindex workflow availability change', { name, error: err instanceof Error ? err.message : String(err) })
     }
@@ -995,7 +949,7 @@ function populateWorkflowRoutes(arr: any[]): void {
         assignee = getTask(taskId)?.agent
       } catch { /* best effort */ }
 
-      const instance = await createValidatedInstance(pluginCtx, taskId, workflowId, assignee)
+      const instance = await createValidatedInstance(getWorkflowPluginContext(), taskId, workflowId, assignee)
 
       // Ensure the task's workflowId is persisted in Bakin task metadata
       try {
@@ -1045,24 +999,9 @@ const workflowsPlugin: BakinPlugin = definePlugin({
   contentFiles: [],
 
   async activate(ctx: PluginContext) {
-    pluginCtx = ctx
+    setWorkflowPluginContext(ctx)
 
     // ─── Search Content Type Registration ─────────────────────────────
-
-    /** Convert a workflow instance to a search document */
-    function instanceToSearchDoc(inst: WorkflowInstance): Record<string, unknown> {
-      const def = loadDefinition(inst.workflowId)
-      const stepsText = def?.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ') || ''
-      return {
-        name: def?.name || inst.workflowId,
-        description: def?.description || '',
-        type: 'instance',
-        status: inst.status,
-        task_id: inst.taskId,
-        steps: stepsText,
-        updated_at: inst.updatedAt || new Date().toISOString(),
-      }
-    }
 
     ctx.search.registerFileBackedContentType({
       table: 'workflows',
@@ -1179,18 +1118,6 @@ const workflowsPlugin: BakinPlugin = definePlugin({
         return false
       },
     })
-
-    /** Index a workflow instance in search */
-    async function indexInstance(taskId: string): Promise<void> {
-      try {
-        const inst = loadInstance(taskId)
-        if (inst) {
-          await ctx.search.index(`inst:${taskId}`, instanceToSearchDoc(inst))
-        }
-      } catch (err) {
-        log.warn('Failed to index workflow instance', { taskId, error: err instanceof Error ? err.message : String(err) })
-      }
-    }
 
     // ─── Plugin-shipped workflow defaults ─────────────────────────────
     // Load every YAML in defaults/workflows/ and register through

--- a/plugins/workflows/lib/plugin-context.ts
+++ b/plugins/workflows/lib/plugin-context.ts
@@ -1,0 +1,21 @@
+/**
+ * Workflow Plugin Context accessor
+ *
+ * Replaces the former mutable `pluginCtx` module global in index.ts. Route
+ * closures are built at module-load time (populateWorkflowRoutes runs at
+ * import, before activate), so they can't capture `ctx` directly — they read
+ * it lazily through this accessor at request time instead. `activate` sets it
+ * once; search-indexing and the start route read it. Null until activate runs,
+ * matching the old guard semantics.
+ */
+import type { PluginContext } from '@bakin/core/plugin-types'
+
+let pluginCtx: PluginContext | null = null
+
+export function setWorkflowPluginContext(ctx: PluginContext): void {
+  pluginCtx = ctx
+}
+
+export function getWorkflowPluginContext(): PluginContext | null {
+  return pluginCtx
+}

--- a/plugins/workflows/lib/search-sync.ts
+++ b/plugins/workflows/lib/search-sync.ts
@@ -1,0 +1,75 @@
+/**
+ * Workflow Search Sync
+ *
+ * Search-document builders for workflow instances and definitions, plus the
+ * ctx-injected index helpers. Previously these were duplicated across a
+ * module-scope copy (reading the pluginCtx global, for route closures) and an
+ * activate-scope copy (closing over ctx, for the file-backed content type and
+ * hooks/exec-tools). Now a single set, reading the shared plugin-context
+ * accessor — null ctx before activate degrades to a no-op, matching the old
+ * `if (!pluginCtx) return` guard.
+ */
+import type { WorkflowDefinition, WorkflowInstance } from '../types'
+import type { DefinitionSource } from './source-registry'
+import { loadDefinition } from './parser'
+import { loadInstance } from './runtime'
+import { isWorkflowDisabled } from './availability'
+import { getWorkflowPluginContext } from './plugin-context'
+import { createLogger } from '@bakin/core/logger'
+
+const log = createLogger('workflows')
+
+/** Convert a workflow instance to a search document. */
+export function instanceToSearchDoc(inst: WorkflowInstance): Record<string, unknown> {
+  const def = loadDefinition(inst.workflowId)
+  const stepsText = def?.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ') || ''
+  return {
+    name: def?.name || inst.workflowId,
+    description: def?.description || '',
+    type: 'instance',
+    status: inst.status,
+    task_id: inst.taskId,
+    steps: stepsText,
+    updated_at: inst.updatedAt || new Date().toISOString(),
+  }
+}
+
+/** Convert a workflow definition to a search document. */
+export function definitionToSearchDoc(name: string, def: WorkflowDefinition, source?: DefinitionSource): Record<string, unknown> {
+  const stepsText = def.steps.map(s => `${s.id}: ${s.label || ''}`).join(', ')
+  const definitionSource = source ?? (def as WorkflowDefinition & { source?: DefinitionSource }).source
+  return {
+    name: def.name,
+    description: def.description || '',
+    type: 'definition',
+    status: definitionSource !== 'user' && isWorkflowDisabled(name) ? 'disabled' : 'active',
+    task_id: '',
+    steps: stepsText,
+    updated_at: new Date().toISOString(),
+  }
+}
+
+/** Index a workflow instance in search. No-op until the plugin has activated. */
+export async function indexInstance(taskId: string): Promise<void> {
+  const ctx = getWorkflowPluginContext()
+  if (!ctx) return
+  try {
+    const inst = loadInstance(taskId)
+    if (inst) {
+      await ctx.search.index(`inst:${taskId}`, instanceToSearchDoc(inst))
+    }
+  } catch (err) {
+    log.warn('Failed to index workflow instance', { taskId, error: err instanceof Error ? err.message : String(err) })
+  }
+}
+
+/**
+ * Index a workflow definition in search. No-op until the plugin has activated.
+ * Errors propagate so callers can log with their own context (mirrors the
+ * former inline `pluginCtx?.search.index` + try/catch at the availability route).
+ */
+export async function indexDefinition(name: string, def: WorkflowDefinition, source?: DefinitionSource): Promise<void> {
+  const ctx = getWorkflowPluginContext()
+  if (!ctx) return
+  await ctx.search.index(`def:${name}`, definitionToSearchDoc(name, def, source))
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -209,10 +209,17 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     HOOK rejects a nested-workflow cycle (parity with the existing REST cycle test) — i.e. all three start paths
     share the recursive validator. 2,146(pre-A) → ~1,760. Verified: typecheck/lint/workflows suite 420-0/full-suite
     5124-0/binary build/boot smoke (POST /instances/start → 400 from createValidatedInstance, not 5xx).
-  - ☐ Phase C (DEFERRED, behavior-touching): `lib/search-sync.ts` + the pluginCtx→ctx-accessor surgery + route
-    extraction (`routes/{definitions,gates,instances}.ts`), exec-tools, register-hooks, channel-approvals — each its
-    own focused PR with a boot smoke. **OPEN DECISION for Mark:** route extraction REQUIRES replacing the mutable
-    `pluginCtx` module global (still read by indexInstance + one route at index.ts ~120/520) with the appendix's
-    shared-ctx-accessor design — confirm before taking it, or stop the split here. The decideGate 6-block collapse +
-    stdJsonResponses const + typed defineRoute[] arrays stay deferred redesigns (not required for the split).
+  - Phase C (Mark approved the pluginCtx→ctx-accessor design) — focused PRs, each with a boot smoke:
+    - ☑ C1 — accessor + search-sync dedup: new `lib/plugin-context.ts` (setWorkflowPluginContext/getWorkflowPluginContext)
+      REPLACES the mutable `pluginCtx` module global outright, and new `lib/search-sync.ts` collapses the module-scope
+      vs activate-scope copies of instanceToSearchDoc/definitionToSearchDoc/indexInstance into one ctx-injected set
+      (reads the accessor; null-before-activate → no-op, matching the old guard) + adds indexDefinition for the
+      availability route. index.ts no longer declares `pluginCtx` at all: the start route reads getWorkflowPluginContext(),
+      activate calls setWorkflowPluginContext(ctx), the registerFileBackedContentType block imports the search docs.
+      ~1,770 → ~1,700. Verified: typecheck/lint/workflows 420-0/full-suite 5124-0/binary build/boot smoke (bakin_workflows
+      content type registers; GET /definitions + /search → 200).
+    - ☐ C2 — route extraction (`routes/{definitions,gates,instances}.ts`) as typed defineRoute[] builders now that
+      handlers reach ctx via the accessor; then C3 — exec-tools + register-hooks + channel-approvals activate-body
+      extractions. The decideGate 6-block collapse + getGateDescription/buildGateAuditPayload dedup + stdJsonResponses
+      const + typed-route casts stay deferred redesigns (not required for the split).
 - Remaining: workflow-canvas-editor (1,803), models-page (1,205), schedule/index (1,443) + test splits.


### PR DESCRIPTION
## What

Phase **C1** of the `workflows/index.ts` split (you approved the `pluginCtx`→ctx-accessor design). Removes the mutable `pluginCtx` module global and collapses the duplicated search helpers.

| Module | Contents |
|---|---|
| `lib/plugin-context.ts` | `setWorkflowPluginContext` / `getWorkflowPluginContext` — the shared ctx accessor |
| `lib/search-sync.ts` | one ctx-injected set of `instanceToSearchDoc` / `definitionToSearchDoc` / `indexInstance` (previously duplicated **module-scope** reading `pluginCtx` *and* **activate-scope** closing over `ctx`), plus a new `indexDefinition` for the availability route |

## Why the accessor

Route closures are built at **module-load** time (`populateWorkflowRoutes` runs at import, before `activate`), so they can't capture `ctx` directly — that's the whole reason the mutable `pluginCtx` global existed. The accessor formalizes that: `activate` sets it once; route handlers + search indexing read it lazily at request time. `index.ts` no longer declares `pluginCtx` at all.

## Behavior-preserving

- The accessor holds the **last-activated ctx**, exactly as the old module global did.
- The unified `indexInstance` keeps the `if (!ctx) return` guard (no-op before activate), so the module-scope copy's guard semantics are preserved on every path.
- `indexDefinition` is a thin index call with no internal try/catch, so the availability route keeps its existing `try/catch` + `log.warn` behavior byte-for-byte (including the no-op-when-no-ctx via the accessor's null return).

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (all 3 changed/new files)
- ✅ workflows plugin suite — **420/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — `bakin_workflows` content type registers; `GET /definitions` → 200; `GET /search?q=test` → 200

## Next (C2/C3)

Route extraction into `routes/{definitions,gates,instances}.ts` as typed `defineRoute[]` builders (now unblocked by the accessor), then exec-tools / register-hooks / channel-approvals. The `decideGate` collapse + `getGateDescription`/`buildGateAuditPayload` dedup + `stdJsonResponses` const stay deferred redesigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)