### PR TITLE
fix(design-system): regenerate the compatibility matrix after the bits repin

### DIFF
--- a/design-system/compatibility.json
+++ b/design-system/compatibility.json
@@ -7,7 +7,7 @@
   ],
   "repositories": {
     "bakin": {
-      "ref": "f53ab06cb5fa5a25f2b5198528983d81dce0c23c"
+      "ref": "2fbb91ad14e5bae95c4692f21e7065d2b6e0f5e9"
     },
     "bakin-bits-official": {
       "ref": "914aff30b8cf877fb81648890889e1f391a22382"
@@ -21,7 +21,7 @@
     "messaging": {
       "repository": "bakin-bits-official",
       "role": "official-plugin",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "bakinRange": ">=0.0.1-rc.1",
       "routes": {
         "total": 5,
@@ -37,7 +37,7 @@
     "projects": {
       "repository": "bakin-bits-official",
       "role": "official-plugin",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "bakinRange": ">=0.0.1-rc.1",
       "routes": {
         "total": 4,


### PR DESCRIPTION
**Main CI has been red since `2fbb91ad1`**, and because `ui:census:check` also runs in PR
CI, it makes *every* new branch red before it changes a line. That's what this unblocks.

## Cause

`2fbb91ad1` repointed `design-system/compatibility.json` at bakin-bits-official #95 **by
hand**, without running `ui:census:generate`. The matrix records data *derived* from the
pinned bits ref, so moving the pin without regenerating leaves the derived half stale.

## Why this isn't "regenerate until green"

The UI conformance rule is explicit that artifacts must never be regenerated merely to make
a failure pass, so I checked what actually moves:

- `design-system/census.json` — **byte-identical**, 102 entries
- every route and slot count — **unchanged**
- the entire diff is 3 lines:

```
repositories.bakin.ref     f53ab06 -> 2fbb91a   (4 commits behind -> current)
plugins.messaging.version    0.9.2 -> 0.10.0
plugins.projects.version     0.8.2 -> 0.9.0
```

Those two versions moved because the pinned bits ref moved to its main, where both plugins
were bumped. No UI surface changed. This finishes the change the previous commit started.

## Verification

Reproduced the way CI resolves it — a worktree at the pinned `914aff30b8` with
`BAKIN_DOCS_EXTERNAL_SOURCES` pointed at its `plugins/`:

- before: `UI census is stale or invalid: - official SDK compatibility matrix is stale` (a
  single error — nothing else had drifted)
- after: `Official UI census valid: 102 entries across core and official Bits`
- sibling gate: `Legacy UI style ratchet valid: 12 paths; 69 findings covered by approved
  exceptions; no new or increased debt`

Lint and typecheck clean.

## Two observations, neither blocking

1. `tests/scripts/build-sdk-package.test.ts` fails **locally** on clean main (4 tests):
   *"SDK stylesheet does not match the canonical artifact."* A local `bun run build:css`
   does produce different bytes than the committed `packages/sdk/styles.css` — but CI's test
   shards are green, so the artifact matches CI's build and not mine. Most likely local
   build output present in my tree that CI doesn't have at test time. Pre-existing and
   unrelated to this PR; flagging it as a possible local/CI divergence worth a look.
2. `ui:legacy-styles:check` failed for me until `bun install` — the tree needed syncing
   after the design-system work landed new dev deps.

## UI conformance

```text
UI conformance
- Pattern: n/a — no UI surface touched (generated inventory data only)
- Contract: n/a
- Story/style-guide update: not needed (census.json byte-identical, 102 entries)
- Deviation: none
- Verification: ui:census:check, ui:legacy-styles:check against the pinned bits ref; lint; typecheck
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)