### PR TITLE
refactor(schedule): extract pure util helpers from index (phase 1)

### DIFF
--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -15,6 +15,7 @@ import { runSchedulerTick, runStartupCatchUp, DEFAULT_TICK_WINDOW_MS, type Sched
 import { migrateBakinSchedulesOffOpenClawCron } from './lib/cutover'
 import { checkScheduleCutover, scheduleCutoverRepair } from './lib/health-checks'
 import { checkSchedulePrompt } from './lib/prompt-guard'
+import { getSystemTimezone, json, expandTemplate } from './lib/schedule-util'
 import { createTaskWithEffects } from '../../src/core/task-service'
 import { createLogger } from '../../src/core/logger'
 import { readTaskboard } from '../../src/core/task-store'
@@ -22,34 +23,6 @@ import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import type { BakinJobMeta, BridgeResult, MergedJob } from './types'
 
 const log = createLogger('schedule')
-
-/** Detect system IANA timezone. Falls back to UTC. */
-function getSystemTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone
-  } catch {
-    return 'UTC'
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function json(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
-function expandTemplate(template: string, vars: Record<string, string>): string {
-  let result = template
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.replace(new RegExp(`\\{${key}\\}`, 'g'), value)
-  }
-  return result
-}
 
 type BakinMutationGuard =
   | { ok: true; meta: BakinJobMeta }

--- a/plugins/schedule/lib/schedule-util.ts
+++ b/plugins/schedule/lib/schedule-util.ts
@@ -1,0 +1,32 @@
+/**
+ * Schedule plugin — pure utility helpers.
+ *
+ * Zero-coupling leaf functions (no plugin ctx, no module state): system-timezone
+ * detection, the JSON Response shorthand the routes use, and `{var}` task-title/
+ * prompt template expansion. Extracted from index.ts so the bigger seam modules
+ * can share them without reaching back into the entry file.
+ */
+
+/** Detect system IANA timezone. Falls back to UTC. */
+export function getSystemTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  } catch {
+    return 'UTC'
+  }
+}
+
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export function expandTemplate(template: string, vars: Record<string, string>): string {
+  let result = template
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replace(new RegExp(`\\{${key}\\}`, 'g'), value)
+  }
+  return result
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -341,4 +341,25 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     onSaved/onCopied, so an in-file hook needs ~12 injected deps for modest gain; its real value is the CROSS-FILE dedup
     (the third copy in workflow-detail.tsx + the slugify consolidation). Best done as a deliberate cross-file dedup, not a
     forced single-file move. canvas-editor: 1,803 → 1,169 across 5 PRs (state model, drawer, dead-renderers, guard).
-- Remaining: schedule/index (1,443) + test splits; deferred canvas-editor copy-form (cross-file dedup) + redesigns.
+- schedule/index — ◧ **split by RISK** (1,443; the live fire path for ALL schedules — most operationally sensitive
+  file in the audit). Landmines (kickoff + appendix risk notes): two module cells `pluginCtx` (read ~15 ways on the
+  fire path) + `schedulerTimer` must each stay in EXACTLY one module; the test public surface `__scheduleTestInternals`
+  + `MISSED_WINDOW_REASON` must re-export from index; default export stays in index (binary static import); the
+  cutover→catch-up→tick + resumeDuePauses-before-catch-up + start/stop ordering preserved EXACTLY. Tiered safest-first;
+  pause for Mark's eyes before the fire-path PRs (fire-engine, scheduler-loop). Dockerized-rig E2E for the fire-path
+  cuts (the bare-binary boot smoke can't fully activate schedule — `activation_failed: openclaw cron list ENOENT` is
+  environmental, openclaw not on PATH; the runtime-mocking schedule test suite is the authoritative gate).
+  - ☑ Phase 1 (pure, zero-risk): `lib/schedule-util.ts` — the zero-coupling leaf helpers getSystemTimezone (Intl tz
+    detection), json (Response shorthand), expandTemplate ({var} title/prompt expansion). No pluginCtx, no state, no
+    fire logic. index.ts imports them back. 1,443 → 1,416. Verified: typecheck/lint/schedule suite 280-0 (incl.
+    cron-dedup + blocked-fire-routing fire-path tests)/full-suite 5124-0/binary build (other 9 plugins load; schedule's
+    env ENOENT is the documented non-regression).
+  - ☐ Phase 2 (foundational cell): `lib/plugin-context.ts` — setPluginCtx/getPluginCtx as ONE cell replacing the
+    module-level `let pluginCtx`; __scheduleTestInternals.setPluginCtxForTests delegates to it. Mechanical but touches
+    every fire-path pluginCtx read → verify cron-dedup + blocked-fire-routing explicitly.
+  - ☐ Phase 3+ (FIRE PATH, needs Mark's eyes): fire-engine.ts (claim→fire→heal: runClaimedFire/healPendingCronClaims/
+    skipFire + MISSED_WINDOW_REASON), scheduler-loop.ts (schedulerTimer cell + start/stop + cutover ordering),
+    job-service.ts (CRUD verbs + the route/exec-tool dedup), routes/jobs.ts, exec-tools.ts. The redesigns (pause-drift
+    fix, dead update-handler code, dead settings keys maxConcurrentJobs/failureCooldownMs, ctx-threading, zod for
+    ensureBakinJob) are behavior-touching — listed, not bundled.
+- Remaining: schedule fire-path phases 2+ + test splits; deferred canvas-editor copy-form (cross-file dedup) + redesigns.


### PR DESCRIPTION
## What

First — and safest — cut of the `schedule/index.ts` split (the **live fire path for all schedules**, the most operationally-sensitive file in the audit). Extracts the three zero-coupling leaf helpers into **`lib/schedule-util.ts`**:

- `getSystemTimezone` — Intl-based IANA tz detection with UTC fallback
- `json` — the JSON `Response` shorthand the routes use
- `expandTemplate` — `{var}` task-title / prompt expansion

All pure — no plugin ctx, no module state, no fire logic. `index.ts` imports them back. **1,443 → 1,416.**

Deliberately leaves the two module cells (`pluginCtx`, `schedulerTimer`) and the fire-engine / scheduler-loop / job-service for later, **eyes-on** phases.

## Pure relocation

Functions are byte-identical. No behavior change.

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (both files)
- ✅ **schedule suite — 280/0** (incl. the `cron-dedup` and `blocked-fire-routing` fire-path tests that exercise these helpers)
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ⚠️ boot smoke: the other nine plugins load; schedule's `activation_failed: openclaw cron list ENOENT` in the bare-binary isolated home is the **documented environmental non-regression** (openclaw isn't on PATH, and a pure-helper move can't touch cron-list). The runtime-mocking test suite is the authoritative gate for schedule changes.

## Plan for the rest (in `tasks/plan.md`)

- **Phase 2 (foundational cell):** `lib/plugin-context.ts` — `set/getPluginCtx` as ONE cell replacing `let pluginCtx`; `setPluginCtxForTests` delegates to it. Verify `cron-dedup` + `blocked-fire-routing` explicitly.
- **Phase 3+ (FIRE PATH — needs your eyes):** `fire-engine.ts` (claim→fire→heal), `scheduler-loop.ts` (the `schedulerTimer` cell + start/stop + cutover ordering), `job-service.ts` (+ the route/exec-tool dedup), `routes/jobs.ts`, `exec-tools.ts`. I'll pause before these and dockerized-rig E2E them. The behavior-touching redesigns (pause-drift fix, dead settings keys, ctx-threading) are listed, not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)