### PR TITLE
fix: pin rig OpenClaw image tag + effort Done-column clarity (#385 follow-ups)

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -6,7 +6,10 @@
 #
 # Used by all services (gateway/cli/sandbox). The Bakin repo is mounted at
 # runtime, not copied, so the build context stays tiny.
-ARG OPENCLAW_IMAGE_TAG=latest
+# Pinned (#385 follow-up): `:latest` drifted 5 weeks stale unnoticed. Keep
+# this tag matched to the production Mac mini's OpenClaw and bump both
+# together (override per-run via OPENCLAW_IMAGE_TAG in dev/docker/.env).
+ARG OPENCLAW_IMAGE_TAG=2026.5.28
 FROM ghcr.io/openclaw/openclaw:${OPENCLAW_IMAGE_TAG}
 
 USER root

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -117,7 +117,7 @@ docker compose -f dev/docker/docker-compose.yml --profile sandbox down --rmi loc
   `secrets.op.env` (commented there).
 - **Discord "access not configured" + pairing code** — DMs are gated by `commands.ownerAllowFrom` (separate from the guild allowlist). `up` sets it from `DISCORD_USER_ID`, so a fresh instance answers DMs without pairing. If you ever hit the prompt manually, approve it via the shim: `./dev/docker/openclaw-shim.sh pairing list discord` then `… pairing approve discord <code>`.
 - **Codex auth** — `up` runs the Codex CLI **device-code** login: it prints `https://auth.openai.com/codex/device` + a one-time code; open the URL, enter the code (the browser-callback flow can't work behind the container's loopback). Only `reset`/`--fresh` wipes the home and forces re-auth.
-- **`:latest` drift** — pin via `OPENCLAW_IMAGE_TAG=<tag>` in `.env`.
+- **Image tag** — defaults are PINNED (Dockerfile/compose/lifecycle share one tag, currently `2026.5.28`) so rig runs are reproducible and match production; bump the pin alongside the Mac mini and override per-run via `OPENCLAW_IMAGE_TAG=<tag>` in `.env`. Floating `:latest` previously drifted 5 weeks stale unnoticed (#385 validation).
 
 ## Other dev modes
 

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -11,7 +11,7 @@ x-bakin-build: &bakin-build
   context: .
   dockerfile: Dockerfile
   args:
-    OPENCLAW_IMAGE_TAG: ${OPENCLAW_IMAGE_TAG:-latest}
+    OPENCLAW_IMAGE_TAG: ${OPENCLAW_IMAGE_TAG:-2026.5.28}
 
 services:
   openclaw-gateway:

--- a/plugins/health/components/supervision-sections.tsx
+++ b/plugins/health/components/supervision-sections.tsx
@@ -240,7 +240,12 @@ export function EffortSection({ refreshNonce }: { refreshNonce: number }) {
               <tr className="text-left text-xs text-muted-foreground">
                 <th className="pb-2 font-medium">Agent</th>
                 <th className="pb-2 font-medium text-right">Runs</th>
-                <th className="pb-2 font-medium text-right">Done</th>
+                <th
+                  className="pb-2 font-medium text-right"
+                  title="Tasks whose completion this agent reported. If another agent (or the orchestrator) reports the completion, it counts there — an agent can do the work while the completion lands elsewhere."
+                >
+                  Done*
+                </th>
                 <th className="pb-2 font-medium text-right">Bakin tokens</th>
                 <th className="pb-2 font-medium text-right">Total observed</th>
                 <th className="pb-2 font-medium text-right">Unattributed</th>
@@ -285,6 +290,7 @@ export function EffortSection({ refreshNonce }: { refreshNonce: number }) {
           Bakin-managed tasks — worth a look at its recent sessions.
           {!anyObserved && ' Observed columns show — until the usage scanner has covered this window.'}
           {' '}High tokens with few completions can mean an agent is spinning — open its timeline.
+          {' '}*Done counts completions the agent itself recorded.
         </ChartExplainer>
       </CardContent>
     </Card>

--- a/scripts/instance/lifecycle.ts
+++ b/scripts/instance/lifecycle.ts
@@ -129,8 +129,11 @@ export function bootstrapCommands(): string[][] {
   ]
 }
 
+/** Default tag pinned to match production (see dev/docker/Dockerfile). */
+export const OPENCLAW_DEFAULT_IMAGE_TAG = '2026.5.28'
+
 function openclawImage(deps: LifecycleDeps): string {
-  return `ghcr.io/openclaw/openclaw:${deps.env.OPENCLAW_IMAGE_TAG || 'latest'}`
+  return `ghcr.io/openclaw/openclaw:${deps.env.OPENCLAW_IMAGE_TAG || OPENCLAW_DEFAULT_IMAGE_TAG}`
 }
 
 function healthCheckArgs(): string[] {


### PR DESCRIPTION
Two small follow-ups from the #385 validation run (PR #613):

- **Rig image pin**: `dev/docker` defaults (Dockerfile ARG, compose, `lifecycle.ts` fallback) now pin `OPENCLAW_IMAGE_TAG=2026.5.28` instead of floating `:latest`, which had silently drifted 5 weeks stale (container ran 2026.5.28 while upstream was at 2026.6.11). The pin should be bumped alongside the production Mac mini's OpenClaw; per-run override via `.env` still works. README updated.
- **Effort "Done" column**: tooltip + explainer footnote clarifying that Done counts completions the agent itself recorded — during validation the dispatched agent did the work while `main` recorded the completion, which would read as "zero outcomes" without the note. #614's UX pass may relabel the column properly.

The larger items were filed separately: #614 (dashboard grouping/UX cleanup), #615 (onboarding llm check blind to plugin-provider auth).

Validation: full suite green (5,747 tests / 0 fail, unpiped exit code this time), typecheck clean, rig script tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)