### PR TITLE
fix(health): resource ids/labels normalize at the builders — closes the worktree-card mystery

### DIFF
--- a/packages/core/src/health/observation-builders.ts
+++ b/packages/core/src/health/observation-builders.ts
@@ -43,7 +43,27 @@ function truncate(value: string, max: number): string {
   return `${value.slice(0, end)}…`
 }
 
-function clampCopy<T extends { summary: string; detail?: string; incident?: { impact: string } }>(input: T): T {
+const RESOURCE_LABEL_MAX = 120
+const STABLE_ID_PATTERN = /^[a-z0-9][a-z0-9._:-]{0,127}$/
+
+type ResourceLike = { id: string; label?: string }
+
+function normalizeResources<R extends ResourceLike>(resources: R[]): R[] {
+  return resources.map((resource) => {
+    const next = { ...resource }
+    // Deterministic sanitize is identity on already-valid ids — only
+    // contract-invalid ids (a filesystem path, uppercase, slashes) change.
+    if (!STABLE_ID_PATTERN.test(next.id)) next.id = healthResourceId(next.id)
+    if (next.label !== undefined) {
+      const label = next.label.trim()
+      if (label.length === 0) delete next.label
+      else next.label = truncate(label, RESOURCE_LABEL_MAX)
+    }
+    return next
+  })
+}
+
+function clampCopy<T extends { summary: string; detail?: string; incident?: { impact: string; resources?: ResourceLike[] } }>(input: T): T {
   const clamped = { ...input }
   const summary = clamped.summary.trim()
   clamped.summary = truncate(summary.length > 0 ? summary : '(no summary provided)', SUMMARY_MAX)
@@ -55,8 +75,11 @@ function clampCopy<T extends { summary: string; detail?: string; incident?: { im
       clamped.detail = truncate(detail, DETAIL_MAX)
     }
   }
-  if (clamped.incident && clamped.incident.impact.length > IMPACT_MAX) {
-    clamped.incident = { ...clamped.incident, impact: truncate(clamped.incident.impact, IMPACT_MAX) }
+  if (clamped.incident) {
+    const incident = { ...clamped.incident }
+    if (incident.impact.length > IMPACT_MAX) incident.impact = truncate(incident.impact, IMPACT_MAX)
+    if (incident.resources) incident.resources = normalizeResources(incident.resources)
+    clamped.incident = incident
   }
   return clamped
 }
@@ -91,4 +114,22 @@ export function healthObserved(
 /** Build an explicit successful not-applicable run. */
 export function healthNotApplicable(reason: string): NotApplicableHealthCheckRunInput {
   return { outcome: 'not_applicable', reason }
+}
+
+/**
+ * Deterministically coerce arbitrary text (a filesystem path, a table
+ * name, a task id) into the contract's stable resource-id format
+ * (`^[a-z0-9][a-z0-9._:-]{0,127}$`). A raw path used as a resource id
+ * failed contract validation and nuked a REAL finding into a generic
+ * "could not be verified" card for three releases (field-diagnosed
+ * 2026-07-23). Put the human-readable original in `label`, never in `id`.
+ */
+export function healthResourceId(raw: string): string {
+  const sanitized = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9._:-]+/g, '-')
+    .replace(/^[^a-z0-9]+/, '')
+    .replace(/-+$/, '')
+    .slice(0, 128)
+  return sanitized.length > 0 ? sanitized : 'unknown'
 }

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -15,6 +15,7 @@ export {
   healthHealthy,
   healthNotApplicable,
   healthObserved,
+  healthResourceId,
   healthUnknown,
   healthWarning,
 } from '../../../core/src/health/observation-builders'

--- a/plugins/git/index.ts
+++ b/plugins/git/index.ts
@@ -15,6 +15,7 @@ import type {
   PluginContext,
 } from '@bakin/core/plugin-types'
 import { healthHealthy, healthObserved, healthWarning } from '@makinbakin/sdk/utils'
+import { healthResourceId } from '@bakin/core/health/observation-builders'
 import type { PluginContextLite } from '@bakin/core/routing'
 import { definePlugin, defineRoute } from '@bakin/core/routing'
 import { getContentDir } from '../../packages/core/src/content-dir'
@@ -542,7 +543,13 @@ export async function checkWorktrees(ctx: PluginContextLite): Promise<HealthChec
           title: 'A tracked Git worktree is missing',
           impact: `Task ${entry.taskId} may no longer have its isolated working directory.`,
           disposition: 'action_required',
-          resources: [{ kind: 'task', id: entry.taskId, label: entry.taskId }, { kind: 'directory', id: entry.worktreePath }],
+          // Resource ids must satisfy the contract's stable-key format — a
+          // raw path here failed validation and hid this REAL finding
+          // behind a generic Verify card for three releases (2026-07-23).
+          resources: [
+            { kind: 'task', id: healthResourceId(entry.taskId), label: entry.taskId.slice(0, 120) },
+            { kind: 'directory', id: healthResourceId(entry.worktreePath), label: entry.worktreePath.slice(0, 120) },
+          ],
           resolution: { key: 'release-worktree', type: 'instructions', label: 'Review worktree', steps: ['Confirm the task no longer needs this worktree, then release its stale registry entry with the Git release tool.'] },
         },
       })) as [ReturnType<typeof healthWarning>, ...ReturnType<typeof healthWarning>[]])

--- a/plugins/health/lib/system-checks/run-dirs.ts
+++ b/plugins/health/lib/system-checks/run-dirs.ts
@@ -33,8 +33,12 @@ export async function checkRunDirs(): Promise<HealthCheckRunInput> {
       incident: {
         key: 'no-sweep-yet',
         title: 'Run-workspace usage unknown',
-        impact: 'Disk growth from per-run agent working directories is unmonitored until the first sweep.',
-        disposition: 'watch',
+        impact: 'Disk growth from per-run agent working directories is unmonitored until the first watchdog sweep completes — it runs on its own shortly after boot; Sweep now measures immediately.',
+        // Boot-warming state: the watchdog's first pass resolves this on
+        // its own within minutes — advisory keeps it out of the Fix first
+        // banner that lit up after every restart (aggressiveness pass,
+        // 2026-07-23; same treatment as the transcript-scan warm-up).
+        disposition: 'advisory',
         class: 'cleanup_backlog',
         resources: [{ kind: 'system', id: 'run-workspaces', label: '~/.bakin/run-workspaces' }],
         resolution: { key: 'sweep', type: 'repair', actionId: 'sweep-run-dirs', label: 'Sweep now' },

--- a/tests/core/health-contract.test.ts
+++ b/tests/core/health-contract.test.ts
@@ -592,3 +592,42 @@ describe('unknown incidents may be advisory — never action_required (2026-07-2
     expect(safeParseHealthCheckRunInput(unknownWith('action_required')).success).toBe(false)
   })
 })
+
+describe('builders normalize incident resources (2026-07-23)', () => {
+  // A filesystem path used as a resource id failed contract validation and
+  // hid a REAL stale-worktree finding behind a generic Verify card for
+  // three releases. Builders sanitize invalid ids deterministically (valid
+  // ids pass through untouched) and bound labels.
+  it('sanitizes a path id, bounds a long label, and the result passes the contract', async () => {
+    const { healthWarning, healthObserved } = await import('@makinbakin/sdk/utils')
+    const observation = healthWarning({
+      key: 'missing.w1',
+      summary: 'The worktree for task t1 is missing.',
+      incident: {
+        key: 'missing.w1',
+        title: 'A tracked Git worktree is missing',
+        impact: 'Task t1 may no longer have its working directory.',
+        disposition: 'action_required',
+        resources: [
+          { kind: 'task', id: 'task-1', label: 'T'.repeat(200) },
+          { kind: 'directory', id: '/Users/margo/.bakin/run-workspaces/Agent X/repo' },
+        ],
+        resolution: { key: 'release', type: 'rerun', label: 'Check again' },
+      },
+    })
+    const resources = observation.incident.resources!
+    expect(resources[0]!.id).toBe('task-1') // valid id untouched
+    expect(resources[0]!.label!.length).toBe(120)
+    expect(resources[1]!.id).toBe('users-margo-.bakin-run-workspaces-agent-x-repo')
+
+    const result = safeParseHealthCheckRunInput(healthObserved([observation]))
+    expect(result.success).toBe(true)
+  })
+
+  it('healthResourceId is deterministic and identity on valid ids', async () => {
+    const { healthResourceId } = await import('@makinbakin/sdk/utils')
+    expect(healthResourceId('already-valid.id:1')).toBe('already-valid.id:1')
+    expect(healthResourceId('/Some/Path')).toBe(healthResourceId('/Some/Path'))
+    expect(healthResourceId('///')).toBe('unknown')
+  })
+})


### PR DESCRIPTION
The rc.25 instrumentation finally named the three-release mystery on the second box: `observations.0.incident.resources.1.id: Value has an invalid format.` The git check wasn't crashing — it found a REAL stale worktree and reported it with the worktree's filesystem path as a resource **id**, which the contract's stable-key format rightly rejects. The whole run was then discarded into the generic Verify card, hiding a legitimate finding since rc.22.

This closes the last copy-shape that could invalidate a run wholesale:

- `healthResourceId()` — deterministic stable-key sanitizer beside the shared builders (SDK re-exported). Identity on already-valid ids, so nothing stable shifts.
- The builders normalize `incident.resources`: invalid ids sanitize deterministically; labels trim and bound to 120 chars. The sweep found the next landmine already in place — `plugins/tasks` puts unbounded task titles in resource labels; one 121-char title would have nuked the tasks check the same way.
- The git producer carries paths in `label` (bounded) with sanitized ids.

Regression tests: path-id sanitize + long-label bound round-trip the contract; sanitizer determinism + identity pinned.

Open question still being probed on the affected box: the server emits the stale-worktree observation while the shell sees no registry file at `~/.bakin/plugin-data/git/worktrees.json` — a launchd HOME divergence is suspected and under investigation (read-only probes sent). This fix makes the finding VISIBLE either way, which is what unblocks that investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)