### PR TITLE
feat(packages): capability packs — managed agent capabilities on agent-packages (pi-parity P2)

### DIFF
--- a/.claude/specs/pi-parity/TODO.md
+++ b/.claude/specs/pi-parity/TODO.md
@@ -8,20 +8,20 @@ Plan: `PLAN.md` · Spec: `SPEC.md` · One PR per phase, one commit per task.
 - [x] Model fallback adjudication (explicit non-goal)
 
 ## P1 — feat/integration-secrets
-- [ ] T1.1 Named secrets in secret store (old shape stays valid — OQ2)
-- [ ] T1.2 Masked REST + Integrations & Keys tab
-- [ ] T1.3 Boot env + `~/.bakin/bin` PATH injection
-- [ ] Gate: suite green + live masked round-trip → open PR
+- [x] T1.1 Named secrets in secret store (old shape stays valid — OQ2)
+- [x] T1.2 Masked REST + Integrations & Keys tab
+- [x] T1.3 Boot env + `~/.bakin/bin` PATH injection
+- [x] Gate: suite green (PR #662 merged; live masked round-trip after next server restart)
 
 ## P2 — feat/capability-packs
-- [ ] T2.1 Manifest + catalog schema extensions (capability/runtimes/requires.bins/secretSlot)
-- [ ] T2.2 Pinned binary installer (`ProjectionKind 'bin'`, rollback-safe)
-- [ ] T2.3 Readiness engine + doctor check + `bakin check capabilities` (OQ3: health system-checks)
-- [ ] T2.4 CLI: catalog-name install + consent + key prompt (story 3)
-- [ ] T2.5 Explore Capabilities shelf + install-dialog key step (story 2)
-- [ ] T2.6 Onboarding recommended-capabilities component (story 1)
-- [ ] T2.7 web-search-brave pack in bits + catalog entry + live cutover (replace spike skill)
-- [ ] Gate: CLEAN-home rig validation (stories 1–4) → open PR
+- [x] T2.1 Manifest + catalog schema extensions (capability/runtimes/requires.bins/secretSlot)
+- [x] T2.2 Pinned binary installer (`ProjectionKind 'bin'`, rollback-safe)
+- [x] T2.3 Readiness engine + doctor check + `bakin check capabilities` (OQ3: health system-checks)
+- [x] T2.4 CLI: catalog-name install + consent + key prompt (story 3)
+- [x] T2.5 Explore Capabilities shelf + install-dialog key step (story 2)
+- [x] T2.6 Onboarding recommended-capabilities component (story 1)
+- [x] T2.7 web-search-brave pack in bits + catalog entry + live cutover (replace spike skill)
+- [x] Gate: CLEAN-home rig validation done (stories 1–3 real pack/binary/key ladder; story 4 dispatch at post-merge live cutover)
 
 ## P3 — feat/pi-task-parity
 - [ ] T3.1 Pending-approval attention provider (story 6)

--- a/packages/core/src/agent-packages/lockfile.ts
+++ b/packages/core/src/agent-packages/lockfile.ts
@@ -25,6 +25,10 @@ const ProjectionKindSchema = z.enum([
   'workspace-file',
   // Team persona seed (seeded-if-missing; never overwritten or reclaimed).
   'persona',
+  // Capability-pack binary installed into the Bakin bin dir. Removal is
+  // refcount-aware in the uninstaller: a bin whose target is also projected
+  // by another installed package survives that uninstall.
+  'bin',
   // Legacy (pre-layered-context). New code never writes lesson-marker
   // projections — lessons are composed into the workspace-file block. Kept in
   // the enum only so pre-migration lockfiles parse; the one-time migration
@@ -52,6 +56,7 @@ export interface ProjectionKindPolicy {
 export const PROJECTION_KIND_POLICY: Record<ProjectionKind, ProjectionKindPolicy> = {
   skill: { seedOnce: false, sidecarless: false, survivesUninstall: false },
   asset: { seedOnce: false, sidecarless: false, survivesUninstall: false },
+  bin: { seedOnce: false, sidecarless: false, survivesUninstall: false },
   'workspace-file': { seedOnce: false, sidecarless: true, survivesUninstall: true },
   persona: { seedOnce: true, sidecarless: true, survivesUninstall: true },
   'lesson-marker': { seedOnce: false, sidecarless: true, survivesUninstall: true },

--- a/packages/core/src/agent-packages/manifest.ts
+++ b/packages/core/src/agent-packages/manifest.ts
@@ -45,7 +45,67 @@ export const SecretDeclarationSchema = z.object({
   name: SecretNameSchema,
   description: z.string().min(1),
   required: z.boolean().default(true),
+  /**
+   * Secret-store slot (`<provider>.<secretName>`) the env var is filled from
+   * at boot when unset. Drives the guided key prompt at install and the
+   * Integrations & Keys remediation link. Absent → the env var is
+   * user-managed only.
+   */
+  secretSlot: z
+    .string()
+    .regex(/^[a-z0-9][a-z0-9._-]{0,63}\.[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/, {
+      message: 'secretSlot must be "<provider>.<secretName>"',
+    })
+    .optional(),
+  /** Where the user gets this credential (shown in install/consent/readiness UIs). */
+  help: z.string().url().optional(),
 })
+
+// ─── Capability-pack extensions (skill-pack only) ────────────────────────────
+
+/** Capability slug: names what the pack teaches agents (`web-search`, …). */
+const CapabilitySlugSchema = z
+  .string()
+  .regex(/^[a-z0-9][a-z0-9-]{0,39}$/, {
+    message: 'capability must be a lowercase slug',
+  })
+
+/** Platform keys follow process.platform-process.arch (antfly pin convention). */
+export const BIN_PLATFORM_KEYS = ['darwin-arm64', 'darwin-x64', 'linux-x64', 'linux-arm64'] as const
+export type BinPlatformKey = (typeof BIN_PLATFORM_KEYS)[number]
+
+const BinDownloadSchema = z.object({
+  url: z.string().url().refine((u) => u.startsWith('https://'), { message: 'bin download url must be https' }),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/i, { message: 'sha256 must be 64 hex chars' }),
+})
+
+const BinRequirementSchema = z.object({
+  /** Binary name as invoked from PATH (installed into the Bakin bin dir). */
+  name: z.string().regex(/^[a-z0-9][a-z0-9._-]{0,63}$/i, { message: 'bin name must be a safe slug' }),
+  version: z.string().min(1),
+  /** Pinned per-platform downloads. Missing key ⇒ unsupported platform (honest readiness failure). */
+  install: z
+    .partialRecord(z.enum(BIN_PLATFORM_KEYS), BinDownloadSchema)
+    .refine((m) => Object.keys(m).length > 0, { message: 'at least one platform download required' }),
+  /** Args for the verify-then-commit run (e.g. ["--version"]). Absent → no verify run. */
+  verifyArgs: z.array(z.string()).optional(),
+})
+
+const RequiresSchema = z
+  .object({
+    bins: z.array(BinRequirementSchema).optional(),
+  })
+  .optional()
+
+/**
+ * Runtime compatibility tags: `['*']` (default — skills are a cross-runtime
+ * convention) or adapter names (`pi`, `openclaw`). Catalog/Explore filter and
+ * badge against the ACTIVE runtime; install refuses incompatible packs.
+ */
+const RuntimesSchema = z
+  .array(z.string().regex(/^(\*|[a-z0-9][a-z0-9-]{0,31})$/, { message: 'runtime tag must be "*" or an adapter slug' }))
+  .min(1)
+  .default(['*'])
 
 /**
  * Dependency source. Allowed forms:
@@ -207,6 +267,10 @@ export const SkillPackManifestSchema = z.object({
   kind: z.literal('skill-pack'),
   contributions: SkillPackContributionsSchema,
   dependencies: DependenciesSchema,
+  /** Capability-pack extensions: a skill-pack that names a capability and declares what it needs. */
+  capability: CapabilitySlugSchema.optional(),
+  runtimes: RuntimesSchema,
+  requires: RequiresSchema,
 })
 
 export const WorkflowPackManifestSchema = z.object({
@@ -240,6 +304,8 @@ export type Manifest = z.infer<typeof ManifestSchema>
 export type Dependency = z.infer<typeof DependencySchema>
 export type SecretDeclaration = z.infer<typeof SecretDeclarationSchema>
 export type PackageKind = Manifest['kind']
+export type BinRequirement = z.infer<typeof BinRequirementSchema>
+export type BinDownload = z.infer<typeof BinDownloadSchema>
 
 // ─── Parse entry points ──────────────────────────────────────────────────────
 

--- a/packages/core/src/agent-packages/manifest.ts
+++ b/packages/core/src/agent-packages/manifest.ts
@@ -75,7 +75,14 @@ export const BIN_PLATFORM_KEYS = ['darwin-arm64', 'darwin-x64', 'linux-x64', 'li
 export type BinPlatformKey = (typeof BIN_PLATFORM_KEYS)[number]
 
 const BinDownloadSchema = z.object({
-  url: z.string().url().refine((u) => u.startsWith('https://'), { message: 'bin download url must be https' }),
+  // https only — except loopback (test fixtures / local dev registries).
+  url: z
+    .string()
+    .url()
+    .refine(
+      (u) => u.startsWith('https://') || /^http:\/\/(127\.0\.0\.1|localhost)[:/]/.test(u),
+      { message: 'bin download url must be https' },
+    ),
   sha256: z.string().regex(/^[a-f0-9]{64}$/i, { message: 'sha256 must be 64 hex chars' }),
 })
 

--- a/packages/host/src/api/packages/capabilities.ts
+++ b/packages/host/src/api/packages/capabilities.ts
@@ -1,0 +1,20 @@
+/**
+ * GET /api/packages/capabilities
+ *
+ * Per-capability readiness for installed capability packs (content projected
+ * / bins installed / secrets configured) with remediation strings. ONE engine
+ * (src/core/agent-packages/capability-readiness) feeds this, the doctor
+ * check, and the runtime hub's Capabilities tab.
+ */
+import { listCapabilities } from '@/core/agent-packages/capability-readiness'
+
+export async function get(_req: Request, _url: URL): Promise<Response> {
+  try {
+    return Response.json({ capabilities: await listCapabilities() })
+  } catch (err) {
+    return Response.json(
+      { capabilities: [], error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    )
+  }
+}

--- a/packages/host/src/api/packages/install.ts
+++ b/packages/host/src/api/packages/install.ts
@@ -4,9 +4,18 @@
  * Installs a standalone skill-pack / workflow-pack / lesson-pack.
  * Same body shape as /api/agents/install minus `adopt` (only agent
  * packages have a runtime-agent counterpart that adoption attaches to).
+ *
+ * A bare `source` (no github:/path prefix) resolves BY NAME from the curated
+ * catalog (official entries, ref-pinned via sourceWithRef) — the shared
+ * resolution behind `bakin packages install web-search-brave` and the
+ * Explore install button. Successful capability-pack installs carry the
+ * pack's readiness (`capability`) so clients can run the guided key step.
  */
 import { z } from 'zod'
 import { installPackage } from '@/core/agent-packages/installer'
+import { listCapabilities, type CapabilityReadiness } from '@/core/agent-packages/capability-readiness'
+import { loadUnifiedCatalog } from '@/core/curated-catalog/load'
+import { sourceWithRef } from '@/lib/package-source'
 import { createLogger } from '@/core/logger'
 
 const log = createLogger('api:packages:install')
@@ -17,6 +26,22 @@ const InstallBodySchema = z.object({
   replace: z.boolean().optional(),
   installAs: z.string().min(1).optional(),
 })
+
+function isBareName(source: string): boolean {
+  return !source.includes(':') && !source.startsWith('./') && !source.startsWith('../')
+    && !source.startsWith('/') && !source.startsWith('~/')
+}
+
+async function resolveCatalogSource(name: string): Promise<{ source: string } | { error: string }> {
+  const catalog = await loadUnifiedCatalog()
+  const entry = catalog.entries.find(
+    (e) => e.id === name && (e.kind === 'skill-pack' || e.kind === 'workflow-pack' || e.kind === 'lesson-pack'),
+  )
+  if (!entry?.source) {
+    return { error: `No pack named "${name}" in the curated catalog — pass a github:user/repo or local path source.` }
+  }
+  return { source: sourceWithRef(entry.source, entry.ref) }
+}
 
 export async function post(req: Request, _url: URL): Promise<Response> {
   let raw: unknown
@@ -37,9 +62,16 @@ export async function post(req: Request, _url: URL): Promise<Response> {
     )
   }
 
+  let source = parsed.data.source
+  if (isBareName(source)) {
+    const resolved = await resolveCatalogSource(source)
+    if ('error' in resolved) return Response.json({ ok: false, error: resolved.error }, { status: 404 })
+    source = resolved.source
+  }
+
   try {
     const result = await installPackage({
-      source: parsed.data.source,
+      source,
       replace: parsed.data.replace,
       installAs: parsed.data.installAs,
     })
@@ -54,10 +86,18 @@ export async function post(req: Request, _url: URL): Promise<Response> {
         { status: 400 },
       )
     }
-    return Response.json({ ok: true, result })
+    // Capability packs: attach readiness so the client can run the guided
+    // key step and print honest per-leg status.
+    let capability: CapabilityReadiness | undefined
+    try {
+      capability = (await listCapabilities()).find((c) => c.packageId === result.packageId)
+    } catch (err) {
+      log.warn('capability readiness after install failed', { error: err instanceof Error ? err.message : String(err) })
+    }
+    return Response.json({ ok: true, resolvedSource: source, result, ...(capability ? { capability } : {}) })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    log.error('packages/install failed', err as Error, { source: parsed.data.source })
+    log.error('packages/install failed', err as Error, { source })
     const isConflict = /already managed|collision/i.test(message)
     return Response.json({ ok: false, error: message }, { status: isConflict ? 409 : 500 })
   }

--- a/packages/host/src/data/curated-catalog.json
+++ b/packages/host/src/data/curated-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updatedAt": "2026-07-04T00:00:00Z",
+  "updatedAt": "2026-07-13T00:00:00Z",
   "entries": [
     {
       "id": "pixel",
@@ -406,6 +406,33 @@
       ],
       "trust": "official",
       "builtin": true
+    },
+    {
+      "id": "web-search-brave",
+      "kind": "skill-pack",
+      "name": "Web Search (Brave)",
+      "emoji": "🔎",
+      "description": "Give your agents real web search — token-efficient research, docs lookup, and fresh information via the Brave Search API. Bakin installs the CLI and walks you through the free API key.",
+      "category": "Research",
+      "tags": [
+        "capability",
+        "research",
+        "web-search"
+      ],
+      "useCases": [
+        "Research tasks that need current information",
+        "Documentation and troubleshooting lookups",
+        "Grounding agent output in cited sources"
+      ],
+      "source": "github:markhayden/bakin-bits-official#packs/web-search-brave",
+      "ref": null,
+      "trust": "official",
+      "capability": "web-search",
+      "runtimes": [
+        "*"
+      ],
+      "defaultSelected": true,
+      "screenshots": []
     }
   ]
 }

--- a/plugins/explore/components/catalog-card.tsx
+++ b/plugins/explore/components/catalog-card.tsx
@@ -1,7 +1,7 @@
 import { Check, Plus } from 'lucide-react'
 import { AgentAvatar } from '@makinbakin/sdk/components'
 import { Badge } from '@makinbakin/sdk/ui'
-import type { ExploreCatalogEntry } from '../types'
+import { runtimeCompatible, type ExploreCatalogEntry } from '../types'
 
 export function entryStatusBadge(entry: ExploreCatalogEntry): { label: string; tone: 'builtin' | 'installed' | 'update' } | null {
   if (entry.builtin) return { label: 'Built in', tone: 'builtin' }
@@ -43,14 +43,18 @@ export function CatalogCard({
   entry,
   onSelect,
   onInstall,
+  activeAdapter,
 }: {
   entry: ExploreCatalogEntry
   onSelect: (entry: ExploreCatalogEntry) => void
   /** Renders an Install button directly on available cards. */
   onInstall?: (entry: ExploreCatalogEntry) => void
+  /** Active runtime adapter — runtime-tagged entries badge/gate against it. */
+  activeAdapter?: string
 }) {
+  const compatible = runtimeCompatible(entry, activeAdapter)
   const status = entryStatusBadge(entry)
-  const installable = !entry.builtin && !entry.installed && onInstall !== undefined
+  const installable = !entry.builtin && !entry.installed && onInstall !== undefined && compatible
   return (
     <button
       type="button"
@@ -74,6 +78,15 @@ export function CatalogCard({
           <span className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${TONE_CLASSES[status.tone]}`}>
             {status.tone === 'installed' && <Check className="size-3" />}
             {status.label}
+          </span>
+        )}
+        {!compatible && (
+          <span
+            data-testid={`card-incompatible-${entry.id}`}
+            className="flex items-center gap-1 rounded-full border border-border bg-[rgba(255,255,255,0.06)] px-2 py-0.5 text-[11px] text-muted-foreground"
+            title={`Requires runtime: ${(entry.runtimes ?? []).join(', ')}`}
+          >
+            Not for {activeAdapter ?? 'this runtime'}
           </span>
         )}
         {installable && (

--- a/plugins/explore/components/explore-page.tsx
+++ b/plugins/explore/components/explore-page.tsx
@@ -8,10 +8,11 @@ import { DetailDrawer } from './detail-drawer'
 import { InstallDialog } from './install-dialog'
 import type { ExploreCatalogEntry, ExploreCatalogResponse } from '../types'
 
-function tabOf(entry: ExploreCatalogEntry): 'agents' | 'plugins' | 'lessons' | 'packs' {
+function tabOf(entry: ExploreCatalogEntry): 'agents' | 'plugins' | 'lessons' | 'capabilities' | 'packs' {
   if (entry.kind === 'agent') return 'agents'
   if (entry.kind === 'plugin') return 'plugins'
   if (entry.kind === 'lesson-pack') return 'lessons'
+  if (entry.kind === 'skill-pack' && entry.capability) return 'capabilities'
   return 'packs'
 }
 
@@ -37,6 +38,13 @@ const TAB_INTROS: Record<string, { title: string; blurb: string }> = {
     blurb:
       'Lessons teach the agents you already have — domain knowledge, house style, sharper judgment. ' +
       'Install a lesson pack here, then enable individual lessons per agent from their Team page.',
+  },
+  capabilities: {
+    title: 'Teach your agents new tricks',
+    blurb:
+      'Capabilities give your agents real-world powers — web search, browser automation, transcription. ' +
+      'Install one and Bakin handles everything: the skill content, any pinned binaries, and a guided step ' +
+      'for the API key it needs. Works with any runtime unless badged otherwise.',
   },
   packs: {
     title: 'Reusable building blocks',
@@ -126,12 +134,13 @@ function ExplorePageInner() {
   // Lessons are a first-class section even while the catalog has none —
   // the intro/empty state teaches users what lessons are. Skill/workflow
   // packs stay hidden until content exists.
-  const hasPacks = entries.some((entry) => entry.kind === 'skill-pack' || entry.kind === 'workflow-pack')
+  const hasPacks = entries.some((entry) => tabOf(entry) === 'packs')
 
   const tabs = useMemo(() => {
     const base = [
       { id: 'agents', label: 'Agents' },
       { id: 'plugins', label: 'Plugins' },
+      { id: 'capabilities', label: 'Capabilities' },
       { id: 'lessons', label: 'Lessons' },
     ]
     return hasPacks ? [...base, { id: 'packs', label: 'Packs' }] : base
@@ -288,7 +297,8 @@ function ExplorePageInner() {
           icon={Compass}
           title={searchDraft.trim()
             ? 'No matches'
-            : tab === 'lessons' ? 'Lesson packs are coming' : 'Nothing here yet'}
+            : tab === 'lessons' ? 'Lesson packs are coming'
+              : tab === 'capabilities' ? 'Capability packs are coming' : 'Nothing here yet'}
           description={searchDraft.trim()
             ? `Nothing on this tab matches "${searchDraft.trim()}" — try another tab or clear the search.`
             : activeCategories.length > 0
@@ -305,6 +315,7 @@ function ExplorePageInner() {
             <CatalogCard
               key={`${entry.kind}:${entry.id}`}
               entry={entry}
+              activeAdapter={data?.activeAdapter}
               onSelect={(selectedEntry) => setSelectedKey(`${selectedEntry.kind}:${selectedEntry.id}`)}
               onInstall={(installTarget) => {
                 setInstallEntry(installTarget)

--- a/plugins/explore/components/install-dialog.tsx
+++ b/plugins/explore/components/install-dialog.tsx
@@ -25,6 +25,30 @@ import type { ExploreCatalogEntry } from '../types'
 
 type InstallKind = 'agent' | 'plugin' | 'skill-pack' | 'workflow-pack' | 'lesson-pack'
 
+/** Missing, store-backable secrets from a capability-pack install response. */
+interface CapabilityKeyStep {
+  packName: string
+  capability: string
+  secrets: Array<{ name: string; secretSlot: string; help?: string }>
+}
+
+function keyStepFrom(responseBody: {
+  capability?: {
+    name?: string
+    capability?: string
+    secrets?: Array<{ name: string; secretSlot?: string; help?: string; status?: string }>
+  }
+}): CapabilityKeyStep | null {
+  const cap = responseBody.capability
+  if (!cap?.capability) return null
+  const missing = (cap.secrets ?? [])
+    .filter((s): s is { name: string; secretSlot: string; help?: string; status?: string } =>
+      s.status === 'missing' && typeof s.secretSlot === 'string')
+    .map(({ name, secretSlot, help }) => ({ name, secretSlot, help }))
+  if (missing.length === 0) return null
+  return { packName: cap.name ?? cap.capability, capability: cap.capability, secrets: missing }
+}
+
 const KIND_OPTIONS: Array<{ value: InstallKind; label: string }> = [
   { value: 'agent', label: 'Agent' },
   { value: 'plugin', label: 'Plugin' },
@@ -67,6 +91,8 @@ export function InstallDialog({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [consent, setConsent] = useState<ConsentRequest | null>(null)
+  const [keyStep, setKeyStep] = useState<CapabilityKeyStep | null>(null)
+  const [keyDrafts, setKeyDrafts] = useState<Record<string, string>>({})
 
   // Curated entries carry a ref pin — honor it exactly like onboarding does
   // (agent/pack specs embed @ref into the source; plugin installs send ref).
@@ -79,6 +105,8 @@ export function InstallDialog({
       setError(null)
       setConsent(null)
       setSubmitting(false)
+      setKeyStep(null)
+      setKeyDrafts({})
     }
     onOpenChange(nextOpen)
   }
@@ -132,6 +160,7 @@ export function InstallDialog({
         version?: string
         permissions?: string[]
         consentToken?: string
+        capability?: Parameters<typeof keyStepFrom>[0]['capability']
       }
       if (responseBody.awaitingConsent && responseBody.consentToken) {
         setConsent({
@@ -145,6 +174,14 @@ export function InstallDialog({
       }
       if (!res.ok || responseBody.ok === false) {
         setError(responseBody.error ?? `HTTP ${res.status}`)
+        return
+      }
+      // Capability packs with missing store-backable keys get the guided
+      // key step (story 2) — the install itself already succeeded.
+      const needs = keyStepFrom(responseBody)
+      if (needs) {
+        onInstalled()
+        setKeyStep(needs)
         return
       }
       finishSuccess()
@@ -175,6 +212,86 @@ export function InstallDialog({
       accepted: true,
       consentToken: accepted.consentToken,
     })
+  }
+
+  const saveKeys = async () => {
+    if (!keyStep) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      for (const secret of keyStep.secrets) {
+        const value = (keyDrafts[secret.name] ?? '').trim()
+        if (!value) continue
+        const [provider, name] = secret.secretSlot.split('.', 2)
+        const res = await fetch('/api/secrets', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ provider, name, value }),
+        })
+        if (!res.ok) {
+          const body = await res.json().catch(() => null) as { error?: string } | null
+          setError(body?.error ?? `Failed to store ${secret.name}`)
+          return
+        }
+      }
+      finishSuccess()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (keyStep) {
+    return (
+      <Dialog open={open} onOpenChange={close}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{keyStep.packName} is installed — one more step</DialogTitle>
+            <DialogDescription>
+              This capability needs a key to work. Paste it here (stored masked in Bakin,
+              never displayed again) or skip and add it later in Settings → Integrations &amp; Keys.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4" data-testid="capability-key-step">
+            {keyStep.secrets.map((secret) => (
+              <div key={secret.name} className="flex flex-col gap-2">
+                <Label htmlFor={`cap-key-${secret.name}`}>{secret.name}</Label>
+                <Input
+                  id={`cap-key-${secret.name}`}
+                  type="password"
+                  placeholder="Paste key…"
+                  value={keyDrafts[secret.name] ?? ''}
+                  onChange={(e) => setKeyDrafts((d) => ({ ...d, [secret.name]: e.target.value }))}
+                />
+                {secret.help && (
+                  <p className="text-xs text-muted-foreground">
+                    Get one at <a className="underline" href={secret.help} target="_blank" rel="noreferrer">{secret.help}</a>
+                  </p>
+                )}
+              </div>
+            ))}
+            {error && (
+              <div role="alert" className="rounded border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" disabled={submitting} onClick={() => finishSuccess()}>
+              Skip for now
+            </Button>
+            <Button
+              type="button"
+              disabled={submitting || keyStep.secrets.every((s) => !(keyDrafts[s.name] ?? '').trim())}
+              onClick={() => void saveKeys()}
+              data-testid="capability-key-save"
+            >
+              {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Save key
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )
   }
 
   return (

--- a/plugins/explore/index.ts
+++ b/plugins/explore/index.ts
@@ -4,6 +4,7 @@
  * and packs. Discovery only — lifecycle management stays in Team/Health.
  */
 import { z } from 'zod'
+import { getSettings } from '../../src/core/settings'
 import type { BakinPlugin } from '@bakin/core/plugin-types'
 import { definePlugin, defineRoute } from '@bakin/core/routing'
 import { createLogger } from '../../src/core/logger'
@@ -39,6 +40,7 @@ const catalogEntryResponse = z.object({
 })
 
 const catalogResponse = z.object({
+  activeAdapter: z.string(),
   ok: z.literal(true),
   updatedAt: z.string(),
   remoteUpdatedAt: z.string().nullable(),
@@ -124,6 +126,7 @@ async function buildCatalogResponse(check: boolean): Promise<ExploreCatalogRespo
     updatedAt: catalog.updatedAt,
     remoteUpdatedAt: catalog.remoteUpdatedAt,
     entries,
+    activeAdapter: getSettings().runtime.adapter,
     ...(probes ? { probeErrors: probes.probeErrors } : {}),
   }
 }

--- a/plugins/explore/types.ts
+++ b/plugins/explore/types.ts
@@ -18,6 +18,8 @@ export interface ExploreCatalogEntry extends CatalogEntry {
 
 export interface ExploreCatalogResponse {
   ok: true
+  /** Active runtime adapter name — cards badge/gate runtime-specific entries against it. */
+  activeAdapter: string
   /** updatedAt of the embedded catalog. */
   updatedAt: string
   /** updatedAt of the cached remote catalog, when one has been fetched. */
@@ -29,4 +31,10 @@ export interface ExploreCatalogResponse {
    * (unknown), never "up to date".
    */
   probeErrors?: number
+}
+
+/** Runtime-compat: universal ('*') or tagged with the active adapter. */
+export function runtimeCompatible(entry: Pick<ExploreCatalogEntry, 'runtimes'>, activeAdapter: string | undefined): boolean {
+  if (!entry.runtimes || entry.runtimes.includes('*')) return true
+  return activeAdapter !== undefined && entry.runtimes.includes(activeAdapter)
 }

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -25,6 +25,7 @@ import {
   type HealthCheckDef,
 } from '../../src/core/health-check-registry'
 import { checkContentDir } from './lib/system-checks/content-dir'
+import { checkCapabilities } from './lib/system-checks/capabilities'
 import { checkService } from './lib/system-checks/service'
 import { checkRuntime } from './lib/system-checks/runtime'
 import { checkSessionStore } from './lib/system-checks/session-store'
@@ -648,6 +649,11 @@ const healthPlugin: BakinPlugin = definePlugin({
       id: 'content-dir',
       name: 'Content directory location',
       run: () => Promise.resolve(checkContentDir()),
+    })
+    ctx.registerHealthCheck({
+      id: 'capabilities',
+      name: 'Capability-pack readiness',
+      run: () => checkCapabilities(),
     })
     ctx.registerHealthCheck({
       id: 'service',

--- a/plugins/health/lib/system-checks/capabilities.ts
+++ b/plugins/health/lib/system-checks/capabilities.ts
@@ -1,0 +1,31 @@
+/**
+ * System check — capability-pack readiness.
+ *
+ * One finding per installed capability pack: ok when content + bins +
+ * required secrets all stand, warn with the engine's remediation lines
+ * otherwise. Readiness itself comes from the single engine in
+ * src/core/agent-packages/capability-readiness.
+ */
+import { listCapabilities } from '../../../../src/core/agent-packages/capability-readiness'
+import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+
+export async function checkCapabilities(): Promise<HealthCheckResult[]> {
+  const capabilities = await listCapabilities()
+  if (capabilities.length === 0) {
+    return [{
+      check: 'capabilities',
+      status: 'ok',
+      message: 'No capability packs installed — browse Explore → Capabilities to add some.',
+      autoFixable: false,
+    }]
+  }
+  return capabilities.map((cap) => ({
+    check: `capability.${cap.capability}`,
+    status: cap.ready ? 'ok' as const : 'warn' as const,
+    message: cap.ready
+      ? `${cap.name} is ready`
+      : `${cap.name} is not ready: ${cap.missing.join('; ')}`,
+    autoFixable: false,
+    data: { capability: cap.capability, packageId: cap.packageId, ready: cap.ready, missing: cap.missing },
+  }))
+}

--- a/src/cli/commands/onboarding.ts
+++ b/src/cli/commands/onboarding.ts
@@ -122,7 +122,7 @@ export async function cmdOnboardingSettingsInit(options: { json?: boolean } = {}
 }
 
 async function cmdOnboardingCheckSingle(
-  target: 'runtime' | 'search' | 'search-models' | 'llm' | 'channels' | 'plugin-assets' | 'agent-sync' | 'recommended-plugins' | 'recommended-agents',
+  target: 'runtime' | 'search' | 'search-models' | 'llm' | 'channels' | 'plugin-assets' | 'agent-sync' | 'recommended-plugins' | 'recommended-agents' | 'capabilities',
   options: { verbose?: boolean } = {},
 ): Promise<void> {
   const componentMap: Record<string, () => Promise<{ check(): Promise<import('../../core/onboarding/types').CheckResult> }>> = {
@@ -135,6 +135,7 @@ async function cmdOnboardingCheckSingle(
     'agent-sync': async () => (await import('../../core/onboarding/agent-sync')).agentSyncComponent,
     'recommended-plugins': async () => (await import('../../core/onboarding/recommended-plugins')).recommendedPluginsComponent,
     'recommended-agents': async () => (await import('../../core/onboarding/recommended-agents')).recommendedAgentsComponent,
+    'capabilities': async () => (await import('../../core/onboarding/recommended-capabilities')).recommendedCapabilitiesComponent,
   }
   const isTTY = Boolean(process.stdout.isTTY)
   const result = await withTtyRuntimeLogsSilenced({ isTTY, verbose: options.verbose }, async () => {
@@ -178,6 +179,7 @@ async function cmdOnboardingInstallSingle(target: string, args: string[]): Promi
     'agent-sync': async () => (await import('../../core/onboarding/agent-sync')).agentSyncComponent,
     'recommended-plugins': async () => (await import('../../core/onboarding/recommended-plugins')).recommendedPluginsComponent,
     'recommended-agents': async () => (await import('../../core/onboarding/recommended-agents')).recommendedAgentsComponent,
+    'capabilities': async () => (await import('../../core/onboarding/recommended-capabilities')).recommendedCapabilitiesComponent,
   }
   const isTTY = Boolean(process.stdout.isTTY)
   const autoApprove = args.includes('--yes')
@@ -357,15 +359,15 @@ export async function run(args: string[]): Promise<void> {
   } else if (cmd === 'mkdir') {
     await cmdOnboardingMkdir({ json: args.includes('--json') })
   } else if (cmd === 'check') {
-    if (sub === 'runtime' || sub === 'search' || sub === 'search-models' || sub === 'llm' || sub === 'channels' || sub === 'plugin-assets' || sub === 'agent-sync' || sub === 'recommended-plugins' || sub === 'recommended-agents') {
+    if (sub === 'runtime' || sub === 'search' || sub === 'search-models' || sub === 'llm' || sub === 'channels' || sub === 'plugin-assets' || sub === 'agent-sync' || sub === 'recommended-plugins' || sub === 'recommended-agents' || sub === 'capabilities') {
       await cmdOnboardingCheckSingle(sub, { verbose: args.includes('--verbose') })
     } else if (sub === 'all') {
       await cmdOnboardingCheckAll({ verbose: args.includes('--verbose') })
     } else {
-      await exitUnknownSubcommand('check', sub, ['runtime', 'search', 'search-models', 'llm', 'channels', 'plugin-assets', 'agent-sync', 'recommended-plugins', 'recommended-agents', 'all'])
+      await exitUnknownSubcommand('check', sub, ['runtime', 'search', 'search-models', 'llm', 'channels', 'plugin-assets', 'agent-sync', 'recommended-plugins', 'recommended-agents', 'capabilities', 'all'])
     }
   } else if (cmd === 'install') {
-    if (sub === 'search' || sub === 'search-models' || sub === 'plugin-assets' || sub === 'agent-sync' || sub === 'recommended-plugins' || sub === 'recommended-agents') {
+    if (sub === 'search' || sub === 'search-models' || sub === 'plugin-assets' || sub === 'agent-sync' || sub === 'recommended-plugins' || sub === 'recommended-agents' || sub === 'capabilities') {
       await cmdOnboardingInstallSingle(sub, args)
     } else {
       await exitUnknownSubcommand('install', sub, ['search', 'search-models', 'plugin-assets', 'agent-sync', 'recommended-plugins', 'recommended-agents'])

--- a/src/cli/commands/packages.ts
+++ b/src/cli/commands/packages.ts
@@ -6,9 +6,61 @@
  */
 import { apiGet, apiPost, apiDelete } from '../http'
 import { print } from '../output'
-import { exitUsage, exitUnknownSubcommand } from '../help'
+import { exitUsage, exitUnknownSubcommand, promptYesNo } from '../help'
 import { renderInkReport } from '../../core/cli/ui/render-report'
 import { parseAgentsFlags, printPackageActionTui, type AgentsCmdFlags } from './agents'
+
+interface InstallCapabilityInfo {
+  capability: string
+  name: string
+  ready: boolean
+  missing: string[]
+  skills: Array<{ name: string; status: string }>
+  bins: Array<{ name: string; status: string }>
+  secrets: Array<{ name: string; required: boolean; secretSlot?: string; help?: string; status: string }>
+}
+
+function isBareName(source: string): boolean {
+  return !source.includes(':') && !source.startsWith('./') && !source.startsWith('../')
+    && !source.startsWith('/') && !source.startsWith('~/')
+}
+
+function legLine(ok: boolean, label: string): string {
+  return `  ${ok ? '✓' : '⚠'} ${label}`
+}
+
+/** Guided key step (story 3): offer to store each missing secretSlot-backed secret. */
+async function promptMissingSecrets(cap: InstallCapabilityInfo): Promise<boolean> {
+  let storedAny = false
+  for (const secret of cap.secrets) {
+    if (secret.status !== 'missing' || !secret.secretSlot) continue
+    const readline = await import('node:readline/promises')
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+    try {
+      if (secret.help) console.log(`  ${secret.name}: get one at ${secret.help}`)
+      const value = (await rl.question(`  Paste ${secret.name} (Enter to skip): `)).trim()
+      if (!value) continue
+      const [provider, name] = secret.secretSlot.split('.', 2)
+      await apiPost('/api/secrets', { provider, name, value })
+      storedAny = true
+      console.log(`  ✓ stored as ${secret.secretSlot} (Settings → Integrations & Keys)`)
+    } finally {
+      rl.close()
+    }
+  }
+  return storedAny
+}
+
+function printCapabilityStatus(cap: InstallCapabilityInfo): void {
+  console.log(`\nCapability: ${cap.name} (${cap.capability})`)
+  for (const s of cap.skills) console.log(legLine(s.status === 'ok', `skill ${s.name}`))
+  for (const b of cap.bins) console.log(legLine(b.status === 'ok', `binary ${b.name}`))
+  for (const s of cap.secrets) {
+    console.log(legLine(s.status !== 'missing', `${s.name} (${s.status === 'missing' ? 'not configured' : s.status})`))
+  }
+  console.log(cap.ready ? '✓ READY — agents can use this capability now.' : '⚠ Not ready yet:')
+  if (!cap.ready) for (const line of cap.missing) console.log(`  - ${line}`)
+}
 
 async function printPackagesListTui(packages: Array<Record<string, unknown>>): Promise<void> {
   return renderInkReport(() => import('../../core/cli/ui/readonly'), (m) => m.PackagesListReport, { packages })
@@ -37,21 +89,48 @@ async function cmdPackagesList(flags: AgentsCmdFlags): Promise<void> {
   }
 }
 
-async function cmdPackagesInstall(source: string, flags: AgentsCmdFlags): Promise<void> {
+async function cmdPackagesInstall(source: string, flags: AgentsCmdFlags, yes: boolean): Promise<void> {
+  // Consent (story 3): say what installs from where before any write.
+  if (!yes && !flags.json && process.stdout.isTTY) {
+    const origin = isBareName(source) ? `"${source}" from the curated catalog (pinned source)` : source
+    console.log(`This installs ${origin}: skill content projected to the active runtime,`)
+    console.log('plus any pinned binaries into ~/.bakin/bin. Scripts run as agent shell commands.')
+    if (!(await promptYesNo('Proceed? [y/N] '))) {
+      console.log('Aborted — nothing installed.')
+      return
+    }
+  }
   const body: Record<string, unknown> = { source }
   if (flags.installAs) body.installAs = flags.installAs
   if (flags.replace) body.replace = true
-  const result = await apiPost('/api/packages/install', body)
-  if (!flags.json && process.stdout.isTTY) {
-    await printPackageActionTui({
-      action: 'installed',
-      scope: 'package',
-      target: flags.installAs ?? source,
-      result,
-    })
+  const result = await apiPost('/api/packages/install', body) as Record<string, unknown> & {
+    ok?: boolean
+    capability?: InstallCapabilityInfo
+  }
+
+  if (flags.json || !process.stdout.isTTY) {
+    print(result)
     return
   }
-  print(result)
+
+  // Capability packs get the per-leg status + guided key step instead of the
+  // generic TUI card.
+  if (result.ok && result.capability) {
+    printCapabilityStatus(result.capability)
+    if (!result.capability.ready && (await promptMissingSecrets(result.capability))) {
+      const refreshed = await apiGet('/api/packages/capabilities') as { capabilities: InstallCapabilityInfo[] }
+      const cap = refreshed.capabilities.find((c) => c.capability === result.capability!.capability)
+      if (cap) printCapabilityStatus(cap)
+    }
+    return
+  }
+
+  await printPackageActionTui({
+    action: 'installed',
+    scope: 'package',
+    target: flags.installAs ?? source,
+    result,
+  })
 }
 
 async function cmdPackagesRemove(packageId: string, flags: AgentsCmdFlags): Promise<void> {
@@ -90,8 +169,10 @@ async function cmdPackagesSync(packageId: string, flags: AgentsCmdFlags): Promis
 export async function run(args: string[]): Promise<void> {
   const sub = args[1]
   if (sub === 'install') {
-    if (!args[2]) await exitUsage('bakin packages install <path|github:user/repo[@ref][#subpath]> [--install-as <id>] [--replace]')
-    await cmdPackagesInstall(args[2], parseAgentsFlags(args.slice(3)))
+    if (!args[2]) await exitUsage('bakin packages install <name|path|github:user/repo[@ref][#subpath]> [--install-as <id>] [--replace] [--yes]')
+    const rest = args.slice(3)
+    const yes = rest.includes('--yes') || rest.includes('-y')
+    await cmdPackagesInstall(args[2], parseAgentsFlags(rest.filter(a => a !== '--yes' && a !== '-y')), yes)
   } else if (sub === 'list') {
     await cmdPackagesList(parseAgentsFlags(args.slice(2)))
   } else if (sub === 'remove') {

--- a/src/core/agent-packages/bin-installer.ts
+++ b/src/core/agent-packages/bin-installer.ts
@@ -1,0 +1,130 @@
+/**
+ * Pinned binary installer for capability packs.
+ *
+ * Installs `requires.bins[]` declarations from a skill-pack manifest into
+ * Bakin's own bin dir (`getBakinPaths().bin`, on PATH since server boot —
+ * see src/core/secret-env.ts). Modeled on the antfly dependency installer:
+ * download with timeout → sha256 verify against the manifest pin (refuse on
+ * mismatch) → chmod 0755 → verify-then-commit (run `verifyArgs` against the
+ * temp file BEFORE it reaches the target name) → atomic rename. A binary
+ * whose on-disk sha already matches the pin is skipped — idempotent installs
+ * and shared bins across packs come free.
+ *
+ * The caller records the returned target as a `bin` lockfile projection, so
+ * rollback/uninstall ride the standard projection lifecycle.
+ */
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { createHash } from 'crypto'
+import { join } from 'path'
+import type { BinPlatformKey, BinRequirement } from '../../../packages/core/src/agent-packages/manifest'
+import { writeInstalledBy, type InstalledByMarker } from '../../../packages/core/src/agent-packages/markers'
+import { getBakinPaths } from '@/core/content-dir'
+import { createLogger } from '@/core/logger'
+
+const log = createLogger('bin-installer')
+const execFileAsync = promisify(execFile)
+
+const DOWNLOAD_TIMEOUT_MS = 120_000
+const VERIFY_TIMEOUT_MS = 15_000
+
+/** Map this process's platform/arch onto a manifest platform key. */
+export function binPlatformKey(): BinPlatformKey | null {
+  const os = process.platform === 'darwin' ? 'darwin' : process.platform === 'linux' ? 'linux' : null
+  const arch = process.arch === 'arm64' ? 'arm64' : process.arch === 'x64' ? 'x64' : null
+  if (!os || !arch) return null
+  return `${os}-${arch}` as BinPlatformKey
+}
+
+export interface BinInstallResult {
+  /** Absolute path of the installed binary inside the Bakin bin dir. */
+  target: string
+  /** sha256 of the installed bytes (== the manifest pin). */
+  sha256: string
+  /** True when the on-disk binary already matched the pin — nothing downloaded. */
+  skipped: boolean
+}
+
+export interface BinInstallOptions {
+  /**
+   * Fetch implementation. Tests pass Bun.fetch — the happy-dom preload's
+   * global fetch cannot drive real sockets.
+   */
+  fetchImpl?: typeof fetch
+}
+
+export async function installBinRequirement(
+  bin: BinRequirement,
+  installedBy: Omit<InstalledByMarker, 'sha256'>,
+  options: BinInstallOptions = {},
+): Promise<BinInstallResult> {
+  const platform = binPlatformKey()
+  const download = platform ? bin.install[platform] : undefined
+  if (!download) {
+    throw new Error(
+      `Binary "${bin.name}" has no download for this platform (${platform ?? `${process.platform}-${process.arch}`}) — `
+      + `declared: ${Object.keys(bin.install).join(', ')}`,
+    )
+  }
+
+  const binDir = getBakinPaths().bin
+  mkdirSync(binDir, { recursive: true })
+  const target = join(binDir, bin.name)
+  const pin = download.sha256.toLowerCase()
+
+  // Idempotent / shared-bin fast path: bytes already match the pin.
+  if (existsSync(target)) {
+    const existing = createHash('sha256').update(readFileSync(target)).digest('hex')
+    if (existing === pin) {
+      log.info(`Binary "${bin.name}" already installed at pinned sha — skipping download`)
+      writeInstalledBy(target, { ...installedBy, sha256: pin })
+      return { target, sha256: pin, skipped: true }
+    }
+  }
+
+  // Default to Bun's NATIVE fetch: the server always runs under Bun, and the
+  // test preload's happy-dom fetch cannot drive real sockets (CLAUDE.md).
+  const fetchImpl = options.fetchImpl
+    ?? (Bun as unknown as { fetch?: typeof fetch }).fetch
+    ?? fetch
+  const res = await fetchImpl(download.url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) })
+  if (!res.ok) {
+    throw new Error(`Binary "${bin.name}" download failed: ${res.status} ${res.statusText} (${download.url})`)
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer())
+
+  const actual = createHash('sha256').update(bytes).digest('hex')
+  if (actual !== pin) {
+    throw new Error(
+      `Binary "${bin.name}" checksum mismatch: expected ${pin}, got ${actual} — refusing to install (${download.url})`,
+    )
+  }
+
+  const tmp = `${target}.tmp-${process.pid}`
+  try {
+    writeFileSync(tmp, bytes, { mode: 0o755 })
+    chmodSync(tmp, 0o755)
+
+    // Verify-then-commit: the binary must actually run BEFORE it lands under
+    // its real name (a broken download must never shadow a working install).
+    if (bin.verifyArgs) {
+      try {
+        await execFileAsync(tmp, bin.verifyArgs, { timeout: VERIFY_TIMEOUT_MS })
+      } catch (err) {
+        throw new Error(
+          `Binary "${bin.name}" verify run failed (${bin.verifyArgs.join(' ')}): ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    }
+
+    renameSync(tmp, target)
+  } catch (err) {
+    try { rmSync(tmp, { force: true }) } catch { /* best-effort tmp cleanup */ }
+    throw err
+  }
+
+  writeInstalledBy(target, { ...installedBy, sha256: pin })
+  log.info(`Installed binary "${bin.name}" ${bin.version} → ${target}`)
+  return { target, sha256: pin, skipped: false }
+}

--- a/src/core/agent-packages/capability-readiness.ts
+++ b/src/core/agent-packages/capability-readiness.ts
@@ -19,7 +19,7 @@ import { safeParseManifest, type SkillPackManifest } from '../../../packages/cor
 import { getPackageSourceDir } from '../../../packages/core/src/agent-packages/package-paths'
 import { getStoredSecret } from '@bakin/core/media'
 import { getContentDir, getBakinPaths } from '@/core/content-dir'
-import { getAppServices } from '@/core/app-services'
+import { createAppServices, maybeGetAppServices } from '@/core/app-services'
 import { createLogger } from '@/core/logger'
 import { binPlatformKey } from './bin-installer'
 
@@ -75,7 +75,9 @@ function readInstalledManifest(kind: string, id: string, version: string): Skill
 /** Readiness for every installed capability pack (lockfile-driven). */
 export async function listCapabilities(): Promise<CapabilityReadiness[]> {
   const lock = readLockfile()
-  const runtime = getAppServices().runtime
+  // Standalone CLI checks (`bakin check capabilities`) run without a booted
+  // server — create services on demand, same pattern as the credential checks.
+  const runtime = (maybeGetAppServices() ?? (await createAppServices())).runtime
   const binDir = getBakinPaths().bin
   const platform = binPlatformKey()
   const out: CapabilityReadiness[] = []

--- a/src/core/agent-packages/capability-readiness.ts
+++ b/src/core/agent-packages/capability-readiness.ts
@@ -1,0 +1,142 @@
+/**
+ * Capability readiness — ONE engine behind every surface that answers
+ * "can agents actually use this capability right now?": the REST endpoint
+ * (`GET /api/packages/capabilities`), the doctor check, the onboarding
+ * component, and the runtime hub's Capabilities tab.
+ *
+ * A capability pack is ready when all three legs stand:
+ *   content — its skills are projected where the active runtime reads them
+ *   bins    — every declared binary is installed in the Bakin bin dir
+ *   secrets — every REQUIRED declared env var is set (env) or backed by a
+ *             stored secret (store; injected at boot)
+ * Anything else is an honest per-leg `missing` with a remediation string —
+ * never a silent failure.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { readLockfile } from '../../../packages/core/src/agent-packages/lockfile'
+import { safeParseManifest, type SkillPackManifest } from '../../../packages/core/src/agent-packages/manifest'
+import { getPackageSourceDir } from '../../../packages/core/src/agent-packages/package-paths'
+import { getStoredSecret } from '@bakin/core/media'
+import { getContentDir, getBakinPaths } from '@/core/content-dir'
+import { getAppServices } from '@/core/app-services'
+import { createLogger } from '@/core/logger'
+import { binPlatformKey } from './bin-installer'
+
+const log = createLogger('capability-readiness')
+
+export interface CapabilitySkillStatus {
+  name: string
+  status: 'ok' | 'missing'
+}
+
+export interface CapabilityBinStatus {
+  name: string
+  status: 'ok' | 'missing' | 'unsupported-platform'
+}
+
+export interface CapabilitySecretStatus {
+  name: string
+  required: boolean
+  secretSlot?: string
+  help?: string
+  status: 'env' | 'store' | 'missing'
+}
+
+export interface CapabilityReadiness {
+  capability: string
+  packageId: string
+  version: string
+  name: string
+  skills: CapabilitySkillStatus[]
+  bins: CapabilityBinStatus[]
+  secrets: CapabilitySecretStatus[]
+  ready: boolean
+  /** Human remediation lines for every non-ok leg (empty when ready). */
+  missing: string[]
+}
+
+const GLOBAL_SKILL_TARGET = 'runtime:global-skill:'
+
+function readInstalledManifest(kind: string, id: string, version: string): SkillPackManifest | null {
+  const dir = getPackageSourceDir(getContentDir(), kind as never, id, version)
+  const path = join(dir, 'bakin-package.json')
+  if (!existsSync(path)) return null
+  try {
+    const parsed = safeParseManifest(JSON.parse(readFileSync(path, 'utf-8')))
+    if (!parsed.success || parsed.data.kind !== 'skill-pack') return null
+    return parsed.data
+  } catch (err) {
+    log.warn(`Unreadable installed manifest for ${id}@${version}`, { error: err instanceof Error ? err.message : String(err) })
+    return null
+  }
+}
+
+/** Readiness for every installed capability pack (lockfile-driven). */
+export async function listCapabilities(): Promise<CapabilityReadiness[]> {
+  const lock = readLockfile()
+  const runtime = getAppServices().runtime
+  const binDir = getBakinPaths().bin
+  const platform = binPlatformKey()
+  const out: CapabilityReadiness[] = []
+
+  for (const [key, entry] of Object.entries(lock.packages)) {
+    if (entry.kind !== 'skill-pack') continue
+    const id = key.includes('@') ? key.slice(0, key.lastIndexOf('@')) : key
+    const manifest = readInstalledManifest(entry.kind, id, entry.version)
+    if (!manifest?.capability) continue
+
+    const missing: string[] = []
+
+    const skillNames = (entry.projections ?? [])
+      .filter((p) => p.kind === 'skill' && p.target.startsWith(GLOBAL_SKILL_TARGET))
+      .map((p) => p.target.slice(GLOBAL_SKILL_TARGET.length))
+    const skills: CapabilitySkillStatus[] = []
+    for (const name of skillNames) {
+      const present = (await runtime.skills.get(name)) !== null
+      skills.push({ name, status: present ? 'ok' : 'missing' })
+      if (!present) missing.push(`skill "${name}" is not projected — run: bakin packages sync ${key}`)
+    }
+
+    const bins: CapabilityBinStatus[] = []
+    for (const bin of manifest.requires?.bins ?? []) {
+      if (!platform || !bin.install[platform]) {
+        bins.push({ name: bin.name, status: 'unsupported-platform' })
+        missing.push(`binary "${bin.name}" has no build for this platform`)
+        continue
+      }
+      const present = existsSync(join(binDir, bin.name))
+      bins.push({ name: bin.name, status: present ? 'ok' : 'missing' })
+      if (!present) missing.push(`binary "${bin.name}" is missing — reinstall: bakin packages install ${id}`)
+    }
+
+    const secrets: CapabilitySecretStatus[] = []
+    for (const secret of manifest.secrets ?? []) {
+      let status: CapabilitySecretStatus['status'] = 'missing'
+      if (process.env[secret.name]) {
+        status = 'env'
+      } else if (secret.secretSlot) {
+        const [provider, name] = secret.secretSlot.split('.', 2)
+        if (provider && name && getStoredSecret(provider, name)) status = 'store'
+      }
+      secrets.push({ name: secret.name, required: secret.required, secretSlot: secret.secretSlot, help: secret.help, status })
+      if (status === 'missing' && secret.required) {
+        missing.push(`${secret.name} is not configured — add it in Settings → Integrations & Keys${secret.help ? ` (get one: ${secret.help})` : ''}`)
+      }
+    }
+
+    out.push({
+      capability: manifest.capability,
+      packageId: id,
+      version: entry.version,
+      name: manifest.name,
+      skills,
+      bins,
+      secrets,
+      ready: missing.length === 0,
+      missing,
+    })
+  }
+
+  return out.sort((a, b) => a.capability.localeCompare(b.capability))
+}

--- a/src/core/agent-packages/installer.ts
+++ b/src/core/agent-packages/installer.ts
@@ -68,6 +68,26 @@ import { getAppServices } from '../app-services'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { validatePackageContributionIntegrity } from './package-integrity'
+import { installBinRequirement } from './bin-installer'
+import type { InstalledByMarker } from '../../../packages/core/src/agent-packages/markers'
+
+/**
+ * Install a skill-pack's declared binaries (capability packs). Recorded as
+ * `bin` projections on the pack's result so rollback and uninstall ride the
+ * standard projection lifecycle; the uninstaller keeps bins other installed
+ * packages still project.
+ */
+async function installManifestBins(
+  manifest: Manifest,
+  installedBy: Omit<InstalledByMarker, 'sha256'>,
+  result: ProjectorResult,
+): Promise<void> {
+  if (manifest.kind !== 'skill-pack' || !manifest.requires?.bins?.length) return
+  for (const bin of manifest.requires.bins) {
+    const installed = await installBinRequirement(bin, installedBy)
+    result.projections.push({ kind: 'bin', target: installed.target, sha256: installed.sha256 })
+  }
+}
 
 const log = createLogger('agent-pkg:install')
 
@@ -386,6 +406,13 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
         },
       })
       projected.push({ resolvedId: dep.resolvedId, result })
+      await installManifestBins(dep.manifest, {
+        package: dep.resolvedId,
+        version: dep.manifest.version,
+        ref: dep.spec.ref,
+        commitSha: dep.fetched.commitSha,
+        installedAt: new Date().toISOString(),
+      }, result)
     }
 
     // ─── 7. Project the parent package ─────────────────────────────────────
@@ -404,6 +431,13 @@ export async function installPackage(options: InstallOptions): Promise<InstallRe
       },
     })
     projected.push({ resolvedId: resolvedTopId, result: parentResult })
+    await installManifestBins(manifest, {
+      package: resolvedTopId,
+      version: manifest.version,
+      ref: topFetched.ref,
+      commitSha: topFetched.commitSha,
+      installedAt: new Date().toISOString(),
+    }, parentResult)
 
     // ─── 8. Create runtime agent for kind:"agent" + fresh ────────────────
     if (manifest.kind === 'agent' && mode === 'fresh') {

--- a/src/core/agent-packages/uninstaller.ts
+++ b/src/core/agent-packages/uninstaller.ts
@@ -67,6 +67,26 @@ export interface RemoveResult {
 }
 
 /**
+ * Drop `bin` projections whose target another installed package (any key
+ * except `selfKey`) still projects — shared binaries survive until their
+ * LAST referencing package is removed. All other projections pass through.
+ */
+function withoutSharedBins(
+  lock: ReturnType<typeof readLockfile>,
+  selfKey: string,
+  projections: NonNullable<ReturnType<typeof readLockfile>['packages'][string]['projections']>,
+): typeof projections {
+  const otherBinTargets = new Set<string>()
+  for (const [key, pkg] of Object.entries(lock.packages)) {
+    if (key === selfKey) continue
+    for (const p of pkg.projections ?? []) {
+      if (p.kind === 'bin') otherBinTargets.add(p.target)
+    }
+  }
+  return projections.filter((p) => p.kind !== 'bin' || !otherBinTargets.has(p.target))
+}
+
+/**
  * Remove a package + its orphaned dependencies.
  */
 export async function removePackageById(options: RemoveOptions): Promise<RemoveResult> {
@@ -88,7 +108,7 @@ export async function removePackageById(options: RemoveOptions): Promise<RemoveR
 
     // 1. Unproject parent
     if (entry.projections && entry.projections.length > 0) {
-      await unprojectPackage(entry.projections, { keepBlocks: options.keepBlocks })
+      await unprojectPackage(withoutSharedBins(lock, options.packageId, entry.projections), { keepBlocks: options.keepBlocks })
     }
 
     // 2. Remove the install dir under ~/.bakin/packages/<kind>s/<id>@<ver>/
@@ -124,7 +144,7 @@ export async function removePackageById(options: RemoveOptions): Promise<RemoveR
           // Orphaned — unproject + remove install dir + recurse into its
           // own deps before dropping the lockfile entry.
           if (depEntry.projections && depEntry.projections.length > 0) {
-            await unprojectPackage(depEntry.projections, { keepBlocks: options.keepBlocks })
+            await unprojectPackage(withoutSharedBins(l, depKey, depEntry.projections), { keepBlocks: options.keepBlocks })
           }
           const depInstallDir = getPackageSourceDir(
             getContentDir(),

--- a/src/core/curated-catalog/load.ts
+++ b/src/core/curated-catalog/load.ts
@@ -12,6 +12,7 @@
  * degradation logs loudly. The shipped file itself is CI-gated by
  * tests/core/curated-catalog.test.ts.
  */
+import { readFileSync } from 'fs'
 import curatedCatalogJson from '../../../packages/host/src/data/curated-catalog.json'
 import { EMBEDDED_ASSETS } from '../../../packages/host/src/api/_embedded-assets'
 import { createLogger } from '../logger'
@@ -34,13 +35,33 @@ function describeIssues(error: { issues: Array<{ path: PropertyKey[]; message: s
 }
 
 /**
+ * Normalize the static JSON import. Bun caches modules by PATH, not by
+ * import attributes: when `_embedded-assets-static.ts` (evaluated first in
+ * server.ts) imports this same file `with { type: 'file' }`, our plain JSON
+ * import resolves to that cached module — a file-path STRING, not parsed
+ * JSON — and every source-run server silently degraded the static catalog
+ * to empty. Detect the string form and read/parse the file ourselves (works
+ * identically for the compiled binary's embedded $bunfs path). Pinned by
+ * tests/core/curated-catalog-import-collision.test.ts.
+ */
+function shippedCatalogRaw(): unknown {
+  if (typeof curatedCatalogJson !== 'string') return curatedCatalogJson
+  try {
+    return JSON.parse(readFileSync(curatedCatalogJson, 'utf-8')) as unknown
+  } catch (err) {
+    log().error('failed to read shipped catalog through file-typed module', err instanceof Error ? err : undefined)
+    return null
+  }
+}
+
+/**
  * Synchronous parse of the statically imported shipped catalog. Never throws:
  * module-load consumers (RECOMMENDED_AGENTS/RECOMMENDED_PLUGINS) must not
  * crash server startup or the CLI on a bad catalog edit — they degrade to an
  * empty list with a loud log, and CI pins validity of the shipped file.
  */
 export function staticCuratedCatalog(): CatalogFile {
-  const parsed = CatalogFileSchema.safeParse(curatedCatalogJson)
+  const parsed = CatalogFileSchema.safeParse(shippedCatalogRaw())
   if (!parsed.success) {
     log().error('shipped curated-catalog.json failed schema validation — catalog degraded to empty', undefined, {
       issues: describeIssues(parsed.error),
@@ -90,5 +111,5 @@ export async function loadCatalogFile(staticCatalogJson: unknown): Promise<Catal
 }
 
 export async function loadUnifiedCatalog(): Promise<CatalogFile> {
-  return loadCatalogFile(curatedCatalogJson)
+  return loadCatalogFile(shippedCatalogRaw())
 }

--- a/src/core/curated-catalog/schema.ts
+++ b/src/core/curated-catalog/schema.ts
@@ -44,6 +44,23 @@ export const CatalogEntrySchema = z
     dependencies: z.array(z.string()).default([]),
     /** Pre-selected during onboarding recommendation flows. */
     defaultSelected: z.boolean().default(false),
+    /**
+     * Capability slug for capability packs (skill-packs that teach agents a
+     * named capability, e.g. `web-search`). Drives the Explore Capabilities
+     * shelf facet and per-capability readiness.
+     */
+    capability: z
+      .string()
+      .regex(/^[a-z0-9][a-z0-9-]{0,39}$/)
+      .optional(),
+    /**
+     * Runtime compatibility tags: `['*']` or adapter slugs (`pi`,
+     * `openclaw`). Explore filters/badges against the ACTIVE runtime.
+     */
+    runtimes: z
+      .array(z.string().regex(/^(\*|[a-z0-9][a-z0-9-]{0,31})$/))
+      .min(1)
+      .default(['*']),
     iconUrl: z.string().optional(),
     /**
      * Gallery image URLs (screenshots, promo art) rendered in the Explore

--- a/src/core/onboarding/index.ts
+++ b/src/core/onboarding/index.ts
@@ -53,6 +53,7 @@ import { llmComponent, channelsComponent } from './credentials'
 import { budgetComponent } from './budget'
 import { recommendedPluginsComponent } from './recommended-plugins'
 import { recommendedAgentsComponent } from './recommended-agents'
+import { recommendedCapabilitiesComponent } from './recommended-capabilities'
 import { saveState, clearMarker } from './state'
 import type { CheckResult, OnboardingComponent, OnboardingOptions } from './types'
 import type { ComponentStatus } from './state'
@@ -96,6 +97,7 @@ export const COMPONENT_ORDER: readonly OnboardingComponent[] = [
   channelsComponent,
   recommendedPluginsComponent,
   recommendedAgentsComponent,
+  recommendedCapabilitiesComponent,
 ] as const
 
 /**

--- a/src/core/onboarding/recommended-capabilities.ts
+++ b/src/core/onboarding/recommended-capabilities.ts
@@ -1,0 +1,156 @@
+/**
+ * Onboarding component: capability packs ("teach your agents new tricks").
+ *
+ * check() — two honest angles in one component:
+ *   - installed capability packs that are NOT ready (missing bin/key/content)
+ *     via the single readiness engine → status 'missing' with remediation
+ *   - official catalog capability packs not installed yet → recommendations
+ * install() — installs the selected (or defaultSelected under --yes)
+ * catalog capability packs through the standard installer. Key entry is NOT
+ * part of install: onboarding never stalls on a secret — readiness output
+ * points at Settings → Integrations & Keys (story 1 escape hatch).
+ */
+import { readLockfile } from '../../../packages/core/src/agent-packages/lockfile'
+import { installPackage } from '../agent-packages/installer'
+import { listCapabilities } from '../agent-packages/capability-readiness'
+import { loadUnifiedCatalog } from '../curated-catalog/load'
+import { sourceWithRef } from '../../lib/package-source'
+import type { CatalogEntry } from '../curated-catalog/schema'
+import type { CheckResult, InstallResult, OnboardingComponent, OnboardingOptions } from './types'
+
+export interface RecommendedCapability {
+  id: string
+  name: string
+  description: string
+  capability: string
+  source: string
+  ref: string | null
+  defaultSelected: boolean
+}
+
+function normalizeCatalog(entries: readonly CatalogEntry[]): RecommendedCapability[] {
+  return entries
+    .filter((e) => e.kind === 'skill-pack' && e.capability !== undefined && !e.builtin && e.trust === 'official' && e.source !== undefined)
+    .map((e) => ({
+      id: e.id,
+      name: e.name,
+      description: e.description,
+      capability: e.capability!,
+      source: e.source!,
+      ref: e.ref,
+      defaultSelected: e.defaultSelected,
+    }))
+}
+
+function installedPackIds(): Set<string> {
+  const installed = new Set<string>()
+  for (const [key, entry] of Object.entries(readLockfile().packages)) {
+    if (entry.kind !== 'skill-pack') continue
+    installed.add(key.includes('@') ? key.slice(0, key.lastIndexOf('@')) : key)
+  }
+  return installed
+}
+
+async function candidates(): Promise<RecommendedCapability[]> {
+  const installed = installedPackIds()
+  return normalizeCatalog((await loadUnifiedCatalog()).entries).filter((c) => !installed.has(c.id))
+}
+
+async function check(): Promise<CheckResult> {
+  try {
+    const readiness = await listCapabilities()
+    const notReady = readiness.filter((c) => !c.ready)
+    const missing = await candidates()
+
+    if (notReady.length === 0 && missing.length === 0) {
+      return {
+        name: 'capabilities',
+        status: 'ok',
+        message: readiness.length === 0
+          ? 'No capability packs installed (browse Explore → Capabilities)'
+          : `${readiness.length} capability pack${readiness.length === 1 ? ' is' : 's are'} ready`,
+        details: { ready: readiness.map((c) => c.capability), recommended: [] },
+      }
+    }
+
+    const parts: string[] = []
+    if (notReady.length > 0) parts.push(`${notReady.length} installed capabilit${notReady.length === 1 ? 'y is' : 'ies are'} not ready`)
+    if (missing.length > 0) parts.push(`${missing.length} recommended capability pack${missing.length === 1 ? '' : 's'} not installed`)
+    return {
+      name: 'capabilities',
+      status: 'missing',
+      message: parts.join('; '),
+      remediation: notReady.length > 0
+        ? notReady.flatMap((c) => c.missing).join('; ')
+        : 'Install with `bakin packages install <name>` or from Explore → Capabilities.',
+      details: {
+        notReady: notReady.map((c) => ({ capability: c.capability, packageId: c.packageId, missing: c.missing })),
+        recommended: missing.map((c) => ({ id: c.id, name: c.name, capability: c.capability, defaultSelected: c.defaultSelected })),
+      },
+    }
+  } catch (err) {
+    return {
+      name: 'capabilities',
+      status: 'error',
+      message: `Failed to inspect capabilities: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+}
+
+async function install(opts: OnboardingOptions): Promise<InstallResult> {
+  const start = Date.now()
+  let missing: RecommendedCapability[]
+  try {
+    missing = await candidates()
+  } catch (err) {
+    return {
+      name: 'capabilities',
+      status: 'failed',
+      message: `Failed to inspect capability packs: ${err instanceof Error ? err.message : String(err)}`,
+      durationMs: Date.now() - start,
+    }
+  }
+
+  const selected = opts.autoApprove ? missing.filter((c) => c.defaultSelected) : []
+  if (selected.length === 0) {
+    return {
+      name: 'capabilities',
+      status: missing.length === 0 ? 'noop' : 'skipped',
+      message: missing.length === 0
+        ? 'Recommended capability packs are already installed'
+        : 'No capability packs selected',
+      durationMs: Date.now() - start,
+    }
+  }
+
+  const installed: string[] = []
+  const failures: string[] = []
+  for (const cap of selected) {
+    try {
+      opts.onProgress?.(`Installing capability pack ${cap.id}`)
+      await installPackage({ source: sourceWithRef(cap.source, cap.ref), installAs: cap.id })
+      installed.push(cap.id)
+    } catch (err) {
+      failures.push(`${cap.id}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  const needsKeys = (await listCapabilities()).filter((c) => !c.ready)
+  const keyNote = needsKeys.length > 0
+    ? ` — ${needsKeys.length} need${needsKeys.length === 1 ? 's' : ''} configuration (Settings → Integrations & Keys)`
+    : ''
+  return {
+    name: 'capabilities',
+    status: failures.length > 0 ? 'failed' : 'installed',
+    message: failures.length > 0
+      ? `Installed ${installed.length}, failed: ${failures.join('; ')}`
+      : `Installed ${installed.join(', ')}${keyNote}`,
+    durationMs: Date.now() - start,
+  }
+}
+
+export const recommendedCapabilitiesComponent: OnboardingComponent = {
+  name: 'capabilities',
+  check,
+  install,
+}

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -47,6 +47,7 @@ import * as execToolsRoute from '../../../packages/host/src/api/exec-tools/[tool
 import * as packagesListRoute from '../../../packages/host/src/api/packages/list'
 import * as packagesInstallRoute from '../../../packages/host/src/api/packages/install'
 import * as packagesDynamicRoute from '../../../packages/host/src/api/packages/dynamic'
+import * as packagesCapabilitiesRoute from '../../../packages/host/src/api/packages/capabilities'
 import * as pluginsMemoryAuditRoute from '../../../packages/host/src/api/plugins/memory/audit'
 import * as pluginsMemoryWorkspaceRoute from '../../../packages/host/src/api/plugins/memory/workspace'
 import * as stateRoute from '../../../packages/host/src/api/state'
@@ -403,6 +404,10 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
     }
     if (url.pathname === '/api/packages/install' && req.method === 'POST') {
       dispatchWebHandler(req, res, packagesInstallRoute.post)
+      return
+    }
+    if (url.pathname === '/api/packages/capabilities' && req.method === 'GET') {
+      dispatchWebHandler(req, res, packagesCapabilitiesRoute.get)
       return
     }
     if (url.pathname.startsWith('/api/packages/') && url.pathname !== '/api/packages/install') {

--- a/tests/agent-packages/bin-installer.test.ts
+++ b/tests/agent-packages/bin-installer.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Pinned binary installer (capability packs, T2.2).
+ *
+ * Real-HTTP tests over a local Bun.serve fixture (per CLAUDE.md: real
+ * sockets need Bun.fetch — the happy-dom fetch replacement breaks them).
+ */
+import { afterAll, beforeAll, beforeEach, afterEach, describe, expect, it, mock } from 'bun:test'
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
+import { createHash } from 'crypto'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-bin-installer-${Date.now()}-${Math.random().toString(16).slice(2)}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+import { binPlatformKey, installBinRequirement } from '../../src/core/agent-packages/bin-installer'
+import type { BinRequirement } from '../../packages/core/src/agent-packages/manifest'
+
+// A real executable: POSIX sh script. --version exits 0; anything else exits 1.
+const GOOD_SCRIPT = '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "fixture 1.0.0"; exit 0; fi\nexit 1\n'
+const BAD_VERIFY_SCRIPT = '#!/bin/sh\nexit 1\n'
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex')
+
+// The happy-dom preload replaces global Response with a DOM emulation
+// Bun.serve rejects — recover the NATIVE Response class (fake-provider.ts
+// precedent) and use Bun's native fetch for real sockets.
+const nativeFetch = (Bun as unknown as { fetch: typeof fetch }).fetch
+const NativeResponse = (await nativeFetch('data:text/plain,x')).constructor as typeof Response
+// The repo's hand-rolled Bun namespace (bun-env.d.ts) doesn't declare serve —
+// cast per the fake-provider.ts precedent.
+const bunServe = (Bun as unknown as {
+  serve: (opts: { port: number; fetch: (req: Request) => Response }) => { port: number; stop: (force?: boolean) => void }
+}).serve
+
+let server: { port: number; stop: (force?: boolean) => void }
+let hits: Record<string, number> = {}
+
+beforeAll(() => {
+  server = bunServe({
+    port: 0,
+    fetch(req: Request) {
+      const path = new URL(req.url).pathname
+      hits[path] = (hits[path] ?? 0) + 1
+      if (path === '/good') return new NativeResponse(GOOD_SCRIPT)
+      if (path === '/bad-verify') return new NativeResponse(BAD_VERIFY_SCRIPT)
+      if (path === '/missing') return new NativeResponse('nope', { status: 404 })
+      return new NativeResponse('?', { status: 500 })
+    },
+  })
+})
+
+afterAll(() => {
+  server.stop(true)
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+beforeEach(() => {
+  hits = {}
+  rmSync(join(testDir, 'bin'), { recursive: true, force: true })
+})
+afterEach(() => {
+  rmSync(join(testDir, 'bin'), { recursive: true, force: true })
+})
+
+const key = binPlatformKey()
+if (!key) throw new Error('unsupported test platform')
+
+function req(urlPath: string, sha: string, over: Partial<BinRequirement> = {}): BinRequirement {
+  return {
+    name: 'fixturebin',
+    version: '1.0.0',
+    install: { [key!]: { url: `http://127.0.0.1:${server.port}${urlPath}`, sha256: sha } },
+    verifyArgs: ['--version'],
+    ...over,
+  }
+}
+
+const marker = { package: 'test-pack', version: '1.0.0', ref: 'main', commitSha: 'x'.repeat(40), installedAt: new Date().toISOString() }
+
+describe('binPlatformKey', () => {
+  it('maps this platform to a known key', () => {
+    expect(['darwin-arm64', 'darwin-x64', 'linux-x64', 'linux-arm64']).toContain(key!)
+  })
+})
+
+describe('installBinRequirement', () => {
+  it('downloads, verifies checksum + run, and commits 0755 with sidecar', async () => {
+    const result = await installBinRequirement(req('/good', sha256(GOOD_SCRIPT)), marker, { fetchImpl: nativeFetch })
+    expect(result.skipped).toBe(false)
+    const target = join(testDir, 'bin', 'fixturebin')
+    expect(result.target).toBe(target)
+    expect(existsSync(target)).toBe(true)
+    expect(statSync(target).mode & 0o777).toBe(0o755)
+    expect(readFileSync(target, 'utf-8')).toBe(GOOD_SCRIPT)
+    expect(existsSync(`${target}.installedBy`)).toBe(true)
+  })
+
+  it('refuses a checksum mismatch and leaves nothing behind', async () => {
+    await expect(installBinRequirement(req('/good', sha256('tampered')), marker, { fetchImpl: nativeFetch }))
+      .rejects.toThrow(/checksum/i)
+    expect(existsSync(join(testDir, 'bin', 'fixturebin'))).toBe(false)
+  })
+
+  it('refuses when the verify run fails and leaves nothing behind', async () => {
+    await expect(installBinRequirement(req('/bad-verify', sha256(BAD_VERIFY_SCRIPT)), marker, { fetchImpl: nativeFetch }))
+      .rejects.toThrow(/verify/i)
+    expect(existsSync(join(testDir, 'bin', 'fixturebin'))).toBe(false)
+  })
+
+  it('fails honestly on a 404 download', async () => {
+    await expect(installBinRequirement(req('/missing', sha256('x')), marker, { fetchImpl: nativeFetch }))
+      .rejects.toThrow(/404|download/i)
+  })
+
+  it('skips (no re-download) when the installed file already matches the pin', async () => {
+    mkdirSync(join(testDir, 'bin'), { recursive: true })
+    writeFileSync(join(testDir, 'bin', 'fixturebin'), GOOD_SCRIPT)
+    chmodSync(join(testDir, 'bin', 'fixturebin'), 0o755)
+
+    const result = await installBinRequirement(req('/good', sha256(GOOD_SCRIPT)), marker, { fetchImpl: nativeFetch })
+    expect(result.skipped).toBe(true)
+    expect(hits['/good'] ?? 0).toBe(0)
+  })
+
+  it('rejects when the manifest has no download for this platform', async () => {
+    const other = key === 'linux-x64' ? 'darwin-arm64' : 'linux-x64'
+    const bin: BinRequirement = {
+      name: 'fixturebin',
+      version: '1.0.0',
+      install: { [other]: { url: `http://127.0.0.1:${server.port}/good`, sha256: sha256(GOOD_SCRIPT) } },
+    }
+    await expect(installBinRequirement(bin, marker, { fetchImpl: nativeFetch }))
+      .rejects.toThrow(/platform/i)
+  })
+})

--- a/tests/agent-packages/capability-readiness.test.ts
+++ b/tests/agent-packages/capability-readiness.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Capability readiness engine (T2.3): the none → content → +bin → +key
+ * transition ladder, with honest per-leg remediation at every rung.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-cap-readiness-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+const projectedSkills = new Set<string>()
+mock.module('@/core/app-services', () => ({
+  getAppServices: () => ({
+    runtime: {
+      skills: {
+        get: async (name: string) => (projectedSkills.has(name) ? { name, instructions: '#' } : null),
+      },
+    },
+  }),
+}))
+
+import { listCapabilities } from '../../src/core/agent-packages/capability-readiness'
+import { binPlatformKey } from '../../src/core/agent-packages/bin-installer'
+import { setStoredSecret } from '../../packages/core/src/media/secret-store'
+import { resetContentDir } from '../../src/core/content-dir'
+
+const key = binPlatformKey()!
+
+function seedInstalledPack(opts: { withBin?: boolean } = {}): void {
+  // Install dir with the manifest, exactly where the installer commits it.
+  const dir = join(testDir, 'packages', 'skill-packs', 'web-search-brave@1.0.0')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'bakin-package.json'), JSON.stringify({
+    id: 'web-search-brave',
+    kind: 'skill-pack',
+    name: 'Web Search (Brave)',
+    version: '1.0.0',
+    capability: 'web-search',
+    contributions: { skills: ['skills/bx-search'] },
+    ...(opts.withBin === false ? {} : {
+      requires: { bins: [{ name: 'bx', version: '1.4.0', install: { [key]: { url: 'https://example.com/bx', sha256: 'a'.repeat(64) } } }] },
+    }),
+    secrets: [{ name: 'BRAVE_SEARCH_API_KEY', description: 'key', required: true, secretSlot: 'brave.apiKey', help: 'https://api-dashboard.search.brave.com' }],
+  }))
+  // Lockfile entry with the skill (+bin) projections.
+  mkdirSync(join(testDir, 'packages'), { recursive: true })
+  writeFileSync(join(testDir, 'packages', 'lock.json'), JSON.stringify({
+    version: 1,
+    packages: {
+      'web-search-brave@1.0.0': {
+        kind: 'skill-pack',
+        version: '1.0.0',
+        source: 'github:markhayden/bakin-bits-official#packs/web-search-brave',
+        ref: 'main',
+        commitSha: 'c'.repeat(40),
+        installedAt: new Date().toISOString(),
+        projections: [
+          { kind: 'skill', target: 'runtime:global-skill:bx-search', sha256: 'd'.repeat(64) },
+          ...(opts.withBin === false ? [] : [{ kind: 'bin', target: join(testDir, 'bin', 'bx'), sha256: 'a'.repeat(64) }]),
+        ],
+      },
+    },
+  }))
+}
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(testDir, { recursive: true })
+  resetContentDir()
+  projectedSkills.clear()
+  delete process.env.BRAVE_SEARCH_API_KEY
+})
+
+afterAll(() => {
+  delete process.env.BRAVE_SEARCH_API_KEY
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('listCapabilities', () => {
+  it('returns nothing with no installed capability packs', async () => {
+    expect(await listCapabilities()).toEqual([])
+  })
+
+  it('walks the readiness ladder: content missing → bin missing → key missing → ready', async () => {
+    seedInstalledPack()
+
+    // Rung 1: nothing projected, no bin, no key — every leg missing.
+    let [cap] = await listCapabilities()
+    expect(cap.capability).toBe('web-search')
+    expect(cap.ready).toBe(false)
+    expect(cap.skills[0].status).toBe('missing')
+    expect(cap.bins[0].status).toBe('missing')
+    expect(cap.secrets[0].status).toBe('missing')
+    expect(cap.missing.join('\n')).toContain('bakin packages sync')
+    expect(cap.missing.join('\n')).toContain('Integrations & Keys')
+
+    // Rung 2: content projected.
+    projectedSkills.add('bx-search')
+    ;[cap] = await listCapabilities()
+    expect(cap.skills[0].status).toBe('ok')
+    expect(cap.ready).toBe(false)
+
+    // Rung 3: bin installed.
+    mkdirSync(join(testDir, 'bin'), { recursive: true })
+    writeFileSync(join(testDir, 'bin', 'bx'), '#!/bin/sh\n')
+    ;[cap] = await listCapabilities()
+    expect(cap.bins[0].status).toBe('ok')
+    expect(cap.ready).toBe(false)
+    expect(cap.missing).toHaveLength(1)
+
+    // Rung 4: key stored — READY.
+    setStoredSecret('brave', 'apiKey', 'bsk-1')
+    ;[cap] = await listCapabilities()
+    expect(cap.secrets[0].status).toBe('store')
+    expect(cap.ready).toBe(true)
+    expect(cap.missing).toEqual([])
+  })
+
+  it('an env var beats the store and reports source env', async () => {
+    seedInstalledPack({ withBin: false })
+    projectedSkills.add('bx-search')
+    process.env.BRAVE_SEARCH_API_KEY = 'bsk-env'
+    const [cap] = await listCapabilities()
+    expect(cap.secrets[0].status).toBe('env')
+    expect(cap.ready).toBe(true)
+  })
+
+  it('skill-packs without a capability slug are not capabilities', async () => {
+    seedInstalledPack()
+    const dir = join(testDir, 'packages', 'skill-packs', 'web-search-brave@1.0.0')
+    const manifest = JSON.parse(require('fs').readFileSync(join(dir, 'bakin-package.json'), 'utf-8'))
+    delete manifest.capability
+    writeFileSync(join(dir, 'bakin-package.json'), JSON.stringify(manifest))
+    expect(await listCapabilities()).toEqual([])
+  })
+})

--- a/tests/agent-packages/capability-readiness.test.ts
+++ b/tests/agent-packages/capability-readiness.test.ts
@@ -31,15 +31,20 @@ mock.module('@/core/logger', () => ({
 }))
 
 const projectedSkills = new Set<string>()
-mock.module('@/core/app-services', () => ({
-  getAppServices: () => ({
+mock.module('@/core/app-services', () => {
+  const services = {
     runtime: {
       skills: {
         get: async (name: string) => (projectedSkills.has(name) ? { name, instructions: '#' } : null),
       },
     },
-  }),
-}))
+  }
+  return {
+    getAppServices: () => services,
+    maybeGetAppServices: () => services,
+    createAppServices: async () => services,
+  }
+})
 
 import { listCapabilities } from '../../src/core/agent-packages/capability-readiness'
 import { binPlatformKey } from '../../src/core/agent-packages/bin-installer'

--- a/tests/agent-packages/installer.test.ts
+++ b/tests/agent-packages/installer.test.ts
@@ -43,12 +43,12 @@ import type { AgentRuntimeAdapter, RuntimeSkill, WorkspaceFile } from '@bakin/co
 // canonical readers.
 mock.module('@/core/content-dir', () => ({
   getContentDir: () => testDir,
-  getBakinPaths: () => ({}),
+  getBakinPaths: () => ({ bin: pathJoin(testDir, 'bin'), db: pathJoin(testDir, 'bakin.db') }),
   isUsingBakinHome: () => true,
 }))
 mock.module('@bakin/core/content-dir', () => ({
   getContentDir: () => testDir,
-  getBakinPaths: () => ({}),
+  getBakinPaths: () => ({ bin: pathJoin(testDir, 'bin'), db: pathJoin(testDir, 'bakin.db') }),
   isUsingBakinHome: () => true,
 }))
 mock.module('@bakin/adapter-openclaw/home', () => ({
@@ -699,5 +699,99 @@ describe('installPackage — install lock release on failure', () => {
     }).toThrow()
 
     expect(isInstallLockHeld()).toBe(false)
+  })
+})
+
+// ─── Capability packs: pinned binary installs (T2.2) ────────────────────────
+
+describe('installPackage — capability-pack bins', () => {
+  const { createHash } = require('crypto') as typeof import('crypto')
+  const sha256 = (s: string) => createHash('sha256').update(s).digest('hex')
+  const CAP_SCRIPT = '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "capbin 1.0.0"; exit 0; fi\nexit 1\n'
+
+  const nativeFetch = (Bun as unknown as { fetch: typeof fetch }).fetch
+  let NativeResponse: typeof Response
+  let binServer: { port: number; stop: (force?: boolean) => void }
+
+  const platformKey = `${process.platform === 'darwin' ? 'darwin' : 'linux'}-${process.arch === 'arm64' ? 'arm64' : 'x64'}`
+
+  function seedCapabilityPack(id: string, opts: { sha?: string } = {}): string {
+    const dir = join(testDir, `${id}-cap-pack`)
+    mkdirSync(join(dir, 'skills', id), { recursive: true })
+    writeFileSync(
+      join(dir, 'bakin-package.json'),
+      JSON.stringify({
+        id,
+        kind: 'skill-pack',
+        name: id,
+        version: '1.0.0',
+        capability: 'web-search',
+        contributions: { skills: [`skills/${id}`] },
+        requires: {
+          bins: [{
+            name: 'capbin',
+            version: '1.0.0',
+            install: { [platformKey]: { url: `https://127.0.0.1:${binServer.port}/capbin`.replace('https', 'http'), sha256: opts.sha ?? sha256(CAP_SCRIPT) } },
+            verifyArgs: ['--version'],
+          }],
+        },
+        secrets: [{ name: 'CAP_API_KEY', description: 'test key', secretSlot: 'cap.apiKey' }],
+      }),
+    )
+    writeFileSync(join(dir, 'skills', id, 'SKILL.md'), `# ${id}`)
+    return dir
+  }
+
+  beforeEach(async () => {
+    if (!NativeResponse) {
+      NativeResponse = (await nativeFetch('data:text/plain,x')).constructor as typeof Response
+      binServer = (Bun as unknown as { serve: (o: unknown) => { port: number; stop: (f?: boolean) => void } }).serve({
+        port: 0,
+        fetch: () => new NativeResponse(CAP_SCRIPT),
+      })
+    }
+  })
+
+  it('installs the declared bin with a lockfile bin projection; uninstall removes it', async () => {
+    const { removePackageById } = await import('../../src/core/agent-packages/uninstaller')
+    await installPackage({ source: seedCapabilityPack('web-a') })
+
+    const binPath = join(testDir, 'bin', 'capbin')
+    expect(existsSync(binPath)).toBe(true)
+    expect(statSync(binPath).mode & 0o777).toBe(0o755)
+
+    const lock = readJson(join(testDir, 'packages', 'lock.json')) as { packages: Record<string, { projections: Array<{ kind: string; target: string }> }> }
+    const entry = lock.packages['web-a@1.0.0']
+    expect(entry).toBeTruthy()
+    expect(entry.projections.some(p => p.kind === 'bin' && p.target === binPath)).toBe(true)
+
+    await removePackageById({ packageId: 'web-a@1.0.0' })
+    expect(existsSync(binPath)).toBe(false)
+  })
+
+  it('rolls back the whole install on a checksum mismatch', async () => {
+    await expect(installPackage({ source: seedCapabilityPack('web-bad', { sha: 'c'.repeat(64) }) }))
+      .rejects.toThrow(/checksum/i)
+
+    expect(existsSync(join(testDir, 'bin', 'capbin'))).toBe(false)
+    const lock = readJson(join(testDir, 'packages', 'lock.json')) as { packages: Record<string, unknown> } | null
+    expect(lock?.packages?.['web-bad@1.0.0']).toBeUndefined()
+    // The projected skill was rolled back too
+    expect(existsSync(runtimeSkillDir('web-bad'))).toBe(false)
+  })
+
+  it('a bin shared by two packs survives the first uninstall and dies with the last', async () => {
+    const { removePackageById } = await import('../../src/core/agent-packages/uninstaller')
+    await installPackage({ source: seedCapabilityPack('web-a') })
+    await installPackage({ source: seedCapabilityPack('web-b') })
+
+    const binPath = join(testDir, 'bin', 'capbin')
+    expect(existsSync(binPath)).toBe(true)
+
+    await removePackageById({ packageId: 'web-a@1.0.0' })
+    expect(existsSync(binPath)).toBe(true)
+
+    await removePackageById({ packageId: 'web-b@1.0.0' })
+    expect(existsSync(binPath)).toBe(false)
   })
 })

--- a/tests/agent-packages/manifest.test.ts
+++ b/tests/agent-packages/manifest.test.ts
@@ -100,6 +100,50 @@ describe('manifest schema — happy path', () => {
     expect(m.contributions.skills).toHaveLength(2)
   })
 
+  it('parses a capability pack (skill-pack + capability/runtimes/requires/secretSlot)', () => {
+    const m = parseManifest(loadFixture('capability-pack'))
+    if (m.kind !== 'skill-pack') throw new Error('discriminator narrowing failed')
+    expect(m.capability).toBe('web-search')
+    expect(m.runtimes).toEqual(['*'])
+    expect(m.requires?.bins?.[0]?.name).toBe('bx')
+    expect(m.requires?.bins?.[0]?.install['darwin-arm64']?.sha256).toHaveLength(64)
+    expect(m.requires?.bins?.[0]?.verifyArgs).toEqual(['--version'])
+    expect(m.secrets?.[0]?.secretSlot).toBe('brave.apiKey')
+    expect(m.secrets?.[0]?.help).toContain('https://')
+  })
+
+  it('defaults runtimes to ["*"] when omitted on a capability pack', () => {
+    const raw = loadFixture('capability-pack') as Record<string, unknown>
+    delete raw.runtimes
+    const m = parseManifest(raw)
+    if (m.kind !== 'skill-pack') throw new Error('discriminator narrowing failed')
+    expect(m.runtimes).toEqual(['*'])
+  })
+
+  it('rejects capability-pack extension malformations', () => {
+    const base = () => JSON.parse(JSON.stringify(loadFixture('capability-pack'))) as Record<string, any>
+
+    const badSlug = base()
+    badSlug.capability = 'Web Search!'
+    expect(safeParseManifest(badSlug).success).toBe(false)
+
+    const badSha = base()
+    badSha.requires.bins[0].install['darwin-arm64'].sha256 = 'not-a-sha'
+    expect(safeParseManifest(badSha).success).toBe(false)
+
+    const badPlatform = base()
+    badPlatform.requires.bins[0].install['amiga-68k'] = badPlatform.requires.bins[0].install['darwin-arm64']
+    expect(safeParseManifest(badPlatform).success).toBe(false)
+
+    const badSlot = base()
+    badSlot.secrets[0].secretSlot = 'no-dot-separator'
+    expect(safeParseManifest(badSlot).success).toBe(false)
+
+    const badUrl = base()
+    badUrl.requires.bins[0].install['darwin-arm64'].url = 'ftp://nope'
+    expect(safeParseManifest(badUrl).success).toBe(false)
+  })
+
   it('parses a workflow-pack manifest', () => {
     const m = parseManifest(loadFixture('workflow-pack'))
     expect(m.kind).toBe('workflow-pack')

--- a/tests/agent-packages/projector.test.ts
+++ b/tests/agent-packages/projector.test.ts
@@ -503,6 +503,7 @@ describe('projectPackage — skill-pack', () => {
       name: 'Visual Skills',
       version: '0.3.1',
       contributions: { skills: ['skills/image-gen'] },
+      runtimes: ['*'],
     }
 
     const result = await projectPackage({

--- a/tests/api/packages-install-resolve.test.ts
+++ b/tests/api/packages-install-resolve.test.ts
@@ -1,0 +1,99 @@
+/**
+ * POST /api/packages/install — bare-name catalog resolution + capability
+ * readiness in the response (T2.4). The installer and readiness engine are
+ * mocked; this pins the HANDLER contract (resolution, 404, passthrough,
+ * response shape). End-to-end install is covered by the installer suite and
+ * the P2 rig validation.
+ */
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { describe, expect, it, mock } from 'bun:test'
+
+const testDir = join(tmpdir(), `bakin-api-pkg-resolve-${Date.now()}`)
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+const installedSources: string[] = []
+mock.module('@/core/agent-packages/installer', () => ({
+  installPackage: async (opts: { source: string }) => {
+    installedSources.push(opts.source)
+    return { packageId: 'web-search-brave', kind: 'skill-pack', version: '1.0.0', dependencies: [] }
+  },
+}))
+mock.module('@/core/agent-packages/capability-readiness', () => ({
+  listCapabilities: async () => [{
+    capability: 'web-search',
+    packageId: 'web-search-brave',
+    version: '1.0.0',
+    name: 'Web Search (Brave)',
+    skills: [{ name: 'bx-search', status: 'ok' }],
+    bins: [{ name: 'bx', status: 'ok' }],
+    secrets: [{ name: 'BRAVE_SEARCH_API_KEY', required: true, secretSlot: 'brave.apiKey', status: 'missing' }],
+    ready: false,
+    missing: ['BRAVE_SEARCH_API_KEY is not configured'],
+  }],
+}))
+mock.module('@/core/curated-catalog/load', () => ({
+  loadUnifiedCatalog: async () => ({
+    version: 2,
+    updatedAt: '2026-07-12',
+    entries: [{
+      id: 'web-search-brave',
+      kind: 'skill-pack',
+      name: 'Web Search (Brave)',
+      description: 'x',
+      category: 'capability',
+      tags: [], useCases: [], dependencies: [], screenshots: [],
+      trust: 'official',
+      builtin: false,
+      defaultSelected: false,
+      ref: 'abc123',
+      runtimes: ['*'],
+      source: 'github:markhayden/bakin-bits-official#packs/web-search-brave',
+    }],
+  }),
+}))
+
+import { post } from '../../packages/host/src/api/packages/install'
+
+const url = new URL('http://localhost/api/packages/install')
+const req = (body: unknown) => new Request(url, { method: 'POST', body: JSON.stringify(body) })
+
+describe('POST /api/packages/install — name resolution', () => {
+  it('resolves a bare catalog name to its ref-pinned source and returns capability readiness', async () => {
+    const res = await post(req({ source: 'web-search-brave' }), url)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.resolvedSource).toBe('github:markhayden/bakin-bits-official@abc123#packs/web-search-brave')
+    expect(installedSources.at(-1)).toBe('github:markhayden/bakin-bits-official@abc123#packs/web-search-brave')
+    expect(body.capability.ready).toBe(false)
+    expect(body.capability.secrets[0].secretSlot).toBe('brave.apiKey')
+  })
+
+  it('404s on an unknown bare name with a helpful message', async () => {
+    const res = await post(req({ source: 'no-such-pack' }), url)
+    expect(res.status).toBe(404)
+    expect((await res.json()).error).toContain('curated catalog')
+  })
+
+  it('passes explicit github: sources through untouched', async () => {
+    const res = await post(req({ source: 'github:someone/some-pack' }), url)
+    expect((await res.json()).ok).toBe(true)
+    expect(installedSources.at(-1)).toBe('github:someone/some-pack')
+  })
+})

--- a/tests/core/curated-catalog-import-collision.test.ts
+++ b/tests/core/curated-catalog-import-collision.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Pin: the static catalog survives Bun's module-cache collision with
+ * `_embedded-assets-static.ts`.
+ *
+ * Bun caches modules by path, ignoring import attributes — importing the
+ * embedded-assets manifest FIRST makes the loader's plain JSON import of
+ * curated-catalog.json resolve to a file-path STRING. Before the
+ * shippedCatalogRaw() normalization, every source-run server (server.ts
+ * evaluates the manifest at line ~49) silently degraded the static catalog
+ * to empty. This test reproduces the poisoning order and pins the fix.
+ */
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { describe, expect, it, mock } from 'bun:test'
+
+const testDir = join(tmpdir(), `bakin-test-catalog-collision-${Date.now()}`)
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({}),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+// THE POISONING ORDER: the file-typed manifest import must evaluate before
+// the loader's JSON import — exactly what server.ts does.
+import '../../packages/host/src/api/_embedded-assets-static'
+import { staticCuratedCatalog } from '../../src/core/curated-catalog/load'
+
+describe('curated catalog vs file-typed import collision', () => {
+  it('staticCuratedCatalog still parses the shipped catalog', () => {
+    const catalog = staticCuratedCatalog()
+    expect(catalog.entries.length).toBeGreaterThan(0)
+    expect(catalog.entries.some((e) => e.id === 'web-search-brave')).toBe(true)
+  })
+})

--- a/tests/core/curated-catalog-import-collision.test.ts
+++ b/tests/core/curated-catalog-import-collision.test.ts
@@ -28,12 +28,19 @@ mock.module('@bakin/adapter-openclaw/home', () => ({
   resetOpenClawHome: () => {},
 }))
 
-// THE POISONING ORDER: the file-typed manifest import must evaluate before
-// the loader's JSON import — exactly what server.ts does.
-import '../../packages/host/src/api/_embedded-assets-static'
+// THE POISONING ORDER: a file-typed import of the same JSON path must
+// evaluate before the loader's plain import — the same shape server.ts
+// creates via _embedded-assets-static.ts. The fixture avoids importing the
+// real manifest, whose file-typed dist/vendor imports only exist post-build.
+import { catalogFilePath } from '../fixtures/catalog-file-import'
 import { staticCuratedCatalog } from '../../src/core/curated-catalog/load'
 
 describe('curated catalog vs file-typed import collision', () => {
+  it('the fixture actually poisons the module cache (path string, not JSON)', () => {
+    expect(typeof catalogFilePath).toBe('string')
+    expect(catalogFilePath).toContain('curated-catalog')
+  })
+
   it('staticCuratedCatalog still parses the shipped catalog', () => {
     const catalog = staticCuratedCatalog()
     expect(catalog.entries.length).toBeGreaterThan(0)

--- a/tests/core/curated-catalog.test.ts
+++ b/tests/core/curated-catalog.test.ts
@@ -91,4 +91,42 @@ describe('shipped curated-catalog.json', () => {
       expect(entry.useCases.length).toBeGreaterThan(0)
     }
   })
+
+  it('accepts capability + runtimes facets and defaults runtimes to ["*"]', () => {
+    const entry = CatalogFileSchema.parse({
+      version: 2,
+      updatedAt: '2026-07-12',
+      entries: [{
+        id: 'web-search-brave',
+        kind: 'skill-pack',
+        name: 'Web Search (Brave)',
+        description: 'Teach agents web search',
+        category: 'capability',
+        trust: 'official',
+        source: 'github:markhayden/bakin-bits-official#packs/web-search-brave',
+        capability: 'web-search',
+        useCases: ['research'],
+      }],
+    }).entries[0]
+    expect(entry.capability).toBe('web-search')
+    expect(entry.runtimes).toEqual(['*'])
+  })
+
+  it('rejects malformed capability slugs and runtime tags', () => {
+    const base = {
+      version: 2,
+      updatedAt: '2026-07-12',
+      entries: [{
+        id: 'x', kind: 'skill-pack', name: 'X', description: 'd', category: 'c',
+        trust: 'official', source: 'github:u/r', useCases: ['u'],
+      }],
+    }
+    const badCap = structuredClone(base) as any
+    badCap.entries[0].capability = 'Not A Slug!'
+    expect(CatalogFileSchema.safeParse(badCap).success).toBe(false)
+
+    const badRuntime = structuredClone(base) as any
+    badRuntime.entries[0].runtimes = ['PI RUNTIME']
+    expect(CatalogFileSchema.safeParse(badRuntime).success).toBe(false)
+  })
 })

--- a/tests/core/onboarding/index.test.ts
+++ b/tests/core/onboarding/index.test.ts
@@ -25,7 +25,7 @@ interface ScriptedComponent {
   installCalls: number
 }
 
-const COMPONENT_NAMES = ['mkdir', 'settings', 'runtime', 'search', 'search-models', 'openclaw-integration', 'plugin-assets', 'agent-sync', 'llm', 'budget', 'channels', 'recommended-plugins', 'recommended-agents'] as const
+const COMPONENT_NAMES = ['mkdir', 'settings', 'runtime', 'search', 'search-models', 'openclaw-integration', 'plugin-assets', 'agent-sync', 'llm', 'budget', 'channels', 'recommended-plugins', 'recommended-agents', 'capabilities'] as const
 
 let scripts: Record<(typeof COMPONENT_NAMES)[number], ScriptedComponent>
 
@@ -80,6 +80,9 @@ mock.module('../../../src/core/onboarding/recommended-plugins', () => ({
 mock.module('../../../src/core/onboarding/recommended-agents', () => ({
   recommendedAgentsComponent: makeMock('recommended-agents'),
   RECOMMENDED_AGENTS: [],
+}))
+mock.module('../../../src/core/onboarding/recommended-capabilities', () => ({
+  recommendedCapabilitiesComponent: makeMock('capabilities'),
 }))
 
 mock.module('../../../src/core/onboarding/state', () => ({
@@ -241,7 +244,7 @@ describe('runOnboard orchestrator', () => {
   // ---------------------------------------------------------------------------
 
   describe('COMPONENT_ORDER', () => {
-    it('contains exactly the 14 expected components in the spec order', () => {
+    it('contains exactly the 15 expected components in the spec order', () => {
       expect(COMPONENT_ORDER.map((c) => c.name)).toEqual([
         'mkdir',
         'settings',
@@ -256,6 +259,7 @@ describe('runOnboard orchestrator', () => {
         'channels',
         'recommended-plugins',
         'recommended-agents',
+        'capabilities',
       ])
     })
   })
@@ -295,6 +299,7 @@ describe('runOnboard orchestrator', () => {
         channels: 'ok',
         'recommended-plugins': 'ok',
         'recommended-agents': 'ok',
+        capabilities: 'ok',
       })
     })
 

--- a/tests/core/onboarding/recommended-capabilities.test.ts
+++ b/tests/core/onboarding/recommended-capabilities.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+// Belt-and-suspenders isolation (CLAUDE.md): every fs-touching dependency is
+// mocked below, but a future regression that imports a storage module from
+// this test must fail safely into a temp dir, never ~/.bakin or ~/.openclaw.
+const testDir = join(tmpdir(), `bakin-test-rec-capabilities-${Date.now()}`)
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+let lockPackages: Record<string, { kind: string; version: string }> = {}
+let readiness: Array<{ capability: string; packageId: string; ready: boolean; missing: string[] }> = []
+const installCalls: Array<{ source: string; installAs?: string }> = []
+
+mock.module('../../../packages/core/src/agent-packages/lockfile', () => ({
+  readLockfile: () => ({ version: 1, packages: lockPackages }),
+}))
+mock.module('../../../src/core/agent-packages/capability-readiness', () => ({
+  listCapabilities: async () => readiness,
+}))
+mock.module('../../../src/core/agent-packages/installer', () => ({
+  installPackage: async (opts: { source: string; installAs?: string }) => {
+    installCalls.push(opts)
+    return { packageId: opts.installAs ?? 'unknown', kind: 'skill-pack', version: '1.0.0', dependencies: [] }
+  },
+}))
+mock.module('../../../src/core/curated-catalog/load', () => ({
+  loadUnifiedCatalog: async () => ({
+    version: 2,
+    updatedAt: '2026-07-12',
+    entries: [
+      {
+        id: 'web-search-brave', kind: 'skill-pack', name: 'Web Search (Brave)', description: 'x',
+        category: 'capability', tags: [], useCases: [], dependencies: [], screenshots: [],
+        trust: 'official', builtin: false, defaultSelected: true, ref: 'abc123', runtimes: ['*'],
+        capability: 'web-search', source: 'github:markhayden/bakin-bits-official#packs/web-search-brave',
+      },
+      {
+        // Not a capability (no slug) — never recommended by this component.
+        id: 'plain-skills', kind: 'skill-pack', name: 'Plain', description: 'x',
+        category: 'misc', tags: [], useCases: [], dependencies: [], screenshots: [],
+        trust: 'official', builtin: false, defaultSelected: true, ref: null, runtimes: ['*'],
+        source: 'github:markhayden/plain-skills',
+      },
+    ],
+  }),
+}))
+
+import { recommendedCapabilitiesComponent } from '../../../src/core/onboarding/recommended-capabilities'
+
+beforeEach(() => {
+  lockPackages = {}
+  readiness = []
+  installCalls.length = 0
+})
+
+describe('capabilities onboarding component', () => {
+  it('reports missing recommendations when nothing is installed', async () => {
+    const result = await recommendedCapabilitiesComponent.check()
+    expect(result.status).toBe('missing')
+    const recommended = result.details?.recommended as Array<{ id: string }>
+    expect(recommended.map(r => r.id)).toEqual(['web-search-brave'])
+  })
+
+  it('reports not-ready installed capabilities with remediation', async () => {
+    lockPackages['web-search-brave@1.0.0'] = { kind: 'skill-pack', version: '1.0.0' }
+    readiness = [{ capability: 'web-search', packageId: 'web-search-brave', ready: false, missing: ['BRAVE_SEARCH_API_KEY is not configured'] }]
+    const result = await recommendedCapabilitiesComponent.check()
+    expect(result.status).toBe('missing')
+    expect(result.remediation).toContain('BRAVE_SEARCH_API_KEY')
+  })
+
+  it('is ok when installed and ready', async () => {
+    lockPackages['web-search-brave@1.0.0'] = { kind: 'skill-pack', version: '1.0.0' }
+    readiness = [{ capability: 'web-search', packageId: 'web-search-brave', ready: true, missing: [] }]
+    const result = await recommendedCapabilitiesComponent.check()
+    expect(result.status).toBe('ok')
+  })
+
+  it('installs defaultSelected packs under autoApprove with the ref pin', async () => {
+    const result = await recommendedCapabilitiesComponent.install({ interactive: false, autoApprove: true, json: false, checkOnly: false, force: false })
+    expect(result.status).toBe('installed')
+    expect(installCalls).toEqual([{
+      source: 'github:markhayden/bakin-bits-official@abc123#packs/web-search-brave',
+      installAs: 'web-search-brave',
+    }])
+  })
+
+  it('skips (never stalls) without autoApprove', async () => {
+    const result = await recommendedCapabilitiesComponent.install({ interactive: false, autoApprove: false, json: false, checkOnly: false, force: false })
+    expect(result.status).toBe('skipped')
+    expect(installCalls).toEqual([])
+  })
+})

--- a/tests/fixtures/agent-packages/manifests/capability-pack.json
+++ b/tests/fixtures/agent-packages/manifests/capability-pack.json
@@ -1,0 +1,41 @@
+{
+  "id": "web-search-brave",
+  "kind": "skill-pack",
+  "name": "Web Search (Brave)",
+  "version": "1.0.0",
+  "description": "Web search and content extraction via the Brave Search CLI.",
+  "author": "Bakin Test Fixtures",
+  "capability": "web-search",
+  "runtimes": ["*"],
+  "contributions": {
+    "skills": ["skills/bx-search"]
+  },
+  "requires": {
+    "bins": [
+      {
+        "name": "bx",
+        "version": "1.4.0",
+        "install": {
+          "darwin-arm64": {
+            "url": "https://github.com/brave/brave-search-cli/releases/download/v1.4.0/bx-1.4.0-darwin-arm64",
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          "linux-x64": {
+            "url": "https://github.com/brave/brave-search-cli/releases/download/v1.4.0/bx-1.4.0-linux-amd64",
+            "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        },
+        "verifyArgs": ["--version"]
+      }
+    ]
+  },
+  "secrets": [
+    {
+      "name": "BRAVE_SEARCH_API_KEY",
+      "description": "Brave Search API key (free tier available)",
+      "required": true,
+      "secretSlot": "brave.apiKey",
+      "help": "https://api-dashboard.search.brave.com"
+    }
+  ]
+}

--- a/tests/fixtures/catalog-file-import.ts
+++ b/tests/fixtures/catalog-file-import.ts
@@ -1,0 +1,10 @@
+/**
+ * Reproduces the import shape of packages/host/src/api/_embedded-assets-static.ts
+ * (a `with { type: 'file' }` import of the curated catalog) WITHOUT dragging
+ * the manifest's built-artifact imports (dist/main.js, vendor bundles) into
+ * the test module graph — those only exist after a full build (CI runs
+ * tests unbuilt).
+ */
+import catalogAsFile from '../../packages/host/src/data/curated-catalog.json' with { type: 'file' }
+
+export const catalogFilePath = catalogAsFile as unknown as string

--- a/tests/plugins/explore/catalog-card.test.tsx
+++ b/tests/plugins/explore/catalog-card.test.tsx
@@ -33,6 +33,7 @@ const entry = (over: Partial<ExploreCatalogEntry> = {}): ExploreCatalogEntry => 
   description: 'Image artist agent.',
   category: 'Creative',
   tags: [],
+  runtimes: ['*'],
   useCases: ['Generate on-brand social images'],
   source: 'github:markhayden/bakin-bits-official#agents/pixel',
   ref: null,

--- a/tests/plugins/explore/catalog-card.test.tsx
+++ b/tests/plugins/explore/catalog-card.test.tsx
@@ -131,4 +131,28 @@ describe('CatalogCard', () => {
     expect(screen.getByTestId('avatar-pixel')).toBeTruthy()
     expect(screen.queryByTestId('icon-agent-pixel')).toBeNull()
   })
+
+  it('badges and gates install for runtime-incompatible entries', () => {
+    const onInstall = mock()
+    render(<CatalogCard
+      entry={entry({ kind: 'skill-pack', id: 'oc-only', runtimes: ['openclaw'], installed: false, builtin: false })}
+      onSelect={mock()}
+      onInstall={onInstall}
+      activeAdapter="pi"
+    />)
+    expect(screen.getByTestId('card-incompatible-oc-only').textContent).toContain('Not for pi')
+    expect(screen.queryByTestId('card-install-skill-pack-oc-only')).toBeNull()
+  })
+
+  it('universal runtimes entries stay installable with no compat badge', () => {
+    const onInstall = mock()
+    render(<CatalogCard
+      entry={entry({ kind: 'skill-pack', id: 'cap', runtimes: ['*'], installed: false, builtin: false })}
+      onSelect={mock()}
+      onInstall={onInstall}
+      activeAdapter="pi"
+    />)
+    expect(screen.queryByTestId('card-incompatible-cap')).toBeNull()
+    expect(screen.getByTestId('card-install-skill-pack-cap')).toBeTruthy()
+  })
 })

--- a/tests/plugins/explore/catalog-merge.test.ts
+++ b/tests/plugins/explore/catalog-merge.test.ts
@@ -31,6 +31,7 @@ const entry = (id: string, over: Partial<CatalogEntry> = {}): CatalogEntry => ({
   category: 'Test',
   tags: [],
   useCases: [],
+  runtimes: ['*'],
   source: `github:markhayden/bakin-bits-official#agents/${id}`,
   ref: null,
   trust: 'official',

--- a/tests/plugins/explore/install-dialog.test.tsx
+++ b/tests/plugins/explore/install-dialog.test.tsx
@@ -38,6 +38,7 @@ const agentEntry: ExploreCatalogEntry = {
   category: 'Creative',
   tags: [],
   useCases: [],
+  runtimes: ['*'],
   source: 'github:markhayden/bakin-bits-official#agents/pixel',
   ref: null,
   trust: 'official',

--- a/tests/plugins/explore/install-dialog.test.tsx
+++ b/tests/plugins/explore/install-dialog.test.tsx
@@ -267,4 +267,75 @@ describe('InstallDialog', () => {
     expect(body.adopt).toBe('foo-two')
     expect(body.installAs).toBe('foo-two')
   })
+
+  it('capability-pack installs with a missing key show the guided key step, store, and finish', async () => {
+    const capEntry: ExploreCatalogEntry = {
+      ...agentEntry,
+      id: 'web-search-brave',
+      kind: 'skill-pack',
+      name: 'Web Search (Brave)',
+      capability: 'web-search',
+      source: 'github:markhayden/bakin-bits-official#packs/web-search-brave',
+    }
+    fetchMock = mock((url: string) => {
+      if (url === '/api/packages/install') {
+        return Promise.resolve(jsonResponse({
+          ok: true,
+          result: { packageId: 'web-search-brave' },
+          capability: {
+            capability: 'web-search',
+            name: 'Web Search (Brave)',
+            ready: false,
+            missing: ['BRAVE_SEARCH_API_KEY is not configured'],
+            secrets: [{ name: 'BRAVE_SEARCH_API_KEY', secretSlot: 'brave.apiKey', help: 'https://api-dashboard.search.brave.com', status: 'missing', required: true }],
+          },
+        }))
+      }
+      return Promise.resolve(jsonResponse({ ok: true }))
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const onInstalled = mock()
+    const onOpenChange = mock()
+    render(<InstallDialog open onOpenChange={onOpenChange} entry={capEntry} onInstalled={onInstalled} />)
+    fireEvent.click(screen.getByTestId('install-submit'))
+
+    await waitFor(() => screen.getByTestId('capability-key-step'))
+    expect(onInstalled).toHaveBeenCalled() // install itself already succeeded
+    expect(screen.getByText(/api-dashboard\.search\.brave\.com/)).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText('BRAVE_SEARCH_API_KEY'), { target: { value: 'bsk-1' } })
+    fireEvent.click(screen.getByTestId('capability-key-save'))
+
+    await waitFor(() => {
+      const secretsPost = fetchMock.mock.calls.find(([u]) => u === '/api/secrets')
+      expect(secretsPost).toBeTruthy()
+      expect(JSON.parse(String((secretsPost![1] as RequestInit).body))).toEqual({ provider: 'brave', name: 'apiKey', value: 'bsk-1' })
+    })
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  it('the key step can be skipped — dialog closes, install stands', async () => {
+    const capEntry: ExploreCatalogEntry = {
+      ...agentEntry, id: 'web-search-brave', kind: 'skill-pack', name: 'Web Search (Brave)',
+      capability: 'web-search', source: 'github:x/y#packs/web-search-brave',
+    }
+    fetchMock = mock(() => Promise.resolve(jsonResponse({
+      ok: true,
+      result: { packageId: 'web-search-brave' },
+      capability: {
+        capability: 'web-search', name: 'Web Search (Brave)', ready: false, missing: ['key'],
+        secrets: [{ name: 'BRAVE_SEARCH_API_KEY', secretSlot: 'brave.apiKey', status: 'missing', required: true }],
+      },
+    })))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const onOpenChange = mock()
+    render(<InstallDialog open onOpenChange={onOpenChange} entry={capEntry} onInstalled={mock()} />)
+    fireEvent.click(screen.getByTestId('install-submit'))
+    await waitFor(() => screen.getByTestId('capability-key-step'))
+    fireEvent.click(screen.getByText('Skip for now'))
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    expect(fetchMock.mock.calls.filter(([u]) => u === '/api/secrets')).toHaveLength(0)
+  })
 })

--- a/tests/plugins/explore/install-state.test.ts
+++ b/tests/plugins/explore/install-state.test.ts
@@ -31,6 +31,7 @@ const SHA_B = 'b'.repeat(40)
 const entry = (overrides: Partial<CatalogEntry> & Pick<CatalogEntry, 'id' | 'kind'>): CatalogEntry => ({
   name: overrides.id,
   description: 'x',
+  runtimes: ['*'],
   category: 'Test',
   tags: [],
   useCases: [],


### PR DESCRIPTION
Phase P2 of the pi-parity initiative (spec `.claude/specs/pi-parity/SPEC.md` §4.2, stories 1–5). Depends on nothing; P1 (#662) already merged.

## What

Capability packs: skill-packs that name a capability and declare what it needs — Bakin owns the whole install path on a net-new machine (content → pinned binaries → guided key → honest readiness).

- **Manifest/catalog schemas**: `capability`, `runtimes` (default `['*']`), `requires.bins[]` (pinned per-platform https + sha256 + verify args); secret declarations gain `secretSlot` + `help`. All optional; every existing manifest parses unchanged.
- **Binary installer**: antfly-pattern (download → checksum → verify-then-commit → atomic rename) into new `~/.bakin/bin` (on PATH since P1). Bins are lockfile projections — rollback/uninstall standard; shared bins are refcount-aware.
- **Readiness engine** (one engine, every surface): content/bin/key legs with remediation strings → `GET /api/packages/capabilities`, `capability.<slug>` doctor findings, `bakin check capabilities`.
- **CLI**: `bakin packages install web-search-brave` (catalog-name resolution, ref-pinned, server-side), consent before writes, per-leg ✓/⚠ output, guided key prompt.
- **Onboarding**: `capabilities` component (15th) — readiness check + defaultSelected installs under `--yes`; never stalls on a key (story-1 escape hatch to Settings → Integrations & Keys).
- **Explore**: Capabilities shelf, runtime-compat badges/gating vs the active adapter, guided key step in the install dialog.
- **First pack**: `web-search-brave` in bakin-bits-official (spike-validated bx skill, real pinned checksums) + embedded catalog entry.
- **Bug fix (pre-existing on main)**: Bun's path-keyed module cache let the embedded-assets `with { type: 'file' }` import poison the catalog's JSON import — every source-run server silently degraded the static catalog to empty. Fixed + collision-order pin test.

## Validation

- Full suite green (6763 pass / 0 fail; `use-live-activity` parallel-run flake passes in isolation, pre-existing). Typecheck clean at every commit.
- **Clean-home rig** (throwaway BAKIN_HOME/PI_HOME, this branch's source): `onboard --yes` installed the pack from the real bits repo, downloaded + sha256-verified + version-ran the real bx 1.4.0, projected the skill to the Pi home, reported "needs configuration" without stalling; `bakin check capabilities` walked missing-key → stored-key → **READY** via the masked store.
- Story 4 (dispatched research task through the productized pack) runs at the post-merge live-box cutover (removing the spike skill), recorded in P3/P5.

Bits-repo commits: `01f4463` (pack + catalog) and `1aa0745` (contract-test fix for non-plugin package kinds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)