### PR TITLE
Agent packages can seed a team persona

### DIFF
--- a/.claude/knowledge/agent-packages.md
+++ b/.claude/knowledge/agent-packages.md
@@ -38,7 +38,7 @@ atomically.
 `packages/core/src/agent-packages/manifest.ts` — zod-validated. The schema is a discriminated union on `kind`. Common base fields (`id`, `name`, `version`, `description`, `bakin`, `author`) plus kind-specific stanzas:
 
 - `agent` only: `agent: { identity, role, defaultModel?, dispatchableBy[], allowedTools[], allowedSkills[] }` and `install: { createIfMissing, adoptIfExists, writeWorkspaceFiles, installSkills, installWorkflows, enableLessons[] }`
-- `contributions`: shape per kind. agent has all six (workspaceFiles/skills/workflows/workflowSkills/lessons/assets); skill-pack requires `skills` non-empty; workflow-pack requires at least one of workflows/workflowSkills; lesson-pack requires `lessons` non-empty.
+- `contributions`: shape per kind. agent has all six (workspaceFiles/skills/workflows/workflowSkills/lessons/assets) plus optional `persona` (single file seeded to `{contentDir}/team/personas/{agentId}.md` ONLY when missing — personas are user territory: never overwritten, never reclaimed, never removed on uninstall); skill-pack requires `skills` non-empty; workflow-pack requires at least one of workflows/workflowSkills; lesson-pack requires `lessons` non-empty.
 - `dependencies`: cross-kind. `{skills?: Dependency[], workflows?: Dependency[], lessons?: Dependency[]}` where each `Dependency = {source, ref, items?, installAs?}`.
 - `secrets`: shared top-level runtime requirements. Each declaration is `{name, description, required}` where `name` is a canonical env var name such as `RUNWAY_API_KEY`. Secret values never live in package manifests or lockfiles.
 

--- a/packages/core/src/agent-packages/lockfile.ts
+++ b/packages/core/src/agent-packages/lockfile.ts
@@ -23,6 +23,8 @@ const ProjectionKindSchema = z.enum([
   'skill',
   'asset',
   'workspace-file',
+  // Team persona seed (seeded-if-missing; never overwritten or reclaimed).
+  'persona',
   // Legacy (pre-layered-context). New code never writes lesson-marker
   // projections — lessons are composed into the workspace-file block. Kept in
   // the enum only so pre-migration lockfiles parse; the one-time migration

--- a/packages/core/src/agent-packages/manifest.ts
+++ b/packages/core/src/agent-packages/manifest.ts
@@ -150,6 +150,8 @@ const AgentContributionsSchema = z.object({
   workflowSkills: z.array(z.string().min(1)).optional(),
   lessons: z.array(z.string().min(1)).optional(),
   assets: z.array(z.string().min(1)).optional(),
+  /** Team persona seed → {contentDir}/team/personas/{agentId}.md. Seeded only when missing — personas are user territory, never overwritten or reclaimed. */
+  persona: z.string().min(1).optional(),
 })
 
 const SkillPackContributionsSchema = z.object({

--- a/src/core/agent-packages/package-integrity.ts
+++ b/src/core/agent-packages/package-integrity.ts
@@ -24,6 +24,7 @@ export function validatePackageContributionIntegrity(options: PackageIntegrityOp
       validateWorkflowFiles(stagingDir, manifest.id, manifest.contributions.workflows ?? [])
       validateWorkflowSkillFiles(stagingDir, manifest.contributions.workflowSkills ?? [])
       validateFiles(stagingDir, manifest.contributions.assets ?? [], 'asset')
+      validateFiles(stagingDir, manifest.contributions.persona ? [manifest.contributions.persona] : [], 'persona')
       break
     case 'skill-pack':
       validateSkillDirectories(stagingDir, manifest.contributions.skills)

--- a/src/core/agent-packages/projector.ts
+++ b/src/core/agent-packages/projector.ts
@@ -471,6 +471,39 @@ function projectAssets(
   }
 }
 
+// ─── Persona (team-page seed: {contentDir}/team/personas/{agentId}.md) ───────
+
+/**
+ * Seed the agent's team persona from the package — ONLY when no persona
+ * exists yet. Personas are user territory (no managed block, no sentinel,
+ * no reclaim): once a file is there, the package never touches it again,
+ * so an existing persona is a silent no-op rather than a skip.
+ */
+function projectPersona(
+  manifest: Manifest,
+  agentId: string | undefined,
+  options: ProjectorOptions,
+  result: ProjectorResult,
+  writeLog: WriteLog,
+): void {
+  if (manifest.kind !== 'agent' || !agentId) return
+  const rel = manifest.contributions.persona
+  if (!rel) return
+
+  const src = join(options.stagingDir, rel)
+  if (!existsSync(src)) {
+    log.warn('Persona source missing — skipping', { rel })
+    return
+  }
+  const target = join(getContentDir(), 'team', 'personas', `${agentId}.md`)
+  if (existsSync(target)) return
+
+  ensureDir(dirname(target), writeLog)
+  copyFileSync(src, target)
+  writeLog.recordCreatedFile(target)
+  result.projections.push({ kind: 'persona', target, sha256: computeFileSha(target) })
+}
+
 // ─── Public entry point ──────────────────────────────────────────────────────
 
 /**
@@ -496,6 +529,7 @@ export async function projectPackage(options: ProjectorOptions): Promise<Project
       await projectComposedBlocks(options.manifest, options.agentId, options, result, writeLog)
       await projectSkills(options.manifest, options, result, writeLog)
       projectAssets(options.manifest, options.agentId, options, result, writeLog)
+      projectPersona(options.manifest, options.agentId, options, result, writeLog)
     } else if (options.manifest.kind === 'skill-pack') {
       await projectSkills(options.manifest, options, result, writeLog)
     }
@@ -524,6 +558,9 @@ export async function unprojectPackage(
 ): Promise<void> {
   const runtime = getAppServices().runtime
   for (const p of projections) {
+    // Personas are user territory from the moment they're seeded — package
+    // removal never takes them back (no sentinel required).
+    if (p.kind === 'persona') continue
     const runtimeTarget = parseRuntimeTarget(p.target)
     if (p.kind === 'lesson-marker') {
       if (options.keepBlocks) continue

--- a/tests/agent-packages/projector.test.ts
+++ b/tests/agent-packages/projector.test.ts
@@ -421,6 +421,46 @@ describe('projectPackage — skills + assets', () => {
   })
 })
 
+// ─── Persona seeding ─────────────────────────────────────────────────────────
+
+describe('projectPackage — persona', () => {
+  function personaOptions(): ProjectorOptions {
+    const stagingDir = seedPackageStaging()
+    writeFileSync(join(stagingDir, 'persona.md'), '# Pixel\n\nPackage-shipped persona.\n')
+    const manifest = pixelManifest()
+    manifest.contributions.persona = 'persona.md'
+    return { manifest, stagingDir, agentId: 'pixel', installedBy: fixedInstalledBy() }
+  }
+  const personaTarget = () => join(testDir, 'team', 'personas', 'pixel.md')
+
+  it('seeds team/personas/{agentId}.md when missing and records a persona projection', async () => {
+    const result = await projectPackage(personaOptions())
+    expect(readFileSync(personaTarget(), 'utf-8')).toContain('Package-shipped persona')
+    expect(result.projections.some((p) => p.kind === 'persona' && p.target === personaTarget())).toBe(true)
+  })
+
+  it('NEVER overwrites an existing persona — silent no-op, no sentinel needed', async () => {
+    mkdirSync(join(testDir, 'team', 'personas'), { recursive: true })
+    writeFileSync(personaTarget(), '# My own take on Pixel\n')
+    const result = await projectPackage(personaOptions())
+    expect(readFileSync(personaTarget(), 'utf-8')).toBe('# My own take on Pixel\n')
+    expect(result.projections.some((p) => p.kind === 'persona')).toBe(false)
+  })
+
+  it('re-projection (sync) after seeding is a no-op — the seed itself is now "existing"', async () => {
+    await projectPackage(personaOptions())
+    writeFileSync(personaTarget(), '# Edited after seeding\n')
+    await projectPackage(personaOptions())
+    expect(readFileSync(personaTarget(), 'utf-8')).toBe('# Edited after seeding\n')
+  })
+
+  it('unprojectPackage leaves the persona in place (user territory)', async () => {
+    const result = await projectPackage(personaOptions())
+    await unprojectPackage(result.projections)
+    expect(existsSync(personaTarget())).toBe(true)
+  })
+})
+
 // ─── Rollback on failure ─────────────────────────────────────────────────────
 
 describe('projectPackage — atomic rollback', () => {


### PR DESCRIPTION
Agent kits gain an optional `contributions.persona` file, seeded to `~/.bakin/team/personas/{agentId}.md` at projection time **only when missing**. Personas are user territory: never overwritten on sync, never reclaimed, never removed on uninstall. Integrity preflight validates the declared file; receipts record a `persona` projection kind.

Motivation: the doctor warns `Missing persona` for every kit-installed agent (H'enrich was the first). The companion bits PR ships H'enrich's persona using this field.

Full suite 5298 pass / 0 fail; projector suite covers seed-when-missing, never-overwrite, sync no-op after user edit, and uninstall-leaves-it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)