### PR TITLE
fix(sdk): drop dead type imports left by the builder relocation (lint)

### DIFF
--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -6,17 +6,6 @@
  * so plugins have a single import path instead of reaching into `@/lib/*`.
  */
 
-import type {
-  ErrorObservationInput,
-  HealthNonEmptyArray,
-  HealthObservationInput,
-  HealthyObservationInput,
-  NotApplicableHealthCheckRunInput,
-  ObservedHealthCheckRunInput,
-  UnknownObservationInput,
-  WarningObservationInput,
-} from '../types'
-
 // The observation builders live in @bakin/core so adapter packages (which
 // depend only on core) share the SAME clamped construction path as
 // plugins. This module re-exports them unchanged — plugin authors keep


### PR DESCRIPTION
Main is red on lint: the #720 builder relocation left orphaned type imports in `packages/sdk/src/utils/index.ts` (8 unused-import errors). This is the one-commit fix — it was pushed to the release branch moments after #721 merged and auto-deleted it, so the commit landed on a re-created branch with no PR. Lint passes locally with 0 errors (6 pre-existing warnings untouched).

Merge before tagging v0.0.1-rc.24 so the release cuts from a green main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)