### PR TITLE
fix(packages): sync scanner stops false-flagging requirement-leg artifacts

### DIFF
--- a/src/core/agent-packages/sync-scanner.ts
+++ b/src/core/agent-packages/sync-scanner.ts
@@ -495,6 +495,14 @@ export async function scanAgentSync(lockfile?: Lockfile): Promise<SyncScanReport
   for (const [packageId, entry] of Object.entries(lock.packages)) {
     for (const p of entry.projections ?? []) {
       if (p.kind === 'workspace-file' || p.kind === 'lesson-marker') continue
+      // npm payloads + models are OWNED by the capability-readiness engine
+      // (presence + remediation; doctor inherits) — content-hashing them
+      // here is a permanent false positive: a payload contains node_modules
+      // + a generated package.json the pack source never had, and re-hashing
+      // ~GB models every scan is real cost. Bins stay: tamper detection
+      // belongs here (repair self-heals), with archive bins compared against
+      // the marker's extractedSha256 below.
+      if (p.kind === 'npm-payload' || p.kind === 'model') continue
 
       // Seed-once kinds (personas today) are user-owned after projection: no
       // .installedBy sidecar, edits are expected, uninstall leaves them
@@ -612,7 +620,11 @@ export async function scanAgentSync(lockfile?: Lockfile): Promise<SyncScanReport
         continue
       }
       const actualSha = statSync(p.target).isDirectory() ? computeDirSha(p.target) : computeFileSha(p.target)
-      if ((p.sha256 && actualSha !== p.sha256) || marker.sha256 !== actualSha) {
+      // Archive-sourced bins: the projection/marker sha pins the TARBALL —
+      // the on-disk binary compares against the marker's extracted hash.
+      const expectedSha = p.kind === 'bin' && marker.extractedSha256 ? marker.extractedSha256 : marker.sha256
+      const rowShaMismatch = p.kind === 'bin' && marker.extractedSha256 ? false : Boolean(p.sha256 && actualSha !== p.sha256)
+      if (rowShaMismatch || expectedSha !== actualSha) {
         report.findings.push({
           type: 'asset-drifted',
           severity: 'warn',

--- a/tests/agent-packages/requirement-legs.test.ts
+++ b/tests/agent-packages/requirement-legs.test.ts
@@ -378,3 +378,14 @@ describe('review hardening pins', () => {
     expect(bunRuns).toHaveLength(1) // still offline-skipped
   })
 })
+
+describe('sync scanner vs requirement legs', () => {
+  it('npm payloads and models never report asset drift (readiness owns those legs)', async () => {
+    await installPackage({ source: seedPack('1.0.0', { npmDeps: { 'fake-dep': '1.2.3' } }) })
+    const { scanAgentSync } = await import('../../src/core/agent-packages/sync-scanner')
+    const report = await scanAgentSync()
+    const legFindings = report.findings.filter((f) =>
+      String(f.target ?? '').includes('/npm/') || String(f.target ?? '').includes('/models/'))
+    expect(legFindings).toEqual([])
+  })
+})


### PR DESCRIPTION
Follow-up to #674, found live by Mark: the drift scanner content-hashed the new `npm-payload` projection against the pack source — `node_modules` + the generated package.json legitimately differ, so agent-sync warned forever and Repair could never converge.

npm payloads and models are now scanner-exempt (the readiness engine owns those legs with presence checks + remediation; doctor inherits). Bins deliberately KEEP scanner tamper detection — archive-sourced ones compare against the marker's `extractedSha256` instead of the tarball pin.

Verified live: agent-sync row reads `ok — 10 agent(s) in sync`. Pinned with a scanner test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)