### PR TITLE
fix(search): prevent + detect + auto-repair wedged-engine incidents

### DIFF
--- a/packages/adapter-antfly/src/adapter.ts
+++ b/packages/adapter-antfly/src/adapter.ts
@@ -27,7 +27,8 @@ import type {
 } from '@bakin/core/adapters/search'
 import { AntflySearchClient } from './client'
 import { mergeSettings, type AntflySettings } from './defaults'
-import { detectServiceMode, ensureProvisioned, startChild, stopChild } from './service'
+import { createEngineStatusProbe } from './engine-status'
+import { detectServiceMode, ensureProvisioned, restartService, startChild, stopChild } from './service'
 
 const log = createLogger('antfly-adapter')
 
@@ -86,6 +87,21 @@ export class AntflyAdapter implements SearchAdapter {
 
   mappingFingerprint(): string {
     return this.client.mappingFingerprint()
+  }
+
+  // Engine-process introspection for the doctor's burn watchdog. One probe
+  // per adapter — it holds the previous CPU sample + log offset, so each
+  // call reports the rate/signals since the last one.
+  private engineProbe = createEngineStatusProbe(() => this.settings)
+
+  engineStatus() {
+    if (!this.settings.enabled) return Promise.resolve(null)
+    return this.engineProbe()
+  }
+
+  /** Graceful supervised restart (doctor repair for a wedged engine). */
+  restartEngine(): Promise<void> {
+    return restartService(this.settings)
   }
 
   tables = {

--- a/packages/adapter-antfly/src/engine-status.ts
+++ b/packages/adapter-antfly/src/engine-status.ts
@@ -1,0 +1,165 @@
+/**
+ * Engine-process introspection behind SearchAdapter.engineStatus() — the
+ * doctor's burn watchdog reads this to catch a wedged engine (the
+ * 2026-07-12 incident: a zero-progress startup catch-up loop pinned the
+ * engine at 200% CPU for 17h while every query starved).
+ *
+ * Two signals, both measured SINCE THE PREVIOUS CALL so the doctor's own
+ * cadence is the sampling window (same pattern as the search-spin check):
+ *
+ *  - cpuUtilization: Δ cumulative process CPU time / Δ wall clock, from
+ *    one `ps -o time=` read per call. Null on the first sample, a pid
+ *    change, or a mode where the pid is unknowable (guest).
+ *  - wedgeSignals: known zero-progress signatures counted in the NEW bytes
+ *    of the engine log (byte-offset tail scan, rotation-safe). A signature
+ *    must recur several times within one window to count — a single line
+ *    is noise, a loop is a wedge.
+ */
+import { openSync, readSync, closeSync, statSync } from 'fs'
+import { createLogger } from '@bakin/core/logger'
+import type { SearchEngineStatus } from '@bakin/core/adapters/search'
+import type { AntflySettings } from './defaults'
+import {
+  LAUNCHD_LABEL,
+  SYSTEMD_UNIT,
+  childPid,
+  defaultServiceIo,
+  detectServiceMode,
+  servicePaths,
+  type ServiceIo,
+} from './service'
+
+const log = createLogger('antfly-engine-status')
+
+/** A signature must appear this many times in one window's log delta. */
+const WEDGE_MIN_OCCURRENCES = 3
+/** Never read more than this much log per probe (a flooding engine). */
+const MAX_TAIL_BYTES = 512 * 1024
+
+/** Known engine wedge signatures (each line = one loop iteration). */
+const WEDGE_PATTERNS: ReadonlyArray<{ signal: string; pattern: RegExp }> = [
+  // The startup catch-up loop re-opening/closing a table group forever
+  // ("provisioned startup catch-up debt persists", one line per ~2s spin).
+  { signal: 'startup-catchup-spin', pattern: /catch-up debt persists/g },
+]
+
+interface ProbeState {
+  pid: number | null
+  cpuSeconds: number | null
+  at: number
+  logOffset: number | null
+}
+
+/** Parse `ps -o time=` cumulative CPU ([[dd-]hh:]mm:ss) into seconds. */
+export function parsePsCpuTime(raw: string): number | null {
+  const text = raw.trim()
+  if (!text) return null
+  const dayMatch = /^(\d+)-(.+)$/.exec(text)
+  const days = dayMatch ? Number(dayMatch[1]) : 0
+  const parts = (dayMatch ? dayMatch[2] : text).split(':').map(Number)
+  if (parts.some(Number.isNaN) || parts.length < 2 || parts.length > 3) return null
+  const [h, m, sec] = parts.length === 3 ? parts : [0, parts[0], parts[1]]
+  return days * 86_400 + h * 3600 + m * 60 + sec
+}
+
+/**
+ * Count wedge signatures in the log's new bytes; advance the offset.
+ * `prevOffset: null` = first probe — baseline to EOF without scanning, so
+ * historical spam from an already-fixed incident never fires a signal.
+ */
+export function scanLogDelta(
+  logFile: string,
+  prevOffset: number | null,
+): { signals: string[]; nextOffset: number } {
+  let size: number
+  try {
+    size = statSync(logFile).size
+  } catch {
+    return { signals: [], nextOffset: 0 } // no log yet
+  }
+  if (prevOffset === null) return { signals: [], nextOffset: size }
+  // Rotation/truncation: the file shrank — start over from the tail.
+  let from = prevOffset > size ? Math.max(0, size - MAX_TAIL_BYTES) : prevOffset
+  if (size - from > MAX_TAIL_BYTES) from = size - MAX_TAIL_BYTES
+  if (size === from) return { signals: [], nextOffset: size }
+
+  const length = size - from
+  const buffer = Buffer.alloc(length)
+  try {
+    const fd = openSync(logFile, 'r')
+    try {
+      readSync(fd, buffer, 0, length, from)
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    return { signals: [], nextOffset: prevOffset }
+  }
+  const delta = buffer.toString('utf-8')
+  const signals = WEDGE_PATTERNS.filter(({ pattern }) => {
+    const count = delta.match(pattern)?.length ?? 0
+    return count >= WEDGE_MIN_OCCURRENCES
+  }).map(({ signal }) => signal)
+  return { signals, nextOffset: size }
+}
+
+async function resolvePid(settings: AntflySettings, io: ServiceIo): Promise<number | null> {
+  const mode = detectServiceMode(settings, io)
+  if (mode === 'guest') return null
+  if (mode === 'child') return childPid()
+  if (mode === 'launchd') {
+    const uid = typeof process.getuid === 'function' ? process.getuid() : 501
+    const result = await io.exec('launchctl', ['print', `gui/${uid}/${LAUNCHD_LABEL}`])
+    if (result.code !== 0) return null
+    const match = /^\s*pid = (\d+)/m.exec(result.stdout)
+    return match ? Number(match[1]) : null
+  }
+  // systemd: MainPID=0 means not running
+  const result = await io.exec('systemctl', ['--user', 'show', '-p', 'MainPID', '--value', SYSTEMD_UNIT])
+  if (result.code !== 0) return null
+  const pid = Number(result.stdout.trim())
+  return Number.isInteger(pid) && pid > 0 ? pid : null
+}
+
+/**
+ * One probe per adapter instance — the state (previous CPU sample + log
+ * offset) is what turns point reads into rates.
+ */
+export function createEngineStatusProbe(
+  getSettings: () => AntflySettings,
+  io: ServiceIo = defaultServiceIo(),
+): () => Promise<SearchEngineStatus | null> {
+  let state: ProbeState | null = null
+
+  return async (): Promise<SearchEngineStatus | null> => {
+    const settings = getSettings()
+    const mode = detectServiceMode(settings, io)
+    if (mode === 'guest') return null // externally managed — not ours to measure
+
+    const now = Date.now()
+    const pid = await resolvePid(settings, io)
+    if (pid === null) {
+      state = { pid: null, cpuSeconds: null, at: now, logOffset: state?.logOffset ?? null }
+      return { running: false, cpuUtilization: null, wedgeSignals: [] }
+    }
+
+    let cpuSeconds: number | null = null
+    try {
+      const ps = await io.exec('ps', ['-o', 'time=', '-p', String(pid)])
+      cpuSeconds = ps.code === 0 ? parsePsCpuTime(ps.stdout) : null
+    } catch (err) {
+      log.warn('engine cpu sample failed', { err: err instanceof Error ? err.message : String(err) })
+    }
+
+    const samePid = state?.pid === pid
+    const utilization =
+      samePid && state && state.cpuSeconds !== null && cpuSeconds !== null && now > state.at
+        ? Math.max(0, (cpuSeconds - state.cpuSeconds) / ((now - state.at) / 1000))
+        : null
+
+    const { signals, nextOffset } = scanLogDelta(servicePaths().logFile, state?.logOffset ?? null)
+    state = { pid, cpuSeconds, at: now, logOffset: nextOffset }
+
+    return { running: true, pid, cpuUtilization: utilization, wedgeSignals: signals }
+  }
+}

--- a/packages/adapter-antfly/src/engine-status.ts
+++ b/packages/adapter-antfly/src/engine-status.ts
@@ -92,7 +92,13 @@ export function scanLogDelta(
     } finally {
       closeSync(fd)
     }
-  } catch {
+  } catch (err) {
+    // Fails safe (offset preserved, no false signals) but never silently:
+    // a persistently unreadable log would blind the wedge watchdog.
+    log.warn('engine log read failed — wedge scan skipped this window', {
+      logFile,
+      err: err instanceof Error ? err.message : String(err),
+    })
     return { signals: [], nextOffset: prevOffset }
   }
   const delta = buffer.toString('utf-8')

--- a/packages/adapter-antfly/src/service.ts
+++ b/packages/adapter-antfly/src/service.ts
@@ -362,11 +362,8 @@ export async function restartService(settings: AntflySettings, io: ServiceIo = d
     const uid = typeof process.getuid === 'function' ? process.getuid() : 501
     // SIGTERM + KeepAlive=true → launchd respawns the service cleanly.
     const kill = await io.exec('launchctl', ['kill', 'SIGTERM', `gui/${uid}/${LAUNCHD_LABEL}`])
-    if (kill.code !== 0) {
-      // Not loaded (or older macOS) — kickstart brings it up either way.
-      const kick = await io.exec('launchctl', ['kickstart', '-k', `gui/${uid}/${LAUNCHD_LABEL}`])
-      if (kick.code !== 0) await ensureProvisioned(settings, io)
-    }
+    // Not loaded (or older macOS) — the one start path owns the fallbacks.
+    if (kill.code !== 0) await startService(settings, io)
     return
   }
   if (mode === 'systemd') {
@@ -374,9 +371,37 @@ export async function restartService(settings: AntflySettings, io: ServiceIo = d
     if (restart.code !== 0) await ensureProvisioned(settings, io)
     return
   }
-  // strict child
-  stopChild()
+  // Strict child: wait for the old process to actually release the port —
+  // spawning immediately races the dying engine for the 3738 bind, and a
+  // bind-failure exit is never respawned (strict child, no restart ladder),
+  // which would convert a wedged engine into a dead one (review finding).
+  await stopChildAndWait()
   startChild(settings)
+}
+
+/**
+ * SIGTERM the strict child and wait for it to exit (SIGKILL fallback after
+ * the grace window — a child that ignores SIGTERM while wedged must still
+ * release the port).
+ */
+export async function stopChildAndWait(graceMs = 10_000): Promise<void> {
+  const child = g.__bakinAntflyChild
+  stopChild()
+  if (!child || child.exitCode !== null) return
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // already gone
+      }
+      resolve()
+    }, graceMs)
+    child.once('exit', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
 }
 
 /** Pid of the strict-child engine, when one is running (engine-status probe). */

--- a/packages/adapter-antfly/src/service.ts
+++ b/packages/adapter-antfly/src/service.ts
@@ -348,6 +348,43 @@ export async function startService(settings: AntflySettings, io: ServiceIo = def
   }
 }
 
+/**
+ * Gracefully restart the supervised engine (doctor repair for a wedged
+ * engine). SIGTERM first so the engine can flush — a hard kill mid-write
+ * is exactly what seeds the startup catch-up spin on the next boot.
+ */
+export async function restartService(settings: AntflySettings, io: ServiceIo = defaultServiceIo()): Promise<void> {
+  const mode = detectServiceMode(settings, io)
+  if (mode === 'guest') {
+    throw new Error(`engine is externally managed (${settings.url}) — restart it where it runs`)
+  }
+  if (mode === 'launchd') {
+    const uid = typeof process.getuid === 'function' ? process.getuid() : 501
+    // SIGTERM + KeepAlive=true → launchd respawns the service cleanly.
+    const kill = await io.exec('launchctl', ['kill', 'SIGTERM', `gui/${uid}/${LAUNCHD_LABEL}`])
+    if (kill.code !== 0) {
+      // Not loaded (or older macOS) — kickstart brings it up either way.
+      const kick = await io.exec('launchctl', ['kickstart', '-k', `gui/${uid}/${LAUNCHD_LABEL}`])
+      if (kick.code !== 0) await ensureProvisioned(settings, io)
+    }
+    return
+  }
+  if (mode === 'systemd') {
+    const restart = await io.exec('systemctl', ['--user', 'restart', SYSTEMD_UNIT])
+    if (restart.code !== 0) await ensureProvisioned(settings, io)
+    return
+  }
+  // strict child
+  stopChild()
+  startChild(settings)
+}
+
+/** Pid of the strict-child engine, when one is running (engine-status probe). */
+export function childPid(): number | null {
+  const child = g.__bakinAntflyChild
+  return child && child.exitCode === null ? child.pid ?? null : null
+}
+
 /** Remove the service entirely (uninstall path). */
 export async function removeService(settings: AntflySettings, io: ServiceIo = defaultServiceIo()): Promise<void> {
   const mode = detectServiceMode(settings, io)

--- a/packages/core/src/adapters/search/concepts.ts
+++ b/packages/core/src/adapters/search/concepts.ts
@@ -2,6 +2,28 @@ import type { RuntimeMetadata } from '../runtime/concepts'
 
 export type Document = Record<string, unknown>
 
+/**
+ * Engine-process introspection for the doctor's burn watchdog. Stateful by
+ * design: cpuUtilization is measured SINCE THE PREVIOUS engineStatus()
+ * call, so the doctor's own cadence is the sampling window.
+ */
+export interface SearchEngineStatus {
+  running: boolean
+  pid?: number
+  /**
+   * CPU fraction since the previous call (1.0 = one saturated core; can
+   * exceed 1 on multi-threaded engines). Null on the first sample, after a
+   * pid change, or when the mode cannot be measured.
+   */
+  cpuUtilization: number | null
+  /**
+   * Adapter-named wedge signatures observed since the previous call (e.g.
+   * a recurring zero-progress maintenance loop in the engine log). Any
+   * entry means the engine is burning CPU without making progress.
+   */
+  wedgeSignals: string[]
+}
+
 export interface TableInfo {
   name: string
   config?: TableConfig

--- a/packages/core/src/adapters/search/index.ts
+++ b/packages/core/src/adapters/search/index.ts
@@ -8,6 +8,7 @@ import type {
   ScanOpts,
   ScannedDocument,
   SearchAdapterCapabilities,
+  SearchEngineStatus,
   TableConfig,
   TableInfo,
   TableLegHealth,
@@ -27,6 +28,21 @@ export interface SearchAdapter {
 
   /** What this adapter can build/serve, in capability terms (D17). */
   capabilities(): SearchAdapterCapabilities
+
+  /**
+   * OPTIONAL: engine-process introspection (pid/CPU/wedge signatures) for
+   * the doctor's burn watchdog. Absent or resolving null = the adapter (or
+   * its current mode, e.g. an externally managed guest engine) cannot
+   * measure — consumers feature-detect, never assume.
+   */
+  engineStatus?(): Promise<SearchEngineStatus | null>
+
+  /**
+   * OPTIONAL: gracefully restart the supervised engine (doctor repair for
+   * a wedged engine). Must throw with a clear message when the engine is
+   * not this adapter's to restart (guest mode).
+   */
+  restartEngine?(): Promise<void>
 
   /**
    * Hash over adapter settings that change the PHYSICAL index layout
@@ -121,6 +137,7 @@ export type {
   ScannedDocument,
   ScoreBreakdown,
   SearchAdapterCapabilities,
+  SearchEngineStatus,
   SearchFieldConfig,
   SearchHit,
   SearchIndexConfig,

--- a/packages/core/src/search/tables.ts
+++ b/packages/core/src/search/tables.ts
@@ -64,6 +64,16 @@ const MODULE = 'search-tables'
 const BACKFILL_CHUNK = 50
 const DEFAULT_CONVERGE_TIMEOUT_MS = 10 * 60 * 1000
 const DEFAULT_CONVERGE_POLL_MS = 2_000
+/**
+ * An orphan candidate must stay unreferenced this long before it is
+ * dropped. A cross-process ensure (CLI onboarding against the same engine)
+ * creates + backfills a NEW logical's table long before its registry row
+ * lands, and a single observation cannot distinguish that window from a
+ * true orphan. Six hours comfortably outlasts any backfill.
+ */
+const ORPHAN_DROP_DWELL_MS = 6 * 60 * 60 * 1000
+/** Every physical this module has ever created: `{logical}_v{N}_{fp8}`. */
+const VERSIONED_PHYSICAL = /^.+_v\d+_[0-9a-f]{8}$/
 
 const store = openNamedDb('search', () => join(getContentDir(), 'search.db'))
 
@@ -88,6 +98,19 @@ const MIGRATIONS = [
         `CREATE TABLE search_table_tombstones (
            physical TEXT PRIMARY KEY,
            noted_at INTEGER NOT NULL
+         )`,
+      )
+    },
+  },
+  {
+    version: 2,
+    up: (db: Db) => {
+      // First-seen ledger for the orphan engine-table sweep: a candidate
+      // must survive a dwell window across sweeps before it is dropped.
+      db.exec(
+        `CREATE TABLE search_orphan_candidates (
+           physical   TEXT PRIMARY KEY,
+           first_seen INTEGER NOT NULL
          )`,
       )
     },
@@ -285,6 +308,88 @@ async function dropTolerant(adapter: SearchAdapter, physical: string): Promise<v
   }
 }
 
+export interface OrphanTableSweepResult {
+  /** Physicals dropped this sweep (drop failures tombstone instead). */
+  dropped: string[]
+  /** Candidates still inside the dwell window — a later sweep drops them. */
+  pending: number
+}
+
+/**
+ * Doctor sweep: drop engine-side tables this module created but no longer
+ * references. Orphan generations appear when search.db is recreated while
+ * the engine keeps its tables, or when a crash lands between the engine
+ * create and the registry insert. They are not just disk waste: a wedged
+ * orphan generation can pin the engine's startup catch-up loop at full CPU
+ * and starve every live query (2026-07-12 incident).
+ *
+ * Safety: only names matching the versioned physical pattern are
+ * considered; the sweep runs on the migration chain so it can never
+ * observe an in-process create/backfill mid-flight; and a candidate must
+ * stay unreferenced for a full dwell window (persisted first-seen ledger)
+ * before it is dropped — see ORPHAN_DROP_DWELL_MS.
+ */
+export async function sweepOrphanEngineTables(
+  adapter: SearchAdapter,
+  opts?: { dwellMs?: number },
+): Promise<OrphanTableSweepResult> {
+  const dwellMs = opts?.dwellMs ?? ORPHAN_DROP_DWELL_MS
+  return serialized(async () => {
+    const engine = await adapter.tables.list()
+    const referenced = new Set<string>()
+    for (const row of db().prepare<Row, []>('SELECT * FROM search_tables').all()) {
+      referenced.add(row.physical)
+      if (row.migrating_to) referenced.add(row.migrating_to)
+    }
+    // Tombstoned physicals are already queued for drop — not ours to track.
+    for (const row of db().prepare<{ physical: string }, []>('SELECT physical FROM search_table_tombstones').all()) {
+      referenced.add(row.physical)
+    }
+
+    const candidates = new Set(
+      engine
+        .map((table) => table.name)
+        .filter((name) => VERSIONED_PHYSICAL.test(name) && !referenced.has(name)),
+    )
+
+    // Reconcile the first-seen ledger: rows for tables that are gone or
+    // referenced again must not linger and later justify a drop.
+    for (const row of db().prepare<{ physical: string }, []>('SELECT physical FROM search_orphan_candidates').all()) {
+      if (!candidates.has(row.physical)) {
+        db().prepare('DELETE FROM search_orphan_candidates WHERE physical = ?').run(row.physical)
+      }
+    }
+
+    const now = Date.now()
+    const dropped: string[] = []
+    for (const name of candidates) {
+      const seen = db()
+        .prepare<{ first_seen: number }, [string]>('SELECT first_seen FROM search_orphan_candidates WHERE physical = ?')
+        .get(name)
+      if (!seen) {
+        db().prepare('INSERT INTO search_orphan_candidates (physical, first_seen) VALUES (?, ?)').run(name, now)
+        continue
+      }
+      if (now - seen.first_seen < dwellMs) continue
+      try {
+        await adapter.tables.drop(name)
+        dropped.push(name)
+        log.info('orphan engine table dropped', { physical: name, orphanedForMs: now - seen.first_seen })
+      } catch (err) {
+        log.warn('orphan engine table drop failed — tombstoned for the doctor sweep', {
+          physical: name,
+          err: err instanceof Error ? err.message : String(err),
+        })
+        noteTombstone(name)
+      }
+      db().prepare('DELETE FROM search_orphan_candidates WHERE physical = ?').run(name)
+    }
+
+    const pending = db().prepare<{ n: number }, []>('SELECT COUNT(*) AS n FROM search_orphan_candidates').get()?.n ?? 0
+    return { dropped, pending }
+  })
+}
+
 /** Doctor sweep: retry dropping tombstoned physicals. Returns remaining. */
 export async function sweepTombstones(adapter: SearchAdapter): Promise<number> {
   const rows = db().prepare<{ physical: string }, []>('SELECT physical FROM search_table_tombstones').all()
@@ -480,5 +585,5 @@ export async function resumeMigrations(
 /** Test-only: wipe registry + tombstones (close-first — see outbox note). */
 export function resetTablesForTests(): void {
   store.close()
-  db().exec('DELETE FROM search_tables; DELETE FROM search_table_tombstones;')
+  db().exec('DELETE FROM search_tables; DELETE FROM search_table_tombstones; DELETE FROM search_orphan_candidates;')
 }

--- a/packages/core/src/search/tables.ts
+++ b/packages/core/src/search/tables.ts
@@ -115,6 +115,22 @@ const MIGRATIONS = [
       )
     },
   },
+  {
+    version: 3,
+    up: (db: Db) => {
+      // Ownership ledger: every physical THIS instance created. The orphan
+      // sweep only ever drops tables recorded here — registry absence alone
+      // cannot distinguish our stale generation from another Bakin home's
+      // LIVE table on a shared engine (review finding: a second instance
+      // pointed at the same engine would otherwise drop production tables).
+      db.exec(
+        `CREATE TABLE search_created_physicals (
+           physical   TEXT PRIMARY KEY,
+           created_at INTEGER NOT NULL
+         )`,
+      )
+    },
+  },
 ]
 
 function db(): Db {
@@ -226,6 +242,18 @@ async function createTableTolerant(adapter: SearchAdapter, physical: string, con
     const stats = await adapter.tables.stats(physical).catch(() => null)
     if (!stats) throw err
   }
+  noteCreatedPhysical(physical)
+}
+
+/** Ownership ledger writes — see migration v3 for why this exists. */
+function noteCreatedPhysical(physical: string): void {
+  db()
+    .prepare('INSERT INTO search_created_physicals (physical, created_at) VALUES (?, ?) ON CONFLICT (physical) DO NOTHING')
+    .run(physical, Date.now())
+}
+
+function forgetCreatedPhysical(physical: string): void {
+  db().prepare('DELETE FROM search_created_physicals WHERE physical = ?').run(physical)
 }
 
 async function backfill(adapter: SearchAdapter, def: TableEnsureDef, physical: string, onProgress?: EnsureOpts['onProgress']): Promise<number> {
@@ -299,6 +327,7 @@ function noteTombstone(physical: string): void {
 async function dropTolerant(adapter: SearchAdapter, physical: string): Promise<void> {
   try {
     await adapter.tables.drop(physical)
+    forgetCreatedPhysical(physical)
   } catch (err) {
     log.warn('table drop failed — tombstoned for the doctor sweep', {
       physical,
@@ -313,81 +342,99 @@ export interface OrphanTableSweepResult {
   dropped: string[]
   /** Candidates still inside the dwell window — a later sweep drops them. */
   pending: number
+  /**
+   * Unreferenced versioned tables NOT in this instance's ownership ledger —
+   * NEVER dropped (another Bakin home sharing the engine may own them, or
+   * they predate the ledger). Surfaced so the doctor can name them for a
+   * deliberate manual cleanup.
+   */
+  unclaimed: string[]
 }
 
 /**
- * Doctor sweep: drop engine-side tables this module created but no longer
+ * Doctor sweep: drop engine-side tables this instance created but no longer
  * references. Orphan generations appear when search.db is recreated while
  * the engine keeps its tables, or when a crash lands between the engine
  * create and the registry insert. They are not just disk waste: a wedged
  * orphan generation can pin the engine's startup catch-up loop at full CPU
  * and starve every live query (2026-07-12 incident).
  *
- * Safety: only names matching the versioned physical pattern are
- * considered; the sweep runs on the migration chain so it can never
- * observe an in-process create/backfill mid-flight; and a candidate must
- * stay unreferenced for a full dwell window (persisted first-seen ledger)
- * before it is dropped — see ORPHAN_DROP_DWELL_MS.
+ * Safety rails: only names in the OWNERSHIP ledger (created by this
+ * instance — see migration v3) are ever dropped; a candidate must stay
+ * unreferenced for a full dwell window (persisted first-seen ledger); and
+ * a candidate whose registry row (re)appears is forgiven. Together these
+ * make the migration chain unnecessary here: an in-flight create is owned
+ * but backfills for far less than the dwell, and holding serialized()
+ * across engine HTTP would couple the doctor to multi-minute migrations in
+ * both directions (review finding) — so this deliberately runs OFF the
+ * chain.
  */
 export async function sweepOrphanEngineTables(
   adapter: SearchAdapter,
   opts?: { dwellMs?: number },
 ): Promise<OrphanTableSweepResult> {
   const dwellMs = opts?.dwellMs ?? ORPHAN_DROP_DWELL_MS
-  return serialized(async () => {
-    const engine = await adapter.tables.list()
-    const referenced = new Set<string>()
-    for (const row of db().prepare<Row, []>('SELECT * FROM search_tables').all()) {
-      referenced.add(row.physical)
-      if (row.migrating_to) referenced.add(row.migrating_to)
-    }
-    // Tombstoned physicals are already queued for drop — not ours to track.
-    for (const row of db().prepare<{ physical: string }, []>('SELECT physical FROM search_table_tombstones').all()) {
-      referenced.add(row.physical)
-    }
+  const engine = await adapter.tables.list()
 
-    const candidates = new Set(
-      engine
-        .map((table) => table.name)
-        .filter((name) => VERSIONED_PHYSICAL.test(name) && !referenced.has(name)),
-    )
+  const referenced = new Set<string>()
+  for (const row of db().prepare<Row, []>('SELECT * FROM search_tables').all()) {
+    referenced.add(row.physical)
+    if (row.migrating_to) referenced.add(row.migrating_to)
+  }
+  // Tombstoned physicals are already queued for drop — not ours to track.
+  for (const row of db().prepare<{ physical: string }, []>('SELECT physical FROM search_table_tombstones').all()) {
+    referenced.add(row.physical)
+  }
+  const owned = new Set(
+    db().prepare<{ physical: string }, []>('SELECT physical FROM search_created_physicals').all().map((row) => row.physical),
+  )
 
-    // Reconcile the first-seen ledger: rows for tables that are gone or
-    // referenced again must not linger and later justify a drop.
-    for (const row of db().prepare<{ physical: string }, []>('SELECT physical FROM search_orphan_candidates').all()) {
-      if (!candidates.has(row.physical)) {
-        db().prepare('DELETE FROM search_orphan_candidates WHERE physical = ?').run(row.physical)
-      }
+  const unreferenced = engine
+    .map((table) => table.name)
+    .filter((name) => VERSIONED_PHYSICAL.test(name) && !referenced.has(name))
+  const candidates = new Set(unreferenced.filter((name) => owned.has(name)))
+  const unclaimed = unreferenced.filter((name) => !owned.has(name))
+
+  // Reconcile the first-seen ledger: rows for tables that are gone or
+  // referenced again must not linger and later justify a drop.
+  const firstSeen = new Map(
+    db()
+      .prepare<{ physical: string; first_seen: number }, []>('SELECT physical, first_seen FROM search_orphan_candidates')
+      .all()
+      .map((row) => [row.physical, row.first_seen] as const),
+  )
+  for (const physical of firstSeen.keys()) {
+    if (!candidates.has(physical)) {
+      db().prepare('DELETE FROM search_orphan_candidates WHERE physical = ?').run(physical)
     }
+  }
 
-    const now = Date.now()
-    const dropped: string[] = []
-    for (const name of candidates) {
-      const seen = db()
-        .prepare<{ first_seen: number }, [string]>('SELECT first_seen FROM search_orphan_candidates WHERE physical = ?')
-        .get(name)
-      if (!seen) {
-        db().prepare('INSERT INTO search_orphan_candidates (physical, first_seen) VALUES (?, ?)').run(name, now)
-        continue
-      }
-      if (now - seen.first_seen < dwellMs) continue
-      try {
-        await adapter.tables.drop(name)
-        dropped.push(name)
-        log.info('orphan engine table dropped', { physical: name, orphanedForMs: now - seen.first_seen })
-      } catch (err) {
-        log.warn('orphan engine table drop failed — tombstoned for the doctor sweep', {
-          physical: name,
-          err: err instanceof Error ? err.message : String(err),
-        })
-        noteTombstone(name)
-      }
-      db().prepare('DELETE FROM search_orphan_candidates WHERE physical = ?').run(name)
+  const now = Date.now()
+  const dropped: string[] = []
+  for (const name of candidates) {
+    const seen = firstSeen.get(name)
+    if (seen === undefined) {
+      db().prepare('INSERT INTO search_orphan_candidates (physical, first_seen) VALUES (?, ?)').run(name, now)
+      continue
     }
+    if (now - seen < dwellMs) continue
+    try {
+      await adapter.tables.drop(name)
+      forgetCreatedPhysical(name)
+      dropped.push(name)
+      log.info('orphan engine table dropped', { physical: name, orphanedForMs: now - seen })
+    } catch (err) {
+      log.warn('orphan engine table drop failed — tombstoned for the doctor sweep', {
+        physical: name,
+        err: err instanceof Error ? err.message : String(err),
+      })
+      noteTombstone(name)
+    }
+    db().prepare('DELETE FROM search_orphan_candidates WHERE physical = ?').run(name)
+  }
 
-    const pending = db().prepare<{ n: number }, []>('SELECT COUNT(*) AS n FROM search_orphan_candidates').get()?.n ?? 0
-    return { dropped, pending }
-  })
+  const pending = db().prepare<{ n: number }, []>('SELECT COUNT(*) AS n FROM search_orphan_candidates').get()?.n ?? 0
+  return { dropped, pending, unclaimed }
 }
 
 /** Doctor sweep: retry dropping tombstoned physicals. Returns remaining. */
@@ -397,6 +444,7 @@ export async function sweepTombstones(adapter: SearchAdapter): Promise<number> {
     try {
       await adapter.tables.drop(row.physical)
       db().prepare('DELETE FROM search_table_tombstones WHERE physical = ?').run(row.physical)
+      forgetCreatedPhysical(row.physical)
     } catch {
       // still failing — stays tombstoned
     }
@@ -585,5 +633,5 @@ export async function resumeMigrations(
 /** Test-only: wipe registry + tombstones (close-first — see outbox note). */
 export function resetTablesForTests(): void {
   store.close()
-  db().exec('DELETE FROM search_tables; DELETE FROM search_table_tombstones; DELETE FROM search_orphan_candidates;')
+  db().exec('DELETE FROM search_tables; DELETE FROM search_table_tombstones; DELETE FROM search_orphan_candidates; DELETE FROM search_created_physicals;')
 }

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -219,6 +219,18 @@ export interface BakinSettings {
      * instead of drowning them in unrelated errors.
      */
     requireOnboard: boolean
+    /**
+     * What the PERIODIC doctor does when a cycle produces ERROR findings:
+     * 'task' creates ONE deduplicated delegated-repair task for the main
+     * agent (skipped while a covering repair task is open, and rate-limited
+     * by escalationCooldownMs); 'notify' messages the main agent; 'off'
+     * keeps the old dashboard-only behavior. Manual `bakin doctor` runs are
+     * never affected. Both agent-facing modes cost an agent turn and ride
+     * the normal budget gates.
+     */
+    escalation: 'off' | 'notify' | 'task'
+    /** Minimum gap before re-escalating the SAME error set as a new task. */
+    escalationCooldownMs: number
   }
   diagnostics: {
     startup: {
@@ -373,6 +385,8 @@ export const DEFAULT_SETTINGS: BakinSettings = {
   doctor: {
     intervalMs: 30 * 60 * 1000, // 30 minutes
     requireOnboard: true,
+    escalation: 'task',
+    escalationCooldownMs: 6 * 60 * 60 * 1000, // 6 hours
   },
   diagnostics: {
     startup: {

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -39,6 +39,7 @@ import { checkSearchAdapter } from './lib/system-checks/search'
 import { checkSearchOutbox, searchOutboxRepair } from './lib/system-checks/search-outbox'
 import { checkSearchConsistency, searchConsistencyRepair } from './lib/system-checks/search-consistency'
 import { checkSearchSpin, searchSpinRepair } from './lib/system-checks/search-spin'
+import { checkSearchCanary, checkSearchEngineBurn, searchCanaryRepair, searchEngineBurnRepair } from './lib/system-checks/search-engine-watch'
 import { checkAndSyncSkill, syncSkillRepair } from './lib/system-checks/sync-skill'
 import { checkPluginAssets } from './lib/system-checks/plugin-assets'
 import { checkPluginArtifacts } from './lib/system-checks/plugin-artifacts'
@@ -299,7 +300,8 @@ const routes = [
 
       const doctor = getLastResults()
       const searchRows = (doctor?.results ?? []).filter((row) =>
-        row.check === 'search' || row.check === 'search-outbox' || row.check === 'search-consistency' || row.check === 'search-spin')
+        row.check === 'search' || row.check === 'search-outbox' || row.check === 'search-consistency' || row.check === 'search-spin'
+        || row.check === 'search-canary' || row.check === 'search-engine-burn')
 
       return Response.json({
         windows: { '1h': byName('1h'), '24h': byName('24h') },
@@ -719,6 +721,18 @@ const healthPlugin: BakinPlugin = definePlugin({
       name: 'Search backfill-spin watchdog (zero-progress building legs)',
       run: () => checkSearchSpin(),
       repair: searchSpinRepair(),
+    })
+    ctx.registerHealthCheck({
+      id: 'search-canary',
+      name: 'Search canary (a real query through the production path)',
+      run: () => checkSearchCanary(),
+      repair: searchCanaryRepair(),
+    })
+    ctx.registerHealthCheck({
+      id: 'search-engine-burn',
+      name: 'Search engine burn watchdog (CPU + wedge signatures)',
+      run: () => checkSearchEngineBurn(),
+      repair: searchEngineBurnRepair(),
     })
     ctx.registerHealthCheck({
       id: 'skill',

--- a/plugins/health/lib/system-checks/search-consistency.ts
+++ b/plugins/health/lib/system-checks/search-consistency.ts
@@ -8,9 +8,10 @@
  * physical, queries stay on the old one throughout) behind a destructive-
  * tier confirmation.
  *
- * The deep sweep (orphan rows + tombstone drops) rides THIS check's run —
- * i.e. the existing doctor interval — throttled to once an hour so doctor
- * cycles stay cheap. No timers of its own, nothing at boot.
+ * The deep sweep (orphan rows + tombstone drops + stale engine-table
+ * generations) rides THIS check's run — i.e. the existing doctor interval —
+ * throttled to once an hour so doctor cycles stay cheap. No timers of its
+ * own, nothing at boot.
  */
 import { healthOk, healthWarn } from '@makinbakin/sdk/utils'
 import type { HealthCheckResult, HealthRepairHandler } from '../../../../packages/core/src/plugin-types'
@@ -66,21 +67,26 @@ export async function checkSearchConsistency(): Promise<HealthCheckResult[]> {
     }
   }
 
-  // Hourly deep sweep: orphaned index rows + tombstoned physicals.
+  // Hourly deep sweep: orphaned index rows + tombstoned physicals + stale
+  // engine-side table generations the registry no longer references.
   if (Date.now() - lastSweepAt >= SWEEP_INTERVAL_MS) {
     lastSweepAt = Date.now()
     try {
       const { runOrphanSweep, sweepOrphanRegistryRows } = await import('../../../../src/core/search-orphan-sweep')
-      const { sweepTombstones } = await import('@bakin/core/search/tables')
+      const { sweepTombstones, sweepOrphanEngineTables } = await import('@bakin/core/search/tables')
       const orphanStats = await runOrphanSweep()
       const removed = orphanStats.reduce((sum, s) => sum + s.orphans, 0)
       const orphanRows = await sweepOrphanRegistryRows()
+      const orphanTables = await sweepOrphanEngineTables(search)
       const tombstonesLeft = await sweepTombstones(search)
       if (removed > 0) {
         results.push(healthOk('search-consistency', `Deep sweep removed ${removed} orphaned index row(s)`))
       }
       if (orphanRows.length > 0) {
         results.push(healthOk('search-consistency', `Deep sweep purged ${orphanRows.length} orphaned registry row(s): ${orphanRows.join(', ')}`))
+      }
+      if (orphanTables.dropped.length > 0) {
+        results.push(healthOk('search-consistency', `Deep sweep dropped ${orphanTables.dropped.length} stale engine table(s): ${orphanTables.dropped.join(', ')}`))
       }
       if (tombstonesLeft > 0) {
         results.push(healthWarn('search-consistency', `${tombstonesLeft} old physical table(s) still refusing to drop — retrying next sweep`))

--- a/plugins/health/lib/system-checks/search-consistency.ts
+++ b/plugins/health/lib/system-checks/search-consistency.ts
@@ -77,7 +77,14 @@ export async function checkSearchConsistency(): Promise<HealthCheckResult[]> {
       const orphanStats = await runOrphanSweep()
       const removed = orphanStats.reduce((sum, s) => sum + s.orphans, 0)
       const orphanRows = await sweepOrphanRegistryRows()
-      const orphanTables = await sweepOrphanEngineTables(search)
+      // Isolated: a transient tables.list() failure must not cost the
+      // tombstone retry its hourly slot (review finding).
+      let orphanTables: Awaited<ReturnType<typeof sweepOrphanEngineTables>> | null = null
+      try {
+        orphanTables = await sweepOrphanEngineTables(search)
+      } catch (err) {
+        results.push(healthWarn('search-consistency', `Stale engine-table sweep failed (retrying next hour): ${err instanceof Error ? err.message : String(err)}`))
+      }
       const tombstonesLeft = await sweepTombstones(search)
       if (removed > 0) {
         results.push(healthOk('search-consistency', `Deep sweep removed ${removed} orphaned index row(s)`))
@@ -85,8 +92,11 @@ export async function checkSearchConsistency(): Promise<HealthCheckResult[]> {
       if (orphanRows.length > 0) {
         results.push(healthOk('search-consistency', `Deep sweep purged ${orphanRows.length} orphaned registry row(s): ${orphanRows.join(', ')}`))
       }
-      if (orphanTables.dropped.length > 0) {
+      if (orphanTables && orphanTables.dropped.length > 0) {
         results.push(healthOk('search-consistency', `Deep sweep dropped ${orphanTables.dropped.length} stale engine table(s): ${orphanTables.dropped.join(', ')}`))
+      }
+      if (orphanTables && orphanTables.unclaimed.length > 0) {
+        results.push(healthWarn('search-consistency', `${orphanTables.unclaimed.length} engine table(s) are unreferenced but not created by this Bakin home — left untouched (another instance may own them): ${orphanTables.unclaimed.join(', ')}. Drop manually if stale.`))
       }
       if (tombstonesLeft > 0) {
         results.push(healthWarn('search-consistency', `${tombstonesLeft} old physical table(s) still refusing to drop — retrying next sweep`))

--- a/plugins/health/lib/system-checks/search-engine-watch.ts
+++ b/plugins/health/lib/system-checks/search-engine-watch.ts
@@ -1,0 +1,186 @@
+/**
+ * System checks — search canary + engine-burn watchdog.
+ *
+ * Both exist because of the 2026-07-12 incident: a wedged engine answered
+ * health probes for 17 hours while every real query starved under the
+ * budget and returned nothing — and the doctor said "ok" the whole time,
+ * because nothing actually RAN a search or looked at the engine process.
+ *
+ *  - search-canary runs one real cross-table query through the exact
+ *    production path (crossTableSearch: budgets, semantic legs, omission
+ *    labels). All tables omitted on two consecutive doctor runs = search
+ *    is dark regardless of cause → error + engine-restart repair.
+ *  - search-engine-burn reads the adapter's engineStatus() (pid CPU rate +
+ *    wedge signatures from the engine log). A wedge signature on two
+ *    consecutive runs = the known zero-progress spin → error + restart
+ *    repair. Sustained high CPU alone only warns — legitimate backfills
+ *    burn CPU for hours and a restart would make those WORSE.
+ *
+ * Same shape as search-spin: module-level samples the doctor's own cadence
+ * advances, pure detection helpers, no timers, nothing at boot.
+ */
+import { healthOk, healthWarn } from '@makinbakin/sdk/utils'
+import type { HealthCheckResult, HealthRepairHandler } from '../../../../packages/core/src/plugin-types'
+
+/** Sustained CPU (fraction of one core) that earns a busy warning. */
+const BUSY_UTILIZATION = 0.9
+
+export type CanaryVerdict = 'ok' | 'partial' | 'dark'
+
+/** Pure: classify one canary response's per-table outcomes. */
+export function classifyCanary(tables: Array<{ budget?: 'degraded' | 'omitted' }>): CanaryVerdict {
+  if (tables.length === 0) return 'ok'
+  if (tables.every((t) => t.budget === 'omitted')) return 'dark'
+  return tables.some((t) => t.budget !== undefined) ? 'partial' : 'ok'
+}
+
+// Doctor-cadence state (module-level, like search-spin's sample).
+let darkStreak = 0
+let wedgeStreak = 0
+let busyStreak = 0
+
+/** Test-only. */
+export function resetEngineWatchStateForTests(): void {
+  darkStreak = 0
+  wedgeStreak = 0
+  busyStreak = 0
+}
+
+export async function checkSearchCanary(): Promise<HealthCheckResult[]> {
+  const { getSettings } = await import('../../../../src/core/settings')
+  if (!getSettings().search.settings.enabled) return []
+
+  const { getAppServices } = await import('../../../../src/core/app-services')
+  const search = getAppServices().search
+  if (!await search.available()) return [] // the base search check owns "engine down"
+
+  const { crossTableSearch } = await import('../../../../src/core/search-query')
+  const response = await crossTableSearch('doctor canary probe', { limit: 1 })
+  if (response.meta.source === 'unavailable') return [] // raced an outage — base check owns it
+
+  const tables = response.meta.tables ?? []
+  const verdict = classifyCanary(tables)
+  darkStreak = verdict === 'dark' ? darkStreak + 1 : 0
+
+  if (verdict === 'dark' && darkStreak >= 2) {
+    return [{
+      check: 'search-canary',
+      status: 'error',
+      message: `Search is DARK: a real query got zero contribution from all ${tables.length} tables (every source omitted under the ${response.meta.took_ms}ms query budget) on ${darkStreak} consecutive doctor runs — the engine answers health probes but cannot serve queries. Repair restarts the engine service; the write journal is durable, nothing is lost.`,
+      autoFixable: true,
+    }]
+  }
+  if (verdict === 'dark') {
+    return [healthWarn('search-canary', `Canary query: every table omitted under the query budget — engine busy or wedged; escalates to an error (with restart repair) if the next doctor run agrees`)]
+  }
+  if (verdict === 'partial') {
+    const omitted = tables.filter((t) => t.budget === 'omitted').length
+    const degraded = tables.filter((t) => t.budget === 'degraded').length
+    return [healthWarn('search-canary', `Canary query degraded: ${omitted} of ${tables.length} table(s) omitted, ${degraded} keyword-only (semantic lane dropped) — honest degrade under load; investigate with \`bakin search:stats\` if it persists`)]
+  }
+  return [healthOk('search-canary', `Canary query answered from all ${tables.length} tables in ${response.meta.took_ms}ms`)]
+}
+
+export async function checkSearchEngineBurn(): Promise<HealthCheckResult[]> {
+  const { getSettings } = await import('../../../../src/core/settings')
+  if (!getSettings().search.settings.enabled) return []
+
+  const { getAppServices } = await import('../../../../src/core/app-services')
+  const search = getAppServices().search
+  if (!search.engineStatus) return [] // adapter can't measure — feature-detect, never assume
+  const status = await search.engineStatus()
+  if (status === null) return [] // current mode can't measure (e.g. externally managed guest)
+  if (!status.running) return [] // the base search check owns "engine down"
+
+  wedgeStreak = status.wedgeSignals.length > 0 ? wedgeStreak + 1 : 0
+  busyStreak = (status.cpuUtilization ?? 0) >= BUSY_UTILIZATION ? busyStreak + 1 : 0
+
+  if (wedgeStreak >= 2) {
+    return [{
+      check: 'search-engine-burn',
+      status: 'error',
+      message: `Search engine is WEDGED: zero-progress signature(s) [${status.wedgeSignals.join(', ')}] recurring in the engine log across ${wedgeStreak} consecutive doctor runs (pid ${status.pid}, ~${Math.round((status.cpuUtilization ?? 0) * 100)}% CPU). This burned a dev box for 17h once — repair restarts the engine service.`,
+      autoFixable: true,
+    }]
+  }
+  if (status.wedgeSignals.length > 0) {
+    return [healthWarn('search-engine-burn', `Engine wedge signature(s) [${status.wedgeSignals.join(', ')}] observed — may be legitimate post-crash catch-up; escalates to an error (with restart repair) if the next doctor run agrees`)]
+  }
+  if (busyStreak >= 2) {
+    return [healthWarn('search-engine-burn', `Engine sustained ~${Math.round((status.cpuUtilization ?? 0) * 100)}% CPU across ${busyStreak} consecutive doctor runs with no wedge signature — normal during backfills/enrichment; check \`bakin search:stats\` backlog if search feels slow`)]
+  }
+  return [healthOk('search-engine-burn', status.cpuUtilization === null
+    ? 'Engine running (first CPU sample — rate available next run)'
+    : `Engine healthy (~${Math.round(status.cpuUtilization * 100)}% CPU, no wedge signatures)`)]
+}
+
+/**
+ * Shared repair: gracefully restart the supervised engine, then wait for
+ * it to answer again. Non-destructive — the outbox is durable and queries
+ * degrade honestly during the bounce (D11).
+ */
+function engineRestartRepair(checkId: 'search-canary' | 'search-engine-burn', title: string): HealthRepairHandler {
+  return {
+    async plan(rows) {
+      const matching = rows.filter((row) => row.check === checkId && row.autoFixable)
+      if (matching.length === 0) return []
+      return [{
+        id: `health.repair-${checkId}`,
+        checkId,
+        title,
+        reason: matching.map((row) => row.message).join('; '),
+        safety: 'safe',
+        requiresConfirmation: true,
+        changes: [{
+          kind: 'other',
+          target: 'search engine service',
+          action: 'update',
+          description: 'Gracefully restart the OS-supervised engine (SIGTERM, supervisor respawns). Writes wait in the durable journal; queries degrade honestly during the bounce.',
+        }],
+      }]
+    },
+    async apply(items) {
+      if (items.length === 0) return []
+      const { getAppServices } = await import('../../../../src/core/app-services')
+      const search = getAppServices().search
+      const fail = (message: string) => [{
+        id: `health.repair-${checkId}`,
+        checkId,
+        status: 'failed' as const,
+        message,
+        changes: [],
+      }]
+      if (!search.restartEngine) return fail('Adapter does not support engine restart — restart the engine where it runs')
+      try {
+        await search.restartEngine()
+      } catch (err) {
+        return fail(`Engine restart failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+      // Wait for the engine to answer again (supervisor respawn + warmup).
+      const deadline = Date.now() + 30_000
+      let up = false
+      while (Date.now() < deadline) {
+        if (await search.available()) { up = true; break }
+        await new Promise((resolve) => setTimeout(resolve, 1_000))
+      }
+      resetEngineWatchStateForTests()
+      return [{
+        id: `health.repair-${checkId}`,
+        checkId,
+        status: up ? 'applied' as const : 'failed' as const,
+        message: up
+          ? 'Engine restarted and answering; the journal drains automatically'
+          : 'Engine restarted but not answering within 30s — check `bakin check search` and the engine log',
+        changes: [],
+      }]
+    },
+  }
+}
+
+export function searchCanaryRepair(): HealthRepairHandler {
+  return engineRestartRepair('search-canary', 'Restart the search engine service (search is dark)')
+}
+
+export function searchEngineBurnRepair(): HealthRepairHandler {
+  return engineRestartRepair('search-engine-burn', 'Restart the search engine service (zero-progress wedge)')
+}

--- a/plugins/health/lib/system-checks/search-engine-watch.ts
+++ b/plugins/health/lib/system-checks/search-engine-watch.ts
@@ -16,14 +16,28 @@
  *    repair. Sustained high CPU alone only warns — legitimate backfills
  *    burn CPU for hours and a restart would make those WORSE.
  *
- * Same shape as search-spin: module-level samples the doctor's own cadence
- * advances, pure detection helpers, no timers, nothing at boot.
+ * Escalation streaks are PERSISTED (plugin-data/health/engine-watch.json)
+ * so a server restart doesn't silently re-arm the two-run escalation on a
+ * restart-heavy dev box, and any run that cannot produce a verdict
+ * (disabled / engine down / unmeasurable) RESETS its streak — "two
+ * consecutive runs" means consecutive observations, never two samples
+ * straddling an outage (a respawned engine's legitimate catch-up must not
+ * inherit a pre-crash streak). No timers, nothing at boot.
  */
+import { mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
 import { healthOk, healthWarn } from '@makinbakin/sdk/utils'
 import type { HealthCheckResult, HealthRepairHandler } from '../../../../packages/core/src/plugin-types'
 
 /** Sustained CPU (fraction of one core) that earns a busy warning. */
 const BUSY_UTILIZATION = 0.9
+/**
+ * One engine bounce serves every correlated detection: a wedged engine
+ * errors BOTH checks, and a `--fix --yes` run applies both repair plans
+ * sequentially — the second apply inside this window reports applied
+ * without bouncing the just-restarted engine again.
+ */
+const RESTART_DEBOUNCE_MS = 2 * 60 * 1000
 
 export type CanaryVerdict = 'ok' | 'partial' | 'dark'
 
@@ -34,39 +48,94 @@ export function classifyCanary(tables: Array<{ budget?: 'degraded' | 'omitted' }
   return tables.some((t) => t.budget !== undefined) ? 'partial' : 'ok'
 }
 
-// Doctor-cadence state (module-level, like search-spin's sample).
-let darkStreak = 0
-let wedgeStreak = 0
-let busyStreak = 0
+// ── Persisted streak state ─────────────────────────────────────────────────
 
-/** Test-only. */
-export function resetEngineWatchStateForTests(): void {
-  darkStreak = 0
-  wedgeStreak = 0
-  busyStreak = 0
+interface StreakState {
+  darkStreak: number
+  wedgeStreak: number
+  busyStreak: number
 }
+
+const ZERO_STREAKS: StreakState = { darkStreak: 0, wedgeStreak: 0, busyStreak: 0 }
+
+async function statePath(): Promise<string> {
+  const { getContentDir } = await import('../../../../src/core/content-dir')
+  return join(getContentDir(), 'plugin-data', 'health', 'engine-watch.json')
+}
+
+async function loadStreaks(): Promise<StreakState> {
+  try {
+    const raw = JSON.parse(readFileSync(await statePath(), 'utf-8')) as Partial<StreakState>
+    return {
+      darkStreak: typeof raw.darkStreak === 'number' ? raw.darkStreak : 0,
+      wedgeStreak: typeof raw.wedgeStreak === 'number' ? raw.wedgeStreak : 0,
+      busyStreak: typeof raw.busyStreak === 'number' ? raw.busyStreak : 0,
+    }
+  } catch {
+    return { ...ZERO_STREAKS } // fresh install / first run
+  }
+}
+
+async function saveStreaks(next: Partial<StreakState>): Promise<StreakState> {
+  const merged = { ...(await loadStreaks()), ...next }
+  const path = await statePath()
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(merged))
+  return merged
+}
+
+/**
+ * Post-restart reset: a bounced engine makes every pre-restart streak moot
+ * (both checks observe the same engine), so ALL streaks clear together.
+ */
+async function resetStreaks(): Promise<void> {
+  await saveStreaks({ ...ZERO_STREAKS })
+}
+
+// In-memory restart debounce — both repair applies run in one process.
+let lastEngineRestartAt = 0
+
+/** Test-only alias — the production reset is resetStreaks(). */
+export async function resetEngineWatchStateForTests(): Promise<void> {
+  await resetStreaks()
+  lastEngineRestartAt = 0
+}
+
+// ── Checks ─────────────────────────────────────────────────────────────────
 
 export async function checkSearchCanary(): Promise<HealthCheckResult[]> {
   const { getSettings } = await import('../../../../src/core/settings')
-  if (!getSettings().search.settings.enabled) return []
+  if (!getSettings().search.settings.enabled) {
+    await saveStreaks({ darkStreak: 0 })
+    return []
+  }
 
   const { getAppServices } = await import('../../../../src/core/app-services')
   const search = getAppServices().search
-  if (!await search.available()) return [] // the base search check owns "engine down"
+  if (!await search.available()) {
+    // The base search check owns "engine down" — and a down engine breaks
+    // the observation chain, so the streak must not survive the gap.
+    await saveStreaks({ darkStreak: 0 })
+    return []
+  }
 
-  const { crossTableSearch } = await import('../../../../src/core/search-query')
+  const { crossTableSearch } = await import('../../../../src/core/search-registry')
   const response = await crossTableSearch('doctor canary probe', { limit: 1 })
-  if (response.meta.source === 'unavailable') return [] // raced an outage — base check owns it
+  if (response.meta.source === 'unavailable') {
+    await saveStreaks({ darkStreak: 0 })
+    return [] // raced an outage — base check owns it
+  }
 
   const tables = response.meta.tables ?? []
   const verdict = classifyCanary(tables)
-  darkStreak = verdict === 'dark' ? darkStreak + 1 : 0
+  const prior = await loadStreaks()
+  const { darkStreak } = await saveStreaks({ darkStreak: verdict === 'dark' ? prior.darkStreak + 1 : 0 })
 
   if (verdict === 'dark' && darkStreak >= 2) {
     return [{
       check: 'search-canary',
       status: 'error',
-      message: `Search is DARK: a real query got zero contribution from all ${tables.length} tables (every source omitted under the ${response.meta.took_ms}ms query budget) on ${darkStreak} consecutive doctor runs — the engine answers health probes but cannot serve queries. Repair restarts the engine service; the write journal is durable, nothing is lost.`,
+      message: `Search is DARK: a real query got zero contribution from all ${tables.length} tables (every source omitted under the query budget) on ${darkStreak} consecutive doctor runs — the engine answers health probes but cannot serve queries. Repair restarts the engine service; the write journal is durable, nothing is lost.`,
       autoFixable: true,
     }]
   }
@@ -83,17 +152,28 @@ export async function checkSearchCanary(): Promise<HealthCheckResult[]> {
 
 export async function checkSearchEngineBurn(): Promise<HealthCheckResult[]> {
   const { getSettings } = await import('../../../../src/core/settings')
-  if (!getSettings().search.settings.enabled) return []
+  if (!getSettings().search.settings.enabled) {
+    await saveStreaks({ wedgeStreak: 0, busyStreak: 0 })
+    return []
+  }
 
   const { getAppServices } = await import('../../../../src/core/app-services')
   const search = getAppServices().search
   if (!search.engineStatus) return [] // adapter can't measure — feature-detect, never assume
   const status = await search.engineStatus()
   if (status === null) return [] // current mode can't measure (e.g. externally managed guest)
-  if (!status.running) return [] // the base search check owns "engine down"
+  if (!status.running) {
+    // Down engine = broken observation chain; a respawn's legitimate
+    // catch-up must not inherit the pre-crash streak (review finding).
+    await saveStreaks({ wedgeStreak: 0, busyStreak: 0 })
+    return [] // the base search check owns "engine down"
+  }
 
-  wedgeStreak = status.wedgeSignals.length > 0 ? wedgeStreak + 1 : 0
-  busyStreak = (status.cpuUtilization ?? 0) >= BUSY_UTILIZATION ? busyStreak + 1 : 0
+  const prior = await loadStreaks()
+  const { wedgeStreak, busyStreak } = await saveStreaks({
+    wedgeStreak: status.wedgeSignals.length > 0 ? prior.wedgeStreak + 1 : 0,
+    busyStreak: (status.cpuUtilization ?? 0) >= BUSY_UTILIZATION ? prior.busyStreak + 1 : 0,
+  })
 
   if (wedgeStreak >= 2) {
     return [{
@@ -114,10 +194,14 @@ export async function checkSearchEngineBurn(): Promise<HealthCheckResult[]> {
     : `Engine healthy (~${Math.round(status.cpuUtilization * 100)}% CPU, no wedge signatures)`)]
 }
 
+// ── Repair ─────────────────────────────────────────────────────────────────
+
 /**
- * Shared repair: gracefully restart the supervised engine, then wait for
- * it to answer again. Non-destructive — the outbox is durable and queries
- * degrade honestly during the bounce (D11).
+ * Shared repair: gracefully restart the supervised engine, then verify
+ * with a REAL query — the incident proved a wedged engine keeps answering
+ * status probes, so `available()` alone would report success while search
+ * stays dark. Non-destructive — the outbox is durable and queries degrade
+ * honestly during the bounce (D11).
  */
 function engineRestartRepair(checkId: 'search-canary' | 'search-engine-burn', title: string): HealthRepairHandler {
   return {
@@ -143,36 +227,46 @@ function engineRestartRepair(checkId: 'search-canary' | 'search-engine-burn', ti
       if (items.length === 0) return []
       const { getAppServices } = await import('../../../../src/core/app-services')
       const search = getAppServices().search
-      const fail = (message: string) => [{
+      const done = (status: 'applied' | 'failed', message: string) => [{
         id: `health.repair-${checkId}`,
         checkId,
-        status: 'failed' as const,
+        status,
         message,
         changes: [],
       }]
-      if (!search.restartEngine) return fail('Adapter does not support engine restart — restart the engine where it runs')
+      if (Date.now() - lastEngineRestartAt < RESTART_DEBOUNCE_MS) {
+        return done('applied', 'Engine was already restarted moments ago by the companion check\'s repair — skipped a duplicate bounce; the next doctor run re-verifies')
+      }
+      if (!search.restartEngine) return done('failed', 'Adapter does not support engine restart — restart the engine where it runs')
       try {
         await search.restartEngine()
+        lastEngineRestartAt = Date.now()
       } catch (err) {
-        return fail(`Engine restart failed: ${err instanceof Error ? err.message : String(err)}`)
+        return done('failed', `Engine restart failed: ${err instanceof Error ? err.message : String(err)}`)
       }
-      // Wait for the engine to answer again (supervisor respawn + warmup).
+      // Verify with the canary query, not the status probe: wait for the
+      // engine to answer AND actually serve (not all tables omitted).
+      const { crossTableSearch } = await import('../../../../src/core/search-registry')
       const deadline = Date.now() + 30_000
-      let up = false
+      let serving = false
       while (Date.now() < deadline) {
-        if (await search.available()) { up = true; break }
+        if (await search.available()) {
+          const probe = await crossTableSearch('doctor canary probe', { limit: 1 }).catch(() => null)
+          const tables = probe?.meta.tables ?? []
+          if (probe && probe.meta.source === 'search' && classifyCanary(tables) !== 'dark') {
+            serving = true
+            break
+          }
+        }
         await new Promise((resolve) => setTimeout(resolve, 1_000))
       }
-      resetEngineWatchStateForTests()
-      return [{
-        id: `health.repair-${checkId}`,
-        checkId,
-        status: up ? 'applied' as const : 'failed' as const,
-        message: up
-          ? 'Engine restarted and answering; the journal drains automatically'
-          : 'Engine restarted but not answering within 30s — check `bakin check search` and the engine log',
-        changes: [],
-      }]
+      if (!serving) {
+        // Deliberately NOT resetting streaks: the wedge likely survived the
+        // bounce, and the next doctor run should escalate immediately.
+        return done('failed', 'Engine restarted but queries are still dark after 30s — the wedge likely survived the bounce; check the engine log (`~/.bakin/logs/antfly.log`) and `bakin search:stats`')
+      }
+      await resetStreaks()
+      return done('applied', 'Engine restarted and serving queries again; the journal drains automatically')
     },
   }
 }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -154,17 +154,15 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
   if (!process.stdout.isTTY) {
     console.log(`Reindexing ${target} into search${options.rebuild ? ' (rebuild indexes)' : ''}...`)
   }
+  // Response shape = the /api/reindex handler: per-table blue/green outcome
+  // ('migrated'/'parked'/'failed') + backfilled doc count. The old enrichment
+  // fields never existed on this route and printed "undefined documents".
   const result = await apiPost(url) as ReindexResultData & {
     ok: boolean
     total: number
     errors: number
-    enrichmentErrors?: number
-    tables: Array<{
-      table: string
-      indexed: number
-      error?: string
-      enrichment?: { healthy: boolean; indexes: Array<{ name: string; error?: string; walBacklog: number }> }
-    }>
+    parked: number
+    tables: Array<{ table: string; result: string; indexed?: number; error?: string }>
   }
   if (process.stdout.isTTY) {
     await printReindexTui(result, { target, rebuild: options.rebuild === true })
@@ -175,16 +173,14 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
       if (t.error) {
         console.log(`  ${t.table}: ERROR — ${t.error}`)
       } else {
-        const enrichTag = t.enrichment
-          ? t.enrichment.healthy ? '' : ' [enrichment unhealthy]'
-          : ''
-        console.log(`  ${t.table}: ${t.indexed} documents${enrichTag}`)
+        const parkedTag = t.result === 'parked' ? ' [PARKED — green never converged; doctor resumes it]' : ''
+        console.log(`  ${t.table}: ${t.indexed ?? 0} documents${parkedTag}`)
       }
     }
   }
   console.log(`Done. ${result.total} total documents indexed.`)
-  if ((result.enrichmentErrors ?? 0) > 0) {
-    console.log(`WARNING: ${result.enrichmentErrors} table(s) have enrichment errors — check health page for details.`)
+  if (result.parked > 0) {
+    console.log(`WARNING: ${result.parked} table(s) parked mid-migration — queries keep answering from the old table; run \`bakin doctor\` to resume.`)
   }
 }
 

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -157,12 +157,14 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
   // Response shape = the /api/reindex handler: per-table blue/green outcome
   // ('migrated'/'parked'/'failed') + backfilled doc count. The old enrichment
   // fields never existed on this route and printed "undefined documents".
+  // `total`/`parked` are OPTIONAL at runtime: an older not-yet-restarted
+  // server (this box's documented normal state) omits them.
   const result = await apiPost(url) as ReindexResultData & {
     ok: boolean
-    total: number
+    total?: number
     errors: number
-    parked: number
-    tables: Array<{ table: string; result: string; indexed?: number; error?: string }>
+    parked?: number
+    tables: Array<import('../../core/search-registry-core').ReindexTableOutcome>
   }
   if (process.stdout.isTTY) {
     await printReindexTui(result, { target, rebuild: options.rebuild === true })
@@ -178,8 +180,8 @@ async function cmdReindex(options: { table?: string; rebuild?: boolean } = {}): 
       }
     }
   }
-  console.log(`Done. ${result.total} total documents indexed.`)
-  if (result.parked > 0) {
+  console.log(typeof result.total === 'number' ? `Done. ${result.total} total documents indexed.` : 'Done.')
+  if ((result.parked ?? 0) > 0) {
     console.log(`WARNING: ${result.parked} table(s) parked mid-migration — queries keep answering from the old table; run \`bakin doctor\` to resume.`)
   }
 }

--- a/src/core/cli/ui/reports/search.tsx
+++ b/src/core/cli/ui/reports/search.tsx
@@ -1,7 +1,7 @@
 import { Box } from 'ink'
 import { DataTable, FindingRows, ScreenHeader, Section, StatusTable, SummaryStrip } from '../tui'
 import type { TuiStatus } from '../style-tokens'
-import { valueText, numberValue, objectField, isPlainRecord, plural } from './format'
+import { valueText, numberValue, objectField, plural } from './format'
 
 export interface SearchResultData {
   id?: unknown
@@ -40,14 +40,13 @@ export interface ReindexTableData {
   indexed?: unknown
   result?: unknown
   error?: unknown
-  enrichment?: unknown
 }
 
 export interface ReindexResultData {
   ok?: unknown
   total?: unknown
   errors?: unknown
-  enrichmentErrors?: unknown
+  parked?: unknown
   tables?: ReindexTableData[]
 }
 
@@ -70,7 +69,7 @@ interface ReindexTableRow {
   status: TuiStatus
   table: string
   docs: string
-  enrichment: string
+  outcome: string
   issue: string
 }
 
@@ -145,33 +144,18 @@ function searchStatsTableRows(tables: SearchStatsTableData[], enabled: boolean):
   }))
 }
 
-function reindexEnrichmentText(value: unknown): string {
-  if (!isPlainRecord(value)) return '-'
-  const indexes = Array.isArray(value.indexes) ? value.indexes : []
-  const issues = indexes.flatMap(index => {
-    if (!isPlainRecord(index)) return []
-    const name = valueText(index.name, 'index')
-    const error = valueText(index.error, '')
-    if (error) return [`${name}: ${error}`]
-    const walBacklog = numberValue(index.walBacklog)
-    if (walBacklog > 0) return [`${name}: ${walBacklog} wal`]
-    return []
-  })
-  if (issues.length > 0) return issues.join(', ')
-  return value.healthy === false ? 'unhealthy' : 'healthy'
-}
-
 function reindexTableRows(tables: ReindexTableData[]): ReindexTableRow[] {
   return tables.map(table => {
     const hasError = Boolean(table.error)
     const parked = table.result === 'parked'
-    const enrichmentUnhealthy = isPlainRecord(table.enrichment) && table.enrichment.healthy === false
     return {
-      status: hasError ? 'fail' : parked || enrichmentUnhealthy ? 'warn' : 'ok',
+      status: hasError ? 'fail' : parked ? 'warn' : 'ok',
       table: valueText(table.table, '(unknown)'),
       docs: valueText(table.indexed, '0'),
-      enrichment: reindexEnrichmentText(table.enrichment),
-      issue: valueText(table.error) || (parked ? 'parked — green never converged' : ''),
+      outcome: valueText(table.result),
+      // NEVER through valueText's '-' fallback here: the truthy '-' made
+      // the parked text unreachable (review finding).
+      issue: hasError ? valueText(table.error) : parked ? 'parked — green never converged' : '',
     }
   })
 }
@@ -268,7 +252,7 @@ export function ReindexReport({ result, target = 'all content', rebuild = false,
   const rows = reindexTableRows(result.tables ?? [])
   const total = numberValue(result.total)
   const errors = numberValue(result.errors)
-  const enrichmentErrors = numberValue(result.enrichmentErrors)
+  const parked = numberValue(result.parked)
 
   return (
     <Box flexDirection="column">
@@ -282,7 +266,7 @@ export function ReindexReport({ result, target = 'all content', rebuild = false,
         { label: plural(total, 'document'), value: total, status: total > 0 ? 'ok' : 'skip' },
         { label: plural(rows.length, 'table'), value: rows.length, status: rows.length > 0 ? 'ok' : 'skip' },
         { label: 'errors', value: errors, status: errors > 0 ? 'fail' : 'ok' },
-        { label: 'enrichment', value: enrichmentErrors, status: enrichmentErrors > 0 ? 'warn' : 'ok' },
+        { label: 'parked', value: parked, status: parked > 0 ? 'warn' : 'ok' },
       ]} color={color} />
       <Section title="Tables" color={color}>
         {rows.length > 0 ? (
@@ -291,7 +275,7 @@ export function ReindexReport({ result, target = 'all content', rebuild = false,
             columns={[
               { key: 'table', header: 'TABLE', width: 16, render: row => row.table },
               { key: 'docs', header: 'DOCS', width: 6, render: row => row.docs },
-              { key: 'enrichment', header: 'ENRICHMENT', width: 18, render: row => row.enrichment },
+              { key: 'outcome', header: 'OUTCOME', width: 12, render: row => row.outcome },
               { key: 'issue', header: 'ISSUE', width: 24, grow: true, render: row => row.issue },
             ]}
             color={color}

--- a/src/core/cli/ui/reports/search.tsx
+++ b/src/core/cli/ui/reports/search.tsx
@@ -38,6 +38,7 @@ export interface SearchStatsTableData {
 export interface ReindexTableData {
   table?: unknown
   indexed?: unknown
+  result?: unknown
   error?: unknown
   enrichment?: unknown
 }
@@ -163,13 +164,14 @@ function reindexEnrichmentText(value: unknown): string {
 function reindexTableRows(tables: ReindexTableData[]): ReindexTableRow[] {
   return tables.map(table => {
     const hasError = Boolean(table.error)
+    const parked = table.result === 'parked'
     const enrichmentUnhealthy = isPlainRecord(table.enrichment) && table.enrichment.healthy === false
     return {
-      status: hasError ? 'fail' : enrichmentUnhealthy ? 'warn' : 'ok',
+      status: hasError ? 'fail' : parked || enrichmentUnhealthy ? 'warn' : 'ok',
       table: valueText(table.table, '(unknown)'),
       docs: valueText(table.indexed, '0'),
       enrichment: reindexEnrichmentText(table.enrichment),
-      issue: valueText(table.error),
+      issue: valueText(table.error) || (parked ? 'parked — green never converged' : ''),
     }
   })
 }

--- a/src/core/doctor-checks.ts
+++ b/src/core/doctor-checks.ts
@@ -1,0 +1,58 @@
+/**
+ * Plugin health-check RUNNER — a leaf module so the repair/delegate stack
+ * can run checks without importing doctor.ts (whose escalation path imports
+ * the repair stack back: that edge was an import cycle).
+ */
+import { listHealthChecks } from './health-check-registry'
+import type { HealthCheckDef, HealthCheckResult } from '../../packages/core/src/plugin-types'
+
+export interface DetailedHealthCheckRun {
+  def: HealthCheckDef
+  results: HealthCheckResult[]
+}
+
+/**
+ * Run every plugin-registered health check in parallel. Per-check try/catch
+ * isolates failures — a single bad handler yields one synthetic error result
+ * and never crashes the doctor sweep. Exported separately from runDiagnostics
+ * so the isolation behavior can be tested without mocking every plugin's
+ * dependency tree.
+ */
+export async function runDetailedPluginHealthChecks(): Promise<DetailedHealthCheckRun[]> {
+  const defs = listHealthChecks()
+  return Promise.all(
+    defs.map(async (def) => {
+      try {
+        const rows = await def.run()
+        if (!Array.isArray(rows)) {
+          return {
+            def,
+            results: [{
+              check: def.id,
+              status: 'error' as const,
+              message: `Plugin health check returned non-array: ${typeof rows}`,
+              autoFixable: false,
+            }],
+          }
+        }
+        return { def, results: rows }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return {
+          def,
+          results: [{
+            check: def.id,
+            status: 'error' as const,
+            message: `Plugin health check threw: ${message}`,
+            autoFixable: false,
+          }],
+        }
+      }
+    }),
+  )
+}
+
+export async function runPluginHealthChecks(): Promise<HealthCheckResult[]> {
+  const groups = await runDetailedPluginHealthChecks()
+  return groups.flatMap(group => group.results)
+}

--- a/src/core/doctor-delegate.ts
+++ b/src/core/doctor-delegate.ts
@@ -16,6 +16,14 @@ export interface DoctorDelegateOptions {
   contentDir: string
   projectRoot: string
   accepted: boolean
+  /**
+   * Override the unresolved-row selection. The cron escalation passes its
+   * ERROR rows directly — including safe-repairable ones, which
+   * unresolvedRows() deliberately excludes for the interactive --delegate
+   * flow (there the answer is `--fix`); the delegated agent can run the
+   * fix itself.
+   */
+  rows?: HealthCheckResult[]
 }
 
 export interface DoctorDelegateReport {
@@ -71,7 +79,7 @@ export async function delegateDoctorRepair(options: DoctorDelegateOptions): Prom
     contentDir: options.contentDir,
     projectRoot: options.projectRoot,
   })
-  const unresolved = unresolvedRows(plan)
+  const unresolved = options.rows ?? unresolvedRows(plan)
   const request = createDoctorRepairRequest(options.contentDir, { plan, unresolved })
 
   if (unresolved.length === 0) {

--- a/src/core/doctor-escalation.ts
+++ b/src/core/doctor-escalation.ts
@@ -1,0 +1,90 @@
+/**
+ * Periodic-doctor escalation — turns cron ERROR findings into action.
+ *
+ * Before this, the 30-min doctor cron surfaced findings ONLY on the
+ * dashboard: notifications were opt-in per CLI run (`--notify-agent`), so
+ * the 2026-07-12 search-dark incident burned for 17h with a red row nobody
+ * was looking at. Per settings.doctor.escalation, a cron cycle whose
+ * results contain errors now either:
+ *
+ *  - 'task'   → creates ONE delegated-repair task for the main agent (the
+ *               existing `bakin doctor --delegate` flow: durable request,
+ *               board-visible task, dispatch kick, budget-gated like any
+ *               task). Deduplicated: skipped while an open repair task
+ *               already covers every current error check, and rate-limited
+ *               by escalationCooldownMs so a persistent error never spawns
+ *               a task per cycle.
+ *  - 'notify' → messages the main agent (the --notify-agent path).
+ *  - 'off'    → old behavior.
+ *
+ * Only the CRON escalates — runDiagnostics itself is untouched, so manual
+ * `bakin doctor` runs never surprise-create tasks.
+ */
+import { createLogger } from './logger'
+import { getSettings } from './settings'
+import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
+
+const log = createLogger('doctor-escalation')
+
+export async function escalateCronErrors(
+  results: HealthCheckResult[],
+  contentDir: string,
+  projectRoot: string,
+): Promise<void> {
+  const { escalation, escalationCooldownMs } = getSettings().doctor
+  if (escalation === 'off') return
+  const errors = results.filter((row) => row.status === 'error')
+  if (errors.length === 0) return
+  // A not-onboarded machine has no main agent to escalate to — the
+  // onboarding surfaces own this state.
+  if (errors.some((row) => row.check === 'onboarded')) return
+
+  try {
+    if (escalation === 'notify') {
+      const { notifyUnfixableIssues } = await import('./doctor')
+      await notifyUnfixableIssues(results)
+      return
+    }
+
+    // 'task': ONE open repair task per persisting error set.
+    const errorChecks = [...new Set(errors.map((row) => row.check))]
+    const { listDoctorRepairRequests } = await import('./doctor-repair-store')
+    const { getTaskDetails } = await import('./task-service')
+    for (const request of listDoctorRepairRequests(contentDir)) {
+      const covered = new Set(request.unresolved.map((row) => row.check))
+      if (!errorChecks.every((check) => covered.has(check))) continue
+      if (request.taskId) {
+        const details = await getTaskDetails(request.taskId).catch(() => null)
+        if (details && details.column !== 'done') {
+          log.info('escalation skipped — an open repair task already covers the current errors', {
+            taskId: request.taskId,
+            checks: errorChecks,
+          })
+          return
+        }
+      }
+      if (Date.now() - Date.parse(request.createdAt) < escalationCooldownMs) {
+        log.info('escalation skipped — same error set escalated inside the cooldown window', {
+          requestId: request.id,
+          checks: errorChecks,
+        })
+        return
+      }
+    }
+
+    const { delegateDoctorRepair } = await import('./doctor-delegate')
+    const report = await delegateDoctorRepair({ contentDir, projectRoot, accepted: true, rows: errors })
+    log.info('cron errors escalated as a delegated repair task', {
+      status: report.status,
+      taskId: report.request.taskId,
+      checks: errorChecks,
+    })
+  } catch (err) {
+    // Escalation is best-effort on top of the diagnostics — a failure here
+    // must never take the doctor cycle down with it.
+    log.error('doctor escalation failed', err instanceof Error ? err : undefined, {
+      mode: escalation,
+      errors: errors.length,
+    })
+  }
+}

--- a/src/core/doctor-escalation.ts
+++ b/src/core/doctor-escalation.ts
@@ -22,9 +22,55 @@
  */
 import { createLogger } from './logger'
 import { getSettings } from './settings'
+import { getAppServices } from './app-services'
+import { meterAgentTurn } from './agent-cost'
+import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
 
 const log = createLogger('doctor-escalation')
+
+// Track what we've already notified about to avoid spamming the main agent.
+// The doctor cron clears this each cycle so recurring issues re-report.
+const notifiedIssues = new Set<string>()
+
+export function clearNotifiedIssues(): void {
+  notifiedIssues.clear()
+}
+
+export async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void> {
+  // Errors ALWAYS qualify — an autoFixable error is still an incident the
+  // user must hear about (the 17h search-dark burn stayed silent partly
+  // because fixable errors were filtered here); only fixable WARNS stay
+  // quiet to bound noise.
+  const issues = results.filter(r =>
+    r.status === 'error' || (r.status === 'warn' && !r.autoFixable)
+  )
+
+  if (issues.length === 0) return
+
+  // Build a dedup key from the issues so we don't spam
+  const issueKey = issues.map(i => `${i.check}:${i.status}`).sort().join('|')
+  if (notifiedIssues.has(issueKey)) return
+  notifiedIssues.add(issueKey)
+
+  const lines = issues.map(i => {
+    const icon = i.status === 'error' ? 'ERROR' : 'WARN'
+    const hint = i.autoFixable ? ' (repair available: `bakin doctor --fix`)' : ''
+    return `[${icon}] ${i.check}: ${i.message}${hint}`
+  })
+
+  const message = `Bakin Doctor found ${issues.length} issue(s) that need your attention:\n\n${lines.join('\n')}\n\nRun \`bakin doctor\` for full details.`
+
+  try {
+    const runtime = getAppServices().runtime
+    const mainAgentId = await getRuntimeMainAgentId(runtime)
+    const result = await runtime.messaging.send({ agentId: mainAgentId, content: message })
+    await meterAgentTurn({ agent: mainAgentId, result, name: 'doctor-notify' })
+    log.info('Notified main agent of unfixable issues', { count: issues.length })
+  } catch (err) {
+    log.error('Failed to notify main agent of doctor issues', err instanceof Error ? err : undefined)
+  }
+}
 
 export async function escalateCronErrors(
   results: HealthCheckResult[],
@@ -41,7 +87,6 @@ export async function escalateCronErrors(
 
   try {
     if (escalation === 'notify') {
-      const { notifyUnfixableIssues } = await import('./doctor')
       await notifyUnfixableIssues(results)
       return
     }

--- a/src/core/doctor-repair.ts
+++ b/src/core/doctor-repair.ts
@@ -6,7 +6,7 @@
  * check-owned repair handler can mutate state.
  */
 import { appendAudit } from './audit'
-import { runDetailedPluginHealthChecks } from './doctor'
+import { runDetailedPluginHealthChecks } from './doctor-checks'
 import { getHealthCheck } from './health-check-registry'
 import type {
   HealthCheckDef,

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -18,6 +18,8 @@ import { isOnboarded } from './onboarding/state'
 import { listHealthChecks } from './health-check-registry'
 import type { HealthCheckDef, HealthCheckResult } from '../../packages/core/src/plugin-types'
 
+import { escalateCronErrors } from './doctor-escalation'
+
 const log = createLogger('doctor')
 
 let doctorTimer: NodeJS.Timeout | null = null
@@ -78,7 +80,7 @@ export async function runPluginHealthChecks(): Promise<HealthCheckResult[]> {
   return groups.flatMap(group => group.results)
 }
 
-async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void> {
+export async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void> {
   // Errors ALWAYS qualify — an autoFixable error is still an incident the
   // user must hear about (the 17h search-dark burn stayed silent partly
   // because fixable errors were filtered here); only fixable WARNS stay
@@ -180,18 +182,22 @@ export function start(contentDir: string, projectRoot: string): void {
   const settings = getSettings()
 
   // Run immediately on startup
-  runDiagnostics(contentDir, projectRoot).catch(err => {
-    log.error('Doctor startup check failed', err)
-  })
+  runDiagnostics(contentDir, projectRoot)
+    .then(results => escalateCronErrors(results, contentDir, projectRoot))
+    .catch(err => {
+      log.error('Doctor startup check failed', err)
+    })
 
   // Then run on interval
   doctorTimer = setInterval(() => {
     // Clear notification cache each cycle so recurring issues get re-reported
     // (but not within the same cycle)
     notifiedIssues.clear()
-    runDiagnostics(contentDir, projectRoot).catch(err => {
-      log.error('Doctor periodic check failed', err)
-    })
+    runDiagnostics(contentDir, projectRoot)
+      .then(results => escalateCronErrors(results, contentDir, projectRoot))
+      .catch(err => {
+        log.error('Doctor periodic check failed', err)
+      })
   }, settings.doctor.intervalMs)
 
   log.info('Doctor started', { intervalMs: settings.doctor.intervalMs })

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -11,110 +11,21 @@
 import { createLogger } from './logger'
 import { getSettings } from './settings'
 import { appendAudit } from './audit'
-import { getAppServices } from './app-services'
-import { meterAgentTurn } from './agent-cost'
-import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { isOnboarded } from './onboarding/state'
-import { listHealthChecks } from './health-check-registry'
-import type { HealthCheckDef, HealthCheckResult } from '../../packages/core/src/plugin-types'
+import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
 
-import { escalateCronErrors } from './doctor-escalation'
+import { runPluginHealthChecks } from './doctor-checks'
+import { escalateCronErrors, notifyUnfixableIssues, clearNotifiedIssues } from './doctor-escalation'
+
+// Re-exported for existing consumers; the implementation lives in the leaf
+// module so doctor-repair can import it without a cycle.
+export { runDetailedPluginHealthChecks, runPluginHealthChecks, type DetailedHealthCheckRun } from './doctor-checks'
 
 const log = createLogger('doctor')
 
 let doctorTimer: NodeJS.Timeout | null = null
 let lastResults: HealthCheckResult[] | null = null
 let lastResultTime: number = 0
-
-// Track what we've already notified about to avoid spamming the main agent
-const notifiedIssues = new Set<string>()
-
-export interface DetailedHealthCheckRun {
-  def: HealthCheckDef
-  results: HealthCheckResult[]
-}
-
-/**
- * Run every plugin-registered health check in parallel. Per-check try/catch
- * isolates failures — a single bad handler yields one synthetic error result
- * and never crashes the doctor sweep. Exported separately from runDiagnostics
- * so the isolation behavior can be tested without mocking every plugin's
- * dependency tree.
- */
-export async function runDetailedPluginHealthChecks(): Promise<DetailedHealthCheckRun[]> {
-  const defs = listHealthChecks()
-  return Promise.all(
-    defs.map(async (def) => {
-      try {
-        const rows = await def.run()
-        if (!Array.isArray(rows)) {
-          return {
-            def,
-            results: [{
-              check: def.id,
-              status: 'error' as const,
-              message: `Plugin health check returned non-array: ${typeof rows}`,
-              autoFixable: false,
-            }],
-          }
-        }
-        return { def, results: rows }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        return {
-          def,
-          results: [{
-            check: def.id,
-            status: 'error' as const,
-            message: `Plugin health check threw: ${message}`,
-            autoFixable: false,
-          }],
-        }
-      }
-    }),
-  )
-}
-
-export async function runPluginHealthChecks(): Promise<HealthCheckResult[]> {
-  const groups = await runDetailedPluginHealthChecks()
-  return groups.flatMap(group => group.results)
-}
-
-export async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void> {
-  // Errors ALWAYS qualify — an autoFixable error is still an incident the
-  // user must hear about (the 17h search-dark burn stayed silent partly
-  // because fixable errors were filtered here); only fixable WARNS stay
-  // quiet to bound noise.
-  const issues = results.filter(r =>
-    r.status === 'error' || (r.status === 'warn' && !r.autoFixable)
-  )
-
-  if (issues.length === 0) return
-
-  // Build a dedup key from the issues so we don't spam
-  const issueKey = issues.map(i => `${i.check}:${i.status}`).sort().join('|')
-  if (notifiedIssues.has(issueKey)) return
-  notifiedIssues.add(issueKey)
-
-  const lines = issues.map(i => {
-    const icon = i.status === 'error' ? 'ERROR' : 'WARN'
-    const hint = i.autoFixable ? ' (repair available: `bakin doctor --fix`)' : ''
-    return `[${icon}] ${i.check}: ${i.message}${hint}`
-  })
-
-  const message = `Bakin Doctor found ${issues.length} issue(s) that need your attention:\n\n${lines.join('\n')}\n\nRun \`bakin doctor\` for full details.`
-
-  try {
-    const runtime = getAppServices().runtime
-    const mainAgentId = await getRuntimeMainAgentId(runtime)
-    const result = await runtime.messaging.send({ agentId: mainAgentId, content: message })
-    await meterAgentTurn({ agent: mainAgentId, result, name: 'doctor-notify' })
-    log.info('Notified main agent of unfixable issues', { count: issues.length })
-  } catch (err) {
-    // Runtime might be the issue — can't notify about that
-    log.warn('Could not notify main agent of doctor issues (runtime may be down)', err)
-  }
-}
 
 export async function runDiagnostics(
   contentDir: string,
@@ -192,7 +103,7 @@ export function start(contentDir: string, projectRoot: string): void {
   doctorTimer = setInterval(() => {
     // Clear notification cache each cycle so recurring issues get re-reported
     // (but not within the same cycle)
-    notifiedIssues.clear()
+    clearNotifiedIssues()
     runDiagnostics(contentDir, projectRoot)
       .then(results => escalateCronErrors(results, contentDir, projectRoot))
       .catch(err => {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -79,8 +79,12 @@ export async function runPluginHealthChecks(): Promise<HealthCheckResult[]> {
 }
 
 async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void> {
+  // Errors ALWAYS qualify — an autoFixable error is still an incident the
+  // user must hear about (the 17h search-dark burn stayed silent partly
+  // because fixable errors were filtered here); only fixable WARNS stay
+  // quiet to bound noise.
   const issues = results.filter(r =>
-    (r.status === 'warn' || r.status === 'error') && !r.autoFixable
+    r.status === 'error' || (r.status === 'warn' && !r.autoFixable)
   )
 
   if (issues.length === 0) return
@@ -92,7 +96,8 @@ async function notifyUnfixableIssues(results: HealthCheckResult[]): Promise<void
 
   const lines = issues.map(i => {
     const icon = i.status === 'error' ? 'ERROR' : 'WARN'
-    return `[${icon}] ${i.check}: ${i.message}`
+    const hint = i.autoFixable ? ' (repair available: `bakin doctor --fix`)' : ''
+    return `[${icon}] ${i.check}: ${i.message}${hint}`
   })
 
   const message = `Bakin Doctor found ${issues.length} issue(s) that need your attention:\n\n${lines.join('\n')}\n\nRun \`bakin doctor\` for full details.`

--- a/src/core/search-registry-core.ts
+++ b/src/core/search-registry-core.ts
@@ -211,19 +211,23 @@ async function ensureTable(search: SearchAdapter, def: SearchContentTypeDefiniti
  * path). Queries keep answering from the old physical throughout; SSE
  * `search.rebuild.*` events drive the health page's live progress.
  */
-export async function rebuildRegisteredTables(tableName?: string): Promise<Array<{ table: string; result: string; error?: string }>> {
+export async function rebuildRegisteredTables(tableName?: string): Promise<Array<{ table: string; result: string; indexed?: number; error?: string }>> {
   const registry = getRegistry()
   const search = getSearchAdapter()
-  const results: Array<{ table: string; result: string; error?: string }> = []
+  const results: Array<{ table: string; result: string; indexed?: number; error?: string }> = []
   for (const [logical, def] of registry.contentTypes) {
     if (tableName && logical !== tableName && def.table !== tableName) continue
     broadcastRebuild('search.rebuild.start', logical)
     try {
+      let indexed = 0
       const result = await rebuildVersionedTable(search, toVersionedDef(def), adapterFingerprint(search), {
-        onProgress: (phase, backfillDone) => broadcastRebuild('search.rebuild.progress', logical, { phase, indexed: backfillDone ?? 0 }),
+        onProgress: (phase, backfillDone) => {
+          if (backfillDone !== undefined) indexed = backfillDone
+          broadcastRebuild('search.rebuild.progress', logical, { phase, indexed: backfillDone ?? 0 })
+        },
       })
-      broadcastRebuild('search.rebuild.complete', logical, { result })
-      results.push({ table: logical, result })
+      broadcastRebuild('search.rebuild.complete', logical, { result, indexed })
+      results.push({ table: logical, result, indexed })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       broadcastRebuild('search.rebuild.complete', logical, { error: message })

--- a/src/core/search-registry-core.ts
+++ b/src/core/search-registry-core.ts
@@ -211,10 +211,18 @@ async function ensureTable(search: SearchAdapter, def: SearchContentTypeDefiniti
  * path). Queries keep answering from the old physical throughout; SSE
  * `search.rebuild.*` events drive the health page's live progress.
  */
-export async function rebuildRegisteredTables(tableName?: string): Promise<Array<{ table: string; result: string; indexed?: number; error?: string }>> {
+/** Per-table rebuild outcome — the ONE shape the /api/reindex route and the CLI share. */
+export interface ReindexTableOutcome {
+  table: string
+  result: string
+  indexed?: number
+  error?: string
+}
+
+export async function rebuildRegisteredTables(tableName?: string): Promise<ReindexTableOutcome[]> {
   const registry = getRegistry()
   const search = getSearchAdapter()
-  const results: Array<{ table: string; result: string; indexed?: number; error?: string }> = []
+  const results: ReindexTableOutcome[] = []
   for (const [logical, def] of registry.contentTypes) {
     if (tableName && logical !== tableName && def.table !== tableName) continue
     broadcastRebuild('search.rebuild.start', logical)

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -321,13 +321,14 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
     if (url.pathname === '/api/reindex' && req.method === 'POST') {
       const { rebuildRegisteredTables } = require('../search-registry')
       const table = url.searchParams.get('table') || undefined
-      rebuildRegisteredTables(table).then((results: Array<{ table: string; result: string; error?: string }>) => {
+      rebuildRegisteredTables(table).then((results: Array<{ table: string; result: string; indexed?: number; error?: string }>) => {
         const errors = results.filter((r) => r.error).length
         const parked = results.filter((r) => r.result === 'parked').length
         jsonResponse(res, 200, {
           ok: errors === 0 && parked === 0,
           errors,
           parked,
+          total: results.reduce((sum, r) => sum + (r.indexed ?? 0), 0),
           tables: results,
         })
       }).catch((err: unknown) => {

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -321,7 +321,7 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
     if (url.pathname === '/api/reindex' && req.method === 'POST') {
       const { rebuildRegisteredTables } = require('../search-registry')
       const table = url.searchParams.get('table') || undefined
-      rebuildRegisteredTables(table).then((results: Array<{ table: string; result: string; indexed?: number; error?: string }>) => {
+      rebuildRegisteredTables(table).then((results: import('../search-registry').ReindexTableOutcome[]) => {
         const errors = results.filter((r) => r.error).length
         const parked = results.filter((r) => r.result === 'parked').length
         jsonResponse(res, 200, {

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -153,6 +153,12 @@ export function shouldIgnoreContentWatcherPath(contentDir: string, path: string)
   // on os_unfair_lock), wedging the entire HTTP server seconds after boot.
   if (rel === 'antfly' || rel.startsWith('antfly/')) return true
 
+  // Sibling backup snapshots of content roots (assets.pre-pivot-*,
+  // assets.bak, ...) are dead copies, never live content. Watching one
+  // costs a kqueue fd per file under Bun and resurfaces stale files as
+  // unmanaged-import badges.
+  if (/^assets\.[^/]+/.test(rel)) return true
+
   const basename = path.split(/[\\/]/).pop() || ''
   // Allow .trash inside assets (we handle skipping in handleFileEvent)
   if (basename === '.trash' && rel.startsWith('assets/')) return false

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -153,11 +153,13 @@ export function shouldIgnoreContentWatcherPath(contentDir: string, path: string)
   // on os_unfair_lock), wedging the entire HTTP server seconds after boot.
   if (rel === 'antfly' || rel.startsWith('antfly/')) return true
 
-  // Sibling backup snapshots of content roots (assets.pre-pivot-*,
-  // assets.bak, ...) are dead copies, never live content. Watching one
-  // costs a kqueue fd per file under Bun and resurfaces stale files as
-  // unmanaged-import badges.
-  if (/^assets\.[^/]+/.test(rel)) return true
+  // Backup/snapshot siblings of ANY content root (assets.pre-pivot-*,
+  // tasks.bak, workflows.old-2026) are dead copies, never live content.
+  // Watching one costs a kqueue fd per file under Bun and resurfaces stale
+  // files as unmanaged-import badges. Marker-based so legitimate top-level
+  // files (assets.md, MEMORY-LOG.md) stay watched.
+  const firstSegment = rel.split('/')[0]
+  if (/\.(bak|backup|old|orig|prev|pre-pivot)([.-][^/]*)?$/i.test(firstSegment)) return true
 
   const basename = path.split(/[\\/]/).pop() || ''
   // Allow .trash inside assets (we handle skipping in handleFileEvent)

--- a/tests/adapter-antfly/engine-status.test.ts
+++ b/tests/adapter-antfly/engine-status.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Engine-status probe — pure parsers + the stateful probe with a fake io.
+ * No real launchctl/ps ever runs; the log scan uses a temp file.
+ */
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync, mkdirSync, writeFileSync, appendFileSync } from 'fs'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-antfly-engine-status-${Date.now()}-${randomUUID()}`)
+process.env.ANTFLY_HOME = join(testDir, 'antfly-home')
+
+import { describe, it, expect, afterAll, mock } from 'bun:test'
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    home: testDir,
+    audit: join(testDir, 'audit.jsonl'),
+    tasks: join(testDir, 'tasks'),
+    logs: join(testDir, 'logs'),
+    db: join(testDir, 'bakin.db'),
+  }),
+})
+mock.module('../../src/core/content-dir', contentDirMock)
+mock.module('../../packages/core/src/content-dir', contentDirMock)
+const loggerMock = () => ({
+  createLogger: () => ({ debug: mock(), info: mock(), warn: mock(), error: mock() }),
+})
+mock.module('../../src/core/logger', loggerMock)
+mock.module('../../packages/core/src/logger', loggerMock)
+
+import { createEngineStatusProbe, parsePsCpuTime, scanLogDelta } from '../../packages/adapter-antfly/src/engine-status'
+import { servicePaths, type ServiceIo } from '../../packages/adapter-antfly/src/service'
+import { DEFAULT_SETTINGS } from '../../packages/adapter-antfly/src/defaults'
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('parsePsCpuTime', () => {
+  it('parses mm:ss, hh:mm:ss, and dd-hh:mm:ss', () => {
+    expect(parsePsCpuTime('0:07.12')).toBeCloseTo(7.12)
+    expect(parsePsCpuTime('14:54.63')).toBeCloseTo(894.63)
+    expect(parsePsCpuTime('2:30:00')).toBe(9000)
+    expect(parsePsCpuTime('1-01:00:00')).toBe(90000)
+  })
+
+  it('rejects garbage', () => {
+    expect(parsePsCpuTime('')).toBeNull()
+    expect(parsePsCpuTime('not-a-time')).toBeNull()
+  })
+})
+
+describe('scanLogDelta', () => {
+  const logDir = join(testDir, 'scan-logs')
+  const logFile = (name: string) => join(logDir, name)
+
+  it('null offset = first probe — baselines to EOF without firing on history', () => {
+    mkdirSync(logDir, { recursive: true })
+    const file = logFile('history.log')
+    writeFileSync(file, 'catch-up debt persists\n'.repeat(50))
+    const first = scanLogDelta(file, null)
+    expect(first.signals).toEqual([])
+    expect(first.nextOffset).toBeGreaterThan(0)
+  })
+
+  it('fires only when the signature recurs in the NEW bytes', () => {
+    const file = logFile('delta.log')
+    writeFileSync(file, 'boot ok\n')
+    const base = scanLogDelta(file, null)
+
+    appendFileSync(file, 'catch-up debt persists\n') // once = noise
+    const once = scanLogDelta(file, base.nextOffset)
+    expect(once.signals).toEqual([])
+
+    appendFileSync(file, 'catch-up debt persists\n'.repeat(5)) // loop = wedge
+    const loop = scanLogDelta(file, once.nextOffset)
+    expect(loop.signals).toEqual(['startup-catchup-spin'])
+
+    // Offset advanced — the same lines never fire twice.
+    const after = scanLogDelta(file, loop.nextOffset)
+    expect(after.signals).toEqual([])
+  })
+
+  it('handles rotation (file shrank) without throwing or double-firing history', () => {
+    const file = logFile('rotated.log')
+    writeFileSync(file, 'x'.repeat(10_000))
+    const base = scanLogDelta(file, null)
+    writeFileSync(file, 'fresh after rotation\n') // truncated below the old offset
+    const scan = scanLogDelta(file, base.nextOffset)
+    expect(scan.signals).toEqual([])
+    expect(scan.nextOffset).toBe('fresh after rotation\n'.length)
+  })
+
+  it('missing log = no signals, offset 0', () => {
+    expect(scanLogDelta(logFile('never-written.log'), null)).toEqual({ signals: [], nextOffset: 0 })
+  })
+})
+
+describe('createEngineStatusProbe', () => {
+  function fakeIo(psTimes: string[], pid = 4242): ServiceIo & { record: string[][] } {
+    const record: string[][] = []
+    let psCall = 0
+    return {
+      platform: 'darwin',
+      hasCommand: () => true,
+      env: { HOME: testDir },
+      exec: async (cmd, args) => {
+        record.push([cmd, ...args])
+        if (cmd === 'launchctl') return { code: 0, stdout: `state = running\n\tpid = ${pid}\n`, stderr: '' }
+        if (cmd === 'ps') return { code: 0, stdout: psTimes[Math.min(psCall++, psTimes.length - 1)], stderr: '' }
+        return { code: 1, stdout: '', stderr: 'unexpected' }
+      },
+      record,
+    }
+  }
+
+  it('first sample has null utilization; the second reports the rate since the first', async () => {
+    mkdirSync(join(testDir, 'logs'), { recursive: true })
+    writeFileSync(servicePaths().logFile, '')
+    // 60 CPU-seconds between samples → utilization = 60 / wallSeconds; with
+    // wall << 60s in-test this just needs to be a positive finite number.
+    const probe = createEngineStatusProbe(() => DEFAULT_SETTINGS, fakeIo(['1:00.00', '2:00.00']))
+    const first = await probe()
+    expect(first).not.toBeNull()
+    expect(first!.running).toBe(true)
+    expect(first!.pid).toBe(4242)
+    expect(first!.cpuUtilization).toBeNull()
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    const second = await probe()
+    expect(second!.cpuUtilization).toBeGreaterThan(0)
+    expect(Number.isFinite(second!.cpuUtilization!)).toBe(true)
+  })
+
+  it('reports running=false when the supervisor has no pid', async () => {
+    const io: ServiceIo = {
+      platform: 'darwin',
+      hasCommand: () => true,
+      env: { HOME: testDir },
+      exec: async () => ({ code: 113, stdout: '', stderr: 'not loaded' }),
+    }
+    const probe = createEngineStatusProbe(() => DEFAULT_SETTINGS, io)
+    const status = await probe()
+    expect(status).toEqual({ running: false, cpuUtilization: null, wedgeSignals: [] })
+  })
+
+  it('guest mode cannot measure — resolves null', async () => {
+    const probe = createEngineStatusProbe(
+      () => ({ ...DEFAULT_SETTINGS, url: 'http://other:1234' }),
+      { platform: 'darwin', hasCommand: () => true, env: { HOME: testDir }, exec: async () => ({ code: 0, stdout: '', stderr: '' }) },
+    )
+    expect(await probe()).toBeNull()
+  })
+
+  it('surfaces wedge signals from the engine log delta', async () => {
+    mkdirSync(join(testDir, 'logs'), { recursive: true })
+    writeFileSync(servicePaths().logFile, 'old history\n')
+    const probe = createEngineStatusProbe(() => DEFAULT_SETTINGS, fakeIo(['1:00.00', '1:30.00']))
+    const first = await probe() // baseline — history never fires
+    expect(first!.wedgeSignals).toEqual([])
+
+    appendFileSync(servicePaths().logFile, 'catch-up debt persists\n'.repeat(10))
+    const second = await probe()
+    expect(second!.wedgeSignals).toEqual(['startup-catchup-spin'])
+  })
+})

--- a/tests/adapter-antfly/service.test.ts
+++ b/tests/adapter-antfly/service.test.ts
@@ -38,6 +38,7 @@ import {
   launchdPlistPath,
   renderLaunchdPlist,
   renderSystemdUnit,
+  restartService,
   servicePaths,
   systemdUnitPath,
   type ServiceIo,
@@ -168,5 +169,40 @@ describe('ensureProvisioned idempotence', () => {
     const child = fakeIo({ env: { HOME: testDir, BAKIN_SEARCH_SERVICE_MODE: 'child' } })
     expect(await ensureProvisioned(DEFAULT_SETTINGS, child)).toEqual({ mode: 'child', action: 'skipped' })
     expect(child.record).toHaveLength(0)
+  })
+})
+
+describe('restartService (graceful — SIGTERM, never a blind kill)', () => {
+  it('launchd: SIGTERM via launchctl kill; KeepAlive respawns', async () => {
+    const io = fakeIo()
+    await restartService(DEFAULT_SETTINGS, io)
+    expect(io.record).toHaveLength(1)
+    expect(io.record[0].slice(0, 3)).toEqual(['launchctl', 'kill', 'SIGTERM'])
+  })
+
+  it('launchd: falls back to kickstart when the label is not loaded', async () => {
+    const record: string[][] = []
+    const io = fakeIo({
+      record,
+      exec: async (cmd, args) => {
+        record.push([cmd, ...args])
+        // `launchctl kill` fails (service not loaded); kickstart succeeds.
+        return { code: args[0] === 'kill' ? 113 : 0, stdout: '', stderr: '' }
+      },
+    })
+    await restartService(DEFAULT_SETTINGS, io)
+    expect(record[1].slice(0, 3)).toEqual(['launchctl', 'kickstart', '-k'])
+  })
+
+  it('systemd: systemctl --user restart', async () => {
+    const io = fakeIo({ platform: 'linux' })
+    await restartService(DEFAULT_SETTINGS, io)
+    expect(io.record).toContainEqual(['systemctl', '--user', 'restart', 'bakin-antfly.service'])
+  })
+
+  it('guest: throws — the engine is not ours to restart', async () => {
+    const io = fakeIo()
+    await expect(restartService({ ...DEFAULT_SETTINGS, url: 'http://other:1234' }, io)).rejects.toThrow('externally managed')
+    expect(io.record).toHaveLength(0)
   })
 })

--- a/tests/cli/readonly-search-trash-schedule.test.ts
+++ b/tests/cli/readonly-search-trash-schedule.test.ts
@@ -183,9 +183,9 @@ describe('read-only CLI TTY commands — schedule, trash, search', () => {
       ok: false,
       total: 12,
       errors: 1,
-      enrichmentErrors: 1,
+      parked: 0,
       tables: [
-        { table: 'bakin_tasks', indexed: 12, enrichment: { healthy: true, indexes: [] } },
+        { table: 'bakin_tasks', indexed: 12, result: 'migrated' },
         { table: 'agent_lessons', indexed: 0, error: 'schema missing' },
       ],
     }))

--- a/tests/cli/readonly-ui.test.tsx
+++ b/tests/cli/readonly-ui.test.tsx
@@ -343,11 +343,11 @@ describe('read-only CLI TUI screens', () => {
           ok: false,
           total: 12,
           errors: 1,
-          enrichmentErrors: 1,
+          parked: 1,
           tables: [
-            { table: 'bakin_tasks', indexed: 12, enrichment: { healthy: true, indexes: [] } },
+            { table: 'bakin_tasks', indexed: 12, result: 'migrated' },
             { table: 'agent_lessons', indexed: 0, error: 'schema missing' },
-            { table: 'assets', indexed: 4, enrichment: { healthy: false, indexes: [{ name: 'semantic', error: 'offline', walBacklog: 2 }] } },
+            { table: 'assets', indexed: 4, result: 'parked' },
           ],
         }}
       />,
@@ -359,7 +359,8 @@ describe('read-only CLI TUI screens', () => {
     expect(output).toContain('bakin_tasks')
     expect(output).toContain('agent_lessons')
     expect(output).toContain('schema missing')
-    expect(output).toContain('semantic: offline')
+    // Parked outcome must be VISIBLE (the '-' fallback once hid it).
+    expect(output).toContain('parked — green never converged')
     expect(output).not.toContain('Reindexing tasks into search')
   })
 

--- a/tests/core/doctor-escalation.test.ts
+++ b/tests/core/doctor-escalation.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Periodic-doctor escalation — cron errors become ONE deduplicated
+ * delegated-repair task (or a notification), never a task per cycle.
+ */
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = mkdtempSync(join(tmpdir(), 'bakin-doctor-escalation-'))
+process.env.BAKIN_HOME = testDir
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: join(testDir, 'bakin.db') }),
+})
+mock.module('../../src/core/content-dir', contentDirMock)
+mock.module('../../packages/core/src/content-dir', contentDirMock)
+const loggerMock = () => ({
+  createLogger: () => ({ debug: mock(), info: mock(), warn: mock(), error: mock() }),
+})
+mock.module('../../src/core/logger', loggerMock)
+mock.module('../../packages/core/src/logger', loggerMock)
+
+// Mutable fixtures
+let escalationMode: 'off' | 'notify' | 'task' = 'task'
+let cooldownMs = 6 * 60 * 60 * 1000
+let repairRequests: Array<{
+  id: string
+  createdAt: string
+  taskId?: string
+  unresolved: Array<{ check: string; status: string; message: string }>
+}> = []
+let openTaskColumns: Record<string, string> = {}
+
+mock.module('../../src/core/settings', () => ({
+  getSettings: () => ({ doctor: { escalation: escalationMode, escalationCooldownMs: cooldownMs } }),
+}))
+mock.module('../../src/core/doctor-repair-store', () => ({
+  listDoctorRepairRequests: () => repairRequests,
+}))
+mock.module('../../src/core/task-service', () => ({
+  getTaskDetails: async (taskId: string) =>
+    taskId in openTaskColumns ? { task: {}, column: openTaskColumns[taskId] } : null,
+}))
+const delegateDoctorRepair = mock(async (options: { rows?: unknown[] }) => ({
+  status: 'sent',
+  request: { id: 'repair-new', taskId: 'task-new' },
+  unresolved: options.rows ?? [],
+}))
+mock.module('../../src/core/doctor-delegate', () => ({ delegateDoctorRepair }))
+const notifyUnfixableIssues = mock(async () => {})
+mock.module('../../src/core/doctor', () => ({ notifyUnfixableIssues }))
+
+import { escalateCronErrors } from '../../src/core/doctor-escalation'
+import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  escalationMode = 'task'
+  cooldownMs = 6 * 60 * 60 * 1000
+  repairRequests = []
+  openTaskColumns = {}
+  delegateDoctorRepair.mockClear()
+  notifyUnfixableIssues.mockClear()
+})
+
+const errorRow = (check: string): HealthCheckResult => ({ check, status: 'error', message: `${check} broke`, autoFixable: true })
+const okRow = (check: string): HealthCheckResult => ({ check, status: 'ok', message: 'fine', autoFixable: false })
+
+describe('escalateCronErrors', () => {
+  it('creates a delegated repair task for cron errors (safe-repairable ones included)', async () => {
+    await escalateCronErrors([okRow('search'), errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
+    const args = delegateDoctorRepair.mock.calls[0][0] as { accepted: boolean; rows: HealthCheckResult[] }
+    expect(args.accepted).toBe(true)
+    expect(args.rows.map((r) => r.check)).toEqual(['search-canary'])
+  })
+
+  it('does nothing without errors, when off, or on a not-onboarded machine', async () => {
+    await escalateCronErrors([okRow('search')], testDir, testDir)
+    escalationMode = 'off'
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    escalationMode = 'task'
+    await escalateCronErrors([errorRow('onboarded'), errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).not.toHaveBeenCalled()
+  })
+
+  it('skips while an OPEN repair task already covers every current error check', async () => {
+    repairRequests = [{
+      id: 'repair-1',
+      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // cooldown long past
+      taskId: 'task-1',
+      unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+    }]
+    openTaskColumns = { 'task-1': 'doing' }
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).not.toHaveBeenCalled()
+  })
+
+  it('skips inside the cooldown window even when the previous task is done', async () => {
+    repairRequests = [{
+      id: 'repair-1',
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+      taskId: 'task-1',
+      unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+    }]
+    openTaskColumns = { 'task-1': 'done' }
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).not.toHaveBeenCalled()
+  })
+
+  it('re-escalates once the cooldown passed and the previous task is done', async () => {
+    repairRequests = [{
+      id: 'repair-1',
+      createdAt: new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(),
+      taskId: 'task-1',
+      unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+    }]
+    openTaskColumns = { 'task-1': 'done' }
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
+  })
+
+  it('a NEW error check escalates even while an older narrower task is open', async () => {
+    repairRequests = [{
+      id: 'repair-1',
+      createdAt: new Date().toISOString(),
+      taskId: 'task-1',
+      unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+    }]
+    openTaskColumns = { 'task-1': 'doing' }
+    await escalateCronErrors([errorRow('search-canary'), errorRow('execution-safety')], testDir, testDir)
+    expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
+  })
+
+  it('notify mode messages the main agent instead of creating a task', async () => {
+    escalationMode = 'notify'
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(notifyUnfixableIssues).toHaveBeenCalledTimes(1)
+    expect(delegateDoctorRepair).not.toHaveBeenCalled()
+  })
+
+  it('a delegation failure never throws out of the cron path', async () => {
+    delegateDoctorRepair.mockImplementationOnce(async () => { throw new Error('runtime down') })
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    // reaching here without throwing IS the assertion
+    expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/core/doctor-escalation.test.ts
+++ b/tests/core/doctor-escalation.test.ts
@@ -49,10 +49,14 @@ const delegateDoctorRepair = mock(async (options: { rows?: unknown[] }) => ({
   unresolved: options.rows ?? [],
 }))
 mock.module('../../src/core/doctor-delegate', () => ({ delegateDoctorRepair }))
-const notifyUnfixableIssues = mock(async () => {})
-mock.module('../../src/core/doctor', () => ({ notifyUnfixableIssues }))
+// notify mode sends through the runtime — spy at the messaging boundary
+const messagingSend = mock(async () => ({ ok: true }))
+const appServices = () => ({ runtime: { messaging: { send: messagingSend } } })
+mock.module('../../src/core/app-services', () => ({ getAppServices: appServices, maybeGetAppServices: appServices }))
+mock.module('../../src/core/agent-cost', () => ({ meterAgentTurn: async () => {} }))
+mock.module('@bakin/core/adapters/runtime', () => ({ getRuntimeMainAgentId: async () => 'main' }))
 
-import { escalateCronErrors } from '../../src/core/doctor-escalation'
+import { clearNotifiedIssues, escalateCronErrors } from '../../src/core/doctor-escalation'
 import type { HealthCheckResult } from '../../packages/core/src/plugin-types'
 
 afterAll(() => {
@@ -65,7 +69,8 @@ beforeEach(() => {
   repairRequests = []
   openTaskColumns = {}
   delegateDoctorRepair.mockClear()
-  notifyUnfixableIssues.mockClear()
+  messagingSend.mockClear()
+  clearNotifiedIssues()
 })
 
 const errorRow = (check: string): HealthCheckResult => ({ check, status: 'error', message: `${check} broke`, autoFixable: true })
@@ -137,10 +142,14 @@ describe('escalateCronErrors', () => {
     expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
   })
 
-  it('notify mode messages the main agent instead of creating a task', async () => {
+  it('notify mode messages the main agent instead of creating a task — autoFixable errors included', async () => {
     escalationMode = 'notify'
     await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
-    expect(notifyUnfixableIssues).toHaveBeenCalledTimes(1)
+    expect(messagingSend).toHaveBeenCalledTimes(1)
+    const sent = (messagingSend.mock.calls[0] as unknown[])[0] as { agentId: string; content: string }
+    expect(sent.agentId).toBe('main')
+    expect(sent.content).toContain('search-canary')
+    expect(sent.content).toContain('repair available')
     expect(delegateDoctorRepair).not.toHaveBeenCalled()
   })
 

--- a/tests/core/search-tables.test.ts
+++ b/tests/core/search-tables.test.ts
@@ -37,6 +37,8 @@ import {
   queryTarget,
   rebuildTable,
   resumeMigrations,
+  sweepOrphanEngineTables,
+  sweepTombstones,
   tableStatus,
   resetTablesForTests,
   type TableEnsureDef,
@@ -341,5 +343,115 @@ describe('blue/green migration', () => {
     await resumeMigrations(adapter, [makeDef({ schemaVersion: 2 })], 'fp-a')
     expect(queryTarget('bakin_notes')).toMatch(/^bakin_notes_v2_/)
     expect(tableStatus('bakin_notes')?.state).toBe('active')
+  })
+})
+
+describe('sweepOrphanEngineTables', () => {
+  const TABLE_CONFIG = {
+    fields: { title: { type: 'text' } },
+    legs: [{ name: 'full_text', capability: 'full-text', fields: ['title'] }],
+  } as TableEnsureDef['config']
+
+  it('drops an unreferenced versioned table only after it survives the dwell window', async () => {
+    const adapter = createMockSearchAdapter()
+    await ensureTable(adapter, makeDef(), 'fp-a')
+    const active = queryTarget('bakin_notes')!
+    // Orphan generation from a wiped registry (never referenced by a row).
+    await adapter.tables.create('bakin_notes_v1_deadbeef', TABLE_CONFIG)
+
+    // First observation only records the candidate — nothing dropped yet.
+    const first = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    expect(first.dropped).toEqual([])
+    expect(first.pending).toBe(1)
+
+    // Second observation past the dwell drops it; the active table survives.
+    const second = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    expect(second.dropped).toEqual(['bakin_notes_v1_deadbeef'])
+    expect(second.pending).toBe(0)
+    expect(await adapter.tables.stats('bakin_notes_v1_deadbeef')).toBeNull()
+    expect(await adapter.tables.stats(active)).not.toBeNull()
+  })
+
+  it('never drops inside the dwell window', async () => {
+    const adapter = createMockSearchAdapter()
+    await adapter.tables.create('bakin_notes_v1_deadbeef', TABLE_CONFIG)
+    await sweepOrphanEngineTables(adapter, { dwellMs: 60_000 })
+    const second = await sweepOrphanEngineTables(adapter, { dwellMs: 60_000 })
+    expect(second.dropped).toEqual([])
+    expect(second.pending).toBe(1)
+    expect(await adapter.tables.stats('bakin_notes_v1_deadbeef')).not.toBeNull()
+  })
+
+  it('ignores names that do not match the versioned physical pattern', async () => {
+    const adapter = createMockSearchAdapter()
+    await adapter.tables.create('someone_elses_table', TABLE_CONFIG)
+    await adapter.tables.create('bakin_notes_backup', TABLE_CONFIG)
+    await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    const second = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    expect(second.dropped).toEqual([])
+    expect(second.pending).toBe(0)
+    expect(await adapter.tables.stats('someone_elses_table')).not.toBeNull()
+    expect(await adapter.tables.stats('bakin_notes_backup')).not.toBeNull()
+  })
+
+  it('a candidate that becomes referenced again is forgiven — first-seen does not linger', async () => {
+    const adapter = createMockSearchAdapter()
+    const def = makeDef()
+    // Simulate the cross-process create window: the physical exists
+    // engine-side before any registry row references it.
+    await ensureTable(adapter, def, 'fp-a')
+    const physical = queryTarget('bakin_notes')!
+    resetTablesForTests() // wipe the registry; the engine keeps the table
+    await sweepOrphanEngineTables(adapter, { dwellMs: 0 }) // records candidate
+    await ensureTable(adapter, def, 'fp-a') // registry row returns (same physical)
+    expect(queryTarget('bakin_notes')).toBe(physical)
+    const sweep = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    expect(sweep.dropped).toEqual([])
+    expect(sweep.pending).toBe(0)
+    expect(await adapter.tables.stats(physical)).not.toBeNull()
+  })
+
+  it('a mid-migration green is referenced — never a candidate', async () => {
+    const adapter = createMockSearchAdapter()
+    await ensureTable(adapter, makeDef(), 'fp-a')
+    // Park a migration: a generator that dies leaves state=migrating with
+    // migrating_to persisted (dual-write on).
+    const def2 = makeDef({
+      schemaVersion: 2,
+      reindex: async function* () {
+        yield { key: 'n1', doc: { title: 'v2' } }
+        throw new Error('process died')
+      },
+    })
+    await expect(ensureTable(adapter, def2, 'fp-a')).rejects.toThrow('process died')
+    const [, green] = resolveDrainTargets('bakin_notes')
+    expect(green).toMatch(/^bakin_notes_v2_/)
+
+    await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    const sweep = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    expect(sweep.dropped).toEqual([])
+    expect(await adapter.tables.stats(green)).not.toBeNull()
+  })
+
+  it('a failing drop is tombstoned for the tombstone sweep instead of retrying forever', async () => {
+    const base = createMockSearchAdapter()
+    await base.tables.create('bakin_notes_v1_deadbeef', TABLE_CONFIG)
+    const failing: SearchAdapter = {
+      ...base,
+      tables: { ...base.tables, drop: async () => { throw new Error('engine 500') } },
+      query: base.query.bind(base),
+      multiQuery: base.multiQuery.bind(base),
+      scan: base.scan.bind(base),
+      documents: base.documents,
+    }
+    await sweepOrphanEngineTables(failing, { dwellMs: 0 })
+    const sweep = await sweepOrphanEngineTables(failing, { dwellMs: 0 })
+    expect(sweep.dropped).toEqual([])
+    expect(sweep.pending).toBe(0) // no longer a candidate — it is a tombstone now
+
+    // The tombstone sweep finishes the job once the engine recovers.
+    const left = await sweepTombstones(base)
+    expect(left).toBe(0)
+    expect(await base.tables.stats('bakin_notes_v1_deadbeef')).toBeNull()
   })
 })

--- a/tests/core/search-tables.test.ts
+++ b/tests/core/search-tables.test.ts
@@ -33,6 +33,7 @@ mock.module('../../packages/core/src/logger', loggerMock)
 
 import {
   ensureTable,
+  removeTableRegistration,
   resolveDrainTargets,
   queryTarget,
   rebuildTable,
@@ -352,34 +353,52 @@ describe('sweepOrphanEngineTables', () => {
     legs: [{ name: 'full_text', capability: 'full-text', fields: ['title'] }],
   } as TableEnsureDef['config']
 
-  it('drops an unreferenced versioned table only after it survives the dwell window', async () => {
-    const adapter = createMockSearchAdapter()
+  /** An orphan THIS instance owns: ensured, then its registry row purged. */
+  async function makeOwnedOrphan(adapter: SearchAdapter): Promise<string> {
     await ensureTable(adapter, makeDef(), 'fp-a')
-    const active = queryTarget('bakin_notes')!
-    // Orphan generation from a wiped registry (never referenced by a row).
-    await adapter.tables.create('bakin_notes_v1_deadbeef', TABLE_CONFIG)
+    const physical = queryTarget('bakin_notes')!
+    removeTableRegistration('bakin_notes')
+    return physical
+  }
+
+  it('drops an owned unreferenced table only after it survives the dwell window', async () => {
+    const adapter = createMockSearchAdapter()
+    const orphan = await makeOwnedOrphan(adapter)
 
     // First observation only records the candidate — nothing dropped yet.
     const first = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
     expect(first.dropped).toEqual([])
     expect(first.pending).toBe(1)
+    expect(first.unclaimed).toEqual([])
 
-    // Second observation past the dwell drops it; the active table survives.
+    // Second observation past the dwell drops it.
     const second = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
-    expect(second.dropped).toEqual(['bakin_notes_v1_deadbeef'])
+    expect(second.dropped).toEqual([orphan])
     expect(second.pending).toBe(0)
-    expect(await adapter.tables.stats('bakin_notes_v1_deadbeef')).toBeNull()
-    expect(await adapter.tables.stats(active)).not.toBeNull()
+    expect(await adapter.tables.stats(orphan)).toBeNull()
+  })
+
+  it('NEVER drops an unreferenced table it did not create — reports it unclaimed (shared-engine safety)', async () => {
+    const adapter = createMockSearchAdapter()
+    // Another Bakin home's live table on a shared engine: versioned name,
+    // absent from this instance's registry AND ownership ledger.
+    await adapter.tables.create('bakin_tasks_v3_ab12cd34', TABLE_CONFIG)
+    await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    const second = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
+    expect(second.dropped).toEqual([])
+    expect(second.pending).toBe(0)
+    expect(second.unclaimed).toEqual(['bakin_tasks_v3_ab12cd34'])
+    expect(await adapter.tables.stats('bakin_tasks_v3_ab12cd34')).not.toBeNull()
   })
 
   it('never drops inside the dwell window', async () => {
     const adapter = createMockSearchAdapter()
-    await adapter.tables.create('bakin_notes_v1_deadbeef', TABLE_CONFIG)
+    const orphan = await makeOwnedOrphan(adapter)
     await sweepOrphanEngineTables(adapter, { dwellMs: 60_000 })
     const second = await sweepOrphanEngineTables(adapter, { dwellMs: 60_000 })
     expect(second.dropped).toEqual([])
     expect(second.pending).toBe(1)
-    expect(await adapter.tables.stats('bakin_notes_v1_deadbeef')).not.toBeNull()
+    expect(await adapter.tables.stats(orphan)).not.toBeNull()
   })
 
   it('ignores names that do not match the versioned physical pattern', async () => {
@@ -390,18 +409,14 @@ describe('sweepOrphanEngineTables', () => {
     const second = await sweepOrphanEngineTables(adapter, { dwellMs: 0 })
     expect(second.dropped).toEqual([])
     expect(second.pending).toBe(0)
+    expect(second.unclaimed).toEqual([])
     expect(await adapter.tables.stats('someone_elses_table')).not.toBeNull()
-    expect(await adapter.tables.stats('bakin_notes_backup')).not.toBeNull()
   })
 
   it('a candidate that becomes referenced again is forgiven — first-seen does not linger', async () => {
     const adapter = createMockSearchAdapter()
     const def = makeDef()
-    // Simulate the cross-process create window: the physical exists
-    // engine-side before any registry row references it.
-    await ensureTable(adapter, def, 'fp-a')
-    const physical = queryTarget('bakin_notes')!
-    resetTablesForTests() // wipe the registry; the engine keeps the table
+    const physical = await makeOwnedOrphan(adapter)
     await sweepOrphanEngineTables(adapter, { dwellMs: 0 }) // records candidate
     await ensureTable(adapter, def, 'fp-a') // registry row returns (same physical)
     expect(queryTarget('bakin_notes')).toBe(physical)
@@ -435,7 +450,7 @@ describe('sweepOrphanEngineTables', () => {
 
   it('a failing drop is tombstoned for the tombstone sweep instead of retrying forever', async () => {
     const base = createMockSearchAdapter()
-    await base.tables.create('bakin_notes_v1_deadbeef', TABLE_CONFIG)
+    const orphan = await makeOwnedOrphan(base)
     const failing: SearchAdapter = {
       ...base,
       tables: { ...base.tables, drop: async () => { throw new Error('engine 500') } },
@@ -452,6 +467,6 @@ describe('sweepOrphanEngineTables', () => {
     // The tombstone sweep finishes the job once the engine recovers.
     const left = await sweepTombstones(base)
     expect(left).toBe(0)
-    expect(await base.tables.stats('bakin_notes_v1_deadbeef')).toBeNull()
+    expect(await base.tables.stats(orphan)).toBeNull()
   })
 })

--- a/tests/core/watcher.test.ts
+++ b/tests/core/watcher.test.ts
@@ -115,6 +115,16 @@ describe('watcher', () => {
       expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'antfly-notes', 'file.md'))).toBe(false)
     })
 
+    it('ignores assets backup snapshots (assets.<suffix>) but not live assets', () => {
+      // Dead sibling copies like assets.pre-pivot-20260417 cost a kqueue fd
+      // per file under Bun and resurface stale files as import badges.
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.pre-pivot-20260417-215547'))).toBe(true)
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.pre-pivot-20260417-215547', 'images', 'old.png'))).toBe(true)
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.bak', 'file.md'))).toBe(true)
+      // The live assets tree stays watched.
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets', 'store', '2026-07', 'a1', 'v1.png'))).toBe(false)
+    })
+
     it('stop is idempotent', async () => {
       await stop()
       // second call should not throw; bun:test's toThrow matcher doesn't

--- a/tests/core/watcher.test.ts
+++ b/tests/core/watcher.test.ts
@@ -115,14 +115,18 @@ describe('watcher', () => {
       expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'antfly-notes', 'file.md'))).toBe(false)
     })
 
-    it('ignores assets backup snapshots (assets.<suffix>) but not live assets', () => {
-      // Dead sibling copies like assets.pre-pivot-20260417 cost a kqueue fd
-      // per file under Bun and resurface stale files as import badges.
+    it('ignores backup/snapshot siblings of ANY content root, never live content', () => {
+      // Dead sibling copies (assets.pre-pivot-*, tasks.bak) cost a kqueue fd
+      // per file under Bun and resurface stale files as import badges. The
+      // rule is marker-based so it covers the CLASS, not one past incident.
       expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.pre-pivot-20260417-215547'))).toBe(true)
       expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.pre-pivot-20260417-215547', 'images', 'old.png'))).toBe(true)
-      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.bak', 'file.md'))).toBe(true)
-      // The live assets tree stays watched.
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'tasks.bak', 'task.json'))).toBe(true)
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'workflows.old-2026', 'w.yaml'))).toBe(true)
+      // Live content and legitimate dotted top-level files stay watched.
       expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets', 'store', '2026-07', 'a1', 'v1.png'))).toBe(false)
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'assets.md'))).toBe(false)
+      expect(shouldIgnoreContentWatcherPath(tempDir, join(tempDir, 'MEMORY-LOG.md'))).toBe(false)
     })
 
     it('stop is idempotent', async () => {

--- a/tests/integration/antfly/workaround-regressions.test.ts
+++ b/tests/integration/antfly/workaround-regressions.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, beforeAll, afterAll, mock } from 'bun:test'
 import { join } from 'path'
 import { homedir } from 'os'
-import { existsSync } from 'fs'
+import { existsSync , readFileSync} from 'fs'
 import { tmpdir } from 'os'
 import { randomUUID } from 'crypto'
 
@@ -322,6 +322,17 @@ if (!binary) {
       const hits = resp0(result.json)?.hits as { hits: unknown[] } | undefined
       expect(result.status).toBe(200)
       expect(hits?.hits).toHaveLength(2)
+    })
+  })
+
+  describe('engine-burn watchdog log signature', () => {
+    it('PIN: the pinned binary still emits the catch-up wedge signature the watchdog greps for', () => {
+      // packages/adapter-antfly/src/engine-status.ts WEDGE_PATTERNS depends
+      // on this exact upstream log string ("provisioned startup catch-up
+      // debt persists", antfly#350). A version bump that rewords it would
+      // silently blind one detection layer — this pin makes that loud.
+      const bytes = readFileSync(binary)
+      expect(bytes.includes('catch-up debt persists')).toBe(true)
     })
   })
 }

--- a/tests/plugins/health/search-engine-watch.test.ts
+++ b/tests/plugins/health/search-engine-watch.test.ts
@@ -52,7 +52,9 @@ mock.module('../../../src/core/app-services', () => ({
   maybeGetAppServices: services,
 }))
 
-mock.module('../../../src/core/search-query', () => ({
+// The check imports the search-registry FACADE (the mockable surface —
+// review finding: bypassing it broke facade-level test mocking).
+mock.module('../../../src/core/search-registry', () => ({
   crossTableSearch: async (q: string) => ({
     results: [],
     meta: {
@@ -72,14 +74,15 @@ import {
   classifyCanary,
   resetEngineWatchStateForTests,
   searchCanaryRepair,
+  searchEngineBurnRepair,
 } from '../../../plugins/health/lib/system-checks/search-engine-watch'
 
 afterAll(() => {
   rmSync(testDir, { recursive: true, force: true })
 })
 
-beforeEach(() => {
-  resetEngineWatchStateForTests()
+beforeEach(async () => {
+  await resetEngineWatchStateForTests()
   searchAvailable = true
   engineStatus = undefined
   restartEngine = undefined
@@ -144,6 +147,25 @@ describe('checkSearchCanary', () => {
     searchAvailable = false
     expect(await checkSearchCanary()).toEqual([])
   })
+
+  it('an outage gap RESETS the streak — non-adjacent dark samples never escalate', async () => {
+    canaryTables = [t({ budget: 'omitted' })]
+    await checkSearchCanary() // dark #1
+    searchAvailable = false
+    await checkSearchCanary() // outage — chain broken, streak reset
+    searchAvailable = true
+    const [result] = await checkSearchCanary() // dark again = #1, not #2
+    expect(result.status).toBe('warn')
+  })
+
+  it('streaks survive a simulated restart (persisted, not module state)', async () => {
+    canaryTables = [t({ budget: 'omitted' })]
+    await checkSearchCanary() // dark #1 — persisted to plugin-data
+    // A server restart re-evaluates the module; the persisted file is the
+    // continuity. Same-process second call reads it back the same way.
+    const [second] = await checkSearchCanary()
+    expect(second.status).toBe('error')
+  })
 })
 
 describe('checkSearchEngineBurn', () => {
@@ -188,6 +210,16 @@ describe('checkSearchEngineBurn', () => {
     const [result] = await checkSearchEngineBurn()
     expect(result.status).toBe('ok')
   })
+
+  it('a not-running gap RESETS the wedge streak — a respawn does not inherit it', async () => {
+    engineStatus = async () => status({ wedgeSignals: ['startup-catchup-spin'] })
+    await checkSearchEngineBurn() // wedge #1
+    engineStatus = async () => status({ running: false })
+    await checkSearchEngineBurn() // crash gap — streak reset
+    engineStatus = async () => status({ wedgeSignals: ['startup-catchup-spin'] })
+    const [result] = await checkSearchEngineBurn() // wedge #1 again
+    expect(result.status).toBe('warn')
+  })
 })
 
 describe('engine restart repair', () => {
@@ -205,13 +237,27 @@ describe('engine restart repair', () => {
     expect(plan[0].requiresConfirmation).toBe(true)
   })
 
-  it('applies via restartEngine and reports applied once the engine answers', async () => {
+  it('applies via restartEngine and reports applied once the engine SERVES QUERIES (not just health probes)', async () => {
     let restarted = false
     restartEngine = async () => { restarted = true }
+    canaryTables = [t(), t()] // post-restart probe answers clean
     const plan = await searchCanaryRepair().plan([errorRow])
     const [result] = await searchCanaryRepair().apply(plan)
     expect(restarted).toBe(true)
     expect(result.status).toBe('applied')
+  })
+
+  it('a second correlated repair inside the debounce window skips the duplicate bounce', async () => {
+    let restarts = 0
+    restartEngine = async () => { restarts++ }
+    canaryTables = [t()]
+    const canaryPlan = await searchCanaryRepair().plan([errorRow])
+    await searchCanaryRepair().apply(canaryPlan)
+    const burnPlan = await searchEngineBurnRepair().plan([{ ...errorRow, check: 'search-engine-burn' }])
+    const [second] = await searchEngineBurnRepair().apply(burnPlan)
+    expect(restarts).toBe(1) // one bounce serves both detections
+    expect(second.status).toBe('applied')
+    expect(second.message).toContain('skipped a duplicate bounce')
   })
 
   it('fails honestly when the adapter cannot restart the engine', async () => {

--- a/tests/plugins/health/search-engine-watch.test.ts
+++ b/tests/plugins/health/search-engine-watch.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Search canary + engine-burn watchdog — the checks born from the
+ * 2026-07-12 incident where a wedged engine passed every health probe for
+ * 17h while all real queries starved (see search-engine-watch.ts).
+ */
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-engine-watch-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { rmSync } from 'fs'
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: join(testDir, 'bakin.db') }),
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+const loggerMock = () => ({
+  createLogger: () => ({ debug: mock(), info: mock(), warn: mock(), error: mock() }),
+})
+mock.module('../../../src/core/logger', loggerMock)
+mock.module('../../../packages/core/src/logger', loggerMock)
+
+mock.module('../../../src/core/settings', () => ({
+  getSettings: () => ({ search: { settings: { enabled: true } } }),
+}))
+
+import type { SearchEngineStatus } from '../../../packages/core/src/adapters/search'
+
+// Mutable fixtures the mocked services read on every call.
+let searchAvailable = true
+let engineStatus: (() => Promise<SearchEngineStatus | null>) | undefined
+let restartEngine: (() => Promise<void>) | undefined
+let canaryTables: Array<{ table: string; hits: number; took_ms: number; budget?: 'degraded' | 'omitted' }> = []
+
+const services = () => ({
+  search: {
+    available: async () => searchAvailable,
+    ...(engineStatus ? { engineStatus } : {}),
+    ...(restartEngine ? { restartEngine } : {}),
+  },
+  runtime: {},
+  tasks: {},
+  health: {},
+})
+mock.module('../../../src/core/app-services', () => ({
+  getAppServices: services,
+  maybeGetAppServices: services,
+}))
+
+mock.module('../../../src/core/search-query', () => ({
+  crossTableSearch: async (q: string) => ({
+    results: [],
+    meta: {
+      query: q,
+      total: 0,
+      took_ms: 42,
+      source: 'search' as const,
+      partial: canaryTables.some((t) => t.budget !== undefined) || undefined,
+      tables: canaryTables,
+    },
+  }),
+}))
+
+import {
+  checkSearchCanary,
+  checkSearchEngineBurn,
+  classifyCanary,
+  resetEngineWatchStateForTests,
+  searchCanaryRepair,
+} from '../../../plugins/health/lib/system-checks/search-engine-watch'
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  resetEngineWatchStateForTests()
+  searchAvailable = true
+  engineStatus = undefined
+  restartEngine = undefined
+  canaryTables = []
+})
+
+const t = (over: Partial<{ budget: 'degraded' | 'omitted' }> = {}) =>
+  ({ table: 'bakin_x', hits: 0, took_ms: 1, ...over })
+
+describe('classifyCanary (pure)', () => {
+  it('ok when every table answered clean (hits or not)', () => {
+    expect(classifyCanary([t(), t()])).toBe('ok')
+    expect(classifyCanary([])).toBe('ok')
+  })
+  it('partial when some tables degraded or omitted', () => {
+    expect(classifyCanary([t(), t({ budget: 'omitted' })])).toBe('partial')
+    expect(classifyCanary([t({ budget: 'degraded' }), t()])).toBe('partial')
+  })
+  it('dark only when EVERY table was omitted', () => {
+    expect(classifyCanary([t({ budget: 'omitted' }), t({ budget: 'omitted' })])).toBe('dark')
+    expect(classifyCanary([t({ budget: 'omitted' }), t({ budget: 'degraded' })])).toBe('partial')
+  })
+})
+
+describe('checkSearchCanary', () => {
+  it('all tables answering → ok', async () => {
+    canaryTables = [t(), t(), t()]
+    const [result] = await checkSearchCanary()
+    expect(result.status).toBe('ok')
+  })
+
+  it('one dark sample warns; two consecutive escalate to an autoFixable error', async () => {
+    canaryTables = [t({ budget: 'omitted' }), t({ budget: 'omitted' })]
+    const [first] = await checkSearchCanary()
+    expect(first.status).toBe('warn')
+
+    const [second] = await checkSearchCanary()
+    expect(second.status).toBe('error')
+    expect(second.autoFixable).toBe(true)
+    expect(second.message).toContain('DARK')
+  })
+
+  it('a healthy run between dark samples resets the streak', async () => {
+    canaryTables = [t({ budget: 'omitted' })]
+    await checkSearchCanary() // dark #1
+    canaryTables = [t()]
+    await checkSearchCanary() // healthy — streak resets
+    canaryTables = [t({ budget: 'omitted' })]
+    const [result] = await checkSearchCanary() // dark #1 again
+    expect(result.status).toBe('warn')
+  })
+
+  it('partial degrade warns without escalating', async () => {
+    canaryTables = [t({ budget: 'degraded' }), t()]
+    const [first] = await checkSearchCanary()
+    const [second] = await checkSearchCanary()
+    expect(first.status).toBe('warn')
+    expect(second.status).toBe('warn')
+  })
+
+  it('engine down → empty (the base search check owns it)', async () => {
+    searchAvailable = false
+    expect(await checkSearchCanary()).toEqual([])
+  })
+})
+
+describe('checkSearchEngineBurn', () => {
+  const status = (over: Partial<SearchEngineStatus> = {}): SearchEngineStatus => ({
+    running: true,
+    pid: 4242,
+    cpuUtilization: 0.1,
+    wedgeSignals: [],
+    ...over,
+  })
+
+  it('adapter without engineStatus → empty (feature-detect, never assume)', async () => {
+    expect(await checkSearchEngineBurn()).toEqual([])
+  })
+
+  it('mode that cannot measure (guest) → empty', async () => {
+    engineStatus = async () => null
+    expect(await checkSearchEngineBurn()).toEqual([])
+  })
+
+  it('one wedge sample warns; two consecutive escalate to an autoFixable error', async () => {
+    engineStatus = async () => status({ wedgeSignals: ['startup-catchup-spin'], cpuUtilization: 1.8 })
+    const [first] = await checkSearchEngineBurn()
+    expect(first.status).toBe('warn')
+
+    const [second] = await checkSearchEngineBurn()
+    expect(second.status).toBe('error')
+    expect(second.autoFixable).toBe(true)
+    expect(second.message).toContain('startup-catchup-spin')
+  })
+
+  it('sustained high CPU without a wedge signature only warns (backfills are legitimate)', async () => {
+    engineStatus = async () => status({ cpuUtilization: 1.5 })
+    await checkSearchEngineBurn()
+    const [second] = await checkSearchEngineBurn()
+    expect(second.status).toBe('warn')
+    expect(second.autoFixable ?? false).toBe(false)
+  })
+
+  it('healthy engine → ok with the measured rate', async () => {
+    engineStatus = async () => status()
+    const [result] = await checkSearchEngineBurn()
+    expect(result.status).toBe('ok')
+  })
+})
+
+describe('engine restart repair', () => {
+  const errorRow = {
+    check: 'search-canary',
+    status: 'error' as const,
+    message: 'Search is DARK',
+    autoFixable: true,
+  }
+
+  it('plans a confirmed, non-destructive restart for matching error rows', async () => {
+    const plan = await searchCanaryRepair().plan([errorRow])
+    expect(plan).toHaveLength(1)
+    expect(plan[0].safety).toBe('safe')
+    expect(plan[0].requiresConfirmation).toBe(true)
+  })
+
+  it('applies via restartEngine and reports applied once the engine answers', async () => {
+    let restarted = false
+    restartEngine = async () => { restarted = true }
+    const plan = await searchCanaryRepair().plan([errorRow])
+    const [result] = await searchCanaryRepair().apply(plan)
+    expect(restarted).toBe(true)
+    expect(result.status).toBe('applied')
+  })
+
+  it('fails honestly when the adapter cannot restart the engine', async () => {
+    const plan = await searchCanaryRepair().plan([errorRow])
+    const [result] = await searchCanaryRepair().apply(plan)
+    expect(result.status).toBe('failed')
+    expect(result.message).toContain('does not support')
+  })
+})

--- a/tests/plugins/health/system-checks.test.ts
+++ b/tests/plugins/health/system-checks.test.ts
@@ -94,6 +94,7 @@ mock.module('@bakin/core/search/tables', () => ({
   queryTarget: () => null,
   resolveDrainTargets: (logical: string) => [logical],
   sweepTombstones: async () => 0,
+  sweepOrphanEngineTables: async () => ({ dropped: [], pending: 0, unclaimed: [] }),
   ensureTable: async () => 'unchanged',
   rebuildTable: async () => 'migrated',
   resumeMigrations: async () => {},


### PR DESCRIPTION
## Why

2026-07-12 incident (a recurring class — ~a dozen occurrences on this dev box): antfly's startup catch-up loop wedged on an orphaned blue/green table generation, pinning the engine at 200% CPU for **17 hours**. Every semantic query leg starved, the 2s query budget honestly omitted all 11 tables, and searches returned 0 results instantly — while `bakin doctor` reported **zero search errors**, because nothing ever ran a real search or looked at the engine process.

This PR closes all three gaps: the fuel (orphaned generations), the detection (doctor blindness), and the repair (manual SSH forensics).

## Prevent — orphan engine-table sweep

`sweepOrphanEngineTables` (in `packages/core/src/search/tables.ts`): lists engine tables, subtracts every registered physical + mid-migration green + tombstone, and drops the rest. Safety rails: versioned-name pattern only; runs on the migration chain (never observes an in-process create/backfill window); **6h dwell** via a persisted first-seen ledger (`search_orphan_candidates`, schema v2) so a cross-process ensure's create-before-registry-insert window is never mistaken for an orphan; drop failures tombstone for the existing retry sweep. Rides the health plugin's hourly deep sweep — nothing at boot (D5 intact).

## Detect — two new doctor checks

- **`search-canary`**: one real cross-table query through the production path (budgets, semantic legs, omission labels) per doctor cycle. All tables omitted on two consecutive runs = search is dark regardless of cause → error → notify.
- **`search-engine-burn`**: reads the new optional `SearchAdapter.engineStatus()` — pid, CPU rate since the previous probe, and wedge signatures counted in the engine log's new bytes (offset tail scan, rotation-safe, first probe baselines to EOF). A recurring wedge signature across two runs → error. Sustained high CPU alone only warns (legitimate backfills burn CPU; restarting those makes them worse).

## Repair — graceful engine restart

New optional `SearchAdapter.restartEngine()`; antfly implements a **SIGTERM-first** supervised restart (launchd `launchctl kill SIGTERM` / systemd restart / strict-child bounce; guest mode throws honestly) — the incident's second spin was seeded by a hard kill, so graceful matters. Both checks attach the repair; apply waits for the engine to answer before reporting `applied`. The write journal is durable throughout — nothing is lost.

## Also

- Honest `bakin reindex` output: real per-table backfill counts + parked state (was `undefined documents`)
- Content watcher ignores `assets.pre-pivot-*` backup snapshots (kqueue fd-per-file under Bun)

## Testing

- 6 orphan-sweep tests (dwell, forgiveness, green protection, tombstone handoff)
- 16 canary/burn/repair tests (streak escalation, feature-detect, honest failures)
- 9 engine-status probe tests (CPU parsing, log-delta scan, rotation, guest mode) + 4 restartService tests
- Full suite: 6,706 pass / 0 fail; typecheck clean; arch tests (adapter-boundary) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)