### PR TITLE
fix(tests,ci): TZ cache leak broke serial release runs — align release tests with PR CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,8 +143,13 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      # Identical invocation to PR CI: same parallelism means the same file
+      # partitioning and execution order, so a suite that's green on the PR
+      # can't fail here from ordering-dependent leaks (rc.21 attempt 2: a TZ
+      # env leak only surfaced under this job's previously-serial run). Also
+      # ~7 min faster (#634).
       - name: Test
-        run: bun test --isolate
+        run: bun test --parallel --isolate --timeout 15000
 
       - name: Build CSS
         run: bun run build:css

--- a/tests/core/agent-burn-window.test.ts
+++ b/tests/core/agent-burn-window.test.ts
@@ -4,8 +4,13 @@ import { getAgentBurnWindowScope } from '../../src/core/agent-burn'
 const ORIGINAL_TZ = process.env.TZ
 
 afterEach(() => {
+  // Restore by ASSIGNMENT first: assigning process.env.TZ is what resets the
+  // engine's cached timezone. A bare `delete` leaves the cache on this test's
+  // Denver TZ, and later files in the same serial worker then render local
+  // times in Denver (broke activity-tab in the rc.21 release build, which
+  // runs the suite serially — parallel runs dodge it by worker partitioning).
+  process.env.TZ = ORIGINAL_TZ ?? 'UTC'
   if (ORIGINAL_TZ === undefined) delete process.env.TZ
-  else process.env.TZ = ORIGINAL_TZ
 })
 
 describe('getAgentBurnWindowScope', () => {


### PR DESCRIPTION
## Summary

The re-tagged rc.21 release build failed 2 tests in `tests/plugins/health/activity-tab.test.tsx` ("12:00 PM" expected, "6:00 AM" rendered). Root cause:

- `tests/core/agent-burn-window.test.ts` sets `process.env.TZ = 'America/Denver'` for its DST cases and restores with a bare `delete process.env.TZ`. Assigning `TZ` resets the engine's cached timezone; deleting does not — so every file that runs later **in the same worker process** renders local times in Denver.
- The release job ran `bun test --isolate` **serially**: one worker, `tests/core/...` before `tests/plugins/...`, so activity-tab deterministically inherited the leak. PR CI's `--parallel` partitions the two files into different workers, which is why every PR run (including the stamped-host guard job) stayed green.

## Changes

- **`agent-burn-window.test.ts`**: afterEach restores by assignment first (`process.env.TZ = ORIGINAL_TZ ?? 'UTC'`), then deletes to keep the env faithful when it was unset. Verified: the serial two-file repro goes 2 fail → 0 fail.
- **`release.yml`**: the Test step now uses PR CI's exact invocation (`bun test --parallel --isolate --timeout 15000`) — identical partitioning and order means a suite that's green on the PR can't fail the release from ordering-dependent leaks, and the step drops ~9min → ~2min (#634).

After merge: delete the failed tag and re-tag `v0.0.1-rc.21` from main (third time's the charm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)