### PR TITLE
feat(secrets): integration secrets foundation (pi-parity P1)

### DIFF
--- a/.claude/specs/pi-parity/PLAN.md
+++ b/.claude/specs/pi-parity/PLAN.md
@@ -1,0 +1,420 @@
+# Pi Runtime Parity — Implementation Plan
+
+Status: FOR REVIEW
+Spec: `.claude/specs/pi-parity/SPEC.md` (v3 + §12 user stories)
+Date: 2026-07-12
+Grounding: two deep code-mapping passes (agent-packages engine; attention/
+routing/switch surfaces) — every task below names real files.
+
+## Dependency graph
+
+```
+P1 secrets/env foundation
+ ├──> P2 capability packs (needs named secrets + env injection + ~/.bakin/bin PATH)
+ │     └──> P4 runtime hub Capabilities tab (needs P2 readiness API)
+ │     └──> P2.7 bits pack (needs P2 engine)
+ ├──> (nothing else blocks on P1)
+P3 task-completion tail — independent of P1/P2 except none
+ ├─ T3.1 approval attention   (independent)
+ ├─ T3.2 subagent decision    (independent)
+ ├─ T3.3 gh readiness         (independent)
+ ├─ T3.4 cron adoption        (independent)
+ └─ T3.5 pin/fixture tests    (independent)
+P4 runtime hub — Overview/Switch tabs independent; Capabilities tab needs P2
+P5 docs & battery — needs all
+```
+
+P3 can proceed in parallel with P1/P2 if desired; the plan orders it after P2
+to keep one PR in flight at a time (single-operator box).
+
+## Key code facts the plan builds on (from exploration)
+
+- Manifest already has `secrets?: SecretDeclarationSchema[]`
+  (`packages/core/src/agent-packages/manifest.ts:44-48`) — parsed, never
+  enforced. P1/P2 wire it instead of inventing a new field.
+- Manifest already has pinned external deps:
+  `dependencies.skills[{source, ref}]` with single-level resolution
+  (`dependency-resolver.ts`) — this IS the upstream pin for capability packs;
+  no new `upstream` schema needed (provenance shown from the dependency).
+- Skill projection already flows through `runtime.skills.write`
+  (`projector.ts:337-406`) — runtime-neutral by construction.
+- Binary installer model: `packages/adapter-antfly/src/installer.ts`
+  (download → sha256 vs pin → verify-then-commit → atomic rename) + pin
+  shape `packages/adapter-antfly/src/pin.ts`.
+- Pi turns inherit the Bakin server's `process.env` (no env seam in
+  `packages/adapter-pi/src/messaging.ts`) — so PATH + secret env injection
+  happen once at server boot.
+- Explore installs skill-packs via `POST /api/packages/install` already
+  (`plugins/explore/components/install-dialog.tsx:44-46`).
+- Nav-badge pattern: `nav-badge-providers` slot + `useNavBadge` +
+  `usePluginEvent`; chat's `attention.ts` is the pure-logic model; workflows
+  has `GET /gates/pending` + `workflow.gate_reached` SSE already.
+- Cron snapshot must happen in the switch's `snapshot-roster` phase (source
+  runtime is torn down before any later phase); per-job adoption precedent:
+  `plugins/schedule/lib/routes/jobs.ts:188-274`; idempotent creation:
+  `ensureBakinJob` (`job-service.ts:64`).
+
+## Open questions for review (blocking only their own tasks)
+
+- **OQ1 (T3.2) — subagent model on Pi.** Exploration finding: Bakin
+  decomposition turns already route via origin policy
+  (`src/core/model-routing.ts`) on BOTH runtimes; `subagentModel` only
+  drives OpenClaw's native internal sub-agent spawning, which Pi doesn't
+  have. Implementing D9 as written would store a dead field and flip
+  `perAgentSubagentModel` dishonestly. **Recommendation:** re-scope D9 to
+  round-trip preservation — store the carried value in the Pi registry
+  (metadata), keep the support flag `false` (honest), and make
+  `roster-reconcile` restore it when switching back to a runtime that
+  honors it (today OpenClaw→Pi→OpenClaw silently drops it). Per-agent
+  subagent-model *routing* stays an OpenClaw-native feature; Bakin-side
+  per-agent granularity, if ever wanted, belongs in the models plugin's
+  origin policy — not the adapter.
+- **OQ2 (T1.1) — existing secrets.json.** Store shape changes from
+  `{providers: {id: {apiKey}}}` to named secrets. No-shims rule, but this
+  box has a live antfly password stored. Plan: the new zod schema ACCEPTS
+  the old inner shape (it's a valid `Record<string,string>` already —
+  `{apiKey: "..."}`), so no migration code at all; just widen the schema.
+- **OQ3 (T2.3) — where capability readiness checks live.** Options: health
+  plugin `system-checks/` (precedent for system-level checks) vs a new
+  checks file registered by the explore plugin. Plan assumes health
+  `system-checks/capabilities.ts` (capability readiness is system state,
+  not storefront state).
+
+---
+
+## Phase P1 — Integration secrets & env foundation
+
+Branch `feat/integration-secrets`. PR #1. Rollback: revert PR (no consumers
+outside this PR yet).
+
+### T1.1 Named secrets in the secret store
+- **Files:** `packages/core/src/media/secret-store.ts` (schema:
+  `providers: Record<providerId, Record<secretName, string>>` — old
+  `{apiKey}` entries are already valid instances; keep
+  `getStoredProviderKey/setStoredProviderKey` as thin `apiKey`-name wrappers
+  so images/antfly callers compile unchanged), new
+  `get/set/unset/listStoredSecrets(provider)`; name validation same slug
+  rules as provider ids.
+- **AC:** old-shape file loads unchanged; named get/set/unset round-trip;
+  0600 + atomic write preserved; `listStoredSecrets` returns names only.
+- **Verify:** `bun test tests/core/secret-store.test.ts --isolate` (extend
+  existing suite); full suite green.
+- **Commit:** `feat(secrets): named secrets per provider in the secret store`
+
+### T1.2 Masked REST + Integrations & Keys UI
+- **Files:** `packages/host/src/api/secrets.ts` (GET returns
+  `{provider: [names]}`; POST `{provider, name, value}`; DELETE
+  `?provider&name`; zod), `src/components/provider-keys-tab.tsx` →
+  generalize to Integrations & Keys (per-integration rows: source =
+  env / store / missing; add/replace/remove named secrets; values never
+  rendered).
+- **AC:** RTL: add key → masked row appears; env-configured shows
+  read-only "env" source; delete works. API never returns values.
+- **Commit:** `feat(secrets): named-secret REST surface + Integrations & Keys tab`
+
+### T1.3 Boot env + PATH injection
+- **Files:** new `src/core/secret-env.ts` — `injectIntegrationEnv()`:
+  for each installed pack's declared `secrets[]` (lockfile → manifest read)
+  plus a static map, `process.env[VAR] ??= storedValue` (unset-only, env
+  always wins); `ensureBakinBinOnPath()` prepends `~/.bakin/bin` (new
+  `getBakinPaths().bin`) to `process.env.PATH` if absent. Called from
+  `server.ts` boot AFTER singleton lock, BEFORE dispatch/services start.
+  NOT in `createAppServices()` (read-only CLI paths must not mutate env).
+- **AC:** unit: unset-only precedence; PATH idempotent (no dup segments);
+  server boot order test-pinned by unit on the helper (not a boot e2e).
+- **Commit:** `feat(core): boot-time integration env + bakin bin PATH injection`
+
+**Phase gate:** full suite green; on the live box, set a dummy named secret
+via UI and confirm masked round-trip.
+
+---
+
+## Phase P2 — Capability packs
+
+Branch `feat/capability-packs`. PR #2. Rollback: revert PR — agent-packages
+returns to content-only installs; catalog entries disappear.
+
+### T2.1 Manifest + catalog schema extensions (pure)
+- **Files:** `packages/core/src/agent-packages/manifest.ts` —
+  `SkillPackManifestSchema` gains `capability?: slug`,
+  `runtimes?: string[]` (default `['*']`),
+  `requires?: { bins?: BinRequirementSchema[] }` where a bin =
+  `{ name, version, install: Record<platformKey, {url, sha256}>,
+  verifyArgs?: string[] }`; extend `SecretDeclarationSchema` with
+  `secretSlot?: 'provider.name'` + `help?: url`.
+  `src/core/curated-catalog/schema.ts` — `CatalogEntrySchema` gains
+  `capability?`, `runtimes?` (facet data only).
+- **AC:** zod round-trips; invalid platform keys / non-sha256 rejected;
+  old manifests still parse (all new fields optional).
+- **Commit:** `feat(packages): capability-pack manifest + catalog schema (requires/capability/runtimes)`
+
+### T2.2 Pinned binary installer
+- **Files:** new `src/core/agent-packages/bin-installer.ts` (modeled on
+  `packages/adapter-antfly/src/installer.ts`: fetch with timeout → sha256
+  verify against manifest pin → verify-then-commit via `verifyArgs` run →
+  atomic rename into `getBakinPaths().bin`); wire into
+  `src/core/agent-packages/installer.ts` after projection (step 8.5);
+  lockfile records `ProjectionKind 'bin'` +
+  `PROJECTION_KIND_POLICY.bin` (`packages/core/src/agent-packages/lockfile.ts`)
+  — not seedOnce, removed on uninstall when no other package references the
+  same bin name; `unprojectPackage` removes it.
+- **AC:** integration test (temp `BAKIN_HOME`, local `Bun.serve` fixture
+  serving a fake binary): install → bin present + 0755 + verified;
+  checksum mismatch → install fails WITH full rollback (no partial bin,
+  lockfile restored); uninstall removes bin; two packs sharing a bin →
+  survives first uninstall.
+- **Commit:** `feat(packages): pinned sha256-verified binary installs to ~/.bakin/bin`
+
+### T2.3 Capability readiness engine + doctor + CLI check
+- **Files:** new `src/core/agent-packages/capability-readiness.ts` —
+  `listCapabilities(): {slug, packId, content: ok|drifted|missing,
+  bins: per-bin ok|missing, secrets: per-secret env|store|missing,
+  ready: boolean}` (content via lockfile projections + `runtime.skills.get`;
+  bins via `existsSync` in bakin bin + PATH; secrets via env-or-store);
+  REST `GET /api/packages/capabilities`
+  (`packages/host/src/api/packages/`); doctor check
+  `plugins/health/lib/system-checks/capabilities.ts` (OQ3) with
+  per-capability findings + remediation strings; CLI
+  `bakin check capabilities` (`src/cli/commands/onboarding.ts` map).
+- **AC:** readiness transitions test: none → content-only → +bin → +key ⇒
+  ready; each intermediate state names exactly what's missing; doctor warn
+  carries remediation.
+- **Commit:** `feat(packages): capability readiness engine + doctor check + bakin check capabilities`
+
+### T2.4 CLI install UX (story 3)
+- **Files:** `src/cli/commands/packages.ts` — catalog-name resolution
+  (`bakin packages install web-search-brave` → curated catalog lookup via
+  `staticCuratedCatalog()`/`loadUnifiedCatalog()` → `sourceWithRef`),
+  consent prompt (source, pinned ref, bins, secrets), per-step ✓/⚠ output,
+  inline secret prompt (TTY) with skip; non-TTY → skip with notice.
+- **AC:** e2e on temp home (spawned CLI against a test server): name
+  resolves, github: sources still work, consent declined = no writes,
+  key skipped ⇒ readiness reports missing key.
+- **Commit:** `feat(cli): catalog-name capability installs with consent + guided key prompt`
+
+### T2.5 Explore Capabilities shelf + install-dialog key step (story 2)
+- **Files:** `plugins/explore/components/explore-page.tsx` (Capabilities
+  tab/shelf, runtime-compat badge from `runtimes` vs active adapter —
+  active adapter from `GET /api/runtime/capabilities`),
+  `catalog-card.tsx`/`detail-drawer.tsx` (capability metadata: upstream
+  dependency source + pin, requires list), `install-dialog.tsx` (post-
+  install needs[] step: secret input → `POST /api/secrets`, bin progress);
+  install REST response extended with `needs` (missing secrets/bins)
+  in `packages/host/src/api/packages/install.ts`.
+- **AC:** RTL: shelf renders from catalog fixture; incompatible runtime
+  badge disables install with reason; install flow reaches Ready; key-skip
+  leaves honest "needs key" state. Explore stays the ONLY UI install path.
+- **Commit:** `feat(explore): capabilities shelf + guided key step in install flow`
+
+### T2.6 Onboarding recommendation (story 1)
+- **Files:** new `src/core/onboarding/recommended-capabilities.ts`
+  (mirrors `recommended-agents.ts`: filter catalog `capability` entries,
+  trust official; install via `installPackage`), register in
+  `src/core/onboarding/index.ts` + CLI map; skippable; key entry deferred
+  to Settings with printed pointer (escape hatch per story 1).
+- **AC:** onboarding component check/install unit tests (temp home);
+  `--yes` path installs without prompt and reports "needs key".
+- **Commit:** `feat(onboarding): recommended capability packs component`
+
+### T2.7 The web-search-brave pack (bits repo) + live cutover
+- **Where:** `bakin-bits-official` repo — `packs/web-search-brave/`
+  (`bakin-package.json`: kind skill-pack, capability web-search,
+  `dependencies.skills: [{source: github:badlogic/pi-skills#brave-search…}]`
+  — DECISION: pin the bx-CLI-based skill CONTENT we authored for the spike
+  (adapted SKILL.md, honest-failure rules) as the pack's own skill, with
+  `requires.bins.bx` (brave-search-cli release URLs + sha256 per platform)
+  + `secrets: [{name: BRAVE_SEARCH_API_KEY, secretSlot: brave.apiKey}]`;
+  the pi-skills node-script variant needs npm install at runtime — the bx
+  binary route has zero runtime deps and matches OpenClaw's bx-search),
+  catalog entry in `packages/host/src/data/curated-catalog.json`.
+- **Live cutover on this box:** remove the hand-dropped spike skill
+  (`~/.pi/agent/skills/bx-search/`), install the pack through the real
+  flow, re-run the spike task, update memory.
+- **AC = spec acceptance 1-4** on the dev rig with a CLEAN home (no bx, no
+  key): full story-1/2/3 flow → dispatched research task completes.
+- **Commit(s):** bits repo commit + `feat(catalog): web-search-brave capability pack entry`
+
+**Phase gate:** rig-clean-home validation recorded; full suite green.
+
+---
+
+## Phase P3 — Task-completion tail
+
+Branch `feat/pi-task-parity`. PR #3. Tasks independently revertable commits.
+
+### T3.1 Pending-approval attention (story 6)
+- **Files:** `plugins/workflows/components/approvals-badge-provider.tsx`
+  (new; pattern: `plugins/chat/components/chat-badge-provider.tsx` +
+  `plugins/tasks/hooks/use-task-summary.ts`): fetch `GET /gates/pending`,
+  subscribe `workflow.gate_reached` / `workflow.gate_approved` /
+  `workflow.gate_rejected` via `usePluginEvent`, `useNavBadge('workflows',
+  <navItemId>, {count, tone: 'attention'})`, toast + `sendBrowserNotification`
+  deep-linking the gate; pure logic in
+  `plugins/workflows/components/attention.ts` (suppress while viewing the
+  gate; mirrors chat `attention.ts`); register slot in
+  `plugins/workflows/client.tsx` + `contributes.slots` in
+  `plugins/workflows/bakin-plugin.json`.
+- **AC:** pure-logic unit tests (badge math, suppression); RTL: gate_reached
+  ⇒ badge+toast; resolve ⇒ badge clears. Works with zero channel layer.
+- **Commit:** `feat(workflows): pending-approval attention via nav badge + notifications`
+
+### T3.2 Subagent model — per OQ1 decision (default: preservation scope)
+- **Files (preservation scope):** `packages/adapter-pi/src/registry.ts`
+  (optional `subagentModel` field, storage-only),
+  `agents.ts` update accepts + stores it WITHOUT flipping
+  `routingSupport().perAgentSubagentModel` (stays false — Pi never honors
+  it; contract doc comment states storage-for-carry semantics),
+  `src/core/roster-reconcile.ts` — carry stores the value on Pi targets and
+  restores it to honoring targets on the way back; report line changes from
+  "unmapped/dropped" to "preserved (not active on pi)".
+- **AC:** switch round-trip test OpenClaw→Pi→OpenClaw retains
+  subagentModel; dry-run reports "preserved"; conformance capability-honesty
+  unaffected.
+- **Commit:** `feat(adapter-pi): preserve subagent-model assignments across runtime switches`
+
+### T3.3 gh readiness + context guidance
+- **Files:** `plugins/health/lib/system-checks/github-readiness.ts` (gh on
+  PATH + `gh auth status` exit code, warn-only, remediation text);
+  guidance line in the Bakin-shipped role context defaults
+  (`team-context-defaults.ts` — locate: `src/core/team-context.ts` imports)
+  teaching worktree tools + gh + ask-before-push/merge.
+- **AC:** check unit test (mock execFile); context byte-fixture updated
+  deliberately (the fixture test will flag the byte change — commit updates
+  it in the same change).
+- **Commit:** `feat(health): github readiness check + agent context guidance`
+
+### T3.4 Switch-time OpenClaw cron adoption (story 7)
+- **Files:** `src/core/switch-report.ts` — snapshot captures full
+  `source.cron.list()` jobs (not just count) during `snapshot-roster`;
+  `src/core/runtime-switch.ts` — new `adopt-cron` phase after
+  `reconcile-roster` (real + dry-run preview), gated by
+  `SwitchRuntimeOptions.adoptCron?: boolean` +
+  `RuntimeSwitchRequestSchema.adoptCron?`; creation via schedule plugin's
+  `ensureBakinJob` semantics with `source: 'adopted'` +
+  `originalRuntimeCron.snapshot` (invoke through the existing
+  `schedule.*` hook surface — core must not import plugin code; add a
+  `schedule.adoptCronJobs` hook in `plugins/schedule/index.ts` mirroring
+  the REST adopt handler at `lib/routes/jobs.ts:188`);
+  `RuntimeSwitchResult.cron = { adopted, skipped, failed }`; cantCarry cron
+  line reflects adoption; CLI flag `bakin runtime use <t> --adopt-cron`;
+  dry-run prints the would-adopt list.
+- **AC:** switch e2e extension: source with 2 cron jobs → dry-run lists
+  them; real switch with `adoptCron` creates 2 Bakin schedules (source
+  'adopted', originals snapshotted) exactly-once (re-run idempotent via
+  logicalJobId); without the flag behavior unchanged.
+- **Commit:** `feat(runtime): opt-in cron adoption into Bakin schedules during switch`
+
+### T3.5 Pin & fixture tests
+- **Files:** `tests/adapter-pi/session-settings.test.ts` (assert the
+  settings manager the adapter builds reports compaction enabled — pins the
+  SDK default against silent flips); dispatch-prompt fixture assertion that
+  schedule exec tools are present in the rendered tool catalog
+  (`tests/fixtures/dispatch-prompts/` harness).
+- **AC:** both tests fail if the guarantee regresses (teeth verified by
+  temporary inversion during development).
+- **Commit:** `test(pi): pin compaction default + schedule-tools dispatch context`
+
+**Phase gate:** full suite green; live: trigger a real gate on the box and
+observe badge + toast + OS notification.
+
+---
+
+## Phase P4 — Runtime hub UX
+
+Branch `feat/runtime-hub`. PR #4. Rollback: revert PR (P2/P3 APIs remain).
+Load `frontend-design` guidance before building; polish bar = explore/
+health/chat.
+
+### T4.1 Hub shell + Overview tab
+- **Files:** `packages/host/src/routes/runtime.tsx` rebuilt: `PluginHeader`
+  + `UnderlineTabs` (Overview/Capabilities/Switch, URL-backed via
+  `useQueryState('tab')`), per-section independent fetch/fault (health-page
+  pattern), `Skeleton` loading, `ErrorBanner`. Overview: adapter identity
+  `Card` (name, version, credential tiles from `credentialStatus`),
+  capability cards with mode `Badge` + plain-language legend, tool-access
+  status; delivery-unavailable copy per story 7. Keep/extend `data-testid`
+  (`runtime-summary`, `onboarding-status`).
+- **AC:** RTL: renders from fixture report; legend present; error + loading
+  states; existing runtime-page tests migrated.
+- **Commit:** `feat(host): runtime hub shell + overview tab on the SDK kit`
+
+### T4.2 Capabilities tab
+- **Files:** same route + a `capabilities-tab.tsx` component: rows from
+  `GET /api/packages/capabilities` (readiness chips per content/bin/key,
+  remediation links → Settings Integrations & Keys / reinstall), EmptyState
+  with "browse capabilities" → Explore. No install UI here (story 2
+  decision).
+- **AC:** RTL: ready/needs-key/missing-bin fixtures render distinct states
+  with working links.
+- **Commit:** `feat(host): runtime hub capabilities tab with readiness chips`
+
+### T4.3 Switch tab
+- **Files:** `switch-tab.tsx`: target pickers, dry-run-by-default preview
+  (roster mapping, workspaces, stays-behind, credentials, would-adopt cron
+  list + adopt checkbox), `ConfirmDialog` for the real switch, live
+  `runtime:switch` SSE progress steps (reuse `reduceSwitchProgress`),
+  result as grouped Cards (carried / warnings / failed) — no glyph prose;
+  restart-required banner.
+- **AC:** RTL over `reduceSwitchProgress` fixtures + result grouping;
+  `switch-progress`/`switch-result` testids preserved; e2e switch test
+  still green.
+- **Commit:** `feat(host): guided switch tab with dry-run preview + grouped results`
+
+**Phase gate:** visual review on the live box (screenshots in PR); full
+suite green.
+
+---
+
+## Phase P5 — Docs, battery, close-out
+
+Branch `chore/pi-parity-docs`. PR #5.
+
+### T5.1 Knowledge + docs
+- New `.claude/knowledge/capability-packs.md`; update `agent-packages.md`
+  (manifest extensions, taxonomy §4.1 rules), `pi-adapter.md`,
+  `runtime-capabilities.md`, `adapter-architecture.md`,
+  `bakin-owned-scheduler.md`, `doctor-and-health-checks.md`,
+  `explore-plugin.md`; extending docs decision table (plugin vs capability
+  pack vs agent + coupling/composition rules); `CLAUDE.md` deltas; README /
+  Astro CLI docs if command surfaces changed.
+- **AC:** docs-check tooling green (`bakin docs` checks if applicable);
+  knowledge docs match shipped behavior (spot-verified against tests).
+
+### T5.2 Task-parity battery (spec acceptance 8)
+- Dispatch on this box: research (web search via the productized pack),
+  image generate+edit, agent-self-scheduled recurring task, gated workflow
+  approved via in-app attention, subagent fan-out. Record results (asset +
+  PR body). Any failure ⇒ fix-forward task before merge.
+
+### T5.3 Close-out
+- Memory updates (`pi-parity-initiative`, live-box state); spec status →
+  SHIPPED with deltas noted; file follow-up issues for reserved lanes
+  (Discord bridge, extension trust) + fast-follow packs (browser-tools,
+  transcribe, youtube-transcript).
+
+---
+
+## Commit strategy summary
+
+- One branch/PR per phase (P1→P5), merged in order; main shippable after
+  each merge; rollback = `git revert -m1 <merge>` of that phase's PR.
+- Within a phase: one commit per task (listed above), each green on
+  `bun run test` before the next task starts; conventional-commit messages
+  as specified per task.
+- Worktrees for branch work (standing memory: main checkout flips branches
+  under you); verify HEAD before every commit.
+- Bits-repo changes (T2.7) are separate commits in `bakin-bits-official`
+  with a plugin/pack version bump per bits conventions, cross-referenced in
+  the P2 PR body.
+- Live-box validation results recorded in each PR body (P2 rig validation,
+  P3 gate attention, P5 battery).
+
+## Verification matrix (phase gates)
+
+| Gate | Proof |
+|---|---|
+| P1 | suite green; masked named-secret round-trip on live box |
+| P2 | suite green; CLEAN-home rig install → dispatched research task completes (stories 1–4); readiness transitions test |
+| P3 | suite green; live gate ⇒ badge/toast/OS notification; switch e2e with cron adoption |
+| P4 | suite green; RTL for all three tabs; visual review screenshots |
+| P5 | battery 5/5 recorded; docs merged; follow-ups filed |

--- a/.claude/specs/pi-parity/SPEC.md
+++ b/.claude/specs/pi-parity/SPEC.md
@@ -1,0 +1,528 @@
+# Pi Runtime Parity — Spec
+
+Status: DRAFT v3 (post-spike revision, pending approval)
+Date: 2026-07-12
+Owner: Mark (single-user dev box today; spec assumes net-new customer machines)
+Inputs: capability audit `48bd30af`, gap ranking `2535726f` (assets
+`20260709-pi-openclaw-capability-audit-da2fa210`,
+`20260709-pi-adapter-gap-ranking-triage-e9c6b8af`), fresh codebase exploration
+2026-07-12 (post-#630/#657 state), **P0 web-search spike results (§11)**.
+
+Revision history:
+- v1: full-parity mega-spec incl. Discord bridge.
+- v2: Discord/channel bridge deferred to its own initiative (architecture
+  reserved, §10); task-completion parity adopted as the north star.
+- v3: post-spike — "runtime packages contract member" replaced by
+  **capability packs** riding the existing agent-packages system; Pi
+  extension trust lane deferred to reserved architecture; ecosystem taxonomy
+  rules added (§4.1).
+
+## 1. Objective
+
+Close the real capability gaps between the Pi runtime and the OpenClaw-backed
+runtime so Pi is a first-class daily driver, and rebuild the `/runtime` page
+into a polished runtime hub. "Real gap" is measured against what OpenClaw
+actually provided — not against imagined governance upgrades (see Non-goals).
+
+**North star: task-completion parity.** The measure of done is that a task
+dispatched to a Pi agent completes wherever the equivalent task completed on
+OpenClaw (research needing web search, media tasks, scheduled work, gated
+workflows, subagent fan-out). Every phase is prioritized by how directly it
+makes tasks complete.
+
+**Net-new machine principle.** The spike (§11) worked because this box had
+leftover OpenClaw-era state (`bx` binary + key). A fresh Bakin install has
+none of that. Bakin — UI and CLI — owns the entire path from "agents can't
+search the web" to "doctor green": discover → consent → install content →
+install pinned binaries → guided key entry → honest readiness. Users never
+clone repos, edit shell profiles, or "figure it out."
+
+After this initiative, on Pi (and equally on OpenClaw, since the vehicle is
+runtime-neutral):
+
+- **Capability packs** (web search first; browser automation, transcription
+  as fast-follow curation) are installable from Explore/onboarding/CLI with
+  consent, pinned trusted upstreams, Bakin-installed binaries, guided key
+  entry, and per-capability doctor readiness.
+- Integration secrets live in the existing masked secret store, env-first,
+  injected so skills just work.
+- Pending approvals surface **in-app** (nav badge + toast/OS notification) —
+  approvals are never silent even with no channel layer.
+- Per-agent **subagent model routing** works on Pi and carries across runtime
+  switches.
+- `/runtime` is a tabbed hub (Overview / Capabilities / Switch) built on the
+  SDK component kit at the explore/health/chat polish bar.
+- Channel delivery stays honestly `unavailable`; the Discord bridge and the
+  Pi-extension trust lane are reserved architecture (§10).
+
+### Verdict on the ranked gap list (decision log)
+
+| Rank | Gap | Decision |
+|---:|---|---|
+| 1 | Discord/channel bridge | **Deferred to its own initiative** — architecture reserved (§10, D2) |
+| 2 | Approval delivery | **Partial build** — in-app attention now (D8); Discord buttons ride the deferred bridge |
+| 3 | Integration secrets/status | **Build** — extend existing secret store, not a new system (D10) |
+| 4 | Integration observability | **Build (scoped)** — per-capability readiness/doctor checks now; delivery audit rides the deferred bridge (D11) |
+| 5 | Web search/browse | **Capability packs** — curated skill-packs on the existing agent-packages system (D3/D4, proven by spike §11) |
+| 6 | GitHub | **Close as at-parity** — `gh` readiness doctor check + managed-context guidance only (D7) |
+| 7 | Email/Gmail | **Deferred entirely** to a future initiative (D6; note: upstream `gmcli` skill exists — likely a capability pack + governance plugin composition later) |
+| 8 | Other social channels | **Out** — Discord-only when the bridge lands; abstraction stays provider-neutral (D1) |
+| 9 | Native cron | **Bakin schedules are the answer** + switch-time adoption helper (D5) |
+| 10 | `tools.invoke` parity | **Moot** — surface was deleted from the contract (T29/T30) |
+| 11 | Subagent model routing | **Build** — small, Pi registry is Bakin-owned (D9) |
+
+## 2. Decisions (interview record, 2026-07-12)
+
+- **D1 — Channels: Discord only, deferred.** When the bridge initiative runs,
+  Discord is the only implemented provider; the channel abstraction (existing
+  `runtime.channels` contract) stays provider-neutral.
+- **D2 — Channels architecture: shared Bakin bridge (reserved).** Runtime-
+  neutral Discord bridge in `src/core/delivery/`; `adapter-pi` delegates the
+  existing `channels` contract member to it, reports `delivery: 'shimmed'`.
+  Consumers untouched. Full reserved design in §10.
+- **D3 — Per-turn capabilities: ecosystem-first.** Web search, browser
+  automation, transcription etc. come from the skills ecosystem — Bakin
+  builds **zero** redundant `bakin_exec_*` wrappers. Validated by spike §11:
+  a single SKILL.md delivered full web-search task parity. Hard boundary:
+  Pi extensions are session-scoped (SDK bans background resources; the
+  adapter disposes sessions per turn) — daemons are structurally impossible
+  as Pi content, so bridges stay Bakin-side.
+- **D4 — Delivery vehicle: capability packs on agent-packages (v3,
+  supersedes the v1 `packages?` contract member).** A capability pack is an
+  agent package `kind: "skill-pack"` curated in `bakin-bits-official`, with
+  manifest extensions:
+  - `capability`: slug for catalog/facets/readiness (`web-search`, …)
+  - `upstream`: trusted source repo + pinned ref/sha + path; content-hash
+    verified at install; `bakin packages upgrade` re-pins deliberately —
+    upstream drift never lands silently
+  - `requires.bins[]`: binaries with pinned per-OS/arch download URLs +
+    sha256 — **Bakin installs them** (the `bakin install search` pattern) to
+    a Bakin-owned bin dir
+  - `requires.env[]`: env var → secret-store slot + help URL — drives the
+    guided key prompt and readiness
+  - `runtimes`: `["*"]` normally (skills are a cross-runtime convention,
+    projected via the existing `runtime.skills` surface); runtime-specific
+    packs tag explicitly; Explore filters/badges against the ACTIVE runtime
+  No new contract member, no new install machinery: install/lockfile/
+  sidecars/sync/receipts/Explore all already exist for agent packages.
+  Packs are à-la-carte: one capability per pack.
+- **D5 — Cron: Bakin schedules are THE answer.** No fake `runtime.cron` on
+  Pi. Agents already self-schedule via `bakin_exec_schedule_*` (verified:
+  `plugins/schedule/lib/exec-tools.ts`). Scope adds: (a) verify dispatch/
+  AGENTS.md context actually teaches the schedule tools, (b) a one-time
+  "adopt OpenClaw cron jobs into Bakin schedules" helper offered during
+  runtime switch.
+- **D6 — Email: deferred entirely.** Future initiative; likely a capability
+  pack (upstream `gmcli`) composed with a governance plugin per the
+  composition rule in §4.1.
+- **D7 — GitHub: readiness + guidance only.** OpenClaw never had a governed
+  GitHub surface either (agents shell `gh` on both runtimes); the git plugin
+  covers worktree isolation. Add a doctor check (`gh` installed +
+  authenticated) and managed-context guidance.
+- **D8 — Approvals: in-app attention now; Discord buttons later.** Pending
+  approvals ride the existing `nav-badge-providers` slot (badge + toast/
+  chime/OS notification, deep link to the gate). The durable Bakin approval
+  record remains the sole authority.
+- **D9 — Subagent model routing on Pi: include.** Store `subagentModel` in
+  the Pi registry, honor it in session assembly, flip
+  `routingSupport().perAgentSubagentModel` to true; switch carry maps both
+  directions.
+- **D10 — Secrets: extend the existing store.** `~/.bakin/secrets.json`
+  (0600, atomic, env-first, masked `/api/secrets`, provider-keys UI)
+  generalizes from `{ apiKey }` to named secrets per integration
+  (`brave.apiKey`, later `discord.botToken`). Boot-time env injection
+  (unset-only) makes stored keys visible to skills expecting env vars.
+  Single-user tradeoff documented: injected env is readable by agent shell
+  commands.
+- **D11 — Observability rides existing engines.** Per-capability readiness
+  via plugin-registered doctor checks; typed error kinds; usage/audit through
+  the existing single engines. Delivery audit + ledger send-dedupe are built
+  with the bridge (§10). No parallel systems, ever.
+- **D12 — Pi extension trust lane: deferred (v3; was allowlist-flip).**
+  Nothing in task-completion parity needs an in-process Pi extension —
+  search/browser/transcribe are all skills. The allowlist/trust design
+  (default `allowlist`, Bakin-consented installs auto-append, terminal
+  installs pending with approve UI) is banked in §10 and activates when a
+  real extension need appears. Until then the `piExtensions` policy knob
+  stays as-is with nothing installed.
+- **D13 — Runtime IA: tabbed hub; config in Settings.** `/runtime` =
+  Overview / Capabilities / Switch (§4.5). Integration secrets live in the
+  Settings surface (provider-keys tab generalized to Integrations & Keys);
+  the runtime page links with status chips.
+- **D14 — Delivery: one PR per phase.** Branch → PR → merge, conventional
+  commits, main stays shippable, rollback = revert one PR.
+- **D15 — Taxonomy: plugins vs capability packs vs agents (v3).** See §4.1.
+  The rule is consumer-based and documented in the extending docs; Explore
+  presents three shelves with plain-language subtitles.
+
+## 3. Non-goals
+
+- The Discord/channel bridge, channel approval buttons, and the Pi-extension
+  trust surface (deferred — §10). Email/Gmail (D6). Slack/Telegram/social.
+- Governed GitHub exec tools / repo allowlists (D7).
+- `runtime.cron` on Pi (D5); `tools.invoke` (deleted surface).
+- Bakin-owned web-search/fetch exec tools (D3).
+- A new `packages?` runtime contract member or any parallel package-manager
+  surface (superseded by D4; reserved in §10 if extensions ever need it).
+- Cross-provider model fallback chains on Pi (P0-adjudicated non-goal, §11 —
+  revisit on the first real sustained-outage incident).
+- Backwards compatibility or migration shims — delete and replace cleanly
+  (standing priority: reduce tech debt).
+
+## 4. Architecture
+
+### 4.1 Ecosystem taxonomy (D15)
+
+One rule: **who consumes it.**
+
+| Primitive | Consumer | Ships | Example |
+|---|---|---|---|
+| Plugin | Bakin (server + browser) | Code: UI, routes, exec tools, health checks | chat, images |
+| Capability pack (skill-pack) | Agents (runtime reads it) | Content: SKILL.md + `requires` declarations | web-search-brave |
+| Agent package (kind: agent) | Team roster | Identity + persona content | nemo, zen |
+
+Boundary rules:
+- **Coupling rule:** a skill that teaches agents to use a plugin's own exec
+  tools ships WITH that plugin (e.g. images' `create-image` skills). A
+  standalone skill wrapping external tools ships as a capability pack
+  (e.g. bx-search). The original plugin intent ("plugins may install a
+  simple skill") stays true, scoped to plugin-coupled skills.
+- **No in-process code in packs:** capability-pack scripts execute as agent
+  shell commands in agent workspaces, never inside Bakin's process.
+  In-process code is a plugin (Bakin-side) or a Pi extension (§10 lane).
+- **Composition rule:** a capability needing both UI/governance AND agent
+  content ships as a plugin that declares a companion capability pack — two
+  artifacts, each in its lane (future email = gmcli pack + governance
+  plugin).
+- **Explore IA:** three shelves — Agents ("add a team member"), Plugins
+  ("add features to your dashboard"), Capabilities ("teach your agents new
+  tricks"). Catalog v2 `kind` + new `capability` tag + `runtimes` facet.
+
+### 4.2 Capability packs (D4)
+
+Manifest sketch (`bakin-bits-official/packs/web-search-brave/bakin-package.json`):
+
+```jsonc
+{
+  "kind": "skill-pack",
+  "capability": "web-search",
+  "upstream": { "repo": "github.com/badlogic/pi-skills", "ref": "<sha>", "path": "brave-search" },
+  "requires": {
+    "bins": [{ "name": "bx", "install": { "darwin-arm64": { "url": "…", "sha256": "…" } } }],
+    "env": [{ "name": "BRAVE_SEARCH_API_KEY", "secret": "brave.apiKey", "help": "https://api-dashboard.search.brave.com" }]
+  },
+  "runtimes": ["*"]
+}
+```
+
+Install flow (Explore card / onboarding recommendation / `bakin packages
+install`): consent (source, what runs where) → project skill content via the
+existing agent-packages projection (`runtime.skills` — lands where the ACTIVE
+runtime reads skills; both runtimes supported by construction) → install
+declared bins (pinned, sha256-verified, Bakin-owned bin dir; PATH handling at
+dispatch) → guided key entry (UI dialog / CLI prompt → secret store → env
+injection) → readiness green. Skippable key ⇒ honest "installed, needs key"
+state. Doctor: per-capability readiness check (content projected ✓ / bin ✓ /
+key ✓) with one-click remediation links.
+
+First curated pack: **web-search-brave** (spike-validated content). Fast
+follows (curation only, no new machinery): browser-tools, transcribe,
+youtube-transcript.
+
+### 4.3 Secrets & readiness
+
+- Secret store: `providers.<id>` → named secrets (`Record<string,string>`);
+  `/api/secrets` gains the secret-name dimension; provider-keys tab
+  generalizes to **Integrations & Keys** (status per integration: env /
+  store / missing; values never leave the server).
+- Boot env injection: for env vars declared by installed packs (+ static
+  map), `process.env[VAR] ??= stored`.
+- Doctor: `capability.<slug>` readiness checks; `github.readiness`.
+
+### 4.4 In-app approval attention
+
+Pending-approvals provider on the global `nav-badge-providers` slot: badge
+count, toast/chime/OS notification on new pending approval, deep link to the
+gate. Runtime-neutral; becomes the always-on companion to channel delivery
+when the bridge lands.
+
+### 4.5 `/runtime` hub rebuild
+
+- Rebuild `packages/host/src/routes/runtime.tsx` (417 hand-rolled lines) on
+  the SDK kit: `PluginHeader`, `Card`, `UnderlineTabs`, `Badge`,
+  `ConfirmDialog`, `Skeleton`, `EmptyState`, `ErrorBanner`.
+- Tabs: **Overview** (adapter + version, capability cards with a
+  native/shimmed/unavailable legend, credential tiles, tool-access status),
+  **Capabilities** (installed capability packs with readiness chips +
+  remediation links; browse/install hands off to Explore's Capabilities
+  shelf), **Switch** (adapter pickers, ConfirmDialog, live SSE progress,
+  result as grouped carried/warnings/failures cards — no glyph prose).
+- Independent per-section fetch/fault (health-page pattern), URL-backed tab
+  state via `useQueryState`, Suspense-wrapped, `data-testid` hooks kept.
+
+### 4.6 Long tail
+
+- Pi subagent model routing (D9).
+- Switch-time OpenClaw cron adoption (D5): preview in dry-run report; never
+  automatic.
+- Dispatch-context check: schedule exec tools taught in composed context
+  (byte-fixture test).
+
+## 5. Phases & commit strategy (D14)
+
+One branch + PR per phase; conventional commits; every phase leaves main
+shippable and independently revertable; checkpoint-sized commits, each green
+on `bun run test`.
+
+| Phase | Branch | Contents | Natural rollback point |
+|---|---|---|---|
+| P0 Spike & adjudication (DONE/in progress) | n/a (no production code) | Web-search spike (§11, DONE); remaining: long-task compaction behavior check, model-fallback adjudication | n/a |
+| P1 Foundation | `feat/integration-secrets` | Secret store → named secrets, Integrations & Keys UI, boot env injection, pack-manifest `requires`/`upstream`/`capability`/`runtimes` schema in packages core | Revert = back to `{apiKey}` store; no consumers yet |
+| P2 Capability packs | `feat/capability-packs` | Install-flow extensions in agent-packages engine (upstream pin+verify, bin installer, key prompt), doctor readiness checks, Explore Capabilities shelf + runtime facet, onboarding recommendation, curated `web-search-brave` pack in bits (+ fast-follow packs) | Revert = agent-packages back to content-only installs |
+| P3 Task-completion tail | `feat/pi-task-parity` | In-app approval attention, subagent model routing, gh readiness check + context guidance, OpenClaw cron adoption helper, schedule-context fixture test, compaction-default pin test | Independent small reverts |
+| P4 Runtime hub UX | `feat/runtime-hub` | Tabbed `/runtime` rebuild (Overview/Capabilities/Switch) on the SDK kit | Revert = old page (P2 APIs remain) |
+| P5 Docs & validation | `chore/pi-parity-docs` | Knowledge docs (incl. taxonomy in extending docs), CLAUDE.md deltas, README/Astro docs, task-parity battery record | Docs-only |
+
+Bits-repo work (the curated packs) lands in `bakin-bits-official` with its
+own version bumps per the bits conventions, referenced from P2.
+
+Commit message examples:
+`feat(secrets): generalize provider store to named integration secrets`,
+`feat(packages): capability-pack manifest (upstream pin, requires, runtimes)`,
+`feat(packages): pinned binary installer for pack-declared bins`,
+`feat(explore): capabilities shelf with runtime facet`,
+`feat(host): rebuild /runtime as tabbed hub on the SDK kit`,
+`feat(workflows): pending-approval attention via nav-badge provider`.
+
+Phase order rationale (task-completion first): P1 is invisible and unblocks
+P2; P2 is the heart — fresh-machine capability installs; P3 closes the
+remaining ways a task fails or stalls on Pi; P4 consumes P2's readiness API;
+P5 closes.
+
+## 6. Testing strategy
+
+- **Unit/module**: secret store schema rewrite (no migration shim); pack
+  manifest zod schema; bin installer (checksum verify, temp-dir download,
+  atomic move) against temp dirs; env injection precedence. All tests mock
+  both content-dir resolvers per CLAUDE.md testing rules; adapter-pi tests
+  set `PI_HOME` env before imports.
+- **Integration**: capability-pack install end-to-end against a temp
+  `BAKIN_HOME`/`PI_HOME` (local fixture upstream, fake bin with checksum);
+  projection lands where the active runtime reads skills on BOTH adapters;
+  readiness check transitions (no content → no bin → no key → green);
+  runtime-switch dry-run byte-identity holds; subagent-model carry
+  round-trip.
+- **Conformance**: unchanged surfaces stay pinned (delivery `unavailable` ⇔
+  channels omitted); `runtime.skills` projection semantics covered by the
+  existing suite; no new contract member to conform.
+- **UI**: RTL for the runtime hub tabs (rtl-settle rules), Explore
+  Capabilities shelf, install dialog + key entry flow, approval attention
+  badge.
+- **Live validation on this box**: install `web-search-brave` through the
+  REAL flow on a throwaway `BAKIN_HOME`/`PI_HOME` (dev rig) simulating a
+  net-new machine — no pre-existing bx/key — then the task-parity battery
+  (§9.8). Recorded in PR bodies.
+- Full suite via `bun run test`; architecture tests: `@earendil-works` stays
+  adapter-private; secret values never in settings/SSE payload types.
+
+## 7. Docs impact (checked at every phase, finalized in P5)
+
+- `.claude/knowledge/`: new `capability-packs.md`; update
+  `agent-packages.md` (manifest extensions, taxonomy), `pi-adapter.md`
+  (skills lane, subagent routing), `runtime-capabilities.md`,
+  `adapter-architecture.md` (ecosystem-first stance),
+  `bakin-owned-scheduler.md` (cron stance + adoption helper),
+  `doctor-and-health-checks.md`, `explore-plugin.md` (Capabilities shelf).
+- Extending docs (`docs/src/content/docs/extending/`): the plugin vs
+  capability-pack vs agent decision table (D15) with the coupling and
+  composition rules.
+- `CLAUDE.md`: agent-packages/capability-pack lines, Pi degradation matrix
+  updates.
+- `README.md` if user-facing framing changes.
+- Memory: update `box-flipped-to-pi-runtime` + spike learnings as phases
+  land.
+
+## 8. Boundaries
+
+**Always:** honest capability modes and readiness states; typed error kinds;
+one engine per concern; adapter boundary (`@earendil-works` only under
+`packages/adapter-pi/`); secrets masked, env-first, never in
+settings.json/SSE; consent before installing anything; pinned + checksum-
+verified upstreams and binaries; tests isolated from `~/.bakin` and `~/.pi`.
+
+**Ask first:** any scope addition beyond the decision log; any new runtime
+dependency; curating a pack whose upstream license/trust is unclear.
+
+**Never:** in-process code in capability packs; background daemons inside Pi
+extensions; silent fallbacks; compat shims; hand-editing
+`settings.runtime.adapter`; committing `generated-version.ts`.
+
+## 9. Acceptance criteria (initiative-level)
+
+1. **Net-new machine flow:** on a clean rig home (no bx, no key, no skills),
+   installing `web-search-brave` from Explore or
+   `bakin packages install …` walks consent → content → pinned bin →
+   guided key → doctor green, with zero manual steps outside Bakin.
+2. A dispatched Pi task then completes real web research with cited sources
+   (the spike task, §11, reproduced through the productized path).
+3. The same pack on OpenClaw projects to OpenClaw's skill location and works
+   (runtime-neutral by construction).
+4. Missing key / missing bin / terminal-deleted content each surface as an
+   honest per-capability readiness warn with a working remediation link —
+   never a silent failure.
+5. A pending workflow gate badges the nav, fires a toast/OS notification, and
+   deep-links to the gate — on Pi with no channel layer.
+6. `/runtime` hub matches the component-kit polish bar; switch flow uses
+   ConfirmDialog + grouped result cards; capability legend explains
+   native/shimmed/unavailable; delivery shows honestly `unavailable` on Pi.
+7. Subagent model routing round-trips a Pi⇄OpenClaw switch dry-run report.
+8. **Task-parity battery:** research (web search), image generate+edit,
+   agent-self-scheduled recurring task, gated workflow approved via in-app
+   attention, subagent fan-out honoring per-agent subagent models — all
+   complete on Pi on this box. Recorded in the P5 PR.
+9. Full suite + conformance green; knowledge docs updated per §7; Explore
+   shelves carry the plain-language taxonomy labels.
+
+## 10. Reserved architecture (deferred initiatives)
+
+Recorded so nothing built now contradicts them; do not build in this
+initiative.
+
+### 10.1 Discord delivery bridge
+
+- Runtime-neutral bridge in `src/core/delivery/` — `bridge.ts` (neutral
+  `ChannelBridge` interface), `discord/client.ts` (discord.js lifecycle),
+  `discord/send.ts` (messages, notifications, content, asset attachments via
+  existing `{ kind: 'asset' }` refs, threads, edits), `discord/approvals.ts`
+  (buttoned cards, interaction subscription → `ApprovalResolveEvent`),
+  `audit.ts` (`delivery.*` audit + execution-ledger dedupe keys), `config.ts`
+  (`settings.integrations.discord`; token = secret-store `discord.botToken` —
+  the P1 store shape already fits).
+- `adapter-pi` implements `runtime.channels` by delegation, present only when
+  configured; `delivery: 'shimmed'` when configured, `unavailable` otherwise.
+  Consumers unchanged. OpenClaw native channels untouched.
+- Discord buttons are transport; the durable Bakin approval record is the
+  authority; in-app attention (built in P3) remains the always-on companion.
+- Bridge boots with the server only when configured; never inside
+  `createAppServices()`; clean shutdown teardown. discord.js confined to
+  `src/core/delivery/` (architecture test).
+
+### 10.2 Pi extension (in-process code) trust lane
+
+- Activates when a real extension need appears (none required for task
+  parity — per-turn capabilities are skills).
+- Design banked: `piExtensions` default flips `all` → `allowlist`;
+  Bakin-consented installs auto-append; terminal `pi install` extensions are
+  discovered but inert until approved in UI (runtime hub) with a doctor
+  check pointing there. If broader lifecycle management is needed, the
+  optional `packages?` contract member design from spec v1 (list/install/
+  remove/update/check/setTrust over Pi's `DefaultPackageManager`) is the
+  shape — but only extensions justify it; skills ride agent-packages (D4).
+
+## 11. P0 spike record (2026-07-12, this box)
+
+**Setup:** Pi active (`runtime.adapter: 'pi'`), live server. Installed a
+Pi-adapted `bx-search` SKILL.md into `~/.pi/agent/skills/bx-search/`
+(content adapted from OpenClaw's bx-search skill). Pre-existing on box:
+`bx` 1.4.0 (`~/.local/bin/bx`), working Brave key
+(`~/Library/Application Support/brave-search`). No server restart (skills
+discovered per session; adapter opens a session per turn).
+
+**Test:** task `890d957f` assigned to `main`: find latest stable Bun version
++ release date + one feature via web search; cite sources; save asset;
+honest-failure instructions.
+
+**Result: PASS.** Dispatch picked up in ~3 min (normal tick); agent work
+~40 s: loaded skill → `bx` searches → found Bun v1.3.14 (2026-05-13 — well
+past training cutoff, proving real search) → noted a cross-source date
+discrepancy honestly → saved asset `20260713-web-search-spike-result-a97c893e`
+with cited URLs → completed.
+
+**Findings that drove spec v3:**
+1. Full web-search task parity = one SKILL.md + a CLI + a key. No contract
+   member, no package manager, no restart.
+2. Skill collections install by cloning into skills dirs, NOT `pi install`
+   (pi-skills has no package manifest) — the v1 `packages?` design targeted
+   the wrong lane; agent-packages skill projection is the existing right
+   vehicle.
+3. `badlogic/pi-skills` also ships `gmcli`/`gccli`/`gdcli` (Google APIs) —
+   the deferred email initiative is likely a pack + governance-plugin
+   composition.
+4. What a net-new machine lacks is exactly the three `requires` dimensions:
+   content, binary, key — hence the capability-pack manifest (D4).
+
+**P0 adjudications (resolved 2026-07-12, code-verified):**
+- **Long-task compaction: no gap.** Pi SDK auto-compaction defaults ON
+  (`settings-manager.js`: `compaction.enabled ?? true`, reserveTokens 16384,
+  keepRecentTokens 20000) and the adapter's
+  `SettingsManager.create(workspace, agentDir, …)` inherits it — long tasks
+  compact, not die. P3 adds one pin test so an SDK default flip can't
+  silently regress this.
+- **Model fallback: explicit non-goal (revisitable).** Pi inner auto-retry +
+  Bakin's dispatch recovery ladder cover transient provider failures; what's
+  missing vs OpenClaw is only cross-provider failover during a sustained
+  outage — rare on a box that runs one subscription provider. Not worth
+  adapter fallback-chain complexity until a real outage bites; revisit on
+  first incident (`provider_cooldown` exhaustion in the wild).
+
+## 12. User stories (walked 2026-07-12, approved)
+
+The plan's tasks trace to these. Stories 1–3 are ONE engine with three thin
+clients — build the engine once, validate via the CLI client first (cheapest),
+then Explore, then onboarding. Story 5 (degradation/remediation) gets test
+coverage parity with the happy path — it is where trust is won or lost.
+
+1. **Fresh install** — onboarding recommendations offer Web Search; consent →
+   content → pinned binary (progress) → guided key with a skip + "finish
+   later in Settings → Integrations & Keys" escape hatch (onboarding never
+   stalls on a key). Summary shows Ready / "Installed — needs API key".
+2. **Explore install (UI)** — Capabilities shelf ("teach your agents new
+   tricks"), runtime-compat badge per card, detail drawer (upstream + pin +
+   what installs where + what it needs), install → consent → progress →
+   inline key → Ready + "try it" hint. Install lives in Explore ONLY; the
+   /runtime Capabilities tab shows status and links here (one install path).
+3. **CLI install** — `bakin packages install web-search-brave` resolves the
+   curated catalog BY NAME (not just github: sources); consent prompt, per-
+   step ✓/⚠ output, inline key prompt with skip; `bakin check capabilities`
+   shows per-capability readiness.
+4. **The payoff** — user asks for research in chat or a board task; the agent
+   searches, cites sources, saves assets. The user never learns the word
+   "skill-pack". (Spike §11, productized.)
+5. **Honest degradation** — missing key: agent fails honestly (pack skill
+   content carries honest-failure instructions), doctor warns
+   `capability.web-search` with a remediation link to Integrations & Keys;
+   deleted bin → reinstall offer; content drift → `bakin packages sync`.
+   DECIDED: no dispatch pre-flight "research task but search not ready"
+   magic in v1.
+6. **Approval attention** — gate pending ⇒ workflows nav badge + toast +
+   optional OS notification/chime, deep link to the gate; approve/reject on
+   the durable record; badge clears on resolve. DECIDED: badge rides the
+   workflows nav item; no new "attention" nav aggregate.
+7. **Runtime hub** — Overview (adapter card, capability chips + plain-
+   language legend: native = runtime provides / shimmed = Bakin provides /
+   unavailable = honestly not available; delivery on Pi reads "unavailable —
+   approvals surface in-app"), Capabilities tab (readiness chips +
+   remediation links + browse→Explore), Switch tab (dry-run preview BY
+   DEFAULT, incl. "N OpenClaw cron jobs — adopt into Bakin schedules?",
+   confirm, live progress, grouped result cards). Every state answers "so
+   what do I do about it?"
+8. **Subagent routing** — Team agent settings' subagent-model select is
+   honored on Pi; fan-out runs show the configured model in usage/health;
+   switch dry-run reports mappings both directions.
+
+Pack removal/upgrade rides the existing `bakin packages remove|upgrade`
+verbs (upgrade = deliberate upstream re-pin, consent shown on source change);
+covered as engine acceptance criteria rather than a separate story.
+
+## 13. Noted follow-up: 1Password integration (2026-07-12)
+
+Secret REFERENCES, not value sync: store `op://vault/item/field` URIs in the
+secret store; resolve at the single read chokepoint
+(`resolveProviderApiKeySource` cascade gains env → op-reference → stored
+value) during boot env injection via `op read`. Headless server ⇒ 1Password
+service account (`OP_SERVICE_ACCOUNT_TOKEN`) — one scoped/revocable token
+instead of N raw keys at rest; rotation happens in 1Password. Doctor: `op`
+readiness check; unresolvable reference = the standard "needs key" state.
+Agent-readable-env caveat unchanged (resolved values still enter process
+env). P1 keeps resolution centralized so this lands without schema or UI
+changes.

--- a/.claude/specs/pi-parity/TODO.md
+++ b/.claude/specs/pi-parity/TODO.md
@@ -1,0 +1,48 @@
+# Pi Parity — Task Checklist
+
+Plan: `PLAN.md` · Spec: `SPEC.md` · One PR per phase, one commit per task.
+
+## P0 — Spike & adjudication ✅ (2026-07-12)
+- [x] Web-search spike end-to-end on Pi (task 890d957f, PASS)
+- [x] Compaction adjudication (SDK default ON — no gap; pin test in T3.5)
+- [x] Model fallback adjudication (explicit non-goal)
+
+## P1 — feat/integration-secrets
+- [ ] T1.1 Named secrets in secret store (old shape stays valid — OQ2)
+- [ ] T1.2 Masked REST + Integrations & Keys tab
+- [ ] T1.3 Boot env + `~/.bakin/bin` PATH injection
+- [ ] Gate: suite green + live masked round-trip → open PR
+
+## P2 — feat/capability-packs
+- [ ] T2.1 Manifest + catalog schema extensions (capability/runtimes/requires.bins/secretSlot)
+- [ ] T2.2 Pinned binary installer (`ProjectionKind 'bin'`, rollback-safe)
+- [ ] T2.3 Readiness engine + doctor check + `bakin check capabilities` (OQ3: health system-checks)
+- [ ] T2.4 CLI: catalog-name install + consent + key prompt (story 3)
+- [ ] T2.5 Explore Capabilities shelf + install-dialog key step (story 2)
+- [ ] T2.6 Onboarding recommended-capabilities component (story 1)
+- [ ] T2.7 web-search-brave pack in bits + catalog entry + live cutover (replace spike skill)
+- [ ] Gate: CLEAN-home rig validation (stories 1–4) → open PR
+
+## P3 — feat/pi-task-parity
+- [ ] T3.1 Pending-approval attention provider (story 6)
+- [ ] T3.2 Subagent model preservation across switches (per OQ1 decision)
+- [ ] T3.3 gh readiness check + agent context guidance
+- [ ] T3.4 Switch-time cron adoption, opt-in `--adopt-cron` (story 7)
+- [ ] T3.5 Pin tests: compaction default + schedule-tools dispatch context
+- [ ] Gate: live gate badge/toast + switch e2e → open PR
+
+## P4 — feat/runtime-hub
+- [ ] T4.1 Hub shell + Overview tab (legend, credential tiles)
+- [ ] T4.2 Capabilities tab (readiness chips + remediation links)
+- [ ] T4.3 Switch tab (dry-run preview, ConfirmDialog, grouped result cards)
+- [ ] Gate: RTL all tabs + visual review screenshots → open PR
+
+## P5 — chore/pi-parity-docs
+- [ ] T5.1 Knowledge/extending/CLAUDE.md/README docs
+- [ ] T5.2 Task-parity battery 5/5 recorded (spec acceptance 8)
+- [ ] T5.3 Close-out: memory, spec → SHIPPED, follow-up issues (Discord bridge, extension trust, fast-follow packs)
+
+## Open questions (resolve before their tasks)
+- [ ] OQ1: subagent-model scope — recommend preservation-only (T3.2)
+- [x] OQ2: secrets.json compat — schema widening, zero migration code (T1.1)
+- [ ] OQ3: readiness check owner — recommend health system-checks (T2.3)

--- a/packages/core/src/content-dir.ts
+++ b/packages/core/src/content-dir.ts
@@ -118,6 +118,8 @@ export interface BakinPaths {
   /** Data dir for Bakin's private antfly instance (created on demand by the adapter). */
   antfly: string
   db: string
+  /** Bakin-owned bin dir for capability-pack binaries; prepended to PATH at server boot. */
+  bin: string
 }
 
 export function getBakinPaths(): BakinPaths {
@@ -144,6 +146,7 @@ export function getBakinPaths(): BakinPaths {
     logs: join(home, 'logs'),
     antfly: join(home, 'antfly'),
     db: join(home, 'bakin.db'),
+    bin: join(home, 'bin'),
   }
 }
 

--- a/packages/core/src/media/secret-store.ts
+++ b/packages/core/src/media/secret-store.ts
@@ -22,12 +22,16 @@ import { getContentDir } from '../content-dir'
 import { resolveDirectImageKey } from './direct-image-provider'
 import { type DirectImageProviderId } from './image-format'
 
-interface ProviderSecret {
-  apiKey?: string
-}
+/**
+ * Named secrets per provider/integration. The historical shape
+ * `{ apiKey: string }` is a valid instance (apiKey is just a secret name),
+ * so pre-existing stores load unchanged — no migration code exists or is
+ * needed.
+ */
+type ProviderSecrets = Record<string, string>
 
 interface SecretStoreFile {
-  providers: Record<string, ProviderSecret>
+  providers: Record<string, ProviderSecrets>
 }
 
 function secretsPath(): string {
@@ -80,29 +84,70 @@ function nonEmpty(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value : null
 }
 
-/** Read a stored provider key (store only — does not consult env). */
-export function getStoredProviderKey(providerId: string): string | null {
-  return nonEmpty(readStore().providers[providerId]?.apiKey)
+/**
+ * Validate a secret name: same safe-slug rules as provider ids (camelCase
+ * names like `apiKey`/`botToken` pass via the `i` flag), never a reserved
+ * object key.
+ */
+export function isValidSecretName(name: unknown): name is string {
+  return typeof name === 'string' && /^[a-z0-9][a-z0-9._-]{0,63}$/i.test(name) && !RESERVED_KEYS.has(name)
 }
 
-/** Persist a provider key to the 0600 store. Rejects invalid/reserved ids. */
-export function setStoredProviderKey(providerId: string, apiKey: string): void {
+/** Read one named secret (store only — does not consult env). */
+export function getStoredSecret(providerId: string, name: string): string | null {
+  return nonEmpty(readStore().providers[providerId]?.[name])
+}
+
+/** Persist one named secret to the 0600 store. Rejects invalid ids/names. */
+export function setStoredSecret(providerId: string, name: string, value: string): void {
   if (!isValidProviderId(providerId)) throw new Error(`Invalid provider id: ${providerId}`)
+  if (!isValidSecretName(name)) throw new Error(`Invalid secret name: ${name}`)
   const store = readStore()
-  store.providers[providerId] = { apiKey }
+  store.providers[providerId] = { ...store.providers[providerId], [name]: value }
   writeStore(store)
 }
 
-/** Remove a stored provider key. Returns false when nothing was set. */
-export function unsetStoredProviderKey(providerId: string): boolean {
+/**
+ * Remove one named secret; drops the provider entry when it holds no other
+ * secrets. Returns false when nothing was set.
+ */
+export function unsetStoredSecret(providerId: string, name: string): boolean {
   const store = readStore()
-  if (!store.providers[providerId]) return false
-  delete store.providers[providerId]
+  const secrets = store.providers[providerId]
+  if (!secrets || !(name in secrets)) return false
+  delete secrets[name]
+  if (Object.keys(secrets).length === 0) delete store.providers[providerId]
   writeStore(store)
   return true
 }
 
-/** Provider ids that currently have a non-empty stored key. */
+/** Secret NAMES per provider (sorted) — values never leave this module unmasked callers. */
+export function listStoredSecrets(): Record<string, string[]> {
+  const store = readStore()
+  const out: Record<string, string[]> = {}
+  for (const [id, secrets] of Object.entries(store.providers)) {
+    const names = Object.keys(secrets).filter(name => nonEmpty(secrets[name])).sort()
+    if (names.length > 0) out[id] = names
+  }
+  return out
+}
+
+/** Read a stored provider key (store only — does not consult env). */
+export function getStoredProviderKey(providerId: string): string | null {
+  return getStoredSecret(providerId, 'apiKey')
+}
+
+/** Persist a provider key to the 0600 store. Rejects invalid/reserved ids. */
+export function setStoredProviderKey(providerId: string, apiKey: string): void {
+  setStoredSecret(providerId, 'apiKey', apiKey)
+}
+
+/** Remove a stored provider key. Returns false when nothing was set. */
+export function unsetStoredProviderKey(providerId: string): boolean {
+  return unsetStoredSecret(providerId, 'apiKey')
+}
+
+/** Provider ids that currently have a non-empty stored `apiKey` secret. */
 export function listStoredProviders(): string[] {
   const store = readStore()
   return Object.keys(store.providers).filter(id => nonEmpty(store.providers[id]?.apiKey))
@@ -112,6 +157,11 @@ export function listStoredProviders(): string[] {
  * Resolve a direct-image provider key with the full Bakin-owned precedence
  * (env override → secret store) AND report which source supplied it, so callers
  * can label the credential source accurately for diagnostics.
+ *
+ * Extension point (spec pi-parity §13): secret-manager references (e.g.
+ * 1Password `op://vault/item/field`) would resolve HERE — env →
+ * reference-resolution → stored value — so keep every read funneled through
+ * this cascade rather than reading the store directly.
  */
 export function resolveProviderApiKeySource(
   provider: DirectImageProviderId,

--- a/packages/host/src/api/secrets.ts
+++ b/packages/host/src/api/secrets.ts
@@ -1,39 +1,62 @@
 /**
- * GET/POST/DELETE /api/secrets — manage the Bakin-owned provider secret store.
+ * GET/POST/DELETE /api/secrets — manage the Bakin-owned integration secret store.
  *
- * Write-only / masked: GET reports only WHICH providers have a stored key,
- * never the value. POST sets a key; DELETE clears one. Provider ids are
- * validated (safe slug, not a reserved object key) and the key length is
- * bounded. env vars still override the store at resolution time, and
- * runtime-owned credentials are never touched here.
+ * Write-only / masked: GET reports only WHICH secret names each provider has
+ * stored, never a value. POST sets one named secret (legacy `apiKey` body
+ * shape targets the `apiKey` name); DELETE clears one. Provider ids and
+ * secret names are validated (safe slug, not a reserved object key) and the
+ * value length is bounded. env vars still override the store at resolution
+ * time, and runtime-owned credentials are never touched here.
  */
 import { z } from 'zod'
-import { isValidProviderId, listStoredProviders, setStoredProviderKey, unsetStoredProviderKey } from '@bakin/core/media'
+import {
+  isValidProviderId,
+  isValidSecretName,
+  listStoredProviders,
+  listStoredSecrets,
+  setStoredSecret,
+  unsetStoredSecret,
+} from '@bakin/core/media'
 
-const setBody = z.object({
-  provider: z.string().refine(isValidProviderId, 'invalid provider id'),
-  apiKey: z.string().min(1).max(8192),
-})
+const secretValue = z.string().min(1).max(8192)
+
+const setBody = z.union([
+  z.object({
+    provider: z.string().refine(isValidProviderId, 'invalid provider id'),
+    name: z.string().refine(isValidSecretName, 'invalid secret name'),
+    value: secretValue,
+  }),
+  // Legacy body shape: { provider, apiKey } targets the `apiKey` secret name.
+  z.object({
+    provider: z.string().refine(isValidProviderId, 'invalid provider id'),
+    apiKey: secretValue,
+  }).transform(({ provider, apiKey }) => ({ provider, name: 'apiKey', value: apiKey })),
+])
 
 function badRequest(error: string): Response {
   return Response.json({ ok: false, error }, { status: 400 })
 }
 
 export async function get(_req: Request, _url: URL): Promise<Response> {
-  // Masked: the actual key values never leave the server.
-  return Response.json({ stored: listStoredProviders() })
+  // Masked: the actual values never leave the server.
+  // `stored` = providers with an apiKey (the images/providers view);
+  // `secrets` = every stored secret NAME per provider.
+  return Response.json({ stored: listStoredProviders(), secrets: listStoredSecrets() })
 }
 
 export async function post(req: Request, _url: URL): Promise<Response> {
   const parsed = setBody.safeParse(await req.json().catch(() => null))
   if (!parsed.success) return badRequest(parsed.error.issues[0]?.message ?? 'invalid request')
-  setStoredProviderKey(parsed.data.provider, parsed.data.apiKey)
-  return Response.json({ ok: true, provider: parsed.data.provider, stored: true })
+  const { provider, name, value } = parsed.data
+  setStoredSecret(provider, name, value)
+  return Response.json({ ok: true, provider, name, stored: true })
 }
 
 export async function del(_req: Request, url: URL): Promise<Response> {
   const provider = (url.searchParams.get('provider') ?? '').trim()
   if (!isValidProviderId(provider)) return badRequest('invalid provider id')
-  const removed = unsetStoredProviderKey(provider)
-  return Response.json({ ok: true, provider, removed })
+  const name = (url.searchParams.get('name') ?? 'apiKey').trim()
+  if (!isValidSecretName(name)) return badRequest('invalid secret name')
+  const removed = unsetStoredSecret(provider, name)
+  return Response.json({ ok: true, provider, name, removed })
 }

--- a/packages/host/src/routes/settings.tsx
+++ b/packages/host/src/routes/settings.tsx
@@ -63,7 +63,7 @@ export function groupAndSortSchemas(schemas: PluginSchemaEntry[]): GroupedSchema
     a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
   core.sort(alpha)
   extensions.sort(alpha)
-  // System & Alerts pinned first, then Provider Keys, then built-ins A-Z.
+  // System & Alerts pinned first, then Integrations & Keys, then built-ins A-Z.
   return { core: [...system, ...providerKeys, ...core], extensions }
 }
 
@@ -82,7 +82,7 @@ function SettingsPage() {
       .then((data: PluginSchemaEntry[]) => {
         const withSystem: PluginSchemaEntry[] = [
           { id: SYSTEM_SETTINGS_TAB_ID, name: 'System & Alerts', schema: SYSTEM_SETTINGS_SCHEMA, source: 'built-in' },
-          { id: PROVIDER_KEYS_TAB_ID, name: 'Provider Keys', schema: { fields: [] }, source: 'built-in' },
+          { id: PROVIDER_KEYS_TAB_ID, name: 'Integrations & Keys', schema: { fields: [] }, source: 'built-in' },
           ...data,
         ]
         setPlugins(withSystem)
@@ -96,7 +96,7 @@ function SettingsPage() {
   // /api/settings (core settings.json) instead of /api/plugin-settings/*.
   useEffect(() => {
     if (!activePlugin) return
-    // Provider Keys manages its own data via /api/secrets + the images
+    // Integrations & Keys manages its own data via /api/secrets + the images
     // readiness route, so the generic values fetch is skipped.
     if (activePlugin === PROVIDER_KEYS_TAB_ID) {
       setValues({})

--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import { runStartupRecovery } from './src/core/server/startup-recovery'
 import { createRequestHandler } from './src/core/server/request-handler'
 import { getBootId } from './src/core/boot-id'
 import { acquireServerLock, formatBindFailureHelp } from './src/core/server-lock'
+import { ensureBakinBinOnPath, injectIntegrationEnv } from './src/core/secret-env'
 import { registerShutdownHandlers, triggerShutdown } from './src/core/lifecycle'
 import { generateDocs } from './src/core/api-docs'
 import type { buildOpenApiDocument } from './packages/host/src/api/docs-runtime'
@@ -79,6 +80,12 @@ const CONTENT_DIR = getContentDir()
     process.exit(1)
   }
 }
+
+// Integration env + PATH injection BEFORE services/dispatch: Pi agent shells
+// inherit this process's env, so stored integration secrets (unset-only,
+// env-first) and Bakin's bin dir must be in place before any turn can run.
+injectIntegrationEnv()
+ensureBakinBinOnPath()
 
 /**
  * Build the source list the OpenAPI runtime builder consumes from the

--- a/src/components/provider-keys-tab.tsx
+++ b/src/components/provider-keys-tab.tsx
@@ -1,14 +1,15 @@
 /**
- * Provider Keys settings tab (image-scoped).
+ * Integrations & Keys settings tab.
  *
- * Shows where each image provider's credential comes from — the active
- * runtime, a Bakin env override, the Bakin secret store, or nothing — and lets you
- * manage the Bakin-owned store key (write-only). Runtime- and env-sourced rows
- * are read-only status. Status comes from the images plugin's /providers
- * readiness; store edits go through /api/secrets.
- *
- * The broader, all-domains credential inventory is tracked in GitHub #378; this
- * tab is intentionally image-scoped for now.
+ * Two sections. Image providers: where each image provider's credential comes
+ * from — the active runtime, a Bakin env override, the Bakin secret store, or
+ * nothing — with write-only store management (runtime-/env-sourced rows are
+ * read-only status; readiness comes from the images plugin's /providers).
+ * Integration secrets: every named secret in the Bakin store grouped by
+ * integration (discord.botToken, brave.apiKey, …) with add/remove — the
+ * standing home capability packs and doctor remediation links point at.
+ * All edits go through the masked /api/secrets surface; values are never
+ * rendered back.
  */
 import { useCallback, useEffect, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -36,6 +37,8 @@ export function ProviderKeysTab() {
   const [rows, setRows] = useState<ReadinessRow[]>([])
   const [runtimeName, setRuntimeName] = useState<string | null>(null)
   const [stored, setStored] = useState<string[]>([])
+  const [secretNames, setSecretNames] = useState<Record<string, string[]>>({})
+  const [addDraft, setAddDraft] = useState({ provider: '', name: '', value: '' })
   const [loading, setLoading] = useState(true)
   const [drafts, setDrafts] = useState<Record<string, string>>({})
   const [busy, setBusy] = useState<string | null>(null)
@@ -53,6 +56,7 @@ export function ProviderKeysTab() {
       setRows(Array.isArray(providers?.readiness) ? providers.readiness : [])
       setRuntimeName(typeof providers?.runtimeName === 'string' ? providers.runtimeName : null)
       setStored(Array.isArray(secrets?.stored) ? secrets.stored : [])
+      setSecretNames(secrets?.secrets && typeof secrets.secrets === 'object' ? secrets.secrets : {})
       setError(null)
     } finally {
       setLoading(false)
@@ -94,6 +98,23 @@ export function ProviderKeysTab() {
   const clear = (id: string) =>
     mutate(id, () => fetch(`/api/secrets?provider=${encodeURIComponent(id)}`, { method: 'DELETE' }))
 
+  const removeSecret = (provider: string, name: string) =>
+    mutate(`${provider}.${name}`, () =>
+      fetch(`/api/secrets?provider=${encodeURIComponent(provider)}&name=${encodeURIComponent(name)}`, { method: 'DELETE' }))
+
+  const addSecret = async () => {
+    const provider = addDraft.provider.trim()
+    const name = addDraft.name.trim()
+    const value = addDraft.value.trim()
+    if (!provider || !name || !value) return
+    await mutate(`${provider}.${name}`, () => fetch('/api/secrets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider, name, value }),
+    }))
+    setAddDraft({ provider: '', name: '', value: '' })
+  }
+
   if (loading) {
     return (
       <div className="space-y-3 max-w-2xl">
@@ -101,10 +122,6 @@ export function ProviderKeysTab() {
         <Skeleton className="h-16 w-full" />
       </div>
     )
-  }
-
-  if (rows.length === 0) {
-    return <p className="text-sm text-muted-foreground">No image providers are available yet.</p>
   }
 
   return (
@@ -118,6 +135,9 @@ export function ProviderKeysTab() {
         Runtime-managed providers are configured in {runtimeLabel} and shown here read-only. Bakin keys are
         used only when the runtime can&apos;t serve a route; an environment variable always overrides a stored key.
       </p>
+      {rows.length === 0 && (
+        <p className="text-sm text-muted-foreground">No image providers are available yet.</p>
+      )}
       {rows.map(row => {
         const storeable = (row.source ?? '').startsWith('native')
         const envSet = (row.configuredEnvVars?.length ?? 0) > 0
@@ -160,6 +180,61 @@ export function ProviderKeysTab() {
           </div>
         )
       })}
+
+      <div className="pt-4 space-y-2">
+        <h3 className="text-sm font-medium">Integration secrets</h3>
+        <p className="text-xs text-muted-foreground">
+          Named secrets used by installed capabilities and integrations (e.g. a search API key or a bot
+          token). Values are write-only — they never leave the server. An environment variable with the
+          matching name always overrides a stored value.
+        </p>
+        {Object.entries(secretNames).sort(([a], [b]) => a.localeCompare(b)).map(([provider, names]) => (
+          <div key={provider} className="flex flex-col gap-2 rounded-md border p-3">
+            <span className="text-sm font-medium">{provider}</span>
+            <div className="flex flex-wrap items-center gap-2">
+              {names.map(name => (
+                <span key={name} className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs">
+                  {name}
+                  <button
+                    type="button"
+                    aria-label={`Remove ${provider} ${name}`}
+                    className="text-muted-foreground hover:text-destructive"
+                    disabled={busy === `${provider}.${name}`}
+                    onClick={() => removeSecret(provider, name)}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+        <div className="flex items-center gap-2">
+          <Input
+            placeholder="integration (e.g. brave)"
+            value={addDraft.provider}
+            onChange={e => setAddDraft(d => ({ ...d, provider: e.target.value }))}
+          />
+          <Input
+            placeholder="secret name (e.g. apiKey)"
+            value={addDraft.name}
+            onChange={e => setAddDraft(d => ({ ...d, name: e.target.value }))}
+          />
+          <Input
+            type="password"
+            placeholder="value"
+            value={addDraft.value}
+            onChange={e => setAddDraft(d => ({ ...d, value: e.target.value }))}
+          />
+          <Button
+            size="sm"
+            disabled={!addDraft.provider.trim() || !addDraft.name.trim() || !addDraft.value.trim()}
+            onClick={() => void addSecret()}
+          >
+            Add secret
+          </Button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/core/secret-env.ts
+++ b/src/core/secret-env.ts
@@ -1,0 +1,71 @@
+/**
+ * Boot-time integration env + PATH injection.
+ *
+ * Skills installed by capability packs consume credentials via env vars
+ * (e.g. BRAVE_SEARCH_API_KEY) and binaries from Bakin's own bin dir. Pi runs
+ * agent sessions in-process, so agent shell commands inherit THIS server
+ * process's env — one injection at boot serves every turn on every runtime.
+ *
+ * Precedence is env-first and unset-only: a value already present in the
+ * environment always wins and is never overwritten. Injection makes stored
+ * secrets readable by agent shell commands — that is the point (the keys are
+ * given to agents deliberately), documented in the capability-pack docs.
+ *
+ * Called from server.ts boot, after the singleton lock and BEFORE app
+ * services / dispatch start. Never call from createAppServices() — read-only
+ * CLI paths must not mutate the process environment.
+ */
+import { delimiter } from 'path'
+import { getStoredSecret } from '@bakin/core/media'
+import { getBakinPaths } from '@/core/content-dir'
+import { createLogger } from '@/core/logger'
+
+const log = createLogger('secret-env')
+
+export interface EnvSecretMapping {
+  /** Environment variable the consumer (skill/CLI) reads. */
+  envVar: string
+  /** Secret-store provider slot. */
+  provider: string
+  /** Secret-store secret name. */
+  name: string
+}
+
+/**
+ * Static mappings for integrations Bakin knows about regardless of installed
+ * packs. Capability packs add their own declarations (manifest `secrets[]`
+ * with `secretSlot`, P2) — those are passed in by the caller at boot.
+ */
+export const STATIC_ENV_SECRET_MAPPINGS: EnvSecretMapping[] = [
+  { envVar: 'BRAVE_SEARCH_API_KEY', provider: 'brave', name: 'apiKey' },
+]
+
+/**
+ * Populate UNSET env vars from the secret store. Returns the names of the
+ * vars actually injected (for boot logging/diagnostics — never values).
+ */
+export function injectIntegrationEnv(
+  mappings: EnvSecretMapping[] = STATIC_ENV_SECRET_MAPPINGS,
+): string[] {
+  const injected: string[] = []
+  for (const { envVar, provider, name } of mappings) {
+    if (process.env[envVar] !== undefined && process.env[envVar] !== '') continue
+    const stored = getStoredSecret(provider, name)
+    if (!stored) continue
+    process.env[envVar] = stored
+    injected.push(envVar)
+  }
+  if (injected.length > 0) log.info(`Injected ${injected.length} integration env var(s): ${injected.join(', ')}`)
+  return injected
+}
+
+/**
+ * Prepend Bakin's bin dir (`~/.bakin/bin`) to PATH so pack-installed
+ * binaries resolve in agent shell commands. Idempotent.
+ */
+export function ensureBakinBinOnPath(): void {
+  const bin = getBakinPaths().bin
+  const segments = (process.env.PATH ?? '').split(delimiter).filter(Boolean)
+  if (segments.includes(bin)) return
+  process.env.PATH = [bin, ...segments].join(delimiter)
+}

--- a/tests/api/secrets.test.ts
+++ b/tests/api/secrets.test.ts
@@ -26,7 +26,7 @@ describe('/api/secrets', () => {
 
   it('starts empty', async () => {
     const res = await get(new Request(url()), url())
-    expect(await res.json()).toEqual({ stored: [] })
+    expect(await res.json()).toEqual({ stored: [], secrets: {} })
   })
 
   it('sets, lists (masked), and deletes a provider key', async () => {
@@ -38,13 +38,13 @@ describe('/api/secrets', () => {
 
     const listRes = await get(new Request(url()), url())
     const listed = await listRes.json()
-    expect(listed).toEqual({ stored: ['openai'] })
+    expect(listed).toEqual({ stored: ['openai'], secrets: { openai: ['apiKey'] } })
     // The value is never returned.
     expect(JSON.stringify(listed)).not.toContain('sk-secret')
 
     const delRes = await del(new Request(url('?provider=openai'), { method: 'DELETE' }), url('?provider=openai'))
     expect(await delRes.json()).toMatchObject({ ok: true, removed: true })
-    expect(await (await get(new Request(url()), url())).json()).toEqual({ stored: [] })
+    expect(await (await get(new Request(url()), url())).json()).toEqual({ stored: [], secrets: {} })
   })
 
   it('rejects a set with a missing provider or key', async () => {
@@ -54,11 +54,51 @@ describe('/api/secrets', () => {
     expect(noKey.status).toBe(400)
   })
 
+  describe('named secrets', () => {
+    it('sets a named secret and lists names per provider (masked)', async () => {
+      const setRes = await post(
+        new Request(url(), { method: 'POST', body: JSON.stringify({ provider: 'discord', name: 'botToken', value: 'tok-secret' }) }),
+        url(),
+      )
+      expect(await setRes.json()).toMatchObject({ ok: true, provider: 'discord', name: 'botToken', stored: true })
+
+      const listed = await (await get(new Request(url()), url())).json()
+      expect(listed.secrets).toEqual({ discord: ['botToken'] })
+      // apiKey-view unchanged: discord has no apiKey
+      expect(listed.stored).toEqual([])
+      expect(JSON.stringify(listed)).not.toContain('tok-secret')
+    })
+
+    it('legacy apiKey body shape still works and appears in both views', async () => {
+      await post(new Request(url(), { method: 'POST', body: JSON.stringify({ provider: 'openai', apiKey: 'sk-1' }) }), url())
+      const listed = await (await get(new Request(url()), url())).json()
+      expect(listed.stored).toEqual(['openai'])
+      expect(listed.secrets).toEqual({ openai: ['apiKey'] })
+    })
+
+    it('deletes one named secret via ?provider=&name=', async () => {
+      await post(new Request(url(), { method: 'POST', body: JSON.stringify({ provider: 'discord', name: 'botToken', value: 't1' }) }), url())
+      await post(new Request(url(), { method: 'POST', body: JSON.stringify({ provider: 'discord', name: 'appId', value: 'a1' }) }), url())
+      const q = '?provider=discord&name=botToken'
+      const delRes = await del(new Request(url(q), { method: 'DELETE' }), url(q))
+      expect(await delRes.json()).toMatchObject({ ok: true, removed: true })
+      const listed = await (await get(new Request(url()), url())).json()
+      expect(listed.secrets).toEqual({ discord: ['appId'] })
+    })
+
+    it('rejects an invalid secret name', async () => {
+      const bad = await post(new Request(url(), { method: 'POST', body: JSON.stringify({ provider: 'discord', name: '__proto__', value: 'x' }) }), url())
+      expect(bad.status).toBe(400)
+      const badDel = await del(new Request(url('?provider=discord&name=bad name!'), { method: 'DELETE' }), url('?provider=discord&name=bad name!'))
+      expect(badDel.status).toBe(400)
+    })
+  })
+
   it('rejects an invalid/reserved provider id and an oversized key', async () => {
     const reserved = await post(new Request(url(), { method: 'POST', body: JSON.stringify({ provider: '__proto__', apiKey: 'x' }) }), url())
     expect(reserved.status).toBe(400)
     const oversized = await post(new Request(url(), { method: 'POST', body: JSON.stringify({ provider: 'openai', apiKey: 'a'.repeat(9000) }) }), url())
     expect(oversized.status).toBe(400)
-    expect(await (await get(new Request(url()), url())).json()).toEqual({ stored: [] })
+    expect(await (await get(new Request(url()), url())).json()).toEqual({ stored: [], secrets: {} })
   })
 })

--- a/tests/components/provider-keys-tab.test.tsx
+++ b/tests/components/provider-keys-tab.test.tsx
@@ -7,7 +7,7 @@ import { ProviderKeysTab } from '../../src/components/provider-keys-tab'
 
 const json = (body: unknown) => ({ ok: true, json: async () => body }) as unknown as Response
 
-function mockFetch(stored: string[] = []) {
+function mockFetch(stored: string[] = [], secrets: Record<string, string[]> = {}) {
   return spyOn(globalThis, 'fetch').mockImplementation((async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = String(input)
     if (url.includes('/api/plugins/images/providers')) {
@@ -22,7 +22,7 @@ function mockFetch(stored: string[] = []) {
     }
     if (url.includes('/api/secrets')) {
       if (init?.method === 'POST' || init?.method === 'DELETE') return json({ ok: true })
-      return json({ stored })
+      return json({ stored, secrets })
     }
     return json({})
   }) as typeof fetch)
@@ -80,5 +80,50 @@ describe('ProviderKeysTab', () => {
     await waitFor(() =>
       expect(fetchSpy).toHaveBeenCalledWith('/api/secrets', expect.objectContaining({ method: 'POST' })),
     )
+  })
+
+  describe('integration secrets section', () => {
+    it('lists stored named secrets grouped by provider, values never shown', async () => {
+      mockFetch([], { discord: ['appId', 'botToken'], brave: ['apiKey'] })
+      render(<ProviderKeysTab />)
+
+      await waitFor(() => screen.getByText('Integration secrets'))
+      expect(screen.getByText('discord')).toBeTruthy()
+      expect(screen.getByText('botToken')).toBeTruthy()
+      expect(screen.getByText('appId')).toBeTruthy()
+      expect(screen.getByText('brave')).toBeTruthy()
+    })
+
+    it('removes a named secret via DELETE with provider and name', async () => {
+      const fetchSpy = mockFetch([], { discord: ['botToken'] })
+      render(<ProviderKeysTab />)
+
+      await waitFor(() => screen.getByText('botToken'))
+      fireEvent.click(screen.getByLabelText('Remove discord botToken'))
+      await waitFor(() =>
+        expect(fetchSpy).toHaveBeenCalledWith(
+          '/api/secrets?provider=discord&name=botToken',
+          expect.objectContaining({ method: 'DELETE' }),
+        ),
+      )
+    })
+
+    it('adds a named secret via the add form', async () => {
+      const fetchSpy = mockFetch([], {})
+      render(<ProviderKeysTab />)
+
+      await waitFor(() => screen.getByText('Integration secrets'))
+      fireEvent.change(screen.getByPlaceholderText('integration (e.g. brave)'), { target: { value: 'brave' } })
+      fireEvent.change(screen.getByPlaceholderText('secret name (e.g. apiKey)'), { target: { value: 'apiKey' } })
+      fireEvent.change(screen.getByPlaceholderText('value'), { target: { value: 'bsk-1' } })
+      fireEvent.click(screen.getByText('Add secret'))
+
+      await waitFor(() => {
+        const post = fetchSpy.mock.calls.find(([, init]) => (init as RequestInit | undefined)?.method === 'POST')
+        expect(post).toBeTruthy()
+        expect(String((post![1] as RequestInit).body)).toContain('"name":"apiKey"')
+        expect(String((post![1] as RequestInit).body)).toContain('"provider":"brave"')
+      })
+    })
   })
 })

--- a/tests/core/media/secret-store.test.ts
+++ b/tests/core/media/secret-store.test.ts
@@ -5,10 +5,14 @@ import { tmpdir } from 'os'
 import { resetContentDir } from '../../../src/core/content-dir'
 import {
   getStoredProviderKey,
+  getStoredSecret,
   listStoredProviders,
+  listStoredSecrets,
   resolveProviderApiKeySource,
   setStoredProviderKey,
+  setStoredSecret,
   unsetStoredProviderKey,
+  unsetStoredSecret,
 } from '../../../packages/core/src/media/secret-store'
 
 describe('media secret-store', () => {
@@ -80,5 +84,59 @@ describe('media secret-store', () => {
   it('falls back to the store when no env key is present', () => {
     setStoredProviderKey('google', 'g-stored')
     expect(resolveProviderApiKeySource('google')).toEqual({ apiKey: 'g-stored', source: 'store' })
+  })
+
+  describe('named secrets', () => {
+    it('round-trips a named secret per provider', () => {
+      setStoredSecret('brave', 'apiKey', 'bsk-1')
+      setStoredSecret('discord', 'botToken', 'tok-1')
+      expect(getStoredSecret('brave', 'apiKey')).toBe('bsk-1')
+      expect(getStoredSecret('discord', 'botToken')).toBe('tok-1')
+      expect(getStoredSecret('discord', 'apiKey')).toBeNull()
+    })
+
+    it('lists secret NAMES per provider — never values', () => {
+      setStoredSecret('brave', 'apiKey', 'bsk-1')
+      setStoredSecret('discord', 'botToken', 'tok-1')
+      setStoredSecret('discord', 'appId', 'app-1')
+      expect(listStoredSecrets()).toEqual({ brave: ['apiKey'], discord: ['appId', 'botToken'] })
+    })
+
+    it('unsets a single named secret and drops the provider when empty', () => {
+      setStoredSecret('discord', 'botToken', 'tok-1')
+      setStoredSecret('discord', 'appId', 'app-1')
+      expect(unsetStoredSecret('discord', 'botToken')).toBe(true)
+      expect(getStoredSecret('discord', 'botToken')).toBeNull()
+      expect(getStoredSecret('discord', 'appId')).toBe('app-1')
+      expect(unsetStoredSecret('discord', 'appId')).toBe(true)
+      expect(listStoredSecrets()).toEqual({})
+      expect(unsetStoredSecret('discord', 'appId')).toBe(false)
+    })
+
+    it('interoperates with the legacy apiKey wrappers (same slot)', () => {
+      setStoredProviderKey('openai', 'sk-legacy')
+      expect(getStoredSecret('openai', 'apiKey')).toBe('sk-legacy')
+      setStoredSecret('openai', 'apiKey', 'sk-named')
+      expect(getStoredProviderKey('openai')).toBe('sk-named')
+      expect(listStoredProviders()).toEqual(['openai'])
+    })
+
+    it('a provider with only non-apiKey secrets is absent from listStoredProviders', () => {
+      setStoredSecret('discord', 'botToken', 'tok-1')
+      expect(listStoredProviders()).toEqual([])
+      expect(listStoredSecrets()).toEqual({ discord: ['botToken'] })
+    })
+
+    it('rejects invalid secret names and reserved keys', () => {
+      expect(() => setStoredSecret('brave', '__proto__', 'x')).toThrow(/Invalid secret name/)
+      expect(() => setStoredSecret('brave', 'bad name!', 'x')).toThrow(/Invalid secret name/)
+      expect(() => setStoredSecret('__proto__', 'apiKey', 'x')).toThrow(/Invalid provider id/)
+      expect(listStoredSecrets()).toEqual({})
+    })
+
+    it('keeps 0600 permissions when writing named secrets', () => {
+      setStoredSecret('brave', 'apiKey', 'bsk-1')
+      expect(statSync(join(testDir, 'secrets.json')).mode & 0o777).toBe(0o600)
+    })
   })
 })

--- a/tests/core/secret-env.test.ts
+++ b/tests/core/secret-env.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { rmSync } from 'fs'
+import { join, delimiter } from 'path'
+import { tmpdir } from 'os'
+import { resetContentDir, getBakinPaths } from '../../src/core/content-dir'
+import { setStoredSecret } from '../../packages/core/src/media/secret-store'
+import { ensureBakinBinOnPath, injectIntegrationEnv, type EnvSecretMapping } from '../../src/core/secret-env'
+
+describe('secret-env boot injection', () => {
+  let testDir: string
+  const original = {
+    home: process.env.BAKIN_HOME,
+    path: process.env.PATH,
+    brave: process.env.BRAVE_SEARCH_API_KEY,
+  }
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `bakin-secret-env-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+    process.env.BAKIN_HOME = testDir
+    resetContentDir()
+    delete process.env.BRAVE_SEARCH_API_KEY
+  })
+
+  afterEach(() => {
+    for (const [key, value] of [['BAKIN_HOME', original.home], ['PATH', original.path], ['BRAVE_SEARCH_API_KEY', original.brave]] as const) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    resetContentDir()
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  const mapping: EnvSecretMapping[] = [{ envVar: 'BRAVE_SEARCH_API_KEY', provider: 'brave', name: 'apiKey' }]
+
+  it('injects a stored secret into an UNSET env var', () => {
+    setStoredSecret('brave', 'apiKey', 'bsk-stored')
+    const injected = injectIntegrationEnv(mapping)
+    expect(process.env.BRAVE_SEARCH_API_KEY).toBe('bsk-stored')
+    expect(injected).toEqual(['BRAVE_SEARCH_API_KEY'])
+  })
+
+  it('never overrides an already-set env var (env-first)', () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'bsk-env'
+    setStoredSecret('brave', 'apiKey', 'bsk-stored')
+    const injected = injectIntegrationEnv(mapping)
+    expect(process.env.BRAVE_SEARCH_API_KEY).toBe('bsk-env')
+    expect(injected).toEqual([])
+  })
+
+  it('leaves the env var unset when nothing is stored', () => {
+    const injected = injectIntegrationEnv(mapping)
+    expect(process.env.BRAVE_SEARCH_API_KEY).toBeUndefined()
+    expect(injected).toEqual([])
+  })
+
+  it('exposes a bin path under the content dir and prepends it to PATH once', () => {
+    const expected = getBakinPaths().bin
+    expect(expected).toBe(join(testDir, 'bin'))
+
+    process.env.PATH = '/usr/bin'
+    ensureBakinBinOnPath()
+    expect(process.env.PATH).toBe(`${expected}${delimiter}/usr/bin`)
+
+    // Idempotent — a second call must not duplicate the segment.
+    ensureBakinBinOnPath()
+    expect(process.env.PATH!.split(delimiter).filter(p => p === expected)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Phase P1 of the Pi parity initiative (spec + plan in `.claude/specs/pi-parity/`, committed here).

## What

- **Named secrets per provider** in the secret store — the historical `{ apiKey }` shape is a valid instance of the new `Record<name, string>` shape, so existing stores load unchanged with zero migration code. Legacy provider-key APIs are now thin wrappers over the named-secret API.
- **Masked REST**: `GET /api/secrets` adds a `secrets` map (provider → secret **names**); `POST` accepts `{ provider, name, value }` (legacy `apiKey` body still works); `DELETE` takes `?name=`. Values never leave the server.
- **Integrations & Keys tab** (renamed from Provider Keys): image-provider readiness section unchanged + a new Integration secrets section (grouped named secrets, add/remove) — the standing surface capability packs and doctor remediation will link to.
- **Boot injection** (`src/core/secret-env.ts`): stored integration secrets → unset env vars (env-first, unset-only) and `~/.bakin/bin` → PATH, once at server boot before dispatch. Pi agent shells inherit the server env, so this serves every turn on every runtime.
- 1Password-reference extension point annotated at the resolution chokepoint (spec §13).

## Why

Foundation for P2 capability packs (guided key entry + pack-installed binaries) — see `.claude/specs/pi-parity/PLAN.md`.

## Test plan

- New: named-secret store round-trips, slug/reserved-key rejection, 0600 perms; REST named-secret set/list/delete + legacy body; Integrations & Keys RTL (list/add/remove, masked); secret-env unset-only precedence + PATH idempotence.
- Full suite green: 6741 tests / 681 files, 0 fail. `bun run typecheck` clean.
- Live masked round-trip on this box after merge + server restart (dev loop doesn't watch server code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)