### PR TITLE
fix(build): regenerate embedded-asset manifest in production build (fixes broken rc.19 plugin load)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Build host shell
         run: bun run build:host-shell
 
+      - name: Regenerate embedded-asset manifest
+        run: bun run build:assets-manifest
+
       - name: Assert production browser assets
         run: bun run build:assert-production-assets
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "bun run scripts/dev.ts",
     "prebuild": "bun run scripts/stamp-version.ts",
-    "build": "bun run build:css && bun run build:vendors && bun run build:plugins && bun run build:host-shell && bun run build:assert-production-assets && bun run build:binary",
+    "build": "bun run build:css && bun run build:vendors && bun run build:plugins && bun run build:host-shell && bun run build:assets-manifest && bun run build:assert-production-assets && bun run build:binary",
     "release": "bun run scripts/prep-release.ts",
     "build:host": "bun run build:css && bun run build:vendors && bun run build:host-shell",
     "build:css": "tailwindcss -i ./packages/host/src/globals.css -o ./packages/host/public/globals.css",

--- a/packages/host/src/api/_embedded-assets-static.ts
+++ b/packages/host/src/api/_embedded-assets-static.ts
@@ -22,26 +22,26 @@ import asset_bakin_hop_svg from '../../public/bakin-hop.svg' with { type: 'file'
 import asset_globals_css from '../../public/globals.css' with { type: 'file' }
 import asset_vendor_sdk_ui_js from '../../public/vendor/sdk-ui.js' with { type: 'file' }
 import asset_vendor_sdk_routing_js from '../../public/vendor/sdk-routing.js' with { type: 'file' }
-import asset_vendor_sdk_shared_jqx186h0_js from '../../public/vendor/sdk-shared-jqx186h0.js' with { type: 'file' }
-import asset_vendor_sdk_shared_y4xh8btg_js from '../../public/vendor/sdk-shared-y4xh8btg.js' with { type: 'file' }
+import asset_vendor_sdk_shared_fyez9bx2_js from '../../public/vendor/sdk-shared-fyez9bx2.js' with { type: 'file' }
+import asset_vendor_sdk_shared_gvcnefty_js from '../../public/vendor/sdk-shared-gvcnefty.js' with { type: 'file' }
+import asset_vendor_sdk_shared_dmp8nd6q_js from '../../public/vendor/sdk-shared-dmp8nd6q.js' with { type: 'file' }
+import asset_vendor_sdk_shared_c6mff0tx_js from '../../public/vendor/sdk-shared-c6mff0tx.js' with { type: 'file' }
 import asset_vendor_react_js from '../../public/vendor/react.js' with { type: 'file' }
-import asset_vendor_sdk_shared_6sk01ks7_js from '../../public/vendor/sdk-shared-6sk01ks7.js' with { type: 'file' }
 import asset_vendor_sdk_shared_9tt7cds6_js from '../../public/vendor/sdk-shared-9tt7cds6.js' with { type: 'file' }
 import asset_vendor_jsx_runtime_js from '../../public/vendor/jsx-runtime.js' with { type: 'file' }
-import asset_vendor_sdk_shared_12gqk9dh_js from '../../public/vendor/sdk-shared-12gqk9dh.js' with { type: 'file' }
 import asset_vendor_sdk_utils_js from '../../public/vendor/sdk-utils.js' with { type: 'file' }
-import asset_vendor_sdk_shared_2ppyhbgt_js from '../../public/vendor/sdk-shared-2ppyhbgt.js' with { type: 'file' }
+import asset_vendor_sdk_shared_dhrr7ct7_js from '../../public/vendor/sdk-shared-dhrr7ct7.js' with { type: 'file' }
 import asset_vendor_sdk_types_js from '../../public/vendor/sdk-types.js' with { type: 'file' }
-import asset_vendor_sdk_shared_yw8cernp_js from '../../public/vendor/sdk-shared-yw8cernp.js' with { type: 'file' }
 import asset_vendor_react_dom_js from '../../public/vendor/react-dom.js' with { type: 'file' }
-import asset_vendor_sdk_shared_qrcrz8ww_js from '../../public/vendor/sdk-shared-qrcrz8ww.js' with { type: 'file' }
+import asset_vendor_sdk_shared_6k5png28_js from '../../public/vendor/sdk-shared-6k5png28.js' with { type: 'file' }
 import asset_vendor_sdk_index_js from '../../public/vendor/sdk-index.js' with { type: 'file' }
 import asset_vendor_sdk_slots_js from '../../public/vendor/sdk-slots.js' with { type: 'file' }
 import asset_vendor_sdk_metadata_js from '../../public/vendor/sdk-metadata.js' with { type: 'file' }
+import asset_vendor_sdk_shared_agfdj1z0_js from '../../public/vendor/sdk-shared-agfdj1z0.js' with { type: 'file' }
+import asset_vendor_sdk_shared_9f9xkp82_js from '../../public/vendor/sdk-shared-9f9xkp82.js' with { type: 'file' }
 import asset_vendor_sdk_components_js from '../../public/vendor/sdk-components.js' with { type: 'file' }
 import asset_vendor_sdk_hooks_js from '../../public/vendor/sdk-hooks.js' with { type: 'file' }
 import asset_vendor_tanstack_router_js from '../../public/vendor/tanstack-router.js' with { type: 'file' }
-import asset_vendor_sdk_shared_qxtzvns5_js from '../../public/vendor/sdk-shared-qxtzvns5.js' with { type: 'file' }
 import asset_vendor_jsx_dev_runtime_js from '../../public/vendor/jsx-dev-runtime.js' with { type: 'file' }
 import asset_api_plugins_schedule_assets_client_js from '../../../../plugins/schedule/dist/client.js' with { type: 'file' }
 import asset_api_plugins_tasks_assets_client_js from '../../../../plugins/tasks/dist/client.js' with { type: 'file' }
@@ -67,26 +67,26 @@ export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
   ['/globals.css', asset_globals_css],
   ['/vendor/sdk-ui.js', asset_vendor_sdk_ui_js],
   ['/vendor/sdk-routing.js', asset_vendor_sdk_routing_js],
-  ['/vendor/sdk-shared-jqx186h0.js', asset_vendor_sdk_shared_jqx186h0_js],
-  ['/vendor/sdk-shared-y4xh8btg.js', asset_vendor_sdk_shared_y4xh8btg_js],
+  ['/vendor/sdk-shared-fyez9bx2.js', asset_vendor_sdk_shared_fyez9bx2_js],
+  ['/vendor/sdk-shared-gvcnefty.js', asset_vendor_sdk_shared_gvcnefty_js],
+  ['/vendor/sdk-shared-dmp8nd6q.js', asset_vendor_sdk_shared_dmp8nd6q_js],
+  ['/vendor/sdk-shared-c6mff0tx.js', asset_vendor_sdk_shared_c6mff0tx_js],
   ['/vendor/react.js', asset_vendor_react_js],
-  ['/vendor/sdk-shared-6sk01ks7.js', asset_vendor_sdk_shared_6sk01ks7_js],
   ['/vendor/sdk-shared-9tt7cds6.js', asset_vendor_sdk_shared_9tt7cds6_js],
   ['/vendor/jsx-runtime.js', asset_vendor_jsx_runtime_js],
-  ['/vendor/sdk-shared-12gqk9dh.js', asset_vendor_sdk_shared_12gqk9dh_js],
   ['/vendor/sdk-utils.js', asset_vendor_sdk_utils_js],
-  ['/vendor/sdk-shared-2ppyhbgt.js', asset_vendor_sdk_shared_2ppyhbgt_js],
+  ['/vendor/sdk-shared-dhrr7ct7.js', asset_vendor_sdk_shared_dhrr7ct7_js],
   ['/vendor/sdk-types.js', asset_vendor_sdk_types_js],
-  ['/vendor/sdk-shared-yw8cernp.js', asset_vendor_sdk_shared_yw8cernp_js],
   ['/vendor/react-dom.js', asset_vendor_react_dom_js],
-  ['/vendor/sdk-shared-qrcrz8ww.js', asset_vendor_sdk_shared_qrcrz8ww_js],
+  ['/vendor/sdk-shared-6k5png28.js', asset_vendor_sdk_shared_6k5png28_js],
   ['/vendor/sdk-index.js', asset_vendor_sdk_index_js],
   ['/vendor/sdk-slots.js', asset_vendor_sdk_slots_js],
   ['/vendor/sdk-metadata.js', asset_vendor_sdk_metadata_js],
+  ['/vendor/sdk-shared-agfdj1z0.js', asset_vendor_sdk_shared_agfdj1z0_js],
+  ['/vendor/sdk-shared-9f9xkp82.js', asset_vendor_sdk_shared_9f9xkp82_js],
   ['/vendor/sdk-components.js', asset_vendor_sdk_components_js],
   ['/vendor/sdk-hooks.js', asset_vendor_sdk_hooks_js],
   ['/vendor/tanstack-router.js', asset_vendor_tanstack_router_js],
-  ['/vendor/sdk-shared-qxtzvns5.js', asset_vendor_sdk_shared_qxtzvns5_js],
   ['/vendor/jsx-dev-runtime.js', asset_vendor_jsx_dev_runtime_js],
   ['/api/plugins/schedule/assets/client.js', asset_api_plugins_schedule_assets_client_js],
   ['/api/plugins/tasks/assets/client.js', asset_api_plugins_tasks_assets_client_js],


### PR DESCRIPTION
## The bug
On a binary installed via `bakin update` (rc.19), every page errors:
> Plugin "tasks" failed to load — The requested module '@makinbakin/sdk/hooks' does not provide an export named 'usePluginEvent'

## Root cause
`packages/host/src/api/_embedded-assets-static.ts` is the manifest of which content-hashed vendor bundles get embedded in the binary. It must be regenerated whenever the SDK vendor bundles change — but **`bun run build` and `release.yml` never ran `generate-embedded-assets`; only `bun run dev` did.**

The SDK resize work in #577 changed the shared-chunk composition (new content hashes). The manifest wasn't regenerated, so rc.19 embedded the **old** chunk set while `build:vendors` produced **new** chunks. In the binary, `sdk-hooks.js` imports `./sdk-shared-<newhash>.js` which were never embedded → 404 → the module can't finish loading → its exports (`usePluginEvent`, etc.) are unavailable → every SDK-hooks-consuming plugin fails.

Verified: the released manifest was missing 5 of the 6 shared chunks `sdk-hooks.js` imports. It worked in dev because the dev loop regenerates the manifest on every start.

## Fix
1. Regenerate the committed manifest to match the current SDK bundles.
2. Add `build:assets-manifest` to the `build` chain and `release.yml` (after host-shell, before assert + binary) so the manifest is always regenerated from freshly-built vendors — staleness can't ship again. This mirrors what the dev loop already does.

## After merge
Cut a new release (rc.20). `bakin update` to it should load plugins cleanly.

## Notes
- `assert-production-assets` only checks for sourcemaps / dev-runtime imports — it didn't (and structurally couldn't) catch a stale-but-valid manifest. Optional follow-up: have it also assert every vendor `.js` on disk is embedded. Happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)