### PR TITLE
refactor(schedule): extract the claim→fire→heal core into fire-engine (phase 3)

### DIFF
--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -2,26 +2,34 @@
  * Schedule plugin — server entry point.
  * Registers API routes, exec tools, and the cron→task bridge.
  */
-import { randomUUID } from 'crypto'
 import { z } from 'zod'
 import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin, defineRoute, searchRoute } from '@bakin/core/routing'
 import { readMergedJobs } from './lib/jobs-reader'
 import { getLastRun, readRuns } from './lib/runs-reader'
-import { upsertJob, removeJob, getJob, readSidecar, isPaused, shouldSkip, recordFailure, recordSuccess, withDefaults, newScheduleId, resumeDuePauses } from './lib/sidecar'
-import { claimCronFire, getCronFire, attachCronTask, markCronFireSkipped, findHealableCronClaims } from '../../src/core/execution-ledger'
+import { upsertJob, removeJob, getJob, readSidecar, withDefaults, newScheduleId, resumeDuePauses } from './lib/sidecar'
+import { claimCronFire, getCronFire } from '../../src/core/execution-ledger'
 import { parseSchedule } from './lib/cron-parser'
 import { runSchedulerTick, runStartupCatchUp, DEFAULT_TICK_WINDOW_MS, type SchedulerDeps } from './lib/scheduler'
 import { migrateBakinSchedulesOffOpenClawCron } from './lib/cutover'
 import { checkScheduleCutover, scheduleCutoverRepair } from './lib/health-checks'
 import { checkSchedulePrompt } from './lib/prompt-guard'
-import { getSystemTimezone, json, expandTemplate } from './lib/schedule-util'
+import { getSystemTimezone, json } from './lib/schedule-util'
 import { setPluginCtx, getPluginCtx } from './lib/plugin-context'
-import { createTaskWithEffects } from '../../src/core/task-service'
+import {
+  MISSED_WINDOW_REASON,
+  runClaimedFire,
+  healPendingCronClaims,
+  fireManualRun,
+  fireScheduledRunFromPayload,
+} from './lib/fire-engine'
+
+// Re-exported so the `@bakin/schedule/index` test surface stays stable
+// (cron-dedup.test.ts / blocked-fire-routing.test.ts import it from here).
+export { MISSED_WINDOW_REASON }
 import { createLogger } from '../../src/core/logger'
-import { readTaskboard } from '../../src/core/task-store'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
-import type { BakinJobMeta, BridgeResult, MergedJob } from './types'
+import type { BakinJobMeta, MergedJob } from './types'
 
 const log = createLogger('schedule')
 
@@ -60,14 +68,6 @@ const DEFAULT_TICK_INTERVAL_SECONDS = 30
 const MIN_TICK_INTERVAL_SECONDS = 5
 const DEFAULT_CATCH_UP_WINDOW_MINUTES = 60
 
-/** `blockedReason` stamped on a catch-up task that landed in `blocked` because
- *  its occurrence was older than the catch-up window. This is a *triage*
- *  marker (the run never dispatched), NOT a failure — distinct from the
- *  dispatch-failure reasons set in `src/core/dispatch.ts`. The outcome check
- *  compares against this constant so a slept-through fire doesn't penalize a
- *  healthy job's auto-pause counter. */
-export const MISSED_WINDOW_REASON = 'missed schedule window'
-
 /** Resolved tick interval in ms, clamped to a safe floor. */
 function tickIntervalMs(): number {
   const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.tickIntervalSeconds
@@ -92,11 +92,6 @@ interface EnsureBakinJobResult {
 }
 
 type ScheduleDeleteContext = Pick<PluginContext, 'runtime' | 'search'>
-
-async function getScheduleDefaultOwner(): Promise<string> {
-  const ctx = getPluginCtx()
-  return ctx?.runtime ? getRuntimeMainAgentId(ctx.runtime) : 'main'
-}
 
 async function ensureBakinJob(ctx: PluginContext, input: Record<string, unknown>): Promise<EnsureBakinJobResult> {
   const logicalId = typeof input.jobId === 'string' && input.jobId.trim() ? input.jobId.trim() : undefined
@@ -282,260 +277,6 @@ const restoreNativeBody = z.object({
   jobId: z.string().optional(),
 }).passthrough().optional()
 
-interface ProcessRunResult {
-  status: number
-  body: BridgeResult
-}
-
-/** Claim a run, then fire it through the shared post-claim path. A lost claim
- *  (duplicate) is suppressed + audited, never an error — the (job_id, run_id)
- *  ledger key is the lock. */
-async function fireScheduledRun(meta: BakinJobMeta, jobId: string, runId: string, firedAtMs: number): Promise<ProcessRunResult> {
-  const claim = claimCronFire(jobId, runId, firedAtMs)
-  if (!claim.claimed) {
-    getPluginCtx()?.activity.audit('fire_suppressed', 'system', {
-      jobId,
-      runId,
-      existingTaskId: claim.existing?.taskId ?? null,
-      existingDisposition: claim.existing?.disposition ?? null,
-    })
-    return { status: 200, body: { ok: true, skipped: 'already-processed' } }
-  }
-  return runClaimedFire(meta, jobId, runId, { firedAtMs })
-}
-
-/** Drive a fire from a {jobId, runId?, timestamp?} payload — manual triggers
- *  and test harnesses. Mints a unique manual runId when none is given. */
-async function fireScheduledRunFromPayload(payload: { jobId: string; runId?: string; timestamp?: string }): Promise<ProcessRunResult> {
-  const meta = getJob(payload.jobId)
-  if (!meta?.isBakinJob) return { status: 200, body: { ok: true, skipped: 'not-bakin' } }
-  const runId = payload.runId || `manual-${randomUUID()}`
-  const parsed = payload.timestamp ? Date.parse(payload.timestamp) : NaN
-  const firedAt = Number.isFinite(parsed) ? parsed : Date.now()
-  return fireScheduledRun(meta, payload.jobId, runId, firedAt)
-}
-
-/** True if a task with this id exists on the board (any column). Lets a fire
- *  detect "row created but a post-create effect threw" and attach the claim
- *  instead of leaving it pending for the healer to duplicate. */
-function storedTaskExists(taskId: string): boolean {
-  try {
-    const board = readTaskboard() as unknown as { columns: Record<string, Array<{ id: string }>> }
-    return Object.values(board.columns).some(col => (col ?? []).some(t => t.id === taskId))
-  } catch {
-    return false
-  }
-}
-
-// Every reason a fire can be skipped. 'job-removed' is the only one set outside
-// skipFire() — the healer consumes an orphaned claim with no live ctx to audit.
-type SkipReason = 'paused' | 'skip-count' | 'auto-paused' | 'overlap' | 'job-removed'
-
-/** Record a skipped fire (ledger disposition + reason) AND surface it on the
- *  activity feed, so an overrunning or paused schedule shows up instead of
- *  silently dropping beats. */
-function skipFire(jobId: string, runId: string, reason: SkipReason): ProcessRunResult {
-  markCronFireSkipped(jobId, runId, reason)
-  // activity.audit prepends the plugin id → observable event is `schedule.fire_skipped`
-  // (matches fire_suppressed/fire_healed/task_created — bare operation, no manual prefix).
-  getPluginCtx()?.activity.audit('fire_skipped', 'system', { jobId, runId, reason })
-  return { status: 200, body: { ok: true, skipped: reason } }
-}
-
-async function runClaimedFire(
-  meta: BakinJobMeta,
-  jobId: string,
-  runId: string,
-  opts: { column?: string; blockedReason?: string; firedAtMs?: number } = {},
-): Promise<ProcessRunResult> {
-  const defaults = withDefaults(meta, await getScheduleDefaultOwner())
-
-  // Check pause state
-  const pauseState = isPaused(meta)
-  if (pauseState.paused) {
-    upsertJob(meta) // persist any auto-resume changes
-    return skipFire(jobId, runId, 'paused') // consumed — never healed into a task
-  }
-
-  // Check skip-next-N
-  if (shouldSkip(meta)) {
-    upsertJob(meta)
-    return skipFire(jobId, runId, 'skip-count')
-  }
-
-  // Check failure auto-pause
-  if ((defaults.consecutiveFailures ?? 0) >= (defaults.maxFailures ?? 3)) {
-    meta.paused = true
-    meta.pauseReason = 'auto-failures'
-    meta.enabled = false // mirror manual pause: skip at the scheduler gate, no claim churn
-    upsertJob(meta)
-    return skipFire(jobId, runId, 'auto-paused')
-  }
-
-  // Both the overlap guard and last-task-outcome tracking inspect the board;
-  // read it once. A read failure means we skip both checks and proceed.
-  type BoardTask = { id: string; blockedReason?: string }
-  let board: { columns: Record<string, BoardTask[]> } | null = null
-  if (meta.lastTaskId) {
-    try {
-      board = readTaskboard() as unknown as { columns: Record<string, BoardTask[]> }
-    } catch {
-      log.debug('Could not read taskboard for overlap/outcome checks', { taskId: meta.lastTaskId })
-    }
-  }
-
-  // Check overlap. `blocked` is intentionally excluded: a blocked task is
-  // awaiting human triage, not running, so it must not suppress the next real
-  // fire (that cascade silently ate scheduled runs — see SPEC).
-  if (board && !defaults.allowOverlap && meta.lastTaskId) {
-    const activeColumns = ['todo', 'inProgress', 'review'] as const
-    for (const col of activeColumns) {
-      const tasks = board.columns[col] ?? []
-      if (tasks.some(t => t.id === meta.lastTaskId)) {
-        return skipFire(jobId, runId, 'overlap')
-      }
-    }
-  }
-
-  // Check last task outcome for failure tracking
-  if (board && meta.lastTaskId) {
-    const doneOrArchived = [...(board.columns.done ?? []), ...(board.columns.archived ?? [])]
-    if (doneOrArchived.some(t => t.id === meta.lastTaskId)) {
-      recordSuccess(meta)
-    } else {
-      // A blocked last-task counts as a failure ONLY if it genuinely failed
-      // during dispatch. A catch-up triage block (MISSED_WINDOW_REASON) never
-      // ran — penalizing the job for it would auto-pause a healthy schedule
-      // just because the server slept through a fire (see SPEC FR2).
-      const blockedTask = (board.columns.blocked ?? []).find(t => t.id === meta.lastTaskId)
-      if (blockedTask && blockedTask.blockedReason !== MISSED_WINDOW_REASON) {
-        const autoPaused = recordFailure(meta)
-        if (autoPaused) {
-          upsertJob(meta)
-          return skipFire(jobId, runId, 'auto-paused')
-        }
-      }
-    }
-  }
-
-  // Create the task. Label by the run's logical OCCURRENCE time, not wall-clock
-  // creation time — a catch-up task for a missed run must read as the day it was
-  // supposed to fire, not the (later) day it was created (see SPEC FR3). The
-  // occurrence is an absolute instant; render it in the JOB's timezone so an
-  // evening run that crosses UTC midnight still reads as its local day.
-  const labelDate = new Date(opts.firedAtMs ?? Date.now())
-  const labelTz = meta.tz || getSystemTimezone()
-  const templateVars = {
-    date: new Intl.DateTimeFormat('en-CA', {
-      timeZone: labelTz, year: 'numeric', month: '2-digit', day: '2-digit',
-    }).format(labelDate), // en-CA → YYYY-MM-DD
-    agent: meta.agentId ?? 'unassigned',
-    jobName: meta.displayName ?? jobId,
-  }
-
-  const title = meta.taskTitle
-    ? expandTemplate(meta.taskTitle, templateVars)
-    : `${meta.displayName ?? jobId} — ${labelDate.toLocaleDateString(undefined, { timeZone: labelTz })}`
-
-  const description = meta.taskPrompt
-    ? expandTemplate(meta.taskPrompt, templateVars)
-    : undefined
-
-  // Pre-mint the task id so that if a post-create effect throws (e.g. the
-  // workflow-start hook fails AFTER the row is written), we can still attach the
-  // existing task to the claim. Otherwise the claim stays `pending`, the healer
-  // re-drives it, and a *second* task is minted for the same occurrence (#472).
-  const column = opts.column ?? 'todo'
-  const taskId = `task-${randomUUID()}`
-  try {
-    await createTaskWithEffects({
-      id: taskId,
-      title,
-      description,
-      column,
-      blockedReason: opts.blockedReason,
-      assignee: defaults.requireTriage ? undefined : meta.agentId,
-      workflowId: meta.workflowId,
-      createdBy: 'schedule',
-      scheduleJobId: jobId,
-      source: {
-        pluginId: 'schedule',
-        entityType: 'job',
-        entityId: jobId,
-        purpose: 'scheduled-run',
-      },
-    })
-  } catch (err) {
-    // If the row was never written, the claim is safe to retry — leave it
-    // pending and surface the failure. If it WAS written (post-create effect
-    // failed), fall through to attach it so the next heal can't duplicate it.
-    if (!storedTaskExists(taskId)) {
-      log.error('Schedule failed to create task', err)
-      recordFailure(meta)
-      upsertJob(meta)
-      return { status: 500, body: { ok: false, error: (err as Error).message } }
-    }
-    log.warn('Scheduled task row created but a post-create effect failed; attaching to claim to avoid a duplicate', {
-      jobId, runId, taskId, error: err instanceof Error ? err.message : String(err),
-    })
-  }
-
-  meta.lastTaskId = taskId
-  attachCronTask(jobId, runId, taskId)
-  upsertJob(meta)
-
-  // Audit + activity feed
-  const auditCtx = getPluginCtx()
-  if (auditCtx) {
-    auditCtx.activity.audit('task_created', 'system', {
-      jobId, runId, taskId, agent: meta.agentId, owner: defaults.owner,
-      ...(column !== 'todo' ? { column, blockedReason: opts.blockedReason } : {}),
-    })
-    const where = column === 'blocked' ? ` (blocked — ${opts.blockedReason ?? MISSED_WINDOW_REASON})` : ''
-    auditCtx.activity.log('system', `Schedule "${meta.displayName ?? jobId}" created task ${taskId}${meta.agentId ? ` for ${meta.agentId}` : ''}${where}`, { taskId })
-  }
-
-  return { status: 200, body: { ok: true, taskId } }
-}
-
-const HEAL_AFTER_MS = 5 * 60_000
-
-/**
- * Re-drive cron-fire claims stuck in 'pending'. The claim row is the lock,
- * so healing creates AT MOST one task per run — and re-evaluates pause/skip
- * state at heal time so a paused job's stranded claim is consumed, not
- * resurrected into a task.
- *
- * The scan→heal pass is not itself transactional; it's safe because the
- * server singleton lock guarantees one process and the scheduler's in-flight
- * guard serializes ticks within it. If either assumption ever changes, the
- * heal needs a claim-the-heal CAS (e.g. pending → healing disposition).
- */
-async function healPendingCronClaims(): Promise<void> {
-  let stale: ReturnType<typeof findHealableCronClaims>
-  try {
-    stale = findHealableCronClaims(HEAL_AFTER_MS)
-  } catch (err) {
-    log.warn('Cron-claim heal scan failed', err)
-    return
-  }
-  for (const claim of stale) {
-    const meta = getJob(claim.jobId)
-    if (!meta?.isBakinJob) {
-      // Job deleted/unmanaged since the claim — consume it.
-      markCronFireSkipped(claim.jobId, claim.runId, 'job-removed')
-      continue
-    }
-    const result = await runClaimedFire(meta, claim.jobId, claim.runId, { firedAtMs: claim.firedAt })
-    getPluginCtx()?.activity.audit('fire_healed', 'system', {
-      jobId: claim.jobId,
-      runId: claim.runId,
-      taskId: (result.body as { taskId?: string }).taskId ?? null,
-      skipped: (result.body as { skipped?: string }).skipped ?? null,
-    })
-  }
-}
-
 // ─── Bakin-owned scheduler ───────────────────────────────────────────────
 // Bakin fires its own schedules directly from the store; each tick computes
 // due occurrences, claims each in the ledger, and runs the shared post-claim
@@ -603,12 +344,6 @@ function stopScheduler(): void {
   if (!schedulerTimer) return
   clearTimeout(schedulerTimer)
   schedulerTimer = null
-}
-
-/** Fire a single occurrence on demand (run-now / manual trigger). Claims a
- *  unique manual run so it is never blocked by occurrence dedup. */
-async function fireManualRun(meta: BakinJobMeta, jobId: string): Promise<void> {
-  await fireScheduledRun(meta, jobId, `manual-${randomUUID()}`, Date.now())
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/schedule/lib/fire-engine.ts
+++ b/plugins/schedule/lib/fire-engine.ts
@@ -1,0 +1,304 @@
+/**
+ * Schedule fire engine — the claim→fire→heal core.
+ *
+ * The exactly-once firing path: claim a run in the execution ledger (the
+ * (job_id, run_id) row IS the lock), evaluate pause/skip/overlap/outcome gates,
+ * create the board task, attach the claim, and audit. Plus the healer that
+ * re-drives claims stranded 'pending' by a crash between claim and task
+ * creation. Reads the activated ctx via the single plugin-context cell; never
+ * threads it. Behavior here is the live fire path for ALL Bakin schedules —
+ * see .claude/knowledge/bakin-owned-scheduler.md.
+ */
+import { randomUUID } from 'crypto'
+import type { BakinJobMeta, BridgeResult } from '../types'
+import { getPluginCtx } from './plugin-context'
+import { getSystemTimezone, expandTemplate } from './schedule-util'
+import {
+  upsertJob,
+  getJob,
+  isPaused,
+  shouldSkip,
+  recordFailure,
+  recordSuccess,
+  withDefaults,
+} from './sidecar'
+import { claimCronFire, attachCronTask, markCronFireSkipped, findHealableCronClaims } from '../../../src/core/execution-ledger'
+import { createTaskWithEffects } from '../../../src/core/task-service'
+import { readTaskboard } from '../../../src/core/task-store'
+import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
+import { createLogger } from '../../../src/core/logger'
+
+const log = createLogger('schedule')
+
+/** `blockedReason` stamped on a catch-up task that landed in `blocked` because
+ *  its occurrence was older than the catch-up window. This is a *triage*
+ *  marker (the run never dispatched), NOT a failure — distinct from the
+ *  dispatch-failure reasons set in `src/core/dispatch.ts`. The outcome check
+ *  compares against this constant so a slept-through fire doesn't penalize a
+ *  healthy job's auto-pause counter. */
+export const MISSED_WINDOW_REASON = 'missed schedule window'
+
+export interface ProcessRunResult {
+  status: number
+  body: BridgeResult
+}
+
+async function getScheduleDefaultOwner(): Promise<string> {
+  const ctx = getPluginCtx()
+  return ctx?.runtime ? getRuntimeMainAgentId(ctx.runtime) : 'main'
+}
+
+/** Claim a run, then fire it through the shared post-claim path. A lost claim
+ *  (duplicate) is suppressed + audited, never an error — the (job_id, run_id)
+ *  ledger key is the lock. */
+async function fireScheduledRun(meta: BakinJobMeta, jobId: string, runId: string, firedAtMs: number): Promise<ProcessRunResult> {
+  const claim = claimCronFire(jobId, runId, firedAtMs)
+  if (!claim.claimed) {
+    getPluginCtx()?.activity.audit('fire_suppressed', 'system', {
+      jobId,
+      runId,
+      existingTaskId: claim.existing?.taskId ?? null,
+      existingDisposition: claim.existing?.disposition ?? null,
+    })
+    return { status: 200, body: { ok: true, skipped: 'already-processed' } }
+  }
+  return runClaimedFire(meta, jobId, runId, { firedAtMs })
+}
+
+/** Drive a fire from a {jobId, runId?, timestamp?} payload — manual triggers
+ *  and test harnesses. Mints a unique manual runId when none is given. */
+export async function fireScheduledRunFromPayload(payload: { jobId: string; runId?: string; timestamp?: string }): Promise<ProcessRunResult> {
+  const meta = getJob(payload.jobId)
+  if (!meta?.isBakinJob) return { status: 200, body: { ok: true, skipped: 'not-bakin' } }
+  const runId = payload.runId || `manual-${randomUUID()}`
+  const parsed = payload.timestamp ? Date.parse(payload.timestamp) : NaN
+  const firedAt = Number.isFinite(parsed) ? parsed : Date.now()
+  return fireScheduledRun(meta, payload.jobId, runId, firedAt)
+}
+
+/** True if a task with this id exists on the board (any column). Lets a fire
+ *  detect "row created but a post-create effect threw" and attach the claim
+ *  instead of leaving it pending for the healer to duplicate. */
+function storedTaskExists(taskId: string): boolean {
+  try {
+    const board = readTaskboard() as unknown as { columns: Record<string, Array<{ id: string }>> }
+    return Object.values(board.columns).some(col => (col ?? []).some(t => t.id === taskId))
+  } catch {
+    return false
+  }
+}
+
+// Every reason a fire can be skipped. 'job-removed' is the only one set outside
+// skipFire() — the healer consumes an orphaned claim with no live ctx to audit.
+type SkipReason = 'paused' | 'skip-count' | 'auto-paused' | 'overlap' | 'job-removed'
+
+/** Record a skipped fire (ledger disposition + reason) AND surface it on the
+ *  activity feed, so an overrunning or paused schedule shows up instead of
+ *  silently dropping beats. */
+function skipFire(jobId: string, runId: string, reason: SkipReason): ProcessRunResult {
+  markCronFireSkipped(jobId, runId, reason)
+  // activity.audit prepends the plugin id → observable event is `schedule.fire_skipped`
+  // (matches fire_suppressed/fire_healed/task_created — bare operation, no manual prefix).
+  getPluginCtx()?.activity.audit('fire_skipped', 'system', { jobId, runId, reason })
+  return { status: 200, body: { ok: true, skipped: reason } }
+}
+
+export async function runClaimedFire(
+  meta: BakinJobMeta,
+  jobId: string,
+  runId: string,
+  opts: { column?: string; blockedReason?: string; firedAtMs?: number } = {},
+): Promise<ProcessRunResult> {
+  const defaults = withDefaults(meta, await getScheduleDefaultOwner())
+
+  // Check pause state
+  const pauseState = isPaused(meta)
+  if (pauseState.paused) {
+    upsertJob(meta) // persist any auto-resume changes
+    return skipFire(jobId, runId, 'paused') // consumed — never healed into a task
+  }
+
+  // Check skip-next-N
+  if (shouldSkip(meta)) {
+    upsertJob(meta)
+    return skipFire(jobId, runId, 'skip-count')
+  }
+
+  // Check failure auto-pause
+  if ((defaults.consecutiveFailures ?? 0) >= (defaults.maxFailures ?? 3)) {
+    meta.paused = true
+    meta.pauseReason = 'auto-failures'
+    meta.enabled = false // mirror manual pause: skip at the scheduler gate, no claim churn
+    upsertJob(meta)
+    return skipFire(jobId, runId, 'auto-paused')
+  }
+
+  // Both the overlap guard and last-task-outcome tracking inspect the board;
+  // read it once. A read failure means we skip both checks and proceed.
+  type BoardTask = { id: string; blockedReason?: string }
+  let board: { columns: Record<string, BoardTask[]> } | null = null
+  if (meta.lastTaskId) {
+    try {
+      board = readTaskboard() as unknown as { columns: Record<string, BoardTask[]> }
+    } catch {
+      log.debug('Could not read taskboard for overlap/outcome checks', { taskId: meta.lastTaskId })
+    }
+  }
+
+  // Check overlap. `blocked` is intentionally excluded: a blocked task is
+  // awaiting human triage, not running, so it must not suppress the next real
+  // fire (that cascade silently ate scheduled runs — see SPEC).
+  if (board && !defaults.allowOverlap && meta.lastTaskId) {
+    const activeColumns = ['todo', 'inProgress', 'review'] as const
+    for (const col of activeColumns) {
+      const tasks = board.columns[col] ?? []
+      if (tasks.some(t => t.id === meta.lastTaskId)) {
+        return skipFire(jobId, runId, 'overlap')
+      }
+    }
+  }
+
+  // Check last task outcome for failure tracking
+  if (board && meta.lastTaskId) {
+    const doneOrArchived = [...(board.columns.done ?? []), ...(board.columns.archived ?? [])]
+    if (doneOrArchived.some(t => t.id === meta.lastTaskId)) {
+      recordSuccess(meta)
+    } else {
+      // A blocked last-task counts as a failure ONLY if it genuinely failed
+      // during dispatch. A catch-up triage block (MISSED_WINDOW_REASON) never
+      // ran — penalizing the job for it would auto-pause a healthy schedule
+      // just because the server slept through a fire (see SPEC FR2).
+      const blockedTask = (board.columns.blocked ?? []).find(t => t.id === meta.lastTaskId)
+      if (blockedTask && blockedTask.blockedReason !== MISSED_WINDOW_REASON) {
+        const autoPaused = recordFailure(meta)
+        if (autoPaused) {
+          upsertJob(meta)
+          return skipFire(jobId, runId, 'auto-paused')
+        }
+      }
+    }
+  }
+
+  // Create the task. Label by the run's logical OCCURRENCE time, not wall-clock
+  // creation time — a catch-up task for a missed run must read as the day it was
+  // supposed to fire, not the (later) day it was created (see SPEC FR3). The
+  // occurrence is an absolute instant; render it in the JOB's timezone so an
+  // evening run that crosses UTC midnight still reads as its local day.
+  const labelDate = new Date(opts.firedAtMs ?? Date.now())
+  const labelTz = meta.tz || getSystemTimezone()
+  const templateVars = {
+    date: new Intl.DateTimeFormat('en-CA', {
+      timeZone: labelTz, year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(labelDate), // en-CA → YYYY-MM-DD
+    agent: meta.agentId ?? 'unassigned',
+    jobName: meta.displayName ?? jobId,
+  }
+
+  const title = meta.taskTitle
+    ? expandTemplate(meta.taskTitle, templateVars)
+    : `${meta.displayName ?? jobId} — ${labelDate.toLocaleDateString(undefined, { timeZone: labelTz })}`
+
+  const description = meta.taskPrompt
+    ? expandTemplate(meta.taskPrompt, templateVars)
+    : undefined
+
+  // Pre-mint the task id so that if a post-create effect throws (e.g. the
+  // workflow-start hook fails AFTER the row is written), we can still attach the
+  // existing task to the claim. Otherwise the claim stays `pending`, the healer
+  // re-drives it, and a *second* task is minted for the same occurrence (#472).
+  const column = opts.column ?? 'todo'
+  const taskId = `task-${randomUUID()}`
+  try {
+    await createTaskWithEffects({
+      id: taskId,
+      title,
+      description,
+      column,
+      blockedReason: opts.blockedReason,
+      assignee: defaults.requireTriage ? undefined : meta.agentId,
+      workflowId: meta.workflowId,
+      createdBy: 'schedule',
+      scheduleJobId: jobId,
+      source: {
+        pluginId: 'schedule',
+        entityType: 'job',
+        entityId: jobId,
+        purpose: 'scheduled-run',
+      },
+    })
+  } catch (err) {
+    // If the row was never written, the claim is safe to retry — leave it
+    // pending and surface the failure. If it WAS written (post-create effect
+    // failed), fall through to attach it so the next heal can't duplicate it.
+    if (!storedTaskExists(taskId)) {
+      log.error('Schedule failed to create task', err)
+      recordFailure(meta)
+      upsertJob(meta)
+      return { status: 500, body: { ok: false, error: (err as Error).message } }
+    }
+    log.warn('Scheduled task row created but a post-create effect failed; attaching to claim to avoid a duplicate', {
+      jobId, runId, taskId, error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  meta.lastTaskId = taskId
+  attachCronTask(jobId, runId, taskId)
+  upsertJob(meta)
+
+  // Audit + activity feed
+  const auditCtx = getPluginCtx()
+  if (auditCtx) {
+    auditCtx.activity.audit('task_created', 'system', {
+      jobId, runId, taskId, agent: meta.agentId, owner: defaults.owner,
+      ...(column !== 'todo' ? { column, blockedReason: opts.blockedReason } : {}),
+    })
+    const where = column === 'blocked' ? ` (blocked — ${opts.blockedReason ?? MISSED_WINDOW_REASON})` : ''
+    auditCtx.activity.log('system', `Schedule "${meta.displayName ?? jobId}" created task ${taskId}${meta.agentId ? ` for ${meta.agentId}` : ''}${where}`, { taskId })
+  }
+
+  return { status: 200, body: { ok: true, taskId } }
+}
+
+const HEAL_AFTER_MS = 5 * 60_000
+
+/**
+ * Re-drive cron-fire claims stuck in 'pending'. The claim row is the lock,
+ * so healing creates AT MOST one task per run — and re-evaluates pause/skip
+ * state at heal time so a paused job's stranded claim is consumed, not
+ * resurrected into a task.
+ *
+ * The scan→heal pass is not itself transactional; it's safe because the
+ * server singleton lock guarantees one process and the scheduler's in-flight
+ * guard serializes ticks within it. If either assumption ever changes, the
+ * heal needs a claim-the-heal CAS (e.g. pending → healing disposition).
+ */
+export async function healPendingCronClaims(): Promise<void> {
+  let stale: ReturnType<typeof findHealableCronClaims>
+  try {
+    stale = findHealableCronClaims(HEAL_AFTER_MS)
+  } catch (err) {
+    log.warn('Cron-claim heal scan failed', err)
+    return
+  }
+  for (const claim of stale) {
+    const meta = getJob(claim.jobId)
+    if (!meta?.isBakinJob) {
+      // Job deleted/unmanaged since the claim — consume it.
+      markCronFireSkipped(claim.jobId, claim.runId, 'job-removed')
+      continue
+    }
+    const result = await runClaimedFire(meta, claim.jobId, claim.runId, { firedAtMs: claim.firedAt })
+    getPluginCtx()?.activity.audit('fire_healed', 'system', {
+      jobId: claim.jobId,
+      runId: claim.runId,
+      taskId: (result.body as { taskId?: string }).taskId ?? null,
+      skipped: (result.body as { skipped?: string }).skipped ?? null,
+    })
+  }
+}
+
+/** Fire a single occurrence on demand (run-now / manual trigger). Claims a
+ *  unique manual run so it is never blocked by occurrence dedup. */
+export async function fireManualRun(meta: BakinJobMeta, jobId: string): Promise<void> {
+  await fireScheduledRun(meta, jobId, `manual-${randomUUID()}`, Date.now())
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -361,8 +361,20 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     cell. Behavior-preserving (the cell is the same, just relocated). 1,416 → 1,418 (local binds). Verified: typecheck/
     lint/the fire-path tests cron-dedup + blocked-fire-routing 24-0 (prove setPluginCtxForTests routes to the right
     cell)/full schedule suite 280-0/full-suite 5124-0/binary build (9 plugins load; schedule env ENOENT non-regression).
-  - ☐ Phase 3+ (FIRE PATH, needs Mark's eyes): fire-engine.ts (claim→fire→heal: runClaimedFire/healPendingCronClaims/
-    skipFire + MISSED_WINDOW_REASON), scheduler-loop.ts (schedulerTimer cell + start/stop + cutover ordering),
+  - ☑ Phase 3 — fire-engine (FIRE PATH): `lib/fire-engine.ts` — the claim→fire→heal core: MISSED_WINDOW_REASON +
+    ProcessRunResult, getScheduleDefaultOwner, fireScheduledRun, fireScheduledRunFromPayload, storedTaskExists, SkipReason
+    + skipFire, runClaimedFire (the 150-line gate→create→attach→audit body), HEAL_AFTER_MS + healPendingCronClaims,
+    fireManualRun. All read ctx via getPluginCtx (the one cell from phase 2). ProcessRunResult.body kept as BridgeResult
+    (NOT Record — preserved exact type). index imports back {MISSED_WINDOW_REASON, runClaimedFire, healPendingCronClaims,
+    fireManualRun, fireScheduledRunFromPayload} for the scheduler-loop + run-now routes/exec + test-internals, and
+    re-exports MISSED_WINDOW_REASON for the `@bakin/schedule/index` test surface. index shed ~12 fire-only imports
+    (createTaskWithEffects/readTaskboard/the ledger claim+heal fns/sidecar gates/randomUUID/expandTemplate/BridgeResult).
+    1,418 → 1,153. Verified: typecheck/lint/cron-dedup + blocked-fire-routing 24-0/full schedule suite 280-0/full-suite
+    5124-0/binary build + **DOCKERIZED-RIG E2E** (real OpenClaw, isolated mode): schedule plugin ACTIVATES (200 +
+    live jobs — the activation the env-ENOENT boot smoke can't show); run-now fired the moved path end-to-end →
+    `success` + task created + matching task_created audit row; a second run-now correctly `skipped: overlap` (the moved
+    board-read + skipFire). The exactly-once claim, gate logic, board IO, and audit all behave against the live stack.
+  - ☐ Phase 4+ : scheduler-loop.ts (schedulerTimer cell + schedulerDeps/start/stop + cutover→catch-up→tick ordering),
     job-service.ts (CRUD verbs + the route/exec-tool dedup), routes/jobs.ts, exec-tools.ts. The redesigns (pause-drift
     fix, dead update-handler code, dead settings keys maxConcurrentJobs/failureCooldownMs, ctx-threading, zod for
     ensureBakinJob) are behavior-touching — listed, not bundled.


### PR DESCRIPTION
## What

Pulls the **exactly-once firing path** out of `index.ts` into **`lib/fire-engine.ts`** — the most cohesive unit in the file and the **live fire path for all schedules**.

Moved: `MISSED_WINDOW_REASON` + `ProcessRunResult`, `getScheduleDefaultOwner`, `fireScheduledRun`, `fireScheduledRunFromPayload`, `storedTaskExists`, `SkipReason` + `skipFire`, `runClaimedFire` (the gate→create→attach→audit body), `HEAL_AFTER_MS` + `healPendingCronClaims`, `fireManualRun`. They all read ctx through `getPluginCtx()` (the single cell from phase 2), so no ctx threading was needed.

`index` re-imports the five names the scheduler loop, run-now routes/exec tool, and `__scheduleTestInternals` still call, and **re-exports `MISSED_WINDOW_REASON`** so the `@bakin/schedule/index` test surface stays stable. It sheds ~12 fire-only imports (`createTaskWithEffects`, `readTaskboard`, the ledger claim/heal verbs, the sidecar gate verbs, `randomUUID`, `expandTemplate`, `BridgeResult`).

**1,418 → 1,153.** Pure behavior-preserving relocation — functions byte-identical; `ProcessRunResult.body` kept as `BridgeResult` (not loosened to `Record`).

## Verification — including real-OpenClaw E2E

- ✅ `bun run typecheck` · `eslint`
- ✅ the two fire-path tests — **`cron-dedup` + `blocked-fire-routing`, 24/0** (the exactly-once + blocked-routing gates)
- ✅ full schedule suite — **280/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build`
- ✅ **Dockerized-rig E2E against real OpenClaw (isolated mode):**
  - schedule plugin **activates** — `GET /api/plugins/schedule/` → 200 with live jobs (the activation the env-ENOENT boot smoke can't exercise)
  - **run-now drove the moved path end to end** → `success`, created `task-f06f…`, with a matching `task_created` row in `audit.jsonl`
  - a **second run-now correctly skipped with reason `overlap`** — the moved board-read + `skipFire` path
  - exactly-once claim, gate logic, board IO, and audit all behave against the live ledger + task-store + runtime

## Next

`scheduler-loop.ts` (the `schedulerTimer` cell + `start`/`stop` + the cutover→catch-up→tick ordering), then `job-service.ts` + routes + exec-tools. The behavioral redesigns (pause-`pauseUntil` drift fix, dead settings keys, ctx-threading) stay listed, not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)