### PR TITLE
fix(team,assets): avatar 304 declaration + pending-search empty state

### DIFF
--- a/plugins/assets/bakin-plugin.json
+++ b/plugins/assets/bakin-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "assets",
   "name": "Assets",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "bakin": ">=1.0.0",
   "description": "Centralized content store for all artifacts with rich rendering, search, task linking, manual upload, and clipboard paste",
   "entry": {

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -564,7 +564,17 @@ export function VersionedAssetGrid() {
       ) : searchUnavailable ? (
         <SearchUnavailable retry={search.retry} />
       ) : displayed.length === 0 ? (
-        <div className="p-8 text-sm text-muted-foreground" data-testid="assets-no-match">No assets match your filters.</div>
+        // A pending search with nothing settled yet (cold deep link like
+        // /assets?q=beef, or a new query after an empty result) must read as
+        // "searching", never as a premature "no match".
+        pending ? (
+          <div className="flex items-center gap-2 p-8 text-sm text-muted-foreground" data-testid="assets-searching">
+            <Loader2 className="size-4 animate-spin" />
+            Searching assets…
+          </div>
+        ) : (
+          <div className="p-8 text-sm text-muted-foreground" data-testid="assets-no-match">No assets match your filters.</div>
+        )
       ) : view === 'list' ? (
         <div className="flex flex-col gap-1.5" data-testid="assets-list">
           {displayed.map(asset => (

--- a/plugins/team/bakin-plugin.json
+++ b/plugins/team/bakin-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "team",
   "name": "Team",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bakin": ">=1.0.0",
   "description": "Agent team management \u2014 adapter layer over runtime agent workspaces",
   "entry": {

--- a/plugins/team/lib/team-routes.ts
+++ b/plugins/team/lib/team-routes.ts
@@ -665,7 +665,9 @@ export function populateTeamRoutes(arr: any[], deps: TeamRouteDeps): void {
     description: 'Serve agent avatar image',
     summary: 'Serve agent avatar image',
     params: z.object({ agentId: z.string() }),
-    responses: { 200: { contentType: 'application/octet-stream' }, 400: errorResponseTeam, 404: errorResponseTeam, 500: errorResponseTeam },
+    // 304: serveAvatar honors If-None-Match/If-Modified-Since (RFC 7232) —
+    // undeclared, every conditional browser refetch logs a dev-validator warn.
+    responses: { 200: { contentType: 'application/octet-stream' }, 304: { contentType: 'none' }, 400: errorResponseTeam, 404: errorResponseTeam, 500: errorResponseTeam },
     handler: async (req: Request, _ctx: PluginContextLite) => {
       const url = new URL(req.url)
       const agentId = url.searchParams.get('agentId')

--- a/tests/plugins/assets/versioned-grid-search-pending.test.tsx
+++ b/tests/plugins/assets/versioned-grid-search-pending.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+/**
+ * VersionedAssetGrid — pending-search empty state.
+ *
+ * A cold deep link (/assets?q=beef) used to flash "No assets match your
+ * filters." while the first search request was still in flight: the grid
+ * keeps the LAST SETTLED list on screen during a pending search, but on
+ * first load nothing has ever settled, so the no-match branch rendered
+ * prematurely. The no-match state must be gated on `pending` — while a
+ * search is in flight with nothing settled, the grid says "Searching…".
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode, ButtonHTMLAttributes, InputHTMLAttributes } from 'react'
+import { rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-assets-grid-${process.pid}-${Date.now()}`)
+
+// Mandatory isolation mocks (CLAUDE.md) — transitive imports must never
+// resolve the real content dir or OpenClaw home.
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+// ---------------------------------------------------------------------------
+// SDK mocks — primed per-test via module-level refs.
+// ---------------------------------------------------------------------------
+
+const queryStateRefs: Record<string, string> = {}
+
+interface SearchHookState {
+  results: Array<{ id: string; table: string; score: number; fields: Record<string, unknown>; indexScores?: Record<string, number> }>
+  loading: boolean
+  status: 'ok' | 'unavailable'
+  meta: { query: string } | null
+}
+const searchState: SearchHookState = { results: [], loading: false, status: 'ok', meta: null }
+
+mock.module('@makinbakin/sdk/hooks', () => ({
+  useQueryState: (key: string, defaultValue: string) => {
+    if (!(key in queryStateRefs)) queryStateRefs[key] = defaultValue
+    const setter = (v: string) => { queryStateRefs[key] = v }
+    return [queryStateRefs[key], setter, setter] as const
+  },
+  useQueryArrayState: (_key: string) => [[], () => {}] as const,
+  useSearch: () => ({
+    results: searchState.results,
+    aggregations: {},
+    loading: searchState.loading,
+    status: searchState.status,
+    error: null,
+    meta: searchState.meta,
+    search: mock(),
+    clear: mock(),
+    retry: mock(),
+  }),
+  useDebug: () => [false, () => {}] as const,
+  useRouter: () => ({ push: mock(), replace: mock() }),
+  usePathname: () => '/assets',
+  useSearchParams: () => new URLSearchParams(),
+  usePluginEvent: () => {},
+}))
+
+mock.module('@tanstack/react-router', () => ({
+  useNavigate: () => mock(),
+}))
+
+const passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>
+mock.module('@makinbakin/sdk/ui', () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  Badge: passthrough,
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: passthrough,
+  Textarea: (props: Record<string, unknown>) => <textarea {...props} />,
+  Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) => (open ? <div role="dialog">{children}</div> : null),
+  DialogContent: passthrough,
+  DialogHeader: passthrough,
+  DialogTitle: passthrough,
+  DialogDescription: passthrough,
+  DialogFooter: passthrough,
+  DropdownMenu: passthrough,
+  DropdownMenuTrigger: passthrough,
+  DropdownMenuContent: passthrough,
+  DropdownMenuItem: passthrough,
+}))
+
+mock.module('@makinbakin/sdk/components', () => ({
+  PluginHeader: ({ title }: { title?: ReactNode }) => <h1>{title}</h1>,
+  FacetFilter: () => <div data-testid="facet-filter" />,
+  SearchUnavailable: () => <div data-testid="search-unavailable" />,
+  ScoreOverlay: () => null,
+  AgentAvatar: () => <span />,
+  BakinDrawer: passthrough,
+  ConfirmDialog: () => null,
+}))
+
+mock.module('@makinbakin/sdk/utils', () => ({
+  formatSize: (n: number) => `${n}B`,
+  formatAge: () => 'now',
+}))
+
+import { VersionedAssetGrid } from '../../../plugins/assets/components/versioned/VersionedAssetGrid'
+
+// fetch stub: the grid loads the full unfiltered asset list on mount.
+const asset = (assetId: string, description: string, type: string) => ({
+  assetId, type, agent: 'jessica', taskId: null,
+  created: new Date().toISOString(), updated: new Date().toISOString(),
+  currentVersion: 1, versionCount: 1, description, tags: [],
+  mimeType: 'image/png', width: null, height: null, size: 10,
+  hasThumb: false, enrichment: 'none',
+})
+const ASSETS = [asset('a1', 'Brisket photo', 'images'), asset('a2', 'Sales doc', 'text')]
+const realFetch = globalThis.fetch
+beforeEach(() => {
+  globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/trash')) return Response.json({ items: [] })
+    return Response.json({ assets: ASSETS })
+  }) as unknown as typeof fetch
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = realFetch
+  for (const key of Object.keys(queryStateRefs)) delete queryStateRefs[key]
+})
+afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+describe('VersionedAssetGrid — pending search vs no-match', () => {
+  it('shows "Searching assets…" (never "no match") on a cold deep link while the search is in flight', async () => {
+    queryStateRefs.q = 'beef'
+    // Cold start: request in flight, nothing has ever settled.
+    searchState.results = []
+    searchState.loading = true
+    searchState.meta = null
+
+    render(<VersionedAssetGrid />)
+    await waitFor(() => expect(screen.queryByText('Loading assets…')).toBeNull())
+
+    expect(screen.getByTestId('assets-searching')).toBeDefined()
+    expect(screen.queryByTestId('assets-no-match')).toBeNull()
+  })
+
+  it('shows the real no-match state once the search settles empty', async () => {
+    queryStateRefs.q = 'beef'
+    searchState.results = []
+    searchState.loading = false
+    searchState.meta = { query: 'beef' } // settled for the current input
+
+    render(<VersionedAssetGrid />)
+    await waitFor(() => expect(screen.queryByText('Loading assets…')).toBeNull())
+
+    expect(screen.getByTestId('assets-no-match')).toBeDefined()
+    expect(screen.queryByTestId('assets-searching')).toBeNull()
+  })
+
+  it('renders results once the search settles with matches', async () => {
+    queryStateRefs.q = 'beef'
+    searchState.results = [{ id: 'a1', table: 'assets', score: 1, fields: {} }]
+    searchState.loading = false
+    searchState.meta = { query: 'beef' }
+
+    render(<VersionedAssetGrid />)
+    await waitFor(() => expect(screen.queryByText('Loading assets…')).toBeNull())
+
+    await waitFor(() => expect(screen.queryByTestId('assets-searching')).toBeNull())
+    expect(screen.queryByTestId('assets-no-match')).toBeNull()
+    // Only the matching asset renders (a2 has no search score).
+    await waitFor(() => expect(screen.getByTestId('assets-grid')).toBeDefined())
+    expect(screen.getByText('Brisket photo')).toBeDefined()
+    expect(screen.queryByText('Sales doc')).toBeNull()
+  })
+})

--- a/tests/plugins/team/routes.test.ts
+++ b/tests/plugins/team/routes.test.ts
@@ -384,6 +384,30 @@ describe('team plugin — avatar upload (dual-format)', () => {
     expect(existsSync(join(testDir, 'agents', 'pix-png', 'avatar.png'))).toBe(true)
   })
 
+  it('serves 304 for a matching If-None-Match and DECLARES it on the route', async () => {
+    const activated = await activatePlugin(teamPlugin, testDir)
+    const upload = findRoute(activated.routes, 'POST', '/:agentId/avatar')!
+    await uploadAvatar(upload, activated.ctx, 'pix-cache', WEBP)
+
+    const serve = findRoute(activated.routes, 'GET', '/:agentId/avatar')!
+    // Undeclared statuses make the dev-mode response validator warn on every
+    // conditional browser refetch ("undeclared response status 304").
+    // `responses` is a RouteDefinition field the legacy APIRoute type omits.
+    const declared = (serve as unknown as { responses?: Record<string, unknown> }).responses
+    expect(Object.keys(declared ?? {})).toContain('304')
+
+    const first = await callRoute(serve, activated.ctx, { searchParams: { agentId: 'pix-cache' }, rawResponse: true })
+    expect(first.response.status).toBe(200)
+    const etag = first.response.headers.get('ETag')
+    expect(etag).toBeTruthy()
+
+    const req = new Request('http://localhost/pix-cache/avatar?agentId=pix-cache', {
+      headers: { 'If-None-Match': etag! },
+    })
+    const res = await serve.handler(req, activated.ctx)
+    expect(res.status).toBe(304)
+  })
+
   it('rejects non-image bytes with 400', async () => {
     const activated = await activatePlugin(teamPlugin, testDir)
     const upload = findRoute(activated.routes, 'POST', '/:agentId/avatar')!


### PR DESCRIPTION
Two small UI/route fixes found during #357 manual testing.

## 1. `fix(team)`: declare 304 on the avatar serve route

Fixes the startup log noise:

```
warn dispatcher GET /:agentId/avatar (...): undeclared response status 304
```

**Root cause — not actually Tailscale.** `serveAvatar` (`packages/core/src/agents/avatar.ts`) correctly implements RFC 7232 conditional requests: a browser with the avatar cached sends `If-None-Match`, and the handler returns **304 Not Modified**. But the team plugin's `GET /:agentId/avatar` route only declared `200/400/404/500`, so the dev-mode response validator (`packages/core/src/routing/dispatcher.ts`) warned on every conditional refetch. It shows up on the Tailscale hostname because that browser profile keeps its own cache full of avatar ETags — any warm-cache browser (local included) produces the same warnings.

**Fix:** declare `304: { contentType: 'none' }` on the route. Test pins both the declaration and the conditional-request behavior (upload → 200 + ETag → refetch with `If-None-Match` → 304). Team plugin 1.0.0 → 1.0.1. The host-api avatar/asset handlers also emit 304s but don't pass through the declared-response validator — no other routes affected.

## 2. `fix(assets)`: pending searches no longer flash "No assets match your filters."

Cold deep links (`/assets?q=beef`) showed the no-match empty state while the first search request was still in flight, then results popped in. The grid already had anti-flash machinery (`pending` + last-settled-list retention), but the no-match render branch never consulted `pending` — and on first load nothing has ever settled, so the retention trick can't help. Same premature no-match appeared when typing a new query right after an empty result.

**Fix:** gate the empty state on `pending` — in-flight searches with nothing settled render a spinner + "Searching assets…" (`data-testid="assets-searching"`). Component test pins RED/GREEN on both states (verified failing against the pre-fix component). Assets plugin 2.2.1 → 2.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)