### PR TITLE
refactor(schedule): server-computed occurrences feed the calendars (PR3 of #191 initiative)

### DIFF
--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -41,7 +41,8 @@ export { useQueryArrayState } from '@/hooks/use-query-state'
 export { useScheduleJobs } from '@/hooks/use-schedule'
 /** Fetch run history for a scheduled job. */
 export { useRunHistory } from '@/hooks/use-schedule'
-export type { ScheduleJob, RunEntry } from '@/hooks/use-schedule'
+export { useOccurrences } from '@/hooks/use-schedule'
+export type { ScheduleJob, RunEntry, ScheduleOccurrence } from '@/hooks/use-schedule'
 /** Fetch dispatch run history for a task. */
 export { useTaskRunHistory } from '@/hooks/use-task-run-history'
 export type { TaskOutcome, TaskRunEntry } from '@/hooks/use-task-run-history'

--- a/plugins/schedule/components/agent-colors.ts
+++ b/plugins/schedule/components/agent-colors.ts
@@ -1,0 +1,38 @@
+/**
+ * Agent visual identity for the calendar views — the ONE color table
+ * (previously duplicated between calendar-weekly's AGENT_STYLES and
+ * calendar-monthly's AGENT_DOT_GLOW, which had drifted).
+ *
+ * Inline style objects carry gradients/glows (Tailwind can't do arbitrary
+ * values); class strings stay literal so the JIT scanner sees them.
+ */
+export interface AgentStyle {
+  border: string
+  bg: string         // Tailwind bg for the card surface
+  glow: string       // box-shadow color token (rgba)
+  accent: string     // text color for the time pill
+  dot: string        // status dot color
+  gradient: string   // CSS gradient for the top accent bar
+}
+
+export const AGENT_STYLES: Record<string, AgentStyle> = {
+  main:     { border: 'border-blue-500/30',    bg: 'bg-blue-500/[0.06]',    glow: 'rgba(96,165,250,0.10)',  accent: 'text-blue-400',    dot: 'bg-blue-400',    gradient: 'linear-gradient(135deg, rgba(96,165,250,0.4), rgba(96,165,250,0.08))' },
+  chef:     { border: 'border-green-500/30',   bg: 'bg-green-500/[0.06]',   glow: 'rgba(74,222,128,0.10)',  accent: 'text-green-400',   dot: 'bg-green-400',   gradient: 'linear-gradient(135deg, rgba(74,222,128,0.4), rgba(74,222,128,0.08))' },
+  pixel:    { border: 'border-violet-500/30',  bg: 'bg-violet-500/[0.06]',  glow: 'rgba(167,139,250,0.10)', accent: 'text-violet-400',  dot: 'bg-violet-400',  gradient: 'linear-gradient(135deg, rgba(167,139,250,0.4), rgba(167,139,250,0.08))' },
+  rolo:     { border: 'border-orange-500/30',  bg: 'bg-orange-500/[0.06]',  glow: 'rgba(251,146,60,0.10)',  accent: 'text-orange-400',  dot: 'bg-orange-400',  gradient: 'linear-gradient(135deg, rgba(251,146,60,0.4), rgba(251,146,60,0.08))' },
+  patch:    { border: 'border-zinc-500/30',    bg: 'bg-zinc-500/[0.06]',    glow: 'rgba(161,161,170,0.10)', accent: 'text-zinc-400',    dot: 'bg-zinc-400',    gradient: 'linear-gradient(135deg, rgba(161,161,170,0.4), rgba(161,161,170,0.08))' },
+  explorer: { border: 'border-emerald-500/30', bg: 'bg-emerald-500/[0.06]', glow: 'rgba(52,211,153,0.10)',  accent: 'text-emerald-400', dot: 'bg-emerald-400', gradient: 'linear-gradient(135deg, rgba(52,211,153,0.4), rgba(52,211,153,0.08))' },
+  trainer:  { border: 'border-cyan-500/30',    bg: 'bg-cyan-500/[0.06]',    glow: 'rgba(34,211,238,0.10)',  accent: 'text-cyan-400',    dot: 'bg-cyan-400',    gradient: 'linear-gradient(135deg, rgba(34,211,238,0.4), rgba(34,211,238,0.08))' },
+  coach:    { border: 'border-amber-500/30',   bg: 'bg-amber-500/[0.06]',   glow: 'rgba(251,191,36,0.10)',  accent: 'text-amber-400',   dot: 'bg-amber-400',   gradient: 'linear-gradient(135deg, rgba(251,191,36,0.4), rgba(251,191,36,0.08))' },
+}
+
+export const FALLBACK_STYLE = AGENT_STYLES.patch!
+
+export function agentStyle(agentId: string | undefined): AgentStyle {
+  return AGENT_STYLES[agentId || ''] || FALLBACK_STYLE
+}
+
+/** Stronger-alpha glow for the month view's tiny dots. */
+export function agentDotGlow(agentId: string | undefined): string {
+  return agentStyle(agentId).glow.replace('0.10)', '0.35)')
+}

--- a/plugins/schedule/components/calendar-monthly.tsx
+++ b/plugins/schedule/components/calendar-monthly.tsx
@@ -1,90 +1,26 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
+import { useOccurrences, type ScheduleJob, type ScheduleOccurrence } from "@makinbakin/sdk/hooks"
 import { AgentBadge } from './agent-badge'
-import type { ScheduleJob } from "@makinbakin/sdk/hooks"
+import { agentDotGlow } from './agent-colors'
+import { jobsById } from './calendar-weekly'
 
-// Matching glow colors from the weekly view's AGENT_STYLES
-const AGENT_DOT_GLOW: Record<string, string> = {
-  main:    'rgba(96,165,250,0.35)',
-  chef:   'rgba(74,222,128,0.35)',
-  pixel:   'rgba(167,139,250,0.35)',
-  rolo:    'rgba(251,146,60,0.35)',
-  patch:   'rgba(161,161,170,0.25)',
-  explorer:   'rgba(52,211,153,0.35)',
-  trainer:    'rgba(34,211,238,0.35)',
-  coach:     'rgba(251,191,36,0.35)',
-}
-
-function getDaysInMonth(year: number, month: number): Date[] {
+function getCalendarGrid(year: number, month: number): (Date | null)[] {
   const days: Date[] = []
   const d = new Date(year, month, 1)
   while (d.getMonth() === month) {
     days.push(new Date(d))
     d.setDate(d.getDate() + 1)
   }
-  return days
-}
-
-function getCalendarGrid(year: number, month: number): (Date | null)[] {
-  const days = getDaysInMonth(year, month)
   const firstDow = days[0]!.getDay()
   const grid: (Date | null)[] = []
   for (let i = 0; i < firstDow; i++) grid.push(null)
   grid.push(...days)
   while (grid.length % 7 !== 0) grid.push(null)
   return grid
-}
-
-function jobFiringOnDay(job: ScheduleJob, date: Date): boolean {
-  if (!job.cron) return false
-  const parts = job.cron.split(/\s+/)
-  if (parts.length < 5) return false
-  const [, , domField, monField, dowField] = parts
-
-  if (monField !== '*') {
-    const months = expandField(monField!, 1, 12)
-    if (!months.includes(date.getMonth() + 1)) return false
-  }
-
-  const domMatch = domField === '*'
-  const dowMatch = dowField === '*'
-
-  if (!domMatch && !dowMatch) {
-    const doms = expandField(domField!, 1, 31)
-    const dows = expandField(dowField!, 0, 6)
-    if (!doms.includes(date.getDate()) && !dows.includes(date.getDay())) return false
-  } else if (!domMatch) {
-    const doms = expandField(domField!, 1, 31)
-    if (!doms.includes(date.getDate())) return false
-  } else if (!dowMatch) {
-    const dows = expandField(dowField!, 0, 6)
-    if (!dows.includes(date.getDay())) return false
-  }
-
-  return true
-}
-
-function expandField(field: string, min: number, max: number): number[] {
-  const result: number[] = []
-  for (const part of field.split(',')) {
-    if (part.includes('/')) {
-      const [range, step] = part.split('/')
-      const s = parseInt(step!, 10)
-      const start = range === '*' ? min : parseInt(range!, 10)
-      for (let i = start; i <= max; i += s) result.push(i)
-    } else if (part.includes('-')) {
-      const [a, b] = part.split('-')
-      for (let i = parseInt(a!, 10); i <= parseInt(b!, 10); i++) result.push(i)
-    } else if (part === '*') {
-      for (let i = min; i <= max; i++) result.push(i)
-    } else {
-      result.push(parseInt(part, 10))
-    }
-  }
-  return result
 }
 
 const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -102,25 +38,27 @@ export function CalendarMonthly({
   const [month, setMonth] = useState(now.getMonth())
 
   const grid = useMemo(() => getCalendarGrid(year, month), [year, month])
+  const monthStart = useMemo(() => new Date(year, month, 1), [year, month])
+  const monthEnd = useMemo(() => new Date(year, month + 1, 1), [year, month])
 
-  const jobsByDay = useMemo(() => {
-    const map = new Map<number, ScheduleJob[]>()
-    const days = getDaysInMonth(year, month)
-    for (const day of days) {
-      const matches = jobs.filter(j => {
-        if (!jobFiringOnDay(j, day)) return false
-        // Only show on or after the job's creation date
-        if (j.createdAt) {
-          const created = new Date(j.createdAt)
-          const createdDay = new Date(created.getFullYear(), created.getMonth(), created.getDate())
-          if (day < createdDay) return false
-        }
-        return true
-      })
-      if (matches.length > 0) map.set(day.getDate(), matches)
+  // Server-computed placements (kind-aware, tz/DST-correct).
+  const { occurrences } = useOccurrences(monthStart.toISOString(), monthEnd.toISOString())
+  const byId = useMemo(() => jobsById(jobs), [jobs])
+
+  // Day-of-month → the day's occurrences (local dates; dedupe a job that
+  // fires multiple times a day down to one row at month zoom).
+  const occurrencesByDay = useMemo(() => {
+    const map = new Map<number, ScheduleOccurrence[]>()
+    for (const occurrence of occurrences) {
+      const d = new Date(occurrence.at)
+      if (d.getMonth() !== month || d.getFullYear() !== year) continue
+      const day = d.getDate()
+      const existing = map.get(day) ?? []
+      if (!existing.some(o => o.jobId === occurrence.jobId)) existing.push(occurrence)
+      map.set(day, existing)
     }
     return map
-  }, [jobs, year, month])
+  }, [occurrences, month, year])
 
   const today = new Date()
   const isToday = (d: Date) =>
@@ -163,8 +101,8 @@ export function CalendarMonthly({
             return <div key={`empty-${i}`} className="bg-background/30 min-h-[88px]" />
           }
 
-          const dayJobs = jobsByDay.get(date.getDate()) || []
-          const hasJobs = dayJobs.length > 0
+          const dayOccurrences = occurrencesByDay.get(date.getDate()) || []
+          const hasRuns = dayOccurrences.length > 0
           const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate())
           const isPast = date.getTime() < todayStart.getTime()
           const MAX_SHOW = 3
@@ -175,7 +113,7 @@ export function CalendarMonthly({
               className={`
                 bg-background min-h-[88px] p-2 transition-colors
                 ${isToday(date) ? 'bg-blue-500/[0.04]' : ''}
-                ${hasJobs ? 'hover:bg-white/[0.02]' : ''}
+                ${hasRuns ? 'hover:bg-white/[0.02]' : ''}
               `}
             >
               {/* Date number */}
@@ -189,28 +127,32 @@ export function CalendarMonthly({
                 {date.getDate()}
               </div>
 
-              {/* Job indicators */}
+              {/* Run indicators */}
               <div className={`flex flex-col gap-1 ${isPast ? 'opacity-35 saturate-[0.3]' : ''}`}>
-                {dayJobs.slice(0, MAX_SHOW).map(j => (
-                  <button
-                    key={j.id}
-                    onClick={() => onSelectJob(j)}
-                    className={`group/dot flex items-center gap-1.5 w-full hover:bg-white/[0.04] rounded px-1 py-0.5 -mx-1 transition-colors ${isPast ? 'hover:opacity-60' : ''}`}
-                  >
-                    <span
-                      className="shrink-0 transition-transform group-hover/dot:scale-110"
-                      style={{ filter: isPast ? 'none' : `drop-shadow(0 0 3px ${AGENT_DOT_GLOW[j.agentId || ''] || 'transparent'})` }}
+                {dayOccurrences.slice(0, MAX_SHOW).map(occurrence => {
+                  const job = byId.get(occurrence.jobId)
+                  if (!job) return null
+                  return (
+                    <button
+                      key={occurrence.jobId}
+                      onClick={() => onSelectJob(job)}
+                      className={`group/dot flex items-center gap-1.5 w-full hover:bg-white/[0.04] rounded px-1 py-0.5 -mx-1 transition-colors ${isPast ? 'hover:opacity-60' : ''}`}
                     >
-                      <AgentBadge agentId={j.agentId} size="sm" showName={false} />
-                    </span>
-                    <span className={`text-[10px] truncate transition-colors ${isPast ? 'text-zinc-600' : 'text-zinc-400 group-hover/dot:text-zinc-300'}`}>
-                      {j.displayName || j.id}
-                    </span>
-                  </button>
-                ))}
-                {dayJobs.length > MAX_SHOW && (
+                      <span
+                        className="shrink-0 transition-transform group-hover/dot:scale-110"
+                        style={{ filter: isPast ? 'none' : `drop-shadow(0 0 3px ${agentDotGlow(job.agentId)})` }}
+                      >
+                        <AgentBadge agentId={job.agentId} size="sm" showName={false} />
+                      </span>
+                      <span className={`text-[10px] truncate transition-colors ${isPast ? 'text-zinc-600' : 'text-zinc-400 group-hover/dot:text-zinc-300'}`}>
+                        {job.displayName || job.id}
+                      </span>
+                    </button>
+                  )
+                })}
+                {dayOccurrences.length > MAX_SHOW && (
                   <span className="text-[9px] text-zinc-600 pl-1 font-medium">
-                    +{dayJobs.length - MAX_SHOW} more
+                    +{dayOccurrences.length - MAX_SHOW} more
                   </span>
                 )}
               </div>

--- a/plugins/schedule/components/calendar-today.tsx
+++ b/plugins/schedule/components/calendar-today.tsx
@@ -2,15 +2,8 @@
 
 import { useMemo } from 'react'
 import { Clock } from 'lucide-react'
-import {
-  getJobHour,
-  getJobMinute,
-  formatHour,
-  jobOnDow,
-  JobCard,
-  CALENDAR_HOURS,
-} from './calendar-weekly'
-import type { ScheduleJob } from "@makinbakin/sdk/hooks"
+import { useOccurrences, type ScheduleJob, type ScheduleOccurrence } from "@makinbakin/sdk/hooks"
+import { OccurrenceCard, formatHour, jobsById, CALENDAR_HOURS } from './calendar-weekly'
 
 export function CalendarToday({
   jobs,
@@ -21,7 +14,21 @@ export function CalendarToday({
 }) {
   const now = new Date()
   const currentHour = now.getHours()
-  const dow = now.getDay()
+
+  const dayStart = useMemo(() => {
+    const d = new Date()
+    d.setHours(0, 0, 0, 0)
+    return d
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  const dayEnd = useMemo(() => {
+    const d = new Date(dayStart)
+    d.setDate(d.getDate() + 1)
+    return d
+  }, [dayStart])
+
+  const { occurrences } = useOccurrences(dayStart.toISOString(), dayEnd.toISOString())
+  const byId = useMemo(() => jobsById(jobs), [jobs])
 
   const todayFormatted = now.toLocaleDateString('en-US', {
     weekday: 'long',
@@ -30,24 +37,16 @@ export function CalendarToday({
     year: 'numeric',
   })
 
-  // Filter jobs that run today, grouped by hour
+  // Group today's occurrences by local hour (already sorted by the server).
   const hourGrid = useMemo(() => {
-    const map: Record<number, ScheduleJob[]> = {}
-    let total = 0
-    for (const job of jobs) {
-      const hour = getJobHour(job)
-      if (hour === null) continue
-      if (!jobOnDow(job, dow)) continue
+    const map: Record<number, ScheduleOccurrence[]> = {}
+    for (const occurrence of occurrences) {
+      const hour = new Date(occurrence.at).getHours()
       if (!map[hour]) map[hour] = []
-      map[hour]!.push(job)
-      total++
+      map[hour]!.push(occurrence)
     }
-    return { map, total }
-  }, [jobs, dow])
-
-  // Sort jobs within each hour by minute
-  const sortedHourJobs = (hourJobs: ScheduleJob[]) =>
-    [...hourJobs].sort((a, b) => getJobMinute(a) - getJobMinute(b))
+    return { map, total: occurrences.length }
+  }, [occurrences])
 
   return (
     <div className="flex flex-col gap-3 h-full min-h-0">
@@ -56,7 +55,7 @@ export function CalendarToday({
         <Clock className="size-4 text-muted-foreground" />
         <span className="text-sm font-medium">{todayFormatted}</span>
         <span className="text-xs text-muted-foreground">
-          {hourGrid.total} job{hourGrid.total !== 1 ? 's' : ''} scheduled
+          {hourGrid.total} run{hourGrid.total !== 1 ? 's' : ''} scheduled
         </span>
       </div>
 
@@ -64,8 +63,7 @@ export function CalendarToday({
       <div className="overflow-auto flex-1 min-h-0 border border-border/30 rounded-lg bg-background/50">
         <div className="divide-y divide-border/[0.06]">
           {CALENDAR_HOURS.map(hour => {
-            const hourJobs = hourGrid.map[hour] || []
-            const isPast = hour < currentHour
+            const hourOccurrences = hourGrid.map[hour] || []
             const isCurrent = hour === currentHour
 
             return (
@@ -86,19 +84,23 @@ export function CalendarToday({
                   )}
                 </div>
 
-                {/* Job cards */}
+                {/* Occurrence cards */}
                 <div className="flex-1 min-w-0">
-                  {hourJobs.length > 0 ? (
+                  {hourOccurrences.length > 0 ? (
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                      {sortedHourJobs(hourJobs).map(job => (
-                        <JobCard
-                          key={job.id}
-                          job={job}
-                          onClick={() => onSelectJob(job)}
-                          expanded
-                          past={isPast}
-                        />
-                      ))}
+                      {hourOccurrences.map(occurrence => {
+                        const job = byId.get(occurrence.jobId)
+                        if (!job) return null
+                        return (
+                          <OccurrenceCard
+                            key={`${occurrence.jobId}-${occurrence.at}`}
+                            occurrence={occurrence}
+                            job={job}
+                            onClick={() => onSelectJob(job)}
+                            expanded
+                          />
+                        )
+                      })}
                     </div>
                   ) : null}
                 </div>

--- a/plugins/schedule/components/calendar-weekly.tsx
+++ b/plugins/schedule/components/calendar-weekly.tsx
@@ -1,32 +1,11 @@
 'use client'
 
-import { Fragment, useState, useMemo } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from "@makinbakin/sdk/ui"
+import { useOccurrences, type ScheduleJob, type ScheduleOccurrence } from "@makinbakin/sdk/hooks"
 import { AgentBadge } from './agent-badge'
-import type { ScheduleJob } from "@makinbakin/sdk/hooks"
-
-// Agent-keyed style tokens — each entry is a self-contained visual identity
-// Uses inline style objects for gradient backgrounds (Tailwind can't do arbitrary gradients)
-export const AGENT_STYLES: Record<string, {
-  border: string
-  bg: string         // Tailwind bg for the card surface
-  glow: string       // box-shadow color token (rgba)
-  accent: string     // text color for the time pill
-  dot: string        // status dot color
-  gradient: string   // CSS gradient for the top accent bar
-}> = {
-  main:    { border: 'border-blue-500/30',    bg: 'bg-blue-500/[0.06]',    glow: 'rgba(96,165,250,0.10)',  accent: 'text-blue-400',    dot: 'bg-blue-400',    gradient: 'linear-gradient(135deg, rgba(96,165,250,0.4), rgba(96,165,250,0.08))' },
-  chef:   { border: 'border-green-500/30',   bg: 'bg-green-500/[0.06]',   glow: 'rgba(74,222,128,0.10)',  accent: 'text-green-400',   dot: 'bg-green-400',   gradient: 'linear-gradient(135deg, rgba(74,222,128,0.4), rgba(74,222,128,0.08))' },
-  pixel:   { border: 'border-violet-500/30',  bg: 'bg-violet-500/[0.06]',  glow: 'rgba(167,139,250,0.10)', accent: 'text-violet-400',  dot: 'bg-violet-400',  gradient: 'linear-gradient(135deg, rgba(167,139,250,0.4), rgba(167,139,250,0.08))' },
-  rolo:    { border: 'border-orange-500/30',  bg: 'bg-orange-500/[0.06]',  glow: 'rgba(251,146,60,0.10)',  accent: 'text-orange-400',  dot: 'bg-orange-400',  gradient: 'linear-gradient(135deg, rgba(251,146,60,0.4), rgba(251,146,60,0.08))' },
-  patch:   { border: 'border-zinc-500/30',    bg: 'bg-zinc-500/[0.06]',    glow: 'rgba(161,161,170,0.10)', accent: 'text-zinc-400',    dot: 'bg-zinc-400',    gradient: 'linear-gradient(135deg, rgba(161,161,170,0.4), rgba(161,161,170,0.08))' },
-  explorer:   { border: 'border-emerald-500/30', bg: 'bg-emerald-500/[0.06]', glow: 'rgba(52,211,153,0.10)',  accent: 'text-emerald-400', dot: 'bg-emerald-400', gradient: 'linear-gradient(135deg, rgba(52,211,153,0.4), rgba(52,211,153,0.08))' },
-  trainer:    { border: 'border-cyan-500/30',    bg: 'bg-cyan-500/[0.06]',    glow: 'rgba(34,211,238,0.10)',  accent: 'text-cyan-400',    dot: 'bg-cyan-400',    gradient: 'linear-gradient(135deg, rgba(34,211,238,0.4), rgba(34,211,238,0.08))' },
-  coach:     { border: 'border-amber-500/30',   bg: 'bg-amber-500/[0.06]',   glow: 'rgba(251,191,36,0.10)',  accent: 'text-amber-400',   dot: 'bg-amber-400',   gradient: 'linear-gradient(135deg, rgba(251,191,36,0.4), rgba(251,191,36,0.08))' },
-}
-
-export const FALLBACK_STYLE = AGENT_STYLES.patch!
+import { agentStyle } from './agent-colors'
 
 export const CALENDAR_HOURS = Array.from({ length: 24 }, (_, i) => i)
 const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -46,68 +25,6 @@ function getWeekDates(weekStart: Date): Date[] {
   })
 }
 
-export function getJobHour(job: ScheduleJob): number | null {
-  if (!job.cron) return null
-  const parts = job.cron.split(/\s+/)
-  if (parts.length < 5) return null
-  const hourField = parts[1]
-  if (!hourField || hourField === '*') return 9
-  const h = parseInt(hourField, 10)
-  return isNaN(h) ? null : h
-}
-
-export function getJobMinute(job: ScheduleJob): number {
-  if (!job.cron) return 0
-  const parts = job.cron.split(/\s+/)
-  if (parts.length < 5) return 0
-  const minField = parts[0]
-  if (!minField || minField === '*' || minField.includes('/')) return 0
-  const m = parseInt(minField, 10)
-  return isNaN(m) ? 0 : m
-}
-
-export function formatJobTime(job: ScheduleJob): string {
-  const h = getJobHour(job)
-  if (h === null) return ''
-  const m = getJobMinute(job)
-  const period = h >= 12 ? 'pm' : 'am'
-  const display = h === 0 ? 12 : h > 12 ? h - 12 : h
-  return m === 0 ? `${display}${period}` : `${display}:${m.toString().padStart(2, '0')}${period}`
-}
-
-export function jobOnDow(job: ScheduleJob, dow: number): boolean {
-  if (!job.cron) return false
-  const parts = job.cron.split(/\s+/)
-  if (parts.length < 5) return false
-  const dowField = parts[4]
-  const domField = parts[2]
-  if (!dowField || !domField) return false
-  if (dowField === '*' && domField === '*') return true
-  if (dowField === '*') return true
-
-  const dows = expandDow(dowField)
-  return dows.includes(dow)
-}
-
-function expandDow(field: string): number[] {
-  const result: number[] = []
-  for (const part of field.split(',')) {
-    if (part.includes('-')) {
-      const [a, b] = part.split('-')
-      for (let i = parseInt(a!, 10); i <= parseInt(b!, 10); i++) result.push(i)
-    } else if (part.includes('/')) {
-      const [, step] = part.split('/')
-      const s = parseInt(step!, 10)
-      for (let i = 0; i <= 6; i += s) result.push(i)
-    } else if (part === '*') {
-      for (let i = 0; i <= 6; i++) result.push(i)
-    } else {
-      result.push(parseInt(part, 10))
-    }
-  }
-  return result
-}
-
 export function formatHour(h: number): string {
   if (h === 0) return '12 AM'
   if (h < 12) return `${h} AM`
@@ -115,10 +32,48 @@ export function formatHour(h: number): string {
   return `${h - 12} PM`
 }
 
-/** A single job card — used in weekly grid and today timeline */
-export function JobCard({ job, onClick, expanded, past }: { job: ScheduleJob; onClick: () => void; expanded?: boolean; past?: boolean }) {
-  const s = AGENT_STYLES[job.agentId || ''] || FALLBACK_STYLE
-  const time = formatJobTime(job)
+/** Local wall-clock label of an occurrence instant ("11:05pm"). */
+export function formatInstantTime(at: string): string {
+  const d = new Date(at)
+  const h = d.getHours()
+  const m = d.getMinutes()
+  const period = h >= 12 ? 'pm' : 'am'
+  const display = h === 0 ? 12 : h > 12 ? h - 12 : h
+  return m === 0 ? `${display}${period}` : `${display}:${m.toString().padStart(2, '0')}${period}`
+}
+
+/** Index jobs by id for occurrence → job lookup. */
+export function jobsById(jobs: ScheduleJob[]): Map<string, ScheduleJob> {
+  return new Map(jobs.map(job => [job.id, job]))
+}
+
+/** Fired/skipped marker for past occurrences (ledger disposition). */
+function DispositionDot({ occurrence }: { occurrence: ScheduleOccurrence }) {
+  if (!occurrence.past || !occurrence.disposition) return null
+  const created = occurrence.disposition === 'created'
+  return (
+    <span
+      title={created ? 'Fired' : `Skipped${occurrence.skipReason ? ` — ${occurrence.skipReason}` : ''}`}
+      className={`size-1.5 rounded-full shrink-0 ${created ? 'bg-emerald-400' : 'bg-amber-400'}`}
+    />
+  )
+}
+
+/** A single occurrence card — used in the weekly grid and today timeline. */
+export function OccurrenceCard({
+  occurrence,
+  job,
+  onClick,
+  expanded,
+}: {
+  occurrence: ScheduleOccurrence
+  job: ScheduleJob
+  onClick: () => void
+  expanded?: boolean
+}) {
+  const s = agentStyle(job.agentId)
+  const time = formatInstantTime(occurrence.at)
+  const past = occurrence.past
 
   return (
     <button
@@ -135,17 +90,16 @@ export function JobCard({ job, onClick, expanded, past }: { job: ScheduleJob; on
       style={{ boxShadow: past ? 'none' : `0 1px 6px -1px ${s.glow}` }}
     >
       <div className={expanded ? 'px-3 py-2.5' : 'px-2 py-1.5'}>
-        {/* Row 1: avatar + name + time pill */}
+        {/* Row 1: avatar + name + disposition + time pill */}
         <div className="flex items-center gap-1.5 min-w-0">
           <AgentBadge agentId={job.agentId} size="sm" showName={expanded} />
           <span className={`font-medium truncate flex-1 leading-tight ${expanded ? 'text-sm' : 'text-[11px]'} ${past ? 'text-zinc-500' : 'text-zinc-200'}`}>
             {job.displayName || job.id}
           </span>
-          {time && (
-            <span className={`font-mono ${past ? 'text-zinc-600' : s.accent} opacity-70 shrink-0 tabular-nums ${expanded ? 'text-xs' : 'text-[9px]'}`}>
-              {time}
-            </span>
-          )}
+          <DispositionDot occurrence={occurrence} />
+          <span className={`font-mono ${past ? 'text-zinc-600' : s.accent} opacity-70 shrink-0 tabular-nums ${expanded ? 'text-xs' : 'text-[9px]'}`}>
+            {time}
+          </span>
         </div>
 
         {/* Row 2: prompt snippet */}
@@ -176,6 +130,16 @@ export function CalendarWeekly({
   const now = new Date()
   const [weekStart, setWeekStart] = useState(() => getWeekStart(now))
   const weekDates = useMemo(() => getWeekDates(weekStart), [weekStart])
+  const weekEnd = useMemo(() => {
+    const d = new Date(weekStart)
+    d.setDate(d.getDate() + 7)
+    return d
+  }, [weekStart])
+
+  // Server-computed placements — the one occurrence engine (kind-aware,
+  // tz/DST-correct). The old client-side cron parsing is gone.
+  const { occurrences } = useOccurrences(weekStart.toISOString(), weekEnd.toISOString())
+  const byId = useMemo(() => jobsById(jobs), [jobs])
 
   const prev = () => setWeekStart(d => { const n = new Date(d); n.setDate(n.getDate() - 7); return n })
   const next = () => setWeekStart(d => { const n = new Date(d); n.setDate(n.getDate() + 7); return n })
@@ -184,28 +148,17 @@ export function CalendarWeekly({
   const isToday = (d: Date) =>
     d.getDate() === now.getDate() && d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear()
 
-  // Build grid: [dow][hour] → jobs[]  (only cells on or after job's creation date)
+  // Grid: [localDow-localHour] → occurrences (instants land in browser-local cells)
   const grid = useMemo(() => {
-    const map: Record<string, ScheduleJob[]> = {}
-    for (const job of jobs) {
-      const hour = getJobHour(job)
-      if (hour === null) continue
-      const jobStart = job.createdAt ? new Date(job.createdAt) : null
-      const jobStartDay = jobStart
-        ? new Date(jobStart.getFullYear(), jobStart.getMonth(), jobStart.getDate())
-        : null
-      for (let dow = 0; dow < 7; dow++) {
-        if (jobOnDow(job, dow)) {
-          const cellDate = weekDates[dow]!
-          if (jobStartDay && cellDate < jobStartDay) continue
-          const key = `${dow}-${hour}`
-          if (!map[key]) map[key] = []
-          map[key]!.push(job)
-        }
-      }
+    const map: Record<string, ScheduleOccurrence[]> = {}
+    for (const occurrence of occurrences) {
+      const d = new Date(occurrence.at)
+      const key = `${d.getDay()}-${d.getHours()}`
+      if (!map[key]) map[key] = []
+      map[key]!.push(occurrence)
     }
     return map
-  }, [jobs, weekDates])
+  }, [occurrences])
 
   return (
     <div className="flex flex-col gap-3 h-full min-h-0">
@@ -214,7 +167,7 @@ export function CalendarWeekly({
         <Button variant="ghost" size="sm" onClick={prev}><ChevronLeft className="size-4" /></Button>
         <span className="text-sm font-medium w-[240px] text-center">
           {weekDates[0]!.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-          {' \u2014 '}
+          {' — '}
           {weekDates[6]!.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
         </span>
         <Button variant="ghost" size="sm" onClick={next}><ChevronRight className="size-4" /></Button>
@@ -252,23 +205,29 @@ export function CalendarWeekly({
                 {formatHour(hour)}
               </div>
               {Array.from({ length: 7 }, (_, dow) => {
-                const cellJobs = grid[`${dow}-${hour}`] || []
+                const cellOccurrences = grid[`${dow}-${hour}`] || []
                 const today = isToday(weekDates[dow]!)
-                const cellDate = weekDates[dow]!
-                const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-                const isPast = cellDate.getTime() < todayStart.getTime() || (today && hour < now.getHours())
                 return (
                   <div
                     key={`${dow}-${hour}`}
                     className={`
                       border-l border-t border-border/[0.06] p-1
                       ${today ? 'bg-blue-500/[0.02]' : ''}
-                      ${cellJobs.length === 0 ? 'hover:bg-white/[0.01]' : ''}
+                      ${cellOccurrences.length === 0 ? 'hover:bg-white/[0.01]' : ''}
                     `}
                   >
-                    {cellJobs.map(j => (
-                      <JobCard key={j.id} job={j} onClick={() => onSelectJob(j)} past={isPast} />
-                    ))}
+                    {cellOccurrences.map(occurrence => {
+                      const job = byId.get(occurrence.jobId)
+                      if (!job) return null
+                      return (
+                        <OccurrenceCard
+                          key={`${occurrence.jobId}-${occurrence.at}`}
+                          occurrence={occurrence}
+                          job={job}
+                          onClick={() => onSelectJob(job)}
+                        />
+                      )
+                    })}
                   </div>
                 )
               })}

--- a/plugins/schedule/lib/occurrences.ts
+++ b/plugins/schedule/lib/occurrences.ts
@@ -1,0 +1,102 @@
+/**
+ * Server-side occurrence computation — THE one engine that places jobs on
+ * the calendar (PR3 of #191). Replaces the calendars' hand-rolled client-side
+ * cron parsing, which was wrong for timezones, DST, and anything beyond
+ * simple expressions.
+ *
+ * Pure and dependency-injected (clock + ledger reader) so it is fake-clock
+ * testable; the route in routes/jobs.ts wires it to readMergedJobs and the
+ * execution ledger.
+ */
+import { scheduleOccurrencesBetween } from './cron-eval'
+import type { MergedJob, ScheduleDef } from '../types'
+
+export interface OccurrenceItem {
+  jobId: string
+  /** Absolute instant, ISO-8601 UTC. Clients render in their local tz. */
+  at: string
+  /** Strictly before `now` at compute time. */
+  past: boolean
+  /** Ledger enrichment for past Bakin-job occurrences (absent = never claimed
+   *  — e.g. the server slept through it and it fell outside catch-up). */
+  disposition?: 'pending' | 'created' | 'skipped' | 'seeded'
+  taskId?: string
+  skipReason?: string
+}
+
+export interface OccurrenceQueryDeps {
+  nowMs: number
+  /** Ledger read for past Bakin occurrences (getCronFire-shaped). */
+  getFire: (jobId: string, runId: string) => {
+    disposition: 'pending' | 'created' | 'skipped' | 'seeded'
+    taskId?: string | null
+    skipReason?: string | null
+  } | null
+}
+
+export interface OccurrencesResult {
+  items: OccurrenceItem[]
+  /** Jobs whose schedule Bakin cannot evaluate (native 'every' kinds) —
+   *  reported, never silently dropped. */
+  unevaluated: string[]
+}
+
+/** The Bakin-evaluable ScheduleDef of a merged job, or null. */
+function evaluableDef(job: MergedJob): ScheduleDef | null {
+  const type = job.schedule.type
+  const expr = job.schedule.value
+  if (!expr) return null
+  if (type !== 'cron' && type !== 'at') return null
+  return { kind: type, expr }
+}
+
+export function computeOccurrences(
+  jobs: MergedJob[],
+  fromMs: number,
+  toMs: number,
+  deps: OccurrenceQueryDeps,
+): OccurrencesResult {
+  const items: OccurrenceItem[] = []
+  const unevaluated: string[] = []
+  const from = new Date(fromMs)
+  const to = new Date(toMs)
+
+  for (const job of jobs) {
+    if (!job.schedule.value) continue
+    const def = evaluableDef(job)
+    if (!def) {
+      unevaluated.push(job.id)
+      continue
+    }
+
+    const tz = job.schedule.tz ?? job.tz
+    const createdMs = job.createdAt ? Date.parse(job.createdAt) : NaN
+    const fireable = job.enabled && !job.paused && !job.completed
+
+    for (const occurrence of scheduleOccurrencesBetween(def, tz, from, to)) {
+      const occMs = occurrence.getTime()
+      // No phantom history: a job has no occurrences from before it existed
+      // (mirrors the catch-up guard in scheduler.ts).
+      if (Number.isFinite(createdMs) && occMs < createdMs) continue
+      const past = occMs < deps.nowMs
+      // Disabled/paused/completed jobs won't fire — show what happened, not
+      // a future that can't. (A completed one-shot's instant is always past.)
+      if (!past && !fireable) continue
+
+      const item: OccurrenceItem = { jobId: job.id, at: occurrence.toISOString(), past }
+      if (past && job.isBakinJob) {
+        // Same runId scheme the fire path claims with (makeOccurrenceRunId).
+        const fire = deps.getFire(job.id, `${job.id}:${occurrence.toISOString()}`)
+        if (fire) {
+          item.disposition = fire.disposition
+          if (fire.taskId) item.taskId = fire.taskId
+          if (fire.skipReason) item.skipReason = fire.skipReason
+        }
+      }
+      items.push(item)
+    }
+  }
+
+  items.sort((a, b) => a.at.localeCompare(b.at) || a.jobId.localeCompare(b.jobId))
+  return { items, unevaluated }
+}

--- a/plugins/schedule/lib/routes/jobs.ts
+++ b/plugins/schedule/lib/routes/jobs.ts
@@ -12,6 +12,8 @@ import { getJob, upsertJob } from '../sidecar'
 import { parseSchedule } from '../cron-parser'
 import { getSystemTimezone, json, nativeCronTz } from '../schedule-util'
 import { readRuns } from '../runs-reader'
+import { computeOccurrences } from '../occurrences'
+import { getCronFire } from '../../../../src/core/execution-ledger'
 import { getRuntimeMainAgentId } from '@bakin/core/adapters/runtime'
 import { fireManualRun } from '../fire-engine'
 import {
@@ -29,6 +31,8 @@ import { validateTeamAssignment, TaskValidationError } from '../../../../src/cor
 // ─── Schemas ─────────────────────────────────────────────────────────────
 
 const jobIdParams = z.object({ jobId: z.string().min(1) })
+/** Occurrence queries cap at ~2 months — the month view needs 6 weeks. */
+const MAX_OCCURRENCE_RANGE_MS = 62 * 24 * 60 * 60 * 1000
 const okResponse = z.object({ ok: z.literal(true) }).passthrough()
 const errorResponse = z.object({ error: z.string() }).passthrough()
 const passthrough = z.object({}).passthrough()
@@ -109,6 +113,32 @@ export const scheduleRoutes = [
         cron: j.schedule.type === 'cron' ? j.schedule.value : undefined,
       }))
       return json({ jobs })
+    },
+  }),
+
+  defineRoute({
+    path: '/occurrences',
+    method: 'GET',
+    summary: 'Job occurrences in a time range',
+    description: 'Server-computed, timezone-correct occurrence instants for every evaluable job (cron + one-shot), past occurrences enriched with their ledger disposition. The single source the calendar views render from.',
+    responses: { 200: passthrough, 400: errorResponse, 500: errorResponse },
+    handler: async (req) => {
+      const url = new URL(req.url)
+      const fromMs = Date.parse(url.searchParams.get('from') ?? '')
+      const toMs = Date.parse(url.searchParams.get('to') ?? '')
+      if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) {
+        return json({ error: 'from and to must be ISO-8601 instants' }, 400)
+      }
+      if (toMs <= fromMs) return json({ error: 'to must be after from' }, 400)
+      if (toMs - fromMs > MAX_OCCURRENCE_RANGE_MS) {
+        return json({ error: `range too large (max ${MAX_OCCURRENCE_RANGE_MS / 86_400_000} days)` }, 400)
+      }
+      const jobs = await readMergedRuntimeJobs()
+      const { items, unevaluated } = computeOccurrences(jobs, fromMs, toMs, {
+        nowMs: Date.now(),
+        getFire: (jobId, runId) => getCronFire(jobId, runId),
+      })
+      return json({ occurrences: items, unevaluated })
     },
   }),
 

--- a/src/hooks/use-schedule.ts
+++ b/src/hooks/use-schedule.ts
@@ -242,6 +242,68 @@ export function useScheduleJobs(options: UseScheduleOptions = {}) {
   }
 }
 
+/** One server-computed calendar placement — see plugins/schedule/lib/occurrences.ts. */
+export interface ScheduleOccurrence {
+  jobId: string
+  /** Absolute instant, ISO-8601 UTC — render in the browser's local tz. */
+  at: string
+  past: boolean
+  /** Ledger disposition for past Bakin occurrences (absent = never claimed). */
+  disposition?: 'pending' | 'created' | 'skipped' | 'seeded'
+  taskId?: string
+  skipReason?: string
+}
+
+/**
+ * Server-computed occurrences for a time range — the ONLY placement source
+ * for the calendar views (kind-aware, timezone/DST-correct; the old client-
+ * side cron parsing is gone). Refetches on schedule SSE events.
+ */
+export function useOccurrences(fromIso: string, toIso: string) {
+  const [occurrences, setOccurrences] = useState<ScheduleOccurrence[]>([])
+  const [unevaluated, setUnevaluated] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchOccurrences = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/plugins/schedule/occurrences?from=${encodeURIComponent(fromIso)}&to=${encodeURIComponent(toIso)}`)
+      if (res.ok) {
+        const data = await res.json()
+        setOccurrences(data.occurrences || [])
+        setUnevaluated(data.unevaluated || [])
+      }
+    } catch { /* transient — SSE or the next range change refetches */ } finally {
+      setLoading(false)
+    }
+  }, [fromIso, toIso])
+
+  useEffect(() => {
+    fetchOccurrences()
+  }, [fetchOccurrences])
+
+  useEffect(() => {
+    const es = new EventSource('/api/events')
+    const handler = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data)
+        if (
+          (data.type === 'activity' && data.message?.includes('Schedule')) ||
+          data.event?.startsWith('schedule.')
+        ) {
+          fetchOccurrences()
+        }
+      } catch { /* ignore */ }
+    }
+    es.addEventListener('message', handler)
+    return () => {
+      es.removeEventListener('message', handler)
+      es.close()
+    }
+  }, [fetchOccurrences])
+
+  return { occurrences, unevaluated, loading, refresh: fetchOccurrences }
+}
+
 export function useRunHistory(jobId: string | null, limit = 20) {
   const [runs, setRuns] = useState<RunEntry[]>([])
   const [loading, setLoading] = useState(false)

--- a/tasks/schedule-hardening-and-events/todo.md
+++ b/tasks/schedule-hardening-and-events/todo.md
@@ -19,8 +19,8 @@
 - [ ] CHECKPOINT: live one-shot end-to-end → Mark approves → merge
 
 ## PR3 — refactor(schedule): server-computed occurrences feed the calendars
-- [ ] T11 Occurrences endpoint (kind-aware, past/future annotated, ledger disposition, DST-pinned) (M)
-- [ ] T12 Calendars consume endpoint; delete client cron parsing; consolidate agent colors (L)
+- [x] T11 Occurrences endpoint (kind-aware, past/future annotated, ledger disposition, DST-pinned) (M)
+- [x] T12 Calendars consume endpoint; delete client cron parsing; consolidate agent colors; disposition dots (L)
 - [ ] CHECKPOINT: calendars eyeballed live → Mark approves → merge
 
 ## PR4 — feat(schedule): plugin-contributed scheduled domain events

--- a/tests/plugins/schedule/calendar-views.test.tsx
+++ b/tests/plugins/schedule/calendar-views.test.tsx
@@ -1,11 +1,56 @@
 // @vitest-environment jsdom
+/**
+ * Calendar views render from the server-computed occurrences endpoint —
+ * placement math lives in lib/occurrences.ts (kind-aware, tz/DST-correct);
+ * the views are pure renderers of fetched instants in browser-local time.
+ */
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { render, screen } from '@testing-library/react'
+import { join } from 'path'
+import { tmpdir } from 'os'
 import '../../rtl-settle'
+import { settleReact } from '../../rtl-settle'
 
-mock.module('@makinbakin/sdk/hooks', () => ({
-  useAgent: (id: string) => id ? { id, name: id } : null,
-}))
+// Pure component tests (fixtured fetch, no storage), but isolation rules are
+// blanket: nothing in a test run may resolve the real ~/.bakin.
+const testDir = join(tmpdir(), `bakin-test-calendar-views-${Date.now()}`)
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: join(testDir, 'bakin.db') }),
+  isUsingBakinHome: () => true,
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+
+// The views fetch /occurrences and subscribe to /api/events — both fixtured.
+const occurrenceFixtures: Array<Record<string, unknown>> = []
+const fetchCalls: string[] = []
+const realFetch = globalThis.fetch
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  const url = String(input)
+  fetchCalls.push(url)
+  if (url.includes('/occurrences')) {
+    return new Response(JSON.stringify({ occurrences: occurrenceFixtures, unevaluated: [] }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  return new Response(JSON.stringify({}), { status: 200 })
+}) as typeof fetch
+
+class FakeEventSource {
+  addEventListener() {}
+  removeEventListener() {}
+  close() {}
+}
+;(globalThis as Record<string, unknown>).EventSource = FakeEventSource
+
+mock.module('@makinbakin/sdk/hooks', () => {
+  const actual = require('../../../src/hooks/use-schedule')
+  return {
+    useAgent: (id: string) => id ? { id, name: id } : null,
+    useOccurrences: actual.useOccurrences,
+  }
+})
 
 mock.module('@makinbakin/sdk/components', () => ({
   AgentAvatar: ({ agentId }: { agentId: string }) => <span>{agentId}</span>,
@@ -13,6 +58,7 @@ mock.module('@makinbakin/sdk/components', () => ({
 
 import { CalendarToday } from '../../../plugins/schedule/components/calendar-today'
 import { CalendarWeekly } from '../../../plugins/schedule/components/calendar-weekly'
+import { CalendarMonthly } from '../../../plugins/schedule/components/calendar-monthly'
 import type { ScheduleJob } from '../../../src/hooks/use-schedule'
 
 function makeJob(overrides: Partial<ScheduleJob> = {}): ScheduleJob {
@@ -33,20 +79,70 @@ function makeJob(overrides: Partial<ScheduleJob> = {}): ScheduleJob {
   }
 }
 
-describe('Schedule calendar views', () => {
-  it('shows jobs scheduled after 10pm in the Today timeline', () => {
+/** An instant at local wall-clock hh:mm today (what the server would return). */
+function todayAtLocal(hour: number, minute: number): string {
+  const d = new Date()
+  d.setHours(hour, minute, 0, 0)
+  return d.toISOString()
+}
+
+afterEach(() => {
+  occurrenceFixtures.length = 0
+  fetchCalls.length = 0
+})
+
+describe('Schedule calendar views (occurrence-fed)', () => {
+  it('Today: renders a fetched 11:05pm occurrence in the 11 PM row', async () => {
+    occurrenceFixtures.push({ jobId: 'late-night-release', at: todayAtLocal(23, 5), past: false })
     render(<CalendarToday jobs={[makeJob()]} onSelectJob={() => {}} />)
+    await settleReact()
 
     expect(screen.getByText('11 PM')).toBeDefined()
     expect(screen.getByText('Late night release')).toBeDefined()
     expect(screen.getByText('11:05pm')).toBeDefined()
+    expect(fetchCalls.some(u => u.includes('/occurrences'))).toBe(true)
   })
 
-  it('shows jobs scheduled after 10pm in the Week grid', () => {
+  it('Week: renders the fetched occurrence and marks a past fired beat', async () => {
+    occurrenceFixtures.push({
+      jobId: 'late-night-release', at: todayAtLocal(23, 5), past: true,
+      disposition: 'created', taskId: 'task-1',
+    })
     render(<CalendarWeekly jobs={[makeJob()]} onSelectJob={() => {}} />)
+    await settleReact()
 
     expect(screen.getByText('11 PM')).toBeDefined()
     expect(screen.getAllByText('Late night release').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('11:05pm').length).toBeGreaterThan(0)
+    expect(screen.getByTitle('Fired')).toBeDefined()
+  })
+
+  it('Week: a skipped past beat carries its skip reason', async () => {
+    occurrenceFixtures.push({
+      jobId: 'late-night-release', at: todayAtLocal(23, 5), past: true,
+      disposition: 'skipped', skipReason: 'overlap',
+    })
+    render(<CalendarWeekly jobs={[makeJob()]} onSelectJob={() => {}} />)
+    await settleReact()
+
+    expect(screen.getByTitle('Skipped — overlap')).toBeDefined()
+  })
+
+  it('Month: renders a day dot for the fetched occurrence', async () => {
+    occurrenceFixtures.push({ jobId: 'late-night-release', at: todayAtLocal(9, 0), past: false })
+    render(<CalendarMonthly jobs={[makeJob()]} onSelectJob={() => {}} />)
+    await settleReact()
+
+    expect(screen.getByText('Late night release')).toBeDefined()
+  })
+
+  it('renders nothing for an occurrence whose job is unknown (stale feed)', async () => {
+    occurrenceFixtures.push({ jobId: 'ghost-job', at: todayAtLocal(9, 0), past: false })
+    render(<CalendarToday jobs={[makeJob()]} onSelectJob={() => {}} />)
+    await settleReact()
+
+    expect(screen.queryByText('ghost-job')).toBeNull()
   })
 })
+
+// restore for co-scheduled files (though --isolate gives each file a fresh global)
+afterEach(() => { void realFetch })

--- a/tests/plugins/schedule/occurrences.test.ts
+++ b/tests/plugins/schedule/occurrences.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Server-side occurrence computation (PR3 of #191) — ONE engine places jobs
+ * on the calendar: kind-aware (cron + one-shot), timezone/DST-correct,
+ * creation-date-guarded, past/future annotated, past Bakin fires enriched
+ * with their ledger disposition. Pure DI module — fake clock, fake ledger.
+ */
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-occurrences-${Date.now()}-${randomUUID()}`)
+process.env.BAKIN_HOME = testDir
+process.env.OPENCLAW_HOME = join(testDir, 'openclaw')
+
+import { describe, it, expect, mock } from 'bun:test'
+
+// The module under test is pure DI (no filesystem), but isolation rules are
+// blanket: nothing in a test run may resolve the real ~/.bakin or ~/.openclaw.
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: join(testDir, 'bakin.db') }),
+  isUsingBakinHome: () => true,
+})
+mock.module('../../../src/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+mock.module('../../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: mock(), error: mock(), debug: mock() }),
+}))
+
+import { computeOccurrences, type OccurrenceQueryDeps } from '@bakin/schedule/lib/occurrences'
+import type { MergedJob } from '@bakin/schedule/types'
+
+const DENVER = 'America/Denver'
+
+function job(overrides: Partial<MergedJob> = {}): MergedJob {
+  return {
+    id: 'sch_daily',
+    name: 'Daily',
+    schedule: { type: 'cron', value: '0 9 * * *', tz: DENVER },
+    enabled: true,
+    completed: false,
+    source: 'bakin',
+    canAdopt: false,
+    canRestoreNative: false,
+    isBakinJob: true,
+    displayName: 'Daily',
+    owner: 'main',
+    requireTriage: false,
+    paused: false,
+    allowOverlap: false,
+    maxFailures: 3,
+    consecutiveFailures: 0,
+    tz: DENVER,
+    createdAt: '2026-01-01T00:00:00Z',
+    humanSchedule: 'Every day at 9am',
+    ...overrides,
+  }
+}
+
+// Tue 2026-06-09, 12:00 UTC (6am Denver)
+const NOW = Date.parse('2026-06-09T12:00:00Z')
+
+function deps(overrides: Partial<OccurrenceQueryDeps> = {}): OccurrenceQueryDeps {
+  return {
+    nowMs: NOW,
+    getFire: () => null,
+    ...overrides,
+  }
+}
+
+describe('computeOccurrences', () => {
+  it('places a daily cron across the range, annotated past/future', () => {
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-11T00:00:00Z')
+    const { items } = computeOccurrences([job()], from, to, deps())
+    expect(items.map(i => i.at)).toEqual([
+      '2026-06-08T15:00:00.000Z', // 9am Denver (MDT)
+      '2026-06-09T15:00:00.000Z',
+      '2026-06-10T15:00:00.000Z',
+    ])
+    expect(items.map(i => i.past)).toEqual([true, false, false])
+    expect(items.every(i => i.jobId === 'sch_daily')).toBe(true)
+  })
+
+  it('is DST-correct: an evening Denver cron shifts its UTC instant across fall-back', () => {
+    // US fall-back 2026-11-01: 9:30pm Denver is 03:30Z (MDT) before, 04:30Z (MST) after.
+    const from = Date.parse('2026-10-31T00:00:00Z')
+    const to = Date.parse('2026-11-03T00:00:00Z')
+    const { items } = computeOccurrences(
+      [job({ schedule: { type: 'cron', value: '30 21 * * *', tz: DENVER } })],
+      from, to,
+      deps({ nowMs: Date.parse('2026-10-30T00:00:00Z') }),
+    )
+    expect(items.map(i => i.at)).toEqual([
+      '2026-10-31T03:30:00.000Z', // Oct 30 9:30pm MDT
+      '2026-11-01T03:30:00.000Z', // Oct 31 9:30pm MDT
+      '2026-11-02T04:30:00.000Z', // Nov 1 9:30pm MST — the UTC instant shifted 1h
+    ])
+  })
+
+  it('skips occurrences that predate the job creation (no phantom history)', () => {
+    const from = Date.parse('2026-06-01T00:00:00Z')
+    const to = Date.parse('2026-06-11T00:00:00Z')
+    const { items } = computeOccurrences([job({ createdAt: '2026-06-08T00:00:00Z' })], from, to, deps())
+    expect(items.map(i => i.at)).toEqual([
+      '2026-06-08T15:00:00.000Z',
+      '2026-06-09T15:00:00.000Z',
+      '2026-06-10T15:00:00.000Z',
+    ])
+  })
+
+  it('one-shots appear exactly once; a completed one-shot keeps its past instant but no future', () => {
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-12T00:00:00Z')
+    const fired = job({
+      id: 'sch_once_done',
+      schedule: { type: 'at', value: '2026-06-08T18:00:00.000Z', tz: DENVER },
+      enabled: false,
+      completed: true,
+      completedAt: '2026-06-08T18:00:00.000Z',
+    })
+    const pending = job({
+      id: 'sch_once_pending',
+      schedule: { type: 'at', value: '2026-06-10T18:00:00.000Z', tz: DENVER },
+    })
+    const { items } = computeOccurrences([fired, pending], from, to, deps())
+    expect(items.map(i => `${i.jobId}@${i.at}`)).toEqual([
+      'sch_once_done@2026-06-08T18:00:00.000Z',
+      'sch_once_pending@2026-06-10T18:00:00.000Z',
+    ])
+  })
+
+  it('disabled/paused jobs contribute no future occurrences but keep their past', () => {
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-11T00:00:00Z')
+    const disabled = computeOccurrences([job({ enabled: false })], from, to, deps())
+    expect(disabled.items.map(i => i.at)).toEqual(['2026-06-08T15:00:00.000Z'])
+    const paused = computeOccurrences([job({ paused: true })], from, to, deps())
+    expect(paused.items.map(i => i.at)).toEqual(['2026-06-08T15:00:00.000Z'])
+  })
+
+  it('enriches past Bakin occurrences with the ledger disposition', () => {
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-10T00:00:00Z')
+    const { items } = computeOccurrences([job()], from, to, deps({
+      getFire: (jobId, runId) => runId === `sch_daily:2026-06-08T15:00:00.000Z`
+        ? { jobId, runId, disposition: 'created', taskId: 'task-1', skipReason: null }
+        : null,
+    }))
+    const past = items.find(i => i.past)!
+    expect(past.disposition).toBe('created')
+    expect(past.taskId).toBe('task-1')
+    const future = items.find(i => !i.past)!
+    expect(future.disposition).toBeUndefined()
+  })
+
+  it('never consults the ledger for native runtime crons', () => {
+    const calls: string[] = []
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-10T00:00:00Z')
+    computeOccurrences(
+      [job({ id: 'native-1', isBakinJob: false, source: 'runtime' })],
+      from, to,
+      deps({ getFire: (jobId) => { calls.push(jobId); return null } }),
+    )
+    expect(calls).toEqual([])
+  })
+
+  it("reports native 'every' jobs as unevaluated instead of silently dropping them", () => {
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-10T00:00:00Z')
+    const { items, unevaluated } = computeOccurrences(
+      [job({ id: 'native-every', isBakinJob: false, source: 'runtime', schedule: { type: 'every', value: '300000' } })],
+      from, to, deps(),
+    )
+    expect(items).toEqual([])
+    expect(unevaluated).toEqual(['native-every'])
+  })
+
+  it('sorts the merged feed ascending across jobs', () => {
+    const from = Date.parse('2026-06-08T00:00:00Z')
+    const to = Date.parse('2026-06-09T00:00:00Z')
+    const { items } = computeOccurrences([
+      job({ id: 'b', schedule: { type: 'cron', value: '0 10 * * *', tz: DENVER } }),
+      job({ id: 'a', schedule: { type: 'cron', value: '0 8 * * *', tz: DENVER } }),
+    ], from, to, deps())
+    expect(items.map(i => i.jobId)).toEqual(['a', 'b'])
+  })
+})

--- a/tests/plugins/schedule/routes-jobs.test.ts
+++ b/tests/plugins/schedule/routes-jobs.test.ts
@@ -1016,6 +1016,49 @@ describe('schedule routes', () => {
   })
 
   // -----------------------------------------------------------------------
+  // GET /occurrences — server-computed calendar feed
+  // -----------------------------------------------------------------------
+  describe('GET /occurrences', () => {
+    it('returns kind-aware, tz-correct occurrences for the range', async () => {
+      harness.mockMergedJobs.push(makeMergedJob({
+        id: 'occ-daily',
+        schedule: { type: 'cron', value: '0 9 * * *', tz: 'America/Denver' },
+        createdAt: '2026-01-01T00:00:00Z',
+      }))
+      const route = findRoute(plugin.routes, 'GET', '/occurrences')!
+      expect(route).toBeDefined()
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { from: '2026-06-08T00:00:00Z', to: '2026-06-10T00:00:00Z' },
+      })
+      expect(status).toBe(200)
+      const items = body.occurrences as Array<{ jobId: string; at: string; past: boolean }>
+      expect(items.map(i => i.at)).toEqual(['2026-06-08T15:00:00.000Z', '2026-06-09T15:00:00.000Z'])
+      expect(items.every(i => i.jobId === 'occ-daily')).toBe(true)
+      expect(items.every(i => i.past)).toBe(true) // range is in the past relative to real now
+      expect(body.unevaluated).toEqual([])
+    })
+
+    it('rejects a missing/invalid range', async () => {
+      const route = findRoute(plugin.routes, 'GET', '/occurrences')!
+      const bad = await callRoute(route, plugin.ctx, { searchParams: { from: 'nope', to: '2026-06-10T00:00:00Z' } })
+      expect(bad.status).toBe(400)
+      const inverted = await callRoute(route, plugin.ctx, {
+        searchParams: { from: '2026-06-10T00:00:00Z', to: '2026-06-08T00:00:00Z' },
+      })
+      expect(inverted.status).toBe(400)
+    })
+
+    it('rejects a range beyond the 62-day cap', async () => {
+      const route = findRoute(plugin.routes, 'GET', '/occurrences')!
+      const { status, body } = await callRoute(route, plugin.ctx, {
+        searchParams: { from: '2026-01-01T00:00:00Z', to: '2026-06-01T00:00:00Z' },
+      })
+      expect(status).toBe(400)
+      expect(String(body.error)).toMatch(/range too large/i)
+    })
+  })
+
+  // -----------------------------------------------------------------------
   // POST /parse — parse schedule expression
   // -----------------------------------------------------------------------
   describe('POST /parse', () => {


### PR DESCRIPTION
## Summary

PR3 of the schedule initiative — the behavior-preserving debt fix that de-risks PR4 (plugin-contributed domain events will ride the same feed). No new features; reverting restores client-side math.

- **New endpoint**: \`GET /api/plugins/schedule/occurrences?from=&to=\` — ONE engine places jobs on the calendar (\`lib/occurrences.ts\`, pure DI, fake-clock tested). Kind-aware (cron + one-shot), evaluated in each job's timezone with a DST pin (a 9:30pm Denver cron demonstrably shifts its UTC instant across fall-back — the old client math could not represent this), creation-date-guarded, 62-day range cap, native \`'every'\` jobs reported as \`unevaluated\` instead of silently dropped.
- **Run visibility on the grid**: past Bakin occurrences are enriched from the execution ledger — fired beats get a green dot, skipped beats an amber dot with the skip reason; a never-claimed past beat stays honestly unmarked.
- **Calendars are now pure renderers** via a new \`useOccurrences\` SDK hook (SSE-refetch on \`schedule.*\`): instants land in browser-local cells, one-shots finally appear on the calendar. ALL client-side cron parsing is deleted (\`getJobHour\`/\`jobOnDow\`/\`expandField\`/\`jobFiringOnDay\`/…), and the duplicated-and-drifted agent color tables consolidate into \`components/agent-colors.ts\`.

## Test plan

- [x] Full suite green + typecheck; new: 9 occurrence-engine cases (DST, one-shots, phantom-history guard, disposition enrichment, native-every honesty, cross-job sort), 3 route cases (range validation/cap), calendar view tests rewritten against a fixtured endpoint (fired/skipped dots, unknown-job resilience)
- [ ] Live on 3737 (Mark): eyeball Today/Week/Month against your known jobs — placement should be identical-or-better (evening jobs in non-UTC tz now land correctly); past days show fired/skipped dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)