### PR TITLE
refactor(schedule): extract the scheduler loop + timer cell (phase 4)

### DIFF
--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -8,17 +8,14 @@ import { definePlugin, defineRoute, searchRoute } from '@bakin/core/routing'
 import { readMergedJobs } from './lib/jobs-reader'
 import { getLastRun, readRuns } from './lib/runs-reader'
 import { upsertJob, removeJob, getJob, readSidecar, withDefaults, newScheduleId, resumeDuePauses } from './lib/sidecar'
-import { claimCronFire, getCronFire } from '../../src/core/execution-ledger'
 import { parseSchedule } from './lib/cron-parser'
-import { runSchedulerTick, runStartupCatchUp, DEFAULT_TICK_WINDOW_MS, type SchedulerDeps } from './lib/scheduler'
-import { migrateBakinSchedulesOffOpenClawCron } from './lib/cutover'
+import { runStartupCatchUp } from './lib/scheduler'
 import { checkScheduleCutover, scheduleCutoverRepair } from './lib/health-checks'
 import { checkSchedulePrompt } from './lib/prompt-guard'
 import { getSystemTimezone, json } from './lib/schedule-util'
 import { setPluginCtx, getPluginCtx } from './lib/plugin-context'
 import {
   MISSED_WINDOW_REASON,
-  runClaimedFire,
   healPendingCronClaims,
   fireManualRun,
   fireScheduledRunFromPayload,
@@ -27,6 +24,13 @@ import {
 // Re-exported so the `@bakin/schedule/index` test surface stays stable
 // (cron-dedup.test.ts / blocked-fire-routing.test.ts import it from here).
 export { MISSED_WINDOW_REASON }
+import {
+  schedulerDeps,
+  runScheduleCutover,
+  startScheduler,
+  stopScheduler,
+  catchUpWindowMs,
+} from './lib/scheduler-loop'
 import { createLogger } from '../../src/core/logger'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import type { BakinJobMeta, MergedJob } from './types'
@@ -53,34 +57,6 @@ async function guardBakinMutation(jobId: string): Promise<BakinMutationGuard> {
   return runtime
     ? { ok: false, status: 403, error: READ_ONLY_ERROR }
     : { ok: false, status: 404, error: 'Schedule not found' }
-}
-
-/** Schedule plugin settings. */
-interface ScheduleSettings {
-  /** Scheduler tick cadence in seconds (floor-clamped). Default 30. */
-  tickIntervalSeconds?: number
-  /** Catch-up safety window in minutes: a missed occurrence fires into `todo`
-   *  if within this window of now, else lands in `blocked`. Default 60. */
-  catchUpWindowMinutes?: number
-}
-
-const DEFAULT_TICK_INTERVAL_SECONDS = 30
-const MIN_TICK_INTERVAL_SECONDS = 5
-const DEFAULT_CATCH_UP_WINDOW_MINUTES = 60
-
-/** Resolved tick interval in ms, clamped to a safe floor. */
-function tickIntervalMs(): number {
-  const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.tickIntervalSeconds
-  const seconds = typeof raw === 'number' && raw >= MIN_TICK_INTERVAL_SECONDS ? raw : DEFAULT_TICK_INTERVAL_SECONDS
-  return seconds * 1000
-}
-
-/** Resolved catch-up safety window in ms. A missed occurrence fires into `todo`
- *  if within this window, else into `blocked` for the user to triage. */
-function catchUpWindowMs(): number {
-  const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.catchUpWindowMinutes
-  const minutes = typeof raw === 'number' && raw >= 0 ? raw : DEFAULT_CATCH_UP_WINDOW_MINUTES
-  return minutes * 60_000
 }
 
 interface EnsureBakinJobResult {
@@ -276,75 +252,6 @@ const adoptJobBody = z.object({
 const restoreNativeBody = z.object({
   jobId: z.string().optional(),
 }).passthrough().optional()
-
-// ─── Bakin-owned scheduler ───────────────────────────────────────────────
-// Bakin fires its own schedules directly from the store; each tick computes
-// due occurrences, claims each in the ledger, and runs the shared post-claim
-// fire path. healPendingCronClaims() then recovers any claim stranded by a
-// crash between claim and task creation.
-
-let schedulerTimer: ReturnType<typeof setTimeout> | null = null
-
-function schedulerDeps(): SchedulerDeps {
-  return {
-    now: () => Date.now(),
-    // Window must exceed the tick interval so no occurrence slips between ticks.
-    tickWindowMs: Math.max(DEFAULT_TICK_WINDOW_MS, tickIntervalMs() * 2),
-    listJobs: () => Object.values(readSidecar().jobs).filter(job => job.isBakinJob),
-    getCronFire: (jobId, runId) => getCronFire(jobId, runId),
-    claimCronFire: (jobId, runId, firedAt) => claimCronFire(jobId, runId, firedAt),
-    fire: async (meta, jobId, runId, occurrence, opts) => {
-      await runClaimedFire(
-        meta, jobId, runId,
-        opts?.blocked
-          ? { column: 'blocked', blockedReason: MISSED_WINDOW_REASON, firedAtMs: occurrence.getTime() }
-          : { firedAtMs: occurrence.getTime() },
-      )
-    },
-    log,
-  }
-}
-
-/** Run the idempotent cutover using the live runtime adapter. Shared by
- *  activate() (automatic) and the doctor repair (manual). */
-function runScheduleCutover(): ReturnType<typeof migrateBakinSchedulesOffOpenClawCron> {
-  const cron = getPluginCtx()!.runtime.cron
-  return migrateBakinSchedulesOffOpenClawCron({
-    cronGet: async (jobId) => {
-      const job = await cron.get(jobId)
-      return job ? { schedule: job.schedule, enabled: job.enabled, metadata: job.metadata } : null
-    },
-    cronRemove: (jobId) => cron.remove(jobId),
-    systemTz: getSystemTimezone,
-  })
-}
-
-function startScheduler(): void {
-  stopScheduler()
-  // Self-rescheduling loop (not setInterval) so each cycle re-reads the tick
-  // interval — a settings change takes effect without a restart, and the next
-  // cycle is only armed after the previous finishes (no overlap). Each cycle:
-  // resume expired timed-pauses → fire due occurrences → heal stranded claims.
-  const cycle = () => {
-    Promise.resolve()
-      .then(() => { resumeDuePauses() })
-      .then(() => runSchedulerTick(schedulerDeps()))
-      .then(() => healPendingCronClaims())
-      .catch(err => log.warn('Scheduler cycle failed', err))
-      .finally(() => {
-        schedulerTimer = setTimeout(cycle, tickIntervalMs())
-        schedulerTimer.unref?.()
-      })
-  }
-  schedulerTimer = setTimeout(cycle, tickIntervalMs())
-  schedulerTimer.unref?.()
-}
-
-function stopScheduler(): void {
-  if (!schedulerTimer) return
-  clearTimeout(schedulerTimer)
-  schedulerTimer = null
-}
 
 // ---------------------------------------------------------------------------
 // Plugin

--- a/plugins/schedule/lib/scheduler-loop.ts
+++ b/plugins/schedule/lib/scheduler-loop.ts
@@ -1,0 +1,111 @@
+/**
+ * Schedule loop — production wiring of the DI'd engine in lib/scheduler.ts.
+ *
+ * Owns the `schedulerTimer` module cell (so start/stop and the timer live in
+ * exactly one place), the settings-derived tick/catch-up accessors, the
+ * SchedulerDeps factory bound to the live ledger + fire engine, and the
+ * idempotent OpenClaw→Bakin cutover. The self-rescheduling cycle
+ * (resume-pauses → tick → heal) re-reads the tick interval each pass so a
+ * settings change takes effect without a restart.
+ */
+import { runSchedulerTick, DEFAULT_TICK_WINDOW_MS, type SchedulerDeps } from './scheduler'
+import { getPluginCtx } from './plugin-context'
+import { runClaimedFire, healPendingCronClaims, MISSED_WINDOW_REASON } from './fire-engine'
+import { readSidecar, resumeDuePauses } from './sidecar'
+import { getCronFire, claimCronFire } from '../../../src/core/execution-ledger'
+import { migrateBakinSchedulesOffOpenClawCron } from './cutover'
+import { getSystemTimezone } from './schedule-util'
+import { createLogger } from '../../../src/core/logger'
+
+const log = createLogger('schedule')
+
+/** Schedule plugin settings. */
+export interface ScheduleSettings {
+  /** Scheduler tick cadence in seconds (floor-clamped). Default 30. */
+  tickIntervalSeconds?: number
+  /** Catch-up safety window in minutes: a missed occurrence fires into `todo`
+   *  if within this window of now, else lands in `blocked`. Default 60. */
+  catchUpWindowMinutes?: number
+}
+
+const DEFAULT_TICK_INTERVAL_SECONDS = 30
+const MIN_TICK_INTERVAL_SECONDS = 5
+const DEFAULT_CATCH_UP_WINDOW_MINUTES = 60
+
+/** Resolved tick interval in ms, clamped to a safe floor. */
+function tickIntervalMs(): number {
+  const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.tickIntervalSeconds
+  const seconds = typeof raw === 'number' && raw >= MIN_TICK_INTERVAL_SECONDS ? raw : DEFAULT_TICK_INTERVAL_SECONDS
+  return seconds * 1000
+}
+
+/** Resolved catch-up safety window in ms. A missed occurrence fires into `todo`
+ *  if within this window, else into `blocked` for the user to triage. */
+export function catchUpWindowMs(): number {
+  const raw = getPluginCtx()?.getSettings<ScheduleSettings>()?.catchUpWindowMinutes
+  const minutes = typeof raw === 'number' && raw >= 0 ? raw : DEFAULT_CATCH_UP_WINDOW_MINUTES
+  return minutes * 60_000
+}
+
+let schedulerTimer: ReturnType<typeof setTimeout> | null = null
+
+export function schedulerDeps(): SchedulerDeps {
+  return {
+    now: () => Date.now(),
+    // Window must exceed the tick interval so no occurrence slips between ticks.
+    tickWindowMs: Math.max(DEFAULT_TICK_WINDOW_MS, tickIntervalMs() * 2),
+    listJobs: () => Object.values(readSidecar().jobs).filter(job => job.isBakinJob),
+    getCronFire: (jobId, runId) => getCronFire(jobId, runId),
+    claimCronFire: (jobId, runId, firedAt) => claimCronFire(jobId, runId, firedAt),
+    fire: async (meta, jobId, runId, occurrence, opts) => {
+      await runClaimedFire(
+        meta, jobId, runId,
+        opts?.blocked
+          ? { column: 'blocked', blockedReason: MISSED_WINDOW_REASON, firedAtMs: occurrence.getTime() }
+          : { firedAtMs: occurrence.getTime() },
+      )
+    },
+    log,
+  }
+}
+
+/** Run the idempotent cutover using the live runtime adapter. Shared by
+ *  activate() (automatic) and the doctor repair (manual). */
+export function runScheduleCutover(): ReturnType<typeof migrateBakinSchedulesOffOpenClawCron> {
+  const cron = getPluginCtx()!.runtime.cron
+  return migrateBakinSchedulesOffOpenClawCron({
+    cronGet: async (jobId) => {
+      const job = await cron.get(jobId)
+      return job ? { schedule: job.schedule, enabled: job.enabled, metadata: job.metadata } : null
+    },
+    cronRemove: (jobId) => cron.remove(jobId),
+    systemTz: getSystemTimezone,
+  })
+}
+
+export function startScheduler(): void {
+  stopScheduler()
+  // Self-rescheduling loop (not setInterval) so each cycle re-reads the tick
+  // interval — a settings change takes effect without a restart, and the next
+  // cycle is only armed after the previous finishes (no overlap). Each cycle:
+  // resume expired timed-pauses → fire due occurrences → heal stranded claims.
+  const cycle = () => {
+    Promise.resolve()
+      .then(() => { resumeDuePauses() })
+      .then(() => runSchedulerTick(schedulerDeps()))
+      .then(() => healPendingCronClaims())
+      .catch(err => log.warn('Scheduler cycle failed', err))
+      .finally(() => {
+        schedulerTimer = setTimeout(cycle, tickIntervalMs())
+        schedulerTimer.unref?.()
+      })
+  }
+  schedulerTimer = setTimeout(cycle, tickIntervalMs())
+  schedulerTimer.unref?.()
+}
+
+export function stopScheduler(): void {
+  if (!schedulerTimer) return
+  clearTimeout(schedulerTimer)
+  schedulerTimer = null
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -374,8 +374,20 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     live jobs — the activation the env-ENOENT boot smoke can't show); run-now fired the moved path end-to-end →
     `success` + task created + matching task_created audit row; a second run-now correctly `skipped: overlap` (the moved
     board-read + skipFire). The exactly-once claim, gate logic, board IO, and audit all behave against the live stack.
-  - ☐ Phase 4+ : scheduler-loop.ts (schedulerTimer cell + schedulerDeps/start/stop + cutover→catch-up→tick ordering),
-    job-service.ts (CRUD verbs + the route/exec-tool dedup), routes/jobs.ts, exec-tools.ts. The redesigns (pause-drift
-    fix, dead update-handler code, dead settings keys maxConcurrentJobs/failureCooldownMs, ctx-threading, zod for
-    ensureBakinJob) are behavior-touching — listed, not bundled.
+  - ☑ Phase 4 — scheduler-loop (FIRE PATH, second cell): `lib/scheduler-loop.ts` — the schedulerTimer cell + the
+    settings-derived tick/catch-up accessors (ScheduleSettings + DEFAULT/MIN consts + tickIntervalMs/catchUpWindowMs),
+    schedulerDeps (bound to the live ledger + fire engine), runScheduleCutover, and startScheduler/stopScheduler with
+    the verbatim self-rescheduling cycle (resume-pauses → tick → heal). The schedulerTimer cell now lives in exactly
+    one module. CRITICAL ordering preserved: the activate() sequence stays IN index unchanged (cutover → … →
+    resumeDuePauses → runStartupCatchUp(schedulerDeps(), catchUpWindowMs()) → startScheduler) — I only moved the
+    functions and import them back; onShutdown still calls stopScheduler. index imports {schedulerDeps,
+    runScheduleCutover, startScheduler, stopScheduler, catchUpWindowMs}; shed the ledger claim/getCronFire +
+    runSchedulerTick/DEFAULT_TICK_WINDOW_MS/SchedulerDeps + migrateBakinSchedulesOffOpenClawCron + runClaimedFire imports
+    (all now scheduler-loop-internal). 1,153 → 1,060. Verified: typecheck/lint/schedule suite 280-0/full-suite 5124-0/
+    binary build + **DOCKERIZED-RIG E2E** (real OpenClaw): an every-minute schedule fired AUTOMATICALLY via the
+    scheduler tick — occurrence runId `sch_…:…T15:31:00Z` (not manual-), status success, task created — proving
+    startScheduler→cycle→runSchedulerTick→schedulerDeps.fire→runClaimedFire end to end on the live stack.
+  - ☐ Phase 5+ : job-service.ts (CRUD verbs + the route/exec-tool dedup), routes/jobs.ts, exec-tools.ts. The redesigns
+    (pause-drift fix, dead update-handler code, dead settings keys maxConcurrentJobs/failureCooldownMs, ctx-threading,
+    zod for ensureBakinJob) are behavior-touching — listed, not bundled.
 - Remaining: schedule fire-path phases 2+ + test splits; deferred canvas-editor copy-form (cross-file dedup) + redesigns.


### PR DESCRIPTION
## What

Moves the production scheduler wiring out of `index.ts` into **`lib/scheduler-loop.ts`**:
- the **`schedulerTimer` module cell** — now in exactly one module (the second of the two cells the audit flagged)
- the settings-derived tick/catch-up accessors (`ScheduleSettings` + constants + `tickIntervalMs`/`catchUpWindowMs`)
- the `schedulerDeps` factory (bound to the live ledger + fire engine)
- the idempotent `runScheduleCutover`
- `startScheduler`/`stopScheduler` with the verbatim self-rescheduling cycle (resume-pauses → tick → heal)

**1,153 → 1,060.**

## Ordering preserved (the landmine)

The `activate()` startup sequence stays **in index, unchanged** — `cutover → … → resumeDuePauses → runStartupCatchUp(schedulerDeps(), catchUpWindowMs()) → startScheduler` — and `onShutdown` still calls `stopScheduler`. Only the functions moved; index imports them back. It sheds the ledger `claim`/`getCronFire`, `runSchedulerTick`/`DEFAULT_TICK_WINDOW_MS`/`SchedulerDeps`, `migrateBakinSchedulesOffOpenClawCron`, and `runClaimedFire` imports (all now scheduler-loop-internal).

Pure behavior-preserving relocation — functions byte-identical, the cycle and the activate ordering unchanged.

## Verification — including a real automatic tick

- ✅ `bun run typecheck` · `eslint`
- ✅ full schedule suite — **280/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build`
- ✅ **Dockerized-rig E2E against real OpenClaw (isolated):** created an every-minute schedule and watched it fire **automatically via the scheduler tick** — occurrence runId `sch_…:2026-06-23T15:31:00.000Z` (**not** `manual-`), status `success`, task created. That proves the whole loop end-to-end on the live stack: `startScheduler` → self-rescheduling cycle → `runSchedulerTick(schedulerDeps())` → `schedulerDeps.fire` → `runClaimedFire` → claim + task.

## Next

`job-service.ts` (CRUD verbs + the route/exec-tool dedup — which includes the real pause-`pauseUntil` behavioral drift the appendix flagged), then `routes/jobs.ts` + `exec-tools.ts`. The behavior-touching redesigns stay listed, not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)