### PR TITLE
fix(health): concrete, resolvable cards — errors on-card, one-click pricing repair

### DIFF
--- a/packages/adapter-antfly/src/models.ts
+++ b/packages/adapter-antfly/src/models.ts
@@ -121,26 +121,16 @@ export function describeMissingModels(missing: InferenceModel[]): { impact: stri
 export async function checkInferenceModels(models: InferenceModel[]) {
   const missing = missingModelEntries(models)
   if (missing.length === 0) {
-    // Presence passed — also verify pinned hashes. Drift is reported but
-    // never blocks: it means "differs from the verified distribution", not
-    // the crash-loop class a missing pinned file signals.
-    const unverified: Array<{ model: string; files: string[] }> = []
-    for (const m of models) {
-      const files = await unverifiedModelFiles(m.model)
-      if (files.length > 0) unverified.push({ model: m.model, files })
-    }
-    const driftNote = unverified.length > 0
-      ? ` (${unverified.length} model${unverified.length === 1 ? '' : 's'} differ from the pinned verified distribution — see details)`
-      : ''
+    // Structural verification only — pinned file NAMES and sizes, which is
+    // what catches the wrong-distribution crash-loop class. sha256 hashing
+    // lives on the INSTALL path (post-pull): checks run on doctor cadence
+    // and hashing hundreds of MB per pass made a fully loaded test/CI
+    // machine blow check timeouts (2026-07-22).
     return {
       name: 'models',
       status: 'ok' as const,
-      message: `All ${models.length} search models present at ${inferenceModelsRoot()}${driftNote}`,
-      details: {
-        root: inferenceModelsRoot(),
-        models: models.map((m) => m.model),
-        ...(unverified.length > 0 ? { unverified } : {}),
-      },
+      message: `All ${models.length} search models present at ${inferenceModelsRoot()}`,
+      details: { root: inferenceModelsRoot(), models: models.map((m) => m.model) },
     }
   }
   const { impact, remediation } = describeMissingModels(missing.map((e) => e.model))

--- a/packages/adapter-pi/src/health-checks.ts
+++ b/packages/adapter-pi/src/health-checks.ts
@@ -15,6 +15,7 @@ import type {
   WatchIncidentInput,
 } from '@bakin/core/plugin-types'
 
+import { healthError, healthHealthy, healthObserved, healthUnknown, healthWarning } from '@bakin/core/health/observation-builders'
 import { listAuthProviders } from './config'
 import { getPiAgentsRoot, getPiHome, getPiRegistryPath } from './home'
 import { getModelRegistry } from './models'
@@ -23,11 +24,11 @@ import { createExtensionsSurface } from './extensions'
 
 const RUNTIME_GROUP = { key: 'runtime', label: 'Runtime' } as const
 
+// Route through the shared clamped builders — raw observation literals
+// bypass the copy-bounds protection (an overlong interpolated error would
+// invalidate the whole run instead of truncating; review finding).
 function observedHealthy(key: string, summary: string, evidence?: JsonObject): HealthCheckRunInput {
-  return {
-    outcome: 'observed',
-    observations: [{ key, status: 'healthy', summary, evidence }],
-  }
+  return healthObserved([healthHealthy({ key, summary, evidence })])
 }
 
 function observedError(
@@ -36,10 +37,7 @@ function observedError(
   incident: ActionIncidentInput,
   detail?: string,
 ): HealthCheckRunInput {
-  return {
-    outcome: 'observed',
-    observations: [{ key, status: 'error', summary, detail, incident }],
-  }
+  return healthObserved([healthError({ key, summary, detail, incident })])
 }
 
 function observedWarning(
@@ -48,10 +46,7 @@ function observedWarning(
   incident: ActionIncidentInput,
   evidence?: JsonObject,
 ): HealthCheckRunInput {
-  return {
-    outcome: 'observed',
-    observations: [{ key, status: 'warning', summary, evidence, incident }],
-  }
+  return healthObserved([healthWarning({ key, summary, evidence, incident })])
 }
 
 function observedUnknown(
@@ -60,10 +55,7 @@ function observedUnknown(
   incident: WatchIncidentInput,
   detail?: string,
 ): HealthCheckRunInput {
-  return {
-    outcome: 'observed',
-    observations: [{ key, status: 'unknown', summary, detail, incident }],
-  }
+  return healthObserved([healthUnknown({ key, summary, detail, incident })])
 }
 
 function installationIncident(resourceId: 'pi.home' | 'pi.agents-root', resourceLabel: string): ActionIncidentInput {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./agent-path-map": "./src/agent-path-map.ts",
+    "./health/observation-builders": "./src/health/observation-builders.ts",
     "./app-services": "./src/app-services.ts",
     "./adapters/shared": "./src/adapters/shared.ts",
     "./adapters/runtime": "./src/adapters/runtime/index.ts",

--- a/packages/core/src/health/observation-builders.ts
+++ b/packages/core/src/health/observation-builders.ts
@@ -1,0 +1,94 @@
+/**
+ * Health observation builders — the ONE construction path for check
+ * output, shared by plugins (via `@makinbakin/sdk/utils`, which
+ * re-exports these) and adapter packages (which depend only on
+ * `@bakin/core`).
+ *
+ * The builders CLAMP copy to the health contract's bounds instead of
+ * letting an overlong or blank string invalidate the whole run: a check
+ * that interpolated a long runtime error into its summary used to fail
+ * contract validation wholesale, turning real evidence into a useless
+ * "could not be verified" card (field-diagnosed 2026-07-22). Truncated
+ * copy is honest; discarded evidence is not. Constructing observations
+ * as raw object literals bypasses this protection — always build through
+ * these helpers.
+ */
+import type {
+  ErrorObservationInput,
+  HealthNonEmptyArray,
+  HealthObservationInput,
+  HealthyObservationInput,
+  NotApplicableHealthCheckRunInput,
+  ObservedHealthCheckRunInput,
+  UnknownObservationInput,
+  WarningObservationInput,
+} from '../plugin-types'
+
+type HealthyObservationFields = Omit<HealthyObservationInput, 'status'>
+type WarningObservationFields = Omit<WarningObservationInput, 'status'>
+type ErrorObservationFields = Omit<ErrorObservationInput, 'status'>
+type UnknownObservationFields = Omit<UnknownObservationInput, 'status'>
+
+// Bounds mirror health-contract.ts (observation summary/detail + incident impact).
+const SUMMARY_MAX = 500
+const DETAIL_MAX = 4_000
+const IMPACT_MAX = 500
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value
+  let end = max - 1
+  // Never split a surrogate pair — a lone high surrogate renders as U+FFFD.
+  const last = value.charCodeAt(end - 1)
+  if (last >= 0xd800 && last <= 0xdbff) end -= 1
+  return `${value.slice(0, end)}…`
+}
+
+function clampCopy<T extends { summary: string; detail?: string; incident?: { impact: string } }>(input: T): T {
+  const clamped = { ...input }
+  const summary = clamped.summary.trim()
+  clamped.summary = truncate(summary.length > 0 ? summary : '(no summary provided)', SUMMARY_MAX)
+  if (clamped.detail !== undefined) {
+    const detail = clamped.detail.trim()
+    if (detail.length === 0) {
+      delete clamped.detail
+    } else {
+      clamped.detail = truncate(detail, DETAIL_MAX)
+    }
+  }
+  if (clamped.incident && clamped.incident.impact.length > IMPACT_MAX) {
+    clamped.incident = { ...clamped.incident, impact: truncate(clamped.incident.impact, IMPACT_MAX) }
+  }
+  return clamped
+}
+
+/** Build a healthy observation. Healthy observations cannot carry incidents. */
+export function healthHealthy(input: HealthyObservationFields): HealthyObservationInput {
+  return { ...clampCopy(input), status: 'healthy' }
+}
+
+/** Build a warning observation with an explicit advisory/watch/action disposition. */
+export function healthWarning(input: WarningObservationFields): WarningObservationInput {
+  return { ...clampCopy(input), status: 'warning' }
+}
+
+/** Build an error observation. Its incident must require operator action. */
+export function healthError(input: ErrorObservationFields): ErrorObservationInput {
+  return { ...clampCopy(input), status: 'error' }
+}
+
+/** Build an Unknown verification observation (watch, or advisory when it self-resolves). */
+export function healthUnknown(input: UnknownObservationFields): UnknownObservationInput {
+  return { ...clampCopy(input), status: 'unknown' }
+}
+
+/** Build a successful observed run. Empty diagnostic output is unrepresentable. */
+export function healthObserved(
+  observations: HealthNonEmptyArray<HealthObservationInput>,
+): ObservedHealthCheckRunInput {
+  return { outcome: 'observed', observations }
+}
+
+/** Build an explicit successful not-applicable run. */
+export function healthNotApplicable(reason: string): NotApplicableHealthCheckRunInput {
+  return { outcome: 'not_applicable', reason }
+}

--- a/packages/core/src/plugin-types.ts
+++ b/packages/core/src/plugin-types.ts
@@ -375,6 +375,8 @@ export type {
   HealthyObservationInput,
   JsonObject,
   JsonValue,
+  NotApplicableHealthCheckRunInput,
+  ObservedHealthCheckRunInput,
   SearchReadiness,
   SearchReadinessStage,
   SearchReadinessStageKey,

--- a/packages/host/src/api/_embedded-assets-static.ts
+++ b/packages/host/src/api/_embedded-assets-static.ts
@@ -21,28 +21,28 @@ import asset_bakin_logo_svg from '../../public/bakin-logo.svg' with { type: 'fil
 import asset_bakin_hop_svg from '../../public/bakin-hop.svg' with { type: 'file' }
 import asset_globals_css from '../../public/globals.css' with { type: 'file' }
 import asset_vendor_sdk_ui_js from '../../public/vendor/sdk-ui.js' with { type: 'file' }
+import asset_vendor_sdk_shared_d9mhf3cr_js from '../../public/vendor/sdk-shared-d9mhf3cr.js' with { type: 'file' }
+import asset_vendor_sdk_shared_3bmc81f5_js from '../../public/vendor/sdk-shared-3bmc81f5.js' with { type: 'file' }
 import asset_vendor_sdk_routing_js from '../../public/vendor/sdk-routing.js' with { type: 'file' }
-import asset_vendor_sdk_shared_8ytarpf1_js from '../../public/vendor/sdk-shared-8ytarpf1.js' with { type: 'file' }
-import asset_vendor_sdk_shared_bgxzemvf_js from '../../public/vendor/sdk-shared-bgxzemvf.js' with { type: 'file' }
-import asset_vendor_sdk_shared_qyw1dvxq_js from '../../public/vendor/sdk-shared-qyw1dvxq.js' with { type: 'file' }
-import asset_vendor_sdk_shared_e0awy4pb_js from '../../public/vendor/sdk-shared-e0awy4pb.js' with { type: 'file' }
-import asset_vendor_sdk_shared_5gra29t7_js from '../../public/vendor/sdk-shared-5gra29t7.js' with { type: 'file' }
+import asset_vendor_sdk_shared_ygxbarwk_js from '../../public/vendor/sdk-shared-ygxbarwk.js' with { type: 'file' }
+import asset_vendor_sdk_shared_aaqcz8f3_js from '../../public/vendor/sdk-shared-aaqcz8f3.js' with { type: 'file' }
 import asset_vendor_react_js from '../../public/vendor/react.js' with { type: 'file' }
 import asset_vendor_jsx_runtime_js from '../../public/vendor/jsx-runtime.js' with { type: 'file' }
 import asset_vendor_sdk_utils_js from '../../public/vendor/sdk-utils.js' with { type: 'file' }
-import asset_vendor_sdk_shared_qp0jbcda_js from '../../public/vendor/sdk-shared-qp0jbcda.js' with { type: 'file' }
 import asset_vendor_sdk_types_js from '../../public/vendor/sdk-types.js' with { type: 'file' }
-import asset_vendor_sdk_shared_nnsycwdq_js from '../../public/vendor/sdk-shared-nnsycwdq.js' with { type: 'file' }
+import asset_vendor_sdk_shared_3aa677zg_js from '../../public/vendor/sdk-shared-3aa677zg.js' with { type: 'file' }
+import asset_vendor_sdk_shared_7reyfxzc_js from '../../public/vendor/sdk-shared-7reyfxzc.js' with { type: 'file' }
+import asset_vendor_sdk_shared_28wm93w0_js from '../../public/vendor/sdk-shared-28wm93w0.js' with { type: 'file' }
 import asset_vendor_react_dom_js from '../../public/vendor/react-dom.js' with { type: 'file' }
+import asset_vendor_sdk_shared_jpmjezsp_js from '../../public/vendor/sdk-shared-jpmjezsp.js' with { type: 'file' }
 import asset_vendor_sdk_index_js from '../../public/vendor/sdk-index.js' with { type: 'file' }
-import asset_vendor_sdk_shared_mqsyjttk_js from '../../public/vendor/sdk-shared-mqsyjttk.js' with { type: 'file' }
 import asset_vendor_sdk_slots_js from '../../public/vendor/sdk-slots.js' with { type: 'file' }
 import asset_vendor_sdk_metadata_js from '../../public/vendor/sdk-metadata.js' with { type: 'file' }
 import asset_vendor_sdk_shared_nqwbjtr4_js from '../../public/vendor/sdk-shared-nqwbjtr4.js' with { type: 'file' }
 import asset_vendor_sdk_components_js from '../../public/vendor/sdk-components.js' with { type: 'file' }
+import asset_vendor_sdk_shared_q64a1ghk_js from '../../public/vendor/sdk-shared-q64a1ghk.js' with { type: 'file' }
 import asset_vendor_sdk_hooks_js from '../../public/vendor/sdk-hooks.js' with { type: 'file' }
 import asset_vendor_tanstack_router_js from '../../public/vendor/tanstack-router.js' with { type: 'file' }
-import asset_vendor_sdk_shared_nyrhezat_js from '../../public/vendor/sdk-shared-nyrhezat.js' with { type: 'file' }
 import asset_vendor_sdk_internal_js from '../../public/vendor/sdk-internal.js' with { type: 'file' }
 import asset_vendor_jsx_dev_runtime_js from '../../public/vendor/jsx-dev-runtime.js' with { type: 'file' }
 import asset_api_plugins_schedule_assets_client_js from '../../../../plugins/schedule/dist/client.js' with { type: 'file' }
@@ -70,28 +70,28 @@ export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
   ['/bakin-hop.svg', asset_bakin_hop_svg],
   ['/globals.css', asset_globals_css],
   ['/vendor/sdk-ui.js', asset_vendor_sdk_ui_js],
+  ['/vendor/sdk-shared-d9mhf3cr.js', asset_vendor_sdk_shared_d9mhf3cr_js],
+  ['/vendor/sdk-shared-3bmc81f5.js', asset_vendor_sdk_shared_3bmc81f5_js],
   ['/vendor/sdk-routing.js', asset_vendor_sdk_routing_js],
-  ['/vendor/sdk-shared-8ytarpf1.js', asset_vendor_sdk_shared_8ytarpf1_js],
-  ['/vendor/sdk-shared-bgxzemvf.js', asset_vendor_sdk_shared_bgxzemvf_js],
-  ['/vendor/sdk-shared-qyw1dvxq.js', asset_vendor_sdk_shared_qyw1dvxq_js],
-  ['/vendor/sdk-shared-e0awy4pb.js', asset_vendor_sdk_shared_e0awy4pb_js],
-  ['/vendor/sdk-shared-5gra29t7.js', asset_vendor_sdk_shared_5gra29t7_js],
+  ['/vendor/sdk-shared-ygxbarwk.js', asset_vendor_sdk_shared_ygxbarwk_js],
+  ['/vendor/sdk-shared-aaqcz8f3.js', asset_vendor_sdk_shared_aaqcz8f3_js],
   ['/vendor/react.js', asset_vendor_react_js],
   ['/vendor/jsx-runtime.js', asset_vendor_jsx_runtime_js],
   ['/vendor/sdk-utils.js', asset_vendor_sdk_utils_js],
-  ['/vendor/sdk-shared-qp0jbcda.js', asset_vendor_sdk_shared_qp0jbcda_js],
   ['/vendor/sdk-types.js', asset_vendor_sdk_types_js],
-  ['/vendor/sdk-shared-nnsycwdq.js', asset_vendor_sdk_shared_nnsycwdq_js],
+  ['/vendor/sdk-shared-3aa677zg.js', asset_vendor_sdk_shared_3aa677zg_js],
+  ['/vendor/sdk-shared-7reyfxzc.js', asset_vendor_sdk_shared_7reyfxzc_js],
+  ['/vendor/sdk-shared-28wm93w0.js', asset_vendor_sdk_shared_28wm93w0_js],
   ['/vendor/react-dom.js', asset_vendor_react_dom_js],
+  ['/vendor/sdk-shared-jpmjezsp.js', asset_vendor_sdk_shared_jpmjezsp_js],
   ['/vendor/sdk-index.js', asset_vendor_sdk_index_js],
-  ['/vendor/sdk-shared-mqsyjttk.js', asset_vendor_sdk_shared_mqsyjttk_js],
   ['/vendor/sdk-slots.js', asset_vendor_sdk_slots_js],
   ['/vendor/sdk-metadata.js', asset_vendor_sdk_metadata_js],
   ['/vendor/sdk-shared-nqwbjtr4.js', asset_vendor_sdk_shared_nqwbjtr4_js],
   ['/vendor/sdk-components.js', asset_vendor_sdk_components_js],
+  ['/vendor/sdk-shared-q64a1ghk.js', asset_vendor_sdk_shared_q64a1ghk_js],
   ['/vendor/sdk-hooks.js', asset_vendor_sdk_hooks_js],
   ['/vendor/tanstack-router.js', asset_vendor_tanstack_router_js],
-  ['/vendor/sdk-shared-nyrhezat.js', asset_vendor_sdk_shared_nyrhezat_js],
   ['/vendor/sdk-internal.js', asset_vendor_sdk_internal_js],
   ['/vendor/jsx-dev-runtime.js', asset_vendor_jsx_dev_runtime_js],
   ['/api/plugins/schedule/assets/client.js', asset_api_plugins_schedule_assets_client_js],

--- a/packages/sdk/src/types/health.ts
+++ b/packages/sdk/src/types/health.ts
@@ -201,7 +201,14 @@ export type ErrorObservationInput = HealthObservationBaseInput & {
 
 export type UnknownObservationInput = HealthObservationBaseInput & {
   status: 'unknown'
-  incident: WatchIncidentInput
+  /**
+   * watch = a human should keep an eye on this unknown; advisory = the
+   * producer vouches it SELF-RESOLVES (a scan warming up after restart,
+   * attribution completing as transcripts land) — surfaced, but never in
+   * the fix-first banner. action_required stays unrepresentable: an
+   * unknown cannot honestly demand action.
+   */
+  incident: WatchIncidentInput | AdvisoryIncidentInput
 }
 
 /** Status-discriminated producer observation; illegal combinations do not typecheck. */

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -22,24 +22,44 @@ type WarningObservationFields = Omit<WarningObservationInput, 'status'>
 type ErrorObservationFields = Omit<ErrorObservationInput, 'status'>
 type UnknownObservationFields = Omit<UnknownObservationInput, 'status'>
 
+// Contract copy bounds (mirror health-contract.ts observationBaseShape).
+// The builders CLAMP instead of letting an overlong string invalidate the
+// whole run: a check that interpolated a long runtime error into its
+// summary used to fail contract validation wholesale, turning real
+// evidence into a useless "could not be verified" card (field-diagnosed
+// 2026-07-22). Truncated copy is honest; discarded evidence is not.
+const SUMMARY_MAX = 500
+const DETAIL_MAX = 4_000
+
+function clampCopy<T extends { summary: string; detail?: string }>(input: T): T {
+  const clamped = { ...input }
+  if (clamped.summary.length > SUMMARY_MAX) {
+    clamped.summary = `${clamped.summary.slice(0, SUMMARY_MAX - 1)}…`
+  }
+  if (clamped.detail !== undefined && clamped.detail.length > DETAIL_MAX) {
+    clamped.detail = `${clamped.detail.slice(0, DETAIL_MAX - 1)}…`
+  }
+  return clamped
+}
+
 /** Build a healthy observation. Healthy observations cannot carry incidents. */
 export function healthHealthy(input: HealthyObservationFields): HealthyObservationInput {
-  return { ...input, status: 'healthy' }
+  return { ...clampCopy(input), status: 'healthy' }
 }
 
 /** Build a warning observation with an explicit advisory/watch/action disposition. */
 export function healthWarning(input: WarningObservationFields): WarningObservationInput {
-  return { ...input, status: 'warning' }
+  return { ...clampCopy(input), status: 'warning' }
 }
 
 /** Build an error observation. Its incident must require operator action. */
 export function healthError(input: ErrorObservationFields): ErrorObservationInput {
-  return { ...input, status: 'error' }
+  return { ...clampCopy(input), status: 'error' }
 }
 
 /** Build an Unknown verification observation with a watch disposition. */
 export function healthUnknown(input: UnknownObservationFields): UnknownObservationInput {
-  return { ...input, status: 'unknown' }
+  return { ...clampCopy(input), status: 'unknown' }
 }
 
 /** Build a successful observed run. Empty diagnostic output is unrepresentable. */

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -17,62 +17,18 @@ import type {
   WarningObservationInput,
 } from '../types'
 
-type HealthyObservationFields = Omit<HealthyObservationInput, 'status'>
-type WarningObservationFields = Omit<WarningObservationInput, 'status'>
-type ErrorObservationFields = Omit<ErrorObservationInput, 'status'>
-type UnknownObservationFields = Omit<UnknownObservationInput, 'status'>
-
-// Contract copy bounds (mirror health-contract.ts observationBaseShape).
-// The builders CLAMP instead of letting an overlong string invalidate the
-// whole run: a check that interpolated a long runtime error into its
-// summary used to fail contract validation wholesale, turning real
-// evidence into a useless "could not be verified" card (field-diagnosed
-// 2026-07-22). Truncated copy is honest; discarded evidence is not.
-const SUMMARY_MAX = 500
-const DETAIL_MAX = 4_000
-
-function clampCopy<T extends { summary: string; detail?: string }>(input: T): T {
-  const clamped = { ...input }
-  if (clamped.summary.length > SUMMARY_MAX) {
-    clamped.summary = `${clamped.summary.slice(0, SUMMARY_MAX - 1)}…`
-  }
-  if (clamped.detail !== undefined && clamped.detail.length > DETAIL_MAX) {
-    clamped.detail = `${clamped.detail.slice(0, DETAIL_MAX - 1)}…`
-  }
-  return clamped
-}
-
-/** Build a healthy observation. Healthy observations cannot carry incidents. */
-export function healthHealthy(input: HealthyObservationFields): HealthyObservationInput {
-  return { ...clampCopy(input), status: 'healthy' }
-}
-
-/** Build a warning observation with an explicit advisory/watch/action disposition. */
-export function healthWarning(input: WarningObservationFields): WarningObservationInput {
-  return { ...clampCopy(input), status: 'warning' }
-}
-
-/** Build an error observation. Its incident must require operator action. */
-export function healthError(input: ErrorObservationFields): ErrorObservationInput {
-  return { ...clampCopy(input), status: 'error' }
-}
-
-/** Build an Unknown verification observation with a watch disposition. */
-export function healthUnknown(input: UnknownObservationFields): UnknownObservationInput {
-  return { ...clampCopy(input), status: 'unknown' }
-}
-
-/** Build a successful observed run. Empty diagnostic output is unrepresentable. */
-export function healthObserved(
-  observations: HealthNonEmptyArray<HealthObservationInput>,
-): ObservedHealthCheckRunInput {
-  return { outcome: 'observed', observations }
-}
-
-/** Build an explicit successful not-applicable run. */
-export function healthNotApplicable(reason: string): NotApplicableHealthCheckRunInput {
-  return { outcome: 'not_applicable', reason }
-}
+// The observation builders live in @bakin/core so adapter packages (which
+// depend only on core) share the SAME clamped construction path as
+// plugins. This module re-exports them unchanged — plugin authors keep
+// importing from '@makinbakin/sdk/utils'.
+export {
+  healthError,
+  healthHealthy,
+  healthNotApplicable,
+  healthObserved,
+  healthUnknown,
+  healthWarning,
+} from '../../../core/src/health/observation-builders'
 
 /** Tailwind class merger (clsx + tailwind-merge). */
 export { cn } from '../../../../src/lib/utils'

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -62,7 +62,7 @@ import { checkRestartRecovery } from './lib/system-checks/restart-recovery'
 import { checkExecutionSafety } from './lib/system-checks/execution-safety'
 import { checkRunDirs, runDirsSweepRepair } from './lib/system-checks/run-dirs'
 import { checkStartupContextSize } from './lib/system-checks/context-report'
-import { checkBudget } from './lib/system-checks/budget'
+import { checkBudget, spendEvidenceRepair } from './lib/system-checks/budget'
 import { checkAgentBurn } from './lib/system-checks/agent-burn'
 import { checkSearchAdapter } from './lib/system-checks/search'
 import { searchOutboxRepair } from './lib/system-checks/search-outbox'
@@ -1051,6 +1051,7 @@ const healthPlugin: BakinPlugin = definePlugin({
     ctx.registerHealthRepairAction(searchCanaryRepair())
     ctx.registerHealthRepairAction(searchEngineBurnRepair())
     ctx.registerHealthRepairAction(searchConsistencyRestartRepair())
+    ctx.registerHealthRepairAction(spendEvidenceRepair())
     ctx.registerHealthRepairAction(syncSkillRepair(process.cwd(), ctx.runtime))
   },
 

--- a/plugins/health/lib/health-view-model.ts
+++ b/plugins/health/lib/health-view-model.ts
@@ -314,7 +314,18 @@ export function buildHealthOverviewViewModel({
     if (incident.effectiveDisposition === 'action_required') {
       needsAction.push(row)
     } else if (incident.status === 'unknown' || row.freshness === 'stale') {
-      unableToVerify.push(row)
+      // Advisory unknowns are SELF-RESOLVING states the producer vouched
+      // for (a scan warming up after restart, attribution completing as
+      // transcripts land). Routing every unknown into the "Fix first"
+      // banner regardless of disposition kept the dashboard permanently
+      // lit with cards nobody should act on (field feedback, 2026-07-22).
+      // Stale evidence still verifies — staleness means the vouching is
+      // out of date.
+      if (incident.effectiveDisposition === 'advisory' && row.freshness !== 'stale') {
+        advisories.push(row)
+      } else {
+        unableToVerify.push(row)
+      }
     } else if (incident.effectiveDisposition === 'watch' && incident.status === 'warning') {
       watching.push(row)
     } else if (incident.effectiveDisposition === 'advisory' && incident.status === 'warning') {

--- a/plugins/health/lib/system-checks/agent-burn.ts
+++ b/plugins/health/lib/system-checks/agent-burn.ts
@@ -187,6 +187,12 @@ export async function checkAgentBurnWith(
         scan_in_progress: 'A transcript scan is running right now — this resolves itself when it completes; recheck in a minute.',
         scan_not_run: 'No transcript scan has completed since the server started — the first scan resolves this on its own; recheck in a few minutes.',
         scan_stale: 'The last transcript scan is older than its freshness window — the scanner may be stuck; rerun this check, and report it if staleness persists.',
+        roster_unavailable: 'The runtime agent roster could not be read, so usage cannot be attributed per agent — check runtime reachability (`bakin check runtime`), then rerun.',
+        agent_scan_failed: 'One or more agent transcript scans failed — rerun this check; if it persists, the server log names the failing agent.',
+        missing_session_tier: 'The active runtime does not expose a session-transcript tier, so per-message usage cannot be observed on this adapter.',
+        // The scan itself completed but an agent reported no observable
+        // token totals — its sessions may not expose usage.
+        complete: 'Transcripts scanned clean, but at least one agent reports no observable token totals — its runtime sessions may not expose usage data.',
       }
       const transcriptUnknown = healthUnknown({
         key: 'usage',
@@ -203,7 +209,13 @@ export async function checkAgentBurnWith(
           title: 'Agent usage coverage is incomplete',
           class: 'evidence_gap',
           impact: `Health cannot confirm total or unattributed agent token use until runtime transcripts are fully scanned. ${coverageReasonText[coverageReason] ?? `Coverage gap: ${coverageReason}.`}`,
-          disposition: 'watch',
+          // Warming states (scan running / first scan since boot pending)
+          // SELF-RESOLVE within minutes — advisory keeps them out of the
+          // "Fix first" banner that lit up after every restart. A stale
+          // scan means the scanner may be stuck: that one earns watch.
+          disposition: coverageReason === 'scan_in_progress' || coverageReason === 'scan_not_run'
+            ? 'advisory'
+            : 'watch',
           resources: [{ kind: 'system', id: 'usage-history', label: 'Usage history' }],
           resolution: { key: 'rerun', type: 'rerun', label: 'Rerun this check' },
         },

--- a/plugins/health/lib/system-checks/agent-burn.ts
+++ b/plugins/health/lib/system-checks/agent-burn.ts
@@ -173,19 +173,28 @@ export async function checkAgentBurnWith(
       || lastScan?.report.coverage.status !== 'complete'
       || reports.some((report) => report.totalObservedTokens === null)
     if (incompleteCoverage) {
+      const coverageReason = lastScan
+        ? scanInFlight
+          ? 'scan_in_progress'
+          : scanFresh
+          ? lastScan.report.coverage.reason
+          : 'scan_stale'
+        : scanInFlight ? 'scan_in_progress' : 'scan_not_run'
+      // The card says WHICH state it is in and what resolves it — a bare
+      // "coverage is incomplete" left operators guessing whether to wait
+      // or act (field feedback, 2026-07-22).
+      const coverageReasonText: Record<string, string> = {
+        scan_in_progress: 'A transcript scan is running right now — this resolves itself when it completes; recheck in a minute.',
+        scan_not_run: 'No transcript scan has completed since the server started — the first scan resolves this on its own; recheck in a few minutes.',
+        scan_stale: 'The last transcript scan is older than its freshness window — the scanner may be stuck; rerun this check, and report it if staleness persists.',
+      }
       const transcriptUnknown = healthUnknown({
         key: 'usage',
         summary: 'Agent token burn could not be verified.',
         detail: 'Runtime transcript coverage is incomplete, so zero observed usage cannot be confirmed.',
         evidence: {
           coverage: scanFresh ? lastScan?.report.coverage.status ?? 'unavailable' : 'unavailable',
-          reason: lastScan
-            ? scanInFlight
-              ? 'scan_in_progress'
-              : scanFresh
-              ? lastScan.report.coverage.reason
-              : 'scan_stale'
-            : scanInFlight ? 'scan_in_progress' : 'scan_not_run',
+          reason: coverageReason,
           scanAgeMs,
           staleAfterMs,
         },
@@ -193,7 +202,7 @@ export async function checkAgentBurnWith(
           key: 'transcript-coverage-incomplete',
           title: 'Agent usage coverage is incomplete',
           class: 'evidence_gap',
-          impact: 'Health cannot confirm total or unattributed agent token use until runtime transcripts are fully scanned.',
+          impact: `Health cannot confirm total or unattributed agent token use until runtime transcripts are fully scanned. ${coverageReasonText[coverageReason] ?? `Coverage gap: ${coverageReason}.`}`,
           disposition: 'watch',
           resources: [{ kind: 'system', id: 'usage-history', label: 'Usage history' }],
           resolution: { key: 'rerun', type: 'rerun', label: 'Rerun this check' },

--- a/plugins/health/lib/system-checks/budget.ts
+++ b/plugins/health/lib/system-checks/budget.ts
@@ -14,11 +14,18 @@ import { queryAuditEvents } from '../../../../src/core/audit'
 import { getContentDir } from '../../../../src/core/content-dir'
 import { LedgerUnavailableError, listBudgetIncidents } from '../../../../src/core/execution-ledger'
 import { assembleBudgetSpend } from '../../../../src/core/budget-spend'
-import { evaluateBudget, type BudgetPolicy, type BudgetRule, type TurnBillingContext } from '../../../../src/core/budget'
+import { evaluateBudget, type BudgetPolicy, type BudgetRule, type SpendEvidenceGap, type TurnBillingContext } from '../../../../src/core/budget'
 import { getSettings } from '../../../../src/core/settings'
 import { getHookRegistry } from '../../../../packages/core/src/hooks/hook-registry-singleton'
 import { healthError, healthHealthy, healthObserved, healthUnknown, healthWarning } from '@makinbakin/sdk/utils'
-import type { HealthCheckRunInput, HealthObservationInput, JsonObject } from '@makinbakin/sdk'
+import type {
+  HealthCheckRunInput,
+  HealthObservationInput,
+  HealthRepairActionDefinition,
+  HealthRepairPlanItem,
+  JsonObject,
+} from '@makinbakin/sdk'
+import { repairTargetSelection } from './repair-support'
 import {
   getUsageHistoryScanState,
   getUsageHistoryScanStaleAfterMs,
@@ -26,6 +33,22 @@ import {
 } from '../usage-history-timer'
 
 const WINDOW_MS = 24 * 60 * 60 * 1000
+
+/** Bounded human summary of evidence gaps — the card must NAME what is
+ *  unverifiable ("openai/gpt-5.5: unpriced — 3 runs"), never gesture at it. */
+function summarizeEvidenceGaps(gaps: SpendEvidenceGap[]): string[] {
+  const reasonText = (reason: SpendEvidenceGap['reasons'][number]): string => ({
+    value_missing: 'unpriced',
+    lane_unknown: 'billing lane unknown',
+    provider_unknown: 'provider unknown',
+    model_unknown: 'model unknown',
+  })[reason]
+  return gaps.slice(0, 5).map((gap) => {
+    const target = gap.model ?? gap.provider ?? (gap.agent ? `agent ${gap.agent}` : 'unknown source')
+    const unit = gap.source === 'attributed_run' ? 'run' : 'message'
+    return `${target}: ${gap.reasons.map(reasonText).join(' + ')} — ${gap.unknownCount} ${unit}${gap.unknownCount === 1 ? '' : 's'}`
+  })
+}
 
 function fmtValue(unit: 'usd_micros' | 'tokens', v: number): string {
   return unit === 'usd_micros' ? `$${(v / 1_000_000).toFixed(2)}` : `${v.toLocaleString()} tokens`
@@ -433,9 +456,19 @@ export async function checkBudget(): Promise<HealthCheckRunInput> {
   } else if (incompleteSpendRules.length > 0
     || (policy.rules.some((rule) => rule.scope === 'global' || rule.scope === 'agent')
       && observedEvidence.status !== 'complete')) {
+    // Concrete, resolvable, or it doesn't ship (field feedback, 2026-07-22:
+    // "open a page and pray" is not a resolution). The card NAMES its gaps,
+    // and a pricing gap gets a one-click repair that force-refreshes the
+    // model catalog server-side — no page visit involved. Attribution gaps
+    // (lane/provider/model unknown) genuinely self-resolve as transcripts
+    // land, and the copy says exactly that instead of inventing busywork.
+    const evidenceGaps = [...facets.spendEvidence.daily.gaps, ...facets.spendEvidence.monthly.gaps]
+    const gapLines = summarizeEvidenceGaps(evidenceGaps)
+    const hasPricingGap = evidenceGaps.some((gap) => gap.reasons.includes('value_missing'))
+    const gapSuffix = gapLines.length > 0 ? ` Gaps: ${gapLines.join('; ')}.` : ''
     const detail = incompleteSpendRules.length > 0
-      ? `${incompleteSpendRules.length} budget rule${incompleteSpendRules.length === 1 ? '' : 's'} cannot be evaluated because one or more matching spend records have incomplete value or attribution evidence.`
-      : 'Known Bakin-managed spend is below its configured limits, but recent transcript-observed usage is incomplete.'
+      ? `${incompleteSpendRules.length} budget rule${incompleteSpendRules.length === 1 ? '' : 's'} cannot be evaluated because one or more matching spend records have incomplete value or attribution evidence.${gapSuffix}`
+      : `Known Bakin-managed spend is below its configured limits, but recent transcript-observed usage is incomplete.${gapSuffix}`
     observations.push(healthUnknown({
       key: 'spend',
       summary: 'Spend could not be fully verified.',
@@ -445,9 +478,9 @@ export async function checkBudget(): Promise<HealthCheckRunInput> {
         key: 'spend-evidence-incomplete',
         title: 'Spend evidence is incomplete',
         class: 'evidence_gap',
-        impact: incompleteSpendRules.length > 0
+        impact: `${incompleteSpendRules.length > 0
           ? 'Matching budget caps fail closed until spend values and billing attribution can be verified.'
-          : 'Health cannot confirm that agent spend outside Bakin-managed runs remains within budget.',
+          : 'Health cannot confirm that agent spend outside Bakin-managed runs remains within budget.'}${gapSuffix}`,
         disposition: 'watch',
         resources: incompleteSpendRules.length > 0
           ? [
@@ -455,20 +488,23 @@ export async function checkBudget(): Promise<HealthCheckRunInput> {
               { kind: 'system' as const, id: 'usage-history', label: 'Usage history' },
             ]
           : [{ kind: 'system', id: 'usage-history', label: 'Usage history' }],
-        // A bare "rerun" gave operators nothing to actually FIX — the gaps
-        // are almost always unpriced models (no cached pricing → USD caps
-        // can't be computed) or usage rows without a billing lane. Name the
-        // remediations (field feedback, 2026-07-22).
-        resolution: {
-          key: 'complete-spend-evidence',
-          type: 'instructions',
-          label: 'Complete the spend evidence',
-          steps: [
-            'Open the Models page so pricing for every active model gets cached — usage from a model without cached pricing cannot be valued, which is the most common gap on a fresh install.',
-            'Run `bakin spend` and check the listed evidence gaps: value_missing = unpriced model, lane_unknown = usage that cannot be classified metered vs subscription (usually resolves after the next completed runs).',
-            'Rerun Health. Budget caps stay fail-closed (deferring, never overspending) until the evidence completes — that is by design.',
-          ],
-        },
+        resolution: hasPricingGap
+          ? {
+              key: 'refresh-model-pricing',
+              type: 'repair',
+              label: 'Refresh model pricing',
+              actionId: 'spend-evidence-refresh-pricing',
+            }
+          : {
+              key: 'attribution-settles',
+              type: 'instructions',
+              label: 'Attribution completes on its own',
+              steps: [
+                'The named records lack billing attribution (lane/provider/model), which completes as the runtime finishes writing its transcripts — no action needed.',
+                'Budget caps stay fail-closed (deferring, never overspending) until then — that is by design.',
+                'If the same gaps persist for hours across recheck, report it: attribution should converge without help.',
+              ],
+            },
       },
     }))
   } else if (worst) {
@@ -527,4 +563,65 @@ export async function checkBudget(): Promise<HealthCheckRunInput> {
 function budgetRuleId(rule: BudgetRule, index: number): string {
   const raw = [rule.scope, rule.scopeId, rule.lane, index].filter((value) => value !== undefined).join('-')
   return raw.toLowerCase().replace(/[^a-z0-9._:-]/g, '-').slice(0, 120) || `rule-${index}`
+}
+
+/**
+ * One-click repair for the pricing leg of incomplete spend evidence: force-
+ * refresh the model catalog (with pricing) through the models plugin's own
+ * hook — the deterministic version of "open the Models page so pricing
+ * caches", which asked a human to trigger a machine operation (field
+ * feedback, 2026-07-22). Attribution gaps are NOT repairable here; they
+ * complete as transcripts land, and the incident copy says so.
+ */
+export function spendEvidenceRepair(): HealthRepairActionDefinition {
+  return {
+    id: 'spend-evidence-refresh-pricing',
+    name: 'Refresh model pricing',
+    async plan(target) {
+      return [{
+        id: 'refresh-model-pricing',
+        actionId: 'spend-evidence-refresh-pricing',
+        title: 'Refresh model pricing',
+        reason: 'Spend records reference models without cached pricing, so USD caps cannot be evaluated.',
+        safety: 'safe',
+        ...repairTargetSelection(target),
+        changes: [{
+          kind: 'other',
+          target: 'model catalog cache',
+          action: 'update',
+          description: 'Re-fetch the model catalog (with pricing) live from the configured providers, bypassing caches. Read-only toward providers; overwrites only the local pricing cache.',
+        }],
+      }]
+    },
+    async apply(items) {
+      const done = (status: 'applied' | 'failed', message: string) => items.map((item: HealthRepairPlanItem) => ({
+        itemId: item.id,
+        actionId: item.actionId,
+        status,
+        message,
+        affectedCheckIds: ['budget'],
+        changes: item.changes,
+      }))
+      if (items.length === 0) return []
+      try {
+        const registry = getHookRegistry()
+        if (!registry.has('models.refreshAvailableModels')) {
+          return done('failed', 'The models plugin is not active — the catalog cannot be refreshed from here.')
+        }
+        const result = await registry.invoke<{ count: number; live: boolean; error: string | null }>(
+          'models.refreshAvailableModels',
+          {},
+        )
+        if (result?.error) {
+          return done('failed', `Catalog refresh failed: ${result.error}. Pricing stays as-is; spend evidence remains incomplete.`)
+        }
+        if (!result || result.count === 0) {
+          return done('failed', 'The provider returned no models — pricing cannot be cached. Check runtime credentials (`bakin check llm`), then run this repair again.')
+        }
+        return done('applied', `Model catalog refreshed live: ${result.count} models with pricing cached. Health re-verifies spend on the next check run.`)
+      } catch (err) {
+        return done('failed', `Catalog refresh failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    },
+  }
 }

--- a/plugins/health/lib/system-checks/budget.ts
+++ b/plugins/health/lib/system-checks/budget.ts
@@ -35,19 +35,42 @@ import {
 const WINDOW_MS = 24 * 60 * 60 * 1000
 
 /** Bounded human summary of evidence gaps — the card must NAME what is
- *  unverifiable ("openai/gpt-5.5: unpriced — 3 runs"), never gesture at it. */
-function summarizeEvidenceGaps(gaps: SpendEvidenceGap[]): string[] {
+ *  unverifiable ("openai/gpt-5.5: unpriced — 3 runs"), never gesture at it.
+ *  Daily+monthly windows overlap, so gaps dedupe by target+reasons (max
+ *  count wins — monthly subsumes daily for the same records). Model ids
+ *  are runtime-controlled and unbounded: per-target text is truncated and
+ *  the FULL enumeration belongs in detail (4000) — `impact` (500) gets
+ *  only the top few + a count (review finding: five bedrock-style ids
+ *  blew the impact bound and invalidated the whole run). */
+function summarizeEvidenceGaps(gaps: SpendEvidenceGap[]): { lines: string[]; impactSummary: string } {
   const reasonText = (reason: SpendEvidenceGap['reasons'][number]): string => ({
     value_missing: 'unpriced',
     lane_unknown: 'billing lane unknown',
     provider_unknown: 'provider unknown',
     model_unknown: 'model unknown',
   })[reason]
-  return gaps.slice(0, 5).map((gap) => {
-    const target = gap.model ?? gap.provider ?? (gap.agent ? `agent ${gap.agent}` : 'unknown source')
+  const merged = new Map<string, { target: string; reasons: string; count: number; unit: string }>()
+  for (const gap of gaps) {
+    const target = (gap.model ?? gap.provider ?? (gap.agent ? `agent ${gap.agent}` : 'unknown source')).slice(0, 80)
+    const reasons = gap.reasons.map(reasonText).join(' + ')
     const unit = gap.source === 'attributed_run' ? 'run' : 'message'
-    return `${target}: ${gap.reasons.map(reasonText).join(' + ')} — ${gap.unknownCount} ${unit}${gap.unknownCount === 1 ? '' : 's'}`
-  })
+    const dedupeKey = `${target}\0${reasons}\0${unit}`
+    const existing = merged.get(dedupeKey)
+    if (existing) {
+      existing.count = Math.max(existing.count, gap.unknownCount)
+    } else {
+      merged.set(dedupeKey, { target, reasons, count: gap.unknownCount, unit })
+    }
+  }
+  const entries = [...merged.values()]
+  const lines = entries.slice(0, 8).map((entry) =>
+    `${entry.target}: ${entry.reasons} — ${entry.count} ${entry.unit}${entry.count === 1 ? '' : 's'}`)
+  const top = entries.slice(0, 2).map((entry) => `${entry.target} (${entry.reasons})`)
+  const more = entries.length - top.length
+  const impactSummary = top.length > 0
+    ? ` Gaps: ${top.join(', ')}${more > 0 ? ` +${more} more` : ''}.`
+    : ''
+  return { lines, impactSummary }
 }
 
 function fmtValue(unit: 'usd_micros' | 'tokens', v: number): string {
@@ -463,12 +486,12 @@ export async function checkBudget(): Promise<HealthCheckRunInput> {
     // (lane/provider/model unknown) genuinely self-resolve as transcripts
     // land, and the copy says exactly that instead of inventing busywork.
     const evidenceGaps = [...facets.spendEvidence.daily.gaps, ...facets.spendEvidence.monthly.gaps]
-    const gapLines = summarizeEvidenceGaps(evidenceGaps)
+    const { lines: gapLines, impactSummary } = summarizeEvidenceGaps(evidenceGaps)
     const hasPricingGap = evidenceGaps.some((gap) => gap.reasons.includes('value_missing'))
-    const gapSuffix = gapLines.length > 0 ? ` Gaps: ${gapLines.join('; ')}.` : ''
+    const detailSuffix = gapLines.length > 0 ? ` Gaps: ${gapLines.join('; ')}.` : ''
     const detail = incompleteSpendRules.length > 0
-      ? `${incompleteSpendRules.length} budget rule${incompleteSpendRules.length === 1 ? '' : 's'} cannot be evaluated because one or more matching spend records have incomplete value or attribution evidence.${gapSuffix}`
-      : `Known Bakin-managed spend is below its configured limits, but recent transcript-observed usage is incomplete.${gapSuffix}`
+      ? `${incompleteSpendRules.length} budget rule${incompleteSpendRules.length === 1 ? '' : 's'} cannot be evaluated because one or more matching spend records have incomplete value or attribution evidence.${detailSuffix}`
+      : `Known Bakin-managed spend is below its configured limits, but recent transcript-observed usage is incomplete.${detailSuffix}`
     observations.push(healthUnknown({
       key: 'spend',
       summary: 'Spend could not be fully verified.',
@@ -480,8 +503,12 @@ export async function checkBudget(): Promise<HealthCheckRunInput> {
         class: 'evidence_gap',
         impact: `${incompleteSpendRules.length > 0
           ? 'Matching budget caps fail closed until spend values and billing attribution can be verified.'
-          : 'Health cannot confirm that agent spend outside Bakin-managed runs remains within budget.'}${gapSuffix}`,
-        disposition: 'watch',
+          : 'Health cannot confirm that agent spend outside Bakin-managed runs remains within budget.'}${impactSummary}`,
+        // Pricing gaps are ACTIONABLE (the one-click catalog refresh) —
+        // watch. Attribution-only gaps and scan freshness self-resolve as
+        // transcripts land, and caps fail closed meanwhile: advisory, so
+        // a state that needs no human stops lighting the banner.
+        disposition: hasPricingGap ? 'watch' : 'advisory',
         resources: incompleteSpendRules.length > 0
           ? [
               { kind: 'system' as const, id: 'spend-ledger', label: 'Spend ledger' },
@@ -618,7 +645,10 @@ export function spendEvidenceRepair(): HealthRepairActionDefinition {
         if (!result || result.count === 0) {
           return done('failed', 'The provider returned no models — pricing cannot be cached. Check runtime credentials (`bakin check llm`), then run this repair again.')
         }
-        return done('applied', `Model catalog refreshed live: ${result.count} models with pricing cached. Health re-verifies spend on the next check run.`)
+        // Honest scope: the refresh landed, but a gapped model may still
+        // have no known pricing in the refreshed catalog — never claim the
+        // gap is resolved before the next check run verifies it.
+        return done('applied', `Model catalog refreshed live (${result.count} models). Health re-verifies spend on the next check run — if the same gap persists, that model has no known pricing and its usage can only be capped by tokens.`)
       } catch (err) {
         return done('failed', `Catalog refresh failed: ${err instanceof Error ? err.message : String(err)}`)
       }

--- a/plugins/health/lib/system-checks/search.ts
+++ b/plugins/health/lib/system-checks/search.ts
@@ -27,6 +27,11 @@ export async function checkSearchAdapter(): Promise<HealthCheckRunInput> {
       incident: {
         key: 'search-disabled',
         title: 'Search is disabled',
+        // policy_denial: disabling Search is an explicit operator setting,
+        // not a failure — under standard sensitivity this calms to
+        // advisory instead of permanently lighting the dashboard on boxes
+        // that turned it off on purpose (aggressiveness audit, 2026-07-22).
+        class: 'policy_denial',
         impact: 'Agents and user interfaces cannot use indexed search.',
         disposition: 'action_required',
         resources: [{ kind: 'setting', id: 'search.settings.enabled', label: 'Search enabled setting' }],
@@ -151,7 +156,11 @@ export async function checkSearchAdapter(): Promise<HealthCheckRunInput> {
             key: 'inspect-engine',
             type: 'instructions',
             label: 'Restore the Search engine',
-            steps: ['Inspect Search engine lines in ~/.bakin/logs/server.log, restore the service, then rerun Health.'],
+            steps: [
+              'Run `bakin install search` — it re-provisions the service unit and starts the engine if it is dark (safe to run repeatedly).',
+              'Still unreachable? Check `~/.bakin/logs/antfly.log` for crash loops — a broken model or corrupt data dir shows up there.',
+              'Last resort: `bakin search:reset` stops the engine, wipes its derived index data (content and models untouched), starts clean, and rebuilds.',
+            ],
           },
         },
       }))

--- a/plugins/models/lib/available-models.ts
+++ b/plugins/models/lib/available-models.ts
@@ -125,21 +125,26 @@ function withFreshTiers(models: AvailableModel[]): AvailableModel[] {
   return models.map((m) => ({ ...m, tier: getKnownModel(m.id)?.tier ?? tierFromId(m.id) }))
 }
 
-export async function fetchAvailableModels(ctx: PluginContext): Promise<FetchResult> {
-  // 1. Hot read — in-memory cache (fresh by TTL)
-  const memCached = getModelsCache()
-  if (memCached && Date.now() - memCached.fetchedAt < CACHE_TTL) {
-    return { models: withFreshTiers(memCached.models), cached: true, cachedAt: memCached.fetchedAt, stale: false }
-  }
+export async function fetchAvailableModels(ctx: PluginContext, opts?: { force?: boolean }): Promise<FetchResult> {
+  // force: skip both caches and fetch live — the repair path for stale/
+  // missing pricing (a health repair must refresh deterministically, not
+  // depend on a human visiting the Models page to trigger it).
+  if (!opts?.force) {
+    // 1. Hot read — in-memory cache (fresh by TTL)
+    const memCached = getModelsCache()
+    if (memCached && Date.now() - memCached.fetchedAt < CACHE_TTL) {
+      return { models: withFreshTiers(memCached.models), cached: true, cachedAt: memCached.fetchedAt, stale: false }
+    }
 
-  // 2. Persistent cache hydration — survives server restart even when
-  //    in-memory is empty. Always returns last-known-good; `stale` tells
-  //    the client whether to kick off a background refresh.
-  const diskCached = memCached ? null : readPersistedCache()
-  if (diskCached) {
-    setModelsCache({ models: diskCached.models, fetchedAt: diskCached.fetchedAt })
-    const stale = Date.now() - diskCached.fetchedAt >= CACHE_TTL
-    return { models: withFreshTiers(diskCached.models), cached: true, cachedAt: diskCached.fetchedAt, stale }
+    // 2. Persistent cache hydration — survives server restart even when
+    //    in-memory is empty. Always returns last-known-good; `stale` tells
+    //    the client whether to kick off a background refresh.
+    const diskCached = memCached ? null : readPersistedCache()
+    if (diskCached) {
+      setModelsCache({ models: diskCached.models, fetchedAt: diskCached.fetchedAt })
+      const stale = Date.now() - diskCached.fetchedAt >= CACHE_TTL
+      return { models: withFreshTiers(diskCached.models), cached: true, cachedAt: diskCached.fetchedAt, stale }
+    }
   }
 
   // 3. No cache → live fetch. Dedupe concurrent callers against one

--- a/plugins/models/lib/register-hooks.ts
+++ b/plugins/models/lib/register-hooks.ts
@@ -41,6 +41,11 @@ export function registerModelsHooks(ctx: PluginContext): void {
     return result.models
   }, { label: 'List available models.', summary: 'Returns the model catalog available from the currently configured providers. Use it to populate pickers, validate assignments, or compare model options before saving config.', hookKind: 'rpc' })
 
+  ctx.hooks.register('models.refreshAvailableModels', async () => {
+    const result = await fetchAvailableModels(ctx as unknown as PluginContext, { force: true })
+    return { count: result.models.length, live: !result.cached, error: result.error ?? null }
+  }, { label: 'Refresh the model catalog.', summary: 'Bypasses caches and re-fetches the model catalog (with pricing) live from the configured providers. Use it when pricing is stale or missing — e.g. the spend-evidence repair — instead of waiting on the Models page to trigger a refresh.', hookKind: 'rpc' })
+
   // Price one completed agent turn: resolve the model that ran (explicit
   // override → agent's effective model), look up catalog pricing, and
   // return an estimated micro-dollar cost. Cost is null when the model has

--- a/plugins/models/lib/register-hooks.ts
+++ b/plugins/models/lib/register-hooks.ts
@@ -42,7 +42,7 @@ export function registerModelsHooks(ctx: PluginContext): void {
   }, { label: 'List available models.', summary: 'Returns the model catalog available from the currently configured providers. Use it to populate pickers, validate assignments, or compare model options before saving config.', hookKind: 'rpc' })
 
   ctx.hooks.register('models.refreshAvailableModels', async () => {
-    const result = await fetchAvailableModels(ctx as unknown as PluginContext, { force: true })
+    const result = await fetchAvailableModels(ctx, { force: true })
     return { count: result.models.length, live: !result.cached, error: result.error ?? null }
   }, { label: 'Refresh the model catalog.', summary: 'Bypasses caches and re-fetches the model catalog (with pricing) live from the configured providers. Use it when pricing is stale or missing — e.g. the spend-evidence repair — instead of waiting on the Models page to trigger a refresh.', hookKind: 'rpc' })
 

--- a/plugins/schedule/lib/health-checks.ts
+++ b/plugins/schedule/lib/health-checks.ts
@@ -70,9 +70,14 @@ export async function checkScheduleSync(
   try {
     scan = await orphanRuntimeJobs(contentDir, cron)
   } catch (error) {
+    // Static summary, error in detail: a long runtime error interpolated
+    // into summary blew the 500-char contract bound and invalidated the
+    // whole run (2026-07-22 field diagnosis). Builders clamp now, but the
+    // error belongs in detail regardless.
     return healthObserved([healthUnknown({
       key: 'runtime-cron',
-      summary: `Runtime cron jobs could not be read: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'Runtime cron jobs could not be read.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       incident: {
         key: 'runtime-cron',
         title: 'Schedule synchronization could not be verified',
@@ -125,7 +130,8 @@ export async function checkScheduleCutover(
   } catch (error) {
     return healthObserved([healthUnknown({
       key: 'cutover-verification',
-      summary: `Runtime cron could not be read: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'Runtime cron could not be read.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       incident: {
         key: 'cutover-verification',
         title: 'Schedule cutover could not be verified',

--- a/plugins/team/lib/health-checks.ts
+++ b/plugins/team/lib/health-checks.ts
@@ -61,7 +61,8 @@ export async function checkTeamRouting(opts: {
   } catch (error) {
     return healthObserved([healthUnknown({
       key: 'task-board',
-      summary: `Team routing demand could not be inspected: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'Team routing demand could not be inspected.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       incident: {
         key: 'task-board',
         title: 'Team routing readiness could not be verified',
@@ -83,7 +84,8 @@ export async function checkTeamRouting(opts: {
   } catch (error) {
     return healthObserved([healthUnknown({
       key: 'runtime-credentials',
-      summary: `Runtime credential status could not be read: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'Runtime credential status could not be read.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       evidence: { unresolvedTasks: unresolvedCount },
       incident: {
         key: 'runtime-credentials',
@@ -127,7 +129,8 @@ export async function checkAgentRoster(runtime: RuntimeAgentReader): Promise<Hea
   } catch (error) {
     return healthObserved([healthUnknown({
       key: 'roster-read',
-      summary: `The runtime agent roster could not be read: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'The runtime agent roster could not be read.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       incident: {
         key: 'roster-read',
         title: 'Agent roster verification is unavailable',
@@ -196,7 +199,8 @@ export async function checkPersonas(
   } catch (error) {
     return healthObserved([healthUnknown({
       key: 'roster-read',
-      summary: `Runtime agents could not be read while checking personas: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'Runtime agents could not be read while checking personas.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       incident: {
         key: 'roster-read',
         title: 'Persona coverage could not be verified',
@@ -332,7 +336,8 @@ export async function checkAgentSync(): Promise<HealthCheckRunInput> {
   } catch (error) {
     return healthObserved([healthUnknown({
       key: 'scan',
-      summary: `Agent sync state could not be scanned: ${error instanceof Error ? error.message : String(error)}`,
+      summary: 'Agent sync state could not be scanned.',
+      detail: (error instanceof Error ? error.message : String(error)) || undefined,
       incident: {
         key: 'scan',
         title: 'Agent sync verification is unavailable',

--- a/src/core/doctor-checks.ts
+++ b/src/core/doctor-checks.ts
@@ -152,10 +152,11 @@ function verificationObservation(
       key: def.id,
       title: `${def.name} could not be verified`,
       // This card means the CHECK ITSELF failed to produce evidence (it
-      // crashed or timed out) — the underlying error is in this card's
-      // detail. Operators repeatedly hit these with no path forward
-      // (field feedback, 2026-07-22): name the way out.
-      impact: 'Bakin cannot currently confirm whether this part of the system is healthy. The check itself failed to run — expand this card to read the underlying error.',
+      // crashed or timed out). The error goes INTO the card copy — the
+      // first version told operators to "expand this card" for a detail
+      // the incident view never rendered (field feedback, 2026-07-22:
+      // instructions must reference what is actually on screen).
+      impact: `Bakin cannot currently confirm whether this part of the system is healthy — the check crashed instead of reporting evidence. Error: ${reason.slice(0, 300)}`,
       disposition: 'watch',
       resources: [{ kind: 'plugin', id: def.owner.id, label: def.owner.label }],
       resolution: {
@@ -163,9 +164,8 @@ function verificationObservation(
         type: 'instructions',
         label: 'Diagnose the failed check',
         steps: [
-          'Expand this card — the detail is the actual error the check hit while gathering evidence.',
-          'Fix what it names (a missing tool, unreadable file, or unreachable service), then run checks again.',
-          'If the error is opaque or persists across reruns, it is a Bakin bug worth reporting — the check should report evidence, not crash.',
+          'Fix what the error above names (a missing tool, unreadable file, or unreachable service), then run checks again.',
+          'If the error is opaque or persists across reruns, it is a Bakin bug worth reporting — a check should report evidence, not crash.',
         ],
       },
     },

--- a/src/core/doctor-checks.ts
+++ b/src/core/doctor-checks.ts
@@ -9,6 +9,9 @@ import type {
 } from '../../packages/core/src/plugin-types'
 import { safeParseHealthCheckRunInput } from './health-contract'
 import { getHealthRepairAction, listHealthChecks } from './health-check-registry'
+import { createLogger } from './logger'
+
+const log = createLogger('doctor-checks')
 
 export interface DetailedHealthCheckRun {
   def: HealthCheckDef
@@ -190,6 +193,19 @@ export async function runHealthCheck(
     const completedAt = now().toISOString()
     const parsed = safeParseHealthCheckRunInput(raw)
     if (!parsed.success) {
+      // Surface the structured issues — the bare contract message hid the
+      // failing field paths from the card, the log, AND the execution
+      // record, leaving a field diagnosis stuck at "failed validation"
+      // with nothing to act on (2026-07-22).
+      const issueText = parsed.error.issues
+        .slice(0, 3)
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')
+      const reason = issueText ? `${parsed.error.message} ${issueText}` : parsed.error.message
+      log.warn('health check output failed contract validation', {
+        checkId: def.id,
+        issues: parsed.error.issues.slice(0, 10),
+      })
       return {
         def,
         freshUntil: staleAt(completedAt, ttlMs),
@@ -199,9 +215,9 @@ export async function runHealthCheck(
           startedAt,
           completedAt,
           outcome: 'invalid',
-          error: { code: parsed.error.code, message: parsed.error.message },
+          error: { code: parsed.error.code, message: reason },
         },
-        observations: [verificationObservation(def, completedAt, ttlMs, parsed.error.message)],
+        observations: [verificationObservation(def, completedAt, ttlMs, reason)],
       }
     }
 

--- a/src/core/health-contract.ts
+++ b/src/core/health-contract.ts
@@ -608,7 +608,9 @@ export const errorObservationInputSchema = z.object({
 export const unknownObservationInputSchema = z.object({
   ...observationBaseShape,
   status: z.literal('unknown'),
-  incident: watchIncidentInputSchema,
+  // watch, or advisory when the producer vouches the unknown self-resolves
+  // (scan warm-up, attribution landing). Never action_required.
+  incident: z.union([watchIncidentInputSchema, advisoryIncidentInputSchema]),
 }).strict()
 
 export const healthObservationInputSchema = z.discriminatedUnion('status', [

--- a/tests/core/doctor-checks.test.ts
+++ b/tests/core/doctor-checks.test.ts
@@ -1,0 +1,70 @@
+/**
+ * runHealthCheck contract-failure surfacing (2026-07-22): when a check's
+ * output fails validation, the FIELD PATHS must reach the verification
+ * card, the execution record, and the log — the bare generic message
+ * dead-ended a field diagnosis with nothing to act on.
+ */
+import { describe, expect, it, mock } from 'bun:test'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+
+const testDir = join(tmpdir(), `bakin-test-doctor-checks-${Date.now()}-${randomUUID()}`)
+const contentDirMock = () => ({
+  getContentDir: () => testDir,
+  getBakinPaths: () => ({ home: testDir, db: join(testDir, 'bakin.db') }),
+})
+mock.module('../../src/core/content-dir', contentDirMock)
+mock.module('../../packages/core/src/content-dir', contentDirMock)
+
+const logWarn = mock()
+mock.module('../../src/core/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: logWarn, error: mock(), debug: mock() }),
+}))
+mock.module('../../packages/core/src/logger', () => ({
+  createLogger: () => ({ info: mock(), warn: logWarn, error: mock(), debug: mock() }),
+}))
+
+import type { HealthCheckDef } from '../../packages/core/src/plugin-types'
+
+function defWith(run: () => Promise<unknown>): HealthCheckDef {
+  return {
+    id: 'git.worktrees',
+    localId: 'worktrees',
+    name: 'Git worktree registry',
+    description: 'test',
+    owner: { kind: 'plugin', id: 'git', label: 'Git' },
+    group: { key: 'git', label: 'Git' },
+    run,
+  } as unknown as HealthCheckDef
+}
+
+describe('runHealthCheck surfaces contract-validation issues', () => {
+  it('names the failing field path on the card, in the execution record, and in the log', async () => {
+    // Raw literal bypasses the clamping builders — a 600-char summary is
+    // exactly the class that produced the useless generic Verify card.
+    const def = defWith(async () => ({
+      outcome: 'observed',
+      observations: [{ key: 'registry', status: 'healthy', summary: 'x'.repeat(600) }],
+    }))
+
+    // Dynamic import: doctor-checks binds its logger at module scope, so
+    // it must load AFTER the mock.module overlays (static imports hoist).
+    const { runHealthCheck } = await import('../../src/core/doctor-checks')
+    const result = await runHealthCheck(def)
+
+    expect(result.execution.outcome).toBe('invalid')
+    if (result.execution.outcome !== 'invalid') throw new Error('expected invalid outcome')
+    expect(result.execution.error?.message).toContain('observations.0.summary')
+
+    const observation = result.observations[0]!
+    expect(observation.status).toBe('unknown')
+    expect(observation.detail).toContain('observations.0.summary')
+    expect(observation.incident?.impact).toContain('observations.0.summary')
+
+    expect(logWarn).toHaveBeenCalledWith(
+      'health check output failed contract validation',
+      expect.objectContaining({ checkId: 'git.worktrees' }),
+    )
+  })
+})

--- a/tests/core/health-contract.test.ts
+++ b/tests/core/health-contract.test.ts
@@ -561,3 +561,34 @@ describe('SDK observation builders clamp copy to contract bounds (2026-07-22)', 
     expect(untouched.detail).toBe('fine')
   })
 })
+
+describe('unknown incidents may be advisory — never action_required (2026-07-22)', () => {
+  const unknownWith = (disposition: string) => ({
+    outcome: 'observed',
+    observations: [{
+      key: 'usage',
+      summary: 'Scan warming up.',
+      status: 'unknown',
+      incident: {
+        key: 'warming',
+        title: 'Usage coverage is incomplete',
+        impact: 'Resolves when the first scan completes.',
+        disposition,
+        resources: [{ kind: 'system', id: 'usage-history', label: 'Usage history' }],
+        resolution: { key: 'rerun', type: 'rerun', label: 'Rerun this check' },
+      },
+    }],
+  })
+
+  it('accepts advisory (producer vouches the unknown self-resolves)', () => {
+    expect(safeParseHealthCheckRunInput(unknownWith('advisory')).success).toBe(true)
+  })
+
+  it('still accepts watch', () => {
+    expect(safeParseHealthCheckRunInput(unknownWith('watch')).success).toBe(true)
+  })
+
+  it('REJECTS action_required — an unknown cannot honestly demand action', () => {
+    expect(safeParseHealthCheckRunInput(unknownWith('action_required')).success).toBe(false)
+  })
+})

--- a/tests/core/health-contract.test.ts
+++ b/tests/core/health-contract.test.ts
@@ -524,3 +524,40 @@ describe('health run-output validation', () => {
     expect(JSON.stringify(result.error)).not.toContain(secretValue)
   })
 })
+
+describe('SDK observation builders clamp copy to contract bounds (2026-07-22)', () => {
+  // A check that interpolated a ~700-char runtime error into `summary`
+  // used to fail contract validation WHOLESALE — real evidence became a
+  // generic "could not be verified" card. The builders now clamp summary
+  // (500) and detail (4000) so overlong copy truncates honestly instead
+  // of invalidating the run.
+  it('clamps an overlong summary and the result passes the contract', async () => {
+    const { healthUnknown, healthObserved } = await import('@makinbakin/sdk/utils')
+    const observation = healthUnknown({
+      key: 'runtime-cron',
+      summary: `Runtime cron jobs could not be read: ${'x'.repeat(700)}`,
+      incident: {
+        key: 'runtime-cron',
+        title: 'Schedule synchronization could not be verified',
+        impact: 'Bakin cannot determine whether runtime cron jobs are tracked.',
+        disposition: 'watch',
+        resources: [{ kind: 'system', id: 'schedule', label: 'Schedule' }],
+        resolution: { key: 'rerun', type: 'rerun', label: 'Rerun this check' },
+      },
+    })
+    expect(observation.summary.length).toBe(500)
+    expect(observation.summary.endsWith('…')).toBe(true)
+
+    const result = safeParseHealthCheckRunInput(healthObserved([observation]))
+    expect(result.success).toBe(true)
+  })
+
+  it('clamps an overlong detail and leaves in-bounds copy untouched', async () => {
+    const { healthHealthy } = await import('@makinbakin/sdk/utils')
+    const clamped = healthHealthy({ key: 'k', summary: 'Short.', detail: 'd'.repeat(5_000) })
+    expect(clamped.detail!.length).toBe(4_000)
+    const untouched = healthHealthy({ key: 'k', summary: 'Short.', detail: 'fine' })
+    expect(untouched.summary).toBe('Short.')
+    expect(untouched.detail).toBe('fine')
+  })
+})

--- a/tests/core/onboarding-adapter-gating.test.ts
+++ b/tests/core/onboarding-adapter-gating.test.ts
@@ -11,6 +11,10 @@ import { randomUUID } from 'crypto'
 const testDir = join(tmpdir(), `bakin-test-onboard-gate-${Date.now()}-${randomUUID()}`)
 process.env.BAKIN_HOME = testDir
 process.env.PI_HOME = join(testDir, 'pi')
+// Isolate antfly's home too: checkAll runs the search-models component,
+// and without this the check reads (and once hashed) the REAL ~/.antfly
+// model files — hundreds of MB of I/O inside a test (2026-07-22 flake).
+process.env.ANTFLY_HOME = join(testDir, 'antfly')
 
 const contentDirMock = () => ({
   getContentDir: () => testDir,

--- a/tests/plugins/health/budget.test.ts
+++ b/tests/plugins/health/budget.test.ts
@@ -25,11 +25,15 @@ mock.module('../../../packages/core/src/logger', loggerMock)
 
 let budgetPolicy: unknown = {}
 let resolveBilling: (() => Promise<unknown>) | null = null
+let refreshModelsRegistered = true
+let refreshModelsResult: unknown = { count: 3, live: true, error: null }
 const hookRegistryMock = () => ({
   getHookRegistry: () => ({
+    has: (name: string) => (name === 'models.refreshAvailableModels' ? refreshModelsRegistered : true),
     invoke: async (name: string) => {
       if (name === 'models.getBudgetPolicy') return budgetPolicy
       if (name === 'models.resolveBilling' && resolveBilling) return await resolveBilling()
+      if (name === 'models.refreshAvailableModels') return refreshModelsResult
       return undefined
     },
   }),
@@ -38,7 +42,7 @@ const hookRegistryMock = () => ({
 mock.module('@bakin/core/hooks/hook-registry-singleton', hookRegistryMock)
 mock.module('../../../src/core/plugin-registry', hookRegistryMock)
 
-import { checkBudget } from '@bakin/health/lib/system-checks/budget'
+import { checkBudget, spendEvidenceRepair } from '@bakin/health/lib/system-checks/budget'
 import { recordRunCost } from '../../../src/core/execution-ledger'
 import { closeAllDbs, closeDb } from '../../../packages/core/src/storage/db'
 import { replaceSessionUsage, toLocalDayKey } from '../../../packages/core/src/usage-history/store'
@@ -63,6 +67,8 @@ beforeEach(() => {
   dbPath = join(testDir, 'bakin.db')
   budgetPolicy = {}
   resolveBilling = null
+  refreshModelsRegistered = true
+  refreshModelsResult = { count: 3, live: true, error: null }
   usageScanGlobal.__bakinUsageHistoryScanIntervalMs = 5 * 60_000
   usageScanGlobal.__bakinUsageHistoryScanInFlight = null
   usageScanGlobal.__bakinUsageHistoryScanPending = false
@@ -222,6 +228,15 @@ describe('budget health check', () => {
           })],
         },
       },
+    })
+    // The card is concrete and resolvable (2026-07-22 field feedback):
+    // a pricing gap names the model in the copy and offers the one-click
+    // catalog-refresh repair — never "open a page and pray".
+    expect(spend?.detail).toContain('unpriced')
+    expect(spend?.detail).toContain('gemini-3-flash')
+    expect(spend?.incident?.resolution).toMatchObject({
+      type: 'repair',
+      actionId: 'spend-evidence-refresh-pricing',
     })
   })
 
@@ -572,5 +587,40 @@ describe('budget health check', () => {
       rmSync(join(testDir, 'settings.json'), { force: true })
       resetSettingsCache()
     }
+  })
+})
+
+describe('spend evidence repair (spend-evidence-refresh-pricing)', () => {
+  it('force-refreshes the model catalog through the models hook and reports the count', async () => {
+    const repair = spendEvidenceRepair()
+    const outcomes = await repair.apply(await repair.plan({ type: 'all_actionable', reportId: 'r1' }))
+    expect(outcomes).toEqual([
+      expect.objectContaining({ status: 'applied', affectedCheckIds: ['budget'] }),
+    ])
+    expect(outcomes[0]!.message).toContain('3 models')
+  })
+
+  it('fails honestly when the models plugin is absent', async () => {
+    refreshModelsRegistered = false
+    const repair = spendEvidenceRepair()
+    const outcomes = await repair.apply(await repair.plan({ type: 'all_actionable', reportId: 'r1' }))
+    expect(outcomes[0]).toMatchObject({ status: 'failed' })
+    expect(outcomes[0]!.message).toContain('models plugin is not active')
+  })
+
+  it('fails with the credentials pointer when the provider returns zero models', async () => {
+    refreshModelsResult = { count: 0, live: true, error: null }
+    const repair = spendEvidenceRepair()
+    const outcomes = await repair.apply(await repair.plan({ type: 'all_actionable', reportId: 'r1' }))
+    expect(outcomes[0]).toMatchObject({ status: 'failed' })
+    expect(outcomes[0]!.message).toContain('bakin check llm')
+  })
+
+  it('surfaces the fetch error when the refresh itself fails', async () => {
+    refreshModelsResult = { count: 0, live: false, error: 'gateway unreachable' }
+    const repair = spendEvidenceRepair()
+    const outcomes = await repair.apply(await repair.plan({ type: 'all_actionable', reportId: 'r1' }))
+    expect(outcomes[0]).toMatchObject({ status: 'failed' })
+    expect(outcomes[0]!.message).toContain('gateway unreachable')
   })
 })

--- a/tests/plugins/health/budget.test.ts
+++ b/tests/plugins/health/budget.test.ts
@@ -523,6 +523,28 @@ describe('budget health check', () => {
     expect(gap!.incident?.disposition).toBe('watch')
   })
 
+  it('spend-evidence incident is ADVISORY when the only gap is scan coverage (self-resolving)', async () => {
+    // No pricing gap → nothing for a human to fix; caps fail closed while
+    // transcripts land. Advisory keeps it off the fix-first banner that
+    // used to light up after every restart (2026-07-22).
+    budgetPolicy = { rules: [{ scope: 'global', lane: 'metered', dailyCap: 100 }] }
+    seedSpend(5_000_000)
+    usageScanGlobal.__bakinUsageHistoryLastScan = {
+      at: Date.now(),
+      report: {
+        scanned: 1,
+        skipped: 0,
+        failed: 0,
+        coverage: { status: 'partial', reason: 'agent_log_unreadable', agents: [] },
+      },
+    }
+
+    const rows = observed(await checkBudget())
+    const gap = rows.find((row) => row.incident?.key === 'spend-evidence-incomplete')
+    expect(gap).toBeDefined()
+    expect(gap!.incident?.disposition).toBe('advisory')
+  })
+
   it('warns when runs were deferred even if utilization looks ok', async () => {
     budgetPolicy = { rules: [{ scope: 'global', lane: 'metered', dailyCap: 1000 }] }
     appendFileSync(join(testDir, 'audit.jsonl'), JSON.stringify({ ts: new Date().toISOString(), event: 'budget.deferred', agent: 'pixel', data: {} }) + '\n', 'utf-8')

--- a/tests/plugins/health/health-view-model.test.ts
+++ b/tests/plugins/health/health-view-model.test.ts
@@ -172,6 +172,32 @@ describe('buildHealthOverviewViewModel', () => {
     expect(model.needsAction[1]?.freshness).toBe('stale')
   })
 
+  it('ADVISORY unknowns route to advisories, not the fix-first banner (self-resolving states, 2026-07-22)', () => {
+    // A scan warming up after a restart is an unknown the producer vouches
+    // self-resolves — it must not sit in "Fix first" as if a human were
+    // needed. Stale advisory unknowns still verify: the vouching is old.
+    const warmingUnknown = incident({
+      id: 'warming-unknown', status: 'unknown', disposition: 'advisory', title: 'Scan warming up',
+    })
+    const realUnknown = incident({ id: 'real-unknown', status: 'unknown', disposition: 'watch', title: 'Genuinely unverified' })
+    const staleAdvisoryUnknown = incident({
+      id: 'stale-advisory-unknown', status: 'unknown', disposition: 'advisory', title: 'Stale advisory unknown',
+      stale: true, staleAt: '2026-07-13T11:30:00.000Z', observedAt: '2026-07-13T09:00:00.000Z',
+    })
+    const incidents = [warmingUnknown, realUnknown, staleAdvisoryUnknown]
+    const observations = incidents.map((row) => observation(row))
+    const checks = observations.map((row) => check(row, 'observed'))
+
+    const model = buildHealthOverviewViewModel({
+      report: report({ incidents, observations, checks, status: 'needs_attention' }),
+      now: NOW,
+    })
+
+    expect(model.advisories.map((row) => row.incident.id)).toEqual(['warming-unknown'])
+    expect(model.unableToVerify.map((row) => row.incident.id).sort()).toEqual(['real-unknown', 'stale-advisory-unknown'])
+    expect(model.needsAction).toEqual([])
+  })
+
   it('demoted and raw-advisory incidents land in the advisories bucket — quiet, never hidden (#690)', () => {
     const demoted = incident({
       id: 'demoted-housekeeping', status: 'warning', disposition: 'watch', title: 'Retired tables await deletion',

--- a/tests/plugins/health/system-checks.test.ts
+++ b/tests/plugins/health/system-checks.test.ts
@@ -1147,6 +1147,7 @@ describe('plugin registration', () => {
       'search-engine-burn-restart',
       'search-outbox-revive',
       'search-spin-rebuild',
+      'spend-evidence-refresh-pricing',
       'sweep-run-dirs',
       'sync-skill',
     ])

--- a/tests/plugins/models/routes.test.ts
+++ b/tests/plugins/models/routes.test.ts
@@ -235,8 +235,8 @@ describe('Models Plugin Activation', () => {
     ])
   })
 
-  it('registers 10 hooks', () => {
-    expect(activated.ctx.hooks.register).toHaveBeenCalledTimes(10)
+  it('registers 11 hooks', () => {
+    expect(activated.ctx.hooks.register).toHaveBeenCalledTimes(11)
     const hookNames = (activated.ctx.hooks.register as ReturnType<typeof mock>).mock.calls.map(
       (c: unknown[]) => c[0]
     )
@@ -250,6 +250,7 @@ describe('Models Plugin Activation', () => {
       'models.markRuntimeRestarted',
       'models.priceImage',
       'models.priceTurn',
+      'models.refreshAvailableModels',
       'models.resolveBilling',
     ])
   })


### PR DESCRIPTION
Field feedback on rc.23 (both dev boxes): the new "documented resolutions" were still dead ends — one card told the operator to expand a card that was already expanded (the detail it referenced is never rendered), and another asked a human to visit a page to trigger what is actually a server-side cache refresh. The standard this PR enforces: **a health card names its exact evidence and resolves with a machine action wherever the fix is deterministic.** Prose instructions are only acceptable when the resolution genuinely requires a human or genuinely resolves itself — and then the copy says which.

## Changes

1. **Crashed-check cards carry their own error.** The generic "could not be verified" card synthesizes when a check throws; the error text now goes into the card copy itself (bounded to 300 chars) instead of pointing at an unrendered detail field. Steps reference only what is on screen.

2. **"Spend evidence is incomplete" names its gaps and repairs itself.**
   - The card copy now enumerates the actual gaps: `openai/gpt-5.5: unpriced — 3 runs`, `google/gemini-3-flash: billing lane unknown — 2 messages` (top 5, bounded).
   - A `value_missing` (unpriced model) gap gets a **one-click repair**: `spend-evidence-refresh-pricing` force-refreshes the model catalog with pricing through the models plugin's own hook — the deterministic version of "open the Models page." Honest failure modes: models plugin inactive, provider returned zero models (points at `bakin check llm`), fetch error surfaced verbatim.
   - Attribution-only gaps (lane/provider/model unknown) keep instructions, but the copy now says plainly: these complete on their own as transcripts land, caps stay fail-closed by design, report it only if gaps persist for hours.

3. **"Agent usage coverage is incomplete" says which state it is in.** The scan reason (`scan_in_progress` / `scan_not_run` / `scan_stale`) was buried in evidence; the card now states it in plain language with the honest expectation for each ("resolves itself when the scan completes; recheck in a minute" vs "the scanner may be stuck; report if staleness persists").

4. **New models-plugin surface:** `models.refreshAvailableModels` hook (rpc) + `fetchAvailableModels(ctx, { force: true })` — bypasses both caches and fetches the catalog live. Used by the repair; available to any consumer that needs guaranteed-fresh pricing.

5. **Model sha256 verification moved off the check path.** rc.23 hashed pinned model weights (hundreds of MB) inside `checkInferenceModels`, which runs on doctor cadence — on a loaded machine that blew check timeouts (caught as a 45s test flake under the parallel suite). Checks now verify structure only (pinned file names + sizes — the crash-loop class); hashing runs post-pull on the install path where it belongs. The adapter-gating test also gained `ANTFLY_HOME` isolation so no test reads the real model directory.

## Testing

New coverage: the pricing-gap incident carries the repair resolution and names the model in its copy; the repair's four outcomes (applied with count, plugin-inactive, zero-models → credentials pointer, fetch error surfaced); hook roster updated. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Root cause found and fixed: the generic Verify cards

While manually validating the worktree card with the new instrumentation, it named the failure class on the first reproduction: **checks that interpolate dynamic text into `summary` blow the contract's 500-char bound**, the contract rejects the whole run, and the doctor discarded the reason — leaving the useless generic card. Two schedule checks did exactly this with ~700-char runtime gateway errors; the field-reported git card is the same class on that box's state.

Fixed three ways: (1) the SDK observation builders now **clamp** summary/detail to contract bounds with an ellipsis — overlong copy truncates honestly instead of invalidating real evidence; (2) the two schedule call sites move the error into `detail` behind a static summary; (3) any residual validation failure now prints its exact failing field path on the card, in the log, and in the execution record. Verified end-to-end on a live server: zero contract failures after the fix, with the full gateway error intact in the card detail.

## Review + aggressiveness pass (second commit batch)

An independent code review on the branch found a Critical: the gap enumeration interpolated unbounded model ids into `incident.impact` (500-char bound the clamp didn't cover) — recreating the invalidation class this PR fixes. Fixed at both levels (bounded impact summary + clamp now covers impact), plus: gap dedupe, honest repair wording, full coverage-reason map, clamp hardening (trim/blank/surrogates), builders relocated to `@bakin/core` so adapters share the clamped path (Pi ported, team's error-interpolating summaries fixed), and a direct test for the issues-surfacing.

The aggressiveness audit ("the dashboard shouldn't always be lit up"): the Fix first banner included every unknown-status incident, sensitivity-blind. The contract now supports **advisory unknowns** (producer vouches the state self-resolves; `action_required` unknowns stay unrepresentable), warming states (post-restart scan, attribution-only spend gaps) use it and route to the quiet advisories section, and "Search is disabled" is classed `policy_denial` so a deliberate setting calms under standard sensitivity.