### PR TITLE
refactor(schedule): extract shared job-service CRUD helpers (phase 5)

### DIFF
--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -7,7 +7,7 @@ import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 import { definePlugin, defineRoute, searchRoute } from '@bakin/core/routing'
 import { readMergedJobs } from './lib/jobs-reader'
 import { getLastRun, readRuns } from './lib/runs-reader'
-import { upsertJob, removeJob, getJob, readSidecar, withDefaults, newScheduleId, resumeDuePauses } from './lib/sidecar'
+import { upsertJob, getJob, readSidecar, withDefaults, newScheduleId, resumeDuePauses } from './lib/sidecar'
 import { parseSchedule } from './lib/cron-parser'
 import { runStartupCatchUp } from './lib/scheduler'
 import { checkScheduleCutover, scheduleCutoverRepair } from './lib/health-checks'
@@ -31,160 +31,19 @@ import {
   stopScheduler,
   catchUpWindowMs,
 } from './lib/scheduler-loop'
+import {
+  guardBakinMutation,
+  ensureBakinJob,
+  deleteScheduleJob,
+  readMergedRuntimeJobs,
+  jobToSearchDoc,
+  indexJob,
+} from './lib/job-service'
 import { createLogger } from '../../src/core/logger'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
-import type { BakinJobMeta, MergedJob } from './types'
+import type { BakinJobMeta } from './types'
 
 const log = createLogger('schedule')
-
-type BakinMutationGuard =
-  | { ok: true; meta: BakinJobMeta }
-  | { ok: false; status: number; error: string }
-
-const READ_ONLY_ERROR = 'Runtime cron jobs are read-only in Bakin — adopt it first to manage it.'
-
-/**
- * Mutations apply only to Bakin-owned schedules. Resolves a jobId to one of:
- * the Bakin schedule (proceed), a native runtime cron that exists but isn't
- * Bakin-owned (read-only → 403), or an unknown id (→ 404). Keeps PUT / pause /
- * delete (route + exec) consistent instead of each guarding differently.
- */
-async function guardBakinMutation(jobId: string): Promise<BakinMutationGuard> {
-  const meta = getJob(jobId)
-  if (meta?.isBakinJob) return { ok: true, meta }
-  const ctx = getPluginCtx()
-  const runtime = ctx ? await ctx.runtime.cron.get(jobId).catch(() => null) : null
-  return runtime
-    ? { ok: false, status: 403, error: READ_ONLY_ERROR }
-    : { ok: false, status: 404, error: 'Schedule not found' }
-}
-
-interface EnsureBakinJobResult {
-  ok: boolean
-  jobId?: string
-  cron?: string
-  human?: string
-  error?: string
-}
-
-type ScheduleDeleteContext = Pick<PluginContext, 'runtime' | 'search'>
-
-async function ensureBakinJob(ctx: PluginContext, input: Record<string, unknown>): Promise<EnsureBakinJobResult> {
-  const logicalId = typeof input.jobId === 'string' && input.jobId.trim() ? input.jobId.trim() : undefined
-  const name = typeof input.name === 'string' ? input.name.trim() : ''
-  const schedule = typeof input.schedule === 'string' ? input.schedule.trim() : ''
-  const command = typeof input.command === 'string' ? input.command.trim() : ''
-  if (!logicalId || !name || !schedule || !command) {
-    return { ok: false, error: 'jobId, name, schedule, and command are required' }
-  }
-
-  const parsed = parseSchedule(schedule)
-  if (!parsed) return { ok: false, error: 'Could not parse schedule expression' }
-
-  const tz = typeof input.tz === 'string' && input.tz.trim() ? input.tz.trim() : getSystemTimezone()
-  const enabled = typeof input.enabled === 'boolean' ? input.enabled : true
-  const now = new Date().toISOString()
-
-  // Idempotent provisioning keyed by the caller-owned logical id. Bakin owns
-  // the schedule outright now — no OpenClaw cron is created.
-  const existing = getJob(logicalId) ?? getJobByLogicalJobId(logicalId)
-  const jobId = existing?.jobId ?? logicalId
-  const owner = typeof input.owner === 'string' && input.owner.trim()
-    ? input.owner.trim()
-    : existing?.owner ?? await getRuntimeMainAgentId(ctx.runtime)
-
-  const meta: BakinJobMeta = {
-    ...(existing ?? {}),
-    jobId,
-    logicalJobId: logicalId,
-    isBakinJob: true,
-    source: 'bakin',
-    schedule: { kind: 'cron', expr: parsed.cron },
-    enabled,
-    displayName: name,
-    description: typeof input.description === 'string' ? input.description : existing?.description,
-    owner,
-    requireTriage: typeof input.requireTriage === 'boolean' ? input.requireTriage : existing?.requireTriage ?? false,
-    agentId: typeof input.agentId === 'string' ? input.agentId : existing?.agentId,
-    workflowId: typeof input.workflowId === 'string' ? input.workflowId : existing?.workflowId,
-    taskPrompt: typeof input.taskPrompt === 'string' ? input.taskPrompt : existing?.taskPrompt ?? command,
-    taskTitle: typeof input.taskTitle === 'string' ? input.taskTitle : existing?.taskTitle,
-    allowOverlap: typeof input.allowOverlap === 'boolean' ? input.allowOverlap : existing?.allowOverlap ?? false,
-    maxFailures: typeof input.maxFailures === 'number' ? input.maxFailures : existing?.maxFailures ?? 3,
-    consecutiveFailures: existing?.consecutiveFailures ?? 0,
-    tz,
-    createdAt: existing?.createdAt ?? now,
-    updatedAt: now,
-  }
-  upsertJob(meta)
-  indexJob(jobId)
-
-  return { ok: true, jobId, cron: parsed.cron, human: parsed.human }
-}
-
-function getJobByLogicalJobId(logicalJobId: string): BakinJobMeta | null {
-  const matches = Object.values(readSidecar().jobs)
-    .filter(job => job.logicalJobId === logicalJobId)
-    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
-  return matches[0] ?? null
-}
-
-function isCronAlreadyGoneError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err)
-  return /\bnot found\b/i.test(message) && /\b(cron|job)\b/i.test(message)
-}
-
-async function deleteScheduleJob(ctx: ScheduleDeleteContext, jobId: string): Promise<{ runtimeMissing: boolean }> {
-  let runtimeMissing = false
-  try {
-    await ctx.runtime.cron.remove(jobId)
-  } catch (err) {
-    if (!isCronAlreadyGoneError(err)) throw err
-    runtimeMissing = true
-    log.warn('Schedule runtime cron was already gone during delete; removing Bakin records', {
-      jobId,
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
-  removeJob(jobId)
-  ctx.search.remove(jobId).catch(() => {})
-  return { runtimeMissing }
-}
-
-// ---------------------------------------------------------------------------
-// Bridge logic (cron → task)
-// ---------------------------------------------------------------------------
-
-// ─── Module-scope helpers (read ctx via getPluginCtx for runtime access) ──
-
-async function readMergedRuntimeJobs(): Promise<MergedJob[]> {
-  const ctx = getPluginCtx()
-  if (!ctx) throw new Error('schedule plugin not activated')
-  return readMergedJobs(ctx.runtime.cron, await getRuntimeMainAgentId(ctx.runtime))
-}
-
-function jobToSearchDoc(job: MergedJob): Record<string, unknown> {
-  return {
-    name: job.displayName || job.name || job.id,
-    schedule: job.humanSchedule || job.schedule.value || '',
-    command: job.taskPrompt || job.taskTitle || '',
-    agent: job.agentId || '',
-    enabled: job.paused ? 'false' : String(job.enabled !== false),
-    updated_at: job.createdAt || new Date().toISOString(),
-  }
-}
-
-function indexJob(jobId: string): void {
-  const ctx = getPluginCtx()
-  if (!ctx) return
-  readMergedRuntimeJobs().then((jobs) => {
-    const job = jobs.find(j => j.id === jobId)
-    if (!job) return
-    return ctx.search.index(jobId, jobToSearchDoc(job))
-  }).catch((err) => {
-    log.warn('Failed to index job', { jobId, error: err instanceof Error ? err.message : String(err) })
-  })
-}
 
 // ─── Schemas ─────────────────────────────────────────────────────────────
 

--- a/plugins/schedule/lib/job-service.ts
+++ b/plugins/schedule/lib/job-service.ts
@@ -1,0 +1,165 @@
+/**
+ * Schedule job service — the CRUD verbs shared by the REST routes and the exec
+ * tools, plus the core-boundary crossings (runtime cron + search). Isolating
+ * them here keeps the route/exec handlers thin and the read-only guard / delete
+ * semantics consistent across both surfaces.
+ *
+ * (The route↔exec-tool dedup the audit flagged — createScheduleJob /
+ * applyPauseAction / updateScheduleJob / projectJobDetail, including the
+ * pause-`pauseUntil` behavioral drift — is a deliberate behavior-touching
+ * follow-up, NOT taken in this pure relocation.)
+ */
+import type { PluginContext } from '@bakin/core/plugin-types'
+import type { BakinJobMeta, MergedJob } from '../types'
+import { getPluginCtx } from './plugin-context'
+import { getJob, upsertJob, removeJob, readSidecar } from './sidecar'
+import { readMergedJobs } from './jobs-reader'
+import { parseSchedule } from './cron-parser'
+import { getSystemTimezone } from './schedule-util'
+import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
+import { createLogger } from '../../../src/core/logger'
+
+const log = createLogger('schedule')
+
+export type BakinMutationGuard =
+  | { ok: true; meta: BakinJobMeta }
+  | { ok: false; status: number; error: string }
+
+export const READ_ONLY_ERROR = 'Runtime cron jobs are read-only in Bakin — adopt it first to manage it.'
+
+/**
+ * Mutations apply only to Bakin-owned schedules. Resolves a jobId to one of:
+ * the Bakin schedule (proceed), a native runtime cron that exists but isn't
+ * Bakin-owned (read-only → 403), or an unknown id (→ 404). Keeps PUT / pause /
+ * delete (route + exec) consistent instead of each guarding differently.
+ */
+export async function guardBakinMutation(jobId: string): Promise<BakinMutationGuard> {
+  const meta = getJob(jobId)
+  if (meta?.isBakinJob) return { ok: true, meta }
+  const ctx = getPluginCtx()
+  const runtime = ctx ? await ctx.runtime.cron.get(jobId).catch(() => null) : null
+  return runtime
+    ? { ok: false, status: 403, error: READ_ONLY_ERROR }
+    : { ok: false, status: 404, error: 'Schedule not found' }
+}
+
+export interface EnsureBakinJobResult {
+  ok: boolean
+  jobId?: string
+  cron?: string
+  human?: string
+  error?: string
+}
+
+export type ScheduleDeleteContext = Pick<PluginContext, 'runtime' | 'search'>
+
+export async function ensureBakinJob(ctx: PluginContext, input: Record<string, unknown>): Promise<EnsureBakinJobResult> {
+  const logicalId = typeof input.jobId === 'string' && input.jobId.trim() ? input.jobId.trim() : undefined
+  const name = typeof input.name === 'string' ? input.name.trim() : ''
+  const schedule = typeof input.schedule === 'string' ? input.schedule.trim() : ''
+  const command = typeof input.command === 'string' ? input.command.trim() : ''
+  if (!logicalId || !name || !schedule || !command) {
+    return { ok: false, error: 'jobId, name, schedule, and command are required' }
+  }
+
+  const parsed = parseSchedule(schedule)
+  if (!parsed) return { ok: false, error: 'Could not parse schedule expression' }
+
+  const tz = typeof input.tz === 'string' && input.tz.trim() ? input.tz.trim() : getSystemTimezone()
+  const enabled = typeof input.enabled === 'boolean' ? input.enabled : true
+  const now = new Date().toISOString()
+
+  // Idempotent provisioning keyed by the caller-owned logical id. Bakin owns
+  // the schedule outright now — no OpenClaw cron is created.
+  const existing = getJob(logicalId) ?? getJobByLogicalJobId(logicalId)
+  const jobId = existing?.jobId ?? logicalId
+  const owner = typeof input.owner === 'string' && input.owner.trim()
+    ? input.owner.trim()
+    : existing?.owner ?? await getRuntimeMainAgentId(ctx.runtime)
+
+  const meta: BakinJobMeta = {
+    ...(existing ?? {}),
+    jobId,
+    logicalJobId: logicalId,
+    isBakinJob: true,
+    source: 'bakin',
+    schedule: { kind: 'cron', expr: parsed.cron },
+    enabled,
+    displayName: name,
+    description: typeof input.description === 'string' ? input.description : existing?.description,
+    owner,
+    requireTriage: typeof input.requireTriage === 'boolean' ? input.requireTriage : existing?.requireTriage ?? false,
+    agentId: typeof input.agentId === 'string' ? input.agentId : existing?.agentId,
+    workflowId: typeof input.workflowId === 'string' ? input.workflowId : existing?.workflowId,
+    taskPrompt: typeof input.taskPrompt === 'string' ? input.taskPrompt : existing?.taskPrompt ?? command,
+    taskTitle: typeof input.taskTitle === 'string' ? input.taskTitle : existing?.taskTitle,
+    allowOverlap: typeof input.allowOverlap === 'boolean' ? input.allowOverlap : existing?.allowOverlap ?? false,
+    maxFailures: typeof input.maxFailures === 'number' ? input.maxFailures : existing?.maxFailures ?? 3,
+    consecutiveFailures: existing?.consecutiveFailures ?? 0,
+    tz,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  }
+  upsertJob(meta)
+  indexJob(jobId)
+
+  return { ok: true, jobId, cron: parsed.cron, human: parsed.human }
+}
+
+export function getJobByLogicalJobId(logicalJobId: string): BakinJobMeta | null {
+  const matches = Object.values(readSidecar().jobs)
+    .filter(job => job.logicalJobId === logicalJobId)
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+  return matches[0] ?? null
+}
+
+function isCronAlreadyGoneError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err)
+  return /\bnot found\b/i.test(message) && /\b(cron|job)\b/i.test(message)
+}
+
+export async function deleteScheduleJob(ctx: ScheduleDeleteContext, jobId: string): Promise<{ runtimeMissing: boolean }> {
+  let runtimeMissing = false
+  try {
+    await ctx.runtime.cron.remove(jobId)
+  } catch (err) {
+    if (!isCronAlreadyGoneError(err)) throw err
+    runtimeMissing = true
+    log.warn('Schedule runtime cron was already gone during delete; removing Bakin records', {
+      jobId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  removeJob(jobId)
+  ctx.search.remove(jobId).catch(() => {})
+  return { runtimeMissing }
+}
+
+export async function readMergedRuntimeJobs(): Promise<MergedJob[]> {
+  const ctx = getPluginCtx()
+  if (!ctx) throw new Error('schedule plugin not activated')
+  return readMergedJobs(ctx.runtime.cron, await getRuntimeMainAgentId(ctx.runtime))
+}
+
+export function jobToSearchDoc(job: MergedJob): Record<string, unknown> {
+  return {
+    name: job.displayName || job.name || job.id,
+    schedule: job.humanSchedule || job.schedule.value || '',
+    command: job.taskPrompt || job.taskTitle || '',
+    agent: job.agentId || '',
+    enabled: job.paused ? 'false' : String(job.enabled !== false),
+    updated_at: job.createdAt || new Date().toISOString(),
+  }
+}
+
+export function indexJob(jobId: string): void {
+  const ctx = getPluginCtx()
+  if (!ctx) return
+  readMergedRuntimeJobs().then((jobs) => {
+    const job = jobs.find(j => j.id === jobId)
+    if (!job) return
+    return ctx.search.index(jobId, jobToSearchDoc(job))
+  }).catch((err) => {
+    log.warn('Failed to index job', { jobId, error: err instanceof Error ? err.message : String(err) })
+  })
+}

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -387,7 +387,16 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     binary build + **DOCKERIZED-RIG E2E** (real OpenClaw): an every-minute schedule fired AUTOMATICALLY via the
     scheduler tick — occurrence runId `sch_…:…T15:31:00Z` (not manual-), status success, task created — proving
     startScheduler→cycle→runSchedulerTick→schedulerDeps.fire→runClaimedFire end to end on the live stack.
-  - ☐ Phase 5+ : job-service.ts (CRUD verbs + the route/exec-tool dedup), routes/jobs.ts, exec-tools.ts. The redesigns
-    (pause-drift fix, dead update-handler code, dead settings keys maxConcurrentJobs/failureCooldownMs, ctx-threading,
-    zod for ensureBakinJob) are behavior-touching — listed, not bundled.
+  - ☑ Phase 5 — job-service (shared CRUD helpers): `lib/job-service.ts` — the EXISTING shared verbs/helpers
+    (guardBakinMutation + READ_ONLY_ERROR + BakinMutationGuard, ensureBakinJob [the hook handler], getJobByLogicalJobId,
+    isCronAlreadyGoneError + deleteScheduleJob + ScheduleDeleteContext, readMergedRuntimeJobs, jobToSearchDoc, indexJob,
+    EnsureBakinJobResult). PURE RELOCATION — explicitly did NOT take the route/exec dedup (createScheduleJob/
+    applyPauseAction/updateScheduleJob/projectJobDetail) because that folds in the pause-`pauseUntil` BEHAVIORAL DRIFT;
+    left as a deliberate behavior-touching follow-up. index imports the public surface back; shed removeJob/MergedJob/
+    getJobByLogicalJobId imports. 1,060 → 919. Verified: typecheck/lint/schedule 280-0/full-suite 5124-0/binary build +
+    **DOCKERIZED-RIG E2E** (real OpenClaw): full CRUD round-trip — create (indexJob) → PUT/pause (guardBakinMutation 200)
+    → bogus-id guard (404) → delete (deleteScheduleJob 200) → gone from list. All moved helpers behave on the live stack.
+  - ☐ Phase 6 : routes/jobs.ts (the 12-route array + zod schemas) + exec-tools.ts (the 10 ctx.registerExecTool calls),
+    leaving index a ~200-line definePlugin shell. The redesigns (pause-drift fix, dead update-handler code, dead settings
+    keys maxConcurrentJobs/failureCooldownMs, ctx-threading, zod for ensureBakinJob) are behavior-touching — not bundled.
 - Remaining: schedule fire-path phases 2+ + test splits; deferred canvas-editor copy-form (cross-file dedup) + redesigns.


### PR DESCRIPTION
## What

Moves the **existing shared job verbs** out of `index.ts` into **`lib/job-service.ts`**: `guardBakinMutation` + `READ_ONLY_ERROR` + `BakinMutationGuard`, `ensureBakinJob` (the `schedule.ensureBakinJob` hook handler), `getJobByLogicalJobId`, `isCronAlreadyGoneError` + `deleteScheduleJob` (+ `ScheduleDeleteContext`), `readMergedRuntimeJobs`, `jobToSearchDoc`, `indexJob`.

These already serve **both** the REST routes and the exec tools; centralizing them makes the runtime-cron + search boundary one auditable module and keeps the read-only-guard / delete semantics consistent.

**1,060 → 919.** index imports the public surface back and sheds `removeJob` / `MergedJob` / `getJobByLogicalJobId` imports.

## Pure relocation — dedup NOT taken (on purpose)

The route↔exec-tool dedup the audit calls for (`createScheduleJob` / `applyPauseAction` / `updateScheduleJob` / `projectJobDetail`) is **deliberately not taken** here — it folds in a real **behavioral drift** (the pause route unconditionally clears `pauseUntil` while the exec tool keeps it). Collapsing those into one verb silently picks a behavior; that belongs in a separate behavior-touching fix, not this relocation. Left listed in `tasks/plan.md`.

## Verification — including live CRUD

- ✅ `bun run typecheck` · `eslint`
- ✅ full schedule suite — **280/0**
- ✅ full suite — **5124/0**
- ✅ `bun run build`
- ✅ **Dockerized-rig E2E against real OpenClaw (isolated):** a full CRUD round-trip — **create** (`indexJob`) → **PUT** then **pause** (`guardBakinMutation`, 200) → mutate a **bogus id → 404** (the guard) → **delete** (`deleteScheduleJob`, 200) → **gone** from the list. All moved helpers behaving on the live stack.

## Next (last one)

`routes/jobs.ts` (the 12-route array + zod schemas) + `exec-tools.ts` (the 10 `ctx.registerExecTool` calls) — leaving `index.ts` a ~200-line `definePlugin` shell and fully resolving the last audit god-file. Redesigns (the pause-drift fix, dead settings keys, ctx-threading) stay listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)