### PR TITLE
fix: text-only PDF support inside compiled binaries (#746)

### DIFF
--- a/.claude/knowledge/release-pipeline.md
+++ b/.claude/knowledge/release-pipeline.md
@@ -143,6 +143,20 @@ Full yank is only for leaked secrets or active security vulnerabilities:
 
 ## User Install UX
 
+## Compiled-binary PDF constraint (#746)
+
+Single-file binaries CANNOT render PDF pages: `@napi-rs/canvas`'s platform
+loader breaks under `$bunfs` (the raw `.node` addon itself DOES embed — the
+blocker is the package's resolution, not Bun). The engine handles the split:
+text extraction (`readPdf`, and therefore asset PDF indexing) works in
+binaries via canvas-less stubs + pdf-parse's embedded data-URL worker
+(`installCanvaslessStubs` + `setWorker(getData())` in
+`src/core/pdf/engine.ts`); `renderPdfPages` throws a typed `pdf_unavailable`
+with an honest message. `bun run verify:compiled-pdf` proves both halves
+against a real compiled binary — run it when touching the engine's import
+story or bumping pdf-parse. Re-evaluate full render support on future Bun
+releases (the `.node`-embeds finding suggests it may become tractable).
+
 Preferred macOS install:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint src packages plugins tests scripts dev cli server.ts bakin.config.ts eslint.config.mjs",
     "lint:home-bypasses": "bun run scripts/bin/check-home-bypasses.mjs",
     "typecheck": "tsc -p tsconfig.app.json --noEmit",
+    "verify:compiled-pdf": "bun run scripts/verify-compiled-pdf.ts",
     "check:cycles": "bun scripts/check-cycles.ts",
     "test": "bun test --parallel=4 --isolate --timeout 15000 --path-ignore-patterns \"dev/**\"",
     "test:components": "bun test --isolate tests/components",

--- a/scripts/verify-compiled-pdf.ts
+++ b/scripts/verify-compiled-pdf.ts
@@ -1,0 +1,42 @@
+/**
+ * Compiled-binary PDF smoke check (#746 exit b) — proves the engine's
+ * canvas-less text path inside a REAL `bun build --compile` binary:
+ *   1. readPdf extracts the text fixture's sentinel (stubs + embedded worker),
+ *   2. renderPdfPages throws the typed `pdf_unavailable` (honest degrade).
+ *
+ * Run manually or from release verification: `bun run verify:compiled-pdf`.
+ * Kept OUT of the test suite — it compiles a binary (seconds, disk churn).
+ */
+import { execFileSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const repoRoot = join(import.meta.dir, '..')
+const workDir = mkdtempSync(join(tmpdir(), 'bakin-compiled-pdf-'))
+const entry = join(repoRoot, '.compiled-pdf-smoke-entry.ts') // repo root: node_modules must resolve at build time
+
+writeFileSync(entry, `
+import { readPdf, renderPdfPages, PdfError } from './src/core/pdf/engine'
+const fixture = process.argv[2]!
+const text = await readPdf(fixture)
+if (!text.pages[0]!.text.includes('alpha-7291')) throw new Error('sentinel missing — text path broken')
+try {
+  await renderPdfPages(fixture)
+  throw new Error('render unexpectedly succeeded in a compiled binary')
+} catch (err) {
+  if (!(err instanceof PdfError) || err.kind !== 'pdf_unavailable') throw err
+}
+console.log('COMPILED-PDF-SMOKE PASS')
+`)
+
+try {
+  const binary = join(workDir, 'smoke')
+  execFileSync('bun', ['build', '--compile', entry, '--outfile', binary], { cwd: repoRoot, stdio: 'pipe' })
+  const out = execFileSync(binary, [join(repoRoot, 'tests/fixtures/pdf/text.pdf')], { stdio: 'pipe' }).toString()
+  if (!out.includes('COMPILED-PDF-SMOKE PASS')) throw new Error(`unexpected output: ${out}`)
+  console.log('verify-compiled-pdf: PASS (text extraction works, render degrades honestly)')
+} finally {
+  rmSync(entry, { force: true })
+  rmSync(workDir, { recursive: true, force: true })
+}

--- a/src/core/pdf/engine.ts
+++ b/src/core/pdf/engine.ts
@@ -9,11 +9,15 @@
  * subsetting, CID fonts, and text matrices — the three features every
  * design-tool PDF uses; pdfjs handles all of them. See Bakin issue #72.
  *
- * Compiled-binary caveat (#742 T0 spike): `bun build --compile` does not
- * embed pdf-parse's @napi-rs/canvas native addon, and without its DOMMatrix
- * polyfill the pdf-parse IMPORT itself throws. Repo-tree runs are unaffected.
- * The lazy import wraps that failure as a typed `pdf_unavailable` error so
- * callers degrade honestly instead of surfacing a cryptic DOMMatrix crash.
+ * Compiled-binary story (#746, spike-proven): `bun build --compile` cannot
+ * deliver @napi-rs/canvas (its platform loader breaks under $bunfs), but
+ * TEXT extraction needs no canvas at all — in a compiled binary this module
+ * installs minimal DOMMatrix/ImageData/Path2D stubs before the pdf-parse
+ * import and points pdfjs at the EMBEDDED data-URL worker
+ * (`pdf-parse/worker` getData()), so readPdf works everywhere. RENDERING
+ * genuinely requires the native canvas: renderPdfPages throws a typed
+ * `pdf_unavailable` in compiled binaries — honest, never a cryptic crash.
+ * Repo-tree runs (the production box) use the real canvas polyfills.
  */
 import { existsSync, mkdtempSync, openSync, readSync, closeSync, readFileSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
@@ -149,17 +153,50 @@ function assertReadablePdf(path: string): void {
 
 type PdfParseModule = typeof import('pdf-parse')
 
+/** True inside a `bun build --compile` single-file binary. */
+export function isCompiledBinary(): boolean {
+  // Bun.main isn't in the app tsconfig's Bun typings — structural access.
+  const main = typeof Bun !== 'undefined' ? (Bun as unknown as { main?: string }).main : undefined
+  return typeof main === 'string' && main.startsWith('/$bunfs/')
+}
+
+/**
+ * Minimal canvas-less globals for pdfjs module-init + text extraction —
+ * ONLY installed in compiled binaries, where @napi-rs/canvas can't load
+ * (repo-tree runs get the real polyfills). Text extraction never draws;
+ * these exist to satisfy module-scope construction. Exported for tests.
+ */
+export function installCanvaslessStubs(g: Record<string, unknown> = globalThis as unknown as Record<string, unknown>): void {
+  class StubDOMMatrix {
+    a = 1; b = 0; c = 0; d = 1; e = 0; f = 0
+    scale() { return this }
+    translate() { return this }
+    multiply() { return this }
+    transformPoint(p: { x: number; y: number }) { return p }
+  }
+  g.DOMMatrix ??= StubDOMMatrix
+  g.ImageData ??= class { constructor(readonly width: number, readonly height: number) {} }
+  g.Path2D ??= class { addPath() {} moveTo() {} lineTo() {} closePath() {} }
+}
+
 let modulePromise: Promise<PdfParseModule> | undefined
 
 async function loadPdfParse(): Promise<PdfParseModule> {
-  modulePromise ??= import('pdf-parse').catch((err: unknown) => {
+  modulePromise ??= (async () => {
+    const compiled = isCompiledBinary()
+    if (compiled) installCanvaslessStubs()
+    const mod = await import('pdf-parse')
+    if (compiled) {
+      // pdfjs's default fake-worker load is a computed dynamic import that
+      // cannot survive bundling — point it at the EMBEDDED data-URL worker.
+      const { getData } = await import('pdf-parse/worker')
+      ;(mod.PDFParse as unknown as { setWorker: (src: string) => void }).setWorker(getData())
+    }
+    return mod
+  })().catch((err: unknown) => {
     modulePromise = undefined
     log.error('pdf-parse failed to load — PDF features unavailable', err as Error)
-    throw new PdfError(
-      'pdf_unavailable',
-      'PDF support failed to load. This is expected inside a compiled single-file binary ' +
-        '(native canvas addon not embedded); run from a source checkout for PDF features.',
-    )
+    throw new PdfError('pdf_unavailable', `PDF support failed to load: ${(err as Error).message}`)
   })
   return modulePromise
 }
@@ -207,6 +244,16 @@ export async function readPdf(path: string, pages?: number[]): Promise<PdfTextRe
 /** Render pages to PNGs in a fresh tmpdir. Output is ephemeral by design —
  * the OS owns cleanup (mirrors the image-downscale pipeline; no GC system). */
 export async function renderPdfPages(path: string, pages?: number[]): Promise<PdfRenderResult> {
+  if (isCompiledBinary()) {
+    // Rendering draws through @napi-rs/canvas, whose native addon cannot be
+    // delivered inside a single-file binary (#746 spike). Text extraction
+    // (readPdf) works everywhere — say exactly that.
+    throw new PdfError(
+      'pdf_unavailable',
+      'PDF page rendering is unavailable inside a compiled binary (native canvas cannot be embedded). ' +
+        'Text extraction still works; for rendering, run from a source checkout.',
+    )
+  }
   if (pages && pages.length > RENDER_MAX_PAGES) {
     throw new PdfError(
       'over_limit',

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9,8 +9,8 @@ Plan: `tasks/plan.md` · Spec: `SPEC.md`
 - [ ] CP-A Gate: full suite + lint + cycles → Mark live-test (scanned PDF → searchable + Spend rows) → PR → merge → close #747
 
 ## Phase B (after CP-A; branch only for exits a/b)
-- [ ] B1  Spike ladder: addon-in-binary → polyfill-stub text → unpdf swap (timeboxed; findings recorded here)
-- [ ] B2  Exit implementation: (a) full fix / (b) text-only + honest render → branch+PR; (c) docs-only wontfix → main directly
+- [x] B1  Spike: .node addons DO embed (r1c) but canvas loader breaks under $bunfs; TEXT works canvas-less via DOMMatrix/ImageData/Path2D stubs + PDFParse.setWorker(pdf-parse/worker getData()) — exit (b); unpdf unnecessary
+- [x] B2  Exit (b) SHIPPED: canvas-less text in binaries + honest render degrade + verify:compiled-pdf smoke
 - [ ] CP-B Gate: per exit — PR/merge or docs commit + close #746 with findings
 
 ## Phase C (after CP-B — PARK-LEAN, consumer = linux-hosted server)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,7 +14,7 @@ Plan: `tasks/plan.md` · Spec: `SPEC.md`
 - [ ] CP-B Gate: per exit — PR/merge or docs commit + close #746 with findings
 
 ## Phase C (after CP-B — PARK-LEAN, consumer = linux-hosted server)
-- [ ] GATE FIRST Mark decision with in-hand findings: park now (recommended) or spike
-- [ ] C1  (on "spike") static tesseract spike (sandbox-rig; ocrs fallback) → second gate
-- [ ] C2  (on "ship") bits mirror release + pack 0.2.0 + sandbox rig verify + PRs
+- [x] GATE  Mark decision: PARK — #745 closed with findings + reopen criteria
+- [-] C1  (n/a — parked)
+- [-] C2  (n/a — parked)
 - [ ] CP-C Close #745 (shipped or parked) · memory update · delete SPEC.md + tasks files · summary comments

--- a/tests/core/pdf/engine.test.ts
+++ b/tests/core/pdf/engine.test.ts
@@ -166,6 +166,29 @@ describe('capPageTexts', () => {
   })
 })
 
+describe('canvas-less stubs (#746 exit b)', () => {
+  test('installs only missing globals and never clobbers existing ones', async () => {
+    const { installCanvaslessStubs } = await import('../../../src/core/pdf/engine')
+    const g: Record<string, unknown> = { DOMMatrix: 'existing' }
+    installCanvaslessStubs(g)
+    expect(g.DOMMatrix).toBe('existing') // ??= never clobbers
+    expect(typeof g.ImageData).toBe('function')
+    expect(typeof g.Path2D).toBe('function')
+    const M = g.DOMMatrix as unknown
+    const fresh: Record<string, unknown> = {}
+    installCanvaslessStubs(fresh)
+    const m = new (fresh.DOMMatrix as new () => { scale(): unknown; a: number })()
+    expect(m.a).toBe(1)
+    expect(m.scale()).toBe(m)
+    void M
+  })
+
+  test('isCompiledBinary is false under bun test (repo-tree run)', async () => {
+    const { isCompiledBinary } = await import('../../../src/core/pdf/engine')
+    expect(isCompiledBinary()).toBe(false)
+  })
+})
+
 describe('PdfError', () => {
   test('is an Error with a kind', () => {
     const err = new PdfError('not_found', 'nope')


### PR DESCRIPTION
Phase B of the #742 follow-ups — spike exit (b), pre-approved in `SPEC.md`.

**Spike findings (ladder):** (1) Bun DOES embed raw `.node` addons in compiled binaries — but `@napi-rs/canvas`'s platform loader can't resolve under `$bunfs`, so full render means pdf-parse-internals surgery: not worth it. (2) Text extraction needs no canvas: three global stubs + pdf-parse's embedded data-URL worker (`pdf-parse/worker` `getData()`) make `readPdf` work in a real compiled binary. (3) unpdf unnecessary — rung 2 wins with zero engine churn.

**What ships:** in compiled binaries the engine auto-installs the stubs + embedded worker (repo-tree runs untouched — they keep the real canvas polyfills); `renderPdfPages` throws a typed `pdf_unavailable` with an honest message. Net effect: **release-binary asset PDF indexing — silently broken until now — works**; rendering degrades honestly instead of crashing on DOMMatrix.

**Verification:** `bun run verify:compiled-pdf` compiles a real binary and asserts both halves (in-repo script, kept out of the suite). Full suite 8426/0 · lint 0 errors · cycles clean. Detection is `Bun.main` under `/$bunfs/` — false in every repo-tree context, pinned by test.

Closes #746 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)