### PR TITLE
fix(schedule): harden scheduling foundation (PR1 of #191 initiative)

### DIFF
--- a/.claude/knowledge/bakin-owned-scheduler.md
+++ b/.claude/knowledge/bakin-owned-scheduler.md
@@ -39,6 +39,12 @@ Skips are **visible**: every `skipFire()` in `runClaimedFire` (overlap / paused 
 
 `schedule-cutover` doctor check (`lib/health-checks.ts`): flags any Bakin schedule still backed by an OpenClaw cron job (incomplete cutover → rogue-fire risk). Its repair runs the same idempotent `migrateBakinSchedulesOffOpenClawCron`. It's a plugin-registered health check, so it's surfaced by `bakin doctor --full` and completed by `bakin doctor --fix` (NOT `bakin check`, which only routes the fixed onboarding checks). The cutover also runs automatically on every `activate()`, so this is the explicit verify/repair path for when OpenClaw was unreachable at boot.
 
+`schedule-sync` doctor check (same file, registered since PR1 of the #191 hardening): flags native runtime cron jobs that aren't tracked in the schedule sidecar (e.g. created by an agent directly in the runtime). Detection is read-only; the repair records `requireTriage: true` sidecar entries only — it NEVER writes runtime cron state, which is what got the legacy sync check removed (double-fire risk). Cron-less runtimes (Pi) get an unconditional OK with no repair surface. The registration guard test in `tests/plugins/schedule/health-checks.test.ts` pins this invariant.
+
+## Retention (cron_fires is bounded)
+
+`pruneCronFires` (ledger verb, `packages/core/src/execution/ledger.ts`) bounds fire history: settled rows (`created`/`skipped`/`seeded`) older than **30 days** are pruned, always keeping the **newest 20 per job**; `pending` rows are untouchable (live claims the healer may consume) and nothing newer than `max(catchUpWindowMinutes, 7 days)` is ever deleted, so re-claims inside the dedup horizon still collide with their original row (test-pinned: `tests/core/ledger-retention.test.ts`). The scheduler loop sweeps at most once per 24h (`maybeRunRetentionSweep` in `scheduler-loop.ts`, in-memory cadence cell — restarts re-sweep, idempotent); sweeps that pruned rows emit a `schedule.retention_swept` audit event — history deletion is never silent.
+
 ## Prompt danger-zone guard
 
 `lib/prompt-guard.ts` (`checkSchedulePrompt`): flags a schedule prompt that tells the agent to keep a single large message and not split near the channel transport limit (~2000 chars) — the shape that caused "Invalid Form Body" + split/repair loops. Surfaced live in the job form and returned as `warnings` from create/update routes + exec tools.
@@ -70,3 +76,28 @@ hook (`plugins/schedule/lib/cron-adoption.ts`) turns each into a Bakin job —
 `source: 'adopted'`, `originalRuntimeCron` snapshot preserved, idempotent
 per job id, dry-run previewable. Mirrors the per-job REST adopt handler
 minus live cron calls (the source runtime is already gone).
+
+**Adopted jobs keep their native timezone.** Adapters hoist the provider
+schedule tz into `CronJob.metadata.tz`; both adoption paths prefer it
+(`nativeCronTz` in `schedule-util.ts`) over `getSystemTimezone()` — before
+this fix an evening job adopted on a UTC-configured box silently shifted
+hours.
+
+## Hardening pins (PR1 of #191, 2026-07-15)
+
+- **Switch survival:** `tests/integration/schedule-switch-survival.test.ts`
+  runs real `switchRuntime` both directions over temp homes and proves
+  schedules keep firing exactly once per occurrence (sidecar + ledger are
+  runtime-independent), and that `--adopt-cron` yields a firing Bakin job.
+- **Cron conformance:** the runtime-conformance suite pins the optional
+  `cron` member — presence-by-declaration (`cron: 'present' | 'absent'`
+  suite option; openclaw present, pi + minimal mock absent) and a CRUD
+  round-trip run against the REAL OpenClaw adapter over the crab CLI shim.
+  `mockCron()` is stateful (Map-backed) and honors the same contract.
+  Teeth fixtures prove every new branch bites.
+- **Deliberate stances (audited, unchanged):** no retry on the OpenClaw
+  cron CLI surface (non-idempotent ops; degrade path is honest), cron stays
+  out of `CapabilitySet` (member presence IS the contract), `--adopt-cron`
+  stays opt-in. Note: current OpenClaw builds route `cron list` through the
+  gateway (credentials required) — CRUD is NOT guaranteed gateway-free;
+  `readMergedJobs` degrading to store-owned schedules covers that failure.

--- a/.claude/knowledge/runtime-capabilities.md
+++ b/.claude/knowledge/runtime-capabilities.md
@@ -28,6 +28,10 @@ Rules of the model:
   are omitted by runtimes without them (Pi omits both). Consumers
   feature-detect (`runtime.channels?.…`); an arch rule bans `.channels!.` /
   `.cron!.` in production code (`tests/architecture/adapter-boundary.test.ts`).
+  Since PR1 of #191 the conformance suite pins the cron side: each runner
+  declares `cron: 'present' | 'absent'` and a CRUD round-trip runs against
+  any adapter exposing the member (openclaw via the crab CLI shim — the real
+  CLI/file-store path). Absence must be member omission, never a stub.
 
 ## Tool access — one renderer, adapter-owned provisioning
 

--- a/.claude/specs/dual-runtime-dev-rig.md
+++ b/.claude/specs/dual-runtime-dev-rig.md
@@ -1,0 +1,254 @@
+# SPEC — Dual-runtime dev rig (`instance`): audit, Pi support, full-fidelity parity
+
+Status: DRAFT — awaiting approval
+Date: 2026-07-11
+Owner: Mark Hayden (single-user machine; no backwards compatibility, no shims)
+Process: /agent-skills:spec → /agent-skills:plan → /agent-skills:build → /agent-skills:test
+
+## 1. Objective
+
+The dockerized dev rig (`bun run instance …`) becomes a **dual-runtime, full-fidelity**
+dev environment: one command provisions a disposable instance running either the
+**OpenClaw** runtime (gateway in Docker, as today) or the **Pi** runtime (in-process,
+throwaway `PI_HOME`), pre-configured end-to-end — and every core capability that works
+in production works in the rig: dispatch, **asset creation from agent turns**, search
+indexing, images, hot reload.
+
+Grounding facts (verified in-code during the spec interview):
+
+- Pi has **no daemon** — it is an SDK loaded inside Bakin's process. "Pi in the rig"
+  means a throwaway `PI_HOME` wherever Bakin runs (host for native/isolated, container
+  for sandbox). Nothing to containerize separately. Accepted consequence: host-mode Pi
+  agents execute tools on the Mac inside dev-scoped workspaces; sandbox mode is the
+  in-container-execution option.
+- The runtime adapter is chosen ONLY by `settings.runtime.adapter`
+  (`packages/core/src/settings.ts`, default `openclaw`). No env override exists today.
+- `bakin_exec_assets_save` (`plugins/assets/lib/exec-tools.ts`) takes an absolute
+  `filePath` read host-side. In native/isolated modes agents write inside the container
+  (`/home/node/.openclaw/workspace/…`) — host-unreadable as-written, but the openclaw
+  home is bind-mounted at `dev/openclaw-home/`, so a prefix translation closes the gap.
+  (Known limitation documented in the rig knowledge doc, now `.claude/knowledge/dev-rig.md`.)
+- **Live hazard (must fix):** antfly's `detectServiceMode` defaults to `launchd` on
+  macOS; the LaunchAgent label (`io.bakin.antfly`) and port (3738) are singletons, and
+  the unit file is a byte-compared fingerprint of `getBakinPaths()`. A rig home that
+  reaches `ensureProvisioned` **rewrites the real LaunchAgent to point at the dev
+  home**. **Verified already fired on this machine (2026-07-11):** the live
+  `io.bakin.antfly` unit's `--data-dir` points at
+  `dev/bakin-instances/isolated/home/antfly` — a past isolated-mode boot hijacked the
+  machine-global service. The rig sets no search env today.
+- The pinned Pi SDK (`@earendil-works/pi-coding-agent@0.80.3`, dep of
+  `packages/adapter-pi`) ships the `pi` CLI (`bin: pi → dist/cli.js`); its own home
+  override is `PI_CODING_AGENT_DIR` (Bakin's adapter uses `PI_HOME`). There is no
+  `~/.pi` and no `pi` on PATH on this machine — fresh login is the only seeding path.
+- `ANTFLY_HOME` env override exists for the engine binary/models root; the machine-wide
+  binary under `~/.antfly/bin` can be shared read-only by rig children (data dirs stay
+  per-instance).
+
+## 2. Decisions (interview record, 2026-07-11)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Pi scope | `--runtime openclaw\|pi` flag on **all three modes** (default `openclaw`; current behavior unchanged). native/isolated + pi: Bakin on host, throwaway `PI_HOME` under `dev/`, **no docker services started**. sandbox + pi: Bakin + Pi inside the container. |
+| D2 | Pi shape | Host Pi for hot-reload dev + sandbox option for in-container execution. No attempt to remote Pi out of process. |
+| D3 | Adapter selection | New `BAKIN_RUNTIME_ADAPTER` env override in settings resolution (same family as `BAKIN_HOME`/`OPENCLAW_HOME`/`PI_HOME`). Rig passes it per-invocation; real `~/.bakin/settings.json` is never written. Throwaway homes (isolated/sandbox) additionally get `runtime.adapter` written into their own settings.json so the home is self-consistent. |
+| D4 | Pi auth | Interactive auth during `instance up --runtime pi`; skipped when already authed; wiped by `reset`. No stored secrets, no auth.json synthesis. Mirrors the existing Codex OAuth flow. **Corrected during planning:** the pinned SDK has NO `pi login` subcommand — the rig spawns the interactive `pi` TUI (`PI_CODING_AGENT_DIR=$PI_HOME/agent`) where the user runs `/login`; success is verified by re-checking `auth.json` exists after the TUI exits. |
+| D5 | Asset-save gap | Fix via env-configured path-prefix translation honored by `bakin_exec_assets_save` (rig sets container-home → host-mount mapping). Exact knob shape decided in plan; generic (no "openclaw"/"docker" in the name), documented, inert when unset. |
+| D6 | Search | **Working search in every mode.** Isolated: rig-managed antfly child on an alternate port (e.g. 3739) sharing the machine-wide binary read-only; throwaway home's antfly URL points at it → guest mode → adapter never provisions/spawns (zero production-code risk). Sandbox: child mode in-container on 3738 (Linux, no systemd → auto). Native: real antfly as today. **In no path may a rig home render/write/restart the real launchd/systemd unit.** |
+| D7 | Verification | Full live E2E on **both** runtimes (user does `pi login` once; existing OpenClaw home reused — no fresh Codex OAuth), plus the automated suite. |
+
+## 3. Scope
+
+### 3.1 Rig audit (find what else is broken/missing)
+
+A systematic sweep of every production capability under each (mode × runtime) cell,
+run BEFORE building — findings feed the plan as concrete tasks. Sweep list:
+
+dispatch + recovery ladder, asset save/import/enrichment, image generation (codex path
+per runtime), search indexing + rebuild + ⌘K, usage recording/usage.db, execution
+ledger, budget gates, chat plugin, memory plugin (tier indexing), doctor checks,
+agent packages install/sync, onboarding components against throwaway homes
+(especially: which components touch **machine-global** state — the search LaunchAgent
+hazard is the known instance of this class; find any others, e.g. `~/.antfly`
+downloads, plugin-assets, notifications), `instance status/env/run/shell` correctness
+per cell, reset scoping (all new state dirs must land in `dev/` reset targets).
+
+### 3.2 Pi runtime support
+
+- `--runtime openclaw|pi` in `args.ts` (validated; default `openclaw`); plan matrix in
+  `modes.ts` extended to (mode × runtime).
+- Pi paths in `paths.ts`: per-mode pi homes under `dev/` (host modes vs sandbox must
+  NOT share one pi home — host/container path strings diverge in registry/sessions);
+  all added to `resetTargets`.
+- `up --runtime pi` (native/isolated): no docker, no `op` preflight, no compose. Ensure
+  pi home dirs, run `pi login` if unauthed, write/patch throwaway settings (isolated),
+  print env.
+- `up --runtime pi --mode sandbox`: container with repo mount + bun + pi home mount;
+  main process must not depend on OpenClaw config (compose service shape decided in
+  plan); `pi login` exec'd into the container.
+- `dev/run/shell/env/status` honor the runtime: correct env set
+  (`BAKIN_RUNTIME_ADAPTER`, `PI_HOME`; no `OPENCLAW_*` for pi), correct health checks
+  (gateway health only for openclaw; pi auth presence for pi).
+- Runtime combinations coexist in one instance's state (separate dirs); switching =
+  `up --runtime <other>` then `dev --runtime <other>`. `reset` wipes both.
+
+### 3.3 Core changes (production code, all small + documented)
+
+- `BAKIN_RUNTIME_ADAPTER` override in settings resolution (D3).
+- Path-translation knob for `bakin_exec_assets_save` (D5).
+- Whatever the audit (3.1) surfaces as *production-side* gaps — each gets its own
+  decision in the plan; nothing lands unexamined.
+
+### 3.4 Search in the rig (D6)
+
+- Rig-managed antfly child for isolated mode (spawn/stop with instance lifecycle,
+  alt port, data under `dev/bakin-instances/…`, binary from `~/.antfly/bin` /
+  `ANTFLY_HOME`).
+- Sandbox: engine binary availability in-container + child mode; decided in plan
+  (macOS vs Linux binaries differ, so likely in-container install via
+  `bakin install search`).
+- Guard against the LaunchAgent clobber: rig homes must be structurally unable to
+  provision OS units (guest-mode URL and/or explicit service-mode env), plus a
+  regression test pinning it.
+- **Remediate the existing clobber on this machine:** re-provision `io.bakin.antfly`
+  back to the real `~/.bakin` paths (and verify the isolated instance gets its own
+  rig-managed child instead). Sequence this so the running isolated dev server isn't
+  yanked mid-session.
+
+### 3.5 Docs (required, per kickoff)
+
+- `.claude/knowledge/dockerized-openclaw-rig.md` → rewritten as the dual-runtime rig
+  reference (rename to `dev-rig.md`; update all inbound repo references — CLAUDE.md,
+  `repo-architecture.md`, skills that cite it).
+- `dev/docker/README.md` — user-facing walkthrough for both runtimes.
+- `CLAUDE.md` — the rig bullets under "OpenClaw Home Directory" + Pi adapter live-ops
+  notes.
+- `.claude/knowledge/pi-adapter.md` — add rig dev-loop section.
+- `.claude/knowledge/assets-versioning.md` + `search-system.md` where the D5/D6 knobs
+  touch their contracts.
+- `README.md` / `CONTRIBUTING.md` — only if they reference the rig (check during build).
+
+### 3.6 Out of scope
+
+- Remote-Pi transport / Pi daemonization (does not exist upstream).
+- Discord/channels for Pi (adapter degradation matrix is by design — the chat plugin
+  is the conversational surface).
+- Changing production runtime-switch (`bakin runtime use`) or onboarding flows beyond
+  what the audit proves broken for rig homes.
+- Multi-machine/CI generalization of the rig (single-user machine).
+
+## 4. Commands (target surface)
+
+```
+bun run instance up     [--mode native|isolated|sandbox] [--runtime openclaw|pi] [--fresh] [--source repo|installed] [--preconfigure]
+bun run instance dev    [--mode …] [--runtime …]      # host modes; onboards if needed; hot reload
+bun run instance run    [--mode …] [--runtime …] -- <bakin args>
+bun run instance shell  [--mode …] [--runtime …]
+bun run instance status | env [--mode …] [--runtime …]
+bun run instance down
+bun run instance reset  [--mode …]                    # wipes ALL runtime state for the mode
+```
+
+Existing invocations (`instance up`, `instance dev --mode isolated`, …) behave exactly
+as today — `--runtime` defaults to `openclaw`.
+
+## 5. Acceptance criteria
+
+Per cell of the support matrix (native, isolated, sandbox) × (openclaw, pi):
+
+1. `up` from clean state completes with at most the documented interactive steps
+   (Codex OAuth on fresh openclaw; `pi login` on fresh pi) and is idempotent on re-run.
+2. `dev` (host modes) boots Bakin with the selected adapter (verified via
+   `/api/runtime` or doctor), hot reload intact.
+3. A dispatched task completes a real turn; the agent writes a deliverable file and
+   `bakin_exec_assets_save` lands a **real versioned asset** (the container-path case
+   included) — verified live per D7.
+4. Search: the saved asset is indexed and findable via `/api/search` in every mode;
+   the real `io.bakin.antfly` LaunchAgent unit file is byte-identical before/after
+   any isolated/sandbox lifecycle (regression-tested + verified live).
+5. `reset` returns the instance to clean state without touching `~/.bakin`,
+   `~/.openclaw`, `~/.pi`, `~/.antfly` contents, or any launchd/systemd unit.
+6. Full suite (`bun run test`) green; new units for the args/modes/paths matrix, path
+   translation, adapter env override, rig-antfly lifecycle, LaunchAgent guard.
+7. All docs in 3.5 updated; no doc refers to the rig as OpenClaw-only.
+
+## 6. Project structure (files expected to change)
+
+```
+scripts/instance.ts                     verb handling per runtime
+scripts/instance/{args,modes,paths}.ts  (mode × runtime) matrix
+scripts/instance/lifecycle.ts           runtime-conditional up/reset; pi login step
+scripts/instance/pi-*.ts (new)          pi home prep + login argv builders
+scripts/instance/antfly-*.ts (new)      rig-managed antfly child (isolated)
+dev/docker/docker-compose.yml           sandbox-pi shape (plan decides exact form)
+packages/core/src/settings.ts (+ facade) BAKIN_RUNTIME_ADAPTER override
+plugins/assets/lib/exec-tools.ts        path translation at the save boundary
+tests/dev/** + tests/core/**            new coverage (tests/dev runs in CI only —
+                                        run `bun test tests/dev/` explicitly, per memory)
+docs per 3.5
+```
+
+## 7. Code style & conventions
+
+Repo conventions apply unchanged (CLAUDE.md): strict TS, zod at boundaries, pure
+argv-builder modules with injected deps (the rig's existing pattern — keep it),
+kebab-case files, conventional commits with scope (`feat(instance): …`,
+`fix(assets): …`). Rig modules stay exempt from provider-boundary rules
+(`tests/architecture/adapter-boundary.test.ts` per-rule list) — extend the exemption
+list for new `scripts/instance/*` files as needed, never weaken the rule itself.
+
+## 8. Testing strategy
+
+- **Unit (bulk of coverage):** args/modes/paths matrix exhaustively (every mode ×
+  runtime × flag combo); lifecycle ordering via injected deps (no Docker needed);
+  path-translation pure function; settings env override; antfly-child argv/lifecycle
+  builders; LaunchAgent guard (rig-produced settings can never yield a provisionable
+  service config).
+- **Integration:** settings override honored through the `createAppServices` boot path
+  (temp homes, BOTH content-dir resolver mocks per CLAUDE.md testing rules); assets
+  save with a translated prefix writing a real asset into a temp content dir.
+- **Live E2E (D7, user-assisted):** the acceptance-criteria matrix run for real on
+  this machine, both runtimes; evidence captured in the task/PR notes. OpenClaw side
+  additionally re-runs `scripts/instance/validate.ts` (campaign unchanged).
+- Every new test follows the CRITICAL testing rules (temp dirs, both content-dir
+  mocks, env vars before imports, `--isolate`).
+
+## 9. Boundaries
+
+**Always:**
+- Keep all instance state under gitignored `dev/`; `reset` targets only there.
+- Keep secrets flowing only through the existing op:// resolution; redact in logs.
+- Keep production behavior identical when the new env knobs are unset.
+- Update `.claude/knowledge/` alongside code in the same commit arc.
+
+**Ask first:**
+- Any additional production-code change the audit surfaces beyond D3/D5/D6 guards.
+- Any new stored secret or credential-copying behavior.
+- Bumping the pinned OpenClaw image tag or Pi SDK version.
+
+**Never:**
+- Write to real `~/.bakin`, `~/.openclaw`, `~/.pi`, or OS service units from rig code
+  paths (native mode's read/onboard of `~/.bakin` in `instance dev` stays the one
+  documented exception, unchanged).
+- Encode provider identifiers upstream of adapter boundaries outside the rig exemption.
+- Add parallel spend/usage/stat systems (existing single-engine rules).
+
+## 10. Commit strategy (checkpoints — detailed sequencing in PLAN)
+
+Work lands on a feature branch as an ordered arc of conventional commits, each
+independently green and revertable:
+
+1. `docs(specs)` — this spec + archived predecessor (`tasks/gate-discord/SPEC.md`).
+2. `feat(core)` — `BAKIN_RUNTIME_ADAPTER` override + tests (inert alone).
+3. `feat(assets)` — path-translation knob + tests (inert alone).
+4. `feat(instance)` — args/modes/paths (mode × runtime) matrix + unit tests (lifecycle
+   still openclaw-only; flag parses + plans correctly).
+5. `feat(instance)` — pi lifecycle (home prep, login, dev/run/shell env) — Pi host
+   modes usable end-to-end.
+6. `feat(instance)` — sandbox-pi (compose + exec paths).
+7. `feat(instance)` — rig-managed antfly child + LaunchAgent guard + tests.
+8. `fix(…)` — per-audit-finding fixes, one commit each.
+9. `docs(…)` — knowledge/README/CLAUDE.md sweep (folded per-arc where a change is
+   doc-coupled).
+
+Rollback points: after 2/3 (core knobs only), after 5 (Pi host dev usable), after 7
+(full matrix). Nothing merges with a red suite.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,254 +1,228 @@
-# SPEC — Dual-runtime dev rig (`instance`): audit, Pi support, full-fidelity parity
+# Spec: Scheduled Tasks Hardening + Plugin-Contributed Scheduled Domain Events (#191)
 
-Status: DRAFT — awaiting approval
-Date: 2026-07-11
-Owner: Mark Hayden (single-user machine; no backwards compatibility, no shims)
-Process: /agent-skills:spec → /agent-skills:plan → /agent-skills:build → /agent-skills:test
+> Issue: https://github.com/markhayden/bakin/issues/191
+> Status: DRAFT — awaiting approval
+> Date: 2026-07-14
+> Owner: Mark Hayden (single-user machine; no backwards compatibility, no shims)
 
-## 1. Objective
+## Objective
 
-The dockerized dev rig (`bun run instance …`) becomes a **dual-runtime, full-fidelity**
-dev environment: one command provisions a disposable instance running either the
-**OpenClaw** runtime (gateway in Docker, as today) or the **Pi** runtime (in-process,
-throwaway `PI_HOME`), pre-configured end-to-end — and every core capability that works
-in production works in the rig: dispatch, **asset creation from agent turns**, search
-indexing, images, hot reload.
+Make scheduled recurring **and one-shot** tasks rock solid — surviving runtime switches and long uptimes on a single runtime — then extend Schedule into the single calendar surface for everything time-shaped in Bakin: cron jobs, one-shot schedules, and read-only **scheduled domain events** contributed by any plugin (in-tree or external) through a typed SDK contract.
 
-Grounding facts (verified in-code during the spec interview):
+**User:** the single operator of this Bakin install (plus external plugin authors who adopt the contract).
 
-- Pi has **no daemon** — it is an SDK loaded inside Bakin's process. "Pi in the rig"
-  means a throwaway `PI_HOME` wherever Bakin runs (host for native/isolated, container
-  for sandbox). Nothing to containerize separately. Accepted consequence: host-mode Pi
-  agents execute tools on the Mac inside dev-scoped workspaces; sandbox mode is the
-  in-container-execution option.
-- The runtime adapter is chosen ONLY by `settings.runtime.adapter`
-  (`packages/core/src/settings.ts`, default `openclaw`). No env override exists today.
-- `bakin_exec_assets_save` (`plugins/assets/lib/exec-tools.ts`) takes an absolute
-  `filePath` read host-side. In native/isolated modes agents write inside the container
-  (`/home/node/.openclaw/workspace/…`) — host-unreadable as-written, but the openclaw
-  home is bind-mounted at `dev/openclaw-home/`, so a prefix translation closes the gap.
-  (Known limitation documented in the rig knowledge doc, now `.claude/knowledge/dev-rig.md`.)
-- **Live hazard (must fix):** antfly's `detectServiceMode` defaults to `launchd` on
-  macOS; the LaunchAgent label (`io.bakin.antfly`) and port (3738) are singletons, and
-  the unit file is a byte-compared fingerprint of `getBakinPaths()`. A rig home that
-  reaches `ensureProvisioned` **rewrites the real LaunchAgent to point at the dev
-  home**. **Verified already fired on this machine (2026-07-11):** the live
-  `io.bakin.antfly` unit's `--data-dir` points at
-  `dev/bakin-instances/isolated/home/antfly` — a past isolated-mode boot hijacked the
-  machine-global service. The rig sets no search env today.
-- The pinned Pi SDK (`@earendil-works/pi-coding-agent@0.80.3`, dep of
-  `packages/adapter-pi`) ships the `pi` CLI (`bin: pi → dist/cli.js`); its own home
-  override is `PI_CODING_AGENT_DIR` (Bakin's adapter uses `PI_HOME`). There is no
-  `~/.pi` and no `pi` on PATH on this machine — fresh login is the only seeding path.
-- `ANTFLY_HOME` env override exists for the engine binary/models root; the machine-wide
-  binary under `~/.antfly/bin` can be shared read-only by rig children (data dirs stay
-  per-instance).
+**Success looks like:** you open Schedule's calendar and see, on correct timezone-aware math, every upcoming cron fire, every one-shot task you've queued for later, every task waiting on `availableAt` or due by `dueAt`, and (after bits adoption) every Messaging publish date and Projects milestone — each clearly labeled by source, deep-linked to its owner, and — where the owner supports it — reschedulable from a date-picker dialog. None of it breaks when a plugin is missing, the runtime is switched, or the box has been up for a year.
 
-## 2. Decisions (interview record, 2026-07-11)
+## Cron Stability Review (pi + openclaw) — audit findings
+
+This review was requested alongside #191. Findings drive Workstream A.
+
+### The Bakin-owned scheduler (fires all Bakin schedules) — SOLID
+- Own tick engine (`plugins/schedule/lib/scheduler.ts` + `scheduler-loop.ts`), dependency-injected, fake-clock tested.
+- Exactly-once via execution-ledger claims (`cron_fires` `(job_id, run_id)` PK); re-ticks and crashes are no-ops; `healPendingCronClaims` recovers claim-then-crash gaps.
+- Startup catch-up coalesces an outage to one occurrence; within-window fires into `todo`, older into `blocked` triage; skips are visible (`schedule.fire_skipped` + `skip_reason`).
+- Runtime cron is **never** in the fire path for Bakin schedules (post-#473). Runtime switches cannot kill Bakin schedules — they fire from the store regardless of adapter.
+
+### OpenClaw cron (native, surfaced read-only) — FUNCTIONAL, LOWEST-ASSURANCE SURFACE
+- Transport is CLI-shelling (`execFileAsync` per call), not gateway RPC. CRUD works with the gateway down; `runNow` implicitly needs it and doesn't surface gateway-down distinctly.
+- No retries anywhere (deliberate for non-idempotent ops); 30s/35s timeouts; heavy defensive loose-JSON normalization in `cron-store.ts` signals unstable CLI output shape; `listRuns` falls back to reading `~/.openclaw/cron/runs/*.jsonl` directly.
+- **Zero conformance/integration coverage** — only argv-shape unit tests with mocked exec. The conformance suite (`tests/integration/runtime-conformance/`) never touches the optional `cron` member.
+- Degrade path is good: `readMergedJobs` try/catches `cron.list()` and falls back to Bakin-owned schedules with a warning.
+
+### Pi cron — CORRECTLY ABSENT
+- The `cron` member is intentionally omitted (not stubbed); consumers feature-detect member presence. Bakin schedules ARE the scheduling answer on Pi; agents self-schedule via `bakin_exec_schedule_*`. No work needed beyond conformance pinning the absence.
+
+### Defects / gaps found (fixed in this initiative)
+1. **`schedule-sync` health check is dead code that claims to be live** — written, tested, its file header says it's registered, but `plugins/schedule/index.ts` only registers `schedule-cutover`. Orphan native crons are silently undetected. → PR1
+2. **`ScheduleDef.kind` allows `'at' | 'every'` but both are dead** — nothing produces them (every creation path hardcodes `kind: 'cron'`) and `scheduler.ts:62` feeds `expr` straight to the cron parser, so an `'at'` job could never fire. Vestigial type noise sitting on a latent bug. → PR2 (make `'at'` real, delete `'every'`)
+3. **Calendar views hand-parse raw cron strings client-side** (`calendar-weekly.tsx`, `calendar-monthly.tsx`, `calendar-today.tsx` split cron fields by hand) instead of using the server's `cron-eval` engine — wrong for TZ/DST and anything beyond simple exprs; no server endpoint returns future occurrences. → PR3
+4. **`cron_fires` ledger rows are never pruned** — unbounded growth; deleted jobs' rows linger forever. Slow on a single-user box, but real on a years-uptime machine. → PR1
+5. **No test pins "Bakin schedules survive a runtime switch"** — the initiative's core fear is only enforced by architecture, not by a test. → PR1
+6. Minor: duplicated hardcoded agent-color maps in `calendar-weekly.tsx` / `calendar-monthly.tsx`. → PR3 (consolidated during the calendar refactor)
+
+### Deliberate stances we are NOT changing (documented, not fixed)
+- No retry on the OpenClaw cron CLI surface (safe default for non-idempotent ops; degrade path already honest).
+- `--adopt-cron` on runtime switch stays opt-in.
+- Cron stays out of `CapabilitySet` (member-presence detection is the contract).
+
+## Tech Stack
+
+Existing stack, no new dependencies: Bun ≥1.2, TypeScript strict, Zod at boundaries, React 19 + TanStack Router (client), `cron-parser` (already sole-imported by `cron-eval.ts`), execution ledger (`bun:sqlite` via `packages/core/src/storage/db.ts`), HookRegistry for all cross-plugin calls.
+
+## Commands
+
+```
+Full test suite:   bun run test
+Single test file:  bun test tests/plugins/schedule/scheduler.test.ts --isolate
+Typecheck:         bun run typecheck
+Build (binary):    bun run build        # never commit generated-version.ts
+Dev loop:          bun run dev          # server code NOT watched; manual restart
+Dev with mock:     bun run dev:mock
+Live verify:       Skill: /verify (isolated server from source)
+```
+
+## Design Decisions (locked in interview 2026-07-14)
 
 | # | Decision | Choice |
 |---|----------|--------|
-| D1 | Pi scope | `--runtime openclaw\|pi` flag on **all three modes** (default `openclaw`; current behavior unchanged). native/isolated + pi: Bakin on host, throwaway `PI_HOME` under `dev/`, **no docker services started**. sandbox + pi: Bakin + Pi inside the container. |
-| D2 | Pi shape | Host Pi for hot-reload dev + sandbox option for in-container execution. No attempt to remote Pi out of process. |
-| D3 | Adapter selection | New `BAKIN_RUNTIME_ADAPTER` env override in settings resolution (same family as `BAKIN_HOME`/`OPENCLAW_HOME`/`PI_HOME`). Rig passes it per-invocation; real `~/.bakin/settings.json` is never written. Throwaway homes (isolated/sandbox) additionally get `runtime.adapter` written into their own settings.json so the home is self-consistent. |
-| D4 | Pi auth | Interactive auth during `instance up --runtime pi`; skipped when already authed; wiped by `reset`. No stored secrets, no auth.json synthesis. Mirrors the existing Codex OAuth flow. **Corrected during planning:** the pinned SDK has NO `pi login` subcommand — the rig spawns the interactive `pi` TUI (`PI_CODING_AGENT_DIR=$PI_HOME/agent`) where the user runs `/login`; success is verified by re-checking `auth.json` exists after the TUI exits. |
-| D5 | Asset-save gap | Fix via env-configured path-prefix translation honored by `bakin_exec_assets_save` (rig sets container-home → host-mount mapping). Exact knob shape decided in plan; generic (no "openclaw"/"docker" in the name), documented, inert when unset. |
-| D6 | Search | **Working search in every mode.** Isolated: rig-managed antfly child on an alternate port (e.g. 3739) sharing the machine-wide binary read-only; throwaway home's antfly URL points at it → guest mode → adapter never provisions/spawns (zero production-code risk). Sandbox: child mode in-container on 3738 (Linux, no systemd → auto). Native: real antfly as today. **In no path may a rig home render/write/restart the real launchd/systemd unit.** |
-| D7 | Verification | Full live E2E on **both** runtimes (user does `pi login` once; existing OpenClaw home reused — no fresh Codex OAuth), plus the automated suite. |
+| D1 | Scope & order | All three workstreams, A (harden) → B (one-shot) → C (#191 events) |
+| D2 | C UI surface | Full calendar grid — extend the existing Today/Week/Month views |
+| D3 | Calendar math debt | Fix now: server-side occurrences endpoint via `cron-eval`; delete client-side cron parsing |
+| D4 | One-shot primitive | Make `kind: 'at'` real in the scheduler; **delete** dead `'every'`; keep task `availableAt` as-is (different job: task exists now, dispatch later) |
+| D5 | One-shot semantics | Post-fire: auto-disable, display "completed", run history preserved, never auto-delete. Missed-fire: identical to cron (catch-up window → todo, older → blocked triage, ledger exactly-once). Creation: NL parse ("tomorrow at 9am"), job form, exec tools |
+| D6 | C contract mechanism | Hook suffix convention: providers register `{pluginId}.scheduledEvents` (hookKind `'rpc'`); Schedule discovers via `getRegisteredHooks()` suffix match, invokes each with a range, zod-validates per provider, isolates failures. `ScheduledDomainEvent` type exported from `@makinbakin/sdk`. No new core machinery |
+| D7 | v1 in-tree providers | Tasks only (`availableAt` → scheduled, `dueAt` → due). Workflows deferred (no future-dated concepts in-tree). Contract additionally proven by a test-harness provider |
+| D8 | Actions on events | Read-only + deep link + ONE optional verb: **reschedule** via conventional `{pluginId}.rescheduleEvent` hook; Schedule renders a date-picker ConfirmDialog. Tasks implements it. Generic action protocol rejected |
+| D9 | Data path | ONE endpoint `GET /api/plugins/schedule/occurrences?from=&to=`: unified chronological feed of job occurrences (server-computed) + domain events (hook fan-in). Calendars consume it exclusively. SSE-driven refetch |
+| D10 | PR structure | Four sequential PRs (below), each live-tested on 3737 before merge |
+| D11 | External adoption | **In scope**: bits work item — messaging (publish dates) + projects (milestones) in `bakin-bits-official` implement the contract after PR4 merges |
 
-## 3. Scope
+## Contract Shapes (v1)
 
-### 3.1 Rig audit (find what else is broken/missing)
+```typescript
+// @makinbakin/sdk — exported for external authors
+export interface ScheduledDomainEvent {
+  id: string                    // stable within the owning plugin
+  pluginId: string              // owner (must match the registering plugin)
+  title: string
+  startsAt?: string             // ISO; at least one of startsAt/dueAt required
+  endsAt?: string               // ISO; optional range end
+  dueAt?: string                // ISO; deadline semantics (rendered distinctly)
+  kind: string                  // owner vocabulary, e.g. 'task-due' | 'publish' | 'milestone'
+  status?: string               // owner vocabulary, display-only
+  url?: string                  // deep link into the owner's UI
+  reschedulable?: boolean       // true → owner registered {pluginId}.rescheduleEvent
+  metadata?: Record<string, unknown>  // read-only extras
+}
 
-A systematic sweep of every production capability under each (mode × runtime) cell,
-run BEFORE building — findings feed the plan as concrete tasks. Sweep list:
-
-dispatch + recovery ladder, asset save/import/enrichment, image generation (codex path
-per runtime), search indexing + rebuild + ⌘K, usage recording/usage.db, execution
-ledger, budget gates, chat plugin, memory plugin (tier indexing), doctor checks,
-agent packages install/sync, onboarding components against throwaway homes
-(especially: which components touch **machine-global** state — the search LaunchAgent
-hazard is the known instance of this class; find any others, e.g. `~/.antfly`
-downloads, plugin-assets, notifications), `instance status/env/run/shell` correctness
-per cell, reset scoping (all new state dirs must land in `dev/` reset targets).
-
-### 3.2 Pi runtime support
-
-- `--runtime openclaw|pi` in `args.ts` (validated; default `openclaw`); plan matrix in
-  `modes.ts` extended to (mode × runtime).
-- Pi paths in `paths.ts`: per-mode pi homes under `dev/` (host modes vs sandbox must
-  NOT share one pi home — host/container path strings diverge in registry/sessions);
-  all added to `resetTargets`.
-- `up --runtime pi` (native/isolated): no docker, no `op` preflight, no compose. Ensure
-  pi home dirs, run `pi login` if unauthed, write/patch throwaway settings (isolated),
-  print env.
-- `up --runtime pi --mode sandbox`: container with repo mount + bun + pi home mount;
-  main process must not depend on OpenClaw config (compose service shape decided in
-  plan); `pi login` exec'd into the container.
-- `dev/run/shell/env/status` honor the runtime: correct env set
-  (`BAKIN_RUNTIME_ADAPTER`, `PI_HOME`; no `OPENCLAW_*` for pi), correct health checks
-  (gateway health only for openclaw; pi auth presence for pi).
-- Runtime combinations coexist in one instance's state (separate dirs); switching =
-  `up --runtime <other>` then `dev --runtime <other>`. `reset` wipes both.
-
-### 3.3 Core changes (production code, all small + documented)
-
-- `BAKIN_RUNTIME_ADAPTER` override in settings resolution (D3).
-- Path-translation knob for `bakin_exec_assets_save` (D5).
-- Whatever the audit (3.1) surfaces as *production-side* gaps — each gets its own
-  decision in the plan; nothing lands unexamined.
-
-### 3.4 Search in the rig (D6)
-
-- Rig-managed antfly child for isolated mode (spawn/stop with instance lifecycle,
-  alt port, data under `dev/bakin-instances/…`, binary from `~/.antfly/bin` /
-  `ANTFLY_HOME`).
-- Sandbox: engine binary availability in-container + child mode; decided in plan
-  (macOS vs Linux binaries differ, so likely in-container install via
-  `bakin install search`).
-- Guard against the LaunchAgent clobber: rig homes must be structurally unable to
-  provision OS units (guest-mode URL and/or explicit service-mode env), plus a
-  regression test pinning it.
-- **Remediate the existing clobber on this machine:** re-provision `io.bakin.antfly`
-  back to the real `~/.bakin` paths (and verify the isolated instance gets its own
-  rig-managed child instead). Sequence this so the running isolated dev server isn't
-  yanked mid-session.
-
-### 3.5 Docs (required, per kickoff)
-
-- `.claude/knowledge/dockerized-openclaw-rig.md` → rewritten as the dual-runtime rig
-  reference (rename to `dev-rig.md`; update all inbound repo references — CLAUDE.md,
-  `repo-architecture.md`, skills that cite it).
-- `dev/docker/README.md` — user-facing walkthrough for both runtimes.
-- `CLAUDE.md` — the rig bullets under "OpenClaw Home Directory" + Pi adapter live-ops
-  notes.
-- `.claude/knowledge/pi-adapter.md` — add rig dev-loop section.
-- `.claude/knowledge/assets-versioning.md` + `search-system.md` where the D5/D6 knobs
-  touch their contracts.
-- `README.md` / `CONTRIBUTING.md` — only if they reference the rig (check during build).
-
-### 3.6 Out of scope
-
-- Remote-Pi transport / Pi daemonization (does not exist upstream).
-- Discord/channels for Pi (adapter degradation matrix is by design — the chat plugin
-  is the conversational surface).
-- Changing production runtime-switch (`bakin runtime use`) or onboarding flows beyond
-  what the audit proves broken for rig homes.
-- Multi-machine/CI generalization of the rig (single-user machine).
-
-## 4. Commands (target surface)
-
-```
-bun run instance up     [--mode native|isolated|sandbox] [--runtime openclaw|pi] [--fresh] [--source repo|installed] [--preconfigure]
-bun run instance dev    [--mode …] [--runtime …]      # host modes; onboards if needed; hot reload
-bun run instance run    [--mode …] [--runtime …] -- <bakin args>
-bun run instance shell  [--mode …] [--runtime …]
-bun run instance status | env [--mode …] [--runtime …]
-bun run instance down
-bun run instance reset  [--mode …]                    # wipes ALL runtime state for the mode
+// Hook: `{pluginId}.scheduledEvents` (hookKind 'rpc')
+//   input:  { from: string; to: string }        // ISO range
+//   output: ScheduledDomainEvent[]
+// Hook: `{pluginId}.rescheduleEvent` (hookKind 'rpc', optional)
+//   input:  { eventId: string; to: string }     // new ISO instant for the event's primary date
+//   output: { ok: true } | { ok: false; error: string }
 ```
 
-Existing invocations (`instance up`, `instance dev --mode isolated`, …) behave exactly
-as today — `--runtime` defaults to `openclaw`.
+Occurrences endpoint item (server-internal, consumed by calendars):
 
-## 5. Acceptance criteria
-
-Per cell of the support matrix (native, isolated, sandbox) × (openclaw, pi):
-
-1. `up` from clean state completes with at most the documented interactive steps
-   (Codex OAuth on fresh openclaw; `pi login` on fresh pi) and is idempotent on re-run.
-2. `dev` (host modes) boots Bakin with the selected adapter (verified via
-   `/api/runtime` or doctor), hot reload intact.
-3. A dispatched task completes a real turn; the agent writes a deliverable file and
-   `bakin_exec_assets_save` lands a **real versioned asset** (the container-path case
-   included) — verified live per D7.
-4. Search: the saved asset is indexed and findable via `/api/search` in every mode;
-   the real `io.bakin.antfly` LaunchAgent unit file is byte-identical before/after
-   any isolated/sandbox lifecycle (regression-tested + verified live).
-5. `reset` returns the instance to clean state without touching `~/.bakin`,
-   `~/.openclaw`, `~/.pi`, `~/.antfly` contents, or any launchd/systemd unit.
-6. Full suite (`bun run test`) green; new units for the args/modes/paths matrix, path
-   translation, adapter env override, rig-antfly lifecycle, LaunchAgent guard.
-7. All docs in 3.5 updated; no doc refers to the rig as OpenClaw-only.
-
-## 6. Project structure (files expected to change)
-
-```
-scripts/instance.ts                     verb handling per runtime
-scripts/instance/{args,modes,paths}.ts  (mode × runtime) matrix
-scripts/instance/lifecycle.ts           runtime-conditional up/reset; pi login step
-scripts/instance/pi-*.ts (new)          pi home prep + login argv builders
-scripts/instance/antfly-*.ts (new)      rig-managed antfly child (isolated)
-dev/docker/docker-compose.yml           sandbox-pi shape (plan decides exact form)
-packages/core/src/settings.ts (+ facade) BAKIN_RUNTIME_ADAPTER override
-plugins/assets/lib/exec-tools.ts        path translation at the save boundary
-tests/dev/** + tests/core/**            new coverage (tests/dev runs in CI only —
-                                        run `bun test tests/dev/` explicitly, per memory)
-docs per 3.5
+```typescript
+type OccurrenceItem =
+  | { source: 'schedule'; jobId: string; at: string; job: /* summary */ }   // cron + 'at' occurrences via cron-eval
+  | { source: 'event'; event: ScheduledDomainEvent }                        // validated hook fan-in
 ```
 
-## 7. Code style & conventions
+Zod-validate every provider's output at Schedule's boundary; a provider that throws, times out, or returns invalid rows is dropped from the feed with a logged warning — never breaks the endpoint (acceptance criterion of #191).
 
-Repo conventions apply unchanged (CLAUDE.md): strict TS, zod at boundaries, pure
-argv-builder modules with injected deps (the rig's existing pattern — keep it),
-kebab-case files, conventional commits with scope (`feat(instance): …`,
-`fix(assets): …`). Rig modules stay exempt from provider-boundary rules
-(`tests/architecture/adapter-boundary.test.ts` per-rule list) — extend the exemption
-list for new `scripts/instance/*` files as needed, never weaken the rule itself.
+## Work Breakdown & Commit Strategy
 
-## 8. Testing strategy
+Every commit conventional, one logical change, suite green at every commit. Branches in the MAIN checkout (3737 serves them); Mark live-tests each PR before merge.
 
-- **Unit (bulk of coverage):** args/modes/paths matrix exhaustively (every mode ×
-  runtime × flag combo); lifecycle ordering via injected deps (no Docker needed);
-  path-translation pure function; settings env override; antfly-child argv/lifecycle
-  builders; LaunchAgent guard (rig-produced settings can never yield a provisionable
-  service config).
-- **Integration:** settings override honored through the `createAppServices` boot path
-  (temp homes, BOTH content-dir resolver mocks per CLAUDE.md testing rules); assets
-  save with a translated prefix writing a real asset into a temp content dir.
-- **Live E2E (D7, user-assisted):** the acceptance-criteria matrix run for real on
-  this machine, both runtimes; evidence captured in the task/PR notes. OpenClaw side
-  additionally re-runs `scripts/instance/validate.ts` (campaign unchanged).
-- Every new test follows the CRITICAL testing rules (temp dirs, both content-dir
-  mocks, env vars before imports, `--isolate`).
+### PR1 — `fix(schedule): harden scheduling foundation` (Workstream A)
+1. `fix(schedule): register the schedule-sync health check` — wire the orphaned check into `activate()`; reconcile its file-header claim with reality.
+2. `feat(core): cron_fires retention sweep` — age+count-bounded pruning in the ledger (preserve rows inside the catch-up window and the most recent N per job so exactly-once dedup and run history keep working); sweep job-removed rows; wired into the existing watchdog/doctor cadence.
+3. `test(conformance): pin the optional cron member` — conformance checks: member honesty (present on openclaw mock via `mockCron()`, absent on pi), CRUD round-trip against the mock, adoption path; teeth entry proving the checks bite.
+4. `test(integration): Bakin schedules survive runtime switch` — both directions (openclaw→pi, pi→openclaw), with and without `--adopt-cron`; schedules keep firing post-switch.
+5. `docs(knowledge): record audit stances` — update `.claude/knowledge/bakin-owned-scheduler.md` (+ `runtime-capabilities.md` cron note).
 
-## 9. Boundaries
+**Rollback:** pure hardening; reverting restores today's behavior exactly.
 
-**Always:**
-- Keep all instance state under gitignored `dev/`; `reset` targets only there.
-- Keep secrets flowing only through the existing op:// resolution; redact in logs.
-- Keep production behavior identical when the new env knobs are unset.
-- Update `.claude/knowledge/` alongside code in the same commit arc.
+### PR2 — `feat(schedule): first-class one-shot 'at' schedules` (Workstream B)
+1. `refactor(schedule): delete dead 'every' schedule kind` — narrow `ScheduleDef.kind` to `'cron' | 'at'`.
+2. `feat(schedule): evaluate 'at' schedules in the engine` — `cron-eval` (or a thin kind-dispatch above it) understands `'at'` (ISO expr, exactly one occurrence); scheduler tick + startup catch-up + `nextRun`/`prevRun` handle it; post-fire auto-disable with preserved history; "completed" derivation in `MergedJob`.
+3. `feat(schedule): create one-shot schedules end-to-end` — NL parse one-shot phrases; `schedule-input` + `job-form` support; routes + zod; exec tools (`bakin_exec_schedule_create` accepts one-shots) so agents self-schedule on any runtime.
+4. `test(schedule): one-shot lifecycle` — fake-clock: fires once, never re-fires, catch-up within window, blocked triage beyond, completed display state.
+5. `docs(knowledge): one-shot semantics` — scheduler knowledge doc section.
 
-**Ask first:**
-- Any additional production-code change the audit surfaces beyond D3/D5/D6 guards.
-- Any new stored secret or credential-copying behavior.
-- Bumping the pinned OpenClaw image tag or Pi SDK version.
+**Rollback:** reverting removes the feature; no schema migration (sidecar JSON is additive).
 
-**Never:**
-- Write to real `~/.bakin`, `~/.openclaw`, `~/.pi`, or OS service units from rig code
-  paths (native mode's read/onboard of `~/.bakin` in `instance dev` stays the one
-  documented exception, unchanged).
-- Encode provider identifiers upstream of adapter boundaries outside the rig exemption.
-- Add parallel spend/usage/stat systems (existing single-engine rules).
+### PR3 — `refactor(schedule): server-computed occurrences feed the calendars` (Workstream C1 — behavior-preserving debt fix)
+1. `feat(schedule): occurrences endpoint` — `GET /occurrences?from=&to=` computing per-job occurrences via `occurrencesBetween` (jobs only at this stage; TZ-correct).
+2. `refactor(schedule): calendars consume the occurrences endpoint` — Today/Week/Month render fetched occurrences; DELETE all client-side cron parsing (`getJobHour`/`jobOnDow`/`expandField`/`jobFiringOnDay`); consolidate the duplicated agent-color maps into one shared module.
+3. `test(schedule): occurrence endpoint + calendar rendering` — TZ/DST cases the old client math got wrong; calendar view tests updated to fixture the endpoint.
 
-## 10. Commit strategy (checkpoints — detailed sequencing in PLAN)
+**Rollback:** revert restores client-side math; zero feature loss (this PR adds none).
 
-Work lands on a feature branch as an ordered arc of conventional commits, each
-independently green and revertable:
+### PR4 — `feat(schedule): plugin-contributed scheduled domain events` (Workstream C2 — the #191 feature)
+1. `feat(sdk): ScheduledDomainEvent contract types` — SDK-exported types + zod schema.
+2. `feat(schedule): domain-event fan-in on the occurrences endpoint` — hook discovery by suffix, per-provider validation/isolation/timeout, unified sorted feed, SSE refetch conventions.
+3. `feat(tasks): tasks.scheduledEvents provider` — availableAt/dueAt tasks as events, deep links to the board.
+4. `feat(schedule): render domain events on the calendars` — visually distinct from job occurrences (source/kind badges), event popover with deep link; graceful empty/missing-provider behavior.
+5. `feat(schedule): reschedule verb` — `reschedulable` events get a date-picker ConfirmDialog invoking `{pluginId}.rescheduleEvent`; `feat(tasks): rescheduleEvent hook` implements it for availableAt/dueAt.
+6. `test(schedule|tasks|sdk): contract, providers, isolation` — including the #191 acceptance criterion: a broken/missing provider drops its events without breaking Schedule.
+7. `docs: contract authoring guide` — `docs/src/content/docs/extending/plugins/` page for external authors; `.claude/knowledge/` doc for the contract; CLAUDE.md Key Patterns blurb; schedule + tasks plugin manifest version bumps.
 
-1. `docs(specs)` — this spec + archived predecessor (`tasks/gate-discord/SPEC.md`).
-2. `feat(core)` — `BAKIN_RUNTIME_ADAPTER` override + tests (inert alone).
-3. `feat(assets)` — path-translation knob + tests (inert alone).
-4. `feat(instance)` — args/modes/paths (mode × runtime) matrix + unit tests (lifecycle
-   still openclaw-only; flag parses + plans correctly).
-5. `feat(instance)` — pi lifecycle (home prep, login, dev/run/shell env) — Pi host
-   modes usable end-to-end.
-6. `feat(instance)` — sandbox-pi (compose + exec paths).
-7. `feat(instance)` — rig-managed antfly child + LaunchAgent guard + tests.
-8. `fix(…)` — per-audit-finding fixes, one commit each.
-9. `docs(…)` — knowledge/README/CLAUDE.md sweep (folded per-arc where a change is
-   doc-coupled).
+**Rollback:** revert leaves PR3's correct calendars intact; contract disappears cleanly (hooks unregister with plugins).
 
-Rollback points: after 2/3 (core knobs only), after 5 (Pi host dev usable), after 7
-(full matrix). Nothing merges with a red suite.
+### Work item 5 — bits adoption (`bakin-bits-official`, after PR4 merges)
+- `messaging.scheduledEvents` (publish dates, reschedulable) + `projects.scheduledEvents` (milestones, read-only) in their respective plugins; manifest version bumps per bits convention.
+- Live-verified against the real install; note: installed projects plugin was previously hot-patched — reconcile installed state with repo state first.
+
+## Project Structure (touched surfaces)
+
+```
+plugins/schedule/lib/         → scheduler, cron-eval kind dispatch, occurrences, event fan-in
+plugins/schedule/lib/routes/  → occurrences route
+plugins/schedule/components/  → calendar-{today,weekly,monthly}, event popover, reschedule dialog
+plugins/tasks/lib/            → scheduledEvents + rescheduleEvent providers
+packages/sdk/src/             → ScheduledDomainEvent types (+ zod)
+packages/core/src/execution/  → cron_fires retention
+tests/plugins/schedule/       → engine/endpoint/calendar/contract tests
+tests/integration/runtime-conformance/ → cron member conformance
+tests/integration/            → switch-survival test
+.claude/knowledge/            → bakin-owned-scheduler.md update + scheduled-events doc
+docs/src/content/docs/extending/plugins/ → external-author contract guide
+```
+
+## Code Style
+
+Match surrounding code. Example of the provider registration (the pattern external authors copy):
+
+```typescript
+// plugins/tasks/index.ts — inside activate(ctx)
+ctx.hooks.register(
+  'tasks.scheduledEvents',
+  async (data: { from: string; to: string }): Promise<ScheduledDomainEvent[]> => {
+    return listScheduledTaskEvents(parseRange(data))
+  },
+  { pluginId: 'tasks', metadata: { hookKind: 'rpc', label: 'Scheduled task events' } },
+)
+```
+
+Conventions: kebab-case files, PascalCase types, zod at every boundary, `createLogger('schedule')`, no empty catches, `const` over `let`, URL-backed view state via `useQueryState`.
+
+## Testing Strategy
+
+- **bun:test**, all files mock both content-dir resolvers + OpenClaw home per CLAUDE.md; `--isolate`; RTL files import `rtl-settle`.
+- Engine/lifecycle: fake-clock unit tests (existing harness in `tests/plugins/schedule/helpers/`).
+- Ledger retention: real-ledger temp-dir tests with `closeDb()` teardown.
+- Conformance: shared checks across mock/pi/openclaw-mock + teeth file.
+- Contract: zod validation, per-provider fault isolation (throwing provider, invalid rows, slow provider), missing-plugin graceful drop.
+- UI: calendar view tests against fixtured occurrences endpoint; reschedule dialog flow.
+- Every PR: full `bun run test` green + live verification on 3737 by Mark before merge.
+
+## Boundaries
+
+- **Always:** ledger claims before any fire; zod at hook boundaries; per-provider fault isolation; occurrence math server-side only; docs updated in the same PR as the change; bits plugin manifest version bumps in the same PR.
+- **Ask first:** any ledger schema migration beyond the retention sweep; any change to dispatch semantics of `availableAt`; any new settings keys; touching the live `~/.bakin` state.
+- **Never:** runtime cron in the Bakin-schedule fire path; Schedule mutating plugin domain data outside the typed reschedule hook; parallel occurrence-math implementations; auto-converting raw dates/files into events; backwards-compat shims (single-user machine — delete dead surface instead).
+
+## Success Criteria
+
+1. `bakin doctor --full` runs the schedule-sync check; orphan native crons are detected and repairable.
+2. Conformance suite fails if an adapter lies about cron presence/behavior; teeth prove it.
+3. Integration test proves Bakin schedules fire after a runtime switch in both directions.
+4. `cron_fires` is bounded; retention never breaks exactly-once inside the catch-up window (test-pinned).
+5. "Remind me tomorrow at 9am" as an agent exec-tool call creates a one-shot that fires exactly once, survives a restart, catches up if missed, and shows "completed" with history afterward.
+6. Calendars place a `30 21 * * *` job correctly across a DST boundary in the job's tz (test-pinned; the old client math demonstrably couldn't).
+7. A plugin registering `{pluginId}.scheduledEvents` appears on the calendar, clearly badged, deep-linked; killing that plugin removes its events and nothing else breaks.
+8. A waiting task's date can be moved from the calendar via the reschedule dialog; the task's `availableAt` actually changes.
+9. Messaging publish dates + Projects milestones visible on the calendar (bits work item).
+10. All knowledge docs + external-author docs updated; README checked (no impact expected); zero regressions in the existing schedule test suite.
+
+## Open Questions (for the plan phase, not blockers)
+
+All resolved at plan review 2026-07-14 (details in `tasks/schedule-hardening-and-events/plan.md`):
+1. Retention: max-age **30 days**, keep-last-20-per-job, never prune pending/recent rows; sweep daily.
+2. Provider timeout: 2s per provider — ship it, log elapsed time on every drop, watch real latencies during live testing and retune if tight.
+3. `'at'` NL vocabulary: enumerated in plan (tomorrow/today/weekday/in-N/date phrases + ISO + date-picker fallback).
+4. Past occurrences: yes — full-range feed annotated past/future, past fires enriched with ledger disposition.

--- a/packages/core/src/adapters/runtime/testing.ts
+++ b/packages/core/src/adapters/runtime/testing.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeAdapter, ChatChunk, MessageArgs, RuntimeAgent, RuntimeSession, RuntimeToolActivity } from './concepts'
+import type { AgentRuntimeAdapter, ChatChunk, CronJob, CronRun, MessageArgs, RuntimeAgent, RuntimeSession, RuntimeToolActivity } from './concepts'
 import { RuntimeError } from './errors'
 
 /**
@@ -32,36 +32,57 @@ export function mockChannels(): NonNullable<AgentRuntimeAdapter['channels']> {
  * Usage: `createMockRuntimeAdapter({ cron: mockCron() })`
  */
 export function mockCron(): NonNullable<AgentRuntimeAdapter['cron']> {
+  // Stateful (Map-backed) so the conformance CRUD round-trip pins real
+  // behavior: created jobs are listable/gettable, updates persist, a missing
+  // id is null on get and a typed not_found on update — same contract shape
+  // the OpenClaw adapter has against its file store.
+  const jobs = new Map<string, CronJob>()
+  const runs = new Map<string, CronRun[]>()
+  let seq = 0
   const cron: NonNullable<AgentRuntimeAdapter['cron']> = {
-    list: async () => [],
-    get: async () => null,
-    create: async (input) => ({
-      id: input.id ?? `cron-${Date.now()}`,
-      name: input.name,
-      schedule: input.schedule,
-      command: input.command,
-      enabled: input.enabled ?? true,
-      toolsAllow: input.toolsAllow,
-      metadata: input.metadata,
-    }),
-    update: async (id, patch) => ({
-      id,
-      name: patch.name ?? id,
-      schedule: patch.schedule ?? '* * * * *',
-      command: patch.command ?? '',
-      enabled: patch.enabled ?? true,
-      toolsAllow: patch.toolsAllow === null ? undefined : patch.toolsAllow,
-      metadata: patch.metadata,
-    }),
-    remove: async () => {},
-    runNow: async (jobId) => ({
-      id: `run-${Date.now()}`,
-      jobId,
-      status: 'succeeded',
-      startedAt: new Date().toISOString(),
-      endedAt: new Date().toISOString(),
-    }),
-    listRuns: async () => [],
+    list: async () => [...jobs.values()],
+    get: async (id) => jobs.get(id) ?? null,
+    create: async (input) => {
+      const job: CronJob = {
+        id: input.id ?? `cron-${++seq}`,
+        name: input.name,
+        schedule: input.schedule,
+        command: input.command,
+        enabled: input.enabled ?? true,
+        toolsAllow: input.toolsAllow,
+        metadata: input.metadata,
+      }
+      jobs.set(job.id, job)
+      return job
+    },
+    update: async (id, patch) => {
+      const existing = jobs.get(id)
+      if (!existing) throw new RuntimeError(`cron job not found: ${id}`, { kind: 'not_found' })
+      const job: CronJob = {
+        ...existing,
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.schedule !== undefined ? { schedule: patch.schedule } : {}),
+        ...(patch.command !== undefined ? { command: patch.command } : {}),
+        ...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
+        ...(patch.toolsAllow !== undefined ? { toolsAllow: patch.toolsAllow === null ? undefined : patch.toolsAllow } : {}),
+        ...(patch.metadata !== undefined ? { metadata: patch.metadata } : {}),
+      }
+      jobs.set(id, job)
+      return job
+    },
+    remove: async (id) => { jobs.delete(id) },
+    runNow: async (jobId) => {
+      const run: CronRun = {
+        id: `run-${++seq}`,
+        jobId,
+        status: 'succeeded',
+        startedAt: new Date().toISOString(),
+        endedAt: new Date().toISOString(),
+      }
+      runs.set(jobId, [...(runs.get(jobId) ?? []), run])
+      return run
+    },
+    listRuns: async (jobId) => runs.get(jobId) ?? [],
     getRaw: async (id, reason) => {
       if (!reason) throw new Error('cron.getRaw requires a reason')
       return (await cron.get(id)) ?? null
@@ -81,7 +102,7 @@ export function mockCron(): NonNullable<AgentRuntimeAdapter['cron']> {
       const schedule = typeof raw.schedule === 'string'
         ? raw.schedule
         : raw.schedule?.expr ?? raw.schedule?.value ?? '* * * * *'
-      return {
+      const job: CronJob = {
         id,
         name: raw.name ?? raw.id ?? id,
         schedule,
@@ -90,6 +111,8 @@ export function mockCron(): NonNullable<AgentRuntimeAdapter['cron']> {
         toolsAllow: raw.toolsAllow,
         metadata: raw.metadata,
       }
+      jobs.set(id, job)
+      return job
     },
   }
   return cron

--- a/packages/core/src/execution/ledger.ts
+++ b/packages/core/src/execution/ledger.ts
@@ -669,6 +669,45 @@ export function findHealableCronClaims(olderThanMs: number, now?: number): CronF
   })
 }
 
+export interface PruneCronFiresOptions {
+  /** Rows with fired_at older than now − maxAgeMs are prune candidates. */
+  maxAgeMs: number
+  /** The newest N rows per job always survive (run-history floor). */
+  keepPerJob: number
+  /** Hard floor: nothing newer than now − minAgeMs is ever deleted, so a
+   *  re-claim inside the catch-up/dedup horizon still collides with its
+   *  original row even under a misconfigured maxAgeMs. */
+  minAgeMs: number
+  now?: number
+}
+
+/**
+ * Bound cron_fires growth. `pending` rows are untouchable — they are live
+ * claims the healer may still consume; only settled dispositions
+ * (created/skipped/seeded) past BOTH age bounds and outside the per-job
+ * keep window are deleted.
+ */
+export function pruneCronFires(opts: PruneCronFiresOptions): { pruned: number } {
+  return guard('pruneCronFires', () => {
+    const now = opts.now ?? Date.now()
+    const cutoff = now - Math.max(opts.maxAgeMs, opts.minAgeMs)
+    const result = ledger()
+      .prepare(
+        `DELETE FROM cron_fires
+         WHERE disposition != 'pending'
+           AND fired_at < ?1
+           AND rowid NOT IN (
+             SELECT keepers.rowid FROM cron_fires AS keepers
+             WHERE keepers.job_id = cron_fires.job_id
+             ORDER BY keepers.fired_at DESC
+             LIMIT ?2
+           )`,
+      )
+      .run(cutoff, opts.keepPerJob)
+    return { pruned: result.changes }
+  })
+}
+
 // ---------------------------------------------------------------------------
 // completions
 // ---------------------------------------------------------------------------

--- a/plugins/schedule/index.ts
+++ b/plugins/schedule/index.ts
@@ -7,7 +7,7 @@ import { definePlugin } from '@bakin/core/routing'
 import { readMergedJobs } from './lib/jobs-reader'
 import { readSidecar, resumeDuePauses } from './lib/sidecar'
 import { runStartupCatchUp } from './lib/scheduler'
-import { checkScheduleCutover, scheduleCutoverRepair } from './lib/health-checks'
+import { checkScheduleCutover, scheduleCutoverRepair, checkScheduleSync, scheduleSyncRepair } from './lib/health-checks'
 import { setPluginCtx, getPluginCtx } from './lib/plugin-context'
 import {
   MISSED_WINDOW_REASON,
@@ -34,6 +34,7 @@ import { adoptCronJobs, type AdoptCronJobsInput } from './lib/cron-adoption'
 import { registerScheduleExecTools } from './lib/exec-tools'
 import { scheduleRoutes } from './lib/routes/jobs'
 import { createLogger } from '../../src/core/logger'
+import { getContentDir } from '../../src/core/content-dir'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 
 const log = createLogger('schedule')
@@ -142,6 +143,25 @@ const schedulePlugin: BakinPlugin = definePlugin({
         ctx.runtime.name,
       ),
       repair: scheduleCutoverRepair(runScheduleCutover),
+    })
+
+    // Orphan native crons: runtime cron jobs invisible to Bakin's sidecar
+    // (e.g. created by an agent directly in the runtime). Detection is
+    // read-only and the repair only records requireTriage sidecar entries —
+    // it NEVER writes runtime cron state, so it cannot reintroduce the
+    // pre-#473 double-fire the legacy sync check was removed for.
+    const syncCron = ctx.runtime.cron
+    ctx.registerHealthCheck({
+      id: 'schedule-sync',
+      name: 'Runtime cron jobs tracked in Bakin sidecar',
+      run: async () => checkScheduleSync(
+        getContentDir(),
+        syncCron,
+        syncCron ? await getRuntimeMainAgentId(ctx.runtime) : 'main',
+      ),
+      ...(syncCron
+        ? { repair: scheduleSyncRepair(getContentDir(), syncCron, () => getRuntimeMainAgentId(ctx.runtime)) }
+        : {}),
     })
 
     // Fire (or block) anything missed while the server was down, then start the

--- a/plugins/schedule/lib/cron-adoption.ts
+++ b/plugins/schedule/lib/cron-adoption.ts
@@ -16,7 +16,7 @@ import type { PluginContext } from '@bakin/core/plugin-types'
 import { getRuntimeMainAgentId, type CronJob } from '@bakin/core/adapters/runtime'
 import type { BakinJobMeta } from '../types'
 import { getJob, upsertJob } from './sidecar'
-import { getSystemTimezone } from './schedule-util'
+import { getSystemTimezone, nativeCronTz } from './schedule-util'
 import { indexJob } from './job-service'
 
 export interface AdoptCronJobsInput {
@@ -78,7 +78,9 @@ export async function adoptCronJobs(
         allowOverlap: existing?.allowOverlap ?? false,
         maxFailures: existing?.maxFailures ?? 3,
         consecutiveFailures: existing?.consecutiveFailures ?? 0,
-        tz: existing?.tz ?? tz,
+        // Native tz wins over the system tz — the job must keep firing at
+        // the local time its author chose, wherever this box thinks it is.
+        tz: existing?.tz ?? nativeCronTz(job) ?? tz,
         originalRuntimeCron: {
           provider: input.provider,
           capturedAt: now,

--- a/plugins/schedule/lib/routes/jobs.ts
+++ b/plugins/schedule/lib/routes/jobs.ts
@@ -10,7 +10,7 @@ import { defineRoute, searchRoute } from '@bakin/core/routing'
 import type { BakinJobMeta } from '../../types'
 import { getJob, upsertJob } from '../sidecar'
 import { parseSchedule } from '../cron-parser'
-import { getSystemTimezone, json } from '../schedule-util'
+import { getSystemTimezone, json, nativeCronTz } from '../schedule-util'
 import { readRuns } from '../runs-reader'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { fireManualRun } from '../fire-engine'
@@ -214,7 +214,7 @@ export const scheduleRoutes = [
       if (!parsed) return json({ error: 'Could not parse schedule' }, 400)
 
       const now = new Date().toISOString()
-      const tz = body.tz || existing?.tz || getSystemTimezone()
+      const tz = body.tz || existing?.tz || nativeCronTz(runtimeJob) || getSystemTimezone()
       const displayName = body.name || existing?.displayName || runtimeJob.name
       const owner = (body.owner ?? undefined) || existing?.owner || await getRuntimeMainAgentId(ctx.runtime)
       const taskPrompt = (body.taskPrompt ?? undefined) || existing?.taskPrompt || runtimeJob.command

--- a/plugins/schedule/lib/schedule-util.ts
+++ b/plugins/schedule/lib/schedule-util.ts
@@ -16,6 +16,17 @@ export function getSystemTimezone(): string {
   }
 }
 
+/**
+ * The timezone a native runtime cron carries, when it carries one. Adapters
+ * hoist the provider's schedule tz into `metadata.tz` (the OpenClaw
+ * cron-store does this explicitly) — adoption must prefer it over the
+ * system timezone or an evening job adopted on a UTC box silently shifts.
+ */
+export function nativeCronTz(job: { metadata?: Record<string, unknown> }): string | undefined {
+  const tz = job.metadata?.tz
+  return typeof tz === 'string' && tz.length > 0 ? tz : undefined
+}
+
 export function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,

--- a/plugins/schedule/lib/scheduler-loop.ts
+++ b/plugins/schedule/lib/scheduler-loop.ts
@@ -12,7 +12,7 @@ import { runSchedulerTick, DEFAULT_TICK_WINDOW_MS, type SchedulerDeps } from './
 import { getPluginCtx } from './plugin-context'
 import { runClaimedFire, healPendingCronClaims, MISSED_WINDOW_REASON } from './fire-engine'
 import { readSidecar, resumeDuePauses } from './sidecar'
-import { getCronFire, claimCronFire } from '../../../src/core/execution-ledger'
+import { getCronFire, claimCronFire, pruneCronFires } from '../../../src/core/execution-ledger'
 import { migrateBakinSchedulesOffOpenClawCron } from './cutover'
 import { getSystemTimezone } from './schedule-util'
 import { createLogger } from '../../../src/core/logger'
@@ -48,6 +48,39 @@ export function catchUpWindowMs(): number {
 }
 
 let schedulerTimer: ReturnType<typeof setTimeout> | null = null
+
+// ─── cron_fires retention (bounded history, dedup-safe) ─────────────────────
+
+const RETENTION_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000
+const RETENTION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+const RETENTION_KEEP_PER_JOB = 20
+// Rows newer than this NEVER prune, so a re-claim inside the dedup horizon
+// still collides with its original row even if maxAge is misconfigured tiny.
+const RETENTION_MIN_AGE_FLOOR_MS = 7 * 24 * 60 * 60 * 1000
+
+let lastRetentionSweepMs = 0
+
+/** Prune settled cron_fires at most once per 24h. In-memory cadence cell —
+ *  a restart re-sweeps on the first cycle, which is idempotent and cheap.
+ *  Sweeps that deleted rows are audited; 0-row sweeps stay off the feed. */
+export function maybeRunRetentionSweep(now = Date.now()): void {
+  if (now - lastRetentionSweepMs < RETENTION_SWEEP_INTERVAL_MS) return
+  lastRetentionSweepMs = now
+  const { pruned } = pruneCronFires({
+    maxAgeMs: RETENTION_MAX_AGE_MS,
+    keepPerJob: RETENTION_KEEP_PER_JOB,
+    minAgeMs: Math.max(catchUpWindowMs(), RETENTION_MIN_AGE_FLOOR_MS),
+    now,
+  })
+  if (pruned > 0) {
+    log.info('cron_fires retention sweep pruned rows', { pruned })
+    getPluginCtx()?.activity.audit('retention_swept', 'system', {
+      pruned,
+      maxAgeDays: RETENTION_MAX_AGE_MS / (24 * 60 * 60 * 1000),
+      keepPerJob: RETENTION_KEEP_PER_JOB,
+    })
+  }
+}
 
 export function schedulerDeps(): SchedulerDeps {
   return {
@@ -97,6 +130,7 @@ export function startScheduler(): void {
       .then(() => { resumeDuePauses() })
       .then(() => runSchedulerTick(schedulerDeps()))
       .then(() => healPendingCronClaims())
+      .then(() => { maybeRunRetentionSweep() })
       .catch(err => log.warn('Scheduler cycle failed', err))
       .finally(() => {
         schedulerTimer = setTimeout(cycle, tickIntervalMs())

--- a/src/core/execution-ledger.ts
+++ b/src/core/execution-ledger.ts
@@ -23,6 +23,7 @@ export {
   attachCronTask,
   markCronFireSkipped,
   listCronFires,
+  pruneCronFires,
   findHealableCronClaims,
   recordCompletion,
   hasCompletion,

--- a/tasks/schedule-hardening-and-events/plan.md
+++ b/tasks/schedule-hardening-and-events/plan.md
@@ -1,0 +1,273 @@
+# Implementation Plan: Schedule Hardening + Plugin-Contributed Scheduled Domain Events (#191)
+
+> Spec: `SPEC.md` (root). Issue: https://github.com/markhayden/bakin/issues/191
+> Four sequential PRs in this repo + one bits work item. Each PR: branch in MAIN checkout, full suite green at every commit, Mark live-tests on 3737, merge after approval.
+
+## Overview
+
+Harden the scheduling foundation (register the dead `schedule-sync` doctor check, bound `cron_fires`, pin cron conformance + switch survival), make one-shot `'at'` schedules real, move occurrence math server-side, then ship the #191 contract: `{pluginId}.scheduledEvents` hook fan-in rendered on the existing calendars, with a single `reschedule` verb, proven in-tree by tasks and externally by messaging/projects in bakin-bits-official.
+
+## Architecture Decisions (carried from SPEC.md D1–D11, plus plan-phase resolutions)
+
+- **Open Q1 — retention parameters (RESOLVED 2026-07-14):** prune `cron_fires` rows older than **30 days**, always keeping the **most recent 20 per job**, and NEVER pruning `pending` rows or rows newer than `max(catchUpWindowMinutes, 7 days)` (dedup safety margin). Sweep runs once per day from the scheduler loop (schedule plugin owns its data lifecycle; ledger exposes the verb).
+- **Open Q2 — provider timeout (RESOLVED, observe in practice):** 2s per provider, invoked in parallel; a timed-out provider is dropped from that response with a logged warning (same philosophy as the search query budget). Every drop logs the provider's elapsed time; during PR4 live testing and bits adoption we watch real provider latencies and retune if 2s is ever tight.
+- **Open Q3 — `'at'` NL vocabulary (deterministic regex tier):** `tomorrow at <time>`, `today at <time>`, `<weekday> at <time>` (next occurrence), `in <N> minutes/hours/days`, `<month> <day> [at <time>]`, ISO-8601 passthrough. UI always offers a datetime-picker fallback; the existing LLM fallback learns to emit `kind: 'at'`.
+- **Open Q4 — past occurrences:** yes. The occurrences endpoint returns math-computed occurrences for the full requested range annotated `past`/`future`, and enriches past Bakin-job occurrences with ledger disposition (`created`/`skipped`) so the calendar can show fired-vs-skipped. Additive field; lands in PR3.
+- **Zod schema placement:** the `ScheduledDomainEvent` TS type lives in `@makinbakin/sdk` (what external authors import); the zod validation schema lives server-side in `plugins/schedule` (the validation point). Keeps zod out of the SDK client bundle surface.
+- **SSE refresh convention:** providers emit a `<pluginId>.scheduled_events_changed` activity event when their domain dates change; the schedule client refetches occurrences on `schedule.*` events (existing behavior) plus any `*.scheduled_events_changed`.
+
+## Dependency Graph
+
+```
+PR1 (independent hardening) ──────────────┐
+PR2 'at' engine ── depends on nothing new ┤
+PR3 occurrences endpoint ── benefits from PR2 ('at' occurrences flow through) 
+PR4 contract + providers + UI ── depends on PR3 (fan-in extends the endpoint)
+bits adoption ── depends on PR4 merged
+```
+
+PR1 and PR2 are independent of each other; order kept A→B for risk (fail fast on foundation). PR3 must precede PR4.
+
+---
+
+## Phase 1 — PR1 `fix(schedule): harden scheduling foundation`
+
+### Task 1: Register the schedule-sync health check
+**Description:** Wire the orphaned `checkScheduleSync`/`scheduleSyncRepair` into `activate()` alongside `schedule-cutover`; make the file-header claim true.
+**Acceptance:**
+- [ ] `bakin doctor --full` lists and runs `schedule.schedule-sync`
+- [ ] An orphan native cron (present in `cron.list()`, absent from sidecar) yields a warn finding with working repair
+- [ ] Runtimes without cron (pi) → check returns OK, never errors
+**Verify:** `bun test tests/plugins/schedule/health-checks.test.ts --isolate` + new registration assertion in activation test
+**Dependencies:** None
+**Files:** `plugins/schedule/index.ts`, `plugins/schedule/lib/health-checks.ts`, `tests/plugins/schedule/health-checks.test.ts`
+**Size:** S
+
+### Task 2: cron_fires retention sweep
+**Description:** New ledger verb `pruneCronFires({ maxAgeDays, keepPerJob, minAgeMs })` (domain verb in `packages/core/src/execution/ledger.ts`, facade re-export). Deletes old `created`/`skipped`/`seeded` rows per the Q1 policy (30d); never touches `pending` or rows newer than the safety margin. Scheduler loop calls it at most once per day.
+**Acceptance:**
+- [ ] Rows older than 30d pruned; newest 20 per job always survive; `pending` rows never pruned regardless of age
+- [ ] Dedup still holds: a re-tick inside the catch-up window after a sweep does not double-fire (test-pinned)
+- [ ] Sweep is audited (`schedule.retention_swept` activity event with counts) — never silent
+**Verify:** new `tests/core/ledger-retention.test.ts` (real ledger in temp dir, `closeDb()` teardown) + fake-clock scheduler test for the daily cadence
+**Dependencies:** None
+**Files:** `packages/core/src/execution/ledger.ts`, `src/core/execution-ledger.ts`, `plugins/schedule/lib/scheduler-loop.ts`, tests
+**Size:** M
+
+### Task 3: Cron conformance coverage
+**Description:** Add a cron section to the runtime-conformance suite: when the adapter exposes `cron`, CRUD round-trip + `listRuns` shape + `get` of missing id behave per contract; when absent (pi), the member is truly absent (not a throwing stub). Mock opts in via existing `mockCron()`. Teeth entry proves the checks bite.
+**Acceptance:**
+- [ ] Conformance fails on a lying adapter (teeth: a stub that throws on `list` or returns malformed jobs)
+- [ ] pi conformance asserts `cron` is `undefined`
+- [ ] openclaw-mock + mock adapters pass the CRUD round-trip
+**Verify:** `bun test tests/integration/runtime-conformance/ --isolate`
+**Dependencies:** None
+**Files:** `tests/integration/runtime-conformance/conformance.ts`, the four `*.conformance.test.ts` files
+**Size:** M
+
+### Task 4: Switch-survival integration test
+**Description:** Integration test: create a Bakin schedule, run `switchRuntime` openclaw→pi and pi→openclaw (mocked adapters), assert the schedule still exists, still ticks, and fires exactly once post-switch; repeat with `--adopt-cron` covering a native cron becoming a Bakin job that then fires.
+**Acceptance:**
+- [ ] Both directions pass; fired task created exactly once post-switch
+- [ ] `--adopt-cron` path: adopted job fires from the Bakin tick after switch
+**Verify:** new `tests/integration/schedule-switch-survival.test.ts`
+**Dependencies:** Task 3 (reuses mock adapters with `mockCron()`)
+**Files:** `tests/integration/schedule-switch-survival.test.ts`
+**Size:** M
+
+### Task 5: Knowledge-doc updates for the audit
+**Description:** Record audit stances in `.claude/knowledge/bakin-owned-scheduler.md` (retention, schedule-sync now live, conformance coverage) and a cron note in `runtime-capabilities.md` (no-retry stance, member-presence contract now conformance-pinned).
+**Acceptance:** docs match shipped behavior; no stale claims
+**Verify:** manual read-through
+**Dependencies:** Tasks 1–4
+**Files:** `.claude/knowledge/bakin-owned-scheduler.md`, `.claude/knowledge/runtime-capabilities.md`
+**Size:** XS
+
+### Checkpoint 1 — PR1
+- [ ] `bun run test` + `bun run typecheck` green
+- [ ] Live on 3737: doctor shows schedule-sync; schedules still fire
+- [ ] Mark approves → merge PR1
+
+---
+
+## Phase 2 — PR2 `feat(schedule): first-class one-shot 'at' schedules`
+
+### Task 6: Delete the dead 'every' kind
+**Description:** Narrow `ScheduleDef.kind` to `'cron' | 'at'`; remove `'every'` from `types.ts`, `jobs-reader.ts` normalization, and any zod unions. Pure deletion.
+**Acceptance:** typecheck green; no `'every'` string remains in plugins/schedule
+**Verify:** `bun run typecheck` + `grep -rn "'every'" plugins/schedule` empty
+**Dependencies:** None
+**Files:** `plugins/schedule/types.ts`, `plugins/schedule/lib/jobs-reader.ts`
+**Size:** XS
+
+### Task 7: Evaluate 'at' schedules in the engine
+**Description:** Introduce kind-dispatch (`schedule-eval` layer over `cron-eval`): `nextRun`/`prevRun`/`occurrencesBetween` take a `ScheduleDef`; `'at'` = exactly one occurrence at the ISO instant. Scheduler tick + startup catch-up handle it via the existing occurrence-claim path (runId = `jobId:occurrenceISO`, so exactly-once and missed-window semantics are inherited). Post-fire: auto-disable (`enabled: false`) with the run recorded; `MergedJob` derives a `completed` display state (fired one-shot). Sidecar stays additive — no migration.
+**Acceptance:**
+- [ ] Fake-clock: 'at' fires exactly once at its instant; never re-fires after restart or re-tick
+- [ ] Missed within window → todo; missed beyond → blocked with `MISSED_WINDOW_REASON`; both exactly-once
+- [ ] After firing, job is disabled, `MergedJob.completed === true`, run history shows the fire
+**Verify:** `bun test tests/plugins/schedule/scheduler.test.ts tests/plugins/schedule/cron-eval.test.ts --isolate` (extended) + new one-shot lifecycle test
+**Dependencies:** Task 6
+**Files:** `plugins/schedule/lib/cron-eval.ts` (or new `schedule-eval.ts`), `lib/scheduler.ts`, `lib/fire-engine.ts`, `lib/jobs-reader.ts`, `types.ts`, tests
+**Size:** M
+
+### Task 8: One-shot creation — server paths
+**Description:** NL parser learns the Q3 one-shot vocabulary (deterministic tier emits `kind: 'at'` + ISO; LLM fallback prompt updated); `ParseResult` carries kind; create/update routes + zod accept `'at'`; exec tools (`bakin_exec_schedule_create/update/parse`) accept it so agents self-schedule one-shots on any runtime; prompt-guard applies unchanged.
+**Acceptance:**
+- [ ] `POST /parse` on "tomorrow at 9am" returns kind 'at' with correct ISO in the job tz
+- [ ] `bakin_exec_schedule_create` with a one-shot phrase creates a working 'at' job
+- [ ] Past-instant creation is rejected with a clear error
+**Verify:** `bun test tests/plugins/schedule/cron-parser.test.ts tests/plugins/schedule/routes-jobs.test.ts tests/plugins/schedule/exec-tools.test.ts --isolate`
+**Dependencies:** Task 7
+**Files:** `plugins/schedule/lib/cron-parser.ts`, `lib/routes/jobs.ts`, `lib/job-service.ts`, `lib/exec-tools.ts`, tests
+**Size:** M
+
+### Task 9: One-shot creation — UI
+**Description:** `schedule-input` gains a recurring/one-time mode (NL field still primary; datetime-picker fallback for one-time); `job-form` submits kind 'at'; `job-row`/`job-drawer` display the "completed" state and the one-shot's target instant; list filtering treats completed one-shots sensibly (shown, badged, not "active").
+**Acceptance:**
+- [ ] Create a one-shot from the UI end-to-end; drawer shows completed state + run history after fire
+- [ ] Existing recurring flow unchanged (no regressions in job-form tests)
+**Verify:** `bun test tests/plugins/schedule/schedule-page.test.tsx tests/plugins/schedule/job-drawer.test.tsx --isolate` (extended)
+**Dependencies:** Task 8
+**Files:** `plugins/schedule/components/schedule-input.tsx`, `job-form.tsx`, `job-row.tsx`, `job-drawer.tsx`, tests
+**Size:** M
+
+### Task 10: Docs — one-shot semantics
+**Description:** `.claude/knowledge/bakin-owned-scheduler.md` gains the one-shot section (semantics, completed state, NL vocabulary); schedule plugin README/manifest version bump.
+**Verify:** manual read-through; manifest version bumped
+**Dependencies:** Tasks 7–9
+**Files:** `.claude/knowledge/bakin-owned-scheduler.md`, `plugins/schedule/bakin-plugin.json`, `plugins/schedule/README.md`
+**Size:** XS
+
+### Checkpoint 2 — PR2
+- [ ] Full suite + typecheck green
+- [ ] Live: "remind me tomorrow at 9am" via exec tool → job visible, fires (test with a near-future instant), completed state correct
+- [ ] Mark approves → merge PR2
+
+---
+
+## Phase 3 — PR3 `refactor(schedule): server-computed occurrences feed the calendars`
+
+### Task 11: Occurrences endpoint
+**Description:** `GET /api/plugins/schedule/occurrences?from=&to=` (zod-validated ISO range, capped span e.g. 62 days). For every merged job: occurrences via the kind-aware eval (Task 7), each annotated `past`/`future`; past Bakin-job occurrences enriched with ledger disposition (`created`/`skipped` + taskId/skipReason). Sorted ascending. Jobs-only at this stage.
+**Acceptance:**
+- [ ] DST-crossing cron in a non-UTC tz places correctly (pinned with the exact case the client math got wrong)
+- [ ] 'at' jobs appear once; disabled jobs excluded from future (past fires still shown)
+- [ ] Range >62 days → 400
+**Verify:** new `tests/plugins/schedule/occurrences-route.test.ts`
+**Dependencies:** PR2 merged (kind-aware eval)
+**Files:** `plugins/schedule/lib/routes/jobs.ts` (or new `routes/occurrences.ts`), `lib/occurrences.ts`, tests
+**Size:** M
+
+### Task 12: Calendars consume the endpoint
+**Description:** New `useOccurrences(from, to)` client hook (SSE-refetch on `schedule.*`); Today/Week/Month render fetched occurrences; DELETE `getJobHour`/`getJobMinute`/`jobOnDow`/`formatJobTime`/`expandField`/`jobFiringOnDay` and all client cron parsing; consolidate the duplicated `AGENT_STYLES`/`AGENT_DOT_GLOW` maps into one shared module; past-fire disposition dots (fired/skipped).
+**Acceptance:**
+- [ ] All three views render from the endpoint; zero cron-string parsing left in components
+- [ ] Week/Today/Month visual behavior preserved for simple jobs (existing tests updated, not weakened)
+**Verify:** `bun test tests/plugins/schedule/calendar-views.test.tsx --isolate` (rewritten against fixtured endpoint)
+**Dependencies:** Task 11
+**Files:** `plugins/schedule/components/calendar-{today,weekly,monthly}.tsx`, new shared `components/agent-colors.ts`, `src/hooks/use-schedule.ts` (or new hook file), tests
+**Size:** L (mechanical, single-concern)
+
+### Checkpoint 3 — PR3
+- [ ] Full suite + typecheck green; live calendar identical-or-better on 3737 (Mark eyeballs week/month against known jobs)
+- [ ] Mark approves → merge PR3
+
+---
+
+## Phase 4 — PR4 `feat(schedule): plugin-contributed scheduled domain events`
+
+### Task 13: SDK contract type
+**Description:** `ScheduledDomainEvent` interface + hook-shape docs (`{pluginId}.scheduledEvents`, `{pluginId}.rescheduleEvent`) exported from `@makinbakin/sdk` (types module — no runtime code, no new vendor sub-path). Zod schema server-side in `plugins/schedule/lib/domain-events.ts`.
+**Acceptance:** type importable from `@makinbakin/sdk`; schema rejects missing-both-dates, wrong pluginId
+**Verify:** `bun run typecheck` + schema unit tests
+**Dependencies:** PR3 merged
+**Files:** `packages/sdk/src/types/*`, `plugins/schedule/lib/domain-events.ts`, tests
+**Size:** S
+
+### Task 14: Domain-event fan-in on the occurrences endpoint
+**Description:** Endpoint discovers providers via `getRegisteredHooks()` suffix match on `.scheduledEvents`, invokes each in parallel with the `{from,to}` range under a 2s timeout, zod-validates rows (pluginId must match the registrant), drops failing/invalid/slow providers with a logged warning + `meta.droppedProviders` in the response (honest degrade, never silent). Merged + sorted with job occurrences. Client refetch convention extended (`*.scheduled_events_changed`).
+**Acceptance:**
+- [ ] Throwing / invalid / slow provider → its events absent, others present, `meta.droppedProviders` names it, endpoint 200
+- [ ] No providers registered → jobs-only feed, no errors
+**Verify:** fan-in unit tests with fixture providers (throwing, slow, invalid, healthy)
+**Dependencies:** Task 13
+**Files:** `plugins/schedule/lib/domain-events.ts`, occurrences route, `src/hooks` occurrences hook, tests
+**Size:** M
+
+### Task 15: Tasks provider
+**Description:** `tasks.scheduledEvents` hook: tasks with future `availableAt` → kind `task-scheduled`; tasks with `dueAt` in range → kind `task-due`; deep links to the board (`/tasks?taskId=`); `reschedulable: true`; emits `tasks.scheduled_events_changed` when those fields change. Test-harness provider added to schedule test helpers as the second proving consumer.
+**Acceptance:**
+- [ ] A waiting task appears on the calendar range feed with correct dates + deep link
+- [ ] Done/archived tasks excluded
+**Verify:** `bun test tests/plugins/tasks/ --isolate` (new provider test) + fan-in integration
+**Dependencies:** Task 14
+**Files:** `plugins/tasks/index.ts`, `plugins/tasks/lib/scheduled-events.ts`, tests
+**Size:** M
+
+### Task 16: Render domain events on the calendars
+**Description:** Event chips visually distinct from job occurrences (source/kind badge, owner plugin label); click → popover with title/status/times + deep link; Month shows event dots distinct from job dots. Graceful empty behavior.
+**Acceptance:**
+- [ ] Cron occurrence vs domain event unmistakable at a glance in all three views (#191 acceptance criterion)
+- [ ] Event click-through navigates to the owner deep link
+**Verify:** calendar view tests extended with fixtured events
+**Dependencies:** Task 14
+**Files:** `plugins/schedule/components/calendar-*.tsx`, new `components/event-popover.tsx`, tests
+**Size:** M
+
+### Task 17: Reschedule verb
+**Description:** Events with `reschedulable: true` get a Reschedule action in the popover → date-picker ConfirmDialog (whole flow in the modal per house rule) → invokes `{pluginId}.rescheduleEvent`; success refetches, failure surfaces the owner's error. Tasks implements `tasks.rescheduleEvent` (updates `availableAt` or `dueAt` per the event kind, audited).
+**Acceptance:**
+- [ ] Moving a waiting task from the calendar actually changes `availableAt` (verified via task API)
+- [ ] Owner rejection (e.g. past instant) surfaces in the dialog, no partial state
+- [ ] Events without the flag show no reschedule affordance
+**Verify:** dialog component test + tasks hook test + integration through the fan-in
+**Dependencies:** Tasks 15, 16
+**Files:** `plugins/schedule/components/reschedule-dialog.tsx`, `event-popover.tsx`, `plugins/tasks/lib/scheduled-events.ts`, tests
+**Size:** M
+
+### Task 18: Docs + versions
+**Description:** External-author guide (`docs/src/content/docs/extending/plugins/scheduled-events.md`); new `.claude/knowledge/scheduled-domain-events.md`; CLAUDE.md Key Patterns blurb; `bakin-owned-scheduler.md` cross-link; README check (expected no change); schedule + tasks manifest version bumps.
+**Verify:** manual read-through; versions bumped
+**Dependencies:** Tasks 13–17
+**Size:** S
+
+### Checkpoint 4 — PR4
+- [ ] Full suite + typecheck green
+- [ ] Live: waiting/due tasks visible on calendar, badged, deep-linked; reschedule works; killing the tasks provider (mock) degrades honestly
+- [ ] Mark approves → merge PR4. Close #191.
+
+---
+
+## Phase 5 — bits adoption (`bakin-bits-official`)
+
+### Task 19: Messaging + Projects adopt the contract
+**Description:** In bakin-bits-official: `messaging.scheduledEvents` (publish dates, `reschedulable: true` via `messaging.rescheduleEvent`) and `projects.scheduledEvents` (milestones, read-only). Manifest version bumps per bits convention (patch/minor judgment). **Pre-step:** reconcile the installed projects plugin's hot-patched state with the repo before branching.
+**Acceptance:**
+- [ ] Publish dates + milestones render on the live calendar with owner badges
+- [ ] Rescheduling a publish date from the calendar moves the content item
+**Verify:** bits test suite (`bun run test` in bits repo — needs preload) + live verification on 3737 after plugin upgrade
+**Dependencies:** PR4 merged
+**Size:** M (external repo)
+
+### Checkpoint 5 — Initiative complete
+- [ ] All SPEC.md success criteria checked off
+- [ ] SPEC.md + this plan archived per repo convention when the next initiative starts
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Retention sweep breaks exactly-once dedup | High | Never prune `pending` or rows newer than max(catch-up window, 7d); dedup-after-sweep is test-pinned before the sweep ships (Task 2) |
+| `cron-parser` edge cases in 'at' dispatch (DST instants, tz of ISO exprs) | Med | 'at' bypasses cron-parser entirely (plain instant compare); DST pins live in occurrences tests (Task 11) |
+| Hook fan-in stalls the occurrences endpoint | Med | 2s per-provider timeout, parallel invocation, honest `meta.droppedProviders` (Task 14) |
+| Calendar refactor visual regressions | Med | PR3 is feature-free by design; existing calendar tests rewritten not weakened; Mark eyeballs live before merge |
+| Conformance vs real OpenClaw drift (suite runs against mocks) | Low | Conformance pins the contract, not the binary; the loose-JSON absorption layer keeps its unit tests; stance documented |
+| Installed projects plugin hot-patch conflicts with bits branch | Med | Task 19 pre-step reconciles installed state first (known from memory: runtime-capabilities PR #630 era) |
+| SDK type addition ripples into vendor bundles | Low | Types-only export; no new runtime module, no import-map change |
+
+## Parallelization
+
+Tasks within a PR are sequential (each commit green). PR1 Tasks 1–4 are mutually independent and could be parallelized across sessions if desired; everything else follows the PR train.

--- a/tasks/schedule-hardening-and-events/todo.md
+++ b/tasks/schedule-hardening-and-events/todo.md
@@ -3,12 +3,12 @@
 > Detail: `tasks/schedule-hardening-and-events/plan.md` · Spec: `SPEC.md`
 
 ## PR1 — fix(schedule): harden scheduling foundation
-- [ ] T1 Register schedule-sync health check (S)
-- [ ] T2 cron_fires retention sweep — ledger verb + daily call + dedup-safety pin (M)
-- [ ] T3 Cron conformance coverage + teeth (M)
-- [ ] T4 Switch-survival integration test, both directions, ±--adopt-cron (M)
-- [ ] T5 Knowledge docs: audit stances (XS)
-- [ ] CHECKPOINT: suite green → live 3737 → Mark approves → merge
+- [x] T1 Register schedule-sync health check (S)
+- [x] T2 cron_fires retention sweep — ledger verb + daily call + dedup-safety pin (M)
+- [x] T3 Cron conformance coverage + teeth (M)
+- [x] T4 Switch-survival integration test, both directions, ±--adopt-cron (M) — found+fixed adopted-cron tz loss
+- [x] T5 Knowledge docs: audit stances (XS)
+- [ ] CHECKPOINT: suite green ✔ → live 3737 → Mark approves → merge
 
 ## PR2 — feat(schedule): first-class one-shot 'at' schedules
 - [ ] T6 Delete dead 'every' kind (XS)

--- a/tasks/schedule-hardening-and-events/todo.md
+++ b/tasks/schedule-hardening-and-events/todo.md
@@ -1,0 +1,37 @@
+# TODO — Schedule Hardening + Scheduled Domain Events (#191)
+
+> Detail: `tasks/schedule-hardening-and-events/plan.md` · Spec: `SPEC.md`
+
+## PR1 — fix(schedule): harden scheduling foundation
+- [ ] T1 Register schedule-sync health check (S)
+- [ ] T2 cron_fires retention sweep — ledger verb + daily call + dedup-safety pin (M)
+- [ ] T3 Cron conformance coverage + teeth (M)
+- [ ] T4 Switch-survival integration test, both directions, ±--adopt-cron (M)
+- [ ] T5 Knowledge docs: audit stances (XS)
+- [ ] CHECKPOINT: suite green → live 3737 → Mark approves → merge
+
+## PR2 — feat(schedule): first-class one-shot 'at' schedules
+- [ ] T6 Delete dead 'every' kind (XS)
+- [ ] T7 Engine: kind-aware eval, 'at' fires once, auto-disable + completed state (M)
+- [ ] T8 Server creation paths: NL parse, routes, exec tools, past-instant rejection (M)
+- [ ] T9 UI: one-time mode in schedule-input/job-form, completed display (M)
+- [ ] T10 Docs + schedule manifest bump (XS)
+- [ ] CHECKPOINT: live one-shot end-to-end → Mark approves → merge
+
+## PR3 — refactor(schedule): server-computed occurrences feed the calendars
+- [ ] T11 Occurrences endpoint (kind-aware, past/future annotated, ledger disposition, DST-pinned) (M)
+- [ ] T12 Calendars consume endpoint; delete client cron parsing; consolidate agent colors (L)
+- [ ] CHECKPOINT: calendars eyeballed live → Mark approves → merge
+
+## PR4 — feat(schedule): plugin-contributed scheduled domain events
+- [ ] T13 SDK ScheduledDomainEvent type + server-side zod schema (S)
+- [ ] T14 Hook fan-in on occurrences endpoint (2s timeout, honest droppedProviders) (M)
+- [ ] T15 tasks.scheduledEvents provider + change events (M)
+- [ ] T16 Calendar rendering: distinct event chips + popover + deep links (M)
+- [ ] T17 Reschedule verb: ConfirmDialog date picker + tasks.rescheduleEvent (M)
+- [ ] T18 Docs (external-author guide, knowledge doc, CLAUDE.md blurb) + manifest bumps (S)
+- [ ] CHECKPOINT: #191 acceptance criteria verified live → Mark approves → merge → close #191
+
+## Phase 5 — bakin-bits-official
+- [ ] T19 Reconcile projects hot-patch → messaging + projects adopt contract → live verify (M)
+- [ ] CHECKPOINT: all SPEC success criteria checked

--- a/tests/core/ledger-retention.test.ts
+++ b/tests/core/ledger-retention.test.ts
@@ -1,0 +1,138 @@
+/**
+ * cron_fires retention sweep — pruneCronFires bounds fire history without ever
+ * weakening the exactly-once guarantees: `pending` rows are untouchable, the
+ * newest N per job always survive, and nothing newer than the safety margin
+ * (catch-up window / 7d floor) is deleted, so re-claims inside the dedup
+ * horizon still collide with their original row.
+ */
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { rmSync } from 'fs'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-ledger-retention-${Date.now()}-${randomUUID()}`)
+const dbPath = join(testDir, 'bakin.db')
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    home: testDir,
+    audit: join(testDir, 'audit.jsonl'),
+    tasks: join(testDir, 'tasks'),
+    logs: join(testDir, 'logs'),
+    db: dbPath,
+  }),
+})
+mock.module('../../src/core/content-dir', contentDirMock)
+mock.module('../../packages/core/src/content-dir', contentDirMock)
+
+const loggerMock = () => ({
+  createLogger: () => ({ debug: mock(), info: mock(), warn: mock(), error: mock() }),
+})
+mock.module('../../src/core/logger', loggerMock)
+mock.module('../../packages/core/src/logger', loggerMock)
+
+import {
+  claimCronFire,
+  attachCronTask,
+  markCronFireSkipped,
+  getCronFire,
+  listCronFires,
+  pruneCronFires,
+} from '../../src/core/execution-ledger'
+import { closeDb } from '../../packages/core/src/storage/db'
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = Date.parse('2026-07-14T12:00:00Z')
+
+/** Seed one settled fire row aged `ageDays` before NOW. */
+function seed(jobId: string, n: number, ageDays: number, disposition: 'created' | 'skipped' | 'pending' = 'created'): string {
+  const firedAt = NOW - ageDays * DAY
+  const runId = `${jobId}:${new Date(firedAt).toISOString()}#${n}`
+  const claim = claimCronFire(jobId, runId, firedAt, 'pending', firedAt)
+  expect(claim.claimed).toBe(true)
+  if (disposition === 'created') attachCronTask(jobId, runId, `task-${runId}`)
+  if (disposition === 'skipped') markCronFireSkipped(jobId, runId, 'overlap')
+  return runId
+}
+
+const POLICY = { maxAgeMs: 30 * DAY, keepPerJob: 20, minAgeMs: 7 * DAY, now: NOW }
+
+describe('pruneCronFires', () => {
+  afterAll(() => {
+    closeDb()
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  let jobSeq = 0
+  let jobId = ''
+  beforeEach(() => {
+    jobId = `sch_job_${jobSeq++}`
+  })
+
+  it('prunes settled rows older than maxAge beyond the newest keepPerJob', () => {
+    // 25 settled rows, all far older than maxAge: the newest 20 must survive.
+    const runIds = Array.from({ length: 25 }, (_, i) => seed(jobId, i, 100 - i)) // ages 100..76d
+    const { pruned } = pruneCronFires(POLICY)
+    expect(pruned).toBe(5)
+    const remaining = listCronFires(jobId, 100)
+    expect(remaining).toHaveLength(20)
+    // Survivors are the 20 newest (ages 76..95d); the 5 oldest are gone.
+    for (const runId of runIds.slice(-20)) expect(getCronFire(jobId, runId)).not.toBeNull()
+    for (const runId of runIds.slice(0, 5)) expect(getCronFire(jobId, runId)).toBeNull()
+  })
+
+  it('never touches rows younger than maxAge', () => {
+    seed(jobId, 0, 5)
+    seed(jobId, 1, 29)
+    const { pruned } = pruneCronFires(POLICY)
+    expect(pruned).toBe(0)
+    expect(listCronFires(jobId, 100)).toHaveLength(2)
+  })
+
+  it('never prunes pending rows regardless of age', () => {
+    const pendingRun = seed(jobId, 0, 200, 'pending')
+    // 21 settled rows newer than the pending one push it past keepPerJob.
+    for (let i = 0; i < 21; i++) seed(jobId, i + 1, 40 + i)
+    pruneCronFires(POLICY)
+    expect(getCronFire(jobId, pendingRun)).not.toBeNull()
+    expect(getCronFire(jobId, pendingRun)!.disposition).toBe('pending')
+  })
+
+  it('minAge floor wins over a misconfigured tiny maxAge', () => {
+    const recent = seed(jobId, 0, 1) // 1 day old, settled
+    for (let i = 0; i < 25; i++) seed(jobId, i + 1, 2 + i) // ages 2..26d
+    const { pruned } = pruneCronFires({ ...POLICY, maxAgeMs: 60 * 60 * 1000, keepPerJob: 1 })
+    expect(getCronFire(jobId, recent)).not.toBeNull()
+    // Cutoff is the 7d floor (strict <): ages 1..7d survive, 8..26d are pruned
+    // (the sole keepPerJob slot is already held by the newest, age-1d row).
+    // `pruned` is global across jobs (other tests' rows share the DB), so
+    // assert at least this job's 19 and pin the survivor set per job.
+    expect(pruned).toBeGreaterThanOrEqual(19)
+    const survivorAges = listCronFires(jobId, 100).map(row => Math.round((NOW - row.firedAt) / DAY)).sort((a, b) => a - b)
+    expect(survivorAges).toEqual([1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('exactly-once dedup survives a sweep: a re-claim inside the safety margin still collides', () => {
+    const firedAt = NOW - 60 * 60 * 1000 // 1h ago — inside catch-up horizon
+    const runId = `${jobId}:${new Date(firedAt).toISOString()}`
+    expect(claimCronFire(jobId, runId, firedAt, 'pending', firedAt).claimed).toBe(true)
+    attachCronTask(jobId, runId, 'task-x')
+    pruneCronFires(POLICY)
+    const reclaim = claimCronFire(jobId, runId, firedAt, 'pending', NOW)
+    expect(reclaim.claimed).toBe(false)
+    if (!reclaim.claimed) expect(reclaim.existing?.taskId).toBe('task-x')
+  })
+
+  it('keepPerJob is per job, not global', () => {
+    const jobA = `${jobId}-a`
+    const jobB = `${jobId}-b`
+    for (let i = 0; i < 30; i++) seed(jobA, i, 100 - i)
+    for (let i = 0; i < 3; i++) seed(jobB, i, 100 - i)
+    const { pruned } = pruneCronFires(POLICY)
+    expect(pruned).toBe(10)
+    expect(listCronFires(jobA, 100)).toHaveLength(20)
+    expect(listCronFires(jobB, 100)).toHaveLength(3)
+  })
+})

--- a/tests/integration/runtime-conformance/conformance.ts
+++ b/tests/integration/runtime-conformance/conformance.ts
@@ -105,6 +105,13 @@ export interface RuntimeConformanceSuiteOptions {
    * declared 'unavailable'.
    */
   sessionsPin?: boolean
+  /**
+   * Cron optional-member declaration (T30). 'present' pins the member to
+   * exist and drives the CRUD round-trip; 'absent' pins true omission
+   * (undefined member, not a throwing stub). Omit to skip the declaration
+   * pin (the round-trip still runs whenever the member exists).
+   */
+  cron?: 'present' | 'absent'
 }
 
 function fail(message: string): never {
@@ -124,6 +131,65 @@ function assertTypedRuntimeError(err: unknown, expectedKind?: string): void {
 }
 
 export const runtimeConformanceChecks = {
+  /**
+   * Optional-member honesty (T30): cron support is signalled by MEMBER
+   * PRESENCE — never a capability mode, never a throwing stub. A runner
+   * declares which side its adapter is on; absence must be `undefined`.
+   */
+  async cronMemberMatchesDeclaration(target: RuntimeConformanceTarget, options?: RuntimeConformanceSuiteOptions): Promise<void> {
+    if (options?.cron === undefined) return
+    const member = target.runtime.cron
+    if (options.cron === 'absent' && member !== undefined) {
+      fail('cron declared absent but the adapter exposes a cron member — absence must be member omission')
+    }
+    if (options.cron === 'present' && member === undefined) {
+      fail('cron declared present but the adapter omits the member')
+    }
+  },
+
+  /**
+   * Native-cron CRUD contract (T30), for adapters that expose the optional
+   * member: creates persist (listable, gettable), updates apply, a missing
+   * id reads as null (never a throw) and mutates as a typed 'not_found',
+   * and removal is observable. Runs against whatever store the adapter
+   * really uses (OpenClaw: the CLI + file store via the crab shim).
+   */
+  async cronCrudRoundTrip(target: RuntimeConformanceTarget): Promise<void> {
+    const cron = target.runtime.cron
+    if (!cron) return
+    const name = `conformance-cron-${Math.random().toString(36).slice(2, 10)}`
+
+    const created = await cron.create({ name, schedule: '0 9 * * *', command: 'conformance noop', enabled: true })
+    if (!created.id) fail('cron.create returned a job without an id')
+    if (created.schedule !== '0 9 * * *') fail(`cron.create did not persist the schedule (got '${created.schedule}')`)
+
+    const listed = await cron.list()
+    if (!listed.some((job) => job.id === created.id)) fail('created cron job is missing from cron.list()')
+
+    const fetched = await cron.get(created.id)
+    if (!fetched || fetched.id !== created.id) fail('cron.get of a created job did not return it')
+
+    const updated = await cron.update(created.id, { schedule: '30 10 * * *' })
+    if (updated.schedule !== '30 10 * * *') fail(`cron.update did not apply the schedule patch (got '${updated.schedule}')`)
+    const refetched = await cron.get(created.id)
+    if (refetched?.schedule !== '30 10 * * *') fail('cron.update result not visible on a subsequent get')
+
+    const ghost = `conformance-cron-ghost-${Math.random().toString(36).slice(2, 10)}`
+    const missing = await cron.get(ghost)
+    if (missing !== null) fail(`cron.get of a missing job must return null (got ${JSON.stringify(missing)})`)
+    try {
+      await cron.update(ghost, { schedule: '0 0 * * *' })
+      fail("cron.update of a missing job resolved — must reject typed 'not_found'")
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('conformance violation')) throw err
+      assertTypedRuntimeError(err, 'not_found')
+    }
+
+    await cron.remove(created.id)
+    if ((await cron.get(created.id)) !== null) fail('cron.get still returns a removed job')
+    if ((await cron.list()).some((job) => job.id === created.id)) fail('cron.list still contains a removed job')
+  },
+
   /**
    * CRUD error contract (R28): reads return null for absence; mutations on a
    * missing agent reject with a typed RuntimeError kind 'not_found'. Ghost id
@@ -547,6 +613,14 @@ export function runRuntimeConformanceSuite(
 
     it("unknown-agent CRUD: get returns null, mutations reject typed 'not_found'", async () => {
       await runtimeConformanceChecks.unknownAgentCrudIsTypedNotFound(getTarget())
+    })
+
+    it('cron member matches its declaration (presence is the contract)', async () => {
+      await runtimeConformanceChecks.cronMemberMatchesDeclaration(getTarget(), options)
+    })
+
+    it('cron CRUD round-trips against the real store (when the member exists)', async () => {
+      await runtimeConformanceChecks.cronCrudRoundTrip(getTarget())
     })
 
     it('initialize() is write-free (provisioning owns home writes)', async () => {

--- a/tests/integration/runtime-conformance/mock.conformance.test.ts
+++ b/tests/integration/runtime-conformance/mock.conformance.test.ts
@@ -4,7 +4,7 @@
  * every real adapter must satisfy — plugin tests that pass against the mock
  * must not be passing against fantasy semantics.
  */
-import { afterAll, beforeEach, mock } from 'bun:test'
+import { afterAll, beforeEach, describe, it, mock } from 'bun:test'
 import { rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
@@ -32,8 +32,8 @@ const loggerMock = () => ({
 mock.module('../../../src/core/logger', loggerMock)
 mock.module('../../../packages/core/src/logger', loggerMock)
 
-import { createMockRuntimeAdapter } from '../../../packages/core/src/adapters/runtime/testing'
-import { runRuntimeConformanceSuite, type RuntimeConformanceTarget } from './conformance'
+import { createMockRuntimeAdapter, mockCron } from '../../../packages/core/src/adapters/runtime/testing'
+import { runRuntimeConformanceSuite, runtimeConformanceChecks, type RuntimeConformanceTarget } from './conformance'
 
 let target: RuntimeConformanceTarget
 let threadSeq = 0
@@ -99,4 +99,13 @@ afterAll(() => {
   rmSync(testDir, { recursive: true, force: true })
 })
 
-runRuntimeConformanceSuite('dev mock', () => target)
+runRuntimeConformanceSuite('dev mock', () => target, { cron: 'absent' })
+
+// The minimal mock omits cron; the opt-in surface must still honor the CRUD
+// contract so schedule tests exercising it inherit pinned behavior.
+describe('mock cron opt-in (mockCron)', () => {
+  it('round-trips the cron CRUD contract', async () => {
+    const cronTarget = { ...target, runtime: createMockRuntimeAdapter({ cron: mockCron() }) }
+    await runtimeConformanceChecks.cronCrudRoundTrip(cronTarget)
+  })
+})

--- a/tests/integration/runtime-conformance/openclaw.conformance.test.ts
+++ b/tests/integration/runtime-conformance/openclaw.conformance.test.ts
@@ -169,4 +169,4 @@ const target: RuntimeConformanceTarget = {
   },
 }
 
-runRuntimeConformanceSuite('openclaw (imitation crab)', () => target, { sessionsPin: SESSIONS_PIN_ENABLED })
+runRuntimeConformanceSuite('openclaw (imitation crab)', () => target, { sessionsPin: SESSIONS_PIN_ENABLED, cron: 'present' })

--- a/tests/integration/runtime-conformance/pi.conformance.test.ts
+++ b/tests/integration/runtime-conformance/pi.conformance.test.ts
@@ -169,4 +169,4 @@ const target: RuntimeConformanceTarget = {
   },
 }
 
-runRuntimeConformanceSuite('pi (fake provider)', () => target)
+runRuntimeConformanceSuite('pi (fake provider)', () => target, { cron: 'absent' })

--- a/tests/integration/runtime-conformance/teeth.conformance.test.ts
+++ b/tests/integration/runtime-conformance/teeth.conformance.test.ts
@@ -28,7 +28,7 @@ mock.module('../../../src/core/logger', () => ({
 }))
 
 import type { ChatChunk, MessageArgs } from '../../../packages/core/src/adapters/runtime'
-import { createMockRuntimeAdapter } from '../../../packages/core/src/adapters/runtime/testing'
+import { createMockRuntimeAdapter, mockCron } from '../../../packages/core/src/adapters/runtime/testing'
 import { runtimeConformanceChecks, type RuntimeConformanceTarget } from './conformance'
 
 /** Every violation in one adapter: the anti-conformance fixture. */
@@ -225,6 +225,46 @@ describe('conformance suite teeth (broken adapter must fail every check)', () =>
     }
     await expect(runtimeConformanceChecks.initializeIsWriteFree(target))
       .rejects.toThrow(/conformance violation: initialize\(\) wrote to the adapter home/)
+  })
+
+  it('fails the cron-declaration check when a declared-absent adapter exposes the member', async () => {
+    const lying = { ...createMockRuntimeAdapter(), cron: mockCron() }
+    await expect(runtimeConformanceChecks.cronMemberMatchesDeclaration({ ...brokenTarget(), runtime: lying }, { cron: 'absent' }))
+      .rejects.toThrow(/conformance violation: cron declared absent/)
+  })
+
+  it('fails the cron-declaration check when a declared-present adapter omits the member', async () => {
+    await expect(runtimeConformanceChecks.cronMemberMatchesDeclaration({ ...brokenTarget(), runtime: createMockRuntimeAdapter() }, { cron: 'present' }))
+      .rejects.toThrow(/conformance violation: cron declared present/)
+  })
+
+  it('fails the cron round-trip on a stateless lie (created job missing from list)', async () => {
+    const statelessCron = { ...mockCron(), list: async () => [] }
+    const runtime = { ...createMockRuntimeAdapter(), cron: statelessCron }
+    await expect(runtimeConformanceChecks.cronCrudRoundTrip({ ...brokenTarget(), runtime }))
+      .rejects.toThrow(/conformance violation: created cron job is missing from cron\.list\(\)/)
+  })
+
+  it('fails the cron round-trip when get of a missing job throws instead of returning null', async () => {
+    const throwingCron = { ...mockCron(), get: async (id: string) => { throw new Error(`boom ${id}`) } }
+    const runtime = { ...createMockRuntimeAdapter(), cron: throwingCron }
+    await expect(runtimeConformanceChecks.cronCrudRoundTrip({ ...brokenTarget(), runtime }))
+      .rejects.toThrow()
+  })
+
+  it('fails the cron round-trip when update of a missing job resolves a fabricated row', async () => {
+    const base = mockCron()
+    const fabricatingCron = {
+      ...base,
+      update: async (id: string, patch: { schedule?: string }) => {
+        const existing = await base.get(id)
+        if (existing) return base.update(id, patch)
+        return { id, name: id, schedule: patch.schedule ?? '* * * * *', command: '', enabled: true }
+      },
+    }
+    const runtime = { ...createMockRuntimeAdapter(), cron: fabricatingCron }
+    await expect(runtimeConformanceChecks.cronCrudRoundTrip({ ...brokenTarget(), runtime }))
+      .rejects.toThrow(/conformance violation: cron\.update of a missing job resolved/)
   })
 
   it('fails the provisioning check when a second provision changes durable state', async () => {

--- a/tests/integration/schedule-switch-survival.test.ts
+++ b/tests/integration/schedule-switch-survival.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Bakin schedules survive a runtime switch (PR1 T4) — the core promise of the
+ * Bakin-owned scheduler: the sidecar store + execution ledger are runtime-
+ * independent, so switching adapters (either direction) must leave schedules
+ * in place, ticking, and firing exactly once per occurrence. Also covers
+ * --adopt-cron: a native OpenClaw cron becomes a Bakin schedule at switch
+ * time and fires from the Bakin tick afterwards.
+ *
+ * Real switchRuntime over real adapters with temp homes (same scaffolding as
+ * runtime-switch.test.ts), real sidecar reads, real ledger claims. The fire
+ * callback is a recorder — task creation is schedule-plugin-internal and
+ * pinned by the schedule suite; survival is about store + claim integrity.
+ */
+import { join as pathJoin } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-sched-survival-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = pathJoin(testDir, 'openclaw')
+process.env.PI_HOME = pathJoin(testDir, 'pi')
+
+import { describe, it, expect, beforeAll, afterAll, mock } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
+
+const contentDirFactory = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({
+    home: testDir,
+    db: pathJoin(testDir, 'bakin.db'),
+    settings: pathJoin(testDir, 'settings.json'),
+    tasks: pathJoin(testDir, 'tasks'),
+    logs: pathJoin(testDir, 'logs'),
+  }),
+  isUsingBakinHome: () => true,
+  resetContentDir: () => {},
+})
+mock.module('../../src/core/content-dir', contentDirFactory)
+mock.module('../../packages/core/src/content-dir', contentDirFactory)
+const loggerFactory = () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+})
+mock.module('../../src/core/logger', loggerFactory)
+mock.module('../../packages/core/src/logger', loggerFactory)
+mock.module('@bakin/core/logger', loggerFactory)
+mock.module('../../src/core/watcher', () => ({ startWatcher: () => {}, stopWatcher: () => {} }))
+mock.module('../../src/core/agent-packages/sync-scanner', () => ({
+  scanAgentSync: async () => ({ findings: [], agentsScanned: 0, blocksOk: 0, projectionsOk: 0 }),
+}))
+
+import { switchRuntime } from '../../src/core/runtime-switch'
+import { getSettings, resetSettingsCache, updateSettings } from '../../src/core/settings'
+import { closeDb } from '../../packages/core/src/storage/db'
+import { resetOpenClawConfigCache } from '../../packages/adapter-openclaw/src/config'
+import { resetPiHome } from '../../packages/adapter-pi/src/home'
+import { resetModelRegistry } from '../../packages/adapter-pi/src/models'
+import { getHookRegistry } from '../../packages/core/src/hooks/hook-registry-singleton'
+import { installCliShim } from '../../dev/imitation-crab/cli-shim-install'
+import { getCronFire, claimCronFire } from '../../src/core/execution-ledger'
+import { runSchedulerTick, type SchedulerDeps } from '../../plugins/schedule/lib/scheduler'
+import { readSidecar, upsertJob } from '../../plugins/schedule/lib/sidecar'
+import { adoptCronJobs, type AdoptCronJobsInput } from '../../plugins/schedule/lib/cron-adoption'
+import type { BakinJobMeta } from '../../plugins/schedule/types'
+
+const openclawHome = pathJoin(testDir, 'openclaw')
+
+function seedOpenClawHome(): void {
+  mkdirSync(openclawHome, { recursive: true })
+  writeFileSync(pathJoin(openclawHome, 'openclaw.json'), JSON.stringify({
+    agents: {
+      defaults: { model: { primary: 'openai/gpt-test-text' } },
+      list: [{ id: 'main', identity: { name: 'Main', emoji: '🐾' } }],
+    },
+  }, null, 2))
+  resetOpenClawConfigCache()
+}
+
+/** A native OpenClaw cron in the on-disk store the CLI shim + adapter read. */
+function seedNativeCron(id: string, expr: string): void {
+  mkdirSync(pathJoin(openclawHome, 'cron'), { recursive: true })
+  writeFileSync(pathJoin(openclawHome, 'cron', 'jobs.json'), JSON.stringify({
+    version: 1,
+    jobs: [{
+      id,
+      name: 'Native Daily',
+      schedule: { kind: 'cron', expr, tz: 'America/Denver' },
+      enabled: true,
+      delivery: { mode: 'none' },
+      payload: { message: 'do the native thing' },
+      createdAt: '2026-06-01T00:00:00Z',
+    }],
+  }, null, 2))
+}
+
+function scheduleMeta(jobId: string, expr: string): BakinJobMeta {
+  return {
+    jobId,
+    isBakinJob: true,
+    enabled: true,
+    schedule: { kind: 'cron', expr },
+    tz: 'America/Denver',
+    displayName: 'Survivor',
+    taskPrompt: 'do the daily thing',
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+  }
+}
+
+/** Real-ledger tick: real sidecar jobs, real (job,run) claims, recorder fire. */
+async function tickAt(nowMs: number): Promise<Array<{ jobId: string; runId: string }>> {
+  const fired: Array<{ jobId: string; runId: string }> = []
+  const deps: SchedulerDeps = {
+    now: () => nowMs,
+    tickWindowMs: 90_000,
+    listJobs: () => Object.values(readSidecar().jobs).filter((job) => job.isBakinJob),
+    getCronFire: (jobId, runId) => getCronFire(jobId, runId),
+    claimCronFire: (jobId, runId, firedAt) => claimCronFire(jobId, runId, firedAt),
+    fire: async (_meta, jobId, runId) => { fired.push({ jobId, runId }) },
+  }
+  await runSchedulerTick(deps)
+  return fired
+}
+
+// 9:00:30am America/Denver (MDT, UTC-6) on successive days — 30s inside the
+// tick window after the 9am occurrence.
+const DAY1_TICK = Date.parse('2026-06-07T15:00:30Z')
+const DAY2_TICK = Date.parse('2026-06-08T15:00:30Z')
+const DAY3_TICK = Date.parse('2026-06-09T15:00:30Z')
+const DAY4_TICK = Date.parse('2026-06-10T15:00:30Z')
+
+let unregisterAdoptHook: (() => void) | null = null
+
+beforeAll(() => {
+  mkdirSync(testDir, { recursive: true })
+  seedOpenClawHome()
+  // The OpenClaw adapter shells this binary for cron CRUD — point it at the
+  // crab CLI shim via the adapter-private runtime settings (initialize()
+  // threads settings.runtime.settings; the env-var default is evaluated at
+  // module load, before this file's statements run).
+  const shimPath = installCliShim(testDir)
+  resetSettingsCache()
+  updateSettings({
+    runtime: { adapter: 'openclaw', settings: { binaryPath: shimPath } },
+    search: { settings: { enabled: false } },
+  })
+
+  // The schedule plugin isn't activated in this harness — register its real
+  // adoption handler the way activate() does, with a minimal ctx.
+  const adoptCtx = {
+    runtime: { agents: { list: async () => [{ id: 'main', name: 'Main', role: 'Orchestrator' }] } },
+    activity: { log: () => {}, audit: () => {} },
+  }
+  unregisterAdoptHook = getHookRegistry().register(
+    'schedule.adoptCronJobs',
+    (data: unknown) => adoptCronJobs(adoptCtx as never, data as AdoptCronJobsInput),
+    'schedule',
+  )
+})
+
+afterAll(() => {
+  unregisterAdoptHook?.()
+  closeDb()
+  rmSync(testDir, { recursive: true, force: true })
+  resetSettingsCache()
+  resetPiHome()
+  resetModelRegistry()
+})
+
+describe('Bakin schedules survive a runtime switch', () => {
+  it('fires before the switch (baseline, exactly once)', async () => {
+    upsertJob(scheduleMeta('sch_survivor', '0 9 * * *'))
+    const fired = await tickAt(DAY1_TICK)
+    expect(fired).toEqual([{ jobId: 'sch_survivor', runId: expect.stringContaining('sch_survivor:') }])
+    // Re-tick of the same window is a ledger no-op.
+    expect(await tickAt(DAY1_TICK)).toEqual([])
+  })
+
+  it('openclaw → pi: schedule intact, next occurrence fires exactly once', async () => {
+    const result = await switchRuntime('pi', { copyWorkspaces: false })
+    expect(result.ok).toBe(true)
+    expect(getSettings().runtime.adapter).toBe('pi')
+
+    const job = readSidecar().jobs['sch_survivor']
+    expect(job).toBeDefined()
+    expect(job.schedule).toEqual({ kind: 'cron', expr: '0 9 * * *' })
+    expect(job.enabled).toBe(true)
+
+    const fired = await tickAt(DAY2_TICK)
+    expect(fired).toHaveLength(1)
+    expect(fired[0].jobId).toBe('sch_survivor')
+    expect(await tickAt(DAY2_TICK)).toEqual([])
+  })
+
+  it('pi → openclaw: schedule still intact, still firing', async () => {
+    const result = await switchRuntime('openclaw', { copyWorkspaces: false })
+    expect(result.ok).toBe(true)
+    expect(getSettings().runtime.adapter).toBe('openclaw')
+
+    expect(readSidecar().jobs['sch_survivor']).toBeDefined()
+    const fired = await tickAt(DAY3_TICK)
+    expect(fired).toHaveLength(1)
+    expect(fired[0].jobId).toBe('sch_survivor')
+  })
+
+  it('openclaw → pi with --adopt-cron: native cron becomes a firing Bakin schedule', async () => {
+    seedNativeCron('native-daily', '0 9 * * *')
+    const result = await switchRuntime('pi', { copyWorkspaces: false, adoptCron: true })
+    expect(result.ok).toBe(true)
+
+    const adoption = result.cron
+    expect(adoption).not.toBeNull()
+    expect(adoption!.adopted).toContain('native-daily')
+    expect(adoption!.failed).toEqual([])
+
+    const adopted = readSidecar().jobs['native-daily']
+    expect(adopted).toBeDefined()
+    expect(adopted.isBakinJob).toBe(true)
+    expect(adopted.source).toBe('adopted')
+    expect(adopted.schedule?.expr).toBe('0 9 * * *')
+    expect(adopted.originalRuntimeCron).toBeDefined()
+
+    // The native job's tz must survive adoption (metadata.tz from the
+    // adapter) — NOT be replaced by the system timezone.
+    expect(adopted.tz).toBe('America/Denver')
+
+    // Both the survivor and the adopted job fire from the Bakin tick now.
+    const fired = await tickAt(DAY4_TICK)
+    expect(fired.map((f) => f.jobId).sort()).toEqual(['native-daily', 'sch_survivor'])
+    expect(await tickAt(DAY4_TICK)).toEqual([])
+  })
+})

--- a/tests/plugins/schedule/cron-adoption.test.ts
+++ b/tests/plugins/schedule/cron-adoption.test.ts
@@ -82,6 +82,18 @@ describe('adoptCronJobs', () => {
     expect(auditCalls.filter((c) => c.event === 'job.adopted')).toHaveLength(2)
   })
 
+  it("preserves the native job's timezone over the system timezone", async () => {
+    // Adapters hoist the provider schedule tz into metadata.tz; losing it
+    // shifts an adopted evening job by hours on a UTC-configured box.
+    const tzJobs = [{
+      job: { id: 'evening-post', name: 'Evening post', schedule: '30 21 * * *', command: 'Post it', enabled: true, metadata: { tz: 'America/Denver' } },
+      raw: { blob: 'z' },
+    }]
+    const result = await adoptCronJobs(ctx, { provider: 'openclaw', jobs: tzJobs })
+    expect(result.adopted).toEqual(['evening-post'])
+    expect(getJob('evening-post')?.tz).toBe('America/Denver')
+  })
+
   it('is idempotent: already-Bakin jobs are skipped, never overwritten', async () => {
     upsertJob({
       jobId: 'daily-report',

--- a/tests/plugins/schedule/health-checks.test.ts
+++ b/tests/plugins/schedule/health-checks.test.ts
@@ -193,25 +193,29 @@ describe('checkScheduleSync - runtime failures', () => {
 })
 
 describe('plugin registration', () => {
-  it('no longer registers the legacy schedule-sync / cron-wake health checks', async () => {
-    // Bakin owns scheduling now: a sync check whose repair re-created OpenClaw
-    // crons would reintroduce the double-fire, and the legacy main-session-wake
-    // repair is obsolete. Both registrations were removed (orphan-cron check
-    // arrives separately). This guards against either creeping back in.
+  interface RegisteredDef {
+    id: string
+    run: () => Promise<Array<{ status: string; message: string }>>
+    repair?: unknown
+  }
+
+  async function activateWithCtx(opts: { cron: boolean }): Promise<RegisteredDef[]> {
     const schedulePlugin = (await import('../../../plugins/schedule')).default
-    const registeredIds: string[] = []
+    const registered: RegisteredDef[] = []
     const noop = mock()
     const noopAsync = mock(async () => {})
     const ctx: Record<string, unknown> = {
       pluginId: 'schedule',
       runtime: {
         agents: { list: mock(async () => [{ id: 'main', name: 'Main', role: 'Orchestrator' }]) },
-        cron: { list: mock(async () => []), get: mock(async () => null), remove: noopAsync },
+        ...(opts.cron
+          ? { cron: { list: mock(async () => []), get: mock(async () => null), remove: noopAsync } }
+          : {}),
       },
       registerRoute: noop, registerExecTool: noop, registerNav: noop,
       registerSlot: noop, registerSkill: noop, registerWorkflow: noop,
       registerNodeType: noop, registerNotificationChannel: noop,
-      registerHealthCheck: (def: { id: string }) => { registeredIds.push(def.id); return `schedule.${def.id}` },
+      registerHealthCheck: (def: RegisteredDef) => { registered.push(def); return `schedule.${def.id}` },
       watchFiles: noop,
       getSettings: () => ({}),
       updateSettings: noop,
@@ -225,13 +229,40 @@ describe('plugin registration', () => {
       storage: {},
       events: { on: noop, emit: noop, off: noop },
     }
-    await schedulePlugin.activate(ctx as unknown as Parameters<typeof schedulePlugin.activate>[0])
-    schedulePlugin.onShutdown?.() // stop the scheduler interval started by activate
+    const plugin = schedulePlugin as { activate: (c: unknown) => Promise<void>; onShutdown?: () => void }
+    await plugin.activate(ctx)
+    plugin.onShutdown?.() // stop the scheduler interval started by activate
+    return registered
+  }
 
-    expect(registeredIds).not.toContain('schedule-sync')
-    expect(registeredIds).not.toContain('schedule-legacy-cron-wake')
-    // The cutover/migration check replaces them.
-    expect(registeredIds).toContain('schedule-cutover')
+  it('registers the schedule-sync orphan-cron check alongside schedule-cutover', async () => {
+    // schedule-sync detects native runtime crons invisible to Bakin's sidecar
+    // (e.g. created by an agent directly in the runtime). Its repair only
+    // writes requireTriage sidecar entries — it must NEVER write runtime cron
+    // state, which is what made the pre-#473 legacy sync check double-fire.
+    // The obsolete main-session-wake repair stays gone.
+    const registered = await activateWithCtx({ cron: true })
+    const ids = registered.map(d => d.id)
+
+    expect(ids).toContain('schedule-sync')
+    expect(ids).toContain('schedule-cutover')
+    expect(ids).not.toContain('schedule-legacy-cron-wake')
+
+    const sync = registered.find(d => d.id === 'schedule-sync')!
+    expect(sync.repair).toBeDefined()
+    const rows = await sync.run()
+    expect(rows.every(r => r.status === 'ok')).toBe(true)
+  })
+
+  it('registers schedule-sync as a no-op OK on cron-less runtimes (pi)', async () => {
+    const registered = await activateWithCtx({ cron: false })
+    const sync = registered.find(d => d.id === 'schedule-sync')
+    expect(sync).toBeDefined()
+    expect(sync!.repair).toBeUndefined()
+    const rows = await sync!.run()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('ok')
+    expect(rows[0].message).toMatch(/no native cron/i)
   })
 })
 

--- a/tests/plugins/schedule/retention-sweep.test.ts
+++ b/tests/plugins/schedule/retention-sweep.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Daily cron_fires retention sweep — the scheduler loop calls pruneCronFires
+ * at most once per 24h with the fixed policy (30d max age, keep 20/job,
+ * minAge = max(catch-up window, 7d floor)), and audits sweeps that actually
+ * pruned rows so history deletion is never silent.
+ */
+import { tmpdir } from 'os'
+import { join as pathJoin } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = pathJoin(tmpdir(), `bakin-test-retention-sweep-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = testDir + '-openclaw'
+
+import { describe, it, expect, afterAll, mock } from 'bun:test'
+import { rmSync } from 'fs'
+
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: pathJoin(testDir, 'bakin.db') }),
+  isUsingBakinHome: () => true,
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ debug: mock(), info: mock(), warn: mock(), error: mock() }),
+}))
+
+mock.module('@bakin/adapter-openclaw/home', () => ({
+  getOpenClawHome: () => testDir + '-openclaw',
+  getOpenClawPath: (...parts: string[]) => pathJoin(testDir + '-openclaw', ...parts),
+  resetOpenClawHome: () => {},
+}))
+
+const pruneCalls: Array<Record<string, unknown>> = []
+let pruneResult = { pruned: 0 }
+mock.module('../../../src/core/execution-ledger', () => ({
+  pruneCronFires: (opts: Record<string, unknown>) => {
+    pruneCalls.push(opts)
+    return pruneResult
+  },
+  getCronFire: () => null,
+  claimCronFire: () => ({ claimed: true }),
+}))
+
+import { maybeRunRetentionSweep } from '../../../plugins/schedule/lib/scheduler-loop'
+import { setPluginCtx } from '../../../plugins/schedule/lib/plugin-context'
+
+const auditEvents: Array<{ event: string; data: Record<string, unknown> }> = []
+setPluginCtx({
+  getSettings: () => ({ catchUpWindowMinutes: 60 }),
+  activity: {
+    log: () => {},
+    audit: (event: string, _actor: string, data: Record<string, unknown>) => {
+      auditEvents.push({ event, data })
+    },
+  },
+} as never)
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = Date.parse('2026-07-14T12:00:00Z')
+
+describe('maybeRunRetentionSweep', () => {
+  afterAll(() => rmSync(testDir, { recursive: true, force: true }))
+
+  it('sweeps with the fixed policy and audits when rows were pruned', () => {
+    pruneResult = { pruned: 3 }
+    maybeRunRetentionSweep(NOW)
+    expect(pruneCalls).toHaveLength(1)
+    expect(pruneCalls[0]).toMatchObject({
+      maxAgeMs: 30 * DAY,
+      keepPerJob: 20,
+      minAgeMs: 7 * DAY, // 60m catch-up window loses to the 7d floor
+      now: NOW,
+    })
+    expect(auditEvents).toHaveLength(1)
+    expect(auditEvents[0].event).toBe('retention_swept')
+    expect(auditEvents[0].data.pruned).toBe(3)
+  })
+
+  it('skips inside the 24h cadence window', () => {
+    maybeRunRetentionSweep(NOW + 60 * 60 * 1000)
+    expect(pruneCalls).toHaveLength(1)
+  })
+
+  it('sweeps again after 24h and stays silent when nothing was pruned', () => {
+    pruneResult = { pruned: 0 }
+    maybeRunRetentionSweep(NOW + 25 * 60 * 60 * 1000)
+    expect(pruneCalls).toHaveLength(2)
+    expect(auditEvents).toHaveLength(1) // no new audit for a 0-row sweep
+  })
+})


### PR DESCRIPTION
## Summary

PR1 of the four-PR schedule-hardening + scheduled-domain-events initiative (spec: \`SPEC.md\`, plan: \`tasks/schedule-hardening-and-events/plan.md\`, feature ticket: #191). Pure hardening — no new user-facing features; reverting restores today's behavior exactly.

- **Register the \`schedule-sync\` doctor check** — it existed, was tested, and its file header claimed it was live, but \`activate()\` never wired it, so orphan native crons went silently undetected. The legacy-removal guard test now pins the real invariant: the repair only writes \`requireTriage\` sidecar entries, never runtime cron state (the pre-#473 double-fire is impossible), and cron-less runtimes (Pi) get an unconditional OK.
- **\`cron_fires\` retention** — new ledger verb \`pruneCronFires\` (30d max age, keep newest 20/job, \`pending\` rows untouchable, 7-day min-age floor so re-claims inside the dedup horizon still collide). Daily sweep from the scheduler loop, audited via \`schedule.retention_swept\` when rows were pruned. Dedup-survives-sweep is test-pinned.
- **Cron conformance coverage** — the optional \`cron\` member had zero conformance coverage. New checks: member-presence-by-declaration (openclaw \`present\`, pi + minimal mock \`absent\`) and a CRUD round-trip that the openclaw runner drives through the REAL adapter against the crab CLI shim's file store. \`mockCron()\` is now stateful; five teeth fixtures prove the new branches bite.
- **Switch-survival integration test** — real \`switchRuntime\` both directions over temp homes: schedules keep firing exactly once per occurrence, and \`--adopt-cron\` yields a firing Bakin job.
- **Bug found & fixed by the new test: adopted-cron timezone loss** — both adoption paths (switch-time hook and per-job REST adopt) stamped the SYSTEM timezone onto adopted jobs, discarding the native job's own tz (which the adapter deliberately hoists into \`metadata.tz\`). An evening job adopted on a UTC box silently shifted hours. Both paths now prefer the native tz.

Audit-corrected note recorded in the knowledge docs: current OpenClaw builds route \`cron list\` through the gateway (credentials required) — cron CRUD is NOT guaranteed gateway-free; the honest-degrade path in \`readMergedJobs\` covers it.

## Test plan

- [x] Full suite green (\`bun run test\`: 6986 pass) + typecheck
- [x] New: \`tests/core/ledger-retention.test.ts\`, \`tests/plugins/schedule/retention-sweep.test.ts\`, \`tests/integration/schedule-switch-survival.test.ts\`, cron conformance + teeth
- [ ] Live on 3737: \`bakin doctor --full\` shows \`schedule.schedule-sync\`; existing schedules still fire (Mark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)