### PR TITLE
refactor(schedule): extract pluginCtx into a single-cell accessor (phase 2)

### DIFF
--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -16,6 +16,7 @@ import { migrateBakinSchedulesOffOpenClawCron } from './lib/cutover'
 import { checkScheduleCutover, scheduleCutoverRepair } from './lib/health-checks'
 import { checkSchedulePrompt } from './lib/prompt-guard'
 import { getSystemTimezone, json, expandTemplate } from './lib/schedule-util'
+import { setPluginCtx, getPluginCtx } from './lib/plugin-context'
 import { createTaskWithEffects } from '../../src/core/task-service'
 import { createLogger } from '../../src/core/logger'
 import { readTaskboard } from '../../src/core/task-store'
@@ -39,7 +40,8 @@ const READ_ONLY_ERROR = 'Runtime cron jobs are read-only in Bakin — adopt it f
 async function guardBakinMutation(jobId: string): Promise<BakinMutationGuard> {
   const meta = getJob(jobId)
   if (meta?.isBakinJob) return { ok: true, meta }
-  const runtime = pluginCtx ? await pluginCtx.runtime.cron.get(jobId).catch(() => null) : null
+  const ctx = getPluginCtx()
+  const runtime = ctx ? await ctx.runtime.cron.get(jobId).catch(() => null) : null
   return runtime
     ? { ok: false, status: 403, error: READ_ONLY_ERROR }
     : { ok: false, status: 404, error: 'Schedule not found' }
@@ -68,7 +70,7 @@ export const MISSED_WINDOW_REASON = 'missed schedule window'
 
 /** Resolved tick interval in ms, clamped to a safe floor. */
 function tickIntervalMs(): number {
-  const raw = pluginCtx?.getSettings<ScheduleSettings>()?.tickIntervalSeconds
+  const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.tickIntervalSeconds
   const seconds = typeof raw === 'number' && raw >= MIN_TICK_INTERVAL_SECONDS ? raw : DEFAULT_TICK_INTERVAL_SECONDS
   return seconds * 1000
 }
@@ -76,7 +78,7 @@ function tickIntervalMs(): number {
 /** Resolved catch-up safety window in ms. A missed occurrence fires into `todo`
  *  if within this window, else into `blocked` for the user to triage. */
 function catchUpWindowMs(): number {
-  const raw = pluginCtx?.getSettings<ScheduleSettings>()?.catchUpWindowMinutes
+  const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.catchUpWindowMinutes
   const minutes = typeof raw === 'number' && raw >= 0 ? raw : DEFAULT_CATCH_UP_WINDOW_MINUTES
   return minutes * 60_000
 }
@@ -92,7 +94,8 @@ interface EnsureBakinJobResult {
 type ScheduleDeleteContext = Pick<PluginContext, 'runtime' | 'search'>
 
 async function getScheduleDefaultOwner(): Promise<string> {
-  return pluginCtx?.runtime ? getRuntimeMainAgentId(pluginCtx.runtime) : 'main'
+  const ctx = getPluginCtx()
+  return ctx?.runtime ? getRuntimeMainAgentId(ctx.runtime) : 'main'
 }
 
 async function ensureBakinJob(ctx: PluginContext, input: Record<string, unknown>): Promise<EnsureBakinJobResult> {
@@ -181,14 +184,12 @@ async function deleteScheduleJob(ctx: ScheduleDeleteContext, jobId: string): Pro
 // Bridge logic (cron → task)
 // ---------------------------------------------------------------------------
 
-/** Module-level ctx set during activate(), used by routes + the scheduler. */
-let pluginCtx: PluginContext | null = null
-
-// ─── Module-scope helpers (use pluginCtx for runtime access) ─────────────
+// ─── Module-scope helpers (read ctx via getPluginCtx for runtime access) ──
 
 async function readMergedRuntimeJobs(): Promise<MergedJob[]> {
-  if (!pluginCtx) throw new Error('schedule plugin not activated')
-  return readMergedJobs(pluginCtx.runtime.cron, await getRuntimeMainAgentId(pluginCtx.runtime))
+  const ctx = getPluginCtx()
+  if (!ctx) throw new Error('schedule plugin not activated')
+  return readMergedJobs(ctx.runtime.cron, await getRuntimeMainAgentId(ctx.runtime))
 }
 
 function jobToSearchDoc(job: MergedJob): Record<string, unknown> {
@@ -203,8 +204,8 @@ function jobToSearchDoc(job: MergedJob): Record<string, unknown> {
 }
 
 function indexJob(jobId: string): void {
-  if (!pluginCtx) return
-  const ctx = pluginCtx
+  const ctx = getPluginCtx()
+  if (!ctx) return
   readMergedRuntimeJobs().then((jobs) => {
     const job = jobs.find(j => j.id === jobId)
     if (!job) return
@@ -292,7 +293,7 @@ interface ProcessRunResult {
 async function fireScheduledRun(meta: BakinJobMeta, jobId: string, runId: string, firedAtMs: number): Promise<ProcessRunResult> {
   const claim = claimCronFire(jobId, runId, firedAtMs)
   if (!claim.claimed) {
-    pluginCtx?.activity.audit('fire_suppressed', 'system', {
+    getPluginCtx()?.activity.audit('fire_suppressed', 'system', {
       jobId,
       runId,
       existingTaskId: claim.existing?.taskId ?? null,
@@ -337,7 +338,7 @@ function skipFire(jobId: string, runId: string, reason: SkipReason): ProcessRunR
   markCronFireSkipped(jobId, runId, reason)
   // activity.audit prepends the plugin id → observable event is `schedule.fire_skipped`
   // (matches fire_suppressed/fire_healed/task_created — bare operation, no manual prefix).
-  pluginCtx?.activity.audit('fire_skipped', 'system', { jobId, runId, reason })
+  getPluginCtx()?.activity.audit('fire_skipped', 'system', { jobId, runId, reason })
   return { status: 200, body: { ok: true, skipped: reason } }
 }
 
@@ -484,13 +485,14 @@ async function runClaimedFire(
   upsertJob(meta)
 
   // Audit + activity feed
-  if (pluginCtx) {
-    pluginCtx.activity.audit('task_created', 'system', {
+  const auditCtx = getPluginCtx()
+  if (auditCtx) {
+    auditCtx.activity.audit('task_created', 'system', {
       jobId, runId, taskId, agent: meta.agentId, owner: defaults.owner,
       ...(column !== 'todo' ? { column, blockedReason: opts.blockedReason } : {}),
     })
     const where = column === 'blocked' ? ` (blocked — ${opts.blockedReason ?? MISSED_WINDOW_REASON})` : ''
-    pluginCtx.activity.log('system', `Schedule "${meta.displayName ?? jobId}" created task ${taskId}${meta.agentId ? ` for ${meta.agentId}` : ''}${where}`, { taskId })
+    auditCtx.activity.log('system', `Schedule "${meta.displayName ?? jobId}" created task ${taskId}${meta.agentId ? ` for ${meta.agentId}` : ''}${where}`, { taskId })
   }
 
   return { status: 200, body: { ok: true, taskId } }
@@ -525,7 +527,7 @@ async function healPendingCronClaims(): Promise<void> {
       continue
     }
     const result = await runClaimedFire(meta, claim.jobId, claim.runId, { firedAtMs: claim.firedAt })
-    pluginCtx?.activity.audit('fire_healed', 'system', {
+    getPluginCtx()?.activity.audit('fire_healed', 'system', {
       jobId: claim.jobId,
       runId: claim.runId,
       taskId: (result.body as { taskId?: string }).taskId ?? null,
@@ -565,7 +567,7 @@ function schedulerDeps(): SchedulerDeps {
 /** Run the idempotent cutover using the live runtime adapter. Shared by
  *  activate() (automatic) and the doctor repair (manual). */
 function runScheduleCutover(): ReturnType<typeof migrateBakinSchedulesOffOpenClawCron> {
-  const cron = pluginCtx!.runtime.cron
+  const cron = getPluginCtx()!.runtime.cron
   return migrateBakinSchedulesOffOpenClawCron({
     cronGet: async (jobId) => {
       const job = await cron.get(jobId)
@@ -987,7 +989,7 @@ const schedulePlugin: BakinPlugin = definePlugin({
   contentFiles: [],
 
   async activate(ctx: PluginContext) {
-    pluginCtx = ctx
+    setPluginCtx(ctx)
 
     ctx.hooks.register('schedule.ensureBakinJob', (data: Record<string, unknown>) => ensureBakinJob(ctx, data), {
       hookKind: 'rpc',
@@ -1386,7 +1388,7 @@ const schedulePlugin: BakinPlugin = definePlugin({
   },
 
   async onReady() {
-    const runtime = pluginCtx?.runtime
+    const runtime = getPluginCtx()?.runtime
     if (!runtime) return
     const jobs = await readMergedJobs(runtime.cron, await getRuntimeMainAgentId(runtime))
     const bakin = jobs.filter(j => j.isBakinJob)
@@ -1411,6 +1413,6 @@ export const __scheduleTestInternals = {
   fireScheduledRunFromPayload,
   healPendingCronClaims,
   setPluginCtxForTests: (ctx: unknown) => {
-    pluginCtx = ctx as PluginContext | null
+    setPluginCtx(ctx as PluginContext | null)
   },
 }

--- a/plugins/schedule/lib/plugin-context.ts
+++ b/plugins/schedule/lib/plugin-context.ts
@@ -1,0 +1,23 @@
+/**
+ * Schedule plugin context cell.
+ *
+ * The single source of the activated PluginContext, shared by every schedule
+ * seam module. The scheduler loop, heal path, and fire engine run with no
+ * incoming request, so they read ctx from here rather than threading it.
+ *
+ * MUST be exactly one cell: if any module kept its own copy, the test hook
+ * `__scheduleTestInternals.setPluginCtxForTests` would set the wrong one and
+ * the cron-dedup / blocked-fire-routing tests would silently exercise a null
+ * ctx (the audit calls are optional-chained).
+ */
+import type { PluginContext } from '@bakin/core/plugin-types'
+
+let pluginCtx: PluginContext | null = null
+
+export function setPluginCtx(ctx: PluginContext | null): void {
+  pluginCtx = ctx
+}
+
+export function getPluginCtx(): PluginContext | null {
+  return pluginCtx
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -354,9 +354,13 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     fire logic. index.ts imports them back. 1,443 → 1,416. Verified: typecheck/lint/schedule suite 280-0 (incl.
     cron-dedup + blocked-fire-routing fire-path tests)/full-suite 5124-0/binary build (other 9 plugins load; schedule's
     env ENOENT is the documented non-regression).
-  - ☐ Phase 2 (foundational cell): `lib/plugin-context.ts` — setPluginCtx/getPluginCtx as ONE cell replacing the
-    module-level `let pluginCtx`; __scheduleTestInternals.setPluginCtxForTests delegates to it. Mechanical but touches
-    every fire-path pluginCtx read → verify cron-dedup + blocked-fire-routing explicitly.
+  - ☑ Phase 2 (foundational cell): `lib/plugin-context.ts` — setPluginCtx/getPluginCtx as ONE cell replacing the
+    module-level `let pluginCtx`. All ~13 fire-path reads now go through getPluginCtx() (guarded patterns bind a local
+    `const ctx = getPluginCtx()`; optional-chain/non-null sites swap to getPluginCtx()?./!); activate calls
+    setPluginCtx(ctx); __scheduleTestInternals.setPluginCtxForTests delegates to setPluginCtx so it still drives the one
+    cell. Behavior-preserving (the cell is the same, just relocated). 1,416 → 1,418 (local binds). Verified: typecheck/
+    lint/the fire-path tests cron-dedup + blocked-fire-routing 24-0 (prove setPluginCtxForTests routes to the right
+    cell)/full schedule suite 280-0/full-suite 5124-0/binary build (9 plugins load; schedule env ENOENT non-regression).
   - ☐ Phase 3+ (FIRE PATH, needs Mark's eyes): fire-engine.ts (claim→fire→heal: runClaimedFire/healPendingCronClaims/
     skipFire + MISSED_WINDOW_REASON), scheduler-loop.ts (schedulerTimer cell + start/stop + cutover ordering),
     job-service.ts (CRUD verbs + the route/exec-tool dedup), routes/jobs.ts, exec-tools.ts. The redesigns (pause-drift


### PR DESCRIPTION
## What

Replaces the module-level `let pluginCtx` in `index.ts` with **`lib/plugin-context.ts`** — `setPluginCtx` / `getPluginCtx` over **one cell**. This is the foundational seam every later schedule module reads ctx through.

## The one-cell invariant (the whole point)

The audit risk note is explicit: this **must** stay exactly one cell. If a later module kept its own copy, `__scheduleTestInternals.setPluginCtxForTests` would set the wrong one and the `cron-dedup` / `blocked-fire-routing` tests would silently run against a `null` ctx (the fire-path audit calls are optional-chained, so they'd no-op instead of failing loudly).

- All ~13 fire-path reads route through `getPluginCtx()`: guarded sites bind a local `const ctx = getPluginCtx()` (`readMergedRuntimeJobs`, `indexJob`, `guardBakinMutation`, `getScheduleDefaultOwner`, the `task_created` audit block); the optional-chain / non-null sites swap to `getPluginCtx()?.` / `getPluginCtx()!`.
- `activate()` calls `setPluginCtx(ctx)`; `setPluginCtxForTests` delegates to `setPluginCtx` — the test hook still drives the one cell.

Behavior-preserving — same single cell, just relocated. **No fire logic, ordering, or scheduler-timer touched yet.**

## Verification

- ✅ `bun run typecheck`
- ✅ `eslint` (both files)
- ✅ **the two fire-path tests — `cron-dedup` + `blocked-fire-routing`, 24/0** (they prove `setPluginCtxForTests` reaches the right cell)
- ✅ full schedule suite — **280/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build` (all 3 targets; build-stamp files reverted)
- ⚠️ boot smoke: nine plugins load; schedule's `activation_failed: openclaw cron list ENOENT` in the bare isolated home is the documented environmental non-regression (the runtime-mocking suite is the gate for schedule changes).

## Next — and a checkpoint for you

That's the last **safe-ish, structural** phase. Phase 3+ is the **actual fire path** — `fire-engine.ts` (claim→fire→heal), `scheduler-loop.ts` (the `schedulerTimer` cell + cutover→catch-up→tick ordering), `job-service.ts`, routes, exec-tools. Per your kickoff I'll **pause for your eyes** and dockerized-rig E2E those rather than push them blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)