### PR TITLE
Fix: flow workspaces drop the pre-stick compact-row reservation (tasks stats gap)

### DIFF
--- a/packages/ui/src/patterns/workspace-page.tsx
+++ b/packages/ui/src/patterns/workspace-page.tsx
@@ -133,6 +133,7 @@ export function WorkspacePageCompactHeader({
   title,
   ...props
 }: WorkspacePageCompactHeaderProps) {
+  const { flow } = React.useContext(WorkspacePageContext)
   // Desktop shows this row only once it is actually stuck (the full header
   // has scrolled away) — pre-scroll it would duplicate the identity and
   // actions. Mobile keeps it always visible: the immersive full header
@@ -165,10 +166,15 @@ export function WorkspacePageCompactHeader({
         // beneath); in flow it would stack a second rule on the section
         // divider below it.
         stuck && 'border-b border-bakin-border-subtle',
-        // invisible (not hidden): the row's flow box must keep contributing
-        // its height to the scroll length or the shell can never scroll far
-        // enough to stick it — pre-stick it reads as header breathing room.
-        !stuck && '@md/page-shell:invisible',
+        // Pre-stick desktop treatment depends on the workspace's scroll
+        // model. Viewport-fit canvases (non-flow): `invisible` — the row's
+        // flow box must keep contributing its height to the scroll length
+        // or the shell can never scroll far enough to stick it. Flow
+        // workspaces: `hidden` — scroll length is content-driven, so the
+        // reserved box is pure dead band between header and body (the
+        // tasks stats gap); the row appears at its sticky position with
+        // no layout shift because its flow slot is already off-screen.
+        !stuck && (flow ? '@md/page-shell:hidden' : '@md/page-shell:invisible'),
         className,
       )}
     >


### PR DESCRIPTION
The oversized gap between the tasks header and the ACTIVE/BLOCKED stats strip was the compact sticky row's pre-stick 56px flow reservation (`invisible`). That reservation is load-bearing only for viewport-fit canvases (workflows — the shell can't scroll far enough to stick the row without it); flow workspaces have content-driven scroll length and don't need it. Pre-stick treatment is now flow-aware: `hidden` in flow, `invisible` otherwise.

Screenshot-verified on the live rig: header→stats rhythm now matches the other sections; the scrolled minify (pinned Tasks/Board/Log/New-Task row) is unchanged; workflows' viewport-fit math untouched (non-flow keeps `invisible`, pinned by the existing workspace-page test).

Suite 9,251 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)