### PR TITLE
fix(plugins): silence audit-feed noise — missing manifest permissions + empty-agent capability probe

### DIFF
--- a/plugins/brands/bakin-plugin.json
+++ b/plugins/brands/bakin-plugin.json
@@ -13,7 +13,8 @@
     "tasks.read",
     "tasks.write",
     "assets.read",
-    "assets.write"
+    "assets.write",
+    "search.write"
   ],
   "contributes": {
     "apiRoutes": [

--- a/plugins/chat/bakin-plugin.json
+++ b/plugins/chat/bakin-plugin.json
@@ -13,7 +13,8 @@
     "events.emit",
     "runtime.read",
     "runtime.agents",
-    "runtime.messaging"
+    "runtime.messaging",
+    "search.write"
   ],
   "contributes": {
     "apiRoutes": [

--- a/plugins/chat/components/use-chat-data.ts
+++ b/plugins/chat/components/use-chat-data.ts
@@ -148,6 +148,8 @@ const imageInputCache = new Map<string, boolean>()
 export function useAgentImageInput(agentId: string): boolean {
   const [enabled, setEnabled] = useState(imageInputCache.get(agentId) ?? false)
   useEffect(() => {
+    // Empty while the chat summary loads — the probe re-runs with the real id.
+    if (!agentId) return
     const cached = imageInputCache.get(agentId)
     if (cached !== undefined) {
       setEnabled(cached)

--- a/plugins/models/bakin-plugin.json
+++ b/plugins/models/bakin-plugin.json
@@ -25,6 +25,7 @@
     "storage.write",
     "events.emit",
     "runtime.read",
+    "runtime.agents",
     "runtime.models"
   ],
   "contributes": {


### PR DESCRIPTION
## Summary

Two classes of noise showed up in the Live Activity feed on every boot / chat-view mount:

**`plugin.permission_missing` (warn-mode, every server start)**
- `brands` and `chat` call `ctx.search.registerFileBackedContentType` during activation but didn't declare `search.write` — added to both manifests
- `models` calls `ctx.runtime.agents.list` but didn't declare `runtime.agents` — added

**`rest.chat.get.fail` (every chat-view mount before data loads)**
- `chat-view.tsx` passes `chat?.agentId ?? ''` while the chat summary loads, so `useAgentImageInput('')` fired `GET /capabilities?agent=`, which fails zod validation (`agent: z.string().min(1)`) → 400 → audit fail event. The hook now skips the probe while the agent id is empty; the effect re-runs with the real id once the summary arrives, so behavior is unchanged.

## Testing

- `bun run test tests/plugins/manifest-drift.test.tsx tests/plugins/chat tests/plugins/brands tests/plugins/models` — 318 pass, 0 fail
- Verified live: both event types traced to these sources via `~/.bakin/audit.jsonl` + `~/.bakin/logs/server.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)