### PR TITLE
fix(doctor): catch the SendFailed wedge variant + un-mute stale/archived escalation covers

### DIFF
--- a/packages/adapter-antfly/src/engine-status.ts
+++ b/packages/adapter-antfly/src/engine-status.ts
@@ -36,11 +36,25 @@ const WEDGE_MIN_OCCURRENCES = 3
 /** Never read more than this much log per probe (a flooding engine). */
 const MAX_TAIL_BYTES = 512 * 1024
 
-/** Known engine wedge signatures (each line = one loop iteration). */
-const WEDGE_PATTERNS: ReadonlyArray<{ signal: string; pattern: RegExp }> = [
+/**
+ * Known engine wedge signatures (each line = one loop iteration). A pattern
+ * may override the occurrence floor: signatures that also appear in benign
+ * bursts (a client dropping mid-restart emits a handful of SendFailed
+ * lines) need a floor only a sustained loop can reach within one ~30-min
+ * doctor window.
+ */
+const WEDGE_PATTERNS: ReadonlyArray<{ signal: string; pattern: RegExp; minOccurrences?: number }> = [
   // The startup catch-up loop re-opening/closing a table group forever
   // ("provisioned startup catch-up debt persists", one line per ~2s spin).
   { signal: 'startup-catchup-spin', pattern: /catch-up debt persists/g },
+  // The 2026-07-14 lock-contention wedge: the engine spammed
+  // "Connection error: error.SendFailed" for a day with NO catch-up-debt
+  // lines, so the watchdog saw only high CPU and never escalated. A few
+  // lines are a normal disconnect; a storm is a wedged I/O loop.
+  { signal: 'connection-send-failed-storm', pattern: /error\.SendFailed/g, minOccurrences: 50 },
+  // Same incident: route handlers repeatedly failing with TableReadChurn
+  // while the engine still answered health probes.
+  { signal: 'table-read-churn', pattern: /error\.TableReadChurn/g, minOccurrences: 10 },
 ]
 
 interface ProbeState {
@@ -102,9 +116,9 @@ export function scanLogDelta(
     return { signals: [], nextOffset: prevOffset }
   }
   const delta = buffer.toString('utf-8')
-  const signals = WEDGE_PATTERNS.filter(({ pattern }) => {
+  const signals = WEDGE_PATTERNS.filter(({ pattern, minOccurrences }) => {
     const count = delta.match(pattern)?.length ?? 0
-    return count >= WEDGE_MIN_OCCURRENCES
+    return count >= (minOccurrences ?? WEDGE_MIN_OCCURRENCES)
   }).map(({ signal }) => signal)
   return { signals, nextOffset: size }
 }

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -222,8 +222,9 @@ export interface BakinSettings {
     /**
      * What the PERIODIC doctor does when a cycle produces ERROR findings:
      * 'task' creates ONE deduplicated delegated-repair task for the main
-     * agent (skipped while a covering repair task is open, and rate-limited
-     * by escalationCooldownMs); 'notify' messages the main agent; 'off'
+     * agent (skipped while a covering repair task is open and younger than
+     * escalationStaleAfterMs, and rate-limited by escalationCooldownMs);
+     * 'notify' messages the main agent; 'off'
      * keeps the old dashboard-only behavior. Manual `bakin doctor` runs are
      * never affected. Both agent-facing modes cost an agent turn and ride
      * the normal budget gates.
@@ -231,6 +232,14 @@ export interface BakinSettings {
     escalation: 'off' | 'notify' | 'task'
     /** Minimum gap before re-escalating the SAME error set as a new task. */
     escalationCooldownMs: number
+    /**
+     * How long an OPEN covering repair task suppresses re-escalation. The
+     * 2026-07-14 search wedge sat behind one stalled repair task for 34h
+     * because an open task muted escalation forever; past this age, a
+     * still-failing error set escalates a fresh task even though the old
+     * one is open.
+     */
+    escalationStaleAfterMs: number
   }
   diagnostics: {
     startup: {
@@ -387,6 +396,7 @@ export const DEFAULT_SETTINGS: BakinSettings = {
     requireOnboard: true,
     escalation: 'task',
     escalationCooldownMs: 6 * 60 * 60 * 1000, // 6 hours
+    escalationStaleAfterMs: 12 * 60 * 60 * 1000, // 12 hours
   },
   diagnostics: {
     startup: {

--- a/src/core/doctor-escalation.ts
+++ b/src/core/doctor-escalation.ts
@@ -107,7 +107,11 @@ export async function escalateCronErrors(
       const ageMs = Date.now() - Date.parse(request.createdAt)
       if (request.taskId) {
         const details = await getTaskDetails(request.taskId).catch(() => null)
-        if (details && details.column !== 'done') {
+        // 'done' AND 'archived' are closed — the 2026-07-14 incident's three
+        // covering tasks were all ARCHIVED, and `!== 'done'` read each one
+        // as an open cover, muting escalation indefinitely.
+        const open = details !== null && details.column !== 'done' && details.column !== 'archived'
+        if (open) {
           if (ageMs < escalationStaleAfterMs) {
             log.info('escalation skipped — an open repair task already covers the current errors', {
               taskId: request.taskId,

--- a/src/core/doctor-escalation.ts
+++ b/src/core/doctor-escalation.ts
@@ -11,9 +11,11 @@
  *               existing `bakin doctor --delegate` flow: durable request,
  *               board-visible task, dispatch kick, budget-gated like any
  *               task). Deduplicated: skipped while an open repair task
- *               already covers every current error check, and rate-limited
- *               by escalationCooldownMs so a persistent error never spawns
- *               a task per cycle.
+ *               already covers every current error check (until that task
+ *               is older than escalationStaleAfterMs — a stalled repair
+ *               task must not mute a still-burning error forever), and
+ *               rate-limited by escalationCooldownMs so a persistent error
+ *               never spawns a task per cycle.
  *  - 'notify' → messages the main agent (the --notify-agent path).
  *  - 'off'    → old behavior.
  *
@@ -77,7 +79,7 @@ export async function escalateCronErrors(
   contentDir: string,
   projectRoot: string,
 ): Promise<void> {
-  const { escalation, escalationCooldownMs } = getSettings().doctor
+  const { escalation, escalationCooldownMs, escalationStaleAfterMs } = getSettings().doctor
   if (escalation === 'off') return
   const errors = results.filter((row) => row.status === 'error')
   if (errors.length === 0) return
@@ -91,30 +93,48 @@ export async function escalateCronErrors(
       return
     }
 
-    // 'task': ONE open repair task per persisting error set.
+    // 'task': ONE open repair task per persisting error set. An open
+    // covering task suppresses re-escalation only while it is FRESH —
+    // the 2026-07-14 wedge hid behind one stalled repair task for 34h
+    // because this suppression had no expiry.
     const errorChecks = [...new Set(errors.map((row) => row.check))]
     const { listDoctorRepairRequests } = await import('./doctor-repair-store')
     const { getTaskDetails } = await import('./task-service')
+    let staleCoveringTaskId: string | null = null
     for (const request of listDoctorRepairRequests(contentDir)) {
       const covered = new Set(request.unresolved.map((row) => row.check))
       if (!errorChecks.every((check) => covered.has(check))) continue
+      const ageMs = Date.now() - Date.parse(request.createdAt)
       if (request.taskId) {
         const details = await getTaskDetails(request.taskId).catch(() => null)
         if (details && details.column !== 'done') {
-          log.info('escalation skipped — an open repair task already covers the current errors', {
-            taskId: request.taskId,
-            checks: errorChecks,
-          })
-          return
+          if (ageMs < escalationStaleAfterMs) {
+            log.info('escalation skipped — an open repair task already covers the current errors', {
+              taskId: request.taskId,
+              checks: errorChecks,
+            })
+            return
+          }
+          // Stale open cover: the errors outlived the task meant to fix
+          // them. Keep scanning — a fresher covering request still wins.
+          staleCoveringTaskId = request.taskId
+          continue
         }
       }
-      if (Date.now() - Date.parse(request.createdAt) < escalationCooldownMs) {
+      if (ageMs < escalationCooldownMs) {
         log.info('escalation skipped — same error set escalated inside the cooldown window', {
           requestId: request.id,
           checks: errorChecks,
         })
         return
       }
+    }
+    if (staleCoveringTaskId) {
+      log.warn('covering repair task is stale — re-escalating despite it being open', {
+        taskId: staleCoveringTaskId,
+        staleAfterMs: escalationStaleAfterMs,
+        checks: errorChecks,
+      })
     }
 
     const { delegateDoctorRepair } = await import('./doctor-delegate')

--- a/tests/adapter-antfly/engine-status.test.ts
+++ b/tests/adapter-antfly/engine-status.test.ts
@@ -83,6 +83,35 @@ describe('scanLogDelta', () => {
     expect(after.signals).toEqual([])
   })
 
+  it('SendFailed fires only as a STORM — a benign disconnect burst stays quiet', () => {
+    const file = logFile('sendfailed.log')
+    writeFileSync(file, 'boot ok\n')
+    const base = scanLogDelta(file, null)
+
+    // A client dropping mid-restart: a handful of lines, not a wedge.
+    appendFileSync(file, 'Connection error: error.SendFailed\n'.repeat(10))
+    const burst = scanLogDelta(file, base.nextOffset)
+    expect(burst.signals).toEqual([])
+
+    // The 2026-07-14 wedge shape: sustained spam within one window.
+    appendFileSync(file, 'Connection error: error.SendFailed\n'.repeat(60))
+    const storm = scanLogDelta(file, burst.nextOffset)
+    expect(storm.signals).toEqual(['connection-send-failed-storm'])
+  })
+
+  it('TableReadChurn fires past its floor', () => {
+    const file = logFile('readchurn.log')
+    writeFileSync(file, 'boot ok\n')
+    const base = scanLogDelta(file, null)
+
+    appendFileSync(file, 'Route handler error: error.TableReadChurn\n'.repeat(3))
+    expect(scanLogDelta(file, base.nextOffset).signals).toEqual([])
+
+    appendFileSync(file, 'Route handler error: error.TableReadChurn\n'.repeat(12))
+    const churn = scanLogDelta(file, base.nextOffset)
+    expect(churn.signals).toEqual(['table-read-churn'])
+  })
+
   it('handles rotation (file shrank) without throwing or double-firing history', () => {
     const file = logFile('rotated.log')
     writeFileSync(file, 'x'.repeat(10_000))

--- a/tests/core/doctor-escalation.test.ts
+++ b/tests/core/doctor-escalation.test.ts
@@ -25,6 +25,7 @@ mock.module('../../packages/core/src/logger', loggerMock)
 // Mutable fixtures
 let escalationMode: 'off' | 'notify' | 'task' = 'task'
 let cooldownMs = 6 * 60 * 60 * 1000
+let staleAfterMs = 12 * 60 * 60 * 1000
 let repairRequests: Array<{
   id: string
   createdAt: string
@@ -34,7 +35,7 @@ let repairRequests: Array<{
 let openTaskColumns: Record<string, string> = {}
 
 mock.module('../../src/core/settings', () => ({
-  getSettings: () => ({ doctor: { escalation: escalationMode, escalationCooldownMs: cooldownMs } }),
+  getSettings: () => ({ doctor: { escalation: escalationMode, escalationCooldownMs: cooldownMs, escalationStaleAfterMs: staleAfterMs } }),
 }))
 mock.module('../../src/core/doctor-repair-store', () => ({
   listDoctorRepairRequests: () => repairRequests,
@@ -66,6 +67,7 @@ afterAll(() => {
 beforeEach(() => {
   escalationMode = 'task'
   cooldownMs = 6 * 60 * 60 * 1000
+  staleAfterMs = 12 * 60 * 60 * 1000
   repairRequests = []
   openTaskColumns = {}
   delegateDoctorRepair.mockClear()
@@ -94,14 +96,46 @@ describe('escalateCronErrors', () => {
     expect(delegateDoctorRepair).not.toHaveBeenCalled()
   })
 
-  it('skips while an OPEN repair task already covers every current error check', async () => {
+  it('skips while a FRESH open repair task already covers every current error check', async () => {
     repairRequests = [{
       id: 'repair-1',
-      createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // cooldown long past
+      createdAt: new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(), // cooldown past, not yet stale
       taskId: 'task-1',
       unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
     }]
     openTaskColumns = { 'task-1': 'doing' }
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).not.toHaveBeenCalled()
+  })
+
+  it('re-escalates when the covering task is STALE — open past escalationStaleAfterMs with the error still burning', async () => {
+    repairRequests = [{
+      id: 'repair-1',
+      createdAt: new Date(Date.now() - 34 * 60 * 60 * 1000).toISOString(), // the 2026-07-14 incident shape
+      taskId: 'task-1',
+      unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+    }]
+    openTaskColumns = { 'task-1': 'doing' }
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
+  })
+
+  it('a fresher covering request still suppresses even when an older stale one exists', async () => {
+    repairRequests = [
+      {
+        id: 'repair-old',
+        createdAt: new Date(Date.now() - 34 * 60 * 60 * 1000).toISOString(),
+        taskId: 'task-old',
+        unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+      },
+      {
+        id: 'repair-new',
+        createdAt: new Date(Date.now() - 60_000).toISOString(), // the re-escalation from last cycle
+        taskId: 'task-new',
+        unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+      },
+    ]
+    openTaskColumns = { 'task-old': 'doing', 'task-new': 'todo' }
     await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
     expect(delegateDoctorRepair).not.toHaveBeenCalled()
   })

--- a/tests/core/doctor-escalation.test.ts
+++ b/tests/core/doctor-escalation.test.ts
@@ -108,6 +108,18 @@ describe('escalateCronErrors', () => {
     expect(delegateDoctorRepair).not.toHaveBeenCalled()
   })
 
+  it('an ARCHIVED covering task is closed, not an open cover (the 2026-07-14 mute)', async () => {
+    repairRequests = [{
+      id: 'repair-1',
+      createdAt: new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(), // cooldown past, would suppress if open
+      taskId: 'task-1',
+      unresolved: [{ check: 'search-canary', status: 'error', message: 'dark' }],
+    }]
+    openTaskColumns = { 'task-1': 'archived' }
+    await escalateCronErrors([errorRow('search-canary')], testDir, testDir)
+    expect(delegateDoctorRepair).toHaveBeenCalledTimes(1)
+  })
+
   it('re-escalates when the covering task is STALE — open past escalationStaleAfterMs with the error still burning', async () => {
     repairRequests = [{
       id: 'repair-1',


### PR DESCRIPTION
## Summary

The 2026-07-14 search-dark incident (antfly engine wedged ~24h at ~278% CPU while answering health probes) exposed three blind spots in the #659 supervision net. All three are fixed here:

- **New wedge signatures.** The engine spammed `Connection error: error.SendFailed` / `error.TableReadChurn` with **zero** `catch-up debt persists` lines, so `search-engine-burn`'s log scan saw only high CPU and never escalated. `WEDGE_PATTERNS` now supports per-pattern occurrence floors and detects both: SendFailed at ≥50 lines/window (a benign disconnect burst of a few lines stays quiet), TableReadChurn at ≥10.
- **Archived covering tasks muted escalation forever.** The dedupe's `column !== 'done'` treated the three ARCHIVED repair tasks as open covers — every doctor cycle logged "an open repair task already covers the current errors" and did nothing, for ~34h. Archived now counts as closed.
- **Open covers now expire.** Even a genuinely open covering task stops suppressing once older than `settings.doctor.escalationStaleAfterMs` (default 12h) while the error set persists — a fresh task is escalated, which then suppresses normally (one new task per stale window, never one per cycle).

Upstream note: antfly#350 (the catch-up spin itself) was fixed on their main today via antflydb/antfly#335 (zero-progress quarantine + scheduler parking), but no release tag contains it yet — a daily routine now watches for the next tag. This PR is the Bakin-side net for whatever the next novel wedge signature is.

## Testing

- `bun test tests/adapter-antfly/engine-status.test.ts tests/core/doctor-escalation.test.ts` — new cases: SendFailed storm vs benign burst, TableReadChurn floor, archived-cover mute (the incident shape), 34h-stale open cover re-escalates, fresher cover still suppresses past a stale one
- Full doctor/health/antfly slice: 236 pass across 22 files
- `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)