### PR TITLE
refactor(adapter-openclaw): move CLI-command error helpers into errors.ts

### DIFF
--- a/packages/adapter-openclaw/src/errors.ts
+++ b/packages/adapter-openclaw/src/errors.ts
@@ -7,6 +7,7 @@
  * provider wording changes, this file is the only thing that needs to know.
  */
 import { RuntimeError, RuntimeTurnError, type RuntimeProviderInfo } from '@bakin/core/adapters/runtime'
+import { stripAnsi } from './runtime-utils'
 
 /** codex app-server ended the run before the turn reported completion. */
 const IDLE_TIMEOUT_PATTERNS = [
@@ -59,4 +60,76 @@ export function openClawRuntimeErrorFromMessage(message: string, cause?: unknown
   }
 
   return new RuntimeError(message, { kind: 'runtime_failed', cause })
+}
+
+
+// ─── CLI command failures ──────────────────────────────────────────────────
+// OpenClaw CLI invocations surface as child_process errors; this captures the
+// stdout/stderr/exit-code so callers can classify (e.g. the open-allowlist
+// warning) without re-parsing free text at every call site.
+
+const OPENCLAW_PLUGIN_ALLOWLIST_WARNING = 'plugins.allow is empty'
+
+export class OpenClawCommandError extends RuntimeError {
+  readonly args: string[]
+  readonly stdout: string
+  readonly stderr: string
+  readonly exitCode: number | string | undefined
+
+  constructor(args: string[], cause: unknown) {
+    const stdout = processOutput(cause, 'stdout')
+    const stderr = processOutput(cause, 'stderr')
+    const exitCode = processExitCode(cause)
+    const details = [stderr, stdout].filter((part) => part.trim().length > 0).join('\n')
+    super([
+      `OpenClaw command failed${exitCode === undefined ? '' : ` (${exitCode})`}: openclaw ${args.join(' ')}`,
+      details,
+    ].filter(Boolean).join('\n'), { kind: 'runtime_failed', cause })
+    this.name = 'OpenClawCommandError'
+    this.args = args
+    this.stdout = stdout
+    this.stderr = stderr
+    this.exitCode = exitCode
+  }
+}
+
+function processOutput(cause: unknown, field: 'stdout' | 'stderr'): string {
+  if (!cause || typeof cause !== 'object') return ''
+  const value = (cause as Record<string, unknown>)[field]
+  if (typeof value === 'string') return value
+  if (Buffer.isBuffer(value)) return value.toString('utf-8')
+  return ''
+}
+
+function processExitCode(cause: unknown): number | string | undefined {
+  if (!cause || typeof cause !== 'object') return undefined
+  const value = (cause as Record<string, unknown>).code
+  return typeof value === 'number' || typeof value === 'string' ? value : undefined
+}
+
+function openClawErrorOutput(err: unknown): string {
+  if (err instanceof OpenClawCommandError) {
+    return [err.stderr, err.stdout, err.message].filter(Boolean).join('\n')
+  }
+  if (!err || typeof err !== 'object') return String(err ?? '')
+  const record = err as Record<string, unknown>
+  return [
+    typeof record.stderr === 'string' ? record.stderr : '',
+    typeof record.stdout === 'string' ? record.stdout : '',
+    typeof record.message === 'string' ? record.message : '',
+  ].filter(Boolean).join('\n')
+}
+
+export function isPluginAllowlistOpenFailure(err: unknown): boolean {
+  if (err instanceof OpenClawCommandError) {
+    const stderr = stripAnsi(err.stderr).trim()
+    const stdout = stripAnsi(err.stdout).trim()
+    const nonWarningStderr = stderr
+      .split('\n')
+      .filter((line) => !line.includes(OPENCLAW_PLUGIN_ALLOWLIST_WARNING))
+      .join('\n')
+      .trim()
+    return stdout.length === 0 && stderr.includes(OPENCLAW_PLUGIN_ALLOWLIST_WARNING) && nonWarningStderr.length === 0
+  }
+  return stripAnsi(openClawErrorOutput(err)).includes(OPENCLAW_PLUGIN_ALLOWLIST_WARNING)
 }

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -63,11 +63,12 @@ import {
   statOpenClawMemoryEntry,
 } from './memory'
 import {
-  stripAnsi, firstString, firstStringAtPaths, getJsonPath,
+  firstString, firstStringAtPaths, getJsonPath,
   isPlainObject, isRecord, readPath, deepMerge, cloneJson, parseJsonValue,
   parseJsonLines, readJsonFile, truncate, redactSensitiveText, slug, sleep,
   metadataValue, metadataFiles,
 } from './runtime-utils'
+import { OpenClawCommandError, isPluginAllowlistOpenFailure } from './errors'
 
 interface OpenClawSettings {
   binaryPath: string
@@ -120,7 +121,6 @@ const NATIVE_APPROVAL_NOTICE = [
   'The durable Bakin approval record remains canonical.',
 ].join(' ')
 const NATIVE_APPROVAL_PROVIDERS = new Set(['discord', 'telegram', 'slack', 'matrix', 'qqbot'])
-const OPENCLAW_PLUGIN_ALLOWLIST_WARNING = 'plugins.allow is empty'
 
 interface OpenClawAgentTurnOptions {
   agentId: string
@@ -144,70 +144,6 @@ interface OpenClawAgentTurnOptions {
 interface OpenClawTurnResult {
   content: string
   usage?: MessageUsage
-}
-
-class OpenClawCommandError extends RuntimeError {
-  readonly args: string[]
-  readonly stdout: string
-  readonly stderr: string
-  readonly exitCode: number | string | undefined
-
-  constructor(args: string[], cause: unknown) {
-    const stdout = processOutput(cause, 'stdout')
-    const stderr = processOutput(cause, 'stderr')
-    const exitCode = processExitCode(cause)
-    const details = [stderr, stdout].filter((part) => part.trim().length > 0).join('\n')
-    super([
-      `OpenClaw command failed${exitCode === undefined ? '' : ` (${exitCode})`}: openclaw ${args.join(' ')}`,
-      details,
-    ].filter(Boolean).join('\n'), { kind: 'runtime_failed', cause })
-    this.name = 'OpenClawCommandError'
-    this.args = args
-    this.stdout = stdout
-    this.stderr = stderr
-    this.exitCode = exitCode
-  }
-}
-
-function processOutput(cause: unknown, field: 'stdout' | 'stderr'): string {
-  if (!cause || typeof cause !== 'object') return ''
-  const value = (cause as Record<string, unknown>)[field]
-  if (typeof value === 'string') return value
-  if (Buffer.isBuffer(value)) return value.toString('utf-8')
-  return ''
-}
-
-function processExitCode(cause: unknown): number | string | undefined {
-  if (!cause || typeof cause !== 'object') return undefined
-  const value = (cause as Record<string, unknown>).code
-  return typeof value === 'number' || typeof value === 'string' ? value : undefined
-}
-
-function openClawErrorOutput(err: unknown): string {
-  if (err instanceof OpenClawCommandError) {
-    return [err.stderr, err.stdout, err.message].filter(Boolean).join('\n')
-  }
-  if (!err || typeof err !== 'object') return String(err ?? '')
-  const record = err as Record<string, unknown>
-  return [
-    typeof record.stderr === 'string' ? record.stderr : '',
-    typeof record.stdout === 'string' ? record.stdout : '',
-    typeof record.message === 'string' ? record.message : '',
-  ].filter(Boolean).join('\n')
-}
-
-function isPluginAllowlistOpenFailure(err: unknown): boolean {
-  if (err instanceof OpenClawCommandError) {
-    const stderr = stripAnsi(err.stderr).trim()
-    const stdout = stripAnsi(err.stdout).trim()
-    const nonWarningStderr = stderr
-      .split('\n')
-      .filter((line) => !line.includes(OPENCLAW_PLUGIN_ALLOWLIST_WARNING))
-      .join('\n')
-      .trim()
-    return stdout.length === 0 && stderr.includes(OPENCLAW_PLUGIN_ALLOWLIST_WARNING) && nonWarningStderr.length === 0
-  }
-  return stripAnsi(openClawErrorOutput(err)).includes(OPENCLAW_PLUGIN_ALLOWLIST_WARNING)
 }
 
 interface OpenClawCronStore {


### PR DESCRIPTION
Second cut of the `runtime.ts` god-file split (WS5). **Stacked on #551** (base = `refactor/openclaw-runtime-utils`).

## What changed
Consolidates the OpenClaw CLI command-failure handling into the existing `errors.ts` (already "the ONE place OpenClaw provider error strings are interpreted"):
- `OpenClawCommandError` class + its `processOutput`/`processExitCode` constructor helpers
- `openClawErrorOutput`, `isPluginAllowlistOpenFailure`, and the `OPENCLAW_PLUGIN_ALLOWLIST_WARNING` sentinel

`errors.ts` imports `stripAnsi` from `runtime-utils` (no cycle — it's the dependency-free leaf from #551). `runtime.ts` imports back only the two symbols it still references (`OpenClawCommandError`, `isPluginAllowlistOpenFailure`); the other three were only used by the moved cluster and stay module-internal to `errors.ts`.

## Scope
Pure relocation — bodies byte-for-byte unchanged. `runtime.ts`: **3,053 → 2,989.**

## Verification
- typecheck ✓ · eslint (changed files) ✓ · adapter suite **115-0** (`--isolate`) ✓ · full suite **5124-0** ✓ · build ✓ (stamps reverted) · boot smoke (adapter loads, schedule activates, list route 200) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)