### PR TITLE
refactor(adapter-openclaw): extract channels + messaging into channel-helpers.ts

### DIFF
--- a/packages/adapter-openclaw/src/channel-helpers.ts
+++ b/packages/adapter-openclaw/src/channel-helpers.ts
@@ -1,0 +1,146 @@
+/**
+ * OpenClaw channels + messaging — channel ref/arg building, delivery-output
+ * parsing, the channel registry read (capabilities + interactive-approval
+ * detection), and the approval-notice text. The class's channels methods own
+ * the exec; this is config-read + pure parsing. gatewayWebSocketUrl stays on
+ * the adapter (it is coupled to OpenClawSettings).
+ */
+import type { ChannelInfo, RuntimeMetadata } from '@bakin/core/adapters/runtime'
+import { firstStringAtPaths, isRecord, metadataValue, parseJsonObject } from './runtime-utils'
+import { readOpenClawConfig } from './config'
+import { requiresRejectReason } from './approval-helpers'
+
+/** Timeout (ms) surfaced per channel for an interactive plugin approval. */
+export const OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS = 600000
+
+const RENDER_ONLY_APPROVAL_NOTICE = [
+  'This channel cannot return approval decisions to Bakin.',
+  'Use the Bakin approval link or approve/reject this gate in the Bakin UI.',
+].join(' ')
+const REJECT_REASON_APPROVAL_NOTICE = [
+  'This gate requires a reject reason.',
+  'Use the Bakin approval link so reject decisions include the required reason.',
+].join(' ')
+const NATIVE_APPROVAL_PROVIDERS = new Set(['discord', 'telegram', 'slack', 'matrix', 'qqbot'])
+
+export function splitChannelRef(channelId: string, metadata: RuntimeMetadata | undefined): { channel: string; target?: string } {
+  const explicitTarget = metadataValue(metadata, 'target') ?? metadataValue(metadata, 'channelTarget')
+  if (explicitTarget) return { channel: channelId, target: explicitTarget }
+  const [channel, ...targetParts] = channelId.split(':')
+  if (channel && targetParts.length > 0) return { channel, target: targetParts.join(':') }
+  return { channel: channelId }
+}
+
+export function openClawMessageSendArgs(
+  ref: { channel: string; target?: string },
+  message: { body: string; title?: string; threadId?: string; metadata?: RuntimeMetadata },
+  files: Array<{ name: string; path: string; contentType?: string }>,
+): string[] {
+  const args = ['message', 'send', '--channel', ref.channel]
+  if (ref.target) args.push('--target', ref.target)
+  const body = [message.title, message.body].filter(Boolean).join('\n\n')
+  if (body) args.push('--message', body)
+  if (message.threadId) args.push('--thread-id', message.threadId)
+  for (const file of files) args.push('--media', file.path)
+  args.push('--json')
+  return args
+}
+
+export function deliveryRefFromOpenClawOutput(stdout: string): string | null {
+  const value = parseOpenClawDeliveryOutput(stdout)
+  const id = firstStringAtPaths(value, [
+    ['messageId'],
+    ['message_id'],
+    ['id'],
+    ['message', 'id'],
+    ['result', 'messageId'],
+    ['result', 'message_id'],
+    ['result', 'id'],
+    ['result', 'message', 'id'],
+    ['delivery', 'messageId'],
+    ['delivery', 'message_id'],
+    ['delivery', 'id'],
+    ['delivery', 'message', 'id'],
+  ])
+  return id ? `message:${id}` : null
+}
+
+export function parseOpenClawDeliveryOutput(stdout: string): Record<string, unknown> | null {
+  const text = stdout.trim()
+  if (!text) return null
+  return parseJsonObject(text)
+    ?? parseJsonObject(text.split('\n').reverse().find(part => part.trim().startsWith('{') && part.trim().endsWith('}')) ?? '')
+}
+
+export function readChannelInfos(): ChannelInfo[] {
+  const config = readOpenClawConfig() as { channels?: unknown } | null
+  const channels = config?.channels
+  if (!channels || typeof channels !== 'object' || Array.isArray(channels)) return []
+
+  return Object.entries(channels as Record<string, unknown>).map(([id, raw]): ChannelInfo => {
+    const entry = isRecord(raw) ? raw : {}
+    const interactive = channelEntrySupportsInteractiveApproval(id, entry)
+    const capabilities: ChannelInfo['capabilities'] = ['message', 'rich-content']
+    if (interactive) capabilities.push('interactive-approval')
+    return {
+      id,
+      platform: typeof entry.platform === 'string' ? entry.platform : id,
+      label: typeof entry.label === 'string' ? entry.label : humanizeChannelId(id),
+      capabilities,
+      metadata: {
+        approvalResponses: interactive ? 'interactive' : 'render-only',
+        approvalMode: interactive ? 'openclaw-plugin-approval' : 'render-only',
+        ...(interactive
+          ? {
+              approvalTimeoutMs: OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS,
+              rejectReason: 'bakin-fallback-link',
+            }
+          : {}),
+      },
+    }
+  })
+}
+
+export function hasAnyInteractiveApprovalChannel(): boolean {
+  return readChannelInfos().some(channel => channel.capabilities.includes('interactive-approval'))
+}
+
+export function channelHasInteractiveApproval(channelId: string): boolean {
+  const ref = splitChannelRef(channelId, undefined)
+  return readChannelInfos().some(channel => (
+    channel.id === ref.channel && channel.capabilities.includes('interactive-approval')
+  ))
+}
+
+export function channelEntrySupportsInteractiveApproval(id: string, entry: Record<string, unknown>): boolean {
+  if (entry.enabled === false) return false
+  const provider = typeof entry.platform === 'string' ? entry.platform : id
+  if (!NATIVE_APPROVAL_PROVIDERS.has(provider)) return false
+
+  const approvalConfig = isRecord(entry.execApprovals)
+    ? entry.execApprovals
+    : isRecord(entry.approvals)
+      ? entry.approvals
+      : null
+  if (!approvalConfig) return false
+  const enabled = approvalConfig.enabled
+  if (!(enabled === true || enabled === 'auto')) return false
+
+  const eventKinds = approvalConfig.eventKinds
+  if (Array.isArray(eventKinds) && !eventKinds.includes('plugin')) return false
+  return true
+}
+
+export function approvalNoticeForMessage(channelId: string, context: RuntimeMetadata): string {
+  return channelHasInteractiveApproval(channelId) && requiresRejectReason(context)
+    ? REJECT_REASON_APPROVAL_NOTICE
+    : RENDER_ONLY_APPROVAL_NOTICE
+}
+
+export function humanizeChannelId(id: string): string {
+  return id
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(' ') || id
+}

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -54,8 +54,8 @@ import {
   statOpenClawMemoryEntry,
 } from './memory'
 import {
-  firstStringAtPaths, getJsonPath,
-  isPlainObject, isRecord, readPath, deepMerge, cloneJson, parseJsonValue,
+  getJsonPath,
+  isPlainObject, readPath, deepMerge, cloneJson, parseJsonValue,
   parseJsonObject, readJsonFile, truncate, slug,
   metadataValue, metadataFiles,
 } from './runtime-utils'
@@ -83,6 +83,12 @@ import {
   agentToRuntime, getWorkspacePath, readGatewayToken, isSafeWorkspaceFile, isSafeSkillFilePath,
   readSkillTree,
 } from './agent-config'
+import {
+  OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS,
+  splitChannelRef, openClawMessageSendArgs, deliveryRefFromOpenClawOutput,
+  readChannelInfos, hasAnyInteractiveApprovalChannel,
+  channelHasInteractiveApproval, approvalNoticeForMessage,
+} from './channel-helpers'
 // Re-exported so the session-store-cache test's `from '.../runtime'` path stays stable.
 export {
   SESSION_STORE_CACHE_MAX, __readSessionStoreCachedForTest,
@@ -121,22 +127,12 @@ const OPENCLAW_AGENT_TIMEOUT_MS = 600000
 const OPENCLAW_AGENT_TIMEOUT_SECONDS = Math.ceil(OPENCLAW_AGENT_TIMEOUT_MS / 1000)
 // Transport must outlast the server-side agent budget so the Gateway can deliver its own timeout.
 const OPENCLAW_AGENT_TRANSPORT_TIMEOUT_MS = OPENCLAW_AGENT_TIMEOUT_MS + 30_000
-const OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS = 600000
 const OPENCLAW_CRON_PROCESS_TIMEOUT_MS = OPENCLAW_CRON_TIMEOUT_MS + 5000
 const OPENCLAW_IMAGE_PROCESS_TIMEOUT_MS = 600000
 const BAKIN_MCPORTER_CALL_TIMEOUT_MS = 600000
 const OPENCLAW_IMAGE_OUTPUT_MAX_BUFFER = 16 * 1024 * 1024
 const OPENCLAW_IMAGE_PROVIDERS_TTL_MS = 5000
 const OPENCLAW_MODELS_LIST_MAX_BUFFER = 16 * 1024 * 1024
-const RENDER_ONLY_APPROVAL_NOTICE = [
-  'This channel cannot return approval decisions to Bakin.',
-  'Use the Bakin approval link or approve/reject this gate in the Bakin UI.',
-].join(' ')
-const REJECT_REASON_APPROVAL_NOTICE = [
-  'This gate requires a reject reason.',
-  'Use the Bakin approval link so reject decisions include the required reason.',
-].join(' ')
-const NATIVE_APPROVAL_PROVIDERS = new Set(['discord', 'telegram', 'slack', 'matrix', 'qqbot'])
 
 interface OpenClawAgentTurnOptions {
   agentId: string
@@ -1538,132 +1534,10 @@ function openClawChildEnv(): NodeJS.ProcessEnv {
   }
 }
 
-function splitChannelRef(channelId: string, metadata: RuntimeMetadata | undefined): { channel: string; target?: string } {
-  const explicitTarget = metadataValue(metadata, 'target') ?? metadataValue(metadata, 'channelTarget')
-  if (explicitTarget) return { channel: channelId, target: explicitTarget }
-  const [channel, ...targetParts] = channelId.split(':')
-  if (channel && targetParts.length > 0) return { channel, target: targetParts.join(':') }
-  return { channel: channelId }
-}
-
-function openClawMessageSendArgs(
-  ref: { channel: string; target?: string },
-  message: { body: string; title?: string; threadId?: string; metadata?: RuntimeMetadata },
-  files: Array<{ name: string; path: string; contentType?: string }>,
-): string[] {
-  const args = ['message', 'send', '--channel', ref.channel]
-  if (ref.target) args.push('--target', ref.target)
-  const body = [message.title, message.body].filter(Boolean).join('\n\n')
-  if (body) args.push('--message', body)
-  if (message.threadId) args.push('--thread-id', message.threadId)
-  for (const file of files) args.push('--media', file.path)
-  args.push('--json')
-  return args
-}
-
-function deliveryRefFromOpenClawOutput(stdout: string): string | null {
-  const value = parseOpenClawDeliveryOutput(stdout)
-  const id = firstStringAtPaths(value, [
-    ['messageId'],
-    ['message_id'],
-    ['id'],
-    ['message', 'id'],
-    ['result', 'messageId'],
-    ['result', 'message_id'],
-    ['result', 'id'],
-    ['result', 'message', 'id'],
-    ['delivery', 'messageId'],
-    ['delivery', 'message_id'],
-    ['delivery', 'id'],
-    ['delivery', 'message', 'id'],
-  ])
-  return id ? `message:${id}` : null
-}
-
-function parseOpenClawDeliveryOutput(stdout: string): Record<string, unknown> | null {
-  const text = stdout.trim()
-  if (!text) return null
-  return parseJsonObject(text)
-    ?? parseJsonObject(text.split('\n').reverse().find(part => part.trim().startsWith('{') && part.trim().endsWith('}')) ?? '')
-}
-
-function readChannelInfos(): ChannelInfo[] {
-  const config = readOpenClawConfig() as { channels?: unknown } | null
-  const channels = config?.channels
-  if (!channels || typeof channels !== 'object' || Array.isArray(channels)) return []
-
-  return Object.entries(channels as Record<string, unknown>).map(([id, raw]): ChannelInfo => {
-    const entry = isRecord(raw) ? raw : {}
-    const interactive = channelEntrySupportsInteractiveApproval(id, entry)
-    const capabilities: ChannelInfo['capabilities'] = ['message', 'rich-content']
-    if (interactive) capabilities.push('interactive-approval')
-    return {
-      id,
-      platform: typeof entry.platform === 'string' ? entry.platform : id,
-      label: typeof entry.label === 'string' ? entry.label : humanizeChannelId(id),
-      capabilities,
-      metadata: {
-        approvalResponses: interactive ? 'interactive' : 'render-only',
-        approvalMode: interactive ? 'openclaw-plugin-approval' : 'render-only',
-        ...(interactive
-          ? {
-              approvalTimeoutMs: OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS,
-              rejectReason: 'bakin-fallback-link',
-            }
-          : {}),
-      },
-    }
-  })
-}
-
-function hasAnyInteractiveApprovalChannel(): boolean {
-  return readChannelInfos().some(channel => channel.capabilities.includes('interactive-approval'))
-}
-
-function channelHasInteractiveApproval(channelId: string): boolean {
-  const ref = splitChannelRef(channelId, undefined)
-  return readChannelInfos().some(channel => (
-    channel.id === ref.channel && channel.capabilities.includes('interactive-approval')
-  ))
-}
-
-function channelEntrySupportsInteractiveApproval(id: string, entry: Record<string, unknown>): boolean {
-  if (entry.enabled === false) return false
-  const provider = typeof entry.platform === 'string' ? entry.platform : id
-  if (!NATIVE_APPROVAL_PROVIDERS.has(provider)) return false
-
-  const approvalConfig = isRecord(entry.execApprovals)
-    ? entry.execApprovals
-    : isRecord(entry.approvals)
-      ? entry.approvals
-      : null
-  if (!approvalConfig) return false
-  const enabled = approvalConfig.enabled
-  if (!(enabled === true || enabled === 'auto')) return false
-
-  const eventKinds = approvalConfig.eventKinds
-  if (Array.isArray(eventKinds) && !eventKinds.includes('plugin')) return false
-  return true
-}
-
 function gatewayWebSocketUrl(settings: OpenClawSettings): string {
   const url = new URL(`${settings.gatewayUrl}:${settings.gatewayPort}`)
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
   return url.toString().replace(/\/$/, '')
-}
-
-function approvalNoticeForMessage(channelId: string, context: RuntimeMetadata): string {
-  return channelHasInteractiveApproval(channelId) && requiresRejectReason(context)
-    ? REJECT_REASON_APPROVAL_NOTICE
-    : RENDER_ONLY_APPROVAL_NOTICE
-}
-
-function humanizeChannelId(id: string): string {
-  return id
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
-    .join(' ') || id
 }
 
 // Exported for tests — pure stream-merging helper with no adapter state.


### PR DESCRIPTION
Ninth cut of the `runtime.ts` god-file split (WS5). **Stacked on #558.**

## What changed
Moves the 10 channel/messaging helpers into a new `channel-helpers.ts`:
- channel ref/arg building (`splitChannelRef`, `openClawMessageSendArgs`)
- delivery-output parsing (`deliveryRefFromOpenClawOutput`, `parseOpenClawDeliveryOutput`)
- the channel registry read + interactive-approval detection (`readChannelInfos`, `hasAnyInteractiveApprovalChannel`, `channelHasInteractiveApproval`, `channelEntrySupportsInteractiveApproval`, `humanizeChannelId`)
- `approvalNoticeForMessage` (the channel-coupled approval-notice text deferred from the approval-helpers cut) + its `NATIVE_APPROVAL_PROVIDERS`/RENDER_ONLY/REJECT_REASON constants + `OPENCLAW_PLUGIN_APPROVAL_TIMEOUT_MS`

`approvalNoticeForMessage` imports `requiresRejectReason` from `approval-helpers` (sibling). **`gatewayWebSocketUrl` stays on the adapter** — it's coupled to the `OpenClawSettings` type the class owns. The class's channels methods import back the 7 helpers + timeout const they call; the rest stay module-internal. `runtime.ts` shed its now-unused `firstStringAtPaths`/`isRecord` imports.

## Scope
Pure relocation — bodies byte-for-byte unchanged. `runtime.ts`: **1,744 → 1,618.**

## Verification
- typecheck ✓ · eslint (changed files) ✓ · adapter suite **115-0** incl. `runtime-channels.test.ts` (`--isolate`) ✓ · full suite **5124-0** ✓ · build ✓ (stamps reverted) · boot smoke (adapter loads, schedule activates, list route 200) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)