### PR TITLE
feat(runtime): task-completion tail — approval attention, model preservation, cron adoption (pi-parity P3)

### DIFF
--- a/.claude/specs/pi-parity/TODO.md
+++ b/.claude/specs/pi-parity/TODO.md
@@ -24,11 +24,11 @@ Plan: `PLAN.md` · Spec: `SPEC.md` · One PR per phase, one commit per task.
 - [x] Gate: CLEAN-home rig validation done (stories 1–3 real pack/binary/key ladder; story 4 dispatch at post-merge live cutover)
 
 ## P3 — feat/pi-task-parity
-- [ ] T3.1 Pending-approval attention provider (story 6)
-- [ ] T3.2 Subagent model preservation across switches (per OQ1 decision)
-- [ ] T3.3 gh readiness check + agent context guidance
-- [ ] T3.4 Switch-time cron adoption, opt-in `--adopt-cron` (story 7)
-- [ ] T3.5 Pin tests: compaction default + schedule-tools dispatch context
+- [x] T3.1 Pending-approval attention provider (story 6)
+- [x] T3.2 Subagent model preservation across switches (per OQ1 decision)
+- [x] T3.3 gh readiness check + agent context guidance
+- [x] T3.4 Switch-time cron adoption, opt-in `--adopt-cron` (story 7)
+- [x] T3.5 Pin tests: compaction default + schedule-tools dispatch context
 - [ ] Gate: live gate badge/toast + switch e2e → open PR
 
 ## P4 — feat/runtime-hub

--- a/packages/adapter-pi/src/messaging.ts
+++ b/packages/adapter-pi/src/messaging.ts
@@ -117,6 +117,18 @@ function imageContentsFor(args: MessageArgs, record: PiAgentRecord) {
   }))
 }
 
+
+/**
+ * The per-turn SettingsManager, exactly as Bakin turns build it. Exported so
+ * the compaction-default pin test exercises the REAL construction: Bakin
+ * relies on the SDK's compaction default staying enabled (long tasks compact,
+ * not die) — if the pinned SDK flips it, the pin fails and this helper must
+ * pass an explicit compaction override.
+ */
+export function createTurnSettingsManager(workspace: string, agentDir: string): SettingsManager {
+  return SettingsManager.create(workspace, agentDir, { projectTrusted: true })
+}
+
 async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promise<TurnHandle> {
   const record = requireAgent(args.agentId)
   scaffoldAgentDirs(record.id)
@@ -124,7 +136,7 @@ async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promis
   const agentDir = getPiAgentDir()
   const { auth, registry: modelRegistry } = getModelRegistry()
 
-  const settingsManager = SettingsManager.create(workspace, agentDir, { projectTrusted: true })
+  const settingsManager = createTurnSettingsManager(workspace, agentDir)
   const adapterSettings = deps.getSettings?.()
   const extPolicy = extensionsPolicy(adapterSettings)
   const resourceLoader = new DefaultResourceLoader({

--- a/packages/host/src/lib/runtime-report.ts
+++ b/packages/host/src/lib/runtime-report.ts
@@ -92,6 +92,7 @@ export const SWITCH_PHASE_LABELS: Record<string, string> = {
   initialize: 'Initialize target runtime',
   provision: 'Provision tool access',
   'reconcile-roster': 'Carry roster over',
+  'adopt-cron': 'Adopt cron jobs',
   'carry-workspaces': 'Carry workspace content',
   'sync-agents': 'Re-project agents',
   'validate-capabilities': 'Validate capabilities',

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -26,6 +26,7 @@ import {
 } from '../../src/core/health-check-registry'
 import { checkContentDir } from './lib/system-checks/content-dir'
 import { checkCapabilities } from './lib/system-checks/capabilities'
+import { checkGithubReadiness } from './lib/system-checks/github-readiness'
 import { checkService } from './lib/system-checks/service'
 import { checkRuntime } from './lib/system-checks/runtime'
 import { checkSessionStore } from './lib/system-checks/session-store'
@@ -654,6 +655,11 @@ const healthPlugin: BakinPlugin = definePlugin({
       id: 'capabilities',
       name: 'Capability-pack readiness',
       run: () => checkCapabilities(),
+    })
+    ctx.registerHealthCheck({
+      id: 'github-readiness',
+      name: 'GitHub CLI readiness',
+      run: () => checkGithubReadiness(),
     })
     ctx.registerHealthCheck({
       id: 'service',

--- a/plugins/health/lib/system-checks/github-readiness.ts
+++ b/plugins/health/lib/system-checks/github-readiness.ts
@@ -1,0 +1,61 @@
+/**
+ * System check — GitHub CLI readiness.
+ *
+ * Agents do GitHub work (issues, PRs, releases) through the `gh` CLI on any
+ * runtime — that IS the parity surface (OpenClaw agents shelled gh too).
+ * Absent gh is informational (not every install uses GitHub); a gh that is
+ * installed but unauthenticated is the broken half-state worth a warn.
+ */
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import type { HealthCheckResult } from '../../../../packages/core/src/plugin-types'
+
+const execFileAsync = promisify(execFile)
+
+export interface GhProbe {
+  /** Resolve the gh binary; null when not installed. */
+  which(): Promise<string | null>
+  /** Exit-code truth of `gh auth status`. */
+  authOk(): Promise<boolean>
+}
+
+export const defaultGhProbe: GhProbe = {
+  async which() {
+    try {
+      const { stdout } = await execFileAsync('which', ['gh'], { timeout: 5_000 })
+      const path = stdout.trim()
+      return path.length > 0 ? path : null
+    } catch {
+      return null
+    }
+  },
+  async authOk() {
+    try {
+      await execFileAsync('gh', ['auth', 'status'], { timeout: 10_000 })
+      return true
+    } catch {
+      return false
+    }
+  },
+}
+
+export async function checkGithubReadiness(probe: GhProbe = defaultGhProbe): Promise<HealthCheckResult[]> {
+  const ghPath = await probe.which()
+  if (!ghPath) {
+    return [{
+      check: 'github-readiness',
+      status: 'ok',
+      message: 'GitHub CLI (gh) is not installed — agents can still do local git work via worktree tools. Install gh to add issue/PR/release abilities.',
+      autoFixable: false,
+    }]
+  }
+  const authed = await probe.authOk()
+  return [{
+    check: 'github-readiness',
+    status: authed ? 'ok' : 'warn',
+    message: authed
+      ? `GitHub CLI is installed and authenticated (${ghPath})`
+      : `GitHub CLI is installed (${ghPath}) but not authenticated — agents' GitHub operations will fail. Run: gh auth login`,
+    autoFixable: false,
+  }]
+}

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -30,6 +30,7 @@ import {
   readMergedRuntimeJobs,
   jobToSearchDoc,
 } from './lib/job-service'
+import { adoptCronJobs, type AdoptCronJobsInput } from './lib/cron-adoption'
 import { registerScheduleExecTools } from './lib/exec-tools'
 import { scheduleRoutes } from './lib/routes/jobs'
 import { createLogger } from '../../src/core/logger'
@@ -69,6 +70,12 @@ const schedulePlugin: BakinPlugin = definePlugin({
       hookKind: 'rpc',
       label: 'Ensure Bakin schedule',
       summary: 'Create or update a Bakin-managed runtime cron job and return the provider job id.',
+    })
+
+    ctx.hooks.register('schedule.adoptCronJobs', (data: unknown) => adoptCronJobs(ctx, data as AdoptCronJobsInput), {
+      hookKind: 'rpc',
+      label: 'Adopt runtime cron jobs',
+      summary: 'Adopt snapshotted runtime cron jobs into Bakin schedules during a runtime switch (opt-in, idempotent per job id).',
     })
 
     // ─── Search Content Type Registration ─────────────────────────────

--- a/plugins/schedule/lib/cron-adoption.ts
+++ b/plugins/schedule/lib/cron-adoption.ts
@@ -1,0 +1,103 @@
+/**
+ * Switch-time cron adoption (pi-parity T3.4, story 7).
+ *
+ * When a runtime switch leaves a cron-bearing runtime, the switch snapshots
+ * the source's native cron jobs BEFORE teardown and — when the user opted in
+ * (`--adopt-cron`) — hands them here via the `schedule.adoptCronJobs` hook.
+ * Each job becomes a Bakin-managed schedule with `source: 'adopted'` and the
+ * provider-raw snapshot preserved (`originalRuntimeCron`), mirroring the
+ * per-job REST adopt handler — minus the live `cron.get`/`cron.remove` calls
+ * (the source runtime is already gone; its native jobs stop firing with it).
+ *
+ * Idempotent per job id: an already-Bakin-managed id is reported `skipped`,
+ * so a re-run switch never duplicates schedules.
+ */
+import type { PluginContext } from '@bakin/core/plugin-types'
+import { getRuntimeMainAgentId, type CronJob } from '@bakin/core/adapters/runtime'
+import type { BakinJobMeta } from '../types'
+import { getJob, upsertJob } from './sidecar'
+import { getSystemTimezone } from './schedule-util'
+import { indexJob } from './job-service'
+
+export interface AdoptCronJobsInput {
+  /** Source runtime adapter name (recorded as the snapshot provider). */
+  provider: string
+  jobs: Array<{ job: CronJob; raw: unknown }>
+  /** Classify without writing (switch dry-run preview). */
+  dryRun?: boolean
+}
+
+export interface AdoptCronJobsResult {
+  adopted: string[]
+  /** Already Bakin-managed — left untouched. */
+  skipped: string[]
+  failed: Array<{ jobId: string; error: string }>
+}
+
+export async function adoptCronJobs(
+  ctx: Pick<PluginContext, 'runtime' | 'activity'>,
+  input: AdoptCronJobsInput,
+): Promise<AdoptCronJobsResult> {
+  const result: AdoptCronJobsResult = { adopted: [], skipped: [], failed: [] }
+  const now = new Date().toISOString()
+  const tz = getSystemTimezone()
+  let defaultOwner: string | undefined
+  try {
+    defaultOwner = await getRuntimeMainAgentId(ctx.runtime)
+  } catch {
+    // Ownerless adoption is still an adoption — the job edits fine later.
+  }
+
+  for (const { job, raw } of input.jobs) {
+    try {
+      const existing = getJob(job.id)
+      if (existing?.isBakinJob) {
+        result.skipped.push(job.id)
+        continue
+      }
+      if (input.dryRun) {
+        result.adopted.push(job.id)
+        continue
+      }
+
+      const meta: BakinJobMeta = {
+        ...(existing ?? {}),
+        jobId: job.id,
+        isBakinJob: true,
+        source: 'adopted',
+        schedule: { kind: 'cron', expr: job.schedule },
+        enabled: job.enabled ?? true,
+        displayName: existing?.displayName ?? job.name,
+        agentId: existing?.agentId,
+        teamId: existing?.teamId,
+        owner: existing?.owner ?? defaultOwner,
+        requireTriage: existing?.requireTriage ?? false,
+        workflowId: existing?.workflowId,
+        taskPrompt: existing?.taskPrompt ?? job.command,
+        taskTitle: existing?.taskTitle,
+        allowOverlap: existing?.allowOverlap ?? false,
+        maxFailures: existing?.maxFailures ?? 3,
+        consecutiveFailures: existing?.consecutiveFailures ?? 0,
+        tz: existing?.tz ?? tz,
+        originalRuntimeCron: {
+          provider: input.provider,
+          capturedAt: now,
+          snapshot: raw,
+        },
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+      }
+      upsertJob(meta)
+      indexJob(job.id)
+      ctx.activity.audit('job.adopted', 'system', { jobId: job.id, via: 'runtime-switch' })
+      result.adopted.push(job.id)
+    } catch (err) {
+      result.failed.push({ jobId: job.id, error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  if (!input.dryRun && result.adopted.length > 0) {
+    ctx.activity.log('system', `Adopted ${result.adopted.length} runtime cron job(s) into Bakin during runtime switch`)
+  }
+  return result
+}

--- a/plugins/workflows/bakin-plugin.json
+++ b/plugins/workflows/bakin-plugin.json
@@ -195,6 +195,7 @@
       }
     ],
     "slots": [
+      "nav-badge-providers",
       "page:/workflows",
       "page:/workflows/[id]",
       "page:/workflows/new",

--- a/plugins/workflows/client.tsx
+++ b/plugins/workflows/client.tsx
@@ -23,6 +23,7 @@ import { MapWorkflowNode } from './components/nodes/map-workflow-node'
 import { CreateTaskNode } from './components/nodes/create-task-node'
 import { SubflowGroupNode } from './components/nodes/subflow-group-node'
 import { WorkflowsPage } from './components/workflows-page'
+import { ApprovalsBadgeProvider } from './components/approvals-badge-provider'
 import { WorkflowDetail } from './components/workflow-detail'
 import { WorkflowCanvasEditor } from './components/workflow-canvas-editor'
 import {
@@ -49,6 +50,7 @@ registerPlugin({
   },
   id: 'workflows',
   slots: {
+    'nav-badge-providers': ApprovalsBadgeProvider,
     'page:/workflows': WorkflowsPage,
     'page:/workflows/[id]': WorkflowDetail,
     // WorkflowCanvasEditor handles both /new and /[id]/edit — the wrapper

--- a/plugins/workflows/components/approvals-badge-provider.tsx
+++ b/plugins/workflows/components/approvals-badge-provider.tsx
@@ -1,0 +1,66 @@
+/**
+ * ApprovalsBadgeProvider — pending gate approvals ride the global attention
+ * system. Mounted in the host's `nav-badge-providers` slot (outside the
+ * router): keeps the Workflows nav badge at the pending-gate count and
+ * fires toast + OS notification when a gate becomes pending while the user
+ * is elsewhere (rules in attention.ts). On Pi — no channel layer — this is
+ * the delivery that keeps gated tasks from stalling silently; when a
+ * channel bridge exists it stays on as the always-on companion.
+ *
+ * The durable approval record remains the sole authority; clicking through
+ * lands on the task detail where gates are approved/rejected.
+ */
+import { useCallback, useEffect } from 'react'
+import { useNavBadge, usePluginEvent, toast } from '@makinbakin/sdk/hooks'
+import { pluginFetch } from '@makinbakin/sdk/utils'
+import { useState } from 'react'
+
+import { sendBrowserNotification } from '../../../src/lib/browser-notify'
+import { attentionForGate, gateBadge, gateUrl, type GateReachedPayload } from './attention'
+
+interface PendingGatesResponse {
+  gates: Array<{ taskId: string; stepId: string; label?: string }>
+}
+
+export function ApprovalsBadgeProvider() {
+  const [pending, setPending] = useState(0)
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await pluginFetch('workflows', 'gates/pending')
+      if (!res.ok) return
+      const body = (await res.json()) as PendingGatesResponse
+      setPending(Array.isArray(body.gates) ? body.gates.length : 0)
+    } catch {
+      /* transient fetch failures keep the last known count */
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  usePluginEvent('workflow.gate_reached', (payload) => {
+    void refresh()
+    const gate = payload as unknown as GateReachedPayload
+    const attention = attentionForGate(gate, window.location)
+    if (!attention.notify) return
+    toast(
+      <button
+        type="button"
+        className="text-left"
+        onClick={() => { window.location.href = attention.url }}
+      >
+        <span className="font-medium">{attention.title}</span>
+        <span className="block text-xs text-muted-foreground">{attention.body}</span>
+      </button>,
+      'info',
+    )
+    sendBrowserNotification(attention.title, attention.body, gateUrl(gate))
+  })
+
+  usePluginEvent('workflow.gate_approved', () => { void refresh() })
+  usePluginEvent('workflow.gate_rejected', () => { void refresh() })
+
+  useNavBadge('workflows', 'workflows', gateBadge(pending))
+
+  return null
+}

--- a/plugins/workflows/components/attention.ts
+++ b/plugins/workflows/components/attention.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure attention rules for pending gate approvals — mirrors the chat
+ * plugin's attention.ts split: every decision is a pure function the badge
+ * provider composes, unit-testable without DOM or fetch.
+ *
+ * A pending gate is actionable-by-human by definition; on Pi (no channel
+ * layer) this in-app path is the ONLY delivery, so nothing here is gated on
+ * runtime capabilities. The durable approval record stays the authority —
+ * this is attention, not approval state.
+ */
+import type { NavBadge } from '@makinbakin/sdk'
+
+export interface GateReachedPayload {
+  instanceId: string
+  taskId: string
+  workflowId: string
+  stepId: string
+  label?: string
+}
+
+/** Nav badge for N pending gates: attention-toned count, hidden at zero. */
+export function gateBadge(pendingCount: number): NavBadge | null {
+  if (pendingCount <= 0) return null
+  return { count: pendingCount, tone: 'attention' }
+}
+
+/** The gate is approved/rejected on the task detail — deep-link there. */
+export function gateUrl(gate: Pick<GateReachedPayload, 'taskId'>): string {
+  return `/tasks?taskId=${encodeURIComponent(gate.taskId)}`
+}
+
+/**
+ * Whether the user is already looking at the task whose gate fired —
+ * suppress toast/notification, the gate panel is on their screen.
+ */
+export function viewingGateTask(gate: Pick<GateReachedPayload, 'taskId'>, location: { pathname: string; search: string }): boolean {
+  if (!location.pathname.startsWith('/tasks')) return false
+  return new URLSearchParams(location.search).get('taskId') === gate.taskId
+}
+
+export interface GateAttention {
+  notify: boolean
+  title: string
+  body: string
+  url: string
+}
+
+/** Toast/OS-notification decision + copy for a freshly pending gate. */
+export function attentionForGate(
+  gate: GateReachedPayload,
+  location: { pathname: string; search: string },
+): GateAttention {
+  return {
+    notify: !viewingGateTask(gate, location),
+    title: 'Approval needed',
+    body: gate.label ? `${gate.label} is waiting for your decision.` : 'A workflow gate is waiting for your decision.',
+    url: gateUrl(gate),
+  }
+}

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -81,11 +81,12 @@ async function cmdRuntimeCapabilities(): Promise<void> {
 interface RuntimeUseFlags {
   dryRun: boolean
   copyWorkspaces: boolean
+  adoptCron: boolean
 }
 
 async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags): Promise<void> {
   if (!target) {
-    console.error('Usage: bakin runtime use <adapter> [--dry-run] [--no-copy-workspaces]')
+    console.error('Usage: bakin runtime use <adapter> [--dry-run] [--no-copy-workspaces] [--adopt-cron]')
     process.exit(1)
   }
   console.log(flags.dryRun
@@ -95,6 +96,7 @@ async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags)
     target,
     ...(flags.dryRun ? { dryRun: true } : {}),
     ...(flags.copyWorkspaces ? {} : { copyWorkspaces: false }),
+    ...(flags.adoptCron ? { adoptCron: true } : {}),
   }) as Record<string, unknown>
 
   if (!result.ok) {
@@ -120,6 +122,15 @@ async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags)
     for (const kept of roster.preserved ?? []) {
       console.log(`  ○ ${kept.agentId}: subagent model '${kept.sourceModel}' preserved (not active on ${result.to}) — restored on switch back`)
     }
+  }
+  const cron = result.cron as { adopted: string[]; skipped: string[]; failed: Array<{ jobId: string; error: string }> } | null
+  if (cron) {
+    console.log(`Cron: ${flags.dryRun ? 'would adopt' : 'adopted'} ${cron.adopted.length}, already Bakin ${cron.skipped.length}, failed ${cron.failed.length}`)
+    for (const failure of cron.failed) {
+      console.log(`  ✗ ${failure.jobId}: ${failure.error}`)
+    }
+  }
+  if (roster) {
     for (const failure of roster.failed) {
       console.log(`  ✗ ${failure.agentId}: ${failure.error}`)
     }
@@ -184,7 +195,7 @@ export async function run(args: string[]): Promise<void> {
       const rest = args.slice(2)
       // Fail CLOSED on unknown flags: `--dryrun` silently ignored would run
       // a REAL switch where the user intended a preview.
-      const KNOWN_FLAGS = ['--dry-run', '--no-copy-workspaces']
+      const KNOWN_FLAGS = ['--dry-run', '--no-copy-workspaces', '--adopt-cron']
       const unknown = rest.filter((arg) => arg.startsWith('--') && !KNOWN_FLAGS.includes(arg))
       if (unknown.length > 0) {
         console.error(`Unknown flag(s): ${unknown.join(', ')}. Supported: ${KNOWN_FLAGS.join(', ')}`)
@@ -194,6 +205,7 @@ export async function run(args: string[]): Promise<void> {
       await cmdRuntimeUse(target, {
         dryRun: rest.includes('--dry-run'),
         copyWorkspaces: !rest.includes('--no-copy-workspaces'),
+        adoptCron: rest.includes('--adopt-cron'),
       })
     } else await cmdRuntimeCapabilities()
     return

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -108,7 +108,7 @@ async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags)
   }
 
   const would = flags.dryRun ? 'Would carry' : 'Carried'
-  const roster = result.roster as { carried: unknown[]; existing: string[]; unmappedModels: Array<{ agentId: string; sourceModel: string; field?: string }>; failed: Array<{ agentId: string; error: string }> } | null
+  const roster = result.roster as { carried: unknown[]; existing: string[]; unmappedModels: Array<{ agentId: string; sourceModel: string; field?: string }>; preserved?: Array<{ agentId: string; sourceModel: string }>; failed: Array<{ agentId: string; error: string }> } | null
   console.log(flags.dryRun ? `Would switch ${result.from} → ${result.to}` : `Switched ${result.from} → ${result.to}`)
   if (result.backupPath) console.log(`Settings backup: ${result.backupPath}`)
   if (roster) {
@@ -116,6 +116,9 @@ async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags)
     for (const unmapped of roster.unmappedModels) {
       const what = unmapped.field === 'subagentModel' ? 'subagent model' : 'model'
       console.log(`  ⚠ ${unmapped.agentId}: ${what} '${unmapped.sourceModel}' has no equivalent on ${result.to} — falls back to the routing default`)
+    }
+    for (const kept of roster.preserved ?? []) {
+      console.log(`  ○ ${kept.agentId}: subagent model '${kept.sourceModel}' preserved (not active on ${result.to}) — restored on switch back`)
     }
     for (const failure of roster.failed) {
       console.log(`  ✗ ${failure.agentId}: ${failure.error}`)

--- a/src/core/roster-reconcile.ts
+++ b/src/core/roster-reconcile.ts
@@ -28,10 +28,17 @@ export interface RosterCarryReport {
   existing: string[]
   /**
    * Source models with no target equivalent (agent carried without them):
-   * no catalog match, or — for `subagentModel` — a runtime without
-   * per-agent subagent models (`routingSupport()`). Never guessed.
+   * no catalog match. Never guessed.
    */
   unmappedModels: Array<{ agentId: string; sourceModel: string; field: 'model' | 'subagentModel' }>
+  /**
+   * Subagent models the target runtime cannot HONOR
+   * (`routingSupport().perAgentSubagentModel === false`) — stashed in the
+   * carried agent's metadata (`carriedSubagentModel`) so a later switch back
+   * to an honoring runtime restores them instead of dropping the assignment
+   * (pi-parity OQ1: preservation without a dishonest capability flag).
+   */
+  preserved: Array<{ agentId: string; sourceModel: string }>
   /** Agents that could not be created on the target, and post-create carry steps that failed. */
   failed: Array<{ agentId: string; error: string }>
 }
@@ -63,12 +70,29 @@ function supportsPerAgentSubagentModel(target: AgentRuntimeAdapter): boolean {
 /** Adapter-private keys never carried across runtimes. */
 const PRIVATE_METADATA_KEYS = new Set(['workspacePath', 'workspace', 'subagentAllowAgents'])
 
+/**
+ * Reconciler-owned metadata stash for a subagent model the hosting runtime
+ * cannot honor. Written when carrying ONTO an unsupporting runtime; consumed
+ * (and not re-carried) when the agent later lands on an honoring one.
+ */
+export const CARRIED_SUBAGENT_MODEL_KEY = 'carriedSubagentModel'
+
 function carriedMetadata(agent: RuntimeAgent): Record<string, unknown> | undefined {
   if (!agent.metadata) return undefined
   const entries = Object.entries(agent.metadata).filter(
-    ([key, value]) => !PRIVATE_METADATA_KEYS.has(key) && value !== undefined && value !== null && value !== '',
+    ([key, value]) =>
+      !PRIVATE_METADATA_KEYS.has(key)
+      && key !== CARRIED_SUBAGENT_MODEL_KEY // reconciler-owned; re-stashed explicitly when still needed
+      && value !== undefined && value !== null && value !== '',
   )
   return entries.length > 0 ? Object.fromEntries(entries) : undefined
+}
+
+/** The effective source subagent model: the live field, else a prior stash. */
+function sourceSubagentModel(agent: RuntimeAgent): string | undefined {
+  if (agent.subagentModel) return agent.subagentModel
+  const stashed = agent.metadata?.[CARRIED_SUBAGENT_MODEL_KEY]
+  return typeof stashed === 'string' && stashed.length > 0 ? stashed : undefined
 }
 
 export interface ReconcileRosterOptions {
@@ -81,7 +105,7 @@ export async function reconcileRoster(
   target: AgentRuntimeAdapter,
   opts: ReconcileRosterOptions = {},
 ): Promise<RosterCarryReport> {
-  const report: RosterCarryReport = { carried: [], existing: [], unmappedModels: [], failed: [] }
+  const report: RosterCarryReport = { carried: [], existing: [], unmappedModels: [], preserved: [], failed: [] }
 
   const targetIds = new Set((await target.agents.list()).map((agent) => agent.id))
   let targetCatalog: string[] = []
@@ -114,24 +138,37 @@ export async function reconcileRoster(
     }
 
     // Subagent model: same mapping rule, applied post-create via update()
-    // (CreateRuntimeAgentInput doesn't accept it) — and only on runtimes that
-    // support per-agent subagent models. Anything else is a report line.
+    // (CreateRuntimeAgentInput doesn't accept it) — but only runtimes with
+    // per-agent subagent-model support HONOR it. On an unsupporting target
+    // the value is PRESERVED in metadata (never dropped): the round trip
+    // OpenClaw→Pi→OpenClaw restores the assignment. A prior stash counts as
+    // the source value on the way back.
     let subagentModel: string | undefined
-    if (agent.subagentModel) {
-      const supported = supportsPerAgentSubagentModel(target)
-      const mapped = supported ? mapModelToCatalog(agent.subagentModel, targetCatalog) : null
-      if (mapped) subagentModel = mapped
-      else report.unmappedModels.push({ agentId: agent.id, sourceModel: agent.subagentModel, field: 'subagentModel' })
+    let stashSubagentModel: string | undefined
+    const sourceSubagent = sourceSubagentModel(agent)
+    if (sourceSubagent) {
+      if (supportsPerAgentSubagentModel(target)) {
+        const mapped = mapModelToCatalog(sourceSubagent, targetCatalog)
+        if (mapped) subagentModel = mapped
+        else report.unmappedModels.push({ agentId: agent.id, sourceModel: sourceSubagent, field: 'subagentModel' })
+      } else {
+        stashSubagentModel = sourceSubagent
+        report.preserved.push({ agentId: agent.id, sourceModel: sourceSubagent })
+      }
     }
 
     if (!opts.dryRun) {
       try {
+        const metadata = {
+          ...(carriedMetadata(agent) ?? {}),
+          ...(stashSubagentModel ? { [CARRIED_SUBAGENT_MODEL_KEY]: stashSubagentModel } : {}),
+        }
         await target.agents.create({
           id: agent.id,
           name: agent.name || agent.id,
           ...(agent.role ? { role: agent.role } : {}),
           ...(model ? { model } : {}),
-          ...(carriedMetadata(agent) ? { metadata: carriedMetadata(agent) } : {}),
+          ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
         })
       } catch (err) {
         report.failed.push({ agentId: agent.id, error: err instanceof Error ? err.message : String(err) })
@@ -165,6 +202,7 @@ export async function reconcileRoster(
     carried: report.carried.length,
     existing: report.existing.length,
     unmapped: report.unmappedModels.length,
+    preserved: report.preserved.length,
     failed: report.failed.length,
   })
   return report

--- a/src/core/runtime-switch.ts
+++ b/src/core/runtime-switch.ts
@@ -39,6 +39,7 @@ import { reconcileRoster, type RosterCarryReport } from './roster-reconcile'
 import { getSettings, updateSettings } from './settings'
 import { snapshotAgentContent, carryAgentContent, previewWorkspaceCarry, type AgentContentSnapshot, type WorkspaceCarryReport } from './workspace-carry'
 import { snapshotSourceCapabilities, buildCantCarryReport, type CantCarryLine, type SourceCapabilitySnapshot } from './switch-report'
+import { getHookRegistry } from '@bakin/core/hooks/hook-registry-singleton'
 
 const log = createLogger('runtime-switch')
 
@@ -55,6 +56,7 @@ export const RuntimeSwitchRequestSchema = z
     target: z.string().min(1),
     dryRun: z.boolean().optional(),
     copyWorkspaces: z.boolean().optional(),
+    adoptCron: z.boolean().optional(),
   })
   .strict()
 
@@ -67,6 +69,7 @@ export type SwitchPhase =
   | 'initialize'
   | 'provision'
   | 'reconcile-roster'
+  | 'adopt-cron'
   | 'carry-workspaces'
   | 'sync-agents'
   | 'validate-capabilities'
@@ -91,6 +94,8 @@ export interface RuntimeSwitchResult {
   sync: { drifted: boolean; findings: number; syncedAgents: number } | null
   capabilities: CapabilitySet | null
   toolAccess: ToolAccessProvisioningStatus | null
+  /** Opt-in cron adoption outcome (null when not requested / nothing to adopt). */
+  cron: { adopted: string[]; skipped: string[]; failed: Array<{ jobId: string; error: string }> } | null
   /** What stays behind, honestly (capability diff + counts; null when the phase didn't run). */
   cantCarry: CantCarryLine[] | null
   /** The TARGET's credential presence — a carried roster with no provider auth dispatches nothing. */
@@ -119,6 +124,69 @@ export interface SwitchRuntimeOptions {
    * constructed as a read-only secondary instance and shut down after.
    */
   dryRun?: boolean
+  /**
+   * Adopt the source runtime's native cron jobs into Bakin schedules
+   * (schedule plugin hook, idempotent per job id). Opt-in — never automatic;
+   * dry runs preview the would-adopt list.
+   */
+  adoptCron?: boolean
+}
+
+type CronAdoptionResult = NonNullable<RuntimeSwitchResult['cron']>
+
+/**
+ * Hand snapshotted source cron jobs to the schedule plugin's adoption hook.
+ * Absent hook (schedule plugin inactive) and empty snapshots are honest
+ * skips; failures never abort the switch — the flip already happened.
+ */
+async function runCronAdoption(
+  provider: string,
+  sourceCapabilities: SourceCapabilitySnapshot | null,
+  dryRun: boolean,
+  emit: (event: SwitchProgressEvent) => void,
+): Promise<CronAdoptionResult | null> {
+  const jobs = sourceCapabilities?.cronJobs ?? []
+  if (jobs.length === 0) {
+    emit({ phase: 'adopt-cron', status: 'skip', detail: sourceCapabilities?.hasCron ? 'no runtime cron jobs in the source snapshot' : 'source runtime has no cron surface' })
+    return null
+  }
+  try {
+    const outcome = await getHookRegistry().invoke<CronAdoptionResult>('schedule.adoptCronJobs', {
+      provider,
+      jobs,
+      dryRun,
+    })
+    if (!outcome) {
+      emit({ phase: 'adopt-cron', status: 'error', detail: 'schedule plugin hook unavailable — jobs NOT adopted (adopt individually from the Schedule page)' })
+      return { adopted: [], skipped: [], failed: jobs.map((j) => ({ jobId: j.job.id, error: 'schedule.adoptCronJobs hook unavailable' })) }
+    }
+    emit({
+      phase: 'adopt-cron',
+      status: 'ok',
+      detail: `${dryRun ? 'would adopt' : 'adopted'} ${outcome.adopted.length}, already Bakin ${outcome.skipped.length}, failed ${outcome.failed.length}`,
+    })
+    return outcome
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    emit({ phase: 'adopt-cron', status: 'error', detail: message })
+    return { adopted: [], skipped: [], failed: jobs.map((j) => ({ jobId: j.job.id, error: message })) }
+  }
+}
+
+/** Fold the adoption outcome into the cron can't-carry line, honestly. */
+function adjustCantCarryForAdoption(lines: CantCarryLine[], cron: CronAdoptionResult | null, dryRun: boolean): CantCarryLine[] {
+  if (!cron || cron.adopted.length === 0) return lines
+  return lines.map((line) => {
+    if (line.concern !== 'cron') return line
+    const verb = dryRun ? 'would be adopted' : 'adopted'
+    const remaining = (line.count ?? cron.adopted.length + cron.failed.length) - cron.adopted.length - cron.skipped.length
+    return {
+      ...line,
+      detail: remaining > 0
+        ? `${cron.adopted.length} runtime cron job(s) ${verb} into Bakin schedules; ${remaining} stay(s) behind`
+        : `runtime cron jobs ${verb} into Bakin schedules — nothing stays behind`,
+    }
+  })
 }
 
 function isRuntimeAdapterName(value: string): value is RuntimeAdapterName {
@@ -163,6 +231,7 @@ export async function switchRuntime(
     roster: null,
     workspaces: null,
     sync: null,
+    cron: null,
     capabilities: null,
     toolAccess: null,
     cantCarry: null,
@@ -279,7 +348,7 @@ export async function switchRuntime(
     const copyWorkspaces = opts.copyWorkspaces !== false
     try {
       // Optional-surface presence + counts must be read pre-teardown too.
-      sourceCapabilities = await snapshotSourceCapabilities(oldRuntime)
+      sourceCapabilities = await snapshotSourceCapabilities(oldRuntime, { captureCronJobs: opts.adoptCron === true })
       sourceRoster = await oldRuntime.agents.list()
       // Workspace content must be captured NOW — the source runtime is torn
       // down before the target exists (snapshotAgentContent degrades read
@@ -358,6 +427,14 @@ export async function switchRuntime(
       detail: `carried ${result.roster.carried.length}, existing ${result.roster.existing.length}, unmapped models ${result.roster.unmappedModels.length}, failed ${result.roster.failed.length}`,
     })
 
+    // ── adopt source cron jobs into Bakin schedules (opt-in) ─────────────
+    emit({ phase: 'adopt-cron', status: 'start' })
+    if (!opts.adoptCron) {
+      emit({ phase: 'adopt-cron', status: 'skip', detail: 'not requested (--adopt-cron)' })
+    } else {
+      result.cron = await runCronAdoption(from, sourceCapabilities, false, emit)
+    }
+
     // ── workspace content carry (switch-created agents only) ─────────────
     emit({ phase: 'carry-workspaces', status: 'start' })
     if (!copyWorkspaces) {
@@ -398,7 +475,7 @@ export async function switchRuntime(
     result.capabilities = await newRuntime.capabilities()
     result.toolAccess = await newRuntime.verifyToolAccess()
     if (sourceCapabilities) {
-      result.cantCarry = buildCantCarryReport(sourceCapabilities, newRuntime)
+      result.cantCarry = adjustCantCarryForAdoption(buildCantCarryReport(sourceCapabilities, newRuntime), result.cron, false)
     }
     try {
       result.credentials = await newRuntime.credentialStatus()
@@ -467,7 +544,7 @@ async function dryRunSwitch(
   let contentSnapshot: AgentContentSnapshot | null = null
   let sourceCapabilities: SourceCapabilitySnapshot | null = null
   try {
-    sourceCapabilities = await snapshotSourceCapabilities(source)
+    sourceCapabilities = await snapshotSourceCapabilities(source, { captureCronJobs: opts.adoptCron === true })
     sourceRoster = await source.agents.list()
     if (copyWorkspaces && sourceRoster.length > 0) {
       contentSnapshot = await snapshotAgentContent(source, sourceRoster)
@@ -489,6 +566,13 @@ async function dryRunSwitch(
       status: 'ok',
       detail: `would carry ${result.roster.carried.length}, existing ${result.roster.existing.length}, unmapped models ${result.roster.unmappedModels.length}`,
     })
+
+    emit({ phase: 'adopt-cron', status: 'start' })
+    if (!opts.adoptCron) {
+      emit({ phase: 'adopt-cron', status: 'skip', detail: 'not requested (--adopt-cron)' })
+    } else {
+      result.cron = await runCronAdoption(result.from, sourceCapabilities, true, emit)
+    }
 
     emit({ phase: 'carry-workspaces', status: 'start' })
     if (!copyWorkspaces) {
@@ -513,7 +597,7 @@ async function dryRunSwitch(
     emit({ phase: 'validate-capabilities', status: 'start' })
     result.capabilities = await targetRuntime.capabilities()
     if (sourceCapabilities) {
-      result.cantCarry = buildCantCarryReport(sourceCapabilities, targetRuntime)
+      result.cantCarry = adjustCantCarryForAdoption(buildCantCarryReport(sourceCapabilities, targetRuntime), result.cron, true)
     }
     try {
       result.credentials = await targetRuntime.credentialStatus()

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -250,10 +250,11 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
           const detail = parsed.error.issues.map((i) => `${i.path.join('.') || 'body'}: ${i.message}`).join('; ')
           throw new BadRequestError(`Invalid runtime switch request — ${detail}`)
         }
-        const { target, dryRun, copyWorkspaces } = parsed.data
+        const { target, dryRun, copyWorkspaces, adoptCron } = parsed.data
         const result = await switchRuntime(target, {
           ...(dryRun !== undefined ? { dryRun } : {}),
           ...(copyWorkspaces !== undefined ? { copyWorkspaces } : {}),
+          ...(adoptCron !== undefined ? { adoptCron } : {}),
           onProgress: (event) => broadcast({ type: 'runtime:switch', ...event }),
         })
         broadcast({ type: 'runtime:switch:result', ok: result.ok, to: result.to, restartRequired: result.restartRequired })

--- a/src/core/switch-report.ts
+++ b/src/core/switch-report.ts
@@ -6,12 +6,19 @@
  * deep enumeration). The user learns what stays behind from the report, not
  * by discovering it broken.
  */
-import type { AgentRuntimeAdapter } from '@bakin/core/adapters/runtime'
+import type { AgentRuntimeAdapter, CronJob } from '@bakin/core/adapters/runtime'
 
 export interface CantCarryLine {
   concern: 'channels' | 'cron' | 'sessions' | 'provider-config'
   detail: string
   count?: number
+}
+
+/** A source cron job captured pre-teardown for switch-time adoption. */
+export interface SnapshottedCronJob {
+  job: CronJob
+  /** Provider-raw snapshot (cron.getRaw) — preserved on the adopted Bakin job. */
+  raw: unknown
 }
 
 export interface SourceCapabilitySnapshot {
@@ -21,6 +28,18 @@ export interface SourceCapabilitySnapshot {
   hasCron: boolean
   /** Best-effort; undefined when the surface exists but the count fetch failed. */
   cronJobCount?: number
+  /**
+   * Full job snapshots — captured ONLY when the caller asked to adopt cron
+   * (the source runtime is torn down before adoption runs, so this is the
+   * one window to read them). Per-job read failures drop that job with a
+   * warn; adoption reports what it received.
+   */
+  cronJobs?: SnapshottedCronJob[]
+}
+
+export interface SnapshotSourceCapabilitiesOptions {
+  /** Capture full cron job payloads (list + per-job getRaw) for adoption. */
+  captureCronJobs?: boolean
 }
 
 /**
@@ -28,7 +47,10 @@ export interface SourceCapabilitySnapshot {
  * Count fetch failures degrade to "present, count unknown" — reported
  * without a number, never guessed, never thrown.
  */
-export async function snapshotSourceCapabilities(source: AgentRuntimeAdapter): Promise<SourceCapabilitySnapshot> {
+export async function snapshotSourceCapabilities(
+  source: AgentRuntimeAdapter,
+  opts: SnapshotSourceCapabilitiesOptions = {},
+): Promise<SourceCapabilitySnapshot> {
   const snapshot: SourceCapabilitySnapshot = {
     hasChannels: source.channels !== undefined,
     hasCron: source.cron !== undefined,
@@ -42,7 +64,22 @@ export async function snapshotSourceCapabilities(source: AgentRuntimeAdapter): P
   }
   if (source.cron) {
     try {
-      snapshot.cronJobCount = (await source.cron.list()).length
+      const jobs = await source.cron.list()
+      snapshot.cronJobCount = jobs.length
+      if (opts.captureCronJobs && jobs.length > 0) {
+        const captured: SnapshottedCronJob[] = []
+        for (const job of jobs) {
+          try {
+            const raw = source.cron.getRaw
+              ? await source.cron.getRaw(job.id, 'runtime switch: preserve native cron for Bakin adoption')
+              : null
+            captured.push({ job, raw })
+          } catch {
+            // Unreadable job — adoption reports it missing from the snapshot.
+          }
+        }
+        snapshot.cronJobs = captured
+      }
     } catch {
       // Present but unreadable — the line still emits, without a count.
     }

--- a/src/core/team-context-defaults.ts
+++ b/src/core/team-context-defaults.ts
@@ -142,6 +142,14 @@ bakin_exec_schedule_create name="daily-recipe" schedule="every day at 11am" agen
 - **Recurring work** (daily posts, weekly reports, periodic checks) → \`bakin_exec_schedule_create\`
 - **One-time deliverables** → \`bakin_exec_tasks_create\`
 
+## Bakin Code & GitHub Rules
+
+For coding tasks against a git repository:
+
+1. **Isolate in a worktree.** Start with \`bakin_exec_git_prepare_worktree taskId=<id>\` and work there; check state with \`bakin_exec_git_status\` and release with \`bakin_exec_git_release_worktree\` when done. Never commit from a shared checkout — branches flip under you.
+2. **GitHub operations use the \`gh\` CLI** (issues, PRs, releases, CI status) when it is installed and authenticated — the doctor's github readiness check tells you.
+3. **Ask before irreversible pushes.** Pushing to or merging into a repo's default branch, force-pushing, or publishing a release needs explicit instruction in the task brief; otherwise stop and ask via \`bakin_exec_log\` + \`bakin_exec_tasks_block\`. Opening a PR from a feature branch is fine without asking.
+
 ## Bakin Asset Rules
 
 All created content (images, video, audio, text, plans, data) MUST go to the assets directory. Use the Bakin skill for full conventions, but here's the minimum:

--- a/tests/adapter-pi/session-settings.test.ts
+++ b/tests/adapter-pi/session-settings.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pin: Pi auto-compaction stays ON for Bakin turns (pi-parity T3.5 / P0
+ * adjudication). Long tasks COMPACT rather than die because the SDK's
+ * settings default is enabled and the adapter's per-turn SettingsManager
+ * (messaging.ts: SettingsManager.create(workspace, agentDir, ...)) inherits
+ * it. If the pinned SDK ever flips this default, this test fails and
+ * messaging.ts must enable compaction explicitly.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-pi-session-settings-${Date.now()}-${randomUUID()}`)
+process.env.PI_HOME = pathJoin(testDir, 'pi')
+process.env.BAKIN_HOME = testDir
+
+import { afterAll, describe, expect, it, mock } from 'bun:test'
+import { mkdirSync, rmSync } from 'fs'
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: pathJoin(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: pathJoin(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => pathJoin(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => pathJoin(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { createTurnSettingsManager } from '../../packages/adapter-pi/src/messaging'
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('pi session settings (SDK default pin)', () => {
+  it('compaction is enabled by default in the adapter-shaped SettingsManager', () => {
+    const workspace = pathJoin(testDir, 'pi', 'agents', 'main', 'workspace')
+    const agentDir = pathJoin(testDir, 'pi', 'agent')
+    mkdirSync(workspace, { recursive: true })
+    mkdirSync(agentDir, { recursive: true })
+
+    // THE construction Bakin turns use (exported from messaging.ts).
+    const settings = createTurnSettingsManager(workspace, agentDir)
+    const compaction = settings.getCompactionSettings()
+    expect(compaction.enabled).toBe(true)
+    expect(compaction.reserveTokens).toBeGreaterThan(0)
+    expect(compaction.keepRecentTokens).toBeGreaterThan(0)
+  })
+})

--- a/tests/core/roster-reconcile.test.ts
+++ b/tests/core/roster-reconcile.test.ts
@@ -18,13 +18,13 @@ mock.module('../../src/core/logger', () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
 }))
 
-import { mapModelToCatalog, reconcileRoster } from '../../src/core/roster-reconcile'
+import { CARRIED_SUBAGENT_MODEL_KEY, mapModelToCatalog, reconcileRoster } from '../../src/core/roster-reconcile'
 import type { AgentRuntimeAdapter, RuntimeAgent } from '@bakin/core/adapters/runtime'
 
 function targetWith(overrides: {
   existing?: string[]
   catalog?: string[]
-  createImpl?: (input: { id: string; model?: string }) => Promise<unknown>
+  createImpl?: (input: { id: string; name?: string; model?: string; metadata?: Record<string, unknown> }) => Promise<unknown>
   updateImpl?: (agentId: string, input: { subagentModel?: string | null }) => Promise<unknown>
   perAgentSubagentModel?: boolean
 }): AgentRuntimeAdapter {
@@ -132,11 +132,16 @@ describe('reconcileRoster — subagentModel carry', () => {
     ])
   })
 
-  it('a runtime without per-agent subagent models gets a report line, not an update call', async () => {
+  it('a runtime without per-agent subagent models PRESERVES the value in metadata, no update call', async () => {
     const updates: string[] = []
+    const created: Array<{ id: string; metadata?: Record<string, unknown> }> = []
     const target = targetWith({
       catalog: ['openai-codex/gpt-5.5', 'openai-codex/gpt-5.5-mini'],
       perAgentSubagentModel: false,
+      createImpl: async (input) => {
+        created.push({ id: input.id, metadata: input.metadata })
+        return { id: input.id, name: input.name }
+      },
       updateImpl: async (agentId) => {
         updates.push(agentId)
         return { id: agentId, name: agentId }
@@ -144,9 +149,39 @@ describe('reconcileRoster — subagentModel carry', () => {
     })
     const report = await reconcileRoster(withSubagent, target)
     expect(updates).toEqual([])
-    expect(report.unmappedModels).toEqual([
-      { agentId: 'main', sourceModel: 'openai/gpt-5.5-mini', field: 'subagentModel' },
-    ])
+    expect(report.unmappedModels).toEqual([])
+    expect(report.preserved).toEqual([{ agentId: 'main', sourceModel: 'openai/gpt-5.5-mini' }])
+    expect(created[0]?.metadata?.[CARRIED_SUBAGENT_MODEL_KEY]).toBe('openai/gpt-5.5-mini')
+  })
+
+  it('round trip: a stashed subagent model is RESTORED on an honoring target and the stash is not re-carried', async () => {
+    const stashedSource: RuntimeAgent[] = [
+      {
+        id: 'main',
+        name: 'Main',
+        model: 'openai-codex/gpt-5.5',
+        metadata: { [CARRIED_SUBAGENT_MODEL_KEY]: 'openai/gpt-5.5-mini', emoji: '🤖' },
+      },
+    ]
+    const updates: Array<{ agentId: string; subagentModel?: string | null }> = []
+    const created: Array<{ id: string; metadata?: Record<string, unknown> }> = []
+    const target = targetWith({
+      catalog: ['openai/gpt-5.5', 'openai/gpt-5.5-mini'],
+      createImpl: async (input) => {
+        created.push({ id: input.id, metadata: input.metadata })
+        return { id: input.id, name: input.name }
+      },
+      updateImpl: async (agentId, input) => {
+        updates.push({ agentId, ...input })
+        return { id: agentId, name: agentId }
+      },
+    })
+    const report = await reconcileRoster(stashedSource, target)
+    expect(updates).toEqual([{ agentId: 'main', subagentModel: 'openai/gpt-5.5-mini' }])
+    expect(report.preserved).toEqual([])
+    // The stash key is reconciler-owned — consumed, never re-carried.
+    expect(created[0]?.metadata?.[CARRIED_SUBAGENT_MODEL_KEY]).toBeUndefined()
+    expect(created[0]?.metadata?.emoji).toBe('🤖')
   })
 
   it('dryRun classifies identically but never calls create or update', async () => {

--- a/tests/core/schedule-context-pin.test.ts
+++ b/tests/core/schedule-context-pin.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Pin: the Bakin-shipped role context TEACHES agents the schedule tools
+ * (pi-parity D5 — "Bakin schedules are THE answer" only holds if agents on
+ * a cron-less runtime actually learn to self-schedule through Bakin).
+ * Composed managed blocks are built from these constants, so asserting here
+ * pins every projected AGENTS.md.
+ */
+import { describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-schedule-context-${Date.now()}`)
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { ROLE_DEFAULTS } from '../../src/core/team-context-defaults'
+
+describe('role context teaches Bakin scheduling', () => {
+  it('subagent rules carry the schedule tool family + the no-native-cron rule', () => {
+    const rules = ROLE_DEFAULTS.subagent
+    expect(rules).toContain('bakin_exec_schedule_create')
+    expect(rules).toContain('bakin_exec_schedule_list')
+    expect(rules).toContain('NEVER use runtime-native cron')
+  })
+
+  it('code/GitHub guidance is present (worktrees + ask-before-default-branch)', () => {
+    const rules = ROLE_DEFAULTS.subagent
+    expect(rules).toContain('bakin_exec_git_prepare_worktree')
+    expect(rules).toContain('gh')
+    expect(rules).toMatch(/default branch/i)
+  })
+})

--- a/tests/core/switch-report.test.ts
+++ b/tests/core/switch-report.test.ts
@@ -93,3 +93,47 @@ describe('snapshotSourceCapabilities', () => {
     })
   })
 })
+
+describe('snapshotSourceCapabilities — cron job capture (adoption)', () => {
+  const jobs = [
+    { id: 'j1', name: 'One', schedule: '0 9 * * *', command: 'do one', enabled: true },
+    { id: 'j2', name: 'Two', schedule: '0 8 * * 1', command: 'do two', enabled: false },
+  ]
+
+  it('captures full jobs + raw snapshots only when asked', async () => {
+    const rawReads: string[] = []
+    const source = {
+      channels: undefined,
+      cron: {
+        list: async () => jobs,
+        getRaw: async (id: string) => { rawReads.push(id); return { blob: id } },
+      },
+    } as never
+
+    const plain = await snapshotSourceCapabilities(source)
+    expect(plain.cronJobs).toBeUndefined()
+    expect(rawReads).toEqual([])
+
+    const captured = await snapshotSourceCapabilities(source, { captureCronJobs: true })
+    expect(captured.cronJobCount).toBe(2)
+    expect(captured.cronJobs).toEqual([
+      { job: jobs[0], raw: { blob: 'j1' } },
+      { job: jobs[1], raw: { blob: 'j2' } },
+    ])
+  })
+
+  it('an unreadable job drops from the capture without killing the snapshot', async () => {
+    const source = {
+      channels: undefined,
+      cron: {
+        list: async () => jobs,
+        getRaw: async (id: string) => {
+          if (id === 'j1') throw new Error('boom')
+          return { blob: id }
+        },
+      },
+    } as never
+    const captured = await snapshotSourceCapabilities(source, { captureCronJobs: true })
+    expect(captured.cronJobs).toEqual([{ job: jobs[1], raw: { blob: 'j2' } }])
+  })
+})

--- a/tests/plugins/health/github-readiness.test.ts
+++ b/tests/plugins/health/github-readiness.test.ts
@@ -1,0 +1,50 @@
+/**
+ * GitHub CLI readiness check (pi-parity T3.3) — probe-injected, no real
+ * subprocess: absent gh is informational ok, unauthenticated gh warns with
+ * remediation, authenticated gh is ok.
+ */
+import { describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-gh-readiness-${Date.now()}`)
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+import { checkGithubReadiness, type GhProbe } from '../../../plugins/health/lib/system-checks/github-readiness'
+
+const probe = (path: string | null, authed: boolean): GhProbe => ({
+  which: async () => path,
+  authOk: async () => authed,
+})
+
+describe('github readiness check', () => {
+  it('absent gh is informational ok', async () => {
+    const [r] = await checkGithubReadiness(probe(null, false))
+    expect(r.status).toBe('ok')
+    expect(r.message).toContain('not installed')
+  })
+
+  it('unauthenticated gh warns with remediation', async () => {
+    const [r] = await checkGithubReadiness(probe('/opt/homebrew/bin/gh', false))
+    expect(r.status).toBe('warn')
+    expect(r.message).toContain('gh auth login')
+  })
+
+  it('authenticated gh is ok', async () => {
+    const [r] = await checkGithubReadiness(probe('/opt/homebrew/bin/gh', true))
+    expect(r.status).toBe('ok')
+    expect(r.message).toContain('authenticated')
+  })
+})

--- a/tests/plugins/schedule/cron-adoption.test.ts
+++ b/tests/plugins/schedule/cron-adoption.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Switch-time cron adoption (pi-parity T3.4): snapshotted source cron jobs
+ * become Bakin-managed schedules — source 'adopted', provider-raw snapshot
+ * preserved, idempotent per job id, dry-run writes nothing.
+ */
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-cron-adoption-${Date.now()}`)
+
+mock.module('../../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
+mock.module('../../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+  initBakinHome: () => {},
+}))
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+// Search indexing is fire-and-forget noise here.
+mock.module('@bakin/schedule/lib/job-service', () => ({
+  indexJob: () => {},
+}))
+
+import { adoptCronJobs } from '@bakin/schedule/lib/cron-adoption'
+import { getJob, upsertJob } from '@bakin/schedule/lib/sidecar'
+
+const auditCalls: Array<{ event: string }> = []
+const ctx = {
+  runtime: {
+    agents: { list: async () => [{ id: 'main', name: 'Main', role: 'orchestrator' }] },
+  },
+  activity: {
+    audit: (event: string) => { auditCalls.push({ event }) },
+    log: () => {},
+  },
+} as unknown as Parameters<typeof adoptCronJobs>[0]
+
+const jobs = [
+  { job: { id: 'daily-report', name: 'Daily report', schedule: '0 9 * * *', command: 'Post the daily report', enabled: true }, raw: { provider: 'openclaw', blob: 'x' } },
+  { job: { id: 'weekly-clean', name: 'Weekly cleanup', schedule: '0 8 * * 1', command: 'Clean the library', enabled: false }, raw: { provider: 'openclaw', blob: 'y' } },
+]
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  auditCalls.length = 0
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('adoptCronJobs', () => {
+  it('adopts snapshotted jobs as Bakin schedules with the raw snapshot preserved', async () => {
+    const result = await adoptCronJobs(ctx, { provider: 'openclaw', jobs })
+    expect(result.adopted.sort()).toEqual(['daily-report', 'weekly-clean'])
+    expect(result.failed).toEqual([])
+
+    const meta = getJob('daily-report')
+    expect(meta?.isBakinJob).toBe(true)
+    expect(meta?.source).toBe('adopted')
+    expect(meta?.schedule).toEqual({ kind: 'cron', expr: '0 9 * * *' })
+    expect(meta?.taskPrompt).toBe('Post the daily report')
+    expect(meta?.owner).toBe('main')
+    expect(meta?.originalRuntimeCron?.provider).toBe('openclaw')
+    expect(meta?.originalRuntimeCron?.snapshot).toEqual({ provider: 'openclaw', blob: 'x' })
+    // Enabled state carries per job.
+    expect(getJob('weekly-clean')?.enabled).toBe(false)
+    expect(auditCalls.filter((c) => c.event === 'job.adopted')).toHaveLength(2)
+  })
+
+  it('is idempotent: already-Bakin jobs are skipped, never overwritten', async () => {
+    upsertJob({
+      jobId: 'daily-report',
+      isBakinJob: true,
+      source: 'bakin',
+      displayName: 'User-tuned name',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    })
+    const result = await adoptCronJobs(ctx, { provider: 'openclaw', jobs })
+    expect(result.skipped).toEqual(['daily-report'])
+    expect(result.adopted).toEqual(['weekly-clean'])
+    expect(getJob('daily-report')?.displayName).toBe('User-tuned name')
+    expect(getJob('daily-report')?.source).toBe('bakin')
+  })
+
+  it('dry run classifies identically but writes nothing', async () => {
+    const result = await adoptCronJobs(ctx, { provider: 'openclaw', jobs, dryRun: true })
+    expect(result.adopted.sort()).toEqual(['daily-report', 'weekly-clean'])
+    expect(getJob('daily-report')).toBeFalsy()
+    expect(auditCalls).toEqual([])
+  })
+})

--- a/tests/plugins/workflows/approvals-attention.test.tsx
+++ b/tests/plugins/workflows/approvals-attention.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+/**
+ * Pending-gate attention (pi-parity T3.1) — the pure rules (attention.ts)
+ * and the ApprovalsBadgeProvider's observable effects: workflows nav badge
+ * from /gates/pending, toast on gate-reached-while-elsewhere, badge clear
+ * on resolution. Modeled on the chat attention harness.
+ */
+import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-wf-attn-${Date.now()}`)
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: join(testDir, 'bakin.db') }),
+})
+mock.module('@/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+// Belt-and-suspenders (CLAUDE.md isolation rules): nothing in this client
+// component graph should touch the task store; if a future import does, it
+// gets an inert stub instead of ~/.bakin.
+mock.module('@/core/task-store', () => ({}))
+
+import { act, render, waitFor } from '@testing-library/react'
+import '../../rtl-settle'
+import { settleReact } from '../../rtl-settle'
+
+import { emitPluginEvent, useToastStore } from '@makinbakin/sdk/hooks'
+import { getNavBadge } from '@makinbakin/sdk'
+
+import { attentionForGate, gateBadge, gateUrl, viewingGateTask } from '../../../plugins/workflows/components/attention'
+import { ApprovalsBadgeProvider } from '../../../plugins/workflows/components/approvals-badge-provider'
+
+describe('gate attention (pure rules)', () => {
+  const gate = { instanceId: 'i1', taskId: 't-42', workflowId: 'wf', stepId: 'g1', label: 'Publish pricing page' }
+
+  it('badges the pending count with attention tone, hidden at zero', () => {
+    expect(gateBadge(0)).toBeNull()
+    expect(gateBadge(3)).toEqual({ count: 3, tone: 'attention' })
+  })
+
+  it('deep-links to the task detail where gates are decided', () => {
+    expect(gateUrl(gate)).toBe('/tasks?taskId=t-42')
+  })
+
+  it('suppresses fanfare while viewing that task, notifies elsewhere', () => {
+    expect(viewingGateTask(gate, { pathname: '/tasks', search: '?taskId=t-42' })).toBe(true)
+    expect(attentionForGate(gate, { pathname: '/tasks', search: '?taskId=t-42' }).notify).toBe(false)
+    expect(attentionForGate(gate, { pathname: '/tasks', search: '?taskId=other' }).notify).toBe(true)
+    const elsewhere = attentionForGate(gate, { pathname: '/health', search: '' })
+    expect(elsewhere.notify).toBe(true)
+    expect(elsewhere.body).toContain('Publish pricing page')
+    expect(elsewhere.url).toBe('/tasks?taskId=t-42')
+  })
+})
+
+describe('ApprovalsBadgeProvider', () => {
+  const realFetch = globalThis.fetch
+  let pendingGates: Array<{ taskId: string; stepId: string; label?: string }> = []
+
+  beforeEach(() => {
+    useToastStore.setState({ toasts: [] })
+    window.history.replaceState(null, '', '/health')
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/plugins/workflows/gates/pending')) {
+        return Promise.resolve(new Response(JSON.stringify({ gates: pendingGates }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        }))
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  it('seeds the workflows nav badge from the pending count', async () => {
+    pendingGates = [{ taskId: 't1', stepId: 'g1' }, { taskId: 't2', stepId: 'g2' }]
+    render(<ApprovalsBadgeProvider />)
+    await waitFor(() => expect(getNavBadge('workflows')).toEqual({ count: 2, tone: 'attention' }))
+  })
+
+  it('gate_reached elsewhere: toast fires and the badge refreshes', async () => {
+    pendingGates = []
+    render(<ApprovalsBadgeProvider />)
+    await settleReact()
+    await waitFor(() => expect(getNavBadge('workflows')).toBeFalsy())
+
+    pendingGates = [{ taskId: 't-42', stepId: 'g1', label: 'Publish' }]
+    act(() => {
+      emitPluginEvent({ event: 'workflow.gate_reached', instanceId: 'i1', taskId: 't-42', workflowId: 'wf', stepId: 'g1', label: 'Publish' })
+    })
+    await waitFor(() => expect(getNavBadge('workflows')).toEqual({ count: 1, tone: 'attention' }))
+    expect(useToastStore.getState().toasts.length).toBe(1)
+  })
+
+  it('gate resolution clears the badge without a toast', async () => {
+    pendingGates = [{ taskId: 't-42', stepId: 'g1' }]
+    render(<ApprovalsBadgeProvider />)
+    await settleReact()
+    await waitFor(() => expect(getNavBadge('workflows')).toEqual({ count: 1, tone: 'attention' }))
+
+    pendingGates = []
+    act(() => {
+      emitPluginEvent({ event: 'workflow.gate_approved', taskId: 't-42', stepId: 'g1' })
+    })
+    await waitFor(() => expect(getNavBadge('workflows')).toBeFalsy())
+    expect(useToastStore.getState().toasts.length).toBe(0)
+  })
+})


### PR DESCRIPTION
Phase P3 of the pi-parity initiative (spec §4.3–4.6, stories 6–7; plan T3.1–T3.5). P1 (#662) and P2 (#664) merged.

## What

- **Pending-approval attention (story 6)**: workflow gates ride the global nav-badge/attention system — Workflows nav badges the pending count (`/gates/pending` + `workflow.gate_*` SSE), gate-reached-while-elsewhere fires toast + OS notification deep-linking to the task detail, suppression rules are pure functions (chat attention pattern). On Pi (no channel layer) this is what keeps gated tasks from stalling silently; the durable approval record stays the authority.
- **Subagent-model preservation (OQ1)**: switches to a runtime that can't honor per-agent subagent models (Pi) now STASH the value in carried-agent metadata instead of dropping it; the round trip back restores it (mapped + applied + stash consumed). New `preserved` report field + CLI line. Capability honesty untouched — Pi's support flag stays false.
- **Switch-time cron adoption (story 7, opt-in)**: `bakin runtime use <t> --adopt-cron` snapshots the source's native cron jobs pre-teardown and adopts them into Bakin schedules via a new `schedule.adoptCronJobs` hook (source `'adopted'`, provider-raw snapshot preserved, idempotent per job id, dry-run previews). Can't-carry cron line folds the outcome in honestly.
- **GitHub readiness (D7)**: `github-readiness` doctor check (absent gh = informational; unauthenticated = warn with remediation) + shared agent context gains Code & GitHub rules (worktree isolation, gh usage, ask before default-branch pushes/merges).
- **P0 pins (T3.5)**: `createTurnSettingsManager` is now THE exported per-turn Pi settings construction, pinned to compaction-enabled (an SDK default flip fails the test); role-context pin asserts schedule tools + the new code guidance are actually taught.

## Test plan

- New: attention pure rules + ApprovalsBadgeProvider RTL (badge seed/refresh/clear, toast on gate-reached-elsewhere); roster-reconcile preservation + round-trip restore; cron adoption unit (adopt/skip/dry-run) + snapshot capture (incl. unreadable-job degradation); gh readiness probe-injected; both pins.
- Updated deliberately: the old "unsupported target drops subagentModel to unmapped" pin → preservation semantics.
- Full suite green (6876 pass / 0 fail), typecheck clean at every commit; real-adapter switch + dry-run byte-identity suites green.
- Live gate badge/toast validation on this box post-merge (client code ships with the merge), recorded in the P5 battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)