### PR TITLE
feat: chat path-based routing — /chat/$chatId (routing overhaul PR2)

### DIFF
--- a/.claude/knowledge/chat-plugin.md
+++ b/.claude/knowledge/chat-plugin.md
@@ -6,6 +6,8 @@ Spec/plan for the 2026-07 overhaul: `.claude/specs/chat-conversation-kit.md`, `t
 
 ## Design invariants
 
+- **URL surface (routing overhaul PR2, spec D1/D2 — path = page identity).** `/chat` (list/launcher, `?agent=` = rail filter), `/chat/$chatId` (conversation — host route `packages/host/src/routes/chat.$chatId.tsx` threads the param into the `page:/chat/[chatId]` slot), `/chat/new?agent=<agentId>` (draft composer — there `?agent=` is the DRAFT agent and the rail renders unfiltered). Conversations `push` history (back/forward walks them); draft first-send `replace`s the dead `/chat/new` URL. Every deep-link builder (reply toast, OS notification, ⌘K hit renderer) emits `/chat/<id>`; `attention.ts` `visibleChatIdFromLocation` parses the pathname. The retired `?chat=`/`?draft=` shapes are dead — no redirects by decision.
+
 - **Runtime-agnostic.** Consumed runtime surfaces: `agents.get` (roster validation), `messaging.stream` with the adapter-neutral threadId **`chat:<chatId>`** (+ `MessageArgs.signal` for abort and `attachments` for images), `messaging.send` (`ephemeral: true`, threadId `chat:<chatId>:title`) for auto-titling, and `capabilities({agentId}).input.imageInput` to gate the attach affordance.
 - **Transcripts are Bakin-owned UI data — schema v2.** `~/.bakin/chat/index.json` (zod summaries: title/titleSource/pinned/messageCount/unreadCount/lastSeenAt/lastMessageAt+Preview) + `<chatId>.jsonl` (append-only rows: `user (± attachments) | assistant | tool | error | aborted`, agent rows carry `turnId`). Tool rows are STRUCTURED (callId/toolName/status/summary/inputPreview/outputPreview/durationMs/metadata, previews clipped with `metadata.truncated`) so replay folds exactly like live streaming. Legacy v1 rows (`"name: summary"` strings) parse leniently — no migration files. User attachments live under `chat/attachments/<chatId>/` (chat-owned; NEVER auto-imported as assets — assets-D7).
 - **One in-flight turn per chat** (202/409); every turn registers an `AbortController` — `POST /chats/:id/abort` cancels the runtime stream (clean `done` per the runtime contract) and persists an `aborted` row.
@@ -13,7 +15,7 @@ Spec/plan for the 2026-07 overhaul: `.claude/specs/chat-conversation-kit.md`, `t
 - **Persistence via the kit's `createTurnRecorder`** (drain-per-chunk so a crash keeps the partial turn; interleaving preserved — text before a tool result flushes as its own row).
 - **Attention system.** `ChatBadgeProvider` in the global `nav-badge-providers` slot: nav badge (unread total, working dot while streaming), `(N)` tab-title prefix, click-to-jump toast + generated WebAudio chime + OS notification (via `src/lib/browser-notify`, self-suppressing when focused) when a reply lands while the user is elsewhere. Pure rules in `components/attention.ts`: viewing the chat = no fanfare + mark seen; aborted = silence. Toggles in the plugin `settingsSchema` (toasts/sound, default on). Unread is server-side (`unreadCount`/`lastSeenAt`, cleared by `POST /chats/:id/seen` or a user send).
 - **Titles**: first user message titles instantly (`titleSource: 'fallback'`); after the FIRST completed exchange one budget-gated ephemeral LLM call upgrades it (`lib/auto-title.ts` — gate = `dispatchPaused` + `budgetGate`, the dispatch primitives; blocked = silent skip). Precedence user > llm > fallback; renames are never overwritten.
-- **Search (S11):** file-backed `chats` content type (`lib/search.ts`) — one doc per chat (title, agent facet, recency-biased user+assistant body, 6k cap; tool noise never indexes). ⌘K hits deep-link `/chat?chat=<id>`.
+- **Search (S11):** file-backed `chats` content type (`lib/search.ts`) — one doc per chat (title, agent facet, recency-biased user+assistant body, 6k cap; tool noise never indexes). ⌘K hits deep-link `/chat/<id>`.
 - **Agents keep their tools.** The turn is a normal runtime turn — `bakin_*` exec tools work mid-chat exactly as in dispatch.
 
 ## File map
@@ -30,7 +32,7 @@ plugins/chat/
   lib/search.ts                  file-backed 'chats' search content type
   components/use-chat-data.ts    useChats/useChatStream (kit rows + live chunks), requests, useAgentImageInput
   components/chat-page.tsx       header (search + Start a chat) + rail + view/draft/launcher; shortcuts
-                                 (⌘⇧O new, ⌥↑/⌥↓ switch, ⇧Esc focus); URL ?chat= ?draft= ?agents=
+                                 (⌘⇧O new, ⌥↑/⌥↓ switch, ⇧Esc focus); paths /chat, /chat/$chatId, /chat/new?agent=
   components/chat-rail.tsx       Pinned/Today/Yesterday/This week/Older groups, unread pills, working
                                  spinner, FacetFilter, collapsible (persisted), hover pin/delete
   components/chat-view.tsx       kit Conversation + Composer + ToolCallDrawer; inline title edit; retry;

--- a/packages/host/src/router.ts
+++ b/packages/host/src/router.ts
@@ -22,6 +22,8 @@ import { Route as BrandsRoute } from './routes/brands'
 import { Route as BrandDetailRoute } from './routes/brands.$brandId'
 import { Route as BrandDocEditorRoute } from './routes/brands.$brandId.docs.$kind.$name'
 import { Route as ChatRoute } from './routes/chat'
+import { Route as ChatNewRoute } from './routes/chat.new'
+import { Route as ChatDetailRoute } from './routes/chat.$chatId'
 import { Route as ExploreRoute } from './routes/explore'
 import { Route as HealthRoute } from './routes/health'
 import { Route as MemoryRoute } from './routes/memory'
@@ -47,6 +49,8 @@ const routeTree = RootRoute.addChildren([
   BrandDetailRoute,
   BrandDocEditorRoute,
   ChatRoute,
+  ChatNewRoute,
+  ChatDetailRoute,
   ExploreRoute,
   HealthRoute,
   MemoryRoute,

--- a/packages/host/src/routes/chat.$chatId.tsx
+++ b/packages/host/src/routes/chat.$chatId.tsx
@@ -1,0 +1,25 @@
+/**
+ * /chat/$chatId — active conversation route (routing overhaul PR2).
+ *
+ * Mirrors team.$id: resolves the path param via `Route.useParams()` and
+ * hands it to the chat plugin's `page:/chat/[chatId]` slot as `chatId`.
+ */
+import { createRoute } from '@tanstack/react-router'
+import { Slot } from '@makinbakin/sdk/slots'
+import { Suspense } from 'react'
+import { Route as RootRoute } from './__root'
+
+function ChatDetailPage() {
+  const { chatId } = Route.useParams()
+  return (
+    <Suspense fallback={null}>
+      <Slot name="page:/chat/[chatId]" chatId={chatId} />
+    </Suspense>
+  )
+}
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/chat/$chatId',
+  component: ChatDetailPage,
+})

--- a/packages/host/src/routes/chat.new.tsx
+++ b/packages/host/src/routes/chat.new.tsx
@@ -1,0 +1,25 @@
+/**
+ * /chat/new — draft conversation route (routing overhaul PR2).
+ *
+ * The draft agent rides `?agent=<agentId>` (read by the plugin), matching
+ * the /workflows/new creation-surface precedent. Static path — TanStack
+ * ranks it above /chat/$chatId (pinned by tests/host/chat-route-ranking).
+ */
+import { createRoute } from '@tanstack/react-router'
+import { Slot } from '@makinbakin/sdk/slots'
+import { Suspense } from 'react'
+import { Route as RootRoute } from './__root'
+
+function ChatNewPage() {
+  return (
+    <Suspense fallback={null}>
+      <Slot name="page:/chat/new" />
+    </Suspense>
+  )
+}
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/chat/new',
+  component: ChatNewPage,
+})

--- a/plugins/chat/bakin-plugin.json
+++ b/plugins/chat/bakin-plugin.json
@@ -85,6 +85,8 @@
     ],
     "slots": [
       "page:/chat",
+      "page:/chat/[chatId]",
+      "page:/chat/new",
       "nav-badge-providers"
     ]
   }

--- a/plugins/chat/client.tsx
+++ b/plugins/chat/client.tsx
@@ -7,10 +7,24 @@ import { registerPlugin } from '@makinbakin/sdk'
 import { ChatPage } from './components/chat-page'
 import { ChatBadgeProvider } from './components/chat-badge-provider'
 
+// Named wrappers so each slot binds its page mode statically (component
+// identity stays stable across renders).
+function ChatListPage() {
+  return <ChatPage />
+}
+function ChatDetailPage({ chatId }: { chatId?: string }) {
+  return <ChatPage chatId={chatId} />
+}
+function ChatDraftPage() {
+  return <ChatPage draft />
+}
+
 registerPlugin({
   id: 'chat',
   slots: {
-    'page:/chat': ChatPage,
+    'page:/chat': ChatListPage,
+    'page:/chat/[chatId]': ChatDetailPage,
+    'page:/chat/new': ChatDraftPage,
     // Global (outside the router): unread nav badge, tab-title prefix,
     // reply toasts/chime/OS notifications — works from any page.
     'nav-badge-providers': ChatBadgeProvider,
@@ -20,7 +34,7 @@ registerPlugin({
       chats: (hit) => ({
         title: String(hit.fields.title ?? 'New chat'),
         subtitle: `chat · ${String(hit.fields.agent_id ?? '')}`,
-        href: `/chat?chat=${encodeURIComponent(hit.id)}`,
+        href: `/chat/${encodeURIComponent(hit.id)}`,
         icon: 'message-square',
       }),
     },

--- a/plugins/chat/components/attention.ts
+++ b/plugins/chat/components/attention.ts
@@ -52,10 +52,16 @@ export function attentionForDone(payload: ChatDonePayload, ctx: AttentionContext
   }
 }
 
-/** The chat the user is currently viewing, derived from the URL. */
-export function visibleChatIdFromLocation(pathname: string, search: string): string {
-  if (!pathname.startsWith('/chat')) return ''
-  return new URLSearchParams(search).get('chat') ?? ''
+/**
+ * The chat the user is currently viewing, derived from the URL path
+ * (/chat/$chatId since the PR2 path migration). /chat (list) and /chat/new
+ * (draft) view no conversation, so they never suppress attention.
+ */
+export function visibleChatIdFromLocation(pathname: string): string {
+  const match = /^\/chat\/([^/]+)\/?$/.exec(pathname)
+  if (!match) return ''
+  const id = decodeURIComponent(match[1])
+  return id === 'new' ? '' : id
 }
 
 /** Nav badge from unread totals + in-flight turns: count wins, dot while working. */

--- a/plugins/chat/components/chat-badge-provider.tsx
+++ b/plugins/chat/components/chat-badge-provider.tsx
@@ -37,7 +37,7 @@ function ReplyToast({ chatId, agentId, preview, onNavigate }: { chatId: string; 
       data-chat-toast={chatId}
       onClick={() => {
         onNavigate?.()
-        router.push(`/chat?chat=${encodeURIComponent(chatId)}`)
+        router.push(`/chat/${encodeURIComponent(chatId)}`)
       }}
       className="flex max-w-sm items-start gap-2 text-left"
     >
@@ -92,7 +92,7 @@ export function ChatBadgeProvider() {
       return next
     })
     const actions = attentionForDone(done, {
-      visibleChatId: visibleChatIdFromLocation(window.location.pathname, window.location.search),
+      visibleChatId: visibleChatIdFromLocation(window.location.pathname),
       settings: settingsRef.current,
     })
     if (actions.toast) {
@@ -111,7 +111,7 @@ export function ChatBadgeProvider() {
     if (actions.sound) playReplyChime()
     if (actions.browserNotification && done.preview) {
       // browser-notify self-suppresses while the tab is focused.
-      sendBrowserNotification(`${done.agentId} replied`, done.preview, `/chat?chat=${done.chatId}`)
+      sendBrowserNotification(`${done.agentId} replied`, done.preview, `/chat/${encodeURIComponent(done.chatId)}`)
     }
     void refreshUnread()
   })
@@ -123,7 +123,7 @@ export function ChatBadgeProvider() {
       next.delete(id)
       return next
     })
-    const visible = visibleChatIdFromLocation(window.location.pathname, window.location.search)
+    const visible = visibleChatIdFromLocation(window.location.pathname)
     if (visible !== id && settingsRef.current.toasts) {
       toast(`Chat reply failed: ${String(payload.message ?? 'unknown error')}`, 'error')
     }

--- a/plugins/chat/components/chat-page.tsx
+++ b/plugins/chat/components/chat-page.tsx
@@ -3,8 +3,12 @@
  * grouped rail, and the conversation pane (launcher when nothing is
  * selected, draft mode before first send).
  *
- * URL state: ?chat=<chatId> (active chat), ?draft=<agentId> (draft
- * conversation), ?agents=a,b (rail facet filter).
+ * URL surface (routing overhaul PR2, spec D2 — path = page identity):
+ *   /chat                  — list / launcher; ?agent= is the rail filter
+ *   /chat/$chatId          — active conversation (chatId arrives as a prop
+ *                            from the host route); ?agent= filter carries
+ *   /chat/new?agent=<id>   — draft composer; here ?agent= is the DRAFT
+ *                            agent, so the rail renders unfiltered
  *
  * Keyboard shortcuts (page-scoped): ⌘⇧O new chat (launcher), ⌥↑/⌥↓
  * previous/next chat, ⇧Esc focus the composer.
@@ -32,30 +36,28 @@ async function createAndSend(agentId: string, content: string): Promise<string |
   return res.ok ? chat.id : chat.id // chat exists either way; errors surface in the view
 }
 
-function ChatPageInner() {
-  const [chatId] = useQueryState('chat', '')
-  const [draftAgent] = useQueryState('draft', '')
-  const [agentFilter, setAgentFilter] = useQueryState('agent', '')
+interface ChatPageProps {
+  /** Active conversation id — threaded in by the /chat/$chatId host route. */
+  chatId?: string
+  /** Draft mode — set by the /chat/new registration; agent rides ?agent=. */
+  draft?: boolean
+}
+
+function ChatPageInner({ chatId = '', draft = false }: ChatPageProps) {
+  const [agentParam, setAgentParam] = useQueryState('agent', '')
+  // On /chat/new the agent param IS the draft agent (spec D2); on the list
+  // and conversation routes it's the rail filter. Never both.
+  const draftAgent = draft ? agentParam : ''
+  const agentFilter = draft ? '' : agentParam
   const [search, setSearch] = useState('')
   const [collapsed, setCollapsed] = useRailCollapsed()
   const { chats, allChats, loading, refresh } = useChats(agentFilter)
   const router = useRouter()
 
-  // ONE navigation per transition. Two useQueryState setters in the same
-  // tick lose updates (each builds from the pre-navigation params snapshot,
-  // so the second clobbers the first — the "booted back to the launcher"
-  // bug). Reads window.location.search at CALL time.
-  const setParams = useCallback(
-    (patch: Record<string, string>) => {
-      const params = new URLSearchParams(window.location.search)
-      for (const [key, value] of Object.entries(patch)) {
-        if (value) params.set(key, value)
-        else params.delete(key)
-      }
-      const qs = params.toString()
-      router.replace(qs ? `/chat?${qs}` : '/chat')
-    },
-    [router],
+  /** Carry the active rail filter across page-identity navigations. */
+  const withFilter = useCallback(
+    (path: string) => (agentFilter ? `${path}?agent=${encodeURIComponent(agentFilter)}` : path),
+    [agentFilter],
   )
 
   // Live in-flight indicators: seed from the list, keep fresh via events.
@@ -89,14 +91,15 @@ function ChatPageInner() {
     )
   }, [chats, search])
 
+  // push — conversations are places; back/forward walks between them.
   const openChat = useCallback(
-    (id: string) => setParams({ chat: id, draft: '' }),
-    [setParams],
+    (id: string) => router.push(withFilter(`/chat/${encodeURIComponent(id)}`)),
+    [router, withFilter],
   )
 
   const startDraft = useCallback(
-    (agentId: string) => setParams({ chat: '', draft: agentId }),
-    [setParams],
+    (agentId: string) => router.push(`/chat/new?agent=${encodeURIComponent(agentId)}`),
+    [router],
   )
 
   // Page-scoped keyboard shortcuts.
@@ -105,7 +108,7 @@ function ChatPageInner() {
       // ⌘⇧O — new chat (back to the launcher)
       if (e.metaKey && e.shiftKey && e.key.toLowerCase() === 'o') {
         e.preventDefault()
-        setParams({ chat: '', draft: '' })
+        router.push(withFilter('/chat'))
         return
       }
       // ⌥↑ / ⌥↓ — previous/next chat in the visible list
@@ -132,7 +135,7 @@ function ChatPageInner() {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [chatId, visibleChats, openChat, setParams])
+  }, [chatId, visibleChats, openChat, router, withFilter])
 
   return (
     <div className="flex h-full flex-col" data-chat-pane>
@@ -155,7 +158,12 @@ function ChatPageInner() {
           collapsed={collapsed}
           onCollapse={setCollapsed}
           onSelect={openChat}
-          onAgentFilter={setAgentFilter}
+          onAgentFilter={(v) => {
+            // On /chat/new the agent param is the draft agent — a rail
+            // filter click there navigates back to the (filtered) list.
+            if (draft) router.push(v ? `/chat?agent=${encodeURIComponent(v)}` : '/chat')
+            else setAgentParam(v)
+          }}
           onChanged={() => { void refresh() }}
         />
         {chatId ? (
@@ -166,7 +174,8 @@ function ChatPageInner() {
             agentId={draftAgent}
             createAndSend={createAndSend}
             onCreated={(id) => {
-              openChat(id)
+              // replace — the dead draft URL shouldn't survive in history.
+              router.replace(`/chat/${encodeURIComponent(id)}`)
               void refresh()
             }}
           />
@@ -178,10 +187,10 @@ function ChatPageInner() {
   )
 }
 
-export function ChatPage() {
+export function ChatPage(props: ChatPageProps) {
   return (
     <Suspense fallback={null}>
-      <ChatPageInner />
+      <ChatPageInner {...props} />
     </Suspense>
   )
 }

--- a/plugins/chat/lib/search.ts
+++ b/plugins/chat/lib/search.ts
@@ -2,7 +2,7 @@
  * Chat search integration (S11) — transcripts join global search as a
  * file-backed content type: one doc per chat (title, agent, recent
  * message text), synced by the watcher on every JSONL append, deep-linked
- * from the ⌘K overlay via /chat?chat=<id>.
+ * from the ⌘K overlay via /chat/<id>.
  */
 import { basename } from 'path'
 

--- a/tasks/todo-routing-overhaul.md
+++ b/tasks/todo-routing-overhaul.md
@@ -12,11 +12,11 @@ Tracks `tasks/plan-routing-overhaul.md`. Check items off as commits land.
 - [ ] CHECKPOINT: suite+lint+tsc green (done 2026-07-15: 7710 pass/0 fail, lint 0 errors, tsc clean) · live pass on 3737 (anchors, toasts, OS notif — SSE conn survives) · Mark approves · merge
 
 ## PR2 — feat/chat-path-routing
-- [ ] 2.1 Host routes chat.$chatId + chat.new + ranking test — `feat(host): /chat/$chatId and /chat/new routes`
-- [ ] 2.2 Chat page identity from path props; draft → /chat/new?agent= — `feat(chat): page reads identity from path; draft moves to /chat/new`
-- [ ] 2.3 All URL builders → path (attention.ts, toast, OS notif, ⌘K hit); zero `?chat=` grep — `feat(chat): path URLs in toast/notification/search builders`
-- [ ] 2.4 RTL + attention pathname table tests — `test(chat): path-based deep-link coverage`
-- [ ] 2.5 chat-plugin.md (+conversation-kit.md) docs — `docs(knowledge): chat-plugin URL surface`
+- [x] 2.1 Host routes chat.$chatId + chat.new + ranking test — `feat(host): /chat/$chatId and /chat/new routes`
+- [x] 2.2 Chat page identity from path props; draft → /chat/new?agent= — `feat(chat): page reads identity from path; draft moves to /chat/new`
+- [x] 2.3 All URL builders → path (attention.ts, toast, OS notif, ⌘K hit); zero `?chat=` grep — `feat(chat): path URLs in toast/notification/search builders`
+- [x] 2.4 RTL + attention pathname table tests — `test(chat): path-based deep-link coverage`
+- [x] 2.5 chat-plugin.md (+conversation-kit.md) docs — `docs(knowledge): chat-plugin URL surface`
 - [ ] CHECKPOINT: suite+lint+tsc green · live pass (cold-boot deep link, draft first-send, back/forward, all three entry points) · Mark approves · merge
 
 ## PR3 — feat/router-polish

--- a/tests/host/chat-route-ranking.test.tsx
+++ b/tests/host/chat-route-ranking.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Chat route surface pins (routing overhaul PR2).
+ *
+ * /chat/new must win over /chat/$chatId for the literal path "new" — that
+ * ranking (static segment > dynamic segment, independent of registration
+ * order) is core TanStack behavior; unit tests here shim the router (see
+ * tests/shims/tanstack-router.ts), so what we pin is OUR surface:
+ *
+ *   1. the three chat route modules carry the exact expected paths,
+ *   2. they are wired into the host route tree (router.ts),
+ *   3. each route renders the slot name the chat plugin registers.
+ *
+ * The /chat/new-vs-$chatId behavior itself is exercised in the PR's live
+ * checklist and guarded implicitly by (1): with these literal paths,
+ * TanStack's ranking is deterministic.
+ */
+import { describe, test, expect, mock } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+// Pure surface pins — no storage — resolvers mocked per the isolation rule.
+const testDir = join(tmpdir(), `bakin-test-chat-routes-${Date.now()}`)
+mock.module('../../src/core/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: join(testDir, 'bakin.db') }),
+}))
+mock.module('../../packages/core/src/content-dir', () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, db: join(testDir, 'bakin.db') }),
+}))
+
+import { Route as ChatRoute } from '../../packages/host/src/routes/chat'
+import { Route as ChatNewRoute } from '../../packages/host/src/routes/chat.new'
+import { Route as ChatDetailRoute } from '../../packages/host/src/routes/chat.$chatId'
+
+const path = (r: unknown) => (r as { path?: string }).path
+
+describe('chat route surface', () => {
+  test('route modules carry the exact paths the taxonomy locked (spec D2)', () => {
+    expect(path(ChatRoute)).toBe('/chat')
+    expect(path(ChatNewRoute)).toBe('/chat/new')
+    expect(path(ChatDetailRoute)).toBe('/chat/$chatId')
+  })
+
+  test('all three chat routes are wired into the host route tree', () => {
+    const routerSrc = readFileSync(join(process.cwd(), 'packages/host/src/router.ts'), 'utf8')
+    for (const mod of ['./routes/chat', './routes/chat.new', './routes/chat.$chatId']) {
+      expect(routerSrc).toContain(`from '${mod}'`)
+    }
+    for (const name of ['ChatRoute', 'ChatNewRoute', 'ChatDetailRoute']) {
+      // Present in the addChildren list, not just imported.
+      expect(routerSrc).toMatch(new RegExp(`^\\s+${name},`, 'm'))
+    }
+  })
+
+  test('route components render the slot names the chat plugin registers', () => {
+    const read = (f: string) => readFileSync(join(process.cwd(), 'packages/host/src/routes', f), 'utf8')
+    expect(read('chat.tsx')).toContain('page:/chat"')
+    expect(read('chat.new.tsx')).toContain('page:/chat/new')
+    expect(read('chat.$chatId.tsx')).toContain('page:/chat/[chatId]')
+    // The detail route must thread the path param into the slot.
+    expect(read('chat.$chatId.tsx')).toContain('chatId={chatId}')
+  })
+})

--- a/tests/plugins/chat/attention.test.tsx
+++ b/tests/plugins/chat/attention.test.tsx
@@ -70,10 +70,17 @@ describe('attentionForDone (pure rules)', () => {
 })
 
 describe('attention helpers', () => {
-  it('visibleChatIdFromLocation only matches the chat page', () => {
-    expect(visibleChatIdFromLocation('/chat', '?chat=c1')).toBe('c1')
-    expect(visibleChatIdFromLocation('/tasks', '?chat=c1')).toBe('')
-    expect(visibleChatIdFromLocation('/chat', '')).toBe('')
+  it('visibleChatIdFromLocation parses the /chat/$chatId path (PR2 migration)', () => {
+    expect(visibleChatIdFromLocation('/chat/c1')).toBe('c1')
+    expect(visibleChatIdFromLocation('/chat/c1/')).toBe('c1')
+    expect(visibleChatIdFromLocation('/chat/abc%20def')).toBe('abc def')
+    // No conversation in view — list, draft, other pages, deeper paths:
+    expect(visibleChatIdFromLocation('/chat')).toBe('')
+    expect(visibleChatIdFromLocation('/chat/new')).toBe('')
+    expect(visibleChatIdFromLocation('/tasks')).toBe('')
+    expect(visibleChatIdFromLocation('/chat/c1/extra')).toBe('')
+    // The retired ?chat= shape is dead by decision (no redirects):
+    expect(visibleChatIdFromLocation('/chat')).toBe('')
   })
 
   it('badgeFor: unread count wins, working dot otherwise, null when idle', () => {

--- a/tests/plugins/chat/chat-page-routing.test.tsx
+++ b/tests/plugins/chat/chat-page-routing.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+/**
+ * ChatPage path-based identity (routing overhaul PR2, spec D2).
+ *
+ * The page mode comes from props threaded by the host routes — chatId
+ * (/chat/$chatId), draft (/chat/new) — never from ?chat=/?draft= query
+ * state. These tests render the full ChatPage against the router shim
+ * with a spy navigate and pin: mode selection per prop, the draft agent
+ * riding ?agent= on /chat/new, and rail selection pushing /chat/<id>.
+ */
+import { describe, expect, it, mock, afterEach } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+const testDir = join(tmpdir(), `bakin-test-chat-page-routing-${Date.now()}`)
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ root: testDir, chat: join(testDir, 'chat'), db: join(testDir, 'bakin.db') }),
+})
+mock.module('@/core/content-dir', contentDirMock)
+mock.module('../../../packages/core/src/content-dir', contentDirMock)
+
+// Router shim (house convention) + a spy navigate so push targets are
+// assertable. useLocation reads happy-dom's real window.location.
+const navigations: unknown[] = []
+mock.module('@tanstack/react-router', () => ({
+  ...require('../../shims/tanstack-router'),
+  useNavigate: () => (opts: unknown) => navigations.push(opts),
+}))
+
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import '../../rtl-settle'
+
+import { ChatPage } from '../../../plugins/chat/components/chat-page'
+
+const CHAT_A = '11111111-1111-1111-1111-111111111111'
+
+const CHAT_SUMMARY = {
+  id: CHAT_A,
+  agentId: 'main',
+  title: 'Reddit research',
+  titleSource: 'fallback',
+  pinned: false,
+  createdAt: '2026-07-11T09:00:00.000Z',
+  updatedAt: new Date().toISOString(),
+  messageCount: 1,
+  unreadCount: 0,
+  lastMessagePreview: 'hi',
+}
+
+// happy-dom: history.replaceState doesn't sync window.location — use setURL.
+function setURL(url: string) {
+  const happy = (window as unknown as { happyDOM?: { setURL: (u: string) => void } }).happyDOM
+  happy?.setURL(url)
+}
+
+const realFetch = globalThis.fetch
+let fetched: string[] = []
+
+function mockFetch() {
+  fetched = []
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = String(input)
+    fetched.push(url)
+    const body = url.includes(`/chats/${CHAT_A}`)
+      ? { chat: CHAT_SUMMARY, messages: [] }
+      : url.includes('/chats')
+        ? { chats: [CHAT_SUMMARY] }
+        : {}
+    return Promise.resolve(
+      new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+  }) as typeof fetch
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch
+  navigations.length = 0
+})
+
+describe('ChatPage path-based identity', () => {
+  it('chatId prop renders the conversation (fetches that chat)', async () => {
+    mockFetch()
+    setURL(`http://localhost:3737/chat/${CHAT_A}`)
+    const { container } = render(<ChatPage chatId={CHAT_A} />)
+    await waitFor(() => {
+      expect(fetched.some((u) => u.includes(`/chats/${CHAT_A}`))).toBe(true)
+    })
+    expect(container.querySelector('[data-chat-pane]')).not.toBeNull()
+  })
+
+  it('draft prop + ?agent= renders the draft composer for that agent', async () => {
+    mockFetch()
+    setURL('http://localhost:3737/chat/new?agent=main')
+    const { container } = render(<ChatPage draft />)
+    await waitFor(() => {
+      expect(container.textContent).toContain('Chat with main')
+    })
+    // The draft agent must NOT filter the rail: the chats list is fetched
+    // without an agent filter.
+    expect(fetched.some((u) => u.includes('chats?agent='))).toBe(false)
+  })
+
+  it('no props renders the launcher (list page)', async () => {
+    mockFetch()
+    setURL('http://localhost:3737/chat')
+    const { container } = render(<ChatPage />)
+    await waitFor(() => {
+      expect(container.textContent).toContain('Start a chat')
+    })
+  })
+
+  it('selecting a rail chat pushes /chat/<id>', async () => {
+    mockFetch()
+    setURL('http://localhost:3737/chat')
+    const { container } = render(<ChatPage />)
+    await waitFor(() => {
+      expect(container.querySelector(`[data-chat-row="${CHAT_A}"]`)).not.toBeNull()
+    })
+    fireEvent.click(container.querySelector(`[data-chat-row="${CHAT_A}"]`)!)
+    const pushed = navigations.find(
+      (n) => (n as { to?: string }).to === `/chat/${CHAT_A}`,
+    )
+    expect(pushed).toBeDefined()
+  })
+})


### PR DESCRIPTION
Part 2 of 3 of the routing overhaul (spec: `.claude/specs/routing-overhaul.md`). Chat was the last identity-bearing surface on query params; it now follows the path taxonomy. **No redirects — old `?chat=` links render the list, by decision (spec D6).**

## URL surface

| URL | Renders |
|---|---|
| `/chat` | list / launcher (`?agent=` = rail filter) |
| `/chat/$chatId` | conversation (pushes history — back/forward walks conversations) |
| `/chat/new?agent=<id>` | draft composer (`?agent=` = the draft agent; rail unfiltered; first send `replace`s the dead draft URL) |

## What changed

- Host routes `chat.$chatId.tsx` / `chat.new.tsx` (team.$id pattern — params → slot props); plugin registers `page:/chat/[chatId]` + `page:/chat/new` slots.
- `ChatPage` takes `chatId`/`draft` props; the `setParams` one-navigation workaround is deleted (identity no longer rides query params).
- Every URL builder emits `/chat/<id>`: reply toast, OS notification, ⌘K hit renderer; `visibleChatIdFromLocation` parses the pathname (suppression rules unchanged, pinned by a parsing table test).
- Rail-filter click on `/chat/new` navigates back to the filtered list (the param means "draft agent" there, never both).

## Verification

- Full suite 7717 pass / 0 fail (772 files), lint 0 errors, tsc clean.
- New tests: chat route surface pins (paths, tree wiring, slot names), ChatPage mode-per-prop + rail-selection push, attention pathname table.

## Live-test checklist (on 3737, before merge)

- [ ] Cold boot (hard refresh) on `/chat/<id>` lands in that conversation
- [ ] Switching chats in the rail updates the path; back/forward walks conversations
- [ ] New chat → draft at `/chat/new?agent=<id>` → first send lands on `/chat/<newId>` with no reload; back does NOT return to the draft
- [ ] Reply toast, OS notification, and ⌘K chat hit all land on `/chat/<id>`
- [ ] Reply landing while viewing that chat still shows no toast/chime (suppression intact)
- [ ] Rail agent filter works on list + conversation; filter click from draft returns to filtered list
- [ ] ⌘⇧O / ⌥↑ / ⌥↓ / ⇧Esc shortcuts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)