### PR TITLE
refactor(workflows): extract hooks + channel-approvals from activate (C3b)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -7,15 +7,10 @@ import { existsSync, readdirSync, readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import yaml from 'js-yaml'
-import type { ApprovalActor, BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
+import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin } from '@bakin/core/routing'
 import { listDefinitions, loadDefinition } from './lib/parser'
-import { workflowDefinitionNameFromHookInput } from './lib/hook-input'
 import { loadDefaultWorkflows } from './lib/load-defaults'
-import {
-  getNotificationChannel,
-  listNotificationChannels,
-} from './lib/notification-channel-registry'
 import {
   checkWorkflowDefinitions,
   checkStaleWorkflowInstances,
@@ -23,50 +18,25 @@ import {
   workflowSkillDriftRepair,
   staleWorkflowInstancesRepair,
 } from './lib/health-checks'
-import {
-  getManagedDefinition,
-} from './lib/source-registry'
-import {
-  loadInstance,
-  saveInstance,
-  getCurrentStep,
-  completeStep,
-  approveGate,
-  rejectGate,
-  reopenFromStep,
-  listInstances,
-  getActiveAgents,
-  authorizeWorkflowToolUse,
-  reconcilePendingApprovalTaskColumns,
-  isGateNotified,
-  markGateNotified,
-  cancelInstance,
-  type WorkflowToolUseAction,
-} from './lib/runtime'
-import { matchWorkflow } from './lib/matcher'
-import { createValidatedInstance } from './lib/start-validation'
+import { getManagedDefinition } from './lib/source-registry'
+import { listInstances, reconcilePendingApprovalTaskColumns } from './lib/runtime'
 import { setWorkflowPluginContext } from './lib/plugin-context'
-import { instanceToSearchDoc, definitionToSearchDoc, indexInstance } from './lib/search-sync'
+import { instanceToSearchDoc, definitionToSearchDoc } from './lib/search-sync'
 import { definitionRoutes } from './lib/routes/definitions'
 import { instanceRoutes } from './lib/routes/instances'
 import { gateRoutes } from './lib/routes/gates'
-import { triggerDispatch } from './lib/trigger-dispatch'
-import { setGateSettings, activeGateSettings } from './lib/gate-settings'
-import { getGateDescription, buildGateAuditPayload } from './lib/gate-audit'
+import { setGateSettings } from './lib/gate-settings'
 import { registerWorkflowExecTools } from './lib/exec-tools'
+import { registerWorkflowHooks } from './lib/register-hooks'
+import { wireChannelApprovals } from './lib/channel-approvals'
 import { createLogger } from '../../src/core/logger'
 import { getContentDir } from '../../src/core/content-dir'
-import { validateStepOutput } from './lib/schema-validator'
 import {
-  resolveGateApproval,
-  sendGateDecisionSummary,
   setEventBus,
   setGateNotificationSettings,
   setNotificationRuntime,
   type GateNotificationSettings,
 } from './lib/notifications'
-import { approvalRefFromRecord, getApprovalRecord } from './lib/approval-store'
-import { rehydratePendingApprovals } from './lib/approval-rehydration'
 import type { WorkflowDefinition, WorkflowInstance } from './types'
 
 const log = createLogger('workflows')
@@ -241,164 +211,10 @@ const workflowsPlugin: BakinPlugin = definePlugin({
     setGateSettings(initialGateSettings)
     setGateNotificationSettings(initialGateSettings)
 
-    const approvalRehydration = await rehydratePendingApprovals({
-      runtime: ctx.runtime,
-      channel: activeGateSettings().approvalChannel || 'general',
-      renderMissingDeliveries: activeGateSettings().approvalChannelAlerts,
-      log,
-    })
-    if (approvalRehydration.pending > 0) {
-      log.info('Rehydrated pending workflow approvals', { ...approvalRehydration })
-    }
-
     unsubscribeApprovalResponses?.()
-    unsubscribeApprovalResponses = ctx.runtime.channels.subscribeApprovalResponses(async (event) => {
-      const approvalRecord = getApprovalRecord(event.approvalId)
-      if (!approvalRecord) {
-        log.warn('Channel approval response ignored: no durable approval record', { approvalId: event.approvalId })
-        return
-      }
+    unsubscribeApprovalResponses = await wireChannelApprovals(ctx)
 
-      const taskId = approvalRecord.owner.taskId
-      const stepId = approvalRecord.owner.stepId
-      if (!taskId || !stepId) return
-      const approver: ApprovalActor = {
-        source: 'channel',
-        id: event.response.actor.id,
-        displayName: event.response.actor.displayName,
-      }
-      const selected = event.response.selectedOption
-
-      if (selected === 'approve') {
-        const approvalRef = approvalRefFromRecord(approvalRecord)
-        const result = approveGate(taskId, stepId, { approver })
-        if (!result.success) {
-          log.warn(`Channel approve failed: ${result.errors?.[0] || 'unknown error'}`, { taskId, stepId })
-          return
-        }
-
-        const auditPayload = buildGateAuditPayload(taskId, stepId, result.decision)
-        ctx.activity.audit('gate.approved', 'channel', auditPayload)
-        ctx.activity.log('channel', `Gate "${stepId}" approved via runtime channel`, { taskId })
-        indexInstance(taskId).catch(() => {})
-        triggerDispatch()
-
-        const instance = loadInstance(taskId)
-        if (instance && result.decision) {
-          resolveGateApproval(
-            approvalRef,
-            'approved',
-            approver,
-            result.decision.decidedAt,
-          ).catch(() => {})
-          sendGateDecisionSummary(
-            instance,
-            stepId,
-            result.decision.gateLabel,
-            getGateDescription(instance.workflowId, stepId),
-            'approved',
-            approver,
-            result.decision.requestedAt,
-            result.decision.decidedAt,
-            undefined,
-            activeGateSettings(),
-          ).catch(() => {})
-        }
-      } else if (selected === 'reject') {
-        const channelComment = event.response.comment?.trim()
-        const requiresRejectReason = approvalRecord.request.context?.requireRejectReason === true
-        if (requiresRejectReason && !channelComment) {
-          log.warn('Channel reject ignored: this gate requires a reject reason', {
-            approvalId: event.approvalId,
-            taskId,
-            stepId,
-            channelId: event.channelId,
-          })
-          ctx.activity.log('channel', `Gate "${stepId}" reject ignored because a reason is required. Use the Bakin approval link to reject with a reason.`, { taskId })
-          return
-        }
-        const rejectReason = channelComment || 'Rejected via runtime channel'
-        const approvalRef = approvalRefFromRecord(approvalRecord)
-        const result = rejectGate(taskId, stepId, rejectReason, { approver })
-        if (!result.success) {
-          log.warn(`Channel reject failed: ${result.errors?.[0] || 'unknown error'}`, { taskId, stepId })
-          return
-        }
-
-        const auditPayload = buildGateAuditPayload(taskId, stepId, result.decision, rejectReason)
-        ctx.activity.audit('gate.rejected', 'channel', auditPayload)
-        ctx.activity.log('channel', `Gate "${stepId}" rejected via runtime channel: ${rejectReason}`, { taskId })
-        indexInstance(taskId).catch(() => {})
-
-        const instance = loadInstance(taskId)
-        if (instance && result.decision) {
-          resolveGateApproval(
-            approvalRef,
-            'rejected',
-            approver,
-            result.decision.decidedAt,
-            rejectReason,
-          ).catch(() => {})
-          sendGateDecisionSummary(
-            instance,
-            stepId,
-            result.decision.gateLabel,
-            getGateDescription(instance.workflowId, stepId),
-            'rejected',
-            approver,
-            result.decision.requestedAt,
-            result.decision.decidedAt,
-            rejectReason,
-            activeGateSettings(),
-          ).catch(() => {})
-        }
-      }
-    })
-
-    ctx.hooks.register('workflows.loadInstance', (d: Record<string, unknown>) => loadInstance(d.taskId as string, d.contentDir as string | undefined), { label: 'Load workflow instance.', summary: 'Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.saveInstance', (d: Record<string, unknown>) => saveInstance(d.instance as Parameters<typeof saveInstance>[0], d.contentDir as string | undefined), { label: 'Save workflow instance.', summary: 'Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.createInstance', (d: Record<string, unknown>) => createValidatedInstance(ctx, d.taskId as string, d.workflowId as string, d.assignee as string | undefined, d.contentDir as string | undefined, d.parentContext as Record<string, unknown> | undefined), { label: 'Create workflow instance.', summary: 'Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.approveGate', (d: Record<string, unknown>) => approveGate(d.taskId as string, d.stepId as string, {
-      approver: d.approver as ApprovalActor | undefined,
-      contentDir: d.contentDir as string | undefined,
-    }), { label: 'Approve workflow gate.', summary: 'Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.rejectGate', (d: Record<string, unknown>) => rejectGate(d.taskId as string, d.stepId as string, String(d.reason ?? ''), {
-      approver: d.approver as ApprovalActor | undefined,
-      rewindTo: d.rewindTo as string | undefined,
-      contentDir: d.contentDir as string | undefined,
-    }), { label: 'Reject workflow gate.', summary: 'Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.reopenFromStep', (d: Record<string, unknown>) => reopenFromStep(d.taskId as string, {
-      instanceId: d.instanceId as string | undefined,
-      stepId: d.stepId as string | undefined,
-      reason: String(d.reason ?? 'Workflow recovery requested'),
-      actor: d.actor as ApprovalActor | undefined,
-      contentDir: d.contentDir as string | undefined,
-    }), { label: 'Reopen workflow from step.', summary: 'Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.instances.list', (d: Record<string, unknown>) => listInstances(d.statusFilter as string | undefined, d.contentDir as string | undefined), { label: 'List workflow instances.', summary: 'Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.getCurrentStep', (d: Record<string, unknown>) => getCurrentStep(d.taskId as string, d.agentId as string | undefined, d.contentDir as string | undefined), { label: 'Get current step.', summary: 'Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.completeStep', (d: Record<string, unknown>) => completeStep(d.taskId as string, d.stepId as string, d.output as Record<string, unknown>, d.callerAgentId as string | undefined, d.contentDir as string | undefined), { label: 'Complete workflow step.', summary: 'Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.matchWorkflow', (d: Record<string, unknown>) => matchWorkflow(d.title as string, d.description as string | undefined), { label: 'Match workflow.', summary: 'Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.definitions.list', (d: Record<string, unknown>) => listDefinitions(d.contentDir as string | undefined), { label: 'List workflow definitions.', summary: 'Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.loadDefinition', (d: Record<string, unknown>) => {
-      const name = workflowDefinitionNameFromHookInput(d)
-      return name ? loadDefinition(name, d.contentDir as string | undefined) : null
-    }, { label: 'Load workflow definition.', summary: 'Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.getActiveAgents', (d: Record<string, unknown>) => getActiveAgents(d.taskId as string, d.contentDir as string | undefined), { label: 'List active workflow agents.', summary: 'Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.authorizeToolUse', (d: Record<string, unknown>) => authorizeWorkflowToolUse(d.taskId as string, d.agent as string, d.action as WorkflowToolUseAction, d.contentDir as string | undefined), { label: 'Authorize workflow tool use.', summary: 'Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.isGateNotified', (d: Record<string, unknown>) => isGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Check gate notification.', summary: 'Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.markGateNotified', (d: Record<string, unknown>) => markGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Mark gate notified.', summary: 'Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.validateStepOutput', (d: Record<string, unknown>) => validateStepOutput(d.schema as Record<string, unknown> | undefined, d.output as Record<string, unknown>), { label: 'Validate step output.', summary: 'Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.cancelInstance', (d: Record<string, unknown>) => {
-      cancelInstance(d.taskId as string, d.contentDir as string | undefined)
-    }, { label: 'Cancel workflow instance.', summary: 'Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue.', hookKind: 'event' })
-
-    // ─── Notification Channel Registry Hooks ─────────────────────────
-    ctx.hooks.register('workflows.notificationChannels.list', () => listNotificationChannels(), { label: 'List notification channels.', summary: 'Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts.', hookKind: 'rpc' })
-    ctx.hooks.register('workflows.getNotificationChannel', (d: Record<string, unknown>) => {
-      return getNotificationChannel(d.id as string) ?? null
-    }, { label: 'Get notification channel.', summary: 'Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation.', hookKind: 'rpc' })
-
-    // ─── Notification Channels Route — registered statically via populateWorkflowRoutes() (T20+) ───
+    registerWorkflowHooks(ctx)
 
     // ─── Health checks (migrated out of core/doctor.ts per #137) ─────
     ctx.registerHealthCheck({

--- a/plugins/workflows/lib/channel-approvals.ts
+++ b/plugins/workflows/lib/channel-approvals.ts
@@ -1,0 +1,135 @@
+/**
+ * Workflow channel approvals
+ *
+ * wireChannelApprovals(ctx) rehydrates any pending approval renders and
+ * subscribes to runtime-channel approval responses, driving approveGate /
+ * rejectGate for gates decided from a channel. Returns the unsubscribe handle
+ * (owned by the caller's lifecycle). Extracted from the activate() body.
+ */
+import type { PluginContext, ApprovalActor } from '@bakin/core/plugin-types'
+import { createLogger } from '@bakin/core/logger'
+import { rehydratePendingApprovals } from './approval-rehydration'
+import { activeGateSettings } from './gate-settings'
+import { getApprovalRecord, approvalRefFromRecord } from './approval-store'
+import { approveGate, rejectGate, loadInstance } from './runtime'
+import { buildGateAuditPayload, getGateDescription } from './gate-audit'
+import { indexInstance } from './search-sync'
+import { triggerDispatch } from './trigger-dispatch'
+import { resolveGateApproval, sendGateDecisionSummary } from './notifications'
+
+const log = createLogger('workflows')
+
+export async function wireChannelApprovals(ctx: PluginContext): Promise<() => void> {
+  const approvalRehydration = await rehydratePendingApprovals({
+    runtime: ctx.runtime,
+    channel: activeGateSettings().approvalChannel || 'general',
+    renderMissingDeliveries: activeGateSettings().approvalChannelAlerts,
+    log,
+  })
+  if (approvalRehydration.pending > 0) {
+    log.info('Rehydrated pending workflow approvals', { ...approvalRehydration })
+  }
+
+  return ctx.runtime.channels.subscribeApprovalResponses(async (event) => {
+    const approvalRecord = getApprovalRecord(event.approvalId)
+    if (!approvalRecord) {
+      log.warn('Channel approval response ignored: no durable approval record', { approvalId: event.approvalId })
+      return
+    }
+
+    const taskId = approvalRecord.owner.taskId
+    const stepId = approvalRecord.owner.stepId
+    if (!taskId || !stepId) return
+    const approver: ApprovalActor = {
+      source: 'channel',
+      id: event.response.actor.id,
+      displayName: event.response.actor.displayName,
+    }
+    const selected = event.response.selectedOption
+
+    if (selected === 'approve') {
+      const approvalRef = approvalRefFromRecord(approvalRecord)
+      const result = approveGate(taskId, stepId, { approver })
+      if (!result.success) {
+        log.warn(`Channel approve failed: ${result.errors?.[0] || 'unknown error'}`, { taskId, stepId })
+        return
+      }
+
+      const auditPayload = buildGateAuditPayload(taskId, stepId, result.decision)
+      ctx.activity.audit('gate.approved', 'channel', auditPayload)
+      ctx.activity.log('channel', `Gate "${stepId}" approved via runtime channel`, { taskId })
+      indexInstance(taskId).catch(() => {})
+      triggerDispatch()
+
+      const instance = loadInstance(taskId)
+      if (instance && result.decision) {
+        resolveGateApproval(
+          approvalRef,
+          'approved',
+          approver,
+          result.decision.decidedAt,
+        ).catch(() => {})
+        sendGateDecisionSummary(
+          instance,
+          stepId,
+          result.decision.gateLabel,
+          getGateDescription(instance.workflowId, stepId),
+          'approved',
+          approver,
+          result.decision.requestedAt,
+          result.decision.decidedAt,
+          undefined,
+          activeGateSettings(),
+        ).catch(() => {})
+      }
+    } else if (selected === 'reject') {
+      const channelComment = event.response.comment?.trim()
+      const requiresRejectReason = approvalRecord.request.context?.requireRejectReason === true
+      if (requiresRejectReason && !channelComment) {
+        log.warn('Channel reject ignored: this gate requires a reject reason', {
+          approvalId: event.approvalId,
+          taskId,
+          stepId,
+          channelId: event.channelId,
+        })
+        ctx.activity.log('channel', `Gate "${stepId}" reject ignored because a reason is required. Use the Bakin approval link to reject with a reason.`, { taskId })
+        return
+      }
+      const rejectReason = channelComment || 'Rejected via runtime channel'
+      const approvalRef = approvalRefFromRecord(approvalRecord)
+      const result = rejectGate(taskId, stepId, rejectReason, { approver })
+      if (!result.success) {
+        log.warn(`Channel reject failed: ${result.errors?.[0] || 'unknown error'}`, { taskId, stepId })
+        return
+      }
+
+      const auditPayload = buildGateAuditPayload(taskId, stepId, result.decision, rejectReason)
+      ctx.activity.audit('gate.rejected', 'channel', auditPayload)
+      ctx.activity.log('channel', `Gate "${stepId}" rejected via runtime channel: ${rejectReason}`, { taskId })
+      indexInstance(taskId).catch(() => {})
+
+      const instance = loadInstance(taskId)
+      if (instance && result.decision) {
+        resolveGateApproval(
+          approvalRef,
+          'rejected',
+          approver,
+          result.decision.decidedAt,
+          rejectReason,
+        ).catch(() => {})
+        sendGateDecisionSummary(
+          instance,
+          stepId,
+          result.decision.gateLabel,
+          getGateDescription(instance.workflowId, stepId),
+          'rejected',
+          approver,
+          result.decision.requestedAt,
+          result.decision.decidedAt,
+          rejectReason,
+          activeGateSettings(),
+        ).catch(() => {})
+      }
+    }
+  })
+}

--- a/plugins/workflows/lib/register-hooks.ts
+++ b/plugins/workflows/lib/register-hooks.ts
@@ -1,0 +1,76 @@
+/**
+ * Workflow HookRegistry registrations
+ *
+ * registerWorkflowHooks(ctx) registers every cross-plugin workflow hook (the
+ * runtime/instance/gate RPC surface + the notification-channel lookups) so
+ * other plugins reach workflow state through the HookRegistry rather than
+ * importing this plugin directly. Extracted verbatim from the activate() body.
+ */
+import type { PluginContext, ApprovalActor } from '@bakin/core/plugin-types'
+import {
+  loadInstance,
+  saveInstance,
+  approveGate,
+  rejectGate,
+  reopenFromStep,
+  listInstances,
+  getCurrentStep,
+  completeStep,
+  getActiveAgents,
+  authorizeWorkflowToolUse,
+  isGateNotified,
+  markGateNotified,
+  cancelInstance,
+  type WorkflowToolUseAction,
+} from './runtime'
+import { createValidatedInstance } from './start-validation'
+import { matchWorkflow } from './matcher'
+import { listDefinitions, loadDefinition } from './parser'
+import { workflowDefinitionNameFromHookInput } from './hook-input'
+import { validateStepOutput } from './schema-validator'
+import { listNotificationChannels, getNotificationChannel } from './notification-channel-registry'
+
+export function registerWorkflowHooks(ctx: PluginContext): void {
+  ctx.hooks.register('workflows.loadInstance', (d: Record<string, unknown>) => loadInstance(d.taskId as string, d.contentDir as string | undefined), { label: 'Load workflow instance.', summary: 'Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.saveInstance', (d: Record<string, unknown>) => saveInstance(d.instance as Parameters<typeof saveInstance>[0], d.contentDir as string | undefined), { label: 'Save workflow instance.', summary: 'Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.createInstance', (d: Record<string, unknown>) => createValidatedInstance(ctx, d.taskId as string, d.workflowId as string, d.assignee as string | undefined, d.contentDir as string | undefined, d.parentContext as Record<string, unknown> | undefined), { label: 'Create workflow instance.', summary: 'Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.approveGate', (d: Record<string, unknown>) => approveGate(d.taskId as string, d.stepId as string, {
+    approver: d.approver as ApprovalActor | undefined,
+    contentDir: d.contentDir as string | undefined,
+  }), { label: 'Approve workflow gate.', summary: 'Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.rejectGate', (d: Record<string, unknown>) => rejectGate(d.taskId as string, d.stepId as string, String(d.reason ?? ''), {
+    approver: d.approver as ApprovalActor | undefined,
+    rewindTo: d.rewindTo as string | undefined,
+    contentDir: d.contentDir as string | undefined,
+  }), { label: 'Reject workflow gate.', summary: 'Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.reopenFromStep', (d: Record<string, unknown>) => reopenFromStep(d.taskId as string, {
+    instanceId: d.instanceId as string | undefined,
+    stepId: d.stepId as string | undefined,
+    reason: String(d.reason ?? 'Workflow recovery requested'),
+    actor: d.actor as ApprovalActor | undefined,
+    contentDir: d.contentDir as string | undefined,
+  }), { label: 'Reopen workflow from step.', summary: 'Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.instances.list', (d: Record<string, unknown>) => listInstances(d.statusFilter as string | undefined, d.contentDir as string | undefined), { label: 'List workflow instances.', summary: 'Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.getCurrentStep', (d: Record<string, unknown>) => getCurrentStep(d.taskId as string, d.agentId as string | undefined, d.contentDir as string | undefined), { label: 'Get current step.', summary: 'Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.completeStep', (d: Record<string, unknown>) => completeStep(d.taskId as string, d.stepId as string, d.output as Record<string, unknown>, d.callerAgentId as string | undefined, d.contentDir as string | undefined), { label: 'Complete workflow step.', summary: 'Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.matchWorkflow', (d: Record<string, unknown>) => matchWorkflow(d.title as string, d.description as string | undefined), { label: 'Match workflow.', summary: 'Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.definitions.list', (d: Record<string, unknown>) => listDefinitions(d.contentDir as string | undefined), { label: 'List workflow definitions.', summary: 'Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.loadDefinition', (d: Record<string, unknown>) => {
+    const name = workflowDefinitionNameFromHookInput(d)
+    return name ? loadDefinition(name, d.contentDir as string | undefined) : null
+  }, { label: 'Load workflow definition.', summary: 'Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.getActiveAgents', (d: Record<string, unknown>) => getActiveAgents(d.taskId as string, d.contentDir as string | undefined), { label: 'List active workflow agents.', summary: 'Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.authorizeToolUse', (d: Record<string, unknown>) => authorizeWorkflowToolUse(d.taskId as string, d.agent as string, d.action as WorkflowToolUseAction, d.contentDir as string | undefined), { label: 'Authorize workflow tool use.', summary: 'Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.isGateNotified', (d: Record<string, unknown>) => isGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Check gate notification.', summary: 'Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.markGateNotified', (d: Record<string, unknown>) => markGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Mark gate notified.', summary: 'Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.validateStepOutput', (d: Record<string, unknown>) => validateStepOutput(d.schema as Record<string, unknown> | undefined, d.output as Record<string, unknown>), { label: 'Validate step output.', summary: 'Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.cancelInstance', (d: Record<string, unknown>) => {
+    cancelInstance(d.taskId as string, d.contentDir as string | undefined)
+  }, { label: 'Cancel workflow instance.', summary: 'Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue.', hookKind: 'event' })
+
+  // ─── Notification Channel Registry Hooks ─────────────────────────
+  ctx.hooks.register('workflows.notificationChannels.list', () => listNotificationChannels(), { label: 'List notification channels.', summary: 'Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.getNotificationChannel', (d: Record<string, unknown>) => {
+    return getNotificationChannel(d.id as string) ?? null
+  }, { label: 'Get notification channel.', summary: 'Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation.', hookKind: 'rpc' })
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -248,9 +248,16 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
       index.ts shed buildTemplateList/resolveSubWorkflows/formatStepContext/getTask/updateTask/z imports. ~755 → 472.
       Verified: typecheck/lint/workflows 420-0 (incl. exec-tools.test.ts callTool coverage)/full-suite 5124-0/binary
       build/boot smoke (plugin Ready; /definitions + /instances + /gates/pending → 200).
-    - ☐ C3b — register-hooks (`lib/register-hooks.ts`, the ~19 ctx.hooks.register calls) + channel-approvals
-      (`lib/channel-approvals.ts` — rehydratePendingApprovals + the subscribeApprovalResponses handler that uses
-      gate-audit/gate-settings) + optionally registerWorkflowSearch (the registerFileBackedContentType block) into
-      search-sync. After that index.ts is activate-orchestration-only (~220-line target). The decideGate 6-block collapse
-      + stdJsonResponses const + typed-route casts + the submit_step error-message classification stay deferred redesigns.
+    - ☑ C3b — register-hooks + channel-approvals: `lib/register-hooks.ts` (registerWorkflowHooks(ctx) — all 21
+      ctx.hooks.register RPC/event registrations) + `lib/channel-approvals.ts` (wireChannelApprovals(ctx) →
+      rehydratePendingApprovals + the subscribeApprovalResponses handler driving approve/rejectGate from a channel,
+      returns the unsubscribe handle for onShutdown). activate() now reads as orchestration: setWorkflowPluginContext →
+      registerFileBackedContentType → loadDefaultWorkflows → notification wiring → wireChannelApprovals →
+      registerWorkflowHooks → health checks → registerWorkflowExecTools. index.ts shed ~28 now-unused imports.
+      472 → 288. Verified: typecheck/lint/workflows 420-0/full-suite 5124-0/binary build/boot smoke (plugin Ready,
+      hooks+channel wiring active, all route groups 200).
+    - ☐ C3c (OPTIONAL, final tidy) — fold the inline registerFileBackedContentType block (~115 lines) into
+      search-sync as registerWorkflowSearch(ctx); would take index.ts to ~175. The remaining 288 is already
+      activate-orchestration-only (beats the appendix's ~220 remainder target). The decideGate 6-block collapse +
+      stdJsonResponses const + typed-route casts + the submit_step error-message classification stay deferred redesigns.
 - Remaining: workflow-canvas-editor (1,803), models-page (1,205), schedule/index (1,443) + test splits.


### PR DESCRIPTION
## What

Phase **C3b** of the `workflows/index.ts` split. Pulls the two remaining logic blocks out of `activate()` into focused modules.

| Module | Contents |
|---|---|
| `lib/register-hooks.ts` | `registerWorkflowHooks(ctx)` — all 21 `ctx.hooks.register` RPC/event hooks (the runtime/instance/gate surface + notification-channel lookups) |
| `lib/channel-approvals.ts` | `wireChannelApprovals(ctx)` — rehydrates pending approval renders and subscribes to runtime-channel approval responses, driving `approveGate`/`rejectGate` for channel-decided gates. Returns the unsubscribe handle, which `index.ts` keeps for `onShutdown` |

`activate()` now reads as pure orchestration:

```
setWorkflowPluginContext → registerFileBackedContentType → loadDefaultWorkflows
→ notification wiring → wireChannelApprovals → registerWorkflowHooks
→ health checks → registerWorkflowExecTools
```

`index.ts` sheds ~28 now-unused imports and drops from **472 → 288** lines.

## Pure relocation

Hook registrations and the channel handler are byte-identical. No behavior change.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (all 3 changed/new files)
- ✅ workflows plugin suite — **420/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — plugin reaches Ready; hooks + channel wiring active; `/definitions` + `/instances` + `/gates/pending` → 200

## Status of the split

`index.ts` started this cluster at **2,146 lines** and is now **288** — pure activate-orchestration + lifecycle, already beating the appendix's ~220 remainder target. One optional final tidy remains (**C3c**): folding the inline `registerFileBackedContentType` block (~115 lines) into `search-sync` as `registerWorkflowSearch(ctx)` would take it to ~175. Deferred redesigns (decideGate collapse, stdJsonResponses, typed-route casts, the submit_step error-message classification) stay out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)