### PR TITLE
fix(tests,hooks): dispatch-concurrency contention wedge + mock-checker false positives

### DIFF
--- a/.claude/hooks/check-test-mocks.mjs
+++ b/.claude/hooks/check-test-mocks.mjs
@@ -6,9 +6,10 @@
 //      previously leaked test data into ~/.bakin/ and ~/.openclaw/. Matches
 //      both Bun's `mock.module(...)` and Vitest's `vi.mock(...)` so the
 //      checker works through the Next.js → Bun migration and any future shift.
-//   2. The test mocks src/core/content-dir (CLAUDE.md hard rule).
-//   3. If the test touches workflows/tasks/openclaw, it also mocks task-store
-//      and openclaw-home.
+//   2. Tests that reference server-reachable code mock src/core/content-dir
+//      (CLAUDE.md rule; pure client component tests have no path to disk).
+//   3. If the test touches workflows/tasks server code or openclaw, it also
+//      mocks task-store and openclaw-home.
 //
 // Broken paths set decision: "block" so Claude re-edits.
 // Missing required mocks emit a warning via additionalContext (no block).
@@ -74,6 +75,28 @@ function resolveRelativeMock(testFile, mockArg) {
 // REQUIRED_PATTERNS run against the *string argument* of vi.mock(...) calls,
 // so they need to match both relative paths ('../../../src/core/content-dir')
 // and aliases ('@/core/content-dir', '@bakin/adapter-openclaw/home').
+// A test can only leak into ~/.bakin/ if it (transitively) runs server-side
+// code. Pure client component tests — imports limited to plugins/*/
+// {components,hooks,types}, @/components, @/hooks, the SDK — have no path to
+// the filesystem, and warning on every edit of those files buries the real
+// signal. Requirements therefore fire on UNMOCKED imports of server-reachable
+// surfaces: a mock.module target never loads the real module, so mocked
+// specifiers don't count as reach (grepping the whole source made every
+// component test that stubs a plugin component look storage-touching).
+// Heuristic, single-file view: a test whose only server reference hides
+// behind a local fixture helper won't be flagged.
+const SERVER_SURFACE_RE =
+  /src\/core\/|packages\/core\/|@\/core\/|@bakin\/core|@bakin\/adapter|plugins\/[-\w]+\/(index|lib|routes|server)|(^|\/)plugins\/[-\w]+$|test-helpers/
+
+// Import/require/dynamic-import specifiers — the surfaces a test actually loads.
+const IMPORT_RE = /(?:from\s+|require\(\s*|import\(\s*)['"]([^'"]+)['"]/g
+
+function extractImportPaths(src) {
+  const out = []
+  for (const m of src.matchAll(IMPORT_RE)) out.push(m[1])
+  return out
+}
+
 const REQUIRED_PATTERNS = [
   {
     label: 'src/core/content-dir (or packages/core/src/content-dir)',
@@ -82,28 +105,33 @@ const REQUIRED_PATTERNS = [
       || /(^|\/)packages\/core\/src\/content-dir$/.test(p)
       || /@\/core\/content-dir$/.test(p)
       || /@bakin\/core\/content-dir$/.test(p),
-    always: true,
+    requiredIf: (ctx) => ctx.unmockedImports.some((p) => SERVER_SURFACE_RE.test(p)),
   },
   {
     label: 'src/core/task-store',
     matches: (p) =>
       /(^|\/)src\/core\/task-store$/.test(p)
       || /@\/core\/task-store$/.test(p),
-    requiredIf: (src) =>
-      /task-store|@bakin\/workflows|plugins\/(tasks|workflows)/.test(src),
+    requiredIf: (ctx) => ctx.unmockedImports.some((p) =>
+      /task-store|@bakin\/workflows/.test(p)
+      // plugins/tasks|workflows imports count only when they reach past the
+      // client-only dirs (components/hooks/types can't touch the store).
+      || (/plugins\/(tasks|workflows)(\/|$)/.test(p) && !/\/(components|hooks|types)(\/|$)/.test(p))),
   },
   {
     label: 'openclaw-home resolver (packages/adapter-openclaw/src/home or @bakin/adapter-openclaw/home)',
     matches: (p) =>
       /(^|\/)packages\/adapter-openclaw\/src\/home$/.test(p)
       || /@bakin\/adapter-openclaw\/home$/.test(p),
-    requiredIf: (src) =>
-      /openclaw-home|getOpenClawPath|getOpenClawHome|@bakin\/adapter-openclaw\/home/.test(src),
+    // Identifier-based (call sites like getOpenClawPath indicate real use),
+    // so this one stays a whole-source check.
+    requiredIf: (ctx) =>
+      /openclaw-home|getOpenClawPath|getOpenClawHome|@bakin\/adapter-openclaw\/home/.test(ctx.src),
   },
   {
     label: 'src/core/openclaw-client',
     matches: (p) => /(^|\/)src\/core\/openclaw-client$/.test(p) || /@\/core\/openclaw-client$/.test(p),
-    requiredIf: (src) => /openclaw-client|sendToAgent|openClawClient/.test(src),
+    requiredIf: (ctx) => /openclaw-client|sendToAgent|openClawClient/.test(ctx.src),
   },
 ]
 
@@ -142,14 +170,15 @@ function check(filePath) {
 
   const missing = []
   if (!isPureArchitectureTest(filePath) && !isSdkTestingFixture(filePath)) {
+    const mockSet = new Set(mockPaths)
+    const unmockedImports = extractImportPaths(src).filter((p) => !mockSet.has(p))
+    const ctx = { src, unmockedImports }
     for (const req of REQUIRED_PATTERNS) {
       const found = mockPaths.some(req.matches)
       if (found) continue
       if (isSelfTest(filePath, req.label)) continue
-      if (req.always) {
-        missing.push(req.label)
-      } else if (req.requiredIf && req.requiredIf(src)) {
-        missing.push(`${req.label} (referenced in this test file)`)
+      if (req.requiredIf && req.requiredIf(ctx)) {
+        missing.push(`${req.label} (this test imports server-reachable code)`)
       }
     }
   }

--- a/tests/core/dispatch-concurrency.test.ts
+++ b/tests/core/dispatch-concurrency.test.ts
@@ -151,6 +151,19 @@ function readState() {
 
 const tick = (ms = 20) => new Promise((r) => setTimeout(r, ms))
 
+// Bounded poll for conditions with genuinely async lead time (worktree
+// subprocesses, post-settle state writes). Fixed ticks lose the race under
+// CPU contention: a starved 50ms tick fires before dispatch prep finishes,
+// the assertion fails, and the still-preparing turn wedges the file (its
+// send lands after afterEach's drain and nothing ever releases it).
+async function waitUntil(cond: () => boolean, what: string, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`)
+    await tick(10)
+  }
+}
+
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), 'bakin-dispatch-conc-'))
   pendingSends.clear()
@@ -166,8 +179,17 @@ beforeEach(() => {
 
 afterEach(async () => {
   // Drain anything left in flight so settle handlers can't leak across tests.
-  for (const [agent, queue] of pendingSends) {
-    while (queue.length) releaseSend(agent)
+  // Re-drain until idle: a send can land AFTER a drain pass (async prep —
+  // worktree materialization — finishing late under load); a single pass
+  // would leave that turn unreleased forever, and its registry entry wedges
+  // every later test with agent_busy deferrals. Deadline keeps a genuine
+  // wedge visible as this test's hook timeout instead of a cascade.
+  const deadline = Date.now() + 10_000
+  while (getInFlightTurnCount() > 0 && Date.now() < deadline) {
+    for (const [agent, queue] of pendingSends) {
+      while (queue.length) releaseSend(agent)
+    }
+    await tick(10)
   }
   await awaitDispatchIdle()
   rmSync(tempDir, { recursive: true, force: true })
@@ -251,7 +273,9 @@ describe('concurrent dispatch', () => {
 
     setColumns({ todo: [{ id: 'bound-1', title: 'Repo work', agent: 'jessica', repoPath: repo }] })
     await dispatchTasks(tempDir, 3737)
-    await tick(50)
+    // Worktree materialization is a real git subprocess — wait for the send,
+    // don't guess its duration.
+    await waitUntil(() => sendCalls.some((c) => c.agentId === 'jessica'), 'repo-bound send')
 
     const send = sendCalls.find((c) => c.agentId === 'jessica')
     expect(send?.runWorkspace?.endsWith('/repo')).toBe(true)
@@ -262,7 +286,8 @@ describe('concurrent dispatch', () => {
 
     releaseSend('jessica')
     await awaitDispatchIdle()
-    await tick(100) // async worktree removal after settle
+    // Worktree removal after settle is async — bounded wait, not a fixed tick.
+    await waitUntil(() => !existsSync(send!.runWorkspace!), 'post-settle worktree removal')
 
     // Worktree died at settle; the branch (the deliverable) survives.
     expect(existsSync(send!.runWorkspace!)).toBe(false)
@@ -574,7 +599,11 @@ describe('concurrent dispatch', () => {
     await dispatchTasks(tempDir, 3737)
 
     releaseSend('jessica', 'error')
-    await tick(50)
+    // The settle handler writes .dispatch-state.json asynchronously — wait
+    // for the write, don't guess its duration.
+    await waitUntil(() => {
+      try { return readState().failedDispatches['t-fail'] !== undefined } catch { return false }
+    }, 'failed-dispatch reconciliation write')
     // jessica's failure is reconciled while pixel is still mid-turn.
     expect(readState().failedDispatches['t-fail']).toBeDefined()
     expect(getInFlightTurnCount('pixel')).toBe(1)


### PR DESCRIPTION
The two loose ends from the #650 / PR #700 investigation, on a clean branch off main.

## 1. dispatch-concurrency file-wide wedge under CPU contention

During #650's load rounds, `tests/core/dispatch-concurrency.test.ts` (from #699) wedged wholesale — all 16 tests at the 15s timeout. Reproduced in isolation under load (20 saturating procs) on round 1.

**Mechanism:** the repo-bound test's fixed `tick(50)` loses the race to the real `git worktree add` subprocess → assertion fails while the turn is still preparing → its send lands *after* `afterEach`'s single drain pass → nothing releases it → the orphaned in-flight registry entry defers every later test with `agent_busy`. One lost race, whole file red.

**Fix:** bounded `waitUntil` polls at the three genuinely-async assertion points, plus a re-draining `afterEach` (10s deadline) so a late send can never outlive its release.

**Verified:** 15/15 clean rounds under the same load that wedged round 1 pre-fix; full suite green.

## 2. check-test-mocks hook false positives

The PostToolUse mock checker flagged clean files on every edit — kanban-dnd was told it was missing a `task-store` mock for a module it never imports. Root cause: whole-source grepping counted `mock.module` **target strings** as storage references, and the content-dir rule was unconditional even for pure client component tests.

**Fix:** requirements fire on **unmocked import specifiers** of server-reachable surfaces. A mocked module never loads, so it no longer counts as reach.

**Verified:** naughty fixture still flags; old-vs-new sweep across all 793 test files → 0 real cases newly unflagged, 87 noise files quiet (spot-checked: they mock properly, import only `src/lib`, or use the CLAUDE.md env-var isolation pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)