### PR TITLE
refactor(workflows): extract WorkflowDetailsDrawer from canvas-editor (phase 2)

### DIFF
--- a/plugins/workflows/components/workflow-canvas-editor.tsx
+++ b/plugins/workflows/components/workflow-canvas-editor.tsx
@@ -55,12 +55,8 @@ import {
   Trash2,
   UserRound,
   Workflow as WorkflowIcon,
-  X,
 } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
-import { Input } from "@makinbakin/sdk/ui"
-import { Label } from "@makinbakin/sdk/ui"
-import { Textarea } from "@makinbakin/sdk/ui"
 import {
   Dialog,
   DialogContent,
@@ -73,6 +69,7 @@ import {
 import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-renderer-registry'
 import { NodeTypePalette, PALETTE_DRAG_MIME_TYPE } from './node-type-palette'
 import { NodeConfigDrawer } from './node-config-drawer'
+import { WorkflowDetailsDrawer } from './workflow-details-drawer'
 import { ManagedWorkflowCopyDialog } from './managed-workflow-copy-dialog'
 import { AgentAssignmentLabel } from './nodes/agent-assignment-label'
 import {
@@ -294,98 +291,6 @@ const BUILTIN_NODE_TYPES: NodeTypes = {
   trigger: EditorTriggerNode,
   subflowGroup: EditorSubflowGroupNode,
   appendStep: EditorAppendStepNode,
-}
-
-function WorkflowDetailsDrawer({
-  definition,
-  onApply,
-  onClose,
-  applyLabel = 'Apply',
-  applying = false,
-}: {
-  definition: WorkflowDefinition
-  onApply: (patch: Pick<WorkflowDefinition, 'name' | 'description'>) => void | Promise<void>
-  onClose: () => void
-  applyLabel?: string
-  applying?: boolean
-}) {
-  const [name, setName] = useState(definition.name)
-  const [description, setDescription] = useState(definition.description ?? '')
-  const canApply = name.trim().length > 0
-
-  useEffect(() => {
-    setName(definition.name)
-    setDescription(definition.description ?? '')
-  }, [definition.description, definition.name])
-
-  return (
-    <aside className="flex w-[25rem] flex-col border-l border-border bg-card">
-      <div className="flex items-start justify-between gap-3 border-b border-border p-3">
-        <div className="min-w-0">
-          <h2 className="truncate text-sm font-medium">Workflow details</h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Edit the workflow name and description.
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Close workflow details"
-          onClick={onClose}
-        >
-          <X className="size-3.5" />
-        </Button>
-      </div>
-      <div className="flex-1 overflow-y-auto p-3">
-        <div className="mb-3">
-          <Label className="text-xs" htmlFor="workflow-details-name">
-            Name <span className="text-red-400">*</span>
-          </Label>
-          <Input
-            id="workflow-details-name"
-            value={name}
-            onChange={(event) => setName(event.target.value)}
-            placeholder="Workflow name"
-            aria-invalid={!canApply || undefined}
-          />
-          {!canApply && (
-            <p className="mt-1 text-[11px] font-medium text-red-300">Enter a workflow name.</p>
-          )}
-        </div>
-        <div className="mb-3">
-          <Label className="text-xs" htmlFor="workflow-details-description">
-            Description
-          </Label>
-          <Textarea
-            id="workflow-details-description"
-            rows={5}
-            value={description}
-            onChange={(event) => setDescription(event.target.value)}
-            placeholder="Describe when this workflow should be used"
-          />
-        </div>
-      </div>
-      <div className="flex items-center justify-between gap-2 border-t border-border p-3">
-        <Button size="sm" variant="ghost" onClick={onClose} disabled={applying}>
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          onClick={async () => {
-            if (!canApply) return
-            await onApply({
-              name: name.trim(),
-              description: description.trim(),
-            })
-          }}
-          disabled={!canApply || applying}
-        >
-          {applying ? 'Saving...' : applyLabel}
-        </Button>
-      </div>
-    </aside>
-  )
 }
 
 interface WorkflowCanvasEditorProps {

--- a/plugins/workflows/components/workflow-details-drawer.tsx
+++ b/plugins/workflows/components/workflow-details-drawer.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import { Button } from "@makinbakin/sdk/ui"
+import { Input } from "@makinbakin/sdk/ui"
+import { Label } from "@makinbakin/sdk/ui"
+import { Textarea } from "@makinbakin/sdk/ui"
+import type { WorkflowDefinition } from '../types'
+
+/**
+ * Controlled drawer for editing a workflow's name + description. Self-contained:
+ * owns its draft name/description state (re-seeded when the definition prop
+ * changes), props-only interface, no closure over editor state.
+ */
+export function WorkflowDetailsDrawer({
+  definition,
+  onApply,
+  onClose,
+  applyLabel = 'Apply',
+  applying = false,
+}: {
+  definition: WorkflowDefinition
+  onApply: (patch: Pick<WorkflowDefinition, 'name' | 'description'>) => void | Promise<void>
+  onClose: () => void
+  applyLabel?: string
+  applying?: boolean
+}) {
+  const [name, setName] = useState(definition.name)
+  const [description, setDescription] = useState(definition.description ?? '')
+  const canApply = name.trim().length > 0
+
+  useEffect(() => {
+    setName(definition.name)
+    setDescription(definition.description ?? '')
+  }, [definition.description, definition.name])
+
+  return (
+    <aside className="flex w-[25rem] flex-col border-l border-border bg-card">
+      <div className="flex items-start justify-between gap-3 border-b border-border p-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-medium">Workflow details</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Edit the workflow name and description.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close workflow details"
+          onClick={onClose}
+        >
+          <X className="size-3.5" />
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3">
+        <div className="mb-3">
+          <Label className="text-xs" htmlFor="workflow-details-name">
+            Name <span className="text-red-400">*</span>
+          </Label>
+          <Input
+            id="workflow-details-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Workflow name"
+            aria-invalid={!canApply || undefined}
+          />
+          {!canApply && (
+            <p className="mt-1 text-[11px] font-medium text-red-300">Enter a workflow name.</p>
+          )}
+        </div>
+        <div className="mb-3">
+          <Label className="text-xs" htmlFor="workflow-details-description">
+            Description
+          </Label>
+          <Textarea
+            id="workflow-details-description"
+            rows={5}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Describe when this workflow should be used"
+          />
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2 border-t border-border p-3">
+        <Button size="sm" variant="ghost" onClick={onClose} disabled={applying}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={async () => {
+            if (!canApply) return
+            await onApply({
+              name: name.trim(),
+              description: description.trim(),
+            })
+          }}
+          disabled={!canApply || applying}
+        >
+          {applying ? 'Saving...' : applyLabel}
+        </Button>
+      </div>
+    </aside>
+  )
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -310,4 +310,9 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
   registry — behavior-touching, its OWN step) + canvas-editor-nodes.tsx, workflow-details-drawer.tsx, use-workflow-copy-form,
   use-unsaved-changes-guard, and the redesigns (slugify consolidation, setIsDirty-in-updater fix, WorkflowStepPatch typing,
   postOrPut helper, key-remount reset). 
-- Remaining: workflow-canvas-editor phases 2+, schedule/index (1,443) + test splits.
+  - ☑ Phase 2 — details drawer: `workflow-details-drawer.tsx` (WorkflowDetailsDrawer) — the self-contained controlled
+    name/description drawer (own draft state, props-only, no editor-state closure). Component sheds the now-unused
+    Input/Label/Textarea/X imports. 1,564 → 1,469. Verified: typecheck/lint/canvas-editor.test 29-0/full-suite 5124-0/
+    binary build/boot smoke (Workflows loads, client.js → 200).
+- Remaining: workflow-canvas-editor phases 3+ (use-workflow-copy-form, use-unsaved-changes-guard hooks; then the
+  behavior-touching dead-renderer deletion + canvas-editor-nodes), schedule/index (1,443) + test splits.


### PR DESCRIPTION
## What

Pulls the self-contained workflow name/description drawer out of `workflow-canvas-editor.tsx` into `workflow-details-drawer.tsx` — following the existing one-component-per-file sibling pattern (`node-config-drawer.tsx`, `step-detail-drawer.tsx`).

`WorkflowDetailsDrawer` owns its draft name/description state (re-seeded from the `definition` prop), has a props-only interface, and closes over **no editor state** — a clean lift. The component imports it back and sheds the now-unused `Input` / `Label` / `Textarea` / `X` imports (the drawer was their only consumer).

**1,564 → 1,469.**

## Pure relocation

JSX is byte-identical. No behavior change.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (both files)
- ✅ `tests/plugins/workflows/workflow-canvas-editor.test.tsx` — **29/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — Workflows loads; rebuilt `client.js` → 200

## Next

The two generic hooks (`use-unsaved-changes-guard`, `use-workflow-copy-form`), then the **behavior-touching dead-renderer deletion** + `canvas-editor-nodes` as a deliberate standalone step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)