### PR TITLE
chore(design-system): make the style ratchet tighten, not just hold

### DIFF
--- a/design-system/exceptions.json
+++ b/design-system/exceptions.json
@@ -154,10 +154,7 @@
         "src/components/provider-keys-tab.tsx",
         "packages/host/src/components/layout/sidebar-nav-item.tsx",
         "packages/host/src/components/runtime/runtimes-tab.tsx",
-        "plugins/workflows/components/workflow-card.tsx",
-        "plugins/workflows/components/workflow-canvas-editor.tsx",
-        "plugins/workflows/components/approvals-badge-provider.tsx",
-        "plugins/brands/components/brand-builder.tsx"
+        "plugins/workflows/components/workflow-canvas-editor.tsx"
       ],
       "allowances": {
         "src/components/conversation/reply-toast.tsx": {

--- a/design-system/kit-coverage.json
+++ b/design-system/kit-coverage.json
@@ -3,7 +3,6 @@
   "generatedBy": "bun run ui:kit-coverage:generate",
   "undemonstrated": [
     "@makinbakin/sdk/conversation :: ConversationReplyToast",
-    "@makinbakin/sdk/conversation :: CopyButton",
     "@makinbakin/sdk/conversation :: QueuedMessageList",
     "@makinbakin/sdk/conversation :: ToolCallRow",
     "@makinbakin/sdk/conversation :: TurnTimestamp",

--- a/design-system/migrations.json
+++ b/design-system/migrations.json
@@ -20,11 +20,11 @@
     "private-import"
   ],
   "summary": {
-    "paths": 111,
+    "paths": 106,
     "totals": {
       "raw-palette": 2,
       "arbitrary-size": 29,
-      "raw-scale": 1019,
+      "raw-scale": 876,
       "raw-control": 3,
       "inline-style": 3,
       "generic-token": 72,
@@ -198,7 +198,7 @@
       "status": "legacy-allowed",
       "allowances": {
         "arbitrary-size": 1,
-        "raw-scale": 81,
+        "raw-scale": 75,
         "inline-style": 1
       }
     },
@@ -216,7 +216,7 @@
       "status": "legacy-allowed",
       "allowances": {
         "arbitrary-size": 1,
-        "raw-scale": 7
+        "raw-scale": 6
       }
     },
     {
@@ -292,7 +292,7 @@
       "target": "canonical shell layout and namespaced semantic tokens",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 47
+        "raw-scale": 46
       }
     },
     {
@@ -397,22 +397,7 @@
       "target": "runtime settings archetype and supported SDK UI",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 28
-      }
-    },
-    {
-      "path": "packages/host/src/components/runtime/extensions-section.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "host"
-      },
-      "censusEntryId": "shared-component:packages/host/src/components/runtime/extensions-section",
-      "migrationTask": "T46b",
-      "archetype": "settings-form",
-      "target": "runtime settings archetype and supported SDK UI",
-      "status": "legacy-allowed",
-      "allowances": {
-        "raw-scale": 17
+        "raw-scale": 2
       }
     },
     {
@@ -427,22 +412,7 @@
       "target": "runtime settings archetype and supported SDK UI",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 42
-      }
-    },
-    {
-      "path": "packages/host/src/components/runtime/runtimes-tab.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "host"
-      },
-      "censusEntryId": "shared-component:packages/host/src/components/runtime/runtimes-tab",
-      "migrationTask": "T46b",
-      "archetype": "settings-form",
-      "target": "runtime settings archetype and supported SDK UI",
-      "status": "legacy-allowed",
-      "allowances": {
-        "raw-scale": 42
+        "raw-scale": 2
       }
     },
     {
@@ -518,7 +488,7 @@
       "target": "supported host UI and namespaced semantic tokens",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 5
+        "raw-scale": 2
       }
     },
     {
@@ -608,7 +578,7 @@
       "target": "focused SDK primitive/pattern and namespaced semantic tokens",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 13
+        "raw-scale": 12
       }
     },
     {
@@ -736,7 +706,7 @@
       "target": "brand list/detail/form archetypes and supported SDK UI",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 22
+        "raw-scale": 20
       }
     },
     {
@@ -785,54 +755,6 @@
       "status": "legacy-allowed",
       "allowances": {
         "raw-scale": 2
-      }
-    },
-    {
-      "path": "plugins/explore/components/catalog-card.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "plugin",
-        "pluginId": "explore"
-      },
-      "censusEntryId": "plugin-slot:explore:page:/explore",
-      "migrationTask": "T54",
-      "archetype": "list-index",
-      "target": "catalog archetype and supported SDK UI",
-      "status": "legacy-allowed",
-      "allowances": {
-        "raw-scale": 2
-      }
-    },
-    {
-      "path": "plugins/explore/components/detail-drawer.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "plugin",
-        "pluginId": "explore"
-      },
-      "censusEntryId": "plugin-slot:explore:page:/explore",
-      "migrationTask": "T54",
-      "archetype": "list-index",
-      "target": "catalog archetype and supported SDK UI",
-      "status": "legacy-allowed",
-      "allowances": {
-        "raw-scale": 1
-      }
-    },
-    {
-      "path": "plugins/explore/components/hub-skills-section.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "plugin",
-        "pluginId": "explore"
-      },
-      "censusEntryId": "plugin-slot:explore:page:/explore",
-      "migrationTask": "T54",
-      "archetype": "list-index",
-      "target": "catalog archetype and supported SDK UI",
-      "status": "legacy-allowed",
-      "allowances": {
-        "raw-scale": 1
       }
     },
     {

--- a/scripts/ui/check-legacy-styles.ts
+++ b/scripts/ui/check-legacy-styles.ts
@@ -471,6 +471,26 @@ export function diffLegacyStyleReport(
       }
     }
   }
+
+  // The ratchet has to tighten, not just hold. Without this, an allowance that
+  // has been paid down stays at its old ceiling forever and the debt can creep
+  // straight back in unnoticed — which is exactly what happened across the
+  // 13-surface conformance sweep. Exceptions already fail this way (see
+  // `applyLegacyStyleExceptions`); migrations now match them.
+  for (const entry of migrations.entries) {
+    const counts = actual.byPath[entry.path]
+    for (const rule of LEGACY_STYLE_RULES) {
+      const allowedCount = entry.allowances[rule]
+      if (allowedCount === undefined) continue
+      const actualCount = counts?.[rule] ?? 0
+      if (allowedCount > actualCount) {
+        errors.push(
+          `stale migration allowance: ${entry.path} ${rule} records ${allowedCount} `
+          + `but only ${actualCount} remain; run bun run ui:legacy-styles:generate`,
+        )
+      }
+    }
+  }
   return errors
 }
 

--- a/tests/ui/architecture/style-ratchet.test.ts
+++ b/tests/ui/architecture/style-ratchet.test.ts
@@ -130,16 +130,16 @@ describe('scanLegacyStyles', () => {
 })
 
 describe('diffLegacyStyleReport', () => {
-  it('allows unchanged or reduced debt but rejects a path increase and a new rule', () => {
+  it('allows unchanged debt but rejects a path increase and a new rule', () => {
     const expected = migrations('plugins/example/components/card.tsx', {
       'raw-palette': 2,
       'raw-control': 1,
     })
 
     expect(diffLegacyStyleReport(expected, {
-      totals: { 'raw-palette': 1, 'raw-control': 1 },
+      totals: { 'raw-palette': 2, 'raw-control': 1 },
       byPath: {
-        'plugins/example/components/card.tsx': { 'raw-palette': 1, 'raw-control': 1 },
+        'plugins/example/components/card.tsx': { 'raw-palette': 2, 'raw-control': 1 },
       },
     })).toEqual([])
 
@@ -157,6 +157,36 @@ describe('diffLegacyStyleReport', () => {
       'legacy style debt increased: plugins/example/components/card.tsx raw-palette 2 -> 3',
       'new legacy style debt: plugins/example/components/card.tsx inline-style (1)',
       'new legacy style debt: plugins/example/components/new-card.tsx raw-control (1)',
+    ])
+  })
+
+  it('rejects a PAID-DOWN allowance so the ratchet tightens instead of holding', () => {
+    // The ratchet used to accept reduced debt silently, which left every
+    // completed migration sitting at its old ceiling — debt could creep all the
+    // way back without CI noticing. Paying debt down now REQUIRES regenerating
+    // the baseline, the same way a stale exception allowance already does.
+    const expected = migrations('plugins/example/components/card.tsx', {
+      'raw-palette': 2,
+      'raw-control': 1,
+    })
+
+    expect(diffLegacyStyleReport(expected, {
+      totals: { 'raw-palette': 1, 'raw-control': 1 },
+      byPath: {
+        'plugins/example/components/card.tsx': { 'raw-palette': 1, 'raw-control': 1 },
+      },
+    })).toEqual([
+      'stale migration allowance: plugins/example/components/card.tsx raw-palette records 2 but only 1 remain; run bun run ui:legacy-styles:generate',
+    ])
+  })
+
+  it('rejects an allowance whose file is now completely clean', () => {
+    // The scanner reports nothing for a fully-migrated file, so the entry has
+    // to disappear from the ledger rather than linger as free headroom.
+    const expected = migrations('plugins/example/components/card.tsx', { 'raw-palette': 2 })
+
+    expect(diffLegacyStyleReport(expected, { totals: {}, byPath: {} })).toEqual([
+      'stale migration allowance: plugins/example/components/card.tsx raw-palette records 2 but only 0 remain; run bun run ui:legacy-styles:generate',
     ])
   })
 })

--- a/tests/ui/architecture/tailwind-merge-token-drop.test.ts
+++ b/tests/ui/architecture/tailwind-merge-token-drop.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'bun:test'
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { cn } from '@bakin/ui/utils'
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+
+/**
+ * A font size and a text colour are BOTH `text-*` utilities, so tailwind-merge
+ * treats them as one group and keeps only the last one it sees. Passing
+ * `text-bakin-typography-size-meta` and `text-bakin-text-muted` through `cn()`
+ * therefore drops the size silently — the markup looks correct, the class list
+ * looks plausible, and the element just renders at the inherited size.
+ *
+ * This is the same failure shape as `off-scale-utilities`: a style that
+ * disappears without any error. It shipped once — WorkspacePage's compact
+ * sticky title rendered at the wrong size until the Text primitive work found
+ * it — so it is pinned here.
+ *
+ * The fix inside kit components is the arbitrary-length form,
+ * `text-[length:var(--bakin-typography-size-meta)]`, which lands in the
+ * font-size group and survives. Plugin files keep the readable shorthand and
+ * reach for the `Text` primitive instead, which is why it exists.
+ *
+ * Note this cannot live in the legacy-styles ratchet: that scanner does not
+ * cover `packages/ui/src` at all, which is part of why the bug went unnoticed.
+ */
+const ROOTS = [
+  'packages/ui/src',
+  'packages/sdk/src',
+  'packages/host/src',
+  'plugins',
+  'src',
+  'storybook/public',
+]
+
+const SIZE_TOKEN = /text-bakin-typography-size-[a-z-]+/
+const COLOUR_TOKEN = /text-bakin-(?:text|signal|action)-[a-z-]+/
+
+/**
+ * Only strings that actually reach tailwind-merge can be damaged by it. A
+ * ternary branch assigned straight to `className` keeps both utilities and is
+ * perfectly fine, so enclosure in a `cn(` call is the thing to detect — not
+ * merely being a quoted string that happens to contain the tokens.
+ */
+function classStringsInsideCn(source: string): Array<{ offset: number, classes: string }> {
+  const found: Array<{ offset: number, classes: string }> = []
+  for (const call of source.matchAll(/\bcn\(/g)) {
+    let depth = 1
+    let index = call.index! + call[0].length
+    let quote: string | null = null
+    let literalStart = -1
+    const pending: Array<{ offset: number, classes: string }> = []
+    while (index < source.length && depth > 0) {
+      const char = source[index]!
+      if (quote !== null) {
+        if (char === '\\') index += 1
+        else if (char === quote) {
+          pending.push({ offset: literalStart, classes: source.slice(literalStart, index) })
+          quote = null
+        }
+      } else if (char === "'" || char === '"' || char === '`') {
+        quote = char
+        literalStart = index + 1
+      } else if (char === '(') depth += 1
+      else if (char === ')') depth -= 1
+      index += 1
+    }
+    // Only trust a call we actually saw close. A `cn(` inside a comment or a
+    // string never balances, and an unbounded walk would otherwise hoover up
+    // every literal to end-of-file and report plain className="…" attributes.
+    if (depth === 0) found.push(...pending)
+  }
+  return found
+}
+
+function findDroppedSizeTokens(): string[] {
+  const offenders: string[] = []
+  const cmd = `grep -rln "text-bakin-typography-size-" ${ROOTS.join(' ')} `
+    + `--include='*.tsx' --include='*.ts' || true`
+  const files = execSync(cmd, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }).trim()
+  if (!files) return offenders
+
+  for (const file of files.split('\n')) {
+    const source = readFileSync(join(REPO_ROOT, file), 'utf8')
+    if (!source.includes('cn(')) continue
+    for (const { offset, classes } of classStringsInsideCn(source)) {
+      if (!SIZE_TOKEN.test(classes) || !COLOUR_TOKEN.test(classes)) continue
+      // The authority is tailwind-merge itself, not a guess about its rules.
+      if (SIZE_TOKEN.test(cn(classes))) continue
+      const line = source.slice(0, offset).split('\n').length
+      offenders.push(`${file}:${line}: ${classes}`)
+    }
+  }
+  return offenders
+}
+
+describe('tailwind-merge token drop', () => {
+  it('never lets a colour utility swallow a font-size token', () => {
+    const offenders = findDroppedSizeTokens()
+    expect(offenders).toEqual([])
+  })
+
+  it('proves the hazard is real, so the scan above is not vacuous', () => {
+    // The shorthand pairing loses its size...
+    expect(cn('text-bakin-typography-size-meta text-bakin-text-muted'))
+      .not.toMatch(SIZE_TOKEN)
+    // ...and the arbitrary-length form the kit uses survives it.
+    expect(cn('text-[length:var(--bakin-typography-size-meta)] text-bakin-text-muted'))
+      .toContain('--bakin-typography-size-meta')
+  })
+})


### PR DESCRIPTION
**PR 2 of 6.** Stacked on #782 — the merge-hazard guard needs the `WorkspacePage` fix that landed there. GitHub will retarget this to `main` automatically once #782 merges.

## The problem

The legacy-styles ratchet only ever errored when debt **increased**. Paying debt down left the old ceiling in place, so every completed migration donated free headroom that debt could creep straight back into without CI noticing.

Exceptions already failed on a stale allowance. Migrations didn't. Now they match.

## What that was hiding

Regenerating against today's actuals closed **143 units of headroom** and dropped 5 fully-migrated files out of the ledger entirely — **111 → 106 paths, raw-scale 1019 → 876**.

Most of it was the runtime hub from the last sweep, still sitting at its pre-migration ceilings:

| File | Ceiling | Actual |
|---|---|---|
| `runtimes-tab.tsx` | 42 | 1 |
| `overview-tab.tsx` | 42 | 2 |
| `capabilities-tab.tsx` | 28 | 2 |
| `extensions-section.tsx` | 17 | 0 |

Also regenerated `kit-coverage.json`, which had a **dead entry** — `CopyButton` moved from `/conversation` to `/patterns` during the sweep and no longer exists on the old entrypoint (29 → 28). And narrowed `semantic-raw-controls` from 9 scoped paths to the 6 that still contain a raw control.

## The merge-hazard guard

Pins the bug the `Text` primitive work uncovered: a font size and a text colour are both `text-*`, so `cn()` keeps only the last and the size vanishes silently.

Two things make this scan trustworthy rather than decorative:

- **It parses balanced `cn(` spans**, not quoted strings. My first grep-based version reported 15 offenders; 14 were plain `className="…"` literals and ternary branches that never reach tailwind-merge. It also stops at an unbalanced `cn(` (one inside a comment) instead of hoovering up every literal to end-of-file.
- **It asks tailwind-merge for the verdict** rather than encoding assumptions about its grouping rules, and ships a companion test proving the hazard is real — so it can't pass vacuously.

It can't live in the legacy-styles ratchet: **that scanner doesn't cover `packages/ui/src` at all**, which is part of why the bug went unnoticed.

## Contract change, called out

`allows unchanged or reduced debt` encoded the old behaviour and now fails by design. Updated to `allows unchanged debt`, plus two new cases pinning that a paid-down allowance and a now-clean file both error.

## Verification

Verified in **both** directions — injecting new debt still fails the check, and a stale allowance now fails it too. (My first attempt at the increase test silently injected nothing because the anchor didn't match; re-ran it properly.)

typecheck ✅ · lint ✅ (0 errors) · `bun test tests/ui/ tests/architecture/ tests/scripts/` **934 pass** ✅
Ratchets: legacy-styles, kit-coverage, census, public-api, story-compliance, performance, check-cycles — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)