### PR TITLE
docs(spec): mark workflows-hardening batch shipped

### DIFF
--- a/.claude/specs/workflows-hardening.md
+++ b/.claude/specs/workflows-hardening.md
@@ -1,6 +1,6 @@
 # Spec: Workflows Hardening Batch
 
-**Status:** Draft — pending approval
+**Status:** Shipped 2026-07-04 — PRs #595 (cross-plugin refs, #374), #600 (YAML-surface deletions + strict schemas), #598 (map_workflow design doc). #203 re-scoped to implementation-only.
 **Date:** 2026-07-03
 **Issues:** #374 (implement), #203 (design doc + issue rewrite)
 **Closed by the audit preceding this spec:** #386 (resolved by skill-registry redesign + #407), #98 (not planned — speculative, architecturally stale), #38 (obsolete premise, contradicts adapter-boundary doctrine)


### PR DESCRIPTION
Closes out the batch: flips the spec status line to shipped with pointers to the three merged PRs. Checkpoint 3 housekeeping from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)