### PR TITLE
feat(workflows): map_workflow engine — dynamic fan-out/fan-in (#203 PR1)

### DIFF
--- a/.claude/specs/map-workflow-and-multi-image-select-plan.md
+++ b/.claude/specs/map-workflow-and-multi-image-select-plan.md
@@ -1,0 +1,325 @@
+# Plan: `map_workflow` + Multi-Image Select (4 PRs)
+
+**Status:** Approved 2026-07-05
+**Spec:** `.claude/specs/map-workflow-and-multi-image-select.md`
+**Engine semantics:** `.claude/specs/workflow-map-fanout-design.md`
+
+## Context
+
+Issue #203: ship the approved `map_workflow` dynamic fan-out/fan-in design, then prove
+it end-to-end with the shipped Multi-Image Select workflow (one brief → 3 concurrent
+image variants → agent vision-selects the winner → variants consolidate as versions of
+one asset → human approves via Discord), validated live on the dockerized rig
+(isolated mode) with cheap image models. All integration points below were verified
+against source, not the design doc's stale paths.
+
+## Verified integration points
+
+- `packages/core/src/workflows/definition-types.ts` — `WorkflowStep` union :118; add `MapWorkflowStep`.
+- `packages/core/src/workflows/node-type-registry.ts` — three coupling points: `BUILTIN_KINDS` :332, `builtinStepSchema` discriminated union :334-341, registration block :287-328. The plugin-reparse branch (:363-382) keys off `BUILTIN_KINDS` — adding to the set suffices.
+- `packages/core/src/workflows/validate-definition.ts` — `workflow`-step three-tier existence validator :169-188 (reuse verbatim); positional checks mirror gate `on_reject.goto` validator :154-162 (`getTopLevelStepIndex`).
+- `plugins/workflows/lib/engine.ts` — `advanceWorkflow` step-type chain :369-459 (map branch beside `'workflow'` :379); `createInstance` first-step case :113-132; `propagateChildCompletion` :260-318 (fork at the :269 guard); `cancelInstance` child loop :478-486; `CompleteStepResult.code` precedent :139-150.
+- `plugins/workflows/types.ts` — `StepState` :105-120 (additive `children[]`, `code`, `error`).
+- `plugins/workflows/lib/step-context.ts` — `getCurrentStep` nested delegate :116-122; `getActiveAgents` :324-333 (consumed by `src/core/dispatch-workflow.ts:52` via the `workflows.getActiveAgents` hook — this is how map children get dispatched).
+- `plugins/workflows/lib/node-dispatch.ts` — `dispatchReopenedStep` single-`childTaskId` branch :189-197.
+- `plugins/workflows/lib/gates.ts` — `reopenFromStep` :343-388 rejects only `cancelled` (a `failed` instance IS reopenable — `map_source_invalid` recovery needs zero reopen changes); `resetWorkflowFromStep` :296-341 resets downstream steps to `{status:'pending'}`, naturally clearing `children[]`/`code`.
+- `plugins/workflows/lib/start-validation.ts` — `collectNestedWorkflowIds` :32-38; all start surfaces funnel through `createValidatedInstance` :98-112. One change point.
+- `src/core/dispatch-workflow.ts` — byte budget fully wired (`resolveWorkflowContextBudget` :175-178, omission markers :231/:239). Map aggregate rides `stepStates[mapId].output` → `buildStepContext.stepOutputs` (`step-context.ts:195-210`) → budgeted renderer. **No new wiring — test only.**
+- `plugins/assets/lib/asset-mutations.ts` — `addVersion` :65-102 (per-asset lock, `AssetVersionInput` :54-62), `promoteVersion` :195-208; `asset-trash.ts` `deleteAsset` :23 (soft trash); `manifest.ts` `GenerationSchema` :21, `AssetVersionSchema.generation` :60.
+- UI: renderers register in `plugins/workflows/client.tsx:60-65` via `lib/node-renderer-registry.ts`; `components/nodes/workflow-node.tsx` is the sibling template; `components/step-detail-drawer.tsx`; config drawer is registry-metadata-driven.
+- Board titles: `task-bridge.ts` `createBoardTaskForChild` :135-165 (title at :148) — map-child titling lands in PR1 with fan-out.
+- Tests: `tests/plugins/workflows/helpers/runtime-harness.ts` (`seedWorkflowFixtures` :280-296 — add `map-flow.yaml` + `map-child.yaml` fixtures), nested patterns `runtime-engine.test.ts:386-505`, budget tests `tests/core/dispatch-workflow-context.test.ts`.
+- E2E precedent: `scripts/validate-gates.ts`, `docs/validation/gate-discord-runbook.md`.
+- HTTP auth: none exists on the API (verified) — agents can GET asset bytes directly; re-verify from inside the rig container in pre-flight.
+
+## Dependency graph
+
+```
+PR1 (engine+types+validation)
+ ├── T1.1 types+schema+registry ──┬── T1.2 validation rules      (T1.2 ∥ T1.3)
+ │                                └── T1.3 fan-out
+ ├── T1.4 fan-in (needs T1.3)
+ ├── T1.5 single-childTaskId sweep + board titles (needs T1.3; ∥ T1.4)
+ └── T1.6 budget test (needs T1.4)
+
+PR2 (recovery+join) — blocked by PR1
+ ├── T2.1 join-blocking semantics → T2.2 per-child retry/cancel
+ ├── T2.3 cancel-parent sweep (∥ T2.2)
+ └── T2.4 surfaces: hooks/routes/exec-tools (needs T2.2, T2.3)
+
+PR3 (UI) — T3.1 map node+rollup (needs PR1) ∥ T3.2 drawer child list (needs PR2) ∥ T3.3 config-drawer check
+
+PR4 — T4.1 consolidate service ∥ T4.3 workflow YAMLs; T4.2 exec tool (needs T4.1);
+      T4.4 harness+runbook (needs T4.2, T4.3); T4.5 live validation + docs + closeout
+```
+
+PR order strict 1→2→3→4; marked tasks parallelize within PRs.
+
+## Settled design details
+
+### (a) Carrier for `map_source_invalid`
+
+`advanceWorkflow` returns `boolean`, so **StepState is the carrier**:
+
+1. `StepState` gains `code?: 'map_source_invalid'` + `error?: string` (additive).
+2. Invalid source (missing key / non-array / > `max_children`): fan-out helper sets
+   `stepStates[mapId] = { status:'failed', startedAt, code:'map_source_invalid', error }`,
+   pushes history, sets `instance.status = 'failed'`. No partial spawn.
+3. Surfacing: `getCurrentStep` gains a `'failed'` variant (parallel to the `'cancelled'`
+   variant at step-context.ts:94) → flows through `CompleteStepResult.nextStep` (the
+   source-step submitter sees it synchronously), `bakin_exec_workflows_get_step`,
+   `GET /steps/:taskId`. UI reads `stepState.code`, never message text.
+4. Recovery: `reopenFromStep(taskId, { stepId: sourceStepId })` works unchanged.
+
+### (b) Map-step StepState lifecycle
+
+- `pending` at init. Fan-out helper `fanOutMapStep(instance, step, def, contentDir, now)`
+  called from the `advanceWorkflow` chain after `currentStepId = mapId`; sets
+  `in_progress` + `children[]`. `getTopLevelIndex` unchanged (fan-in marks the step
+  complete before calling `advanceWorkflow`).
+- First-step map is statically illegal (source must name an earlier step); `createInstance`
+  gets a defensive branch that fails typed if a non-validating path slips through.
+- Empty array → `{ status:'complete', output:{ outputs: [] } }` + recursive
+  `advanceWorkflow` in the same tick.
+- Children: `childTaskId = ${taskId}--${stepId}--${i}`;
+  `parentContext = { ...sourceStepOutput, [item_key ?? 'item']: item, mapIndex: i, mapTotal: N }`;
+  `createInstance` + linkage + board task, identical machinery to the nested branch.
+- `getCurrentStep` on the parent returns `null` mid-map (no single honest delegate);
+  `getActiveAgents` returns the **union** of in-progress children's agents with
+  `effectiveTaskId` so parent-task dispatch fans correctly.
+
+### (c) Aggregated output → byte budget
+
+Confirmed zero new wiring: fan-in writes `stepStates[mapId].output = { outputs: [...] }`
+(index order; per-child value = the child's `finalOutput` per the existing promotion rule
+at :274-285). T1.6 proves trimming + omission markers with a fat aggregate.
+
+### (d) Consolidate idempotency
+
+- `AssetVersionSchema` gains optional `consolidatedFrom: { assetId, version }`;
+  `AssetVersionInput` passes it through `addVersion`.
+- `consolidateAssets({ winnerAssetId, loserAssetIds, taskId })` in new
+  `plugins/assets/lib/asset-consolidate.ts`:
+  1. If no winner version carries `consolidatedFrom` → `promoteTarget = winner.currentVersion`
+     (first run). If some do (re-run) → never promote (don't clobber manual re-promotes).
+  2. Per loser in input order: already absorbed (`consolidatedFrom.assetId === loserId`)
+     → skip addVersion, still ensure trashed. Else `addVersion(winner, { sourceFilePath,
+     op:'import', tool:'consolidate', description, generation: loserCurrent.generation,
+     consolidatedFrom })`.
+  3. Loser missing and not absorbed → typed per-loser failure
+     (`{ failed: [{assetId, code:'loser_not_found'}] }`), not a throw.
+  4. Promote (first run only), then soft-trash still-live losers.
+- Mutations take the per-asset lock internally; orchestration is check-then-act made
+  safe by `consolidatedFrom` detection (first-write-wins ethos, single-operator box).
+- Absorbed versions enrich once each (accepted, spec §9).
+
+### (e) Workflow YAMLs (PR4)
+
+`plugins/images/defaults/workflows/image-variant.yaml` — child, gate-free, one agent step
+`generate-variant` (`$preferred(pixel,$assigned)`): reads `stepOutputs.__parentContext`
+(prompt packet + `variant` directive + `mapIndex`/`mapTotal`), applies the directive
+without changing subject/required-text/brand constraints, calls
+`bakin_exec_images_generate` with the parent route (mcporter `--timeout 600000`), submits
+`{ assetId, version, provider, model, promptHash }` per output_schema.
+
+`plugins/images/defaults/workflows/image-multi-select.yaml` — parent:
+1. `develop-prompt` — mirrors image-generation.yaml's packet framework +
+   `bakin_exec_images_recommend` (quality draft, small surface) **plus** exactly 3
+   variant directives; output_schema adds `variants` (array).
+2. `prompt-gate` — `approval_required`, `on_reject: { goto: develop-prompt, note_to_agent: true }`.
+3. `generate-variants` — `type: map_workflow`, `source: develop-prompt.variants`,
+   `workflow_id: image-variant`, `item_key: variant`, `max_children: 3`.
+4. `select-best` — fetch each `outputs[].assetId` over HTTP from
+   `{BAKIN_URL}/api/assets/<assetId>`, view with vision, pick with written rationale,
+   call `bakin_exec_assets_consolidate`, DELETE downloaded workspace copies, submit
+   `{ assetId, selectedVersion, rationale }`.
+5. `selection-gate` — `on_reject: { goto: select-best }` (re-select = re-promote a
+   different version; no regeneration).
+6. `output` — deliver final assetId (output steps require an agent owner,
+   validate-definition.ts:109-111).
+
+### (f) E2E harness scenarios (`scripts/validate-map-select.ts`)
+
+Modeled on validate-gates.ts (scenario runner, Check records, operator y/n, `--report`):
+
+- **happy**: start via REST → prompt-gate `pending_approval` [operator approves in
+  Discord] → map `in_progress`, exactly 3 children `${taskId}--generate-variants--{0,1,2}`,
+  board titles `{parent} — Generate Variants {i+1}/3`, each child has
+  `parentContext.variant`/`mapIndex`/`mapTotal:3` → join: `output.outputs.length === 3`
+  in source order regardless of completion order → post-select: winner manifest 3
+  versions (2 with `consolidatedFrom`), `currentVersion` = winner's original, losers
+  trashed → selection-gate approval `source: 'channel'` → instance complete.
+- **reject-prompt**: reject at prompt-gate → rewind to develop-prompt, **zero children
+  spawned** (spend guard) → approve second pass.
+- **retry-child**: cancel one child via PR2 route → join blocked (siblings complete,
+  entry `cancelled`) → retry → same `childTaskId` reused → join completes ordered.
+- **cancel-parent**: mid-fan-out cancel → every live child cancelled, board tasks done.
+- Pre-flight (all): image-route check (Codex-served first; `OPENAI_API_KEY` fallback),
+  asset-bytes GET from inside the container, rig `--mode isolated`.
+
+### (g) Gaps settled beyond the design doc
+
+- **Re-fan-out after source reopen**: reopen resets the map step to `pending`; on
+  re-fan-out the helper checks `loadInstance(childTaskId)` per would-be id, cancels any
+  live prior child before `createInstance` overwrites, and revives the board task
+  (`createBoardTaskForChild` duplicate-skip + move back to inProgress). PR1 test.
+- **Out-of-band child cancellation**: parent entry stays `in_progress`, join blocks
+  (by design). PR2's `GET .../map/:stepId/children` reports **live** child statuses
+  (loads each child), so the drawer shows truth and offers retry/cancel.
+
+## PR1 — engine + types + validation (`feat(workflows)`)
+
+- **T1.1 Types + schema + registry** — definition-types.ts (`MapWorkflowStep`), 
+  node-type-registry.ts (strict schema, form fields [source req, workflow_id req,
+  item_key, max_children], `registerNodeType` with `edgeRules: { maxOutbound: 1 }`,
+  `BUILTIN_KINDS`, discriminated union), types.ts (`children?/code?/error?`).
+  TDD via node-type-registry/edge-rules/yaml-roundtrip tests.
+  Verify: `bun test tests/plugins/workflows/node-type-registry.test.ts --isolate && bun test tests/plugins/workflows/yaml-roundtrip.test.ts --isolate`
+- **T1.2 Validation + cycles** — validate-definition.ts (source `<stepId>.<key>` format;
+  exists/top-level/strictly-earlier; workflow_id three-tier reuse incl. self-ref fatal;
+  explicit not-inside-parallel error; nested-map **warning** via a new additive
+  `collectDefinitionWarnings(def)` export — the `string[]` error contract stays
+  untouched), start-validation.ts (`collectNestedWorkflowIds` walks map refs).
+  Verify: `bun test tests/plugins/workflows/parser.test.ts --isolate && bun test tests/plugins/workflows/load-defaults.test.ts --isolate`
+- **T1.3 Fan-out** — engine.ts `fanOutMapStep` + advanceWorkflow branch + defensive
+  createInstance branch; task-bridge.ts map-child titling (optional param). Semantics
+  per (b); stale-child sweep per (g). New `runtime-map.test.ts` (preferred over growing
+  runtime-engine) + harness fixtures: N children ids/linkage/context; board titles;
+  typed failure ×3 shapes (assert code, zero children, instance failed); empty-array
+  advance; reopen-source re-fan-out; crash-restart (reload instance mid-fan-out).
+  Verify: `bun test tests/plugins/workflows/runtime-map.test.ts --isolate`
+- **T1.4 Fan-in** — propagateChildCompletion map branch: update entry by childTaskId
+  with the child's finalOutput; all complete → aggregate ordered, mark complete +
+  history, board-task-done per child, advanceWorkflow + existing completion tail.
+  Tests: out-of-order stable aggregation; partial leaves in_progress; map-as-last-step
+  completes parent; nested recursion (map inside a child of another parent).
+  Verify: `bun test tests/plugins/workflows/runtime-map.test.ts --isolate && bun test tests/plugins/workflows/runtime-engine.test.ts --isolate`
+- **T1.5 Single-childTaskId sweep** — cancelInstance iterates `children[]`;
+  getCurrentStep (`'failed'` variant / null mid-map); getActiveAgents union;
+  node-dispatch reopened-step revive per child.
+  Verify: `bun test tests/plugins/workflows/runtime-step-context.test.ts --isolate`
+- **T1.6 Budget proof** — tests/core/dispatch-workflow-context.test.ts only: fat
+  `{outputs:[…]}` trims with the :231 marker, newest kept, under-budget byte-identical.
+  Verify: `bun test tests/core/dispatch-workflow-context.test.ts --isolate`
+
+**Commits:**
+1. `feat(workflows): add map_workflow step type, strict schema, and registry entry`
+2. `feat(workflows): validate map_workflow source, workflow_id, and nesting cycles`
+3. `feat(workflows): fan out map_workflow children with typed map_source_invalid failure`
+4. `feat(workflows): join map_workflow children with stable-order aggregation`
+5. `feat(workflows): teach child-aware surfaces about map children`
+6. `test(core): prove map aggregates ride the workflow context byte budget`
+
+Each commit leaves `bun run test` + `bun run check` green; any suffix reverts to a
+coherent smaller feature.
+
+**Risks:** mutual recursion (createInstance↔advanceWorkflow↔propagateChildCompletion) —
+map branch as a leaf helper, never restructure; existing nested/parallel tests stay
+green untouched. StepState union ripple — `bun run check` per commit, variant additive.
+Fire-and-forget board tasks — assert via harness hooks as nested tests do.
+
+## PR2 — recovery + join semantics (`feat(workflows)`)
+
+- **T2.1 Join-blocking** (tests-first): failed/cancelled child never cascades; join
+  fires only when ALL entries complete.
+- **T2.2 Per-child retry/cancel** — new `plugins/workflows/lib/map-children.ts`:
+  `retryMapChild(parentTaskId, stepId, index)` — live child → `reopenFromStep`;
+  terminally dead → recompute item from the parent's source-step output, sweep old
+  instance, re-create with same childTaskId + rebuilt context + board revive; entry →
+  `in_progress`. `cancelMapChild` — cancelInstance + entry `cancelled` + board done.
+  `listMapChildren` — entries hydrated with live child statuses per (g).
+  Tests incl. child-gate-inside-map approval flows to join.
+- **T2.3 Cancel-parent semantics tests** (mechanical sweep landed in T1.5): mixed child
+  states → only live children cancelled.
+- **T2.4 Surfaces** — register-hooks.ts (`workflows.{retryMapChild,cancelMapChild,listMapChildren}`),
+  routes/instances.ts (`GET /instances/:taskId/map/:stepId/children`,
+  `POST .../children/:index/retry`, `POST .../cancel`), exec-tools.ts
+  (`bakin_exec_workflows_retry_map_child`, `bakin_exec_workflows_cancel_map_child`;
+  audit + indexInstance + triggerDispatch on retry). Tests via `callRoute`/`callTool`.
+
+**Commits:**
+1. `test(workflows): pin map join-blocking semantics`
+2. `feat(workflows): per-child retry and cancel for map_workflow steps`
+3. `test(workflows): cancel-parent sweeps live map children`
+4. `feat(workflows): expose map-child recovery via hooks, routes, and exec tools`
+
+**Risks:** dead-child re-create uses the instance's current source output (single source
+of truth; pinned by test). Retry racing an in-flight turn — same exposure as any reopen;
+ledger claims cover; noted in PR description.
+
+**Checkpoint → PR3:** full suite + check green; PR1+PR2 merged; mock-mode smoke
+(`bun run dev:mock`: start a map fixture, watch children on the board).
+
+## PR3 — UI (`feat(workflows)`)
+
+- **T3.1 Canvas node + rollup** — new `components/nodes/map-workflow-node.tsx`
+  (template: workflow-node.tsx; badge `5/8 complete, 1 failed` from
+  `stepStates[id].children[]`; children never canvas nodes); register in client.tsx.
+  Reuse workflow-detail's existing instance-state-on-canvas wiring (SSE) — no new
+  polling path.
+- **T3.2 Drawer child list** — step-detail-drawer.tsx: per-child list from the PR2 GET
+  route (live statuses), retry/cancel buttons → PR2 POSTs; `map_source_invalid` banner
+  from typed code + "Re-run source step" affordance via existing reopen surface.
+- **T3.3 Config drawer registry check** — likely test-only (registry-driven); fix any
+  hardcoded kind switches found.
+
+**Commits:**
+1. `feat(workflows): map_workflow canvas node with live child rollup`
+2. `feat(workflows): map-step drawer child list with retry and cancel actions`
+3. `test(workflows): map_workflow config drawer renders from registry metadata`
+
+**Checkpoint → PR4:** full suite + check; visual smoke in dev:mock.
+
+## PR4 — consolidate + workflows + E2E (`feat(assets)`, `feat(images)`)
+
+- **T4.1 Consolidate service** — manifest.ts `consolidatedFrom`, asset-mutations.ts
+  passthrough, new asset-consolidate.ts per (d), barrel export. TDD:
+  `tests/plugins/assets/asset-consolidate.test.ts` (full CLAUDE.md mock block): happy
+  path (3→1 asset/3 versions/current=winner/losers trashed/provenance + copied
+  generation); full re-run no-op; partial re-run absorbs only missing, never
+  re-promotes; loser-not-found typed failure; input-order numbering.
+- **T4.2 Exec tool** — `bakin_exec_assets_consolidate` (zod: winnerAssetId,
+  loserAssetIds min 1, taskId), audit event, description states end state + re-call
+  safety. No REST route (drawer doesn't need it).
+- **T4.3 Workflow YAMLs** — per (e); load-defaults parse+validate tests + a scripted
+  end-to-end runtime test of the parent shape (3 variants → children → ordered
+  aggregate → select-best context has `outputs[]`).
+- **T4.4 Harness + runbook** — validate-map-select.ts per (f);
+  docs/validation/map-select-runbook.md (isolated rig bring-up,
+  `channelAliases.approvals: "discord:channel:<id>"` explicit-prefix gotcha, image
+  pre-flight, Codex-first + secrets.op.env fallback, container→host BAKIN_URL, asset
+  bytes check, known gaps).
+- **T4.5 Live validation + docs + closeout** — run all 4 scenarios on the rig, record
+  results in the spec (#385 precedent). Docs sweep: `.claude/knowledge/workflows-plugin.md`
+  (map semantics, StepState.children, recovery, typed code),
+  `.claude/knowledge/assets-versioning.md` (consolidate + consolidatedFrom),
+  `.claude/knowledge/dockerized-openclaw-rig.md` (only if validation teaches something),
+  `docs/src/content/docs/` workflow-authoring map step, CLAUDE.md one-liner only if
+  warranted. Close #203 with a summary comment.
+
+**Commits:**
+1. `feat(assets): consolidateAssets service with consolidatedFrom provenance`
+2. `feat(assets): bakin_exec_assets_consolidate exec tool`
+3. `feat(images): image-variant and image-multi-select default workflows`
+4. `feat(images): map-select e2e validation harness and runbook`
+5. `docs: map_workflow and asset-consolidation knowledge + user docs; record validation results`
+
+**Risks:** asset-fetch auth (none exists, but re-verify from inside the container in
+pre-flight; fallback decided then, not pre-built). Codex-served images (confirmed
+working on the main instance; pre-flight anyway). select-best agent compliance is
+instruction-driven (harness machine-checks end state; selection-gate is the human
+backstop). Consolidate races (single operator + provenance detection + per-asset lock;
+documented, not over-engineered). Double-enrichment cost accepted per spec §9.
+
+## Checkpoints
+
+| Gate | Must be green |
+|---|---|
+| PR1 → PR2 | full `bun run test` + `bun run check`; runtime-map + budget tests pass; zero changes to existing nested/parallel expectations |
+| PR2 → PR3 | full suite + check; retry/cancel proven at route + exec-tool level; mock-mode board smoke |
+| PR3 → PR4 | full suite + check; visual smoke (badge, drawer actions) in dev:mock |
+| PR4 done | full suite + check; all 4 rig scenarios recorded in the spec; #203 closed |
+
+Global rules on every commit: conventional commits with scope; tests mock BOTH
+content-dir resolvers + OpenClaw home, `--isolate` per file; typed codes only; gates run
+bare (never piped); never write real `~/.bakin`/`~/.openclaw` from tests or the rig.

--- a/.claude/specs/map-workflow-and-multi-image-select.md
+++ b/.claude/specs/map-workflow-and-multi-image-select.md
@@ -1,0 +1,242 @@
+# Spec: `map_workflow` Implementation + Multi-Image Select Workflow
+
+**Status:** Approved 2026-07-05 (interview completed; user sign-off)
+**Issue:** #203
+**Design doc (authoritative for engine semantics):** `.claude/specs/workflow-map-fanout-design.md`
+**Builds on:** workflows-hardening (#595/#598/#600), gate/Discord validation harness (#607)
+
+## 1. Objective
+
+Ship the `map_workflow` step type exactly per the approved design doc, then prove it
+end-to-end with a real, shipped workflow: **Multi-Image Select** — one prompt, three
+concurrently-generated image variants (map fan-out), an agent picks the best with
+vision, variants are consolidated as versions of a single winning asset, and a human
+approves via Discord. Validation runs live on the dockerized rig (isolated mode)
+using cheap image models instead of the video pipeline.
+
+Users: this machine's single operator. No backwards-compat concerns; no shims.
+
+## 2. Decisions settled in the spec interview
+
+| Question | Decision |
+|---|---|
+| Engine semantics | Exactly per design doc. No deviations. |
+| `maxWorkflowContextBytes` | Already wired (`src/core/dispatch-workflow.ts` budgets prior-step outputs with omission markers; recon initially missed it). In scope: a test proving map-aggregated `{ outputs: [...] }` flows through the budgeted path and trims with markers. No new wiring. |
+| Context compaction | Existing pattern is the answer: truncate visibly + `bakin_exec_workflows_get_instance` retrieval. No summarization mechanism. |
+| E2E test workflow | NOT the collage/fantasy-creature idea (a collage is one good prompt — doesn't exercise fan-out). Instead **Multi-Image Select**: generate 3 unique variants of one brief, agent selects the best. Genuinely useful for social posts. |
+| Workflow disposition | Ships as a **plugin default** in `plugins/images/defaults/workflows/` (alongside `image-generation.yaml`). May be culled later; kept for testability. |
+| Gates | Both: prompt gate before fan-out (guards 3× spend) + selection gate after the pick. Children are gate-free. |
+| Agent judges images by | HTTP fetch from the Bakin asset API + vision (works in prod and rig). Step instructions require deleting downloaded workspace copies after judging. |
+| Variant asset disposition | All three become **versions of one asset**: children create 3 standalone assets (concurrency forbids shared `versionOf`); a new `bakin_exec_assets_consolidate` tool absorbs losers as versions of the winner, promotes the winning version, trashes the loser assets. End state: one asset, 3 versions, current = winner. |
+| Rig credentials | Try Codex-served OpenAI first; documented fallback = uncomment `OPENAI_API_KEY` op:// ref in `dev/docker/secrets.op.env`. Pre-flight route check before any billed run. |
+| Rig mode | `--mode isolated` (never native for tests — native touches real `~/.bakin`). |
+| PR strategy | 4 PRs (below), each independently green + revertable, atomic conventional commits as rollback checkpoints. |
+| Variant count | Fixed at 3 by prompt instruction in v1 (array is still runtime-produced — dynamic path exercised). |
+| Spec/plan location | `.claude/specs/` (repo convention; no root SPEC.md). |
+
+## 3. Scope
+
+### PR1 — engine + types + validation (`feat(workflows)`)
+
+Per design doc §Implementation sketch item 1, with **corrected paths** (the doc predates
+the FW7 refactor):
+
+- `MapWorkflowStep` in `packages/core/src/workflows/definition-types.ts` (union at :118).
+- Strict zod schema + form fields + `registerNodeType` in
+  `packages/core/src/workflows/node-type-registry.ts` — update all three coupling
+  points together: `BUILTIN_KINDS`, `builtinStepSchema` discriminated union,
+  registration block.
+- Validation in `packages/core/src/workflows/validate-definition.ts`:
+  - `source: <stepId>.<key>` — earlier top-level step (mirror the deleted `dependsOn`
+    validator shape from commit `f93d3f8b`: exists / top-level / earlier).
+  - `workflow_id` — reuse the three-tier existence model verbatim (:169-188).
+  - Explicit "not inside parallel children" message (structurally already rejected).
+  - Nested-map (map child containing a map) → validation **warning**, per doc non-goals.
+- Cycle detection: `collectNestedWorkflowIds` in
+  `plugins/workflows/lib/start-validation.ts` also walks `map_workflow.workflow_id`.
+- Fan-out in `plugins/workflows/lib/engine.ts`:
+  - New branch in `advanceWorkflow` (:371-462) AND the first-step case in
+    `createInstance` (:114-132).
+  - `childTaskId = ${taskId}--${stepId}--${i}`; parentContext = prior step output +
+    `{ [item_key ?? 'item']: item, mapIndex: i, mapTotal: N }`;
+    `createBoardTaskForChild` per child.
+  - Source contract enforcement at fan-out time (independent of `output_schema`):
+    missing key / non-array / length > `max_children` (default 32) →
+    step `status: 'failed'` with typed `code: 'map_source_invalid'` on `StepState`
+    (extends the `rejection_repeat` code-discriminant precedent; never message-text
+    matching). Recoverable via `reopenFromStep` on the source step. Empty array →
+    step completes immediately with `output: { outputs: [] }`.
+- Fan-in: map-aware branch in `propagateChildCompletion` (:260-318) — update the
+  child's entry in `StepState.children[]`; all terminal-successful → aggregate
+  `{ outputs: [...] }` in index order, complete step, advance parent.
+- `StepState` gains `children?: { index: number; childTaskId: string; status: ... }[]`
+  (`plugins/workflows/types.ts:105-120`, additive).
+- Sweep the single-`childTaskId` assumptions: `cancelInstance` recursion
+  (engine.ts:478), `getCurrentStep` + `getActiveAgents`
+  (`step-context.ts:115-122, :327-330`), `node-dispatch.ts:191`.
+
+Tests (extend `tests/plugins/workflows/helpers/runtime-harness.ts` fixtures +
+`runtime-engine.test.ts` patterns): fan-out N children with correct ids/linkage/context;
+stable-order aggregation regardless of completion order; empty-array advance;
+`map_source_invalid` on missing key / non-array / over-max; crash-restart (reload
+instance mid-fanout); map aggregation subject to `maxWorkflowContextBytes` with
+omission markers (extends `tests/core/dispatch-workflow-context.test.ts`).
+
+### PR2 — recovery + join semantics (`feat(workflows)`)
+
+Per design doc item 2:
+
+- Per-child retry (`reopenFromStep` on the child; full re-create with same
+  `childTaskId` + item context if terminally dead) and per-child cancel
+  (`cancelInstance` on the child → entry `cancelled`).
+- Join-blocking: failed/cancelled child blocks the join, never cascades; parent map
+  step stays `in_progress`.
+- Cancel-parent recursion sweeps `children[]`.
+- Surfaces: hooks in `plugins/workflows/lib/register-hooks.ts` + REST routes +
+  exec tools, mirroring existing `reopenFromStep`/`cancelInstance` registration.
+
+Tests: single-child failure blocks join; retry unblocks and join completes; cancel-parent
+sweeps live children; child gate approval flows to join (child workflows with gates).
+
+### PR3 — UI (`feat(workflows)`)
+
+Per design doc item 3:
+
+- Canvas: `map_workflow` node renderer (alongside nested-workflow node) with live
+  rollup badge (`5/8 complete, 1 failed`). Children never appear as canvas nodes.
+- Step drawer: per-child list (status, link to child board task, retry/cancel actions
+  wired to PR2 surfaces).
+- Board task titles: `{parent title} — {label} {i+1}/{N}`.
+- Node config drawer: form fields from registry metadata only (no special-casing).
+
+Component tests per existing canvas/drawer suites.
+
+### PR4 — consolidate tool + Multi-Image Select + E2E harness (`feat(images)`, `feat(assets)`)
+
+**`bakin_exec_assets_consolidate`** (assets plugin — service logic in
+`asset-mutations.ts` territory, tool in `exec-tools.ts`):
+
+- Input: `{ winnerAssetId, loserAssetIds: string[], taskId }`.
+- Behavior: for each loser (input order), `addVersion(winnerAssetId)` from the loser's
+  current-version file with provenance metadata (source assetId, generation record);
+  promote the winner's original version as `currentVersion`; soft-delete (trash) the
+  loser assets. Serialized under the existing per-asset manifest lock; idempotent on
+  retry (re-consolidating already-absorbed losers is a no-op, not an error — follows
+  the ledger first-write-wins ethos).
+- Runs server-side (host filesystem) — immune to the container-path rig gap.
+
+**Workflows** in `plugins/images/defaults/workflows/`:
+
+`image-variant.yaml` (child, minimal):
+- One agent step: read `stepOutputs.__parentContext` (prompt packet + `variant`
+  uniqueness directive + `mapIndex`/`mapTotal`), call `bakin_exec_images_generate`
+  (taskId, packet, provider/model/surface/quality from parent route), submit
+  `{ assetId, version, provider, model, promptHash }` per output_schema. No gates.
+
+`image-multi-select.yaml` (parent; display name "Multi-Image Select", final naming
+at build time):
+1. `develop-prompt` — agent `$preferred(pixel,$assigned)`, mirrors
+   `image-generation.yaml`'s prompt-packet framework + `bakin_exec_images_recommend`
+   routing; output_schema adds `variants` — exactly 3 entries, each a short
+   uniqueness directive (composition/style/mood divergence).
+2. `prompt-gate` — gate, `approval_required`, `on_reject: goto develop-prompt`.
+3. `generate-variants` — `type: map_workflow`, `source: develop-prompt.variants`,
+   `workflow_id: image-variant`, `item_key: variant`, `max_children: 3`.
+4. `select-best` — agent: fetch each variant image over HTTP from the Bakin asset API
+   (`{BAKIN_URL}/api/assets/<assetId>`), view with vision, pick a winner with written
+   rationale, call `bakin_exec_assets_consolidate`, **delete downloaded workspace
+   copies**, submit `{ assetId, selectedVersion, rationale }`.
+5. `selection-gate` — gate, `on_reject: goto select-best` (all versions live on the
+   one asset; a re-select just re-promotes a different version — no regeneration).
+6. `output` — selected assetId.
+
+Quality/cost defaults: budget-tier model (`gpt-image-1-mini` or whatever
+`bakin_exec_images_recommend` returns at `quality: draft`), small surface.
+
+**E2E validation** (gate-discord precedent):
+- `scripts/validate-map-select.ts` — machine-checked harness (start instance via REST,
+  poll instance/step states, assert: 3 children spawned with correct ids, join
+  aggregation order, consolidate end-state one-asset-three-versions-winner-current,
+  gate approval records with `source: 'channel'`), operator prompts for the Discord
+  button clicks + visual confirmations. Scenarios: happy path; reject-at-prompt-gate;
+  child-failure → per-child retry → join completes; cancel-parent sweep.
+- `docs/validation/map-select-runbook.md` — rig setup (isolated mode), Discord
+  notification config (`channelAliases.approvals: "discord:channel:<id>"` — explicit
+  `channel:` prefix required), image-route pre-flight, Codex-served-first credential
+  plan + `OPENAI_API_KEY` fallback, known rig gaps and their workarounds.
+- Results recorded back into this spec (validation section), per #385 precedent.
+
+**Docs sweep (same PR):**
+- `.claude/knowledge/workflows-plugin.md` — map_workflow semantics, StepState.children,
+  recovery, typed error.
+- `.claude/knowledge/assets-versioning.md` — consolidate semantics.
+- `.claude/knowledge/dockerized-openclaw-rig.md` — image-credential note if we learn
+  anything new in validation.
+- `CLAUDE.md` — only if a one-liner in the workflows bullet is warranted.
+- `docs/src/content/docs/` (Astro user docs) — workflow authoring: the map step type.
+- Close out #203 with a summary comment.
+
+## 4. Commands
+
+- `bun run test` (full suite), `bun test tests/plugins/workflows/<file> --isolate` (single file)
+- `bun run check` / typecheck + lint gates as wired in package.json — run bare, never piped
+- `bun run instance up --mode isolated` / `bun run instance dev --mode isolated` (rig)
+- `bun scripts/validate-map-select.ts --scenario <happy|reject-prompt|retry-child|cancel-parent>`
+
+## 5. Project structure (touch surface)
+
+```
+packages/core/src/workflows/{definition-types,node-type-registry,validate-definition}.ts
+plugins/workflows/lib/{engine,step-context,node-dispatch,start-validation,register-hooks,exec-tools,routes/*}.ts
+plugins/workflows/types.ts
+plugins/workflows/components/*            (PR3)
+plugins/assets/lib/{asset-mutations,asset-service,exec-tools}.ts   (PR4)
+plugins/images/defaults/workflows/{image-multi-select,image-variant}.yaml
+scripts/validate-map-select.ts
+docs/validation/map-select-runbook.md
+tests/plugins/workflows/*, tests/core/dispatch-workflow-context.test.ts, tests/plugins/assets/*
+.claude/knowledge/{workflows-plugin,assets-versioning}.md
+```
+
+## 6. Code style
+
+Repo conventions per CLAUDE.md: strict TS, zod at boundaries, functional preference,
+`createLogger`, kebab-case files, conventional commits with scope. Typed error codes
+only — never error-message-text branching (architecture-test enforced).
+
+## 7. Testing strategy
+
+- All unit/integration tests mock BOTH content-dir resolvers + OpenClaw home per
+  CLAUDE.md testing rules; workflow tests build on `runtime-harness.ts`.
+- Source-step outputs are scripted by passing arrays to `completeStep` — no live
+  runtime in CI.
+- E2E (billed, operator-present) is rig-only via the harness + runbook; never in CI.
+- TDD per task: failing test first for every engine behavior.
+
+## 8. Boundaries
+
+**Always:** follow the design doc's decision table for any engine question; keep
+children ordinary nested-workflow instances; typed codes for failures; atomic
+manifest writes via existing asset lock.
+
+**Ask first:** any deviation from the design doc's semantics; any new settings key;
+promoting the harness workflow beyond the images plugin defaults.
+
+**Never:** DAG/readiness semantics, `on_child_failure` policy knobs, nested-map
+support (warn only), cross-child communication, silent skip of a failed child
+(join waits — explicit user action or cancel-parent only), backwards-compat shims,
+writes to real `~/.bakin`/`~/.openclaw` from tests or the rig.
+
+## 9. Risks / open items tracked into the plan
+
+- Codex-served image generation is confirmed working on the user's main Bakin
+  instance (Codex auth only, no API key) — expected to work on the rig; keep the
+  pre-flight route check + `OPENAI_API_KEY` fallback as cheap insurance.
+- `select-best` needs the rig container to reach the host Bakin URL — same
+  requirement gate-discord validated; confirm in pre-flight.
+- Asset HTTP fetch by the agent assumes the asset route serves bytes without
+  browser-session auth from the agent's context — verify early in PR4; if blocked,
+  mint a short-lived token or serve via existing export mechanism (decide then).
+- Enrichment runs per consolidated version — confirm no double-billing (enrichment
+  skip guard is `done+forVersion`; absorbing a file as a new version will enrich the
+  new version once — acceptable, it's a vision-LLM call, not an image generation).

--- a/packages/core/src/workflows/definition-types.ts
+++ b/packages/core/src/workflows/definition-types.ts
@@ -93,6 +93,22 @@ export interface NestedWorkflowStep extends BaseStep {
   description?: string
 }
 
+/**
+ * Dynamic fan-out: one child workflow instance per element of an earlier
+ * step's output array. `source` is `<stepId>.<outputKey>` where stepId names
+ * an earlier top-level step. See .claude/specs/workflow-map-fanout-design.md.
+ */
+export interface MapWorkflowStep extends BaseStep {
+  type: 'map_workflow'
+  source: string
+  workflow_id: string
+  /** Key the child sees its item under in parentContext (default: "item"). */
+  item_key?: string
+  /** Fan-out width guardrail — wider source arrays fail typed (default: 32). */
+  max_children?: number
+  description?: string
+}
+
 export interface CreateTaskStep extends BaseStep {
   type: 'createTask'
   taskId?: string
@@ -115,7 +131,7 @@ export interface CreateTaskStep extends BaseStep {
   skipWorkflowReason?: string
 }
 
-export type WorkflowStep = AgentStep | GateStep | ParallelStep | OutputStep | NestedWorkflowStep | CreateTaskStep
+export type WorkflowStep = AgentStep | GateStep | ParallelStep | OutputStep | NestedWorkflowStep | MapWorkflowStep | CreateTaskStep
 
 export interface NodePosition {
   x: number

--- a/packages/core/src/workflows/node-type-registry.ts
+++ b/packages/core/src/workflows/node-type-registry.ts
@@ -199,6 +199,17 @@ export const nestedWorkflowStepSchema = z.object({
   description: z.string().optional(),
 }).strict()
 
+export const mapWorkflowStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('map_workflow'),
+  label: z.string().min(1),
+  source: z.string().min(1),
+  workflow_id: z.string().min(1),
+  item_key: z.string().min(1).optional(),
+  max_children: z.number().int().positive().optional(),
+  description: z.string().optional(),
+}).strict()
+
 const taskSourceSchema = z.object({
   pluginId: z.string().optional(),
   entityType: z.string().optional(),
@@ -269,6 +280,14 @@ const nestedWorkflowFormFields: FormField[] = [
   { name: 'description', type: 'text' },
 ]
 
+const mapWorkflowFormFields: FormField[] = [
+  { name: 'source', type: 'string', required: true, description: 'Array source as <stepId>.<outputKey> — one child per element' },
+  { name: 'workflow_id', type: 'string', required: true, description: 'Id of the child workflow to run per item' },
+  { name: 'item_key', type: 'string', description: 'Parent-context key the child sees its item under (default: item)' },
+  { name: 'max_children', type: 'number', description: 'Fan-out width guardrail (default: 32)' },
+  { name: 'description', type: 'text' },
+]
+
 const createTaskFormFields: FormField[] = [
   { name: 'title', type: 'string', required: true, description: 'Task title' },
   { name: 'description', type: 'text', description: 'Task description' },
@@ -320,6 +339,13 @@ registerNodeType({
   edgeRules: { maxOutbound: 1 },
 })
 registerNodeType({
+  kind: 'map_workflow',
+  runtime: 'builtin',
+  zodSchema: mapWorkflowStepSchema,
+  formFields: mapWorkflowFormFields,
+  edgeRules: { maxOutbound: 1 },
+})
+registerNodeType({
   kind: 'createTask',
   runtime: 'builtin',
   zodSchema: createTaskStepSchema,
@@ -329,7 +355,7 @@ registerNodeType({
 
 // ─── Top-level workflow schema ──────────────────────────────────────────────
 
-const BUILTIN_KINDS = new Set(['agent', 'gate', 'parallel', 'output', 'workflow', 'createTask'])
+const BUILTIN_KINDS = new Set(['agent', 'gate', 'parallel', 'output', 'workflow', 'map_workflow', 'createTask'])
 
 const builtinStepSchema = z.discriminatedUnion('type', [
   agentStepSchema,
@@ -337,6 +363,7 @@ const builtinStepSchema = z.discriminatedUnion('type', [
   parallelStepSchema,
   outputStepSchema,
   nestedWorkflowStepSchema,
+  mapWorkflowStepSchema,
   createTaskStepSchema,
 ])
 

--- a/packages/core/src/workflows/validate-definition.ts
+++ b/packages/core/src/workflows/validate-definition.ts
@@ -7,7 +7,7 @@
  */
 import { existsSync } from 'fs'
 import { join } from 'path'
-import type { WorkflowDefinition, WorkflowStep, ParallelStep, NestedWorkflowStep } from './definition-types'
+import type { WorkflowDefinition, WorkflowStep, ParallelStep, NestedWorkflowStep, MapWorkflowStep } from './definition-types'
 import { getContentDir } from '../content-dir'
 import { getDefinition as getRegistryDefinition, type DefinitionSource } from './source-registry'
 
@@ -166,23 +166,44 @@ export function validateDefinition(def: WorkflowDefinition, opts: ValidateDefini
     // gated by validateNestedWorkflowRefs because plugin-default loading runs
     // before every plugin has activated (#374) — there, existence is enforced
     // at start time and surfaced by the workflow-definitions health check.
-    if (step.type === 'workflow') {
-      const nested = step as NestedWorkflowStep
-      if (!nested.workflow_id) {
-        errors.push(`Step "${step.id}": workflow step requires workflow_id`)
-      } else if (opts.definitionId && nested.workflow_id === opts.definitionId) {
-        errors.push(`Step "${step.id}": workflow_id "${nested.workflow_id}" cannot reference its own workflow`)
+    // map_workflow child references follow the exact same three-tier model.
+    if (step.type === 'workflow' || step.type === 'map_workflow') {
+      const workflowId = (step as NestedWorkflowStep | MapWorkflowStep).workflow_id
+      if (!workflowId) {
+        errors.push(`Step "${step.id}": ${step.type} step requires workflow_id`)
+      } else if (opts.definitionId && workflowId === opts.definitionId) {
+        errors.push(`Step "${step.id}": workflow_id "${workflowId}" cannot reference its own workflow`)
       } else if (validateNestedWorkflowRefs) {
         // Referenced workflow must exist in the current validation set, on
         // disk, or in the registry.
-        const inKnownSet = knownWorkflowIds?.has(nested.workflow_id) ?? false
+        const inKnownSet = knownWorkflowIds?.has(workflowId) ?? false
         const defsDir = join(opts.contentDir || getContentDir(), 'workflows', 'definitions')
-        const nestedYaml = join(defsDir, `${nested.workflow_id}.yaml`)
-        const nestedYml = join(defsDir, `${nested.workflow_id}.yml`)
+        const nestedYaml = join(defsDir, `${workflowId}.yaml`)
+        const nestedYml = join(defsDir, `${workflowId}.yml`)
         const onDisk = existsSync(nestedYaml) || existsSync(nestedYml)
-        const inRegistry = !!getRegistryDefinition(nested.workflow_id)
+        const inRegistry = !!getRegistryDefinition(workflowId)
         if (!inKnownSet && !onDisk && !inRegistry) {
-          errors.push(`Step "${step.id}": workflow_id "${nested.workflow_id}" not found in definitions`)
+          errors.push(`Step "${step.id}": workflow_id "${workflowId}" not found in definitions`)
+        }
+      }
+    }
+
+    // Validate map_workflow source references: positional, statically
+    // checkable — same rule shape the deleted dependsOn validator used
+    // (exists / top-level / strictly earlier).
+    if (step.type === 'map_workflow') {
+      const map = step as MapWorkflowStep
+      const match = typeof map.source === 'string' ? /^([^.\s]+)\.(\S+)$/.exec(map.source) : null
+      if (!match) {
+        errors.push(`Step "${step.id}": source must be "<stepId>.<outputKey>"; got "${map.source}"`)
+      } else {
+        const sourceStepId = match[1]
+        if (!idSet.has(sourceStepId)) {
+          errors.push(`Step "${step.id}": source references nonexistent step "${sourceStepId}"`)
+        } else if (!topLevelIds.has(sourceStepId)) {
+          errors.push(`Step "${step.id}": source must reference a top-level step`)
+        } else if (getTopLevelStepIndex(def.steps, sourceStepId) >= idx) {
+          errors.push(`Step "${step.id}": source must reference an earlier top-level step`)
         }
       }
     }

--- a/packages/core/src/workflows/validate-definition.ts
+++ b/packages/core/src/workflows/validate-definition.ts
@@ -158,6 +158,8 @@ export function validateDefinition(def: WorkflowDefinition, opts: ValidateDefini
         errors.push(`Step "${step.id}": on_reject.goto must target a top-level step`)
       } else if (getTopLevelStepIndex(def.steps, step.on_reject.goto) > idx) {
         errors.push(`Step "${step.id}": on_reject.goto must rewind to this or an earlier step`)
+      } else if (def.steps[getTopLevelStepIndex(def.steps, step.on_reject.goto)]?.type === 'map_workflow') {
+        errors.push(`Step "${step.id}": on_reject.goto cannot target a map_workflow step — target its source step instead`)
       }
     }
 

--- a/plugins/workflows/lib/engine.ts
+++ b/plugins/workflows/lib/engine.ts
@@ -41,7 +41,7 @@ import {
   moveTaskInStore,
 } from './task-bridge'
 import { dispatchPluginNode, dispatchCreateTaskNode } from './node-dispatch'
-import { resolveAgent, getCurrentStep, type StepContext } from './step-context'
+import { resolveAgent, getCurrentStep } from './step-context'
 
 const log = createLogger('workflow-runtime')
 
@@ -254,7 +254,8 @@ export interface CompleteStepResult {
    * error-message text.
    */
   code?: 'rejection_repeat'
-  nextStep?: StepContext | { status: 'complete' } | { status: 'cancelled' } | { status: 'pending_approval'; stepId: string; label: string }
+  /** Mirrors getCurrentStep's union (StepContext or a typed status object). */
+  nextStep?: Exclude<ReturnType<typeof getCurrentStep>, null>
   workflowComplete?: boolean
 }
 
@@ -626,6 +627,15 @@ export function cancelInstance(taskId: string, contentDir?: string): void {
       // Remove the child from active work.
       moveTaskInStore(state.childTaskId, 'done').catch((err) => {
         log.warn('Failed to move cancelled child workflow task', err)
+      })
+    }
+    // Map fan-out children: sweep every still-live entry.
+    for (const child of state.children ?? []) {
+      if (child.status !== 'in_progress') continue
+      cancelInstance(child.childTaskId, dir)
+      child.status = 'cancelled'
+      moveTaskInStore(child.childTaskId, 'done').catch((err) => {
+        log.warn('Failed to move cancelled map child task', err)
       })
     }
   }

--- a/plugins/workflows/lib/engine.ts
+++ b/plugins/workflows/lib/engine.ts
@@ -377,11 +377,6 @@ export function propagateChildCompletion(childInstance: WorkflowInstance, conten
   const stepState = parentInstance.stepStates[stepId]
   if (!stepState || stepState.status !== 'in_progress') return
 
-  // Map steps join on ALL children — the map-aware branch (entry update +
-  // stable-order aggregation) lands with fan-in; a single completing child
-  // must never complete the whole step. (T1.4 replaces this guard.)
-  if (findStep(parentDef, stepId)?.type === 'map_workflow') return
-
   // Collect child workflow outputs in definition order.
   // `finalOutput` is the last agent step's output (gates don't produce output).
   const childDef = loadDefinition(childInstance.workflowId, contentDir)
@@ -399,21 +394,54 @@ export function propagateChildCompletion(childInstance: WorkflowInstance, conten
   }
 
   const now = new Date().toISOString()
-  stepState.status = 'complete'
-  stepState.completedAt = now
-  stepState.output = { childWorkflowId: childInstance.workflowId, finalOutput, outputs: childOutputs }
+  const moveChildBoardTaskDone = (): void => {
+    addTaskLogToStore(childInstance.taskId, 'workflow', `Sub-workflow "${childInstance.workflowId}" completed.`)
+      .then(() => moveTaskInStore(childInstance.taskId, 'done'))
+      .catch((err) => { log.warn('Failed to complete child workflow task', err) })
+  }
 
-  parentInstance.history.push({
-    stepId,
-    status: 'complete',
-    completedAt: now,
-    output: stepState.output,
-  })
+  if (findStep(parentDef, stepId)?.type === 'map_workflow') {
+    // Map join: update THIS child's entry; the step only completes when every
+    // sibling is complete, aggregating in stable source order regardless of
+    // completion order. Failed/cancelled siblings block the join — no cascade.
+    const children = stepState.children ?? []
+    const entry = children.find((c) => c.childTaskId === childInstance.taskId)
+    if (!entry || entry.status === 'complete') return
+    entry.status = 'complete'
+    entry.output = finalOutput
+    moveChildBoardTaskDone()
 
-  // Move the child's board task to Done.
-  addTaskLogToStore(childInstance.taskId, 'workflow', `Sub-workflow "${childInstance.workflowId}" completed.`)
-    .then(() => moveTaskInStore(childInstance.taskId, 'done'))
-    .catch((err) => { log.warn('Failed to complete child workflow task', err) })
+    if (!children.every((c) => c.status === 'complete')) {
+      saveInstance(parentInstance, contentDir)
+      return
+    }
+
+    stepState.status = 'complete'
+    stepState.completedAt = now
+    stepState.output = {
+      outputs: [...children].sort((a, b) => a.index - b.index).map((c) => c.output ?? {}),
+    }
+    parentInstance.history.push({
+      stepId,
+      status: 'complete',
+      completedAt: now,
+      output: stepState.output,
+    })
+  } else {
+    stepState.status = 'complete'
+    stepState.completedAt = now
+    stepState.output = { childWorkflowId: childInstance.workflowId, finalOutput, outputs: childOutputs }
+
+    parentInstance.history.push({
+      stepId,
+      status: 'complete',
+      completedAt: now,
+      output: stepState.output,
+    })
+
+    // Move the child's board task to Done.
+    moveChildBoardTaskDone()
+  }
 
   advanceWorkflow(parentInstance, parentDef, contentDir)
   saveInstance(parentInstance, contentDir)

--- a/plugins/workflows/lib/engine.ts
+++ b/plugins/workflows/lib/engine.ts
@@ -10,10 +10,12 @@ import type {
   WorkflowDefinition,
   WorkflowInstance,
   StepState,
+  MapChildEntry,
   ParallelStep,
   AgentStep,
   OutputStep,
   NestedWorkflowStep,
+  MapWorkflowStep,
   CreateTaskStep,
 } from '../types'
 import { loadDefinition, validateWorkflowId, flattenSteps, findStep, getTopLevelIndex } from './parser'
@@ -30,7 +32,7 @@ import {
 import { getContentDir } from './content-dir'
 import { isPluginKind } from '@bakin/core/workflows/node-type-registry'
 import { createLogger } from '@bakin/core/logger'
-import { loadInstance, saveInstance, generateId } from './instance-store'
+import { loadInstance, saveInstance, generateId, listInstances } from './instance-store'
 import {
   createBoardTaskForChild,
   completeTaskViaHooks,
@@ -42,6 +44,9 @@ import { dispatchPluginNode, dispatchCreateTaskNode } from './node-dispatch'
 import { resolveAgent, getCurrentStep, type StepContext } from './step-context'
 
 const log = createLogger('workflow-runtime')
+
+/** Fan-out width guardrail when a map step declares no max_children. */
+const DEFAULT_MAX_CHILDREN = 32
 
 // ─── Instance Creation ──────────────────────────────────────────────────────
 
@@ -124,6 +129,12 @@ export function createInstance(
     // Create a board task so the child workflow's gates are visible in the UI
     const childDef = loadDefinition(nested.workflow_id, dir)
     createBoardTaskForChild(childTaskId, taskId, nested, childDef, assignee)
+  } else if (firstStep.type === 'map_workflow') {
+    // Statically illegal (source must name an EARLIER step, so validation
+    // rejects a first-step map) — but createInstance is reachable without
+    // validation, so fail typed instead of dangling in_progress forever.
+    fanOutMapStep(instance, firstStep as MapWorkflowStep, def, dir, now)
+    saveInstance(instance, dir)
   } else if (isPluginKind(firstStep.type)) {
     // First step is a plugin-owned kind — fire its executeNode hook.
     dispatchPluginNode(instance, firstStep, dir)
@@ -132,6 +143,104 @@ export function createInstance(
   }
 
   return instance
+}
+
+// ─── Map Fan-out ────────────────────────────────────────────────────────────
+
+/**
+ * Fan out a map_workflow step: one child workflow instance per element of the
+ * source step's output array. Invalid sources fail typed (map_source_invalid)
+ * with zero children spawned; empty arrays complete immediately and advance.
+ * Children are ordinary nested-workflow instances — gates, cycle detection,
+ * and board visibility come from the existing machinery.
+ * See .claude/specs/workflow-map-fanout-design.md.
+ */
+function fanOutMapStep(
+  instance: WorkflowInstance,
+  mapStep: MapWorkflowStep,
+  def: WorkflowDefinition,
+  contentDir: string,
+  now: string,
+): void {
+  const failTyped = (error: string): void => {
+    instance.stepStates[mapStep.id] = {
+      status: 'failed',
+      startedAt: now,
+      code: 'map_source_invalid',
+      error,
+    }
+    instance.history.push({ stepId: mapStep.id, status: 'failed', completedAt: now })
+    instance.status = 'failed'
+  }
+
+  const dotIdx = mapStep.source.indexOf('.')
+  const sourceStepId = dotIdx > 0 ? mapStep.source.slice(0, dotIdx) : mapStep.source
+  const sourceKey = dotIdx > 0 ? mapStep.source.slice(dotIdx + 1) : ''
+  const sourceOutput = instance.stepStates[sourceStepId]?.output
+  const value = sourceOutput?.[sourceKey]
+
+  if (!Array.isArray(value)) {
+    const detail = sourceOutput
+      ? `key "${sourceKey}" is ${value === undefined ? 'missing' : `a ${typeof value}, not an array`}`
+      : `step "${sourceStepId}" has no output`
+    failTyped(`source "${mapStep.source}" must resolve to an array; ${detail}`)
+    return
+  }
+
+  const maxChildren = mapStep.max_children ?? DEFAULT_MAX_CHILDREN
+  if (value.length > maxChildren) {
+    failTyped(`source array has ${value.length} items, exceeding max_children (${maxChildren}); no children were spawned`)
+    return
+  }
+
+  if (value.length === 0) {
+    // An empty segmentation is a valid outcome — complete and move on.
+    const output = { outputs: [] }
+    instance.stepStates[mapStep.id] = { status: 'complete', startedAt: now, completedAt: now, output }
+    instance.history.push({ stepId: mapStep.id, status: 'complete', completedAt: now, output })
+    advanceWorkflow(instance, def, contentDir)
+    return
+  }
+
+  // Sweep stale live children from a prior fan-out of this step (source-step
+  // rewind wiped children[]): cancel them before re-creating over the same
+  // ids; orphans beyond the new width also leave the board.
+  const childIdPrefix = `${instance.taskId}--${mapStep.id}--`
+  const staleChildren = listInstances(undefined, contentDir).filter(
+    (inst) => inst.parentTaskId === instance.taskId && inst.parentStepId === mapStep.id &&
+      inst.status !== 'complete' && inst.status !== 'cancelled',
+  )
+  for (const stale of staleChildren) {
+    cancelInstance(stale.taskId, contentDir)
+    const staleIndex = Number(stale.taskId.slice(childIdPrefix.length))
+    if (!(staleIndex >= 0 && staleIndex < value.length)) {
+      // Not being re-created — retire its board task too.
+      moveTaskInStore(stale.taskId, 'done').catch((err) => {
+        log.warn('Failed to retire stale map child task', err)
+      })
+    }
+  }
+
+  const itemKey = mapStep.item_key ?? 'item'
+  const total = value.length
+  const childDef = loadDefinition(mapStep.workflow_id, contentDir)
+  const children: MapChildEntry[] = []
+  for (let i = 0; i < total; i++) {
+    const childTaskId = `${childIdPrefix}${i}`
+    const childParentContext: Record<string, unknown> = {
+      ...(sourceOutput || {}),
+      [itemKey]: value[i],
+      mapIndex: i,
+      mapTotal: total,
+    }
+    const childInstance = createInstance(childTaskId, mapStep.workflow_id, contentDir, instance.resolvedAgent, childParentContext, instance.availableAgents)
+    childInstance.parentTaskId = instance.taskId
+    childInstance.parentStepId = mapStep.id
+    saveInstance(childInstance, contentDir)
+    createBoardTaskForChild(childTaskId, instance.taskId, mapStep, childDef, instance.resolvedAgent, { index: i, total })
+    children.push({ index: i, childTaskId, status: 'in_progress' })
+  }
+  instance.stepStates[mapStep.id] = { status: 'in_progress', startedAt: now, children }
 }
 
 // ─── Step Completion ────────────────────────────────────────────────────────
@@ -267,6 +376,11 @@ export function propagateChildCompletion(childInstance: WorkflowInstance, conten
   const stepId = childInstance.parentStepId!
   const stepState = parentInstance.stepStates[stepId]
   if (!stepState || stepState.status !== 'in_progress') return
+
+  // Map steps join on ALL children — the map-aware branch (entry update +
+  // stable-order aggregation) lands with fan-in; a single completing child
+  // must never complete the whole step. (T1.4 replaces this guard.)
+  if (findStep(parentDef, stepId)?.type === 'map_workflow') return
 
   // Collect child workflow outputs in definition order.
   // `finalOutput` is the last agent step's output (gates don't produce output).
@@ -406,6 +520,9 @@ export function advanceWorkflow(instance: WorkflowInstance, def: WorkflowDefinit
     // Create a board task so the child workflow's gates are visible in the UI
     const childDef = loadDefinition(nested.workflow_id, contentDir)
     createBoardTaskForChild(childTaskId, instance.taskId, nested, childDef, instance.resolvedAgent)
+  } else if (nextStep.type === 'map_workflow') {
+    // Dynamic fan-out — one child instance per source-array element.
+    fanOutMapStep(instance, nextStep as MapWorkflowStep, def, contentDir, now)
   } else if (nextStep.type === 'gate') {
     // Gates go to pending_approval and record requestedAt so the decision
     // timeline can be computed later.

--- a/plugins/workflows/lib/exec-tools.ts
+++ b/plugins/workflows/lib/exec-tools.ts
@@ -212,6 +212,9 @@ export function registerWorkflowExecTools(ctx: PluginContext): void {
         if (step.status === 'cancelled') {
           return { ok: false, error: 'Workflow is cancelled — do not submit output. Stop work on this task.' }
         }
+        if (step.status === 'failed') {
+          return { ok: false, error: `Workflow is in a failed state${step.code ? ` (${String(step.code)})` : ''} — it must be recovered (reopen the failing step's source) before submissions are accepted.` }
+        }
 
         const schema = step.output_schema as Record<string, unknown> | undefined
 

--- a/plugins/workflows/lib/gates.ts
+++ b/plugins/workflows/lib/gates.ts
@@ -275,19 +275,25 @@ export function rejectGate(
 function resolveReopenStep(def: WorkflowDefinition, requestedStepId: string): { stepId: string } | { errors: string[] } {
   const requestedStep = findStep(def, requestedStepId)
   if (!requestedStep) return { errors: [`Step not found: ${requestedStepId}`] }
+  if (requestedStep.type === 'map_workflow') {
+    return { errors: [`Reopen target "${requestedStepId}" is a map fan-out — reopen its source step or retry individual children instead`] }
+  }
   if (requestedStep.type !== 'gate') return { stepId: requestedStepId }
 
   const gateStep = requestedStep as GateStep
   if (gateStep.on_reject?.goto) {
     const targetStep = findStep(def, gateStep.on_reject.goto)
     if (!targetStep) return { errors: [`Gate reopen target step not found: ${gateStep.on_reject.goto}`] }
+    if (targetStep.type === 'map_workflow') {
+      return { errors: [`Gate reopen target "${gateStep.on_reject.goto}" is a map fan-out — target its source step instead`] }
+    }
     return { stepId: gateStep.on_reject.goto }
   }
 
   const gateTopIdx = getTopLevelIndex(def, requestedStepId)
   for (let index = gateTopIdx - 1; index >= 0; index--) {
     const candidate = def.steps[index]
-    if (candidate.type !== 'gate') return { stepId: candidate.id }
+    if (candidate.type !== 'gate' && candidate.type !== 'map_workflow') return { stepId: candidate.id }
   }
 
   return { errors: [`Gate "${requestedStepId}" has no actionable previous step`] }

--- a/plugins/workflows/lib/health-checks.ts
+++ b/plugins/workflows/lib/health-checks.ts
@@ -217,10 +217,21 @@ export async function checkWorkflowDefinitions(contentDir: string): Promise<Heal
           results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" references skill "${skillName}" which does not exist`))
         }
         const stepType = (step as { type?: string }).type
-        if (stepType === 'workflow') {
+        if (stepType === 'workflow' || stepType === 'map_workflow') {
           const workflowId = (step as { workflow_id?: string }).workflow_id
           if (workflowId && !knownWorkflowIds.has(workflowId)) {
             results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" references nested workflow "${workflowId}" which does not exist`))
+          }
+          // Nested maps (a map child whose workflow contains another map) are
+          // structurally legal but unsupported/untested in v1 — advisory only.
+          if (stepType === 'map_workflow' && workflowId) {
+            const child = defs.find((entry) => entry.name === workflowId)
+            const childHasMap = child?.definition.steps.some(
+              (childStep) => (childStep as { type?: string }).type === 'map_workflow',
+            )
+            if (childHasMap) {
+              results.push(warn('workflow-definitions', `Workflow "${name}" step "${(step as { id: string }).id}" fans out to "${workflowId}" which itself contains a map_workflow step — nested maps are unsupported in v1`))
+            }
           }
         }
         // Check parallel children too

--- a/plugins/workflows/lib/start-validation.ts
+++ b/plugins/workflows/lib/start-validation.ts
@@ -14,7 +14,7 @@
  * the old module-scope guard.
  */
 import type { PluginContext } from '@bakin/core/plugin-types'
-import type { WorkflowDefinition, NestedWorkflowStep } from '../types'
+import type { WorkflowDefinition, NestedWorkflowStep, MapWorkflowStep } from '../types'
 import { listDefinitions, loadDefinition, validateDefinition, validateWorkflowId } from './parser'
 import { createInstance } from './runtime'
 
@@ -31,8 +31,8 @@ export async function getRuntimeAgentNames(ctx: PluginContext | null): Promise<S
 
 function collectNestedWorkflowIds(def: WorkflowDefinition, out: Set<string>): void {
   for (const step of def.steps) {
-    if (step.type === 'workflow') {
-      out.add((step as NestedWorkflowStep).workflow_id)
+    if (step.type === 'workflow' || step.type === 'map_workflow') {
+      out.add((step as NestedWorkflowStep | MapWorkflowStep).workflow_id)
     }
   }
 }

--- a/plugins/workflows/lib/step-context.ts
+++ b/plugins/workflows/lib/step-context.ts
@@ -12,6 +12,7 @@ import type {
   ParallelStep,
   AgentStep,
   OutputStep,
+  StepErrorCode,
 } from '../types'
 import { loadDefinition, parsePreferredAgentExpression, findStep } from './parser'
 import { loadSkill } from './skill-loader'
@@ -81,7 +82,7 @@ export function getCurrentStep(
   taskId: string,
   agentId?: string,
   contentDir?: string
-): StepContext | { status: 'complete' } | { status: 'cancelled' } | { status: 'pending_approval'; stepId: string; label: string } | null {
+): StepContext | { status: 'complete' } | { status: 'cancelled' } | { status: 'failed'; stepId: string; code?: StepErrorCode; error?: string } | { status: 'pending_approval'; stepId: string; label: string } | null {
   const dir = contentDir || getContentDir()
   const instance = loadInstance(taskId, dir)
   if (!instance) return null
@@ -94,6 +95,17 @@ export function getCurrentStep(
   if (instance.status === 'cancelled') return { status: 'cancelled' }
   if (instance.status === 'complete') {
     return { status: 'complete' }
+  }
+  // Failed carries the typed code from the failing step (map_source_invalid
+  // today) so agents/UIs branch on code, never on error text.
+  if (instance.status === 'failed') {
+    const failedState = instance.stepStates[instance.currentStepId]
+    return {
+      status: 'failed',
+      stepId: instance.currentStepId,
+      code: failedState?.code,
+      error: failedState?.error,
+    }
   }
 
   const def = loadDefinition(instance.workflowId, dir)
@@ -118,6 +130,12 @@ export function getCurrentStep(
     if (stepState?.childTaskId) {
       return getCurrentStep(stepState.childTaskId, agentId, dir)
     }
+    return null
+  }
+
+  // Map fan-out — no single delegate is honest for N children; agents work
+  // their child board tasks (getActiveAgents unions them with effectiveTaskIds).
+  if (step.type === 'map_workflow') {
     return null
   }
 
@@ -331,6 +349,17 @@ export function getActiveAgents(
       }))
     }
     return []
+  } else if (currentStep.type === 'map_workflow') {
+    // Union over every live fan-out child, each under its own child taskId.
+    const out: { agent: string; stepId: string; effectiveTaskId?: string }[] = []
+    for (const entry of instance.stepStates[currentStep.id]?.children ?? []) {
+      if (entry.status !== 'in_progress') continue
+      out.push(...getActiveAgents(entry.childTaskId, dir).map(a => ({
+        ...a,
+        effectiveTaskId: a.effectiveTaskId || entry.childTaskId,
+      })))
+    }
+    return out
   } else if (currentStep.type === 'parallel') {
     for (const child of (currentStep as ParallelStep).steps) {
       if (child.type === 'agent' && instance.stepStates[child.id]?.status === 'in_progress') {

--- a/plugins/workflows/lib/task-bridge.ts
+++ b/plugins/workflows/lib/task-bridge.ts
@@ -6,7 +6,7 @@
  * board tasks — lives here. CLAUDE.md flags this as the natural place to later
  * swap direct core imports for ctx.tasks / hook calls.
  */
-import type { WorkflowInstance, WorkflowDefinition, AgentStep, NestedWorkflowStep } from '../types'
+import type { WorkflowInstance, WorkflowDefinition, AgentStep, NestedWorkflowStep, MapWorkflowStep } from '../types'
 import { getContentDir } from './content-dir'
 import { createLogger } from '@bakin/core/logger'
 import {
@@ -135,17 +135,30 @@ export async function completeTaskViaHooks(instance: WorkflowInstance, from: str
 export function createBoardTaskForChild(
   childTaskId: string,
   parentTaskId: string,
-  nestedStep: NestedWorkflowStep,
+  nestedStep: NestedWorkflowStep | MapWorkflowStep,
   childDef: WorkflowDefinition | null,
   assignee?: string,
+  /** Map fan-out children: fraction titles + board-task revive on id reuse. */
+  mapMeta?: { index: number; total: number },
 ) {
   void (async () => {
     if (await findTaskFromStore(childTaskId)) {
+      if (mapMeta) {
+        // Reused map-child id (re-fan-out after a source rewind) — pull the
+        // existing board task back into active work instead of duplicating.
+        await moveTaskInStore(childTaskId, 'inProgress')
+        return
+      }
       log.debug(`Skipping duplicate child task for ${childTaskId} — already on board`)
       return
     }
 
-    const title = `${nestedStep.label || nestedStep.workflow_id} (sub-workflow)`
+    let title = `${nestedStep.label || nestedStep.workflow_id} (sub-workflow)`
+    if (mapMeta) {
+      const parentTask = await findTaskFromStore(parentTaskId)
+      const fraction = `${nestedStep.label || nestedStep.workflow_id} ${mapMeta.index + 1}/${mapMeta.total}`
+      title = parentTask?.title ? `${parentTask.title} — ${fraction}` : `${fraction} (sub-workflow)`
+    }
     const description = nestedStep.description || childDef?.description || undefined
     // Find the first agent step in the child workflow for the assignee
     const childAgent = childDef?.steps.find(s => s.type === 'agent')

--- a/plugins/workflows/types.ts
+++ b/plugins/workflows/types.ts
@@ -26,6 +26,7 @@ export type {
   ParallelStep,
   OutputStep,
   NestedWorkflowStep,
+  MapWorkflowStep,
   CreateTaskStep,
   WorkflowStep,
   NodePosition,
@@ -102,6 +103,23 @@ export type InstanceStatus =
   | 'failed'
   | 'cancelled'
 
+/**
+ * Typed step-failure codes. UIs and agents branch on these — never on error
+ * message text (architecture-test enforced convention).
+ */
+export type StepErrorCode = 'map_source_invalid'
+
+export type MapChildStatus = 'in_progress' | 'complete' | 'failed' | 'cancelled'
+
+/** One fanned-out map_workflow child, in source-array order. */
+export interface MapChildEntry {
+  index: number
+  childTaskId: string
+  status: MapChildStatus
+  /** The child's finalOutput, recorded at completion; aggregated on join. */
+  output?: Record<string, unknown>
+}
+
 export interface StepState {
   status: StepStatus
   startedAt?: string
@@ -111,6 +129,12 @@ export interface StepState {
   rejectionReason?: string
   /** For nested workflow steps — the child instance's task ID (used as instance key) */
   childTaskId?: string
+  /** For map_workflow steps — one entry per fanned-out child, in source-array order */
+  children?: MapChildEntry[]
+  /** Typed failure code — set with status 'failed' where no CompleteStepResult carries it */
+  code?: StepErrorCode
+  /** Human-readable failure detail accompanying `code` */
+  error?: string
   /** Runtime-rendered gate approval reference used to resolve the rendered approval after a decision */
   approvalRef?: ApprovalRenderRef
   /** Gate decision metadata — set when a gate enters pending_approval and when a decision is recorded */

--- a/src/core/dispatch-workflow.ts
+++ b/src/core/dispatch-workflow.ts
@@ -74,7 +74,7 @@ export async function dispatchWorkflowTask(
     // For nested workflows, use the child's taskId for step context resolution
     const contextTaskId = effectiveTaskId || task.id
     const stepContext = await hooks().invoke<Record<string, unknown>>('workflows.getCurrentStep', { taskId: contextTaskId, agentId: agent })
-    if (!stepContext || 'status' in stepContext && (stepContext.status === 'complete' || stepContext.status === 'cancelled' || stepContext.status === 'pending_approval')) {
+    if (!stepContext || 'status' in stepContext && (stepContext.status === 'complete' || stepContext.status === 'cancelled' || stepContext.status === 'failed' || stepContext.status === 'pending_approval')) {
       continue
     }
 

--- a/tests/core/dispatch-workflow-context.test.ts
+++ b/tests/core/dispatch-workflow-context.test.ts
@@ -114,6 +114,40 @@ describe('workflow context cap', () => {
     expect(msg).toContain('"marker": "newest"')
   })
 
+  it('budgets a map_workflow aggregate like any step output — trimmed with a marker when fat (#203)', () => {
+    // A map join writes { outputs: [...] } as ordinary stepState.output, so a
+    // wide fan-out's aggregate must ride the same budget as everything else.
+    const stepOutputs = {
+      'generate-variants': {
+        outputs: [bigOutput('variant-0', 2500), bigOutput('variant-1', 2500), bigOutput('variant-2', 2500)],
+      },
+      'select-best': bigOutput('winner', 300),
+    }
+    const msg = buildWorkflowDispatchMessage(
+      task, { ...step, stepOutputs }, 'jessica', '', undefined, '',
+      { maxWorkflowContextBytes: 1024 },
+    )
+    // Newest (post-map) output survives; the fat aggregate is dropped whole
+    // with the visible recovery marker — never silently, never mid-JSON.
+    expect(msg).toContain('"marker": "winner"')
+    expect(msg).not.toContain('"marker": "variant-0"')
+    expect(msg).not.toContain('### Step: generate-variants')
+    expect(msg).toContain('step output omitted')
+    expect(msg).toContain('bakin_exec_workflows_get_instance')
+  })
+
+  it('keeps a map_workflow aggregate intact when the budget allows it', () => {
+    const stepOutputs = {
+      'generate-variants': { outputs: [{ assetId: 'a-0' }, { assetId: 'a-1' }, { assetId: 'a-2' }] },
+      'select-best': { assetId: 'a-1', rationale: 'best composition' },
+    }
+    const msg = buildWorkflowDispatchMessage(task, { ...step, stepOutputs }, 'jessica')
+    expect(msg).toContain('"assetId": "a-0"')
+    expect(msg).toContain('"assetId": "a-2"')
+    expect(msg).toContain('"rationale": "best composition"')
+    expect(msg).not.toContain('omitted')
+  })
+
   it('keeps the parent JSON body when the budget allows it', () => {
     const stepOutputs = {
       'step-a': bigOutput('newest', 200),

--- a/tests/plugins/workflows/gate-hooks.test.ts
+++ b/tests/plugins/workflows/gate-hooks.test.ts
@@ -293,6 +293,40 @@ steps:
     ).rejects.toThrow('cycle detected')
   })
 
+  it('start validation detects cycles through map_workflow child references', async () => {
+    writeFileSync(join(defsDir, 'map-cycle-a.yaml'), `name: Map Cycle A
+description: A
+version: 1
+steps:
+  - id: seg
+    type: agent
+    label: Segment
+    agent: $assigned
+  - id: fan
+    type: map_workflow
+    label: Fan
+    source: seg.items
+    workflow_id: map-cycle-b
+`)
+    writeFileSync(join(defsDir, 'map-cycle-b.yaml'), `name: Map Cycle B
+description: B
+version: 1
+steps:
+  - id: nest-a
+    type: workflow
+    label: Run A
+    workflow_id: map-cycle-a
+`)
+    const hooks = await activateWithHooks()
+    await expect(
+      hooks.get('workflows.createInstance')!({
+        taskId: 'task-map-cycle-hook',
+        workflowId: 'map-cycle-a',
+        contentDir: testDir,
+      }),
+    ).rejects.toThrow('cycle detected')
+  })
+
   it('workflows.reopenFromStep reopens the same workflow instance', async () => {
     const hooks = await activateWithHooks()
     createPendingGate('task-reopen-hook')

--- a/tests/plugins/workflows/health-checks.test.ts
+++ b/tests/plugins/workflows/health-checks.test.ts
@@ -293,6 +293,97 @@ steps:
     )).toBe(true)
   })
 
+  it('warns when a map_workflow step references a missing child workflow', async () => {
+    writeFileSync(
+      join(definitionsDir, 'map-orphan.yaml'),
+      `name: Map orphan
+description: test
+version: 1
+steps:
+  - id: seg
+    label: Segment
+    type: agent
+    agent: main
+  - id: fan
+    label: Fan
+    type: map_workflow
+    source: seg.items
+    workflow_id: ghost-map-child
+`,
+    )
+    const results = await checkWorkflowDefinitions(testDir)
+    expect(results.some(r =>
+      r.status === 'warn' &&
+      r.message.includes('map-orphan') &&
+      r.message.includes('ghost-map-child'),
+    )).toBe(true)
+  })
+
+  it('warns when a map child workflow itself contains a map_workflow step (nested maps unsupported)', async () => {
+    writeFileSync(
+      join(definitionsDir, 'map-parent.yaml'),
+      `name: Map parent
+description: test
+version: 1
+steps:
+  - id: seg
+    label: Segment
+    type: agent
+    agent: main
+  - id: fan
+    label: Fan
+    type: map_workflow
+    source: seg.items
+    workflow_id: map-inner
+`,
+    )
+    writeFileSync(
+      join(definitionsDir, 'map-inner.yaml'),
+      `name: Map inner
+description: test
+version: 1
+steps:
+  - id: seg2
+    label: Segment
+    type: agent
+    agent: main
+  - id: fan2
+    label: Fan again
+    type: map_workflow
+    source: seg2.items
+    workflow_id: map-leaf
+  - id: done
+    label: Done
+    type: agent
+    agent: main
+`,
+    )
+    writeFileSync(
+      join(definitionsDir, 'map-leaf.yaml'),
+      `name: Map leaf
+description: test
+version: 1
+steps:
+  - id: go
+    label: Go
+    type: agent
+    agent: main
+`,
+    )
+    const results = await checkWorkflowDefinitions(testDir)
+    expect(results.some(r =>
+      r.status === 'warn' &&
+      r.message.includes('map-parent') &&
+      r.message.includes('nested map'),
+    )).toBe(true)
+    // The leaf-level map (map-inner -> map-leaf) is fine — only one map deep.
+    expect(results.some(r =>
+      r.status === 'warn' &&
+      r.message.startsWith('Workflow "map-inner"') &&
+      r.message.includes('nested map'),
+    )).toBe(false)
+  })
+
   it('does not warn when the nested workflow exists on disk or in the registry', async () => {
     const { registerPluginDefinition, clearSourceRegistry } = await import('@bakin/core/workflows/source-registry')
     writeFileSync(

--- a/tests/plugins/workflows/helpers/runtime-harness.ts
+++ b/tests/plugins/workflows/helpers/runtime-harness.ts
@@ -287,6 +287,22 @@ steps:
     description: Work one item
 `
 
+// Nested recursion: a parent whose child workflow (map-flow) contains the map
+export const mapWrapperWorkflow = `
+name: Map Wrapper
+description: Nested workflow whose child contains a map step
+version: 1
+steps:
+  - id: run-map-flow
+    type: workflow
+    label: Run Map Flow
+    workflow_id: map-flow
+  - id: wrap-after
+    type: agent
+    label: Wrap After
+    agent: main
+`
+
 // Statically illegal (map at index 0 has no earlier source step) — exercises
 // the defensive createInstance branch on non-validating paths.
 export const mapFirstWorkflow = `
@@ -351,5 +367,6 @@ export function seedWorkflowFixtures(testDir: string): void {
   writeFileSync(join(defsDir, 'map-flow.yaml'), mapWorkflow)
   writeFileSync(join(defsDir, 'map-child.yaml'), mapChildWorkflow)
   writeFileSync(join(defsDir, 'map-first.yaml'), mapFirstWorkflow)
+  writeFileSync(join(defsDir, 'map-wrapper.yaml'), mapWrapperWorkflow)
   writeFileSync(join(skillsDir, 'test-skill.md'), testSkillMarkdown)
 }

--- a/tests/plugins/workflows/helpers/runtime-harness.ts
+++ b/tests/plugins/workflows/helpers/runtime-harness.ts
@@ -249,6 +249,62 @@ steps:
     description: Continue after task creation
 `
 
+// Map fan-out parent: source agent step → map_workflow → after
+export const mapWorkflow = `
+name: Map Flow
+description: Dynamic fan-out test workflow
+version: 1
+steps:
+  - id: source-step
+    type: agent
+    label: Segment
+    agent: chef
+    description: Produce the items array
+  - id: produce-items
+    type: map_workflow
+    label: Produce Items
+    source: source-step.items
+    workflow_id: map-child
+    item_key: brief
+    max_children: 4
+  - id: after-map
+    type: agent
+    label: After Map
+    agent: main
+    description: Consume the aggregate
+`
+
+// Minimal child workflow for map fan-out
+export const mapChildWorkflow = `
+name: Map Child
+description: Single-step map child
+version: 1
+steps:
+  - id: do-work
+    type: agent
+    label: Do Work
+    agent: pixel
+    description: Work one item
+`
+
+// Statically illegal (map at index 0 has no earlier source step) — exercises
+// the defensive createInstance branch on non-validating paths.
+export const mapFirstWorkflow = `
+name: Map First
+description: Defensive first-step map
+version: 1
+steps:
+  - id: fan
+    type: map_workflow
+    label: Fan
+    source: ghost.items
+    workflow_id: map-child
+  - id: after
+    type: agent
+    label: After
+    agent: main
+`
+
 export const testSkillMarkdown = `---
 name: Test Skill
 output_schema:
@@ -292,5 +348,8 @@ export function seedWorkflowFixtures(testDir: string): void {
   writeFileSync(join(defsDir, 'final-gate.yaml'), finalGateWorkflow)
   writeFileSync(join(defsDir, 'skill-test.yaml'), skillWorkflow)
   writeFileSync(join(defsDir, 'task-node.yaml'), taskNodeWorkflow)
+  writeFileSync(join(defsDir, 'map-flow.yaml'), mapWorkflow)
+  writeFileSync(join(defsDir, 'map-child.yaml'), mapChildWorkflow)
+  writeFileSync(join(defsDir, 'map-first.yaml'), mapFirstWorkflow)
   writeFileSync(join(skillsDir, 'test-skill.md'), testSkillMarkdown)
 }

--- a/tests/plugins/workflows/node-type-registry.test.ts
+++ b/tests/plugins/workflows/node-type-registry.test.ts
@@ -36,19 +36,20 @@ import {
   outputStepSchema,
   nestedWorkflowStepSchema,
   createTaskStepSchema,
+  mapWorkflowStepSchema,
   type NodeTypeDef,
 } from '@bakin/core/workflows/node-type-registry'
 import { z } from 'zod'
 
 describe('node-type-registry', () => {
   describe('builtin registration', () => {
-    it('registers all 6 builtin node types at module load', () => {
+    it('registers all 7 builtin node types at module load', () => {
       const kinds = listNodeTypes().map(n => n.kind).sort()
-      expect(kinds).toEqual(['agent', 'createTask', 'gate', 'output', 'parallel', 'workflow'])
+      expect(kinds).toEqual(['agent', 'createTask', 'gate', 'map_workflow', 'output', 'parallel', 'workflow'])
     })
 
     it('exposes each builtin via getNodeType()', () => {
-      for (const kind of ['agent', 'createTask', 'gate', 'output', 'parallel', 'workflow']) {
+      for (const kind of ['agent', 'createTask', 'gate', 'output', 'parallel', 'workflow', 'map_workflow']) {
         const def = getNodeType(kind)
         expect(def, `expected ${kind} to be registered`).toBeDefined()
         expect(def!.kind).toBe(kind)
@@ -148,6 +149,19 @@ describe('node-type-registry', () => {
       expect(result.success).toBe(false)
     })
 
+    it('rejects a parallel step with a map_workflow child (agent-only)', () => {
+      const result = parallelStepSchema.safeParse({
+        id: 'p1',
+        type: 'parallel',
+        label: 'Parallel',
+        steps: [
+          { id: 'c1', type: 'agent', label: 'Child 1', agent: 'chef' },
+          { id: 'c2', type: 'map_workflow', label: 'Map', source: 'c1.items', workflow_id: 'x' },
+        ],
+      })
+      expect(result.success).toBe(false)
+    })
+
     it('rejects a parallel step with no children', () => {
       const result = parallelStepSchema.safeParse({
         id: 'p1',
@@ -193,6 +207,79 @@ describe('node-type-registry', () => {
     })
   })
 
+  describe('mapWorkflowStepSchema', () => {
+    it('accepts the full design-doc YAML surface', () => {
+      const result = mapWorkflowStepSchema.safeParse({
+        id: 'produce-clips',
+        type: 'map_workflow',
+        label: 'Produce clips',
+        source: 'segment-script.clips',
+        workflow_id: 'clip-creation',
+        item_key: 'clip',
+        max_children: 24,
+        description: 'One child per clip brief',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts a minimal map step (source + workflow_id only)', () => {
+      const result = mapWorkflowStepSchema.safeParse({
+        id: 'fan',
+        type: 'map_workflow',
+        label: 'Fan out',
+        source: 'prev.items',
+        workflow_id: 'child-wf',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a map step missing source', () => {
+      const result = mapWorkflowStepSchema.safeParse({
+        id: 'fan',
+        type: 'map_workflow',
+        label: 'Fan out',
+        workflow_id: 'child-wf',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a map step missing workflow_id', () => {
+      const result = mapWorkflowStepSchema.safeParse({
+        id: 'fan',
+        type: 'map_workflow',
+        label: 'Fan out',
+        source: 'prev.items',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects unknown keys (strict, like every builtin)', () => {
+      const result = mapWorkflowStepSchema.safeParse({
+        id: 'fan',
+        type: 'map_workflow',
+        label: 'Fan out',
+        source: 'prev.items',
+        workflow_id: 'child-wf',
+        on_child_failure: 'ignore',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects non-positive or fractional max_children', () => {
+      for (const bad of [0, -1, 2.5]) {
+        const result = mapWorkflowStepSchema.safeParse({
+          id: 'fan',
+          type: 'map_workflow',
+          label: 'Fan out',
+          source: 'prev.items',
+          workflow_id: 'child-wf',
+          max_children: bad,
+        })
+        expect(result.success, `max_children=${bad}`).toBe(false)
+      }
+    })
+  })
+
   describe('createTaskStepSchema', () => {
     it('accepts a scheduled source-linked task creation step', () => {
       const result = createTaskStepSchema.safeParse({
@@ -235,6 +322,32 @@ describe('node-type-registry', () => {
         ],
       })
       expect(result.success).toBe(true)
+    })
+
+    it('accepts a definition containing a map_workflow step', () => {
+      const result = workflowDefinitionSchema.safeParse({
+        name: 'Fan Out',
+        description: 'x',
+        version: 1,
+        steps: [
+          { id: 'seg', type: 'agent', label: 'Segment', agent: 'chef' },
+          { id: 'fan', type: 'map_workflow', label: 'Fan', source: 'seg.items', workflow_id: 'child' },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a map_workflow step with unknown keys at the definition level', () => {
+      const result = workflowDefinitionSchema.safeParse({
+        name: 'Fan Out',
+        description: 'x',
+        version: 1,
+        steps: [
+          { id: 'seg', type: 'agent', label: 'Segment', agent: 'chef' },
+          { id: 'fan', type: 'map_workflow', label: 'Fan', source: 'seg.items', workflow_id: 'child', dependsOn: 'seg' },
+        ],
+      })
+      expect(result.success).toBe(false)
     })
 
     it('rejects a definition with an unknown step type', () => {
@@ -302,8 +415,8 @@ describe('node-type-registry', () => {
   })
 
   describe('edgeRules (builtin defaults)', () => {
-    it('sets maxOutbound=1 for agent/gate/parallel/workflow/createTask kinds', () => {
-      for (const kind of ['agent', 'gate', 'parallel', 'workflow', 'createTask']) {
+    it('sets maxOutbound=1 for agent/gate/parallel/workflow/createTask/map_workflow kinds', () => {
+      for (const kind of ['agent', 'gate', 'parallel', 'workflow', 'createTask', 'map_workflow']) {
         expect(getNodeType(kind)?.edgeRules?.maxOutbound, `${kind}`).toBe(1)
       }
     })

--- a/tests/plugins/workflows/parser.test.ts
+++ b/tests/plugins/workflows/parser.test.ts
@@ -394,6 +394,21 @@ steps:
     it('skips the existence check when validateNestedWorkflowRefs is false', () => {
       expect(validateDefinition(mapDef('seg.items'), { validateNestedWorkflowRefs: false })).toEqual([])
     })
+
+    it('rejects a gate on_reject.goto that targets a map step (not an actionable reopen target)', () => {
+      const def: WorkflowDefinition = {
+        name: 'Map Flow',
+        description: 'x',
+        version: 1,
+        steps: [
+          { id: 'seg', type: 'agent', label: 'Segment', agent: 'chef' },
+          { id: 'fan', type: 'map_workflow', label: 'Fan', source: 'seg.items', workflow_id: 'map-child' },
+          { id: 'check', type: 'gate', label: 'Check', on_reject: { goto: 'fan' } },
+        ],
+      }
+      const errors = validateDefinition(def, { knownWorkflowIds: ['map-child'] })
+      expect(errors.some(e => e.includes('"check"') && e.includes('map_workflow'))).toBe(true)
+    })
   })
 
   describe('loadDefinition / listDefinitions', () => {

--- a/tests/plugins/workflows/parser.test.ts
+++ b/tests/plugins/workflows/parser.test.ts
@@ -320,6 +320,82 @@ steps:
     })
   })
 
+  describe('validateDefinition — map_workflow steps', () => {
+    const mapDef = (source: string, extra: Partial<WorkflowDefinition> = {}): WorkflowDefinition => ({
+      name: 'Map Flow',
+      description: 'Fan out',
+      version: 1,
+      steps: [
+        { id: 'seg', type: 'agent', label: 'Segment', agent: 'chef' },
+        { id: 'fan', type: 'map_workflow', label: 'Fan', source, workflow_id: 'map-child' },
+        { id: 'after', type: 'agent', label: 'After', agent: 'chef' },
+      ],
+      ...extra,
+    })
+
+    it('accepts a map step sourcing an earlier top-level step', () => {
+      expect(validateDefinition(mapDef('seg.items'), { knownWorkflowIds: ['map-child'] })).toEqual([])
+    })
+
+    it('rejects a source without the <stepId>.<outputKey> shape', () => {
+      const errors = validateDefinition(mapDef('segitems'), { knownWorkflowIds: ['map-child'] })
+      expect(errors.some(e => e.includes('"fan"') && e.includes('<stepId>.<outputKey>'))).toBe(true)
+    })
+
+    it('rejects a source referencing a nonexistent step', () => {
+      const errors = validateDefinition(mapDef('ghost.items'), { knownWorkflowIds: ['map-child'] })
+      expect(errors.some(e => e.includes('nonexistent step "ghost"'))).toBe(true)
+    })
+
+    it('rejects a source referencing a parallel child (not top-level)', () => {
+      const def: WorkflowDefinition = {
+        name: 'Map Flow',
+        description: 'x',
+        version: 1,
+        steps: [
+          {
+            id: 'par', type: 'parallel', label: 'Par',
+            steps: [{ id: 'inner', type: 'agent', label: 'Inner', agent: 'chef' }],
+          },
+          { id: 'fan', type: 'map_workflow', label: 'Fan', source: 'inner.items', workflow_id: 'map-child' },
+        ],
+      }
+      const errors = validateDefinition(def, { knownWorkflowIds: ['map-child'] })
+      expect(errors.some(e => e.includes('top-level'))).toBe(true)
+    })
+
+    it('rejects a source referencing a later step', () => {
+      const errors = validateDefinition(mapDef('after.items'), { knownWorkflowIds: ['map-child'] })
+      expect(errors.some(e => e.includes('earlier'))).toBe(true)
+    })
+
+    it('rejects a source referencing the map step itself', () => {
+      const errors = validateDefinition(mapDef('fan.items'), { knownWorkflowIds: ['map-child'] })
+      expect(errors.some(e => e.includes('earlier'))).toBe(true)
+    })
+
+    it('rejects a map step whose workflow_id references its own workflow', () => {
+      const def = mapDef('seg.items')
+      ;(def.steps[1] as { workflow_id: string }).workflow_id = 'map-flow'
+      const errors = validateDefinition(def, { definitionId: 'map-flow', knownWorkflowIds: ['map-flow'] })
+      expect(errors.some(e => e.includes('cannot reference its own workflow'))).toBe(true)
+    })
+
+    it('rejects an unknown map child workflow_id', () => {
+      const errors = validateDefinition(mapDef('seg.items'))
+      expect(errors.some(e => e.includes('"map-child" not found'))).toBe(true)
+    })
+
+    it('accepts a map child workflow_id that exists on disk', () => {
+      writeFileSync(join(defsDir, 'map-child.yaml'), 'name: Map Child\ndescription: x\nversion: 1\nsteps:\n  - id: go\n    type: agent\n    label: Go\n    agent: chef\n')
+      expect(validateDefinition(mapDef('seg.items'), { contentDir: testDir })).toEqual([])
+    })
+
+    it('skips the existence check when validateNestedWorkflowRefs is false', () => {
+      expect(validateDefinition(mapDef('seg.items'), { validateNestedWorkflowRefs: false })).toEqual([])
+    })
+  })
+
   describe('loadDefinition / listDefinitions', () => {
     it('loads a definition from file', () => {
       writeFileSync(join(defsDir, 'test.yaml'), `

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Workflow runtime tests for map_workflow fan-out/fan-in (#203).
+ * Fixtures: map-flow.yaml (source → map → after) + map-child.yaml in
+ * helpers/runtime-harness.ts; engine semantics per
+ * .claude/specs/workflow-map-fanout-design.md.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test'
+import { rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  taskStoreMock,
+  taskServiceMock,
+  resetRuntimeHarness,
+  seedWorkflowFixtures,
+  hookTasks,
+} from './helpers/runtime-harness'
+
+const testDir = join(tmpdir(), `bakin-test-runtime-map-${Date.now()}`)
+
+// ─── CRITICAL: Mock content-dir to prevent writes to ~/.bakin/ ─────────────
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+
+mock.module('../../../src/core/task-store', () => taskStoreMock)
+mock.module('@/core/task-store', () => taskStoreMock)
+
+mock.module('../../../src/core/task-service', taskServiceMock)
+mock.module('@/core/task-service', taskServiceMock)
+
+mock.module('../../../src/core/audit', () => ({
+  appendAudit: mock(),
+}))
+
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  }),
+}))
+
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => testDir,
+  getOpenClawPath: (...parts: string[]) => join(testDir, ...parts),
+  resetOpenClawHome: mock(),
+}))
+
+import {
+  createInstance,
+  loadInstance,
+  completeStep,
+  reopenFromStep,
+} from '@bakin/workflows/lib/runtime'
+import { invalidateSkillCache } from '@bakin/workflows/lib/skill-loader'
+import { setEventBus } from '@bakin/workflows/lib/notifications'
+import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
+
+/** Wait for fire-and-forget board-task promises to settle. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 20))
+
+describe('runtime — map_workflow', () => {
+  beforeEach(() => {
+    invalidateSkillCache()
+    resetRuntimeHarness()
+    seedWorkflowFixtures(testDir)
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+    getHookRegistry().clearAll()
+    setEventBus({ emit: () => {} } as never)
+  })
+
+  const items = ['clip-a', 'clip-b', 'clip-c']
+
+  const startAndFan = (taskId: string, sourceOutput: Record<string, unknown> = { items }) => {
+    createInstance(taskId, 'map-flow', testDir)
+    return completeStep(taskId, 'source-step', sourceOutput, undefined, testDir)
+  }
+
+  describe('fan-out', () => {
+    it('spawns one child per source item with stable ids, linkage, and item context', () => {
+      const result = startAndFan('task-map')
+      expect(result.success).toBe(true)
+
+      const parent = loadInstance('task-map', testDir)!
+      expect(parent.status).toBe('in_progress')
+      expect(parent.currentStepId).toBe('produce-items')
+
+      const state = parent.stepStates['produce-items']
+      expect(state.status).toBe('in_progress')
+      expect(state.children).toHaveLength(3)
+
+      for (let i = 0; i < 3; i++) {
+        const entry = state.children![i]
+        expect(entry.index).toBe(i)
+        expect(entry.childTaskId).toBe(`task-map--produce-items--${i}`)
+        expect(entry.status).toBe('in_progress')
+
+        const child = loadInstance(entry.childTaskId, testDir)!
+        expect(child.workflowId).toBe('map-child')
+        expect(child.parentTaskId).toBe('task-map')
+        expect(child.parentStepId).toBe('produce-items')
+        expect(child.status).toBe('in_progress')
+        // item under item_key, plus map coordinates, plus the source output
+        expect(child.parentContext).toMatchObject({
+          brief: items[i],
+          mapIndex: i,
+          mapTotal: 3,
+          items,
+        })
+      }
+    })
+
+    it('creates one board task per child titled {parent} — {label} {i+1}/{N}', async () => {
+      hookTasks.set('task-map-board', {
+        id: 'task-map-board',
+        title: 'Make variants',
+        column: 'inProgress',
+      })
+      startAndFan('task-map-board')
+      await settle()
+
+      for (let i = 0; i < 3; i++) {
+        const task = hookTasks.get(`task-map-board--produce-items--${i}`)
+        expect(task, `board task ${i}`).toBeDefined()
+        expect(task!.title).toBe(`Make variants — Produce Items ${i + 1}/3`)
+        expect(task!.column).toBe('inProgress')
+      }
+    })
+
+    it('falls back to a label-only board title when the parent task is unknown', async () => {
+      startAndFan('task-map-noparent')
+      await settle()
+      const task = hookTasks.get('task-map-noparent--produce-items--0')
+      expect(task).toBeDefined()
+      expect(task!.title).toBe('Produce Items 1/3 (sub-workflow)')
+    })
+
+    it('fails typed when the source key is missing', () => {
+      const result = startAndFan('task-map-nokey', { wrong: ['a'] })
+      // The source step itself completed fine; the failure is on the map step.
+      expect(result.success).toBe(true)
+
+      const parent = loadInstance('task-map-nokey', testDir)!
+      expect(parent.status).toBe('failed')
+      const state = parent.stepStates['produce-items']
+      expect(state.status).toBe('failed')
+      expect(state.code).toBe('map_source_invalid')
+      expect(state.error).toContain('items')
+      expect(state.children).toBeUndefined()
+      expect(loadInstance('task-map-nokey--produce-items--0', testDir)).toBeNull()
+      expect(parent.history.at(-1)).toMatchObject({ stepId: 'produce-items', status: 'failed' })
+    })
+
+    it('fails typed when the source value is not an array', () => {
+      startAndFan('task-map-notarray', { items: 'nope' })
+      const parent = loadInstance('task-map-notarray', testDir)!
+      expect(parent.status).toBe('failed')
+      expect(parent.stepStates['produce-items'].code).toBe('map_source_invalid')
+      expect(loadInstance('task-map-notarray--produce-items--0', testDir)).toBeNull()
+    })
+
+    it('fails typed with no partial spawn when items exceed max_children', () => {
+      startAndFan('task-map-over', { items: ['a', 'b', 'c', 'd', 'e'] })
+      const parent = loadInstance('task-map-over', testDir)!
+      expect(parent.status).toBe('failed')
+      const state = parent.stepStates['produce-items']
+      expect(state.code).toBe('map_source_invalid')
+      expect(state.error).toContain('max_children')
+      for (let i = 0; i < 5; i++) {
+        expect(loadInstance(`task-map-over--produce-items--${i}`, testDir)).toBeNull()
+      }
+    })
+
+    it('completes immediately and advances on an empty source array', () => {
+      startAndFan('task-map-empty', { items: [] })
+      const parent = loadInstance('task-map-empty', testDir)!
+      expect(parent.status).toBe('in_progress')
+      expect(parent.stepStates['produce-items'].status).toBe('complete')
+      expect(parent.stepStates['produce-items'].output).toEqual({ outputs: [] })
+      expect(parent.currentStepId).toBe('after-map')
+      expect(parent.stepStates['after-map'].status).toBe('in_progress')
+    })
+
+    it('recovers from map_source_invalid via reopenFromStep on the source step', () => {
+      startAndFan('task-map-recover', { wrong: ['a'] })
+      expect(loadInstance('task-map-recover', testDir)!.status).toBe('failed')
+
+      const reopened = reopenFromStep('task-map-recover', {
+        stepId: 'source-step',
+        reason: 'produce a real array this time',
+        contentDir: testDir,
+      })
+      expect(reopened.success).toBe(true)
+
+      const afterReopen = loadInstance('task-map-recover', testDir)!
+      expect(afterReopen.status).toBe('in_progress')
+      expect(afterReopen.stepStates['produce-items'].status).toBe('pending')
+      expect(afterReopen.stepStates['produce-items'].code).toBeUndefined()
+
+      const result = completeStep('task-map-recover', 'source-step', { items: ['x'] }, undefined, testDir)
+      expect(result.success).toBe(true)
+      const parent = loadInstance('task-map-recover', testDir)!
+      expect(parent.stepStates['produce-items'].status).toBe('in_progress')
+      expect(parent.stepStates['produce-items'].children).toHaveLength(1)
+    })
+
+    it('re-fan-out after source reopen reuses child ids and cancels stale children', () => {
+      startAndFan('task-map-refan')
+      // All three children live. Now rewind the source step.
+      const reopened = reopenFromStep('task-map-refan', {
+        stepId: 'source-step',
+        reason: 'redo segmentation',
+        contentDir: testDir,
+      })
+      expect(reopened.success).toBe(true)
+
+      // Old children still on disk, still in_progress (sweep happens at re-fan-out).
+      expect(loadInstance('task-map-refan--produce-items--2', testDir)!.status).toBe('in_progress')
+
+      // Re-complete the source with FEWER items — narrower fan.
+      completeStep('task-map-refan', 'source-step', { items: ['only-a', 'only-b'] }, undefined, testDir)
+
+      const parent = loadInstance('task-map-refan', testDir)!
+      const state = parent.stepStates['produce-items']
+      expect(state.children).toHaveLength(2)
+
+      // Reused ids are fresh in_progress instances with the new items.
+      const child0 = loadInstance('task-map-refan--produce-items--0', testDir)!
+      expect(child0.status).toBe('in_progress')
+      expect(child0.parentContext?.brief).toBe('only-a')
+
+      // The orphaned third child was cancelled by the sweep.
+      expect(loadInstance('task-map-refan--produce-items--2', testDir)!.status).toBe('cancelled')
+    })
+
+    it('persists fan-out state across a reload (crash-restart)', () => {
+      startAndFan('task-map-reload')
+      // Fresh read from disk — nothing held in memory.
+      const parent = loadInstance('task-map-reload', testDir)!
+      expect(parent.stepStates['produce-items'].children).toHaveLength(3)
+      expect(parent.stepStates['produce-items'].children![1]).toMatchObject({
+        index: 1,
+        childTaskId: 'task-map-reload--produce-items--1',
+        status: 'in_progress',
+      })
+      const child = loadInstance('task-map-reload--produce-items--1', testDir)!
+      expect(child.parentStepId).toBe('produce-items')
+    })
+
+    it('defensively fails a first-step map on non-validating createInstance paths', () => {
+      const instance = createInstance('task-map-first', 'map-first', testDir)
+      expect(instance.status).toBe('failed')
+      expect(instance.stepStates['fan'].status).toBe('failed')
+      expect(instance.stepStates['fan'].code).toBe('map_source_invalid')
+    })
+  })
+})

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -276,4 +276,95 @@ describe('runtime — map_workflow', () => {
       expect(instance.stepStates['fan'].code).toBe('map_source_invalid')
     })
   })
+
+  describe('fan-in (join)', () => {
+    const completeChild = (taskId: string, i: number, output?: Record<string, unknown>) =>
+      completeStep(`${taskId}--produce-items--${i}`, 'do-work', output ?? { made: items[i] }, undefined, testDir)
+
+    it('aggregates child outputs in source order regardless of completion order', () => {
+      startAndFan('task-join')
+      for (const i of [2, 0, 1]) {
+        expect(completeChild('task-join', i).success).toBe(true)
+      }
+
+      const parent = loadInstance('task-join', testDir)!
+      const state = parent.stepStates['produce-items']
+      expect(state.status).toBe('complete')
+      expect(state.output).toEqual({
+        outputs: [{ made: 'clip-a' }, { made: 'clip-b' }, { made: 'clip-c' }],
+      })
+      expect(parent.currentStepId).toBe('after-map')
+      expect(parent.stepStates['after-map'].status).toBe('in_progress')
+      expect(parent.history.at(-1)).toMatchObject({ stepId: 'produce-items', status: 'complete' })
+    })
+
+    it('leaves the map step in_progress until every child completes', () => {
+      startAndFan('task-partial')
+      completeChild('task-partial', 0, { made: 'a' })
+
+      const parent = loadInstance('task-partial', testDir)!
+      const state = parent.stepStates['produce-items']
+      expect(state.status).toBe('in_progress')
+      expect(state.children![0].status).toBe('complete')
+      expect(state.children![0].output).toEqual({ made: 'a' })
+      expect(state.children![1].status).toBe('in_progress')
+      expect(state.children![2].status).toBe('in_progress')
+      expect(parent.currentStepId).toBe('produce-items')
+    })
+
+    it('moves each completed child board task to done as it finishes', async () => {
+      startAndFan('task-board-done')
+      await settle()
+      completeChild('task-board-done', 1)
+      await settle()
+      expect(hookTasks.get('task-board-done--produce-items--1')!.column).toBe('done')
+      expect(hookTasks.get('task-board-done--produce-items--0')!.column).toBe('inProgress')
+    })
+
+    it('completes the parent workflow after the map when the remaining steps finish', () => {
+      startAndFan('task-full')
+      for (const i of [0, 1, 2]) completeChild('task-full', i)
+      const result = completeStep('task-full', 'after-map', { done: true }, undefined, testDir)
+      expect(result.success).toBe(true)
+      expect(result.workflowComplete).toBe(true)
+      expect(loadInstance('task-full', testDir)!.status).toBe('complete')
+    })
+
+    it('propagates a map join upward through nested workflow recursion', () => {
+      // Grandparent (map-wrapper) → child (map-flow, spawned as first step) →
+      // grandchildren (map-child ×N).
+      createInstance('task-grand', 'map-wrapper', testDir)
+      const childTaskId = 'task-grand--run-map-flow'
+      expect(loadInstance(childTaskId, testDir)).not.toBeNull()
+
+      completeStep(childTaskId, 'source-step', { items: ['x', 'y'] }, undefined, testDir)
+      for (const i of [1, 0]) {
+        completeStep(`${childTaskId}--produce-items--${i}`, 'do-work', { made: i }, undefined, testDir)
+      }
+      // Child's map joined; finish the child's tail step → child completes →
+      // propagation marks the grandparent's nested step complete and advances.
+      completeStep(childTaskId, 'after-map', { wrapped: true }, undefined, testDir)
+
+      const grand = loadInstance('task-grand', testDir)!
+      expect(grand.stepStates['run-map-flow'].status).toBe('complete')
+      expect(grand.currentStepId).toBe('wrap-after')
+      const child = loadInstance(childTaskId, testDir)!
+      expect(child.status).toBe('complete')
+      expect(child.stepStates['produce-items'].output).toEqual({ outputs: [{ made: 0 }, { made: 1 }] })
+    })
+
+    it('is idempotent on duplicate child-completion propagation', () => {
+      startAndFan('task-dup')
+      completeChild('task-dup', 0)
+      const afterFirst = loadInstance('task-dup', testDir)!
+      // A second submission against the already-complete child step is refused
+      // upstream, and the parent entry stays complete either way.
+      const dup = completeStep('task-dup--produce-items--0', 'do-work', { made: 'again' }, undefined, testDir)
+      expect(dup.success).toBe(false)
+      const parent = loadInstance('task-dup', testDir)!
+      expect(parent.stepStates['produce-items'].children![0]).toEqual(
+        afterFirst.stepStates['produce-items'].children![0],
+      )
+    })
+  })
 })

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -70,6 +70,9 @@ import {
   loadInstance,
   completeStep,
   reopenFromStep,
+  cancelInstance,
+  getCurrentStep,
+  getActiveAgents,
 } from '@bakin/workflows/lib/runtime'
 import { invalidateSkillCache } from '@bakin/workflows/lib/skill-loader'
 import { setEventBus } from '@bakin/workflows/lib/notifications'
@@ -365,6 +368,74 @@ describe('runtime — map_workflow', () => {
       expect(parent.stepStates['produce-items'].children![0]).toEqual(
         afterFirst.stepStates['produce-items'].children![0],
       )
+    })
+  })
+
+  describe('child-aware surfaces', () => {
+    const completeChild = (taskId: string, i: number) =>
+      completeStep(`${taskId}--produce-items--${i}`, 'do-work', { made: items[i] }, undefined, testDir)
+
+    it('cancel-parent sweeps live children and leaves completed ones untouched', async () => {
+      startAndFan('task-sweep')
+      await settle() // board tasks are fire-and-forget; let them land before cancelling
+      completeChild('task-sweep', 0)
+      cancelInstance('task-sweep', testDir)
+      await settle()
+
+      expect(loadInstance('task-sweep', testDir)!.status).toBe('cancelled')
+      expect(loadInstance('task-sweep--produce-items--0', testDir)!.status).toBe('complete')
+      expect(loadInstance('task-sweep--produce-items--1', testDir)!.status).toBe('cancelled')
+      expect(loadInstance('task-sweep--produce-items--2', testDir)!.status).toBe('cancelled')
+
+      const entries = loadInstance('task-sweep', testDir)!.stepStates['produce-items'].children!
+      expect(entries.map((e) => e.status)).toEqual(['complete', 'cancelled', 'cancelled'])
+      expect(hookTasks.get('task-sweep--produce-items--1')!.column).toBe('done')
+    })
+
+    it('getActiveAgents unions the live children with effectiveTaskIds', () => {
+      startAndFan('task-agents')
+      const before = getActiveAgents('task-agents', testDir)
+      expect(before).toHaveLength(3)
+      for (let i = 0; i < 3; i++) {
+        expect(before[i]).toEqual({
+          agent: 'pixel',
+          stepId: 'do-work',
+          effectiveTaskId: `task-agents--produce-items--${i}`,
+        })
+      }
+
+      completeChild('task-agents', 1)
+      const after = getActiveAgents('task-agents', testDir)
+      expect(after.map((a) => a.effectiveTaskId)).toEqual([
+        'task-agents--produce-items--0',
+        'task-agents--produce-items--2',
+      ])
+    })
+
+    it('getCurrentStep returns null mid-map and a typed failed context after map_source_invalid', () => {
+      startAndFan('task-ctx')
+      expect(getCurrentStep('task-ctx', undefined, testDir)).toBeNull()
+
+      createInstance('task-ctx-fail', 'map-flow', testDir)
+      const result = completeStep('task-ctx-fail', 'source-step', { wrong: [] }, undefined, testDir)
+      expect(result.success).toBe(true)
+      expect(result.nextStep).toMatchObject({ status: 'failed', stepId: 'produce-items', code: 'map_source_invalid' })
+
+      const ctx = getCurrentStep('task-ctx-fail', undefined, testDir)
+      expect(ctx).toMatchObject({ status: 'failed', stepId: 'produce-items', code: 'map_source_invalid' })
+    })
+
+    it('refuses to reopen AT a map step — recovery is the source step or per-child retry', () => {
+      startAndFan('task-noreopen')
+      const result = reopenFromStep('task-noreopen', {
+        stepId: 'produce-items',
+        reason: 'nope',
+        contentDir: testDir,
+      })
+      expect(result.success).toBe(false)
+      expect((result as { errors: string[] }).errors[0]).toContain('source step')
+      // Nothing was reset.
+      expect(loadInstance('task-noreopen', testDir)!.stepStates['produce-items'].children).toHaveLength(3)
     })
   })
 })


### PR DESCRIPTION
## Summary

PR1 of 4 for #203, implementing the engine core of `map_workflow` per the approved design (`.claude/specs/workflow-map-fanout-design.md`) and spec/plan (`.claude/specs/map-workflow-and-multi-image-select{,-plan}.md`, committed here):

- **Types + registry:** `MapWorkflowStep` (`source`/`workflow_id`/`item_key`/`max_children`) joins the union; strict zod schema, form fields, `BUILTIN_KINDS`, discriminated union — 7th builtin.
- **Validation:** `source` must be `<stepId>.<outputKey>` naming an earlier top-level step; `workflow_id` reuses the nested three-tier existence model; start-time cycle detection walks map refs; gate `on_reject.goto` may not target a map step; nested maps warn via the definitions health check.
- **Fan-out:** one child instance per source-array element (`{task}--{step}--{i}`, item + `mapIndex`/`mapTotal` in parentContext, fraction-titled board tasks). Invalid source fails typed (`StepState.code = 'map_source_invalid'`, zero children); empty arrays complete and advance; re-fan-out after a source rewind sweeps stale children.
- **Fan-in:** map-aware `propagateChildCompletion` — per-child entry updates, join only when ALL complete, `{ outputs: [...] }` aggregated in stable source order, nested recursion propagates upward.
- **Child-aware surfaces:** `cancelInstance` sweeps `children[]`; `getActiveAgents` unions live children (dispatch fans correctly); `getCurrentStep` returns a typed `failed` context; reopen-at-map refused (recovery = source step / per-child retry, PR2).
- **Budget:** pinned that map aggregates ride the existing `maxWorkflowContextBytes` cap with visible markers — zero new wiring.

## Test plan
- 21 new engine tests (`tests/plugins/workflows/runtime-map.test.ts`) + validation/health/schema/budget coverage across 5 suites
- Full suite: 5793 tests, 0 fail; typecheck + lint clean

Next: PR2 per-child retry/cancel + join-blocking surfaces; PR3 UI; PR4 consolidate tool + Multi-Image Select workflow + rig E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)