### PR TITLE
refactor(workflows): fold search registration into search-sync (C3c)

### DIFF
--- a/plugins/workflows/index.ts
+++ b/plugins/workflows/index.ts
@@ -3,13 +3,11 @@
  * Enforces step-by-step agent execution with gated delivery,
  * parallel steps, human gates, and output validation.
  */
-import { existsSync, readdirSync, readFileSync } from 'fs'
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
-import yaml from 'js-yaml'
 import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin } from '@bakin/core/routing'
-import { listDefinitions, loadDefinition } from './lib/parser'
+import { listDefinitions } from './lib/parser'
 import { loadDefaultWorkflows } from './lib/load-defaults'
 import {
   checkWorkflowDefinitions,
@@ -18,10 +16,9 @@ import {
   workflowSkillDriftRepair,
   staleWorkflowInstancesRepair,
 } from './lib/health-checks'
-import { getManagedDefinition } from './lib/source-registry'
 import { listInstances, reconcilePendingApprovalTaskColumns } from './lib/runtime'
 import { setWorkflowPluginContext } from './lib/plugin-context'
-import { instanceToSearchDoc, definitionToSearchDoc } from './lib/search-sync'
+import { registerWorkflowSearch } from './lib/search-sync'
 import { definitionRoutes } from './lib/routes/definitions'
 import { instanceRoutes } from './lib/routes/instances'
 import { gateRoutes } from './lib/routes/gates'
@@ -37,7 +34,6 @@ import {
   setNotificationRuntime,
   type GateNotificationSettings,
 } from './lib/notifications'
-import type { WorkflowDefinition, WorkflowInstance } from './types'
 
 const log = createLogger('workflows')
 let unsubscribeApprovalResponses: (() => void) | null = null
@@ -69,122 +65,7 @@ const workflowsPlugin: BakinPlugin = definePlugin({
     setWorkflowPluginContext(ctx)
 
     // ─── Search Content Type Registration ─────────────────────────────
-
-    ctx.search.registerFileBackedContentType({
-      table: 'workflows',
-      schema: {
-        name: { type: 'text' },
-        description: { type: 'text' },
-        type: { type: 'keyword' },
-        status: { type: 'keyword' },
-        task_id: { type: 'keyword' },
-        steps: { type: 'text' },
-        updated_at: { type: 'datetime' },
-      },
-      searchableFields: ['name', 'description', 'steps'],
-      rerankField: 'description',
-      embeddingTemplate: '{{name}} {{description}} {{steps}}',
-      facets: ['type', 'status'],
-      filePatterns: [
-        {
-          pattern: 'workflows/definitions/*.{yaml,yml}',
-          fileToId: (rel) => {
-            const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
-            return `def:${name}`
-          },
-          fileToDoc: async (rel) => {
-            const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
-            const def = loadDefinition(name)
-            return def ? definitionToSearchDoc(name, def, def.source) : null
-          },
-        },
-        {
-          pattern: 'workflows/instances/*.json',
-          fileToId: (rel) => {
-            const taskId = rel.replace(/^workflows\/instances\//, '').replace(/\.json$/, '')
-            return `inst:${taskId}`
-          },
-          fileToDoc: async (rel, content) => {
-            try {
-              const data = JSON.parse(content) as WorkflowInstance
-              return instanceToSearchDoc(data)
-            } catch {
-              return null
-            }
-          },
-        },
-      ],
-      preserveVirtualDocuments: true,
-      onUnlink: async (rel) => {
-        if (rel.startsWith('workflows/definitions/')) {
-          const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
-          const defsDir = join(getContentDir(), 'workflows', 'definitions')
-          const alternateUserPath = rel.endsWith('.yaml')
-            ? join(defsDir, `${name}.yml`)
-            : join(defsDir, `${name}.yaml`)
-
-          if (existsSync(alternateUserPath)) {
-            const alternateDefinition = yaml.load(readFileSync(alternateUserPath, 'utf-8')) as WorkflowDefinition
-            await ctx.search.index(
-              `def:${name}`,
-              definitionToSearchDoc(name, { ...alternateDefinition, source: 'user' }, 'user'),
-            )
-            return
-          }
-
-          const fallbackEntry = getManagedDefinition(name)
-          if (fallbackEntry) {
-            await ctx.search.index(
-              `def:${name}`,
-              definitionToSearchDoc(
-                name,
-                { ...fallbackEntry.definition, source: fallbackEntry.source },
-                fallbackEntry.source,
-              ),
-            )
-          } else {
-            await ctx.search.remove(`def:${name}`)
-          }
-          return
-        }
-        if (rel.startsWith('workflows/instances/')) {
-          const taskId = rel.replace(/^workflows\/instances\//, '').replace(/\.json$/, '')
-          await ctx.search.remove(`inst:${taskId}`)
-        }
-      },
-      reindex: async function* () {
-        const contentDir = getContentDir()
-
-        // Yield effective definitions from every source: plugin defaults,
-        // agent-package definitions, and user YAML shadows.
-        for (const entry of listDefinitions(contentDir)) {
-          yield { key: `def:${entry.name}`, doc: definitionToSearchDoc(entry.name, entry.definition, entry.source) }
-        }
-
-        // Yield instances
-        const instancesDir = join(contentDir, 'workflows', 'instances')
-        if (existsSync(instancesDir)) {
-          for (const file of readdirSync(instancesDir).filter(f => f.endsWith('.json'))) {
-            try {
-              const data = JSON.parse(readFileSync(join(instancesDir, file), 'utf-8')) as WorkflowInstance
-              yield { key: `inst:${data.taskId}`, doc: instanceToSearchDoc(data) }
-            } catch { /* skip corrupt instances */ }
-          }
-        }
-      },
-      verifyExists: async (key: string) => {
-        const contentDir = getContentDir()
-        if (key.startsWith('def:')) {
-          const name = key.slice(4)
-          return loadDefinition(name, contentDir) !== null
-        }
-        if (key.startsWith('inst:')) {
-          const taskId = key.slice(5)
-          return existsSync(join(contentDir, 'workflows', 'instances', `${taskId}.json`))
-        }
-        return false
-      },
-    })
+    registerWorkflowSearch(ctx)
 
     // ─── Plugin-shipped workflow defaults ─────────────────────────────
     // Load every YAML in defaults/workflows/ and register through

--- a/plugins/workflows/lib/search-sync.ts
+++ b/plugins/workflows/lib/search-sync.ts
@@ -9,12 +9,18 @@
  * accessor — null ctx before activate degrades to a no-op, matching the old
  * `if (!pluginCtx) return` guard.
  */
+import { existsSync, readFileSync, readdirSync } from 'fs'
+import { join } from 'path'
+import yaml from 'js-yaml'
+import type { PluginContext } from '@bakin/core/plugin-types'
 import type { WorkflowDefinition, WorkflowInstance } from '../types'
 import type { DefinitionSource } from './source-registry'
-import { loadDefinition } from './parser'
+import { getManagedDefinition } from './source-registry'
+import { loadDefinition, listDefinitions } from './parser'
 import { loadInstance } from './runtime'
 import { isWorkflowDisabled } from './availability'
 import { getWorkflowPluginContext } from './plugin-context'
+import { getContentDir } from './content-dir'
 import { createLogger } from '@bakin/core/logger'
 
 const log = createLogger('workflows')
@@ -72,4 +78,127 @@ export async function indexDefinition(name: string, def: WorkflowDefinition, sou
   const ctx = getWorkflowPluginContext()
   if (!ctx) return
   await ctx.search.index(`def:${name}`, definitionToSearchDoc(name, def, source))
+}
+
+/**
+ * Register the file-backed `workflows` search content type: definitions
+ * (yaml/yml) and instances (json) under the content dir, with the onUnlink
+ * shadow-fallback, full reindex generator, and existence verifier.
+ */
+export function registerWorkflowSearch(ctx: PluginContext): void {
+  ctx.search.registerFileBackedContentType({
+    table: 'workflows',
+    schema: {
+      name: { type: 'text' },
+      description: { type: 'text' },
+      type: { type: 'keyword' },
+      status: { type: 'keyword' },
+      task_id: { type: 'keyword' },
+      steps: { type: 'text' },
+      updated_at: { type: 'datetime' },
+    },
+    searchableFields: ['name', 'description', 'steps'],
+    rerankField: 'description',
+    embeddingTemplate: '{{name}} {{description}} {{steps}}',
+    facets: ['type', 'status'],
+    filePatterns: [
+      {
+        pattern: 'workflows/definitions/*.{yaml,yml}',
+        fileToId: (rel) => {
+          const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
+          return `def:${name}`
+        },
+        fileToDoc: async (rel) => {
+          const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
+          const def = loadDefinition(name)
+          return def ? definitionToSearchDoc(name, def, def.source) : null
+        },
+      },
+      {
+        pattern: 'workflows/instances/*.json',
+        fileToId: (rel) => {
+          const taskId = rel.replace(/^workflows\/instances\//, '').replace(/\.json$/, '')
+          return `inst:${taskId}`
+        },
+        fileToDoc: async (rel, content) => {
+          try {
+            const data = JSON.parse(content) as WorkflowInstance
+            return instanceToSearchDoc(data)
+          } catch {
+            return null
+          }
+        },
+      },
+    ],
+    preserveVirtualDocuments: true,
+    onUnlink: async (rel) => {
+      if (rel.startsWith('workflows/definitions/')) {
+        const name = rel.replace(/^workflows\/definitions\//, '').replace(/\.(yaml|yml)$/, '')
+        const defsDir = join(getContentDir(), 'workflows', 'definitions')
+        const alternateUserPath = rel.endsWith('.yaml')
+          ? join(defsDir, `${name}.yml`)
+          : join(defsDir, `${name}.yaml`)
+
+        if (existsSync(alternateUserPath)) {
+          const alternateDefinition = yaml.load(readFileSync(alternateUserPath, 'utf-8')) as WorkflowDefinition
+          await ctx.search.index(
+            `def:${name}`,
+            definitionToSearchDoc(name, { ...alternateDefinition, source: 'user' }, 'user'),
+          )
+          return
+        }
+
+        const fallbackEntry = getManagedDefinition(name)
+        if (fallbackEntry) {
+          await ctx.search.index(
+            `def:${name}`,
+            definitionToSearchDoc(
+              name,
+              { ...fallbackEntry.definition, source: fallbackEntry.source },
+              fallbackEntry.source,
+            ),
+          )
+        } else {
+          await ctx.search.remove(`def:${name}`)
+        }
+        return
+      }
+      if (rel.startsWith('workflows/instances/')) {
+        const taskId = rel.replace(/^workflows\/instances\//, '').replace(/\.json$/, '')
+        await ctx.search.remove(`inst:${taskId}`)
+      }
+    },
+    reindex: async function* () {
+      const contentDir = getContentDir()
+
+      // Yield effective definitions from every source: plugin defaults,
+      // agent-package definitions, and user YAML shadows.
+      for (const entry of listDefinitions(contentDir)) {
+        yield { key: `def:${entry.name}`, doc: definitionToSearchDoc(entry.name, entry.definition, entry.source) }
+      }
+
+      // Yield instances
+      const instancesDir = join(contentDir, 'workflows', 'instances')
+      if (existsSync(instancesDir)) {
+        for (const file of readdirSync(instancesDir).filter(f => f.endsWith('.json'))) {
+          try {
+            const data = JSON.parse(readFileSync(join(instancesDir, file), 'utf-8')) as WorkflowInstance
+            yield { key: `inst:${data.taskId}`, doc: instanceToSearchDoc(data) }
+          } catch { /* skip corrupt instances */ }
+        }
+      }
+    },
+    verifyExists: async (key: string) => {
+      const contentDir = getContentDir()
+      if (key.startsWith('def:')) {
+        const name = key.slice(4)
+        return loadDefinition(name, contentDir) !== null
+      }
+      if (key.startsWith('inst:')) {
+        const taskId = key.slice(5)
+        return existsSync(join(contentDir, 'workflows', 'instances', `${taskId}.json`))
+      }
+      return false
+    },
+  })
 }

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -256,8 +256,17 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
       registerWorkflowHooks → health checks → registerWorkflowExecTools. index.ts shed ~28 now-unused imports.
       472 → 288. Verified: typecheck/lint/workflows 420-0/full-suite 5124-0/binary build/boot smoke (plugin Ready,
       hooks+channel wiring active, all route groups 200).
-    - ☐ C3c (OPTIONAL, final tidy) — fold the inline registerFileBackedContentType block (~115 lines) into
-      search-sync as registerWorkflowSearch(ctx); would take index.ts to ~175. The remaining 288 is already
-      activate-orchestration-only (beats the appendix's ~220 remainder target). The decideGate 6-block collapse +
-      stdJsonResponses const + typed-route casts + the submit_step error-message classification stay deferred redesigns.
+    - ☑ C3c — search registration: folded the inline registerFileBackedContentType block into
+      `search-sync.ts` as `registerWorkflowSearch(ctx)` (definitions+instances file patterns, onUnlink shadow-fallback,
+      reindex generator, verifyExists). index.ts shed the fs/yaml/path/getManagedDefinition/loadDefinition/type imports
+      the block solely used. 288 → **169 — pure activate-orchestration + lifecycle**. Verified: typecheck/lint/workflows
+      420-0/full-suite 5124-0/binary build/boot smoke (bakin_workflows content type registers; /definitions + /instances
+      + /gates/pending + /search → 200).
+  - **WS6 workflows cluster — ☑ DONE.** runtime.ts (1,634) + index.ts (2,146) ≈ 3,780 lines of god-file decomposed into
+    ~22 cohesive lib modules across 10 sequential PRs (#527 runtime split; #528 step-format+template-list; #529 #510
+    validator dedup; #530 ctx-accessor+search-sync; #531 routes/definitions; #532 routes/instances; #533 routes/gates;
+    #534 exec-tools; #535 hooks+channel-approvals; C3c search-reg) — every PR green on full suite + binary build + boot
+    smoke. index.ts: 2,146 → 169 (92% reduction). Deferred redesigns (decideGate 6-block collapse, stdJsonResponses
+    const, typed-route casts, submit_step error-message classification, gate-settings dual-source-of-truth) noted as
+    follow-ups, not taken.
 - Remaining: workflow-canvas-editor (1,803), models-page (1,205), schedule/index (1,443) + test splits.


### PR DESCRIPTION
## What

Final phase of the `workflows/index.ts` split. Moves the inline `registerFileBackedContentType` block out of `activate()` into `search-sync` as **`registerWorkflowSearch(ctx)`** — definitions + instances file patterns, the `onUnlink` shadow-fallback, the full `reindex` generator, and `verifyExists`, all beside the search-doc builders they already use.

`activate()` now just calls `registerWorkflowSearch(ctx)`. `index.ts` sheds the `fs` / `yaml` / `getManagedDefinition` / `loadDefinition` / `WorkflowDefinition` / `WorkflowInstance` imports the block solely used, and drops from **288 → 169** lines — pure activate-orchestration + lifecycle.

## Pure relocation

The content-type config is byte-identical. No behavior change.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (both changed files)
- ✅ workflows plugin suite — **420/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — `bakin_workflows` content type registers; `/definitions` + `/instances` + `/gates/pending` + `/search` → 200

## Completes the workflows cluster

`workflows/index.ts`: **2,146 → 169 (92% reduction).** Together with the `runtime.ts` split (#527), the WS6 workflows cluster — ~3,780 lines of god-file — is now decomposed across ~22 cohesive `lib/` modules over 10 sequential PRs (#527–#535 + this), every one green on the full suite + binary build + boot smoke.

Deferred redesigns (decideGate 6-block collapse, `stdJsonResponses` const, typed-route casts, `submit_step` error-message classification, gate-settings dual-source-of-truth) are noted in `tasks/plan.md` as follow-ups — intentionally not taken, to keep every PR pure behavior-preserving relocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)