### PR TITLE
fix(search): restore the antfly#319 idle-detection override (rc.21 fix is partial)

### DIFF
--- a/packages/adapter-antfly/src/translate.ts
+++ b/packages/adapter-antfly/src/translate.ts
@@ -388,9 +388,21 @@ export function mapIndexStatuses(entries: WireIndexStatusEntry[]): TableLegHealt
       || (runtime?.fatal_error_count ?? 0) > 0
       || status?.backfill_state === 'failed'
     let building = status?.rebuilding === true || status?.backfill_active === true
-    // (The antfly#319 idle-detection override that lived here — mixed-corpus
-    // media legs stuck rebuilding forever — was retired at the rc.21 pin:
-    // upstream fixed the backfill accounting for empty-template docs.)
+    // antfly#319 idle-detection override — RESTORED at rc.21 (2026-07-22,
+    // the memory-table park during the production rebuild). Upstream's
+    // rc.21 fix is PARTIAL: MEDIA-template skip accounting clears its
+    // flags (the mixed-corpus guard pin), but TEXT-template legs whose
+    // docs render empty (memory: 50 embeddable of ~10k audit rows) still
+    // report rebuilding/backfill_active forever while fully idle —
+    // pending 0, no active batch, not retrying. Idle ⇒ ready, or every
+    // skip-heavy green parks unconverged. Pinned by the text-skip canary
+    // in workaround-regressions; delete when THAT pin fails.
+    if (building && runtime
+      && runtime.pending_sequence_count === 0
+      && runtime.retrying !== true
+      && (runtime.active_embed_batch_items ?? 0) === 0) {
+      building = false
+    }
     // rc.18 WORKAROUND — runtime-less legs (full_text) report
     // rebuilding/backfill_active FOREVER once caught up, including on
     // freshly created EMPTY tables (observed live 2026-07-11: every empty

--- a/tests/integration/antfly/workaround-regressions.test.ts
+++ b/tests/integration/antfly/workaround-regressions.test.ts
@@ -193,6 +193,61 @@ if (!binary) {
       expect(vis?.indexedCount).toBe(1)
     }, 180_000)
 
+    it('GUARD antfly#319 (idle-detection override): an idle embeddings leg maps ready regardless of raw flags', async () => {
+      // The override this guards was retired at the rc.21 repin, then
+      // RESTORED hours later: the production memory-table green (50
+      // embeddable of ~10k skipped audit rows, rebuild interrupted by an
+      // engine bounce) sat with rebuilding/backfill_active raised while
+      // fully idle — and parked unconverged. A minimal 2-doc skip corpus
+      // does NOT reproduce the stuck flags on rc.21 (they clear), so the
+      // trigger is scale- or interruption-dependent and this cannot be a
+      // fails-when-fixed pin. The override's semantics are safe regardless
+      // (pending 0 + no active batch + not retrying ⇒ idle ⇒ ready).
+      // Retirement is MANUAL: prove a full-scale interrupted rebuild
+      // converges without it before deleting.
+      const T6 = 'pins_textskip'
+      await api('POST', `/db/v1/tables/${T6}`, {
+        num_shards: 1,
+        indexes: { sem: { name: 'sem', type: 'embeddings', template: '{{#if body}}{{body}}{{/if}}', dimension: 384, embedder: { provider: 'antfly', model: 'BAAI/bge-small-en-v1.5' } } },
+      })
+      await sleep(1200)
+      for (let i = 0; i < 10; i++) {
+        const r = await api('POST', `/db/v1/tables/${T6}/batch`, {
+          inserts: { s1: { title: 'has body', body: 'embeddable text' }, s2: { title: 'no body field' } },
+          sync_level: 'full_index',
+        })
+        if (r.status < 300) break
+        await sleep(500)
+      }
+      // Wait for idle: the one embeddable doc lands, nothing in flight.
+      let raw: Record<string, unknown> | null = null
+      for (let i = 0; i < 120; i++) {
+        const st = await api('GET', `/db/v1/tables/${T6}/indexes`)
+        const entries = Array.isArray(st.json) ? st.json as Array<{ config?: { name?: string }; status?: Record<string, unknown> }> : []
+        const sem = entries.find((e) => e.config?.name === 'sem')?.status ?? null
+        const runtime = sem?.enrichment_runtime as { pending_sequence_count?: number; active_embed_batch_items?: number } | undefined
+        if (sem && (sem.total_indexed as number) >= 1 && runtime?.pending_sequence_count === 0 && (runtime?.active_embed_batch_items ?? 0) === 0) {
+          raw = sem
+          break
+        }
+        await sleep(1000)
+      }
+      if (raw === null) {
+        console.warn('⚠ text-skip pin skipped — embeddable doc never indexed (no BAAI model?)')
+        return
+      }
+      // Record (not assert) whether the raw flags lie on this corpus —
+      // evidence for eventual manual retirement, not a gate.
+      console.warn(`text-skip raw flags: rebuilding=${String(raw.rebuilding)} backfill_active=${String(raw.backfill_active)}`)
+      // WORKAROUND GUARD: idle-detection maps the leg ready either way.
+      const { AntflySearchClient } = await import('../../../packages/adapter-antfly/src/client')
+      const { DEFAULT_SETTINGS } = await import('../../../packages/adapter-antfly/src/defaults')
+      const client = new AntflySearchClient({ ...DEFAULT_SETTINGS, url: instance.url }, { fetchImpl: nativeFetch })
+      const legs = await client.tables.health(T6)
+      const sem = legs.find((l) => l.leg === 'sem')
+      expect(sem?.state).toBe('ready')
+    }, 180_000)
+
     it('PIN rc.18: an EMPTY (never-written) table reports backfill running forever on every leg', async () => {
       // WHEN THIS FAILS (flags clear on an empty table): upstream fixed
       // empty-table backfill accounting → delete the !runtime idle-detection


### PR DESCRIPTION
## Summary

The rc.21 repin (#712) retired the idle-detection override in `mapIndexStatuses` because the #319 pin failed in the fixed direction. That evidence was narrower than it looked: upstream fixed the **media-template** skip accounting, but during the production blue/green rebuild the **memory table** (50 embeddable of ~10k template-skipped audit rows, rebuild interrupted by an engine bounce) sat with `rebuilding/backfill_active` raised while fully idle — so `legsReady` never passed and the migration honestly parked, stalling the whole sequential rebuild behind it.

- Restore the override: `pending 0 + no active batch + not retrying ⇒ idle ⇒ ready` — safe semantics on any engine version.
- Companion test is a **guard** on the mapping (idle leg → ready regardless of raw flags) with raw-flag evidence logging, not a fails-when-fixed pin: a minimal 2-doc skip corpus does not reproduce the stuck flags on rc.21 (they clear), so the trigger is scale/interruption-dependent and retirement must be manual.
- All 12 workaround/guard tests green against the rc.21 release binary; adapter units 63/63.

Unblocks the in-flight production rebuild (parked greens converge via resumeMigrations once the server restarts on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)