### PR TITLE
fix(tests): de-flake the workflow-deletion dialog test (rc.21 attempt 3's timeout)

### DIFF
--- a/tests/plugins/workflows/workflow-actions.test.tsx
+++ b/tests/plugins/workflows/workflow-actions.test.tsx
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import '../../rtl-settle'
+import { settleReact } from '../../rtl-settle'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -104,6 +104,11 @@ describe('workflow action components', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }))
 
     expect(onDelete).toHaveBeenCalled()
+    // Drain the scheduler before polling: the close re-render resumes via
+    // the scheduler's MessageChannel, which waitFor's timers can't join —
+    // under CI worker contention this wedged past the 15s harness timeout
+    // (rc.21 release attempt 3).
+    await settleReact()
     await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
   })
 
@@ -121,6 +126,7 @@ describe('workflow action components', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: /^delete$/i }))
 
     expect(onDelete).toHaveBeenCalled()
+    await settleReact()
     await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined())
   })
 })


### PR DESCRIPTION
## Summary

Release attempt 3 failed on exactly one test — a contention flake, not a regression:

```
(fail) workflow action components > uses a confirmation dialog for workflow deletion and closes after success [19743ms]
  ^ timed out after 15000ms
```

The final `waitFor` polls with timers while the dialog-close re-render is a time-sliced React render that resumes via the scheduler's MessageChannel — under 4-core CI worker contention the poll can wedge indefinitely (the documented rtl-settle failure class). Both async delete tests now `await settleReact()` before their `waitFor`, matching the sibling `approvals-attention.test.tsx` pattern. Verified 5 consecutive green runs.

Not release-blocking — the failed release job was rerun and this flake is intermittent — but this removes it for every future run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)