### PR TITLE
fix(health): report wire mirror accepts advisory unknowns

### DIFF
--- a/plugins/health/lib/route-schemas.ts
+++ b/plugins/health/lib/route-schemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { HEALTH_INCIDENT_CLASSES } from '@makinbakin/sdk/types'
 import {
   actionIncidentInputSchema,
+  advisoryIncidentInputSchema,
   healthIncidentInputSchema,
   healthResourceSchema,
   healthResolutionSchema,
@@ -116,7 +117,12 @@ const unknownObservationSchema = z.object({
   ...canonicalObservationBase,
   status: z.literal('unknown'),
   incidentId: nonEmptyString,
-  incident: watchIncidentInputSchema,
+  // Mirror of the producer contract: watch, or advisory when the unknown
+  // self-resolves. This mirror lagging the contract made the CLIENT reject
+  // the ENTIRE health report the first time a server emitted an advisory
+  // unknown — "Health report response was invalid" on a healthy box
+  // (rc.24 field report, 2026-07-23). Keep the two in lockstep.
+  incident: z.union([watchIncidentInputSchema, advisoryIncidentInputSchema]),
 }).strict()
 
 export const canonicalHealthObservationSchema = z.discriminatedUnion('status', [

--- a/tests/plugins/health/route-schemas.test.ts
+++ b/tests/plugins/health/route-schemas.test.ts
@@ -47,6 +47,20 @@ describe('canonical Health HTTP observation schema', () => {
 
     expect(result.success).toBe(false)
   })
+
+  it('accepts an ADVISORY Unknown observation — the wire mirror must not lag the producer contract', () => {
+    // This mirror lagging the contract made the CLIENT reject the whole
+    // health report the first time a server emitted an advisory unknown:
+    // "Health report response was invalid" on a healthy box (rc.24 field
+    // report, 2026-07-23).
+    const result = canonicalHealthObservationSchema.safeParse({
+      ...observationBase,
+      status: 'unknown',
+      incident: { ...incidentBase, disposition: 'advisory' },
+    })
+
+    expect(result.success).toBe(true)
+  })
 })
 
 function canonicalReport() {


### PR DESCRIPTION
rc.24 field report: "Health report response was invalid" banner on a healthy box. The #720 contract widening (advisory unknowns) missed the client-side wire mirror — `route-schemas.ts` still pinned unknown incidents to watch-only, so the first advisory unknown a server emitted (the scan-warm-up card, minutes after every restart) made the client reject the whole report. Self-clears when the scan finishes on rc.24, but every restart re-triggers it until this ships.

One-line schema fix + regression test asserting the mirror accepts the advisory-unknown shape (and still rejects action_required unknowns). Wants an rc.25 tag once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)