### PR TITLE
fix(workflows): order-independent cross-plugin nested refs (#374)

### DIFF
--- a/.claude/knowledge/workflows-plugin.md
+++ b/.claude/knowledge/workflows-plugin.md
@@ -109,9 +109,24 @@ Start-time validation checks those ids against the runtime roster. `$assigned`
 requires the task to already have an assignee and fails before instance creation
 if it cannot resolve.
 
-Default workflow loading is two-pass: Bakin parses every file, builds the set of
-known workflow ids, then validates. Nested workflow references are therefore not
-filesystem-order dependent.
+### Three-tier reference validation (#374)
+
+Nested `workflow_id` existence is deliberately validated at three tiers,
+because plugin-default loading runs per-plugin during `activate()` and a
+referenced workflow may ship in a plugin that has not activated yet:
+
+1. **Load (structural only, fatal):** `loadDefaultWorkflows` validates each
+   YAML in a single pass with `validateNestedWorkflowRefs: false`. Malformed
+   definitions, missing `workflow_id`, and self-references are skipped with a
+   warn log. A nested ref pointing at a workflow that is not (yet) registered
+   is NOT a load error — cross-plugin composition must not depend on plugin
+   activation order, hot-reload timing, or user-plugin install order.
+2. **Start (strict, fatal):** every start path (REST, hooks, exec tools) goes
+   through `createValidatedInstance`, which recursively loads each nested
+   definition, detects cycles, and rejects genuinely missing children.
+3. **Health (advisory):** the `workflow-definitions` check warns when any
+   definition references a nested workflow absent from the live user-disk +
+   registry set — order-independent and current under hot reload.
 
 ## Runtime Execution Contract
 
@@ -125,7 +140,7 @@ Validation enforces the current engine's real contract:
 - `gate.on_approve` must advance to the next top-level step, or `done` for a final gate.
 - `gate.on_reject.goto` can only target the current or an earlier top-level step.
 - `parallel` groups can only contain agent child steps; gates, output steps, nested workflows, and child `dependsOn` are rejected.
-- `workflow` nested references must resolve to known definitions and cannot reference themselves. Start-time validation rejects nested workflow cycles.
+- `workflow` nested references cannot reference themselves (fatal everywhere). Existence is tiered (#374): not checked at plugin-default load, fatal at start time, advisory in the `workflow-definitions` health check.
 - `output` steps require an agent owner so channel-post authorization has a concrete principal.
 
 Agents are also gated at tool-use time. Workflow step reads and submissions use

--- a/.claude/specs/workflows-hardening-plan.md
+++ b/.claude/specs/workflows-hardening-plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: Workflows Hardening Batch
+
+**Spec:** `.claude/specs/workflows-hardening.md` (approved 2026-07-03)
+**Shape:** 3 sequential PRs; every commit green (`bun run test` + `bun run typecheck` + `bun run lint`); each commit is a rollback checkpoint.
+
+## Architecture Decisions (from spec interview)
+
+- **#374 via demotion, not settle pass** — load-time keeps structural/self-ref checks fatal, defers nested-ref *existence* to the (already strict, recursive) start-time validator plus a health-check warning. Covers boot order, hot reload, and user-plugin install timing with less machinery.
+- **Delete, don't deprecate** — workflow-step `dependsOn` and gate `on_approve` are removed outright. No shims (single-user machine, spec boundary).
+- **Fan-out is design-only** — ordered-list engine + one `map_workflow` node, join-waits-all, per-child retry. No implementation this batch.
+
+## Plan-phase findings (resolved spec open questions)
+
+1. **Node-type schemas were `.passthrough()` everywhere** — unknown YAML keys silently ignored. **Decided at plan review (user call): flip builtin schemas to `.strict()` in PR 2.** Rationale: all plugins are managed in this repo + bakin-bits; plugin-contributed node types validate against their own registered schemas via the registry-dispatch branch (`node-type-registry.ts:356-400`), so builtin strictness has no third-party blast radius — and no plugin even registers a node type today. The zod schemas gate only the CRUD/save boundary (`plugins/workflows/lib/routes/definitions.ts:168,214`); the disk-load path uses the manual semantic validator and stays lenient, so a health-check warning covers stray keys in on-disk definitions.
+2. **No `on_approve`/`dependsOn` references** under `agents/`, `README.md`, or `docs/*.md`. Test files referencing them: 8 under `tests/plugins/workflows/` (the `tests/core/` hits are task-domain `dependsOn` — untouched).
+3. **Health check folds in**: `checkWorkflowDefinitions` (`plugins/workflows/lib/health-checks.ts:175`) already walks every definition's steps for skill refs; add a `workflow`-type branch resolving `workflow_id` via the same user-disk + registry tiers. Same check id (`workflow-definitions`).
+
+---
+
+## PR 1 — `fix(workflows): order-independent cross-plugin nested refs (#374)`
+Branch: `fix/workflow-cross-plugin-refs`
+
+### Task 1: Defer nested-ref existence at default load; collapse two-pass
+**Description:** `loadDefaultWorkflows` passes `validateNestedWorkflowRefs: false` to `validateDefinition`; with the known-set no longer consulted at load, collapse the parse→known-set→validate two-pass into a single parse+validate pass. `validateDefinition` keeps `knownWorkflowIds` (start-validation uses it). CRUD/save and start paths unchanged (stay strict).
+**Acceptance:**
+- [ ] A parent workflow registering a nested ref to a not-yet-activated plugin's workflow registers successfully (both activation orders).
+- [ ] Structural errors and self-references still skip the definition at load with a warn log.
+- [ ] Starting a workflow whose nested child is truly absent still hard-fails via `createValidatedInstance`.
+**Verify:** `bun test tests/plugins/workflows/load-defaults.test.ts tests/plugins/workflows/start-validation.test.ts --isolate` (add cross-plugin both-orders regression — image-social-post↔image-generation shaped, per #374 acceptance); `bun run typecheck`.
+**Files:** `packages/core/src/workflows/load-defaults.ts`, `tests/plugins/workflows/load-defaults.test.ts` (+ start-validation test if not already covering absent-child). **Scope: S**
+**Commit:** `fix(workflows): defer nested-ref existence to start validation; single-pass default loading (#374)`
+
+### Task 2: Health-check warning for missing nested workflow refs
+**Description:** Extend `checkWorkflowDefinitions` to warn `Workflow "X" step "S" references nested workflow "Y" which does not exist`, resolving Y against user disk + source registry (mirror `loadDefinition` tiers). Evaluated live, so it is order-independent and current under hot reload.
+**Acceptance:**
+- [ ] Warning appears for a definition referencing a missing child; clears once the child is registered.
+- [ ] Existing skill-ref warnings unchanged; `ok` result still emitted when clean.
+**Verify:** `bun test tests/plugins/workflows/health-checks.test.ts --isolate`.
+**Files:** `plugins/workflows/lib/health-checks.ts`, `tests/plugins/workflows/health-checks.test.ts`. **Scope: S**
+**Commit:** `feat(workflows): health-check warning for missing nested workflow refs`
+
+### Task 3: Knowledge doc — three-tier validation model
+**Description:** Update `.claude/knowledge/workflows-plugin.md`: document load (structural, fatal) / start (strict recursive existence + cycles, fatal) / health (advisory refs) tiers; remove the now-stale two-pass known-set description; note cross-plugin refs are order-independent.
+**Acceptance:** doc matches shipped behavior; no stale two-pass reference remains.
+**Verify:** `bun run docs:generate && bun run docs:validate`.
+**Files:** `.claude/knowledge/workflows-plugin.md`. **Scope: XS**
+**Commit:** `docs(knowledge): document the three-tier workflow validation model`
+
+### Checkpoint 1 (gate to PR 2)
+- [ ] Full `bun run test` + `bun run typecheck` + `bun run lint` + docs validation green.
+- [ ] Open PR 1; user reviews.
+
+---
+
+## PR 2 — `refactor(workflows)!: delete dead YAML surface`
+Branch: `refactor/workflow-yaml-honesty` (off `main`; independent of PR 1 — rebase-free)
+
+### Task 4: Delete workflow-step `dependsOn`
+**Description:** One vertical deletion (type → validator → node registry → UI → tests must land together to stay green): remove `dependsOn` from step interfaces; delete `validateDependsOn` + parallel-child `dependsOn` rejection; remove `dependsOnSchema` + field descriptor; remove `node-config-fields.ts` filter, canvas "dependsOn preserved" badge, drawer metadata note, `DependsOnSection`.
+**Acceptance:**
+- [ ] `grep -rn "dependsOn" packages/core/src/workflows plugins/workflows` → 0 hits.
+- [ ] Canvas, node-config drawer, step-detail drawer render without the removed affordances.
+**Verify:** `bun test tests/plugins/workflows/ --isolate`; `bun run typecheck`.
+**Files (~10, mechanical single concern):** `packages/core/src/workflows/{definition-types,validate-definition,node-type-registry}.ts`, `plugins/workflows/lib/node-config-fields.ts`, `plugins/workflows/components/{workflow-canvas-editor,node-config-drawer,step-detail-drawer}.tsx`, affected tests. **Scope: L-mechanical**
+**Commit:** `refactor(workflows)!: delete workflow-step dependsOn`
+
+### Task 5: Delete gate `on_approve`; approval advances by position
+**Description:** Remove `on_approve` from `GateStep`, the validator's expected-next check, the node-registry gate schema + descriptor, `canvas-editor-state.ts` default gate object, `node-config-fields.ts` labels/help/examples, the `routes/gates.ts:333` echo, and all 7 shipped YAMLs (`plugins/workflows/defaults/workflows/*.yaml`, `plugins/images/defaults/workflows/image-generation.yaml`). Runtime behavior is already position-based — no engine change.
+**Acceptance:**
+- [ ] Repo grep for `on_approve` → 0 hits outside git history.
+- [ ] New/updated test: mid-workflow gate approval advances to the next step; final-gate approval completes the workflow.
+- [ ] All 7 shipped YAMLs load and validate.
+**Verify:** `bun test tests/plugins/workflows/ --isolate` (gate-hooks, parser, exec-tools, runtime, yaml-roundtrip, canvas/drawer suites).
+**Files (~14, mechanical):** the above + tests. **Scope: L-mechanical**
+**Commit:** `refactor(workflows)!: delete gate on_approve; approval advances by position`
+
+### Task 6: Align `ParallelStep` children type with validator
+**Description:** `ParallelStep.steps: AgentStep[]` (validator already rejects non-agent children); fix any type-level fallout (audit found casts in health-checks/engine that may simplify).
+**Acceptance:** type matches validator; no behavior change.
+**Verify:** `bun run typecheck`; `bun test tests/plugins/workflows/ --isolate`.
+**Files:** `packages/core/src/workflows/definition-types.ts` + fallout. **Scope: XS**
+**Commit:** `refactor(workflows): align ParallelStep children type with validator`
+
+### Task 7: Strict builtin schemas + unknown-key health warning
+**Description:** Flip the six builtin step schemas and their sub-schemas (`stepOutputSchema`, `notifyChannelSchema`, `on_reject` object, `taskSourceSchema`, `workflowInputSchema`, `nodePositionSchema`, `workflowLayoutSchema`, `workflowDefinitionSchema`) from `.passthrough()` to `.strict()`. Extend the `workflow-definitions` health check to warn on unknown keys in on-disk definitions (zod-parse each; report per-definition). Must land AFTER Tasks 4–5 in commit order (else shipped YAMLs' `on_approve` would strict-fail mid-branch).
+**Acceptance:**
+- [ ] Saving a definition with an unknown key (e.g. leftover `on_approve`) via PUT/POST is rejected with an error that names the key and step — NOT the generic "Invalid builtin step" union-fallthrough message.
+- [ ] All 7 shipped YAMLs strict-parse clean.
+- [ ] Health check warns on a fixture definition carrying a stray key; clean otherwise.
+**Verify:** `bun test tests/plugins/workflows/node-type-registry.test.ts tests/plugins/workflows/routes.test.ts tests/plugins/workflows/health-checks.test.ts --isolate` (+ new unknown-key rejection tests).
+**Files:** `packages/core/src/workflows/node-type-registry.ts`, `plugins/workflows/lib/health-checks.ts`, tests. **Scope: M**
+**Commit:** `feat(workflows)!: strict builtin step schemas; unknown keys reject on save, warn in health`
+
+### Task 8: Docs sweep for PR 2
+**Description:** Update `.claude/knowledge/workflows-plugin.md` Runtime Execution Contract (drop `dependsOn`-as-metadata and `on_approve` rules; state gate-advance-by-position); re-grep `docs/`, `README.md`, `agents/` for stragglers (plan-phase grep was clean — confirm post-change).
+**Verify:** `bun run docs:generate && bun run docs:validate && bun run docs:validate:routes`.
+**Files:** `.claude/knowledge/workflows-plugin.md`. **Scope: XS**
+**Commit:** `docs(knowledge): workflows YAML surface after dependsOn/on_approve removal`
+
+### Checkpoint 2 (gate to PR 3)
+- [ ] Full suite + typecheck + lint + docs validation green.
+- [ ] Manual: load the workflows UI against dev/mock (`bun run dev:mock`), open a shipped workflow in the canvas, confirm gate nodes render and the config drawer shows no ghost fields.
+- [ ] Open PR 2; user reviews.
+
+---
+
+## PR 3 — `docs(workflows): map_workflow fan-out design (#203)`
+Branch: `docs/workflow-map-fanout-design`
+
+### Task 9: Write the fan-out design doc
+**Description:** `.claude/specs/workflow-map-fanout-design.md` — the buildable design for #203's core requirement. Must cover: motivation (video pipeline); `map_workflow` node semantics (`source` = prior-step output array path; one child instance per item via existing nested-workflow machinery; item injected as parent context); join-waits-all with stable source-order output aggregation; failure model (parent stays in_progress, per-child retry/cancel, no fail-fast, no policy knob); source-step `output_schema` contract; concurrency (children flow through existing dispatch caps — no new surface); UI (canvas node with child-status rollup; children appear as tasks like nested workflows today); validation rules; explicit non-goals (DAG, branching, forward jumps); implementation sketch + test plan for the future build.
+**Acceptance:** doc answers every "Broader refactor questions" bullet in #203 that the interview scoped in, and names the rest as non-goals.
+**Verify:** `bun run docs:validate`; user review of the doc is the real gate.
+**Files:** `.claude/specs/workflow-map-fanout-design.md` (new). **Scope: M (one file, dense)**
+**Commit:** `docs(workflows): map_workflow fan-out design (#203)`
+
+### Task 10: Rewrite #203 (post-merge)
+**Description:** `gh issue edit 203` — new body: current-engine summary (post-PR-1/2), link to the design doc, scope narrowed to "implement map_workflow per the design doc." Not a repo change; do after PR 3 merges.
+**Verify:** issue body renders correctly; old context preserved via a comment noting the rewrite.
+
+### Checkpoint 3 (batch complete)
+- [ ] Spec success criteria 1–5 all check out (grep proofs, regression tests, docs).
+- [ ] Update `.claude/specs/workflows-hardening.md` status → shipped; note in plan doc.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Deletion sweeps miss a consumer (runtime cast, test fixture) | Med | Success-criteria greps are part of Task 4/5 acceptance; typecheck catches typed consumers; `--isolate` full suite per commit |
+| `.passthrough()` keeps stale keys inert (silently ignored) rather than rejected | Low | Deliberate: keep existing posture (see open question); stale keys are dead weight, not behavior |
+| Known order-dependent full-suite flake (`header-update-banner`) | Low | Re-run the failing file individually before diagnosing (established pattern) |
+| `bun run build` rewrites the tracked build stamp in the worktree | Med | Don't run `build` in this batch; if ever run, never `git add -A` (memory: generated-version build-stamp trap) |
+| PR 2 UI edits conflict with concurrent canvas work on the machine | Low | Worktree isolates us; PRs are small and short-lived |
+
+## Parallelization
+
+PR 1 and PR 2 touch disjoint code (load path vs YAML surface) and can be built in parallel; land sequentially for review sanity. PR 3 is independent prose.
+
+## Open Questions
+
+None — all resolved (strictness decided at plan review; see finding 1 and Task 7).

--- a/.claude/specs/workflows-hardening.md
+++ b/.claude/specs/workflows-hardening.md
@@ -1,0 +1,162 @@
+# Spec: Workflows Hardening Batch
+
+**Status:** Draft — pending approval
+**Date:** 2026-07-03
+**Issues:** #374 (implement), #203 (design doc + issue rewrite)
+**Closed by the audit preceding this spec:** #386 (resolved by skill-registry redesign + #407), #98 (not planned — speculative, architecturally stale), #38 (obsolete premise, contradicts adapter-boundary doctrine)
+
+## Objective
+
+Reduce workflow-engine tech debt by making the YAML surface honest (no fields the engine ignores, no load-order landmines) and settle the dynamic fan-out design on paper so #203 becomes a buildable ticket instead of an umbrella.
+
+Success looks like:
+- A workflow in plugin A that nests a workflow shipped by plugin B loads identically regardless of plugin activation order.
+- Every field a workflow author can write is a field the runtime actually reads.
+- `.claude/specs/workflow-map-fanout-design.md` exists and settles the map-node semantics; #203's body points at it.
+
+This machine is the only user. **No backwards compatibility, no shims, no deprecation windows** — dead surface is deleted outright.
+
+## Context (verified against code, 2026-07-03)
+
+- Execution is a strict ordered-list engine: top-level index advance, static `parallel` groups (validator restricts children to agent steps), recursive nested `workflow` steps, plugin node kinds. (`plugins/workflows/lib/engine.ts`, `packages/core/src/workflows/validate-definition.ts`)
+- Start-time validation is already strict and recursive with cycle detection on **every** start path (REST, hooks, exec tools) via `createValidatedInstance` (`plugins/workflows/lib/start-validation.ts`).
+- Load-time nested-ref validation is the only order-sensitive piece: `loadDefaultWorkflows` validates during each plugin's `activate()` with a known-set limited to that plugin's own batch, falling back to the live registry — so cross-plugin refs depend on activation order, and a miss **silently skips the parent workflow** (`packages/core/src/workflows/load-defaults.ts:57-68`).
+- Workflow-step `dependsOn` is parsed, validated, and displayed — never read by the engine. No shipped YAML uses it. (Task-level `dependsOn` is a different, live system — out of scope.)
+- Gate `on_approve` is required, has exactly one legal value (next top-level step id, or `done` when last — `validate-definition.ts:184-193`), and the runtime never branches on it. All 7 shipped YAMLs carry it; reordering steps forces manual re-sync.
+- `ParallelStep` type admits `AgentStep | GateStep` children (`definition-types.ts:67-70`) but the validator rejects non-agent children (`validate-definition.ts:222-224`) — type/validator mismatch.
+- `validateDefinition` already accepts `validateNestedWorkflowRefs?: boolean` (default `true`); no caller passes `false` (`validate-definition.ts:22,82,196`).
+
+## Scope — three workstreams
+
+### WS1 — #374: order-independent cross-plugin nested refs (PR 1)
+
+**Decision (interview):** demote the load-time nested-ref existence check rather than add a boot settle pass. A settle pass would still miss hot-reload and user-plugin install timing; the health check + strict start validation cover all timings with less machinery.
+
+1. `loadDefaultWorkflows` passes `validateNestedWorkflowRefs: false`. Structural validation, self-reference, and every other check stay **fatal** at load; only cross-workflow existence is deferred.
+2. Collapse the now-unneeded two-pass parse in `load-defaults.ts` to a single pass (`knownWorkflowIds` no longer needed at load; `validateDefinition` keeps the param for start-validation use).
+3. Extend the existing `workflow-definitions` health check (`plugins/workflows/lib/health-checks.ts` — already warns on missing skill refs) to also warn per definition: `workflow "X" references missing nested workflow "Y"`, evaluated against the live registry + user disk. Order-independent by construction, current under hot reload.
+4. CRUD/save paths keep the existence check fatal (server is fully activated at save time, so the registry is complete — rejecting a bad save is correct there).
+5. Start-time validation: unchanged (already the strict gate).
+
+### WS2 — YAML-surface honesty (PR 2)
+
+**Delete workflow-step `dependsOn`** (interview decision):
+- Type family: remove from all step interfaces (`packages/core/src/workflows/definition-types.ts`).
+- Validator: remove `validateDependsOn` and the parallel-child `dependsOn` rejection (`validate-definition.ts:148-165,225-227`).
+- Node-type registry: remove `dependsOnSchema` and its 5 usages + the field descriptor (`node-type-registry.ts:137,161,181,194,204,230,251`).
+- UI: remove the canvas "dependsOn preserved" badge (`workflow-canvas-editor.tsx:855-1035` region), the drawer note (`node-config-drawer.tsx:357-359`), `DependsOnSection` (`step-detail-drawer.tsx`), and the `node-config-fields.ts:31` filter.
+
+**Delete gate `on_approve`** (interview decision):
+- Approval always advances to the next top-level step, or completes the workflow at the last step — this is already the only runtime behavior (`gates.ts` advances via `advanceWorkflow`; `on_approve` is only echoed at `routes/gates.ts:333`).
+- Remove from: `GateStep` type, validator check (`validate-definition.ts:184-193`), node-type gate schema (`node-type-registry.ts:173,258`), default gate object (`canvas-editor-state.ts:78`), labels/help/examples (`node-config-fields.ts:137,158,177`), route echo (`routes/gates.ts:333`), and all 7 shipped YAMLs (`plugins/workflows/defaults/workflows/*.yaml`, `plugins/images/defaults/workflows/image-generation.yaml`).
+- `on_reject` (rewind via `goto`, `rejection_repeat` handling) is real and **stays untouched**.
+
+**Align `ParallelStep`:** children typed `AgentStep[]` to match the validator.
+
+**Flip builtin node-type schemas to `.strict()`** (decided at plan review): all plugins are managed in this repo + bakin-bits, and plugin-contributed node types validate against their own registered schemas (registry-dispatch branch), so strictness on the builtin schemas has no third-party blast radius. Unknown keys reject at the CRUD/save boundary (`routes/definitions.ts`); a health-check warning surfaces stray keys in already-on-disk definitions (the disk-load path uses the manual semantic validator and stays lenient). Unknown-key rejection errors must stay readable — a strict-failed builtin step falls through the zod union to the plugin-dispatch branch, which must not mask the real issue.
+
+### WS3 — fan-out design doc + #203 rewrite (PR 3)
+
+Write `.claude/specs/workflow-map-fanout-design.md`. Decisions already made in interview, to be elaborated:
+- **Engine model:** ordered-list executor stays; add ONE step type — `map_workflow` (`source`: path to a prior step's output array; one child per item; child receives its item as parent context). No DAG, no scheduler rewrite.
+- **Children reuse nested-workflow machinery** — instances, gates-inside-children, cycle detection, task-board visibility all come for free.
+- **Join:** parent step stays `in_progress` until every child terminal-succeeds; outputs aggregated in stable source order.
+- **Failure model:** join waits; failed children are individually retryable/cancellable; no fail-fast, no per-node policy knob.
+- Doc must also cover: output-schema contract on the source step, concurrency (children flow through the existing dispatch caps — no new surface), UI representation (canvas rollup + children as tasks), and explicit non-goals (branching, forward jumps, arbitrary graphs).
+- Rewrite #203's body: current-state summary, link to the design doc, scope narrowed to "implement map_workflow per the design doc."
+
+## Non-goals
+
+- Implementing `map_workflow` (design only).
+- Touching task-level `dependsOn`, dispatch, or the recovery ladder.
+- Instance-persistence changes (atomic JSON store stays; #38 closed).
+- Notification formatting (#98 closed).
+
+## Tech Stack
+
+Existing: Bun ≥1.2, TypeScript strict, Zod at boundaries, React 19 (canvas UI), `bun:test`.
+
+## Commands
+
+```
+Test (full):    bun run test
+Test (single):  bun test tests/plugins/workflows/<file>.test.ts --isolate
+Typecheck:      bun run typecheck
+Lint:           bun run lint
+Docs:           bun run docs:generate && bun run docs:validate && bun run docs:validate:routes
+```
+
+## Project Structure (touched surface)
+
+```
+packages/core/src/workflows/
+  definition-types.ts       WS2: remove dependsOn, on_approve; align ParallelStep
+  validate-definition.ts    WS1: (no change — flag exists) / WS2: remove dead checks
+  load-defaults.ts          WS1: pass flag, collapse two-pass
+  node-type-registry.ts     WS2: schema + field-descriptor removals
+plugins/workflows/
+  lib/health-checks.ts      WS1: nested-ref warnings in workflow-definitions check
+  lib/routes/gates.ts       WS2: drop on_approve echo
+  lib/canvas-editor-state.ts / lib/node-config-fields.ts   WS2
+  components/{workflow-canvas-editor,node-config-drawer,step-detail-drawer}.tsx  WS2
+  defaults/workflows/*.yaml WS2: strip on_approve
+plugins/images/defaults/workflows/image-generation.yaml    WS2
+tests/plugins/workflows/    all WSs: see Testing Strategy
+.claude/knowledge/workflows-plugin.md    WS1+WS2: update Runtime Execution Contract,
+                            document load-vs-start-vs-health validation tiers
+.claude/specs/workflow-map-fanout-design.md   WS3 (new)
+```
+
+`README.md`: check for workflow YAML examples mentioning removed fields; update if present.
+
+## Code Style
+
+Repo conventions per `CLAUDE.md` (strict TS, kebab-case files, `createLogger`, import order). Deletions must be complete — no commented-out remnants, no `@deprecated` markers, no compat aliases.
+
+## Testing Strategy
+
+`bun:test`, files under `tests/plugins/workflows/`, mandatory content-dir + OpenClaw-home mocks per CLAUDE.md testing rules. Green at **every commit**, not just per PR.
+
+- **WS1:** extend `load-defaults.test.ts` — parent in plugin A referencing child in plugin B, asserted in **both activation orders** (the #374 acceptance regression, image-social-post↔image-generation shaped); parent registers when child is absent; start-time still fails when child truly missing. Extend `health-checks.test.ts` — missing-nested-ref warning appears/clears.
+- **WS2:** update `schema-validator.test.ts`, validator tests, `yaml-roundtrip.test.ts`, canvas/drawer component tests for removed fields; add a test that gate approval advances correctly with no `on_approve` present (last-gate → workflow completes).
+- **WS3:** no code; docs validation commands only.
+
+## Commit & Rollback Strategy
+
+Three sequential PRs off `main`, each independently revertable; every commit conventional-format and green (`test` + `typecheck` + `lint`).
+
+**PR 1 — `fix(workflows): order-independent cross-plugin nested refs (#374)`**
+1. `fix(workflows): defer nested-ref existence to start validation; single-pass default loading` (+ tests)
+2. `feat(workflows): health-check warning for missing nested workflow refs` (+ tests)
+3. `docs(knowledge): document the three-tier validation model in workflows-plugin.md`
+
+**PR 2 — `refactor(workflows)!: delete dead YAML surface (dependsOn, on_approve)`**
+1. `refactor(workflows)!: delete workflow-step dependsOn` (types → validator → registry → UI → tests)
+2. `refactor(workflows)!: delete gate on_approve; approval advances by position` (+ 7 YAMLs, tests)
+3. `refactor(workflows): align ParallelStep children type with validator`
+4. `docs: update workflows knowledge doc + any README examples`
+
+**PR 3 — `docs(workflows): map_workflow fan-out design (#203)`**
+1. Design doc + #203 issue-body rewrite (issue edit happens at merge time).
+
+Rollback = revert the offending commit or PR; no cross-PR coupling. PR 2 depends on nothing in PR 1 (parallel-safe, but land sequentially for clean review).
+
+## Boundaries
+
+- **Always:** work only in this worktree (`.claude/worktrees/workflows-hardening`); full test suite + typecheck + lint green per commit; mock content-dir/OpenClaw-home in every test; update `.claude/knowledge/workflows-plugin.md` in the same PR as the behavior it documents.
+- **Ask first:** any schema/type change beyond the three agreed deletions; anything touching dispatch, task-store, or task-level `dependsOn`; adding new YAML surface; changing gate `on_reject` semantics.
+- **Never:** compat shims or deprecation aliases; edits in the main checkout; touching `~/.bakin/`; implementing fan-out in this batch; force-push to shared branches.
+
+## Success Criteria
+
+1. Regression test proves plugin-A→plugin-B nested refs load in both activation orders; missing children surface as health warnings and hard start-time errors — never silent skips.
+2. `grep -r "dependsOn" packages/core/src/workflows plugins/workflows` returns zero hits (task-domain hits untouched); same for `on_approve` repo-wide outside git history.
+3. All 7 shipped YAMLs load and their gates approve/advance/complete correctly.
+4. Full suite green; docs validation green; knowledge doc matches the shipped behavior.
+5. `.claude/specs/workflow-map-fanout-design.md` merged; #203 body rewritten to reference it with narrowed scope.
+
+## Open Questions — resolved in plan phase
+
+1. **Strictness:** flip builtin schemas to `.strict()` in PR 2 (see WS2) — decided with user at plan review; passthrough was the mechanism this batch exists to kill, and the ratchet only gets harder.
+2. **`agents/` sweep:** clean — no `on_approve`/`dependsOn` in shipped agent content, README, or docs/.
+3. **Health check placement:** fold into the existing `workflow-definitions` check id (it already walks all definitions' steps).

--- a/docs/.generated/coverage.json
+++ b/docs/.generated/coverage.json
@@ -4,8 +4,8 @@
   "surfaces": {
     "cliCommands": {
       "status": "active",
-      "count": 64,
-      "examples": 73,
+      "count": 65,
+      "examples": 75,
       "source": "src/core/cli/registry.ts"
     },
     "httpRoutes": {
@@ -23,7 +23,7 @@
     },
     "hookRegistrations": {
       "status": "audited",
-      "count": 46,
+      "count": 48,
       "source": "source scan"
     },
     "slots": {
@@ -34,7 +34,7 @@
     },
     "execTools": {
       "status": "audited",
-      "count": 123,
+      "count": 125,
       "source": "source scan"
     },
     "corePlugins": {
@@ -44,7 +44,7 @@
     },
     "settings": {
       "status": "active",
-      "count": 64,
+      "count": 66,
       "source": "packages/core/src/settings.ts"
     },
     "sdkSubpaths": {

--- a/docs/public/llms/cli.md
+++ b/docs/public/llms/cli.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The CLI reference is generated from src/core/cli/registry.ts. Current public command count: 64. Help output and generated docs use the same registry.
+The CLI reference is generated from src/core/cli/registry.ts. Current public command count: 65. Help output and generated docs use the same registry.

--- a/docs/public/llms/exec-tools.md
+++ b/docs/public/llms/exec-tools.md
@@ -78,6 +78,29 @@ mcporter call bakin-<agent>.bakin_exec_assets_get --args '{
 }'
 ```
 
+### bakin_exec_assets_import
+
+Label: Imported unmanaged files
+Purpose: Explicitly import unmanaged files into managed versioned assets. Pass path (content-dir relative, e.g. assets/inbox/pic.png) or all: true. Optional type override and taskId link.
+
+| Argument | Type | Required | Description |
+| --- | --- | --- | --- |
+| `path` | string | no | One unmanaged file to import (content-dir relative) |
+| `all` | boolean | no | Import every unmanaged file |
+| `type` | choice | no | Override the suggested asset type |
+| `taskId` | string | no | Link the imported asset(s) to this task |
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_assets_import --args '{
+  "path": "value",
+  "all": true,
+  "type": "value",
+  "taskId": "value"
+}'
+```
+
 ### bakin_exec_assets_link
 
 Label: Linked an asset
@@ -232,6 +255,19 @@ mcporter call bakin-<agent>.bakin_exec_assets_save --args '{
   "tool": "value",
   "slug": "value"
 }'
+```
+
+### bakin_exec_assets_scan_unmanaged
+
+Label: Scanned for unmanaged files
+Purpose: List files under assets/ that are NOT managed assets (inbox drops, loose files). Nothing is imported automatically — use bakin_exec_assets_import to import.
+
+Arguments: none.
+
+Example:
+
+```sh
+mcporter call bakin-<agent>.bakin_exec_assets_scan_unmanaged
 ```
 
 ## Check
@@ -1139,13 +1175,13 @@ Publishing tools send completed work to configured channels through Bakin adapte
 ### bakin_exec_post_channel
 
 Label: Posted to channel
-Purpose: Post a message through the active runtime channel adapter. Supports image/video attachments when the adapter supports rich content.
+Purpose: Post a message through the active runtime channel adapter. Supports image/video attachments when the adapter supports rich content. Oversized images are downscaled automatically for the channel (as a derived export of the same asset) — pass the original asset id; do NOT create a separate, smaller asset just to post it.
 
 | Argument | Type | Required | Description |
 | --- | --- | --- | --- |
 | `channel` | string | yes | Channel name or runtime channel target |
 | `content` | string | yes | Message text / caption |
-| `imageAssetId` | string | no | Asset id of an image to attach (current version is sent). |
+| `imageAssetId` | string | no | Asset id of an image to attach. The current version is sent, or an auto-downscaled export if it exceeds the channel attachment limit (no separate asset is created). |
 | `videoAssetId` | string | no | Asset id of a video to attach (current version is sent). |
 | `embed` | record | no | Optional rich metadata for adapters that support it |
 | `taskId` | string | no | Task ID for audit trail |
@@ -2127,6 +2163,7 @@ Purpose: Update a task on the board — change title, description, or assigned a
 | `agent` | string | no | New assigned agent |
 | `availableAt` | string | no | ISO timestamp before which dispatch should not pick up the task |
 | `dueAt` | string | no | ISO timestamp representing the task deadline or target delivery time |
+| `expectedVersion` | number | no | Optimistic-concurrency check: fail if the task version has moved past this |
 
 Example:
 
@@ -2137,7 +2174,8 @@ mcporter call bakin-<agent>.bakin_exec_tasks_update --args '{
   "description": "value",
   "agent": "value",
   "availableAt": "value",
-  "dueAt": "value"
+  "dueAt": "value",
+  "expectedVersion": 20
 }'
 ```
 

--- a/docs/public/llms/hooks.md
+++ b/docs/public/llms/hooks.md
@@ -18,12 +18,28 @@ Invocation style depends on `kind`:
 
 Asset hooks expose file, sidecar, variant, and trash helpers for plugins that need to work with Bakin-managed files.
 
+### assets.enrichmentStats
+
+Label: Enrichment queue stats.
+Purpose: Returns the vision-enrichment queue depth and processed/failed/skipped counters for telemetry.
+Kind: rpc
+Source: plugins/assets/lib/register-hooks.ts:30
+
+Example:
+
+```ts
+const result = await ctx.hooks.invoke(
+  'assets.enrichmentStats',
+  {},
+)
+```
+
 ### assets.getAssetTypes
 
 Label: List asset types.
 Purpose: Returns the asset type definitions known to the assets plugin. Use it to build filters, upload forms, or validation messages that match Bakin asset categories.
 Kind: rpc
-Source: plugins/assets/index.ts:415
+Source: plugins/assets/lib/register-hooks.ts:44
 
 Example:
 
@@ -39,7 +55,7 @@ const result = await ctx.hooks.invoke(
 Label: List assets linked to a task.
 Purpose: Returns {assetId, description, type} for every versioned asset whose manifest taskId matches. Backed by an in-memory index — the sanctioned way for core (dispatch) to resolve a task’s attached assets without scanning plugin storage.
 Kind: rpc
-Source: plugins/assets/index.ts:407
+Source: plugins/assets/lib/register-hooks.ts:36
 
 Example:
 
@@ -55,7 +71,7 @@ const result = await ctx.hooks.invoke(
 Label: Purge task clipboard assets.
 Purpose: Deletes clipboard-sourced assets associated with a completed task when that cleanup setting is enabled. Use it from task completion flows that want asset cleanup to stay centralized.
 Kind: rpc
-Source: plugins/assets/index.ts:448
+Source: plugins/assets/lib/register-hooks.ts:77
 
 Example:
 
@@ -73,7 +89,7 @@ const result = await ctx.hooks.invoke(
 Label: Resolve versioned asset serve request.
 Purpose: Resolves an /api/assets/<assetId> path (current, /v/<n>, /thumb, /export/<name>) to a file on disk for serving.
 Kind: rpc
-Source: plugins/assets/index.ts:416
+Source: plugins/assets/lib/register-hooks.ts:45
 
 Example:
 
@@ -94,7 +110,7 @@ const result = await ctx.hooks.invoke(
 Label: Save a file as a managed asset.
 Purpose: Upserts a file into the versioned asset store by source path (new asset, version bump, or no-op when unchanged). The sanctioned cross-plugin/core save path; mirrors bakin_exec_assets_save.
 Kind: rpc
-Source: plugins/assets/index.ts:422
+Source: plugins/assets/lib/register-hooks.ts:51
 
 Example:
 
@@ -114,7 +130,7 @@ Health hooks expose registered readiness and diagnostic checks so other surfaces
 Label: Get a health check.
 Purpose: Returns metadata for one registered health check by id, without running the check. Use it when a plugin needs the check name, owner, and autofix capability before deciding what to show or run.
 Kind: rpc
-Source: plugins/health/index.ts:433
+Source: plugins/health/index.ts:478
 
 Example:
 
@@ -132,7 +148,7 @@ const result = await ctx.hooks.invoke(
 Label: List health checks.
 Purpose: Returns the health checks registered by core and plugins without executing them. Use it when another surface needs to show the available diagnostics or autofix support.
 Kind: rpc
-Source: plugins/health/index.ts:432
+Source: plugins/health/index.ts:477
 
 Example:
 
@@ -152,7 +168,7 @@ Model hooks expose the effective model configuration and notify dependent surfac
 Label: Model config changed.
 Purpose: Notifies listeners after an agent model assignment changes. Use it to refresh dependent state, update UI, or invalidate plugin caches that depend on model routing.
 Kind: event
-Source: plugins/models/index.ts:778
+Source: plugins/models/lib/register-hooks.ts:20
 
 Example:
 
@@ -172,7 +188,7 @@ await ctx.hooks.callAll(
 Label: List available models.
 Purpose: Returns the model catalog available from the currently configured providers. Use it to populate pickers, validate assignments, or compare model options before saving config.
 Kind: rpc
-Source: plugins/models/index.ts:794
+Source: plugins/models/lib/register-hooks.ts:36
 
 Example:
 
@@ -188,7 +204,7 @@ const result = await ctx.hooks.invoke(
 Label: Get budget policy.
 Purpose: Returns the spend-cap policy (global + per-agent daily/monthly limits) that dispatch consults before each turn. Use it to read the current budget limits.
 Kind: rpc
-Source: plugins/models/index.ts:843
+Source: plugins/models/lib/register-hooks.ts:85
 
 Example:
 
@@ -204,7 +220,7 @@ const result = await ctx.hooks.invoke(
 Label: Get effective model.
 Purpose: Resolves the model an agent will actually use after defaults, overrides, and provider settings are applied. Use it when a plugin needs runtime-ready model information for one agent.
 Kind: rpc
-Source: plugins/models/index.ts:782
+Source: plugins/models/lib/register-hooks.ts:24
 
 Example:
 
@@ -222,7 +238,7 @@ const result = await ctx.hooks.invoke(
 Label: Get routing config.
 Purpose: Returns the per-turn model/thinking routing policy (origins + tag overrides) that dispatch applies before each agent turn. Use it to read the current routing rules.
 Kind: rpc
-Source: plugins/models/index.ts:836
+Source: plugins/models/lib/register-hooks.ts:78
 
 Example:
 
@@ -238,7 +254,7 @@ const result = await ctx.hooks.invoke(
 Label: Mark config dirty.
 Purpose: Marks model configuration as changed so the runtime knows a refresh is needed. Use it after writing model settings that should not be treated as live yet.
 Kind: event
-Source: plugins/models/index.ts:790
+Source: plugins/models/lib/register-hooks.ts:32
 
 Example:
 
@@ -254,7 +270,7 @@ await ctx.hooks.callAll(
 Label: Mark runtime refreshed.
 Purpose: Records that the runtime has picked up the latest model configuration. Use it after restart or reload flows so stale dirty-state warnings can clear.
 Kind: event
-Source: plugins/models/index.ts:792
+Source: plugins/models/lib/register-hooks.ts:34
 
 Example:
 
@@ -270,7 +286,7 @@ await ctx.hooks.callAll(
 Label: Price an image.
 Purpose: Returns an estimated cost in micro-dollars for an image generation (count × the model’s flat per-image rate), or null when the model is provider-priced. Use it to attribute image-generation spend.
 Kind: rpc
-Source: plugins/models/index.ts:826
+Source: plugins/models/lib/register-hooks.ts:68
 
 Example:
 
@@ -286,7 +302,7 @@ const result = await ctx.hooks.invoke(
 Label: Price a turn.
 Purpose: Resolves the model an agent turn ran on and returns an estimated cost in micro-dollars from the catalog pricing. Use it to attribute spend to a completed turn. Cost is null when the model is unpriced.
 Kind: rpc
-Source: plugins/models/index.ts:805
+Source: plugins/models/lib/register-hooks.ts:47
 
 Example:
 
@@ -304,7 +320,7 @@ const result = await ctx.hooks.invoke(
 Label: Ensure Bakin schedule
 Purpose: Create or update a Bakin-managed runtime cron job and return the provider job id.
 Kind: rpc
-Source: plugins/schedule/index.ts:1019
+Source: plugins/schedule/index.ts:68
 
 Example:
 
@@ -369,7 +385,7 @@ Team hooks expose runtime agent and team metadata for plugins that need agent-aw
 Label: Get an agent.
 Purpose: Returns one runtime agent by id, including team-aware metadata when available. Use it when a plugin already has an agent id and needs the full display record.
 Kind: rpc
-Source: plugins/team/index.ts:1879
+Source: plugins/team/index.ts:267
 
 Example:
 
@@ -387,7 +403,7 @@ const result = await ctx.hooks.invoke(
 Label: List agent ids.
 Purpose: Returns the ids of agents currently known to the runtime. Use it for lightweight validation, assignment pickers, or loops that do not need full agent metadata.
 Kind: rpc
-Source: plugins/team/index.ts:1884
+Source: plugins/team/index.ts:272
 
 Example:
 
@@ -403,7 +419,7 @@ const result = await ctx.hooks.invoke(
 Label: Get agent team.
 Purpose: Returns the team currently assigned to an agent, or null when the agent is unassigned. Use it to add team context to task, workflow, or activity views.
 Kind: rpc
-Source: plugins/team/index.ts:1891
+Source: plugins/team/index.ts:279
 
 Example:
 
@@ -421,7 +437,7 @@ const result = await ctx.hooks.invoke(
 Label: Get org structure.
 Purpose: Returns the current organization structure for teams and agents. Use it when a plugin needs the full hierarchy instead of individual team or agent records.
 Kind: rpc
-Source: plugins/team/index.ts:1897
+Source: plugins/team/index.ts:285
 
 Example:
 
@@ -437,7 +453,7 @@ const result = await ctx.hooks.invoke(
 Label: List team members.
 Purpose: Returns the agents assigned to one team. Use it for team dashboards, routing rules, or workflow logic that needs team membership.
 Kind: rpc
-Source: plugins/team/index.ts:1888
+Source: plugins/team/index.ts:276
 
 Example:
 
@@ -455,7 +471,7 @@ const result = await ctx.hooks.invoke(
 Label: List agents.
 Purpose: Returns runtime agents with their display and team metadata attached. Use it when another plugin needs the agent roster as Bakin presents it.
 Kind: rpc
-Source: plugins/team/index.ts:1878
+Source: plugins/team/index.ts:266
 
 Example:
 
@@ -471,7 +487,7 @@ const result = await ctx.hooks.invoke(
 Label: Resolve agent profile.
 Purpose: Returns the runtime profile for an agent id. Use it when a plugin needs the lower-level profile data behind an agent display record.
 Kind: rpc
-Source: plugins/team/index.ts:1885
+Source: plugins/team/index.ts:273
 
 Example:
 
@@ -493,7 +509,7 @@ Workflow hooks expose workflow definitions, instances, steps, gates, and notific
 Label: Approve workflow gate.
 Purpose: Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks.
 Kind: rpc
-Source: plugins/workflows/index.ts:1682
+Source: plugins/workflows/lib/register-hooks.ts:38
 
 Example:
 
@@ -509,7 +525,7 @@ const result = await ctx.hooks.invoke(
 Label: Authorize workflow tool use.
 Purpose: Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation.
 Kind: rpc
-Source: plugins/workflows/index.ts:1708
+Source: plugins/workflows/lib/register-hooks.ts:64
 
 Example:
 
@@ -525,7 +541,7 @@ const result = await ctx.hooks.invoke(
 Label: Cancel workflow instance.
 Purpose: Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue.
 Kind: event
-Source: plugins/workflows/index.ts:1712
+Source: plugins/workflows/lib/register-hooks.ts:68
 
 Example:
 
@@ -538,12 +554,28 @@ await ctx.hooks.callAll(
 )
 ```
 
+### workflows.clearSkillCache
+
+Label: Clear workflow skill cache.
+Purpose: Drops the in-memory workflow-skill resolution cache so the next lookup re-reads disk and the registries. Use it after agent-package sync, migration, install, or removal changes which skills resolve.
+Kind: event
+Source: plugins/workflows/lib/register-hooks.ts:71
+
+Example:
+
+```ts
+await ctx.hooks.callAll(
+  'workflows.clearSkillCache',
+  {},
+)
+```
+
 ### workflows.completeStep
 
 Label: Complete workflow step.
 Purpose: Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action.
 Kind: rpc
-Source: plugins/workflows/index.ts:1700
+Source: plugins/workflows/lib/register-hooks.ts:56
 
 Example:
 
@@ -565,7 +597,7 @@ const result = await ctx.hooks.invoke(
 Label: Create workflow instance.
 Purpose: Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow.
 Kind: rpc
-Source: plugins/workflows/index.ts:1681
+Source: plugins/workflows/lib/register-hooks.ts:37
 
 Example:
 
@@ -585,7 +617,7 @@ const result = await ctx.hooks.invoke(
 Label: List workflow definitions.
 Purpose: Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances.
 Kind: rpc
-Source: plugins/workflows/index.ts:1702
+Source: plugins/workflows/lib/register-hooks.ts:58
 
 Example:
 
@@ -601,7 +633,7 @@ const result = await ctx.hooks.invoke(
 Label: List active workflow agents.
 Purpose: Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants.
 Kind: rpc
-Source: plugins/workflows/index.ts:1707
+Source: plugins/workflows/lib/register-hooks.ts:63
 
 Example:
 
@@ -619,7 +651,7 @@ const result = await ctx.hooks.invoke(
 Label: Get current step.
 Purpose: Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable.
 Kind: rpc
-Source: plugins/workflows/index.ts:1699
+Source: plugins/workflows/lib/register-hooks.ts:55
 
 Example:
 
@@ -638,7 +670,7 @@ const result = await ctx.hooks.invoke(
 Label: Get notification channel.
 Purpose: Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation.
 Kind: rpc
-Source: plugins/workflows/index.ts:1718
+Source: plugins/workflows/lib/register-hooks.ts:77
 
 Example:
 
@@ -656,7 +688,7 @@ const result = await ctx.hooks.invoke(
 Label: List workflow instances.
 Purpose: Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state.
 Kind: rpc
-Source: plugins/workflows/index.ts:1698
+Source: plugins/workflows/lib/register-hooks.ts:54
 
 Example:
 
@@ -674,7 +706,7 @@ const result = await ctx.hooks.invoke(
 Label: Check gate notification.
 Purpose: Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.
 Kind: rpc
-Source: plugins/workflows/index.ts:1709
+Source: plugins/workflows/lib/register-hooks.ts:65
 
 Example:
 
@@ -693,7 +725,7 @@ const result = await ctx.hooks.invoke(
 Label: Load workflow definition.
 Purpose: Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id.
 Kind: rpc
-Source: plugins/workflows/index.ts:1703
+Source: plugins/workflows/lib/register-hooks.ts:59
 
 Example:
 
@@ -711,7 +743,7 @@ const result = await ctx.hooks.invoke(
 Label: Load workflow instance.
 Purpose: Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly.
 Kind: rpc
-Source: plugins/workflows/index.ts:1679
+Source: plugins/workflows/lib/register-hooks.ts:35
 
 Example:
 
@@ -729,7 +761,7 @@ const result = await ctx.hooks.invoke(
 Label: Mark gate notified.
 Purpose: Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates.
 Kind: rpc
-Source: plugins/workflows/index.ts:1710
+Source: plugins/workflows/lib/register-hooks.ts:66
 
 Example:
 
@@ -748,7 +780,7 @@ const result = await ctx.hooks.invoke(
 Label: Match workflow.
 Purpose: Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template.
 Kind: rpc
-Source: plugins/workflows/index.ts:1701
+Source: plugins/workflows/lib/register-hooks.ts:57
 
 Example:
 
@@ -767,7 +799,7 @@ const result = await ctx.hooks.invoke(
 Label: List notification channels.
 Purpose: Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts.
 Kind: rpc
-Source: plugins/workflows/index.ts:1717
+Source: plugins/workflows/lib/register-hooks.ts:76
 
 Example:
 
@@ -783,7 +815,7 @@ const result = await ctx.hooks.invoke(
 Label: Reject workflow gate.
 Purpose: Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks.
 Kind: rpc
-Source: plugins/workflows/index.ts:1686
+Source: plugins/workflows/lib/register-hooks.ts:42
 
 Example:
 
@@ -799,7 +831,7 @@ const result = await ctx.hooks.invoke(
 Label: Reopen workflow from step.
 Purpose: Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task.
 Kind: rpc
-Source: plugins/workflows/index.ts:1691
+Source: plugins/workflows/lib/register-hooks.ts:47
 
 Example:
 
@@ -815,7 +847,7 @@ const result = await ctx.hooks.invoke(
 Label: Save workflow instance.
 Purpose: Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer.
 Kind: rpc
-Source: plugins/workflows/index.ts:1680
+Source: plugins/workflows/lib/register-hooks.ts:36
 
 Example:
 
@@ -836,7 +868,7 @@ const result = await ctx.hooks.invoke(
 Label: Validate step output.
 Purpose: Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow.
 Kind: rpc
-Source: plugins/workflows/index.ts:1711
+Source: plugins/workflows/lib/register-hooks.ts:67
 
 Example:
 

--- a/docs/public/llms/settings.md
+++ b/docs/public/llms/settings.md
@@ -6,4 +6,4 @@ Audience: coding agents and technical authors.
 
 Canonical docs: https://makinbakin.com/docs/
 
-The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 64. Operators can override settings in settings.json under the resolved Bakin home directory.
+The settings reference is generated from packages/core/src/settings.ts. Current flattened setting count: 66. Operators can override settings in settings.json under the resolved Bakin home directory.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -47,6 +47,118 @@
     }
   ],
   "paths": {
+    "/api/plugins/assets/import/scan": {
+      "get": {
+        "operationId": "assets.get.import-scan",
+        "summary": "List unmanaged files awaiting explicit import",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Assets"
+        ],
+        "x-bakin-full-path": "/api/plugins/assets/import/scan"
+      }
+    },
+    "/api/plugins/assets/import": {
+      "post": {
+        "operationId": "assets.post.import",
+        "summary": "Import unmanaged files into versioned assets",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Assets"
+        ],
+        "x-bakin-full-path": "/api/plugins/assets/import"
+      }
+    },
     "/api/plugins/assets/upload": {
       "post": {
         "operationId": "assets.post.upload",
@@ -592,6 +704,136 @@
           }
         ],
         "x-bakin-full-path": "/api/plugins/assets/versioned/:assetId/metadata"
+      }
+    },
+    "/api/plugins/assets/enrich": {
+      "post": {
+        "operationId": "assets.post.enrich",
+        "summary": "Enqueue vision enrichment (one asset or backfill all); billed per asset version",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Assets"
+        ],
+        "x-bakin-full-path": "/api/plugins/assets/enrich"
+      }
+    },
+    "/api/plugins/assets/versioned/{assetId}/enrichment": {
+      "patch": {
+        "operationId": "assets.patch.versioned-asset-id-enrichment",
+        "summary": "Manually edit derived enrichment (locks fields against machine overwrites)",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Assets"
+        ],
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/assets/versioned/:assetId/enrichment"
       }
     },
     "/api/plugins/assets/versioned/{assetId}/relink": {
@@ -1227,6 +1469,25 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -1845,6 +2106,31 @@
         ],
         "description": "Returns search adapter readiness and per-table index stats.",
         "x-bakin-full-path": "/api/plugins/health/search-status"
+      }
+    },
+    "/api/plugins/health/search-telemetry": {
+      "get": {
+        "operationId": "health.get.search-telemetry",
+        "summary": "Search activity telemetry",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Health"
+        ],
+        "description": "Query/drain/enrichment activity from the shared usage recorder, outbox depth, and the latest search doctor rows.",
+        "x-bakin-full-path": "/api/plugins/health/search-telemetry"
       }
     },
     "/api/plugins/health/usage": {
@@ -6292,6 +6578,25 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -8195,6 +8500,25 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Service unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -9219,13 +9543,16 @@
           "200": {
             "description": "Successful response.",
             "content": {
-              "image/jpeg": {
+              "application/octet-stream": {
                 "schema": {
                   "type": "string",
                   "format": "binary"
                 }
               }
             }
+          },
+          "304": {
+            "description": "Not modified."
           },
           "400": {
             "description": "Invalid input.",
@@ -11440,6 +11767,420 @@
         "x-bakin-full-path": "/api/plugins/team/settings"
       }
     },
+    "/api/plugins/team/context": {
+      "get": {
+        "operationId": "team.get.context",
+        "summary": "List layered context files",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Team"
+        ],
+        "description": "List layered context files (global, roles, teams)",
+        "x-bakin-full-path": "/api/plugins/team/context"
+      }
+    },
+    "/api/plugins/team/context/{scope}": {
+      "get": {
+        "operationId": "team.get.context-scope",
+        "summary": "Read a layered context file",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Team"
+        ],
+        "description": "Read a layered context file (scope: global, or role/team via ?id=)",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/team/context/:scope"
+      },
+      "put": {
+        "operationId": "team.put.context-scope",
+        "summary": "Write a layered context file",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Team"
+        ],
+        "description": "Write a layered context file (scope: global, or role/team via ?id=)",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/team/context/:scope"
+      }
+    },
     "/api/plugins/team/teams": {
       "get": {
         "operationId": "team.get.teams",
@@ -12124,420 +12865,6 @@
           }
         ],
         "x-bakin-full-path": "/api/plugins/team/teams/:teamId/members"
-      }
-    },
-    "/api/plugins/team/context": {
-      "get": {
-        "operationId": "team.get.context",
-        "summary": "List layered context files",
-        "responses": {
-          "200": {
-            "description": "Successful response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Team"
-        ],
-        "description": "List layered context files (global, roles, teams)",
-        "x-bakin-full-path": "/api/plugins/team/context"
-      }
-    },
-    "/api/plugins/team/context/{scope}": {
-      "get": {
-        "operationId": "team.get.context-scope",
-        "summary": "Read a layered context file",
-        "responses": {
-          "200": {
-            "description": "Successful response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Team"
-        ],
-        "description": "Read a layered context file (scope: global, or role/team via ?id=)",
-        "parameters": [
-          {
-            "name": "scope",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "x-bakin-full-path": "/api/plugins/team/context/:scope"
-      },
-      "put": {
-        "operationId": "team.put.context-scope",
-        "summary": "Write a layered context file",
-        "responses": {
-          "200": {
-            "description": "Successful response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Team"
-        ],
-        "description": "Write a layered context file (scope: global, or role/team via ?id=)",
-        "parameters": [
-          {
-            "name": "scope",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "x-bakin-full-path": "/api/plugins/team/context/:scope"
       }
     },
     "/api/plugins/team/teams/{teamId}/sync": {
@@ -14365,6 +14692,412 @@
         "x-bakin-full-path": "/api/plugins/workflows/steps/:taskId/complete"
       }
     },
+    "/api/plugins/workflows/instances": {
+      "get": {
+        "operationId": "workflows.get.instances",
+        "summary": "List active workflow instances. Optional status filter.",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ],
+        "description": "List active workflow instances. Optional status filter.",
+        "x-bakin-full-path": "/api/plugins/workflows/instances"
+      }
+    },
+    "/api/plugins/workflows/instances/{taskId}": {
+      "get": {
+        "operationId": "workflows.get.instances-task-id",
+        "summary": "Get full workflow instance state for a task",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ],
+        "description": "Get full workflow instance state for a task",
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-bakin-full-path": "/api/plugins/workflows/instances/:taskId"
+      }
+    },
+    "/api/plugins/workflows/instances/start": {
+      "post": {
+        "operationId": "workflows.post.instances-start",
+        "summary": "Start a workflow instance for a task",
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Workflows"
+        ],
+        "description": "Start a workflow instance for a task",
+        "x-bakin-full-path": "/api/plugins/workflows/instances/start"
+      }
+    },
     "/api/plugins/workflows/gates/{taskId}/approve": {
       "post": {
         "operationId": "workflows.post.gates-task-id-approve",
@@ -14759,280 +15492,6 @@
         "x-bakin-full-path": "/api/plugins/workflows/gates/:taskId/decision"
       }
     },
-    "/api/plugins/workflows/instances": {
-      "get": {
-        "operationId": "workflows.get.instances",
-        "summary": "List active workflow instances. Optional status filter.",
-        "responses": {
-          "200": {
-            "description": "Successful response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Workflows"
-        ],
-        "description": "List active workflow instances. Optional status filter.",
-        "x-bakin-full-path": "/api/plugins/workflows/instances"
-      }
-    },
-    "/api/plugins/workflows/instances/{taskId}": {
-      "get": {
-        "operationId": "workflows.get.instances-task-id",
-        "summary": "Get full workflow instance state for a task",
-        "responses": {
-          "200": {
-            "description": "Successful response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Workflows"
-        ],
-        "description": "Get full workflow instance state for a task",
-        "parameters": [
-          {
-            "name": "taskId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "x-bakin-full-path": "/api/plugins/workflows/instances/:taskId"
-      }
-    },
     "/api/plugins/workflows/gates/pending": {
       "get": {
         "operationId": "workflows.get.gates-pending",
@@ -15295,138 +15754,6 @@
         ],
         "description": "Batch check gate status for tasks",
         "x-bakin-full-path": "/api/plugins/workflows/gates/status"
-      }
-    },
-    "/api/plugins/workflows/instances/start": {
-      "post": {
-        "operationId": "workflows.post.instances-start",
-        "summary": "Start a workflow instance for a task",
-        "responses": {
-          "200": {
-            "description": "Successful response.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid input.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ],
-                  "additionalProperties": {}
-                }
-              }
-            }
-          }
-        },
-        "tags": [
-          "Workflows"
-        ],
-        "description": "Start a workflow instance for a task",
-        "x-bakin-full-path": "/api/plugins/workflows/instances/start"
       }
     },
     "/api/agents": {

--- a/docs/src/content/docs/reference/generated/api.mdx
+++ b/docs/src/content/docs/reference/generated/api.mdx
@@ -512,6 +512,29 @@ curl -sS \
 
 <OpenApiReference tag="Assets" summary />
 
+<OpenApiReference operationId="assets.post.enrich">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/assets/enrich'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="assets.post.import">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X POST \
+  'http://localhost:3737/api/plugins/assets/import'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="assets.get.import-scan">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  'http://localhost:3737/api/plugins/assets/import/scan'
+```
+</OpenApiReference>
+
 <OpenApiReference operationId="assets.get.search">
 ```sh frame="terminal" showLineNumbers
 curl -sS \
@@ -603,6 +626,14 @@ curl -sS \
 curl -sS \
   -X DELETE \
   'http://localhost:3737/api/plugins/assets/versioned/<assetId>'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="assets.patch.versioned-asset-id-enrichment">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  -X PATCH \
+  'http://localhost:3737/api/plugins/assets/versioned/<assetId>/enrichment'
 ```
 </OpenApiReference>
 
@@ -765,6 +796,13 @@ curl -sS \
 ```sh frame="terminal" showLineNumbers
 curl -sS \
   'http://localhost:3737/api/plugins/health/search-status'
+```
+</OpenApiReference>
+
+<OpenApiReference operationId="health.get.search-telemetry">
+```sh frame="terminal" showLineNumbers
+curl -sS \
+  'http://localhost:3737/api/plugins/health/search-telemetry'
 ```
 </OpenApiReference>
 
@@ -1725,5 +1763,5 @@ curl -sS \
 </OpenApiReference>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/cli.mdx
+++ b/docs/src/content/docs/reference/generated/cli.mdx
@@ -307,23 +307,23 @@ bakin mkdir [--json]
 </CliCommandCard>
 <CliCommandCard id="check" name="check" summary="Run onboarding checks." description="Runs one or all first-run readiness checks.">
 ```sh frame="terminal"
-bakin check <runtime|search|search-models|llm|channels|plugin-assets|agent-assets|recommended-plugins|recommended-agents|all>
+bakin check <runtime|search|search-models|llm|channels|plugin-assets|agent-sync|recommended-plugins|recommended-agents|all>
 ```
   <table class="cli-command__args">
     <thead><tr><th>Part</th><th>Type</th><th>Required</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td><code>&lt;value&gt;</code><span class="cli-command__choices"><span>runtime</span><span>search</span><span>search-models</span><span>llm</span><span>channels</span><span>plugin-assets</span><span>agent-assets</span><span>recommended-plugins</span><span>recommended-agents</span><span>all</span></span></td><td>choice</td><td>yes</td><td>Choose one of these values.</td></tr>
+      <tr><td><code>&lt;value&gt;</code><span class="cli-command__choices"><span>runtime</span><span>search</span><span>search-models</span><span>llm</span><span>channels</span><span>plugin-assets</span><span>agent-sync</span><span>recommended-plugins</span><span>recommended-agents</span><span>all</span></span></td><td>choice</td><td>yes</td><td>Choose one of these values.</td></tr>
     </tbody>
   </table>
 </CliCommandCard>
 <CliCommandCard id="install" name="install" summary="Install onboarding components." description="Installs Bakin dependencies, plugin/agent assets, or official recommended plugins and agents.">
 ```sh frame="terminal"
-bakin install <search|search-models|mcporter|plugin-assets|agent-assets|recommended-plugins|recommended-agents>
+bakin install <search|search-models|mcporter|plugin-assets|agent-sync|recommended-plugins|recommended-agents>
 ```
   <table class="cli-command__args">
     <thead><tr><th>Part</th><th>Type</th><th>Required</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td><code>&lt;value&gt;</code><span class="cli-command__choices"><span>search</span><span>search-models</span><span>mcporter</span><span>plugin-assets</span><span>agent-assets</span><span>recommended-plugins</span><span>recommended-agents</span></span></td><td>choice</td><td>yes</td><td>Choose one of these values.</td></tr>
+      <tr><td><code>&lt;value&gt;</code><span class="cli-command__choices"><span>search</span><span>search-models</span><span>mcporter</span><span>plugin-assets</span><span>agent-sync</span><span>recommended-plugins</span><span>recommended-agents</span></span></td><td>choice</td><td>yes</td><td>Choose one of these values.</td></tr>
     </tbody>
   </table>
 </CliCommandCard>
@@ -826,6 +826,18 @@ bakin workflows submit <taskId> <stepId> <json>
 bakin serve
 ```
 </CliCommandCard>
+<CliCommandCard id="agents-context" name="agents context" summary="Startup-context size diagnostics." description="Reports per-source startup-context sizes for a fresh task dispatch: static prompt sections (measured from the real builders), configured caps for dynamic blocks, runtime workspace file sizes, and observed dispatch-run tokens from the cost ledger. Names and numbers only — never prompt content. Distinct from `bakin diagnostics startup`, which reports server boot timing.">
+```sh frame="terminal"
+bakin agents context [agent-id] [--json]
+```
+  <table class="cli-command__args">
+    <thead><tr><th>Part</th><th>Type</th><th>Required</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td><code>[agent-id]</code></td><td>argument</td><td>no</td><td>Agent id to install, update, remove, or inspect.</td></tr>
+      <tr><td><code>[--json]</code></td><td>option</td><td>no</td><td>Emit machine-readable output.</td></tr>
+    </tbody>
+  </table>
+</CliCommandCard>
 <CliCommandCard id="agents-sync" name="agents sync" summary="Sync agents with their packages + context layers." description="Fetches package updates, recomposes managed blocks (global/role/team/package/lessons), re-projects skills and assets, verifies, and writes a receipt. --check reports without writing. --reclaim discards local edits on a sentineled skill/asset after confirmation.">
 ```sh frame="terminal"
 bakin agents sync [agent-id] [--check] [--reclaim <target>] [--reclaim-all] [--yes]
@@ -857,5 +869,5 @@ bakin diagnostics startup <status|on|off> [--slow-ms <ms>] [--json]
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/core-plugins.md
+++ b/docs/src/content/docs/reference/generated/core-plugins.md
@@ -16,7 +16,7 @@ description: Generated catalog of official plugins supported by Bakin.
       <td>Assets<br/><span>Centralized content store for all artifacts with rich rendering, search, task linking, manual upload, and clipboard paste</span></td>
       <td><code>assets</code></td>
       <td>Core</td>
-      <td><code>2.0.0</code></td>
+      <td><code>2.2.2</code></td>
       <td>none</td>
     </tr>
     <tr>
@@ -30,7 +30,7 @@ description: Generated catalog of official plugins supported by Bakin.
       <td>Health<br/><span>System health dashboard — MCP stats, diagnostics, and uptime</span></td>
       <td><code>health</code></td>
       <td>Core</td>
-      <td><code>1.0.0</code></td>
+      <td><code>1.2.0</code></td>
       <td>none</td>
     </tr>
     <tr>
@@ -44,14 +44,14 @@ description: Generated catalog of official plugins supported by Bakin.
       <td>Memory<br/><span>Observability dashboard over runtime memory tiers plus Bakin's audit log</span></td>
       <td><code>memory</code></td>
       <td>Core</td>
-      <td><code>2.0.0</code></td>
+      <td><code>2.0.1</code></td>
       <td>none</td>
     </tr>
     <tr>
       <td>Messaging<br/><span>Content messaging with scheduling, brainstorming, and multi-agent content pipeline</span></td>
       <td><code>messaging</code></td>
       <td>Official</td>
-      <td><code>0.5.0</code></td>
+      <td><code>0.5.1</code></td>
       <td><code>team</code> <code>workflows</code></td>
     </tr>
     <tr>
@@ -65,7 +65,7 @@ description: Generated catalog of official plugins supported by Bakin.
       <td>Projects<br/><span>Project management with specs, checklists, task linking, and agent access via MCP tools</span></td>
       <td><code>projects</code></td>
       <td>Official</td>
-      <td><code>0.5.0</code></td>
+      <td><code>0.5.1</code></td>
       <td><code>tasks</code> <code>assets</code> <code>team</code></td>
     </tr>
     <tr>
@@ -86,19 +86,19 @@ description: Generated catalog of official plugins supported by Bakin.
       <td>Team<br/><span>Agent team management — adapter layer over runtime agent workspaces</span></td>
       <td><code>team</code></td>
       <td>Core</td>
-      <td><code>1.0.0</code></td>
+      <td><code>1.0.1</code></td>
       <td>none</td>
     </tr>
     <tr>
       <td>Workflows<br/><span>Workflow runtime — enforces step-by-step agent execution with gated delivery, parallel steps, human gates, and output validation</span></td>
       <td><code>workflows</code></td>
       <td>Core</td>
-      <td><code>2.0.0</code></td>
+      <td><code>2.0.1</code></td>
       <td><code>tasks</code></td>
     </tr>
   </tbody>
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/exec-tools.mdx
+++ b/docs/src/content/docs/reference/generated/exec-tools.mdx
@@ -15,31 +15,41 @@ import McpToolCard from '../../../../components/McpToolCard.astro'
 <p class="mcp-section-description">Asset tools let agents list, inspect, save, link, restore, and clean up files managed by Bakin.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="assets-audit" name="bakin_exec_assets_audit" label="Audited assets" description="Audit versioned-asset health: manifest integrity, current-pointer resolution, and missing version files." source="plugins/assets/index.ts:700">
+<McpToolCard id="assets-audit" name="bakin_exec_assets_audit" label="Audited assets" description="Audit versioned-asset health: manifest integrity, current-pointer resolution, and missing version files." source="plugins/assets/lib/exec-tools.ts:290">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_audit
 ```
 </McpToolCard>
-<McpToolCard id="assets-delete" name="bakin_exec_assets_delete" label="Deleted an asset" description="Soft-delete a whole asset (all versions) to trash, restorable until trash is emptied." source="plugins/assets/index.ts:583" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"}]}>
+<McpToolCard id="assets-delete" name="bakin_exec_assets_delete" label="Deleted an asset" description="Soft-delete a whole asset (all versions) to trash, restorable until trash is emptied." source="plugins/assets/lib/exec-tools.ts:173" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_delete --args '{
   "assetId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-empty-trash" name="bakin_exec_assets_empty_trash" label="Emptied asset trash" description="Permanently delete all trashed assets. This cannot be undone." source="plugins/assets/index.ts:673">
+<McpToolCard id="assets-empty-trash" name="bakin_exec_assets_empty_trash" label="Emptied asset trash" description="Permanently delete all trashed assets. This cannot be undone." source="plugins/assets/lib/exec-tools.ts:263">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_empty_trash
 ```
 </McpToolCard>
-<McpToolCard id="assets-get" name="bakin_exec_assets_get" label="Read asset details" description="Retrieve an asset manifest (versions, current pointer, exports) by assetId." source="plugins/assets/index.ts:522" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id, e.g. \"20260401-hero-a1b2c3d4\""}]}>
+<McpToolCard id="assets-get" name="bakin_exec_assets_get" label="Read asset details" description="Retrieve an asset manifest (versions, current pointer, exports) by assetId." source="plugins/assets/lib/exec-tools.ts:112" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id, e.g. \"20260401-hero-a1b2c3d4\""}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_get --args '{
   "assetId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-link" name="bakin_exec_assets_link" label="Linked an asset" description="Link an asset to a different task, or unlink it (set taskId to null)." source="plugins/assets/index.ts:602" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"},{"name":"taskId","type":"string","required":true,"description":"Target task ID, or null to unlink"}]}>
+<McpToolCard id="assets-import" name="bakin_exec_assets_import" label="Imported unmanaged files" description="Explicitly import unmanaged files into managed versioned assets. Pass path (content-dir relative, e.g. assets/inbox/pic.png) or all: true. Optional type override and taskId link." source="plugins/assets/lib/exec-tools.ts:62" parameters={[{"name":"path","type":"string","required":false,"description":"One unmanaged file to import (content-dir relative)"},{"name":"all","type":"boolean","required":false,"description":"Import every unmanaged file"},{"name":"type","type":"choice","required":false,"description":"Override the suggested asset type"},{"name":"taskId","type":"string","required":false,"description":"Link the imported asset(s) to this task"}]}>
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_assets_import --args '{
+  "path": "value",
+  "all": true,
+  "type": "value",
+  "taskId": "value"
+}'
+```
+</McpToolCard>
+<McpToolCard id="assets-link" name="bakin_exec_assets_link" label="Linked an asset" description="Link an asset to a different task, or unlink it (set taskId to null)." source="plugins/assets/lib/exec-tools.ts:192" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"},{"name":"taskId","type":"string","required":true,"description":"Target task ID, or null to unlink"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_link --args '{
   "assetId": "value",
@@ -47,7 +57,7 @@ mcporter call bakin-<agent>.bakin_exec_assets_link --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-list" name="bakin_exec_assets_list" label="Listed assets" description="List managed assets (one entry per asset, current-version view). Optional type, task, and tag filters. Tags are the UI &quot;folders&quot; — pass tags to list a folder, e.g. [&quot;brand&quot;]." source="plugins/assets/index.ts:503" parameters={[{"name":"type","type":"choice","required":false,"description":"Filter by asset type"},{"name":"taskId","type":"string","required":false,"description":"Filter to assets linked to this task id"},{"name":"tags","type":"array","required":false,"description":"Filter to assets carrying ALL of these tags (the UI \"folders\")."}]}>
+<McpToolCard id="assets-list" name="bakin_exec_assets_list" label="Listed assets" description="List managed assets (one entry per asset, current-version view). Optional type, task, and tag filters. Tags are the UI &quot;folders&quot; — pass tags to list a folder, e.g. [&quot;brand&quot;]." source="plugins/assets/lib/exec-tools.ts:93" parameters={[{"name":"type","type":"choice","required":false,"description":"Filter by asset type"},{"name":"taskId","type":"string","required":false,"description":"Filter to assets linked to this task id"},{"name":"tags","type":"array","required":false,"description":"Filter to assets carrying ALL of these tags (the UI \"folders\")."}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_list --args '{
   "type": "value",
@@ -58,33 +68,33 @@ mcporter call bakin-<agent>.bakin_exec_assets_list --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-list-trash" name="bakin_exec_assets_list_trash" label="Listed trashed assets" description="List trashed assets (whole-asset deletions) with deletion time and version count." source="plugins/assets/index.ts:646">
+<McpToolCard id="assets-list-trash" name="bakin_exec_assets_list_trash" label="Listed trashed assets" description="List trashed assets (whole-asset deletions) with deletion time and version count." source="plugins/assets/lib/exec-tools.ts:236">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_list_trash
 ```
 </McpToolCard>
-<McpToolCard id="assets-open" name="bakin_exec_assets_open" label="Opened an asset" description="Open an asset by assetId: returns its manifest plus the current version’s extracted text for text-like assets." source="plugins/assets/index.ts:535" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"}]}>
+<McpToolCard id="assets-open" name="bakin_exec_assets_open" label="Opened an asset" description="Open an asset by assetId: returns its manifest plus the current version’s extracted text for text-like assets." source="plugins/assets/lib/exec-tools.ts:125" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_open --args '{
   "assetId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-permanent-delete" name="bakin_exec_assets_permanent_delete" label="Permanently deleted an asset" description="Permanently delete a specific trashed asset. This cannot be undone." source="plugins/assets/index.ts:686" parameters={[{"name":"trashName","type":"string","required":true,"description":"Trash name (includes __deleted- suffix)"}]}>
+<McpToolCard id="assets-permanent-delete" name="bakin_exec_assets_permanent_delete" label="Permanently deleted an asset" description="Permanently delete a specific trashed asset. This cannot be undone." source="plugins/assets/lib/exec-tools.ts:276" parameters={[{"name":"trashName","type":"string","required":true,"description":"Trash name (includes __deleted- suffix)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_permanent_delete --args '{
   "trashName": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-restore" name="bakin_exec_assets_restore" label="Restored an asset" description="Restore a trashed asset by its trash name (from bakin_exec_assets_list_trash)." source="plugins/assets/index.ts:657" parameters={[{"name":"trashName","type":"string","required":true,"description":"Trash name (includes __deleted- suffix)"}]}>
+<McpToolCard id="assets-restore" name="bakin_exec_assets_restore" label="Restored an asset" description="Restore a trashed asset by its trash name (from bakin_exec_assets_list_trash)." source="plugins/assets/lib/exec-tools.ts:247" parameters={[{"name":"trashName","type":"string","required":true,"description":"Trash name (includes __deleted- suffix)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_restore --args '{
   "trashName": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-retype" name="bakin_exec_assets_retype" label="Retyped an asset" description="Change an asset type classification." source="plugins/assets/index.ts:624" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"},{"name":"type","type":"choice","required":true}]}>
+<McpToolCard id="assets-retype" name="bakin_exec_assets_retype" label="Retyped an asset" description="Change an asset type classification." source="plugins/assets/lib/exec-tools.ts:214" parameters={[{"name":"assetId","type":"string","required":true,"description":"Asset id"},{"name":"type","type":"choice","required":true}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_retype --args '{
   "assetId": "value",
@@ -92,7 +102,7 @@ mcporter call bakin-<agent>.bakin_exec_assets_retype --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="assets-save" name="bakin_exec_assets_save" label="Saved an asset" description="Save an agent-created file as a managed, versioned asset. Re-saving the SAME source file appends a new version to the existing asset (or no-ops if unchanged) instead of creating a duplicate — so an evolving doc stays one asset with a version history. Returns the asset id." source="plugins/assets/index.ts:552" parameters={[{"name":"filePath","type":"string","required":true,"description":"Absolute path to the source file to save. Re-saving the same path versions the existing asset."},{"name":"taskId","type":"string","required":true,"description":"Task ID to link the asset."},{"name":"type","type":"choice","required":true},{"name":"description","type":"string","required":false,"description":"One-sentence summary visible in the asset grid and search. Be specific."},{"name":"tags","type":"array","required":false,"description":"Lowercase hyphenated tags for filtering."},{"name":"tool","type":"string","required":false,"description":"Tool used to generate or import the asset."},{"name":"slug","type":"string","required":false,"description":"Custom slug for the asset id. Auto-derived from source filename if omitted."}]}>
+<McpToolCard id="assets-save" name="bakin_exec_assets_save" label="Saved an asset" description="Save an agent-created file as a managed, versioned asset. Re-saving the SAME source file appends a new version to the existing asset (or no-ops if unchanged) instead of creating a duplicate — so an evolving doc stays one asset with a version history. Returns the asset id." source="plugins/assets/lib/exec-tools.ts:142" parameters={[{"name":"filePath","type":"string","required":true,"description":"Absolute path to the source file to save. Re-saving the same path versions the existing asset."},{"name":"taskId","type":"string","required":true,"description":"Task ID to link the asset."},{"name":"type","type":"choice","required":true},{"name":"description","type":"string","required":false,"description":"One-sentence summary visible in the asset grid and search. Be specific."},{"name":"tags","type":"array","required":false,"description":"Lowercase hyphenated tags for filtering."},{"name":"tool","type":"string","required":false,"description":"Tool used to generate or import the asset."},{"name":"slug","type":"string","required":false,"description":"Custom slug for the asset id. Auto-derived from source filename if omitted."}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_assets_save --args '{
   "filePath": "value",
@@ -107,6 +117,11 @@ mcporter call bakin-<agent>.bakin_exec_assets_save --args '{
 }'
 ```
 </McpToolCard>
+<McpToolCard id="assets-scan-unmanaged" name="bakin_exec_assets_scan_unmanaged" label="Scanned for unmanaged files" description="List files under assets/ that are NOT managed assets (inbox drops, loose files). Nothing is imported automatically — use bakin_exec_assets_import to import." source="plugins/assets/lib/exec-tools.ts:48">
+```sh frame="terminal"
+mcporter call bakin-<agent>.bakin_exec_assets_scan_unmanaged
+```
+</McpToolCard>
 </div>
 
 ## Check
@@ -114,7 +129,7 @@ mcporter call bakin-<agent>.bakin_exec_assets_save --args '{
 <p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="check-gates" name="bakin_exec_check_gates" label="Checked workflow gates" description="Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending." source="plugins/workflows/index.ts:1972" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (or workflow instance ID)"}]}>
+<McpToolCard id="check-gates" name="bakin_exec_check_gates" label="Checked workflow gates" description="Get a human-readable overview of all gate statuses in a workflow. Shows which gates are approved, waiting, or pending." source="plugins/workflows/lib/exec-tools.ts:249" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (or workflow instance ID)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_check_gates --args '{
   "taskId": "value"
@@ -128,12 +143,12 @@ mcporter call bakin-<agent>.bakin_exec_check_gates --args '{
 <p class="mcp-section-description">Runtime lookup tools return local Bakin paths and state agents should not hardcode.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="get-paths" name="bakin_exec_get_paths" label="Resolved paths" description="Get Bakin content directory paths — where to find assets, team info, docs, etc." source="scripts/lib/get-paths.ts:9">
+<McpToolCard id="get-paths" name="bakin_exec_get_paths" label="Resolved paths" description="Get Bakin content directory paths — where to find assets, team info, docs, etc." source="src/core/exec-tools/tools/get-paths.ts:9">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_get_paths
 ```
 </McpToolCard>
-<McpToolCard id="get-step" name="bakin_exec_get_step" label="Read workflow step" description="Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure." source="plugins/workflows/index.ts:1896" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="get-step" name="bakin_exec_get_step" label="Read workflow step" description="Get the current workflow step as human-readable formatted text. Includes instructions, prior outputs, schema, and rejection context in a clear structure." source="plugins/workflows/lib/exec-tools.ts:174" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_get_step --args '{
   "taskId": "value"
@@ -169,14 +184,14 @@ mcporter call bakin-<agent>.bakin_exec_git_status
 <p class="mcp-section-description">Health tools let agents check whether Bakin is running correctly before or during work.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="health-doctor" name="bakin_exec_health_doctor" label="Ran diagnostics" description="Run system diagnostics (agent roster, skill sync, runtime, taskboard, assets, etc.). Returns detailed check results. Use fresh=true to force a full re-check instead of returning cached results." source="plugins/health/index.ts:470" parameters={[{"name":"fresh","type":"boolean","required":false,"description":"Force fresh diagnostics instead of cached results"}]}>
+<McpToolCard id="health-doctor" name="bakin_exec_health_doctor" label="Ran diagnostics" description="Run system diagnostics (agent roster, skill sync, runtime, taskboard, assets, etc.). Returns detailed check results. Use fresh=true to force a full re-check instead of returning cached results." source="plugins/health/index.ts:515" parameters={[{"name":"fresh","type":"boolean","required":false,"description":"Force fresh diagnostics instead of cached results"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_health_doctor --args '{
   "fresh": true
 }'
 ```
 </McpToolCard>
-<McpToolCard id="health-status" name="bakin_exec_health_status" label="Checked system health" description="Get a quick system health summary — uptime, memory, active MCP sessions, and doctor error/warning counts. Useful for checking system state before starting work." source="plugins/health/index.ts:441">
+<McpToolCard id="health-status" name="bakin_exec_health_status" label="Checked system health" description="Get a quick system health summary — uptime, memory, active MCP sessions, and doctor error/warning counts. Useful for checking system state before starting work." source="plugins/health/index.ts:486">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_health_status
 ```
@@ -188,7 +203,7 @@ mcporter call bakin-<agent>.bakin_exec_health_status
 <p class="mcp-section-description">Heartbeat tools let agents publish lightweight status so Bakin can show who is active and what they are doing.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="heartbeat" name="bakin_exec_heartbeat" label="Sent heartbeat" description="Write a heartbeat signal. Call periodically (every 5-10 minutes) to indicate you are alive. Also call when starting or finishing a task." source="scripts/lib/heartbeat.ts:13" parameters={[{"name":"status","type":"choice","required":false,"description":"Current status"},{"name":"currentTask","type":"string","required":false,"description":"Task ID currently being worked on"},{"name":"message","type":"string","required":false,"description":"Brief status note"}]}>
+<McpToolCard id="heartbeat" name="bakin_exec_heartbeat" label="Sent heartbeat" description="Write a heartbeat signal. Call periodically (every 5-10 minutes) to indicate you are alive. Also call when starting or finishing a task." source="src/core/exec-tools/tools/heartbeat.ts:13" parameters={[{"name":"status","type":"choice","required":false,"description":"Current status"},{"name":"currentTask","type":"string","required":false,"description":"Task ID currently being worked on"},{"name":"message","type":"string","required":false,"description":"Brief status note"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_heartbeat --args '{
   "status": "value",
@@ -241,7 +256,7 @@ mcporter call bakin-<agent>.bakin_exec_images_recommend
 <p class="mcp-section-description">MCP tools discovered from registered exec tool definitions.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="lesson-search" name="bakin_exec_lesson_search" label="Searched package lessons" description="Search the enabled agent-package lessons for the calling agent." source="plugins/team/index.ts:1955" parameters={[{"name":"query","type":"string","required":true,"description":"Search query"},{"name":"limit","type":"number","required":false,"description":"Max lessons to return (default from settings, max 10)"}]}>
+<McpToolCard id="lesson-search" name="bakin_exec_lesson_search" label="Searched package lessons" description="Search the enabled agent-package lessons for the calling agent." source="plugins/team/index.ts:343" parameters={[{"name":"query","type":"string","required":true,"description":"Search query"},{"name":"limit","type":"number","required":false,"description":"Max lessons to return (default from settings, max 10)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_lesson_search --args '{
   "query": "value",
@@ -256,7 +271,7 @@ mcporter call bakin-<agent>.bakin_exec_lesson_search --args '{
 <p class="mcp-section-description">Logging tools record progress updates in Bakin task history and audit surfaces.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="log" name="bakin_exec_log" label="Logged message" description="Log a formatted progress update with category and stage tags. Categories: start, progress, milestone, blocked, complete. More structured than raw bakin_exec_tasks_log_progress." source="scripts/lib/log-progress.ts:45" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"message","type":"string","required":true,"description":"Human-readable status update"},{"name":"category","type":"choice","required":false,"description":"Log category (default: progress)"},{"name":"stage","type":"string","required":false,"description":"Workflow stage tag (e.g., \"image-gen\", \"copy-review\")"}]}>
+<McpToolCard id="log" name="bakin_exec_log" label="Logged message" description="Log a formatted progress update with category and stage tags. Categories: start, progress, milestone, blocked, complete. More structured than raw bakin_exec_tasks_log_progress." source="src/core/exec-tools/tools/log-progress.ts:45" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"message","type":"string","required":true,"description":"Human-readable status update"},{"name":"category","type":"choice","required":false,"description":"Log category (default: progress)"},{"name":"stage","type":"string","required":false,"description":"Workflow stage tag (e.g., \"image-gen\", \"copy-review\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_log --args '{
   "taskId": "value",
@@ -536,14 +551,14 @@ mcporter call bakin-<agent>.bakin_exec_messaging_session_update --args '{
 <p class="mcp-section-description">Model tools expose model configuration and available model choices to agents.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="models-get-config" name="bakin_exec_models_get_config" label="Read model config" description="Get model configuration for all agents or a specific agent. Shows effective model (own override or default), subagent model, and system defaults." source="plugins/models/index.ts:872" parameters={[{"name":"agentId","type":"string","required":false,"description":"Specific agent ID to query (omit for all agents)"}]}>
+<McpToolCard id="models-get-config" name="bakin_exec_models_get_config" label="Read model config" description="Get model configuration for all agents or a specific agent. Shows effective model (own override or default), subagent model, and system defaults." source="plugins/models/lib/exec-tools.ts:37" parameters={[{"name":"agentId","type":"string","required":false,"description":"Specific agent ID to query (omit for all agents)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_models_get_config --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="models-list" name="bakin_exec_models_list" label="Listed models" description="List available AI models with tier classification (budget/standard/premium). Use this to discover what models are available for assignment." source="plugins/models/index.ts:853" parameters={[{"name":"tier","type":"choice","required":false,"description":"Filter by model tier"}]}>
+<McpToolCard id="models-list" name="bakin_exec_models_list" label="Listed models" description="List available AI models with tier classification (budget/standard/premium). Use this to discover what models are available for assignment." source="plugins/models/lib/exec-tools.ts:18" parameters={[{"name":"tier","type":"choice","required":false,"description":"Filter by model tier"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_models_list --args '{
   "tier": "value"
@@ -557,7 +572,7 @@ mcporter call bakin-<agent>.bakin_exec_models_list --args '{
 <p class="mcp-section-description">Publishing tools send completed work to configured channels through Bakin adapters.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="post-channel" name="bakin_exec_post_channel" label="Posted to channel" description="Post a message through the active runtime channel adapter. Supports image/video attachments when the adapter supports rich content." source="scripts/lib/post-channel.ts:306" parameters={[{"name":"channel","type":"string","required":true,"description":"Channel name or runtime channel target"},{"name":"content","type":"string","required":true,"description":"Message text / caption"},{"name":"imageAssetId","type":"string","required":false,"description":"Asset id of an image to attach (current version is sent)."},{"name":"videoAssetId","type":"string","required":false,"description":"Asset id of a video to attach (current version is sent)."},{"name":"embed","type":"record","required":false,"description":"Optional rich metadata for adapters that support it"},{"name":"taskId","type":"string","required":false,"description":"Task ID for audit trail"},{"name":"repost","type":"boolean","required":false,"description":"An attached asset is delivered to a channel once per task; set true ONLY when a second copy is genuinely intended."}]}>
+<McpToolCard id="post-channel" name="bakin_exec_post_channel" label="Posted to channel" description="Post a message through the active runtime channel adapter. Supports image/video attachments when the adapter supports rich content. Oversized images are downscaled automatically for the channel (as a derived export of the same asset) — pass the original asset id; do NOT create a separate, smaller asset just to post it." source="src/core/exec-tools/tools/post-channel.ts:367" parameters={[{"name":"channel","type":"string","required":true,"description":"Channel name or runtime channel target"},{"name":"content","type":"string","required":true,"description":"Message text / caption"},{"name":"imageAssetId","type":"string","required":false,"description":"Asset id of an image to attach. The current version is sent, or an auto-downscaled export if it exceeds the channel attachment limit (no separate asset is created)."},{"name":"videoAssetId","type":"string","required":false,"description":"Asset id of a video to attach (current version is sent)."},{"name":"embed","type":"record","required":false,"description":"Optional rich metadata for adapters that support it"},{"name":"taskId","type":"string","required":false,"description":"Task ID for audit trail"},{"name":"repost","type":"boolean","required":false,"description":"An attached asset is delivered to a channel once per task; set true ONLY when a second copy is genuinely intended."}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_post_channel --args '{
   "channel": "value",
@@ -743,14 +758,14 @@ mcporter call bakin-<agent>.bakin_exec_projects_update_item --args '{
 <p class="mcp-section-description">Schedule tools let agents create, inspect, pause, run, and update recurring Bakin jobs.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="schedule-briefing" name="bakin_exec_schedule_briefing" label="Generated schedule briefing" description="Today's schedule summary — which jobs fire, assigned agents, alerts. Designed for orchestrator daily briefing." source="plugins/schedule/index.ts:1333" parameters={[{"name":"date","type":"string","required":false,"description":"ISO date to check (defaults to today)"}]}>
+<McpToolCard id="schedule-briefing" name="bakin_exec_schedule_briefing" label="Generated schedule briefing" description="Today's schedule summary — which jobs fire, assigned agents, alerts. Designed for orchestrator daily briefing." source="plugins/schedule/lib/exec-tools.ts:293" parameters={[{"name":"date","type":"string","required":false,"description":"ISO date to check (defaults to today)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_briefing --args '{
   "date": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-create" name="bakin_exec_schedule_create" label="Created a scheduled job" description="Create a new scheduled job that creates tasks on the board" source="plugins/schedule/index.ts:1095" parameters={[{"name":"name","type":"string","required":true,"description":"Job name (required)"},{"name":"schedule","type":"string","required":true,"description":"Schedule expression: NL (\"every day at 9am\") or raw cron (\"0 9 * * *\") (required)"},{"name":"agentId","type":"string","required":false,"description":"Agent to assign tasks to"},{"name":"workflowId","type":"string","required":false,"description":"Workflow to attach to tasks"},{"name":"taskPrompt","type":"string","required":false,"description":"Task description template"},{"name":"taskTitle","type":"string","required":false,"description":"Task title template (supports {date}, {agent})"}]}>
+<McpToolCard id="schedule-create" name="bakin_exec_schedule_create" label="Created a scheduled job" description="Create a new scheduled job that creates tasks on the board" source="plugins/schedule/lib/exec-tools.ts:52" parameters={[{"name":"name","type":"string","required":true,"description":"Job name (required)"},{"name":"schedule","type":"string","required":true,"description":"Schedule expression: NL (\"every day at 9am\") or raw cron (\"0 9 * * *\") (required)"},{"name":"agentId","type":"string","required":false,"description":"Agent to assign tasks to"},{"name":"workflowId","type":"string","required":false,"description":"Workflow to attach to tasks"},{"name":"taskPrompt","type":"string","required":false,"description":"Task description template"},{"name":"taskTitle","type":"string","required":false,"description":"Task title template (supports {date}, {agent})"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_create --args '{
   "name": "value",
@@ -762,21 +777,21 @@ mcporter call bakin-<agent>.bakin_exec_schedule_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-delete" name="bakin_exec_schedule_delete" label="Deleted a scheduled job" description="Delete a scheduled job" source="plugins/schedule/index.ts:1229" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"}]}>
+<McpToolCard id="schedule-delete" name="bakin_exec_schedule_delete" label="Deleted a scheduled job" description="Delete a scheduled job" source="plugins/schedule/lib/exec-tools.ts:189" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_delete --args '{
   "jobId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-get" name="bakin_exec_schedule_get" label="Read schedule details" description="Get details for a single scheduled job" source="plugins/schedule/index.ts:1245" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"}]}>
+<McpToolCard id="schedule-get" name="bakin_exec_schedule_get" label="Read schedule details" description="Get details for a single scheduled job" source="plugins/schedule/lib/exec-tools.ts:205" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_get --args '{
   "jobId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-list" name="bakin_exec_schedule_list" label="Listed scheduled jobs" description="List all scheduled jobs (merged runtime cron + Bakin view)" source="plugins/schedule/index.ts:1066" parameters={[{"name":"filter","type":"choice","required":false,"description":"Filter by job type"},{"name":"agentId","type":"string","required":false,"description":"Filter by assigned agent"}]}>
+<McpToolCard id="schedule-list" name="bakin_exec_schedule_list" label="Listed scheduled jobs" description="List all scheduled jobs (merged runtime cron + Bakin view)" source="plugins/schedule/lib/exec-tools.ts:23" parameters={[{"name":"filter","type":"choice","required":false,"description":"Filter by job type"},{"name":"agentId","type":"string","required":false,"description":"Filter by assigned agent"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_list --args '{
   "filter": "value",
@@ -784,14 +799,14 @@ mcporter call bakin-<agent>.bakin_exec_schedule_list --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-parse" name="bakin_exec_schedule_parse" label="Parsed cron expression" description="Parse a natural language or raw cron schedule expression" source="plugins/schedule/index.ts:1318" parameters={[{"name":"input","type":"string","required":true,"description":"Schedule expression to parse (required)"}]}>
+<McpToolCard id="schedule-parse" name="bakin_exec_schedule_parse" label="Parsed cron expression" description="Parse a natural language or raw cron schedule expression" source="plugins/schedule/lib/exec-tools.ts:278" parameters={[{"name":"input","type":"string","required":true,"description":"Schedule expression to parse (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_parse --args '{
   "input": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-pause" name="bakin_exec_schedule_pause" label="Paused a scheduled job" description="Pause, resume, or skip runs for a scheduled job" source="plugins/schedule/index.ts:1184" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"},{"name":"action","type":"choice","required":true,"description":"Action to take (required)"},{"name":"pauseUntil","type":"string","required":false,"description":"ISO date to auto-resume (for pause action)"},{"name":"skipN","type":"number","required":false,"description":"Number of runs to skip (for skip action)"}]}>
+<McpToolCard id="schedule-pause" name="bakin_exec_schedule_pause" label="Paused a scheduled job" description="Pause, resume, or skip runs for a scheduled job" source="plugins/schedule/lib/exec-tools.ts:141" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"},{"name":"action","type":"choice","required":true,"description":"Action to take (required)"},{"name":"pauseUntil","type":"string","required":false,"description":"ISO date to auto-resume (for pause action)"},{"name":"skipN","type":"number","required":false,"description":"Number of runs to skip (for skip action)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_pause --args '{
   "jobId": "value",
@@ -801,14 +816,14 @@ mcporter call bakin-<agent>.bakin_exec_schedule_pause --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-run-now" name="bakin_exec_schedule_run_now" label="Triggered scheduled job" description="Trigger an immediate run of a scheduled job" source="plugins/schedule/index.ts:1283" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"}]}>
+<McpToolCard id="schedule-run-now" name="bakin_exec_schedule_run_now" label="Triggered scheduled job" description="Trigger an immediate run of a scheduled job" source="plugins/schedule/lib/exec-tools.ts:243" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_run_now --args '{
   "jobId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-runs" name="bakin_exec_schedule_runs" label="Listed schedule runs" description="Get run history for a scheduled job" source="plugins/schedule/index.ts:1302" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"},{"name":"limit","type":"number","required":false,"description":"Max runs to return (default 50)"}]}>
+<McpToolCard id="schedule-runs" name="bakin_exec_schedule_runs" label="Listed schedule runs" description="Get run history for a scheduled job" source="plugins/schedule/lib/exec-tools.ts:262" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"},{"name":"limit","type":"number","required":false,"description":"Max runs to return (default 50)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_runs --args '{
   "jobId": "value",
@@ -816,7 +831,7 @@ mcporter call bakin-<agent>.bakin_exec_schedule_runs --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="schedule-update" name="bakin_exec_schedule_update" label="Updated a scheduled job" description="Update an existing scheduled job" source="plugins/schedule/index.ts:1145" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"},{"name":"name","type":"string","required":false,"description":"New job name"},{"name":"schedule","type":"string","required":false,"description":"New schedule expression"},{"name":"agentId","type":"string","required":false,"description":"New agent assignment"},{"name":"workflowId","type":"string","required":false,"description":"New workflow binding"},{"name":"taskPrompt","type":"string","required":false,"description":"New task prompt template"},{"name":"taskTitle","type":"string","required":false,"description":"New task title template"}]}>
+<McpToolCard id="schedule-update" name="bakin_exec_schedule_update" label="Updated a scheduled job" description="Update an existing scheduled job" source="plugins/schedule/lib/exec-tools.ts:102" parameters={[{"name":"jobId","type":"string","required":true,"description":"Job ID (required)"},{"name":"name","type":"string","required":false,"description":"New job name"},{"name":"schedule","type":"string","required":false,"description":"New schedule expression"},{"name":"agentId","type":"string","required":false,"description":"New agent assignment"},{"name":"workflowId","type":"string","required":false,"description":"New workflow binding"},{"name":"taskPrompt","type":"string","required":false,"description":"New task prompt template"},{"name":"taskTitle","type":"string","required":false,"description":"New task title template"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_schedule_update --args '{
   "jobId": "value",
@@ -836,7 +851,7 @@ mcporter call bakin-<agent>.bakin_exec_schedule_update --args '{
 <p class="mcp-section-description">Search tools query Bakin-indexed content across plugins or inside a specific surface.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="search-facets" name="bakin_exec_search_facets" label="Search facets" description="Get facet value counts for a plugin. Useful for understanding data distribution (e.g., how many tasks per status)." source="scripts/lib/search-tools.ts:158" parameters={[{"name":"plugin","type":"string","required":true,"description":"Plugin id (tasks, assets, projects, etc.)"},{"name":"facets","type":"string","required":true,"description":"Comma-separated facet fields (e.g., \"status,agent\")"}]}>
+<McpToolCard id="search-facets" name="bakin_exec_search_facets" label="Search facets" description="Get facet value counts for a plugin. Useful for understanding data distribution (e.g., how many tasks per status)." source="src/core/exec-tools/tools/search-tools.ts:158" parameters={[{"name":"plugin","type":"string","required":true,"description":"Plugin id (tasks, assets, projects, etc.)"},{"name":"facets","type":"string","required":true,"description":"Comma-separated facet fields (e.g., \"status,agent\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_facets --args '{
   "plugin": "value",
@@ -844,7 +859,7 @@ mcporter call bakin-<agent>.bakin_exec_search_facets --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="search-lookup" name="bakin_exec_search_lookup" label="Search lookup" description="Look up a specific indexed document by its key and plugin." source="scripts/lib/search-tools.ts:126" parameters={[{"name":"plugin","type":"string","required":true,"description":"Plugin id (tasks, assets, projects, etc.)"},{"name":"key","type":"string","required":true,"description":"Document key to look up"}]}>
+<McpToolCard id="search-lookup" name="bakin_exec_search_lookup" label="Search lookup" description="Look up a specific indexed document by its key and plugin." source="src/core/exec-tools/tools/search-tools.ts:126" parameters={[{"name":"plugin","type":"string","required":true,"description":"Plugin id (tasks, assets, projects, etc.)"},{"name":"key","type":"string","required":true,"description":"Document key to look up"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_lookup --args '{
   "plugin": "value",
@@ -852,7 +867,7 @@ mcporter call bakin-<agent>.bakin_exec_search_lookup --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="search-query" name="bakin_exec_search_query" label="Search" description="Search across all Bakin content (tasks, assets, projects, workflows, schedule, team, memory, messaging) or a specific plugin. Returns ranked results with scores." source="scripts/lib/search-tools.ts:48" parameters={[{"name":"q","type":"string","required":false,"description":"Search query text"},{"name":"limit","type":"number","required":false,"description":"Maximum results to return (default: 20)"},{"name":"offset","type":"number","required":false,"description":"Skip this many results (for pagination)"}]}>
+<McpToolCard id="search-query" name="bakin_exec_search_query" label="Search" description="Search across all Bakin content (tasks, assets, projects, workflows, schedule, team, memory, messaging) or a specific plugin. Returns ranked results with scores." source="src/core/exec-tools/tools/search-tools.ts:48" parameters={[{"name":"q","type":"string","required":false,"description":"Search query text"},{"name":"limit","type":"number","required":false,"description":"Maximum results to return (default: 20)"},{"name":"offset","type":"number","required":false,"description":"Skip this many results (for pagination)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_query --args '{
   "q": "value",
@@ -861,7 +876,7 @@ mcporter call bakin-<agent>.bakin_exec_search_query --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="search-reindex" name="bakin_exec_search_reindex" label="Reindex search" description="Trigger a full reindex of all content types (or a specific plugin). Use after bulk data changes." source="scripts/lib/search-tools.ts:221" parameters={[{"name":"plugin","type":"string","required":false,"description":"Specific plugin id to reindex (optional — omit for all)"},{"name":"rebuild","type":"boolean","required":false,"description":"Drop and recreate indexes before reindexing (default: false)"},{"name":"verify","type":"boolean","required":false,"description":"Re-query tables after reindex to verify doc counts (default: false)"}]}>
+<McpToolCard id="search-reindex" name="bakin_exec_search_reindex" label="Reindex search" description="Trigger a full reindex of all content types (or a specific plugin). Use after bulk data changes." source="src/core/exec-tools/tools/search-tools.ts:221" parameters={[{"name":"plugin","type":"string","required":false,"description":"Specific plugin id to reindex (optional — omit for all)"},{"name":"rebuild","type":"boolean","required":false,"description":"Drop and recreate indexes before reindexing (default: false)"},{"name":"verify","type":"boolean","required":false,"description":"Re-query tables after reindex to verify doc counts (default: false)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_reindex --args '{
   "plugin": "value",
@@ -870,7 +885,7 @@ mcporter call bakin-<agent>.bakin_exec_search_reindex --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="search-similar" name="bakin_exec_search_similar" label="Find similar" description="Find documents similar to a given text description. Uses semantic (vector) search for meaning-based matching." source="scripts/lib/search-tools.ts:187" parameters={[{"name":"text","type":"string","required":true,"description":"Text to find similar documents for"},{"name":"plugin","type":"string","required":false,"description":"Limit to a specific plugin id (optional)"},{"name":"limit","type":"number","required":false,"description":"Maximum results (default: 10)"}]}>
+<McpToolCard id="search-similar" name="bakin_exec_search_similar" label="Find similar" description="Find documents similar to a given text description. Uses semantic (vector) search for meaning-based matching." source="src/core/exec-tools/tools/search-tools.ts:187" parameters={[{"name":"text","type":"string","required":true,"description":"Text to find similar documents for"},{"name":"plugin","type":"string","required":false,"description":"Limit to a specific plugin id (optional)"},{"name":"limit","type":"number","required":false,"description":"Maximum results (default: 10)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_similar --args '{
   "text": "value",
@@ -879,12 +894,12 @@ mcporter call bakin-<agent>.bakin_exec_search_similar --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="search-stats" name="bakin_exec_search_stats" label="Search stats" description="Get search system health: enabled status, per-table document counts, and index stats." source="scripts/lib/search-tools.ts:256">
+<McpToolCard id="search-stats" name="bakin_exec_search_stats" label="Search stats" description="Get search system health: enabled status, per-table document counts, and index stats." source="src/core/exec-tools/tools/search-tools.ts:251">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_stats
 ```
 </McpToolCard>
-<McpToolCard id="search-table" name="bakin_exec_search_table" label="Search plugin" description="Search a specific Bakin plugin with facet filtering. Returns results plus facet counts for filtering." source="scripts/lib/search-tools.ts:90" parameters={[{"name":"q","type":"string","required":false,"description":"Search query text"},{"name":"limit","type":"number","required":false,"description":"Maximum results (default: 20)"}]}>
+<McpToolCard id="search-table" name="bakin_exec_search_table" label="Search plugin" description="Search a specific Bakin plugin with facet filtering. Returns results plus facet counts for filtering." source="src/core/exec-tools/tools/search-tools.ts:90" parameters={[{"name":"q","type":"string","required":false,"description":"Search query text"},{"name":"limit","type":"number","required":false,"description":"Maximum results (default: 20)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_search_table --args '{
   "q": "value",
@@ -899,7 +914,7 @@ mcporter call bakin-<agent>.bakin_exec_search_table --args '{
 <p class="mcp-section-description">Workflow submission tools let agents submit step output back to the workflow engine.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="submit-step" name="bakin_exec_submit_step" label="Submitted workflow step" description="Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip." source="plugins/workflows/index.ts:1916" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to submit for"},{"name":"output","type":"record","required":true,"description":"JSON output matching the step schema"}]}>
+<McpToolCard id="submit-step" name="bakin_exec_submit_step" label="Submitted workflow step" description="Submit workflow step output with local pre-validation. Validates against the step schema BEFORE hitting the server, giving you detailed field-level errors without a round trip." source="plugins/workflows/lib/exec-tools.ts:194" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to submit for"},{"name":"output","type":"record","required":true,"description":"JSON output matching the step schema"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_submit_step --args '{
   "taskId": "value",
@@ -917,7 +932,7 @@ mcporter call bakin-<agent>.bakin_exec_submit_step --args '{
 <p class="mcp-section-description">Task tools are the main agent interface for creating, reading, moving, logging, blocking, and completing work.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="tasks-assign" name="bakin_exec_tasks_assign" label="Assigned a task" description="Assign a task to an agent." source="plugins/tasks/index.ts:1003" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"agent","type":"string","required":true,"description":"Agent to assign the task to"}]}>
+<McpToolCard id="tasks-assign" name="bakin_exec_tasks_assign" label="Assigned a task" description="Assign a task to an agent." source="plugins/tasks/lib/exec-tools.ts:377" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"agent","type":"string","required":true,"description":"Agent to assign the task to"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_assign --args '{
   "taskId": "value",
@@ -925,7 +940,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_assign --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-block" name="bakin_exec_tasks_block" label="Blocked a task" description="Mark a task as blocked with a reason. Use when you cannot proceed." source="plugins/tasks/index.ts:853" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"reason","type":"string","required":true,"description":"Why the task is blocked"}]}>
+<McpToolCard id="tasks-block" name="bakin_exec_tasks_block" label="Blocked a task" description="Mark a task as blocked with a reason. Use when you cannot proceed." source="plugins/tasks/lib/exec-tools.ts:223" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"reason","type":"string","required":true,"description":"Why the task is blocked"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_block --args '{
   "taskId": "value",
@@ -933,7 +948,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_block --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-complete" name="bakin_exec_tasks_complete" label="Completed a task" description="Report that your task is complete. Moves the task to Done and notifies the orchestrator." source="plugins/tasks/index.ts:878" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"summary","type":"string","required":true,"description":"Summary of what you accomplished"}]}>
+<McpToolCard id="tasks-complete" name="bakin_exec_tasks_complete" label="Completed a task" description="Report that your task is complete. Moves the task to Done and notifies the orchestrator." source="plugins/tasks/lib/exec-tools.ts:248" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"summary","type":"string","required":true,"description":"Summary of what you accomplished"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_complete --args '{
   "taskId": "value",
@@ -941,7 +956,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_complete --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-create" name="bakin_exec_tasks_create" label="Created a task" description="Create a new task on the task board. Workflows are auto-matched by title when workflowId is not provided. Provide workflowId to force a specific workflow, or skipWorkflowReason to explicitly skip." source="plugins/tasks/index.ts:755" parameters={[{"name":"title","type":"string","required":true,"description":"Task title"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign (chef, pixel, rolo, patch, trainer, etc.)"},{"name":"description","type":"string","required":false,"description":"Task description and context"},{"name":"parentId","type":"string","required":false,"description":"Parent task ID if this is a subtask"},{"name":"workflowId","type":"string","required":false,"description":"Workflow to start (e.g. image-social-post, video-script). Use bakin_exec_workflows_list to see options."},{"name":"skipWorkflowReason","type":"string","required":false,"description":"Reason no workflow applies (required if workflowId is not set and this is not a subtask)"},{"name":"projectId","type":"string","required":false,"description":"Project ID to link this task to"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"},{"name":"sourcePluginId","type":"string","required":false,"description":"Plugin that owns the source entity for this task"},{"name":"sourceEntityType","type":"string","required":false,"description":"Source entity type, such as plan or deliverable"},{"name":"sourceEntityId","type":"string","required":false,"description":"Source entity ID"},{"name":"sourcePurpose","type":"string","required":false,"description":"Source purpose, such as kickoff or publish"}]}>
+<McpToolCard id="tasks-create" name="bakin_exec_tasks_create" label="Created a task" description="Create a new task on the task board. Workflows are auto-matched by title when workflowId is not provided. Provide workflowId to force a specific workflow, or skipWorkflowReason to explicitly skip." source="plugins/tasks/lib/exec-tools.ts:125" parameters={[{"name":"title","type":"string","required":true,"description":"Task title"},{"name":"assignee","type":"string","required":false,"description":"Agent to assign (chef, pixel, rolo, patch, trainer, etc.)"},{"name":"description","type":"string","required":false,"description":"Task description and context"},{"name":"parentId","type":"string","required":false,"description":"Parent task ID if this is a subtask"},{"name":"workflowId","type":"string","required":false,"description":"Workflow to start (e.g. image-social-post, video-script). Use bakin_exec_workflows_list to see options."},{"name":"skipWorkflowReason","type":"string","required":false,"description":"Reason no workflow applies (required if workflowId is not set and this is not a subtask)"},{"name":"projectId","type":"string","required":false,"description":"Project ID to link this task to"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"},{"name":"sourcePluginId","type":"string","required":false,"description":"Plugin that owns the source entity for this task"},{"name":"sourceEntityType","type":"string","required":false,"description":"Source entity type, such as plan or deliverable"},{"name":"sourceEntityId","type":"string","required":false,"description":"Source entity ID"},{"name":"sourcePurpose","type":"string","required":false,"description":"Source purpose, such as kickoff or publish"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_create --args '{
   "title": "value",
@@ -960,21 +975,21 @@ mcporter call bakin-<agent>.bakin_exec_tasks_create --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-delete" name="bakin_exec_tasks_delete" label="Deleted a task" description="Delete a task from the board." source="plugins/tasks/index.ts:982" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="tasks-delete" name="bakin_exec_tasks_delete" label="Deleted a task" description="Delete a task from the board." source="plugins/tasks/lib/exec-tools.ts:356" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_delete --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-get" name="bakin_exec_tasks_get" label="Read task details" description="Get details about a task — title, description, current column, logs, dependencies, project context." source="plugins/tasks/index.ts:721" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="tasks-get" name="bakin_exec_tasks_get" label="Read task details" description="Get details about a task — title, description, current column, logs, dependencies, project context." source="plugins/tasks/lib/exec-tools.ts:91" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_get --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-list" name="bakin_exec_tasks_list" label="Listed tasks" description="List all tasks on the board. Optionally filter by column or agent." source="plugins/tasks/index.ts:691" parameters={[{"name":"column","type":"choice","required":false,"description":"Filter by column"},{"name":"agent","type":"string","required":false,"description":"Filter by assigned agent"}]}>
+<McpToolCard id="tasks-list" name="bakin_exec_tasks_list" label="Listed tasks" description="List all tasks on the board. Optionally filter by column or agent." source="plugins/tasks/lib/exec-tools.ts:61" parameters={[{"name":"column","type":"choice","required":false,"description":"Filter by column"},{"name":"agent","type":"string","required":false,"description":"Filter by assigned agent"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_list --args '{
   "column": "value",
@@ -982,7 +997,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_list --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-log-progress" name="bakin_exec_tasks_log_progress" label="Logged progress" description="Log a human-readable progress update to the live activity feed. Call this at every significant step." source="plugins/tasks/index.ts:903" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (e.g. \"fe84ac51\")"},{"name":"message","type":"string","required":true,"description":"Human-readable status update"}]}>
+<McpToolCard id="tasks-log-progress" name="bakin_exec_tasks_log_progress" label="Logged progress" description="Log a human-readable progress update to the live activity feed. Call this at every significant step." source="plugins/tasks/lib/exec-tools.ts:273" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID (e.g. \"fe84ac51\")"},{"name":"message","type":"string","required":true,"description":"Human-readable status update"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_log_progress --args '{
   "taskId": "value",
@@ -990,7 +1005,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_log_progress --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-move" name="bakin_exec_tasks_move" label="Moved a task" description="Move a task to a different column on the task board." source="plugins/tasks/index.ts:825" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"to","type":"choice","required":true,"description":"Target column"},{"name":"reason","type":"string","required":false,"description":"Required when moving to \"blocked\""}]}>
+<McpToolCard id="tasks-move" name="bakin_exec_tasks_move" label="Moved a task" description="Move a task to a different column on the task board." source="plugins/tasks/lib/exec-tools.ts:195" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"to","type":"choice","required":true,"description":"Target column"},{"name":"reason","type":"string","required":false,"description":"Required when moving to \"blocked\""}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_move --args '{
   "taskId": "value",
@@ -999,7 +1014,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_move --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-set-dependency" name="bakin_exec_tasks_set_dependency" label="Set task dependency" description="Register a dependency between tasks. Your task will be auto-re-dispatched when the dependency completes. After registering, exit — do not wait." source="plugins/tasks/index.ts:922" parameters={[{"name":"taskId","type":"string","required":true,"description":"Your task ID (the one that depends)"},{"name":"dependsOn","type":"string","required":true,"description":"Task ID you depend on"}]}>
+<McpToolCard id="tasks-set-dependency" name="bakin_exec_tasks_set_dependency" label="Set task dependency" description="Register a dependency between tasks. Your task will be auto-re-dispatched when the dependency completes. After registering, exit — do not wait." source="plugins/tasks/lib/exec-tools.ts:292" parameters={[{"name":"taskId","type":"string","required":true,"description":"Your task ID (the one that depends)"},{"name":"dependsOn","type":"string","required":true,"description":"Task ID you depend on"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_set_dependency --args '{
   "taskId": "value",
@@ -1007,7 +1022,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_set_dependency --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="tasks-update" name="bakin_exec_tasks_update" label="Updated a task" description="Update a task on the board — change title, description, or assigned agent." source="plugins/tasks/index.ts:941" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"title","type":"string","required":false,"description":"New task title"},{"name":"description","type":"string","required":false,"description":"New task description"},{"name":"agent","type":"string","required":false,"description":"New assigned agent"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"}]}>
+<McpToolCard id="tasks-update" name="bakin_exec_tasks_update" label="Updated a task" description="Update a task on the board — change title, description, or assigned agent." source="plugins/tasks/lib/exec-tools.ts:313" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"title","type":"string","required":false,"description":"New task title"},{"name":"description","type":"string","required":false,"description":"New task description"},{"name":"agent","type":"string","required":false,"description":"New assigned agent"},{"name":"availableAt","type":"string","required":false,"description":"ISO timestamp before which dispatch should not pick up the task"},{"name":"dueAt","type":"string","required":false,"description":"ISO timestamp representing the task deadline or target delivery time"},{"name":"expectedVersion","type":"number","required":false,"description":"Optimistic-concurrency check: fail if the task version has moved past this"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_tasks_update --args '{
   "taskId": "value",
@@ -1015,7 +1030,8 @@ mcporter call bakin-<agent>.bakin_exec_tasks_update --args '{
   "description": "value",
   "agent": "value",
   "availableAt": "value",
-  "dueAt": "value"
+  "dueAt": "value",
+  "expectedVersion": 20
 }'
 ```
 </McpToolCard>
@@ -1026,7 +1042,7 @@ mcporter call bakin-<agent>.bakin_exec_tasks_update --args '{
 <p class="mcp-section-description">Team tools expose agent roster, identity, status, messaging, and permission operations.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="team-create-agent" name="bakin_exec_team_create_agent" label="Created agent" description="Create a new agent: registers it with the active runtime, writes persona files, configures dispatch permissions, optionally assigns it to a team. Returns next-step instructions." source="plugins/team/index.ts:2122" parameters={[{"name":"id","type":"string","required":false,"description":"Agent ID (lowercase alphanumeric + hyphens). Auto-derived from name if omitted."},{"name":"name","type":"string","required":true,"description":"Display name (e.g. \"Jessica\")"},{"name":"emoji","type":"string","required":false,"description":"Single emoji (e.g. \"🔎\")"},{"name":"role","type":"string","required":false,"description":"One-line role description"},{"name":"vibe","type":"string","required":false,"description":"Personality vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"What the agent does"},{"name":"defaultMode","type":"string","required":false,"description":"How the agent operates by default"},{"name":"model","type":"string","required":false,"description":"Full provider/model string. Uses default if omitted."},{"name":"soul","type":"string","required":false,"description":"Raw markdown for SOUL.md"},{"name":"tools","type":"string","required":false,"description":"Raw markdown for TOOLS.md"},{"name":"teamId","type":"string","required":false,"description":"Bakin team to assign the agent to"},{"name":"dispatchable","type":"union","required":false,"description":"Who can dispatch tasks to this agent. Default: \"main\"."}]}>
+<McpToolCard id="team-create-agent" name="bakin_exec_team_create_agent" label="Created agent" description="Create a new agent: registers it with the active runtime, writes persona files, configures dispatch permissions, optionally assigns it to a team. Returns next-step instructions." source="plugins/team/index.ts:510" parameters={[{"name":"id","type":"string","required":false,"description":"Agent ID (lowercase alphanumeric + hyphens). Auto-derived from name if omitted."},{"name":"name","type":"string","required":true,"description":"Display name (e.g. \"Jessica\")"},{"name":"emoji","type":"string","required":false,"description":"Single emoji (e.g. \"🔎\")"},{"name":"role","type":"string","required":false,"description":"One-line role description"},{"name":"vibe","type":"string","required":false,"description":"Personality vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"What the agent does"},{"name":"defaultMode","type":"string","required":false,"description":"How the agent operates by default"},{"name":"model","type":"string","required":false,"description":"Full provider/model string. Uses default if omitted."},{"name":"soul","type":"string","required":false,"description":"Raw markdown for SOUL.md"},{"name":"tools","type":"string","required":false,"description":"Raw markdown for TOOLS.md"},{"name":"teamId","type":"string","required":false,"description":"Bakin team to assign the agent to"},{"name":"dispatchable","type":"union","required":false,"description":"Who can dispatch tasks to this agent. Default: \"main\"."}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_create_agent --args '{
   "id": "value",
@@ -1044,7 +1060,7 @@ mcporter call bakin-<agent>.bakin_exec_team_create_agent --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-delete-agent" name="bakin_exec_team_delete_agent" label="Deleted agent" description="Remove an agent from the active runtime and clean up Bakin state. Requires confirm=true as a safety guard." source="plugins/team/index.ts:2232" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent to delete"},{"name":"confirm","type":"boolean","required":true,"description":"Must be true — safety guard against accidental deletion"}]}>
+<McpToolCard id="team-delete-agent" name="bakin_exec_team_delete_agent" label="Deleted agent" description="Remove an agent from the active runtime and clean up Bakin state. Requires confirm=true as a safety guard." source="plugins/team/index.ts:620" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent to delete"},{"name":"confirm","type":"boolean","required":true,"description":"Must be true — safety guard against accidental deletion"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_delete_agent --args '{
   "agentId": "value",
@@ -1052,19 +1068,19 @@ mcporter call bakin-<agent>.bakin_exec_team_delete_agent --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-list" name="bakin_exec_team_list" label="Listed team" description="List all agents with their current status (online/working/available/offline)." source="plugins/team/index.ts:1906">
+<McpToolCard id="team-list" name="bakin_exec_team_list" label="Listed team" description="List all agents with their current status (online/working/available/offline)." source="plugins/team/index.ts:294">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_list
 ```
 </McpToolCard>
-<McpToolCard id="team-members" name="bakin_exec_team_members" label="Listed team members" description="Get agents that belong to a specific team (e.g. &quot;builders&quot;, &quot;creators&quot;)." source="plugins/team/index.ts:2077" parameters={[{"name":"teamId","type":"string","required":true,"description":"Team ID (e.g. \"builders\", \"creators\")"}]}>
+<McpToolCard id="team-members" name="bakin_exec_team_members" label="Listed team members" description="Get agents that belong to a specific team (e.g. &quot;builders&quot;, &quot;creators&quot;)." source="plugins/team/index.ts:465" parameters={[{"name":"teamId","type":"string","required":true,"description":"Team ID (e.g. \"builders\", \"creators\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_members --args '{
   "teamId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-message" name="bakin_exec_team_message" label="Sent a message" description="Send a message to an agent via the active runtime." source="plugins/team/index.ts:2020" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"message","type":"string","required":true,"description":"Message to send. Do NOT use this to brief an agent about a task they were just assigned — dispatch already notified them, and a second message starts a duplicate worker in their main session."}]}>
+<McpToolCard id="team-message" name="bakin_exec_team_message" label="Sent a message" description="Send a message to an agent via the active runtime." source="plugins/team/index.ts:408" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"message","type":"string","required":true,"description":"Message to send. Do NOT use this to brief an agent about a task they were just assigned — dispatch already notified them, and a second message starts a duplicate worker in their main session."}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_message --args '{
   "agentId": "value",
@@ -1072,26 +1088,26 @@ mcporter call bakin-<agent>.bakin_exec_team_message --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-my-team" name="bakin_exec_team_my_team" label="Read own team" description="Get the team that a specific agent belongs to, including all teammates." source="plugins/team/index.ts:2096" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
+<McpToolCard id="team-my-team" name="bakin_exec_team_my_team" label="Read own team" description="Get the team that a specific agent belongs to, including all teammates." source="plugins/team/index.ts:484" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_my_team --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-org" name="bakin_exec_team_org" label="Read organization" description="Get the full org structure: teams with their members. Use this to understand who is on which team and reporting lines." source="plugins/team/index.ts:2067">
+<McpToolCard id="team-org" name="bakin_exec_team_org" label="Read organization" description="Get the full org structure: teams with their members. Use this to understand who is on which team and reporting lines." source="plugins/team/index.ts:455">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_org
 ```
 </McpToolCard>
-<McpToolCard id="team-profile" name="bakin_exec_team_profile" label="Read agent profile" description="Get the full profile for an agent including soul, rules, and tools." source="plugins/team/index.ts:1926" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
+<McpToolCard id="team-profile" name="bakin_exec_team_profile" label="Read agent profile" description="Get the full profile for an agent including soul, rules, and tools." source="plugins/team/index.ts:314" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_profile --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-read-file" name="bakin_exec_team_read_file" label="Read agent file" description="Read a workspace file for an agent (e.g., SOUL.md, AGENTS.md, TOOLS.md)." source="plugins/team/index.ts:2005" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"filename","type":"string","required":true,"description":"File name (e.g., SOUL.md)"}]}>
+<McpToolCard id="team-read-file" name="bakin_exec_team_read_file" label="Read agent file" description="Read a workspace file for an agent (e.g., SOUL.md, AGENTS.md, TOOLS.md)." source="plugins/team/index.ts:393" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"},{"name":"filename","type":"string","required":true,"description":"File name (e.g., SOUL.md)"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_read_file --args '{
   "agentId": "value",
@@ -1099,7 +1115,7 @@ mcporter call bakin-<agent>.bakin_exec_team_read_file --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-set-permissions" name="bakin_exec_team_set_permissions" label="Updated permissions" description="Update dispatch permissions — which agents a given agent can dispatch tasks to (subagents.allowAgents)." source="plugins/team/index.ts:2277" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent whose allowAgents to modify"},{"name":"allowAgents","type":"array","required":true,"description":"Full replacement list of agent IDs this agent can dispatch to"}]}>
+<McpToolCard id="team-set-permissions" name="bakin_exec_team_set_permissions" label="Updated permissions" description="Update dispatch permissions — which agents a given agent can dispatch tasks to (subagents.allowAgents)." source="plugins/team/index.ts:665" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent whose allowAgents to modify"},{"name":"allowAgents","type":"array","required":true,"description":"Full replacement list of agent IDs this agent can dispatch to"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_set_permissions --args '{
   "agentId": "value",
@@ -1109,14 +1125,14 @@ mcporter call bakin-<agent>.bakin_exec_team_set_permissions --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-status" name="bakin_exec_team_status" label="Checked agent status" description="Get the heartbeat and health status for an agent." source="plugins/team/index.ts:1940" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
+<McpToolCard id="team-status" name="bakin_exec_team_status" label="Checked agent status" description="Get the heartbeat and health status for an agent." source="plugins/team/index.ts:328" parameters={[{"name":"agentId","type":"string","required":true,"description":"Agent ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_status --args '{
   "agentId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="team-update-identity" name="bakin_exec_team_update_identity" label="Updated agent identity" description="Update an existing agent's identity fields (name, emoji, role, vibe, etc.) and/or workspace files (SOUL.md, TOOLS.md)." source="plugins/team/index.ts:2197" parameters={[{"name":"agentId","type":"string","required":true,"description":"Target agent ID"},{"name":"name","type":"string","required":false,"description":"New display name"},{"name":"emoji","type":"string","required":false,"description":"New emoji"},{"name":"role","type":"string","required":false,"description":"Updated role"},{"name":"vibe","type":"string","required":false,"description":"Updated vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"Updated primary function"},{"name":"defaultMode","type":"string","required":false,"description":"Updated default mode"},{"name":"soul","type":"string","required":false,"description":"Replace SOUL.md content"},{"name":"tools","type":"string","required":false,"description":"Replace TOOLS.md content"}]}>
+<McpToolCard id="team-update-identity" name="bakin_exec_team_update_identity" label="Updated agent identity" description="Update an existing agent's identity fields (name, emoji, role, vibe, etc.) and/or workspace files (SOUL.md, TOOLS.md)." source="plugins/team/index.ts:585" parameters={[{"name":"agentId","type":"string","required":true,"description":"Target agent ID"},{"name":"name","type":"string","required":false,"description":"New display name"},{"name":"emoji","type":"string","required":false,"description":"New emoji"},{"name":"role","type":"string","required":false,"description":"Updated role"},{"name":"vibe","type":"string","required":false,"description":"Updated vibe"},{"name":"primaryFunction","type":"string","required":false,"description":"Updated primary function"},{"name":"defaultMode","type":"string","required":false,"description":"Updated default mode"},{"name":"soul","type":"string","required":false,"description":"Replace SOUL.md content"},{"name":"tools","type":"string","required":false,"description":"Replace TOOLS.md content"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_team_update_identity --args '{
   "agentId": "value",
@@ -1138,7 +1154,7 @@ mcporter call bakin-<agent>.bakin_exec_team_update_identity --args '{
 <p class="mcp-section-description">Workflow tools expose workflow definitions, active instances, current steps, and step completion.</p>
 
 <div class="mcp-tool-list">
-<McpToolCard id="workflows-complete-step" name="bakin_exec_workflows_complete_step" label="Completed workflow step" description="Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete." source="plugins/workflows/index.ts:1860" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to complete"},{"name":"output","type":"record","required":true,"description":"Step output object"}]}>
+<McpToolCard id="workflows-complete-step" name="bakin_exec_workflows_complete_step" label="Completed workflow step" description="Complete a workflow step with output. Validates output against the step schema, advances the workflow to the next step. Returns success status and whether the workflow is complete." source="plugins/workflows/lib/exec-tools.ts:138" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"},{"name":"stepId","type":"string","required":true,"description":"Step ID to complete"},{"name":"output","type":"record","required":true,"description":"Step output object"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_complete_step --args '{
   "taskId": "value",
@@ -1149,40 +1165,40 @@ mcporter call bakin-<agent>.bakin_exec_workflows_complete_step --args '{
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-definition" name="bakin_exec_workflows_get_definition" label="Read workflow definition" description="Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows." source="plugins/workflows/index.ts:1766" parameters={[{"name":"name","type":"string","required":true,"description":"Workflow definition filename (e.g. \"content-pipeline\")"}]}>
+<McpToolCard id="workflows-get-definition" name="bakin_exec_workflows_get_definition" label="Read workflow definition" description="Get a workflow definition by filename. Returns the full definition with steps, inputs, and resolved sub-workflows." source="plugins/workflows/lib/exec-tools.ts:44" parameters={[{"name":"name","type":"string","required":true,"description":"Workflow definition filename (e.g. \"content-pipeline\")"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_definition --args '{
   "name": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-instance" name="bakin_exec_workflows_get_instance" label="Read workflow instance" description="Get the full state of a workflow instance for a task, including step states and history." source="plugins/workflows/index.ts:1832" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="workflows-get-instance" name="bakin_exec_workflows_get_instance" label="Read workflow instance" description="Get the full state of a workflow instance for a task, including step states and history." source="plugins/workflows/lib/exec-tools.ts:110" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_instance --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-get-step" name="bakin_exec_workflows_get_step" label="Read workflow step" description="Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next." source="plugins/workflows/index.ts:1846" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
+<McpToolCard id="workflows-get-step" name="bakin_exec_workflows_get_step" label="Read workflow step" description="Get the current workflow step for a task. Returns only the current step (information gating — future steps are hidden). Critical for agents to know what to do next." source="plugins/workflows/lib/exec-tools.ts:124" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_get_step --args '{
   "taskId": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-list" name="bakin_exec_workflows_list" label="Listed workflows" description="List all workflow definitions (templates). Returns name, filename, description, and step count for each." source="plugins/workflows/index.ts:1747">
+<McpToolCard id="workflows-list" name="bakin_exec_workflows_list" label="Listed workflows" description="List all workflow definitions (templates). Returns name, filename, description, and step count for each." source="plugins/workflows/lib/exec-tools.ts:25">
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_list
 ```
 </McpToolCard>
-<McpToolCard id="workflows-list-instances" name="bakin_exec_workflows_list_instances" label="Listed workflow runs" description="List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled)." source="plugins/workflows/index.ts:1819" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by instance status"}]}>
+<McpToolCard id="workflows-list-instances" name="bakin_exec_workflows_list_instances" label="Listed workflow runs" description="List workflow instances. Optionally filter by status (in_progress, pending_approval, complete, failed, cancelled)." source="plugins/workflows/lib/exec-tools.ts:97" parameters={[{"name":"status","type":"choice","required":false,"description":"Filter by instance status"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_list_instances --args '{
   "status": "value"
 }'
 ```
 </McpToolCard>
-<McpToolCard id="workflows-start" name="bakin_exec_workflows_start" label="Started a workflow" description="Start a workflow instance for a task. The task must exist on the board. Returns the created instance." source="plugins/workflows/index.ts:1784" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID to start workflow for"},{"name":"workflowId","type":"string","required":true,"description":"Workflow definition filename"}]}>
+<McpToolCard id="workflows-start" name="bakin_exec_workflows_start" label="Started a workflow" description="Start a workflow instance for a task. The task must exist on the board. Returns the created instance." source="plugins/workflows/lib/exec-tools.ts:62" parameters={[{"name":"taskId","type":"string","required":true,"description":"Task ID to start workflow for"},{"name":"workflowId","type":"string","required":true,"description":"Workflow definition filename"}]}>
 ```sh frame="terminal"
 mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
   "taskId": "value",
@@ -1193,5 +1209,5 @@ mcporter call bakin-<agent>.bakin_exec_workflows_start --args '{
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/hooks.mdx
+++ b/docs/src/content/docs/reference/generated/hooks.mdx
@@ -15,7 +15,15 @@ import HookCard from '../../../../components/HookCard.astro'
 <p class="hook-section-description">Asset hooks expose file, sidecar, variant, and trash helpers for plugins that need to work with Bakin-managed files.</p>
 
 <div class="hook-card-list">
-<HookCard id="assets-getassettypes" name="assets.getAssetTypes" label="List asset types." summary="Returns the asset type definitions known to the assets plugin. Use it to build filters, upload forms, or validation messages that match Bakin asset categories." source="plugins/assets/index.ts:415" badges={["rpc"]}>
+<HookCard id="assets-enrichmentstats" name="assets.enrichmentStats" label="Enrichment queue stats." summary="Returns the vision-enrichment queue depth and processed/failed/skipped counters for telemetry." source="plugins/assets/lib/register-hooks.ts:30" badges={["rpc"]}>
+```ts frame="terminal"
+const result = await ctx.hooks.invoke(
+  'assets.enrichmentStats',
+  {},
+)
+```
+</HookCard>
+<HookCard id="assets-getassettypes" name="assets.getAssetTypes" label="List asset types." summary="Returns the asset type definitions known to the assets plugin. Use it to build filters, upload forms, or validation messages that match Bakin asset categories." source="plugins/assets/lib/register-hooks.ts:44" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'assets.getAssetTypes',
@@ -23,7 +31,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="assets-listbytask" name="assets.listByTask" label="List assets linked to a task." summary="Returns {assetId, description, type} for every versioned asset whose manifest taskId matches. Backed by an in-memory index — the sanctioned way for core (dispatch) to resolve a task’s attached assets without scanning plugin storage." source="plugins/assets/index.ts:407" badges={["rpc"]}>
+<HookCard id="assets-listbytask" name="assets.listByTask" label="List assets linked to a task." summary="Returns {assetId, description, type} for every versioned asset whose manifest taskId matches. Backed by an in-memory index — the sanctioned way for core (dispatch) to resolve a task’s attached assets without scanning plugin storage." source="plugins/assets/lib/register-hooks.ts:36" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'assets.listByTask',
@@ -31,7 +39,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="assets-purgeclipboardfortask" name="assets.purgeClipboardForTask" label="Purge task clipboard assets." summary="Deletes clipboard-sourced assets associated with a completed task when that cleanup setting is enabled. Use it from task completion flows that want asset cleanup to stay centralized." source="plugins/assets/index.ts:448" badges={["rpc"]}>
+<HookCard id="assets-purgeclipboardfortask" name="assets.purgeClipboardForTask" label="Purge task clipboard assets." summary="Deletes clipboard-sourced assets associated with a completed task when that cleanup setting is enabled. Use it from task completion flows that want asset cleanup to stay centralized." source="plugins/assets/lib/register-hooks.ts:77" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'assets.purgeClipboardForTask',
@@ -41,7 +49,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="assets-resolveserve" name="assets.resolveServe" label="Resolve versioned asset serve request." summary="Resolves an /api/assets/&lt;assetId&gt; path (current, /v/&lt;n&gt;, /thumb, /export/&lt;name&gt;) to a file on disk for serving." source="plugins/assets/index.ts:416" badges={["rpc"]}>
+<HookCard id="assets-resolveserve" name="assets.resolveServe" label="Resolve versioned asset serve request." summary="Resolves an /api/assets/&lt;assetId&gt; path (current, /v/&lt;n&gt;, /thumb, /export/&lt;name&gt;) to a file on disk for serving." source="plugins/assets/lib/register-hooks.ts:45" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'assets.resolveServe',
@@ -54,7 +62,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="assets-savefromsource" name="assets.saveFromSource" label="Save a file as a managed asset." summary="Upserts a file into the versioned asset store by source path (new asset, version bump, or no-op when unchanged). The sanctioned cross-plugin/core save path; mirrors bakin_exec_assets_save." source="plugins/assets/index.ts:422" badges={["rpc"]}>
+<HookCard id="assets-savefromsource" name="assets.saveFromSource" label="Save a file as a managed asset." summary="Upserts a file into the versioned asset store by source path (new asset, version bump, or no-op when unchanged). The sanctioned cross-plugin/core save path; mirrors bakin_exec_assets_save." source="plugins/assets/lib/register-hooks.ts:51" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'assets.saveFromSource',
@@ -69,7 +77,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Health hooks expose registered readiness and diagnostic checks so other surfaces can list or inspect them.</p>
 
 <div class="hook-card-list">
-<HookCard id="health-getcheck" name="health.getCheck" label="Get a health check." summary="Returns metadata for one registered health check by id, without running the check. Use it when a plugin needs the check name, owner, and autofix capability before deciding what to show or run." source="plugins/health/index.ts:433" badges={["rpc"]}>
+<HookCard id="health-getcheck" name="health.getCheck" label="Get a health check." summary="Returns metadata for one registered health check by id, without running the check. Use it when a plugin needs the check name, owner, and autofix capability before deciding what to show or run." source="plugins/health/index.ts:478" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'health.getCheck',
@@ -79,7 +87,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="health-list" name="health.list" label="List health checks." summary="Returns the health checks registered by core and plugins without executing them. Use it when another surface needs to show the available diagnostics or autofix support." source="plugins/health/index.ts:432" badges={["rpc"]}>
+<HookCard id="health-list" name="health.list" label="List health checks." summary="Returns the health checks registered by core and plugins without executing them. Use it when another surface needs to show the available diagnostics or autofix support." source="plugins/health/index.ts:477" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'health.list',
@@ -94,7 +102,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Model hooks expose the effective model configuration and notify dependent surfaces when runtime model state changes.</p>
 
 <div class="hook-card-list">
-<HookCard id="models-configchanged" name="models.configChanged" label="Model config changed." summary="Notifies listeners after an agent model assignment changes. Use it to refresh dependent state, update UI, or invalidate plugin caches that depend on model routing." source="plugins/models/index.ts:778" badges={["event"]}>
+<HookCard id="models-configchanged" name="models.configChanged" label="Model config changed." summary="Notifies listeners after an agent model assignment changes. Use it to refresh dependent state, update UI, or invalidate plugin caches that depend on model routing." source="plugins/models/lib/register-hooks.ts:20" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'models.configChanged',
@@ -106,7 +114,7 @@ await ctx.hooks.callAll(
 )
 ```
 </HookCard>
-<HookCard id="models-getavailablemodels" name="models.getAvailableModels" label="List available models." summary="Returns the model catalog available from the currently configured providers. Use it to populate pickers, validate assignments, or compare model options before saving config." source="plugins/models/index.ts:794" badges={["rpc"]}>
+<HookCard id="models-getavailablemodels" name="models.getAvailableModels" label="List available models." summary="Returns the model catalog available from the currently configured providers. Use it to populate pickers, validate assignments, or compare model options before saving config." source="plugins/models/lib/register-hooks.ts:36" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'models.getAvailableModels',
@@ -114,7 +122,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="models-getbudgetpolicy" name="models.getBudgetPolicy" label="Get budget policy." summary="Returns the spend-cap policy (global + per-agent daily/monthly limits) that dispatch consults before each turn. Use it to read the current budget limits." source="plugins/models/index.ts:843" badges={["rpc"]}>
+<HookCard id="models-getbudgetpolicy" name="models.getBudgetPolicy" label="Get budget policy." summary="Returns the spend-cap policy (global + per-agent daily/monthly limits) that dispatch consults before each turn. Use it to read the current budget limits." source="plugins/models/lib/register-hooks.ts:85" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'models.getBudgetPolicy',
@@ -122,7 +130,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="models-geteffectivemodel" name="models.getEffectiveModel" label="Get effective model." summary="Resolves the model an agent will actually use after defaults, overrides, and provider settings are applied. Use it when a plugin needs runtime-ready model information for one agent." source="plugins/models/index.ts:782" badges={["rpc"]}>
+<HookCard id="models-geteffectivemodel" name="models.getEffectiveModel" label="Get effective model." summary="Resolves the model an agent will actually use after defaults, overrides, and provider settings are applied. Use it when a plugin needs runtime-ready model information for one agent." source="plugins/models/lib/register-hooks.ts:24" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'models.getEffectiveModel',
@@ -132,7 +140,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="models-getroutingconfig" name="models.getRoutingConfig" label="Get routing config." summary="Returns the per-turn model/thinking routing policy (origins + tag overrides) that dispatch applies before each agent turn. Use it to read the current routing rules." source="plugins/models/index.ts:836" badges={["rpc"]}>
+<HookCard id="models-getroutingconfig" name="models.getRoutingConfig" label="Get routing config." summary="Returns the per-turn model/thinking routing policy (origins + tag overrides) that dispatch applies before each agent turn. Use it to read the current routing rules." source="plugins/models/lib/register-hooks.ts:78" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'models.getRoutingConfig',
@@ -140,7 +148,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="models-markconfigdirty" name="models.markConfigDirty" label="Mark config dirty." summary="Marks model configuration as changed so the runtime knows a refresh is needed. Use it after writing model settings that should not be treated as live yet." source="plugins/models/index.ts:790" badges={["event"]}>
+<HookCard id="models-markconfigdirty" name="models.markConfigDirty" label="Mark config dirty." summary="Marks model configuration as changed so the runtime knows a refresh is needed. Use it after writing model settings that should not be treated as live yet." source="plugins/models/lib/register-hooks.ts:32" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'models.markConfigDirty',
@@ -148,7 +156,7 @@ await ctx.hooks.callAll(
 )
 ```
 </HookCard>
-<HookCard id="models-markruntimerestarted" name="models.markRuntimeRestarted" label="Mark runtime refreshed." summary="Records that the runtime has picked up the latest model configuration. Use it after restart or reload flows so stale dirty-state warnings can clear." source="plugins/models/index.ts:792" badges={["event"]}>
+<HookCard id="models-markruntimerestarted" name="models.markRuntimeRestarted" label="Mark runtime refreshed." summary="Records that the runtime has picked up the latest model configuration. Use it after restart or reload flows so stale dirty-state warnings can clear." source="plugins/models/lib/register-hooks.ts:34" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'models.markRuntimeRestarted',
@@ -156,7 +164,7 @@ await ctx.hooks.callAll(
 )
 ```
 </HookCard>
-<HookCard id="models-priceimage" name="models.priceImage" label="Price an image." summary="Returns an estimated cost in micro-dollars for an image generation (count × the model’s flat per-image rate), or null when the model is provider-priced. Use it to attribute image-generation spend." source="plugins/models/index.ts:826" badges={["rpc"]}>
+<HookCard id="models-priceimage" name="models.priceImage" label="Price an image." summary="Returns an estimated cost in micro-dollars for an image generation (count × the model’s flat per-image rate), or null when the model is provider-priced. Use it to attribute image-generation spend." source="plugins/models/lib/register-hooks.ts:68" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'models.priceImage',
@@ -164,7 +172,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="models-priceturn" name="models.priceTurn" label="Price a turn." summary="Resolves the model an agent turn ran on and returns an estimated cost in micro-dollars from the catalog pricing. Use it to attribute spend to a completed turn. Cost is null when the model is unpriced." source="plugins/models/index.ts:805" badges={["rpc"]}>
+<HookCard id="models-priceturn" name="models.priceTurn" label="Price a turn." summary="Resolves the model an agent turn ran on and returns an estimated cost in micro-dollars from the catalog pricing. Use it to attribute spend to a completed turn. Cost is null when the model is unpriced." source="plugins/models/lib/register-hooks.ts:47" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'models.priceTurn',
@@ -179,7 +187,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Hooks discovered from source registration audit.</p>
 
 <div class="hook-card-list">
-<HookCard id="schedule-ensurebakinjob" name="schedule.ensureBakinJob" label="Ensure Bakin schedule" summary="Create or update a Bakin-managed runtime cron job and return the provider job id." source="plugins/schedule/index.ts:1019" badges={["rpc"]}>
+<HookCard id="schedule-ensurebakinjob" name="schedule.ensureBakinJob" label="Ensure Bakin schedule" summary="Create or update a Bakin-managed runtime cron job and return the provider job id." source="plugins/schedule/index.ts:68" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'schedule.ensureBakinJob',
@@ -226,7 +234,7 @@ await ctx.hooks.callAll(
 <p class="hook-section-description">Team hooks expose runtime agent and team metadata for plugins that need agent-aware behavior.</p>
 
 <div class="hook-card-list">
-<HookCard id="team-getagent" name="team.getAgent" label="Get an agent." summary="Returns one runtime agent by id, including team-aware metadata when available. Use it when a plugin already has an agent id and needs the full display record." source="plugins/team/index.ts:1879" badges={["rpc"]}>
+<HookCard id="team-getagent" name="team.getAgent" label="Get an agent." summary="Returns one runtime agent by id, including team-aware metadata when available. Use it when a plugin already has an agent id and needs the full display record." source="plugins/team/index.ts:267" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getAgent',
@@ -236,7 +244,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getagentids" name="team.getAgentIds" label="List agent ids." summary="Returns the ids of agents currently known to the runtime. Use it for lightweight validation, assignment pickers, or loops that do not need full agent metadata." source="plugins/team/index.ts:1884" badges={["rpc"]}>
+<HookCard id="team-getagentids" name="team.getAgentIds" label="List agent ids." summary="Returns the ids of agents currently known to the runtime. Use it for lightweight validation, assignment pickers, or loops that do not need full agent metadata." source="plugins/team/index.ts:272" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getAgentIds',
@@ -244,7 +252,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getagentteam" name="team.getAgentTeam" label="Get agent team." summary="Returns the team currently assigned to an agent, or null when the agent is unassigned. Use it to add team context to task, workflow, or activity views." source="plugins/team/index.ts:1891" badges={["rpc"]}>
+<HookCard id="team-getagentteam" name="team.getAgentTeam" label="Get agent team." summary="Returns the team currently assigned to an agent, or null when the agent is unassigned. Use it to add team context to task, workflow, or activity views." source="plugins/team/index.ts:279" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getAgentTeam',
@@ -254,7 +262,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getorgstructure" name="team.getOrgStructure" label="Get org structure." summary="Returns the current organization structure for teams and agents. Use it when a plugin needs the full hierarchy instead of individual team or agent records." source="plugins/team/index.ts:1897" badges={["rpc"]}>
+<HookCard id="team-getorgstructure" name="team.getOrgStructure" label="Get org structure." summary="Returns the current organization structure for teams and agents. Use it when a plugin needs the full hierarchy instead of individual team or agent records." source="plugins/team/index.ts:285" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getOrgStructure',
@@ -262,7 +270,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-getteammembers" name="team.getTeamMembers" label="List team members." summary="Returns the agents assigned to one team. Use it for team dashboards, routing rules, or workflow logic that needs team membership." source="plugins/team/index.ts:1888" badges={["rpc"]}>
+<HookCard id="team-getteammembers" name="team.getTeamMembers" label="List team members." summary="Returns the agents assigned to one team. Use it for team dashboards, routing rules, or workflow logic that needs team membership." source="plugins/team/index.ts:276" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.getTeamMembers',
@@ -272,7 +280,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-list" name="team.list" label="List agents." summary="Returns runtime agents with their display and team metadata attached. Use it when another plugin needs the agent roster as Bakin presents it." source="plugins/team/index.ts:1878" badges={["rpc"]}>
+<HookCard id="team-list" name="team.list" label="List agents." summary="Returns runtime agents with their display and team metadata attached. Use it when another plugin needs the agent roster as Bakin presents it." source="plugins/team/index.ts:266" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.list',
@@ -280,7 +288,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="team-resolveprofile" name="team.resolveProfile" label="Resolve agent profile." summary="Returns the runtime profile for an agent id. Use it when a plugin needs the lower-level profile data behind an agent display record." source="plugins/team/index.ts:1885" badges={["rpc"]}>
+<HookCard id="team-resolveprofile" name="team.resolveProfile" label="Resolve agent profile." summary="Returns the runtime profile for an agent id. Use it when a plugin needs the lower-level profile data behind an agent display record." source="plugins/team/index.ts:273" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'team.resolveProfile',
@@ -297,7 +305,7 @@ const result = await ctx.hooks.invoke(
 <p class="hook-section-description">Workflow hooks expose workflow definitions, instances, steps, gates, and notification helpers for task automation.</p>
 
 <div class="hook-card-list">
-<HookCard id="workflows-approvegate" name="workflows.approveGate" label="Approve workflow gate." summary="Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1682" badges={["rpc"]}>
+<HookCard id="workflows-approvegate" name="workflows.approveGate" label="Approve workflow gate." summary="Approves a pending workflow gate and advances the instance. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/lib/register-hooks.ts:38" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.approveGate',
@@ -305,7 +313,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-authorizetooluse" name="workflows.authorizeToolUse" label="Authorize workflow tool use." summary="Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation." source="plugins/workflows/index.ts:1708" badges={["rpc"]}>
+<HookCard id="workflows-authorizetooluse" name="workflows.authorizeToolUse" label="Authorize workflow tool use." summary="Checks whether an agent may perform a workflow-scoped tool action for a task. Use it before executing workflow-sensitive automation." source="plugins/workflows/lib/register-hooks.ts:64" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.authorizeToolUse',
@@ -313,7 +321,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-cancelinstance" name="workflows.cancelInstance" label="Cancel workflow instance." summary="Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue." source="plugins/workflows/index.ts:1712" badges={["event"]}>
+<HookCard id="workflows-cancelinstance" name="workflows.cancelInstance" label="Cancel workflow instance." summary="Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue." source="plugins/workflows/lib/register-hooks.ts:68" badges={["event"]}>
 ```ts frame="terminal"
 await ctx.hooks.callAll(
   'workflows.cancelInstance',
@@ -323,7 +331,15 @@ await ctx.hooks.callAll(
 )
 ```
 </HookCard>
-<HookCard id="workflows-completestep" name="workflows.completeStep" label="Complete workflow step." summary="Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action." source="plugins/workflows/index.ts:1700" badges={["rpc"]}>
+<HookCard id="workflows-clearskillcache" name="workflows.clearSkillCache" label="Clear workflow skill cache." summary="Drops the in-memory workflow-skill resolution cache so the next lookup re-reads disk and the registries. Use it after agent-package sync, migration, install, or removal changes which skills resolve." source="plugins/workflows/lib/register-hooks.ts:71" badges={["event"]}>
+```ts frame="terminal"
+await ctx.hooks.callAll(
+  'workflows.clearSkillCache',
+  {},
+)
+```
+</HookCard>
+<HookCard id="workflows-completestep" name="workflows.completeStep" label="Complete workflow step." summary="Submits output for a workflow step and advances the instance when validation passes. Use it from agents or tools that finish a workflow action." source="plugins/workflows/lib/register-hooks.ts:56" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.completeStep',
@@ -337,7 +353,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-createinstance" name="workflows.createInstance" label="Create workflow instance." summary="Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow." source="plugins/workflows/index.ts:1681" badges={["rpc"]}>
+<HookCard id="workflows-createinstance" name="workflows.createInstance" label="Create workflow instance." summary="Creates a workflow instance for a task and optional assignee context. Use it when task creation or routing should immediately attach a workflow." source="plugins/workflows/lib/register-hooks.ts:37" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.createInstance',
@@ -349,7 +365,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-definitions-list" name="workflows.definitions.list" label="List workflow definitions." summary="Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances." source="plugins/workflows/index.ts:1702" badges={["rpc"]}>
+<HookCard id="workflows-definitions-list" name="workflows.definitions.list" label="List workflow definitions." summary="Returns available workflow definitions from the configured content directory. Use it to populate workflow selectors or validate workflow ids before creating instances." source="plugins/workflows/lib/register-hooks.ts:58" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.definitions.list',
@@ -357,7 +373,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getactiveagents" name="workflows.getActiveAgents" label="List active workflow agents." summary="Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants." source="plugins/workflows/index.ts:1707" badges={["rpc"]}>
+<HookCard id="workflows-getactiveagents" name="workflows.getActiveAgents" label="List active workflow agents." summary="Returns agents currently active in a workflow task. Use it for coordination, notification, or assignment views that need live workflow participants." source="plugins/workflows/lib/register-hooks.ts:63" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getActiveAgents',
@@ -367,7 +383,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getcurrentstep" name="workflows.getCurrentStep" label="Get current step." summary="Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable." source="plugins/workflows/index.ts:1699" badges={["rpc"]}>
+<HookCard id="workflows-getcurrentstep" name="workflows.getCurrentStep" label="Get current step." summary="Returns the current workflow step for a task, optionally scoped to an agent. Use it when a plugin needs to know what work is currently actionable." source="plugins/workflows/lib/register-hooks.ts:55" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getCurrentStep',
@@ -378,7 +394,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-getnotificationchannel" name="workflows.getNotificationChannel" label="Get notification channel." summary="Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation." source="plugins/workflows/index.ts:1718" badges={["rpc"]}>
+<HookCard id="workflows-getnotificationchannel" name="workflows.getNotificationChannel" label="Get notification channel." summary="Returns one workflow notification channel by id. Use it before sending or configuring alerts that depend on a specific channel implementation." source="plugins/workflows/lib/register-hooks.ts:77" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.getNotificationChannel',
@@ -388,7 +404,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-instances-list" name="workflows.instances.list" label="List workflow instances." summary="Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state." source="plugins/workflows/index.ts:1698" badges={["rpc"]}>
+<HookCard id="workflows-instances-list" name="workflows.instances.list" label="List workflow instances." summary="Returns workflow instances, optionally filtered by status. Use it for dashboards, queues, and maintenance flows that need a broad view of active workflow state." source="plugins/workflows/lib/register-hooks.ts:54" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.instances.list',
@@ -398,7 +414,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-isgatenotified" name="workflows.isGateNotified" label="Check gate notification." summary="Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step." source="plugins/workflows/index.ts:1709" badges={["rpc"]}>
+<HookCard id="workflows-isgatenotified" name="workflows.isGateNotified" label="Check gate notification." summary="Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step." source="plugins/workflows/lib/register-hooks.ts:65" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.isGateNotified',
@@ -409,7 +425,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-loaddefinition" name="workflows.loadDefinition" label="Load workflow definition." summary="Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id." source="plugins/workflows/index.ts:1703" badges={["rpc"]}>
+<HookCard id="workflows-loaddefinition" name="workflows.loadDefinition" label="Load workflow definition." summary="Loads one workflow definition by name. Use it when a plugin needs the template shape, steps, or metadata behind a workflow id." source="plugins/workflows/lib/register-hooks.ts:59" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.loadDefinition',
@@ -419,7 +435,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-loadinstance" name="workflows.loadInstance" label="Load workflow instance." summary="Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly." source="plugins/workflows/index.ts:1679" badges={["rpc"]}>
+<HookCard id="workflows-loadinstance" name="workflows.loadInstance" label="Load workflow instance." summary="Loads the workflow instance attached to a task. Use it when a plugin needs current workflow state without reading workflow files directly." source="plugins/workflows/lib/register-hooks.ts:35" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.loadInstance',
@@ -429,7 +445,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-markgatenotified" name="workflows.markGateNotified" label="Mark gate notified." summary="Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates." source="plugins/workflows/index.ts:1710" badges={["rpc"]}>
+<HookCard id="workflows-markgatenotified" name="workflows.markGateNotified" label="Mark gate notified." summary="Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates." source="plugins/workflows/lib/register-hooks.ts:66" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.markGateNotified',
@@ -440,7 +456,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-matchworkflow" name="workflows.matchWorkflow" label="Match workflow." summary="Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template." source="plugins/workflows/index.ts:1701" badges={["rpc"]}>
+<HookCard id="workflows-matchworkflow" name="workflows.matchWorkflow" label="Match workflow." summary="Suggests a workflow based on a task title and description. Use it when creating tasks that should automatically pick the most relevant workflow template." source="plugins/workflows/lib/register-hooks.ts:57" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.matchWorkflow',
@@ -451,7 +467,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-notificationchannels-list" name="workflows.notificationChannels.list" label="List notification channels." summary="Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts." source="plugins/workflows/index.ts:1717" badges={["rpc"]}>
+<HookCard id="workflows-notificationchannels-list" name="workflows.notificationChannels.list" label="List notification channels." summary="Returns workflow notification channels registered by core or plugins. Use it to show available delivery targets for gate and workflow alerts." source="plugins/workflows/lib/register-hooks.ts:76" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.notificationChannels.list',
@@ -459,7 +475,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-rejectgate" name="workflows.rejectGate" label="Reject workflow gate." summary="Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/index.ts:1686" badges={["rpc"]}>
+<HookCard id="workflows-rejectgate" name="workflows.rejectGate" label="Reject workflow gate." summary="Rejects a pending workflow gate, records the reason, and rewinds the instance per the workflow gate policy. Use it from plugins that own an external review surface for workflow-backed tasks." source="plugins/workflows/lib/register-hooks.ts:42" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.rejectGate',
@@ -467,7 +483,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-reopenfromstep" name="workflows.reopenFromStep" label="Reopen workflow from step." summary="Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task." source="plugins/workflows/index.ts:1691" badges={["rpc"]}>
+<HookCard id="workflows-reopenfromstep" name="workflows.reopenFromStep" label="Reopen workflow from step." summary="Reopens an existing workflow instance at a prior actionable step. Use it when a plugin needs explicit user recovery without creating a replacement workflow task." source="plugins/workflows/lib/register-hooks.ts:47" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.reopenFromStep',
@@ -475,7 +491,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-saveinstance" name="workflows.saveInstance" label="Save workflow instance." summary="Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer." source="plugins/workflows/index.ts:1680" badges={["rpc"]}>
+<HookCard id="workflows-saveinstance" name="workflows.saveInstance" label="Save workflow instance." summary="Persists a workflow instance after a plugin has changed its state. Use it to keep workflow updates routed through the workflow plugin storage layer." source="plugins/workflows/lib/register-hooks.ts:36" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.saveInstance',
@@ -488,7 +504,7 @@ const result = await ctx.hooks.invoke(
 )
 ```
 </HookCard>
-<HookCard id="workflows-validatestepoutput" name="workflows.validateStepOutput" label="Validate step output." summary="Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow." source="plugins/workflows/index.ts:1711" badges={["rpc"]}>
+<HookCard id="workflows-validatestepoutput" name="workflows.validateStepOutput" label="Validate step output." summary="Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow." source="plugins/workflows/lib/register-hooks.ts:67" badges={["rpc"]}>
 ```ts frame="terminal"
 const result = await ctx.hooks.invoke(
   'workflows.validateStepOutput',
@@ -506,5 +522,5 @@ const result = await ctx.hooks.invoke(
 </div>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/runtime-paths.md
+++ b/docs/src/content/docs/reference/generated/runtime-paths.md
@@ -100,5 +100,5 @@ description: Reference for Bakin runtime files under the resolved Bakin home dir
 </table>
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/sdk.md
+++ b/docs/src/content/docs/reference/generated/sdk.md
@@ -34,6 +34,9 @@ The main entry. Re-exports the plugin contract types (`./types`) plus the high-t
 | `getPluginRoutes` | Get all registered client routes (across all plugins). |
 | `setManifestNav` | Seed a plugin's declarative nav from its manifest (host-side; survives unregisterPlugin). |
 | `getManifestNav` | Read the manifest nav currently seeded for a plugin (drift validation). |
+| `getSearchHitRenderer` | Look up the ⌘K hit renderer registered for a content type. |
+| `getSearchHitRenderersSnapshot` | Stable snapshot of all registered hit renderers keyed by content type. |
+| `subscribeSearchHitRenderers` | Subscribe to hit-renderer mutations (own channel). |
 | `ClientRouteEntry` | — |
 | `MatchedPluginRoute` | — |
 | `PluginRegistration` | — |
@@ -147,9 +150,15 @@ import { useSearch, useDebug } from '@makinbakin/sdk/hooks'
 | Hook | Description |
 | --- | --- |
 | `useNavBadge` | Sync a nav item's badge to a derived value; the recommended provider glue. |
+| `useJsonFetch` | Cancellable JSON GET with a `{ data, loading, error, refresh }` lifecycle. |
+| `UseJsonFetchResult` | — |
 | `useTaskRunHistory` | Fetch dispatch run history for a task. |
 | `TaskOutcome` | — |
 | `TaskRunEntry` | — |
+| `usePluginEvent` | Subscribe to a server-pushed plugin event over the shell's single connection. |
+| `PluginEventPayload` | Subscribe to a server-pushed plugin event over the shell's single connection. |
+| `useHorizontalResize` | Resize a side-by-side split pane by dragging the divider between columns. |
+| `useAvailableModels` | The available-models catalog (cached, read-only); empty until loaded. |
 
 ## `@makinbakin/sdk/components`
 
@@ -168,7 +177,12 @@ import { PluginHeader, FacetFilter, AgentAvatar } from '@makinbakin/sdk/componen
 | `AgentStatus` | Compound agent status (dot + label + last-seen timestamp). |
 | `BakinDrawer` | Right-side slide-out drawer with backdrop and focus trap. |
 | `ColorPicker` | Color picker swatch grid for tag/agent color assignment. |
+| `ConfirmDialog` | Controlled confirmation dialog for destructive actions (busy/error aware). |
+| `ConfirmDialogProps` | — |
 | `EmptyState` | Centered empty-state component with icon, title, and CTA. |
+| `SearchUnavailable` | — |
+| `ScoreOverlay` | — |
+| `ScoreOverlayInfo` | — |
 | `ErrorBanner` | Inline error banner with dismiss + retry actions. |
 | `ErrorState` | Full-page error state with title, description, and retry button. |
 | `FacetFilter` | Popover multi-select facet filter (column, owner, tag, etc.). |
@@ -240,8 +254,18 @@ Source: `packages/sdk/src/utils/index.ts`.
 
 | Utility | Description |
 | --- | --- |
+| `healthOk` | Build an `ok` health-check result. |
+| `healthWarn` | Build a `warn` health-check result (optionally auto-fixable). |
+| `healthError` | Build an `error` health-check result (optionally auto-fixable). |
+| `healthFixed` | Build a `fixed` health-check result (the auto-repair just ran). |
 | `cn` | Tailwind class merger (clsx + tailwind-merge). |
+| `BadgeTone` | Semantic tone for an outline status badge. |
+| `toneBadgeClass` | Classes for an outline status badge of the given tone — the |
+| `isValidAssetId` | Pure assetId shape validators (see ./asset-id). |
+| `yearMonthFromAssetId` | Pure assetId shape validators (see ./asset-id). |
 | `formatAge` | Format a Date or ISO string as a relative age (e.g. "5m ago"). |
+| `formatDateTime` | Format an ISO timestamp as a calendar-aware absolute date+time (e.g. "Today 3:45 PM", "Jan 5 9:02 AM"). |
+| `formatDuration` | Format a millisecond count as an elapsed duration (e.g. "42s", "3m 5s"); null when undefined. |
 | `formatSize` | Format a byte count as a human-readable size string (e.g. "1.2 MB"). |
 | `isStale` | Returns true if a timestamp is older than a configurable staleness threshold. |
 | `brainstormActivityMessageFromCustom` | Convert a custom activity message into a brainstorm activity input. |
@@ -314,5 +338,5 @@ Source: `packages/sdk/src/routing/index.ts`.
 | `DefinePluginInput` | — |
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/reference/generated/settings.md
+++ b/docs/src/content/docs/reference/generated/settings.md
@@ -67,6 +67,10 @@ description: Generated reference for Bakin core settings defaults.
   </thead>
   <tbody>
     <tr>
+      <td><code>dispatch.contextBudgetBytes</code></td>
+      <td><code>65536</code></td>
+    </tr>
+    <tr>
       <td><code>dispatch.failureCooldownMs</code></td>
       <td><code>1800000</code></td>
     </tr>
@@ -89,6 +93,10 @@ description: Generated reference for Bakin core settings defaults.
     <tr>
       <td><code>dispatch.maxTurnsPerAgent</code></td>
       <td><code>1</code></td>
+    </tr>
+    <tr>
+      <td><code>dispatch.maxWorkflowContextBytes</code></td>
+      <td><code>16384</code></td>
     </tr>
     <tr>
       <td><code>dispatch.oversizedOutputBytes</code></td>
@@ -236,7 +244,7 @@ description: Generated reference for Bakin core settings defaults.
     </tr>
     <tr>
       <td><code>search.settings.embedders.visual.model</code></td>
-      <td><code>&quot;Xenova/clip-vit-base-patch32&quot;</code></td>
+      <td><code>&quot;antflydb/clipclap&quot;</code></td>
     </tr>
     <tr>
       <td><code>search.settings.embedders.visual.provider</code></td>
@@ -395,5 +403,5 @@ description: Generated reference for Bakin core settings defaults.
 
 
 <aside class="generated-page-note" aria-label="Generated page metadata">
-  <span>Generated Jun 13, 2026 · Bakin 0.0.0-dev</span>
+  <span>Generated Jul 4, 2026 · Bakin 0.0.0-dev</span>
 </aside>

--- a/docs/src/content/docs/using/assets.md
+++ b/docs/src/content/docs/using/assets.md
@@ -144,6 +144,10 @@ Plugins compose by `assetId` (`/api/assets/<assetId>` is a stable URL) or by slo
 | Generate thumbnails | `boolean` | `true` | Auto-create optimized thumbnails on upload |
 | Max file size (MB) | `number` | `50` | Reject uploads larger than this |
 | Purge clipboard assets on task completion | `boolean` | `false` | Auto-delete clipboard-pasted assets when their linked task is marked done |
+| Vision enrichment | `boolean` | `true` | Derive caption/OCR/tags from asset content with a vision model (billed per asset version) |
+| Enrichment provider | `select` | `auto` | auto = cheapest configured API model, else the runtime agent when its model accepts images; runtime = agent turns only (subscription quota) |
+| Enrichment model override | `string` |  | Exact model id (catalog or provider-native); empty = auto |
+| Enrichment agent | `string` | `enrich` | Runtime agent for subscription-quota enrichment turns — its configured model must accept images (per-turn overrides don't pass the attachment gate; bakin#583/#584) |
 
 </div>
 <!-- /docs:settings -->
@@ -156,6 +160,8 @@ Most asset workflows happen in the UI or through agents. Trash is CLI-friendly:
 | Command | Purpose |
 | --- | --- |
 | `bakin trash [list\|restore\|empty] ...` | Manage trashed assets. |
+| `bakin assets scan` | List unmanaged files awaiting explicit import |
+| `bakin assets import [--all\|<path>] [--type t]` | Import unmanaged files into managed versioned assets |
 <!-- /docs:cli-commands -->
 
 Full surface in the [CLI reference](/docs/reference/generated/cli/). HTTP API surface: see the [API reference](/docs/reference/generated/api/#assets).
@@ -171,6 +177,7 @@ Agents create, version, link, and curate assets through MCP exec tools. The head
 - `bakin_exec_assets_delete`: Soft-delete a whole asset (all versions) to trash, restorable until trash is emptied.
 - `bakin_exec_assets_empty_trash`: Permanently delete all trashed assets. This cannot be undone.
 - `bakin_exec_assets_get`: Retrieve an asset manifest (versions, current pointer, exports) by assetId.
+- `bakin_exec_assets_import`: Explicitly import unmanaged files into managed versioned assets. Pass path (content-dir relative, e.g. assets/inbox/pic.png) or all: true. Optional type override and taskId link.
 - `bakin_exec_assets_link`: Link an asset to a different task, or unlink it (set taskId to null).
 - `bakin_exec_assets_list`: List managed assets (one entry per asset, current-version view). Optional type, task, and tag filters. Tags are the UI "folders" — pass tags to list a folder, e.g. ["brand"].
 - `bakin_exec_assets_list_trash`: List trashed assets (whole-asset deletions) with deletion time and version count.
@@ -179,6 +186,7 @@ Agents create, version, link, and curate assets through MCP exec tools. The head
 - `bakin_exec_assets_restore`: Restore a trashed asset by its trash name (from bakin_exec_assets_list_trash).
 - `bakin_exec_assets_retype`: Change an asset type classification.
 - `bakin_exec_assets_save`: Save an agent-created file as a managed, versioned asset. Re-saving the SAME source file appends a new version to the existing asset (or no-ops if unchanged) instead of creating a duplicate — so an evolving doc stays one asset with a version history. Returns the asset id.
+- `bakin_exec_assets_scan_unmanaged`: List files under assets/ that are NOT managed assets (inbox drops, loose files). Nothing is imported automatically — use bakin_exec_assets_import to import.
 <!-- /docs:exec-tools -->
 
 Full schemas and arguments in the [Exec tools reference](/docs/reference/generated/exec-tools/).

--- a/docs/src/content/docs/using/schedule.md
+++ b/docs/src/content/docs/using/schedule.md
@@ -76,8 +76,6 @@ Cron expressions and run logs live in the runtime home. Bakin reads them; the ru
 
 | Setting | Type | Default | What it does |
 | --- | --- | --- | --- |
-| Max concurrent jobs | `number` | `3` | Maximum jobs that can run at the same time |
-| Failure cooldown (ms) | `number` | `300000` | Wait time after failure before retrying |
 | Max consecutive failures | `number` | `3` | Pause job after this many consecutive failures |
 | Scheduler tick interval (seconds) | `number` | `30` | How often the scheduler checks for due schedules. Floor-clamped to 5s. |
 | Missed-fire safety window (minutes) | `number` | `60` | After downtime, a missed run fires normally if within this window; older runs land in Blocked for you to triage. Larger = more tolerant. |

--- a/packages/core/src/workflows/load-defaults.ts
+++ b/packages/core/src/workflows/load-defaults.ts
@@ -40,26 +40,29 @@ export function loadDefaultWorkflows(
     (f) => f.endsWith('.yaml') || f.endsWith('.yml'),
   )
 
-  const parsedFiles: Array<{ id: string; definition: WorkflowDefinition }> = []
   for (const file of files) {
     const id = file.replace(/\.(yaml|yml)$/, '')
+    let definition: WorkflowDefinition
     try {
       const raw = readFileSync(join(defaultsDir, file), 'utf-8')
-      const parsed = yaml.load(raw) as unknown as WorkflowDefinition
-      parsedFiles.push({ id, definition: parsed })
+      definition = yaml.load(raw) as unknown as WorkflowDefinition
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       result.skipped.push({ id, errors: [message] })
       log.warn(`Failed to load plugin-shipped workflow "${id}"`, { error: message })
+      continue
     }
-  }
 
-  const knownWorkflowIds = new Set(parsedFiles.map((entry) => entry.id))
-  for (const { id, definition } of parsedFiles) {
+    // Nested-ref EXISTENCE is deliberately not checked at load time: the
+    // referenced workflow may ship in a plugin that has not activated yet
+    // (#374). Structural validation and self-references stay fatal here; a
+    // truly missing child is rejected by start-time validation
+    // (createValidatedInstance) and surfaced by the workflow-definitions
+    // health check.
     const errors = validateDefinition(definition, {
       definitionId: id,
       source: 'plugin',
-      knownWorkflowIds,
+      validateNestedWorkflowRefs: false,
     })
     if (errors.length > 0) {
       result.skipped.push({ id, errors })

--- a/packages/core/src/workflows/validate-definition.ts
+++ b/packages/core/src/workflows/validate-definition.ts
@@ -192,17 +192,20 @@ export function validateDefinition(def: WorkflowDefinition, opts: ValidateDefini
       }
     }
 
-    // Validate workflow step references
-    if (validateNestedWorkflowRefs && step.type === 'workflow') {
+    // Validate workflow step references. Structural checks (workflow_id
+    // present, no self-reference) are always fatal; the EXISTENCE check is
+    // gated by validateNestedWorkflowRefs because plugin-default loading runs
+    // before every plugin has activated (#374) — there, existence is enforced
+    // at start time and surfaced by the workflow-definitions health check.
+    if (step.type === 'workflow') {
       const nested = step as NestedWorkflowStep
       if (!nested.workflow_id) {
         errors.push(`Step "${step.id}": workflow step requires workflow_id`)
       } else if (opts.definitionId && nested.workflow_id === opts.definitionId) {
         errors.push(`Step "${step.id}": workflow_id "${nested.workflow_id}" cannot reference its own workflow`)
-      } else {
-        // Check that referenced workflow exists in the current validation set,
-        // on disk, or in the registry. The validation-set path is what lets
-        // plugin-shipped defaults validate in two passes before registration.
+      } else if (validateNestedWorkflowRefs) {
+        // Referenced workflow must exist in the current validation set, on
+        // disk, or in the registry.
         const inKnownSet = knownWorkflowIds?.has(nested.workflow_id) ?? false
         const defsDir = join(opts.contentDir || getContentDir(), 'workflows', 'definitions')
         const nestedYaml = join(defsDir, `${nested.workflow_id}.yaml`)

--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -166,11 +166,15 @@ function workflowSkillRepairabilityLabel(repairability: WorkflowSkillDriftReport
   }
 }
 
-// ─── Workflow definitions: skill reference integrity ──────────────────────
+// ─── Workflow definitions: skill + nested-workflow reference integrity ─────
 
 /**
- * Verify every step `skill:` reference in every workflow definition resolves
- * to an existing skill file. Walks builtin + parallel children.
+ * Verify every step `skill:` reference and every nested `workflow_id`
+ * reference in every workflow definition resolves. Walks builtin + parallel
+ * children. Nested-workflow existence is checked HERE (against the live
+ * user-disk + registry set) rather than at plugin-default load time, because
+ * load order must not decide validity (#374) — this check is order-independent
+ * and stays current under hot reload.
  */
 export async function checkWorkflowDefinitions(contentDir: string): Promise<HealthCheckResult[]> {
   const results: HealthCheckResult[] = []
@@ -188,14 +192,24 @@ export async function checkWorkflowDefinitions(contentDir: string): Promise<Heal
 
   try {
     const defs = listDefinitions(contentDir)
+    // listDefinitions merges user-disk and plugin/agent-package registry
+    // definitions (user wins), so this set IS the resolvable-workflow universe.
+    const knownWorkflowIds = new Set(defs.map((entry) => entry.name))
     for (const { name, definition } of defs) {
       for (const step of definition.steps) {
         const skillName = (step as { skill?: string }).skill
         if (skillName && !skillExists(skillName)) {
           results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" references skill "${skillName}" which does not exist`))
         }
+        const stepType = (step as { type?: string }).type
+        if (stepType === 'workflow') {
+          const workflowId = (step as { workflow_id?: string }).workflow_id
+          if (workflowId && !knownWorkflowIds.has(workflowId)) {
+            results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" references nested workflow "${workflowId}" which does not exist`))
+          }
+        }
         // Check parallel children too
-        if ((step as { type?: string }).type === 'parallel' && 'steps' in step) {
+        if (stepType === 'parallel' && 'steps' in step) {
           for (const child of (step as { steps: Array<{ id: string; skill?: string }> }).steps) {
             if (child.skill && !skillExists(child.skill)) {
               results.push(warn('workflow-definitions', `Workflow "${name}" parallel step "${child.id}" references skill "${child.skill}" which does not exist`))
@@ -209,7 +223,7 @@ export async function checkWorkflowDefinitions(contentDir: string): Promise<Heal
   }
 
   if (results.length === 0) {
-    results.push(ok('workflow-definitions', 'All workflow skill references resolve'))
+    results.push(ok('workflow-definitions', 'All workflow references resolve'))
   }
 
   return results

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -243,7 +243,72 @@ describe('checkWorkflowDefinitions', () => {
     const results = await checkWorkflowDefinitions(testDir)
     expect(results).toHaveLength(1)
     expect(results[0].status).toBe('ok')
-    expect(results[0].message).toMatch(/All workflow skill references resolve/)
+    expect(results[0].message).toMatch(/All workflow references resolve/)
+  })
+
+  it('warns when a definition references a missing nested workflow (#374)', async () => {
+    writeFileSync(
+      join(definitionsDir, 'orphan-parent.yaml'),
+      `name: Orphan parent
+description: test
+version: 1
+steps:
+  - id: run-child
+    label: Run Child
+    type: workflow
+    workflow_id: ghost-child
+`,
+    )
+    const results = await checkWorkflowDefinitions(testDir)
+    expect(results.some(r =>
+      r.status === 'warn' &&
+      r.message.includes('orphan-parent') &&
+      r.message.includes('ghost-child'),
+    )).toBe(true)
+  })
+
+  it('does not warn when the nested workflow exists on disk or in the registry', async () => {
+    const { registerPluginDefinition, clearSourceRegistry } = await import('@bakin/core/workflows/source-registry')
+    writeFileSync(
+      join(definitionsDir, 'disk-child.yaml'),
+      `name: Disk child
+description: test
+version: 1
+steps:
+  - id: s1
+    label: Step 1
+    type: agent
+    agent: main
+`,
+    )
+    registerPluginDefinition('some-plugin', 'registry-child', {
+      name: 'Registry child',
+      description: 'test',
+      version: 1,
+      steps: [{ id: 's1', label: 'Step 1', type: 'agent', agent: 'main' }],
+    } as never)
+    try {
+      writeFileSync(
+        join(definitionsDir, 'happy-parent.yaml'),
+        `name: Happy parent
+description: test
+version: 1
+steps:
+  - id: run-disk
+    label: Run Disk Child
+    type: workflow
+    workflow_id: disk-child
+  - id: run-registry
+    label: Run Registry Child
+    type: workflow
+    workflow_id: registry-child
+`,
+      )
+      const results = await checkWorkflowDefinitions(testDir)
+      expect(results.some(r => r.message.includes('happy-parent'))).toBe(false)
+    } finally {
+      clearSourceRegistry()
+    }
   })
 
   it('flags a workflow step referencing a missing skill', async () => {

--- a/tests/plugins/workflows/load-defaults.test.ts
+++ b/tests/plugins/workflows/load-defaults.test.ts
@@ -51,10 +51,10 @@ import type { BakinPlugin, PluginContext } from '@bakin/core/plugin-types'
 
 const fakeLog = { warn: mock(), info: mock(), error: mock(), debug: mock() }
 
-function makeHostPlugin(defaultsDir: string): BakinPlugin {
+function makeHostPlugin(defaultsDir: string, id = 'workflows-host'): BakinPlugin {
   return {
-    id: 'workflows-host',
-    name: 'workflows-host',
+    id,
+    name: id,
     version: '1.0.0',
     activate: (ctx: PluginContext) => {
       loadDefaultWorkflows(ctx, defaultsDir, fakeLog)
@@ -163,7 +163,7 @@ steps:
     expect(getDefinition('child')).toBeDefined()
   })
 
-  it('skips defaults with truly missing nested workflow refs', async () => {
+  it('registers defaults whose nested refs are missing at load — existence is start-time + health, not load-fatal (#374)', async () => {
     writeFileSync(join(fakeDefaultsDir, 'parent.yaml'), `name: Parent
 description: Parent workflow
 version: 1
@@ -176,8 +176,56 @@ steps:
 
     await activatePlugin(makeHostPlugin(fakeDefaultsDir), testDir)
 
-    expect(getDefinition('parent')).toBeUndefined()
+    expect(getDefinition('parent')).toBeDefined()
+  })
+
+  it('still skips structural failures and self-references at load', async () => {
+    writeFileSync(join(fakeDefaultsDir, 'self-ref.yaml'), `name: Self
+description: references itself
+version: 1
+steps:
+  - id: run-self
+    type: workflow
+    label: Run Self
+    workflow_id: self-ref
+`)
+    writeFileSync(join(fakeDefaultsDir, 'bad.yaml'), invalidYaml)
+
+    await activatePlugin(makeHostPlugin(fakeDefaultsDir), testDir)
+
+    expect(getDefinition('self-ref')).toBeUndefined()
+    expect(getDefinition('bad')).toBeUndefined()
     expect(fakeLog.warn).toHaveBeenCalled()
+  })
+
+  it('loads cross-plugin nested refs regardless of plugin activation order (#374)', async () => {
+    const parentDir = join(testDir, 'plugin-a', 'defaults', 'workflows')
+    const childDir = join(testDir, 'plugin-b', 'defaults', 'workflows')
+    mkdirSync(parentDir, { recursive: true })
+    mkdirSync(childDir, { recursive: true })
+    writeFileSync(join(parentDir, 'composite-post.yaml'), `name: Composite Post
+description: parent in plugin A
+version: 1
+steps:
+  - id: make-image
+    type: workflow
+    label: Make Image
+    workflow_id: shared-child
+`)
+    writeFileSync(join(childDir, 'shared-child.yaml'), validYaml)
+
+    // Parent's plugin activates FIRST — child not yet in the registry.
+    await activatePlugin(makeHostPlugin(parentDir, 'plugin-a'), testDir)
+    await activatePlugin(makeHostPlugin(childDir, 'plugin-b'), testDir)
+    expect(getDefinition('composite-post')).toBeDefined()
+    expect(getDefinition('shared-child')).toBeDefined()
+
+    // And the reverse order.
+    clearSourceRegistry()
+    await activatePlugin(makeHostPlugin(childDir, 'plugin-b'), testDir)
+    await activatePlugin(makeHostPlugin(parentDir, 'plugin-a'), testDir)
+    expect(getDefinition('composite-post')).toBeDefined()
+    expect(getDefinition('shared-child')).toBeDefined()
   })
 
   it('returns an empty result when the defaults dir does not exist', async () => {

--- a/tests/plugins/workflows/routes.test.ts
+++ b/tests/plugins/workflows/routes.test.ts
@@ -386,5 +386,28 @@ steps:
       expect(status).toBeGreaterThanOrEqual(400)
       expect(JSON.stringify(body)).toContain('cycle detected')
     })
+
+    it('rejects starting a workflow whose nested child is truly missing (load no longer gates existence, #374)', async () => {
+      const defsDir = join(testDir, 'workflows', 'definitions')
+      mkdirSync(defsDir, { recursive: true })
+      writeFileSync(join(defsDir, 'orphan-parent.yaml'), `
+name: Orphan Parent
+description: references a child that does not exist anywhere
+version: 1
+steps:
+  - id: run-child
+    type: workflow
+    label: Run Child
+    workflow_id: nowhere-to-be-found
+`)
+
+      const route = findRoute(activated.routes, 'POST', '/instances/start')!
+      const { status, body } = await callRoute(route, activated.ctx, {
+        body: { taskId: 'task-orphan', workflowId: 'orphan-parent' },
+      })
+
+      expect(status).toBeGreaterThanOrEqual(400)
+      expect(JSON.stringify(body)).toContain('nowhere-to-be-found')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Implements #374 per `.claude/specs/workflows-hardening.md` (PR 1 of 3).

- **Load no longer gates nested-ref existence**: `loadDefaultWorkflows` validates with `validateNestedWorkflowRefs: false` and collapses the two-pass known-set parse to a single pass. A parent workflow referencing a child shipped by a not-yet-activated plugin now registers instead of being silently skipped — cross-plugin composition no longer depends on activation order, hot-reload timing, or user-plugin install order.
- **Structural checks stay fatal at load**: `workflow_id`-required and self-reference moved out of the flag gate in `validate-definition.ts`.
- **Start-time stays the strict gate**: every start path already rejects truly missing children recursively with cycle detection; new REST regression test.
- **Health surfaces genuinely missing refs**: the `workflow-definitions` check now warns per definition against the live user-disk + registry set (order-independent, hot-reload current).
- **Knowledge doc**: documents the three-tier (load/start/health) validation model.
- **Also**: regenerates the stale generated docs (separate commit — `docs:validate` failed on baseline after the June refactors; pure regeneration).

## Acceptance (#374)

- ✅ Cross-plugin nested refs load in BOTH activation orders (regression test, image-social-post↔image-generation shaped)
- ✅ Missing nested workflows still produce clear start-time failures + health warnings
- ✅ Existing default workflows continue to load (repo-defaults portability test unchanged)

## Verification

- `bun run test` — 5381 pass / 0 fail (535 files)
- `bun run typecheck`, eslint clean on touched files (repo lint has pre-existing baseline errors in untouched files)
- `bun run docs:generate && bun run docs:validate` — green (with `BAKIN_DOCS_EXTERNAL_SOURCES` pointing at the bits sibling; worktree quirk)

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)