### PR TITLE
fix(search): noop install still provisions and starts the engine service

### DIFF
--- a/packages/adapter-antfly/src/installer.ts
+++ b/packages/adapter-antfly/src/installer.ts
@@ -121,10 +121,19 @@ export async function installAntflyDependency(
   const existing = findAntflyBinary()
   const existingVersion = existing ? await antflyBinaryVersion(existing) : null
   if (existing && existingVersion === pin.version) {
+    // Binary is current — but the SERVICE may be unprovisioned or stopped
+    // (the clean-slate recovery boots the unit out before reinstalling,
+    // and the old noop path left the engine dead: 2026-07-22, a fresh
+    // rc.22 box's reindex failed 12/12 with "antfly unreachable").
+    // A noop install still guarantees a provisioned, running engine.
+    await ensureProvisioned(SERVICE_DEFAULTS)
+    if (!await isLocalServerResponding()) {
+      await startService(SERVICE_DEFAULTS)
+    }
     return {
       name: 'antfly',
       status: 'noop' as const,
-      message: `Antfly v${pin.version} is already installed at ${existing}`,
+      message: `Antfly v${pin.version} is already installed at ${existing}; service provisioned and running`,
       durationMs: Date.now() - start,
     }
   }


### PR DESCRIPTION
## Summary

Field-found on a fresh rc.22 install following the documented clean-slate recovery (`launchctl bootout` → `rm -rf ~/.bakin/antfly` → `bakin install search` → `bakin reindex`): the installer's noop early-return (binary already at the pinned version) skipped service provisioning entirely, leaving the just-booted-out engine dead — reindex then failed 12/12 with "antfly unreachable".

The noop path now runs `ensureProvisioned` and starts the service when the private port isn't answering, so "already installed" guarantees a provisioned, **running** engine. Adapter suite 64/64.

**Merge order note:** this should land on main before `v0.0.1-rc.22` is tagged (release-notes PR #716 references the recovery recipe this fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)