### PR TITLE
fix(core): async package-update probes — server no longer freezes on Team page

### DIFF
--- a/packages/host/src/api/agent-packages/list.ts
+++ b/packages/host/src/api/agent-packages/list.ts
@@ -9,7 +9,7 @@
  * `bakin agents list`. Distinct from `/api/agents` (runtime status).
  */
 import { listAllAgentStates } from '@/core/agent-packages/agent-state'
-import { checkPackageUpdate } from '@/core/agent-packages/checker'
+import { checkPackageUpdateAsync } from '@/core/agent-packages/checker'
 
 export async function get(_req: Request, url: URL): Promise<Response> {
   void _req
@@ -20,7 +20,7 @@ export async function get(_req: Request, url: URL): Promise<Response> {
         if (!state.packageId) return state
         return {
           ...state,
-          updateStatus: checkPackageUpdate(state.packageId),
+          updateStatus: await checkPackageUpdateAsync(state.packageId),
         }
       }))
       return Response.json({ ok: true, agents: enriched })

--- a/src/core/agent-packages/checker.ts
+++ b/src/core/agent-packages/checker.ts
@@ -12,7 +12,7 @@ import {
   readLockfile,
   type PackageEntry,
 } from '../../../packages/core/src/agent-packages/lockfile'
-import { fetchSource, fetchSourceAsync, sourceSpecWithRef, type FetchedSource } from './source-fetcher'
+import { fetchSourceAsync, sourceSpecWithRef, type FetchedSource } from './source-fetcher'
 
 export interface PackageUpdateStatus {
   currentVersion: string
@@ -85,32 +85,12 @@ function statusFromError(entry: PackageEntry, checkedAt: string, err: unknown): 
   }
 }
 
-export function checkPackageUpdate(
-  packageId: string,
-  options: CheckPackageUpdateOptions = {},
-): PackageUpdateStatus {
-  const checkedAt = (options.now ?? (() => new Date()))().toISOString()
-  const lock = readLockfile()
-  const entry = lock.packages[packageId]
-  if (!entry) {
-    throw new Error(`Package "${packageId}" is not installed.`)
-  }
-
-  let fetched: FetchedSource | null = null
-  try {
-    fetched = fetchSource(sourceWithRef(entry))
-    return statusFromFetched(packageId, entry, fetched, checkedAt)
-  } catch (err) {
-    return statusFromError(entry, checkedAt, err)
-  } finally {
-    cleanupFetched(fetched)
-  }
-}
-
 /**
- * Async variant for request-path callers: the git/network fetch runs off the
- * event loop (fetchSourceAsync), so a slow remote can't stall the server the
- * way the execFileSync-backed sync path can.
+ * The git/network fetch runs off the event loop (fetchSourceAsync) so a slow
+ * remote can't stall the server. The old execFileSync-backed sync variant is
+ * deliberately GONE: `/api/agent-packages?check=1` (the Team page) once froze
+ * the whole server for N × git-timeout through it — every request, including
+ * the plugin manifest, queued behind blocking clones.
  */
 export async function checkPackageUpdateAsync(
   packageId: string,

--- a/src/core/agent-packages/sync.ts
+++ b/src/core/agent-packages/sync.ts
@@ -54,7 +54,7 @@ import { unmarkUserEdited } from '../../../packages/core/src/agent-packages/mark
 import { PackageNotInstalledError } from './errors'
 import { projectPackage, type ProjectorResult } from './projector'
 import { updatePackageById } from './updater'
-import { checkPackageUpdate } from './checker'
+import { checkPackageUpdateAsync } from './checker'
 import {
   COMPOSABLE_FILES,
   type SyncFinding,
@@ -266,7 +266,7 @@ export async function syncAgent(agentId: string, opts: SyncOptions = {}): Promis
     if (check) {
       if (fetch) {
         try {
-          const status = await checkPackageUpdate(owner.id)
+          const status = await checkPackageUpdateAsync(owner.id)
           versionAfter = status.latestVersion ?? versionBefore
           commitAfter = status.latestCommitSha ?? commitBefore
           changed = status.upgradeAvailable === true
@@ -473,7 +473,7 @@ export async function syncPack(
   }
 
   if (opts.check) {
-    const status = await checkPackageUpdate(packageId)
+    const status = await checkPackageUpdateAsync(packageId)
     return {
       packageId,
       kind: entry.kind,


### PR DESCRIPTION
## Summary

Root cause of the recurring 15–30s "Loading plugins" stalls: `GET /api/agent-packages?check=1` (Team page) called the **synchronous, execFileSync-backed** `checkPackageUpdate` once per installed package — each a blocking `git clone` that froze the entire event loop, queueing every other request (including the 2ms plugin manifest) behind it. The `Promise.all(async …)` wrapper around it was decorative.

- All callers (the list route + both `agents sync --check` paths) now use `checkPackageUpdateAsync` (which exists precisely for request-path safety)
- The sync variant is **deleted** — this class of freeze is now unreachable
- Verified live: manifest answers in 4–9ms while a `?check=1` probe runs real git fetches concurrently (previously: full freeze for the probe duration)

Full suite: 6607 pass / 0 fail.

Note: #654's boot timeout turned this from an infinite spinner into a bounded one, but the server-side freeze was the actual disease — this PR removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)