### PR TITLE
feat: never full-reload internal navigation (routing overhaul PR1)

### DIFF
--- a/.claude/knowledge/url-state-deep-linking.md
+++ b/.claude/knowledge/url-state-deep-linking.md
@@ -1,5 +1,16 @@
 # URL State & Deep Linking
 
+## Navigation Rule — never a full reload (routing overhaul PR1)
+
+Internal navigation ALWAYS goes through the SPA router; a hard navigation re-boots the whole shell (manifest fetch, plugin loads, SSE reconnect):
+
+- **Links:** `PluginLink` from `@makinbakin/sdk/components` (plugins + shared `src/components`) or TanStack `Link` (host internals). Both keep real-anchor semantics (copy, cmd/middle-click) while routing primary clicks client-side. Raw internal `<a href="/…">` is banned; `<a href="/api/…">` (real server resources: downloads, exports) is exempt.
+- **Programmatic:** `useRouter().push/replace` from `@makinbakin/sdk/hooks` — never `window.location.assign/replace/href`.
+- **Outside React (OS notification clicks):** `navigateToUrl()` in `src/lib/browser-notify.ts` routes through the `globalThis.__bakinNavigate` bridge the host registers at boot (`packages/host/src/main.tsx`); falls back to a hard load only when the shell isn't booted. globalThis because plugin bundles inline their own copy of that module.
+- **Toast click-throughs** navigate via `useRouter().push` and dismiss themselves with the id `toast()` returns (see chat's `ReplyToast` / workflows' `GateToast`).
+
+Enforced twice: `tests/architecture/no-hard-navigation.test.ts` (CI gate — scanner with teeth + path-pinned allowlist with reasons) and mirrored `no-restricted-syntax` rules in `eslint.config.mjs` (editor feedback). Keep the two allowlists in sync. Legitimate full reloads (unsaved-changes guard, `router.refresh()`, dev loop, update recovery, plugin-failure banner, manifest-change reload) are allowlisted there — new entries must be recovery/dev-tooling paths, never user-facing links.
+
 ## Rule
 
 All interactive UI state that a user would want to bookmark, share, or navigate back to **must** be reflected in the URL. This includes:

--- a/.claude/specs/routing-overhaul.md
+++ b/.claude/specs/routing-overhaul.md
@@ -1,0 +1,161 @@
+# Spec: Routing Overhaul (pre-launch)
+
+**Status:** Draft — pending approval
+**Date:** 2026-07-15
+**Priority:** Tech-debt reduction before launch. Deep links become a public contract at launch; URL shapes must be final before then.
+**Constraints:** Single user, single machine. NO backwards compatibility, NO redirect shims for old URL shapes. Clean and clear over compatible.
+
+## Objective
+
+Unify Bakin on ONE routing strategy and make every internal navigation client-side. Today two identity conventions coexist (`/team/<id>` vs `/chat?chat=<id>`), seven internal links full-reload the app, there is no real 404, and the router shim carries documented footguns (multi-setter clobber, JSON coercion of query values). All of it gets fixed under one initiative with regression enforcement so it stays fixed.
+
+### The URL Taxonomy (the rule everything follows)
+
+**Path = page identity.** Which page you are on, including full-page resource views and creation surfaces:
+
+- Lists: `/tasks`, `/chat`, `/schedule`, `/memory`, `/assets`, `/brands`, `/team`, `/workflows`
+- Full-page details: `/chat/$chatId` (NEW), `/team/$id`, `/assets/$assetId`, `/brands/$brandId`, `/workflows/$id`
+- Creation surfaces: `/chat/new` (NEW), `/workflows/new`, `/projects/new`
+
+**Query = overlay + view state.** Anything layered over a page that must compose with the page's other state:
+
+- Drawers (overlay identity): `?taskId=`, `?jobId=`, `?recordId=` — these stay query params by design
+- Tabs: `?tab=`
+- Filters/view state: `?view=`, `?q=`, `?agent=`, `?status=`, `?type=`, `?sort=`, `?dir=`, `?page=`
+
+**Never a full page reload for internal navigation.** Allowed full reloads are pinned to an explicit allowlist (unsaved-changes guard, `router.refresh()`, dev-loop/manifest reloads, update recovery, plugin-failure banner).
+
+### Decisions locked during interview
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Taxonomy rule | Presentation-based: path = page identity, query = overlays/tabs/filters. Drawers deliberately stay query-param. |
+| D2 | Chat URLs | `/chat` (list), `/chat?agent=<f>` (filtered list), `/chat/$chatId` (conversation), `/chat/new?agent=<agentId>` (draft composer). |
+| D3 | Enforcement | BOTH an architecture test (CI gate) and ESLint restrictions (editor feedback). ESLint 9 flat config already exists; use `no-restricted-properties`/`no-restricted-syntax` — no custom rule infra. |
+| D4 | OS notification clicks | SPA navigation via a navigate bridge registered by the host at boot (`browser-notify.ts` falls back to `location.href` if no bridge). |
+| D5 | Polish scope | ALL of: useQueryState multi-setter clobber fix, JSON-coercion fix in the router shim, TanStack scroll restoration, real 404 page, plugin-route shadow warning, Health + Models `?tab=` URL state. *(Planning discovery: Health `health-page.tsx:100` and Models `use-models-data.ts:101` already use `useQueryState('tab', …)` — the knowledge doc table is stale; this item is docs-only.)* |
+| D6 | Out of scope | TanStack typed-route migration (string-URL API IS the plugin SDK contract), route-level code splitting, route masking, URL redirects/aliases for old shapes. |
+| D7 | Delivery | 3 PRs by risk (see Commit Strategy). Branches in the MAIN checkout so 3737 serves them; Mark live-tests each before merge. |
+
+### Assumptions (surfaced, not asked)
+
+1. Old `?chat=<id>` deep links simply stop resolving (render the chat list). Nothing server-side persists chat URLs; the toast/notification/search builders are all computed at event time and get updated in PR2.
+2. Drawer param names stay exactly as documented: `taskId`, `jobId`, `recordId`.
+3. The already-fixed chat reply toast (uncommitted working-tree change: `chat-badge-provider.tsx`, `use-toast.ts`) ships as the first commit of PR1.
+4. The unrelated uncommitted `packages/host/src/api/_embedded-assets-static.ts` change is NOT part of this initiative and stays out of its commits.
+5. `visibleChatIdFromLocation` in `plugins/chat/components/attention.ts` moves from parsing `?chat=` to parsing the `/chat/$chatId` pathname in PR2 (suppression rules unchanged).
+6. The stale `?asset=` row in the knowledge doc is documentation drift (code already uses `/assets/$assetId`); fixed in the docs sweep.
+
+## Tech Stack
+
+- Bun ≥ 1.2 (runtime, bundler, test runner) — no Node, no Vite
+- React 19 + TanStack Router (code-based routes — file-based generation unavailable under `Bun.build()`)
+- ESLint 9 flat config (`eslint.config.mjs`)
+- Existing SDK surface: `useRouter`/`useQueryState`/`useQueryArrayState` (`@makinbakin/sdk/hooks`), `PluginLink` (`@makinbakin/sdk/components`)
+
+## Commands
+
+```
+Typecheck:   bunx tsc --noEmit -p tsconfig.json     (pre-existing astro/fixture errors are known noise)
+Lint:        bun run lint
+Test (all):  bun run test                            (never bare `bun test` — preload + --isolate matter)
+Test (one):  bun test tests/path/foo.test.ts --isolate
+Dev:         bun run dev                             (client changes hot-reload; server changes need manual restart)
+Live server: nohup bun run dev from MAIN checkout on 3737 (Mark's box — restart required for server-code changes)
+```
+
+## Project Structure (files this initiative touches)
+
+```
+packages/host/src/router.ts                       → route tree wiring (+ chat.$chatId, chat.new, notFoundComponent, scrollRestoration)
+packages/host/src/routes/chat.tsx                 → becomes parent/list route; new chat.$chatId.tsx, chat.new.tsx
+packages/host/src/routes/plugin-catchall.tsx      → renders shared NotFound; shadow warning
+packages/sdk/src/hooks/router.ts                  → JSON-coercion fix, scroll option honored
+src/hooks/use-query-state.ts                      → multi-setter clobber fix
+src/lib/browser-notify.ts                         → navigate bridge + fallback
+src/components/…                                  → shared NotFound component; search-unavailable anchor fix
+plugins/chat/…                                    → chat page path migration, attention.ts, client.tsx (search hit), badge provider
+plugins/{tasks,brands,explore,memory}/…           → raw-anchor → PluginLink fixes
+plugins/workflows/components/approvals-badge-provider.tsx → toast SPA fix
+plugins/{health,models}/…                         → ?tab= URL state
+tests/architecture/no-hard-navigation.test.ts     → NEW enforcement scanner
+eslint.config.mjs                                 → no-restricted-syntax/properties for client globs
+.claude/knowledge/url-state-deep-linking.md       → rewritten around the taxonomy
+```
+
+## Code Style
+
+Follow existing conventions (CLAUDE.md). The navigation-specific rules this spec adds:
+
+```tsx
+// Internal links in plugins/shared components: PluginLink (real <a>, SPA on plain click)
+import { PluginLink } from '@makinbakin/sdk/components'
+<PluginLink to={`/chat/${chatId}`}>Open chat</PluginLink>
+
+// Programmatic navigation: the SDK router — never window.location
+const router = useRouter()
+router.push(`/chat/${encodeURIComponent(chatId)}`)
+
+// Host-internal code may use TanStack <Link> directly.
+// Multi-param updates: one URL, one push — never two setters in one tick
+// (rule survives until the clobber fix lands in PR3, then setters compose).
+```
+
+## Testing Strategy
+
+- **Unit (bun:test):** router shim URL round-trips (string `"123"` stays a string; hash/search preservation), `use-query-state` multi-setter composition, chat `attention.ts` path parsing, notification-bridge fallback.
+- **Architecture (`tests/architecture/`):** the new no-hard-navigation scanner — bans `window.location.{assign,replace,href=}` and raw internal `<a href="/…">` in client code, path-pinned allowlist with reasons; a teeth case proving the scanner bites.
+- **Component (RTL, `--isolate`, `rtl-settle`):** chat page renders conversation from path param; drawer deep-links still open from query params; 404 renders for unknown paths.
+- **Live verification (per PR, by Mark on 3737):** documented click-through checklist in each PR description — cold-boot deep links, back/forward, notification click without reload (SSE connection visibly survives in the network tab).
+- Full suite green (`bun run test`) + lint + typecheck before every commit.
+
+## Boundaries
+
+- **Always:** route internal navigation through `PluginLink`/TanStack `Link`/`useRouter()`; update `.claude/knowledge/` docs in the same PR as the behavior change; conventional commits (`feat(chat): …`, `fix(tasks): …`, `test(architecture): …`); branch from `main` in the MAIN checkout; run test+lint+typecheck before each commit; verify HEAD before committing.
+- **Ask first:** any URL shape the taxonomy doesn't cover; adding dependencies; non-additive changes to the SDK's public API; touching `packages/core` storage or anything outside the routing surface.
+- **Never:** back-compat shims or redirects for old URL shapes; `window.location` navigation for internal paths outside the pinned allowlist; typed-route migration; committing `generated-version.ts`; merging before Mark's live test passes.
+
+## Commit Strategy (rollback checkpoints)
+
+Each commit is atomic, green (test+lint+typecheck), and revertable alone.
+
+**PR1 — `feat/routing-no-hard-nav`** (mechanical, low risk)
+1. `fix(chat): SPA-navigate + dismiss reply toast` (the already-done working-tree change)
+2. `fix(plugins): replace raw internal anchors with PluginLink` (tasks ×2, brands, explore, memory, search-unavailable)
+3. `fix(workflows): SPA-navigate approval toast`
+4. `feat(sdk): navigate bridge for browser notifications` (+ host boot registration, fallback)
+5. `test(architecture): no-hard-navigation scanner + eslint restrictions`
+6. `docs(knowledge): navigation rules in url-state-deep-linking`
+
+**PR2 — `feat/chat-path-routing`** (highest behavior change, isolated)
+1. `feat(host): /chat/$chatId and /chat/new routes`
+2. `feat(chat): page reads identity from path; draft moves to /chat/new?agent=`
+3. `feat(chat): update toast/notification/search-hit URL builders + attention.ts`
+4. `test(chat): path-based deep-link coverage`
+5. `docs(knowledge): chat-plugin.md URL surface`
+
+**PR3 — `feat/router-polish`** (subtle cross-cutting behavior)
+1. `fix(sdk): stop JSON-coercing query values in router shim`
+2. `fix(hooks): compose multi-setter useQueryState updates`
+3. `feat(host): scroll restoration`
+4. `feat(host): NotFound page + catch-all integration + route-shadow warning`
+5. `feat(health,models): ?tab= URL state`
+6. `docs: knowledge sweep (drop clobber warning, drop stale ?asset=, CLAUDE.md URL-state bullet, plugin authoring docs)`
+
+Rollback: `git revert` any checkpoint; PR boundaries isolate the blast radius (a shim regression never holds back the chat migration, etc.).
+
+## Success Criteria
+
+1. Arch test + `bun run lint` prove zero unallowlisted hard navigations in client code — and fail on a seeded offender (teeth test).
+2. `/chat/<id>` cold-boots (hard refresh) into the right conversation; back/forward moves between conversations; `/chat/new?agent=x` opens the draft composer; first send lands on `/chat/<newId>` without a reload.
+3. Clicking the reply toast, the workflow approval toast, and an OS notification navigates with NO full reload (SSE connection id unchanged).
+4. Every raw internal anchor is gone; middle-click/cmd-click on `PluginLink`s still opens a new tab correctly.
+5. Two `useQueryState` setters in one handler both land; query value `"123"` survives as a string through push/replace round-trips.
+6. Back/forward restores scroll position on `/tasks` and `/assets`.
+7. Unknown paths render the styled 404 with sidebar/nav intact; a plugin route shadowed by a core route logs a warning.
+8. Health and Models tabs are deep-linkable via `?tab=` and survive refresh.
+9. Full suite, lint, and typecheck green; `.claude/knowledge/url-state-deep-linking.md` rewritten around the taxonomy; CLAUDE.md URL-state bullet updated; README checked (no routing content expected).
+
+## Open Questions
+
+None blocking. Deferred (explicitly out of scope, revisit post-launch if ever): typed-route API adoption, route-level code splitting, route masking.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -245,6 +245,58 @@ const eslintConfig = defineConfig([
       }],
     },
   },
+  // No hard navigation for internal routes (routing overhaul D3): internal
+  // links go through PluginLink / TanStack Link / useRouter().push — never a
+  // full page load. CI gate + allowlist live in
+  // tests/architecture/no-hard-navigation.test.ts; this block mirrors it for
+  // in-editor feedback. Keep the two allowlists in sync.
+  {
+    files: [
+      "packages/host/src/**/*.{ts,tsx}",
+      "packages/sdk/src/**/*.{ts,tsx}",
+      "plugins/**/*.{ts,tsx}",
+      "src/components/**/*.{ts,tsx}",
+      "src/hooks/**/*.{ts,tsx}",
+      "src/lib/**/*.{ts,tsx}",
+      "src/context/**/*.{ts,tsx}",
+    ],
+    ignores: [
+      // Server handlers + dev tooling (reloads by design):
+      "packages/host/src/api/**",
+      "packages/host/src/dev-client/**",
+      // Deliberate full reloads, reasons in the arch test:
+      "src/components/unsaved-changes-guard.tsx",
+      "src/lib/browser-notify.ts",
+      "packages/host/src/components/layout/header.tsx",
+      "packages/host/src/plugin-host/PluginHost.tsx",
+      "packages/sdk/src/hooks/router.ts",
+      "src/hooks/use-sse.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": ["error",
+        {
+          selector: "CallExpression[callee.property.name=/^(assign|replace|reload)$/][callee.object.property.name='location']",
+          message: "Hard navigation for internal routes is banned — use useRouter().push / PluginLink (see tests/architecture/no-hard-navigation.test.ts).",
+        },
+        {
+          selector: "CallExpression[callee.property.name=/^(assign|replace|reload)$/][callee.object.name='location']",
+          message: "Hard navigation for internal routes is banned — use useRouter().push / PluginLink (see tests/architecture/no-hard-navigation.test.ts).",
+        },
+        {
+          selector: "AssignmentExpression[left.property.name='href'][left.object.property.name='location']",
+          message: "`location.href =` full-reloads the shell — use useRouter().push / PluginLink.",
+        },
+        {
+          selector: "AssignmentExpression[left.property.name='href'][left.object.name='location']",
+          message: "`location.href =` full-reloads the shell — use useRouter().push / PluginLink.",
+        },
+        {
+          selector: "JSXOpeningElement[name.name='a'] JSXAttribute[name.name='href'] Literal[value=/^\\u002F(?!api\\u002F)/]",
+          message: "Raw internal <a href=\"/…\"> anchors full-reload the shell — use PluginLink (SDK) or TanStack Link.",
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/packages/host/src/main.tsx
+++ b/packages/host/src/main.tsx
@@ -5,12 +5,20 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from '@tanstack/react-router'
+import { toNavigationOptions } from '@makinbakin/sdk/hooks'
 import { router } from './router'
 import { registerShellReact } from './lib/react-identity'
+import { setNotificationNavigator } from '@/lib/browser-notify'
 
 // Register the shell's React instance for plugin-load-time identity checks
 // (Phase F uses `assertReactInstance` on every dynamically loaded plugin).
 registerShellReact()
+
+// OS-notification clicks route client-side through this bridge; without it
+// browser-notify falls back to a full page load.
+setNotificationNavigator((url) => {
+  void router.navigate(toNavigationOptions(url) as never)
+})
 
 const root = document.getElementById('root')
 if (!root) throw new Error('#root element missing from index.html')

--- a/packages/sdk/src/hooks/index.ts
+++ b/packages/sdk/src/hooks/index.ts
@@ -117,3 +117,5 @@ export { usePathname } from './router'
 export { useSearchParams } from './router'
 /** Current route's typed path parameters. */
 export { useParams } from './router'
+/** Split a browser-style URL string into TanStack navigate options (non-hook). */
+export { toNavigationOptions } from './router'

--- a/plugins/brands/components/task-brand-panel.tsx
+++ b/plugins/brands/components/task-brand-panel.tsx
@@ -10,6 +10,7 @@
  */
 import { useEffect, useState } from 'react'
 import { useDebug, useJsonFetch } from '@makinbakin/sdk/hooks'
+import { PluginLink } from '@makinbakin/sdk/components'
 
 interface TaskBrandInfo {
   brandId: string
@@ -80,9 +81,9 @@ export function TaskBrandPanel({ taskId }: { taskId?: string }) {
           <span className="text-xs text-muted-foreground">({SOURCE_LABEL[brand.source]})</span>
         </div>
         {brand.blocked && (
-          <a href="/brands" className="text-xs font-medium text-amber-400 hover:underline">
+          <PluginLink to="/brands" className="text-xs font-medium text-amber-400 hover:underline">
             brand unavailable — dispatch is waiting
-          </a>
+          </PluginLink>
         )}
       </div>
 

--- a/plugins/chat/components/chat-badge-provider.tsx
+++ b/plugins/chat/components/chat-badge-provider.tsx
@@ -7,7 +7,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AgentAvatar } from '@makinbakin/sdk/components'
-import { useAgent, useNavBadge, usePluginEvent, toast } from '@makinbakin/sdk/hooks'
+import { useAgent, useNavBadge, usePluginEvent, useRouter, toast, useToastStore } from '@makinbakin/sdk/hooks'
 import { pluginFetch } from '@makinbakin/sdk/utils'
 
 import { sendBrowserNotification } from '../../../src/lib/browser-notify'
@@ -28,13 +28,17 @@ interface ChatAttentionSettings {
 
 const DEFAULT_ATTENTION_SETTINGS: ChatAttentionSettings = { sound: true, toasts: true }
 
-function ReplyToast({ chatId, agentId, preview }: { chatId: string; agentId: string; preview?: string }) {
+function ReplyToast({ chatId, agentId, preview, onNavigate }: { chatId: string; agentId: string; preview?: string; onNavigate?: () => void }) {
   const agent = useAgent(agentId)
+  const router = useRouter()
   return (
     <button
       type="button"
       data-chat-toast={chatId}
-      onClick={() => window.location.assign(`/chat?chat=${encodeURIComponent(chatId)}`)}
+      onClick={() => {
+        onNavigate?.()
+        router.push(`/chat?chat=${encodeURIComponent(chatId)}`)
+      }}
       className="flex max-w-sm items-start gap-2 text-left"
     >
       <AgentAvatar agentId={agentId} size="xs" />
@@ -92,7 +96,17 @@ export function ChatBadgeProvider() {
       settings: settingsRef.current,
     })
     if (actions.toast) {
-      toast(<ReplyToast chatId={done.chatId} agentId={done.agentId} preview={done.preview} />, 'info')
+      // The closure reads `id` only on click, after toast() has returned it —
+      // navigating in-app dismisses the toast instead of leaving it to expire.
+      const id: string = toast(
+        <ReplyToast
+          chatId={done.chatId}
+          agentId={done.agentId}
+          preview={done.preview}
+          onNavigate={() => useToastStore.getState().dismiss(id)}
+        />,
+        'info',
+      )
     }
     if (actions.sound) playReplyChime()
     if (actions.browserNotification && done.preview) {

--- a/plugins/explore/components/detail-drawer.tsx
+++ b/plugins/explore/components/detail-drawer.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, Check, Image as ImageIcon } from 'lucide-react'
-import { BakinDrawer } from '@makinbakin/sdk/components'
+import { BakinDrawer, PluginLink } from '@makinbakin/sdk/components'
 import { Badge } from '@makinbakin/sdk/ui'
 import { EntryVisual } from './catalog-card'
 import type { ExploreCatalogEntry } from '../types'
@@ -108,12 +108,12 @@ export function DetailDrawer({
         )}
 
         {entry.updateAvailable === true && entry.kind === 'agent' && (
-          <a
-            href={`/team/${entry.id}`}
+          <PluginLink
+            to={`/team/${entry.id}`}
             className="flex items-center gap-1 text-sm text-amber-400 hover:underline"
           >
             Update available — manage in Team <ArrowUpRight className="size-3.5" />
-          </a>
+          </PluginLink>
         )}
 
         {actions && <div className="mt-2 flex justify-end gap-2">{actions}</div>}

--- a/plugins/memory/components/memory-cleanup.tsx
+++ b/plugins/memory/components/memory-cleanup.tsx
@@ -13,6 +13,7 @@
 import { useState } from 'react'
 import { Search, Send, CheckCircle2, AlertTriangle, Loader2, Lock } from 'lucide-react'
 import { Button, Input, Textarea, Badge, Label, Checkbox } from '@makinbakin/sdk/ui'
+import { PluginLink } from '@makinbakin/sdk/components'
 
 interface CleanupHit {
   rowId: string
@@ -239,7 +240,7 @@ export function MemoryCleanup() {
           <div className="text-sm font-medium">Dispatched {dispatch.dispatched.length} cleanup task(s)</div>
           {dispatch.dispatched.map((d) => (
             <div key={d.agent} className="text-xs text-muted-foreground">
-              {d.agent} → <a className="underline" href="/tasks">task {d.taskId}</a> ({d.hitCount} file(s){d.managedCount ? `, ${d.managedCount} pinned` : ''})
+              {d.agent} → <PluginLink className="underline" to="/tasks">task {d.taskId}</PluginLink> ({d.hitCount} file(s){d.managedCount ? `, ${d.managedCount} pinned` : ''})
             </div>
           ))}
           {dispatch.skipped.map((s) => (

--- a/plugins/tasks/components/task-card.tsx
+++ b/plugins/tasks/components/task-card.tsx
@@ -3,7 +3,7 @@
 import { useEffect, type CSSProperties } from 'react'
 import { useSortable } from '@dnd-kit/react/sortable'
 import { AlertTriangle, Users, X } from 'lucide-react'
-import { AgentAvatar } from "@makinbakin/sdk/components"
+import { AgentAvatar, PluginLink } from "@makinbakin/sdk/components"
 import { STATUS_BADGE_STYLES } from '../constants'
 import { compactDispatchFailureLabel, getLatestDispatchFailure } from '../lib/dispatch-failure'
 import { getTaskAvailableAtMs } from '../lib/scheduled'
@@ -152,8 +152,8 @@ export function TaskCardContent({ task, columnId, className, gateLabel, childTas
       {/* Budget-deferred indicator (cost-control v2): the task is eligible
           but the spend gate is holding it — visibly, never silently. */}
       {budgetHold && (
-        <a
-          href="/models?tab=spend"
+        <PluginLink
+          to="/models?tab=spend"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
           className="flex items-center gap-1.5 mt-1.5 px-2 py-1 rounded-md bg-red-500/10 border border-red-500/20 whitespace-nowrap overflow-hidden hover:bg-red-500/20"
@@ -161,7 +161,7 @@ export function TaskCardContent({ task, columnId, className, gateLabel, childTas
         >
           <span className="text-red-400 text-[11px] font-semibold shrink-0">{budgetHold.label}</span>
           <span className="text-red-400/60 text-[10px] truncate">{budgetHold.detail}</span>
-        </a>
+        </PluginLink>
       )}
 
       {/* Gate approval indicator */}
@@ -221,8 +221,8 @@ export function TaskCardContent({ task, columnId, className, gateLabel, childTas
       {/* Brand-blocked indicator (#419): the task is eligible but its brand
           is missing/draft — visibly deferring, never silently. */}
       {brandHold && (
-        <a
-          href="/brands"
+        <PluginLink
+          to="/brands"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
           className="flex items-center gap-1.5 mt-1.5 px-2 py-1 rounded-md bg-amber-500/10 border border-amber-500/20 whitespace-nowrap overflow-hidden hover:bg-amber-500/20"
@@ -230,7 +230,7 @@ export function TaskCardContent({ task, columnId, className, gateLabel, childTas
         >
           <span className="text-amber-400 text-[11px] font-semibold shrink-0">Brand unavailable</span>
           <span className="text-amber-400/60 text-[10px] truncate">{brandHold.detail}</span>
-        </a>
+        </PluginLink>
       )}
 
       {isFutureScheduled && task.availableAt && (

--- a/plugins/workflows/components/approvals-badge-provider.tsx
+++ b/plugins/workflows/components/approvals-badge-provider.tsx
@@ -11,7 +11,7 @@
  * lands on the task detail where gates are approved/rejected.
  */
 import { useCallback, useEffect } from 'react'
-import { useNavBadge, usePluginEvent, toast } from '@makinbakin/sdk/hooks'
+import { useNavBadge, usePluginEvent, useRouter, toast, useToastStore } from '@makinbakin/sdk/hooks'
 import { pluginFetch } from '@makinbakin/sdk/utils'
 import { useState } from 'react'
 
@@ -20,6 +20,23 @@ import { attentionForGate, gateBadge, gateUrl, type GateReachedPayload } from '.
 
 interface PendingGatesResponse {
   gates: Array<{ taskId: string; stepId: string; label?: string }>
+}
+
+function GateToast({ url, title, body, onNavigate }: { url: string; title: string; body: string; onNavigate?: () => void }) {
+  const router = useRouter()
+  return (
+    <button
+      type="button"
+      className="text-left"
+      onClick={() => {
+        onNavigate?.()
+        router.push(url)
+      }}
+    >
+      <span className="font-medium">{title}</span>
+      <span className="block text-xs text-muted-foreground">{body}</span>
+    </button>
+  )
 }
 
 export function ApprovalsBadgeProvider() {
@@ -43,15 +60,15 @@ export function ApprovalsBadgeProvider() {
     const gate = payload as unknown as GateReachedPayload
     const attention = attentionForGate(gate, window.location)
     if (!attention.notify) return
-    toast(
-      <button
-        type="button"
-        className="text-left"
-        onClick={() => { window.location.href = attention.url }}
-      >
-        <span className="font-medium">{attention.title}</span>
-        <span className="block text-xs text-muted-foreground">{attention.body}</span>
-      </button>,
+    // The closure reads `id` only on click, after toast() has returned it —
+    // navigating in-app dismisses the toast instead of leaving it to expire.
+    const id: string = toast(
+      <GateToast
+        url={attention.url}
+        title={attention.title}
+        body={attention.body}
+        onNavigate={() => useToastStore.getState().dismiss(id)}
+      />,
       'info',
     )
     sendBrowserNotification(attention.title, attention.body, gateUrl(gate))

--- a/src/components/search-unavailable.tsx
+++ b/src/components/search-unavailable.tsx
@@ -1,4 +1,5 @@
 import { SearchX } from 'lucide-react'
+import { PluginLink } from '@makinbakin/sdk/components'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
@@ -29,12 +30,12 @@ export function SearchUnavailable({ retry, className }: SearchUnavailableProps) 
             Retry
           </Button>
         )}
-        <a
-          href="/health"
+        <PluginLink
+          to="/health"
           className="inline-flex h-8 items-center rounded-md px-3 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
         >
           Open health
-        </a>
+        </PluginLink>
       </div>
     </div>
   )

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -16,7 +16,7 @@ export interface Toast {
 
 interface ToastStore {
   toasts: Toast[]
-  add: (toast: Omit<Toast, 'id'>) => void
+  add: (toast: Omit<Toast, 'id'>) => string
   dismiss: (id: string) => void
 }
 
@@ -30,11 +30,12 @@ export const useToastStore = create<ToastStore>((set) => ({
     setTimeout(() => {
       set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) }))
     }, toast.duration ?? DEFAULT_DURATION[toast.type])
+    return id
   },
   dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
 }))
 
-/** Convenience: call from anywhere without hooks */
-export function toast(message: ReactNode, type: Toast['type'] = 'info', duration?: number) {
-  useToastStore.getState().add({ message, type, ...(duration ? { duration } : {}) })
+/** Convenience: call from anywhere without hooks. Returns the toast id for programmatic dismiss. */
+export function toast(message: ReactNode, type: Toast['type'] = 'info', duration?: number): string {
+  return useToastStore.getState().add({ message, type, ...(duration ? { duration } : {}) })
 }

--- a/src/lib/browser-notify.ts
+++ b/src/lib/browser-notify.ts
@@ -1,5 +1,28 @@
 const STORAGE_KEY = 'bakin-notifications-enabled'
 
+/**
+ * Navigate bridge — the host registers its router here at boot so
+ * notification clicks route client-side instead of full-reloading the shell.
+ * globalThis-based (like __bakinBroadcast) because every plugin bundle
+ * inlines its own copy of this module; a module-level variable would never
+ * reach those copies.
+ */
+type NavigateFn = (url: string) => void
+
+export function setNotificationNavigator(navigate: NavigateFn): void {
+  ;(globalThis as { __bakinNavigate?: NavigateFn }).__bakinNavigate = navigate
+}
+
+export function navigateToUrl(url: string): void {
+  const bridge = (globalThis as { __bakinNavigate?: NavigateFn }).__bakinNavigate
+  if (bridge) {
+    bridge(url)
+    return
+  }
+  // No bridge registered (shell not booted) — hard navigation is the only option.
+  window.location.assign(url)
+}
+
 export function isNotificationsSupported(): boolean {
   return typeof window !== 'undefined' && 'Notification' in window && window.isSecureContext
 }
@@ -28,7 +51,7 @@ export function sendBrowserNotification(title: string, body: string, url?: strin
   if (url) {
     notification.onclick = () => {
       window.focus()
-      window.location.href = url
+      navigateToUrl(url)
       notification.close()
     }
   }

--- a/tasks/plan-routing-overhaul.md
+++ b/tasks/plan-routing-overhaul.md
@@ -1,0 +1,182 @@
+# Implementation Plan: Routing Overhaul
+
+**Spec:** `.claude/specs/routing-overhaul.md` (approved 2026-07-15)
+**Delivery:** 3 PRs by risk, branched from `main` in the MAIN checkout (3737 serves each for live testing). Merge only after Mark's live pass.
+**Task list:** `tasks/todo-routing-overhaul.md`
+
+## Overview
+
+Unify on the presentation-based URL taxonomy (path = page identity, query = overlays/tabs/filters), eliminate every full-reload internal navigation with dual enforcement (arch test + ESLint), migrate chat to `/chat/$chatId`, and fix the router shim's footguns. No backwards compatibility.
+
+## Architecture Decisions (from spec + planning discoveries)
+
+- **Navigate bridge must be `globalThis`-based** (`globalThis.__bakinNavigate`, mirroring `__bakinBroadcast`): plugins inline their own copy of `src/lib/browser-notify.ts` (only react/SDK are externalized), so a module-level bridge variable would never reach plugin bundles.
+- **Chat routes follow the `team.$id.tsx` pattern:** host route reads params via `Route.useParams()` and passes them to plugin slots as props (`page:/chat/[chatId]` with `chatId`, `page:/chat/new`). TanStack ranks static `/chat/new` above dynamic `/chat/$chatId` — pinned by a test anyway.
+- **JSON-coercion fix targets the router config, not more shim gymnastics:** prefer custom `parseSearch`/`stringifySearch` on `createRouter` that treat all values as plain strings (the whole app uses string params). Fallback if TanStack internals fight it: keep parsing in the shim but preserve strings. Decision made inside T3.1 with tests either way.
+- **Clobber fix = microtask batching:** `useQueryState` setters merge into ONE navigation per tick (a module-level pending-update queue; `push` wins over `replace` if any update pushed). Reading `window.location` at call time is not reliable mid-tick.
+- **Scroll restoration needs a scout step:** the installed TanStack 1.168 exports `<ScrollRestoration />`; but if the app scrolls inside inner containers rather than the window, window-level restoration is a no-op and we need `useElementScrollRestoration` or explicit opt-outs. T3.3 starts with a 15-minute investigation and reports before wiring.
+- **Health/Models `?tab=` already exists** (`health-page.tsx:100`, `use-models-data.ts:101`) — PR3's item is docs-only.
+- **404 renders inside the root layout** (the `$` catch-all is a child of `__root`), so sidebar/nav stay intact for free; the work is a shared `NotFound` component + wiring + shadow warning.
+
+## Dependency Graph
+
+```
+PR1 (independent)                    PR2 (after PR1 merges)          PR3 (after PR2 merges)
+  T1.1 toast fix commit                T2.1 host routes                T3.1 search-string fix
+  T1.2 anchors → PluginLink            T2.2 chat page props     ┌──── T3.2 clobber fix (uses T3.1's tests)
+  T1.3 workflows toast   (needs T1.1's  T2.3 URL builders ◄─────┤     T3.3 scroll restoration (independent)
+       toast-id return, already in tree)     (needs T2.1+T2.2)  │     T3.4 NotFound + shadow warn (independent)
+  T1.4 navigate bridge                 T2.4 tests               └──── T3.5 docs sweep (last — documents all)
+  T1.5 enforcement (LAST — pins T1.1–T1.4)
+  T1.6 PR1 docs note
+```
+
+PR order is risk-based, not dependency-forced: PR1 mechanical, PR2 the biggest behavior change isolated, PR3 subtle cross-cutting. Within PRs, tasks are sequential except T3.3/T3.4 (either order).
+
+---
+
+## PR1 — `feat/routing-no-hard-nav`
+
+### Task 1.1: Commit the chat reply-toast fix
+**Description:** The working tree already contains the chat toast SPA fix (`chat-badge-provider.tsx` + `use-toast.ts` returning the toast id). Commit it as-is; exclude the unrelated `_embedded-assets-static.ts` change.
+**Acceptance:** Toast click navigates via router and dismisses the toast; `toast()` returns the id.
+**Verify:** `bun test tests/plugins/chat/ --isolate` green; `git status` shows `_embedded-assets-static.ts` still uncommitted.
+**Files:** `plugins/chat/components/chat-badge-provider.tsx`, `src/hooks/use-toast.ts` (already edited)
+**Commit:** `fix(chat): SPA-navigate + dismiss reply toast` · **Size:** XS
+
+### Task 1.2: Raw internal anchors → PluginLink
+**Description:** Replace the six raw `<a href="/…">` internal anchors with `PluginLink` (SDK) / TanStack `Link` (host-shared): `task-card.tsx:156` (`/models?tab=spend`), `task-card.tsx:225` (`/brands`), `task-brand-panel.tsx:83`, `explore/detail-drawer.tsx:112` (`/team/<id>`), `memory-cleanup.tsx:242` (`/tasks`), `search-unavailable.tsx:33` (`/health`). Preserve styling and any `onClick`/stopPropagation semantics (task-card anchors live inside clickable cards — verify propagation).
+**Acceptance:** All six navigate without reload; cmd/middle-click still opens a new tab; card-click behavior around nested links unchanged.
+**Verify:** `bun run test` (touched plugins' suites), `bunx tsc --noEmit`, manual click-through in dev.
+**Files:** 5 files above + `src/components/search-unavailable.tsx` (uses TanStack `Link` or PluginLink — match its import surface)
+**Commit:** `fix(plugins): replace raw internal anchors with PluginLink` · **Size:** S
+
+### Task 1.3: Workflows approval toast → SPA
+**Description:** Mirror the chat toast fix in `plugins/workflows/components/approvals-badge-provider.tsx:50`: `window.location.href = attention.url` becomes `useRouter().push` + dismiss-on-click via the toast id from T1.1's API.
+**Acceptance:** Clicking the approval toast lands on `/tasks?taskId=…` with no reload; toast dismisses.
+**Verify:** `bun test tests/plugins/workflows/approvals-attention.test.tsx --isolate` (+ add a click-path assertion if the harness allows).
+**Files:** `plugins/workflows/components/approvals-badge-provider.tsx` (+ its test)
+**Commit:** `fix(workflows): SPA-navigate approval toast` · **Size:** XS
+
+### Task 1.4: Navigate bridge for OS notifications
+**Description:** Add `setNavigateBridge`/`navigateTo` in `src/lib/browser-notify.ts` backed by `globalThis.__bakinNavigate` (typed, mirroring `__bakinBroadcast`). Host registers it at boot (where the router instance exists — `main.tsx` or a `__root` effect) with `router.navigate(toNavigationOptions(url))`. `notification.onclick` → `window.focus()` then bridge; falls back to `window.location.href` when unregistered.
+**Acceptance:** Notification click SPA-navigates (SSE connection survives — verify in network tab); with the bridge stubbed out, fallback still navigates.
+**Verify:** New unit test for bridge/fallback (`tests/lib/browser-notify*.test.ts`, happy-dom); manual OS-notification click in dev.
+**Files:** `src/lib/browser-notify.ts`, host boot file, new test
+**Commit:** `feat(sdk): navigate bridge for browser notifications` · **Size:** S
+
+### Task 1.5: Enforcement — arch test + ESLint (pins T1.1–T1.4)
+**Description:** (a) `tests/architecture/no-hard-navigation.test.ts`: pure scanner (no app imports — stays exempt from content-dir mocks) over client-side source banning `window.location.assign/replace`, `window.location.href =`, and raw internal `<a href="/…">`; path-pinned allowlist with reasons: `unsaved-changes-guard.tsx`, SDK `router.ts` (`refresh()`), `use-sse.ts` manifest reload, `header.tsx` update recovery, `PluginHost.tsx` failure banner, `browser-notify.ts` fallback line. Teeth: fixture-string cases proving each pattern is caught. (b) `eslint.config.mjs`: `no-restricted-syntax`/`no-restricted-properties` block scoped to client globs with the same allowlist via per-file disables or glob excludes.
+**Acceptance:** Suite fails on a seeded offender in a scratch file (manually verified, then removed); `bun run lint` flags the same; current tree passes both.
+**Verify:** `bun test tests/architecture/no-hard-navigation.test.ts --isolate`, `bun run lint`, seeded-offender check.
+**Files:** new arch test, `eslint.config.mjs`
+**Commit:** `test(architecture): no-hard-navigation scanner + eslint restrictions` · **Size:** M
+
+### Task 1.6: PR1 docs
+**Description:** Add the navigation rules (PluginLink/useRouter only; allowlisted full reloads; bridge) to `.claude/knowledge/url-state-deep-linking.md` as a new section (full taxonomy rewrite waits for PR3 when the clobber rule dies).
+**Verify:** Doc references real file paths; no stale claims introduced.
+**Commit:** `docs(knowledge): navigation rules in url-state-deep-linking` · **Size:** XS
+
+### Checkpoint PR1 (before merge)
+- [ ] `bun run test` + `bun run lint` + `bunx tsc --noEmit` green
+- [ ] Live on 3737: all six former anchors, both toasts, one OS notification — zero full reloads (network tab: SSE conn id stable)
+- [ ] Mark approves → merge
+
+---
+
+## PR2 — `feat/chat-path-routing`
+
+### Task 2.1: Host routes for chat
+**Description:** Add `routes/chat.$chatId.tsx` and `routes/chat.new.tsx` following the `team.$id.tsx` pattern (`Route.useParams()` → slot props: `page:/chat/[chatId]` with `chatId`; `page:/chat/new`, agent read by the plugin from `?agent=`). Wire into `router.ts`. `routes/chat.tsx` stays the list route.
+**Acceptance:** `/chat/abc` renders the `page:/chat/[chatId]` slot with `chatId="abc"`; `/chat/new` matches the static route, not `$chatId`.
+**Verify:** New route-ranking test; `bunx tsc --noEmit`.
+**Files:** `packages/host/src/routes/chat.$chatId.tsx` (new), `chat.new.tsx` (new), `packages/host/src/router.ts`
+**Commit:** `feat(host): /chat/$chatId and /chat/new routes` · **Size:** S
+
+### Task 2.2: Chat page reads identity from props/path
+**Description:** `plugins/chat/client.tsx` registers the two new slots; `chat-page.tsx` takes `chatId`/draft-mode via props instead of `useQueryState('chat')`/`('draft')`. Internal transitions become path navigations: select chat → `router.push('/chat/<id>')`, new-chat → `router.push('/chat/new?agent=<id>')`, first send lands on `/chat/<newId>` (replace — the draft URL shouldn't survive in history), close/back → `/chat`. The `?agent=` list filter keeps `useQueryState`. Remove the single-navigation-per-transition `setParams` workaround (obsolete once identity is path-based).
+**Acceptance:** All chat flows work from path URLs; cold-boot deep link renders the conversation; draft first-send transitions without reload; `?agent=` filter survives conversation switches only if currently designed to (match existing behavior).
+**Verify:** `bun test tests/plugins/chat/ --isolate`; RTL coverage in T2.4.
+**Files:** `plugins/chat/client.tsx`, `plugins/chat/components/chat-page.tsx` (+ maybe `chat-view.tsx` props)
+**Commit:** `feat(chat): page reads identity from path; draft moves to /chat/new` · **Size:** M
+
+### Task 2.3: Update every chat URL builder
+**Description:** `attention.ts` `visibleChatIdFromLocation` parses `/chat/<id>` pathname (suppression semantics unchanged — `/chat/new` and `/chat` yield `''`); badge-provider toast + OS notification URLs → `/chat/<id>`; search-hit renderer in `client.tsx` → `/chat/<id>`; sweep for any other `?chat=` builders (`grep -rn "chat?chat\|?chat=" plugins packages src`).
+**Acceptance:** Toast, OS notification, and ⌘K hit all land on the path URL; viewing `/chat/<id>` still suppresses that chat's toast.
+**Verify:** `bun test tests/plugins/chat/attention.test.tsx --isolate` (updated); grep returns zero `?chat=` builders.
+**Files:** `plugins/chat/components/attention.ts`, `chat-badge-provider.tsx`, `plugins/chat/client.tsx`
+**Commit:** `feat(chat): path URLs in toast/notification/search builders` · **Size:** S
+
+### Task 2.4: Chat path tests
+**Description:** RTL: chat page renders conversation from `chatId` prop; draft mode from `/chat/new`. Unit: attention pathname parsing table (`/chat/x`, `/chat/x?agent=y`, `/chat/new`, `/chat`, `/tasks`). Follow rtl-settle rules (`import rtl-settle`, `await settleReact()` where a final assertion races a re-render).
+**Verify:** `bun test tests/plugins/chat/ --isolate` green; suite green under `bun run test`.
+**Commit:** `test(chat): path-based deep-link coverage` · **Size:** S
+
+### Task 2.5: Chat docs
+**Description:** Update `.claude/knowledge/chat-plugin.md` URL surface (and `conversation-kit.md` if it references `?chat=`).
+**Commit:** `docs(knowledge): chat-plugin URL surface` · **Size:** XS
+
+### Checkpoint PR2 (before merge)
+- [ ] Full suite + lint + typecheck green
+- [ ] Live on 3737: cold-boot `/chat/<id>` hard refresh, back/forward across conversations, draft → first send → `/chat/<newId>` no reload, toast + OS notif + ⌘K land correctly, old `/chat?chat=<id>` renders list (accepted death)
+- [ ] Mark approves → merge
+
+---
+
+## PR3 — `feat/router-polish`
+
+### Task 3.1: Query values stay strings
+**Description:** Kill the JSON coercion. Preferred: custom `parseSearch`/`stringifySearch` on `createRouter` treating every value as a plain string, then simplify `toNavigationOptions`/`parseRouterSearch` and `useSearchParams`. Fallback (if TanStack internals require the default serializer): fix inside the shim only. Write the round-trip tests FIRST (they define done): `"123"`, `"true"`, `"a,b"`, URL-encoded, multi-value, hash preservation; `DebugSeed`'s `?debug=true` seed and every `useQueryState` consumer unaffected.
+**Acceptance:** All round-trips preserve strings; no `%22`-quoted values in produced URLs; existing param-driven pages behave identically.
+**Verify:** New `tests/sdk/router-search.test.ts` (or similar) + full suite.
+**Files:** `packages/host/src/router.ts`, `packages/sdk/src/hooks/router.ts`, new test
+**Commit:** `fix(sdk): query values survive as strings through the router` · **Size:** M
+
+### Task 3.2: useQueryState multi-setter batching
+**Description:** Batch all `useQueryState`/`useQueryArrayState` mutations in one microtask into a single navigation (merged params; `push` if any update pushed). Two setters in one handler both land. Update the assets `pushParams` call-site comment; the workaround pattern keeps working but is no longer required.
+**Acceptance:** A handler calling `setView(...)` + `setTags(...)` produces one history entry containing both; existing single-setter behavior unchanged.
+**Verify:** New unit test for the batcher; `bun run test` (kanban/assets/schedule suites exercise setters heavily).
+**Files:** `src/hooks/use-query-state.ts`, new test
+**Commit:** `fix(hooks): compose multi-setter useQueryState updates` · **Size:** M
+
+### Task 3.3: Scroll restoration (scout first)
+**Description:** 15-minute scout: find the real scroll container (window vs inner `overflow` div in the shell layout). Then wire the v1.168-supported mechanism (`<ScrollRestoration />` in `__root` and/or `useElementScrollRestoration` for the container). Honor filter-replace ergonomics (no scroll jump on `?q=` typing — `resetScroll: false` on replace navigations if needed).
+**Acceptance:** `/tasks` scroll → open detail elsewhere → back restores position; filter typing never jumps scroll.
+**Verify:** Manual on 3737 (primary); unit where feasible.
+**Files:** `packages/host/src/routes/__root.tsx` and/or `router.ts`
+**Commit:** `feat(host): scroll restoration` · **Size:** S
+
+### Task 3.4: Real 404 + route-shadow warning
+**Description:** Shared `NotFound` component (styled, link back to `/tasks`, renders inside root layout so nav stays); used by `plugin-catchall.tsx` (replacing the bare div) and registered as router `notFoundComponent` (backstop). At plugin-route registration/resolution, `console.warn` when a plugin pattern is shadowed by a host static route (host route paths are enumerable from `router.ts`).
+**Acceptance:** Unknown path renders styled 404 with sidebar intact; a test plugin route colliding with `/tasks` logs the warning.
+**Verify:** RTL test for 404 render; unit test for shadow detection.
+**Files:** new `packages/host/src/components/not-found.tsx`, `plugin-catchall.tsx`, `router.ts`
+**Commit:** `feat(host): NotFound page + route-shadow warning` · **Size:** M
+
+### Task 3.5: Docs sweep (last)
+**Description:** Rewrite `.claude/knowledge/url-state-deep-linking.md` around the taxonomy (D1 table, chat URLs, navigation rules; DELETE the multi-setter warning + `pushParams` requirement, stale `?asset=` row, stale Health/Models "pending" rows). Update CLAUDE.md's URL-state bullet. Check `docs/src/content/docs/extending/plugins/` for navigation guidance (PluginLink), README (no routing content expected — verify).
+**Verify:** Grep the docs for `?chat=`, `?asset=`, "never call two setters" — zero stale hits.
+**Commit:** `docs: routing taxonomy sweep` · **Size:** S
+
+### Checkpoint PR3 / initiative complete
+- [ ] Full suite + lint + typecheck green
+- [ ] Live on 3737: multi-param interactions (assets folder click), string params with numeric values, back/forward scroll, unknown URL 404, health/models `?tab=` deep links
+- [ ] All spec Success Criteria (1–9) checked off explicitly
+- [ ] Mark approves → merge → spec status flipped to Shipped
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Custom search serializer breaks an existing param consumer somewhere | High | Tests-first in T3.1; fallback plan is shim-scoped fix; full suite + live pass gate the merge |
+| Chat migration breaks attention suppression (toast while viewing) | Med | Dedicated pathname-parsing table test in T2.3/T2.4 before live test |
+| Scroll restoration no-ops or misfires with inner scroll containers | Med | Scout step first; feature is droppable from PR3 without blocking the rest |
+| Arch scanner false positives (external links, `mailto:`, template literals) | Low | Teeth tests both directions (catches offenders, passes legit); allowlist is path+reason pinned |
+| ESLint restrictions flag server-side `window` references | Low | Globs scoped to client dirs only; lint run is part of every commit gate |
+| Nested `PluginLink` inside clickable task cards double-fires | Med | T1.2 explicitly verifies propagation on task-card; RTL click test if fragile |
+
+## Open Questions
+
+None — all decisions locked in the spec interview. The only in-flight decision is T3.1's serializer-vs-shim implementation choice, which its tests resolve internally (both outcomes satisfy the same acceptance criteria).

--- a/tasks/todo-routing-overhaul.md
+++ b/tasks/todo-routing-overhaul.md
@@ -1,0 +1,28 @@
+# TODO: Routing Overhaul
+
+Tracks `tasks/plan-routing-overhaul.md`. Check items off as commits land.
+
+## PR1 — feat/routing-no-hard-nav
+- [ ] 1.1 Commit chat reply-toast fix (already in working tree) — `fix(chat): SPA-navigate + dismiss reply toast`
+- [ ] 1.2 Six raw anchors → PluginLink/Link — `fix(plugins): replace raw internal anchors with PluginLink`
+- [ ] 1.3 Workflows approval toast SPA + dismiss — `fix(workflows): SPA-navigate approval toast`
+- [ ] 1.4 globalThis navigate bridge + browser-notify fallback — `feat(sdk): navigate bridge for browser notifications`
+- [ ] 1.5 Arch scanner + teeth + ESLint restrictions — `test(architecture): no-hard-navigation scanner + eslint restrictions`
+- [ ] 1.6 Navigation-rules docs section — `docs(knowledge): navigation rules in url-state-deep-linking`
+- [ ] CHECKPOINT: suite+lint+tsc green · live pass on 3737 (anchors, toasts, OS notif — SSE conn survives) · Mark approves · merge
+
+## PR2 — feat/chat-path-routing
+- [ ] 2.1 Host routes chat.$chatId + chat.new + ranking test — `feat(host): /chat/$chatId and /chat/new routes`
+- [ ] 2.2 Chat page identity from path props; draft → /chat/new?agent= — `feat(chat): page reads identity from path; draft moves to /chat/new`
+- [ ] 2.3 All URL builders → path (attention.ts, toast, OS notif, ⌘K hit); zero `?chat=` grep — `feat(chat): path URLs in toast/notification/search builders`
+- [ ] 2.4 RTL + attention pathname table tests — `test(chat): path-based deep-link coverage`
+- [ ] 2.5 chat-plugin.md (+conversation-kit.md) docs — `docs(knowledge): chat-plugin URL surface`
+- [ ] CHECKPOINT: suite+lint+tsc green · live pass (cold-boot deep link, draft first-send, back/forward, all three entry points) · Mark approves · merge
+
+## PR3 — feat/router-polish
+- [ ] 3.1 Query values stay strings (tests first; serializer preferred, shim fallback) — `fix(sdk): query values survive as strings through the router`
+- [ ] 3.2 Multi-setter microtask batching — `fix(hooks): compose multi-setter useQueryState updates`
+- [ ] 3.3 Scroll restoration (scout container first) — `feat(host): scroll restoration`
+- [ ] 3.4 NotFound page + catch-all + notFoundComponent + shadow warning — `feat(host): NotFound page + route-shadow warning`
+- [ ] 3.5 Docs sweep: taxonomy rewrite, delete clobber rule + stale rows, CLAUDE.md bullet, authoring docs, README check — `docs: routing taxonomy sweep`
+- [ ] CHECKPOINT: suite+lint+tsc green · live pass (multi-param, string params, scroll, 404, tabs) · all spec Success Criteria 1–9 · Mark approves · merge · spec → Shipped

--- a/tasks/todo-routing-overhaul.md
+++ b/tasks/todo-routing-overhaul.md
@@ -3,13 +3,13 @@
 Tracks `tasks/plan-routing-overhaul.md`. Check items off as commits land.
 
 ## PR1 — feat/routing-no-hard-nav
-- [ ] 1.1 Commit chat reply-toast fix (already in working tree) — `fix(chat): SPA-navigate + dismiss reply toast`
-- [ ] 1.2 Six raw anchors → PluginLink/Link — `fix(plugins): replace raw internal anchors with PluginLink`
-- [ ] 1.3 Workflows approval toast SPA + dismiss — `fix(workflows): SPA-navigate approval toast`
-- [ ] 1.4 globalThis navigate bridge + browser-notify fallback — `feat(sdk): navigate bridge for browser notifications`
-- [ ] 1.5 Arch scanner + teeth + ESLint restrictions — `test(architecture): no-hard-navigation scanner + eslint restrictions`
-- [ ] 1.6 Navigation-rules docs section — `docs(knowledge): navigation rules in url-state-deep-linking`
-- [ ] CHECKPOINT: suite+lint+tsc green · live pass on 3737 (anchors, toasts, OS notif — SSE conn survives) · Mark approves · merge
+- [x] 1.1 Commit chat reply-toast fix (already in working tree) — `fix(chat): SPA-navigate + dismiss reply toast`
+- [x] 1.2 Six raw anchors → PluginLink/Link — `fix(plugins): replace raw internal anchors with PluginLink`
+- [x] 1.3 Workflows approval toast SPA + dismiss — `fix(workflows): SPA-navigate approval toast`
+- [x] 1.4 globalThis navigate bridge + browser-notify fallback — `feat(sdk): navigate bridge for browser notifications`
+- [x] 1.5 Arch scanner + teeth + ESLint restrictions — `test(architecture): no-hard-navigation scanner + eslint restrictions`
+- [x] 1.6 Navigation-rules docs section — `docs(knowledge): navigation rules in url-state-deep-linking`
+- [ ] CHECKPOINT: suite+lint+tsc green (done 2026-07-15: 7710 pass/0 fail, lint 0 errors, tsc clean) · live pass on 3737 (anchors, toasts, OS notif — SSE conn survives) · Mark approves · merge
 
 ## PR2 — feat/chat-path-routing
 - [ ] 2.1 Host routes chat.$chatId + chat.new + ranking test — `feat(host): /chat/$chatId and /chat/new routes`

--- a/tests/architecture/no-hard-navigation.test.ts
+++ b/tests/architecture/no-hard-navigation.test.ts
@@ -1,0 +1,194 @@
+/**
+ * No hard navigation for internal routes (routing overhaul, spec
+ * .claude/specs/routing-overhaul.md D3).
+ *
+ * Internal navigation must go through the SPA router — PluginLink /
+ * TanStack Link / useRouter().push — never a full page load. A hard
+ * navigation re-boots the whole shell (manifest fetch, plugin loads, SSE
+ * reconnect) and loses in-memory state.
+ *
+ * Banned in client-side code:
+ *   - window.location.assign/replace, `location.href =` assignments
+ *   - window.location.reload outside the pinned recovery paths
+ *   - raw <a href="/..."> anchors to internal SPA routes
+ *
+ * Every allowlisted file is a deliberate full reload with a reason below.
+ * If you're adding a new one, it must be a recovery/dev-tooling path — not
+ * a user-facing link. ESLint mirrors these bans (eslint.config.mjs) for
+ * in-editor feedback; this test is the CI gate.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readdirSync, readFileSync } from 'fs'
+import { join, relative } from 'path'
+
+const ROOT = process.cwd()
+
+// Client-side code only: server code has no window and full-page anchors in
+// docs/emails are fine. src/{components,hooks,lib,context} are client-shared.
+const SCAN_ROOTS = [
+  'packages/host/src',
+  'packages/sdk/src',
+  'plugins',
+  'src/components',
+  'src/hooks',
+  'src/lib',
+  'src/context',
+]
+const EXT_RE = /\.(ts|tsx|jsx)$/
+
+// Server-side / dev-tooling subtrees inside otherwise-client roots.
+const EXCLUDED = [
+  'packages/host/src/api/', // Fetch-style server handlers — no window here
+  'packages/host/src/dev-client/', // dev loop: reloads/CSS swaps by design
+]
+
+interface Ban {
+  label: string
+  regex: RegExp
+  /** Repo-relative paths allowed to keep the pattern, each with a reason. */
+  allow?: (rel: string) => boolean
+  /** Teeth: snippets the regex MUST catch / MUST ignore. */
+  catches: string[]
+  ignores: string[]
+}
+
+const BANS: Ban[] = [
+  {
+    label: 'window.location.assign/replace (use useRouter().push / PluginLink)',
+    regex: /(?:window\.)?location\.(?:assign|replace)\(/,
+    allow: (rel) =>
+      // Deliberately re-issues an intercepted same-origin navigation as a
+      // full load after the user confirms discarding unsaved changes.
+      rel === 'src/components/unsaved-changes-guard.tsx'
+      // Hard-navigation fallback when the shell's navigate bridge isn't
+      // registered (notification clicked before boot).
+      || rel === 'src/lib/browser-notify.ts',
+    catches: [
+      'window.location.assign(`/chat?chat=${id}`)',
+      'location.replace("/tasks")',
+    ],
+    ignores: [
+      'router.replace(buildUrl(v), { scroll: false })',
+      'params.replace("a", "b")',
+    ],
+  },
+  {
+    label: '`location.href =` assignment (use useRouter().push / PluginLink)',
+    regex: /location\.href\s*=[^=]/,
+    catches: [
+      'window.location.href = attention.url',
+      'location.href = "/tasks"',
+    ],
+    ignores: [
+      'if (window.location.href === url) return',
+      'const current = new URL(window.location.href)',
+    ],
+  },
+  {
+    label: 'window.location.reload outside pinned recovery paths',
+    regex: /location\.reload\(/,
+    allow: (rel) =>
+      // Post-update recovery once /api/version comes back after a restart.
+      rel === 'packages/host/src/components/layout/header.tsx'
+      // Explicit "Reload" button in the plugin-boot-failure banner.
+      || rel === 'packages/host/src/plugin-host/PluginHost.tsx'
+      // The public router.refresh() API — a full reload is its contract.
+      || rel === 'packages/sdk/src/hooks/router.ts'
+      // Runtime manifest changed; non-dev tabs must re-boot to pick it up.
+      || rel === 'src/hooks/use-sse.ts',
+    catches: ['window.location.reload()'],
+    ignores: ['router.refresh()'],
+  },
+  {
+    label: 'raw internal <a href="/..."> anchor (use PluginLink / Link)',
+    // JSX href literals starting with "/": href="/x", href={'/x'}, href={`/x…`}.
+    // /api/ is exempt — those are real server resources (downloads, exports),
+    // not SPA routes.
+    regex: /href=\{?["'`]\/(?!api\/|\/)/,
+    catches: [
+      '<a href="/models?tab=spend">spend</a>',
+      "<a href={'/brands'}>brands</a>',",
+      '<a href={`/team/${entry.id}`}>team</a>',
+    ],
+    ignores: [
+      '<a href="https://example.com/docs">docs</a>',
+      '<a href="/api/assets/abc/export/print.pdf">download</a>',
+      '<a href={to}>generic</a>',
+      "href: '/models?tab=spend',",
+      '<a href="#section">jump</a>',
+    ],
+  },
+]
+
+function walk(path: string, out: string[] = []): string[] {
+  let entries
+  try {
+    entries = readdirSync(path, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) continue
+    const full = join(path, entry.name)
+    if (entry.isDirectory()) walk(full, out)
+    else if (entry.isFile() && EXT_RE.test(entry.name)) out.push(full)
+  }
+  return out
+}
+
+function scanFiles(): string[] {
+  const files: string[] = []
+  for (const root of SCAN_ROOTS) walk(join(ROOT, root), files)
+  return files.filter((f) => !EXCLUDED.some((ex) => relative(ROOT, f).startsWith(ex)))
+}
+
+describe('no hard navigation for internal routes', () => {
+  const files = scanFiles()
+
+  it('scans a plausible client-side file set', () => {
+    expect(files.length).toBeGreaterThan(100)
+  })
+
+  for (const ban of BANS) {
+    it(`bans: ${ban.label}`, () => {
+      const offenders: string[] = []
+      for (const file of files) {
+        const rel = relative(ROOT, file)
+        if (ban.allow?.(rel)) continue
+        const content = readFileSync(file, 'utf8')
+        if (!ban.regex.test(content)) continue
+        for (const [i, line] of content.split('\n').entries()) {
+          if (ban.regex.test(line)) offenders.push(`${rel}:${i + 1}  ${line.trim()}`)
+        }
+      }
+      expect(offenders).toEqual([])
+    })
+  }
+
+  // Teeth: prove each regex bites its offenders and spares legit code —
+  // a regex edit that silently stops matching fails here, not in review.
+  for (const ban of BANS) {
+    it(`teeth: ${ban.label}`, () => {
+      for (const snippet of ban.catches) {
+        expect(ban.regex.test(snippet)).toBe(true)
+      }
+      for (const snippet of ban.ignores) {
+        expect(ban.regex.test(snippet)).toBe(false)
+      }
+    })
+  }
+
+  it('allowlisted files still exist (stale entries rot the allowlist)', () => {
+    const pinned = [
+      'src/components/unsaved-changes-guard.tsx',
+      'src/lib/browser-notify.ts',
+      'packages/host/src/components/layout/header.tsx',
+      'packages/host/src/plugin-host/PluginHost.tsx',
+      'packages/sdk/src/hooks/router.ts',
+      'src/hooks/use-sse.ts',
+    ]
+    for (const rel of pinned) {
+      expect(() => readFileSync(join(ROOT, rel), 'utf8')).not.toThrow()
+    }
+  })
+})

--- a/tests/lib/browser-notify.test.ts
+++ b/tests/lib/browser-notify.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Navigate bridge for OS-notification clicks (routing overhaul PR1).
+ *
+ * The bridge is globalThis-based on purpose: every plugin bundle inlines its
+ * own copy of src/lib/browser-notify.ts (only react/SDK are externalized), so
+ * a module-level variable registered by the host would never reach those
+ * copies. These tests pin the contract: registered bridge wins, missing
+ * bridge falls back to a hard navigation.
+ */
+import { describe, test, expect, afterEach, mock, spyOn } from 'bun:test'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// browser-notify is a pure client lib (no storage), but the content-dir
+// resolvers are mocked defensively per the repo-wide test isolation rule.
+const testDir = join(tmpdir(), `bakin-test-browser-notify-${Date.now()}`)
+mock.module('../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: join(testDir, 'bakin.db') }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: join(testDir, 'bakin.db') }),
+}))
+
+import { setNotificationNavigator, navigateToUrl } from '../../src/lib/browser-notify'
+
+const globalBridge = globalThis as { __bakinNavigate?: (url: string) => void }
+
+afterEach(() => {
+  delete globalBridge.__bakinNavigate
+})
+
+describe('navigate bridge', () => {
+  test('setNotificationNavigator registers the globalThis bridge', () => {
+    const seen: string[] = []
+    setNotificationNavigator((url) => seen.push(url))
+    expect(typeof globalBridge.__bakinNavigate).toBe('function')
+
+    navigateToUrl('/tasks?taskId=abc')
+    expect(seen).toEqual(['/tasks?taskId=abc'])
+  })
+
+  test('bridge registered by another module copy is still used', () => {
+    // Simulates the host registering while a plugin bundle's inlined copy
+    // calls navigateToUrl — only globalThis is shared between them.
+    const seen: string[] = []
+    globalBridge.__bakinNavigate = (url) => seen.push(url)
+
+    navigateToUrl('/chat/abc')
+    expect(seen).toEqual(['/chat/abc'])
+  })
+
+  test('falls back to a hard navigation when no bridge is registered', () => {
+    expect(globalBridge.__bakinNavigate).toBeUndefined()
+    const assign = spyOn(window.location, 'assign').mockImplementation(() => {})
+    try {
+      navigateToUrl('/health')
+      expect(assign).toHaveBeenCalledWith('/health')
+    } finally {
+      assign.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
Part 1 of 3 of the routing overhaul (spec: `.claude/specs/routing-overhaul.md`, plan: `tasks/plan-routing-overhaul.md`).

## What

- **Chat reply toast** and **workflows approval toast** navigate client-side and dismiss on click (`toast()` now returns the toast id — additive).
- **Six raw internal anchors** → `PluginLink`: tasks budget/brand holds, brands panel, explore drawer, memory cleanup, search-unavailable.
- **OS-notification clicks** route client-side via a `globalThis.__bakinNavigate` bridge registered at shell boot (globalThis because plugin bundles inline their own copy of `browser-notify.ts`); hard-load fallback when unbooted.
- **Enforcement:** `tests/architecture/no-hard-navigation.test.ts` (scanner + teeth + pinned allowlist) and mirrored `no-restricted-syntax` ESLint rules.

## Verification

- Full suite 7710 pass / 0 fail (770 files), lint 0 errors, tsc clean.
- Scanner + ESLint both verified to bite a seeded offender and pass the tree.

## Live-test checklist (on 3737, before merge)

- [ ] Task card budget-hold chip → Models/Spend, no reload (SSE conn id stable in network tab)
- [ ] Task card brand-hold chip → Brands, no reload
- [ ] Explore agent detail "manage in Team" → team page, no reload
- [ ] Memory cleanup dispatched-task link → Tasks, no reload
- [ ] Search-unavailable "Open health" → Health, no reload
- [ ] Chat reply toast click → lands in chat, toast dismisses, no reload
- [ ] Workflow gate toast click → task detail, toast dismisses, no reload
- [ ] OS notification click (background the tab first) → SPA navigation, no reload
- [ ] Cmd/middle-click any of the above links still opens a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)