### PR TITLE
fix(core): 405 sessionless MCP GETs — kill the codex client's 5s transport-fallback stall

### DIFF
--- a/.claude/knowledge/repo-architecture.md
+++ b/.claude/knowledge/repo-architecture.md
@@ -384,7 +384,7 @@ Browser →  HTTP request → Bakin (server.ts)
   Dispatch by URL prefix:
     /api/sse           → handleSSE                   (streams)
     /api/*             → dispatchWebHandler(handler) (Web Fetch shape)
-    /mcp               → handleMcpRequest            (SSE + Streamable HTTP)
+    /mcp               → handleMcpRequest            (Streamable HTTP only; sessionless GET → 405)
     /api/plugins/<id>/<path> → plugin catch-all router
     /vendor/*          → static handler (from public/vendor or embedded)
     /_app/*            → host shell bundle (packages/host/dist; NOT /assets —
@@ -486,7 +486,7 @@ Created by `bakin onboard` or `initBakinHome()`.
 | Core plugin config | `bakin.config.ts` | Imported by `server.ts` + `registerCorePlugins` |
 | Plugin loading | `src/core/plugin-registry.ts` | `registerCorePlugins(CORE_PLUGIN_IMPORTS)` + `pluginRegistry` called by `server.ts` during startup |
 | HTTP router | `src/core/server/request-handler.ts` | `createRequestHandler({...})` factory passed to `http.createServer` by `server.ts` |
-| MCP tools | `src/core/mcp-server.ts` | Calls `getAllExecTools()` from `src/core/exec-tools/registry.ts`; built-in tools self-register via `addExecTool()` on import (`src/core/exec-tools/tools/*`), plugins register via `ctx.registerExecTool()`. Supports Streamable HTTP and SSE transports. |
+| MCP tools | `src/core/mcp-server.ts` | Calls `getAllExecTools()` from `src/core/exec-tools/registry.ts`; built-in tools self-register via `addExecTool()` on import (`src/core/exec-tools/tools/*`), plugins register via `ctx.registerExecTool()`. Streamable HTTP only — sessionless GETs are 405 (the legacy SSE auto-handshake made codex MCP clients stall a fixed 5s per turn before falling back; provisioned OpenClaw entries declare `type: "streamable-http"` because the embedded runtime defaults to legacy SSE). |
 | Runtime adapters | `packages/adapter-*` | Provider-specific runtime implementations for agents, channels, approvals, cron, memory, and raw access gates |
 | Doctor cron | `src/core/doctor.ts` | `doctor.start(contentDir, projectRoot)` from `server.ts`. ~200-line orchestrator (cron + cache + audit + notify); every check is plugin-registered. Deep ref: `.claude/knowledge/doctor-and-health-checks.md`. |
 | TanStack router | `packages/host/src/router.ts` | Boots on client, matches URL to `routes/*.tsx` |

--- a/packages/adapter-openclaw/src/tool-access-provisioning.ts
+++ b/packages/adapter-openclaw/src/tool-access-provisioning.ts
@@ -13,7 +13,18 @@ export interface BakinMcpServerEntry {
   description?: string
   /** OpenClaw per-server MCP request timeout (ms). */
   requestTimeoutMs?: number
+  /**
+   * OpenClaw HTTP transport selection. MUST be `streamable-http`: the
+   * embedded runtime's MCP client DEFAULTS to the legacy SSE transport when
+   * `type` is absent, and Bakin's /mcp endpoint no longer speaks legacy SSE
+   * (sessionless GETs are 405 — the legacy handshake made the codex client
+   * stall a fixed 5s per turn before falling back).
+   */
+  type?: string
 }
+
+/** The only transport Bakin's /mcp endpoint speaks. */
+export const BAKIN_MCP_TRANSPORT_TYPE = 'streamable-http'
 
 export interface BakinMcpConfig {
   mcp?: { servers?: Record<string, BakinMcpServerEntry> }
@@ -68,8 +79,18 @@ export function applyBakinMcpEntries(
     const name = serverName(agent)
     const url = mcpUrl(agent, baseUrl)
     const existing = servers[name]
-    if (!existing || existing.url !== url || existing.requestTimeoutMs !== BAKIN_MCP_REQUEST_TIMEOUT_MS) {
-      servers[name] = { url, description: `Bakin MCP for ${agent}`, requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS }
+    if (
+      !existing ||
+      existing.url !== url ||
+      existing.requestTimeoutMs !== BAKIN_MCP_REQUEST_TIMEOUT_MS ||
+      existing.type !== BAKIN_MCP_TRANSPORT_TYPE
+    ) {
+      servers[name] = {
+        url,
+        description: `Bakin MCP for ${agent}`,
+        requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS,
+        type: BAKIN_MCP_TRANSPORT_TYPE,
+      }
       changes.push(existing ? `updated ${name}` : `added ${name}`)
     }
   }
@@ -116,7 +137,10 @@ export function verifyBakinMcpEntries(
     const name = serverName(agent)
     const expectedUrl = mcpUrl(agent, baseUrl)
     const entry = servers[name]
-    const correct = entry?.url === expectedUrl && entry?.requestTimeoutMs === BAKIN_MCP_REQUEST_TIMEOUT_MS
+    const correct =
+      entry?.url === expectedUrl &&
+      entry?.requestTimeoutMs === BAKIN_MCP_REQUEST_TIMEOUT_MS &&
+      entry?.type === BAKIN_MCP_TRANSPORT_TYPE
     return { agent, name, url: entry?.url ?? '', correct }
   })
   const staleEntries = Object.keys(servers).filter(

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -1,13 +1,17 @@
 /**
  * Bakin MCP Server.
  *
- * Exposes agent-facing operations as MCP tools over Streamable HTTP and SSE.
+ * Exposes agent-facing operations as MCP tools over Streamable HTTP.
  * Agents connect to /mcp?agent=<name> and get tools for task management,
  * progress logging, workflow step submission, etc.
  *
- * Supports two transports:
- * - Streamable HTTP (POST-only, session ID in headers) — modern MCP clients
- * - SSE (GET to establish stream, POST to send messages) — legacy MCP clients
+ * Transport: Streamable HTTP only (POST initialize; Mcp-Session-Id header;
+ * GET with a session id opens the notification stream). Sessionless GETs are
+ * 405 per spec — the legacy SSE auto-handshake was removed because the codex
+ * MCP client ignores it and waits a fixed 5s before falling back to
+ * streamable-http, taxing every codex-runtime turn ~5s. Provisioned OpenClaw
+ * entries declare `type: "streamable-http"` so the embedded runtime (whose
+ * HTTP client DEFAULTS to legacy SSE) picks the right transport too.
  *
  * All tools are registered dynamically via the exec tool registry:
  * - Plugin tools: registered via ctx.registerExecTool() in plugin activate()
@@ -20,7 +24,6 @@ import { randomUUID } from 'crypto'
 import type { IncomingMessage, ServerResponse } from 'http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
-import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
 import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { createLogger } from './logger'
 import { getContentDir } from './content-dir'
@@ -62,26 +65,16 @@ interface McpSession {
 
 const sessions = new Map<string, McpSession>()
 
-// SSE sessions are keyed by session ID from the SSE transport
-interface SseSession {
-  server: McpServer
-  transport: SSEServerTransport
-  agentId: string
-  createdAt: number
-}
-const sseSessions = new Map<string, SseSession>()
-
 const startedAt = new Date().toISOString()
 
-type SessionSummaryInput = Pick<McpSession | SseSession, 'agentId' | 'createdAt'>
+type SessionSummaryInput = Pick<McpSession, 'agentId' | 'createdAt'>
 
 export function summarizeMcpSessions(
   streamable: Iterable<SessionSummaryInput>,
-  sse: Iterable<SessionSummaryInput>,
   upSince: string = startedAt,
 ): { activeSessions: Array<{ agent: string; sessions: number; connectedAt: string }>; upSince: string } {
   const agentMap = new Map<string, { sessions: number; latestAt: number }>()
-  for (const session of [...streamable, ...sse]) {
+  for (const session of streamable) {
     const existing = agentMap.get(session.agentId)
     if (existing) {
       existing.sessions++
@@ -104,7 +97,7 @@ export function summarizeMcpSessions(
 // plugin reads this via globalThis to avoid coupling to mcp-server.ts
 // directly — same pattern as __bakinBroadcast.
 ;(globalThis as unknown as { __bakinGetMcpSessions?: () => { activeSessions: Array<{ agent: string; sessions: number; connectedAt: string }>; upSince: string } }).__bakinGetMcpSessions = () => {
-  return summarizeMcpSessions(sessions.values(), sseSessions.values(), startedAt)
+  return summarizeMcpSessions(sessions.values(), startedAt)
 }
 
 // Clean up stale sessions every 5 minutes.
@@ -119,15 +112,8 @@ setInterval(() => {
       cleaned++
     }
   }
-  for (const [id, session] of sseSessions) {
-    if (now - session.createdAt > SESSION_TTL_MS) {
-      session.transport.close?.()
-      sseSessions.delete(id)
-      cleaned++
-    }
-  }
   if (cleaned > 0) {
-    log.info('Cleaned up stale MCP sessions', { cleaned, remaining: sessions.size + sseSessions.size })
+    log.info('Cleaned up stale MCP sessions', { cleaned, remaining: sessions.size })
   }
 }, 5 * 60 * 1000)
 
@@ -342,40 +328,30 @@ export async function handleMcpRequest(
 
   const agentId = url.searchParams.get('agent')
 
-  // ─── SSE Transport (GET) ───────────────────────────────────────────
-  // Legacy MCP clients connect via GET to establish an SSE stream.
-  // The SSE transport sends an `endpoint` event with a POST URL for messages.
+  // ─── GET: streamable-http notification stream ───────────────────────
+  // A GET with a live Mcp-Session-Id opens the session's server→client
+  // notification stream. A GET WITHOUT one is 405 per the streamable-http
+  // spec. (This endpoint previously auto-started a legacy SSE handshake for
+  // sessionless GETs; the codex MCP client ignores that handshake and waits
+  // a fixed 5s before falling back to streamable-http — a 5s tax on every
+  // codex-runtime turn. 405 makes clients fall back immediately.)
   if (method === 'GET') {
-    if (!agentId) {
-      res.writeHead(400, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ error: 'agent query parameter required (e.g. /mcp?agent=chef)' }))
+    const existingSessionId = req.headers['mcp-session-id'] as string | undefined
+    if (existingSessionId) {
+      const session = sessions.get(existingSessionId)
+      if (!session) {
+        res.writeHead(404, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Session not found' }))
+        return
+      }
+      await session.transport.handleRequest(req, res)
       return
     }
 
-    const server = new McpServer(
-      { name: 'bakin', version: '1.0.0' },
-      { capabilities: { logging: {} } },
-    )
-    registerTools(server, () => agentId)
-
-    // The endpoint is where the SSE client will POST messages back.
-    // Use /mcp with a sessionId query param so we can route them.
-    const transport = new SSEServerTransport(`/mcp`, res)
-    // server.connect(transport) internally calls transport.start() — calling
-    // start() again here throws "SSEServerTransport already started" from
-    // the MCP SDK.
-    await server.connect(transport)
-
-    const sid = transport.sessionId
-    sseSessions.set(sid, { server, transport, agentId, createdAt: Date.now() })
-    log.info('SSE MCP session created', { sessionId: sid, agent: agentId })
-
-    // Clean up on disconnect
-    res.on('close', () => {
-      transport.close?.()
-      sseSessions.delete(sid)
-      log.info('SSE MCP session closed', { sessionId: sid, agent: agentId })
-    })
+    res.writeHead(405, { 'Content-Type': 'application/json', Allow: 'POST, DELETE' })
+    res.end(JSON.stringify({
+      error: 'Streamable HTTP only: POST a JSON-RPC initialize request to /mcp?agent=<id>. GET requires an Mcp-Session-Id header from an initialized session.',
+    }))
     return
   }
 
@@ -408,19 +384,6 @@ export async function handleMcpRequest(
         return
       }
       await session.transport.handleRequest(req, res, body)
-      return
-    }
-
-    // Check for SSE session (query param-based — SSE transport POSTs to /mcp?sessionId=...)
-    const sseSessionId = url.searchParams.get('sessionId')
-    if (sseSessionId) {
-      const sseSession = sseSessions.get(sseSessionId)
-      if (!sseSession) {
-        res.writeHead(404, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: 'SSE session not found' }))
-        return
-      }
-      await sseSession.transport.handlePostMessage(req, res, body)
       return
     }
 

--- a/tests/adapter-openclaw/tool-access-provisioning.test.ts
+++ b/tests/adapter-openclaw/tool-access-provisioning.test.ts
@@ -39,9 +39,9 @@ describe('applyBakinMcpEntries', () => {
     expect(changes).toEqual(['added bakin-main', 'added bakin-pixel', 'added bakin-patch'])
     expect(config.mcp!.servers).toEqual({
       existing: { url: 'http://localhost:9999/mcp' },
-      'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS },
-      'bakin-pixel': { url: 'http://localhost:3737/mcp?agent=pixel', description: 'Bakin MCP for pixel', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS },
-      'bakin-patch': { url: 'http://localhost:3737/mcp?agent=patch', description: 'Bakin MCP for patch', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS },
+      'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS, type: 'streamable-http' },
+      'bakin-pixel': { url: 'http://localhost:3737/mcp?agent=pixel', description: 'Bakin MCP for pixel', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS, type: 'streamable-http' },
+      'bakin-patch': { url: 'http://localhost:3737/mcp?agent=patch', description: 'Bakin MCP for patch', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS, type: 'streamable-http' },
     })
   })
 
@@ -81,7 +81,7 @@ describe('applyBakinMcpEntries', () => {
     const config: BakinMcpConfig = {
       mcp: {
         servers: {
-          'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS },
+          'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS, type: 'streamable-http' },
         },
       },
     }
@@ -124,7 +124,7 @@ describe('verifyBakinMcpEntries', () => {
     const config: BakinMcpConfig = {
       mcp: {
         servers: {
-          'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS },
+          'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS, type: 'streamable-http' },
           'bakin-stale': { url: 'http://localhost:3737/mcp?agent=stale', description: 'Bakin MCP for stale' },
         },
       },
@@ -154,6 +154,26 @@ describe('verifyBakinMcpEntries', () => {
 
     expect(applyBakinMcpEntries(config, ['main'], BASE)).toEqual(['updated bakin-main'])
     expect(config.mcp!.servers!['bakin-main'].requestTimeoutMs).toBe(BAKIN_MCP_REQUEST_TIMEOUT_MS)
+  })
+
+  it('flags an entry without a transport type as incorrect so provisioning heals it', () => {
+    // OpenClaw's embedded runtime DEFAULTS HTTP MCP servers to the legacy SSE
+    // transport when `type` is absent — and Bakin's /mcp now 405s sessionless
+    // GETs (the legacy handshake made the codex client stall a fixed 5s per
+    // turn). Existing installs carry type-less entries — verify must report
+    // them incorrect and apply must rewrite them with type: streamable-http.
+    const config: BakinMcpConfig = {
+      mcp: {
+        servers: {
+          'bakin-main': { url: 'http://localhost:3737/mcp?agent=main', description: 'Bakin MCP for main', requestTimeoutMs: BAKIN_MCP_REQUEST_TIMEOUT_MS },
+        },
+      },
+    }
+    const status = verifyBakinMcpEntries(config, ['main'], BASE)
+    expect(status.agentEntries[0].correct).toBe(false)
+
+    expect(applyBakinMcpEntries(config, ['main'], BASE)).toEqual(['updated bakin-main'])
+    expect(config.mcp!.servers!['bakin-main'].type).toBe('streamable-http')
   })
 })
 

--- a/tests/core/mcp-server.test.ts
+++ b/tests/core/mcp-server.test.ts
@@ -29,6 +29,33 @@ mock.module('@/core/content-dir', () => ({
     plugins: `${process.env.BAKIN_HOME || '/tmp/test'}/plugins`,
     audit: `${process.env.BAKIN_HOME || '/tmp/test'}/audit.jsonl`,
     logs: `${process.env.BAKIN_HOME || '/tmp/test'}/logs`,
+    db: `${process.env.BAKIN_HOME || '/tmp/test'}/bakin.db`,
+  })),
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
+
+mock.module('@/core/task-store', () => ({
+  readTaskboard: mock(() => ({ columns: { todo: [], inProgress: [], review: [], done: [] } })),
+  getTask: mock(() => null),
+  getSharedBakinTaskStore: mock(() => ({})),
+  normalizeColumn: mock((c: string) => c),
+  localDateString: mock(() => '2026-01-01'),
+}))
+
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: mock(() => process.env.BAKIN_HOME || '/tmp/test'),
+  getBakinPaths: mock(() => ({
+    root: process.env.BAKIN_HOME || '/tmp/test',
+    home: process.env.BAKIN_HOME || '/tmp/test',
+    assets: `${process.env.BAKIN_HOME || '/tmp/test'}/assets`,
+    settings: `${process.env.BAKIN_HOME || '/tmp/test'}/settings.json`,
+    pluginSettings: `${process.env.BAKIN_HOME || '/tmp/test'}/plugin-settings`,
+    plugins: `${process.env.BAKIN_HOME || '/tmp/test'}/plugins`,
+    audit: `${process.env.BAKIN_HOME || '/tmp/test'}/audit.jsonl`,
+    logs: `${process.env.BAKIN_HOME || '/tmp/test'}/logs`,
+    db: `${process.env.BAKIN_HOME || '/tmp/test'}/bakin.db`,
   })),
   isUsingBakinHome: () => true,
   resetContentDir: () => {},
@@ -85,15 +112,13 @@ describe('MCP Server', () => {
     expect(getActiveSessions()).toEqual([])
   })
 
-  it('should summarize both streamable and SSE sessions for health stats', async () => {
+  it('should summarize streamable sessions for health stats', async () => {
     const { summarizeMcpSessions } = await import('@/core/mcp-server')
 
     const summary = summarizeMcpSessions(
       [
         { agentId: 'patch', createdAt: 1_000 },
         { agentId: 'chef', createdAt: 2_000 },
-      ],
-      [
         { agentId: 'patch', createdAt: 3_000 },
       ],
       '2026-05-04T00:00:00.000Z',
@@ -156,7 +181,13 @@ describe('MCP Server', () => {
     expect(res.writeHead).toHaveBeenCalledWith(404, expect.any(Object))
   })
 
-  it('should reject GET without session ID', async () => {
+  // Sessionless GETs previously auto-started a legacy SSE handshake. The
+  // codex MCP client ignores that handshake and waits a fixed 5s before
+  // falling back to streamable-http — a 5s tax on EVERY codex turn (579 of
+  // 1,074 logged MCP inits sat at 5.0±0.1s). Per the streamable-http spec a
+  // GET without Mcp-Session-Id is 405, which makes clients fall back
+  // immediately.
+  it('should 405 a GET without Mcp-Session-Id (no agent param)', async () => {
     const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
 
     const req = createMockRequest('GET', '/mcp', null)
@@ -164,7 +195,101 @@ describe('MCP Server', () => {
 
     await handleMcpRequest(req, res)
 
-    expect(res.writeHead).toHaveBeenCalledWith(400, expect.any(Object))
+    expect(res.writeHead).toHaveBeenCalledWith(405, expect.objectContaining({ Allow: expect.any(String) }))
+  })
+
+  it('should 405 a sessionless GET even with an agent param (the codex transport probe)', async () => {
+    const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
+
+    const req = createMockRequest('GET', '/mcp?agent=main', null)
+    const res = createMockResponse()
+
+    await handleMcpRequest(req, res)
+
+    expect(res.writeHead).toHaveBeenCalledWith(405, expect.objectContaining({ Allow: expect.any(String) }))
+    expect(res._body).toContain('Mcp-Session-Id')
+  })
+
+  it('should 404 a GET with an unknown Mcp-Session-Id', async () => {
+    const { handleMcpRequest } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
+
+    const req = createMockRequest('GET', '/mcp', null, { 'mcp-session-id': 'nope' })
+    const res = createMockResponse()
+
+    await handleMcpRequest(req, res)
+
+    expect(res.writeHead).toHaveBeenCalledWith(404, expect.any(Object))
+  })
+
+  it('should serve the streamable notification stream on GET with a live session', async () => {
+    const { handleMcpRequest, getActiveSessions } = require('@/core/mcp-server') as typeof import('@/core/mcp-server')
+    const { createServer } = require('http') as typeof import('http')
+    // Bun.fetch, NOT global fetch: the test preload registers happy-dom,
+    // whose window fetch breaks on real HTTP sockets.
+    const nativeFetch = (Bun as unknown as { fetch: typeof fetch }).fetch
+
+    // Real HTTP round-trip: hand mocks can't satisfy the MCP SDK transport's
+    // ServerResponse expectations. Bun.fetch, NOT global fetch — the
+    // happy-dom preload's fetch breaks on real sockets (CLAUDE.md).
+    const server = createServer((req, res) => {
+      void handleMcpRequest(req, res)
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as { port: number }).port
+    const base = `http://127.0.0.1:${port}`
+
+    try {
+      const initRes = await nativeFetch(`${base}/mcp?agent=main`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '0' },
+          },
+        }),
+      })
+      expect(initRes.status).toBe(200)
+      const sid = initRes.headers.get('mcp-session-id')
+      expect(sid).toBeTruthy()
+      expect(getActiveSessions().some((s) => s.sessionId === sid && s.agentId === 'main')).toBe(true)
+      await initRes.body?.cancel()
+
+      // GET with the live session id = the notification stream, not a 4xx.
+      const streamRes = await nativeFetch(`${base}/mcp`, {
+        method: 'GET',
+        headers: {
+          'mcp-session-id': sid!,
+          accept: 'text/event-stream',
+          'mcp-protocol-version': '2025-06-18',
+        },
+      })
+      // 200 = the session's transport owns the response (the notification
+      // stream), vs the 405/404 the routing layer returns itself. The real
+      // content-type is text/event-stream, but the happy-dom preload's
+      // Response implementation makes Hono's request-listener coerce the
+      // streamed body to text/plain in-test — so only status is asserted
+      // here; the SSE content-type is exercised against real node HTTP by
+      // the transport SDK itself.
+      expect(streamRes.status).toBe(200)
+      await streamRes.body?.cancel()
+
+      // And the sessionless GET a real codex client probes with → immediate 405.
+      const probeRes = await nativeFetch(`${base}/mcp?agent=main`, {
+        method: 'GET',
+        headers: { accept: 'text/event-stream' },
+      })
+      expect(probeRes.status).toBe(405)
+    } finally {
+      server.close()
+    }
   })
 })
 
@@ -206,6 +331,56 @@ function createMockResponse() {
       if (data) bodyContent = data
     }),
     headersSent: false,
+    get _body() {
+      return bodyContent
+    },
+  }
+  return res
+}
+
+// Richer mock for paths where the MCP SDK transport owns the response
+// (initialize round-trips, notification streams): records status/headers,
+// supports write/flush, and behaves as a minimal ServerResponse.
+function createStreamingMockResponse() {
+  let bodyContent = ''
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>()
+  const res: any = {
+    statusCode: 0,
+    headers: {} as Record<string, unknown>,
+    headersSent: false,
+    writeHead: mock(function (this: unknown, status: number, headers?: Record<string, unknown>) {
+      res.statusCode = status
+      if (headers) Object.assign(res.headers, headers)
+      res.headersSent = true
+      return res
+    }),
+    setHeader: mock((k: string, v: unknown) => {
+      res.headers[k.toLowerCase()] = v
+    }),
+    getHeader: mock((k: string) => res.headers[k.toLowerCase()]),
+    write: mock((chunk: unknown) => {
+      bodyContent += String(chunk)
+      return true
+    }),
+    end: mock((data?: string) => {
+      if (data) bodyContent += data
+    }),
+    flushHeaders: mock(() => {
+      res.headersSent = true
+    }),
+    on: mock((event: string, cb: (...args: unknown[]) => void) => {
+      const arr = listeners.get(event) ?? []
+      arr.push(cb)
+      listeners.set(event, arr)
+      return res
+    }),
+    once: mock((event: string, cb: (...args: unknown[]) => void) => {
+      const arr = listeners.get(event) ?? []
+      arr.push(cb)
+      listeners.set(event, arr)
+      return res
+    }),
+    removeListener: mock(() => res),
     get _body() {
       return bodyContent
     },


### PR DESCRIPTION
## Summary

The latency investigation found a fixed **5.0-second stall on every codex-runtime turn** (chat, dispatch, heartbeats): the codex MCP client probes `GET /mcp`, ignores the legacy SSE handshake Bakin auto-starts, waits a hardcoded 5s, then falls back to streamable-http. **579 of 1,074 logged MCP initializations sat at 5.0±0.1s**, each blocking its turn's session start — while Bakin answers the GET in 2.6ms. The wait is purely client-side transport fallback.

- `/mcp` is now **streamable-http only** (per spec): sessionless GET → **405** (clients fall back immediately); GET with a live `Mcp-Session-Id` → the session's notification stream (previously misrouted into a new legacy SSE handshake); legacy SSE machinery deleted.
- **Provisioned OpenClaw entries declare `type: "streamable-http"`** (golden shape + verify/heal at boot): the embedded runtime's HTTP MCP client *defaults* to legacy SSE when `type` is absent — without this, the anthropic lane would 405 on connect.
- Expected impact: chat turns ~11–13s → **~6–8s**; applies to every codex turn.
- Upstream (codex) issue worth filing: fixed 5s transport-fallback wait even when the server responds instantly.

Note: will conflict trivially with #639 (same golden-shape function gains `codex.agents` there) — whichever merges second needs a 2-line resolution.

## Test plan
- [x] GET-no-session → 405; GET+unknown session → 404; GET+live session → notification stream (real HTTP round-trip via Bun.fetch); POST initialize unchanged
- [x] Provisioning: type in golden shape, verify flags type-less entries, apply heals them (idempotency preserved)
- [x] Full suite 6383 ran / 0 fail; typecheck clean
- [ ] Live verification post-merge: MCP init gap 5s → <100ms in server.log; chat TTFV drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)