### PR TITLE
fix(host): runtime hub header padding + one-click Fix for setup checks

### DIFF
--- a/packages/host/src/components/runtime/overview-tab.tsx
+++ b/packages/host/src/components/runtime/overview-tab.tsx
@@ -3,6 +3,9 @@
  * plain language), and whether setup is healthy. Every non-native state
  * says what happens instead — the reader never has to decode an enum.
  */
+import { useState } from 'react'
+import { Loader2, Wrench } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { capabilityRows } from '../../lib/runtime-report'
@@ -90,7 +93,35 @@ function CapabilityGrid({ report }: { report: CapabilityReport }) {
   )
 }
 
-function SetupSection({ onboarding }: { onboarding: OnboardingComponentStatus[] | null | undefined }) {
+/** Setup checks whose install() is safe to run headlessly from the UI. */
+const FIXABLE_COMPONENTS = new Set(['mkdir', 'settings', 'search', 'search-models', 'plugin-assets', 'agent-sync'])
+
+function SetupSection({ onboarding, onFixed }: { onboarding: OnboardingComponentStatus[] | null | undefined; onFixed: () => void }) {
+  const [fixing, setFixing] = useState<string | null>(null)
+  const [fixError, setFixError] = useState<string | null>(null)
+
+  const runFix = async (name: string) => {
+    setFixing(name)
+    setFixError(null)
+    try {
+      const res = await fetch('/api/runtime/onboarding/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ component: name }),
+      })
+      const body = await res.json().catch(() => null) as { ok?: boolean; result?: { message?: string }; error?: string } | null
+      if (!res.ok || body?.ok === false) {
+        setFixError(`${name}: ${body?.result?.message ?? body?.error ?? `HTTP ${res.status}`}`)
+        return
+      }
+      onFixed()
+    } catch (err) {
+      setFixError(`${name}: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      setFixing(null)
+    }
+  }
+
   return (
     <section className="space-y-3" data-testid="onboarding-status">
       <div>
@@ -106,21 +137,41 @@ function SetupSection({ onboarding }: { onboarding: OnboardingComponentStatus[] 
       {onboarding === null && (
         <p className="text-sm text-muted-foreground">Setup checks are unavailable right now — retry with Refresh.</p>
       )}
+      {fixError && (
+        <p role="alert" className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">{fixError}</p>
+      )}
       {onboarding && (
         <Card>
           <CardContent className="divide-y divide-border p-0">
-            {onboarding.map((component) => (
-              <div key={component.name} className="flex items-start justify-between gap-3 px-4 py-2.5">
-                <div className="min-w-0">
-                  <p className="text-sm font-medium">{component.name}</p>
-                  <p className="truncate text-xs text-muted-foreground" title={component.message}>{component.message}</p>
-                  {component.remediation && component.status !== 'ok' && (
-                    <p className="mt-0.5 text-xs text-muted-foreground/80">→ {component.remediation}</p>
-                  )}
+            {onboarding.map((component) => {
+              const fixable = component.status !== 'ok' && FIXABLE_COMPONENTS.has(component.name)
+              return (
+                <div key={component.name} className="flex items-start justify-between gap-3 px-4 py-2.5">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">{component.name}</p>
+                    <p className="truncate text-xs text-muted-foreground" title={component.message}>{component.message}</p>
+                    {component.remediation && component.status !== 'ok' && (
+                      <p className="mt-0.5 text-xs text-muted-foreground/80">→ {component.remediation}</p>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {fixable && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={fixing !== null}
+                        onClick={() => void runFix(component.name)}
+                        data-testid={`setup-fix-${component.name}`}
+                      >
+                        {fixing === component.name ? <Loader2 className="mr-1.5 size-3 animate-spin" /> : <Wrench className="mr-1.5 size-3" />}
+                        Fix
+                      </Button>
+                    )}
+                    <StatusBadge status={component.status} />
+                  </div>
                 </div>
-                <StatusBadge status={component.status} />
-              </div>
-            ))}
+              )
+            })}
           </CardContent>
         </Card>
       )}
@@ -131,15 +182,17 @@ function SetupSection({ onboarding }: { onboarding: OnboardingComponentStatus[] 
 export function OverviewTab({
   report,
   onboarding,
+  onRefreshOnboarding,
 }: {
   report: CapabilityReport
   onboarding: OnboardingComponentStatus[] | null | undefined
+  onRefreshOnboarding: () => void
 }) {
   return (
     <div className="space-y-6" data-testid="runtime-summary">
       <CredentialTiles report={report} />
       <CapabilityGrid report={report} />
-      <SetupSection onboarding={onboarding} />
+      <SetupSection onboarding={onboarding} onFixed={onRefreshOnboarding} />
     </div>
   )
 }

--- a/packages/host/src/routes/runtime.tsx
+++ b/packages/host/src/routes/runtime.tsx
@@ -69,7 +69,9 @@ function RuntimePage() {
   useEffect(() => { refresh() }, [refresh])
 
   return (
-    <div className="flex flex-1 flex-col">
+    // PluginHeader ships unpadded — it lives INSIDE the p-6 frame, exactly
+    // like the health page wraps it.
+    <div className="flex flex-1 flex-col space-y-6 p-6">
       <PluginHeader
         title="Runtime"
         subtitle={report ? `${report.adapter} · ${report.runtime.name}@${report.runtime.version}` : 'The engine that runs your agents'}
@@ -79,7 +81,7 @@ function RuntimePage() {
           </Button>
         }
       />
-      <div className="flex-1 space-y-6 p-6">
+      <div className="flex-1 space-y-6">
         <UnderlineTabs tabs={TABS} value={tab} onValueChange={setTab} />
 
         {reportError && (
@@ -93,7 +95,7 @@ function RuntimePage() {
           </div>
         )}
 
-        {report && tab === 'overview' && <OverviewTab report={report} onboarding={onboarding} />}
+        {report && tab === 'overview' && <OverviewTab report={report} onboarding={onboarding} onRefreshOnboarding={() => void loadOnboarding()} />}
         {tab === 'capabilities' && <CapabilitiesTab />}
         {report && tab === 'switch' && <SwitchTab report={report} onSwitched={refresh} />}
       </div>

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -236,6 +236,25 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
       return
     }
 
+    // One-click setup repair from the runtime hub: run a SAFE onboarding
+    // component's install() headlessly. Whitelisted — components with
+    // interactive prompts or package selection stay CLI/Explore territory.
+    if (url.pathname === '/api/runtime/onboarding/install' && req.method === 'POST') {
+      handleJsonPost(req, res, async (body) => {
+        const name = (body as { component?: string } | null)?.component
+        const FIXABLE = new Set(['mkdir', 'settings', 'search', 'search-models', 'plugin-assets', 'agent-sync'])
+        if (!name || !FIXABLE.has(name)) {
+          throw new Error(`component must be one of: ${[...FIXABLE].join(', ')}`)
+        }
+        const { COMPONENT_ORDER } = require('../onboarding/index') as typeof import('../onboarding/index')
+        const component = COMPONENT_ORDER.find((c) => c.name === name)
+        if (!component) throw new Error(`unknown component: ${name}`)
+        const result = await component.install({ interactive: false, autoApprove: true, json: false, checkOnly: false, force: false })
+        return { ok: result.status !== 'failed', result }
+      })
+      return
+    }
+
     // Runtime switch (P3.2): runs the full orchestrated lifecycle; progress
     // streams over the activity SSE channel as runtime:switch events. A
     // completed switch requires a server restart to rebind plugin contexts —

--- a/tests/components/runtime-hub.test.tsx
+++ b/tests/components/runtime-hub.test.tsx
@@ -63,6 +63,7 @@ describe('OverviewTab', () => {
     render(
       <OverviewTab
         report={report}
+        onRefreshOnboarding={() => {}}
         onboarding={[
           { name: 'runtime', status: 'ok', message: 'pi runtime adapter is available' },
           { name: 'budget', status: 'warn', message: 'No spending budget is set', remediation: 'Set one in Settings' },
@@ -79,6 +80,31 @@ describe('OverviewTab', () => {
     expect(screen.getByText(/Via Bakin — Bakin fills the gap itself/)).toBeTruthy()
     // Setup rows carry remediation for non-ok
     expect(screen.getByText('→ Set one in Settings')).toBeTruthy()
+    // budget is not headless-fixable — no Fix button; fixable components get one
+    expect(screen.queryByTestId('setup-fix-budget')).toBeNull()
+  })
+
+  it('warn rows for headless-fixable components expose a Fix button that posts the install', async () => {
+    const posts: Array<Record<string, unknown>> = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/api/runtime/onboarding/install')) {
+        posts.push(JSON.parse(String(init?.body)))
+        return new Response(JSON.stringify({ ok: true, result: { status: 'installed' } }), { status: 200 })
+      }
+      return new Response('{}', { status: 200 })
+    }) as unknown as typeof fetch
+
+    const refreshed: number[] = []
+    render(
+      <OverviewTab
+        report={report}
+        onRefreshOnboarding={() => refreshed.push(1)}
+        onboarding={[{ name: 'agent-sync', status: 'warn', message: '3 findings', remediation: 'Run bakin install agent-sync' }]}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('setup-fix-agent-sync'))
+    await waitFor(() => expect(posts).toEqual([{ component: 'agent-sync' }]))
+    await waitFor(() => expect(refreshed.length).toBe(1))
   })
 })
 


### PR DESCRIPTION
Two live-testing follow-ups to the pi-parity runtime hub:

- **Header padding**: PluginHeader is unpadded by design and belongs inside the page's `p-6` frame (the health-page pattern) — the Runtime title and Refresh button no longer touch the viewport edge.
- **One-click setup repair**: warn/missing setup rows for headless-safe components (`mkdir`, `settings`, `search`, `search-models`, `plugin-assets`, `agent-sync`) get a **Fix** button → new `POST /api/runtime/onboarding/install` (server-side whitelist, non-interactive `install()`, list refreshes after). Components that need prompts or package selection (budget, recommended-*) intentionally stay CLI/Explore territory.

Full suite green (6883 pass / 0 fail), typecheck clean. RTL covers: fixable rows expose the button and POST the component name; non-fixable warns don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
