### PR TITLE
feat(search): cold drops — tombstone-first table retirement with a cold dwell

### DIFF
--- a/packages/core/src/search/tables.ts
+++ b/packages/core/src/search/tables.ts
@@ -374,23 +374,20 @@ export function removeTableRegistration(logical: string): string[] {
   return physicals
 }
 
+/**
+ * Public retirement path for a physical table: tombstone it for the
+ * doctor's cold-dwell sweep. NEVER call adapter.tables.drop directly on a
+ * table that may have received writes — hot-queue drops crash affected
+ * engine versions (antfly#386).
+ */
+export function retireTablePhysical(physical: string): void {
+  noteTombstone(physical)
+}
+
 function noteTombstone(physical: string): void {
   db()
     .prepare('INSERT INTO search_table_tombstones (physical, noted_at) VALUES (?, ?) ON CONFLICT (physical) DO NOTHING')
     .run(physical, Date.now())
-}
-
-async function dropTolerant(adapter: SearchAdapter, physical: string): Promise<void> {
-  try {
-    await adapter.tables.drop(physical)
-    forgetCreatedPhysical(physical)
-  } catch (err) {
-    log.warn('table drop failed — tombstoned for the doctor sweep', {
-      physical,
-      err: err instanceof Error ? err.message : String(err),
-    })
-    noteTombstone(physical)
-  }
 }
 
 export interface OrphanTableSweepResult {
@@ -493,9 +490,21 @@ export async function sweepOrphanEngineTables(
   return { dropped, pending, unclaimed }
 }
 
-/** Doctor sweep: retry dropping tombstoned physicals. Returns remaining. */
-export async function sweepTombstones(adapter: SearchAdapter): Promise<number> {
-  const rows = db().prepare<{ physical: string }, []>('SELECT physical FROM search_table_tombstones').all()
+/**
+ * Doctor sweep: drop tombstoned physicals whose COLD DWELL has passed.
+ * Every engine-side drop in this module is lazy (tombstone-first): the
+ * dwell guarantees a table's embed queue is stone cold before the DELETE
+ * reaches the engine — dropping hot-queue tables crashes affected engine
+ * versions (antfly#386, regression since rc.18, present at their HEAD).
+ */
+export const TOMBSTONE_COLD_DWELL_MS = 30 * 60 * 1000
+
+export async function sweepTombstones(adapter: SearchAdapter, opts?: { dwellMs?: number }): Promise<number> {
+  const dwellMs = opts?.dwellMs ?? TOMBSTONE_COLD_DWELL_MS
+  const cutoff = Date.now() - dwellMs
+  const rows = db()
+    .prepare<{ physical: string }, [number]>('SELECT physical FROM search_table_tombstones WHERE noted_at <= ?')
+    .all(cutoff)
   for (const row of rows) {
     try {
       await adapter.tables.drop(row.physical)
@@ -683,8 +692,13 @@ async function convergeAndFlip(
   log.info('table migrated', { logical: def.logical, from: oldPhysical, to: green })
 
   if (oldPhysical !== green) {
-    setPhase(def.logical, 'dropping')
-    await dropTolerant(adapter, oldPhysical)
+    // COLD DROP (antfly#386 defense, 2026-07-22): dual-write fed the old
+    // physical right up to this flip, so its engine-internal embed queue
+    // may be hot — and dropping a hot-queue table crashes affected engine
+    // versions outright. Never drop live: tombstone it and let the doctor
+    // sweep drop it after the cold dwell. This also lightens flip-time
+    // engine load; stale generations cost a little disk for a few hours.
+    noteTombstone(oldPhysical)
     db().prepare('UPDATE search_tables SET migration_phase = NULL WHERE logical = ?').run(def.logical)
   }
   return 'migrated'
@@ -788,7 +802,9 @@ export async function ensureTable(
     ) {
       // The desired layout changed underneath an in-flight migration —
       // abandon the stale green and migrate to the new target instead.
-      await dropTolerant(adapter, current.migrating_to)
+      // Tombstoned, not dropped live: an abandoned green mid-backfill has
+      // the hottest queue of all (antfly#386 — cold drops only).
+      noteTombstone(current.migrating_to)
     }
 
     return 'migrate'

--- a/src/core/search-orphan-sweep.ts
+++ b/src/core/search-orphan-sweep.ts
@@ -82,7 +82,7 @@ export async function sweepTableOrphans(
 export async function sweepOrphanRegistryRows(): Promise<string[]> {
   const search = getAppServices().search
   if (!await search.available()) return []
-  const { listTableStates, removeTableRegistration } = await import('@bakin/core/search/tables')
+  const { listTableStates, removeTableRegistration, retireTablePhysical } = await import('@bakin/core/search/tables')
   const { purgeTable } = await import('@bakin/core/search/outbox')
   const registered = getContentTypes()
   const removed: string[] = []
@@ -93,7 +93,8 @@ export async function sweepOrphanRegistryRows(): Promise<string[]> {
       migratingTo: row.migratingTo,
     })
     for (const physical of removeTableRegistration(row.logical)) {
-      await search.tables.drop(physical).catch(() => {})
+      // Cold drop (antfly#386): tombstone; the dwell sweep does the DELETE.
+      retireTablePhysical(physical)
     }
     purgeTable(row.logical)
     removed.push(row.logical)

--- a/src/core/search-registry-core.ts
+++ b/src/core/search-registry-core.ts
@@ -647,12 +647,11 @@ export async function purgeContentType(name: string): Promise<number> {
     log.warn('purgeContentType: failed to read row count before drop', err, { tableName })
   }
 
-  try {
-    await search.tables.drop(physical)
-  } catch (err) {
-    log.error('purgeContentType: table drop failed', err, { tableName })
-    throw err
-  }
+  // Cold drop (antfly#386): a purged content type's table may have taken
+  // writes moments ago — tombstone it; the doctor's dwell sweep DELETEs
+  // once its embed queue is stone cold.
+  const { retireTablePhysical } = await import('@bakin/core/search/tables')
+  retireTablePhysical(physical)
 
   // Tear down ALL durable state, not just the engine table: the registry
   // row (a survivor here resurrects the table on the next rebuild pass —
@@ -661,7 +660,7 @@ export async function purgeContentType(name: string): Promise<number> {
   const { purgeTable } = await import('@bakin/core/search/outbox')
   for (const leftover of removeTableRegistration(tableName)) {
     if (leftover !== physical) {
-      await search.tables.drop(leftover).catch(() => {})
+      retireTablePhysical(leftover)
     }
   }
   purgeTable(tableName)

--- a/tests/core/search-registry.test.ts
+++ b/tests/core/search-registry.test.ts
@@ -82,7 +82,7 @@ import {
   pumpParkedMigrations,
 } from '@/core/search-registry'
 import { sweepOrphanRegistryRows } from '@/core/search-orphan-sweep'
-import { tableStatus } from '@bakin/core/search/tables'
+import { tableStatus, sweepTombstones } from '@bakin/core/search/tables'
 import { enqueueIndex, outboxStats } from '@bakin/core/search/outbox'
 import { broadcast } from '@/core/sse'
 
@@ -825,6 +825,9 @@ describe('search-registry', () => {
 
       expect(removed).toEqual(['bakin_gone'])
       expect(tableStatus('bakin_gone')).toBeNull()
+      // Cold drop (antfly#386): retirement tombstones; the dwell sweep DELETEs.
+      expect(searchHarness.calls.tablesDrop).not.toHaveBeenCalledWith(gonePhysical)
+      await sweepTombstones(searchHarness.adapter, { dwellMs: 0 })
       expect(searchHarness.calls.tablesDrop).toHaveBeenCalledWith(gonePhysical)
       // registered row untouched
       expect(tableStatus('bakin_keeper')).not.toBeNull()
@@ -841,6 +844,7 @@ describe('search-registry', () => {
       const removed = await sweepOrphanRegistryRows()
 
       expect(removed).toEqual(['bakin_gone'])
+      await sweepTombstones(searchHarness.adapter, { dwellMs: 0 })
       expect(searchHarness.calls.tablesDrop).toHaveBeenCalledWith('bakin_gone_v1_deadbeef')
       expect(tableStatus('bakin_gone')).toBeNull()
     })
@@ -979,7 +983,9 @@ describe('rebuild pass semantics (2026-07-21 redesign)', () => {
     const after = tableStatus('bakin_ppone')!
     expect(after.state).toBe('active')
     expect(after.physical).toBe(green)
-    // The old live physical was dropped after the flip.
+    // Cold drop: the old physical survives as a tombstone until the sweep.
+    expect(await searchHarness.adapter.tables.stats(live)).not.toBeNull()
+    await sweepTombstones(searchHarness.adapter, { dwellMs: 0 })
     expect(await searchHarness.adapter.tables.stats(live)).toBeNull()
   })
 

--- a/tests/core/search-tables.test.ts
+++ b/tests/core/search-tables.test.ts
@@ -192,8 +192,11 @@ describe('blue/green migration', () => {
     expect(green).not.toBe(blue)
     expect(resolveDrainTargets('bakin_notes')).toEqual([green])
     expect((await adapter.tables.stats(green))?.documents).toBe(2)
-    const tables = await adapter.tables.list()
-    expect(tables.map((t) => t.name)).not.toContain(blue)
+    // COLD DROP (antfly#386): the old physical survives the flip as a
+    // tombstone; the dwell sweep performs the actual engine DELETE.
+    expect((await adapter.tables.list()).map((t) => t.name)).toContain(blue)
+    expect(await sweepTombstones(adapter, { dwellMs: 0 })).toBe(0)
+    expect((await adapter.tables.list()).map((t) => t.name)).not.toContain(blue)
     expect(tableStatus('bakin_notes')?.state).toBe('active')
   })
 
@@ -681,7 +684,7 @@ describe('sweepOrphanEngineTables', () => {
     expect(sweep.pending).toBe(0) // no longer a candidate — it is a tombstone now
 
     // The tombstone sweep finishes the job once the engine recovers.
-    const left = await sweepTombstones(base)
+    const left = await sweepTombstones(base, { dwellMs: 0 })
     expect(left).toBe(0)
     expect(await base.tables.stats(orphan)).toBeNull()
   })


### PR DESCRIPTION
## Summary

Defense-in-depth for [antfly#386](https://github.com/antflydb/antfly/issues/386) (hot-queue table drops crash the engine — regression since rc.18, still present at their HEAD): every engine-side drop in the search stack is now **tombstone-first**. The actual `DELETE` happens only in the doctor's tombstone sweep after a **30-minute cold dwell**, guaranteeing the table's embed queue is stone cold.

Routed through the one sanctioned door (`retireTablePhysical`): blue/green flip retirement (dual-write keeps the old physical hot right up to the flip), stale-green abandonment (hottest queue of all), orphan registry rows, and content-type purge. The orphan engine-table sweep already had its own 6-hour dwell. Dead `dropTolerant` removed.

Why carry this on rc.18, which doesn't crash: end users run whatever antfly releases next, and #386 proves this class regresses silently — the ladder gate protects *our pin choices*; cold drops protect users from the regression nobody tested for. Cost: a few stale tables of disk for ~30 minutes post-migration.

## Verification

Full suite 8046 pass / 0 fail. Contract tests updated: flip leaves the old physical live until the dwell sweep; retirement paths assert tombstone-then-sweep; the failing-drop tombstone path keeps its coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)