### PR TITLE
fix(brands): declare the capability permissions the plugin uses

### DIFF
--- a/plugins/brands/bakin-plugin.json
+++ b/plugins/brands/bakin-plugin.json
@@ -13,7 +13,11 @@
   "dependencies": [],
   "permissions": [
     "storage.read",
-    "storage.write"
+    "storage.write",
+    "tasks.read",
+    "tasks.write",
+    "assets.read",
+    "assets.write"
   ],
   "contributes": {
     "apiRoutes": [


### PR DESCRIPTION
The permission checker warned on every `ctx.tasks.list` call from brands — the manifest only declared `storage.*`. This declares the full set the code actually touches: `tasks.read`/`tasks.write` (list/get/create) and `assets.read`/`assets.write` (getAsset/resolveVersionFile/createAsset). Brands tests green (56/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)