### PR TITLE
feat(workflows): map_workflow per-child recovery (#203 PR2)

### DIFF
--- a/plugins/workflows/lib/engine.ts
+++ b/plugins/workflows/lib/engine.ts
@@ -148,6 +148,31 @@ export function createInstance(
 // ─── Map Fan-out ────────────────────────────────────────────────────────────
 
 /**
+ * Rebuild the parentContext a map child at `index` receives: the source
+ * step's full output plus the item under item_key and its map coordinates.
+ * Shared by fan-out and per-child retry (map-children.ts) so a re-created
+ * child always sees exactly what the original spawn saw. Returns null when
+ * the source no longer resolves an array containing `index`.
+ */
+export function buildMapChildContext(
+  instance: WorkflowInstance,
+  mapStep: MapWorkflowStep,
+  index: number,
+): Record<string, unknown> | null {
+  const dotIdx = mapStep.source.indexOf('.')
+  if (dotIdx <= 0) return null
+  const sourceOutput = instance.stepStates[mapStep.source.slice(0, dotIdx)]?.output
+  const items = sourceOutput?.[mapStep.source.slice(dotIdx + 1)]
+  if (!Array.isArray(items) || index < 0 || index >= items.length) return null
+  return {
+    ...(sourceOutput || {}),
+    [mapStep.item_key ?? 'item']: items[index],
+    mapIndex: index,
+    mapTotal: items.length,
+  }
+}
+
+/**
  * Fan out a map_workflow step: one child workflow instance per element of the
  * source step's output array. Invalid sources fail typed (map_source_invalid)
  * with zero children spawned; empty arrays complete immediately and advance.
@@ -221,18 +246,12 @@ function fanOutMapStep(
     }
   }
 
-  const itemKey = mapStep.item_key ?? 'item'
   const total = value.length
   const childDef = loadDefinition(mapStep.workflow_id, contentDir)
   const children: MapChildEntry[] = []
   for (let i = 0; i < total; i++) {
     const childTaskId = `${childIdPrefix}${i}`
-    const childParentContext: Record<string, unknown> = {
-      ...(sourceOutput || {}),
-      [itemKey]: value[i],
-      mapIndex: i,
-      mapTotal: total,
-    }
+    const childParentContext = buildMapChildContext(instance, mapStep, i) ?? {}
     const childInstance = createInstance(childTaskId, mapStep.workflow_id, contentDir, instance.resolvedAgent, childParentContext, instance.availableAgents)
     childInstance.parentTaskId = instance.taskId
     childInstance.parentStepId = mapStep.id

--- a/plugins/workflows/lib/exec-tools.ts
+++ b/plugins/workflows/lib/exec-tools.ts
@@ -12,7 +12,7 @@ import type { PluginContext } from '@bakin/core/plugin-types'
 import type { WorkflowDefinition } from '../types'
 import { buildTemplateList, resolveSubWorkflows } from './template-list'
 import { loadDefinition, findStep } from './parser'
-import { getCurrentStep, completeStep, listInstances, loadInstance } from './runtime'
+import { getCurrentStep, completeStep, listInstances, loadInstance, retryMapChild, cancelMapChild } from './runtime'
 import { createValidatedInstance } from './start-validation'
 import { indexInstance } from './search-sync'
 import { triggerDispatch } from './trigger-dispatch'
@@ -164,6 +164,56 @@ export function registerWorkflowExecTools(ctx: PluginContext): void {
       }
 
       return { ok: true, workflowComplete: result.workflowComplete, nextStep: result.nextStep }
+    },
+  })
+
+  ctx.registerExecTool({
+    name: 'bakin_exec_workflows_retry_map_child',
+    label: 'Retried map child',
+    activityDuplicate: true,
+    description: 'Retry one fan-out child of a map_workflow step. Live children reopen in place; dead/cancelled children are re-created under the same child task id with their original item context. Unblocks a blocked map join without rewinding the parent.',
+    parameters: {
+      taskId: z.string().describe('PARENT task ID (the instance holding the map step)'),
+      stepId: z.string().describe('The map_workflow step ID'),
+      index: z.number().int().min(0).describe('Child index within the fan-out (0-based)'),
+      reason: z.string().optional().describe('Why this child is being retried'),
+    },
+    handler: async (params: Record<string, unknown>, agent: string) => {
+      const taskId = params.taskId as string
+      const stepId = params.stepId as string
+      const index = params.index as number
+
+      const result = retryMapChild(taskId, stepId, index, { reason: params.reason as string | undefined })
+      if (!result.success) return { ok: false, error: 'Map child retry failed', errors: result.errors }
+
+      ctx.activity.audit('map_child.retried', agent, { taskId, stepId, index, reason: params.reason })
+      indexInstance(taskId).catch(() => {})
+      triggerDispatch()
+      return { ok: true, childTaskId: `${taskId}--${stepId}--${index}` }
+    },
+  })
+
+  ctx.registerExecTool({
+    name: 'bakin_exec_workflows_cancel_map_child',
+    label: 'Cancelled map child',
+    activityDuplicate: true,
+    description: 'Cancel one fan-out child of a map_workflow step. The map join stays blocked until the child is retried or the whole parent is cancelled — children are never silently skipped.',
+    parameters: {
+      taskId: z.string().describe('PARENT task ID (the instance holding the map step)'),
+      stepId: z.string().describe('The map_workflow step ID'),
+      index: z.number().int().min(0).describe('Child index within the fan-out (0-based)'),
+    },
+    handler: async (params: Record<string, unknown>, agent: string) => {
+      const taskId = params.taskId as string
+      const stepId = params.stepId as string
+      const index = params.index as number
+
+      const result = cancelMapChild(taskId, stepId, index)
+      if (!result.success) return { ok: false, error: 'Map child cancel failed', errors: result.errors }
+
+      ctx.activity.audit('map_child.cancelled', agent, { taskId, stepId, index })
+      indexInstance(taskId).catch(() => {})
+      return { ok: true }
     },
   })
 

--- a/plugins/workflows/lib/map-children.ts
+++ b/plugins/workflows/lib/map-children.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-child recovery operations for map_workflow steps (#203).
+ *
+ * The unit of retry is the CHILD, never the parent: a live child reopens in
+ * place (reopenFromStep); a terminally dead (cancelled/failed/missing) child
+ * is re-created under the same childTaskId with its item context rebuilt from
+ * the parent's source-step output — the single source of truth. The join in
+ * propagateChildCompletion is untouched: these ops only change child state
+ * and the parent's children[] bookkeeping, so a blocked join unblocks the
+ * moment the retried child completes.
+ */
+import type { WorkflowInstance, MapWorkflowStep, MapChildEntry, InstanceStatus } from '../types'
+import { loadDefinition, findStep } from './parser'
+import { getContentDir } from './content-dir'
+import { createLogger } from '@bakin/core/logger'
+import { loadInstance, saveInstance } from './instance-store'
+import { createInstance, cancelInstance, buildMapChildContext } from './engine'
+import { reopenFromStep } from './gates'
+import { createBoardTaskForChild, moveTaskInStore } from './task-bridge'
+
+const log = createLogger('workflow-runtime')
+
+export interface MapChildOpResult {
+  success: boolean
+  errors?: string[]
+}
+
+export interface MapChildInfo {
+  index: number
+  childTaskId: string
+  /** The parent's join bookkeeping for this child. */
+  entryStatus: MapChildEntry['status']
+  /** The child instance's actual status — 'missing' when its file is gone. */
+  liveStatus: InstanceStatus | 'missing'
+  currentStepId?: string
+  workflowId?: string
+  output?: Record<string, unknown>
+}
+
+interface ResolvedMapChild {
+  parent: WorkflowInstance
+  mapStep: MapWorkflowStep
+  entry: MapChildEntry
+}
+
+function resolveMapChild(
+  parentTaskId: string,
+  stepId: string,
+  index: number,
+  dir: string,
+): ResolvedMapChild | { errors: string[] } {
+  const parent = loadInstance(parentTaskId, dir)
+  if (!parent) return { errors: ['Workflow instance not found'] }
+  const def = loadDefinition(parent.workflowId, dir)
+  if (!def) return { errors: ['Workflow definition not found'] }
+  const step = findStep(def, stepId)
+  if (!step || step.type !== 'map_workflow') {
+    return { errors: [`Step "${stepId}" is not a map_workflow step`] }
+  }
+  const entry = parent.stepStates[stepId]?.children?.find((c) => c.index === index)
+  if (!entry) return { errors: [`No map child at index ${index} for step "${stepId}"`] }
+  return { parent, mapStep: step as MapWorkflowStep, entry }
+}
+
+/** Cancel one fan-out child: child instance cancelled, entry marked, board task retired. */
+export function cancelMapChild(
+  parentTaskId: string,
+  stepId: string,
+  index: number,
+  contentDir?: string,
+): MapChildOpResult {
+  const dir = contentDir || getContentDir()
+  const resolved = resolveMapChild(parentTaskId, stepId, index, dir)
+  if ('errors' in resolved) return { success: false, errors: resolved.errors }
+  const { parent, entry } = resolved
+  if (entry.status === 'complete') {
+    return { success: false, errors: ['Child already completed — nothing to cancel'] }
+  }
+
+  cancelInstance(entry.childTaskId, dir)
+  entry.status = 'cancelled'
+  parent.updatedAt = new Date().toISOString()
+  saveInstance(parent, dir)
+  moveTaskInStore(entry.childTaskId, 'done').catch((err) => {
+    log.warn('Failed to retire cancelled map child task', err)
+  })
+  return { success: true }
+}
+
+/**
+ * Retry one fan-out child. Live children reopen in place; terminally dead or
+ * missing children are re-created under the same childTaskId. Either way the
+ * parent entry returns to in_progress so the join waits for the fresh run.
+ */
+export function retryMapChild(
+  parentTaskId: string,
+  stepId: string,
+  index: number,
+  opts: { reason?: string; contentDir?: string } = {},
+): MapChildOpResult {
+  const dir = opts.contentDir || getContentDir()
+  const resolved = resolveMapChild(parentTaskId, stepId, index, dir)
+  if ('errors' in resolved) return { success: false, errors: resolved.errors }
+  const { parent, mapStep, entry } = resolved
+  if (entry.status === 'complete') {
+    return { success: false, errors: ['Child already completed — nothing to retry'] }
+  }
+  if (parent.status === 'cancelled' || parent.status === 'complete') {
+    return { success: false, errors: [`Parent workflow is ${parent.status} — children cannot be retried`] }
+  }
+
+  const reason = opts.reason || 'Map child retry requested'
+  const child = loadInstance(entry.childTaskId, dir)
+  if (child && (child.status === 'in_progress' || child.status === 'pending_approval')) {
+    const reopened = reopenFromStep(entry.childTaskId, { reason, contentDir: dir })
+    if (!reopened.success) return { success: false, errors: reopened.errors }
+  } else {
+    // Terminally dead (cancelled/failed) or missing — re-create with the item
+    // context rebuilt from the parent's source-step output.
+    const context = buildMapChildContext(parent, mapStep, index)
+    if (!context) {
+      return {
+        success: false,
+        errors: [`Source "${mapStep.source}" no longer resolves an item at index ${index} — re-run the source step instead`],
+      }
+    }
+    const childInstance = createInstance(entry.childTaskId, mapStep.workflow_id, dir, parent.resolvedAgent, context, parent.availableAgents)
+    childInstance.parentTaskId = parent.taskId
+    childInstance.parentStepId = mapStep.id
+    saveInstance(childInstance, dir)
+    const total = parent.stepStates[stepId].children?.length ?? index + 1
+    createBoardTaskForChild(entry.childTaskId, parent.taskId, mapStep, loadDefinition(mapStep.workflow_id, dir), parent.resolvedAgent, { index, total })
+  }
+
+  entry.status = 'in_progress'
+  delete entry.output
+  parent.updatedAt = new Date().toISOString()
+  saveInstance(parent, dir)
+  return { success: true }
+}
+
+/**
+ * List a map step's children with LIVE instance statuses. The cached entry
+ * can lag reality (e.g. a child cancelled out-of-band still reads
+ * in_progress in the parent) — UIs need the truth to offer retry/cancel.
+ */
+export function listMapChildren(
+  parentTaskId: string,
+  stepId: string,
+  contentDir?: string,
+): { success: true; children: MapChildInfo[] } | { success: false; errors: string[] } {
+  const dir = contentDir || getContentDir()
+  const parent = loadInstance(parentTaskId, dir)
+  if (!parent) return { success: false, errors: ['Workflow instance not found'] }
+  const entries = parent.stepStates[stepId]?.children
+  if (!entries) return { success: false, errors: [`Step "${stepId}" has no map children`] }
+
+  const children = entries.map((entry): MapChildInfo => {
+    const child = loadInstance(entry.childTaskId, dir)
+    return {
+      index: entry.index,
+      childTaskId: entry.childTaskId,
+      entryStatus: entry.status,
+      liveStatus: child?.status ?? 'missing',
+      currentStepId: child?.currentStepId,
+      workflowId: child?.workflowId,
+      output: entry.output,
+    }
+  })
+  return { success: true, children }
+}

--- a/plugins/workflows/lib/register-hooks.ts
+++ b/plugins/workflows/lib/register-hooks.ts
@@ -22,6 +22,9 @@ import {
   isGateNotified,
   markGateNotified,
   cancelInstance,
+  retryMapChild,
+  cancelMapChild,
+  listMapChildren,
   type WorkflowToolUseAction,
 } from './runtime'
 import { createValidatedInstance } from './start-validation'
@@ -67,6 +70,12 @@ export function registerWorkflowHooks(ctx: PluginContext): void {
   ctx.hooks.register('workflows.isGateNotified', (d: Record<string, unknown>) => isGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Check gate notification.', summary: 'Checks whether a workflow gate notification has already been sent. Use it to avoid duplicate alerts for the same task and gate step.', hookKind: 'rpc' })
   ctx.hooks.register('workflows.markGateNotified', (d: Record<string, unknown>) => markGateNotified(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'Mark gate notified.', summary: 'Records that a workflow gate notification was sent. Use it immediately after notifying a reviewer or channel so future checks can suppress duplicates.', hookKind: 'rpc' })
   ctx.hooks.register('workflows.validateStepOutput', (d: Record<string, unknown>) => validateStepOutput(d.schema as Record<string, unknown> | undefined, d.output as Record<string, unknown>), { label: 'Validate step output.', summary: 'Validates workflow step output against the step schema. Use it before accepting agent or tool output that should advance a workflow.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.retryMapChild', (d: Record<string, unknown>) => retryMapChild(d.taskId as string, d.stepId as string, d.index as number, {
+    reason: d.reason as string | undefined,
+    contentDir: d.contentDir as string | undefined,
+  }), { label: 'Retry map child.', summary: 'Retries one fan-out child of a map_workflow step: live children reopen in place, dead ones re-create under the same child task id. Use it to unblock a map join without rewinding the parent.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.cancelMapChild', (d: Record<string, unknown>) => cancelMapChild(d.taskId as string, d.stepId as string, d.index as number, d.contentDir as string | undefined), { label: 'Cancel map child.', summary: 'Cancels one fan-out child of a map_workflow step. The join stays blocked until the child is retried or the parent is cancelled — silently skipping children is never the default.', hookKind: 'rpc' })
+  ctx.hooks.register('workflows.listMapChildren', (d: Record<string, unknown>) => listMapChildren(d.taskId as string, d.stepId as string, d.contentDir as string | undefined), { label: 'List map children.', summary: 'Lists a map_workflow step\'s fan-out children with LIVE instance statuses (the parent\'s cached entries can lag out-of-band changes). Use it to drive recovery UIs.', hookKind: 'rpc' })
   ctx.hooks.register('workflows.cancelInstance', (d: Record<string, unknown>) => {
     cancelInstance(d.taskId as string, d.contentDir as string | undefined)
   }, { label: 'Cancel workflow instance.', summary: 'Cancels the workflow instance attached to a task. Use it when task state changes make the workflow no longer relevant or safe to continue.', hookKind: 'event' })

--- a/plugins/workflows/lib/routes/instances.ts
+++ b/plugins/workflows/lib/routes/instances.ts
@@ -10,7 +10,7 @@ import { z } from 'zod'
 import { defineRoute } from '@bakin/core/routing'
 import type { PluginContextLite } from '@bakin/core/routing'
 import { getTask, updateTask } from '../../../../src/core/task-store'
-import { getCurrentStep, completeStep, listInstances, loadInstance } from '../runtime'
+import { getCurrentStep, completeStep, listInstances, loadInstance, retryMapChild, cancelMapChild, listMapChildren } from '../runtime'
 import { createValidatedInstance } from '../start-validation'
 import { getWorkflowPluginContext } from '../plugin-context'
 import { indexInstance } from '../search-sync'
@@ -130,6 +130,64 @@ const startHandler = async (req: Request, ctx: PluginContextLite) => {
   }
 }
 
+// Shared param plumbing for the map-child routes: the router surfaces path
+// params via searchParams (see /steps/:taskId above).
+const readMapChildParams = (req: Request): { taskId: string; stepId: string; index?: number } | null => {
+  const url = new URL(req.url)
+  const taskId = url.searchParams.get('taskId')
+  const stepId = url.searchParams.get('stepId')
+  if (!taskId || !stepId) return null
+  const rawIndex = url.searchParams.get('index')
+  const index = rawIndex === null ? undefined : Number(rawIndex)
+  if (index !== undefined && !Number.isInteger(index)) return null
+  return { taskId, stepId, index }
+}
+
+const listMapChildrenHandler = async (req: Request, _ctx: PluginContextLite) => {
+  const params = readMapChildParams(req)
+  if (!params) return Response.json({ error: 'taskId and stepId are required' }, { status: 400 })
+  const result = listMapChildren(params.taskId, params.stepId)
+  if (!result.success) return Response.json({ error: result.errors[0], errors: result.errors }, { status: 404 })
+  return Response.json({ children: result.children })
+}
+
+const retryMapChildHandler = async (req: Request, ctx: PluginContextLite) => {
+  const params = readMapChildParams(req)
+  if (!params || params.index === undefined) {
+    return Response.json({ error: 'taskId, stepId, and index are required' }, { status: 400 })
+  }
+  let body: { reason?: string } = {}
+  try { body = await req.json() } catch { /* empty body is fine */ }
+
+  const result = retryMapChild(params.taskId, params.stepId, params.index, { reason: body.reason })
+  if (!result.success) {
+    return Response.json({ error: 'Map child retry failed', errors: result.errors }, { status: 400 })
+  }
+
+  ctx.activity.audit('map_child.retried', 'user', { taskId: params.taskId, stepId: params.stepId, index: params.index, reason: body.reason })
+  ctx.activity.log('user', `Retried map child ${params.index} of "${params.stepId}"`, { taskId: params.taskId })
+  indexInstance(params.taskId).catch(() => {})
+  triggerDispatch()
+  return Response.json(result)
+}
+
+const cancelMapChildHandler = async (req: Request, ctx: PluginContextLite) => {
+  const params = readMapChildParams(req)
+  if (!params || params.index === undefined) {
+    return Response.json({ error: 'taskId, stepId, and index are required' }, { status: 400 })
+  }
+
+  const result = cancelMapChild(params.taskId, params.stepId, params.index)
+  if (!result.success) {
+    return Response.json({ error: 'Map child cancel failed', errors: result.errors }, { status: 400 })
+  }
+
+  ctx.activity.audit('map_child.cancelled', 'user', { taskId: params.taskId, stepId: params.stepId, index: params.index })
+  ctx.activity.log('user', `Cancelled map child ${params.index} of "${params.stepId}"`, { taskId: params.taskId })
+  indexInstance(params.taskId).catch(() => {})
+  return Response.json(result)
+}
+
 export const instanceRoutes = [
   defineRoute({ path: '/steps/:taskId', method: 'GET', description: 'Get current workflow step for a task', summary: 'Get current workflow step for a task', params: z.object({ taskId: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: getStepHandler }),
   defineRoute({ path: '/steps/:taskId/complete', method: 'POST', description: 'Submit step output, validates against schema, advances workflow', summary: 'Submit step output, validates against schema, advances workflow', params: z.object({ taskId: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: completeStepHandler }),
@@ -148,4 +206,7 @@ export const instanceRoutes = [
   }),
   defineRoute({ path: '/instances/:taskId', method: 'GET', description: 'Get full workflow instance state for a task', summary: 'Get full workflow instance state for a task', params: z.object({ taskId: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: getInstanceHandler }),
   defineRoute({ path: '/instances/start', method: 'POST', description: 'Start a workflow instance for a task', summary: 'Start a workflow instance for a task', responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: startHandler }),
+  defineRoute({ path: '/instances/:taskId/map/:stepId/children', method: 'GET', description: 'List a map step\'s fan-out children with live child-instance statuses', summary: 'List map children with live statuses', params: z.object({ taskId: z.string(), stepId: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: listMapChildrenHandler }),
+  defineRoute({ path: '/instances/:taskId/map/:stepId/children/:index/retry', method: 'POST', description: 'Retry one map child: live children reopen in place, dead ones re-create under the same child task id', summary: 'Retry a map child', params: z.object({ taskId: z.string(), stepId: z.string(), index: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: retryMapChildHandler }),
+  defineRoute({ path: '/instances/:taskId/map/:stepId/children/:index/cancel', method: 'POST', description: 'Cancel one map child; the join stays blocked until it is retried or the parent is cancelled', summary: 'Cancel a map child', params: z.object({ taskId: z.string(), stepId: z.string(), index: z.string() }), responses: { 200: passthroughWf, 201: passthroughWf, 400: errorResponseWf, 403: errorResponseWf, 404: errorResponseWf, 409: errorResponseWf, 500: errorResponseWf }, handler: cancelMapChildHandler }),
 ]

--- a/plugins/workflows/lib/runtime.ts
+++ b/plugins/workflows/lib/runtime.ts
@@ -60,6 +60,15 @@ export {
   type CompleteStepResult,
 } from './engine'
 
+// ─── Map-child recovery (per-child retry/cancel/list) ───────────────────────
+export {
+  retryMapChild,
+  cancelMapChild,
+  listMapChildren,
+  type MapChildOpResult,
+  type MapChildInfo,
+} from './map-children'
+
 // ─── Gate operations (human approval) ───────────────────────────────────────
 export {
   approveGate,

--- a/tests/plugins/workflows/helpers/runtime-harness.ts
+++ b/tests/plugins/workflows/helpers/runtime-harness.ts
@@ -287,6 +287,47 @@ steps:
     description: Work one item
 `
 
+// Map child WITH a gate — proves child gate approvals flow to the join
+export const mapGatedChildWorkflow = `
+name: Map Gated Child
+description: Map child containing a gate
+version: 1
+steps:
+  - id: work
+    type: agent
+    label: Work
+    agent: pixel
+  - id: check
+    type: gate
+    label: Check
+    approval_required: true
+  - id: finish
+    type: agent
+    label: Finish
+    agent: pixel
+`
+
+// Map parent whose children carry gates
+export const mapGatedWorkflow = `
+name: Map Gated Flow
+description: Fan-out into gated children
+version: 1
+steps:
+  - id: source-step
+    type: agent
+    label: Segment
+    agent: chef
+  - id: produce-items
+    type: map_workflow
+    label: Produce Items
+    source: source-step.items
+    workflow_id: map-gated-child
+  - id: after-map
+    type: agent
+    label: After Map
+    agent: main
+`
+
 // Nested recursion: a parent whose child workflow (map-flow) contains the map
 export const mapWrapperWorkflow = `
 name: Map Wrapper
@@ -368,5 +409,7 @@ export function seedWorkflowFixtures(testDir: string): void {
   writeFileSync(join(defsDir, 'map-child.yaml'), mapChildWorkflow)
   writeFileSync(join(defsDir, 'map-first.yaml'), mapFirstWorkflow)
   writeFileSync(join(defsDir, 'map-wrapper.yaml'), mapWrapperWorkflow)
+  writeFileSync(join(defsDir, 'map-gated-child.yaml'), mapGatedChildWorkflow)
+  writeFileSync(join(defsDir, 'map-gated.yaml'), mapGatedWorkflow)
   writeFileSync(join(skillsDir, 'test-skill.md'), testSkillMarkdown)
 }

--- a/tests/plugins/workflows/map-child-surfaces.test.ts
+++ b/tests/plugins/workflows/map-child-surfaces.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Map-child recovery surfaces (#203 PR2): REST routes, exec tools, and hooks
+ * over the map-children.ts ops. The ops themselves are covered in
+ * runtime-map.test.ts — these tests prove the wiring (params, status codes,
+ * audit-safe error shapes), not the semantics.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  activatePlugin,
+  callRoute,
+  callTool,
+  findRoute,
+  type ActivatedPlugin,
+} from '../test-helpers'
+import { seedWorkflowFixtures, taskStoreMock, taskServiceMock, resetRuntimeHarness } from './helpers/runtime-harness'
+
+const testDir = join(tmpdir(), `bakin-test-map-surfaces-${Date.now()}`)
+
+mock.module('@bakin/core/main-agent', () => ({
+  getMainAgentId: () => 'main',
+  tryGetMainAgentId: () => 'main',
+  getMainAgentName: () => 'Main',
+}))
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+  resetContentDir: mock(),
+  initBakinHome: mock(),
+  isUsingBakinHome: () => false,
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+mock.module('../../../src/core/watcher', () => ({
+  registerSyncHook: mock(),
+  registerUnlinkHook: mock(),
+}))
+mock.module('../../../src/core/audit', () => ({ appendAudit: mock() }))
+mock.module('../../../src/core/task-store', () => taskStoreMock)
+mock.module('@/core/task-store', () => taskStoreMock)
+mock.module('../../../src/core/task-service', taskServiceMock)
+mock.module('@/core/task-service', taskServiceMock)
+
+const triggerDispatchSpy = mock()
+mock.module('../../../plugins/workflows/lib/trigger-dispatch', () => ({
+  triggerDispatch: triggerDispatchSpy,
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => testDir,
+  getOpenClawPath: (...parts: string[]) => join(testDir, ...parts),
+  resetOpenClawHome: mock(),
+}))
+;(globalThis as unknown as { __bakinBroadcast?: unknown }).__bakinBroadcast = mock()
+
+import workflowsPlugin from '../../../plugins/workflows'
+import { createInstance, completeStep, loadInstance } from '../../../plugins/workflows/lib/runtime'
+
+let activated: ActivatedPlugin
+let seq = 0
+
+beforeAll(async () => {
+  if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
+  seedWorkflowFixtures(testDir)
+  activated = await activatePlugin(workflowsPlugin, testDir)
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  resetRuntimeHarness()
+  triggerDispatchSpy.mockClear()
+  seedWorkflowFixtures(testDir)
+})
+
+/** Fan a fresh 3-child map instance and return its taskId. */
+function fanned(): string {
+  const taskId = `task-surface-${++seq}`
+  createInstance(taskId, 'map-flow', testDir)
+  completeStep(taskId, 'source-step', { items: ['a', 'b', 'c'] }, undefined, testDir)
+  return taskId
+}
+
+describe('map-child REST routes', () => {
+  it('GET children returns live-hydrated entries', async () => {
+    const taskId = fanned()
+    const route = findRoute(activated.routes, 'GET', '/instances/:taskId/map/:stepId/children')!
+    expect(route).toBeDefined()
+
+    const res = await callRoute(route, activated.ctx, { searchParams: { taskId, stepId: 'produce-items' } })
+    expect(res.status).toBe(200)
+    const children = res.body.children as Array<Record<string, unknown>>
+    expect(children).toHaveLength(3)
+    expect(children[0]).toMatchObject({ index: 0, entryStatus: 'in_progress', liveStatus: 'in_progress' })
+  })
+
+  it('GET children 404s for a step without map children', async () => {
+    const taskId = fanned()
+    const route = findRoute(activated.routes, 'GET', '/instances/:taskId/map/:stepId/children')!
+    const res = await callRoute(route, activated.ctx, { searchParams: { taskId, stepId: 'source-step' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('POST cancel then retry round-trips a child through the routes', async () => {
+    const taskId = fanned()
+    const cancelRoute = findRoute(activated.routes, 'POST', '/instances/:taskId/map/:stepId/children/:index/cancel')!
+    const retryRoute = findRoute(activated.routes, 'POST', '/instances/:taskId/map/:stepId/children/:index/retry')!
+
+    const cancelled = await callRoute(cancelRoute, activated.ctx, {
+      searchParams: { taskId, stepId: 'produce-items', index: '1' },
+    })
+    expect(cancelled.status).toBe(200)
+    expect(loadInstance(`${taskId}--produce-items--1`, testDir)!.status).toBe('cancelled')
+
+    const retried = await callRoute(retryRoute, activated.ctx, {
+      searchParams: { taskId, stepId: 'produce-items', index: '1' },
+      body: { reason: 'route retry' },
+    })
+    expect(retried.status).toBe(200)
+    expect(loadInstance(`${taskId}--produce-items--1`, testDir)!.status).toBe('in_progress')
+    expect(triggerDispatchSpy).toHaveBeenCalled()
+  })
+
+  it('POST retry 400s on a completed child and on bad params', async () => {
+    const taskId = fanned()
+    completeStep(`${taskId}--produce-items--0`, 'do-work', { made: 'a' }, undefined, testDir)
+    const retryRoute = findRoute(activated.routes, 'POST', '/instances/:taskId/map/:stepId/children/:index/retry')!
+
+    const completed = await callRoute(retryRoute, activated.ctx, {
+      searchParams: { taskId, stepId: 'produce-items', index: '0' },
+      body: {},
+    })
+    expect(completed.status).toBe(400)
+
+    const badIndex = await callRoute(retryRoute, activated.ctx, {
+      searchParams: { taskId, stepId: 'produce-items', index: 'nope' },
+      body: {},
+    })
+    expect(badIndex.status).toBe(400)
+  })
+})
+
+describe('map-child exec tools', () => {
+  const tool = (name: string) => {
+    const found = activated.execTools.find((t) => t.name === name)
+    if (!found) throw new Error(`Tool ${name} not registered`)
+    return found
+  }
+
+  it('cancel + retry tools round-trip a child', async () => {
+    const taskId = fanned()
+
+    const cancelled = await callTool(tool('bakin_exec_workflows_cancel_map_child'), {
+      taskId, stepId: 'produce-items', index: 2,
+    })
+    expect(cancelled.ok).toBe(true)
+    expect(loadInstance(`${taskId}--produce-items--2`, testDir)!.status).toBe('cancelled')
+
+    const retried = await callTool(tool('bakin_exec_workflows_retry_map_child'), {
+      taskId, stepId: 'produce-items', index: 2, reason: 'tool retry',
+    })
+    expect(retried.ok).toBe(true)
+    expect(retried.childTaskId).toBe(`${taskId}--produce-items--2`)
+    expect(loadInstance(`${taskId}--produce-items--2`, testDir)!.status).toBe('in_progress')
+  })
+
+  it('tools return typed errors instead of throwing', async () => {
+    const bad = await callTool(tool('bakin_exec_workflows_retry_map_child'), {
+      taskId: 'ghost', stepId: 'produce-items', index: 0,
+    })
+    expect(bad.ok).toBe(false)
+    expect(Array.isArray(bad.errors)).toBe(true)
+  })
+})
+
+describe('map-child hooks', () => {
+  type HookHandler = (data: Record<string, unknown>) => unknown
+  const registeredHook = (name: string): HookHandler | undefined => {
+    const registerMock = activated.ctx.hooks.register as unknown as { mock: { calls: unknown[][] } }
+    const call = registerMock.mock.calls.find((c) => c[0] === name)
+    return call?.[1] as HookHandler | undefined
+  }
+
+  it('registers the three recovery hooks and listMapChildren round-trips', async () => {
+    expect(registeredHook('workflows.retryMapChild')).toBeDefined()
+    expect(registeredHook('workflows.cancelMapChild')).toBeDefined()
+
+    const listHook = registeredHook('workflows.listMapChildren')
+    expect(listHook).toBeDefined()
+
+    const taskId = fanned()
+    const listed = await listHook!({
+      taskId, stepId: 'produce-items', contentDir: testDir,
+    }) as { success: boolean; children: unknown[] }
+    expect(listed.success).toBe(true)
+    expect(listed.children).toHaveLength(3)
+  })
+})

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -73,7 +73,13 @@ import {
   cancelInstance,
   getCurrentStep,
   getActiveAgents,
+  approveGate,
 } from '@bakin/workflows/lib/runtime'
+import {
+  retryMapChild,
+  cancelMapChild,
+  listMapChildren,
+} from '@bakin/workflows/lib/map-children'
 import { invalidateSkillCache } from '@bakin/workflows/lib/skill-loader'
 import { setEventBus } from '@bakin/workflows/lib/notifications'
 import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
@@ -405,6 +411,116 @@ describe('runtime — map_workflow', () => {
       const state = loadInstance('task-late', testDir)!.stepStates['produce-items']
       expect(state.status).toBe('in_progress')
       expect(state.children![1].output).toBeUndefined()
+    })
+  })
+
+  describe('per-child recovery', () => {
+    const completeChild = (taskId: string, i: number) =>
+      completeStep(`${taskId}--produce-items--${i}`, 'do-work', { made: items[i] }, undefined, testDir)
+
+    it('cancelMapChild blocks the join; retryMapChild re-creates the same id and unblocks it', async () => {
+      startAndFan('task-recover-cycle')
+      await settle()
+
+      const cancelled = cancelMapChild('task-recover-cycle', 'produce-items', 1, testDir)
+      expect(cancelled.success).toBe(true)
+      await settle()
+
+      expect(loadInstance('task-recover-cycle--produce-items--1', testDir)!.status).toBe('cancelled')
+      let state = loadInstance('task-recover-cycle', testDir)!.stepStates['produce-items']
+      expect(state.children![1].status).toBe('cancelled')
+      expect(hookTasks.get('task-recover-cycle--produce-items--1')!.column).toBe('done')
+
+      // Complete the siblings — join must stay blocked on the cancelled child.
+      completeChild('task-recover-cycle', 0)
+      completeChild('task-recover-cycle', 2)
+      state = loadInstance('task-recover-cycle', testDir)!.stepStates['produce-items']
+      expect(state.status).toBe('in_progress')
+
+      // Retry re-creates a fresh instance under the SAME childTaskId with the
+      // same item context, revives the board task, and resets the entry.
+      const retried = retryMapChild('task-recover-cycle', 'produce-items', 1, { reason: 'try again', contentDir: testDir })
+      expect(retried.success).toBe(true)
+      await settle()
+
+      const revived = loadInstance('task-recover-cycle--produce-items--1', testDir)!
+      expect(revived.status).toBe('in_progress')
+      expect(revived.parentContext).toMatchObject({ brief: 'clip-b', mapIndex: 1, mapTotal: 3 })
+      expect(revived.parentTaskId).toBe('task-recover-cycle')
+      expect(hookTasks.get('task-recover-cycle--produce-items--1')!.column).toBe('inProgress')
+
+      // Completing the retried child completes the join in source order.
+      completeChild('task-recover-cycle', 1)
+      const joined = loadInstance('task-recover-cycle', testDir)!
+      expect(joined.stepStates['produce-items'].status).toBe('complete')
+      expect(joined.stepStates['produce-items'].output).toEqual({
+        outputs: [{ made: 'clip-a' }, { made: 'clip-b' }, { made: 'clip-c' }],
+      })
+      expect(joined.currentStepId).toBe('after-map')
+    })
+
+    it('retryMapChild reopens a LIVE child in place (reason lands as rejection context)', () => {
+      startAndFan('task-retry-live')
+      const retried = retryMapChild('task-retry-live', 'produce-items', 0, { reason: 'redo this one', contentDir: testDir })
+      expect(retried.success).toBe(true)
+
+      const child = loadInstance('task-retry-live--produce-items--0', testDir)!
+      expect(child.status).toBe('in_progress')
+      expect(child.stepStates['do-work'].rejectionReason).toBe('redo this one')
+      // Same instance reopened, not re-created — history carries the reopen.
+      expect(child.history.some((h) => (h.output as { reopened?: boolean } | undefined)?.reopened)).toBe(true)
+    })
+
+    it('refuses to retry or cancel a completed child', () => {
+      startAndFan('task-refuse')
+      completeChild('task-refuse', 0)
+      const retry = retryMapChild('task-refuse', 'produce-items', 0, { reason: 'nope', contentDir: testDir })
+      expect(retry.success).toBe(false)
+      const cancel = cancelMapChild('task-refuse', 'produce-items', 0, testDir)
+      expect(cancel.success).toBe(false)
+    })
+
+    it('returns typed errors for unknown parent, step, or index', () => {
+      expect(retryMapChild('ghost-task', 'produce-items', 0, { reason: 'x', contentDir: testDir }).success).toBe(false)
+      startAndFan('task-bad-args')
+      expect(retryMapChild('task-bad-args', 'not-a-map', 0, { reason: 'x', contentDir: testDir }).success).toBe(false)
+      expect(retryMapChild('task-bad-args', 'produce-items', 9, { reason: 'x', contentDir: testDir }).success).toBe(false)
+      expect(cancelMapChild('task-bad-args', 'produce-items', 9, testDir).success).toBe(false)
+    })
+
+    it('listMapChildren reports LIVE child statuses, not just the cached entries', () => {
+      startAndFan('task-list')
+      // Cancel one child OUT OF BAND — the parent entry still says in_progress.
+      cancelInstance('task-list--produce-items--2', testDir)
+
+      const listed = listMapChildren('task-list', 'produce-items', testDir)
+      expect(listed.success).toBe(true)
+      if (!listed.success) throw new Error('unreachable')
+      const children = listed.children
+      expect(children).toHaveLength(3)
+      expect(children[0]).toMatchObject({ index: 0, entryStatus: 'in_progress', liveStatus: 'in_progress' })
+      expect(children[2]).toMatchObject({ index: 2, entryStatus: 'in_progress', liveStatus: 'cancelled' })
+    })
+
+    it('child gate approvals flow through to the join', () => {
+      createInstance('task-gated', 'map-gated', testDir)
+      completeStep('task-gated', 'source-step', { items: ['x', 'y'] }, undefined, testDir)
+
+      for (const i of [0, 1]) {
+        const childId = `task-gated--produce-items--${i}`
+        completeStep(childId, 'work', { draft: i }, undefined, testDir)
+        expect(loadInstance(childId, testDir)!.status).toBe('pending_approval')
+        const approval = approveGate(childId, 'check', { contentDir: testDir, approver: { id: 'mark', source: 'web' } })
+        expect(approval.success).toBe(true)
+        completeStep(childId, 'finish', { final: i }, undefined, testDir)
+      }
+
+      const parent = loadInstance('task-gated', testDir)!
+      expect(parent.stepStates['produce-items'].status).toBe('complete')
+      expect(parent.stepStates['produce-items'].output).toEqual({
+        outputs: [{ final: 0 }, { final: 1 }],
+      })
+      expect(parent.currentStepId).toBe('after-map')
     })
   })
 

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -371,6 +371,43 @@ describe('runtime — map_workflow', () => {
     })
   })
 
+  describe('join-blocking (failures never cascade)', () => {
+    const completeChild = (taskId: string, i: number) =>
+      completeStep(`${taskId}--produce-items--${i}`, 'do-work', { made: items[i] }, undefined, testDir)
+
+    it('a cancelled child blocks the join without failing the parent or siblings', () => {
+      startAndFan('task-block')
+      cancelInstance('task-block--produce-items--1', testDir)
+      completeChild('task-block', 0)
+      completeChild('task-block', 2)
+
+      const parent = loadInstance('task-block', testDir)!
+      const state = parent.stepStates['produce-items']
+      // Join waits: the map step and the parent stay honestly in_progress.
+      expect(parent.status).toBe('in_progress')
+      expect(state.status).toBe('in_progress')
+      expect(state.output).toBeUndefined()
+      expect(parent.currentStepId).toBe('produce-items')
+      // Completed siblings recorded; nothing cascaded to them.
+      expect(state.children![0].status).toBe('complete')
+      expect(state.children![2].status).toBe('complete')
+      expect(loadInstance('task-block--produce-items--0', testDir)!.status).toBe('complete')
+    })
+
+    it('refuses late submissions to a cancelled child and keeps the join intact', () => {
+      startAndFan('task-late')
+      cancelInstance('task-late--produce-items--1', testDir)
+      const late = completeStep('task-late--produce-items--1', 'do-work', { made: 'zombie' }, undefined, testDir)
+      expect(late.success).toBe(false)
+
+      completeChild('task-late', 0)
+      completeChild('task-late', 2)
+      const state = loadInstance('task-late', testDir)!.stepStates['produce-items']
+      expect(state.status).toBe('in_progress')
+      expect(state.children![1].output).toBeUndefined()
+    })
+  })
+
   describe('child-aware surfaces', () => {
     const completeChild = (taskId: string, i: number) =>
       completeStep(`${taskId}--produce-items--${i}`, 'do-work', { made: items[i] }, undefined, testDir)

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -545,6 +545,37 @@ describe('runtime — map_workflow', () => {
       expect(hookTasks.get('task-sweep--produce-items--1')!.column).toBe('done')
     })
 
+    it('cancel-parent with mixed child states sweeps only the live ones', async () => {
+      // Gated children: child 0 runs to completion, child 1 parks at its gate
+      // (pending_approval), child 2 (map-flow fixture is ungated, so use the
+      // gated parent with 3 items) is cancelled per-child beforehand.
+      createInstance('task-mixed', 'map-gated', testDir)
+      completeStep('task-mixed', 'source-step', { items: ['a', 'b', 'c'] }, undefined, testDir)
+      await settle()
+
+      // Child 0 → complete.
+      completeStep('task-mixed--produce-items--0', 'work', { draft: 0 }, undefined, testDir)
+      approveGate('task-mixed--produce-items--0', 'check', { contentDir: testDir, approver: { id: 'mark', source: 'web' } })
+      completeStep('task-mixed--produce-items--0', 'finish', { final: 0 }, undefined, testDir)
+      // Child 1 → parked at its gate.
+      completeStep('task-mixed--produce-items--1', 'work', { draft: 1 }, undefined, testDir)
+      expect(loadInstance('task-mixed--produce-items--1', testDir)!.status).toBe('pending_approval')
+      // Child 2 → already cancelled per-child.
+      cancelMapChild('task-mixed', 'produce-items', 2, testDir)
+
+      cancelInstance('task-mixed', testDir)
+      await settle()
+
+      const parent = loadInstance('task-mixed', testDir)!
+      expect(parent.status).toBe('cancelled')
+      expect(parent.stepStates['produce-items'].children!.map((c) => c.status)).toEqual([
+        'complete', 'cancelled', 'cancelled',
+      ])
+      expect(loadInstance('task-mixed--produce-items--0', testDir)!.status).toBe('complete')
+      expect(loadInstance('task-mixed--produce-items--1', testDir)!.status).toBe('cancelled')
+      expect(loadInstance('task-mixed--produce-items--2', testDir)!.status).toBe('cancelled')
+    })
+
     it('getActiveAgents unions the live children with effectiveTaskIds', () => {
       startAndFan('task-agents')
       const before = getActiveAgents('task-agents', testDir)


### PR DESCRIPTION
## Summary

PR2 of 4 for #203 (stacked on #617). Per-child recovery + join semantics per the approved plan:

- **Join-blocking pinned:** a cancelled/failed child blocks the join without cascading to the parent or siblings; late submissions to cancelled children are refused.
- **`map-children.ts` ops:** `retryMapChild` (live child reopens in place via `reopenFromStep`; terminally dead/missing child re-creates under the SAME `childTaskId` with item context rebuilt from the source step via the shared `buildMapChildContext`), `cancelMapChild` (entry marked, board task retired), `listMapChildren` (LIVE child statuses — cached entries can lag out-of-band changes).
- **Cancel-parent mixed-state pin:** completed children untouched, gate-parked children swept, already-cancelled entries stable.
- **Child gates:** approvals inside map children flow through to the join unchanged.
- **Surfaces:** `workflows.{retryMapChild,cancelMapChild,listMapChildren}` hooks; `GET /instances/:taskId/map/:stepId/children` + `POST .../children/:index/{retry,cancel}` routes (audit + reindex + dispatch kick on retry); `bakin_exec_workflows_{retry,cancel}_map_child` exec tools.

## Test plan
- 13 new tests across `runtime-map.test.ts` (semantics) + `map-child-surfaces.test.ts` (wiring)
- Full suite: 5809 tests, 0 fail; typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)