### PR TITLE
Manual-test batch: dev start, team sync UX, resizable split panes, channel delivery + perms

### DIFF
--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -51,6 +51,8 @@ export { toast } from '@/hooks/use-toast'
 export { useToastStore } from '@/hooks/use-toast'
 /** Imperatively resize a vertical pane via mouse drag handle. */
 export { useVerticalResize } from '@/hooks/use-vertical-resize'
+/** Resize a side-by-side split pane by dragging the divider between columns. */
+export { useHorizontalResize } from '@/hooks/use-horizontal-resize'
 
 // Group 2: Agent data (from team plugin)
 

--- a/plugins/assets/lib/asset-mutations.ts
+++ b/plugins/assets/lib/asset-mutations.ts
@@ -238,6 +238,13 @@ export interface AssetExportInput {
   width: number
   height: number
   quality?: number
+  /**
+   * Resize strategy. 'cover' (default) crops to exactly width×height — right for
+   * fixed-aspect surface profiles. 'inside' scales down to fit within the
+   * width×height box preserving aspect ratio and never upscaling — right for a
+   * delivery-friendly copy that must stay recognizable (e.g. channel uploads).
+   */
+  fit?: 'cover' | 'inside'
 }
 
 const EXPORT_FORMATS = new Set(['jpg', 'png', 'webp'])
@@ -279,7 +286,10 @@ export async function addExport(assetId: string, input: AssetExportInput): Promi
 
     const sharp = await loadSharp()
     if (!sharp) throw new Error('Image export requires sharp, but the native sharp package is unavailable for this runtime')
-    let pipeline = sharp(join(dirAbs, src.file)).resize(input.width, input.height, { fit: 'cover' })
+    const resizeOpts = input.fit === 'inside'
+      ? { fit: 'inside' as const, withoutEnlargement: true }
+      : { fit: 'cover' as const }
+    let pipeline = sharp(join(dirAbs, src.file)).resize(input.width, input.height, resizeOpts)
     if (input.format === 'jpg') pipeline = pipeline.jpeg({ quality: input.quality ?? 82 })
     else if (input.format === 'png') pipeline = pipeline.png()
     else pipeline = pipeline.webp({ quality: input.quality ?? 82 })

--- a/plugins/team/components/package-card.tsx
+++ b/plugins/team/components/package-card.tsx
@@ -18,7 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@makinbakin/sdk/ui'
-import { useAgentStore, useMainAgentId, useRouter } from '@makinbakin/sdk/hooks'
+import { toast, useAgentStore, useMainAgentId, useRouter } from '@makinbakin/sdk/hooks'
 import { PackageStateBadge } from './package-state-badge'
 import { AdoptDialog } from './adopt-dialog'
 import type { PackageStateRow } from '../types'
@@ -159,8 +159,11 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
         skipped.length > 0 ? `${skipped.length} user-edited file(s) preserved (reclaim to overwrite).` : null,
         `Verification: ${receipt.verification?.status ?? 'unknown'}.`,
       ].filter(Boolean)
-      setActionMessage(parts.join(' '))
       await refreshPackageStates()
+      // Sync succeeded: surface the receipt as a toast and auto-close the
+      // dialog. Errors keep the dialog open (actionError is shown inline).
+      toast(parts.join(' '), 'success')
+      setUpdateOpen(false)
     } catch (err) {
       setActionError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -363,8 +366,9 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
             <Button variant="outline" onClick={() => setUpdateOpen(false)}>
               Close
             </Button>
-            <Button variant="info" disabled={actionBusy || Boolean(actionMessage)} onClick={() => syncPackage()}>
-              Sync agent
+            <Button variant="info" disabled={actionBusy || Boolean(actionMessage)} onClick={() => syncPackage()} className="gap-1.5">
+              {actionBusy && <RefreshCw className="h-3.5 w-3.5 animate-spin" />}
+              {actionBusy ? 'Syncing…' : 'Sync agent'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -36,9 +36,11 @@ function parseDevOptions(args: string[]): DevOptions {
 }
 
 const DEV_OPTIONS = parseDevOptions(process.argv.slice(2))
-// scripts/dev.ts runs server.ts in-process. Consume dev-only flags here so
-// server.ts's CLI dispatcher sees the same argv shape as plain `bakin start`.
-process.argv.splice(2)
+// scripts/dev.ts runs server.ts in-process. Consume dev-only flags here and
+// hand the CLI dispatcher an explicit `serve` command so it boots the server
+// in the foreground. A bare argv now defaults to `help` (cli.ts), which would
+// print the command reference and exit instead of starting the dev server.
+process.argv.splice(2, Infinity, 'serve')
 const DEV_VERBOSE = DEV_OPTIONS.verbose
   || process.env.BAKIN_DEV_VERBOSE === '1'
   || process.env.BAKIN_CONSOLE_FORMAT === 'verbose'

--- a/scripts/lib/post-channel.ts
+++ b/scripts/lib/post-channel.ts
@@ -3,14 +3,14 @@
  */
 import { z } from 'zod'
 import { createHash } from 'crypto'
-import { existsSync } from 'fs'
-import { basename, extname } from 'path'
+import { existsSync, statSync } from 'fs'
+import { basename, dirname, extname, join } from 'path'
 import { getAppServices } from '@/core/app-services'
 import { getIdempotent, putIdempotent, LedgerUnavailableError } from '@/core/execution-ledger'
 import { createLogger } from '@/core/logger'
 import { resolveRuntimeChannelRef } from '@/core/channel-aliases'
 import { assertWorkflowToolAllowed } from '@/core/workflow-tool-authorization'
-import { resolveFile } from '@bakin/assets/lib/asset-service'
+import { addExport, getAsset, resolveFile } from '@bakin/assets/lib/asset-service'
 import { succeed, fail } from './common'
 import { addExecTool } from '../../src/core/exec-tools/registry'
 import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
@@ -36,6 +36,67 @@ function resolveAssetAbsPath(assetId: string | undefined): string | null {
   if (!assetId) return null
   const ref = resolveFile(assetId)
   return ref && existsSync(ref.absPath) ? ref.absPath : null
+}
+
+// A channel attachment over this size is delivered as a downscaled export
+// rather than the raw version, so agents never need to hand-roll a second,
+// smaller asset (which clutters the asset list). Conservative vs Discord's
+// per-upload limit; the export is derived (lives in the asset's exports/),
+// never a new top-level asset.
+const CHANNEL_ATTACHMENT_LIMIT_BYTES = 8 * 1024 * 1024
+const DELIVERY_EXPORT_SURFACE = 'channel-delivery'
+const DELIVERY_EXPORT_MAX_DIM = 2048
+const RESIZABLE_IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp'])
+
+/**
+ * Resolve the file to actually attach for an image asset. Small images and
+ * non-image assets are sent as-is; an oversized image is delivered as a
+ * derived, aspect-preserving export (idempotent per surface) instead of the
+ * raw version — so a channel-friendly copy is an export of the original, not a
+ * separate asset.
+ */
+async function resolveImageDeliveryFile(assetId: string | undefined): Promise<string | null> {
+  if (!assetId) return null
+  const ref = resolveFile(assetId)
+  if (!ref || !existsSync(ref.absPath)) return null
+  if (!RESIZABLE_IMAGE_EXTS.has(extname(ref.absPath).toLowerCase())) return ref.absPath
+
+  let size = 0
+  try {
+    size = statSync(ref.absPath).size
+  } catch {
+    return ref.absPath
+  }
+  if (size <= CHANNEL_ATTACHMENT_LIMIT_BYTES) return ref.absPath
+
+  try {
+    const manifest = getAsset(assetId)
+    const assetDir = dirname(ref.absPath)
+    // Reuse a fresh export for the current version if one is already small enough.
+    const fresh = manifest?.exports.find(
+      (e) => e.name === DELIVERY_EXPORT_SURFACE && e.fromVersion === manifest.currentVersion,
+    )
+    if (fresh) {
+      const freshAbs = join(assetDir, fresh.file)
+      if (existsSync(freshAbs) && statSync(freshAbs).size <= CHANNEL_ATTACHMENT_LIMIT_BYTES) return freshAbs
+    }
+    const { file } = await addExport(assetId, {
+      surface: DELIVERY_EXPORT_SURFACE,
+      format: 'jpg',
+      width: DELIVERY_EXPORT_MAX_DIM,
+      height: DELIVERY_EXPORT_MAX_DIM,
+      fit: 'inside',
+      quality: 82,
+    })
+    const exportAbs = join(assetDir, file)
+    return existsSync(exportAbs) ? exportAbs : ref.absPath
+  } catch (err) {
+    log.warn('Failed to derive channel-delivery export; sending original', {
+      assetId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return ref.absPath
+  }
 }
 
 // When BAKIN_CHANNEL_TEST_MODE=1 (or "true"), all posts are routed to
@@ -75,7 +136,7 @@ export async function postChannel(
   const { content, imageAssetId, videoAssetId, embed, taskId } = params
 
   const files = [
-    filePayload(imageAssetId, resolveAssetAbsPath(imageAssetId)),
+    filePayload(imageAssetId, await resolveImageDeliveryFile(imageAssetId)),
     filePayload(videoAssetId, resolveAssetAbsPath(videoAssetId)),
   ].filter((file): file is { name: string; path: string } => Boolean(file))
 
@@ -305,12 +366,12 @@ function filePayload(assetId: string | undefined, path: string | null): { name: 
 addExecTool({
   name: 'bakin_exec_post_channel',
   label: 'Posted to channel',
-  description: 'Post a message through the active runtime channel adapter. Supports image/video attachments when the adapter supports rich content.',
+  description: 'Post a message through the active runtime channel adapter. Supports image/video attachments when the adapter supports rich content. Oversized images are downscaled automatically for the channel (as a derived export of the same asset) — pass the original asset id; do NOT create a separate, smaller asset just to post it.',
   source: 'core',
   parameters: {
     channel: z.string().describe('Channel name or runtime channel target'),
     content: z.string().describe('Message text / caption'),
-    imageAssetId: z.string().optional().describe('Asset id of an image to attach (current version is sent).'),
+    imageAssetId: z.string().optional().describe('Asset id of an image to attach. The current version is sent, or an auto-downscaled export if it exceeds the channel attachment limit (no separate asset is created).'),
     videoAssetId: z.string().optional().describe('Asset id of a video to attach (current version is sent).'),
     embed: z.record(z.string(), z.unknown()).optional().describe('Optional rich metadata for adapters that support it'),
     taskId: z.string().optional().describe('Task ID for audit trail'),

--- a/src/components/integrated-brainstorm/index.tsx
+++ b/src/components/integrated-brainstorm/index.tsx
@@ -140,8 +140,6 @@ export function IntegratedBrainstorm({
       {isOpen && !fitParent && (
         <div
           {...handleProps}
-          role="separator"
-          aria-orientation="horizontal"
           aria-label="Resize brainstorm panel"
           className="absolute inset-x-0 top-0 h-1.5 -translate-y-1/2 cursor-row-resize hover:bg-accent/50 active:bg-accent transition-colors z-10"
           data-testid="resize-handle"

--- a/src/core/exec-tools/registry.ts
+++ b/src/core/exec-tools/registry.ts
@@ -22,6 +22,7 @@ import {
   createPluginTaskService,
 } from '../../lib/plugin-context-services'
 import { wrapPluginContextPermissions } from '../../lib/plugin-permissions'
+import { PermissionSchema } from '@bakin/core/plugins/permissions'
 
 // ---------------------------------------------------------------------------
 // Registry state
@@ -148,7 +149,14 @@ export function getToolContext(toolName: string): PluginToolContext | undefined 
   return wrapPluginContextPermissions(ctx, {
     pluginId,
     source: state?.source ?? (pluginId === 'core' ? 'core' : 'user'),
-    manifestPermissions: state?.manifest?.permissions ?? [],
+    // The bare `core` exec-tool context (post-channel, etc.) is trusted
+    // first-party code with no manifest. Grant it the full permission set so
+    // core tools using runtime.channels and friends don't trip the
+    // permission_missing warning on every call. The 10 core PLUGINS keep their
+    // own declared (and gated) manifest permissions.
+    manifestPermissions: pluginId === 'core'
+      ? [...PermissionSchema.options]
+      : state?.manifest?.permissions ?? [],
   })
 }
 

--- a/src/hooks/use-horizontal-resize.ts
+++ b/src/hooks/use-horizontal-resize.ts
@@ -1,0 +1,36 @@
+'use client'
+
+import { useResizablePane, type ResizeHandleProps } from './use-resizable-pane'
+
+interface Options {
+  defaultWidth: number
+  minWidth: number
+  maxWidth: number
+  /** When set, width is persisted in localStorage under `bakin-hresize:${storageKey}`. */
+  storageKey?: string
+}
+
+interface Return {
+  width: number
+  setWidth: (w: number) => void
+  handleProps: ResizeHandleProps
+}
+
+/**
+ * Resize a right-anchored panel by dragging its left edge. The handle lives at
+ * the left of the element; dragging left grows the panel, dragging right
+ * shrinks it. Keyboard: ArrowLeft/ArrowRight (Shift for a larger step). The
+ * companion to {@link useVerticalResize} for side-by-side split panes; both are
+ * thin wrappers over {@link useResizablePane}.
+ */
+export function useHorizontalResize({ defaultWidth, minWidth, maxWidth, storageKey }: Options): Return {
+  const { size, setSize, handleProps } = useResizablePane({
+    axis: 'x',
+    defaultSize: defaultWidth,
+    minSize: minWidth,
+    maxSize: maxWidth,
+    storageKey,
+    storagePrefix: 'bakin-hresize:',
+  })
+  return { width: size, setWidth: setSize, handleProps }
+}

--- a/src/hooks/use-resizable-pane.ts
+++ b/src/hooks/use-resizable-pane.ts
@@ -1,0 +1,183 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Shared core for the two split-pane resize hooks. A pane is anchored to the
+ * trailing edge (bottom for 'y', right for 'x') and resized by dragging the
+ * divider on its leading edge — dragging toward that edge (up / left) grows it.
+ * {@link useVerticalResize} and {@link useHorizontalResize} are thin wrappers;
+ * keep all drag / persistence / a11y logic here so it lives in exactly one place.
+ */
+export type ResizeAxis = 'x' | 'y'
+
+interface CoreOptions {
+  axis: ResizeAxis
+  defaultSize: number
+  minSize: number
+  maxSize: number
+  /** localStorage key suffix; persisted under `${storagePrefix}${storageKey}`. */
+  storageKey?: string
+  storagePrefix: string
+}
+
+export interface ResizeHandleProps {
+  role: 'separator'
+  tabIndex: 0
+  'aria-orientation': 'horizontal' | 'vertical'
+  'aria-valuenow': number
+  'aria-valuemin': number
+  'aria-valuemax': number
+  onMouseDown: (e: React.MouseEvent) => void
+  onTouchStart: (e: React.TouchEvent) => void
+  onKeyDown: (e: React.KeyboardEvent) => void
+}
+
+export interface ResizablePane {
+  size: number
+  setSize: (n: number) => void
+  handleProps: ResizeHandleProps
+}
+
+const KEY_STEP = 16
+const KEY_STEP_LARGE = 64
+
+function clamp(n: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, n))
+}
+
+function readStored(def: number, min: number, max: number, prefix: string, storageKey?: string): number {
+  if (!storageKey || typeof window === 'undefined') return clamp(def, min, max)
+  try {
+    const raw = window.localStorage.getItem(prefix + storageKey)
+    if (!raw) return clamp(def, min, max)
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) ? clamp(parsed, min, max) : clamp(def, min, max)
+  } catch (err) {
+    console.error('useResizablePane: failed to read stored size', err)
+    return clamp(def, min, max)
+  }
+}
+
+export function useResizablePane({ axis, defaultSize, minSize, maxSize, storageKey, storagePrefix }: CoreOptions): ResizablePane {
+  const [size, setSizeState] = useState(() => readStored(defaultSize, minSize, maxSize, storagePrefix, storageKey))
+  // sizeRef mirrors the latest size and is kept current at every mutation site
+  // (setSize, onMove, the re-clamp effect), so drag handlers read it without a
+  // dependency on the render cycle and without a separate ref-sync effect.
+  const sizeRef = useRef(size)
+  const dragging = useRef(false)
+  const dragStart = useRef(0)
+  const dragStartSize = useRef(0)
+
+  const persist = useCallback((n: number) => {
+    if (!storageKey || typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(storagePrefix + storageKey, String(clamp(n, minSize, maxSize)))
+    } catch (err) {
+      console.error('useResizablePane: failed to persist size', err)
+    }
+  }, [storageKey, storagePrefix, minSize, maxSize])
+
+  const setSize = useCallback((n: number) => {
+    const next = clamp(n, minSize, maxSize)
+    sizeRef.current = next
+    setSizeState(next)
+    persist(next)
+  }, [minSize, maxSize, persist])
+
+  // Re-clamp the live size if the bounds tighten between renders (e.g. a
+  // consumer drives min/max responsively). Only fires when bounds change.
+  useEffect(() => {
+    const clamped = clamp(sizeRef.current, minSize, maxSize)
+    if (clamped !== sizeRef.current) setSize(clamped)
+  }, [minSize, maxSize, setSize])
+
+  const beginDrag = useCallback((client: number) => {
+    dragging.current = true
+    dragStart.current = client
+    dragStartSize.current = sizeRef.current
+  }, [])
+
+  const onMove = useCallback((client: number) => {
+    if (!dragging.current) return
+    // Dragging toward the leading edge (up / left) grows the pane.
+    const delta = dragStart.current - client
+    const next = clamp(dragStartSize.current + delta, minSize, maxSize)
+    sizeRef.current = next
+    setSizeState(next)
+  }, [minSize, maxSize])
+
+  const endDrag = useCallback(() => {
+    if (!dragging.current) return
+    dragging.current = false
+    persist(sizeRef.current)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }, [persist])
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    beginDrag(axis === 'x' ? e.clientX : e.clientY)
+    const move = (ev: MouseEvent) => onMove(axis === 'x' ? ev.clientX : ev.clientY)
+    const up = () => {
+      document.removeEventListener('mousemove', move)
+      document.removeEventListener('mouseup', up)
+      endDrag()
+    }
+    document.addEventListener('mousemove', move)
+    document.addEventListener('mouseup', up)
+    document.body.style.cursor = axis === 'x' ? 'col-resize' : 'row-resize'
+    document.body.style.userSelect = 'none'
+  }, [axis, beginDrag, onMove, endDrag])
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0]
+    if (!touch) return
+    beginDrag(axis === 'x' ? touch.clientX : touch.clientY)
+    const move = (ev: TouchEvent) => {
+      const t = ev.touches[0]
+      if (!t) return
+      // Suppress the page scroll/rubber-band so the drag actually resizes.
+      // Requires the listener below to be registered with { passive: false }.
+      ev.preventDefault()
+      onMove(axis === 'x' ? t.clientX : t.clientY)
+    }
+    const up = () => {
+      document.removeEventListener('touchmove', move)
+      document.removeEventListener('touchend', up)
+      document.removeEventListener('touchcancel', up)
+      endDrag()
+    }
+    document.addEventListener('touchmove', move, { passive: false })
+    document.addEventListener('touchend', up)
+    document.addEventListener('touchcancel', up)
+  }, [axis, beginDrag, onMove, endDrag])
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const growKey = axis === 'x' ? 'ArrowLeft' : 'ArrowUp'
+    const shrinkKey = axis === 'x' ? 'ArrowRight' : 'ArrowDown'
+    let dir = 0
+    if (e.key === growKey) dir = 1
+    else if (e.key === shrinkKey) dir = -1
+    else return
+    e.preventDefault()
+    const step = e.shiftKey ? KEY_STEP_LARGE : KEY_STEP
+    setSize(sizeRef.current + dir * step)
+  }, [axis, setSize])
+
+  return {
+    size,
+    setSize,
+    handleProps: {
+      role: 'separator',
+      tabIndex: 0,
+      'aria-orientation': axis === 'x' ? 'vertical' : 'horizontal',
+      'aria-valuenow': size,
+      'aria-valuemin': minSize,
+      'aria-valuemax': maxSize,
+      onMouseDown,
+      onTouchStart,
+      onKeyDown,
+    },
+  }
+}

--- a/src/hooks/use-vertical-resize.ts
+++ b/src/hooks/use-vertical-resize.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useResizablePane, type ResizeHandleProps } from './use-resizable-pane'
 
 interface Options {
   defaultHeight: number
@@ -10,125 +10,26 @@ interface Options {
   storageKey?: string
 }
 
-interface HandleProps {
-  onMouseDown: (e: React.MouseEvent) => void
-  onTouchStart: (e: React.TouchEvent) => void
-}
-
 interface Return {
   height: number
   setHeight: (h: number) => void
-  handleProps: HandleProps
-}
-
-const STORAGE_PREFIX = 'bakin-vresize:'
-
-function clamp(n: number, min: number, max: number) {
-  return Math.min(max, Math.max(min, n))
-}
-
-function readStored(defaultHeight: number, min: number, max: number, storageKey?: string): number {
-  if (!storageKey || typeof window === 'undefined') return clamp(defaultHeight, min, max)
-  try {
-    const raw = window.localStorage.getItem(STORAGE_PREFIX + storageKey)
-    if (!raw) return clamp(defaultHeight, min, max)
-    const parsed = Number.parseInt(raw, 10)
-    return Number.isFinite(parsed) ? clamp(parsed, min, max) : clamp(defaultHeight, min, max)
-  } catch {
-    return clamp(defaultHeight, min, max)
-  }
+  handleProps: ResizeHandleProps
 }
 
 /**
- * Resize a panel by dragging its top edge. The handle lives at the top of the
- * element; dragging upward grows the panel, dragging downward shrinks it.
+ * Resize a bottom-anchored panel by dragging its top edge. The handle lives at
+ * the top of the element; dragging upward grows the panel, dragging downward
+ * shrinks it. Keyboard: ArrowUp/ArrowDown (Shift for a larger step). Thin
+ * wrapper over {@link useResizablePane}.
  */
 export function useVerticalResize({ defaultHeight, minHeight, maxHeight, storageKey }: Options): Return {
-  const [height, setHeightState] = useState(() => readStored(defaultHeight, minHeight, maxHeight, storageKey))
-  const heightRef = useRef(height)
-  const dragging = useRef(false)
-  const startY = useRef(0)
-  const startHeight = useRef(0)
-
-  useEffect(() => {
-    heightRef.current = height
-  }, [height])
-
-  const persist = useCallback((h: number) => {
-    if (!storageKey || typeof window === 'undefined') return
-    try {
-      window.localStorage.setItem(STORAGE_PREFIX + storageKey, String(clamp(h, minHeight, maxHeight)))
-    } catch {
-      // ignore storage failures
-    }
-  }, [storageKey, minHeight, maxHeight])
-
-  const setHeight = useCallback((h: number) => {
-    const next = clamp(h, minHeight, maxHeight)
-    heightRef.current = next
-    setHeightState(next)
-    persist(next)
-  }, [minHeight, maxHeight, persist])
-
-  const beginDrag = useCallback((clientY: number) => {
-    dragging.current = true
-    startY.current = clientY
-    startHeight.current = heightRef.current
-  }, [])
-
-  const onMove = useCallback((clientY: number) => {
-    if (!dragging.current) return
-    const delta = startY.current - clientY
-    const next = clamp(startHeight.current + delta, minHeight, maxHeight)
-    heightRef.current = next
-    setHeightState(next)
-  }, [minHeight, maxHeight])
-
-  const endDrag = useCallback(() => {
-    if (!dragging.current) return
-    dragging.current = false
-    persist(heightRef.current)
-    document.body.style.cursor = ''
-    document.body.style.userSelect = ''
-  }, [persist])
-
-  const onMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    beginDrag(e.clientY)
-    const move = (ev: MouseEvent) => onMove(ev.clientY)
-    const up = () => {
-      document.removeEventListener('mousemove', move)
-      document.removeEventListener('mouseup', up)
-      endDrag()
-    }
-    document.addEventListener('mousemove', move)
-    document.addEventListener('mouseup', up)
-    document.body.style.cursor = 'row-resize'
-    document.body.style.userSelect = 'none'
-  }, [beginDrag, onMove, endDrag])
-
-  const onTouchStart = useCallback((e: React.TouchEvent) => {
-    const touch = e.touches[0]
-    if (!touch) return
-    beginDrag(touch.clientY)
-    const move = (ev: TouchEvent) => {
-      const t = ev.touches[0]
-      if (t) onMove(t.clientY)
-    }
-    const up = () => {
-      document.removeEventListener('touchmove', move)
-      document.removeEventListener('touchend', up)
-      document.removeEventListener('touchcancel', up)
-      endDrag()
-    }
-    document.addEventListener('touchmove', move)
-    document.addEventListener('touchend', up)
-    document.addEventListener('touchcancel', up)
-  }, [beginDrag, onMove, endDrag])
-
-  return {
-    height,
-    setHeight,
-    handleProps: { onMouseDown, onTouchStart },
-  }
+  const { size, setSize, handleProps } = useResizablePane({
+    axis: 'y',
+    defaultSize: defaultHeight,
+    minSize: minHeight,
+    maxSize: maxHeight,
+    storageKey,
+    storagePrefix: 'bakin-vresize:',
+  })
+  return { height: size, setHeight: setSize, handleProps }
 }

--- a/tests/plugins/assets/asset-lifecycle.test.ts
+++ b/tests/plugins/assets/asset-lifecycle.test.ts
@@ -33,6 +33,8 @@ beforeAll(async () => {
   mkdirSync(srcDir, { recursive: true })
   await png('a.png', 10)
   await png('b.png', 20)
+  // A wide 4:1 source for exercising export fit modes.
+  await sharp({ create: { width: 40, height: 10, channels: 3, background: { r: 0, g: 0, b: 255 } } }).png().toFile(join(srcDir, 'wide.png'))
 })
 
 afterAll(() => rmSync(testDir, { recursive: true, force: true }))
@@ -110,6 +112,24 @@ describe('addExport', () => {
     // Different surface → second export.
     await addExport(assetId, { surface: 'square', format: 'jpg', width: 60, height: 60 })
     expect(getAsset(assetId)!.exports).toHaveLength(2)
+  })
+
+  it("fit:'inside' preserves aspect ratio (no crop); default 'cover' fills the box", async () => {
+    const { assetId } = await createAsset({
+      sourceFilePath: join(srcDir, 'wide.png'), type: 'images', agent: 'pixel', taskId: 't1',
+      slug: 'wide', op: 'generate', description: 'wide',
+    })
+    const exportPath = (surface: string, fmt: string) => join(testDir, assetDirRelPath(assetId)!, 'exports', `${surface}.${fmt}`)
+
+    // Default 'cover' crops the 4:1 source to exactly the box.
+    await addExport(assetId, { surface: 'cover-box', format: 'png', width: 20, height: 20 })
+    const cover = await sharp(exportPath('cover-box', 'png')).metadata()
+    expect([cover.width, cover.height]).toEqual([20, 20])
+
+    // 'inside' scales the 4:1 source to fit within the box, preserving aspect (20x5), no crop.
+    await addExport(assetId, { surface: 'inside-box', format: 'png', width: 20, height: 20, fit: 'inside' })
+    const inside = await sharp(exportPath('inside-box', 'png')).metadata()
+    expect([inside.width, inside.height]).toEqual([20, 5])
   })
 
   it('rejects unsafe format/dimensions/quality before touching disk', async () => {


### PR DESCRIPTION
A batch of fixes and improvements found during end-to-end manual testing.

## Changes

**`fix(dev)`** — `bakin dev` now starts the server instead of printing the command reference. `scripts/dev.ts` was leaving an empty argv, which a recent CLI change defaults to `help`; it now hands the dispatcher an explicit `serve`.

**`fix(team)`** — the agent-package **Sync** dialog auto-closes on success (with a receipt toast) and shows a spinner / "Syncing…" while the request is in flight.

**`feat(sdk)`** — adds `useHorizontalResize` for side-by-side split panes and factors it + the existing `useVerticalResize` onto one parameterized core, `useResizablePane`. The core fixes latent issues (touch drag now uses `{ passive: false }` + `preventDefault`; handles carry a full separator a11y contract — `role`, `tabIndex`, `aria-orientation`, `aria-value*`, Arrow-key `onKeyDown`; re-clamps on bounds change; logs storage failures). _Companion consumer changes (projects/brainstorm dividers) live in a separate `bakin-bits-official` branch._

**`fix(core)`** — the bare `core` exec-tool context (e.g. `post-channel`) was built with an empty manifest and got zero permissions, tripping a `permission_missing` warning on every `runtime.channels` call. Core is trusted first-party code; it now gets the full permission set. The 10 real core plugins keep their declared, gated permissions.

**`feat(channels)`** — oversized images posted via `bakin_exec_post_channel` are now delivered as an **aspect-preserving derived export** of the same asset (in `exports/`), instead of an agent hand-rolling a second top-level asset that clutters the list. Adds a `fit: 'inside'` mode to `addExport`; falls back to the original on any error.

## From the same E2E run — intentionally NOT fixed here (OpenClaw-side)
- **Channel `user` reply mismatch** (`Unknown channel: user`): the `user:<id>` ref is minted by OpenClaw's conversation metadata, not any Bakin/bits code. Real fix is in OpenClaw.
- **`Invalid Form Body`** on Discord image posts: the command Bakin built was well-formed; Discord rejected it downstream via the `openclaw` binary.

## Testing
- Targeted suites green across all touched areas (permissions, context factory, post-channel, asset lifecycle incl. new `fit` test, images tools, openclaw runtime-channels, integrated-brainstorm resize).
- `bakin dev` verified to boot (HTTP 200); dividers verified by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)