### PR TITLE
fix(build): honest build-plugins output for server-only plugins

### DIFF
--- a/scripts/build-plugins.ts
+++ b/scripts/build-plugins.ts
@@ -23,6 +23,7 @@ const CORE_PLUGINS = CORE_PLUGIN_IDS
 // Single source for the externals contract — see src/core/whiskit/externals.ts.
 const EXTERNAL = PLUGIN_CLIENT_EXTERNALS
 
+let built = 0
 for (const id of CORE_PLUGINS) {
   // serverEntry: false — core plugin server code is statically imported from
   // source (src/lib/plugin-static-imports.ts); dist holds browser assets only (#421).
@@ -31,9 +32,14 @@ for (const id of CORE_PLUGINS) {
     console.error(`Failed to build ${result.stderr}`)
     process.exit(1)
   }
-  console.log(`  built plugins/${id}/dist/`)
+  if (result.clientBuilt) {
+    built++
+    console.log(`  built plugins/${id}/dist/`)
+  } else {
+    console.log(`  plugins/${id}: server-only (no client.tsx) — no dist`)
+  }
 }
 
-console.log(`plugins/<id>/dist: ${CORE_PLUGINS.length} plugins built`)
+console.log(`plugins/<id>/dist: ${built} client bundles built, ${CORE_PLUGINS.length - built} server-only`)
 
 export {}

--- a/scripts/dev-build-one-plugin.ts
+++ b/scripts/dev-build-one-plugin.ts
@@ -30,7 +30,8 @@ export interface BuildOnePluginOptions {
 }
 
 export type BuildOnePluginResult =
-  | { ok: true }
+  /** clientBuilt=false: server-only plugin (no client.tsx) — no dist produced. */
+  | { ok: true; clientBuilt: boolean }
   | { ok: false; stderr: string }
 
 interface RunResult {
@@ -81,20 +82,23 @@ export async function buildOnePlugin(
   }
 
   const clientEntry = join(pluginDir, 'client.tsx')
-  if (existsSync(clientEntry)) {
-    const clientRes = await run('bun', [
-      'build', clientEntry,
-      '--outdir', distDir,
-      '--target', 'browser',
-      '--format', 'esm',
-      '--entry-naming', 'client.[ext]',
-      ...(opts.production ? ['--production'] : []),
-      ...externalArgs,
-    ])
-    if (clientRes.exitCode !== 0) {
-      return { ok: false, stderr: `client entry for ${id}:\n${clientRes.stderr}` }
-    }
+  if (!existsSync(clientEntry)) {
+    // Server-only plugin (e.g. git, images): nothing to bundle, no dist.
+    // Callers must not log "built <dist>" — that phantom cost real debugging.
+    return { ok: true, clientBuilt: false }
+  }
+  const clientRes = await run('bun', [
+    'build', clientEntry,
+    '--outdir', distDir,
+    '--target', 'browser',
+    '--format', 'esm',
+    '--entry-naming', 'client.[ext]',
+    ...(opts.production ? ['--production'] : []),
+    ...externalArgs,
+  ])
+  if (clientRes.exitCode !== 0) {
+    return { ok: false, stderr: `client entry for ${id}:\n${clientRes.stderr}` }
   }
 
-  return { ok: true }
+  return { ok: true, clientBuilt: true }
 }

--- a/tasks/dev-rig-dual-runtime/todo.md
+++ b/tasks/dev-rig-dual-runtime/todo.md
@@ -55,16 +55,19 @@ Plan: ./plan.md · Spec: /SPEC.md · Branch: feat/dev-rig-dual-runtime
 
 ## Follow-ups (post-PR, one by one)
 
-- [ ] PluginHost boot hardening: no timeout or error surface — a single hung
-      manifest fetch / module import shows an infinite "Loading plugins"
-      spinner with zero feedback (bit Mark live when a tab loaded mid-server-
-      restart). Add a boot timeout + honest error panel with retry.
-- [ ] build-plugins log honesty: prints "built plugins/git/dist/" for
-      server-only plugins (git, images) that produce NO dist — cost real
-      debugging time chasing phantom deletions. Log "no client — skipped".
+- [x] PluginHost boot hardening — merged (#654): bounded boot, error panel + retry,
+      failure banner.
+- [x] build-plugins log honesty — done: buildOnePlugin reports clientBuilt;
+      log now reads "11 client bundles built, 2 server-only".
 - [ ] sandbox×pi live smoke (implemented + compose-validated; needs one
       in-container /login).
-- [ ] Old isolated home carries two 'failed' github user plugins
-      (projects, messaging) — stale June installs; reinstall or
-      `instance reset --mode isolated` clears them.
+- [x] Stale failed user plugins removed from the isolated home
+      (`plugins remove projects/messaging --yes`, 2026-07-12).
 - [ ] Live reset-scoping proof (optional; recipe above).
+
+## Machine baseline (2026-07-12, post-button-up)
+
+- Engine upgraded rc.17 → rc.18 (`bakin install search`; checksum verified).
+  NOTE for the search initiative: the installer's stop→swap→restart left the
+  LaunchAgent booted out — needed a manual `launchctl bootstrap`. Worth a look.
+- Full suite on this machine: 6607 pass / 0 fail, exit 0 (rc.18 pins + conformance green).


### PR DESCRIPTION
## Summary

Last button-up from the dev-rig initiative:

- `buildOnePlugin` returns `clientBuilt`; `build-plugins` no longer prints "built plugins/git/dist/" for server-only plugins (git, images) that produce no dist — the phantom line that cost real debugging time during the E2E. Summary now reads "11 client bundles built, 2 server-only".
- Ledger (`tasks/dev-rig-dual-runtime/todo.md`) closes out the follow-ups: #654 merged, stale failed user plugins removed from the isolated home, machine engine upgraded rc.17 → rc.18 (pins + conformance now green locally; full suite 6607 pass / 0 fail).

⚠️ Finding for the search-initiative owner, recorded in the ledger: `bakin install search`'s stop→swap→restart left the `io.bakin.antfly` LaunchAgent booted out (plist intact, unit unloaded) — needed a manual `launchctl bootstrap`.

Remaining (deliberately deferred): sandbox×pi live smoke (needs an interactive in-container /login) and the optional live reset-scoping proof — both have recipes in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)