### PR TITLE
H'enrich joins the curated agent catalog (default-selected)

### DIFF
--- a/packages/host/src/data/curated-agents.json
+++ b/packages/host/src/data/curated-agents.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-05-10T00:00:00Z",
+  "updatedAt": "2026-07-03T00:00:00Z",
   "agents": [
     {
       "id": "pixel",
@@ -41,6 +41,17 @@
       "source": "github:markhayden/bakin-bits-official#agents/patch",
       "ref": null,
       "trust": "official"
+    },
+    {
+      "id": "enrich",
+      "name": "H'enrich",
+      "emoji": "🔍",
+      "description": "Vision utility agent — captions, OCR, and tags for asset search. Powers zero-config enrichment; not dispatchable, no channels.",
+      "tags": ["utility", "vision", "enrichment"],
+      "source": "github:markhayden/bakin-bits-official#agents/enrich",
+      "ref": null,
+      "trust": "official",
+      "defaultSelected": true
     }
   ]
 }

--- a/tests/api/curated.test.ts
+++ b/tests/api/curated.test.ts
@@ -76,6 +76,7 @@ describe('GET /api/curated', () => {
     const body = await res.json()
 
     expect(body.catalog.agents.map((agent: { id: string }) => agent.id).sort()).toEqual([
+      'enrich',
       'jessica',
       'patch',
       'pixel',

--- a/tests/core/onboarding/recommended-catalogs.test.ts
+++ b/tests/core/onboarding/recommended-catalogs.test.ts
@@ -16,7 +16,7 @@ describe('official plugin onboarding catalog', () => {
 describe('official agent onboarding catalog', () => {
   it('loads official agent choices from the shipped catalog', () => {
     expect(agentCatalog.version).toBe(1)
-    expect(agentCatalog.agents.map(agent => agent.id)).toEqual(['pixel', 'rolo', 'jessica', 'patch'])
+    expect(agentCatalog.agents.map(agent => agent.id)).toEqual(['pixel', 'rolo', 'jessica', 'patch', 'enrich'])
     expect(agentCatalog.agents.every(agent => agent.trust === 'official')).toBe(true)
     expect(agentCatalog.agents.every(agent => agent.source.startsWith('github:markhayden/bakin-bits-official#agents/'))).toBe(true)
   })


### PR DESCRIPTION
The recommended-agents list is the shipped curated catalog (`packages/host/src/data/curated-agents.json`) — nothing lands there automatically, so this adds the entry.

H'enrich is the only **default-selected** agent: he's infrastructure (vision captions/OCR/tags powering zero-config asset enrichment), so `bakin onboard --yes` installs him without an explicit pick — a fresh machine gets working enrichment out of the box. The other four agents stay opt-in personality choices.

Points at `github:markhayden/bakin-bits-official#agents/enrich` (H'enrich merged there in bits#74; persona ships in bits#75).

Full suite 5294 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)