### PR TITLE
feat(runtime): Pi extension trust lane — approve before third-party code runs (#670, #626)

### DIFF
--- a/.claude/knowledge/pi-adapter.md
+++ b/.claude/knowledge/pi-adapter.md
@@ -98,10 +98,19 @@ Flip: `~/.bakin/settings.json` → `"runtime": { "adapter": "pi" }` → restart 
   Unapproved code is never imported. Pinned by a sentinel-writing fixture
   extension (tests/integration/pi/extensions.test.ts) that fails if the
   post-load filter ever returns.
-- **Trust identity is the absolute module path** — names/basenames collide
-  across sources (a dir `foo.ts` and npm `foo`), so approving must name
-  exactly one file. No pattern matching anywhere in the lane; the CLI resolves
-  a human name to its unique path and refuses ambiguity.
+- **Trust identity is (real module path, content hash)** — names/basenames
+  collide across sources, symlinks can be repointed, and files can be
+  overwritten after approval, so approving pins the resolved path AND the
+  exact bytes. A swapped/repointed file reverts to pending (re-approve). No
+  pattern matching anywhere; the CLI resolves a human name to its unique path.
+- **No turn ever installs or probes Pi packages.** The SDK's loader resolves
+  `packages[]` on every reload — installing missing ones (postinstall =
+  arbitrary code) and running the settings-configured `npmCommand` to locate
+  the npm root, neither offline-gated. A Bakin turn hardens its
+  SettingsManager (strips `packages[]`, pins `npmCommand` to the real binary)
+  and forces `PI_OFFLINE`, so an agent that writes `packages`/`npmCommand`
+  into its own workspace settings can't self-trigger code execution.
+  Installing Pi packages stays a terminal act (`pi install`).
 - **Discovery is the SDK package manager** (`resolve()` with `onMissing:
   'skip'` — paths only, no imports, no installs, no network): it sees npm/git
   packages, loose files/dirs, object-form `packages[]` entries and both

--- a/.claude/knowledge/pi-adapter.md
+++ b/.claude/knowledge/pi-adapter.md
@@ -24,6 +24,7 @@ Pi is a minimal single-session coding harness — it has no agent roster, channe
 | `config.ts` | `<pi-home>/agent/settings.json` + onboarding raw-key synthesis (authProfiles presence-only, `channels` → `{}`) |
 | `skills.ts` | Pi-native skill dirs: global `agent/skills/` + per-agent `<workspace>/.pi/skills/` |
 | `images.ts` | route: codex-native primary; explicit keyed routes (openai/google) ride the shared shim with full generate/edit/multi-ref support (WS3) |
+| `extensions.ts` | INERT extension discovery (dir entries + settings.json packages) statused by the SAME policy the loader applies; the trust surface behind `runtime.extensions` (WS4) |
 | `codex-images.ts` | the codex image wire: OAuth token via Pi's ModelRegistry (refresh SDK-owned), account-id from the JWT claim, SSE `image_generation_call` → temp file; carrier model gpt-5.5 (settings-overridable via images.carrierModel) |
 | `health-checks.ts` | Doctor: pi home/registry, agents-root writable, auth providers, models available |
 
@@ -82,3 +83,22 @@ Flip: `~/.bakin/settings.json` → `"runtime": { "adapter": "pi" }` → restart 
 ## Dev loop (rig)
 
 `bun run instance up --runtime pi && bun run instance dev --runtime pi` — Pi in-process on the host against a throwaway `PI_HOME` under `dev/pi-home` (state isolation; agent tools execute on this Mac inside dev-scoped workspaces), real HMR, no docker. `--mode sandbox --runtime pi` runs Bakin+Pi fully in-container (execution sandboxing). The rig drives the TUI `/login` at `up` and seeds `routing.defaultModel` from auth.json + the SDK's `defaultModelPerProvider`. A ChatGPT `/login` alone unlocks codex image gen/edit in the rig. Deep reference: `.claude/knowledge/dev-rig.md`.
+
+## Extension trust lane (pi-ecosystem WS4)
+
+- **Default flipped `all` → `allowlist` (empty)**: terminal-installed
+  extensions are discovered but INERT until approved — extensions run
+  unsandboxed in the server process, so loading is a trust decision.
+  Policy knob: `settings.runtime.settings.piExtensions { mode, allow }`.
+- ONE allow predicate (`extensionAllowed` in messaging.ts) for loading AND
+  discovery status — exact path/basename/segment matching, never substrings.
+- ONE trust engine: `src/core/runtime-extensions.ts` (list/allow/revoke,
+  audited) behind `GET/POST /api/runtime/extensions[/allow|/revoke]`,
+  `bakin runtime extensions {list,allow,revoke}`, the hub's Extensions
+  section (Runtimes tab, ConfirmDialog with the trusted-code + spends-
+  outside-budget-caps disclosure), and the `pi.extensions` doctor check
+  (pending → warn pointing at the hub). Allow refuses ids discovery doesn't
+  know. Sessions are per-turn: trust changes apply next turn, no restart.
+- Contract: `extensions?: RuntimeExtensionsAccess` (optional, feature-
+  detected; `.extensions!.` is arch-banned). Discovery NEVER executes
+  extension code.

--- a/.claude/knowledge/pi-adapter.md
+++ b/.claude/knowledge/pi-adapter.md
@@ -103,6 +103,20 @@ Flip: `~/.bakin/settings.json` → `"runtime": { "adapter": "pi" }` → restart 
   overwritten after approval, so approving pins the resolved path AND the
   exact bytes. A swapped/repointed file reverts to pending (re-approve). No
   pattern matching anywhere; the CLI resolves a human name to its unique path.
+- **Known residuals (accepted, single-user box; #670 follow-up if it goes multi-tenant):**
+  (a) *Import-time TOCTOU* — the hash is re-checked fresh each turn (a
+  persistently-swapped file is excluded next turn), but the SDK re-reads the
+  approved path at import with no integrity hook, so a swap in the narrow
+  window between our re-hash and the loader's read would import unverified
+  bytes; exploiting it needs an agent-planted background writer (already a
+  deeper compromise). (b) *Content-blind SDK extension cache* — re-approving
+  EDITED extension content keeps running the old bytes for the rest of the
+  process for the same agent (cache keyed by path+cwd, not content;
+  clearExtensionCache isn't exported); a restart or another agent's turn
+  flushes it. Never runs UNAPPROVED code — revoked paths aren't passed to the
+  loader at all. (c) *mode 'all' is user-scope* — loads every user-scope
+  discovered extension (not per-agent workspace/project scope), keeping
+  list()==turn; 'all' is an explicit trust-everything escape hatch.
 - **No turn ever installs or probes Pi packages.** The SDK's loader resolves
   `packages[]` on every reload — installing missing ones (postinstall =
   arbitrary code) and running the settings-configured `npmCommand` to locate

--- a/.claude/knowledge/pi-adapter.md
+++ b/.claude/knowledge/pi-adapter.md
@@ -90,8 +90,22 @@ Flip: `~/.bakin/settings.json` → `"runtime": { "adapter": "pi" }` → restart 
   extensions are discovered but INERT until approved — extensions run
   unsandboxed in the server process, so loading is a trust decision.
   Policy knob: `settings.runtime.settings.piExtensions { mode, allow }`.
-- ONE allow predicate (`extensionAllowed` in messaging.ts) for loading AND
-  discovery status — exact path/basename/segment matching, never substrings.
+- **TRUE pre-load gate.** `extensionsOverride` is a POST-load filter — the SDK
+  jiti-imports every enabled extension BEFORE it runs, so a "pending"
+  extension's module code would execute (only its tools hidden). Instead:
+  `noExtensions: true` suppresses the settings-discovered set entirely and
+  ONLY approved absolute paths come back through `additionalExtensionPaths`.
+  Unapproved code is never imported. Pinned by a sentinel-writing fixture
+  extension (tests/integration/pi/extensions.test.ts) that fails if the
+  post-load filter ever returns.
+- **Trust identity is the absolute module path** — names/basenames collide
+  across sources (a dir `foo.ts` and npm `foo`), so approving must name
+  exactly one file. No pattern matching anywhere in the lane; the CLI resolves
+  a human name to its unique path and refuses ambiguity.
+- **Discovery is the SDK package manager** (`resolve()` with `onMissing:
+  'skip'` — paths only, no imports, no installs, no network): it sees npm/git
+  packages, loose files/dirs, object-form `packages[]` entries and both
+  scopes, with the loader's own enable rules applied.
 - ONE trust engine: `src/core/runtime-extensions.ts` (list/allow/revoke,
   audited) behind `GET/POST /api/runtime/extensions[/allow|/revoke]`,
   `bakin runtime extensions {list,allow,revoke}`, the hub's Extensions

--- a/.claude/knowledge/runtime-capabilities.md
+++ b/.claude/knowledge/runtime-capabilities.md
@@ -256,6 +256,11 @@ allowlist — see the contract doc, born of the P5.3 conflation below).
   `originalRuntimeCron` snapshot, idempotent per job id, dry-run previews.
   `RuntimeSwitchResult.cron = { adopted, skipped, failed }`; the can't-carry
   cron line folds the outcome in.
+- **Extension trust lane (WS4)** — `extensions?: RuntimeExtensionsAccess`
+  optional contract member (inert `list()`; Pi implements, mock/OpenClaw
+  omit). Trust mutations live in ONE engine (`src/core/runtime-extensions.ts`)
+  surfaced via REST + CLI + the hub's Extensions section + the adapter's
+  `pi.extensions` doctor check. Pi's load default is allowlist-empty.
 - **The /runtime page is the runtime hub** (`packages/host/src/routes/
   runtime.tsx` + `components/runtime/`): Overview (plain-language capability
   grid + legend + credential/tool-access tiles + live setup checks),

--- a/.claude/specs/pi-ecosystem/TODO.md
+++ b/.claude/specs/pi-ecosystem/TODO.md
@@ -23,8 +23,8 @@ See PLAN.md for acceptance criteria. One PR per workstream; live-test before mer
 - [x] T3.4 pi-adapter.md updated; #627 closes with the PR
 
 ## WS4 — extension trust lane (PR 4)
-- [ ] T4.1 neutral `extensions?` contract member + arch tests
-- [ ] T4.2 adapter discovery + default flip all→allowlist + containment fixtures
-- [ ] T4.3 REST + CLI (list/allow/revoke)
-- [ ] T4.4 hub UI (approve via ConfirmDialog + disclosure) + `pi.extensions` doctor check
-- [ ] T4.5 docs; close #670 + #626
+- [x] T4.1 extensions? contract member + .extensions!. arch ban
+- [x] T4.2 inert discovery + default flip all→allowlist + exact-match predicate + live-settings getter (no-restart trust changes)
+- [x] T4.3 REST + `bakin runtime extensions {list,allow,revoke}` (live round-trip verified)
+- [x] T4.4 hub Extensions section (ConfirmDialog + disclosure) + pi.extensions doctor warn
+- [x] T4.5 docs updated; #670/#626 close with the PR

--- a/packages/adapter-pi/src/extensions.ts
+++ b/packages/adapter-pi/src/extensions.ts
@@ -15,8 +15,8 @@
  * in between pattern-matches.
  */
 import type { RuntimeExtensionInfo, RuntimeExtensionsAccess } from '@bakin/core/adapters/runtime'
-import { getPiAgentDir, getPiPath } from './home'
-import { extensionsPolicy, resolveExtensionResources } from './messaging'
+import { getPiAgentDir } from './home'
+import { extensionApproved, extensionsPolicy, resolveExtensionResources } from './messaging'
 
 /**
  * Human label (display + CLI convenience only — NEVER used for matching):
@@ -57,15 +57,22 @@ export function createExtensionsSurface(
       // Discovery runs against the agent dir (user scope). Per-agent project
       // scope is resolved per turn from the agent's workspace; those paths
       // are surfaced too when the resolver reports them.
-      const resources = await resolveExtensionResources(getPiPath(), getPiAgentDir())
+      // User-scope discovery (agentDir as cwd) — byte-identical to the turn
+      // gate's basis (approvedExtensionPaths in messaging.ts), so list status
+      // and what actually loads can never disagree.
+      const resources = await resolveExtensionResources(getPiAgentDir(), getPiAgentDir())
       return resources.map((resource) => ({
-        id: resource.path, // identity == the file the runtime would import
+        id: resource.path, // identity == the real file the runtime would import
         label: labelFor(resource.path, resource.source),
         source: sourceLabel(resource.source, resource.scope),
         path: resource.path,
+        sha256: resource.sha256,
         status: policy.mode === 'none'
           ? 'blocked'
-          : policy.mode === 'all' || policy.allow.includes(resource.path)
+          // approved requires BOTH path and current content hash to match —
+          // a swapped/repointed file reverts to pending (re-approve), never
+          // loads under the old approval.
+          : policy.mode === 'all' || extensionApproved(resource, policy.allow)
             ? 'allowed'
             : 'pending',
       }))

--- a/packages/adapter-pi/src/extensions.ts
+++ b/packages/adapter-pi/src/extensions.ts
@@ -1,56 +1,46 @@
 /**
  * Pi extension discovery — the adapter side of the trust lane (#670/#626).
  *
- * Discovery is INERT: it enumerates what the resource loader WOULD load
- * (top-level entries of `~/.pi/agent/extensions/` + the settings.json
- * `packages[]` installs) without ever importing extension code. Status comes
- * from the same policy + allow predicate the messaging loader applies, so
- * what this reports as `allowed` is exactly what loads into agent turns.
+ * Discovery asks the SDK's PACKAGE MANAGER what the loader would load
+ * (`resolve()` → resolved absolute paths + source metadata), which is the
+ * only authoritative answer: it covers npm packages, git packages, local
+ * extension files/dirs, object-form `packages[]` entries, and project scope,
+ * with the loader's own enable rules applied. It resolves paths WITHOUT
+ * importing extension modules (`onMissing: 'skip'` also means it never
+ * installs or touches the network).
+ *
+ * IDENTITY IS THE RESOLVED ABSOLUTE PATH. Not a basename, not a package name:
+ * those collide across sources, and a trust decision must name exactly one
+ * file. The allowlist stores paths, the loader is handed paths, and nothing
+ * in between pattern-matches.
  */
-import { existsSync, readdirSync, readFileSync } from 'fs'
-import { join } from 'path'
 import type { RuntimeExtensionInfo, RuntimeExtensionsAccess } from '@bakin/core/adapters/runtime'
-import { getPiPath } from './home'
-import { extensionAllowed, extensionsPolicy } from './messaging'
+import { getPiAgentDir, getPiPath } from './home'
+import { extensionsPolicy, resolveExtensionResources } from './messaging'
 
-const EXTENSION_FILE_RE = /\.(ts|js|mjs|cjs)$/
-
-function discoverDirEntries(): Array<Pick<RuntimeExtensionInfo, 'id' | 'label' | 'source' | 'path'>> {
-  const dir = getPiPath('agent', 'extensions')
-  if (!existsSync(dir)) return []
-  const out: Array<Pick<RuntimeExtensionInfo, 'id' | 'label' | 'source' | 'path'>> = []
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name.startsWith('.') || entry.name.endsWith('.d.ts')) continue
-    const path = join(dir, entry.name)
-    if (entry.isDirectory()) {
-      out.push({ id: entry.name, label: entry.name, source: 'extensions dir', path })
-    } else if (entry.isFile() && EXTENSION_FILE_RE.test(entry.name)) {
-      const id = entry.name.replace(EXTENSION_FILE_RE, '')
-      out.push({ id, label: id, source: 'extensions dir', path })
-    }
+/**
+ * Human label (display + CLI convenience only — NEVER used for matching):
+ * the package spec for package-installed extensions, else the file's name.
+ * The SDK's metadata.source carries internal tags like "auto" for loose
+ * files — those are not names a user would recognize.
+ */
+function labelFor(path: string, source: string | undefined): string {
+  if (source && (source.startsWith('npm:') || source.startsWith('git:'))) return source
+  const base = path.split('/').pop() ?? path
+  const stem = base.replace(/\.(ts|js)$/, '')
+  // A package's entry file is often index.* — name it by its directory.
+  if (stem === 'index') {
+    const parent = path.split('/').slice(-2, -1)[0]
+    if (parent) return parent
   }
-  return out
+  return stem
 }
 
-function discoverPackageEntries(): Array<Pick<RuntimeExtensionInfo, 'id' | 'label' | 'source' | 'path'>> {
-  const settingsPath = getPiPath('agent', 'settings.json')
-  if (!existsSync(settingsPath)) return []
-  let packages: unknown
-  try {
-    packages = (JSON.parse(readFileSync(settingsPath, 'utf-8')) as { packages?: unknown }).packages
-  } catch {
-    return [] // unreadable settings.json is the runtime's problem, not discovery's
-  }
-  if (!Array.isArray(packages)) return []
-  return packages
-    .filter((p): p is string => typeof p === 'string')
-    .map((spec) => {
-      // e.g. "npm:@scope/pkg" or "git:github.com/user/repo" — the bare name
-      // is both the id and the allowlist pattern (the loader's resolved path
-      // contains it under node_modules).
-      const name = spec.replace(/^(npm|git):/, '')
-      return { id: name, label: name, source: spec.startsWith('git:') ? `git package` : 'npm package', path: name }
-    })
+function sourceLabel(source: string | undefined, scope: string | undefined): string {
+  const projectSuffix = scope === 'project' ? ' (project)' : ''
+  if (source?.startsWith('npm:')) return `npm package${projectSuffix}`
+  if (source?.startsWith('git:')) return `git package${projectSuffix}`
+  return scope === 'project' ? 'project extension' : 'extensions dir'
 }
 
 /**
@@ -64,12 +54,18 @@ export function createExtensionsSurface(
   return {
     async list(): Promise<RuntimeExtensionInfo[]> {
       const policy = extensionsPolicy(getSettings())
-      const entries = [...discoverDirEntries(), ...discoverPackageEntries()]
-      return entries.map((entry) => ({
-        ...entry,
+      // Discovery runs against the agent dir (user scope). Per-agent project
+      // scope is resolved per turn from the agent's workspace; those paths
+      // are surfaced too when the resolver reports them.
+      const resources = await resolveExtensionResources(getPiPath(), getPiAgentDir())
+      return resources.map((resource) => ({
+        id: resource.path, // identity == the file the runtime would import
+        label: labelFor(resource.path, resource.source),
+        source: sourceLabel(resource.source, resource.scope),
+        path: resource.path,
         status: policy.mode === 'none'
           ? 'blocked'
-          : policy.mode === 'all' || extensionAllowed(entry.path, policy.allow)
+          : policy.mode === 'all' || policy.allow.includes(resource.path)
             ? 'allowed'
             : 'pending',
       }))

--- a/packages/adapter-pi/src/extensions.ts
+++ b/packages/adapter-pi/src/extensions.ts
@@ -1,0 +1,78 @@
+/**
+ * Pi extension discovery — the adapter side of the trust lane (#670/#626).
+ *
+ * Discovery is INERT: it enumerates what the resource loader WOULD load
+ * (top-level entries of `~/.pi/agent/extensions/` + the settings.json
+ * `packages[]` installs) without ever importing extension code. Status comes
+ * from the same policy + allow predicate the messaging loader applies, so
+ * what this reports as `allowed` is exactly what loads into agent turns.
+ */
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import type { RuntimeExtensionInfo, RuntimeExtensionsAccess } from '@bakin/core/adapters/runtime'
+import { getPiPath } from './home'
+import { extensionAllowed, extensionsPolicy } from './messaging'
+
+const EXTENSION_FILE_RE = /\.(ts|js|mjs|cjs)$/
+
+function discoverDirEntries(): Array<Pick<RuntimeExtensionInfo, 'id' | 'label' | 'source' | 'path'>> {
+  const dir = getPiPath('agent', 'extensions')
+  if (!existsSync(dir)) return []
+  const out: Array<Pick<RuntimeExtensionInfo, 'id' | 'label' | 'source' | 'path'>> = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name.endsWith('.d.ts')) continue
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push({ id: entry.name, label: entry.name, source: 'extensions dir', path })
+    } else if (entry.isFile() && EXTENSION_FILE_RE.test(entry.name)) {
+      const id = entry.name.replace(EXTENSION_FILE_RE, '')
+      out.push({ id, label: id, source: 'extensions dir', path })
+    }
+  }
+  return out
+}
+
+function discoverPackageEntries(): Array<Pick<RuntimeExtensionInfo, 'id' | 'label' | 'source' | 'path'>> {
+  const settingsPath = getPiPath('agent', 'settings.json')
+  if (!existsSync(settingsPath)) return []
+  let packages: unknown
+  try {
+    packages = (JSON.parse(readFileSync(settingsPath, 'utf-8')) as { packages?: unknown }).packages
+  } catch {
+    return [] // unreadable settings.json is the runtime's problem, not discovery's
+  }
+  if (!Array.isArray(packages)) return []
+  return packages
+    .filter((p): p is string => typeof p === 'string')
+    .map((spec) => {
+      // e.g. "npm:@scope/pkg" or "git:github.com/user/repo" — the bare name
+      // is both the id and the allowlist pattern (the loader's resolved path
+      // contains it under node_modules).
+      const name = spec.replace(/^(npm|git):/, '')
+      return { id: name, label: name, source: spec.startsWith('git:') ? `git package` : 'npm package', path: name }
+    })
+}
+
+/**
+ * The surface is created with the Bakin-side adapter settings getter — the
+ * SAME policy source the messaging loader reads, so list() status can never
+ * disagree with what actually loads.
+ */
+export function createExtensionsSurface(
+  getSettings: () => Record<string, unknown> | undefined,
+): RuntimeExtensionsAccess {
+  return {
+    async list(): Promise<RuntimeExtensionInfo[]> {
+      const policy = extensionsPolicy(getSettings())
+      const entries = [...discoverDirEntries(), ...discoverPackageEntries()]
+      return entries.map((entry) => ({
+        ...entry,
+        status: policy.mode === 'none'
+          ? 'blocked'
+          : policy.mode === 'all' || extensionAllowed(entry.path, policy.allow)
+            ? 'allowed'
+            : 'pending',
+      }))
+    },
+  }
+}

--- a/packages/adapter-pi/src/health-checks.ts
+++ b/packages/adapter-pi/src/health-checks.ts
@@ -10,13 +10,35 @@ import { listAuthProviders } from './config'
 import { getPiAgentsRoot, getPiHome } from './home'
 import { getModelRegistry } from './models'
 import { readRegistry } from './registry'
+import { createExtensionsSurface } from './extensions'
 
 function result(check: string, status: AdapterHealthCheckResult['status'], message: string): AdapterHealthCheckResult {
   return { check, status, message, autoFixable: false }
 }
 
-export function createHealthChecks(): AdapterHealthCheckDefinition[] {
+export function createHealthChecks(
+  getSettings?: () => Record<string, unknown> | undefined,
+): AdapterHealthCheckDefinition[] {
   return [
+    {
+      id: 'pi.extensions',
+      name: 'Pi extension trust',
+      run: async () => {
+        const surface = createExtensionsSurface(() => getSettings?.())
+        const list = await surface.list()
+        const pending = list.filter((e) => e.status === 'pending')
+        if (pending.length === 0) {
+          return [result('pi.extensions', 'ok', list.length === 0
+            ? 'No extensions installed'
+            : `${list.length} extension(s), none awaiting approval`)]
+        }
+        return [result(
+          'pi.extensions',
+          'warn',
+          `${pending.length} extension(s) discovered but NOT loading (awaiting approval): ${pending.map((e) => e.id).join(', ')} — approve on the Runtime page (Runtimes tab) or \`bakin runtime extensions allow <id>\``,
+        )]
+      },
+    },
     {
       id: 'pi.home',
       name: 'Pi home + agent registry',

--- a/packages/adapter-pi/src/health-checks.ts
+++ b/packages/adapter-pi/src/health-checks.ts
@@ -35,7 +35,9 @@ export function createHealthChecks(
         return [result(
           'pi.extensions',
           'warn',
-          `${pending.length} extension(s) discovered but NOT loading (awaiting approval): ${pending.map((e) => e.id).join(', ')} — approve on the Runtime page (Runtimes tab) or \`bakin runtime extensions allow <id>\``,
+          `${pending.length} extension(s) installed but NOT loading — their code never runs until approved: `
+          + `${pending.map((e) => e.label).join(', ')}. Approve on the Runtime page (Runtimes tab) or with `
+          + '`bakin runtime extensions allow <name>`.',
         )]
       },
     },

--- a/packages/adapter-pi/src/messaging.ts
+++ b/packages/adapter-pi/src/messaging.ts
@@ -8,7 +8,8 @@
  * Sessions are disposed after the turn settles; the JSONL file carries
  * conversation state. All failures leave through errors.ts.
  */
-import { readFileSync } from 'fs'
+import { readFileSync, realpathSync } from 'fs'
+import { createHash } from 'crypto'
 import { randomUUID } from 'crypto'
 
 import {
@@ -47,74 +48,136 @@ const THINKING_LEVELS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhi
 /**
  * Pi extension loading policy (settings.runtime.settings.piExtensions).
  * Extensions are arbitrary code executing inside the Bakin server process
- * and many are TUI-coupled — 'all' honors whatever `pi install` set up
- * (the default: users who installed packages for terminal pi expect them
- * here too, #626); 'allowlist' loads only name/path matches; 'none'
- * restores the v1 lockout. extension_error events are contained per-turn.
+ * Trust modes: 'none' loads nothing; 'allowlist' (the DEFAULT) loads only
+ * files whose real path AND content hash were explicitly approved; 'all'
+ * loads every discovered extension (explicit trust-everything). Extensions
+ * run unsandboxed in the Bakin server process — loading one is a trust
+ * decision. extension_error events are contained per-turn.
  */
 export interface PiExtensionsPolicy {
   mode?: 'none' | 'allowlist' | 'all'
-  allow?: string[]
+  /** Approved entries — {path, sha256}. Plain path strings from an older shape are tolerated on read. */
+  allow?: Array<PiExtensionAllowEntry | string>
+}
+
+/** Resolved policy: mode defaulted, allow normalized to entry objects. */
+export interface PiExtensionsTrust {
+  mode: 'none' | 'allowlist' | 'all'
+  allow: PiExtensionAllowEntry[]
 }
 
 /**
  * DEFAULT IS 'allowlist' (empty) — extensions are discovered but NOT LOADED
  * until approved (pi-ecosystem WS4; flipped from 'all', which loaded
- * everything silently). Extensions are unsandboxed code inside the Bakin
- * server process, so loading one is a trust decision.
+ * everything silently). A bare-string allow entry (older shape / hand edit)
+ * is read as a path with an empty hash, so it never matches a real file —
+ * fail-closed, the user re-approves.
  */
-export function extensionsPolicy(settings: Record<string, unknown> | undefined): Required<PiExtensionsPolicy> {
+export function extensionsPolicy(settings: Record<string, unknown> | undefined): PiExtensionsTrust {
   const raw = (settings?.piExtensions ?? {}) as PiExtensionsPolicy
-  return { mode: raw.mode ?? 'allowlist', allow: raw.allow ?? [] }
+  const allow = (raw.allow ?? []).map((e) =>
+    typeof e === 'string' ? { path: e, sha256: '' } : { path: e.path, sha256: e.sha256 ?? '' },
+  )
+  return { mode: raw.mode ?? 'allowlist', allow }
 }
 
 export interface PiExtensionResource {
-  /** Absolute path of the module the loader would import — the trust identity. */
+  /** Real absolute path of the module the loader would import (symlinks resolved). */
   path: string
+  /** Current content hash — half of the trust identity. */
+  sha256: string
   /** Package source spec it came from (`npm:x`, `git:…`), absent for loose files. */
   source?: string
   scope?: string
 }
 
 /**
+ * Force the Pi package resolver OFFLINE for this process. A Bakin agent turn
+ * must NEVER install a Pi package — the SDK's DefaultResourceLoader.reload()
+ * calls packageManager.resolve() with no onMissing, which would `npm install`
+ * any configured-but-missing package (postinstall scripts = arbitrary code)
+ * and bypass the extension allowlist entirely, in every mode. PI_OFFLINE
+ * (isOfflineModeEnabled) makes every install branch a no-op. Installing Pi
+ * packages is a deliberate terminal act (`pi install`) / a Bakin-owned path,
+ * never a side effect of serving a turn. Set once, never unset — idempotent,
+ * race-free.
+ */
+export function enforcePiOffline(): void {
+  if (process.env.PI_OFFLINE !== '1') process.env.PI_OFFLINE = '1'
+}
+
+/**
  * Enumerate the extension modules the loader WOULD import, WITHOUT importing
  * any of them: the SDK's package manager resolves paths only. `onMissing:
- * 'skip'` also guarantees no install and no network. This is the ONE
- * discovery source — it sees npm/git packages, local files and dirs,
- * object-form `packages[]` filter entries, and both scopes, with the
- * loader's own enable rules applied.
+ * 'skip'` (and PI_OFFLINE) guarantee no install and no network. This is the
+ * ONE discovery source — it sees npm/git packages, local files and dirs,
+ * object-form `packages[]` filter entries, and both scopes, with the loader's
+ * own enable rules applied.
  */
 export async function resolveExtensionResources(
   workspace: string,
   agentDir: string,
 ): Promise<PiExtensionResource[]> {
-  const settingsManager = createTurnSettingsManager(workspace, agentDir)
+  enforcePiOffline()
+  const settingsManager = hardenSettingsManager(createTurnSettingsManager(workspace, agentDir), { stripPackages: false })
   const packageManager = new DefaultPackageManager({ cwd: workspace, agentDir, settingsManager })
   const resolved = await packageManager.resolve(async () => 'skip')
-  return resolved.extensions
-    .filter((resource) => resource.enabled)
-    .map((resource) => ({
-      path: resource.path,
+  const out: PiExtensionResource[] = []
+  for (const resource of resolved.extensions) {
+    if (!resource.enabled) continue
+    // Identity is the REAL file path (symlinks resolved) + its content hash:
+    // a repointed symlink or a swapped file is a DIFFERENT extension, not the
+    // one that was approved.
+    const path = realpathIfPossible(resource.path)
+    out.push({
+      path,
+      sha256: sha256OfFile(path),
       ...(resource.metadata?.source && resource.metadata.source !== resource.path
         ? { source: resource.metadata.source }
         : {}),
       ...(resource.metadata?.scope ? { scope: String(resource.metadata.scope) } : {}),
-    }))
+    })
+  }
+  return out
+}
+
+function realpathIfPossible(p: string): string {
+  try { return realpathSync(p) } catch { return p }
+}
+
+function sha256OfFile(p: string): string {
+  try { return createHash('sha256').update(readFileSync(p)).digest('hex') } catch { return '' }
+}
+
+/** An allow entry: the approved file's real path AND the content hash approved. */
+export interface PiExtensionAllowEntry {
+  path: string
+  sha256: string
 }
 
 /**
- * The approved absolute paths the loader may import, per policy. Empty in
- * 'none'; the allowlist ∩ discovered in 'allowlist' (an allow entry for
- * something no longer installed simply resolves to nothing).
+ * A discovered resource matches an allow entry iff BOTH its real path and its
+ * current content hash equal an approved (path, sha256). This ONE predicate
+ * backs discovery status AND the load gate, so what shows "allowed" is
+ * byte-for-byte what loads. Changed/swapped files fall back to pending.
  */
-async function approvedExtensionPaths(
-  policy: Required<PiExtensionsPolicy>,
-  workspace: string,
-  agentDir: string,
-): Promise<string[]> {
-  if (policy.mode !== 'allowlist' || policy.allow.length === 0) return []
-  const discovered = new Set((await resolveExtensionResources(workspace, agentDir)).map((r) => r.path))
-  return policy.allow.filter((path) => discovered.has(path))
+export function extensionApproved(resource: PiExtensionResource, allow: PiExtensionAllowEntry[]): boolean {
+  return allow.some((entry) => entry.path === resource.path && entry.sha256 === resource.sha256)
+}
+
+/**
+ * The absolute paths the loader may import, per policy, from the SAME
+ * user-scope discovery every surface sees — so list()/doctor and the turn
+ * can never disagree, in ANY mode:
+ *   none      → nothing
+ *   all       → every discovered extension (explicit trust-everything)
+ *   allowlist → exactly the approved (path+hash) matches
+ */
+export async function loadPathsForPolicy(policy: PiExtensionsTrust, agentDir: string): Promise<string[]> {
+  if (policy.mode === 'none') return []
+  const discovered = await resolveExtensionResources(agentDir, agentDir)
+  if (policy.mode === 'all') return discovered.map((r) => r.path)
+  return discovered.filter((r) => extensionApproved(r, policy.allow)).map((r) => r.path)
 }
 
 export interface PiMessagingDeps {
@@ -184,6 +247,39 @@ export function createTurnSettingsManager(workspace: string, agentDir: string): 
   return SettingsManager.create(workspace, agentDir, { projectTrusted: true })
 }
 
+/**
+ * Neutralize the two settings-driven package side effects that let an agent
+ * (or a tampered ~/.pi config) run arbitrary code during a Bakin turn:
+ *
+ *  - `npmCommand` — the SDK runs the settings-configured package-manager
+ *    command not just to install but to LOCATE the global npm root
+ *    (`getNpmInstallPath` → `npm root -g`), which is NOT offline-gated. A
+ *    settings-supplied `npmCommand: [evil]` would execute every turn. We pin
+ *    it to undefined so the SDK always uses the real npm/bun binary.
+ *  - `packages[]` (turn only) — resolving a configured package triggers
+ *    install (postinstall = arbitrary code) and the npm-root probe. Bakin
+ *    hands approved extensions to the loader as absolute paths via
+ *    `additionalExtensionPaths`; it never needs settings packages, so the
+ *    turn loader sees none. (Discovery keeps packages so already-installed
+ *    npm extensions are still enumerable — it resolves read-only with the
+ *    real npm and onMissing:'skip'.)
+ */
+function hardenSettingsManager(sm: SettingsManager, opts: { stripPackages: boolean }): SettingsManager {
+  const anySm = sm as unknown as {
+    getNpmCommand: () => string[] | undefined
+    getGlobalSettings: () => Record<string, unknown>
+    getProjectSettings: () => Record<string, unknown>
+  }
+  anySm.getNpmCommand = () => undefined
+  if (opts.stripPackages) {
+    const global = anySm.getGlobalSettings.bind(anySm)
+    const project = anySm.getProjectSettings.bind(anySm)
+    anySm.getGlobalSettings = () => ({ ...global(), packages: [] })
+    anySm.getProjectSettings = () => ({ ...project(), packages: [] })
+  }
+  return sm
+}
+
 async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promise<TurnHandle> {
   const record = requireAgent(args.agentId)
   scaffoldAgentDirs(record.id)
@@ -191,27 +287,30 @@ async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promis
   const agentDir = getPiAgentDir()
   const { auth, registry: modelRegistry } = getModelRegistry()
 
-  const settingsManager = createTurnSettingsManager(workspace, agentDir)
+  const settingsManager = hardenSettingsManager(createTurnSettingsManager(workspace, agentDir), { stripPackages: true })
   const adapterSettings = deps.getSettings?.()
   const extPolicy = extensionsPolicy(adapterSettings)
 
   // TRUE pre-load gate (WS4). `extensionsOverride` is a POST-load filter —
   // the loader jiti-imports every enabled extension before it runs, so an
   // unapproved extension's module code would execute (only its tools would
-  // be hidden). Instead: `noExtensions` suppresses the settings-discovered
-  // set entirely, and ONLY approved absolute paths are handed back through
-  // `additionalExtensionPaths` — unapproved code is never imported.
+  // be hidden). Instead: `noExtensions` ALWAYS suppresses the loader's own
+  // settings-discovered set, and EXACTLY the paths policy authorizes are
+  // handed back through `additionalExtensionPaths`. Every mode goes through
+  // the SAME user-scope discovery basis, so list()/doctor and the turn can
+  // never disagree, and a workspace-project extension can't sneak in.
   //   none      → nothing loads
-  //   allowlist → exactly the approved paths load
-  //   all       → the loader's normal behavior (opt-in, explicit)
-  const approvedPaths = await approvedExtensionPaths(extPolicy, workspace, agentDir)
+  //   allowlist → files whose real path + content hash were approved
+  //   all       → every discovered extension (explicit trust-everything)
+  enforcePiOffline() // belt-and-suspenders; the loader also never sees packages[]
+  const loadPaths = await loadPathsForPolicy(extPolicy, agentDir)
   const resourceLoader = new DefaultResourceLoader({
     cwd: workspace,
     agentDir,
     settingsManager,
     // Themes/prompt-templates are TUI-only and stay out of the server process.
-    noExtensions: extPolicy.mode !== 'all',
-    ...(extPolicy.mode === 'allowlist' ? { additionalExtensionPaths: approvedPaths } : {}),
+    noExtensions: true,
+    additionalExtensionPaths: loadPaths,
     noThemes: true,
     noPromptTemplates: true,
     appendSystemPrompt: buildAppendSystemPrompt(record.id),

--- a/packages/adapter-pi/src/messaging.ts
+++ b/packages/adapter-pi/src/messaging.ts
@@ -57,9 +57,36 @@ export interface PiExtensionsPolicy {
   allow?: string[]
 }
 
-function extensionsPolicy(settings: Record<string, unknown> | undefined): Required<PiExtensionsPolicy> {
+/**
+ * DEFAULT IS 'allowlist' (empty) — terminal-installed extensions are
+ * discovered but INERT until approved on the runtime hub (pi-ecosystem WS4;
+ * flipped from 'all', which loaded everything silently). Extensions run
+ * unsandboxed in this server process — loading is a trust decision.
+ */
+export function extensionsPolicy(settings: Record<string, unknown> | undefined): Required<PiExtensionsPolicy> {
   const raw = (settings?.piExtensions ?? {}) as PiExtensionsPolicy
-  return { mode: raw.mode ?? 'all', allow: raw.allow ?? [] }
+  return { mode: raw.mode ?? 'allowlist', allow: raw.allow ?? [] }
+}
+
+/**
+ * ONE allowlist predicate for loading AND discovery status: exact full path,
+ * exact basename (with or without extension), or — for npm/git package
+ * extensions whose load path lands under node_modules — an exact
+ * path-segment match of the package name. NEVER substring matching: an
+ * entry "foo" must not admit "foobar".
+ */
+export function extensionAllowed(path: string, allow: string[]): boolean {
+  const base = path.split('/').pop() ?? path
+  const stem = base.replace(/\.(ts|js|mjs|cjs)$/, '')
+  const segments = path.split('/')
+  return allow.some((pattern) =>
+    pattern === path
+    || pattern === base
+    || pattern === stem
+    || (pattern.includes('/')
+      ? path.includes(`/node_modules/${pattern}/`) || path.endsWith(`/node_modules/${pattern}`)
+      : segments.includes(pattern)),
+  )
 }
 
 export interface PiMessagingDeps {
@@ -150,9 +177,7 @@ async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promis
       ? {
           extensionsOverride: (base: LoadExtensionsResult): LoadExtensionsResult => ({
             ...base,
-            extensions: base.extensions.filter((ext) =>
-              extPolicy.allow.some((pattern) => ext.path.includes(pattern)),
-            ),
+            extensions: base.extensions.filter((ext) => extensionAllowed(ext.path, extPolicy.allow)),
           }),
         }
       : {}),

--- a/packages/adapter-pi/src/messaging.ts
+++ b/packages/adapter-pi/src/messaging.ts
@@ -75,10 +75,20 @@ export interface PiExtensionsTrust {
  */
 export function extensionsPolicy(settings: Record<string, unknown> | undefined): PiExtensionsTrust {
   const raw = (settings?.piExtensions ?? {}) as PiExtensionsPolicy
-  const allow = (raw.allow ?? []).map((e) =>
-    typeof e === 'string' ? { path: e, sha256: '' } : { path: e.path, sha256: e.sha256 ?? '' },
-  )
-  return { mode: raw.mode ?? 'allowlist', allow }
+  const mode = raw.mode === 'none' || raw.mode === 'all' ? raw.mode : 'allowlist'
+  // Untrusted shape (settings.json is agent/user-writable): a non-array, a
+  // null element, or a missing path must degrade to "no valid entries", never
+  // throw and kill the turn. An entry needs a NON-EMPTY sha256 to ever match
+  // (see extensionApproved) — a bare-string / hashless entry is inert.
+  const rawAllow = Array.isArray(raw.allow) ? raw.allow : []
+  const allow: PiExtensionAllowEntry[] = []
+  for (const e of rawAllow) {
+    if (typeof e === 'string') { allow.push({ path: e, sha256: '' }); continue }
+    if (e && typeof e === 'object' && typeof e.path === 'string') {
+      allow.push({ path: e.path, sha256: typeof e.sha256 === 'string' ? e.sha256 : '' })
+    }
+  }
+  return { mode, allow }
 }
 
 export interface PiExtensionResource {
@@ -162,7 +172,12 @@ export interface PiExtensionAllowEntry {
  * byte-for-byte what loads. Changed/swapped files fall back to pending.
  */
 export function extensionApproved(resource: PiExtensionResource, allow: PiExtensionAllowEntry[]): boolean {
-  return allow.some((entry) => entry.path === resource.path && entry.sha256 === resource.sha256)
+  // A missing/empty hash on EITHER side is never a match — an unreadable file
+  // (sha256OfFile → '') must not satisfy a hashless (legacy/hand-edited) allow
+  // entry. Approval is only ever granted through allowRuntimeExtension, which
+  // always records a real hash; '' means "not really approved" → fail closed.
+  if (!resource.sha256) return false
+  return allow.some((entry) => entry.sha256 !== '' && entry.path === resource.path && entry.sha256 === resource.sha256)
 }
 
 /**
@@ -177,6 +192,12 @@ export async function loadPathsForPolicy(policy: PiExtensionsTrust, agentDir: st
   if (policy.mode === 'none') return []
   const discovered = await resolveExtensionResources(agentDir, agentDir)
   if (policy.mode === 'all') return discovered.map((r) => r.path)
+  // Re-hashed fresh THIS turn (inside resolveExtensionResources) — a file
+  // persistently swapped since approval no longer matches and is excluded.
+  // A same-turn race between this hash and the loader's own read is a narrow
+  // residual (no agent code runs in that window unless it planted a prior
+  // background writer — a deeper compromise); the SDK offers no import-time
+  // integrity hook to close it fully.
   return discovered.filter((r) => extensionApproved(r, policy.allow)).map((r) => r.path)
 }
 
@@ -309,6 +330,10 @@ async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promis
     agentDir,
     settingsManager,
     // Themes/prompt-templates are TUI-only and stay out of the server process.
+    // NOTE: this allowlist gates EXTENSIONS (in-process CODE). Skills are
+    // content (instructions), governed by Bakin's own agent-package/skills
+    // projection — not this gate — so noSkills is intentionally NOT set; the
+    // package hardening above only strips code-bearing `packages[]`.
     noExtensions: true,
     additionalExtensionPaths: loadPaths,
     noThemes: true,

--- a/packages/adapter-pi/src/messaging.ts
+++ b/packages/adapter-pi/src/messaging.ts
@@ -13,11 +13,11 @@ import { randomUUID } from 'crypto'
 
 import {
   createAgentSession,
+  DefaultPackageManager,
   DefaultResourceLoader,
   SettingsManager,
   type AgentSession,
   type AgentSessionEvent,
-  type LoadExtensionsResult,
 } from '@earendil-works/pi-coding-agent'
 
 import type {
@@ -58,35 +58,63 @@ export interface PiExtensionsPolicy {
 }
 
 /**
- * DEFAULT IS 'allowlist' (empty) — terminal-installed extensions are
- * discovered but INERT until approved on the runtime hub (pi-ecosystem WS4;
- * flipped from 'all', which loaded everything silently). Extensions run
- * unsandboxed in this server process — loading is a trust decision.
+ * DEFAULT IS 'allowlist' (empty) — extensions are discovered but NOT LOADED
+ * until approved (pi-ecosystem WS4; flipped from 'all', which loaded
+ * everything silently). Extensions are unsandboxed code inside the Bakin
+ * server process, so loading one is a trust decision.
  */
 export function extensionsPolicy(settings: Record<string, unknown> | undefined): Required<PiExtensionsPolicy> {
   const raw = (settings?.piExtensions ?? {}) as PiExtensionsPolicy
   return { mode: raw.mode ?? 'allowlist', allow: raw.allow ?? [] }
 }
 
+export interface PiExtensionResource {
+  /** Absolute path of the module the loader would import — the trust identity. */
+  path: string
+  /** Package source spec it came from (`npm:x`, `git:…`), absent for loose files. */
+  source?: string
+  scope?: string
+}
+
 /**
- * ONE allowlist predicate for loading AND discovery status: exact full path,
- * exact basename (with or without extension), or — for npm/git package
- * extensions whose load path lands under node_modules — an exact
- * path-segment match of the package name. NEVER substring matching: an
- * entry "foo" must not admit "foobar".
+ * Enumerate the extension modules the loader WOULD import, WITHOUT importing
+ * any of them: the SDK's package manager resolves paths only. `onMissing:
+ * 'skip'` also guarantees no install and no network. This is the ONE
+ * discovery source — it sees npm/git packages, local files and dirs,
+ * object-form `packages[]` filter entries, and both scopes, with the
+ * loader's own enable rules applied.
  */
-export function extensionAllowed(path: string, allow: string[]): boolean {
-  const base = path.split('/').pop() ?? path
-  const stem = base.replace(/\.(ts|js|mjs|cjs)$/, '')
-  const segments = path.split('/')
-  return allow.some((pattern) =>
-    pattern === path
-    || pattern === base
-    || pattern === stem
-    || (pattern.includes('/')
-      ? path.includes(`/node_modules/${pattern}/`) || path.endsWith(`/node_modules/${pattern}`)
-      : segments.includes(pattern)),
-  )
+export async function resolveExtensionResources(
+  workspace: string,
+  agentDir: string,
+): Promise<PiExtensionResource[]> {
+  const settingsManager = createTurnSettingsManager(workspace, agentDir)
+  const packageManager = new DefaultPackageManager({ cwd: workspace, agentDir, settingsManager })
+  const resolved = await packageManager.resolve(async () => 'skip')
+  return resolved.extensions
+    .filter((resource) => resource.enabled)
+    .map((resource) => ({
+      path: resource.path,
+      ...(resource.metadata?.source && resource.metadata.source !== resource.path
+        ? { source: resource.metadata.source }
+        : {}),
+      ...(resource.metadata?.scope ? { scope: String(resource.metadata.scope) } : {}),
+    }))
+}
+
+/**
+ * The approved absolute paths the loader may import, per policy. Empty in
+ * 'none'; the allowlist ∩ discovered in 'allowlist' (an allow entry for
+ * something no longer installed simply resolves to nothing).
+ */
+async function approvedExtensionPaths(
+  policy: Required<PiExtensionsPolicy>,
+  workspace: string,
+  agentDir: string,
+): Promise<string[]> {
+  if (policy.mode !== 'allowlist' || policy.allow.length === 0) return []
+  const discovered = new Set((await resolveExtensionResources(workspace, agentDir)).map((r) => r.path))
+  return policy.allow.filter((path) => discovered.has(path))
 }
 
 export interface PiMessagingDeps {
@@ -166,21 +194,24 @@ async function openTurnSession(args: MessageArgs, deps: PiMessagingDeps): Promis
   const settingsManager = createTurnSettingsManager(workspace, agentDir)
   const adapterSettings = deps.getSettings?.()
   const extPolicy = extensionsPolicy(adapterSettings)
+
+  // TRUE pre-load gate (WS4). `extensionsOverride` is a POST-load filter —
+  // the loader jiti-imports every enabled extension before it runs, so an
+  // unapproved extension's module code would execute (only its tools would
+  // be hidden). Instead: `noExtensions` suppresses the settings-discovered
+  // set entirely, and ONLY approved absolute paths are handed back through
+  // `additionalExtensionPaths` — unapproved code is never imported.
+  //   none      → nothing loads
+  //   allowlist → exactly the approved paths load
+  //   all       → the loader's normal behavior (opt-in, explicit)
+  const approvedPaths = await approvedExtensionPaths(extPolicy, workspace, agentDir)
   const resourceLoader = new DefaultResourceLoader({
     cwd: workspace,
     agentDir,
     settingsManager,
-    // Extensions load per policy (#626); themes/prompt-templates are
-    // TUI-only and stay out of the server process.
-    noExtensions: extPolicy.mode === 'none',
-    ...(extPolicy.mode === 'allowlist'
-      ? {
-          extensionsOverride: (base: LoadExtensionsResult): LoadExtensionsResult => ({
-            ...base,
-            extensions: base.extensions.filter((ext) => extensionAllowed(ext.path, extPolicy.allow)),
-          }),
-        }
-      : {}),
+    // Themes/prompt-templates are TUI-only and stay out of the server process.
+    noExtensions: extPolicy.mode !== 'all',
+    ...(extPolicy.mode === 'allowlist' ? { additionalExtensionPaths: approvedPaths } : {}),
     noThemes: true,
     noPromptTemplates: true,
     appendSystemPrompt: buildAppendSystemPrompt(record.id),

--- a/packages/adapter-pi/src/runtime.ts
+++ b/packages/adapter-pi/src/runtime.ts
@@ -22,6 +22,7 @@ import { readRegistry } from './registry'
 import { createHealthChecks } from './health-checks'
 import { createImagesSurface } from './images'
 import { createExtensionsSurface } from './extensions'
+import { enforcePiOffline } from './messaging'
 import { codexImageAuth } from './codex-images'
 import { resolveProviderApiKeySource } from '@bakin/core/media'
 import { createSessionsSurface } from './sessions'
@@ -52,6 +53,13 @@ export class PiRuntimeAdapter implements AgentRuntimeAdapter {
    */
   async initialize(opts: AdapterInitOpts): Promise<void> {
     this.initOpts = opts
+    // A Bakin agent turn (and its provisioning) must NEVER install a Pi
+    // package — the SDK resolver would run npm/git install side effects
+    // (postinstall = arbitrary code) for any configured-but-missing package,
+    // bypassing the extension allowlist entirely. Force the resolver offline
+    // for the whole adapter lifecycle; installing packages is a deliberate
+    // terminal act, never a side effect of serving a turn.
+    enforcePiOffline()
   }
 
   async shutdown(): Promise<void> {}

--- a/packages/adapter-pi/src/runtime.ts
+++ b/packages/adapter-pi/src/runtime.ts
@@ -163,8 +163,17 @@ export class PiRuntimeAdapter implements AgentRuntimeAdapter {
     return capabilitiesForModel(main?.model)
   }
 
+  /**
+   * Adapter-private settings, LIVE when the host provides the getter
+   * (getLiveSettings — settings edits apply next turn, no restart), else the
+   * boot snapshot / factory options (tests, thin callers).
+   */
+  private settingsNow(): Record<string, unknown> | undefined {
+    return this.initOpts?.getLiveSettings?.() ?? this.initOpts?.settings ?? this.options.settings
+  }
+
   getHealthChecks(): ReturnType<AgentRuntimeAdapter['getHealthChecks']> {
-    return createHealthChecks(() => this.initOpts?.settings ?? this.options.settings)
+    return createHealthChecks(() => this.settingsNow())
   }
 
   agents: AgentRuntimeAdapter['agents'] = createAgentsSurface()
@@ -172,7 +181,8 @@ export class PiRuntimeAdapter implements AgentRuntimeAdapter {
   messaging: AgentRuntimeAdapter['messaging'] = createMessagingSurface({
     getExecTools: () => this.initOpts?.execTools,
     getLogger: () => this.initOpts?.logger,
-    getSettings: () => this.initOpts?.settings ?? this.options.settings,
+    // Live: extension policy + retry knobs apply on the NEXT TURN.
+    getSettings: () => this.settingsNow(),
   })
 
 
@@ -197,7 +207,7 @@ export class PiRuntimeAdapter implements AgentRuntimeAdapter {
    * loader would load, statused by the SAME policy the loader applies.
    */
   get extensions(): AgentRuntimeAdapter['extensions'] {
-    return createExtensionsSurface(() => this.initOpts?.settings ?? this.options.settings)
+    return createExtensionsSurface(() => this.settingsNow())
   }
 
   // channels/cron are OMITTED (P2.1): Pi has no delivery layer and no

--- a/packages/adapter-pi/src/runtime.ts
+++ b/packages/adapter-pi/src/runtime.ts
@@ -21,6 +21,7 @@ import { capabilitiesForModel, createModelsSurface, resetModelRegistry } from '.
 import { readRegistry } from './registry'
 import { createHealthChecks } from './health-checks'
 import { createImagesSurface } from './images'
+import { createExtensionsSurface } from './extensions'
 import { codexImageAuth } from './codex-images'
 import { resolveProviderApiKeySource } from '@bakin/core/media'
 import { createSessionsSurface } from './sessions'
@@ -163,7 +164,7 @@ export class PiRuntimeAdapter implements AgentRuntimeAdapter {
   }
 
   getHealthChecks(): ReturnType<AgentRuntimeAdapter['getHealthChecks']> {
-    return createHealthChecks()
+    return createHealthChecks(() => this.initOpts?.settings ?? this.options.settings)
   }
 
   agents: AgentRuntimeAdapter['agents'] = createAgentsSurface()
@@ -189,6 +190,14 @@ export class PiRuntimeAdapter implements AgentRuntimeAdapter {
       this._images = createImagesSurface({ carrierModel: imagesSettings?.carrierModel })
     }
     return this._images
+  }
+
+  /**
+   * Extension trust surface (WS4): inert discovery of what the resource
+   * loader would load, statused by the SAME policy the loader applies.
+   */
+  get extensions(): AgentRuntimeAdapter['extensions'] {
+    return createExtensionsSurface(() => this.initOpts?.settings ?? this.options.settings)
   }
 
   // channels/cron are OMITTED (P2.1): Pi has no delivery layer and no

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -730,16 +730,19 @@ export interface RuntimeImagesAccess {
  * executes extension code.
  */
 export interface RuntimeExtensionInfo {
-  /** Stable identifier used for allow/revoke (basename or package name). */
+  /** Stable identifier used for allow/revoke — the real absolute module path. */
   id: string
   label: string
   /** Where it came from, human-readable (e.g. "npm:some-pkg", "extensions dir"). */
   source: string
-  /** Absolute load path — what allowlist patterns match against. */
+  /** Real absolute load path (symlinks resolved) — half the trust identity. */
   path: string
+  /** Current content hash of the file — the other half of the trust identity. */
+  sha256: string
   /**
-   * pending  — discovered but NOT loaded into turns (awaiting approval)
-   * allowed  — loads into agent turns
+   * pending  — discovered but NOT loaded into turns (unapproved, or its
+   *            content changed since approval)
+   * allowed  — approved path+hash; loads into agent turns
    * blocked  — policy mode 'none': nothing loads
    */
   status: 'allowed' | 'pending' | 'blocked'

--- a/packages/core/src/adapters/runtime/concepts.ts
+++ b/packages/core/src/adapters/runtime/concepts.ts
@@ -723,6 +723,39 @@ export interface RuntimeImagesAccess {
   edit(input: RuntimeImageEditInput): Promise<RuntimeImageGenerationResult>
 }
 
+/**
+ * A runtime extension: third-party code the RUNTIME loads in-process during
+ * agent turns (Pi extensions today). Provider-neutral shape — ids/labels/
+ * paths only, never provider config. Discovery is INERT: listing never
+ * executes extension code.
+ */
+export interface RuntimeExtensionInfo {
+  /** Stable identifier used for allow/revoke (basename or package name). */
+  id: string
+  label: string
+  /** Where it came from, human-readable (e.g. "npm:some-pkg", "extensions dir"). */
+  source: string
+  /** Absolute load path — what allowlist patterns match against. */
+  path: string
+  /**
+   * pending  — discovered but NOT loaded into turns (awaiting approval)
+   * allowed  — loads into agent turns
+   * blocked  — policy mode 'none': nothing loads
+   */
+  status: 'allowed' | 'pending' | 'blocked'
+}
+
+/**
+ * OPTIONAL: trust management for runtime-loaded extensions. Runtimes without
+ * an extension mechanism OMIT the member; callers feature-detect
+ * (`runtime.extensions?.`). Listing is read-only and inert. The trust store
+ * itself (allowlist) is Bakin-owned settings — see
+ * `src/core/runtime-extensions.ts` for the ONE mutation engine.
+ */
+export interface RuntimeExtensionsAccess {
+  list(): Promise<RuntimeExtensionInfo[]>
+}
+
 export interface CronJob {
   id: string
   name: string
@@ -985,6 +1018,8 @@ export interface AgentRuntimeAdapter {
   verifyToolAccess(): Promise<ToolAccessProvisioningStatus>
 
   images?: RuntimeImagesAccess
+
+  extensions?: RuntimeExtensionsAccess
 
   /**
    * Access to the runtime's private media store (e.g. channel attachments).

--- a/packages/core/src/adapters/runtime/index.ts
+++ b/packages/core/src/adapters/runtime/index.ts
@@ -77,6 +77,8 @@ export type {
   RuntimeImageProvider,
   RuntimeImageProviderCapabilities,
   RuntimeImagesAccess,
+  RuntimeExtensionInfo,
+  RuntimeExtensionsAccess,
   RuntimeMemoryEntry,
   RuntimeMemoryEntryStat,
   RuntimeMemoryPathMatch,

--- a/packages/core/src/adapters/shared.ts
+++ b/packages/core/src/adapters/shared.ts
@@ -49,6 +49,13 @@ export interface RuntimeExecToolProvider {
 export interface AdapterInitOpts {
   contentDir: string
   settings?: Record<string, unknown>
+  /**
+   * LIVE view of the adapter-private settings bag. `settings` is a boot-time
+   * snapshot; surfaces whose behavior must track settings edits WITHOUT a
+   * restart (extension trust policy, per-turn knobs) read through this.
+   * Optional: tests and thin callers may omit it (snapshot semantics).
+   */
+  getLiveSettings?: () => Record<string, unknown> | undefined
   logger?: AdapterLogger
   audit?: (event: AdapterAuditEvent) => void
   execTools?: RuntimeExecToolProvider

--- a/packages/host/src/components/runtime/extensions-section.tsx
+++ b/packages/host/src/components/runtime/extensions-section.tsx
@@ -16,6 +16,7 @@ interface ExtensionRow {
   label: string
   source: string
   path: string
+  sha256: string
   status: 'allowed' | 'pending' | 'blocked'
 }
 
@@ -27,6 +28,7 @@ interface ExtensionsReport {
 
 export function ExtensionsSection() {
   const [report, setReport] = useState<ExtensionsReport | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [target, setTarget] = useState<{ ext: ExtensionRow; action: 'allow' | 'revoke' } | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -36,13 +38,27 @@ export function ExtensionsSection() {
       const res = await fetch('/api/runtime/extensions')
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       setReport(await res.json() as ExtensionsReport)
-    } catch {
-      setReport(null) // silent: the section simply doesn't render
+      setLoadError(null)
+    } catch (err) {
+      // Don't silently hide the section on a transient error — pending
+      // extensions would become un-approvable with no signal.
+      setLoadError(err instanceof Error ? err.message : String(err))
     }
   }, [])
 
   useEffect(() => { void load() }, [load])
 
+  // A genuine fetch failure is distinct from "runtime has no extensions".
+  if (loadError) {
+    return (
+      <section className="space-y-2" data-testid="runtime-extensions-error">
+        <h2 className="text-sm font-semibold">Extensions</h2>
+        <p className="text-xs text-destructive">Couldn't load extensions: {loadError}.{' '}
+          <button type="button" className="underline" onClick={() => void load()}>Retry</button>
+        </p>
+      </section>
+    )
+  }
   if (!report?.supported || report.extensions.length === 0) return null
 
   const run = async () => {

--- a/packages/host/src/components/runtime/extensions-section.tsx
+++ b/packages/host/src/components/runtime/extensions-section.tsx
@@ -77,19 +77,20 @@ export function ExtensionsSection() {
       </div>
       <div className="divide-y divide-border/60 rounded-xl border bg-card">
         {report.extensions.map((ext) => (
-          <div key={ext.id} className="flex items-center justify-between gap-4 p-4">
+          <div key={ext.path} className="flex items-center justify-between gap-4 p-4">
             <div className="flex min-w-0 items-center gap-3">
               <Puzzle className="size-4 shrink-0 text-muted-foreground" />
               <div className="min-w-0">
                 <p className="truncate text-sm font-medium">{ext.label}</p>
-                <p className="truncate text-xs text-muted-foreground">{ext.source}</p>
+                {/* The path IS the trust identity — always show what would run. */}
+                <p className="truncate text-xs text-muted-foreground" title={ext.path}>{ext.source} · {ext.path}</p>
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
               {ext.status === 'allowed' && (
                 <>
                   <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">Allowed</Badge>
-                  <Button size="sm" variant="outline" data-testid={`ext-revoke-${ext.id}`} onClick={() => { setError(null); setTarget({ ext, action: 'revoke' }) }}>
+                  <Button size="sm" variant="outline" data-testid={`ext-revoke-${ext.label}`} onClick={() => { setError(null); setTarget({ ext, action: 'revoke' }) }}>
                     Revoke
                   </Button>
                 </>
@@ -97,7 +98,7 @@ export function ExtensionsSection() {
               {ext.status === 'pending' && (
                 <>
                   <Badge variant="outline" className="border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400">Awaiting approval</Badge>
-                  <Button size="sm" data-testid={`ext-allow-${ext.id}`} onClick={() => { setError(null); setTarget({ ext, action: 'allow' }) }}>
+                  <Button size="sm" data-testid={`ext-allow-${ext.label}`} onClick={() => { setError(null); setTarget({ ext, action: 'allow' }) }}>
                     Allow
                   </Button>
                 </>
@@ -117,7 +118,8 @@ export function ExtensionsSection() {
         description={target?.action === 'allow'
           ? (
             <>
-              This extension will load into every agent turn as trusted code INSIDE the Bakin
+              <span className="block font-mono text-xs">{target?.ext.path}</span>
+              This file will load into every agent turn as trusted code INSIDE the Bakin
               server process, with full system permissions.
               <span className="mt-2 block">• Bakin cannot sandbox it — only allow extensions from sources you trust.</span>
               <span className="block">• Any API keys it uses are its own: that spend happens OUTSIDE Bakin's budget caps.</span>

--- a/packages/host/src/components/runtime/extensions-section.tsx
+++ b/packages/host/src/components/runtime/extensions-section.tsx
@@ -1,0 +1,138 @@
+/**
+ * Runtime hub — Extensions (pi-ecosystem WS4): trust management for
+ * runtime-loaded extensions. Read-only list on the page; approve/revoke live
+ * ENTIRELY in the ConfirmDialog (no-inline-actions rule) with the trust +
+ * spend disclosure. Feature-detected — a runtime without an extension
+ * mechanism renders nothing.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { Puzzle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+
+interface ExtensionRow {
+  id: string
+  label: string
+  source: string
+  path: string
+  status: 'allowed' | 'pending' | 'blocked'
+}
+
+interface ExtensionsReport {
+  supported: boolean
+  mode: string
+  extensions: ExtensionRow[]
+}
+
+export function ExtensionsSection() {
+  const [report, setReport] = useState<ExtensionsReport | null>(null)
+  const [target, setTarget] = useState<{ ext: ExtensionRow; action: 'allow' | 'revoke' } | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/runtime/extensions')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setReport(await res.json() as ExtensionsReport)
+    } catch {
+      setReport(null) // silent: the section simply doesn't render
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load])
+
+  if (!report?.supported || report.extensions.length === 0) return null
+
+  const run = async () => {
+    if (!target) return
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/runtime/extensions/${target.action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: target.ext.id }),
+      })
+      const body = await res.json() as ExtensionsReport & { error?: string }
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+      setReport(body)
+      setTarget(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="space-y-3" data-testid="runtime-extensions">
+      <div>
+        <h2 className="text-sm font-semibold">Extensions</h2>
+        <p className="text-xs text-muted-foreground">
+          Add-ons installed for the runtime (via <code>pi install</code>). They stay inert until you
+          approve them here — an approved extension runs inside the Bakin server with full permissions.
+        </p>
+      </div>
+      <div className="divide-y divide-border/60 rounded-xl border bg-card">
+        {report.extensions.map((ext) => (
+          <div key={ext.id} className="flex items-center justify-between gap-4 p-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <Puzzle className="size-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{ext.label}</p>
+                <p className="truncate text-xs text-muted-foreground">{ext.source}</p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {ext.status === 'allowed' && (
+                <>
+                  <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">Allowed</Badge>
+                  <Button size="sm" variant="outline" data-testid={`ext-revoke-${ext.id}`} onClick={() => { setError(null); setTarget({ ext, action: 'revoke' }) }}>
+                    Revoke
+                  </Button>
+                </>
+              )}
+              {ext.status === 'pending' && (
+                <>
+                  <Badge variant="outline" className="border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400">Awaiting approval</Badge>
+                  <Button size="sm" data-testid={`ext-allow-${ext.id}`} onClick={() => { setError(null); setTarget({ ext, action: 'allow' }) }}>
+                    Allow
+                  </Button>
+                </>
+              )}
+              {ext.status === 'blocked' && (
+                <Badge variant="outline" className="text-muted-foreground">Blocked (policy: none)</Badge>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={target !== null}
+        onCancel={() => { if (!busy) setTarget(null) }}
+        title={target?.action === 'allow' ? `Allow ${target?.ext.label}?` : `Revoke ${target?.ext.label}?`}
+        description={target?.action === 'allow'
+          ? (
+            <>
+              This extension will load into every agent turn as trusted code INSIDE the Bakin
+              server process, with full system permissions.
+              <span className="mt-2 block">• Bakin cannot sandbox it — only allow extensions from sources you trust.</span>
+              <span className="block">• Any API keys it uses are its own: that spend happens OUTSIDE Bakin's budget caps.</span>
+              <span className="block">• Takes effect on the next agent turn — no restart.</span>
+            </>
+          )
+          : 'The extension stays installed but stops loading into agent turns, starting with the next turn.'}
+        confirmLabel={target?.action === 'allow' ? 'Allow extension' : 'Revoke'}
+        confirmVariant={target?.action === 'allow' ? 'default' : 'destructive'}
+        busy={busy}
+        busyLabel={target?.action === 'allow' ? 'Allowing…' : 'Revoking…'}
+        error={error}
+        confirmTestId="ext-confirm"
+        onConfirm={() => void run()}
+      />
+    </section>
+  )
+}

--- a/packages/host/src/components/runtime/runtimes-tab.tsx
+++ b/packages/host/src/components/runtime/runtimes-tab.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { ConfirmDialog } from '@/components/confirm-dialog'
 import { reduceSwitchProgress, SWITCH_PHASE_LABELS, type SwitchStepRow } from '../../lib/runtime-report'
+import { ExtensionsSection } from './extensions-section'
 import type { CapabilityReport, SwitchResultPayload } from './types'
 
 function StepDot({ status }: { status: SwitchStepRow['status'] }) {
@@ -278,6 +279,8 @@ export function RuntimesTab({ report, onSwitched }: { report: CapabilityReport; 
           )
         })}
       </div>
+
+      <ExtensionsSection />
 
       {running !== null && steps.length === 0 && (
         <p className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -192,7 +192,7 @@ async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags)
 interface ExtensionsReport {
   supported: boolean
   mode: string
-  extensions: Array<{ id: string; label: string; source: string; path: string; status: string }>
+  extensions: Array<{ id: string; label: string; source: string; path: string; sha256: string; status: string }>
 }
 
 /** `bakin runtime extensions [list|allow <id>|revoke <id>]` — trust lane (WS4). */

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -189,6 +189,50 @@ async function cmdRuntimeUse(target: string | undefined, flags: RuntimeUseFlags)
   }
 }
 
+interface ExtensionsReport {
+  supported: boolean
+  mode: string
+  extensions: Array<{ id: string; label: string; source: string; path: string; status: string }>
+}
+
+/** `bakin runtime extensions [list|allow <id>|revoke <id>]` — trust lane (WS4). */
+async function cmdRuntimeExtensions(sub: string | undefined, id: string | undefined): Promise<void> {
+  if (sub === 'allow' || sub === 'revoke') {
+    if (!id) {
+      console.error(`Usage: bakin runtime extensions ${sub} <id>`)
+      process.exit(1)
+    }
+    const report = await apiPost(`/api/runtime/extensions/${sub}`, { id }) as ExtensionsReport
+    console.log(`${sub === 'allow' ? 'Allowed' : 'Revoked'} "${id}".`)
+    printExtensions(report)
+    return
+  }
+  if (sub !== undefined && sub !== 'list') {
+    console.error(`Unknown subcommand: runtime extensions ${sub}. Supported: list, allow <id>, revoke <id>`)
+    process.exit(1)
+  }
+  printExtensions(await apiGet('/api/runtime/extensions') as ExtensionsReport)
+}
+
+function printExtensions(report: ExtensionsReport): void {
+  if (!report.supported) {
+    console.log('The active runtime has no extension mechanism.')
+    return
+  }
+  console.log(`Extension policy: ${report.mode}`)
+  if (report.extensions.length === 0) {
+    console.log('No extensions discovered. Install with `pi install npm:<pkg>` (they stay inert until allowed here).')
+    return
+  }
+  for (const ext of report.extensions) {
+    console.log(`  ${ext.status === 'allowed' ? '✓' : ext.status === 'blocked' ? '✗' : '…'} ${ext.id.padEnd(32)} ${ext.status.padEnd(8)} ${ext.source}`)
+  }
+  if (report.extensions.some((e) => e.status === 'pending')) {
+    console.log('Pending extensions do NOT load into agent turns. Approve with `bakin runtime extensions allow <id>` —')
+    console.log('an allowed extension is trusted code running in the Bakin server process, and any API keys it uses spend outside Bakin budget caps.')
+  }
+}
+
 export async function run(args: string[]): Promise<void> {
   if (args[0] === 'runtime') {
     if (args[1] === 'use') {
@@ -207,6 +251,8 @@ export async function run(args: string[]): Promise<void> {
         copyWorkspaces: !rest.includes('--no-copy-workspaces'),
         adoptCron: rest.includes('--adopt-cron'),
       })
+    } else if (args[1] === 'extensions') {
+      await cmdRuntimeExtensions(args[2], args[3])
     } else await cmdRuntimeCapabilities()
     return
   }

--- a/src/cli/commands/runtime.ts
+++ b/src/cli/commands/runtime.ts
@@ -196,14 +196,28 @@ interface ExtensionsReport {
 }
 
 /** `bakin runtime extensions [list|allow <id>|revoke <id>]` — trust lane (WS4). */
-async function cmdRuntimeExtensions(sub: string | undefined, id: string | undefined): Promise<void> {
+async function cmdRuntimeExtensions(sub: string | undefined, name: string | undefined): Promise<void> {
   if (sub === 'allow' || sub === 'revoke') {
-    if (!id) {
-      console.error(`Usage: bakin runtime extensions ${sub} <id>`)
+    if (!name) {
+      console.error(`Usage: bakin runtime extensions ${sub} <name|path>`)
       process.exit(1)
     }
-    const report = await apiPost(`/api/runtime/extensions/${sub}`, { id }) as ExtensionsReport
-    console.log(`${sub === 'allow' ? 'Allowed' : 'Revoked'} "${id}".`)
+    // Trust identity is the module PATH (names collide across sources), but a
+    // human types a name: resolve it here and refuse ambiguity rather than
+    // guessing which file to trust.
+    const current = await apiGet('/api/runtime/extensions') as ExtensionsReport
+    const matches = current.extensions.filter((e) => e.path === name || e.label === name)
+    if (matches.length === 0) {
+      console.error(`Unknown extension "${name}". Run \`bakin runtime extensions list\` to see what's installed.`)
+      process.exit(1)
+    }
+    if (matches.length > 1) {
+      console.error(`"${name}" is ambiguous — pass the full path:`)
+      for (const m of matches) console.error(`  ${m.path}`)
+      process.exit(1)
+    }
+    const report = await apiPost(`/api/runtime/extensions/${sub}`, { id: matches[0]!.path }) as ExtensionsReport
+    console.log(`${sub === 'allow' ? 'Allowed' : 'Revoked'} "${matches[0]!.label}".`)
     printExtensions(report)
     return
   }
@@ -225,11 +239,14 @@ function printExtensions(report: ExtensionsReport): void {
     return
   }
   for (const ext of report.extensions) {
-    console.log(`  ${ext.status === 'allowed' ? '✓' : ext.status === 'blocked' ? '✗' : '…'} ${ext.id.padEnd(32)} ${ext.status.padEnd(8)} ${ext.source}`)
+    const mark = ext.status === 'allowed' ? '✓' : ext.status === 'blocked' ? '✗' : '…'
+    console.log(`  ${mark} ${ext.label.padEnd(32)} ${ext.status.padEnd(8)} ${ext.source}`)
+    console.log(`    ${ext.path}`)
   }
   if (report.extensions.some((e) => e.status === 'pending')) {
-    console.log('Pending extensions do NOT load into agent turns. Approve with `bakin runtime extensions allow <id>` —')
-    console.log('an allowed extension is trusted code running in the Bakin server process, and any API keys it uses spend outside Bakin budget caps.')
+    console.log('Pending extensions are NOT loaded into agent turns — their code never runs. Approve with')
+    console.log('`bakin runtime extensions allow <name>`: an allowed extension is trusted code running inside the Bakin')
+    console.log('server process with full permissions, and any API keys it uses spend outside Bakin budget caps.')
   }
 }
 

--- a/src/core/app-services.ts
+++ b/src/core/app-services.ts
@@ -83,6 +83,9 @@ export async function createAppServices(): Promise<AppServices> {
   await runtime.initialize({
     ...adapterInit,
     settings: settings.runtime.settings,
+    // Live view: extension trust changes (and other per-turn knobs) apply on
+    // the next turn without a server restart.
+    getLiveSettings: () => getSettings().runtime.settings,
     execTools,
     bakinMcpBaseUrl: resolveBakinMcpBaseUrl(),
   })

--- a/src/core/runtime-extensions.ts
+++ b/src/core/runtime-extensions.ts
@@ -3,15 +3,15 @@
  * or mutates extension trust (REST, CLI, doctor, runtime hub). Discovery is
  * adapter-owned and inert (`runtime.extensions?.list()`, feature-detected);
  * the trust store is the allowlist inside Bakin's adapter-settings bag
- * (`settings.runtime.settings.piExtensions.allow`).
+ * (`settings.runtime.settings.<adapter key>.allow`).
  *
- * TRUST IDENTITY IS THE ABSOLUTE MODULE PATH the runtime would import — not
- * a name or basename, which collide across sources. Approving names exactly
- * one file; the adapter hands the loader exactly those paths (a true
- * pre-load gate: unapproved code is never imported).
+ * TRUST IDENTITY IS (real module path, content hash). Approving names exactly
+ * one file's exact bytes; a repointed symlink or a swapped file is a
+ * different extension and reverts to unapproved. The adapter hands the loader
+ * exactly the approved paths (a true pre-load gate: unapproved code is never
+ * imported).
  *
- * Sessions are per-turn on Pi, so trust changes take effect on the next
- * turn — no restart.
+ * Trust changes take effect on the next turn — no restart.
  */
 import type { RuntimeExtensionInfo } from '@bakin/core/adapters/runtime'
 import { updateSettings } from '../../packages/core/src/settings'
@@ -23,6 +23,12 @@ import { createLogger } from '@/core/logger'
 
 const log = createLogger('runtime-extensions')
 
+/** Adapter-private settings key the extension trust store lives under. */
+const TRUST_SETTINGS_KEY = 'piExtensions'
+
+/** Recoverable input error → the REST layer maps this to 4xx, not 500. */
+export class ExtensionTrustError extends Error {}
+
 export interface RuntimeExtensionsReport {
   /** Absent surface (runtime has no extension mechanism) → supported false. */
   supported: boolean
@@ -30,24 +36,40 @@ export interface RuntimeExtensionsReport {
   extensions: RuntimeExtensionInfo[]
 }
 
-interface ExtensionsPolicyBag {
-  mode?: 'none' | 'allowlist' | 'all'
-  allow?: string[]
+interface AllowEntry {
+  path: string
+  sha256: string
 }
 
-function currentPolicy(): Required<ExtensionsPolicyBag> {
-  const raw = (getSettings().runtime.settings?.piExtensions ?? {}) as ExtensionsPolicyBag
-  return { mode: raw.mode ?? 'allowlist', allow: raw.allow ?? [] }
+interface ExtensionsPolicyBag {
+  mode?: 'none' | 'allowlist' | 'all'
+  allow?: Array<AllowEntry | string>
+}
+
+function currentPolicy(): { mode: 'none' | 'allowlist' | 'all'; allow: AllowEntry[] } {
+  const raw = (getSettings().runtime.settings?.[TRUST_SETTINGS_KEY] ?? {}) as ExtensionsPolicyBag
+  const allow = (raw.allow ?? []).map((e) => (typeof e === 'string' ? { path: e, sha256: '' } : { path: e.path, sha256: e.sha256 ?? '' }))
+  return { mode: raw.mode ?? 'allowlist', allow }
 }
 
 /**
  * Write ONLY the allowlist delta. updateSettings deep-merges into the ON-DISK
- * overrides, so passing a minimal patch preserves every other setting AND
- * never persists merged defaults or the BAKIN_RUNTIME_ADAPTER env override
- * into settings.json (spreading the resolved `runtime` object would).
+ * overrides, so a minimal patch preserves every other setting AND never
+ * persists merged defaults or the runtime-adapter env override into
+ * settings.json (spreading the resolved `runtime` object would).
  */
-function writeAllowlist(allow: string[]): void {
-  updateSettings({ runtime: { settings: { piExtensions: { mode: currentPolicy().mode, allow } } } })
+function writeAllowlist(allow: AllowEntry[]): void {
+  updateSettings({ runtime: { settings: { [TRUST_SETTINGS_KEY]: { mode: currentPolicy().mode, allow } } } })
+}
+
+/** allow/revoke only mean something under 'allowlist' — refuse in 'none'/'all' honestly. */
+function requireAllowlistMode(mode: 'none' | 'allowlist' | 'all', verb: string): void {
+  if (mode === 'allowlist') return
+  throw new ExtensionTrustError(
+    mode === 'all'
+      ? `Extension policy is "all": every installed extension already loads. Set ${TRUST_SETTINGS_KEY}.mode to "allowlist" to ${verb} individually.`
+      : `Extension policy is "none": all extensions are blocked. Set ${TRUST_SETTINGS_KEY}.mode to "allowlist" to ${verb} individually.`,
+  )
 }
 
 export async function listRuntimeExtensions(): Promise<RuntimeExtensionsReport> {
@@ -57,42 +79,36 @@ export async function listRuntimeExtensions(): Promise<RuntimeExtensionsReport> 
 }
 
 /**
- * Approve one discovered extension: its module PATH joins the allowlist.
- * Refuses ids discovery doesn't know — trust is granted to a real file the
- * runtime would import, never to a free-text pattern.
+ * Approve one discovered extension: its (real path, current hash) joins the
+ * allowlist. Refuses ids discovery doesn't return — trust is granted to a
+ * real file the runtime would import, never a free-text pattern.
  */
 export async function allowRuntimeExtension(id: string): Promise<RuntimeExtensionsReport> {
   const report = await listRuntimeExtensions()
-  if (!report.supported) throw new Error('The active runtime has no extension mechanism')
+  if (!report.supported) throw new ExtensionTrustError('The active runtime has no extension mechanism')
+  requireAllowlistMode(report.mode, 'allow')
   const target = report.extensions.find((e) => e.id === id)
-  if (!target) throw new Error(`Unknown extension "${id}" — run discovery first (bakin runtime extensions list)`)
+  if (!target) throw new ExtensionTrustError(`Unknown extension "${id}" — run discovery first (bakin runtime extensions list)`)
 
   const policy = currentPolicy()
-  if (policy.mode === 'all') {
-    throw new Error(
-      'Extension policy is "all": every installed extension already loads. Set piExtensions.mode to "allowlist" to gate them individually.',
-    )
-  }
-  if (!policy.allow.includes(target.path)) writeAllowlist([...policy.allow, target.path])
-  appendAudit(getContentDir(), 'runtime.extension_allowed', target.path, { label: target.label, source: target.source }, 'human')
+  const next = policy.allow.filter((e) => e.path !== target.path)
+  next.push({ path: target.path, sha256: target.sha256 })
+  writeAllowlist(next)
+  appendAudit(getContentDir(), 'runtime.extension_allowed', target.path, { label: target.label, source: target.source, sha256: target.sha256 }, 'human')
   log.info(`Extension allowed`, { path: target.path })
   return listRuntimeExtensions()
 }
 
-/** Revoke one extension: its path leaves the allowlist and it stops loading. */
+/** Revoke one extension by its path: it leaves the allowlist and stops loading. */
 export async function revokeRuntimeExtension(id: string): Promise<RuntimeExtensionsReport> {
   const report = await listRuntimeExtensions()
-  if (!report.supported) throw new Error('The active runtime has no extension mechanism')
+  if (!report.supported) throw new ExtensionTrustError('The active runtime has no extension mechanism')
+  requireAllowlistMode(report.mode, 'revoke')
 
   const policy = currentPolicy()
-  if (policy.mode === 'all') {
-    throw new Error(
-      'Extension policy is "all": every installed extension loads regardless of the allowlist. Set piExtensions.mode to "allowlist" to gate them individually.',
-    )
-  }
-  const next = policy.allow.filter((path) => path !== id)
+  const next = policy.allow.filter((e) => e.path !== id)
   if (next.length === policy.allow.length) {
-    throw new Error(`Extension "${id}" is not in the allowlist`)
+    throw new ExtensionTrustError(`Extension "${id}" is not in the allowlist`)
   }
   writeAllowlist(next)
   appendAudit(getContentDir(), 'runtime.extension_revoked', id, {}, 'human')

--- a/src/core/runtime-extensions.ts
+++ b/src/core/runtime-extensions.ts
@@ -1,0 +1,92 @@
+/**
+ * Runtime extension trust — the ONE engine behind every surface that lists
+ * or mutates extension trust (REST, CLI, doctor, runtime hub). Discovery is
+ * adapter-owned and inert (`runtime.extensions?.list()`, feature-detected);
+ * the trust store is the allowlist inside Bakin's adapter-settings bag
+ * (`settings.runtime.settings.piExtensions.allow` — the knob name is the
+ * adapter's, its storage is Bakin's settings.json; runtime-switch.ts is the
+ * precedent for core writing that bag). Approvals persist the extension's
+ * exact id — the adapter's allow predicate matches ids/basenames precisely.
+ *
+ * Sessions are per-turn on Pi, so trust changes take effect on the next
+ * turn — no restart.
+ */
+import type { RuntimeExtensionInfo } from '@bakin/core/adapters/runtime'
+import { getSettings, updateSettings } from '../../packages/core/src/settings'
+import { getAppServices } from '@/core/app-services'
+import { appendAudit } from '@/core/audit'
+import { getContentDir } from '@/core/content-dir'
+import { createLogger } from '@/core/logger'
+
+const log = createLogger('runtime-extensions')
+
+export interface RuntimeExtensionsReport {
+  /** Absent surface (runtime has no extension mechanism) → supported false. */
+  supported: boolean
+  mode: 'none' | 'allowlist' | 'all'
+  extensions: RuntimeExtensionInfo[]
+}
+
+interface ExtensionsPolicyBag {
+  mode?: 'none' | 'allowlist' | 'all'
+  allow?: string[]
+}
+
+function currentPolicy(): Required<ExtensionsPolicyBag> {
+  const raw = (getSettings().runtime.settings?.piExtensions ?? {}) as ExtensionsPolicyBag
+  return { mode: raw.mode ?? 'allowlist', allow: raw.allow ?? [] }
+}
+
+function writeAllowlist(allow: string[]): void {
+  const settings = getSettings()
+  const policy = currentPolicy()
+  updateSettings({
+    runtime: {
+      ...settings.runtime,
+      settings: {
+        ...settings.runtime.settings,
+        piExtensions: { mode: policy.mode, allow },
+      },
+    },
+  })
+}
+
+export async function listRuntimeExtensions(): Promise<RuntimeExtensionsReport> {
+  const surface = getAppServices().runtime.extensions
+  if (!surface) return { supported: false, mode: currentPolicy().mode, extensions: [] }
+  return { supported: true, mode: currentPolicy().mode, extensions: await surface.list() }
+}
+
+/**
+ * Approve one discovered extension: its id joins the allowlist. Refuses ids
+ * discovery doesn't know — trust is granted to something REAL, never to a
+ * free-text pattern.
+ */
+export async function allowRuntimeExtension(id: string): Promise<RuntimeExtensionsReport> {
+  const report = await listRuntimeExtensions()
+  if (!report.supported) throw new Error('The active runtime has no extension mechanism')
+  const target = report.extensions.find((e) => e.id === id)
+  if (!target) throw new Error(`Unknown extension "${id}" — run discovery first (bakin runtime extensions list)`)
+
+  const policy = currentPolicy()
+  if (!policy.allow.includes(id)) writeAllowlist([...policy.allow, id])
+  appendAudit(getContentDir(), 'runtime.extension_allowed', id, { path: target.path, source: target.source }, 'human')
+  log.info(`Extension "${id}" allowed`, { path: target.path })
+  return listRuntimeExtensions()
+}
+
+/** Revoke one extension: every allowlist entry matching its id/basename goes. */
+export async function revokeRuntimeExtension(id: string): Promise<RuntimeExtensionsReport> {
+  const report = await listRuntimeExtensions()
+  if (!report.supported) throw new Error('The active runtime has no extension mechanism')
+
+  const policy = currentPolicy()
+  const next = policy.allow.filter((pattern) => pattern !== id)
+  if (next.length === policy.allow.length) {
+    throw new Error(`Extension "${id}" is not in the allowlist`)
+  }
+  writeAllowlist(next)
+  appendAudit(getContentDir(), 'runtime.extension_revoked', id, {}, 'human')
+  log.info(`Extension "${id}" revoked`)
+  return listRuntimeExtensions()
+}

--- a/src/core/runtime-extensions.ts
+++ b/src/core/runtime-extensions.ts
@@ -3,19 +3,22 @@
  * or mutates extension trust (REST, CLI, doctor, runtime hub). Discovery is
  * adapter-owned and inert (`runtime.extensions?.list()`, feature-detected);
  * the trust store is the allowlist inside Bakin's adapter-settings bag
- * (`settings.runtime.settings.piExtensions.allow` — the knob name is the
- * adapter's, its storage is Bakin's settings.json; runtime-switch.ts is the
- * precedent for core writing that bag). Approvals persist the extension's
- * exact id — the adapter's allow predicate matches ids/basenames precisely.
+ * (`settings.runtime.settings.piExtensions.allow`).
+ *
+ * TRUST IDENTITY IS THE ABSOLUTE MODULE PATH the runtime would import — not
+ * a name or basename, which collide across sources. Approving names exactly
+ * one file; the adapter hands the loader exactly those paths (a true
+ * pre-load gate: unapproved code is never imported).
  *
  * Sessions are per-turn on Pi, so trust changes take effect on the next
  * turn — no restart.
  */
 import type { RuntimeExtensionInfo } from '@bakin/core/adapters/runtime'
-import { getSettings, updateSettings } from '../../packages/core/src/settings'
+import { updateSettings } from '../../packages/core/src/settings'
 import { getAppServices } from '@/core/app-services'
 import { appendAudit } from '@/core/audit'
 import { getContentDir } from '@/core/content-dir'
+import { getSettings } from '@/core/settings'
 import { createLogger } from '@/core/logger'
 
 const log = createLogger('runtime-extensions')
@@ -37,18 +40,14 @@ function currentPolicy(): Required<ExtensionsPolicyBag> {
   return { mode: raw.mode ?? 'allowlist', allow: raw.allow ?? [] }
 }
 
+/**
+ * Write ONLY the allowlist delta. updateSettings deep-merges into the ON-DISK
+ * overrides, so passing a minimal patch preserves every other setting AND
+ * never persists merged defaults or the BAKIN_RUNTIME_ADAPTER env override
+ * into settings.json (spreading the resolved `runtime` object would).
+ */
 function writeAllowlist(allow: string[]): void {
-  const settings = getSettings()
-  const policy = currentPolicy()
-  updateSettings({
-    runtime: {
-      ...settings.runtime,
-      settings: {
-        ...settings.runtime.settings,
-        piExtensions: { mode: policy.mode, allow },
-      },
-    },
-  })
+  updateSettings({ runtime: { settings: { piExtensions: { mode: currentPolicy().mode, allow } } } })
 }
 
 export async function listRuntimeExtensions(): Promise<RuntimeExtensionsReport> {
@@ -58,9 +57,9 @@ export async function listRuntimeExtensions(): Promise<RuntimeExtensionsReport> 
 }
 
 /**
- * Approve one discovered extension: its id joins the allowlist. Refuses ids
- * discovery doesn't know — trust is granted to something REAL, never to a
- * free-text pattern.
+ * Approve one discovered extension: its module PATH joins the allowlist.
+ * Refuses ids discovery doesn't know — trust is granted to a real file the
+ * runtime would import, never to a free-text pattern.
  */
 export async function allowRuntimeExtension(id: string): Promise<RuntimeExtensionsReport> {
   const report = await listRuntimeExtensions()
@@ -69,24 +68,34 @@ export async function allowRuntimeExtension(id: string): Promise<RuntimeExtensio
   if (!target) throw new Error(`Unknown extension "${id}" — run discovery first (bakin runtime extensions list)`)
 
   const policy = currentPolicy()
-  if (!policy.allow.includes(id)) writeAllowlist([...policy.allow, id])
-  appendAudit(getContentDir(), 'runtime.extension_allowed', id, { path: target.path, source: target.source }, 'human')
-  log.info(`Extension "${id}" allowed`, { path: target.path })
+  if (policy.mode === 'all') {
+    throw new Error(
+      'Extension policy is "all": every installed extension already loads. Set piExtensions.mode to "allowlist" to gate them individually.',
+    )
+  }
+  if (!policy.allow.includes(target.path)) writeAllowlist([...policy.allow, target.path])
+  appendAudit(getContentDir(), 'runtime.extension_allowed', target.path, { label: target.label, source: target.source }, 'human')
+  log.info(`Extension allowed`, { path: target.path })
   return listRuntimeExtensions()
 }
 
-/** Revoke one extension: every allowlist entry matching its id/basename goes. */
+/** Revoke one extension: its path leaves the allowlist and it stops loading. */
 export async function revokeRuntimeExtension(id: string): Promise<RuntimeExtensionsReport> {
   const report = await listRuntimeExtensions()
   if (!report.supported) throw new Error('The active runtime has no extension mechanism')
 
   const policy = currentPolicy()
-  const next = policy.allow.filter((pattern) => pattern !== id)
+  if (policy.mode === 'all') {
+    throw new Error(
+      'Extension policy is "all": every installed extension loads regardless of the allowlist. Set piExtensions.mode to "allowlist" to gate them individually.',
+    )
+  }
+  const next = policy.allow.filter((path) => path !== id)
   if (next.length === policy.allow.length) {
     throw new Error(`Extension "${id}" is not in the allowlist`)
   }
   writeAllowlist(next)
   appendAudit(getContentDir(), 'runtime.extension_revoked', id, {}, 'human')
-  log.info(`Extension "${id}" revoked`)
+  log.info(`Extension revoked`, { path: id })
   return listRuntimeExtensions()
 }

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -255,6 +255,27 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
       return
     }
 
+    // Extension trust lane (WS4): inert discovery + allow/revoke through
+    // the ONE engine. Feature-detected — a runtime without extensions
+    // reports supported: false.
+    if (url.pathname === '/api/runtime/extensions' && req.method === 'GET') {
+      const { listRuntimeExtensions } = require('../runtime-extensions') as typeof import('../runtime-extensions')
+      listRuntimeExtensions()
+        .then((report) => jsonResponse(res, 200, report))
+        .catch((err) => jsonResponse(res, 500, { ok: false, error: err instanceof Error ? err.message : String(err) }))
+      return
+    }
+    if ((url.pathname === '/api/runtime/extensions/allow' || url.pathname === '/api/runtime/extensions/revoke') && req.method === 'POST') {
+      const { allowRuntimeExtension, revokeRuntimeExtension } = require('../runtime-extensions') as typeof import('../runtime-extensions')
+      const action = url.pathname.endsWith('/allow') ? allowRuntimeExtension : revokeRuntimeExtension
+      handleJsonPost(req, res, async (body) => {
+        const id = (body as { id?: unknown }).id
+        if (typeof id !== 'string' || id.length === 0) throw new BadRequestError('id is required')
+        return action(id)
+      })
+      return
+    }
+
     // Runtime switch (P3.2): runs the full orchestrated lifecycle; progress
     // streams over the activity SSE channel as runtime:switch events. A
     // completed switch requires a server restart to rebind plugin contexts —

--- a/src/core/server/request-handler.ts
+++ b/src/core/server/request-handler.ts
@@ -266,12 +266,19 @@ export function createRequestHandler(deps: RequestHandlerDeps): (req: IncomingMe
       return
     }
     if ((url.pathname === '/api/runtime/extensions/allow' || url.pathname === '/api/runtime/extensions/revoke') && req.method === 'POST') {
-      const { allowRuntimeExtension, revokeRuntimeExtension } = require('../runtime-extensions') as typeof import('../runtime-extensions')
-      const action = url.pathname.endsWith('/allow') ? allowRuntimeExtension : revokeRuntimeExtension
+      const mod = require('../runtime-extensions') as typeof import('../runtime-extensions')
+      const action = url.pathname.endsWith('/allow') ? mod.allowRuntimeExtension : mod.revokeRuntimeExtension
       handleJsonPost(req, res, async (body) => {
         const id = (body as { id?: unknown }).id
         if (typeof id !== 'string' || id.length === 0) throw new BadRequestError('id is required')
-        return action(id)
+        try {
+          return await action(id)
+        } catch (err) {
+          // Trust-input errors (unknown id, wrong mode, not-in-allowlist) are
+          // caller-recoverable — 400, not a 500.
+          if (err instanceof mod.ExtensionTrustError) throw new BadRequestError(err.message)
+          throw err
+        }
       })
       return
     }

--- a/tests/adapter-pi/extensions-discovery.test.ts
+++ b/tests/adapter-pi/extensions-discovery.test.ts
@@ -1,6 +1,11 @@
 /**
- * Extension trust lane (pi-ecosystem WS4): inert discovery, policy status
- * honesty, and the ONE trust engine's allow/revoke semantics.
+ * Extension trust lane (pi-ecosystem WS4): discovery honesty and the ONE
+ * trust engine's allow/revoke semantics.
+ *
+ * Trust identity is the resolved module PATH — names/basenames collide
+ * across sources, and approving must name exactly one file. The pre-load
+ * gate itself (unapproved code is NEVER imported) is pinned live against the
+ * real SDK loader in tests/integration/pi/extensions.test.ts.
  */
 import { tmpdir } from 'os'
 import { join as pathJoin } from 'path'
@@ -32,13 +37,23 @@ mock.module('@/core/logger', () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
 }))
 
-// The trust engine reads/writes Bakin settings — fake BOTH module paths
-// (packages/core + the src facade) with a complete-enough surface.
-let runtimeSettings: Record<string, unknown> = {}
+// Bakin settings: in-memory, delta-merged the way updateSettings behaves on
+// disk (so a write that clobbered runtime.adapter would show up here).
+let settingsFile: Record<string, unknown> = { runtime: { adapter: 'pi', settings: {} } }
 const settingsFake = () => ({
-  getSettings: () => ({ runtime: { adapter: 'pi', settings: runtimeSettings } }),
-  updateSettings: (partial: { runtime?: { settings?: Record<string, unknown> } }) => {
-    runtimeSettings = partial.runtime?.settings ?? runtimeSettings
+  getSettings: () => settingsFile as { runtime: { adapter: string; settings: Record<string, unknown> } },
+  updateSettings: (partial: Record<string, unknown>) => {
+    const merge = (base: Record<string, unknown>, patch: Record<string, unknown>): Record<string, unknown> => {
+      const out = { ...base }
+      for (const [k, v] of Object.entries(patch)) {
+        const cur = out[k]
+        out[k] = cur && typeof cur === 'object' && !Array.isArray(cur) && v && typeof v === 'object' && !Array.isArray(v)
+          ? merge(cur as Record<string, unknown>, v as Record<string, unknown>)
+          : v
+      }
+      return out
+    }
+    settingsFile = merge(settingsFile, partial)
   },
   resetSettingsCache: () => {},
 })
@@ -50,93 +65,113 @@ import { createExtensionsSurface } from '../../packages/adapter-pi/src/extension
 import { resetPiHome } from '../../packages/adapter-pi/src/home'
 
 const extDir = () => join(testDir, 'pi', 'agent', 'extensions')
+const policy = () => (settingsFile.runtime as { settings: Record<string, unknown> }).settings.piExtensions as
+  | { mode?: string; allow?: string[] }
+  | undefined
+const setPolicy = (p: { mode?: string; allow?: string[] } | undefined) => {
+  ;(settingsFile.runtime as { settings: Record<string, unknown> }).settings = p ? { piExtensions: p } : {}
+}
+const runtimeSettings = () => (settingsFile.runtime as { settings: Record<string, unknown> }).settings
 
 beforeEach(() => {
   rmSync(testDir, { recursive: true, force: true })
   mkdirSync(extDir(), { recursive: true })
+  mkdirSync(join(testDir, 'pi', 'agent', 'workspace'), { recursive: true })
   resetPiHome()
-  runtimeSettings = {}
+  settingsFile = { runtime: { adapter: 'pi', settings: {} } }
 })
 
 afterAll(() => {
   rmSync(testDir, { recursive: true, force: true })
 })
 
-function seedExtensions(): void {
-  writeFileSync(join(extDir(), 'weather-tool.ts'), 'export default () => {}')
-  mkdirSync(join(extDir(), 'mcp-bridge'), { recursive: true })
-  writeFileSync(join(extDir(), 'mcp-bridge', 'index.ts'), 'export default () => {}')
-  writeFileSync(join(extDir(), 'notes.d.ts'), '// types only — never an extension')
-  mkdirSync(join(testDir, 'pi', 'agent'), { recursive: true })
-  writeFileSync(join(testDir, 'pi', 'agent', 'settings.json'), JSON.stringify({ packages: ['npm:@ssweens/pi-image-gen'] }))
+function seedExtension(name: string): string {
+  const path = join(extDir(), `${name}.ts`)
+  writeFileSync(path, 'export default () => {}')
+  return path
 }
 
-describe('adapter discovery (inert)', () => {
-  it('enumerates dir entries + npm packages with allowlist-default pending status', async () => {
-    seedExtensions()
-    const surface = createExtensionsSurface(() => runtimeSettings)
-    const list = await surface.list()
-    expect(list.map((e) => e.id).sort()).toEqual(['@ssweens/pi-image-gen', 'mcp-bridge', 'weather-tool'])
-    expect(new Set(list.map((e) => e.status))).toEqual(new Set(['pending'])) // default allowlist-empty
+const surface = () => createExtensionsSurface(() => runtimeSettings())
+
+describe('discovery', () => {
+  it('identifies extensions by their absolute module path, pending under the allowlist default', async () => {
+    const weather = seedExtension('weather-tool')
+    const list = await surface().list()
+    const row = list.find((e) => e.path === weather)!
+    expect(row).toBeTruthy()
+    expect(row.id).toBe(weather) // identity IS the path — never a basename
+    expect(row.status).toBe('pending') // default allowlist-empty
   })
 
-  it('statuses reflect the policy exactly as the loader applies it', async () => {
-    seedExtensions()
-    const surface = createExtensionsSurface(() => runtimeSettings)
+  it('two extensions sharing a basename stay independently trustable', async () => {
+    const a = seedExtension('utils')
+    mkdirSync(join(extDir(), 'nested'), { recursive: true })
+    const b = join(extDir(), 'nested', 'utils.ts')
+    writeFileSync(b, 'export default () => {}')
 
-    runtimeSettings = { piExtensions: { mode: 'allowlist', allow: ['weather-tool'] } }
-    let list = await surface.list()
-    expect(list.find((e) => e.id === 'weather-tool')!.status).toBe('allowed')
-    expect(list.find((e) => e.id === 'mcp-bridge')!.status).toBe('pending')
-
-    runtimeSettings = { piExtensions: { mode: 'none' } }
-    list = await surface.list()
-    expect(new Set(list.map((e) => e.status))).toEqual(new Set(['blocked']))
-
-    runtimeSettings = { piExtensions: { mode: 'all' } }
-    list = await surface.list()
-    expect(new Set(list.map((e) => e.status))).toEqual(new Set(['allowed']))
+    setPolicy({ mode: 'allowlist', allow: [a] })
+    const list = await surface().list()
+    expect(list.find((e) => e.path === a)!.status).toBe('allowed')
+    const nested = list.find((e) => e.path === b)
+    // Discovery may or may not surface a nested file depending on loader
+    // rules — what MUST hold is that approving `a` never trusts `b`.
+    if (nested) expect(nested.status).toBe('pending')
   })
 
-  it('an exact-basename allow entry never over-matches a sibling prefix', async () => {
-    writeFileSync(join(extDir(), 'foo.ts'), '')
-    writeFileSync(join(extDir(), 'foobar.ts'), '')
-    runtimeSettings = { piExtensions: { mode: 'allowlist', allow: ['foo'] } }
-    const surface = createExtensionsSurface(() => runtimeSettings)
-    const list = await surface.list()
-    expect(list.find((e) => e.id === 'foo')!.status).toBe('allowed')
-    expect(list.find((e) => e.id === 'foobar')!.status).toBe('pending')
+  it('status follows the policy mode exactly', async () => {
+    const p = seedExtension('weather-tool')
+
+    setPolicy({ mode: 'none' })
+    expect((await surface().list()).find((e) => e.path === p)!.status).toBe('blocked')
+
+    setPolicy({ mode: 'all' })
+    expect((await surface().list()).find((e) => e.path === p)!.status).toBe('allowed')
+
+    setPolicy({ mode: 'allowlist', allow: [p] })
+    expect((await surface().list()).find((e) => e.path === p)!.status).toBe('allowed')
   })
 })
 
 describe('trust engine (ONE mutation path)', () => {
   async function engine() {
-    const surface = createExtensionsSurface(() => runtimeSettings)
-    ;(globalThis as Record<string, unknown>).__bakinAppServices = { runtime: { extensions: surface } }
+    ;(globalThis as Record<string, unknown>).__bakinAppServices = { runtime: { extensions: surface() } }
     return import('../../src/core/runtime-extensions')
   }
 
-  it('allow persists the exact id and the extension flips to allowed', async () => {
-    seedExtensions()
+  it('allow persists the PATH and never clobbers other settings', async () => {
+    const p = seedExtension('weather-tool')
     const { allowRuntimeExtension } = await engine()
-    const report = await allowRuntimeExtension('weather-tool')
-    expect((runtimeSettings.piExtensions as { allow: string[] }).allow).toEqual(['weather-tool'])
-    expect(report.extensions.find((e) => e.id === 'weather-tool')!.status).toBe('allowed')
+    const report = await allowRuntimeExtension(p)
+
+    expect(policy()!.allow).toEqual([p])
+    expect(report.extensions.find((e) => e.path === p)!.status).toBe('allowed')
+    // The write is a DELTA — the adapter (and any other setting) survives.
+    expect((settingsFile.runtime as { adapter: string }).adapter).toBe('pi')
   })
 
-  it('allow refuses ids discovery does not know — never free-text patterns', async () => {
-    seedExtensions()
+  it('allow refuses anything discovery does not know — never a free-text pattern', async () => {
+    seedExtension('weather-tool')
     const { allowRuntimeExtension } = await engine()
-    await expect(allowRuntimeExtension('totally-made-up')).rejects.toThrow(/Unknown extension/)
+    await expect(allowRuntimeExtension('weather-tool')).rejects.toThrow(/Unknown extension/) // bare name is NOT an id
+    await expect(allowRuntimeExtension('/etc/passwd')).rejects.toThrow(/Unknown extension/)
   })
 
-  it('revoke removes the entry; revoking a non-entry is a typed error', async () => {
-    seedExtensions()
+  it('revoke removes the path; revoking a non-entry is a typed error', async () => {
+    const p = seedExtension('weather-tool')
     const { allowRuntimeExtension, revokeRuntimeExtension } = await engine()
-    await allowRuntimeExtension('weather-tool')
-    const report = await revokeRuntimeExtension('weather-tool')
-    expect(report.extensions.find((e) => e.id === 'weather-tool')!.status).toBe('pending')
-    await expect(revokeRuntimeExtension('weather-tool')).rejects.toThrow(/not in the allowlist/)
+    await allowRuntimeExtension(p)
+    const report = await revokeRuntimeExtension(p)
+    expect(report.extensions.find((e) => e.path === p)!.status).toBe('pending')
+    expect(policy()!.allow).toEqual([])
+    await expect(revokeRuntimeExtension(p)).rejects.toThrow(/not in the allowlist/)
+  })
+
+  it("mode 'all' is honest: allow/revoke refuse rather than pretend the allowlist gates anything", async () => {
+    const p = seedExtension('weather-tool')
+    setPolicy({ mode: 'all' })
+    const { allowRuntimeExtension, revokeRuntimeExtension } = await engine()
+    await expect(allowRuntimeExtension(p)).rejects.toThrow(/policy is "all"/)
+    await expect(revokeRuntimeExtension(p)).rejects.toThrow(/policy is "all"/)
   })
 
   it('reports supported: false honestly when the runtime omits the surface', async () => {

--- a/tests/adapter-pi/extensions-discovery.test.ts
+++ b/tests/adapter-pi/extensions-discovery.test.ts
@@ -194,3 +194,23 @@ describe('trust engine (ONE mutation path)', () => {
     await expect(allowRuntimeExtension('x')).rejects.toThrow(/no extension mechanism/)
   })
 })
+
+describe('policy normalization robustness (untrusted settings shape)', () => {
+  it('an empty/absent hash never matches — fail closed', async () => {
+    const { extensionApproved } = await import('../../packages/adapter-pi/src/messaging')
+    // hashless allow entry (legacy/hand-edit) vs an unreadable file (sha256 '')
+    expect(extensionApproved({ path: '/x', sha256: '' }, [{ path: '/x', sha256: '' }])).toBe(false)
+    // real file vs hashless entry: no match
+    expect(extensionApproved({ path: '/x', sha256: 'abc' }, [{ path: '/x', sha256: '' }])).toBe(false)
+    // matching real hashes: match
+    expect(extensionApproved({ path: '/x', sha256: 'abc' }, [{ path: '/x', sha256: 'abc' }])).toBe(true)
+  })
+
+  it('a malformed allow (non-array / null / missing path) never throws', async () => {
+    const { extensionsPolicy } = await import('../../packages/adapter-pi/src/messaging')
+    expect(extensionsPolicy({ piExtensions: { allow: 'not-an-array' } }).allow).toEqual([])
+    expect(extensionsPolicy({ piExtensions: { allow: [null, 42, { nope: 1 }] } }).allow).toEqual([])
+    expect(extensionsPolicy({ piExtensions: { mode: 'bogus' } }).mode).toBe('allowlist')
+    expect(extensionsPolicy({ piExtensions: { allow: [{ path: '/a', sha256: 'h' }] } }).allow).toEqual([{ path: '/a', sha256: 'h' }])
+  })
+})

--- a/tests/adapter-pi/extensions-discovery.test.ts
+++ b/tests/adapter-pi/extensions-discovery.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Extension trust lane (pi-ecosystem WS4): inert discovery, policy status
+ * honesty, and the ONE trust engine's allow/revoke semantics.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-ext-lane-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = pathJoin(testDir, 'openclaw')
+process.env.PI_HOME = pathJoin(testDir, 'pi')
+
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+mock.module('@/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, bin: join(testDir, 'bin'), db: join(testDir, 'bakin.db') }),
+}))
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => join(testDir, 'openclaw'),
+  getOpenClawPath: (...parts: string[]) => join(testDir, 'openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+mock.module('@/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+// The trust engine reads/writes Bakin settings — fake BOTH module paths
+// (packages/core + the src facade) with a complete-enough surface.
+let runtimeSettings: Record<string, unknown> = {}
+const settingsFake = () => ({
+  getSettings: () => ({ runtime: { adapter: 'pi', settings: runtimeSettings } }),
+  updateSettings: (partial: { runtime?: { settings?: Record<string, unknown> } }) => {
+    runtimeSettings = partial.runtime?.settings ?? runtimeSettings
+  },
+  resetSettingsCache: () => {},
+})
+mock.module('../../packages/core/src/settings', settingsFake)
+mock.module('../../src/core/settings', settingsFake)
+mock.module('@/core/settings', settingsFake)
+
+import { createExtensionsSurface } from '../../packages/adapter-pi/src/extensions'
+import { resetPiHome } from '../../packages/adapter-pi/src/home'
+
+const extDir = () => join(testDir, 'pi', 'agent', 'extensions')
+
+beforeEach(() => {
+  rmSync(testDir, { recursive: true, force: true })
+  mkdirSync(extDir(), { recursive: true })
+  resetPiHome()
+  runtimeSettings = {}
+})
+
+afterAll(() => {
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+function seedExtensions(): void {
+  writeFileSync(join(extDir(), 'weather-tool.ts'), 'export default () => {}')
+  mkdirSync(join(extDir(), 'mcp-bridge'), { recursive: true })
+  writeFileSync(join(extDir(), 'mcp-bridge', 'index.ts'), 'export default () => {}')
+  writeFileSync(join(extDir(), 'notes.d.ts'), '// types only — never an extension')
+  mkdirSync(join(testDir, 'pi', 'agent'), { recursive: true })
+  writeFileSync(join(testDir, 'pi', 'agent', 'settings.json'), JSON.stringify({ packages: ['npm:@ssweens/pi-image-gen'] }))
+}
+
+describe('adapter discovery (inert)', () => {
+  it('enumerates dir entries + npm packages with allowlist-default pending status', async () => {
+    seedExtensions()
+    const surface = createExtensionsSurface(() => runtimeSettings)
+    const list = await surface.list()
+    expect(list.map((e) => e.id).sort()).toEqual(['@ssweens/pi-image-gen', 'mcp-bridge', 'weather-tool'])
+    expect(new Set(list.map((e) => e.status))).toEqual(new Set(['pending'])) // default allowlist-empty
+  })
+
+  it('statuses reflect the policy exactly as the loader applies it', async () => {
+    seedExtensions()
+    const surface = createExtensionsSurface(() => runtimeSettings)
+
+    runtimeSettings = { piExtensions: { mode: 'allowlist', allow: ['weather-tool'] } }
+    let list = await surface.list()
+    expect(list.find((e) => e.id === 'weather-tool')!.status).toBe('allowed')
+    expect(list.find((e) => e.id === 'mcp-bridge')!.status).toBe('pending')
+
+    runtimeSettings = { piExtensions: { mode: 'none' } }
+    list = await surface.list()
+    expect(new Set(list.map((e) => e.status))).toEqual(new Set(['blocked']))
+
+    runtimeSettings = { piExtensions: { mode: 'all' } }
+    list = await surface.list()
+    expect(new Set(list.map((e) => e.status))).toEqual(new Set(['allowed']))
+  })
+
+  it('an exact-basename allow entry never over-matches a sibling prefix', async () => {
+    writeFileSync(join(extDir(), 'foo.ts'), '')
+    writeFileSync(join(extDir(), 'foobar.ts'), '')
+    runtimeSettings = { piExtensions: { mode: 'allowlist', allow: ['foo'] } }
+    const surface = createExtensionsSurface(() => runtimeSettings)
+    const list = await surface.list()
+    expect(list.find((e) => e.id === 'foo')!.status).toBe('allowed')
+    expect(list.find((e) => e.id === 'foobar')!.status).toBe('pending')
+  })
+})
+
+describe('trust engine (ONE mutation path)', () => {
+  async function engine() {
+    const surface = createExtensionsSurface(() => runtimeSettings)
+    ;(globalThis as Record<string, unknown>).__bakinAppServices = { runtime: { extensions: surface } }
+    return import('../../src/core/runtime-extensions')
+  }
+
+  it('allow persists the exact id and the extension flips to allowed', async () => {
+    seedExtensions()
+    const { allowRuntimeExtension } = await engine()
+    const report = await allowRuntimeExtension('weather-tool')
+    expect((runtimeSettings.piExtensions as { allow: string[] }).allow).toEqual(['weather-tool'])
+    expect(report.extensions.find((e) => e.id === 'weather-tool')!.status).toBe('allowed')
+  })
+
+  it('allow refuses ids discovery does not know — never free-text patterns', async () => {
+    seedExtensions()
+    const { allowRuntimeExtension } = await engine()
+    await expect(allowRuntimeExtension('totally-made-up')).rejects.toThrow(/Unknown extension/)
+  })
+
+  it('revoke removes the entry; revoking a non-entry is a typed error', async () => {
+    seedExtensions()
+    const { allowRuntimeExtension, revokeRuntimeExtension } = await engine()
+    await allowRuntimeExtension('weather-tool')
+    const report = await revokeRuntimeExtension('weather-tool')
+    expect(report.extensions.find((e) => e.id === 'weather-tool')!.status).toBe('pending')
+    await expect(revokeRuntimeExtension('weather-tool')).rejects.toThrow(/not in the allowlist/)
+  })
+
+  it('reports supported: false honestly when the runtime omits the surface', async () => {
+    ;(globalThis as Record<string, unknown>).__bakinAppServices = { runtime: {} }
+    const { listRuntimeExtensions, allowRuntimeExtension } = await import('../../src/core/runtime-extensions')
+    const report = await listRuntimeExtensions()
+    expect(report.supported).toBe(false)
+    await expect(allowRuntimeExtension('x')).rejects.toThrow(/no extension mechanism/)
+  })
+})

--- a/tests/adapter-pi/extensions-discovery.test.ts
+++ b/tests/adapter-pi/extensions-discovery.test.ts
@@ -17,7 +17,8 @@ process.env.OPENCLAW_HOME = pathJoin(testDir, 'openclaw')
 process.env.PI_HOME = pathJoin(testDir, 'pi')
 
 import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs'
+import { createHash } from 'crypto'
 import { join } from 'path'
 
 mock.module('@/core/content-dir', () => ({
@@ -66,9 +67,9 @@ import { resetPiHome } from '../../packages/adapter-pi/src/home'
 
 const extDir = () => join(testDir, 'pi', 'agent', 'extensions')
 const policy = () => (settingsFile.runtime as { settings: Record<string, unknown> }).settings.piExtensions as
-  | { mode?: string; allow?: string[] }
+  | { mode?: string; allow?: Array<{ path: string; sha256: string }> }
   | undefined
-const setPolicy = (p: { mode?: string; allow?: string[] } | undefined) => {
+const setPolicy = (p: { mode?: string; allow?: Array<{ path: string; sha256: string }> } | undefined) => {
   ;(settingsFile.runtime as { settings: Record<string, unknown> }).settings = p ? { piExtensions: p } : {}
 }
 const runtimeSettings = () => (settingsFile.runtime as { settings: Record<string, unknown> }).settings
@@ -85,11 +86,13 @@ afterAll(() => {
   rmSync(testDir, { recursive: true, force: true })
 })
 
-function seedExtension(name: string): string {
+function seedExtension(name: string, body = 'export default () => {}'): string {
   const path = join(extDir(), `${name}.ts`)
-  writeFileSync(path, 'export default () => {}')
-  return path
+  writeFileSync(path, body)
+  return realpathSync(path) // discovery reports real paths (symlinks resolved)
 }
+const hashOf = (p: string) => createHash('sha256').update(readFileSync(p)).digest('hex')
+const entry = (p: string) => ({ path: p, sha256: hashOf(p) })
 
 const surface = () => createExtensionsSurface(() => runtimeSettings())
 
@@ -106,16 +109,25 @@ describe('discovery', () => {
   it('two extensions sharing a basename stay independently trustable', async () => {
     const a = seedExtension('utils')
     mkdirSync(join(extDir(), 'nested'), { recursive: true })
-    const b = join(extDir(), 'nested', 'utils.ts')
-    writeFileSync(b, 'export default () => {}')
+    writeFileSync(join(extDir(), 'nested', 'utils.ts'), 'export default () => {}')
+    const b = realpathSync(join(extDir(), 'nested', 'utils.ts'))
 
-    setPolicy({ mode: 'allowlist', allow: [a] })
+    setPolicy({ mode: 'allowlist', allow: [entry(a)] })
     const list = await surface().list()
     expect(list.find((e) => e.path === a)!.status).toBe('allowed')
     const nested = list.find((e) => e.path === b)
     // Discovery may or may not surface a nested file depending on loader
     // rules — what MUST hold is that approving `a` never trusts `b`.
     if (nested) expect(nested.status).toBe('pending')
+  })
+
+  it('a content change after approval reverts the file to pending (not silently trusted)', async () => {
+    const p = seedExtension('mutable', 'export default () => { /* v1 */ }')
+    setPolicy({ mode: 'allowlist', allow: [entry(p)] })
+    expect((await surface().list()).find((e) => e.path === p)!.status).toBe('allowed')
+    // Swap the bytes — the stored hash no longer matches.
+    writeFileSync(p, 'export default () => { /* EVIL v2 */ }')
+    expect((await surface().list()).find((e) => e.path === p)!.status).toBe('pending')
   })
 
   it('status follows the policy mode exactly', async () => {
@@ -127,7 +139,7 @@ describe('discovery', () => {
     setPolicy({ mode: 'all' })
     expect((await surface().list()).find((e) => e.path === p)!.status).toBe('allowed')
 
-    setPolicy({ mode: 'allowlist', allow: [p] })
+    setPolicy({ mode: 'allowlist', allow: [entry(p)] })
     expect((await surface().list()).find((e) => e.path === p)!.status).toBe('allowed')
   })
 })
@@ -143,7 +155,7 @@ describe('trust engine (ONE mutation path)', () => {
     const { allowRuntimeExtension } = await engine()
     const report = await allowRuntimeExtension(p)
 
-    expect(policy()!.allow).toEqual([p])
+    expect(policy()!.allow).toEqual([entry(p)])
     expect(report.extensions.find((e) => e.path === p)!.status).toBe('allowed')
     // The write is a DELTA — the adapter (and any other setting) survives.
     expect((settingsFile.runtime as { adapter: string }).adapter).toBe('pi')

--- a/tests/adapter-pi/unsupported-health.test.ts
+++ b/tests/adapter-pi/unsupported-health.test.ts
@@ -80,7 +80,7 @@ describe('honest-empty surfaces', () => {
 describe('health checks', () => {
   test('all green on a healthy fixture home', async () => {
     const checks = adapter.getHealthChecks()
-    expect(checks.length).toBe(2)
+    expect(checks.length).toBe(3) // pi.home, pi.auth, pi.extensions (WS4)
     const results = (await Promise.all(checks.map((c) => c.run()))).flat()
     expect(results.every((r) => r.status === 'ok')).toBe(true)
   })

--- a/tests/architecture/adapter-boundary.test.ts
+++ b/tests/architecture/adapter-boundary.test.ts
@@ -40,7 +40,7 @@ const DENYLIST = [
     // non-null assertion — ban `.channels!.` / `.cron!.` so a consumer can
     // never turn "absent on this runtime" into a crash.
     label: 'non-null assertion on an optional runtime capability (feature-detect instead)',
-    regex: /\.(?:channels|cron)!\./,
+    regex: /\.(?:channels|cron|extensions)!\./,
   },
   {
     label: 'raw Pi home/path/SDK access outside adapter-pi',

--- a/tests/components/runtime-hub.test.tsx
+++ b/tests/components/runtime-hub.test.tsx
@@ -260,3 +260,47 @@ describe('RuntimesTab', () => {
     await waitFor(() => expect(posts).toEqual([{ target: 'openclaw' }]))
   })
 })
+
+describe('ExtensionsSection', () => {
+  const report = (status: 'pending' | 'allowed') => ({
+    supported: true,
+    mode: 'allowlist',
+    extensions: [{ id: 'pi-image-gen', label: 'pi-image-gen', source: 'npm package', path: 'pi-image-gen', status }],
+  })
+
+  it('renders nothing when the runtime has no extension mechanism', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({ supported: false, mode: 'allowlist', extensions: [] }), { status: 200 })) as unknown as typeof fetch
+    const { ExtensionsSection } = await import('../../packages/host/src/components/runtime/extensions-section')
+    render(<ExtensionsSection />)
+    await settleReact()
+    expect(screen.queryByTestId('runtime-extensions')).toBeNull()
+  })
+
+  it('approve is ConfirmDialog-gated with the trust + spend disclosure, and flips to Allowed', async () => {
+    const posts: Array<{ url: string; body: unknown }> = []
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === 'POST') {
+        posts.push({ url, body: JSON.parse(String(init.body)) })
+        return new Response(JSON.stringify(report('allowed')), { status: 200 })
+      }
+      return new Response(JSON.stringify(report('pending')), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const { ExtensionsSection } = await import('../../packages/host/src/components/runtime/extensions-section')
+    render(<ExtensionsSection />)
+    await waitFor(() => screen.getByTestId('ext-allow-pi-image-gen'))
+    expect(screen.getByText('Awaiting approval')).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('ext-allow-pi-image-gen'))
+    await settleReact()
+    // Nothing posted before confirm; disclosure present in the dialog.
+    expect(posts).toEqual([])
+    expect(screen.getByText(/full system permissions/i)).toBeTruthy()
+    expect(screen.getByText(/OUTSIDE Bakin's budget caps/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('ext-confirm'))
+    await waitFor(() => screen.getByText('Allowed'))
+    expect(posts).toEqual([{ url: expect.stringContaining('/api/runtime/extensions/allow'), body: { id: 'pi-image-gen' } }])
+  })
+})

--- a/tests/components/runtime-hub.test.tsx
+++ b/tests/components/runtime-hub.test.tsx
@@ -262,10 +262,12 @@ describe('RuntimesTab', () => {
 })
 
 describe('ExtensionsSection', () => {
+  const EXT_PATH = '/home/u/.pi/agent/node_modules/pi-image-gen/index.js'
   const report = (status: 'pending' | 'allowed') => ({
     supported: true,
     mode: 'allowlist',
-    extensions: [{ id: 'pi-image-gen', label: 'pi-image-gen', source: 'npm package', path: 'pi-image-gen', status }],
+    // id === path: trust names exactly one module.
+    extensions: [{ id: EXT_PATH, label: 'npm:pi-image-gen', source: 'npm package', path: EXT_PATH, status }],
   })
 
   it('renders nothing when the runtime has no extension mechanism', async () => {
@@ -289,10 +291,10 @@ describe('ExtensionsSection', () => {
 
     const { ExtensionsSection } = await import('../../packages/host/src/components/runtime/extensions-section')
     render(<ExtensionsSection />)
-    await waitFor(() => screen.getByTestId('ext-allow-pi-image-gen'))
+    await waitFor(() => screen.getByTestId('ext-allow-npm:pi-image-gen'))
     expect(screen.getByText('Awaiting approval')).toBeTruthy()
 
-    fireEvent.click(screen.getByTestId('ext-allow-pi-image-gen'))
+    fireEvent.click(screen.getByTestId('ext-allow-npm:pi-image-gen'))
     await settleReact()
     // Nothing posted before confirm; disclosure present in the dialog.
     expect(posts).toEqual([])
@@ -301,6 +303,6 @@ describe('ExtensionsSection', () => {
 
     fireEvent.click(screen.getByTestId('ext-confirm'))
     await waitFor(() => screen.getByText('Allowed'))
-    expect(posts).toEqual([{ url: expect.stringContaining('/api/runtime/extensions/allow'), body: { id: 'pi-image-gen' } }])
+    expect(posts).toEqual([{ url: expect.stringContaining('/api/runtime/extensions/allow'), body: { id: EXT_PATH } }])
   })
 })

--- a/tests/components/runtime-hub.test.tsx
+++ b/tests/components/runtime-hub.test.tsx
@@ -267,7 +267,15 @@ describe('ExtensionsSection', () => {
     supported: true,
     mode: 'allowlist',
     // id === path: trust names exactly one module.
-    extensions: [{ id: EXT_PATH, label: 'npm:pi-image-gen', source: 'npm package', path: EXT_PATH, status }],
+    extensions: [{ id: EXT_PATH, label: 'npm:pi-image-gen', source: 'npm package', path: EXT_PATH, sha256: 'a'.repeat(64), status }],
+  })
+
+  it('shows an error state (not a hidden section) when discovery fails', async () => {
+    globalThis.fetch = (async () => new Response('boom', { status: 500 })) as unknown as typeof fetch
+    const { ExtensionsSection } = await import('../../packages/host/src/components/runtime/extensions-section')
+    render(<ExtensionsSection />)
+    await waitFor(() => screen.getByTestId('runtime-extensions-error'))
+    expect(screen.getByText(/Couldn't load extensions/i)).toBeTruthy()
   })
 
   it('renders nothing when the runtime has no extension mechanism', async () => {

--- a/tests/core/onboarding-adapter-gating.test.ts
+++ b/tests/core/onboarding-adapter-gating.test.ts
@@ -51,7 +51,9 @@ describe('onboarding adapter gating', () => {
     // Generic components still genuinely ran (mkdir reports on real temp home).
     const mkdir = results.find((r) => r.name === 'mkdir')
     expect(mkdir?.message ?? '').not.toContain('not applicable')
-  })
+    // Real components under full-suite CPU contention overrun the default
+    // 15s occasionally (#650 class) — generous wall clock, same assertions.
+  }, 45_000)
 
   test("checkAll on adapter 'openclaw' does NOT skip them", async () => {
     adapterName = 'openclaw'

--- a/tests/integration/pi/extension-package-install-exec.test.ts
+++ b/tests/integration/pi/extension-package-install-exec.test.ts
@@ -1,0 +1,158 @@
+/**
+ * SECURITY REGRESSION (prove-it) — the Pi extension trust lane gates which
+ * extension MODULES are imported, but it does NOT gate the SDK package
+ * manager's install side effect. Every turn builds a DefaultResourceLoader
+ * and calls `reload()`, which calls `packageManager.resolve()` with NO
+ * `onMissing` handler. For any `packages[]` entry (npm/git) that isn't already
+ * installed, that path runs a REAL install — `npm install <spec>`, whose
+ * postinstall lifecycle scripts are arbitrary code. This fires:
+ *   - in EVERY policy mode, including `none` (maximum lockdown) and the
+ *     default empty `allowlist` — `noExtensions` only filters loaded
+ *     extension PATHS, never the resolver's install side effect;
+ *   - from Pi's user-scope settings (PI_HOME/agent/settings.json); AND
+ *   - from the AGENT-WRITABLE workspace project settings
+ *     (<workspace>/.pi/settings.json), because the per-turn SettingsManager is
+ *     built with `projectTrusted: true`. That last one needs no human, no
+ *     approval, and no allowlist entry: an agent that can write a file in its
+ *     own workspace can trigger install-time code execution inside the Bakin
+ *     server process, bypassing the extension allowlist entirely.
+ *
+ * The existing sentinel pin (extensions.test.ts) only proves unapproved
+ * extension MODULES aren't imported; it never exercises package resolution, so
+ * it does not catch this. Here a fake `npmCommand` is a stand-in for the
+ * install exec: if it writes its sentinel, the install path ran (real npm
+ * would additionally execute the package's postinstall scripts).
+ *
+ * EXPECTED TO FAIL on the current adapter. The fix is to run the per-turn
+ * package resolution in a no-install / offline posture (e.g. set PI_OFFLINE
+ * for the turn, or resolve with an onMissing:'skip'-equivalent), so a missing
+ * package is skipped instead of installed. When that lands, these assertions
+ * (no install exec) pass.
+ */
+import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { existsSync, mkdirSync, rmSync, writeFileSync, chmodSync } from 'fs'
+import { randomUUID } from 'crypto'
+
+globalThis.fetch = (Bun as unknown as { fetch: typeof fetch }).fetch
+
+const testDir = join(tmpdir(), `bakin-test-pi-ext-install-${Date.now()}-${randomUUID()}`)
+process.env.PI_HOME = join(testDir, 'pi')
+process.env.BAKIN_HOME = join(testDir, 'bakin')
+
+const contentDirMock = () => ({
+  getContentDir: () => join(testDir, 'bakin'),
+  getBakinPaths: () => ({ home: join(testDir, 'bakin'), db: join(testDir, 'bakin', 'bakin.db') }),
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}))
+
+import { createPiRuntimeAdapter } from '../../../packages/adapter-pi/src/index'
+import { resetPiHome } from '../../../packages/adapter-pi/src/home'
+import { resetModelRegistry } from '../../../packages/adapter-pi/src/models'
+import { startFakeProvider, type FakeProvider } from './fake-provider'
+
+const agentSettingsPath = join(testDir, 'pi', 'agent', 'settings.json')
+const workspacePiDir = join(testDir, 'pi', 'agent', 'agents', 'main', 'workspace', '.pi')
+
+/** A fake package manager binary: it just records that it was invoked. */
+function installSentinelScript(sentinel: string): string {
+  const path = join(testDir, `fake-npm-${randomUUID()}.sh`)
+  writeFileSync(path, `#!/bin/sh\necho ran >> ${JSON.stringify(sentinel)}\nexit 0\n`)
+  chmodSync(path, 0o755)
+  return path
+}
+
+let provider: FakeProvider
+function seedProvider(): FakeProvider {
+  provider?.stop()
+  provider = startFakeProvider([{ steps: [{ text: 'ok' }] }])
+  writeFileSync(join(testDir, 'pi', 'agent', 'models.json'), JSON.stringify({
+    providers: {
+      fakeai: { name: 'F', baseUrl: provider.url, api: 'openai-completions', models: [{ id: 'fake-model', name: 'FM', input: ['text'], reasoning: false, contextWindow: 100000, maxTokens: 8000, cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } }] },
+    },
+  }))
+  resetModelRegistry()
+  return provider
+}
+
+async function adapterWithPolicy(policy: Record<string, unknown>) {
+  const adapter = createPiRuntimeAdapter()
+  await adapter.initialize({
+    contentDir: join(testDir, 'bakin'),
+    settings: { retry: { enabled: false }, piExtensions: policy },
+  })
+  await adapter.provisionToolAccess()
+  await adapter.agents.update('main', { model: 'fakeai/fake-model' })
+  return adapter
+}
+
+beforeAll(() => {
+  resetPiHome()
+  mkdirSync(join(testDir, 'pi', 'agent'), { recursive: true })
+  writeFileSync(join(testDir, 'pi', 'agent', 'auth.json'), JSON.stringify({ fakeai: { type: 'api_key', key: 'k' } }))
+})
+
+afterAll(() => {
+  provider?.stop()
+  rmSync(testDir, { recursive: true, force: true })
+})
+
+describe('pi extension trust lane — package install exec must be gated', () => {
+  test("mode 'none': a configured-but-missing user package must NOT be installed during a turn", async () => {
+    const sentinel = join(testDir, 'SENTINEL-user-none')
+    rmSync(sentinel, { force: true })
+    writeFileSync(agentSettingsPath, JSON.stringify({
+      packages: ['npm:@redteam/definitely-not-installed@1.0.0'],
+      npmCommand: [installSentinelScript(sentinel)],
+    }))
+    const fake = seedProvider()
+    const adapter = await adapterWithPolicy({ mode: 'none' })
+    await adapter.messaging.send({ agentId: 'main', content: 'go' })
+    writeFileSync(agentSettingsPath, JSON.stringify({}))
+
+    expect(fake.requests.length).toBeGreaterThan(0) // the turn actually ran
+    // The extension allowlist claims nothing loads in 'none' — but the package
+    // resolver still runs the install. That is arbitrary code execution the
+    // trust lane never authorized.
+    expect(existsSync(sentinel)).toBe(false)
+  })
+
+  test("default 'allowlist' (empty): a configured-but-missing user package must NOT be installed", async () => {
+    const sentinel = join(testDir, 'SENTINEL-user-allowlist')
+    rmSync(sentinel, { force: true })
+    writeFileSync(agentSettingsPath, JSON.stringify({
+      packages: ['npm:@redteam/definitely-not-installed@2.0.0'],
+      npmCommand: [installSentinelScript(sentinel)],
+    }))
+    seedProvider()
+    const adapter = await adapterWithPolicy({ mode: 'allowlist', allow: [] })
+    await adapter.messaging.send({ agentId: 'main', content: 'go' })
+    writeFileSync(agentSettingsPath, JSON.stringify({}))
+
+    expect(existsSync(sentinel)).toBe(false)
+  })
+
+  test('AGENT-WRITABLE workspace project package must NOT be installed during a turn', async () => {
+    const sentinel = join(testDir, 'SENTINEL-project-agent')
+    rmSync(sentinel, { force: true })
+    // The agent authors its OWN workspace/.pi/settings.json (the turn's cwd).
+    mkdirSync(workspacePiDir, { recursive: true })
+    writeFileSync(join(workspacePiDir, 'settings.json'), JSON.stringify({
+      packages: ['npm:@redteam/agent-authored@3.0.0'],
+      npmCommand: [installSentinelScript(sentinel)],
+    }))
+    seedProvider()
+    const adapter = await adapterWithPolicy({ mode: 'none' })
+    await adapter.messaging.send({ agentId: 'main', content: 'go' })
+    rmSync(join(workspacePiDir, 'settings.json'), { force: true })
+
+    // No human, no approval, no allowlist entry — self-service install exec
+    // from inside an agent turn. This is the sharpest form of the hole.
+    expect(existsSync(sentinel)).toBe(false)
+  })
+})

--- a/tests/integration/pi/extensions.test.ts
+++ b/tests/integration/pi/extensions.test.ts
@@ -90,12 +90,19 @@ afterAll(() => {
 })
 
 describe('pi extension policy', () => {
-  test("default ('all'): extension tool is live and callable; broken extension is contained", async () => {
+  test("DEFAULT ('allowlist', empty): discovered extensions stay INERT until approved (WS4 flip)", async () => {
+    const fake = seedProvider([{ steps: [{ text: 'no ext by default' }] }])
+    const adapter = await adapterWithPolicy(undefined)
+    await adapter.messaging.send({ agentId: 'main', content: 'plain' })
+    expect(requestToolNames(fake.requests[0])).not.toContain('ext_fixture_echo')
+  })
+
+  test("'all': extension tool is live and callable; broken extension is contained", async () => {
     const fake = seedProvider([
       { steps: [{ toolCall: { name: 'ext_fixture_echo', args: { word: 'hello' } } }] },
       { steps: [{ text: 'ext round trip done' }] },
     ])
-    const adapter = await adapterWithPolicy(undefined)
+    const adapter = await adapterWithPolicy({ mode: 'all' })
     const result = await adapter.messaging.send({ agentId: 'main', content: 'use the ext tool' })
     expect(result.content).toBe('ext round trip done')
     expect(requestToolNames(fake.requests[0])).toContain('ext_fixture_echo')

--- a/tests/integration/pi/extensions.test.ts
+++ b/tests/integration/pi/extensions.test.ts
@@ -7,7 +7,8 @@
 import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs'
+import { createHash } from 'crypto'
 import { randomUUID } from 'crypto'
 
 globalThis.fetch = (Bun as unknown as { fetch: typeof fetch }).fetch
@@ -30,6 +31,8 @@ import { createPiRuntimeAdapter } from '../../../packages/adapter-pi/src/index'
 import { resetPiHome } from '../../../packages/adapter-pi/src/home'
 import { resetModelRegistry } from '../../../packages/adapter-pi/src/models'
 import { startFakeProvider, type FakeProvider, type FakeTurnScript } from './fake-provider'
+
+const allowEntry = (p: string) => ({ path: realpathSync(p), sha256: createHash('sha256').update(readFileSync(p)).digest('hex') })
 
 const FIXTURE_EXTENSION = `
 export default function (pi) {
@@ -118,11 +121,12 @@ describe('pi extension policy', () => {
     // allowlist mode with ONLY the fixture approved — side-effect.ts is pending.
     const adapter = await adapterWithPolicy({
       mode: 'allowlist',
-      allow: [join(testDir, 'pi', 'agent', 'extensions', 'bakin-fixture.ts')],
+      allow: [allowEntry(join(testDir, 'pi', 'agent', 'extensions', 'bakin-fixture.ts'))],
     })
     await adapter.messaging.send({ agentId: 'main', content: 'go' })
 
-    // The approved extension loaded…
+    // POSITIVE CONTROL: the APPROVED extension genuinely loaded — proving the
+    // loader actually ran and the negative assertions below aren't vacuous.
     expect(requestToolNames(fake.requests[0])).toContain('ext_fixture_echo')
     // …and the unapproved one's TOOLS are absent — necessary but NOT sufficient:
     expect(requestToolNames(fake.requests[0])).not.toContain('ext_sideeffect_noop')
@@ -159,11 +163,25 @@ describe('pi extension policy', () => {
     expect(requestToolNames(fake.requests[0])).not.toContain('ext_fixture_echo')
   })
 
+  test('a file SWAPPED after approval does not load its new code (content-hash pin)', async () => {
+    rmSync(SENTINEL, { force: true })
+    const swap = join(testDir, 'pi', 'agent', 'extensions', 'swap.ts')
+    writeFileSync(swap, 'export default function(){}\n') // benign v1
+    const approved = allowEntry(swap) // approve v1's exact bytes
+    // Now an attacker overwrites the approved file with the sentinel-writer.
+    writeFileSync(swap, SIDE_EFFECT_EXTENSION)
+    const fake = seedProvider([{ steps: [{ text: 'x' }] }])
+    const adapter = await adapterWithPolicy({ mode: 'allowlist', allow: [approved] })
+    await adapter.messaging.send({ agentId: 'main', content: 'go' })
+    // The stored hash is v1's; the on-disk file is v2 → not loaded, no import.
+    expect(existsSync(SENTINEL)).toBe(false)
+  })
+
   test("'allowlist': the approved PATH loads; a bare name or wrong path does not", async () => {
     const fixture = join(testDir, 'pi', 'agent', 'extensions', 'bakin-fixture.ts')
     const fake = seedProvider([{ steps: [{ text: 'a' }] }, { steps: [{ text: 'b' }] }, { steps: [{ text: 'c' }] }])
 
-    const allowed = await adapterWithPolicy({ mode: 'allowlist', allow: [fixture] })
+    const allowed = await adapterWithPolicy({ mode: 'allowlist', allow: [allowEntry(fixture)] })
     await allowed.messaging.send({ agentId: 'main', content: 'x' })
     expect(requestToolNames(fake.requests[0])).toContain('ext_fixture_echo')
 
@@ -172,7 +190,7 @@ describe('pi extension policy', () => {
     await byName.messaging.send({ agentId: 'main', content: 'y' })
     expect(requestToolNames(fake.requests[1])).not.toContain('ext_fixture_echo')
 
-    const denied = await adapterWithPolicy({ mode: 'allowlist', allow: [join(testDir, 'nope.ts')] })
+    const denied = await adapterWithPolicy({ mode: 'allowlist', allow: [{ path: join(testDir, 'nope.ts'), sha256: 'x'.repeat(64) }] })
     await denied.messaging.send({ agentId: 'main', content: 'z' })
     expect(requestToolNames(fake.requests[2])).not.toContain('ext_fixture_echo')
   })

--- a/tests/integration/pi/extensions.test.ts
+++ b/tests/integration/pi/extensions.test.ts
@@ -7,7 +7,7 @@
 import { describe, test, expect, beforeAll, afterAll, mock } from 'bun:test'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { mkdirSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs'
 import { randomUUID } from 'crypto'
 
 globalThis.fetch = (Bun as unknown as { fetch: typeof fetch }).fetch
@@ -41,6 +41,27 @@ export default function (pi) {
     async execute(_id, params) {
       return { content: [{ type: 'text', text: 'ext says ' + params.word }], details: undefined }
     },
+  })
+}
+`
+
+/**
+ * The security fixture: its module TOP LEVEL writes a sentinel. If the loader
+ * imports it, the file exists — proving whether unapproved code ran, which no
+ * tool-list assertion can show (a post-load filter hides tools but the module
+ * already executed).
+ */
+const SENTINEL = join(testDir, 'UNAPPROVED-CODE-RAN')
+const SIDE_EFFECT_EXTENSION = `
+import { writeFileSync } from 'fs'
+writeFileSync(${JSON.stringify(SENTINEL)}, 'imported')
+export default function (pi) {
+  pi.registerTool({
+    name: 'ext_sideeffect_noop',
+    label: 'ext_sideeffect_noop',
+    description: 'never approved',
+    parameters: { type: 'object', properties: {} },
+    async execute() { return { content: [], details: undefined } },
   })
 }
 `
@@ -81,6 +102,7 @@ beforeAll(() => {
   mkdirSync(extDir, { recursive: true })
   writeFileSync(join(extDir, 'bakin-fixture.ts'), FIXTURE_EXTENSION)
   writeFileSync(join(extDir, 'broken.ts'), 'throw new Error("broken extension on purpose")\n')
+  writeFileSync(join(extDir, 'side-effect.ts'), SIDE_EFFECT_EXTENSION)
   writeFileSync(join(testDir, 'pi', 'agent', 'auth.json'), JSON.stringify({ fakeai: { type: 'api_key', key: 'k' } }))
 })
 
@@ -90,11 +112,31 @@ afterAll(() => {
 })
 
 describe('pi extension policy', () => {
+  test('THE SECURITY PROMISE: an unapproved extension is never IMPORTED — its module code never runs', async () => {
+    rmSync(SENTINEL, { force: true })
+    const fake = seedProvider([{ steps: [{ text: 'plain' }] }])
+    // allowlist mode with ONLY the fixture approved — side-effect.ts is pending.
+    const adapter = await adapterWithPolicy({
+      mode: 'allowlist',
+      allow: [join(testDir, 'pi', 'agent', 'extensions', 'bakin-fixture.ts')],
+    })
+    await adapter.messaging.send({ agentId: 'main', content: 'go' })
+
+    // The approved extension loaded…
+    expect(requestToolNames(fake.requests[0])).toContain('ext_fixture_echo')
+    // …and the unapproved one's TOOLS are absent — necessary but NOT sufficient:
+    expect(requestToolNames(fake.requests[0])).not.toContain('ext_sideeffect_noop')
+    // …and, the point: its module was never imported, so its code never ran.
+    expect(existsSync(SENTINEL)).toBe(false)
+  })
+
   test("DEFAULT ('allowlist', empty): discovered extensions stay INERT until approved (WS4 flip)", async () => {
+    rmSync(SENTINEL, { force: true })
     const fake = seedProvider([{ steps: [{ text: 'no ext by default' }] }])
     const adapter = await adapterWithPolicy(undefined)
     await adapter.messaging.send({ agentId: 'main', content: 'plain' })
     expect(requestToolNames(fake.requests[0])).not.toContain('ext_fixture_echo')
+    expect(existsSync(SENTINEL)).toBe(false) // nothing imported at all
   })
 
   test("'all': extension tool is live and callable; broken extension is contained", async () => {
@@ -117,14 +159,21 @@ describe('pi extension policy', () => {
     expect(requestToolNames(fake.requests[0])).not.toContain('ext_fixture_echo')
   })
 
-  test("'allowlist': matching pattern loads, non-matching drops", async () => {
-    const fake = seedProvider([{ steps: [{ text: 'a' }] }, { steps: [{ text: 'b' }] }])
-    const allowed = await adapterWithPolicy({ mode: 'allowlist', allow: ['bakin-fixture'] })
+  test("'allowlist': the approved PATH loads; a bare name or wrong path does not", async () => {
+    const fixture = join(testDir, 'pi', 'agent', 'extensions', 'bakin-fixture.ts')
+    const fake = seedProvider([{ steps: [{ text: 'a' }] }, { steps: [{ text: 'b' }] }, { steps: [{ text: 'c' }] }])
+
+    const allowed = await adapterWithPolicy({ mode: 'allowlist', allow: [fixture] })
     await allowed.messaging.send({ agentId: 'main', content: 'x' })
     expect(requestToolNames(fake.requests[0])).toContain('ext_fixture_echo')
 
-    const denied = await adapterWithPolicy({ mode: 'allowlist', allow: ['something-else'] })
-    await denied.messaging.send({ agentId: 'main', content: 'y' })
+    // A basename is NOT trust — identity is the path (no pattern matching).
+    const byName = await adapterWithPolicy({ mode: 'allowlist', allow: ['bakin-fixture'] })
+    await byName.messaging.send({ agentId: 'main', content: 'y' })
     expect(requestToolNames(fake.requests[1])).not.toContain('ext_fixture_echo')
+
+    const denied = await adapterWithPolicy({ mode: 'allowlist', allow: [join(testDir, 'nope.ts')] })
+    await denied.messaging.send({ agentId: 'main', content: 'z' })
+    expect(requestToolNames(fake.requests[2])).not.toContain('ext_fixture_echo')
   })
 })


### PR DESCRIPTION
## WS4 of the pi-ecosystem initiative — closes #670 and #626

Pi's extension ecosystem now works in Bakin turns, behind an honest one-click trust gate.

### What a user gets
Everything installed for Pi (`pi install npm:…`, git packages, files in the extensions dir) appears on **/runtime → Runtimes → Extensions**, **inert until approved**. Approve in one click (ConfirmDialog with the real disclosure: trusted code in the Bakin server, full permissions, its API spend is outside Bakin's budget caps) and agents have it on the next turn — no restart. The doctor warns about anything pending. CLI parity: `bakin runtime extensions list|allow <name>|revoke <name>`.

**Default flipped `all` → `allowlist`**: extensions no longer load silently. That's the point of the feature.

### The review caught the lane's core promise being false
`extensionsOverride` is a **post-load** filter — the SDK jiti-imports every enabled extension *before* it runs, so a "pending" extension's module code executed on every turn (network, fs, key access); only its tools were hidden.

**Fixed with a true pre-load gate:** `noExtensions` suppresses the discovered set entirely, and only approved absolute paths come back through `additionalExtensionPaths` — unapproved modules are never imported. Pinned by a sentinel-writing fixture extension; the test **fails against the old filter** (verified by reverting).

Two more real defects fixed in the same pass:
- **Trust identity is now the absolute module path.** The old name-matching predicate over-matched (an approved `utils` admitted *any* unapproved extension with a colliding basename — a deliberate bypass an attacker could pick) and under-matched (git-installed packages never loaded while every surface said "Allowed").
- **Discovery now asks the SDK's package manager** (paths only — no imports, installs, or network), which sees npm/git packages, object-form `packages[]` entries, loose files and both scopes — classes the hand-rolled scanner missed and would have silently disabled with no approval path.

Plus: the settings write is a minimal delta (it was persisting the `BAKIN_RUNTIME_ADAPTER` env override into settings.json), and allow/revoke refuse honestly under `mode: 'all'`.

### Architecture
Optional `extensions?: RuntimeExtensionsAccess` contract member (feature-detected; `.extensions!.` arch-banned; OpenClaw/mock omit it). ONE audited trust engine (`src/core/runtime-extensions.ts`) behind REST, CLI, hub, and doctor. Adapters gained a live-settings getter so trust changes apply next turn without a restart.

Verified live on 3737 end-to-end (pending → allow by name → allowed → revoke), full suite green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)