### PR TITLE
refactor(adapter-openclaw): extract agent-turn I/O into agent-turn.ts

### DIFF
--- a/packages/adapter-openclaw/src/agent-turn.ts
+++ b/packages/adapter-openclaw/src/agent-turn.ts
@@ -1,0 +1,70 @@
+/**
+ * OpenClaw agent-turn I/O — building the CLI prompt from a message list,
+ * normalizing the tool allow-list, and extracting the assistant text + token
+ * usage from the gateway/CLI turn response. Pure parsing/formatting over the
+ * turn payload; the adapter's turn methods own the exec + session wiring.
+ */
+import type { MessageUsage, RuntimeMetadata } from '@bakin/core/adapters/runtime'
+import { getJsonPath, isPlainObject, parseJsonObject } from './runtime-utils'
+
+export function oversizedOutputBytesFrom(metadata: RuntimeMetadata | undefined): number | undefined {
+  const value = metadata?.oversizedOutputBytes
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+export function messagesToOpenClawPrompt(messages: Array<{ role: string; content: string }>): string {
+  const lastUser = [...messages].reverse().find((message) => message.role === 'user' && message.content.trim())
+  if (lastUser) return lastUser.content
+  return messages.map((message) => message.content).filter(Boolean).join('\n\n')
+}
+
+export function normalizeToolList(value: string[] | undefined): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const seen = new Set<string>()
+  const tools: string[] = []
+  for (const entry of value) {
+    const tool = typeof entry === 'string' ? entry.trim() : ''
+    if (!tool || seen.has(tool)) continue
+    seen.add(tool)
+    tools.push(tool)
+  }
+  return tools.length > 0 ? tools : undefined
+}
+
+export function extractOpenClawAgentText(value: unknown): string {
+  const parsed = typeof value === 'string' ? parseJsonObject(value.trim()) ?? value.trim() : value
+  if (!parsed) return ''
+  if (typeof parsed === 'string') return parsed
+
+  const finalVisible = getJsonPath(parsed, ['result', 'meta', 'finalAssistantVisibleText'])
+  if (typeof finalVisible === 'string') return finalVisible
+  const finalRaw = getJsonPath(parsed, ['result', 'meta', 'finalAssistantRawText'])
+  if (typeof finalRaw === 'string') return finalRaw
+  const payloads = getJsonPath(parsed, ['result', 'payloads'])
+  if (Array.isArray(payloads)) {
+    return payloads
+      .map((payload) => isPlainObject(payload) && typeof payload.text === 'string' ? payload.text : '')
+      .filter(Boolean)
+      .join('\n\n')
+  }
+  const summary = getJsonPath(parsed, ['summary'])
+  return typeof summary === 'string' ? summary : ''
+}
+
+export function extractOpenClawAgentUsage(value: unknown): MessageUsage | undefined {
+  const parsed = typeof value === 'string' ? parseJsonObject(value.trim()) : value
+  if (!parsed) return undefined
+  const usage = getJsonPath(parsed, ['result', 'meta', 'agentMeta', 'usage'])
+  if (!isPlainObject(usage)) return undefined
+  const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
+  const out: MessageUsage = {}
+  const input = num(usage.input); if (input !== undefined) out.input = input
+  const output = num(usage.output); if (output !== undefined) out.output = output
+  const total = num(usage.total); if (total !== undefined) out.total = total
+  const cacheRead = num(usage.cacheRead); if (cacheRead !== undefined) out.cacheRead = cacheRead
+  const cacheWrite = num(usage.cacheWrite); if (cacheWrite !== undefined) out.cacheWrite = cacheWrite
+  // Require the input/output split for the result to be priceable. A
+  // total-only block isn't — returning it would short-circuit the trajectory
+  // fallback (which may carry the split), leaving the turn unmetered.
+  return out.input !== undefined || out.output !== undefined ? out : undefined
+}

--- a/packages/adapter-openclaw/src/runtime.ts
+++ b/packages/adapter-openclaw/src/runtime.ts
@@ -54,8 +54,7 @@ import {
   statOpenClawMemoryEntry,
 } from './memory'
 import {
-  getJsonPath,
-  isPlainObject, readPath, deepMerge, cloneJson, parseJsonValue,
+  readPath, deepMerge, cloneJson, parseJsonValue,
   parseJsonObject, readJsonFile, truncate, slug,
   metadataValue, metadataFiles,
 } from './runtime-utils'
@@ -89,6 +88,10 @@ import {
   readChannelInfos, hasAnyInteractiveApprovalChannel,
   channelHasInteractiveApproval, approvalNoticeForMessage,
 } from './channel-helpers'
+import {
+  oversizedOutputBytesFrom, messagesToOpenClawPrompt, normalizeToolList,
+  extractOpenClawAgentText, extractOpenClawAgentUsage,
+} from './agent-turn'
 // Re-exported so the session-store-cache test's `from '.../runtime'` path stays stable.
 export {
   SESSION_STORE_CACHE_MAX, __readSessionStoreCachedForTest,
@@ -1408,56 +1411,12 @@ export class OpenClawRuntimeAdapter implements AgentRuntimeAdapter {
   }
 }
 
-function oversizedOutputBytesFrom(metadata: RuntimeMetadata | undefined): number | undefined {
-  const value = metadata?.oversizedOutputBytes
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
-}
-
-function messagesToOpenClawPrompt(messages: Array<{ role: string; content: string }>): string {
-  const lastUser = [...messages].reverse().find((message) => message.role === 'user' && message.content.trim())
-  if (lastUser) return lastUser.content
-  return messages.map((message) => message.content).filter(Boolean).join('\n\n')
-}
-
-function normalizeToolList(value: string[] | undefined): string[] | undefined {
-  if (!Array.isArray(value)) return undefined
-  const seen = new Set<string>()
-  const tools: string[] = []
-  for (const entry of value) {
-    const tool = typeof entry === 'string' ? entry.trim() : ''
-    if (!tool || seen.has(tool)) continue
-    seen.add(tool)
-    tools.push(tool)
-  }
-  return tools.length > 0 ? tools : undefined
-}
-
 function applyRuntimeMessageToolPolicy(params: Record<string, unknown>, opts: OpenClawAgentTurnOptions): void {
   if (opts.toolsMode === 'none' || opts.toolsMode === 'auto') params.toolsMode = opts.toolsMode
   const toolsAllow = normalizeToolList(opts.toolsAllow)
   const toolsDeny = normalizeToolList(opts.toolsDeny)
   if (toolsAllow) params.toolsAllow = toolsAllow
   if (toolsDeny) params.toolsDeny = toolsDeny
-}
-
-function extractOpenClawAgentText(value: unknown): string {
-  const parsed = typeof value === 'string' ? parseJsonObject(value.trim()) ?? value.trim() : value
-  if (!parsed) return ''
-  if (typeof parsed === 'string') return parsed
-
-  const finalVisible = getJsonPath(parsed, ['result', 'meta', 'finalAssistantVisibleText'])
-  if (typeof finalVisible === 'string') return finalVisible
-  const finalRaw = getJsonPath(parsed, ['result', 'meta', 'finalAssistantRawText'])
-  if (typeof finalRaw === 'string') return finalRaw
-  const payloads = getJsonPath(parsed, ['result', 'payloads'])
-  if (Array.isArray(payloads)) {
-    return payloads
-      .map((payload) => isPlainObject(payload) && typeof payload.text === 'string' ? payload.text : '')
-      .filter(Boolean)
-      .join('\n\n')
-  }
-  const summary = getJsonPath(parsed, ['summary'])
-  return typeof summary === 'string' ? summary : ''
 }
 
 /**
@@ -1468,23 +1427,6 @@ function extractOpenClawAgentText(value: unknown): string {
  * avoid provider-id-string mismatches against the pricing catalog. Returns
  * undefined when no token counts are present (never fabricated).
  */
-function extractOpenClawAgentUsage(value: unknown): MessageUsage | undefined {
-  const parsed = typeof value === 'string' ? parseJsonObject(value.trim()) : value
-  if (!parsed) return undefined
-  const usage = getJsonPath(parsed, ['result', 'meta', 'agentMeta', 'usage'])
-  if (!isPlainObject(usage)) return undefined
-  const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined)
-  const out: MessageUsage = {}
-  const input = num(usage.input); if (input !== undefined) out.input = input
-  const output = num(usage.output); if (output !== undefined) out.output = output
-  const total = num(usage.total); if (total !== undefined) out.total = total
-  const cacheRead = num(usage.cacheRead); if (cacheRead !== undefined) out.cacheRead = cacheRead
-  const cacheWrite = num(usage.cacheWrite); if (cacheWrite !== undefined) out.cacheWrite = cacheWrite
-  // Require the input/output split for the result to be priceable. A
-  // total-only block isn't — returning it would short-circuit the trajectory
-  // fallback (which may carry the split), leaving the turn unmetered.
-  return out.input !== undefined || out.output !== undefined ? out : undefined
-}
 
 function mergeSettings(raw: Record<string, unknown> | undefined): OpenClawSettings {
   const input = (raw ?? {}) as Partial<OpenClawSettings>

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -110,7 +110,25 @@ pre-existing duplicate — WS6 workflows-split dedup territory; noted there.)
     ordering, so it gets its own commit + boot smoke, mirroring the dispatch dedup cadence). Plus the physical
     **move out of src/lib** (churns 55 importers + 40 mock paths — mechanical, separate).
 - server.split — ☐ (router-table + boot.ts; search-startup/recovery already extracted; HOLD until the dispatch
-  live-test passes — it stresses the same boot/router surface)   runtime.split — ☐ (adapter, 3,188 lines)
+  live-test passes — it stresses the same boot/router surface)
+- runtime.split — ☑ **DONE** (adapter, 3,188 → 1,560, 51%, across 10 stacked PRs #551–#560). Barrel-preserving:
+  the class `OpenClawRuntimeAdapter` + the test seams (`mergeChatStreams`, the `__*ForTest` session-cache exports +
+  `SESSION_STORE_CACHE_MAX`) stay exported from runtime.ts; every sibling imports the shared leaf module, never the
+  barrel, so no cycle. Extracted modules (in dependency order): `runtime-utils.ts` (shared JSON/object/string leaves
+  — the foundation), `errors.ts` (CLI command-failure helpers, folded into the existing error module), `cron-store.ts`
+  (the `.cron` persistence/parse layer — rig-E2E'd against real OpenClaw: native cron created via CLI → parsed through
+  Bakin's list → removed → re-parse confirmed), `activity-summary.ts` (transcript→ChatChunk + tool-call summarizers;
+  also relocated the `parseJsonObject` leaf into runtime-utils), `image-inference.ts` (image arg/parse helpers),
+  `approval-helpers.ts` (pure approval converters + their constants), `session-activity.ts` (session transcript reader +
+  the `sessionStoreCache` LRU cell + re-exported test seams), `agent-config.ts` (openclaw.json agent/workspace mutators +
+  config writer + identity parsers), `channel-helpers.ts` (channel registry + messaging + delivery parsing + the
+  channel-coupled approval notice), `agent-turn.ts` (prompt build + tool-list + turn-result extraction). Each PR: pure
+  byte-for-byte relocation, verified typecheck/eslint/adapter-suite 115-0 (--isolate)/full-suite 5124-0/binary build
+  (stamps reverted)/boot smoke; cron additionally dockerized-rig E2E'd. Two type-coupled glue fns stay on the adapter
+  (`gatewayWebSocketUrl` ← OpenClawSettings, `applyRuntimeMessageToolPolicy` ← OpenClawAgentTurnOptions). DEFERRED
+  (behavior-touching, NOT taken): the cross-package `deepMerge` dedup with core/settings.ts; the settings/binary
+  resolver extraction (would relocate the class-central OpenClawSettings type); the Tier-3 capability-subclass refactor
+  of the facade itself. What remains in runtime.ts is the irreducible capability facade + class-central types.
 
 ## WS7 — tooling
 


### PR DESCRIPTION
Tenth (final) cut of the `runtime.ts` god-file split (WS5). **Stacked on #559.**

## What changed
Moves the 5 pure agent-turn I/O helpers into a new `agent-turn.ts`: `messagesToOpenClawPrompt` (message-list → CLI prompt), `normalizeToolList` (tool allow-list dedup), `oversizedOutputBytesFrom`, and `extractOpenClawAgentText` / `extractOpenClawAgentUsage` (assistant text + token usage out of the gateway/CLI turn response).

`applyRuntimeMessageToolPolicy` **stays** on the adapter — it's typed against `OpenClawAgentTurnOptions` (class-central, 8 uses, depends on `MessageArgs`); it imports `normalizeToolList` back. The class's turn methods import back all 5.

## Scope
Pure relocation — bodies byte-for-byte unchanged. `runtime.ts`: **1,618 → 1,560.**

## Completes the runtime.ts split
**3,188 → 1,560 (51%)** across 10 stacked PRs (#551–#560) into 10 cohesive sibling modules: `runtime-utils`, `errors`, `cron-store`, `activity-summary`, `image-inference`, `approval-helpers`, `session-activity`, `agent-config`, `channel-helpers`, `agent-turn`.

What remains is the `OpenClawRuntimeAdapter` capability facade + its class-central types (`OpenClawSettings`, `OpenClawAgentTurnOptions`) + the two type-coupled glue fns (`gatewayWebSocketUrl`, `applyRuntimeMessageToolPolicy`) + the settings/binary resolver. The capability-subclass refactor of the facade itself is behavior-touching (Tier 3) and deliberately not taken.

## Verification
- typecheck ✓ · eslint (changed files) ✓ · adapter suite **115-0** (`--isolate`) ✓ · full suite **5124-0** ✓ · build ✓ (stamps reverted) · boot smoke (adapter loads, schedule activates, list route 200) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)