### PR TITLE
refactor(workflows): extract definition routes into lib/routes/definitions (C2a)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -3,7 +3,7 @@
  * Enforces step-by-step agent execution with gated delivery,
  * parallel steps, human gates, and output validation.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, readdirSync, readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import { userInfo } from 'os'
@@ -12,10 +12,9 @@ import { z } from 'zod'
 import type { ApprovalActor, BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { defineRoute, definePlugin } from '@bakin/core/routing'
 import type { PluginContextLite } from '@bakin/core/routing'
-import { listDefinitions, loadDefinition, validateDefinition, validateWorkflowId } from './lib/parser'
+import { listDefinitions, loadDefinition } from './lib/parser'
 import { workflowDefinitionNameFromHookInput } from './lib/hook-input'
 import { loadDefaultWorkflows } from './lib/load-defaults'
-import { workflowDefinitionSchema, listNodeTypes } from './lib/node-type-registry'
 import {
   getNotificationChannel,
   listNotificationChannels,
@@ -28,15 +27,8 @@ import {
   staleWorkflowInstancesRepair,
 } from './lib/health-checks'
 import {
-  repairWorkflowSkillDrift,
-} from './lib/workflow-skill-drift'
-import {
-  isReadOnly,
-  getDefinition as getRegistryDefinition,
   getManagedDefinition,
-  getShadowedSource,
 } from './lib/source-registry'
-import { isWorkflowDisabled, setWorkflowDisabled } from './lib/availability'
 import {
   loadInstance,
   saveInstance,
@@ -59,13 +51,13 @@ import { matchWorkflow } from './lib/matcher'
 import {
   buildTemplateList,
   resolveSubWorkflows,
-  workflowSkillDriftBySkill,
-  workflowSkillDriftForDefinition,
 } from './lib/template-list'
 import { formatStepContext } from './lib/step-format'
 import { createValidatedInstance } from './lib/start-validation'
 import { getWorkflowPluginContext, setWorkflowPluginContext } from './lib/plugin-context'
-import { instanceToSearchDoc, definitionToSearchDoc, indexInstance, indexDefinition } from './lib/search-sync'
+import { instanceToSearchDoc, definitionToSearchDoc, indexInstance } from './lib/search-sync'
+import { passthroughWf, errorResponseWf, htmlResponseWf } from './lib/route-schemas'
+import { definitionRoutes } from './lib/routes/definitions'
 import { createLogger } from '../../src/core/logger'
 import { getContentDir } from '../../src/core/content-dir'
 import { getTask, updateTask } from '../../src/core/task-store'
@@ -86,10 +78,6 @@ import type { WorkflowDefinition, WorkflowInstance } from './types'
 const log = createLogger('workflows')
 let unsubscribeApprovalResponses: (() => void) | null = null
 
-const passthroughWf = z.object({}).passthrough()
-const errorResponseWf = z.object({ error: z.string() }).passthrough()
-const htmlResponseWf = { contentType: 'text/html' as const }
-const repairSkillBodyWf = z.object({ confirmKnownOld: z.boolean().optional() }).optional()
 let gateNotificationSettings: GateNotificationSettings = {
   approvalChannelAlerts: false,
   approvalChannel: 'general',
@@ -137,307 +125,6 @@ function triggerDispatch() {
 }
 
 function populateWorkflowRoutes(arr: any[]): void {
-  arr.push(defineRoute({
-    path: '/notification-channels',
-    method: 'GET',
-    description: 'List registered notification channels',
-    summary: 'List registered notification channels',
-    responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf },
-    handler: async (_req: Request, _ctx: PluginContextLite) => new Response(
-      JSON.stringify({ channels: listNotificationChannels() }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    ),
-  }))
-
-  // ─── Template Routes ──────────────────────────────────────────────
-
-  // GET /definitions — list all workflow templates
-  const listHandler = async (req: Request, _ctx: PluginContextLite) => {
-    const url = new URL(req.url)
-    const includeDisabled = url.searchParams.get('includeDisabled') === '1' || url.searchParams.get('includeDisabled') === 'true'
-    return Response.json(buildTemplateList({ includeDisabled }))
-  }
-  arr.push(defineRoute({ path: '/definitions', method: 'GET', description: 'List all workflow templates with step counts and resolved sub-workflows', summary: 'List all workflow templates with step counts and resolved sub-workflows', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: listHandler }))
-
-  // GET /definitions/:name — get a specific definition with resolved sub-workflows
-  const getDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
-    const url = new URL(req.url)
-    const name = url.searchParams.get('name')
-
-    if (!name) {
-      return Response.json({ error: 'name param required' }, { status: 400 })
-    }
-    const nameError = validateWorkflowId(name)
-    if (nameError) {
-      return Response.json({ error: nameError }, { status: 400 })
-    }
-
-    const definition = loadDefinition(name)
-    if (!definition) {
-      return Response.json({ error: 'Definition not found' }, { status: 404 })
-    }
-
-    // Include resolved sub-workflows so clients don't need a second fetch
-    const subWorkflows: Record<string, WorkflowDefinition> = {}
-    resolveSubWorkflows(definition.steps, subWorkflows)
-
-    return Response.json({
-      definition,
-      subWorkflows,
-      source: definition.source,
-      pluginId: definition.pluginId,
-      disabled: definition.source !== 'user' && isWorkflowDisabled(name),
-      shadowedSource: definition.source === 'user' ? getShadowedSource(name) : undefined,
-      skillDrift: workflowSkillDriftForDefinition(definition, workflowSkillDriftBySkill(), subWorkflows),
-    })
-  }
-  arr.push(defineRoute({ path: '/definitions/:name', method: 'GET', description: 'Get a specific workflow definition by name', summary: 'Get a specific workflow definition by name', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: getDefinitionHandler }))
-
-  // POST /skills/:name/repair — replace a stale local workflow skill when provenance proves it is safe.
-  const repairSkillHandler = async (_req: Request, _ctx: PluginContextLite, parsed?: { params?: { name?: string }; body?: { confirmKnownOld?: boolean } }) => {
-    const name = parsed?.params?.name
-    if (!name) {
-      return Response.json({ error: 'name param required' }, { status: 400 })
-    }
-
-    const result = repairWorkflowSkillDrift({
-      contentDir: getContentDir(),
-      skillName: name,
-      confirmKnownOld: parsed?.body?.confirmKnownOld === true,
-    })
-    const status = result.status === 'applied'
-      ? 200
-      : result.status === 'not-found'
-        ? 404
-        : result.status === 'failed'
-          ? 500
-          : 409
-    return Response.json(result.status === 'failed' ? { ...result, error: result.message } : result, { status })
-  }
-  arr.push(defineRoute({ path: '/skills/:name/repair', method: 'POST', description: 'Repair a stale local workflow skill from its managed source when safe', summary: 'Repair stale workflow skill', params: z.object({ name: z.string() }), body: repairSkillBodyWf, responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: passthroughWf, 409: passthroughWf, 500: errorResponseWf }, handler: repairSkillHandler }))
-
-  // ─── CRUD Routes (user definitions only) ──────────────────────────
-  // User YAML files live at ~/.bakin/workflows/definitions/{id}.yaml.
-  // Plugin-shipped definitions are read-only — POST refuses to overwrite
-  // a plugin-owned id, DELETE refuses to remove a plugin-only id with no
-  // user shadow. PUT always writes to disk (creating a shadow if needed)
-  // because the user-wins rule lets a user override a plugin definition.
-
-  const getDefinitionsDir = (): string => join(getContentDir(), 'workflows', 'definitions')
-  const getUserDefinitionPaths = (id: string): { yamlPath: string; ymlPath: string } => {
-    const dir = getDefinitionsDir()
-    return {
-      yamlPath: join(dir, `${id}.yaml`),
-      ymlPath: join(dir, `${id}.yml`),
-    }
-  }
-
-  const findExistingUserDefinitionPath = (id: string): string | null => {
-    const { yamlPath, ymlPath } = getUserDefinitionPaths(id)
-    return existsSync(yamlPath) ? yamlPath : existsSync(ymlPath) ? ymlPath : null
-  }
-
-  const userDefinitionExists = (id: string): boolean => findExistingUserDefinitionPath(id) !== null
-
-  const writeUserDefinition = (id: string, def: unknown): void => {
-    const dir = getDefinitionsDir()
-    mkdirSync(dir, { recursive: true })
-    writeFileSync(findExistingUserDefinitionPath(id) ?? join(dir, `${id}.yaml`), yaml.dump(def), 'utf-8')
-  }
-
-  // POST /definitions — create a new user-owned workflow YAML
-  const createDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
-    let body: { id?: string; [k: string]: unknown }
-    try {
-      body = await req.json()
-    } catch {
-      return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
-    }
-
-    const id = typeof body.id === 'string' ? body.id : undefined
-    if (!id) {
-      return Response.json({ error: 'id is required' }, { status: 400 })
-    }
-    const idError = validateWorkflowId(id)
-    if (idError) {
-      return Response.json({ error: idError }, { status: 400 })
-    }
-    if (userDefinitionExists(id)) {
-      return Response.json(
-        { error: `Workflow id "${id}" already exists. Use PUT to update it.` },
-        { status: 409 },
-      )
-    }
-
-    // Refuse to overwrite a plugin-only id (no user shadow yet)
-    if (isReadOnly(id)) {
-      const entry = getRegistryDefinition(id)
-      return Response.json(
-        { error: `Workflow id "${id}" is owned by plugin "${entry?.pluginId ?? 'unknown'}" — POST refuses to overwrite. Use PUT to create a user shadow.` },
-        { status: 409 },
-      )
-    }
-
-    const rest = { ...body }
-    delete rest.id
-    const parsed = workflowDefinitionSchema.safeParse(rest)
-    if (!parsed.success) {
-      return Response.json(
-        { error: 'validation failed', issues: parsed.error.issues },
-        { status: 400 },
-      )
-    }
-    const definition = parsed.data as WorkflowDefinition
-    const semanticErrors = validateDefinition(definition, {
-      definitionId: id,
-      source: 'user',
-      knownWorkflowIds: new Set([...listDefinitions().map((entry) => entry.name), id]),
-      allowEmptySteps: true,
-    })
-    if (semanticErrors.length > 0) {
-      return Response.json(
-        { error: 'validation failed', errors: semanticErrors },
-        { status: 400 },
-      )
-    }
-
-    writeUserDefinition(id, definition)
-    return Response.json({ id, source: 'user', definition }, { status: 201 })
-  }
-  arr.push(defineRoute({ path: '/definitions', method: 'POST', description: 'Create a new user-owned workflow definition', summary: 'Create a new user-owned workflow definition', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: createDefinitionHandler }))
-
-  // PUT /definitions/:name — update or create a user-owned workflow YAML
-  const updateDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
-    const url = new URL(req.url)
-    const name = url.searchParams.get('name')
-    if (!name) {
-      return Response.json({ error: 'name param required' }, { status: 400 })
-    }
-    const nameError = validateWorkflowId(name)
-    if (nameError) {
-      return Response.json({ error: nameError }, { status: 400 })
-    }
-
-    let body: Record<string, unknown>
-    try {
-      body = await req.json()
-    } catch {
-      return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
-    }
-
-    const rest = { ...body }
-    delete rest.id
-    const parsed = workflowDefinitionSchema.safeParse(rest)
-    if (!parsed.success) {
-      return Response.json(
-        { error: 'validation failed', issues: parsed.error.issues },
-        { status: 400 },
-      )
-    }
-    const definition = parsed.data as WorkflowDefinition
-    const semanticErrors = validateDefinition(definition, {
-      definitionId: name,
-      source: 'user',
-      knownWorkflowIds: new Set([...listDefinitions().map((entry) => entry.name), name]),
-      allowEmptySteps: true,
-    })
-    if (semanticErrors.length > 0) {
-      return Response.json(
-        { error: 'validation failed', errors: semanticErrors },
-        { status: 400 },
-      )
-    }
-
-    writeUserDefinition(name, definition)
-    return Response.json({ id: name, source: 'user', definition })
-  }
-  arr.push(defineRoute({ path: '/definitions/:name', method: 'PUT', description: 'Update or shadow a workflow definition (writes user YAML)', summary: 'Update or shadow a workflow definition (writes user YAML)', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: updateDefinitionHandler }))
-
-  // PATCH /definitions/:name/availability — enable/disable a managed workflow
-  const updateAvailabilityHandler = async (req: Request, _ctx: PluginContextLite) => {
-    const url = new URL(req.url)
-    const name = url.searchParams.get('name')
-    if (!name) {
-      return Response.json({ error: 'name param required' }, { status: 400 })
-    }
-    const nameError = validateWorkflowId(name)
-    if (nameError) {
-      return Response.json({ error: nameError }, { status: 400 })
-    }
-
-    let body: { disabled?: unknown }
-    try {
-      body = await req.json()
-    } catch {
-      return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
-    }
-
-    if (typeof body.disabled !== 'boolean') {
-      return Response.json({ error: 'disabled must be a boolean' }, { status: 400 })
-    }
-
-    const effectiveDefinition = loadDefinition(name)
-    if (!effectiveDefinition || effectiveDefinition.source === 'user') {
-      return Response.json({ error: 'Only managed workflows can be disabled' }, { status: 409 })
-    }
-
-    setWorkflowDisabled(name, body.disabled)
-    try {
-      await indexDefinition(name, effectiveDefinition, effectiveDefinition.source)
-    } catch (err) {
-      log.warn('Failed to reindex workflow availability change', { name, error: err instanceof Error ? err.message : String(err) })
-    }
-    return Response.json({ id: name, disabled: body.disabled })
-  }
-  arr.push(defineRoute({ path: '/definitions/:name/availability', method: 'PATCH', description: 'Enable or disable a managed workflow definition for automatic selection', summary: 'Toggle managed workflow availability', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: updateAvailabilityHandler }))
-
-  // DELETE /definitions/:name — remove the user-owned YAML for this id
-  const deleteDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
-    const url = new URL(req.url)
-    const name = url.searchParams.get('name')
-    if (!name) {
-      return Response.json({ error: 'name param required' }, { status: 400 })
-    }
-    const nameError = validateWorkflowId(name)
-    if (nameError) {
-      return Response.json({ error: nameError }, { status: 400 })
-    }
-
-    const existing = findExistingUserDefinitionPath(name)
-
-    if (!existing) {
-      // No user file. If plugin owns this id, the user is trying to delete
-      // something they don't own — return 409 so the UI can explain.
-      if (isReadOnly(name)) {
-        const entry = getRegistryDefinition(name)
-        return Response.json(
-          { error: `Workflow id "${name}" is owned by plugin "${entry?.pluginId ?? 'unknown'}" — cannot delete. Edit the plugin or shadow it with PUT.` },
-          { status: 409 },
-        )
-      }
-      return Response.json({ error: 'Definition not found' }, { status: 404 })
-    }
-
-    unlinkSync(existing)
-    return Response.json({ id: name, deleted: true })
-  }
-  arr.push(defineRoute({ path: '/definitions/:name', method: 'DELETE', description: 'Delete a user-owned workflow definition', summary: 'Delete a user-owned workflow definition', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: deleteDefinitionHandler }))
-
-  // GET /node-types — palette data source. Returns the registered node-type
-  // metadata (builtin + plugin-registered) minus the Zod schemas (which
-  // aren't JSON-serializable). The canvas-editor palette hydrates from this.
-  const nodeTypesHandler = async (_req: Request, _ctx: PluginContextLite) => {
-    const items = listNodeTypes().map((def) => ({
-      kind: def.kind,
-      runtime: def.runtime,
-      pluginId: def.pluginId,
-      edgeRules: def.edgeRules,
-      formFields: def.formFields,
-    }))
-    return Response.json({ nodeTypes: items })
-  }
-  arr.push(defineRoute({ path: '/node-types', method: 'GET', description: 'List registered workflow node types (builtin + plugin-registered) for the canvas palette', summary: 'List registered workflow node types (builtin + plugin-registered) for the canvas palette', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: nodeTypesHandler }))
-
   // ─── Runtime Routes ───────────────────────────────────────────────
 
   // GET /steps/:taskId — get current step for a task
@@ -972,11 +659,13 @@ function populateWorkflowRoutes(arr: any[]): void {
 }
 
 // Static array — populated by populateWorkflowRoutes() at module load.
+// (Definition routes already live as typed defineRoute[] in lib/routes/definitions.ts;
+// the remaining instance + gate routes are still assembled here pending C2b/C2c.)
 const workflowRoutes: any[] = []
 populateWorkflowRoutes(workflowRoutes)
 
 const workflowsPlugin: BakinPlugin = definePlugin({
-  routes: workflowRoutes as unknown as Parameters<typeof definePlugin>[0]['routes'],
+  routes: [...definitionRoutes, ...workflowRoutes] as unknown as Parameters<typeof definePlugin>[0]['routes'],
   id: 'workflows',
   name: 'Workflows',
   version: '2.0.0',

--- a/plugins/workflows/lib/route-schemas.ts
+++ b/plugins/workflows/lib/route-schemas.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared Zod response/body schemas for workflow routes.
+ *
+ * Extracted so the per-group route modules (routes/definitions, routes/gates,
+ * routes/instances) and the activate-body route registrations share one copy.
+ */
+import { z } from 'zod'
+
+export const passthroughWf = z.object({}).passthrough()
+export const errorResponseWf = z.object({ error: z.string() }).passthrough()
+export const htmlResponseWf = { contentType: 'text/html' as const }
+export const repairSkillBodyWf = z.object({ confirmKnownOld: z.boolean().optional() }).optional()

--- a/plugins/workflows/lib/routes/definitions.ts
+++ b/plugins/workflows/lib/routes/definitions.ts
@@ -1,0 +1,341 @@
+/**
+ * Workflow Definition routes
+ *
+ * Notification-channel listing, template/definition reads, the user-owned
+ * definition CRUD (YAML on disk), managed-availability toggling, skill repair,
+ * and the node-type palette feed. Self-contained: handlers depend only on the
+ * parser/template-list/source-registry/availability/node-type lib modules and
+ * the search-sync indexer — no gate, dispatch, or instance state.
+ */
+import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import yaml from 'js-yaml'
+import { z } from 'zod'
+import { defineRoute } from '@bakin/core/routing'
+import type { PluginContextLite } from '@bakin/core/routing'
+import { createLogger } from '@bakin/core/logger'
+import type { WorkflowDefinition } from '../../types'
+import { getContentDir } from '../content-dir'
+import { loadDefinition, listDefinitions, validateDefinition, validateWorkflowId } from '../parser'
+import {
+  buildTemplateList,
+  resolveSubWorkflows,
+  workflowSkillDriftForDefinition,
+  workflowSkillDriftBySkill,
+} from '../template-list'
+import {
+  isReadOnly,
+  getDefinition as getRegistryDefinition,
+  getShadowedSource,
+} from '../source-registry'
+import { isWorkflowDisabled, setWorkflowDisabled } from '../availability'
+import { indexDefinition } from '../search-sync'
+import { repairWorkflowSkillDrift } from '../workflow-skill-drift'
+import { workflowDefinitionSchema, listNodeTypes } from '../node-type-registry'
+import { listNotificationChannels } from '../notification-channel-registry'
+import { passthroughWf, errorResponseWf, repairSkillBodyWf } from '../route-schemas'
+
+const log = createLogger('workflows')
+
+// ─── User-definition YAML paths ──────────────────────────────────────────
+// User YAML files live at ~/.bakin/workflows/definitions/{id}.yaml.
+// Plugin-shipped definitions are read-only — POST refuses to overwrite a
+// plugin-owned id, DELETE refuses to remove a plugin-only id with no user
+// shadow. PUT always writes to disk (creating a shadow if needed) because the
+// user-wins rule lets a user override a plugin definition.
+
+const getDefinitionsDir = (): string => join(getContentDir(), 'workflows', 'definitions')
+const getUserDefinitionPaths = (id: string): { yamlPath: string; ymlPath: string } => {
+  const dir = getDefinitionsDir()
+  return {
+    yamlPath: join(dir, `${id}.yaml`),
+    ymlPath: join(dir, `${id}.yml`),
+  }
+}
+
+const findExistingUserDefinitionPath = (id: string): string | null => {
+  const { yamlPath, ymlPath } = getUserDefinitionPaths(id)
+  return existsSync(yamlPath) ? yamlPath : existsSync(ymlPath) ? ymlPath : null
+}
+
+const userDefinitionExists = (id: string): boolean => findExistingUserDefinitionPath(id) !== null
+
+const writeUserDefinition = (id: string, def: unknown): void => {
+  const dir = getDefinitionsDir()
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(findExistingUserDefinitionPath(id) ?? join(dir, `${id}.yaml`), yaml.dump(def), 'utf-8')
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────
+
+// GET /definitions — list all workflow templates
+const listHandler = async (req: Request, _ctx: PluginContextLite) => {
+  const url = new URL(req.url)
+  const includeDisabled = url.searchParams.get('includeDisabled') === '1' || url.searchParams.get('includeDisabled') === 'true'
+  return Response.json(buildTemplateList({ includeDisabled }))
+}
+
+// GET /definitions/:name — get a specific definition with resolved sub-workflows
+const getDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
+  const url = new URL(req.url)
+  const name = url.searchParams.get('name')
+
+  if (!name) {
+    return Response.json({ error: 'name param required' }, { status: 400 })
+  }
+  const nameError = validateWorkflowId(name)
+  if (nameError) {
+    return Response.json({ error: nameError }, { status: 400 })
+  }
+
+  const definition = loadDefinition(name)
+  if (!definition) {
+    return Response.json({ error: 'Definition not found' }, { status: 404 })
+  }
+
+  // Include resolved sub-workflows so clients don't need a second fetch
+  const subWorkflows: Record<string, WorkflowDefinition> = {}
+  resolveSubWorkflows(definition.steps, subWorkflows)
+
+  return Response.json({
+    definition,
+    subWorkflows,
+    source: definition.source,
+    pluginId: definition.pluginId,
+    disabled: definition.source !== 'user' && isWorkflowDisabled(name),
+    shadowedSource: definition.source === 'user' ? getShadowedSource(name) : undefined,
+    skillDrift: workflowSkillDriftForDefinition(definition, workflowSkillDriftBySkill(), subWorkflows),
+  })
+}
+
+// POST /skills/:name/repair — replace a stale local workflow skill when provenance proves it is safe.
+const repairSkillHandler = async (_req: Request, _ctx: PluginContextLite, parsed?: { params?: { name?: string }; body?: { confirmKnownOld?: boolean } }) => {
+  const name = parsed?.params?.name
+  if (!name) {
+    return Response.json({ error: 'name param required' }, { status: 400 })
+  }
+
+  const result = repairWorkflowSkillDrift({
+    contentDir: getContentDir(),
+    skillName: name,
+    confirmKnownOld: parsed?.body?.confirmKnownOld === true,
+  })
+  const status = result.status === 'applied'
+    ? 200
+    : result.status === 'not-found'
+      ? 404
+      : result.status === 'failed'
+        ? 500
+        : 409
+  return Response.json(result.status === 'failed' ? { ...result, error: result.message } : result, { status })
+}
+
+// POST /definitions — create a new user-owned workflow YAML
+const createDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
+  let body: { id?: string; [k: string]: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const id = typeof body.id === 'string' ? body.id : undefined
+  if (!id) {
+    return Response.json({ error: 'id is required' }, { status: 400 })
+  }
+  const idError = validateWorkflowId(id)
+  if (idError) {
+    return Response.json({ error: idError }, { status: 400 })
+  }
+  if (userDefinitionExists(id)) {
+    return Response.json(
+      { error: `Workflow id "${id}" already exists. Use PUT to update it.` },
+      { status: 409 },
+    )
+  }
+
+  // Refuse to overwrite a plugin-only id (no user shadow yet)
+  if (isReadOnly(id)) {
+    const entry = getRegistryDefinition(id)
+    return Response.json(
+      { error: `Workflow id "${id}" is owned by plugin "${entry?.pluginId ?? 'unknown'}" — POST refuses to overwrite. Use PUT to create a user shadow.` },
+      { status: 409 },
+    )
+  }
+
+  const rest = { ...body }
+  delete rest.id
+  const parsed = workflowDefinitionSchema.safeParse(rest)
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'validation failed', issues: parsed.error.issues },
+      { status: 400 },
+    )
+  }
+  const definition = parsed.data as WorkflowDefinition
+  const semanticErrors = validateDefinition(definition, {
+    definitionId: id,
+    source: 'user',
+    knownWorkflowIds: new Set([...listDefinitions().map((entry) => entry.name), id]),
+    allowEmptySteps: true,
+  })
+  if (semanticErrors.length > 0) {
+    return Response.json(
+      { error: 'validation failed', errors: semanticErrors },
+      { status: 400 },
+    )
+  }
+
+  writeUserDefinition(id, definition)
+  return Response.json({ id, source: 'user', definition }, { status: 201 })
+}
+
+// PUT /definitions/:name — update or create a user-owned workflow YAML
+const updateDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
+  const url = new URL(req.url)
+  const name = url.searchParams.get('name')
+  if (!name) {
+    return Response.json({ error: 'name param required' }, { status: 400 })
+  }
+  const nameError = validateWorkflowId(name)
+  if (nameError) {
+    return Response.json({ error: nameError }, { status: 400 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const rest = { ...body }
+  delete rest.id
+  const parsed = workflowDefinitionSchema.safeParse(rest)
+  if (!parsed.success) {
+    return Response.json(
+      { error: 'validation failed', issues: parsed.error.issues },
+      { status: 400 },
+    )
+  }
+  const definition = parsed.data as WorkflowDefinition
+  const semanticErrors = validateDefinition(definition, {
+    definitionId: name,
+    source: 'user',
+    knownWorkflowIds: new Set([...listDefinitions().map((entry) => entry.name), name]),
+    allowEmptySteps: true,
+  })
+  if (semanticErrors.length > 0) {
+    return Response.json(
+      { error: 'validation failed', errors: semanticErrors },
+      { status: 400 },
+    )
+  }
+
+  writeUserDefinition(name, definition)
+  return Response.json({ id: name, source: 'user', definition })
+}
+
+// PATCH /definitions/:name/availability — enable/disable a managed workflow
+const updateAvailabilityHandler = async (req: Request, _ctx: PluginContextLite) => {
+  const url = new URL(req.url)
+  const name = url.searchParams.get('name')
+  if (!name) {
+    return Response.json({ error: 'name param required' }, { status: 400 })
+  }
+  const nameError = validateWorkflowId(name)
+  if (nameError) {
+    return Response.json({ error: nameError }, { status: 400 })
+  }
+
+  let body: { disabled?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  if (typeof body.disabled !== 'boolean') {
+    return Response.json({ error: 'disabled must be a boolean' }, { status: 400 })
+  }
+
+  const effectiveDefinition = loadDefinition(name)
+  if (!effectiveDefinition || effectiveDefinition.source === 'user') {
+    return Response.json({ error: 'Only managed workflows can be disabled' }, { status: 409 })
+  }
+
+  setWorkflowDisabled(name, body.disabled)
+  try {
+    await indexDefinition(name, effectiveDefinition, effectiveDefinition.source)
+  } catch (err) {
+    log.warn('Failed to reindex workflow availability change', { name, error: err instanceof Error ? err.message : String(err) })
+  }
+  return Response.json({ id: name, disabled: body.disabled })
+}
+
+// DELETE /definitions/:name — remove the user-owned YAML for this id
+const deleteDefinitionHandler = async (req: Request, _ctx: PluginContextLite) => {
+  const url = new URL(req.url)
+  const name = url.searchParams.get('name')
+  if (!name) {
+    return Response.json({ error: 'name param required' }, { status: 400 })
+  }
+  const nameError = validateWorkflowId(name)
+  if (nameError) {
+    return Response.json({ error: nameError }, { status: 400 })
+  }
+
+  const existing = findExistingUserDefinitionPath(name)
+
+  if (!existing) {
+    // No user file. If plugin owns this id, the user is trying to delete
+    // something they don't own — return 409 so the UI can explain.
+    if (isReadOnly(name)) {
+      const entry = getRegistryDefinition(name)
+      return Response.json(
+        { error: `Workflow id "${name}" is owned by plugin "${entry?.pluginId ?? 'unknown'}" — cannot delete. Edit the plugin or shadow it with PUT.` },
+        { status: 409 },
+      )
+    }
+    return Response.json({ error: 'Definition not found' }, { status: 404 })
+  }
+
+  unlinkSync(existing)
+  return Response.json({ id: name, deleted: true })
+}
+
+// GET /node-types — palette data source. Returns the registered node-type
+// metadata (builtin + plugin-registered) minus the Zod schemas (which
+// aren't JSON-serializable). The canvas-editor palette hydrates from this.
+const nodeTypesHandler = async (_req: Request, _ctx: PluginContextLite) => {
+  const items = listNodeTypes().map((def) => ({
+    kind: def.kind,
+    runtime: def.runtime,
+    pluginId: def.pluginId,
+    edgeRules: def.edgeRules,
+    formFields: def.formFields,
+  }))
+  return Response.json({ nodeTypes: items })
+}
+
+export const definitionRoutes = [
+  defineRoute({
+    path: '/notification-channels',
+    method: 'GET',
+    description: 'List registered notification channels',
+    summary: 'List registered notification channels',
+    responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf },
+    handler: async (_req: Request, _ctx: PluginContextLite) => new Response(
+      JSON.stringify({ channels: listNotificationChannels() }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  }),
+  defineRoute({ path: '/definitions', method: 'GET', description: 'List all workflow templates with step counts and resolved sub-workflows', summary: 'List all workflow templates with step counts and resolved sub-workflows', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: listHandler }),
+  defineRoute({ path: '/definitions/:name', method: 'GET', description: 'Get a specific workflow definition by name', summary: 'Get a specific workflow definition by name', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: getDefinitionHandler }),
+  defineRoute({ path: '/skills/:name/repair', method: 'POST', description: 'Repair a stale local workflow skill from its managed source when safe', summary: 'Repair stale workflow skill', params: z.object({ name: z.string() }), body: repairSkillBodyWf, responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: passthroughWf, 409: passthroughWf, 500: errorResponseWf }, handler: repairSkillHandler }),
+  defineRoute({ path: '/definitions', method: 'POST', description: 'Create a new user-owned workflow definition', summary: 'Create a new user-owned workflow definition', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: createDefinitionHandler }),
+  defineRoute({ path: '/definitions/:name', method: 'PUT', description: 'Update or shadow a workflow definition (writes user YAML)', summary: 'Update or shadow a workflow definition (writes user YAML)', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: updateDefinitionHandler }),
+  defineRoute({ path: '/definitions/:name/availability', method: 'PATCH', description: 'Enable or disable a managed workflow definition for automatic selection', summary: 'Toggle managed workflow availability', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: updateAvailabilityHandler }),
+  defineRoute({ path: '/definitions/:name', method: 'DELETE', description: 'Delete a user-owned workflow definition', summary: 'Delete a user-owned workflow definition', params: z.object({ name: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: deleteDefinitionHandler }),
+  defineRoute({ path: '/node-types', method: 'GET', description: 'List registered workflow node types (builtin + plugin-registered) for the canvas palette', summary: 'List registered workflow node types (builtin + plugin-registered) for the canvas palette', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: nodeTypesHandler }),
+]

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -218,8 +218,16 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
       activate calls setWorkflowPluginContext(ctx), the registerFileBackedContentType block imports the search docs.
       ~1,770 → ~1,700. Verified: typecheck/lint/workflows 420-0/full-suite 5124-0/binary build/boot smoke (bakin_workflows
       content type registers; GET /definitions + /search → 200).
-    - ☐ C2 — route extraction (`routes/{definitions,gates,instances}.ts`) as typed defineRoute[] builders now that
-      handlers reach ctx via the accessor; then C3 — exec-tools + register-hooks + channel-approvals activate-body
-      extractions. The decideGate 6-block collapse + getGateDescription/buildGateAuditPayload dedup + stdJsonResponses
-      const + typed-route casts stay deferred redesigns (not required for the split).
+    - ☑ C2a — definition routes: `lib/route-schemas.ts` (the shared passthroughWf/errorResponseWf/htmlResponseWf/
+      repairSkillBodyWf zod consts) + `lib/routes/definitions.ts` exporting a typed `defineRoute[]` (notification-channels,
+      /definitions GET/POST/PUT/DELETE/:name GET, /skills/:name/repair, availability PATCH, /node-types) with the
+      user-YAML CRUD helpers (getDefinitionsDir/writeUserDefinition/findExistingUserDefinitionPath) folded in. definePlugin
+      now spreads `[...definitionRoutes, ...workflowRoutes]`; populateWorkflowRoutes shrank to instances+gates. index.ts
+      shed ~10 now-unused imports. 2,146(pre-A) → ~1,400. Verified: typecheck/lint/workflows 420-0/full-suite 5124-0/binary
+      build/boot smoke (GET /definitions + /node-types + /notification-channels → 200, POST /definitions bad body → 400).
+    - ☐ C2b — `routes/instances.ts` (steps/instances/start), ☐ C2c — `routes/gates.ts` (approve/reject/decision-page/
+      pending/status; needs lib/gate-audit.ts [getGateDescription+buildGateAuditPayload dedup] + lib/gate-html.ts
+      [formValue/gateDecisionHtmlResponse/escapeHtml] + a gate-settings accessor for activeGateSettings). Then C3 —
+      exec-tools + register-hooks + channel-approvals activate-body extractions. The decideGate 6-block collapse +
+      stdJsonResponses const + typed-route casts stay deferred redesigns (not required for the split).
 - Remaining: workflow-canvas-editor (1,803), models-page (1,205), schedule/index (1,443) + test splits.


### PR DESCRIPTION
## What

Phase **C2a** of the `workflows/index.ts` split. Pulls the definition-management route group out of the module-load `populateWorkflowRoutes` mutation into a typed `defineRoute[]` module — unblocked by the ctx accessor from #530.

| Module | Contents |
|---|---|
| `lib/route-schemas.ts` | the shared `passthroughWf` / `errorResponseWf` / `htmlResponseWf` / `repairSkillBodyWf` zod consts (one copy for every route group) |
| `lib/routes/definitions.ts` | exports `definitionRoutes`: notification-channels list, `/definitions` GET/POST/PUT/DELETE + `/:name` GET, `/skills/:name/repair`, availability PATCH, `/node-types` — plus the user-owned-YAML CRUD helpers (`getDefinitionsDir`/`findExistingUserDefinitionPath`/`writeUserDefinition`), which had no callers outside this group |

`definePlugin` now spreads `[...definitionRoutes, ...workflowRoutes]`; `populateWorkflowRoutes` is down to the instance + gate routes (C2b/C2c). `index.ts` sheds ~10 now-unused imports and its local zod-const copies.

This group was chosen first because it's the most self-contained — its handlers depend only on parser / template-list / source-registry / availability / node-type / search-sync, with **no gate, dispatch, or instance-state coupling**.

## Pure relocation

The route objects are byte-identical; only their assembly site moved. No behavior change.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (all 3 changed/new files)
- ✅ workflows plugin suite — **420/0** (incl. `definitions-crud` + `routes` tests)
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — `GET /definitions`, `/node-types`, `/notification-channels` → 200; `POST /definitions` with a bad body → 400

## Next

C2b `routes/instances.ts` (steps/instances/start), then C2c `routes/gates.ts` (which also needs a small `lib/gate-audit.ts` + `lib/gate-html.ts` + a gate-settings accessor). Deferred redesigns (decideGate collapse, stdJsonResponses) stay out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)