### PR TITLE
fix(host): notification polish — toast overflow, badge rollup, instant working dot

### DIFF
--- a/packages/host/src/components/layout/nav-badge-logic.ts
+++ b/packages/host/src/components/layout/nav-badge-logic.ts
@@ -68,6 +68,41 @@ export function collapsedParentRollupTone(
 }
 
 /**
+ * Aggregated badge for an expanded-sidebar group header whose children are
+ * HIDDEN (the group is closed). Children's badges must surface here or a
+ * child's unread count / working dot is invisible until the user happens to
+ * open the group. Merge rule mirrors the kit's badge precedence: pick the
+ * highest-severity tone across the parent's own badge and all active child
+ * badges, then sum the counts carried by badges of that tone (no counts →
+ * presence-only dot). Returns the parent's own badge untouched when nothing
+ * rolls up, and undefined when nothing is active at all.
+ */
+export function closedGroupRollupBadge(
+  item: NavItem,
+  parentBadge: NavBadgeData | undefined,
+  badges: ReadonlyMap<string, NavBadgeData>,
+): NavBadgeData | undefined {
+  const active: NavBadgeData[] = []
+  if (badgeIsActive(parentBadge)) active.push(parentBadge)
+  for (const child of item.children ?? []) {
+    const b = badges.get(child.id) ?? child.badge
+    if (badgeIsActive(b)) active.push(b)
+  }
+  if (active.length === 0) return undefined
+  let tone: NavBadgeTone = active[0].tone ?? 'attention'
+  for (const b of active) {
+    const t = b.tone ?? 'attention'
+    if (TONE_PRIORITY[t] < TONE_PRIORITY[tone]) tone = t
+  }
+  let count: number | undefined
+  for (const b of active) {
+    if ((b.tone ?? 'attention') !== tone || typeof b.count !== 'number') continue
+    count = (count ?? 0) + b.count
+  }
+  return typeof count === 'number' ? { tone, count } : { tone }
+}
+
+/**
  * Aria-label suffix for a collapsed parent. When the dot comes from the
  * parent's own badge we announce its count/tone; when a child provides the
  * highest severity we announce that children need attention — otherwise the

--- a/packages/host/src/components/layout/sidebar-nav-item.tsx
+++ b/packages/host/src/components/layout/sidebar-nav-item.tsx
@@ -36,6 +36,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { NavBadge, NavBadgeDot, navBadgeAriaSuffix } from './nav-badge'
 import {
   badgeIsActive,
+  closedGroupRollupBadge,
   collapsedParentAriaSuffix,
   collapsedParentRollupTone,
   isNavActive,
@@ -179,6 +180,10 @@ export function SidebarNavItem({
 
   if (hasChildren && !collapsed) {
     const parentBadge = badgeFor(item)
+    // Closed group → the children (and their badges) are hidden, so roll
+    // their badges up into the header; open group → the children show their
+    // own badges, the header keeps only its own.
+    const headerBadge = expanded ? parentBadge : closedGroupRollupBadge(item, parentBadge, badges)
     const groupId = `sidebar-group-${item.id}`
     return (
       <div className="flex flex-col">
@@ -188,11 +193,11 @@ export function SidebarNavItem({
           className={navRowClass(active, false)}
           aria-expanded={expanded}
           aria-controls={groupId}
-          aria-label={`${item.label}${navBadgeAriaSuffix(parentBadge)}`}
+          aria-label={`${item.label}${navBadgeAriaSuffix(headerBadge)}`}
         >
           <Icon className="size-4 shrink-0" />
           <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
-          <NavBadge badge={parentBadge} />
+          <NavBadge badge={headerBadge} />
           <ChevronRight
             className={`size-3.5 shrink-0 transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
             aria-hidden="true"

--- a/packages/host/src/components/layout/toaster.tsx
+++ b/packages/host/src/components/layout/toaster.tsx
@@ -29,7 +29,10 @@ export function Toaster() {
             className={`flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-sm shadow-lg animate-in fade-in slide-in-from-bottom-2 ${COLORS[t.type]}`}
           >
             <Icon className="size-4 shrink-0 mt-0.5" />
-            <div className="flex-1">{t.message}</div>
+            {/* min-w-0: without it the automatic flex minimum inherits the
+                width of nowrap content (e.g. the reply toast's truncated
+                preview line) and the row paints past the toast's box. */}
+            <div className="flex-1 min-w-0">{t.message}</div>
             <button
               onClick={() => dismiss(t.id)}
               className="shrink-0 opacity-60 hover:opacity-100 transition-opacity"

--- a/packages/sdk/src/types/conversation-turns.ts
+++ b/packages/sdk/src/types/conversation-turns.ts
@@ -76,7 +76,7 @@ export interface ConversationTurnServiceConfig {
   /** Consumer label for log lines (e.g. 'projects.brainstorm'). */
   name: string
   /** Bus event names — the consumer's wire contract. */
-  events: { chunk: string; done: string; error: string }
+  events: { chunk: string; done: string; error: string; started?: string }
   /** Base payload identifying the thread on every event (e.g. key => ({ projectId: key })). */
   payload: (key: string) => Record<string, unknown>
   /** Resolve the thread's agent; null → start() returns 'not_found'. */

--- a/plugins/chat/components/chat-badge-provider.tsx
+++ b/plugins/chat/components/chat-badge-provider.tsx
@@ -38,6 +38,7 @@ export function ChatBadgeProvider() {
     pluginId: 'chat',
     navItemId: 'chat',
     events: {
+      started: 'chat.started',
       chunk: 'chat.chunk',
       done: 'chat.done',
       error: 'chat.error',

--- a/plugins/chat/lib/stream-bridge.ts
+++ b/plugins/chat/lib/stream-bridge.ts
@@ -42,7 +42,7 @@ export const CHAT_TURN_FRAMING =
 
 const service = createConversationTurnService({
   name: 'chat',
-  events: { chunk: 'chat.chunk', done: 'chat.done', error: 'chat.error' },
+  events: { chunk: 'chat.chunk', done: 'chat.done', error: 'chat.error', started: 'chat.started' },
   payload: (chatId) => ({ chatId }),
   resolveThread: (chatId) => {
     const chat = getChatSummary(chatId)

--- a/src/components/conversation/use-conversation-attention.tsx
+++ b/src/components/conversation/use-conversation-attention.tsx
@@ -35,7 +35,7 @@ export interface ConversationAttentionConfig {
    * events — AT MOST TWO (hook-count constraints; extras would be
    * silently dropped, so the type forbids them).
    */
-  events: { chunk: string; done: string; error: string; refresh?: [string] | [string, string] }
+  events: { chunk: string; done: string; error: string; started?: string; refresh?: [string] | [string, string] }
   keyOf: (payload: PluginEventPayload) => string
   /** The thread key currently on screen ('' = none) — read at event time. */
   visibleKey: () => string
@@ -83,6 +83,14 @@ export function useConversationAttention(config: ConversationAttentionConfig): v
   useEffect(() => {
     void refreshTotals()
   }, [refreshTotals])
+
+  // `started` fires at turn-accept (before any runtime chunk) — the working
+  // dot lights instantly; the chunk listener stays as the fallback for
+  // consumers without a started event and for mid-turn mounts.
+  usePluginEvent(config.events.started ?? `${config.pluginId}.__attention_noop_started`, (payload) => {
+    const key = configRef.current.keyOf(payload)
+    setInflight((prev) => (prev.has(key) ? prev : new Set(prev).add(key)))
+  })
 
   usePluginEvent(config.events.chunk, (payload) => {
     const key = configRef.current.keyOf(payload)

--- a/src/core/conversation-turns.ts
+++ b/src/core/conversation-turns.ts
@@ -93,8 +93,11 @@ export interface InflightTurnInfo {
 export interface ConversationTurnServiceConfig {
   /** Consumer label for log lines (e.g. 'chat', 'projects.brainstorm'). */
   name: string
-  /** Bus event names — the consumer's wire contract (e.g. chat.chunk/done/error). */
-  events: { chunk: string; done: string; error: string }
+  /** Bus event names — the consumer's wire contract (e.g. chat.chunk/done/error).
+   *  `started` (optional) fires at turn-accept, BEFORE any runtime chunk —
+   *  attention providers light the working dot instantly instead of waiting
+   *  out model latency for the first chunk (#707). */
+  events: { chunk: string; done: string; error: string; started?: string }
   /** Base payload identifying the thread on every event (e.g. key => ({ chatId: key })). */
   payload: (key: string) => Record<string, unknown>
   /** Resolve the thread's agent; null → start() returns 'not_found'. */
@@ -229,6 +232,12 @@ export function createConversationTurnService(config: ConversationTurnServiceCon
       inflight.delete(key)
       log.error(`[${config.name}] user row append failed for ${key}`, err as Error)
       return 'not_found'
+    }
+
+    // Accept signal for attention surfaces — the first runtime chunk can be
+    // seconds away (model latency), and the working dot must not wait it out.
+    if (config.events.started) {
+      ctx.events.emit(config.events.started, { ...config.payload(key), agentId })
     }
 
     // The busy slot releases when the TURN settles; onSettled work (e.g.

--- a/tests/components/conversation-attention.test.tsx
+++ b/tests/components/conversation-attention.test.tsx
@@ -127,6 +127,24 @@ describe('useConversationAttention (provider hook)', () => {
     await waitFor(() => expect(getNavBadge('probe2-nav')).toEqual({ tone: 'info' }))
   })
 
+  it('started events light the working dot before any chunk arrives (#707)', async () => {
+    const { config } = makeConfig({ events: { ...EVENTS, started: 'probe2.started' } })
+    renderHook(() => useConversationAttention(config))
+    await act(async () => {})
+    expect(getNavBadge('probe2-nav')).toBeUndefined()
+
+    act(() => {
+      emitPluginEvent({ event: 'probe2.started', threadKey: 't1', agentId: 'main' })
+    })
+    await waitFor(() => expect(getNavBadge('probe2-nav')).toEqual({ tone: 'info' }))
+
+    // The done clears the started-seeded key even when no chunk ever fired.
+    await act(async () => {
+      emitPluginEvent({ event: EVENTS.done, threadKey: 't1', agentId: 'main' })
+    })
+    await waitFor(() => expect(getNavBadge('probe2-nav')).toBeUndefined())
+  })
+
   it('done while elsewhere: toast + chime + refresh; done while viewing: silent', async () => {
     const { config, calls } = makeConfig()
     renderHook(() => useConversationAttention(config))

--- a/tests/components/nav-badge-logic.test.ts
+++ b/tests/components/nav-badge-logic.test.ts
@@ -17,6 +17,7 @@ mock.module('../../packages/core/src/content-dir', () => ({
 
 import {
   badgeIsActive,
+  closedGroupRollupBadge,
   isNavActive,
   pickRollupTone,
   collapsedParentRollupTone,
@@ -160,5 +161,49 @@ describe('collapsedParentAriaSuffix', () => {
 
   it('empty string when the parent badge is count-0 and no rollup', () => {
     expect(collapsedParentAriaSuffix({ count: 0 }, null)).toBe('')
+  })
+})
+
+describe('closedGroupRollupBadge', () => {
+  it('undefined when neither parent nor children have active badges', () => {
+    const item = parent([child('a'), child('b')])
+    expect(closedGroupRollupBadge(item, undefined, new Map())).toBeUndefined()
+    expect(closedGroupRollupBadge(item, { count: 0 }, new Map([['a', { count: 0 }]]))).toBeUndefined()
+  })
+
+  it("surfaces a hidden child's counted badge on the closed header (the messaging bug)", () => {
+    const item = parent([child('calendar'), child('plans'), child('brainstorm')])
+    const badges = new Map([['brainstorm', { count: 1, tone: 'attention' as const }]])
+    expect(closedGroupRollupBadge(item, undefined, badges)).toEqual({ tone: 'attention', count: 1 })
+  })
+
+  it('surfaces a presence-only working dot from a child', () => {
+    const item = parent([child('brainstorm')])
+    const badges = new Map([['brainstorm', { tone: 'info' as const }]])
+    expect(closedGroupRollupBadge(item, undefined, badges)).toEqual({ tone: 'info' })
+  })
+
+  it('picks the highest-severity tone and sums only that tone\'s counts', () => {
+    const item = parent([child('a'), child('b'), child('c')])
+    const badges = new Map([
+      ['a', { count: 2, tone: 'attention' as const }],
+      ['b', { count: 5, tone: 'info' as const }],
+      ['c', { count: 3, tone: 'attention' as const }],
+    ])
+    expect(closedGroupRollupBadge(item, undefined, badges)).toEqual({ tone: 'attention', count: 5 })
+  })
+
+  it('merges the parent\'s own badge into the rollup', () => {
+    const item = parent([child('a')])
+    const badges = new Map([['a', { count: 1, tone: 'attention' as const }]])
+    expect(closedGroupRollupBadge(item, { count: 2, tone: 'attention' }, badges)).toEqual({ tone: 'attention', count: 3 })
+    // Parent error outranks child attention; error side has no count → dot.
+    expect(closedGroupRollupBadge(item, { tone: 'error' }, badges)).toEqual({ tone: 'error' })
+  })
+
+  it('falls back to the static child.badge when the live map has no entry', () => {
+    const staticChild: NavItem = { ...child('a'), badge: { count: 4, tone: 'attention' } }
+    const item = parent([staticChild])
+    expect(closedGroupRollupBadge(item, undefined, new Map())).toEqual({ tone: 'attention', count: 4 })
   })
 })

--- a/tests/core/conversation-turns.test.ts
+++ b/tests/core/conversation-turns.test.ts
@@ -96,6 +96,36 @@ function makeService(
 }
 
 describe('conversation turn service', () => {
+  test('started event fires at accept, before any runtime chunk (#707)', async () => {
+    const h = makeHarness()
+    let releaseStream!: () => void
+    const gate = new Promise<void>((resolve) => { releaseStream = resolve })
+    h.setStream(async function* () {
+      await gate
+      yield { type: 'text', content: 'hi' } as ChatChunk
+      yield { type: 'done' } as ChatChunk
+    })
+    const service = makeService(h, {
+      events: { chunk: 'test.chunk', done: 'test.done', error: 'test.error', started: 'test.started' },
+    })
+
+    expect(await service.start(h.ctx, 't1', 'hello')).toBe('accepted')
+    // The stream is gated — no chunk has been produced, yet started is out.
+    expect(h.events).toEqual([{ event: 'test.started', data: { threadKey: 't1', agentId: 'main' } }])
+
+    releaseStream()
+    await service.waitFor('t1')
+    expect(h.events.map((e) => e.event)).toEqual(['test.started', 'test.chunk', 'test.done'])
+  })
+
+  test('no started event configured → none emitted (optional wire contract)', async () => {
+    const h = makeHarness()
+    const service = makeService(h)
+    expect(await service.start(h.ctx, 't1', 'hello')).toBe('accepted')
+    await service.waitFor('t1')
+    expect(h.events.some((e) => e.event.endsWith('.started'))).toBe(false)
+  })
+
   test('happy path: liveness chunks ride the chunk event, rows persist incrementally, done carries preview', async () => {
     const h = makeHarness()
     const service = makeService(h, {


### PR DESCRIPTION
Three small notification-surface fixes from live use after the #703/#706 merges.

**Toast overflow** — the reply-landed toast sometimes painted its preview text and close button past the toast's bounding box. The Toaster row's `flex-1` message cell had no `min-w-0`, so its automatic flex minimum inherited the full width of the nowrap preview line and the inner `truncate` never received a constraint. One class fixes every toast with wide content.

**Closed-group badge rollup** — badge providers badge child nav items (messaging badges `messaging-brainstorm`), but the expanded-sidebar group header only rendered the parent's own badge, so closing the "Messaging" group hid the unread count / working dot entirely. The closed-group header now rolls children up like the icon-only sidebar already did: highest-severity tone across parent + children, counts summed within that tone, presence-only dot otherwise. Open groups unchanged.

**Instant working dot (`started` event)** — the kit attention hook only marked a thread in-flight on the first runtime chunk, so every surface's nav dot lagged a send by seconds of model latency (pre-#703 chat signaled at send time). The engine now emits an optional `events.started` at 202-accept; the attention hook subscribes (chunk stays as the mid-turn-mount fallback) and chat wires `chat.started`. Projects + messaging adopt it in bakin-bits-official#91 — merge this PR first, and note the engine change is server-side, so it needs a **server restart** after merge.

Gates: full suite 8047/0, tsc clean, new unit coverage for the rollup logic, the engine's started wire order, and the hook's started-before-chunk behavior.

Verify live (after restart): send in chat / a brainstorm with the group closed — the working dot appears on the nav immediately at send, the "1" shows on the Messaging row when a reply lands unseen, and toasts stay inside their box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)