### PR TITLE
FW1: guards & correctness — the audit follow-up's first workstream

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -6,6 +6,7 @@ import fs from 'fs'
 import path from 'path'
 import { createLogger } from './logger'
 import { getContentDir } from './content-dir'
+import { setStoredProviderKey } from './media/secret-store'
 
 const log = createLogger('settings')
 
@@ -446,6 +447,24 @@ export function getSettings(): BakinSettings {
   return settings
 }
 
+/**
+ * settings.json must never carry secrets (GET /api/settings serves it
+ * unredacted). A write that smuggles the search auth password back in —
+ * the exact shape the boot-time migration relocates — is intercepted
+ * here: the password moves to the secret store and never lands in the
+ * file, instead of lingering until the next boot re-runs the migration.
+ */
+function relocateSecretsFromWrite(merged: Record<string, unknown>): void {
+  const search = merged.search as { settings?: { auth?: Record<string, unknown> } } | undefined
+  const auth = search?.settings?.auth
+  const password = typeof auth?.password === 'string' && auth.password.trim() !== '' ? auth.password : undefined
+  if (!auth || !password) return
+  setStoredProviderKey('antfly', password)
+  delete auth.password
+  if (Object.keys(auth).length === 0) delete search!.settings!.auth
+  log.info('Relocated search auth password from a settings write to the secret store')
+}
+
 export function updateSettings(partial: Record<string, unknown>): BakinSettings {
   const settingsPath = getSettingsPath()
   const dir = path.dirname(settingsPath)
@@ -462,6 +481,7 @@ export function updateSettings(partial: Record<string, unknown>): BakinSettings 
   }
 
   const merged = deepMerge(current, partial)
+  relocateSecretsFromWrite(merged)
   fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2), 'utf-8')
   log.info('Settings updated', { keys: Object.keys(partial) })
 

--- a/packages/host/src/api/plugins/install.ts
+++ b/packages/host/src/api/plugins/install.ts
@@ -715,6 +715,11 @@ export async function post(req: Request, _url: URL): Promise<Response> {
       // so the build step is skipped entirely.
       if (!installedFromArtifact) {
         try {
+          // A source install must never execute a dist/ it shipped with —
+          // only provenance-verified artifacts skip the rebuild. Deleting
+          // the copied dist also closes the freshness-check mtime race
+          // (cpSync stamps everything ~now; a tie would skip the compile).
+          rmSync(join(targetDir, 'dist'), { recursive: true, force: true })
           await buildUserPlugin(targetDir)
         } catch (buildErr) {
           // Build failed — clean up the installed files so the install

--- a/packages/host/src/plugin-host/user-plugin-builder.ts
+++ b/packages/host/src/plugin-host/user-plugin-builder.ts
@@ -216,7 +216,11 @@ export async function buildUserPlugin(
       errorStage = 'freshness check failed'
       const newestSource = newestMtimeMs(pluginDir, new Set(['dist', 'node_modules']))
       const oldestDist = oldestMtimeMs(expectedDist)
-      if (clientDistFresh && oldestDist > 0 && newestSource > 0 && oldestDist >= newestSource) {
+      // Strictly newer, as documented above: an mtime TIE rebuilds. A
+      // same-millisecond tie is exactly what a cpSync'd source install
+      // produces, and treating it as fresh would execute shipped dist
+      // bytes that were never rebuilt from validated source.
+      if (clientDistFresh && oldestDist > 0 && newestSource > 0 && oldestDist > newestSource) {
         totalSpan?.end({ status: 'skipped', reason: 'fresh-dist', hasClient })
         return
       }

--- a/plugins/health/lib/system-checks/mcporter.ts
+++ b/plugins/health/lib/system-checks/mcporter.ts
@@ -5,7 +5,7 @@
  * because it only installs a CLI tool and writes config.
  */
 import * as mcporter from '../../../../src/core/mcporter'
-import { healthOk, healthWarn, healthError } from '@makinbakin/sdk/utils'
+import { healthOk, healthWarn, healthError, healthFixed } from '@makinbakin/sdk/utils'
 import type { HealthCheckResult, HealthRepairHandler } from '../../../../packages/core/src/plugin-types'
 
 function ok(message: string): HealthCheckResult {
@@ -18,7 +18,7 @@ function error(message: string): HealthCheckResult {
   return healthError('mcporter', message)
 }
 function fixed(message: string): HealthCheckResult {
-  return { check: 'mcporter', status: 'fixed', message, autoFixable: true }
+  return healthFixed('mcporter', message)
 }
 
 export async function checkMcporter(): Promise<HealthCheckResult[]> {

--- a/plugins/images/lib/idempotency.ts
+++ b/plugins/images/lib/idempotency.ts
@@ -79,14 +79,24 @@ const imageCallRegistry = createIdempotencyRegistry<ExecToolResult>()
 /**
  * The ledger holds coordination facts only — never content. The tool result
  * returned to the caller carries prompt text and provider commentary; the
- * persisted dedup row must not. Identity stays in promptHash (already part
- * of the call signature), so a replay still returns the right asset.
+ * persisted dedup row must not. The row is built from an ALLOWLIST so a
+ * future content-bearing result field cannot leak into the ledger by
+ * default (the previous denylist leaked-by-default). Identity stays in
+ * promptHash (already part of the call signature), so a replay still
+ * returns the right asset.
  */
-const CONTENT_FIELDS = ['prompt', 'providerText'] as const
+const COORDINATION_FIELDS = [
+  'ok', 'assetId', 'version', 'width', 'height', 'surface',
+  'provider', 'model', 'quality', 'routeSource', 'credentialSource',
+  'promptHash', 'reused', 'idempotency',
+] as const
 
 function coordinationOnly(result: ExecToolResult): ExecToolResult {
-  const row: Record<string, unknown> = { ...(result as Record<string, unknown>) }
-  for (const field of CONTENT_FIELDS) delete row[field]
+  const source = result as Record<string, unknown>
+  const row: Record<string, unknown> = {}
+  for (const field of COORDINATION_FIELDS) {
+    if (field in source) row[field] = source[field]
+  }
   return row as ExecToolResult
 }
 

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -53,8 +53,6 @@ const schedulePlugin: BakinPlugin = definePlugin({
 
   settingsSchema: {
     fields: [
-      { key: 'maxConcurrentJobs', type: 'number', label: 'Max concurrent jobs', description: 'Maximum jobs that can run at the same time', default: 3 },
-      { key: 'failureCooldownMs', type: 'number', label: 'Failure cooldown (ms)', description: 'Wait time after failure before retrying', default: 300000 },
       { key: 'maxFailures', type: 'number', label: 'Max consecutive failures', description: 'Pause job after this many consecutive failures', default: 3 },
       { key: 'tickIntervalSeconds', type: 'number', label: 'Scheduler tick interval (seconds)', description: 'How often the scheduler checks for due schedules. Floor-clamped to 5s.', default: 30 },
       { key: 'catchUpWindowMinutes', type: 'number', label: 'Missed-fire safety window (minutes)', description: 'After downtime, a missed run fires normally if within this window; older runs land in Blocked for you to triage. Larger = more tolerant.', default: 60 },

--- a/plugins/schedule/lib/exec-tools.ts
+++ b/plugins/schedule/lib/exec-tools.ts
@@ -126,7 +126,7 @@ export function registerScheduleExecTools(ctx: PluginContext): void {
 
       const fields = ['displayName', 'agentId', 'workflowId', 'taskPrompt', 'taskTitle']
       for (const f of fields) {
-        if (params[f] !== undefined) (meta as unknown as Record<string, unknown>)[f === 'name' ? 'displayName' : f] = params[f]
+        if (params[f] !== undefined) (meta as unknown as Record<string, unknown>)[f] = params[f]
       }
       if (params.name) meta.displayName = params.name as string
       upsertJob(meta)

--- a/plugins/tasks/lib/edit-guard.ts
+++ b/plugins/tasks/lib/edit-guard.ts
@@ -15,6 +15,21 @@
 import { getTask } from '../../../src/core/task-store'
 import { hasCompletion } from '../../../src/core/execution-ledger'
 
+/**
+ * Single identifier-fallback resolver for the mutation routes: path param
+ * first, then body.id, then the legacy title fallbacks. Update passes
+ * bodyTitleIsPayload because there body.title is the NEW title — never an
+ * identifier — and identifies by body.originalTitle instead. Previously each
+ * route inlined its own chain and update's had silently diverged.
+ */
+export function resolveTaskIdentifier(
+  paramsTaskId: string | undefined,
+  body: { id?: string; originalTitle?: string; title?: string },
+  opts: { bodyTitleIsPayload?: boolean } = {},
+): string | undefined {
+  return paramsTaskId || body.id || body.originalTitle || (opts.bodyTitleIsPayload ? undefined : body.title)
+}
+
 export function taskEditGuard(
   ctx: { activity: { audit: (event: string, agent: string, data?: Record<string, unknown>) => void } },
   identifier: string,

--- a/plugins/tasks/lib/exec-tools.ts
+++ b/plugins/tasks/lib/exec-tools.ts
@@ -6,6 +6,13 @@
  * update/delete/assign) against the plugin context. The tools share the same
  * helpers as the REST routes — the edit-safety guard, search indexing, and the
  * checklist-nudge advisory — so they're imported from the same lib modules.
+ *
+ * Guard coverage mirrors the REST routes exactly: update/assign/set_dependency
+ * pass through `taskEditGuard` (freeze-on-complete + optimistic versioning).
+ * move/complete are exempt (they ARE the reopen/complete paths), block's
+ * completion freeze lives inside `blockTaskWithEffects` (agents retrying a
+ * block on a meanwhile-completed task must see success), and delete is
+ * unguarded on both channels (deleting a completed task is legitimate cleanup).
  */
 import { z } from 'zod'
 
@@ -290,7 +297,9 @@ export function registerTaskExecTools(ctx: PluginContext): void {
         taskId: z.string().describe('Your task ID (the one that depends)'),
         dependsOn: z.string().describe('Task ID you depend on'),
       },
-      handler: async (params: Record<string, unknown>) => {
+      handler: async (params: Record<string, unknown>, agent: string) => {
+        const guard = taskEditGuard(ctx, params.taskId as string, { agent })
+        if (guard) return { ok: false, error: guard.error }
         try {
           await setDependencyWithEffects(params.taskId as string, params.dependsOn as string, 'mcp')
           return { ok: true, message: `Dependency registered. You will be re-dispatched when ${params.dependsOn} completes. Stop now.` }
@@ -312,17 +321,19 @@ export function registerTaskExecTools(ctx: PluginContext): void {
         agent: z.string().optional().describe('New assigned agent'),
         availableAt: z.string().nullable().optional().describe('ISO timestamp before which dispatch should not pick up the task'),
         dueAt: z.string().nullable().optional().describe('ISO timestamp representing the task deadline or target delivery time'),
+        expectedVersion: z.number().optional().describe('Optimistic-concurrency check: fail if the task version has moved past this'),
       },
       handler: async (params: Record<string, unknown>, agent: string) => {
-        const { taskId, title, description, agent: assignee, availableAt, dueAt } = params as {
+        const { taskId, title, description, agent: assignee, availableAt, dueAt, expectedVersion } = params as {
           taskId: string
           title?: string
           description?: string
           agent?: string
           availableAt?: string | null
           dueAt?: string | null
+          expectedVersion?: number
         }
-        const guard = taskEditGuard(ctx, taskId, { agent })
+        const guard = taskEditGuard(ctx, taskId, { agent, expectedVersion })
         if (guard) return { ok: false, error: guard.error }
         try {
           const updates: Record<string, unknown> = {}
@@ -374,6 +385,8 @@ export function registerTaskExecTools(ctx: PluginContext): void {
       handler: async (params: Record<string, unknown>, callingAgent: string) => {
         const taskId = params.taskId as string
         const targetAgent = params.agent as string
+        const guard = taskEditGuard(ctx, taskId, { agent: callingAgent })
+        if (guard) return { ok: false, error: guard.error }
         try {
           await assignTask(taskId, targetAgent)
           ctx.activity.audit('assigned', callingAgent, { taskId, agent: targetAgent })

--- a/plugins/tasks/lib/routes.ts
+++ b/plugins/tasks/lib/routes.ts
@@ -32,7 +32,7 @@ import {
 } from '../../../src/core/task-service'
 import { readTaskOutcome, readTaskRuns } from './runs-reader'
 import type { ColumnId } from '../types'
-import { taskEditGuard, guardResponse } from './edit-guard'
+import { taskEditGuard, guardResponse, resolveTaskIdentifier } from './edit-guard'
 import { indexTask } from './search-doc'
 import {
   taskIdParams,
@@ -163,7 +163,7 @@ export const tasksRoutes = [
     body: updateTaskBody,
     responses: { 200: okResponse, 400: errorResponse, 409: errorResponse, 500: errorResponse },
     handler: async (_req, ctx, { params, body }) => {
-      const identifier = params.taskId || body.id || body.originalTitle
+      const identifier = resolveTaskIdentifier(params.taskId, body, { bodyTitleIsPayload: true })
       if (!identifier) {
         return Response.json({ error: 'taskId required' }, { status: 400 })
       }
@@ -201,7 +201,7 @@ export const tasksRoutes = [
     handler: async (req, ctx, { params }) => {
       let body: any = {}
       try { body = await req.clone().json() } catch { /* no body is fine */ }
-      const identifier = params.taskId || body.id || body.title
+      const identifier = resolveTaskIdentifier(params.taskId, body)
       if (!identifier) {
         return Response.json({ error: 'taskId required' }, { status: 400 })
       }
@@ -225,7 +225,7 @@ export const tasksRoutes = [
     body: moveTaskBody,
     responses: { 200: okResponse, 400: errorResponse, 403: errorResponse, 409: errorResponse, 500: errorResponse },
     handler: async (_req, ctx, { params, body }) => {
-      const identifier = params.taskId || body.id || body.title
+      const identifier = resolveTaskIdentifier(params.taskId, body)
       if (!identifier) {
         return Response.json({ error: 'taskId and to required' }, { status: 400 })
       }
@@ -272,7 +272,7 @@ export const tasksRoutes = [
     body: assignTaskBody,
     responses: { 200: okResponse, 400: errorResponse, 409: errorResponse, 500: errorResponse },
     handler: async (_req, ctx, { params, body }) => {
-      const identifier = params.taskId || body.id || body.title
+      const identifier = resolveTaskIdentifier(params.taskId, body)
       if (!identifier) {
         return Response.json({ error: 'taskId required' }, { status: 400 })
       }
@@ -298,7 +298,7 @@ export const tasksRoutes = [
     body: logEntryBody,
     responses: { 200: okResponse, 400: errorResponse, 500: errorResponse },
     handler: async (_req, ctx, { params, body }) => {
-      const identifier = params.taskId || body.id || body.title
+      const identifier = resolveTaskIdentifier(params.taskId, body)
       if (!identifier) {
         return Response.json({ error: 'taskId required' }, { status: 400 })
       }
@@ -320,7 +320,7 @@ export const tasksRoutes = [
     body: blockTaskBody,
     responses: { 200: okResponse, 400: errorResponse, 409: errorResponse, 500: errorResponse },
     handler: async (_req, ctx, { params, body }) => {
-      const identifier = params.taskId || body.id || body.title
+      const identifier = resolveTaskIdentifier(params.taskId, body)
       if (!identifier) {
         return Response.json({ error: 'taskId required' }, { status: 400 })
       }

--- a/plugins/tasks/types.ts
+++ b/plugins/tasks/types.ts
@@ -2,52 +2,11 @@
 import type { TaskLogEntry } from '@makinbakin/sdk/types'
 export type { TaskLogEntry }
 
-export interface TaskSource {
-  pluginId?: string
-  entityType?: string
-  entityId?: string
-  purpose?: string
-}
-
-export interface Task {
-  id: string
-  title: string
-  agent?: string
-  createdBy?: string
-  checked: boolean
-  date?: string
-  blockedReason?: string
-  description?: string
-  log?: TaskLogEntry[]
-  dependsOn?: string
-  parentId?: string
-  workflowId?: string
-  scheduleJobId?: string
-  projectId?: string
-  availableAt?: string
-  dueAt?: string
-  source?: TaskSource
-  order?: number
-  /** Wall-clock ms of the last DB row update — used by the watchdog as a fallback "last activity" when a task has no log entries yet. */
-  updatedAt?: number
-}
-
-export interface TaskColumns {
-  backlog: Task[]
-  inProgress: Task[]
-  todo: Task[]
-  review: Task[]
-  done: Task[]
-  archived: Task[]
-  blocked: Task[]
-}
-
-export interface TaskBoard {
-  columns: TaskColumns
-  timestamp?: string
-}
-
-export type ColumnId = keyof TaskColumns
+// The board wire shapes are single-homed in the task store. Re-exported
+// type-only, so client bundles never pull the server module (type-only
+// re-exports are erased at build). A local copy here had already drifted
+// (it was missing `version`) — pinned by tests/architecture/type-single-home.
+export type { Task, TaskColumns, TaskBoard, ColumnId, TaskSource } from '../../src/core/task-store'
 
 /** Task-level terminal outcome, derived from the completion ledger + task column.
  *  Mirrored client-side in src/hooks/use-task-run-history.ts — keep in sync. */

--- a/plugins/workflows/lib/engine.ts
+++ b/plugins/workflows/lib/engine.ts
@@ -139,6 +139,12 @@ export function createInstance(
 export interface CompleteStepResult {
   success: boolean
   errors?: string[]
+  /**
+   * Typed failure discriminant. 'rejection_repeat' = the near-duplicate
+   * resubmission detector fired. Callers branch on this, never on the
+   * error-message text.
+   */
+  code?: 'rejection_repeat'
   nextStep?: StepContext | { status: 'complete' } | { status: 'pending_approval'; stepId: string; label: string }
   workflowComplete?: boolean
 }
@@ -196,7 +202,7 @@ export function completeStep(
   if (stepState.previousOutput) {
     const repeatError = detectRejectionRepeat(stepState.previousOutput, output)
     if (repeatError) {
-      return { success: false, errors: [repeatError] }
+      return { success: false, errors: [repeatError], code: 'rejection_repeat' }
     }
   }
 

--- a/plugins/workflows/lib/exec-tools.ts
+++ b/plugins/workflows/lib/exec-tools.ts
@@ -11,7 +11,7 @@ import { z } from 'zod'
 import type { PluginContext } from '@bakin/core/plugin-types'
 import type { WorkflowDefinition } from '../types'
 import { buildTemplateList, resolveSubWorkflows } from './template-list'
-import { loadDefinition } from './parser'
+import { loadDefinition, findStep } from './parser'
 import { getCurrentStep, completeStep, listInstances, loadInstance } from './runtime'
 import { createValidatedInstance } from './start-validation'
 import { indexInstance } from './search-sync'
@@ -224,6 +224,9 @@ export function registerWorkflowExecTools(ctx: PluginContext): void {
         const result = completeStep(taskId, stepId, output, agent)
 
         if (!result.success) {
+          if (result.code === 'rejection_repeat') {
+            return { ok: false, error: 'Submission rejected: output is too similar to your previous rejected submission. Address the feedback and make substantive changes.', errors: result.errors }
+          }
           return { ok: false, error: 'Step completion failed', errors: result.errors }
         }
 
@@ -236,11 +239,7 @@ export function registerWorkflowExecTools(ctx: PluginContext): void {
 
         return { ok: true, workflowComplete: result.workflowComplete, nextStep: result.nextStep }
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        if (msg.includes('near-duplicate') || msg.includes('rejection')) {
-          return { ok: false, error: 'Submission rejected: output is too similar to your previous rejected submission. Address the feedback and make substantive changes.' }
-        }
-        return { ok: false, error: `Failed to submit step: ${msg}` }
+        return { ok: false, error: `Failed to submit step: ${err instanceof Error ? err.message : String(err)}` }
       }
     },
   })
@@ -258,6 +257,10 @@ export function registerWorkflowExecTools(ctx: PluginContext): void {
         const instance = loadInstance(params.taskId as string)
         if (!instance) return { ok: false, error: 'No workflow instance found for this task' }
 
+        // Gate detection is by the definition's step type — never by
+        // stepId naming (a step merely NAMED "review" is not a gate).
+        const def = loadDefinition(instance.workflowId)
+
         const STATUS_DISPLAY: Record<string, string> = {
           complete: 'APPROVED', pending_approval: 'WAITING', pending: 'PENDING',
           rejected: 'REJECTED', in_progress: 'IN PROGRESS',
@@ -273,8 +276,8 @@ export function registerWorkflowExecTools(ctx: PluginContext): void {
         const stepStates = (instance.stepStates || {}) as unknown as Record<string, Record<string, unknown>>
         for (const [stepId, state] of Object.entries(stepStates)) {
           const s = state as { status: string; completedAt?: string; startedAt?: string }
-          const isGate = s.status === 'pending_approval' ||
-            stepId.includes('gate') || stepId.includes('review') || stepId.includes('approval')
+          const defStep = def ? findStep(def, stepId) : null
+          const isGate = defStep?.type === 'gate' || s.status === 'pending_approval'
           if (!isGate) continue
           hasGates = true
 

--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -15,6 +15,7 @@ import { join } from 'path'
 import { readTaskboard } from '../../../src/core/task-store'
 import type { HealthCheckResult, HealthRepairHandler } from '../../../packages/core/src/plugin-types'
 import { healthOk as ok, healthWarn as warn, healthFixed as fixed } from '@makinbakin/sdk/utils'
+import { splitFrontmatter } from '@bakin/core/format/frontmatter'
 
 import { listDefinitions } from './parser'
 import { getAgentPackageSkills } from './agent-package-skill-registry'
@@ -46,8 +47,7 @@ export function checkWorkflowSkills(contentDir: string): HealthCheckResult[] {
     for (const file of files) {
       try {
         const content = readFileSync(join(skillsDir, file), 'utf-8')
-        const match = content.match(/^---\n([\s\S]*?)\n---/)
-        if (!match) {
+        if (splitFrontmatter(content).raw === null) {
           results.push(warn('workflow-skills', `Skill ${file} has no YAML frontmatter — output will not be validated`))
           continue
         }

--- a/plugins/workflows/lib/instance-store.ts
+++ b/plugins/workflows/lib/instance-store.ts
@@ -5,9 +5,10 @@
  * file. Everything here is parameterized by a contentDir and carries no
  * workflow semantics — pure persistence.
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { readFileSync, readdirSync, existsSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import { randomBytes } from 'crypto'
+import { atomicWriteJson } from '@bakin/core/storage/atomic-write'
 import type { WorkflowInstance } from '../types'
 import { getContentDir } from './content-dir'
 
@@ -37,7 +38,9 @@ export function saveInstance(instance: WorkflowInstance, contentDir?: string): v
   const instancesDir = getInstancesDir(dir)
   if (!existsSync(instancesDir)) mkdirSync(instancesDir, { recursive: true })
   instance.updatedAt = new Date().toISOString()
-  writeFileSync(getInstancePath(dir, instance.taskId), JSON.stringify(instance, null, 2), 'utf-8')
+  // Atomic: this is the engine's state file — a crash mid-write must never
+  // leave a truncated instance behind.
+  atomicWriteJson(getInstancePath(dir, instance.taskId), instance)
 }
 
 /**
@@ -51,7 +54,6 @@ export function listInstances(
   const instancesDir = getInstancesDir(dir)
   if (!existsSync(instancesDir)) return []
 
-  const { readdirSync } = require('fs')
   const files = readdirSync(instancesDir).filter((f: string) => f.endsWith('.json'))
 
   const instances: WorkflowInstance[] = []
@@ -87,7 +89,7 @@ function saveNotifiedGates(data: Record<string, string>, contentDir: string): vo
   const p = getNotifiedGatesPath(contentDir)
   const dir = join(contentDir, 'workflows')
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-  writeFileSync(p, JSON.stringify(data, null, 2), 'utf-8')
+  atomicWriteJson(p, data)
 }
 
 export function isGateNotified(taskId: string, stepId: string, contentDir?: string): boolean {

--- a/plugins/workflows/lib/skill-loader.ts
+++ b/plugins/workflows/lib/skill-loader.ts
@@ -22,7 +22,7 @@
  * Frontmatter carries metadata (name, output_schema); the markdown body
  * becomes the agent's step instructions.
  */
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, readdirSync, existsSync } from 'fs'
 import { join } from 'path'
 import { parseFrontmatter } from '@bakin/core/format/frontmatter'
 import type { SkillDefinition } from '../types'
@@ -140,7 +140,6 @@ export function listAllSkills(contentDir?: string): Array<{
   const dir = contentDir || getContentDir()
   const skillsDir = join(dir, 'workflows', 'skills')
   if (existsSync(skillsDir)) {
-    const { readdirSync } = require('fs') as typeof import('fs')
     try {
       const files = readdirSync(skillsDir)
       for (const file of files) {

--- a/src/core/task-store.ts
+++ b/src/core/task-store.ts
@@ -23,7 +23,7 @@ import { createLogger } from './logger'
 const log = createLogger('task-store')
 
 // TaskLogEntry is single-homed in the SDK; re-exported via @bakin/core/tasks/store.
-export type { TaskLogEntry } from '@bakin/core/tasks/store'
+export type { TaskLogEntry, TaskSource } from '@bakin/core/tasks/store'
 
 export interface Task {
   id: string

--- a/tasks/plan-audit-follow-up.md
+++ b/tasks/plan-audit-follow-up.md
@@ -1,0 +1,310 @@
+# Plan: Audit Follow-Up — close the gaps the 2026-06 refactor left
+
+**Date:** 2026-07-01 · **Re-verified:** 2026-07-03 against post-#457 main (the antfly-zig search
+migration, 139 commits) — every item re-checked; deltas folded in below. · **Predecessors:**
+`SPEC.md` (root), `.claude/specs/audit-2026-06/REPORT.md`, `tasks/plan.md` (WS5/6/7 status),
+`tasks/plan-ws{1..4}-*.md`, `tasks/plan-fix-security.md`.
+**Method:** 7 parallel verification agents re-audited every workstream's claims against current main
+(post PR #580 / rc.20). Every claim below was verified in code with file:line evidence, not from
+the plan docs' checkmarks.
+
+**#457 impact summary:** the search migration created no new god-files (largest new module 427
+lines) and no new test-size violations; it deleted `search-reconcile.ts` and
+`scripts/backfill-manifests.ts` (shrinking two FW6 items), grew `cli/bakin.ts` (4,278 → 4,413),
+`plugins/health/components/health-page.tsx` (1,012 → 1,137), and `plugins/assets/index.ts`
+(744 → 913, now over the SPEC threshold — added to FW5), added a 4th duplicate sharp loader,
+obsoleted the re-deferred search-registry micro-cleanups, and its T24/F5 doc sweeps fixed the
+search-side doc staleness while leaving the registry/dispatch staleness intact (FW8 revised).
+
+## Verification scoreboard — what actually landed
+
+| Workstream | Verdict |
+|---|---|
+| fix/security (6 items) | ✅ ALL DONE (4 small hardening residuals below) |
+| WS1 contract-types | ✅ DONE per the revised (approved) two-tier design; 2 residuals |
+| WS2 core-extractions | ◧ PARTIAL by design — the **boundary work never landed** (item 2 + guards) |
+| WS3 sdk-gaps | ◧ Primitives all exist + tested; **adoption partial** (8 fetch effects, 1 formatter dup, 1 modal) |
+| WS4 cli | ❌ **STALLED at Part 3** — cli/bakin.ts still 4,278 lines; B5.3/B6/B7/docs never done |
+| WS5 core-splits | ✅ DONE except **upgrade.ts split never happened** (still 895 lines, one file) |
+| WS6 plugin-splits | ◧ DONE for tracked files, but **task-detail-dialog (1,033) + node-config-drawer (976) were silently dropped** from plan.md; health-page section split deferred (1,012); team split created a new 1,047-line god-routes-module |
+| WS7 tooling | ◧ docs-generate + CORE_PLUGINS/externals done; dir-walker, orphan scripts, embedded-assets escaping, imitation-crab prod gate all open |
+| Phase 4 (tests + docs sweep) | ❌ **NEVER RAN** — no doc touched since 2026-06-17 while refactors landed through 06-24; all 4 test god-files intact |
+| 7 incidental correctness bugs | ✅ ALL FIXED (verified individually) |
+| 28 P2 findings | 10 fixed · 1 obsolete · 6 partial · **11 still open** |
+
+**SPEC success criteria still unmet (re-confirmed 2026-07-03):** (1) two-CLI consolidation;
+(2) "no test file over ~1,200 lines" — five violate (1,954 / 1,606 / 1,443 / 1,374 / 1,212,
+unchanged by #457); (3) "no source file over ~800 lines without recorded justification" — ~9
+unjustified (cli/bakin 4,413 · health-page 1,137 · team-routes 1,047 · task-detail-dialog 1,033 ·
+node-config-drawer 976 · assets/index 913 · models/index 896 · upgrade 895 · install 788-adjacent);
+(4) "docs accurate" — repo-architecture.md, plugin-system.md, and dispatch.md still contain
+concretely wrong paths/descriptions (the #457 doc sweeps fixed only the search/asset docs).
+
+**Barrel hygiene held** (dispatch, search-registry, asset-service, workflows/runtime all still pure
+re-export barrels) and the four security-invariant P2s are structurally fixed. The foundation is
+good; what's left is the stalled tail plus items that fell off tracking.
+
+---
+
+## Workstreams
+
+Dependency-ordered. Same rules as before (SPEC §7): branch + PR per workstream, one revertable
+commit per finding/file, every commit green on `bun run test` + `bun run typecheck`, binary-graph
+changes get `bun run build`, behavior changes get the dockerized rig. **New rule enforced this
+round (SPEC §8 was violated last round): docs ride in the same PR as the change they describe.**
+
+### FW1 `fix/guards-and-correctness` — small, high-value, land first
+
+Verified correctness/hardening gaps. One commit each.
+
+1. **Tasks MCP guard gap.** REST routes guard every mutation via `taskEditGuard`
+   (`plugins/tasks/lib/routes.ts:170,279,327,352`); the exec tools guard ONLY `update`
+   (`plugins/tasks/lib/exec-tools.ts` — one call). Agents can move/complete/block/delete/assign
+   past the guard. Apply the guard uniformly + tests.
+2. **Tasks identifier-fallback divergence.** `routes.ts:166` falls back to `body.originalTitle`,
+   `:204` to `body.title`. Unify into one resolver in `lib/edit-guard.ts` (or sibling) + test.
+3. **submit_step error-message classification.** `plugins/workflows/lib/exec-tools.ts:240,277`
+   classifies by `msg.includes('near-duplicate')` and `stepId.includes('gate')` — the exact
+   pattern CLAUDE.md bans for dispatch. Replace with a typed result/discriminant from the engine.
+4. **Workflow instance-store durability.** `plugins/workflows/lib/instance-store.ts:40,90` uses
+   plain `writeFileSync` for engine state (crash = corrupt instance). Move to
+   `atomicWriteJson`; convert the `require('fs')` at `:54` (+ `lib/skill-loader.ts:143`) while there.
+5. **Settings strip-on-write.** `updateSettings` (`packages/core/src/settings.ts:464`, deepMerge
+   at :402) deep-merges arbitrary keys — a POST can re-admit `search.settings.auth.password`,
+   served unredacted until next boot re-runs the migration. Strip/deny secret-bearing paths on
+   write + test.
+6. **Images idempotency allowlist.** `plugins/images/lib/idempotency.ts:147-153` strips a
+   denylist (`prompt`, `providerText`); a future content field leaks silently. Convert
+   `coordinationOnly()` to an allowlist (assetId/version/dims/provider/model/promptHash/op/ok) + test.
+7. **Cloned-dist freshness race.** `user-plugin-builder.ts:215-223` uses `oldestDist >= newestSource`;
+   a same-ms tie after `cpSync` can execute attacker-shipped dist bytes on a github install.
+   `rmSync` the cloned `dist/` before non-artifact builds (or strict `>`).
+8. **Missing mandated test mock.** `tests/plugins/tasks/routes.test.ts:29` mocks only
+   `src/core/content-dir` — the `packages/core/src/content-dir` mock (CLAUDE.md-mandated, flagged
+   by the original audit) is still absent. Add it; sweep tests/ for other single-mock files.
+9. **Type re-drift guard.** `plugins/tasks/types.ts:12` `Task` is an unannotated near-copy of the
+   storage shape that already drifted (missing `version`). Annotate-or-rederive it, then add a
+   `tests/architecture/` scanner pinning the two-tier type names (PluginContext, BakinPlugin,
+   ExecToolDefinition, Task, WorkflowInstance, HealthCheckResult…) to their sanctioned
+   declaration files so forks fail CI.
+10. **Tiny dedups adjacent to the above:** `plugins/workflows/lib/health-checks.ts:49` raw
+    frontmatter regex → `parseFrontmatter`; mcporter's hand-rolled `fixed()` → `healthFixed`;
+    delete schedule's dead settings keys (`maxConcurrentJobs`/`failureCooldownMs`,
+    `plugins/schedule/index.ts:56-57`) and the unreachable `f === 'name'` ternary
+    (`lib/exec-tools.ts:129`).
+
+**FW1 STATUS — ☑ DONE (2026-07-03, branch `fix/guards-and-correctness`, 10 commits, one per item).**
+All ten items landed as specified, with these verification-driven refinements:
+(1) took the true REST-parity shape — assign + set_dependency gained the guard, update gained
+`expectedVersion`; move/complete/block/delete exemptions are deliberate and now documented in the
+exec-tools header. (3) the near-duplicate text-match turned out to be dead code (completeStep
+returns, never throws) — replaced with a typed `code: 'rejection_repeat'` on CompleteStepResult;
+check_gates now classifies by definition step type. (5) settings writes RELOCATE the password to
+the secret store (migration parity), not just strip. (7) took both belts: strict `>` in the
+freshness check AND rm of the copied dist on source installs; regression test plants attacker
+bytes behind an mtime tie. (8) the sweep found the mock gap in **42** files, not 1 — all fixed,
+full suite green. (9) re-derived via type-only re-exports (client bundle verified clean of the
+server module) + `tests/architecture/type-single-home.test.ts` pins 11 contract types to their
+sanctioned homes. Gates: full suite 5,301-0, typecheck, binary build (stamps reverted).
+Note: `bun run lint` currently fails on PRE-EXISTING #457 files (adapter-antfly/translate,
+search-outbox, memory, assets/search-doc unused vars) — not touched by this branch; fix belongs
+to the search-migration follow-up.
+
+### FW2 `refactor/cli-part3` — finish WS4 (the stalled biggest win)
+
+Resume `tasks/plan-ws4-cli.md` at B5.3. cli/bakin.ts is 4,413 lines — and growing: the search
+migration added to it, which is the cost of every deferral month. B1–B5.2 landed (#503+), the
+fragile remainder did not. Scope:
+
+- **B5.3** — per-scope command modules under `src/cli/commands/` (or `src/core/cli/commands/`),
+  lifecycle module, move the top-of-file static server-core imports into command modules,
+  slim `cli/bakin.ts` to a router. Keep the load-bearing contracts (plan-ws4 §"Load-bearing"):
+  `main()` export + `import.meta.main`, `process.exit` semantics, lazy heavy deps, dynamic
+  bakin.ts ↔ src/core/cli.ts edge.
+- **emit() dispatcher** — collapse the ~95 inline isTTY/plain/json branches.
+- **Help-registry-driven dispatch** — fixes the still-open P2 #7: `src/core/cli/registry.ts:150-151`
+  advertises `agent-assets` while dispatch accepts `agent-sync` (`cli/bakin.ts:4183`), and
+  plugin-contributed commands are invisible in help.
+- **B6** — wire or retire the zero-caller framework (`src/core/cli/{runner,parser,options,result}.ts`).
+- **B7** — extract the ×10 copy-pasted TTY harness into `tests/cli/helpers/tty-cli-harness.ts`;
+  split `readonly-commands.test.ts` (1,443) along source seams.
+- **Docs in-PR:** CLAUDE.md CLI section + repo-architecture.md.
+- **Gate:** dockerized-rig E2E on the binary + npm-bin surfaces (exit codes, help, delegation).
+
+### FW3 `refactor/boundary` — the WS2 work that never landed
+
+The core→plugin boundary violation is live and unguarded; nothing stops it multiplying.
+
+1. **Workflow registries → `packages/core/src/workflows/`.** `source-registry.ts`,
+   `node-type-registry.ts`, `notification-channel-registry.ts` — plus the post-migration
+   `node-renderer-registry.ts`, so the cluster is growing — still live in
+   `plugins/workflows/lib/`; core imports the plugin's tree from 5 places
+   (`src/core/plugin-registry.ts:27-33`, `agent-packages/load-sources.ts:44-49`,
+   `plugin-host/reload-pipeline.ts:42-43`, `package-integrity.ts:7`, `post-sync-reload.ts:13`).
+2. **images→assets via hooks.** `plugins/images/lib/tools.ts:6-8` still direct-imports
+   `../../assets/lib/*`. Extend assets' hooks (the REPORT's sanctioned mechanism).
+3. **Cross-plugin import architecture rule** — the guard promised in WS2, absent from
+   `tests/architecture/`. Land it in the same PR that removes the last violation.
+4. **Config-surface governance.** `config.get<T>()`/`update()` remain reason-less and unaudited;
+   live whole-config read-modify-`replace` at `src/core/openclaw-integration.ts:41,79`,
+   `plugins/models/index.ts:86,90`, `plugins/team/lib/runtime-agents.ts:71`. Promote to typed
+   adapter methods; extend the adapter-boundary test to gate `get`/`update`/`replace` like `.raw`.
+5. **Cycle gate.** madge shows 15 cycles today (new dispatch-module cluster, engine↔node-dispatch,
+   SDK-components/brainstorm). Add a CI check with an explicit allowlist so drift stops being silent.
+6. **scripts/ out of the production graph** (P2 #24 residue): `src/core/mcp-server.ts:44-48`
+   statically imports 5 tool peers from `scripts/lib/` — move the peers to
+   `src/core/exec-tools/tools/`; fix `scripts/bin/post-channel.ts`'s `npx tsx` shebang.
+7. **Decide the SDK→plugin re-exports** (P2 #5): `packages/sdk/src/hooks/index.ts` reaches into
+   `@bakin/team`, `@bakin/workflows`, `@bakin/models`. Either move those hooks to the SDK home
+   with the implementations, or record the cohesion justification. (The larger SDK↔app cycle
+   stays deferred — see Re-deferred.)
+
+### FW4 `refactor/ui-godfiles` — the dropped WS6 files
+
+All four have audited seams; pure decomposition, one PR each or stacked.
+
+1. **`plugins/tasks/components/task-detail-dialog.tsx` (1,033 → ~7).** Silently dropped from
+   plan.md; audit verdict intact: one component from line 186 → EOF with 26 hooks. Split
+   create/edit/detail modes per APPENDIX-cohesion. Fold in the WS3 straggler while the file is
+   open: it locally extends SDK types and raw-fetches the workflows API.
+2. **`plugins/workflows/components/node-config-drawer.tsx` (976 → 4).** Zero commits since the
+   audit. Seams already visible: field/coercion helpers + label tables (61–256), drawer proper
+   (258–610), `DrawerHeader` (611), `ParallelChildrenEditor` (638–976). Assess the
+   `let cancelled` effect at `:310` for `useJsonFetch` during the split.
+3. **`plugins/health/components/health-page.tsx` (1,137 → sections).** Grew again with the
+   migration's blue/green search panel (was 1,012). The deferred React work: per-section
+   components (usage/plugins/search/agent-usage), per-section fetching instead of the
+   all-or-nothing `Promise.all`, promote `SearchHealthData`.
+4. **`plugins/team/lib/team-routes.ts` (1,047).** The refactor relocated `populateTeamRoutes`
+   (one function, 32 routes) instead of decomposing it. Follow the in-repo template from the same
+   effort (`workflows/lib/routes/*`, `schedule/lib/routes/jobs.ts`): split to
+   `lib/routes/{agents,teams,context}.ts`, same single `indexAgentStatic` dep.
+
+### FW5 `refactor/server-godfiles` — audit misses + the un-split WS5 file
+
+1. **`plugins/models/index.ts` (896, actively growing).** The clearest audit miss — only the
+   models *page* was WS6 scope, and the index has since grown routing/spend/budget features.
+   Mirror the tasks-plugin split: `lib/{config-io,models-cache-fetch,aliases,schemas}.ts` +
+   `lib/routes/models.ts` + `lib/exec-tools.ts`; `lib/` already exists.
+2. **`packages/host/src/api/plugins/install.ts` (788).** `post()` runs ~508 lines with
+   security-sensitive logic (consent-token manifestSha binding ~:608, core-id squatting :545)
+   buried mid-function and untestable in isolation. 4-way seam: dev-install/link branch, source
+   resolution, manifest+permission validation, commit. This is supply-chain code — splitting it
+   is a security testability win, not just hygiene.
+3. **`src/core/plugins/upgrade.ts` (895 → 6).** The one WS5 file never decomposed. Includes the
+   deliberately-deferred **hasher consolidation** (`computeSourceTreeSha` upgrade.ts:144 vs
+   `hashSourceTree` whiskit/source-hash.ts:25 — different skip-sets and formulas): pick a
+   canonical hasher + one-time stored-sha reset/migration, exactly as plan.md prescribed.
+   Update the two stale whiskit spec docs that still describe `trustExistingDist` in present tense.
+4. **`plugins/assets/index.ts` (913).** New threshold crossing: grew 744 → 913 with the #457
+   enrichment work (engine wiring, import routes, enrichment exec tools). Mirror the tasks/models
+   split pattern — `lib/routes/` + `lib/exec-tools.ts`; `plugins/assets/lib/` already has the
+   enrichment modules, so this is index-orchestration extraction, not new design.
+
+### FW6 `refactor/dedup-remainder` — kill the surviving copy-paste
+
+Mechanical; batch into one PR with per-item commits.
+
+- **WS3 stragglers:** `plugins/tasks/components/task-log-table.tsx:153-175` local
+  formatDuration/date formatter → core `formatDuration`/`formatDateTime` (the one true
+  unaccounted duplicate); `plugins/assets/components/versioned/VersionedAssetDetail.tsx:265-292`
+  hand-rolled delete-scope modal → SDK `ConfirmDialog` (rich `description`); optional:
+  `STATUS_BADGE_STYLES` + `formatRelativeDate` → SDK equivalents.
+- **atomicWriteJson stragglers** (named in the WS2 plan, unconverted):
+  `packages/core/src/tasks/store.ts:274-278` `writeTask`, `src/core/doctor-repair-store.ts:44-49`,
+  `src/core/dispatch-state.ts:97-100`.
+- **deepMerge dedup:** `packages/core/src/settings.ts:388` vs
+  `packages/adapter-openclaw/src/runtime-utils.ts:68`.
+- **sharp loader dedup — grew to 4 sites with #457:** `plugins/images/lib/tools.ts:21-76`,
+  `plugins/assets/lib/asset-media.ts`, `plugins/assets/lib/asset-mutations.ts`,
+  `plugins/assets/lib/enrichment/downscale.ts` (each caches its own sharp module) — one lazy
+  loader in assets, images consumes via the FW3.2 hooks.
+- **Shared dir-walker** (WS7 remaining; 7 ad-hoc sites after #457 deleted search-reconcile:
+  upgrade, markdown-adapter, agent-packages/markers, generate-embedded-assets,
+  assert-production-assets, docs/source-scan, assets/health-checks).
+- **Host API body-parse helper + param-injection single-run** (P2 #15/#16, re-scoped post-#457):
+  `parseJsonBody` already exists exported in `src/core/middleware.ts` — adopt it in
+  `packages/host/src/api/{packages,agent-packages}/dynamic.ts` (both still hand-roll) and
+  replace their `/still required by/i` regex status-mapping (`packages/dynamic.ts:82`,
+  `agent-packages/dynamic.ts:148`) with typed errors. The catch-all still rebuilds the Request
+  to inject params (`[[...path]].ts:137`); the second injection site the audit cited
+  (`_lib/dispatcher.ts`) no longer exists — re-locate before assuming the double-run persists.
+- **Tooling hardening** (P2 #25/#26/#27): gate the imitation-crab usage-seed out of production
+  (`src/core/server/startup-recovery.ts:70-73` — env flag alone still dynamic-imports `dev/` in
+  the binary); `JSON.stringify` the interpolations in `scripts/generate-embedded-assets.ts` (~:200-210);
+  delete/wire orphan scripts (`migration/validate-package.ts`, `release.ts` dead `main()` —
+  `backfill-manifests.ts` was already deleted by #457) — **ask-first per SPEC §8 three-mode
+  verification**.
+- **Schedule route/exec dedup** (the deliberate follow-up): extract
+  `createScheduleJob/applyPauseAction/updateScheduleJob/projectJobDetail` into `lib/job-service.ts`.
+  The behavioral drift is already fixed, so this is now pure dedup — rig E2E on pause/update.
+
+### FW7 `refactor/test-godfiles` — the SPEC's unmet test ceiling
+
+Split along source seams with shared harnesses (readonly-commands is FW2's B7):
+- `tests/plugins/schedule/routes.test.ts` (1,954) — seams now obvious post-split: routes/jobs,
+  fire-engine, scheduler-loop, job-service, exec-tools.
+- `tests/plugins/tasks/routes.test.ts` (1,606) — routes vs exec-tools vs maintenance; carries the
+  FW1.8 mock fix.
+- `tests/plugins/workflows/runtime.test.ts` (1,374) — mirror the 6 runtime seam modules.
+- `tests/core/plugin-registry.test.ts` (1,212) — at threshold; split if touched, else record
+  justification.
+- Extract shared harnesses; every split file gets the CLAUDE.md dual content-dir mocks.
+
+### FW8 `chore/docs-sweep` — run the Phase 4 that never ran
+
+Backlog sweep now; the in-PR rule prevents recurrence. **Re-scoped after #457's T24/F5 doc
+sweeps** (which fixed the search/asset docs but only those):
+- **`.claude/knowledge/repo-architecture.md`** — search content now current (F5), but still wrong
+  on: `src/lib/plugin-registry.ts` (:437; moved to src/core in #572); adapter tree vs the actual
+  post-split module set; dispatch described as one module (now a barrel over ~10); missing
+  `src/core/server/request-handler.ts`.
+- **`.claude/knowledge/plugin-system.md`** — T24-touched but :1512 still cites
+  `src/lib/plugin-registry.ts`.
+- **`dispatch.md`** — untouched since 2026-06-13; :29 and :305 still describe the pre-split
+  monolith; add a module map.
+- **`dev-loop.md`** — untouched since 2026-06-11; missing the `core-plugin-ids.ts` consolidation.
+- ~~search-system.md~~ / ~~adapter-architecture.md~~ — RESOLVED by T24/F5 (2026-07-02/03);
+  verify only the OpenClaw runtime-module inventory paragraph while in adapter-architecture.md.
+- **CLAUDE.md** — search section now current (#457); directory-map + CLI section update rides FW2.
+- **README.md** (untouched since 2026-05-27) + rerun `docs:generate` and commit.
+- `/agent-skills:test` coverage pass over FW1's behavior changes and any FW3–FW6 redesigns.
+
+---
+
+## Re-deferred (explicitly NOT taken, again — with reasons)
+
+- **SDK↔app circular dependency** (implementations in `src/components`/`src/hooks`): works,
+  release-smoke-covered, large blast radius; defer until it bites. Document in repo-architecture.md.
+- **Tier-3 capability-subclass refactor** of the OpenClaw facade; **settings/binary resolver
+  extraction** — runtime.ts (1,560) is the documented irreducible facade.
+- **server.ts declarative route table** — behavior-touching; request-handler header already
+  records the deferral.
+- **Workflows redesigns:** decideGate 6-block collapse, gate-settings dual-source-of-truth,
+  discriminated `getCurrentStep` union, stdJsonResponses. (submit_step classification IS taken — FW1.3.)
+- **Models-page redesigns:** 3-way sentinel cleanup, batch saveAll, RuntimeRestartBanner/
+  TableSkeleton SDK extraction; **use-workflow-copy-form cross-file dedup + slugify** — take
+  opportunistically if FW4 opens those files.
+- **search-registry micro-cleanups** — OBSOLETED by #457: the $inc/$push transform and
+  pendingReconciles code no longer exist (outbox/blue-green rewrite); crossTableSearch was
+  restructured (`crossTableSearchInner`). Nothing left to take.
+- **Docs hook/slot regex scraping → declarative** — build-time only.
+- **Remaining triaged WS3 non-fits** (8 `let cancelled` sites with written rationale).
+- **Historical data:** pre-existing prompt-bearing ledger rows; pre-migration settings backups.
+
+## Suggested execution order
+
+```
+FW1 fix/guards-and-correctness   — small, independent, land first
+FW2 refactor/cli-part3           — the stalled biggest win; unblocks its own docs/tests
+FW3 refactor/boundary            — before FW4/FW5 so splits land on sanctioned surfaces
+FW4 refactor/ui-godfiles     ──┐
+FW5 refactor/server-godfiles ──┼— independent of each other; can interleave
+FW6 refactor/dedup-remainder ──┘  (FW6.4 sharp-dedup needs FW3.2 hooks)
+FW7 refactor/test-godfiles       — after the source splits settle the seams
+FW8 chore/docs-sweep             — final PR + the recurring in-PR rule
+```
+
+FW1 is a day-scale batch. FW2 is the largest single effort (the WS4 plan's own "fragile,
+wants E2E" warning stands). FW3–FW6 are mostly mechanical with known seams. FW7/FW8 close out
+the SPEC's unmet success criteria.

--- a/tests/architecture/type-single-home.test.ts
+++ b/tests/architecture/type-single-home.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Architecture scan guarding the contract types against re-forking.
+ *
+ * WS1 (audit 2026-06) collapsed the plugin-contract types to single homes —
+ * or, for the deliberate two-tier pairs (SDK published projection vs core/
+ * storage full shape), to exactly two. Until now only header comments
+ * enforced that; the one unguarded copy (plugins/tasks/types.ts Task) had
+ * already drifted (missing `version`). This scan pins every guarded name's
+ * EXPORTED declarations to its sanctioned files, so a new fork fails CI.
+ *
+ * Local, non-exported declarations (e.g. `interface WorkflowInstance extends
+ * SdkWorkflowInstance` inside a component) are file-scoped and deliberately
+ * NOT flagged — they cannot cause cross-module drift.
+ *
+ * Pure scanner: walks the source tree as text, imports no app modules.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, relative } from 'path'
+
+const ROOT = process.cwd()
+
+/** Guarded name → the only files allowed to EXPORT a declaration of it. */
+const SANCTIONED_HOMES: Record<string, string[]> = {
+  // Deliberate two-tier pairs (SDK published projection + internal full shape)
+  PluginContext: ['packages/sdk/src/types/context.ts', 'packages/core/src/plugin-types.ts'],
+  BakinPlugin: ['packages/sdk/src/types/context.ts', 'packages/core/src/plugin-types.ts'],
+  ExecToolDefinition: ['packages/sdk/src/types/registration.ts', 'packages/core/src/plugin-types.ts'],
+  Task: ['packages/sdk/src/types/services.ts', 'src/core/task-store.ts'],
+  TaskSource: ['packages/sdk/src/types/services.ts', 'packages/core/src/tasks/store.ts'],
+  WorkflowInstance: ['packages/sdk/src/types/registration.ts', 'plugins/workflows/types.ts'],
+  // Single-homed (SDK is the one source; everything else re-exports)
+  TaskLogEntry: ['packages/sdk/src/types/services.ts'],
+  HealthCheckResult: ['packages/sdk/src/types/registration.ts'],
+  AvailableModel: ['packages/sdk/src/types/services.ts'],
+  AgentUsage: ['packages/sdk/src/types/services.ts'],
+  PluginManifest: ['packages/sdk/src/types/manifest.ts'],
+}
+
+const SCAN_ROOTS = [
+  'packages/sdk/src', 'packages/core/src', 'packages/host/src',
+  'packages/adapter-openclaw/src', 'packages/adapter-antfly/src',
+  'plugins', 'src', 'cli', 'scripts',
+]
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git'])
+
+function* walk(dir: string): Generator<string> {
+  for (const name of readdirSync(dir)) {
+    if (SKIP_DIRS.has(name)) continue
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) yield* walk(full)
+    else if (/\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name)) yield full
+  }
+}
+
+describe('contract types stay in their sanctioned homes', () => {
+  const names = Object.keys(SANCTIONED_HOMES)
+  const pattern = new RegExp(
+    `^\\s*export\\s+(?:declare\\s+)?(?:interface|type)\\s+(${names.join('|')})\\b[^.\\w]`,
+    'gm',
+  )
+
+  const declarations = new Map<string, string[]>()
+  for (const root of SCAN_ROOTS) {
+    for (const file of walk(join(ROOT, root))) {
+      const src = readFileSync(file, 'utf-8')
+      for (const m of src.matchAll(pattern)) {
+        const name = m[1]
+        const rel = relative(ROOT, file)
+        declarations.set(name, [...(declarations.get(name) ?? []), rel])
+      }
+    }
+  }
+
+  for (const [name, homes] of Object.entries(SANCTIONED_HOMES)) {
+    it(`${name} is declared only in: ${homes.join(', ')}`, () => {
+      const found = declarations.get(name) ?? []
+      const rogue = found.filter((f) => !homes.includes(f))
+      expect(rogue).toEqual([])
+      // The sanctioned homes must actually declare it — a silent rename would
+      // otherwise leave this scan asserting against nothing.
+      for (const home of homes) {
+        expect(found).toContain(home)
+      }
+    })
+  }
+})

--- a/tests/core/antfly-password-migration.test.ts
+++ b/tests/core/antfly-password-migration.test.ts
@@ -36,6 +36,7 @@ import {
   resolveAntflyPassword,
   setStoredProviderKey,
 } from '../../packages/core/src/media/secret-store'
+import { updateSettings, resetSettingsCache } from '../../packages/core/src/settings'
 
 const settingsPath = join(testDir, 'settings.json')
 
@@ -97,6 +98,29 @@ describe('antfly password migration', () => {
     expect(migrateAntflyPasswordToSecretStore()).toBe(true)
     expect(resolveAntflyPassword()).toEqual({ password: 'STORE-FIRST', source: 'store' })
     expect(readFileSync(settingsPath, 'utf-8')).not.toContain('LEGACY-SECRET')
+  })
+
+  it('a settings WRITE cannot re-admit the password — it relocates to the store instead', () => {
+    resetSettingsCache()
+
+    // The exact re-admission shape: a POST /api/settings body carrying the
+    // legacy auth.password path after the boot migration already ran.
+    updateSettings({
+      search: { settings: { auth: { username: 'bakin', password: 'SMUGGLED-SECRET' } } },
+    })
+
+    const raw = readFileSync(settingsPath, 'utf-8')
+    expect(raw).not.toContain('SMUGGLED-SECRET')
+    expect(JSON.parse(raw).search.settings.auth).toEqual({ username: 'bakin' })
+    expect(resolveAntflyPassword()).toEqual({ password: 'SMUGGLED-SECRET', source: 'store' })
+
+    // Password-only write: the emptied auth object is dropped entirely.
+    updateSettings({ search: { settings: { auth: { password: 'AGAIN' } } } })
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    // deepMerge keeps the earlier username; the password never lands.
+    expect(readFileSync(settingsPath, 'utf-8')).not.toContain('AGAIN')
+    expect(after.search.settings.auth?.password).toBeUndefined()
+    expect(resolveAntflyPassword()).toEqual({ password: 'AGAIN', source: 'store' })
   })
 
   it('resolution order: ANTFLY_PASSWORD env beats the store; empty when neither set', () => {

--- a/tests/core/exec-tools/registry.test.ts
+++ b/tests/core/exec-tools/registry.test.ts
@@ -9,6 +9,10 @@ mock.module('../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ content: testDir }),
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ content: testDir }),
+}))
 
 // Mock self-registering tool imports to prevent side-effect errors
 mock.module('../../scripts/lib/log-progress', () => ({}))

--- a/tests/core/mcporter.test.ts
+++ b/tests/core/mcporter.test.ts
@@ -39,6 +39,10 @@ mock.module('../../src/core/content-dir', () => ({
   getContentDir: () => '/tmp/mcporter-test-bakin',
   getBakinPaths: () => ({ root: '/tmp/mcporter-test-bakin' }),
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => '/tmp/mcporter-test-bakin',
+  getBakinPaths: () => ({ root: '/tmp/mcporter-test-bakin' }),
+}))
 
 mock.module('child_process', () => ({
   execSync: mock(),

--- a/tests/core/onboarding/index.test.ts
+++ b/tests/core/onboarding/index.test.ts
@@ -150,6 +150,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => '/tmp/bakin-onboarding-orchestrator-test',
   getBakinPaths: () => ({}),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => '/tmp/bakin-onboarding-orchestrator-test',
+  getBakinPaths: () => ({}),
+}))
 
 describe('runOnboard orchestrator', () => {
   let runOnboard: typeof import('../../../src/core/onboarding/index').runOnboard

--- a/tests/core/onboarding/runtime.test.ts
+++ b/tests/core/onboarding/runtime.test.ts
@@ -48,6 +48,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ logs: join(testDir, 'logs') }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ logs: join(testDir, 'logs') }),
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/core/onboarding/state.test.ts
+++ b/tests/core/onboarding/state.test.ts
@@ -18,6 +18,12 @@ mock.module('../../../src/core/content-dir', () => ({
   resetContentDir: () => {},
   initBakinHome: () => {},
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/core/runtime-config-raw.test.ts
+++ b/tests/core/runtime-config-raw.test.ts
@@ -24,6 +24,9 @@ mock.module('../../src/core/audit', () => ({
 mock.module('../../src/core/content-dir', () => ({
   getContentDir: () => '/tmp/bakin-runtime-config-raw-test',
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => '/tmp/bakin-runtime-config-raw-test',
+}))
 
 mock.module('../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/core/search-tools-mcp.test.ts
+++ b/tests/core/search-tools-mcp.test.ts
@@ -48,6 +48,28 @@ mock.module('../../src/core/content-dir', () => ({
   }),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => TEST_DIR,
+  getBakinPaths: () => ({
+    home: TEST_DIR,
+    assets: join(TEST_DIR, 'assets'),
+    audit: join(TEST_DIR, 'audit.jsonl'),
+    heartbeats: join(TEST_DIR, 'heartbeats'),
+    inbox: join(TEST_DIR, 'inbox'),
+    pluginSettings: join(TEST_DIR, 'plugin-settings'),
+    schedule: join(TEST_DIR, 'schedule'),
+    workflows: join(TEST_DIR, 'workflows'),
+    projects: join(TEST_DIR, 'projects'),
+    team: join(TEST_DIR, 'team'),
+    messaging: join(TEST_DIR, 'messaging'),
+    docs: join(TEST_DIR, 'docs'),
+    settings: join(TEST_DIR, 'settings.json'),
+    memory: join(TEST_DIR, 'MEMORY-LOG.md'),
+    plugins: join(TEST_DIR, 'plugins'),
+    logs: join(TEST_DIR, 'logs'),
+  }),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/core/task-service.test.ts
+++ b/tests/core/task-service.test.ts
@@ -13,6 +13,7 @@ const contentDirMock = {
 }
 mock.module('@/core/content-dir', () => contentDirMock)
 mock.module('../../src/core/content-dir', () => contentDirMock)
+mock.module('../../packages/core/src/content-dir', () => contentDirMock)
 
 mock.module('@/core/audit', () => ({
   appendAudit: mock(),

--- a/tests/core/usage.test.ts
+++ b/tests/core/usage.test.ts
@@ -21,6 +21,15 @@ mock.module('../../src/core/content-dir', () => ({
     logs: join(testDir, 'logs'),
   }),
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    root: testDir,
+    settings: join(testDir, 'settings.json'),
+    audit: join(testDir, 'audit.jsonl'),
+    logs: join(testDir, 'logs'),
+  }),
+}))
 
 import {
   recordUsage,

--- a/tests/integration/search-watcher-sync.test.ts
+++ b/tests/integration/search-watcher-sync.test.ts
@@ -43,6 +43,17 @@ mock.module('../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    home: testDir,
+    workflows: join(testDir, 'workflows'),
+    assets: join(testDir, 'assets'),
+  }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/integration/usage-wiring-agent.test.ts
+++ b/tests/integration/usage-wiring-agent.test.ts
@@ -24,6 +24,16 @@ mock.module('../../src/core/content-dir', () => ({
     logs: join(testDir, 'logs'),
   }),
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    root: testDir,
+    tasks: join(testDir, 'tasks'),
+    settings: join(testDir, 'settings.json'),
+    audit: join(testDir, 'audit.jsonl'),
+    logs: join(testDir, 'logs'),
+  }),
+}))
 
 mock.module('../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),

--- a/tests/integration/usage-wiring-mcp.test.ts
+++ b/tests/integration/usage-wiring-mcp.test.ts
@@ -28,6 +28,15 @@ mock.module('../../src/core/content-dir', () => ({
     logs: join(testDir, 'logs'),
   }),
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    root: testDir,
+    settings: join(testDir, 'settings.json'),
+    audit: join(testDir, 'audit.jsonl'),
+    logs: join(testDir, 'logs'),
+  }),
+}))
 
 mock.module('../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/integration/usage-wiring-rest.test.ts
+++ b/tests/integration/usage-wiring-rest.test.ts
@@ -28,6 +28,15 @@ mock.module('../../src/core/content-dir', () => ({
     logs: join(testDir, 'logs'),
   }),
 }))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    root: testDir,
+    settings: join(testDir, 'settings.json'),
+    audit: join(testDir, 'audit.jsonl'),
+    logs: join(testDir, 'logs'),
+  }),
+}))
 
 mock.module('../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/assets/clipboard-purge.test.ts
+++ b/tests/plugins/assets/clipboard-purge.test.ts
@@ -20,6 +20,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/assets/filename-id.test.ts
+++ b/tests/plugins/assets/filename-id.test.ts
@@ -15,6 +15,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
 }))

--- a/tests/plugins/assets/multimodal-indexing.test.ts
+++ b/tests/plugins/assets/multimodal-indexing.test.ts
@@ -46,6 +46,13 @@ mock.module('../../../src/core/content-dir', () => ({
     assets: assetsRoot,
   }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    home: testDir,
+    assets: assetsRoot,
+  }),
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),

--- a/tests/plugins/assets/routes.test.ts
+++ b/tests/plugins/assets/routes.test.ts
@@ -35,6 +35,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/assets/save-from-source-hook.test.ts
+++ b/tests/plugins/assets/save-from-source-hook.test.ts
@@ -22,6 +22,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/assets/upload.test.ts
+++ b/tests/plugins/assets/upload.test.ts
@@ -33,6 +33,18 @@ mock.module('../../../src/core/content-dir', () => ({
     }
   },
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => {
+    const base = join(testDir, 'assets')
+    return {
+      assets: base,
+      'assets.store': join(base, 'store'),
+      'assets.inbox': join(base, 'inbox'),
+      'assets.trash': join(base, '.trash'),
+    }
+  },
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/assets/versioned-exec-tools.test.ts
+++ b/tests/plugins/assets/versioned-exec-tools.test.ts
@@ -18,6 +18,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ assets: join(testDir, 'assets') }),
+}))
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
 }))

--- a/tests/plugins/images/idempotency-durable.test.ts
+++ b/tests/plugins/images/idempotency-durable.test.ts
@@ -135,6 +135,21 @@ describe('durable image idempotency', () => {
     expect(bills).toBe(0)
   })
 
+  it('the persisted row is allowlist-built — an unknown future field never reaches the ledger', async () => {
+    const key = makeKey({ promptHash: 'prompt-allowlist' })
+    const full = {
+      ok: true, assetId: 'asset-d', version: 1, width: 512, height: 512,
+      promptHash: 'prompt-allowlist',
+      futureDebugTranscript: 'CONTENT NOBODY STRIPPED', // not in any denylist
+    } as unknown as ExecToolResult
+
+    await runBilledImageCall(key, async () => full)
+
+    const row = getIdempotent(imageCallSignature(key))
+    expect(JSON.stringify(row)).not.toContain('CONTENT NOBODY STRIPPED')
+    expect((row?.result as { assetId?: string }).assetId).toBe('asset-d')
+  })
+
   it('concurrent identical calls share one in-flight promise (one bill)', async () => {
     const key = makeKey({ promptHash: 'prompt-conc' })
     let release: (() => void) | null = null

--- a/tests/plugins/lifecycle/user-plugin-builder-freshness.test.ts
+++ b/tests/plugins/lifecycle/user-plugin-builder-freshness.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Freshness-check tie handling (audit follow-up FW1.7): a source install's
+ * cpSync stamps source and any shipped dist/ with ~identical mtimes. A tie
+ * treated as "fresh" would execute shipped dist bytes that were never
+ * rebuilt from validated source. The check is strictly-newer: ties rebuild.
+ */
+import { describe, it, expect, beforeAll, afterAll, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { mkdirSync, rmSync, writeFileSync, readFileSync, utimesSync } from 'fs'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-builder-freshness-${Date.now()}-${randomUUID()}`)
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: join(testDir, 'bakin.db') }),
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+import { buildUserPlugin } from '../../../packages/host/src/plugin-host/user-plugin-builder'
+
+const pluginDir = join(testDir, 'plugins', 'tie-test')
+const ATTACKER_DIST = '// ATTACKER BYTES — must never survive a tie\n'
+
+beforeAll(() => {
+  mkdirSync(join(pluginDir, 'dist'), { recursive: true })
+  writeFileSync(join(pluginDir, 'index.ts'), [
+    'const plugin = {',
+    "  id: 'tie-test',",
+    "  name: 'Tie Test',",
+    '  activate() {},',
+    '}',
+    'export default plugin',
+    '',
+  ].join('\n'))
+  writeFileSync(join(pluginDir, 'package.json'), JSON.stringify({
+    name: 'tie-test', version: '0.0.1',
+  }))
+  writeFileSync(join(pluginDir, 'bakin-plugin.json'), JSON.stringify({
+    id: 'tie-test', name: 'Tie Test', version: '0.0.1',
+  }))
+  writeFileSync(join(pluginDir, 'dist', 'index.js'), ATTACKER_DIST)
+
+  // The cpSync shape: every file carries the same mtime.
+  const tie = new Date('2026-01-01T00:00:00.000Z')
+  for (const rel of ['index.ts', 'package.json', 'bakin-plugin.json', join('dist', 'index.js')]) {
+    utimesSync(join(pluginDir, rel), tie, tie)
+  }
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('user-plugin-builder freshness tie', () => {
+  it('an mtime tie between dist and source REBUILDS — shipped dist bytes do not survive', async () => {
+    await buildUserPlugin(pluginDir)
+    const dist = readFileSync(join(pluginDir, 'dist', 'index.js'), 'utf-8')
+    expect(dist).not.toContain('ATTACKER BYTES')
+    expect(dist).toContain('tie-test')
+  })
+
+  it('a strictly-newer dist is fresh and skips the rebuild', async () => {
+    // Make dist strictly newer than every source file, then plant a sentinel.
+    writeFileSync(join(pluginDir, 'dist', 'index.js'), '// SENTINEL fresh dist for tie-test\n')
+    const older = new Date('2026-01-01T00:00:00.000Z')
+    const newer = new Date('2026-01-02T00:00:00.000Z')
+    for (const rel of ['index.ts', 'package.json', 'bakin-plugin.json']) {
+      utimesSync(join(pluginDir, rel), older, older)
+    }
+    utimesSync(join(pluginDir, 'dist', 'index.js'), newer, newer)
+
+    await buildUserPlugin(pluginDir)
+    expect(readFileSync(join(pluginDir, 'dist', 'index.js'), 'utf-8')).toContain('SENTINEL')
+  })
+})

--- a/tests/plugins/schedule/cutover.test.ts
+++ b/tests/plugins/schedule/cutover.test.ts
@@ -11,6 +11,12 @@ mock.module('../../../src/core/content-dir', () => ({
   resetContentDir: () => {},
   initBakinHome: () => {},
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),

--- a/tests/plugins/schedule/sidecar.test.ts
+++ b/tests/plugins/schedule/sidecar.test.ts
@@ -18,6 +18,12 @@ mock.module('../../../src/core/content-dir', () => ({
   resetContentDir: () => {},
   initBakinHome: () => {},
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/tasks/routes.test.ts
+++ b/tests/plugins/tasks/routes.test.ts
@@ -36,6 +36,16 @@ mock.module('../../../src/core/content-dir', () => ({
   resetContentDir: () => {},
   initBakinHome: () => {},
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    tasks: join(testDir, 'tasks'),
+    heartbeats: join(testDir, 'heartbeats'),
+  }),
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/tasks/task-edit-safety.test.ts
+++ b/tests/plugins/tasks/task-edit-safety.test.ts
@@ -91,6 +91,7 @@ mock.module('../../../src/core/task-service', () => ({
 
 import { recordCompletion, deleteCompletion } from '../../../src/core/execution-ledger'
 import { closeDb } from '../../../packages/core/src/storage/db'
+import { resolveTaskIdentifier } from '../../../plugins/tasks/lib/edit-guard'
 
 let activated: ActivatedPlugin
 
@@ -113,6 +114,20 @@ beforeEach(() => {
   mockAssignTask.mockClear()
   mockSetDependencyWithEffects.mockClear()
   ;(activated.ctx.activity.audit as ReturnType<typeof mock>).mockClear()
+})
+
+describe('resolveTaskIdentifier', () => {
+  it('prefers path param, then body.id, then the title fallbacks', () => {
+    expect(resolveTaskIdentifier('t-1', { id: 't-2', title: 'T' })).toBe('t-1')
+    expect(resolveTaskIdentifier(undefined, { id: 't-2', title: 'T' })).toBe('t-2')
+    expect(resolveTaskIdentifier(undefined, { title: 'T' })).toBe('T')
+    expect(resolveTaskIdentifier(undefined, {})).toBeUndefined()
+  })
+
+  it('update mode: body.title is payload, body.originalTitle is the identifier', () => {
+    expect(resolveTaskIdentifier(undefined, { originalTitle: 'Old', title: 'New' }, { bodyTitleIsPayload: true })).toBe('Old')
+    expect(resolveTaskIdentifier(undefined, { title: 'New' }, { bodyTitleIsPayload: true })).toBeUndefined()
+  })
 })
 
 describe('optimistic versioning', () => {

--- a/tests/plugins/tasks/task-edit-safety.test.ts
+++ b/tests/plugins/tasks/task-edit-safety.test.ts
@@ -110,6 +110,8 @@ beforeEach(() => {
   tasks.set('t-1', { id: 't-1', title: 'Editable', agent: 'pixel', version: 3 })
   deleteCompletion('t-1')
   mockUpdateTask.mockClear()
+  mockAssignTask.mockClear()
+  mockSetDependencyWithEffects.mockClear()
   ;(activated.ctx.activity.audit as ReturnType<typeof mock>).mockClear()
 })
 
@@ -152,6 +154,24 @@ describe('optimistic versioning', () => {
     expect(status).toBe(200)
     expect(mockUpdateTask).toHaveBeenCalledTimes(1)
   })
+
+  it('the MCP update tool honors expectedVersion (REST parity)', async () => {
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_update')!
+
+    const stale = await callTool(tool, { taskId: 't-1', title: 'Nope', expectedVersion: 2 }, 'pixel')
+    expect(stale.ok).toBe(false)
+    expect(String(stale.error)).toContain('Version conflict')
+    expect(mockUpdateTask).not.toHaveBeenCalled()
+    expect(activated.ctx.activity.audit).toHaveBeenCalledWith(
+      'edit_conflict',
+      'pixel',
+      expect.objectContaining({ taskId: 't-1', expectedVersion: 2, currentVersion: 3 }),
+    )
+
+    const fresh = await callTool(tool, { taskId: 't-1', title: 'Yep', expectedVersion: 3 }, 'pixel')
+    expect(fresh.ok).toBe(true)
+    expect(mockUpdateTask).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('freeze-on-complete', () => {
@@ -176,6 +196,22 @@ describe('freeze-on-complete', () => {
     const result = await callTool(tool, { taskId: 't-1', description: 'Nope' }, 'pixel')
     expect(result.ok).toBe(false)
     expect(String(result.error)).toContain('reopen')
+  })
+
+  it('the MCP assign tool refuses (REST parity — no write reaches the store)', async () => {
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_assign')!
+    const result = await callTool(tool, { taskId: 't-1', agent: 'chef' }, 'pixel')
+    expect(result.ok).toBe(false)
+    expect(String(result.error)).toContain('reopen')
+    expect(mockAssignTask).not.toHaveBeenCalled()
+  })
+
+  it('the MCP set_dependency tool refuses (REST parity — no dependency is written)', async () => {
+    const tool = findTool(activated.execTools, 'bakin_exec_tasks_set_dependency')!
+    const result = await callTool(tool, { taskId: 't-1', dependsOn: 't-2' }, 'pixel')
+    expect(result.ok).toBe(false)
+    expect(String(result.error)).toContain('reopen')
+    expect(mockSetDependencyWithEffects).not.toHaveBeenCalled()
   })
 
   it('reopen unfreezes: after deleteCompletion the edit succeeds', async () => {

--- a/tests/plugins/workflows/dagre-layout.test.ts
+++ b/tests/plugins/workflows/dagre-layout.test.ts
@@ -36,6 +36,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({
   createTask: mock(),
   addTaskLog: mock(),

--- a/tests/plugins/workflows/edge-rules.test.ts
+++ b/tests/plugins/workflows/edge-rules.test.ts
@@ -39,6 +39,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({
   createTask: mock(),
   addTaskLog: mock(),

--- a/tests/plugins/workflows/exec-tools.test.ts
+++ b/tests/plugins/workflows/exec-tools.test.ts
@@ -21,6 +21,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/workflows/exec-tools.test.ts
+++ b/tests/plugins/workflows/exec-tools.test.ts
@@ -77,7 +77,7 @@ mock.module('../../../src/core/task-store', () => taskStoreMock)
 mock.module('@/core/task-store', () => taskStoreMock)
 
 import workflowsPlugin from '../../../plugins/workflows'
-import { createInstance } from '@bakin/workflows/lib/runtime'
+import { createInstance, rejectGate } from '@bakin/workflows/lib/runtime'
 
 const gateWorkflow = `name: Gate Exec Tool Test
 description: Workflow used by exec tool tests
@@ -99,12 +99,41 @@ steps:
       note_to_agent: true
 `
 
+// Gate whose id carries no gate/review/approval token, plus an agent step
+// whose id LOOKS like a gate — check_gates must classify by definition
+// type, never by stepId naming.
+const signoffWorkflow = `name: Signoff Exec Tool Test
+description: Gate detection by type, not name
+version: 1
+steps:
+  - id: draft
+    type: agent
+    label: Draft
+    agent: chef
+    description: Write the draft
+  - id: review-notes
+    type: agent
+    label: Compile review notes
+    agent: chef
+    description: Not a gate, despite the name
+  - id: signoff
+    type: gate
+    label: Final signoff
+    description: Human signoff
+    approval_required: true
+    on_approve: done
+    on_reject:
+      goto: draft
+      note_to_agent: true
+`
+
 let activated: ActivatedPlugin
 
 beforeAll(async () => {
   globalThis.fetch = mock(async () => new Response('{}')) as unknown as typeof fetch
   mkdirSync(definitionsDir, { recursive: true })
   writeFileSync(join(definitionsDir, 'gate-exec.yaml'), gateWorkflow)
+  writeFileSync(join(definitionsDir, 'signoff-exec.yaml'), signoffWorkflow)
   activated = await activatePlugin(workflowsPlugin, testDir)
 })
 
@@ -159,5 +188,36 @@ describe('workflow exec tools', () => {
       status: 'pending_approval',
       stepId: 'review',
     })
+  })
+
+  it('surfaces the rejection-repeat guidance via the typed code, not message text', async () => {
+    createInstance('task-repeat', 'gate-exec', testDir, 'chef')
+    const submit = findTool(activated.execTools, 'bakin_exec_submit_step')!
+
+    const first = await callTool(submit, {
+      taskId: 'task-repeat', stepId: 'draft', output: { text: 'the draft' },
+    }, 'chef')
+    expect(first.ok).toBe(true)
+
+    const rejected = rejectGate('task-repeat', 'review', 'needs work', { contentDir: testDir })
+    expect(rejected.success).toBe(true)
+
+    const repeat = await callTool(submit, {
+      taskId: 'task-repeat', stepId: 'draft', output: { text: 'the draft' },
+    }, 'chef')
+    expect(repeat.ok).toBe(false)
+    expect(String(repeat.error)).toContain('too similar')
+    expect(String(repeat.errors)).toContain('identical')
+  })
+
+  it('check_gates classifies gates by definition type, not stepId naming', async () => {
+    createInstance('task-signoff', 'signoff-exec', testDir, 'chef')
+    const checkGates = findTool(activated.execTools, 'bakin_exec_check_gates')!
+
+    const result = await callTool(checkGates, { taskId: 'task-signoff' })
+    expect(result.ok).toBe(true)
+    const formatted = String(result.formatted)
+    expect(formatted).toContain('signoff')
+    expect(formatted).not.toContain('review-notes')
   })
 })

--- a/tests/plugins/workflows/gate-hooks.test.ts
+++ b/tests/plugins/workflows/gate-hooks.test.ts
@@ -25,6 +25,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/workflows/load-defaults.test.ts
+++ b/tests/plugins/workflows/load-defaults.test.ts
@@ -26,6 +26,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({
   addTaskLog: mock(),
   createTask: mock(),

--- a/tests/plugins/workflows/node-config-drawer.test.tsx
+++ b/tests/plugins/workflows/node-config-drawer.test.tsx
@@ -36,6 +36,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
 mock.module('@/core/task-store', () => ({}))
 
 // Stub AgentSelect so the agent-field renderer renders in jsdom without

--- a/tests/plugins/workflows/node-renderer-registry.test.ts
+++ b/tests/plugins/workflows/node-renderer-registry.test.ts
@@ -19,6 +19,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({ root: testDir }),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir }),
+}))
 
 mock.module('@/core/task-store', () => ({
   getTask: mock(),

--- a/tests/plugins/workflows/node-type-palette.test.tsx
+++ b/tests/plugins/workflows/node-type-palette.test.tsx
@@ -33,6 +33,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
 mock.module('@/core/task-store', () => ({}))
 
 import {

--- a/tests/plugins/workflows/parser.test.ts
+++ b/tests/plugins/workflows/parser.test.ts
@@ -28,6 +28,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ workflows: join(testDir, 'workflows') }),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({
   addTaskLog: mock(),
   createTask: mock(),

--- a/tests/plugins/workflows/plugin-node-integration.test.ts
+++ b/tests/plugins/workflows/plugin-node-integration.test.ts
@@ -20,6 +20,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../../src/core/audit', () => ({
   appendAudit: mock(),

--- a/tests/plugins/workflows/routes.test.ts
+++ b/tests/plugins/workflows/routes.test.ts
@@ -40,6 +40,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/workflows/runtime.test.ts
+++ b/tests/plugins/workflows/runtime.test.ts
@@ -19,6 +19,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 type HookTask = { id: string; title: string; column: string; description?: string }
 const hookTasks = new Map<string, HookTask>()

--- a/tests/plugins/workflows/sync-hook.test.ts
+++ b/tests/plugins/workflows/sync-hook.test.ts
@@ -40,6 +40,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('../../../src/core/logger', () => ({
   createLogger: () => ({

--- a/tests/plugins/workflows/workflow-canvas-editor.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas-editor.test.tsx
@@ -46,6 +46,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({
   createTask: mock(),
   addTaskLog: mock(),

--- a/tests/plugins/workflows/workflow-canvas.test.tsx
+++ b/tests/plugins/workflows/workflow-canvas.test.tsx
@@ -22,6 +22,10 @@ mock.module('../../../src/core/content-dir', () => ({
   getContentDir: () => testDir,
   getBakinPaths: () => ({}),
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
 mock.module('@/core/task-store', () => ({}))
 
 interface ReactFlowStubProps {

--- a/tests/plugins/workflows/workflow-detail.test.tsx
+++ b/tests/plugins/workflows/workflow-detail.test.tsx
@@ -31,6 +31,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('@/core/task-store', () => ({
   createTask: mock(),

--- a/tests/plugins/workflows/workflows-page.test.tsx
+++ b/tests/plugins/workflows/workflows-page.test.tsx
@@ -45,6 +45,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 
 mock.module('@/core/task-store', () => ({
   createTask: mock(),

--- a/tests/plugins/workflows/yaml-roundtrip.test.ts
+++ b/tests/plugins/workflows/yaml-roundtrip.test.ts
@@ -41,6 +41,13 @@ mock.module('../../../src/core/content-dir', () => ({
   initBakinHome: mock(),
   isUsingBakinHome: () => false,
 }))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
 mock.module('@/core/task-store', () => ({
   createTask: mock(),
   addTaskLog: mock(),

--- a/tests/scripts/post-channel.test.ts
+++ b/tests/scripts/post-channel.test.ts
@@ -17,6 +17,7 @@ const contentDirMock = {
   isUsingBakinHome: () => false,
 }
 mock.module('../../src/core/content-dir', () => contentDirMock)
+mock.module('../../packages/core/src/content-dir', () => contentDirMock)
 mock.module('@/core/content-dir', () => contentDirMock)
 
 let mockChannelAliases: Record<string, string> = {}


### PR DESCRIPTION
First workstream of the audit follow-up plan (\`tasks/plan-audit-follow-up.md\`, committed here). Ten verified correctness/hardening gaps, one revertable commit each.

## Fixes
1. **Tasks MCP guard gap** — exec tools now mirror REST guard coverage exactly: \`assign\` + \`set_dependency\` pass through \`taskEditGuard\` (agents could previously mutate completed/frozen tasks via MCP), \`update\` gains \`expectedVersion\` optimistic concurrency. Deliberate exemptions (move/complete/block/delete) documented in the module header.
2. **Identifier-fallback divergence** — one \`resolveTaskIdentifier\` with an explicit \`bodyTitleIsPayload\` mode replaces six inline chains that had silently diverged.
3. **submit_step text classification** — \`CompleteStepResult\` carries a typed \`code: 'rejection_repeat'\`; the old \`msg.includes('near-duplicate')\` catch was dead-aimed (the failure is returned, never thrown). \`check_gates\` classifies by definition step type, not stepId naming.
4. **Workflow instance durability** — engine state writes go through \`atomicWriteJson\` (crash mid-write can no longer truncate an instance).
5. **Settings secret re-admission** — a POST carrying \`search.settings.auth.password\` now relocates it to the secret store at write time (was: served unredacted until next boot).
6. **Images idempotency allowlist** — ledger rows are allowlist-built; a future content-bearing field can no longer leak into the execution ledger silently.
7. **Shipped-dist mtime-tie** — freshness check is strictly-newer + source installs delete the copied \`dist/\` before building; regression test plants attacker bytes behind a tie.
8. **Test-mock leak surface** — the CLAUDE.md-mandated dual content-dir mock was missing in **42** test files (audit flagged 1); all fixed.
9. **Type re-drift guard** — tasks-plugin board types re-derived from the store (the local copy had drifted); new \`tests/architecture/type-single-home.test.ts\` pins 11 contract types to their sanctioned homes.
10. **Dedup stragglers** — last raw frontmatter regex, mcporter's hand-rolled \`fixed()\`, schedule's two dead settings keys + unreachable ternary.

## Verification
- Full suite **5,301 pass / 0 fail** (521 files); typecheck clean at every commit
- Full binary build green (stamps reverted)
- Plugin client bundle verified free of server modules after the type re-derive

**Note:** \`bun run lint\` fails on pre-existing #457 files (unused vars in adapter-antfly, search-outbox, memory, assets/search-doc) — untouched by this branch, belongs to a search-migration follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)