### PR TITLE
refactor(workflows): delete shadowed editor node renderers (phase 3)

### DIFF
--- a/plugins/workflows/components/workflow-canvas-editor.tsx
+++ b/plugins/workflows/components/workflow-canvas-editor.tsx
@@ -14,7 +14,7 @@
  * without special-casing.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import {
   ReactFlow,
   Background,
@@ -32,7 +32,6 @@ import {
   type EdgeProps,
   type EdgeTypes,
   type NodeChange,
-  type NodeProps,
   type NodeTypes,
   type ReactFlowInstance,
 } from '@xyflow/react'
@@ -42,18 +41,14 @@ import {
   ArrowLeft,
   ArrowDown,
   ArrowUp,
-  CheckCircle2,
-  ClipboardPlus,
   Copy,
   GitBranch,
   Info,
   LayoutGrid,
   Pencil,
-  Radio,
   Save,
   ShieldAlert,
   Trash2,
-  UserRound,
   Workflow as WorkflowIcon,
 } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
@@ -71,7 +66,6 @@ import { NodeTypePalette, PALETTE_DRAG_MIME_TYPE } from './node-type-palette'
 import { NodeConfigDrawer } from './node-config-drawer'
 import { WorkflowDetailsDrawer } from './workflow-details-drawer'
 import { ManagedWorkflowCopyDialog } from './managed-workflow-copy-dialog'
-import { AgentAssignmentLabel } from './nodes/agent-assignment-label'
 import {
   clearWorkflowDialogFieldError,
   hasWorkflowDialogFieldErrors,
@@ -123,156 +117,11 @@ function hasPaletteDragType(dataTransfer: DataTransfer): boolean {
   return Array.from(dataTransfer.types ?? []).includes(PALETTE_DRAG_MIME_TYPE)
 }
 
-interface EditorNodeData extends Record<string, unknown> {
-  label?: string
-  agent?: string
-  title?: string
-  task?: string
-  description?: string
-  workflow_id?: string
-  channels?: string[]
-  column?: string
-}
-
-interface EditorNodeShellProps {
-  data: EditorNodeData
-  tone: 'blue' | 'amber' | 'violet' | 'emerald' | 'zinc'
-  title: string
-  icon: ReactNode
-  sourceHandle?: boolean
-}
-
-function EditorNodeShell({ data, tone, title, icon, sourceHandle = true }: EditorNodeShellProps) {
-  const toneClass = {
-    blue: 'border-blue-500/50 text-blue-300 bg-blue-500/10',
-    amber: 'border-amber-400/60 text-amber-300 bg-amber-500/10',
-    violet: 'border-violet-500/50 text-violet-300 bg-violet-500/10',
-    emerald: 'border-emerald-500/50 text-emerald-300 bg-emerald-500/10',
-    zinc: 'border-zinc-600 text-zinc-300 bg-zinc-800/60',
-  }[tone]
-  const detail = data.task || data.title || data.description || data.workflow_id || data.column
-
-  return (
-    <div className={`flex h-full w-full flex-col justify-center rounded-lg border bg-zinc-950 px-4 py-3 shadow-lg ${toneClass}`}>
-      <div className="flex items-center gap-2">
-        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-md bg-black/25">
-          {icon}
-        </span>
-        <div className="min-w-0">
-          <div className="text-xs font-semibold uppercase leading-none tracking-wide opacity-80">
-            {title}
-          </div>
-          <div className="mt-1 truncate text-sm font-medium text-zinc-100">
-            {data.label || title}
-          </div>
-        </div>
-      </div>
-      {data.agent && (
-        <AgentAssignmentLabel agent={data.agent} className="mt-2" />
-      )}
-      {typeof detail === 'string' && detail.length > 0 && (
-        <p className={`${data.agent ? 'mt-1' : 'mt-2'} line-clamp-2 text-xs leading-snug text-zinc-400`}>
-          {detail}
-        </p>
-      )}
-      <Handle type="target" position={Position.Top} className="!bg-zinc-500" />
-      {sourceHandle && <Handle type="source" position={Position.Bottom} className="!bg-zinc-500" />}
-    </div>
-  )
-}
-
-function EditorAgentNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="emerald"
-      title="Agent Task"
-      icon={<UserRound className="size-3.5" />}
-    />
-  )
-}
-
-function EditorGateNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="amber"
-      title="Approval Gate"
-      icon={<CheckCircle2 className="size-3.5" />}
-    />
-  )
-}
-
-function EditorOutputNode({ data }: NodeProps) {
-  const nodeData = data as EditorNodeData
-  return (
-    <EditorNodeShell
-      data={{
-        ...nodeData,
-        description: Array.isArray(nodeData.channels) ? nodeData.channels.join(', ') : nodeData.description,
-      }}
-      tone="violet"
-      title="Completion"
-      icon={<Radio className="size-3.5" />}
-    />
-  )
-}
-
-function EditorParallelNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="blue"
-      title="Parallel Group"
-      icon={<GitBranch className="size-3.5" />}
-    />
-  )
-}
-
-function EditorWorkflowNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="zinc"
-      title="Nested Workflow"
-      icon={<WorkflowIcon className="size-3.5" />}
-    />
-  )
-}
-
-function EditorCreateTaskNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="blue"
-      title="Create Task"
-      icon={<ClipboardPlus className="size-3.5" />}
-    />
-  )
-}
-
-function EditorTriggerNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="blue"
-      title="Trigger"
-      icon={<Radio className="size-3.5" />}
-    />
-  )
-}
-
-function EditorSubflowGroupNode({ data }: NodeProps) {
-  return (
-    <EditorNodeShell
-      data={data as EditorNodeData}
-      tone="zinc"
-      title="Subflow Group"
-      icon={<WorkflowIcon className="size-3.5" />}
-    />
-  )
-}
-
+// The real node renderers (agent/gate/parallel/output/workflow/createTask/
+// trigger/subflowGroup) come from the node-renderer registry, populated by
+// client.tsx — exactly like the read-only workflow-canvas.tsx viewer. Only
+// 'appendStep' is editor-private (an invisible drop target the registry never
+// provides), so it's the sole builtin fallback here.
 function EditorAppendStepNode() {
   return (
     <div aria-hidden="true" className="h-px w-px opacity-0">
@@ -282,14 +131,6 @@ function EditorAppendStepNode() {
 }
 
 const BUILTIN_NODE_TYPES: NodeTypes = {
-  agent: EditorAgentNode,
-  gate: EditorGateNode,
-  output: EditorOutputNode,
-  parallel: EditorParallelNode,
-  workflow: EditorWorkflowNode,
-  createTask: EditorCreateTaskNode,
-  trigger: EditorTriggerNode,
-  subflowGroup: EditorSubflowGroupNode,
   appendStep: EditorAppendStepNode,
 }
 
@@ -1463,7 +1304,3 @@ export function WorkflowCanvasEditor({
     </div>
   )
 }
-
-// Explicitly re-export the ReactNode type to keep TS happy in strict builds
-// where React types are only imported transitively.
-export type { ReactNode }

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -314,5 +314,18 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     name/description drawer (own draft state, props-only, no editor-state closure). Component sheds the now-unused
     Input/Label/Textarea/X imports. 1,564 → 1,469. Verified: typecheck/lint/canvas-editor.test 29-0/full-suite 5124-0/
     binary build/boot smoke (Workflows loads, client.js → 200).
-- Remaining: workflow-canvas-editor phases 3+ (use-workflow-copy-form, use-unsaved-changes-guard hooks; then the
-  behavior-touching dead-renderer deletion + canvas-editor-nodes), schedule/index (1,443) + test splits.
+  - ☑ Phase 3 — dead-renderer deletion (BEHAVIOR-TOUCHING, isolated): deleted EditorNodeShell + the 8 shadowed
+    Editor*Node renderers (agent/gate/output/parallel/workflow/createTask/trigger/subflowGroup) + EditorNodeData/
+    EditorNodeShellProps. They never rendered in the running app — nodeTypes = {...BUILTIN_NODE_TYPES, ...registry} and
+    the registry (populated by client.tsx) won for every kind; only 'appendStep' (registry never provides it) is live.
+    BUILTIN_NODE_TYPES is now just { appendStep: EditorAppendStepNode } — the editor consumes the registry exclusively
+    like the workflow-canvas.tsx viewer already does. Shed AgentAssignmentLabel/UserRound/CheckCircle2/Radio/GitBranch?-no/
+    ClipboardPlus/NodeProps imports + the dead `export type { ReactNode }` strict-build hack. TEST UPDATED: the smoke test
+    used the real (empty-in-test) registry and relied on BUILTIN for the 'agent' nodeTypes key; now it registers stub
+    renderers for the 8 client.tsx kinds in beforeEach/unregisters in afterEach, so data-node-types carries 'agent'
+    (registry) + 'appendStep' (builtin) — mirroring reality. HMR note: during a registry sweep the canvas briefly has no
+    renderer for swept kinds (same as the viewer already), re-populated on plugin re-activate. 1,469 → 1,306. Verified:
+    typecheck/lint/canvas-editor.test 29-0/workflows 420-0/full-suite 5124-0/binary build/boot smoke (Workflows loads,
+    client.js + /definitions → 200).
+- Remaining: workflow-canvas-editor phases 4+ (use-workflow-copy-form, use-unsaved-changes-guard hooks — both need the
+  key-remount redesign first to decouple from the props-change reset effect; flagged), schedule/index (1,443) + test splits.

--- a/tests/plugins/workflows/workflow-canvas-editor.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas-editor.test.tsx
@@ -256,6 +256,13 @@ mock.module('../../../plugins/workflows/components/node-config-drawer', () => ({
 // Imported AFTER mocks.
 import { WorkflowCanvasEditor } from '../../../plugins/workflows/components/workflow-canvas-editor'
 import type { WorkflowDefinition } from '../../../plugins/workflows/types'
+import { registerNodeRenderer, unregisterNodeRenderer } from '../../../plugins/workflows/lib/node-renderer-registry'
+
+// The editor consumes node renderers from the registry (populated by client.tsx
+// in the running app); only 'appendStep' is a builtin fallback. Mirror that
+// registration here so nodeTypes carries the real kinds.
+const REGISTERED_NODE_KINDS = ['trigger', 'agent', 'gate', 'parallel', 'output', 'workflow', 'createTask', 'subflowGroup'] as const
+const StubNodeRenderer = () => null
 
 const sampleDefinition: WorkflowDefinition = {
   name: 'Video Script',
@@ -287,11 +294,13 @@ beforeEach(() => {
     ),
   )
   vi.stubGlobal('fetch', fetchMock)
+  for (const kind of REGISTERED_NODE_KINDS) registerNodeRenderer(kind, StubNodeRenderer)
 })
 
 afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
+  for (const kind of REGISTERED_NODE_KINDS) unregisterNodeRenderer(kind)
 })
 
 function closeNodeDrawer() {


### PR DESCRIPTION
## What

Removes the eight `Editor*Node` renderers (`EditorAgentNode` / `EditorGateNode` / `EditorOutputNode` / `EditorParallelNode` / `EditorWorkflowNode` / `EditorCreateTaskNode` / `EditorTriggerNode` / `EditorSubflowGroupNode`) plus the shared `EditorNodeShell` and the `EditorNodeData` / `EditorNodeShellProps` types.

**These never rendered in the running app.** `nodeTypes` is built as `{ ...BUILTIN_NODE_TYPES, ...registeredNodeTypes }`, and the node-renderer registry — populated by `client.tsx` for all eight kinds — **wins the spread**. Only `'appendStep'` (which the registry never provides) was actually live. The editor now consumes the registry exclusively, exactly like the read-only `workflow-canvas.tsx` viewer already does; `BUILTIN_NODE_TYPES` shrinks to `{ appendStep: EditorAppendStepNode }`.

**1,469 → 1,306.**

## Behavior-touching, but app-behavior-preserving

What the user sees is unchanged — the registry already provided these renderers. This only removes dead, **visually-divergent** duplicates (the editor versions silently dropped `skillDrift`). Also sheds the now-unused `AgentAssignmentLabel` / lucide-icon / `NodeProps` imports and the dead `export type { ReactNode }` strict-build hack.

## Test updated

The smoke test exercises the **real** registry (empty under test) and asserted that the `'agent'` `nodeTypes` key came from `BUILTIN_NODE_TYPES`. It now registers **stub renderers for the eight `client.tsx` kinds** in `beforeEach` (unregistered in `afterEach`), so `data-node-types` carries `'agent'` (registry) + `'appendStep'` (builtin) — reflecting the running app rather than the old dead-fallback.

## HMR note

During a registry sweep (hot reload) the canvas briefly lacks a renderer for swept kinds — the same window the viewer already has — re-populated on plugin re-activation. No fallback masking is reintroduced (that's the point of the deletion).

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (component + test)
- ✅ `tests/plugins/workflows/workflow-canvas-editor.test.tsx` — **29/0** (incl. the updated `data-node-types` assertion)
- ✅ workflows suite — **420/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — Workflows loads; `client.js` + `/definitions` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)