### PR TITLE
fix(workflows): resolve $preferred selectors on fan-out board tasks

### DIFF
--- a/plugins/workflows/lib/engine.ts
+++ b/plugins/workflows/lib/engine.ts
@@ -128,7 +128,7 @@ export function createInstance(
 
     // Create a board task so the child workflow's gates are visible in the UI
     const childDef = loadDefinition(nested.workflow_id, dir)
-    createBoardTaskForChild(childTaskId, taskId, nested, childDef, assignee)
+    createBoardTaskForChild(childTaskId, taskId, nested, childDef, childInstance)
   } else if (firstStep.type === 'map_workflow') {
     // Statically illegal (source must name an EARLIER step, so validation
     // rejects a first-step map) — but createInstance is reachable without
@@ -293,7 +293,7 @@ function fanOutMapStep(
     childInstance.parentTaskId = instance.taskId
     childInstance.parentStepId = mapStep.id
     saveInstance(childInstance, contentDir)
-    createBoardTaskForChild(childTaskId, instance.taskId, mapStep, childDef, instance.resolvedAgent, { index: i, total })
+    createBoardTaskForChild(childTaskId, instance.taskId, mapStep, childDef, childInstance, { index: i, total })
     // A child can fail during its own createInstance (e.g. a defensive
     // first-step map failure) — record an honest entry, never in_progress.
     children.push({ index: i, childTaskId, status: childInstance.status === 'failed' ? 'failed' : 'in_progress' })
@@ -613,7 +613,7 @@ export function advanceWorkflow(instance: WorkflowInstance, def: WorkflowDefinit
 
     // Create a board task so the child workflow's gates are visible in the UI
     const childDef = loadDefinition(nested.workflow_id, contentDir)
-    createBoardTaskForChild(childTaskId, instance.taskId, nested, childDef, instance.resolvedAgent)
+    createBoardTaskForChild(childTaskId, instance.taskId, nested, childDef, childInstance)
   } else if (nextStep.type === 'map_workflow') {
     // Dynamic fan-out — one child instance per source-array element.
     fanOutMapStep(instance, nextStep as MapWorkflowStep, def, contentDir, now)

--- a/plugins/workflows/lib/map-children.ts
+++ b/plugins/workflows/lib/map-children.ts
@@ -129,7 +129,7 @@ export function retryMapChild(
     childInstance.parentStepId = mapStep.id
     saveInstance(childInstance, dir)
     const total = parent.stepStates[stepId].children?.length ?? index + 1
-    createBoardTaskForChild(entry.childTaskId, parent.taskId, mapStep, loadDefinition(mapStep.workflow_id, dir), parent.resolvedAgent, { index, total })
+    createBoardTaskForChild(entry.childTaskId, parent.taskId, mapStep, loadDefinition(mapStep.workflow_id, dir), childInstance, { index, total })
     // The re-created child can fail synchronously inside createInstance
     // (defensive first-step failures) — record an honest entry. The in-spawn
     // markMapChildFailed no-ops there because linkage is assigned after.

--- a/plugins/workflows/lib/task-bridge.ts
+++ b/plugins/workflows/lib/task-bridge.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../src/core/task-store'
 import { syncLedgerForStoreMove } from '../../../src/core/task-service'
 import { listInstances } from './instance-store'
+import { resolveAgent } from './step-context'
 
 const log = createLogger('workflow-runtime')
 
@@ -137,7 +138,7 @@ export function createBoardTaskForChild(
   parentTaskId: string,
   nestedStep: NestedWorkflowStep | MapWorkflowStep,
   childDef: WorkflowDefinition | null,
-  assignee?: string,
+  childInstance: WorkflowInstance,
   /** Map fan-out children: fraction titles + board-task revive on id reuse. */
   mapMeta?: { index: number; total: number },
 ) {
@@ -160,10 +161,15 @@ export function createBoardTaskForChild(
       title = parentTask?.title ? `${parentTask.title} — ${fraction}` : `${fraction} (sub-workflow)`
     }
     const description = nestedStep.description || childDef?.description || undefined
-    // Find the first agent step in the child workflow for the assignee
+    // Seed the assignee from the child workflow's first agent step, resolved
+    // through the same selector engine dispatch uses (resolveAgent handles
+    // $assigned and $preferred(...) against the instance's agent snapshot).
+    // Storing a raw selector string here left fan-out tasks with an
+    // unrenderable "$preferred(pixel,$assigned)" agent on the board.
     const childAgent = childDef?.steps.find(s => s.type === 'agent')
-    const agent = childAgent ? (childAgent as AgentStep).agent : assignee
-    const resolvedAgent = agent === '$assigned' ? assignee : agent
+    const agent = childAgent ? (childAgent as AgentStep).agent : childInstance.resolvedAgent
+    const resolved = agent ? resolveAgent(agent, childInstance) : undefined
+    const resolvedAgent = resolved && !resolved.startsWith('$') ? resolved : childInstance.resolvedAgent
 
     await createTask(
       title,

--- a/tests/plugins/workflows/helpers/runtime-harness.ts
+++ b/tests/plugins/workflows/helpers/runtime-harness.ts
@@ -17,7 +17,7 @@ import { mock } from 'bun:test'
 import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
-export type HookTask = { id: string; title: string; column: string; description?: string }
+export type HookTask = { id: string; title: string; column: string; description?: string; agent?: string }
 export const hookTasks = new Map<string, HookTask>()
 export const createTaskHook = mock(async (data: Record<string, unknown>) => {
   const id = data.id as string
@@ -26,6 +26,7 @@ export const createTaskHook = mock(async (data: Record<string, unknown>) => {
     title: data.title as string,
     column: data.column as string,
     description: data.description as string | undefined,
+    agent: data.agent as string | undefined,
   })
   return { id }
 })
@@ -72,12 +73,12 @@ export const taskStoreMock = {
   createTask: (
     title: string,
     column?: string,
-    _assignee?: string,
+    assignee?: string,
     description?: string,
     _workflowId?: string,
     _createdBy?: string,
     id?: string,
-  ) => createTaskHook({ id, title, column, description }),
+  ) => createTaskHook({ id, title, column, description, agent: assignee }),
   getTask: (id: string) => hookTasks.get(id) ?? null,
   getTaskWithColumn: (id: string) => {
     const task = hookTasks.get(id)
@@ -287,6 +288,28 @@ steps:
     description: Work one item
 `
 
+// Map parent whose children use a $preferred(...) agent selector — proves the
+// fan-out board tasks store a RESOLVED agent, not the raw selector string.
+export const mapPreferredWorkflow = `
+name: Map Preferred Flow
+description: Fan-out into preferred-selector children
+version: 1
+steps:
+  - id: source-step
+    type: agent
+    label: Segment
+    agent: chef
+  - id: produce-items
+    type: map_workflow
+    label: Produce Items
+    source: source-step.items
+    workflow_id: preferred
+  - id: after-map
+    type: agent
+    label: After Map
+    agent: main
+`
+
 // Map child WITH a gate — proves child gate approvals flow to the join
 export const mapGatedChildWorkflow = `
 name: Map Gated Child
@@ -411,5 +434,6 @@ export function seedWorkflowFixtures(testDir: string): void {
   writeFileSync(join(defsDir, 'map-wrapper.yaml'), mapWrapperWorkflow)
   writeFileSync(join(defsDir, 'map-gated-child.yaml'), mapGatedChildWorkflow)
   writeFileSync(join(defsDir, 'map-gated.yaml'), mapGatedWorkflow)
+  writeFileSync(join(defsDir, 'map-preferred.yaml'), mapPreferredWorkflow)
   writeFileSync(join(skillsDir, 'test-skill.md'), testSkillMarkdown)
 }

--- a/tests/plugins/workflows/runtime-map.test.ts
+++ b/tests/plugins/workflows/runtime-map.test.ts
@@ -161,6 +161,28 @@ describe('runtime — map_workflow', () => {
       }
     })
 
+    it('stores a resolved agent on fan-out board tasks, never the raw $preferred selector', async () => {
+      createInstance('task-map-pref', 'map-preferred', testDir, 'roscoe', undefined, ['chef', 'pixel', 'main'])
+      completeStep('task-map-pref', 'source-step', { items: ['a', 'b'] }, undefined, testDir)
+      await settle()
+
+      for (let i = 0; i < 2; i++) {
+        const task = hookTasks.get(`task-map-pref--produce-items--${i}`)
+        expect(task, `board task ${i}`).toBeDefined()
+        expect(task!.agent).toBe('pixel')
+      }
+    })
+
+    it('resolves a $preferred child selector to the assignee when the preferred agent is off-roster', async () => {
+      createInstance('task-map-pref-fb', 'map-preferred', testDir, 'roscoe', undefined, ['chef', 'main'])
+      completeStep('task-map-pref-fb', 'source-step', { items: ['a'] }, undefined, testDir)
+      await settle()
+
+      const task = hookTasks.get('task-map-pref-fb--produce-items--0')
+      expect(task).toBeDefined()
+      expect(task!.agent).toBe('roscoe')
+    })
+
     it('falls back to a label-only board title when the parent task is unknown', async () => {
       startAndFan('task-map-noparent')
       await settle()


### PR DESCRIPTION
## Problem

Found during #625 validation: map fan-out board tasks (e.g. image-multi-select → "Generate Variants N/3") showed an empty assignee avatar even though Pixel executed every one of them.

`createBoardTaskForChild` copied the child workflow's first agent step verbatim onto the board task, only unwrapping the literal `$assigned`. A `$preferred(...)` selector — like image-variant's `$preferred(pixel,$assigned)` — was stored raw:

```json
"agent": "$preferred(pixel,$assigned)"
```

Dispatch was unaffected (it resolves the selector independently via `getActiveAgents` → `resolveAgent`), but the board rendered the unknown-agent fallback icon, and the tasks never grouped under the executing agent in any UI keyed off `task.agent`.

## Fix

Pass the child workflow instance into `createBoardTaskForChild` and resolve the agent through the same `resolveAgent` engine dispatch uses — roster snapshot honored, `$assigned` falls back to the instance's assignee, and an unresolvable selector stores the assignee instead of a `$`-string. Covers all four spawn paths: initial nested spawn, map fan-out, mid-workflow nested spawn, and per-child retry.

Existing task records keep their raw string (fix applies at creation); dispatch behavior is unchanged.

## Tests

- Two regression tests in `runtime-map.test.ts`: fan-out children store `pixel` when it's on the roster snapshot; fall back to the assignee when it isn't (both fail on the old code).
- Test harness now captures the assignee passed to `createTask` (previously dropped).
- Full suite: 6657 pass; `tsc --noEmit` clean.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)