### PR TITLE
refactor(workflows): extract useUnsavedChangesGuard from canvas-editor (phase 4)

### DIFF
--- a/plugins/workflows/components/use-unsaved-changes-guard.tsx
+++ b/plugins/workflows/components/use-unsaved-changes-guard.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { useRouter as useTanStackRouter } from '@tanstack/react-router'
+import { Button } from "@makinbakin/sdk/ui"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@makinbakin/sdk/ui"
+
+type RouteNavigationBlocker =
+  | { status: 'idle' }
+  | { status: 'blocked'; proceed: () => void; reset: () => void }
+
+interface UnsavedChangesGuardOptions {
+  /** True while the surface holds unsaved edits — gates all the interception. */
+  hasUnsavedChanges: boolean
+  /** True while a save is in flight — disables the dialog actions. */
+  saving: boolean
+  /** Whether the "Save and exit" action is offered (e.g. managed sources can't save in place). */
+  canSaveInPlace: boolean
+  /** Extra disable for "Save and exit" beyond `saving` (e.g. an open node drawer). */
+  saveDisabled: boolean
+  /** Final navigation when there is nothing to confirm / after the user proceeds. */
+  onCancel?: () => void
+  /** Persist + clear dirty state. Resolves true to proceed with the exit, false to stay. */
+  onSaveAndExit: () => Promise<boolean>
+  /** Drop dirty state without saving. */
+  onDiscardAndExit: () => void
+}
+
+/**
+ * Generic unsaved-changes navigation guard: beforeunload, the TanStack
+ * history blocker, and a capture-phase anchor-click interceptor (TanStack's
+ * blocker misses plain `<a href>` navigation). Surfaces an exit-confirmation
+ * dialog and a `requestExit()` to drive from an explicit cancel/back button.
+ * `reset()` clears the in-flight prompt state — call it when the host re-seeds
+ * (its props-change reset effect) so a stale prompt can't linger.
+ */
+export function useUnsavedChangesGuard({
+  hasUnsavedChanges,
+  saving,
+  canSaveInPlace,
+  saveDisabled,
+  onCancel,
+  onSaveAndExit,
+  onDiscardAndExit,
+}: UnsavedChangesGuardOptions): { requestExit: () => void; reset: () => void; dialog: ReactNode } {
+  const [routeBlocker, setRouteBlocker] = useState<RouteNavigationBlocker>({ status: 'idle' })
+  const [confirmingExit, setConfirmingExit] = useState(false)
+  const [pendingNavigationHref, setPendingNavigationHref] = useState<string | null>(null)
+  const tanStackRouter = useTanStackRouter()
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [hasUnsavedChanges])
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    return tanStackRouter.history.block({
+      enableBeforeUnload: false,
+      blockerFn: async ({ currentLocation, nextLocation }) => {
+        const current = tanStackRouter.parseLocation(currentLocation)
+        const next = tanStackRouter.parseLocation(nextLocation)
+        if (current.pathname === next.pathname) return false
+
+        const shouldBlock = await new Promise<boolean>((resolve) => {
+          setRouteBlocker({
+            status: 'blocked',
+            proceed: () => resolve(false),
+            reset: () => resolve(true),
+          })
+        })
+        setRouteBlocker({ status: 'idle' })
+        return shouldBlock
+      },
+    })
+  }, [hasUnsavedChanges, tanStackRouter])
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (event.defaultPrevented) return
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+      const target = event.target as Element | null
+      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null
+      if (!anchor) return
+      if (anchor.target && anchor.target !== '_self') return
+      if (anchor.hasAttribute('download')) return
+      if (anchor.origin !== window.location.origin) return
+      if (anchor.href === window.location.href) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      setPendingNavigationHref(anchor.href)
+      setConfirmingExit(true)
+    }
+
+    document.addEventListener('click', handleDocumentClick, true)
+    return () => document.removeEventListener('click', handleDocumentClick, true)
+  }, [hasUnsavedChanges])
+
+  function completeExit() {
+    if (routeBlocker.status === 'blocked') {
+      routeBlocker.proceed()
+      return
+    }
+    const href = pendingNavigationHref
+    setPendingNavigationHref(null)
+    if (href) {
+      window.location.assign(href)
+      return
+    }
+    onCancel?.()
+  }
+
+  function cancelExitPrompt() {
+    if (routeBlocker.status === 'blocked') {
+      routeBlocker.reset()
+    }
+    setPendingNavigationHref(null)
+    setConfirmingExit(false)
+  }
+
+  function requestExit() {
+    if (!onCancel) return
+    if (hasUnsavedChanges) {
+      setPendingNavigationHref(null)
+      setConfirmingExit(true)
+      return
+    }
+    onCancel()
+  }
+
+  function reset() {
+    setConfirmingExit(false)
+    setPendingNavigationHref(null)
+  }
+
+  async function handleSaveAndExit() {
+    if (await onSaveAndExit()) {
+      setConfirmingExit(false)
+      completeExit()
+    }
+  }
+
+  function handleDiscardAndExit() {
+    onDiscardAndExit()
+    setConfirmingExit(false)
+    completeExit()
+  }
+
+  const dialog = (
+    <Dialog
+      open={confirmingExit || routeBlocker.status === 'blocked'}
+      onOpenChange={(open) => {
+        if (!open && !saving) cancelExitPrompt()
+      }}
+    >
+      <DialogContent className="bg-card border-border sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Unsaved workflow changes</DialogTitle>
+          <DialogDescription>
+            You have unsaved changes on this workflow. Save them before leaving, discard them, or stay on the canvas.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button
+            variant="destructive"
+            onClick={handleDiscardAndExit}
+            disabled={saving}
+          >
+            Discard changes
+          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={cancelExitPrompt}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            {canSaveInPlace && (
+              <Button
+                onClick={handleSaveAndExit}
+                disabled={saving || saveDisabled}
+              >
+                {saving ? 'Saving...' : 'Save and exit'}
+              </Button>
+            )}
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+
+  return { requestExit, reset, dialog }
+}

--- a/plugins/workflows/components/workflow-canvas-editor.tsx
+++ b/plugins/workflows/components/workflow-canvas-editor.tsx
@@ -35,7 +35,6 @@ import {
   type NodeTypes,
   type ReactFlowInstance,
 } from '@xyflow/react'
-import { useRouter as useTanStackRouter } from '@tanstack/react-router'
 import '@xyflow/react/dist/style.css'
 import {
   ArrowLeft,
@@ -52,19 +51,12 @@ import {
   Workflow as WorkflowIcon,
 } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@makinbakin/sdk/ui"
 
 import { getNodeRendererSnapshot, subscribeNodeRenderers } from '../lib/node-renderer-registry'
 import { NodeTypePalette, PALETTE_DRAG_MIME_TYPE } from './node-type-palette'
 import { NodeConfigDrawer } from './node-config-drawer'
 import { WorkflowDetailsDrawer } from './workflow-details-drawer'
+import { useUnsavedChangesGuard } from './use-unsaved-changes-guard'
 import { ManagedWorkflowCopyDialog } from './managed-workflow-copy-dialog'
 import {
   clearWorkflowDialogFieldError,
@@ -165,9 +157,6 @@ function slugify(name: string): string {
     .slice(0, 60)
 }
 
-type RouteNavigationBlocker =
-  | { status: 'idle' }
-  | { status: 'blocked'; proceed: () => void; reset: () => void }
 
 interface InsertEdgeData extends Record<string, unknown> {
   insertIndex: number
@@ -276,10 +265,8 @@ export function WorkflowCanvasEditor({
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [confirmingExit, setConfirmingExit] = useState(false)
   const [isDirty, setIsDirty] = useState(false)
   const [nodeDrawerDirty, setNodeDrawerDirty] = useState(false)
-  const [pendingNavigationHref, setPendingNavigationHref] = useState<string | null>(null)
   const [workflowDetailsOpen, setWorkflowDetailsOpen] = useState(false)
   const [effectiveSource, setEffectiveSource] = useState(source)
   const [managedCopyOpen, setManagedCopyOpen] = useState(false)
@@ -293,12 +280,37 @@ export function WorkflowCanvasEditor({
   const [disableOriginal, setDisableOriginal] = useState(true)
   const [paletteCollapsed, setPaletteCollapsed] = useState(false)
   const [createSetupOpen, setCreateSetupOpen] = useState(mode === 'create' && !initialDefinition?.id)
-  const [routeBlocker, setRouteBlocker] = useState<RouteNavigationBlocker>({ status: 'idle' })
-  const tanStackRouter = useTanStackRouter()
 
   const rfInstanceRef = useRef<ReactFlowInstance | null>(null)
   const lastFitViewKeyRef = useRef<string | null>(null)
   const hasUnsavedChanges = isDirty || nodeDrawerDirty
+  const isManagedSource = effectiveSource === 'plugin' || effectiveSource === 'agent-package'
+  const canSaveInPlace = mode === 'create' || !isManagedSource
+
+  // Navigation guard: owns the exit-confirmation flow (beforeunload + TanStack
+  // history block + anchor interception) and the unsaved-changes dialog.
+  const unsavedChangesGuard = useUnsavedChangesGuard({
+    hasUnsavedChanges,
+    saving,
+    canSaveInPlace,
+    saveDisabled: nodeDrawerDirty,
+    onCancel,
+    onSaveAndExit: async () => {
+      if (nodeDrawerDirty) {
+        setError(NODE_DRAWER_DIRTY_MESSAGE)
+        return false
+      }
+      const saved = await saveDefinition(buildDefinition(), { notifySaved: false })
+      if (!saved) return false
+      setIsDirty(false)
+      setNodeDrawerDirty(false)
+      return true
+    },
+    onDiscardAndExit: () => {
+      setIsDirty(false)
+      setNodeDrawerDirty(false)
+    },
+  })
 
   // Subscribe to registry mutations — see note in workflow-canvas.tsx.
   const registeredNodeTypes = useSyncExternalStore(subscribeNodeRenderers, getNodeRendererSnapshot, getNodeRendererSnapshot) as NodeTypes
@@ -365,10 +377,9 @@ export function WorkflowCanvasEditor({
     setState(seedState(nextDefinition))
     setEditingId(initialId)
     setSelectedId(null)
-    setConfirmingExit(false)
+    unsavedChangesGuard.reset()
     setIsDirty(false)
     setNodeDrawerDirty(false)
-    setPendingNavigationHref(null)
     setWorkflowDetailsOpen(false)
     setError(null)
     setEffectiveSource(source)
@@ -381,61 +392,6 @@ export function WorkflowCanvasEditor({
     setDisableOriginal(true)
     setCreateSetupOpen(mode === 'create' && !nextDefinition.id)
   }, [mode, source, initialId, initialDefinition])
-
-  useEffect(() => {
-    if (!hasUnsavedChanges) return
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault()
-      event.returnValue = ''
-    }
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [hasUnsavedChanges])
-
-  useEffect(() => {
-    if (!hasUnsavedChanges) return
-    return tanStackRouter.history.block({
-      enableBeforeUnload: false,
-      blockerFn: async ({ currentLocation, nextLocation }) => {
-        const current = tanStackRouter.parseLocation(currentLocation)
-        const next = tanStackRouter.parseLocation(nextLocation)
-        if (current.pathname === next.pathname) return false
-
-        const shouldBlock = await new Promise<boolean>((resolve) => {
-          setRouteBlocker({
-            status: 'blocked',
-            proceed: () => resolve(false),
-            reset: () => resolve(true),
-          })
-        })
-        setRouteBlocker({ status: 'idle' })
-        return shouldBlock
-      },
-    })
-  }, [hasUnsavedChanges, tanStackRouter])
-
-  useEffect(() => {
-    if (!hasUnsavedChanges) return
-    const handleDocumentClick = (event: MouseEvent) => {
-      if (event.defaultPrevented) return
-      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
-      const target = event.target as Element | null
-      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null
-      if (!anchor) return
-      if (anchor.target && anchor.target !== '_self') return
-      if (anchor.hasAttribute('download')) return
-      if (anchor.origin !== window.location.origin) return
-      if (anchor.href === window.location.href) return
-
-      event.preventDefault()
-      event.stopPropagation()
-      setPendingNavigationHref(anchor.href)
-      setConfirmingExit(true)
-    }
-
-    document.addEventListener('click', handleDocumentClick, true)
-    return () => document.removeEventListener('click', handleDocumentClick, true)
-  }, [hasUnsavedChanges])
 
   useEffect(() => {
     if (mode !== 'edit') return
@@ -672,8 +628,6 @@ export function WorkflowCanvasEditor({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [deleteSelectedStep, selectedId])
 
-  const isManagedSource = effectiveSource === 'plugin' || effectiveSource === 'agent-package'
-  const canSaveInPlace = mode === 'create' || !isManagedSource
   const canDelete = mode === 'edit' && effectiveSource === 'user'
 
   function buildDefinition(definitionOverride = definition): WorkflowDefinition {
@@ -890,57 +844,6 @@ export function WorkflowCanvasEditor({
     }
   }
 
-  function handleCancelRequest() {
-    if (!onCancel) return
-    if (hasUnsavedChanges) {
-      setPendingNavigationHref(null)
-      setConfirmingExit(true)
-      return
-    }
-    onCancel()
-  }
-
-  function completeExit() {
-    if (routeBlocker.status === 'blocked') {
-      routeBlocker.proceed()
-      return
-    }
-    const href = pendingNavigationHref
-    setPendingNavigationHref(null)
-    if (href) {
-      window.location.assign(href)
-      return
-    }
-    onCancel?.()
-  }
-
-  async function handleSaveAndExit() {
-    if (nodeDrawerDirty) {
-      setError(NODE_DRAWER_DIRTY_MESSAGE)
-      return
-    }
-    const saved = await saveDefinition(buildDefinition(), { notifySaved: false })
-    if (!saved) return
-    setIsDirty(false)
-    setNodeDrawerDirty(false)
-    setConfirmingExit(false)
-    completeExit()
-  }
-
-  function handleDiscardAndExit() {
-    setIsDirty(false)
-    setNodeDrawerDirty(false)
-    setConfirmingExit(false)
-    completeExit()
-  }
-
-  function cancelExitPrompt() {
-    if (routeBlocker.status === 'blocked') {
-      routeBlocker.reset()
-    }
-    setPendingNavigationHref(null)
-    setConfirmingExit(false)
-  }
 
   const selectedStep = selectedId ? (state.steps[selectedId] as {
     id: string
@@ -970,7 +873,7 @@ export function WorkflowCanvasEditor({
               className="self-center"
               aria-label="Back to workflows"
               title="Back to workflows"
-              onClick={handleCancelRequest}
+              onClick={unsavedChangesGuard.requestExit}
             >
               <ArrowLeft className="size-4" />
             </Button>
@@ -1260,47 +1163,7 @@ export function WorkflowCanvasEditor({
         onCreate={handleCreateLocalCopy}
       />
 
-      <Dialog
-        open={confirmingExit || routeBlocker.status === 'blocked'}
-        onOpenChange={(open) => {
-          if (!open && !saving) cancelExitPrompt()
-        }}
-      >
-        <DialogContent className="bg-card border-border sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Unsaved workflow changes</DialogTitle>
-            <DialogDescription>
-              You have unsaved changes on this workflow. Save them before leaving, discard them, or stay on the canvas.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="gap-2 sm:justify-between">
-            <Button
-              variant="destructive"
-              onClick={handleDiscardAndExit}
-              disabled={saving}
-            >
-              Discard changes
-            </Button>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                onClick={cancelExitPrompt}
-                disabled={saving}
-              >
-                Cancel
-              </Button>
-              {canSaveInPlace && (
-                <Button
-                  onClick={handleSaveAndExit}
-                  disabled={saving || nodeDrawerDirty}
-                >
-                  {saving ? 'Saving...' : 'Save and exit'}
-                </Button>
-              )}
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {unsavedChangesGuard.dialog}
     </div>
   )
 }

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -327,5 +327,18 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     renderer for swept kinds (same as the viewer already), re-populated on plugin re-activate. 1,469 → 1,306. Verified:
     typecheck/lint/canvas-editor.test 29-0/workflows 420-0/full-suite 5124-0/binary build/boot smoke (Workflows loads,
     client.js + /definitions → 200).
-- Remaining: workflow-canvas-editor phases 4+ (use-workflow-copy-form, use-unsaved-changes-guard hooks — both need the
-  key-remount redesign first to decouple from the props-change reset effect; flagged), schedule/index (1,443) + test splits.
+  - ☑ Phase 4 — unsaved-changes guard: `use-unsaved-changes-guard.tsx` (useUnsavedChangesGuard) — the generic
+    navigation guard (beforeunload + TanStack history.block + the capture-phase anchor-click interceptor), the
+    exit-confirmation dialog, and `requestExit()`. The key-remount "prerequisite" turned out unnecessary: instead of
+    deleting the props-change reset effect, the hook exposes `reset()` and the editor's reset effect calls it — pure
+    behavior-preserving relocation, no page-wrapper change. The Save/Discard paths cross back via `onSaveAndExit`
+    (async→bool: nodeDrawerDirty guard + save + dirty-reset) / `onDiscardAndExit` callbacks; `canSaveInPlace` +
+    `isManagedSource` moved up so the hook can be constructed before the reset effect. index.ts shed the Dialog* +
+    useTanStackRouter imports + the RouteNavigationBlocker type. 1,306 → 1,169. Verified: typecheck/lint/canvas-editor.test
+    29-0 (incl. the stubbed history.block flow)/workflows 420-0/full-suite 5124-0/binary build/boot smoke.
+  - ☐ DEFERRED — use-workflow-copy-form: NOT taken as an in-file lift. The two copy handlers mutate ~8 pieces of editor
+    state on success (definition/editingId/effectiveSource/isDirty/nodeDrawerDirty/dialog-open/error) + call buildDefinition/
+    onSaved/onCopied, so an in-file hook needs ~12 injected deps for modest gain; its real value is the CROSS-FILE dedup
+    (the third copy in workflow-detail.tsx + the slugify consolidation). Best done as a deliberate cross-file dedup, not a
+    forced single-file move. canvas-editor: 1,803 → 1,169 across 5 PRs (state model, drawer, dead-renderers, guard).
+- Remaining: schedule/index (1,443) + test splits; deferred canvas-editor copy-form (cross-file dedup) + redesigns.


### PR DESCRIPTION
## What

Pulls the unsaved-changes navigation guard out of `workflow-canvas-editor.tsx` into a generic hook — **`use-unsaved-changes-guard.tsx`**:

- `beforeunload` + the TanStack `history.block` blocker + the **capture-phase anchor-click interceptor** (TanStack's blocker misses plain `<a href>` navigation)
- the exit-confirmation dialog
- `requestExit()` to drive from the cancel/back button

**1,306 → 1,169.**

## The key-remount "prerequisite" was unnecessary

I'd flagged this hook as blocked on the key-remount redesign (to delete the props-change reset effect that also resets the guard's `confirmingExit`/`pendingNavigationHref`). The cleaner path: the hook exposes **`reset()`** and the editor's reset effect calls it — **pure behavior-preserving relocation, no page-wrapper change.**

## Boundary

The Save/Discard paths cross back into the editor via callbacks:
- `onSaveAndExit: () => Promise<boolean>` — node-drawer-dirty guard, `saveDefinition`, dirty reset; `true` to proceed
- `onDiscardAndExit: () => void` — drop dirty state

`completeExit` + the dialog stay owned by the hook. `isManagedSource`/`canSaveInPlace` move up a few lines so the hook can be constructed before the reset effect references its `reset`. The editor sheds the `Dialog*` + `useTanStackRouter` imports and the `RouteNavigationBlocker` type.

## On the sibling copy-form hook (deferred, deliberately)

Not taken as an in-file lift: its handlers mutate ~8 editor-state fields and call `buildDefinition`/`onSaved`/`onCopied` (an in-file hook would need ~12 injected deps for modest gain), and its real payoff is the **cross-file dedup** (the third copy in `workflow-detail.tsx` + slugify consolidation). Better as a deliberate cross-file dedup than a forced single-file move.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (both files)
- ✅ `tests/plugins/workflows/workflow-canvas-editor.test.tsx` — **29/0** (incl. the stubbed `history.block` flow)
- ✅ workflows suite — **420/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ✅ isolated-home boot smoke — Workflows loads; `client.js` → 200

## canvas-editor: 1,803 → 1,169 across 5 PRs
state model (#540) · details drawer (#541) · dead-renderers (#542) · this guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)