### PR TITLE
feat(host): runtime hub — tabbed /runtime rebuild on the SDK kit (pi-parity P4)

### DIFF
--- a/.claude/specs/pi-parity/TODO.md
+++ b/.claude/specs/pi-parity/TODO.md
@@ -32,10 +32,10 @@ Plan: `PLAN.md` · Spec: `SPEC.md` · One PR per phase, one commit per task.
 - [ ] Gate: live gate badge/toast + switch e2e → open PR
 
 ## P4 — feat/runtime-hub
-- [ ] T4.1 Hub shell + Overview tab (legend, credential tiles)
-- [ ] T4.2 Capabilities tab (readiness chips + remediation links)
-- [ ] T4.3 Switch tab (dry-run preview, ConfirmDialog, grouped result cards)
-- [ ] Gate: RTL all tabs + visual review screenshots → open PR
+- [x] T4.1 Hub shell + Overview tab (legend, credential tiles)
+- [x] T4.2 Capabilities tab (readiness chips + remediation links)
+- [x] T4.3 Switch tab (dry-run preview, ConfirmDialog, grouped result cards)
+- [x] Gate: RTL all tabs green + rig visual review (all three tabs screenshotted) → PR
 
 ## P5 — chore/pi-parity-docs
 - [ ] T5.1 Knowledge/extending/CLAUDE.md/README docs

--- a/packages/host/src/components/runtime/capabilities-tab.tsx
+++ b/packages/host/src/components/runtime/capabilities-tab.tsx
@@ -1,0 +1,124 @@
+/**
+ * Runtime hub — Capabilities: readiness of installed capability packs, with
+ * a working remediation path for every non-ready leg. Browsing/installing
+ * stays in Explore (one install path — story 2); this tab answers "is it
+ * working, and if not, what do I do".
+ */
+import { useEffect, useState } from 'react'
+import { Compass } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { EmptyState } from '@/components/empty-state'
+import type { CapabilityReadiness } from './types'
+
+function LegChip({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${
+        ok
+          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+          : 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400'
+      }`}
+    >
+      {ok ? '✓' : '⚠'} {label}
+    </span>
+  )
+}
+
+export function CapabilitiesTab() {
+  const [capabilities, setCapabilities] = useState<CapabilityReadiness[] | null | undefined>(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/api/packages/capabilities')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const body = (await res.json()) as { capabilities: CapabilityReadiness[] }
+        if (!cancelled) setCapabilities(body.capabilities)
+      } catch {
+        if (!cancelled) setCapabilities(null)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  if (capabilities === undefined) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    )
+  }
+
+  if (capabilities === null) {
+    return <p className="text-sm text-muted-foreground">Capability readiness is unavailable right now — retry with Refresh.</p>
+  }
+
+  if (capabilities.length === 0) {
+    return (
+      <EmptyState
+        icon={Compass}
+        title="No capabilities installed yet"
+        description="Capabilities teach your agents new tricks — web search, browser automation, transcription. Bakin installs everything they need, including the API-key step."
+        action={
+          <Link
+            to="/explore"
+            search={{ tab: 'capabilities' }}
+            className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Browse capabilities
+          </Link>
+        }
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-3" data-testid="capabilities-readiness">
+      {capabilities.map((cap) => (
+        <Card key={cap.capability}>
+          <CardContent className="flex flex-col gap-2 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">{cap.name}</p>
+                <p className="text-xs text-muted-foreground">{cap.packageId}@{cap.version}</p>
+              </div>
+              {cap.ready ? (
+                <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">Ready</Badge>
+              ) : (
+                <Badge variant="outline" className="border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400">Needs attention</Badge>
+              )}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {cap.skills.map((s) => <LegChip key={`s-${s.name}`} ok={s.status === 'ok'} label={`skill ${s.name}`} />)}
+              {cap.bins.map((b) => <LegChip key={`b-${b.name}`} ok={b.status === 'ok'} label={`binary ${b.name}`} />)}
+              {cap.secrets.map((s) => <LegChip key={`k-${s.name}`} ok={s.status !== 'missing'} label={s.status === 'missing' ? `${s.name} not set` : `${s.name} · ${s.status}`} />)}
+            </div>
+            {!cap.ready && (
+              <ul className="space-y-0.5 text-xs text-muted-foreground">
+                {cap.missing.map((line) => <li key={line}>→ {line}</li>)}
+              </ul>
+            )}
+            {!cap.ready && cap.secrets.some((s) => s.status === 'missing') && (
+              <div>
+                <Link
+                  to="/settings"
+                  className="inline-flex h-8 items-center rounded-md border border-border px-3 text-sm font-medium hover:bg-muted/40"
+                >
+                  Add the key in Settings
+                </Link>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+      <p className="text-xs text-muted-foreground">
+        Add more from <Link className="underline" to="/explore" search={{ tab: 'capabilities' }}>Explore → Capabilities</Link>.
+      </p>
+    </div>
+  )
+}

--- a/packages/host/src/components/runtime/overview-tab.tsx
+++ b/packages/host/src/components/runtime/overview-tab.tsx
@@ -1,0 +1,145 @@
+/**
+ * Runtime hub — Overview: who is running the agents, what it can do (in
+ * plain language), and whether setup is healthy. Every non-native state
+ * says what happens instead — the reader never has to decode an enum.
+ */
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { capabilityRows } from '../../lib/runtime-report'
+import { ModeBadge, MODE_LEGEND, StatusBadge, capabilityStateCopy } from './shared'
+import type { CapabilityReport, OnboardingComponentStatus } from './types'
+
+function CredentialTiles({ report }: { report: CapabilityReport }) {
+  const creds = report.credentialStatus
+  const providers = creds?.llmProviders ?? []
+  const kinds = new Map((creds?.llmCredentials ?? []).map((c) => [c.provider, c.kind]))
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>Active runtime</CardDescription>
+          <CardTitle className="text-xl">{report.adapter}</CardTitle>
+        </CardHeader>
+        <CardContent className="text-xs text-muted-foreground">
+          {report.runtime.name}@{report.runtime.version}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>Model providers</CardDescription>
+          <CardTitle className="text-xl">{providers.length}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-1.5 text-xs">
+          {providers.length === 0 && <span className="text-muted-foreground">None configured — agents cannot run turns.</span>}
+          {providers.map((p) => (
+            <span key={p} className="rounded-full border border-border px-2 py-0.5 text-muted-foreground">
+              {p}{kinds.get(p) === 'oauth' ? ' · subscription' : kinds.has(p) ? ' · API key' : ''}
+            </span>
+          ))}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>Tool access</CardDescription>
+          <CardTitle className="text-xl">{report.toolAccess.ok ? 'Healthy' : 'Needs attention'}</CardTitle>
+        </CardHeader>
+        <CardContent className="text-xs text-muted-foreground">
+          {report.toolAccess.ok
+            ? capabilityStateCopy('toolCalling', 'native', report.adapter, report.toolAccess.style)
+            : report.toolAccess.issues.join('; ')}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function CapabilityGrid({ report }: { report: CapabilityReport }) {
+  const rows = capabilityRows(report.capabilities).filter((row) => row.key !== 'toolCalling' && row.key !== 'input')
+  const input = report.capabilities.input
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-sm font-semibold">What this runtime can do</h2>
+        <p className="text-xs text-muted-foreground">{MODE_LEGEND}</p>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {rows.map((row) => (
+          <Card key={row.key}>
+            <CardHeader className="flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm">{row.label}</CardTitle>
+              <ModeBadge mode={row.mode} />
+            </CardHeader>
+            <CardContent className="text-xs text-muted-foreground">
+              {capabilityStateCopy(row.key, row.mode, report.adapter, row.detail)}
+            </CardContent>
+          </Card>
+        ))}
+        {input && (
+          <Card>
+            <CardHeader className="flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm">Attachments</CardTitle>
+            </CardHeader>
+            <CardContent className="text-xs text-muted-foreground">
+              {input.imageInput ? 'Agents can see images you attach.' : 'The active model cannot take image attachments.'}{' '}
+              {input.audioInput ? 'Audio attachments work too.' : ''}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function SetupSection({ onboarding }: { onboarding: OnboardingComponentStatus[] | null | undefined }) {
+  return (
+    <section className="space-y-3" data-testid="onboarding-status">
+      <div>
+        <h2 className="text-sm font-semibold">Setup checks</h2>
+        <p className="text-xs text-muted-foreground">Live checks against the active runtime — the same ones `bakin check all` runs.</p>
+      </div>
+      {onboarding === undefined && (
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </div>
+      )}
+      {onboarding === null && (
+        <p className="text-sm text-muted-foreground">Setup checks are unavailable right now — retry with Refresh.</p>
+      )}
+      {onboarding && (
+        <Card>
+          <CardContent className="divide-y divide-border p-0">
+            {onboarding.map((component) => (
+              <div key={component.name} className="flex items-start justify-between gap-3 px-4 py-2.5">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">{component.name}</p>
+                  <p className="truncate text-xs text-muted-foreground" title={component.message}>{component.message}</p>
+                  {component.remediation && component.status !== 'ok' && (
+                    <p className="mt-0.5 text-xs text-muted-foreground/80">→ {component.remediation}</p>
+                  )}
+                </div>
+                <StatusBadge status={component.status} />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  )
+}
+
+export function OverviewTab({
+  report,
+  onboarding,
+}: {
+  report: CapabilityReport
+  onboarding: OnboardingComponentStatus[] | null | undefined
+}) {
+  return (
+    <div className="space-y-6" data-testid="runtime-summary">
+      <CredentialTiles report={report} />
+      <CapabilityGrid report={report} />
+      <SetupSection onboarding={onboarding} />
+    </div>
+  )
+}

--- a/packages/host/src/components/runtime/shared.tsx
+++ b/packages/host/src/components/runtime/shared.tsx
@@ -1,0 +1,70 @@
+/**
+ * Runtime hub — shared visual + language primitives.
+ *
+ * The hub's one job is honesty a person can act on: every capability mode
+ * renders as plain language ("the runtime provides this" / "Bakin provides
+ * this" / "not available — here's what happens instead"), never as a bare
+ * enum. Keep every mode → word mapping HERE so the three tabs can't drift.
+ */
+import { Badge } from '@/components/ui/badge'
+
+export type CapabilityMode = 'native' | 'shimmed' | 'unavailable' | string
+
+const MODE_LABEL: Record<string, string> = {
+  native: 'Native',
+  shimmed: 'Via Bakin',
+  unavailable: 'Not available',
+}
+
+const MODE_CLASS: Record<string, string> = {
+  native: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  shimmed: 'border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-400',
+  unavailable: 'border-border bg-muted/40 text-muted-foreground',
+}
+
+export function ModeBadge({ mode }: { mode: CapabilityMode }) {
+  return (
+    <Badge variant="outline" className={`shrink-0 ${MODE_CLASS[mode] ?? MODE_CLASS.unavailable}`}>
+      {MODE_LABEL[mode] ?? mode}
+    </Badge>
+  )
+}
+
+/** One plain-language line per capability × mode — what it means for the user. */
+export function capabilityStateCopy(key: string, mode: CapabilityMode, adapter: string, detail?: string): string {
+  switch (key) {
+    case 'toolCalling':
+      return detail === 'in-process'
+        ? 'Bakin tools run inside the server process — no gateway hop.'
+        : detail === 'mcp'
+          ? "Bakin tools reach agents over the runtime's MCP client."
+          : 'Agents can call Bakin tools.'
+    case 'delivery':
+      if (mode === 'native') return "Messages, alerts, and approvals deliver through the runtime's channels."
+      if (mode === 'shimmed') return 'Bakin delivers messages and approvals on behalf of the runtime.'
+      return `Alerts and approvals appear in the app — ${adapter} has no channel delivery.`
+    case 'imageGen':
+      if (mode === 'native') return 'The runtime generates images with its own credentials.'
+      if (mode === 'shimmed') return "Bakin generates images with your provider keys (Settings → Integrations & Keys)."
+      return 'Add a provider key in Settings → Integrations & Keys to enable image generation.'
+    case 'memory':
+      return mode === 'native' ? 'Agent memory is readable for search and diagnostics.' : 'Agent memory is not readable on this runtime.'
+    case 'sessions':
+      return mode === 'native' ? 'Session history is readable for forensics and usage.' : 'Session history is not readable on this runtime.'
+    case 'workspaceFiles':
+      return mode === 'native' ? 'Agent workspace files (SOUL, AGENTS, skills) are managed by Bakin.' : 'Workspace files are not manageable on this runtime.'
+    default:
+      return ''
+  }
+}
+
+export const MODE_LEGEND = 'Native — the runtime provides it. Via Bakin — Bakin fills the gap itself. Not available — degrades honestly, never silently.'
+
+export function StatusBadge({ status }: { status: string }) {
+  const cls = status === 'ok'
+    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+    : status === 'warn' || status === 'skipped'
+      ? 'border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400'
+      : 'border-red-500/30 bg-red-500/10 text-red-600 dark:text-red-400'
+  return <Badge variant="outline" className={`shrink-0 ${cls}`}>{status}</Badge>
+}

--- a/packages/host/src/components/runtime/switch-tab.tsx
+++ b/packages/host/src/components/runtime/switch-tab.tsx
@@ -1,0 +1,279 @@
+/**
+ * Runtime hub — Switch: the guided flow. Preview first (a dry run is the
+ * DEFAULT action — zero writes), then a confirm dialog for the real switch,
+ * live progress steps over the runtime:switch SSE stream, and a result told
+ * as grouped cards (carried / attention / stays behind) instead of prose.
+ */
+import { useCallback, useRef, useState } from 'react'
+import { ArrowRight, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import { reduceSwitchProgress, SWITCH_PHASE_LABELS, type SwitchStepRow } from '../../lib/runtime-report'
+import type { CapabilityReport, SwitchResultPayload } from './types'
+
+function StepDot({ status }: { status: SwitchStepRow['status'] }) {
+  const cls = status === 'ok'
+    ? 'bg-emerald-500'
+    : status === 'error'
+      ? 'bg-red-500'
+      : status === 'skip'
+        ? 'bg-zinc-400'
+        : 'animate-pulse bg-sky-500'
+  return <span className={`mt-1 inline-block size-2 shrink-0 rounded-full ${cls}`} />
+}
+
+function ProgressSteps({ steps }: { steps: SwitchStepRow[] }) {
+  if (steps.length === 0) return null
+  return (
+    <Card data-testid="switch-progress">
+      <CardContent className="space-y-1.5 p-4">
+        {steps.map((step) => (
+          <div key={step.phase} className="flex items-start gap-2 text-sm">
+            <StepDot status={step.status} />
+            <div className="min-w-0">
+              <span>{SWITCH_PHASE_LABELS[step.phase] ?? step.phase}</span>
+              {step.detail && <span className="ml-2 text-xs text-muted-foreground">{step.detail}</span>}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ResultCards({ result }: { result: SwitchResultPayload }) {
+  const verb = result.dryRun ? 'Would carry' : 'Carried'
+  const attention: string[] = []
+  for (const u of result.roster?.unmappedModels ?? []) {
+    attention.push(`${u.agentId}: ${u.field === 'subagentModel' ? 'subagent model' : 'model'} '${u.sourceModel}' has no equivalent on ${result.to} — falls back to the routing default`)
+  }
+  for (const p of result.roster?.preserved ?? []) {
+    attention.push(`${p.agentId}: subagent model '${p.sourceModel}' preserved — restored when you switch back`)
+  }
+  for (const f of result.roster?.failed ?? []) attention.push(`${f.agentId}: ${f.error}`)
+  for (const f of result.workspaces?.failed ?? []) attention.push(`${f.agentId} (${f.path}): ${f.error}`)
+  for (const f of result.cron?.failed ?? []) attention.push(`cron ${f.jobId}: ${f.error}`)
+  if (result.credentials && result.credentials.llmProviders.length === 0) {
+    attention.push(`${result.to} has no model providers configured — carried agents cannot run turns until you log in on the target.`)
+  }
+
+  const workspaceFiles = (result.workspaces?.carried ?? []).reduce((sum, c) => sum + c.files, 0)
+  const workspaceSkills = (result.workspaces?.skills ?? []).reduce((sum, s) => sum + s.carried, 0)
+
+  return (
+    <div className="space-y-3" data-testid="switch-result">
+      {!result.ok && (
+        <Card className="border-red-500/30">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm text-red-600 dark:text-red-400">Switch failed</CardTitle>
+            <CardDescription>
+              {result.error}
+              {result.restored !== undefined && (result.restored ? ' — the previous runtime was restored.' : ' — restore ALSO failed; check settings backup.')}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      {result.ok && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">
+              {result.dryRun ? `Preview: ${result.from} → ${result.to}` : `Switched ${result.from} → ${result.to}`}
+            </CardTitle>
+            {result.restartRequired && (
+              <CardDescription>Restart the Bakin server to finish — plugins hold the old runtime until then.</CardDescription>
+            )}
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+            <div><p className="text-lg font-semibold">{result.roster?.carried.length ?? 0}</p><p className="text-xs text-muted-foreground">agents {verb.toLowerCase()}</p></div>
+            <div><p className="text-lg font-semibold">{result.roster?.existing.length ?? 0}</p><p className="text-xs text-muted-foreground">already on {result.to}</p></div>
+            <div><p className="text-lg font-semibold">{workspaceFiles + workspaceSkills}</p><p className="text-xs text-muted-foreground">files + skills {verb.toLowerCase()}</p></div>
+            <div><p className="text-lg font-semibold">{result.cron ? result.cron.adopted.length : '—'}</p><p className="text-xs text-muted-foreground">cron jobs {result.dryRun ? 'would be adopted' : 'adopted'}</p></div>
+          </CardContent>
+        </Card>
+      )}
+
+      {attention.length > 0 && (
+        <Card className="border-amber-500/30">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Needs your attention</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1 text-xs text-muted-foreground">
+              {attention.map((line) => <li key={line}>→ {line}</li>)}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {(result.cantCarry?.length ?? 0) > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Stays behind</CardTitle>
+            <CardDescription>Runtime-owned things that never cross a switch.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-1 text-xs text-muted-foreground">
+              {result.cantCarry!.map((line) => (
+                <li key={line.concern}>{line.detail}{line.count !== undefined ? ` (${line.count})` : ''}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {result.backupPath && !result.dryRun && (
+        <p className="text-xs text-muted-foreground">Settings backup: {result.backupPath}</p>
+      )}
+    </div>
+  )
+}
+
+export function SwitchTab({ report, onSwitched }: { report: CapabilityReport; onSwitched: () => void }) {
+  const [target, setTarget] = useState<string | null>(null)
+  const [adoptCron, setAdoptCron] = useState(false)
+  const [copyWorkspaces, setCopyWorkspaces] = useState(true)
+  const [running, setRunning] = useState<'preview' | 'switch' | null>(null)
+  const [confirming, setConfirming] = useState(false)
+  const [steps, setSteps] = useState<SwitchStepRow[]>([])
+  const [result, setResult] = useState<SwitchResultPayload | null>(null)
+  const esRef = useRef<EventSource | null>(null)
+
+  const others = report.adapters.filter((name) => name !== report.adapter)
+
+  const run = useCallback(async (dryRun: boolean) => {
+    if (!target) return
+    setRunning(dryRun ? 'preview' : 'switch')
+    setSteps([])
+    setResult(null)
+
+    // Dedicated short-lived stream: fresh SSE connections get no replay, so
+    // wait (bounded) for the handshake before firing the POST or a fast
+    // local switch renders only its late phases.
+    const es = new EventSource('/api/events')
+    esRef.current = es
+    es.onmessage = (msg) => {
+      try {
+        const event = JSON.parse(msg.data as string)
+        if (event?.type === 'runtime:switch') setSteps((prev) => reduceSwitchProgress(prev, event))
+      } catch { /* non-JSON keepalives */ }
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 2000)
+      es.onopen = () => { clearTimeout(timer); resolve() }
+    })
+
+    try {
+      const res = await fetch('/api/runtime/switch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target,
+          ...(dryRun ? { dryRun: true } : {}),
+          ...(copyWorkspaces ? {} : { copyWorkspaces: false }),
+          ...(adoptCron ? { adoptCron: true } : {}),
+        }),
+      })
+      setResult(await res.json() as SwitchResultPayload)
+      if (!dryRun) onSwitched()
+    } catch (err) {
+      setResult({
+        ok: false,
+        from: report.adapter,
+        to: target,
+        error: err instanceof Error ? err.message : String(err),
+        backupPath: null,
+        restartRequired: false,
+        roster: null,
+        workspaces: null,
+        cron: null,
+        cantCarry: null,
+        credentials: null,
+        sync: null,
+        ...(dryRun ? { dryRun: true } : {}),
+      })
+    } finally {
+      es.close()
+      esRef.current = null
+      setRunning(null)
+    }
+  }, [target, adoptCron, copyWorkspaces, report.adapter, onSwitched])
+
+  if (others.length === 0) {
+    return <p className="text-sm text-muted-foreground">No other runtime adapters are available to switch to.</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {others.map((name) => (
+          <button
+            key={name}
+            type="button"
+            data-testid={`switch-target-${name}`}
+            onClick={() => { setTarget(name); setResult(null); setSteps([]) }}
+            className={`rounded-xl border p-4 text-left transition-colors ${
+              target === name ? 'border-primary bg-primary/5' : 'border-border hover:bg-muted/40'
+            }`}
+          >
+            <p className="flex items-center gap-2 text-sm font-medium">
+              {report.adapter} <ArrowRight className="size-3.5 text-muted-foreground" /> {name}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Agents, models, and workspace content carry over; Bakin data (tasks, assets, chats) is never touched.
+            </p>
+          </button>
+        ))}
+      </div>
+
+      {target && (
+        <Card>
+          <CardContent className="flex flex-col gap-3 p-4">
+            <label className="flex items-start gap-2.5 text-sm">
+              <input type="checkbox" className="mt-1 rounded" checked={copyWorkspaces} onChange={(e) => setCopyWorkspaces(e.target.checked)} />
+              <span className="flex flex-col">
+                <span>Carry workspace content</span>
+                <span className="text-xs text-muted-foreground">Soul, memory, and agent-authored skills copy onto agents the switch creates.</span>
+              </span>
+            </label>
+            <label className="flex items-start gap-2.5 text-sm">
+              <input type="checkbox" className="mt-1 rounded" checked={adoptCron} onChange={(e) => setAdoptCron(e.target.checked)} data-testid="switch-adopt-cron" />
+              <span className="flex flex-col">
+                <span>Adopt the runtime's cron jobs into Bakin schedules</span>
+                <span className="text-xs text-muted-foreground">Native cron jobs stop with the old runtime — adopting keeps them running as Bakin schedules.</span>
+              </span>
+            </label>
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="outline" disabled={running !== null} onClick={() => void run(true)} data-testid="switch-preview">
+                {running === 'preview' && <Loader2 className="mr-2 size-4 animate-spin" />}
+                Preview switch
+              </Button>
+              <Button size="sm" disabled={running !== null} onClick={() => setConfirming(true)} data-testid="switch-execute">
+                {running === 'switch' && <Loader2 className="mr-2 size-4 animate-spin" />}
+                Switch to {target}
+              </Button>
+              <span className="text-xs text-muted-foreground">Preview is a dry run — nothing is written.</span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <ProgressSteps steps={steps} />
+      {result && <ResultCards result={result} />}
+
+      <ConfirmDialog
+        open={confirming}
+        onCancel={() => setConfirming(false)}
+        title={`Switch to ${target}?`}
+        description="The switch backs up settings first and restores them if anything fails. A server restart finishes the change."
+        confirmLabel={`Switch to ${target}`}
+        confirmTestId="switch-confirm"
+        onConfirm={() => {
+          setConfirming(false)
+          void run(false)
+        }}
+      />
+    </div>
+  )
+}

--- a/packages/host/src/components/runtime/types.ts
+++ b/packages/host/src/components/runtime/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Runtime hub — shared response types for the three tabs. These mirror the
+ * server payloads exactly (GET /api/runtime/capabilities, /api/runtime/
+ * onboarding, /api/packages/capabilities, POST /api/runtime/switch).
+ */
+import type { CapabilitiesPayload } from '../../lib/runtime-report'
+
+export interface CapabilityReport {
+  adapter: string
+  adapters: string[]
+  runtime: { name: string; version: string }
+  capabilities: CapabilitiesPayload
+  toolAccess: { style: string; ok: boolean; issues: string[] }
+  credentialStatus?: {
+    llmProviders: string[]
+    llmCredentials?: Array<{ provider: string; kind: 'api-key' | 'oauth' }>
+    channels: string[]
+  }
+}
+
+export interface OnboardingComponentStatus {
+  name: string
+  status: 'ok' | 'warn' | 'missing' | 'broken' | 'error' | string
+  message: string
+  remediation?: string
+}
+
+export interface CapabilityReadiness {
+  capability: string
+  packageId: string
+  version: string
+  name: string
+  skills: Array<{ name: string; status: 'ok' | 'missing' }>
+  bins: Array<{ name: string; status: 'ok' | 'missing' | 'unsupported-platform' }>
+  secrets: Array<{ name: string; required: boolean; secretSlot?: string; help?: string; status: 'env' | 'store' | 'missing' }>
+  ready: boolean
+  missing: string[]
+}
+
+export interface SwitchResultPayload {
+  ok: boolean
+  from: string
+  to: string
+  error?: string
+  restored?: boolean
+  backupPath: string | null
+  restartRequired: boolean
+  dryRun?: boolean
+  roster: {
+    carried: Array<{ agentId: string; model?: string; mappedFrom?: string; subagentModel?: string }>
+    existing: string[]
+    unmappedModels: Array<{ agentId: string; sourceModel: string; field?: 'model' | 'subagentModel' }>
+    preserved?: Array<{ agentId: string; sourceModel: string }>
+    failed: Array<{ agentId: string; error: string }>
+  } | null
+  workspaces: {
+    carried: Array<{ agentId: string; files: number; bytes: number }>
+    skills: Array<{ agentId: string; carried: number; skippedPackageManaged: number }>
+    skippedExisting: string[]
+    failed: Array<{ agentId: string; path: string; error: string }>
+  } | null
+  cron: { adopted: string[]; skipped: string[]; failed: Array<{ jobId: string; error: string }> } | null
+  cantCarry: Array<{ concern: string; detail: string; count?: number }> | null
+  credentials: { llmProviders: string[] } | null
+  sync: { drifted: boolean; findings: number; syncedAgents: number } | null
+}

--- a/packages/host/src/routes/runtime.tsx
+++ b/packages/host/src/routes/runtime.tsx
@@ -1,89 +1,42 @@
 /**
- * /runtime — runtime-management page (P3.3).
+ * /runtime — the runtime hub (pi-parity P4, story 7).
  *
- * Shows the active runtime adapter, its capability matrix
- * (native/shimmed/unavailable per capability), tool-access status, and the
- * onboarding setup state; runs the orchestrated switch with confirmation +
- * live progress (runtime:switch SSE events) + honest carry report, and
- * surfaces the target runtime's setup steps after a switch.
+ * Three tabs on the SDK kit, each answering one question in plain language:
+ *   Overview     — who runs your agents and what it can do (honest modes)
+ *   Capabilities — are installed capability packs actually working
+ *   Switch       — guided runtime switch: preview (dry run) first, confirm,
+ *                  live progress, grouped result cards
+ * Sections fetch and fault independently (health-page pattern); tab state is
+ * URL-backed for deep links.
  */
 import { createRoute } from '@tanstack/react-router'
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { Suspense, useCallback, useEffect, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
-import { PageLayout } from '@/components/page-layout'
-import {
-  capabilityRows,
-  reduceSwitchProgress,
-  SWITCH_PHASE_LABELS,
-  type CapabilitiesPayload,
-  type SwitchStepRow,
-} from '../lib/runtime-report'
+import { PluginHeader } from '@/components/plugin-header'
+import { UnderlineTabs } from '@/components/underline-tabs'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ErrorBanner } from '@/components/error-banner'
+import { useQueryState } from '@/hooks/use-query-state'
+import { OverviewTab } from '../components/runtime/overview-tab'
+import { CapabilitiesTab } from '../components/runtime/capabilities-tab'
+import { SwitchTab } from '../components/runtime/switch-tab'
+import type { CapabilityReport, OnboardingComponentStatus } from '../components/runtime/types'
 import { Route as RootRoute } from './__root'
 
-interface CapabilityReport {
-  adapter: string
-  adapters: string[]
-  runtime: { name: string; version: string }
-  capabilities: CapabilitiesPayload
-  toolAccess: { style: string; ok: boolean; issues: string[] }
-}
-
-interface OnboardingComponentStatus {
-  name: string
-  status: 'ok' | 'warn' | 'missing' | 'broken' | 'error' | string
-  message: string
-  remediation?: string
-}
-
-interface SwitchResultPayload {
-  ok: boolean
-  from: string
-  to: string
-  error?: string
-  restored?: boolean
-  backupPath: string | null
-  restartRequired: boolean
-  dryRun?: boolean
-  roster: {
-    carried: Array<{ agentId: string; model?: string; mappedFrom?: string; subagentModel?: string }>
-    existing: string[]
-    unmappedModels: Array<{ agentId: string; sourceModel: string; field?: 'model' | 'subagentModel' }>
-    failed: Array<{ agentId: string; error: string }>
-  } | null
-  workspaces: {
-    carried: Array<{ agentId: string; files: number; bytes: number }>
-    skills: Array<{ agentId: string; carried: number; skippedPackageManaged: number }>
-    skippedExisting: string[]
-    failed: Array<{ agentId: string; path: string; error: string }>
-  } | null
-  cantCarry: Array<{ concern: string; detail: string; count?: number }> | null
-  credentials: { llmProviders: string[] } | null
-  sync: { drifted: boolean; findings: number; syncedAgents: number } | null
-}
-
-function modeBadgeClass(mode: string): string {
-  if (mode === 'native') return 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
-  if (mode === 'shimmed') return 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
-  return 'bg-zinc-500/15 text-zinc-500 dark:text-zinc-400'
-}
-
-function statusBadgeClass(status: string): string {
-  if (status === 'ok') return 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
-  if (status === 'warn' || status === 'skipped') return 'bg-amber-500/15 text-amber-600 dark:text-amber-400'
-  return 'bg-red-500/15 text-red-600 dark:text-red-400'
-}
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'capabilities', label: 'Capabilities' },
+  { id: 'switch', label: 'Switch' },
+]
 
 function RuntimePage() {
+  const [tab, setTab] = useQueryState('tab', 'overview')
   const [report, setReport] = useState<CapabilityReport | null>(null)
   const [reportError, setReportError] = useState<string | null>(null)
-  // undefined = fetch in flight (the setup check runs every component live —
+  // undefined = in flight (the setup check runs every component live —
   // seconds, not ms); null = fetch failed.
   const [onboarding, setOnboarding] = useState<OnboardingComponentStatus[] | null | undefined>(undefined)
-  const [confirmTarget, setConfirmTarget] = useState<string | null>(null)
-  const [switching, setSwitching] = useState(false)
-  const [steps, setSteps] = useState<SwitchStepRow[]>([])
-  const [result, setResult] = useState<SwitchResultPayload | null>(null)
-  const esRef = useRef<EventSource | null>(null)
 
   const loadReport = useCallback(async () => {
     try {
@@ -108,300 +61,43 @@ function RuntimePage() {
     }
   }, [])
 
-  useEffect(() => {
+  const refresh = useCallback(() => {
     void loadReport()
     void loadOnboarding()
-    return () => { esRef.current?.close() }
   }, [loadReport, loadOnboarding])
 
-  const runSwitch = useCallback(async (target: string) => {
-    setConfirmTarget(null)
-    setSwitching(true)
-    setSteps([])
-    setResult(null)
-
-    // Dedicated short-lived stream for the switch progress events.
-    const es = new EventSource('/api/events')
-    esRef.current = es
-    es.onmessage = (msg) => {
-      try {
-        const event = JSON.parse(msg.data as string)
-        if (event?.type === 'runtime:switch') setSteps((prev) => reduceSwitchProgress(prev, event))
-      } catch { /* non-JSON keepalives */ }
-    }
-    // Fresh SSE connections get no replay — events broadcast before the
-    // handshake completes are lost, so a fast local switch would render only
-    // its late phases. Wait for the stream (bounded) before firing the POST.
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, 2000)
-      es.onopen = () => { clearTimeout(timer); resolve() }
-    })
-
-    try {
-      const res = await fetch('/api/runtime/switch', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ target }),
-      })
-      const payload = await res.json() as SwitchResultPayload
-      setResult(payload)
-    } catch (err) {
-      setResult({
-        ok: false,
-        from: report?.adapter ?? '?',
-        to: target,
-        error: err instanceof Error ? err.message : String(err),
-        backupPath: null,
-        restartRequired: false,
-        roster: null,
-        workspaces: null,
-        cantCarry: null,
-        credentials: null,
-        sync: null,
-      })
-    } finally {
-      es.close()
-      esRef.current = null
-      setSwitching(false)
-      void loadReport()
-      void loadOnboarding()
-    }
-  }, [report, loadReport, loadOnboarding])
-
-  const rows = capabilityRows(report?.capabilities)
-  const otherAdapters = (report?.adapters ?? []).filter((name) => name !== report?.adapter)
+  useEffect(() => { refresh() }, [refresh])
 
   return (
-    <PageLayout title="Runtime" subtitle="Adapter status, capability matrix, and switching">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-4">
+    <div className="flex flex-1 flex-col">
+      <PluginHeader
+        title="Runtime"
+        subtitle={report ? `${report.adapter} · ${report.runtime.name}@${report.runtime.version}` : 'The engine that runs your agents'}
+        actions={
+          <Button size="sm" variant="outline" onClick={refresh}>
+            <RefreshCw className="mr-2 size-3.5" /> Refresh
+          </Button>
+        }
+      />
+      <div className="mx-auto w-full max-w-5xl flex-1 space-y-6 p-6">
+        <UnderlineTabs tabs={TABS} value={tab} onValueChange={setTab} />
+
         {reportError && (
-          <div className="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm">
-            Failed to load the runtime report: {reportError}
-          </div>
+          <ErrorBanner message={`The runtime report failed to load: ${reportError}`} onRetry={refresh} />
         )}
 
         {!report && !reportError && (
-          <section className="rounded-lg border p-4">
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <RefreshCw className="size-3 animate-spin" /> Loading runtime report…
-            </div>
-          </section>
+          <div className="space-y-3">
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-40 w-full" />
+          </div>
         )}
 
-        {report && (
-          <section className="rounded-lg border p-4" data-testid="runtime-summary">
-            <div className="flex items-center justify-between gap-2">
-              <div>
-                <div className="text-sm text-muted-foreground">Active runtime</div>
-                <div className="text-lg font-semibold">
-                  {report.adapter}
-                  <span className="ml-2 text-sm font-normal text-muted-foreground">
-                    {report.runtime.name}@{report.runtime.version}
-                  </span>
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => { void loadReport(); void loadOnboarding() }}
-                className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-accent"
-              >
-                <RefreshCw className="size-3" /> Refresh
-              </button>
-            </div>
-            <div className={`mt-2 text-sm ${report.toolAccess.ok ? 'text-muted-foreground' : 'text-red-500'}`}>
-              Tool access: {report.toolAccess.ok ? `ok (${report.toolAccess.style})` : report.toolAccess.issues.join('; ')}
-            </div>
-          </section>
-        )}
-
-        {rows.length > 0 && (
-          <section className="rounded-lg border p-4">
-            <h2 className="mb-3 text-sm font-semibold">Capability matrix</h2>
-            <div className="flex flex-col gap-2" data-testid="capability-matrix">
-              {rows.map((row) => (
-                <div key={row.key} className="flex items-center justify-between gap-2 text-sm">
-                  <span>{row.label}</span>
-                  <span className="flex items-center gap-2">
-                    {row.detail && <span className="text-xs text-muted-foreground">{row.detail}</span>}
-                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${modeBadgeClass(row.mode)}`}>
-                      {row.mode}
-                    </span>
-                  </span>
-                </div>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {otherAdapters.length > 0 && (
-          <section className="rounded-lg border p-4">
-            <h2 className="mb-1 text-sm font-semibold">Switch runtime</h2>
-            <p className="mb-3 text-xs text-muted-foreground">
-              Settings are backed up first; the roster carries over best-effort with an honest report;
-              a completed switch needs a server restart to rebind plugins. Failures auto-restore the
-              previous runtime.
-            </p>
-            <div className="flex flex-wrap items-center gap-2">
-              {otherAdapters.map((name) => (
-                confirmTarget === name ? (
-                  <span key={name} className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      disabled={switching}
-                      onClick={() => void runSwitch(name)}
-                      className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
-                    >
-                      Confirm switch to {name}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setConfirmTarget(null)}
-                      className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
-                    >
-                      Cancel
-                    </button>
-                  </span>
-                ) : (
-                  <button
-                    key={name}
-                    type="button"
-                    disabled={switching}
-                    onClick={() => setConfirmTarget(name)}
-                    className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
-                  >
-                    Switch to {name}…
-                  </button>
-                )
-              ))}
-            </div>
-
-            {(switching || steps.length > 0) && (
-              <div className="mt-4 flex flex-col gap-1 text-sm" data-testid="switch-progress">
-                {steps.map((step) => (
-                  <div key={step.phase} className="flex items-center gap-2">
-                    <span className={`inline-block size-2 rounded-full ${
-                      step.status === 'ok' ? 'bg-emerald-500'
-                        : step.status === 'running' ? 'animate-pulse bg-blue-500'
-                          : step.status === 'skip' ? 'bg-zinc-400'
-                            : 'bg-red-500'
-                    }`} />
-                    <span>{SWITCH_PHASE_LABELS[step.phase] ?? step.phase}</span>
-                    {step.detail && <span className="text-xs text-muted-foreground">— {step.detail}</span>}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {result && (
-              <div className={`mt-4 rounded-md border p-3 text-sm ${result.ok ? 'border-emerald-500/30 bg-emerald-500/10' : 'border-red-500/30 bg-red-500/10'}`} data-testid="switch-result">
-                {result.ok ? (
-                  <>
-                    <div className="font-medium">{result.dryRun ? 'Dry run — would switch' : 'Switched'} {result.from} → {result.to}</div>
-                    {result.roster && (
-                      <div className="mt-1">
-                        Roster: {result.dryRun ? 'would carry' : 'carried'} {result.roster.carried.length}, existing {result.roster.existing.length}, failed {result.roster.failed.length}
-                      </div>
-                    )}
-                    {result.roster?.unmappedModels.map((u) => (
-                      <div key={`${u.agentId}:${u.field ?? 'model'}`} className="mt-1 text-amber-600 dark:text-amber-400">
-                        ⚠ {u.agentId}: {u.field === 'subagentModel' ? 'subagent model' : 'model'} “{u.sourceModel}” has no {result.to} equivalent — falls back to the routing default
-                      </div>
-                    ))}
-                    {result.roster?.failed.map((f) => (
-                      <div key={f.agentId} className="mt-1 text-red-600 dark:text-red-400">
-                        ✗ {f.agentId}: {f.error}
-                      </div>
-                    ))}
-                    {result.workspaces && (
-                      <div className="mt-1">
-                        Workspace content: {result.dryRun ? 'would carry' : 'carried'}{' '}
-                        {result.workspaces.carried.reduce((sum, c) => sum + c.files, 0)} file(s) +{' '}
-                        {result.workspaces.skills.reduce((sum, s) => sum + s.carried, 0)} skill(s) across{' '}
-                        {result.workspaces.carried.length} agent(s)
-                        {result.workspaces.skippedExisting.length > 0 && (
-                          <span className="text-muted-foreground"> — existing on target (untouched): {result.workspaces.skippedExisting.join(', ')}</span>
-                        )}
-                      </div>
-                    )}
-                    {result.workspaces?.failed.map((f) => (
-                      <div key={`${f.agentId}:${f.path}`} className="mt-1 text-amber-600 dark:text-amber-400">
-                        ⚠ {f.agentId} {f.path}: {f.error}
-                      </div>
-                    ))}
-                    {result.cantCarry && result.cantCarry.length > 0 && (
-                      <div className="mt-2">
-                        <div className="font-medium">Stays behind:</div>
-                        {result.cantCarry.map((line) => (
-                          <div key={line.concern} className="mt-0.5 text-xs text-muted-foreground">
-                            ✗ {line.concern}{line.count !== undefined ? ` (${line.count})` : ''}: {line.detail}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                    {result.credentials && result.credentials.llmProviders.length === 0 && (
-                      <div className="mt-2 font-medium text-amber-600 dark:text-amber-400">
-                        ⚠ {result.to} has no provider credentials — agents cannot dispatch until auth is configured on the target runtime.
-                      </div>
-                    )}
-                    {result.backupPath && (
-                      <div className="mt-1 text-xs text-muted-foreground">Rollback backup: {result.backupPath}</div>
-                    )}
-                    {result.restartRequired && (
-                      <div className="mt-2 font-medium">⚠ Restart required — run <code>bakin restart</code> so plugins rebind.</div>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <div className="font-medium">Switch failed: {result.error}</div>
-                    {result.restored !== undefined && (
-                      <div className="mt-1">
-                        {result.restored
-                          ? `The previous runtime (${result.from}) was restored.`
-                          : `RESTORE FAILED — compare settings.json with the backup: ${result.backupPath}`}
-                      </div>
-                    )}
-                    {result.restartRequired && (
-                      <div className="mt-2 font-medium">⚠ Restart required — plugins are still bound to the pre-switch runtime instance.</div>
-                    )}
-                  </>
-                )}
-              </div>
-            )}
-          </section>
-        )}
-
-        <section className="rounded-lg border p-4">
-          <h2 className="mb-1 text-sm font-semibold">Runtime setup</h2>
-          <p className="mb-3 text-xs text-muted-foreground">
-            Onboarding status for the active runtime — anything below “ok” needs attention after a switch.
-          </p>
-          {onboarding === undefined ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <RefreshCw className="size-3 animate-spin" /> Checking runtime setup (runs every component live — this takes a few seconds)…
-            </div>
-          ) : onboarding === null ? (
-            <div className="text-sm text-muted-foreground">Setup status unavailable.</div>
-          ) : (
-            <div className="flex flex-col gap-2" data-testid="onboarding-status">
-              {onboarding.map((component) => (
-                <div key={component.name} className="flex items-start justify-between gap-3 text-sm">
-                  <div className="min-w-0">
-                    <div className="font-medium">{component.name}</div>
-                    <div className="truncate text-xs text-muted-foreground" title={component.message}>{component.message}</div>
-                    {component.status !== 'ok' && component.remediation && (
-                      <div className="mt-0.5 text-xs">{component.remediation}</div>
-                    )}
-                  </div>
-                  <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass(component.status)}`}>
-                    {component.status}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
+        {report && tab === 'overview' && <OverviewTab report={report} onboarding={onboarding} />}
+        {tab === 'capabilities' && <CapabilitiesTab />}
+        {report && tab === 'switch' && <SwitchTab report={report} onSwitched={refresh} />}
       </div>
-    </PageLayout>
+    </div>
   )
 }
 

--- a/tests/components/runtime-hub.test.tsx
+++ b/tests/components/runtime-hub.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+/**
+ * Runtime hub tabs (pi-parity P4): honest capability language on Overview,
+ * per-leg readiness on Capabilities, and the guided Switch flow (dry-run
+ * default, ConfirmDialog-gated execute, grouped result cards).
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-runtime-hub-${Date.now()}`)
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ db: join(testDir, 'bakin.db') }),
+}))
+// The hub links into /explore and /settings; a bare RTL render has no
+// router, so Link becomes a plain anchor.
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ to, children, className }: { to: string; children: unknown; className?: string }) => (
+    <a href={to} className={className}>{children as never}</a>
+  ),
+  createRoute: () => ({}),
+}))
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '../rtl-settle'
+import { settleReact } from '../rtl-settle'
+
+import { OverviewTab } from '../../packages/host/src/components/runtime/overview-tab'
+import { CapabilitiesTab } from '../../packages/host/src/components/runtime/capabilities-tab'
+import { SwitchTab } from '../../packages/host/src/components/runtime/switch-tab'
+import type { CapabilityReport } from '../../packages/host/src/components/runtime/types'
+
+const report: CapabilityReport = {
+  adapter: 'pi',
+  adapters: ['openclaw', 'pi'],
+  runtime: { name: 'pi', version: '0.1.0' },
+  capabilities: {
+    toolCalling: { mode: 'native', access: { style: 'in-process' } },
+    delivery: { mode: 'unavailable' },
+    imageGen: { mode: 'native' },
+    memory: { mode: 'native' },
+    sessions: { mode: 'native' },
+    workspaceFiles: { mode: 'native' },
+    input: { imageInput: true, audioInput: false },
+  },
+  toolAccess: { style: 'in-process', ok: true, issues: [] },
+  credentialStatus: { llmProviders: ['anthropic'], llmCredentials: [{ provider: 'anthropic', kind: 'oauth' }], channels: [] },
+}
+
+const realFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+})
+
+describe('OverviewTab', () => {
+  it('speaks plain language: honest unavailable copy, legend, credential tiles, setup rows', () => {
+    render(
+      <OverviewTab
+        report={report}
+        onboarding={[
+          { name: 'runtime', status: 'ok', message: 'pi runtime adapter is available' },
+          { name: 'budget', status: 'warn', message: 'No spending budget is set', remediation: 'Set one in Settings' },
+        ]}
+      />,
+    )
+    // Identity + credentials
+    expect(screen.getByText('pi')).toBeTruthy()
+    expect(screen.getByText(/anthropic · subscription/)).toBeTruthy()
+    // Honest unavailable copy for delivery on pi — never a bare enum
+    expect(screen.getByText(/Alerts and approvals appear in the app/)).toBeTruthy()
+    expect(screen.getByText('Not available')).toBeTruthy()
+    // Legend present
+    expect(screen.getByText(/Via Bakin — Bakin fills the gap itself/)).toBeTruthy()
+    // Setup rows carry remediation for non-ok
+    expect(screen.getByText('→ Set one in Settings')).toBeTruthy()
+  })
+})
+
+describe('CapabilitiesTab', () => {
+  it('renders ready and needs-attention packs with per-leg chips + remediation', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      capabilities: [
+        {
+          capability: 'web-search', packageId: 'web-search-brave', version: '1.0.0', name: 'Web Search (Brave)',
+          skills: [{ name: 'bx-search', status: 'ok' }],
+          bins: [{ name: 'bx', status: 'ok' }],
+          secrets: [{ name: 'BRAVE_SEARCH_API_KEY', required: true, secretSlot: 'brave.apiKey', status: 'missing' }],
+          ready: false,
+          missing: ['BRAVE_SEARCH_API_KEY is not configured — add it in Settings → Integrations & Keys'],
+        },
+      ],
+    }), { status: 200 })) as unknown as typeof fetch
+
+    render(<CapabilitiesTab />)
+    await waitFor(() => screen.getByText('Web Search (Brave)'))
+    expect(screen.getByText('Needs attention')).toBeTruthy()
+    expect(screen.getByText(/BRAVE_SEARCH_API_KEY not set/)).toBeTruthy()
+    expect(screen.getByText('Add the key in Settings')).toBeTruthy()
+  })
+
+  it('empty state invites the user to Explore', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ capabilities: [] }), { status: 200 })) as unknown as typeof fetch
+    render(<CapabilitiesTab />)
+    await waitFor(() => screen.getByText('No capabilities installed yet'))
+    expect(screen.getByText('Browse capabilities')).toBeTruthy()
+  })
+})
+
+describe('SwitchTab', () => {
+  let posts: Array<Record<string, unknown>> = []
+
+  beforeEach(() => {
+    posts = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/api/runtime/switch')) {
+        posts.push(JSON.parse(String(init?.body)))
+        return new Response(JSON.stringify({
+          ok: true, from: 'pi', to: 'openclaw', dryRun: true, backupPath: null, restartRequired: false,
+          roster: {
+            carried: [{ agentId: 'main' }], existing: ['pixel'],
+            unmappedModels: [], preserved: [{ agentId: 'scout', sourceModel: 'openai/gpt-5.5-mini' }], failed: [],
+          },
+          workspaces: { carried: [{ agentId: 'main', files: 3, bytes: 100 }], skills: [], skippedExisting: [], failed: [] },
+          cron: { adopted: ['daily-report'], skipped: [], failed: [] },
+          cantCarry: [{ concern: 'sessions', detail: 'runtime session context resets' }],
+          credentials: { llmProviders: [] }, sync: null,
+        }), { status: 200 })
+      }
+      return new Response('{}', { status: 200 })
+    }) as typeof fetch
+    // EventSource: the tab opens a progress stream before POSTing.
+    ;(globalThis as Record<string, unknown>).EventSource = class {
+      onopen: (() => void) | null = null
+      onmessage: unknown = null
+      constructor() { setTimeout(() => this.onopen?.(), 0) }
+      close() {}
+    }
+  })
+
+  it('preview posts a dry run with the chosen options and renders grouped result cards', async () => {
+    render(<SwitchTab report={report} onSwitched={() => {}} />)
+    fireEvent.click(screen.getByTestId('switch-target-openclaw'))
+    fireEvent.click(screen.getByTestId('switch-adopt-cron'))
+    fireEvent.click(screen.getByTestId('switch-preview'))
+
+    await waitFor(() => screen.getByTestId('switch-result'))
+    expect(posts).toEqual([{ target: 'openclaw', dryRun: true, adoptCron: true }])
+    // Summary card + attention card content
+    expect(screen.getByText('Preview: pi → openclaw')).toBeTruthy()
+    expect(screen.getByText(/would be adopted/)).toBeTruthy()
+    expect(screen.getByText(/subagent model 'openai\/gpt-5.5-mini' preserved/)).toBeTruthy()
+    expect(screen.getByText(/no model providers configured/)).toBeTruthy()
+    expect(screen.getByText('Stays behind')).toBeTruthy()
+  })
+
+  it('the real switch is gated behind the confirm dialog', async () => {
+    render(<SwitchTab report={report} onSwitched={() => {}} />)
+    fireEvent.click(screen.getByTestId('switch-target-openclaw'))
+    fireEvent.click(screen.getByTestId('switch-execute'))
+    await settleReact()
+
+    // Dialog open, nothing posted yet.
+    expect(posts).toEqual([])
+    fireEvent.click(screen.getByTestId('switch-confirm'))
+    await waitFor(() => expect(posts).toEqual([{ target: 'openclaw' }]))
+  })
+})


### PR DESCRIPTION
Phase P4 of the pi-parity initiative (spec §4.5, story 7, D13). P1–P3 merged.

## What

The hand-rolled pre-component-kit `/runtime` page becomes a three-tab hub built entirely on the SDK kit (PluginHeader, UnderlineTabs, Card, ConfirmDialog, Skeleton, EmptyState, ErrorBanner), URL-backed tab state, independently-faulting sections.

- **Overview** — adapter identity + model-provider + tool-access tiles; a capability grid that speaks plain language instead of enums (*Native / Via Bakin / Not available*), one what-happens-instead line per state (e.g. delivery on Pi: "Alerts and approvals appear in the app — pi has no channel delivery"), with a legend; live setup checks with remediation lines.
- **Capabilities** — installed capability packs with per-leg readiness chips (skill / binary / key), the engine's remediation lines, and working links (Settings for keys, Explore for browsing — install stays in Explore, one path).
- **Switch** — target cards, carry options (adopt cron jobs, copy workspaces), **dry-run preview as the default action**, ConfirmDialog-gated execute, live SSE progress steps, and results as grouped cards: summary stats, needs-your-attention (unmapped models, preserved subagent models, cron failures, missing target credentials), and stays-behind. The old glyph-prefixed prose dump is gone.

## Validation

- RTL: honest-language assertions on Overview, readiness/empty states on Capabilities, and the Switch contract (preview POSTs `{dryRun, adoptCron}` exactly; execute is dialog-gated; result cards render preserved/attention/stays-behind). 5/5.
- Visual review on the isolated rig (real server, real installed capability pack): all three tabs screenshotted at the explore/health polish bar; one visual defect caught and fixed (duplicate empty "Model input" card from the generic capability-row loop).
- Full suite green (6881 pass / 0 fail), typecheck clean. `data-testid` hooks preserved (`runtime-summary`, `switch-progress`, `switch-result`, `onboarding-status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)