### PR TITLE
refactor(ui): kit composition and doctrine fixes across the fleet

### DIFF
--- a/design-system/census.json
+++ b/design-system/census.json
@@ -2329,10 +2329,10 @@
       },
       "sourcePath": "packages/host/src/components/runtime/shared.tsx",
       "symbols": [
+        "CheckStatusBadge",
         "EntityCardBody",
         "MODE_LEGEND",
         "ModeBadge",
-        "StatusBadge",
         "capabilityStateCopy"
       ],
       "exportStatus": "private",

--- a/design-system/compatibility.json
+++ b/design-system/compatibility.json
@@ -7,7 +7,7 @@
   ],
   "repositories": {
     "bakin": {
-      "ref": "45bfaf5bc0e87685122db8a4c34dd8b4a98234eb"
+      "ref": "3b01dbe6136d65584345715127fc20021aa32fd6"
     },
     "bakin-bits-official": {
       "ref": "2f50ddf35be8daea3754391291bad896fe9cacb8"

--- a/design-system/migrations.json
+++ b/design-system/migrations.json
@@ -24,7 +24,7 @@
     "totals": {
       "raw-palette": 2,
       "arbitrary-size": 29,
-      "raw-scale": 876,
+      "raw-scale": 873,
       "raw-control": 3,
       "inline-style": 3,
       "generic-token": 72,
@@ -1546,7 +1546,7 @@
       "target": "workflow pages/canvas archetypes and supported SDK UI",
       "status": "legacy-allowed",
       "allowances": {
-        "raw-scale": 80
+        "raw-scale": 77
       }
     },
     {

--- a/design-system/performance.json
+++ b/design-system/performance.json
@@ -19,7 +19,7 @@
   },
   "hostInitialJs": {
     "path": "packages/host/dist/main.js",
-    "bytes": 285796
+    "bytes": 285775
   },
   "sdkUiBundles": [
     {
@@ -38,7 +38,7 @@
       "name": "sdk-conversation",
       "path": "packages/host/public/vendor/sdk-conversation.js",
       "bytes": 60362,
-      "reachableBytes": 644443
+      "reachableBytes": 644444
     },
     {
       "name": "sdk-layout",
@@ -50,13 +50,13 @@
       "name": "sdk-navigation",
       "path": "packages/host/public/vendor/sdk-navigation.js",
       "bytes": 563,
-      "reachableBytes": 411931
+      "reachableBytes": 411932
     },
     {
       "name": "sdk-patterns",
       "path": "packages/host/public/vendor/sdk-patterns.js",
       "bytes": 2430,
-      "reachableBytes": 548999
+      "reachableBytes": 549000
     },
     {
       "name": "sdk-ui",
@@ -127,10 +127,6 @@
       "bytes": 157
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-0ce71840.js",
-      "bytes": 82774
-    },
-    {
       "path": "packages/host/public/vendor/sdk-shared-2xrtj366.js",
       "bytes": 1328
     },
@@ -139,16 +135,16 @@
       "bytes": 3476
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-7ecv189w.js",
-      "bytes": 3295
-    },
-    {
       "path": "packages/host/public/vendor/sdk-shared-7x82wzt8.js",
       "bytes": 1938
     },
     {
       "path": "packages/host/public/vendor/sdk-shared-87nnc3kf.js",
       "bytes": 5243
+    },
+    {
+      "path": "packages/host/public/vendor/sdk-shared-91ys6sqv.js",
+      "bytes": 30778
     },
     {
       "path": "packages/host/public/vendor/sdk-shared-axwqnxts.js",
@@ -167,10 +163,6 @@
       "bytes": 290739
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-g8xa8hx3.js",
-      "bytes": 30778
-    },
-    {
       "path": "packages/host/public/vendor/sdk-shared-h5mfc0ya.js",
       "bytes": 28974
     },
@@ -183,12 +175,20 @@
       "bytes": 711
     },
     {
+      "path": "packages/host/public/vendor/sdk-shared-tbtbr6bf.js",
+      "bytes": 82775
+    },
+    {
       "path": "packages/host/public/vendor/sdk-shared-wyktsxx1.js",
       "bytes": 103
     },
     {
       "path": "packages/host/public/vendor/sdk-shared-xk5hy9k5.js",
       "bytes": 2165
+    },
+    {
+      "path": "packages/host/public/vendor/sdk-shared-yhs43ptk.js",
+      "bytes": 3295
     },
     {
       "path": "packages/host/public/vendor/sdk-slots.js",
@@ -234,7 +234,7 @@
       "repository": "bakin",
       "pluginId": "assets",
       "path": "plugins/assets/dist/client.js",
-      "bytes": 72844
+      "bytes": 72781
     },
     {
       "repository": "bakin",
@@ -258,43 +258,43 @@
       "repository": "bakin",
       "pluginId": "health",
       "path": "plugins/health/dist/client.js",
-      "bytes": 506734
+      "bytes": 506692
     },
     {
       "repository": "bakin",
       "pluginId": "memory",
       "path": "plugins/memory/dist/client.js",
-      "bytes": 32271
+      "bytes": 32250
     },
     {
       "repository": "bakin",
       "pluginId": "models",
       "path": "plugins/models/dist/client.js",
-      "bytes": 77365
+      "bytes": 77323
     },
     {
       "repository": "bakin",
       "pluginId": "schedule",
       "path": "plugins/schedule/dist/client.js",
-      "bytes": 55632
+      "bytes": 55682
     },
     {
       "repository": "bakin",
       "pluginId": "tasks",
       "path": "plugins/tasks/dist/client.js",
-      "bytes": 200743
+      "bytes": 200763
     },
     {
       "repository": "bakin",
       "pluginId": "team",
       "path": "plugins/team/dist/client.js",
-      "bytes": 278811
+      "bytes": 278647
     },
     {
       "repository": "bakin",
       "pluginId": "workflows",
       "path": "plugins/workflows/dist/client.js",
-      "bytes": 619058
+      "bytes": 618902
     }
   ]
 }

--- a/packages/host/src/components/layout/dispatch-timer.tsx
+++ b/packages/host/src/components/layout/dispatch-timer.tsx
@@ -64,7 +64,11 @@ export function DispatchTimer() {
   return (
     <div className="flex items-center gap-1.5 text-xs font-mono text-bakin-text-muted">
       <Clock className={`size-3 ${isDispatching ? 'animate-pulse' : ''}`} />
-      <span title="Next dispatch">{display}</span>
+      {/* Was a native `title`, which ARIA drops on a role-less span — so AT
+          users got nothing while sighted users got a hover-only hint. The
+          clock icon and countdown carry the meaning visually; this names it
+          for everyone else. */}
+      <span><span className="sr-only">Next dispatch in </span>{display}</span>
       <Button
         type="button"
         variant="ghost"

--- a/packages/host/src/components/runtime/extensions-section.tsx
+++ b/packages/host/src/components/runtime/extensions-section.tsx
@@ -167,7 +167,6 @@ export function ExtensionsSection() {
       </Stack>
       <DataTable
         label="Runtime extensions"
-        collapseBelow="none"
         columns={columns}
         rows={report.extensions}
         rowKey={(ext) => ext.path}

--- a/packages/host/src/components/runtime/overview-tab.tsx
+++ b/packages/host/src/components/runtime/overview-tab.tsx
@@ -10,7 +10,7 @@ import { Section, Stack } from '@makinbakin/sdk/layout'
 import { ConfirmDialog, DataTable, StatGroup, StatTile, type DataTableColumn } from '@makinbakin/sdk/patterns'
 import { Badge, Button, Skeleton, SystemState } from '@makinbakin/sdk/ui'
 import { capabilityRows } from '../../lib/runtime-report'
-import { ModeBadge, MODE_LEGEND, StatusBadge, capabilityStateCopy, type CapabilityMode } from './shared'
+import { ModeBadge, MODE_LEGEND, CheckStatusBadge, capabilityStateCopy, type CapabilityMode } from './shared'
 import type { CapabilityReport, OnboardingComponentStatus } from './types'
 
 function CredentialTiles({ report }: { report: CapabilityReport }) {
@@ -110,7 +110,6 @@ function CapabilityGrid({ report }: { report: CapabilityReport }) {
       </Stack>
       <DataTable
         label="Runtime capabilities"
-        collapseBelow="none"
         columns={columns}
         rows={rows}
         rowKey={(row) => row.key}
@@ -184,7 +183,7 @@ function SetupSection({ onboarding, onRescan }: { onboarding: OnboardingComponen
     {
       key: 'status',
       header: 'Status',
-      cell: (component) => <StatusBadge status={component.status} />,
+      cell: (component) => <CheckStatusBadge status={component.status} />,
     },
     {
       key: 'action',
@@ -232,7 +231,6 @@ function SetupSection({ onboarding, onRescan }: { onboarding: OnboardingComponen
       {onboarding && (
         <DataTable
           label="Setup checks"
-          collapseBelow="none"
           columns={columns}
           rows={onboarding}
           rowKey={(component) => component.name}

--- a/packages/host/src/components/runtime/shared.tsx
+++ b/packages/host/src/components/runtime/shared.tsx
@@ -13,7 +13,7 @@
  */
 import type { ComponentType, ReactNode } from 'react'
 import { Inline, Stack } from '@makinbakin/sdk/layout'
-import { StatusBadge as StatusBadgePattern, type StatusTone } from '@makinbakin/sdk/patterns'
+import { StatusBadge, type StatusTone } from '@makinbakin/sdk/patterns'
 
 export type CapabilityMode = 'native' | 'shimmed' | 'unavailable' | string
 
@@ -31,9 +31,9 @@ const MODE_TONE: Record<string, StatusTone> = {
 
 export function ModeBadge({ mode }: { mode: CapabilityMode }) {
   return (
-    <StatusBadgePattern tone={MODE_TONE[mode] ?? 'neutral'} variant="soft" className="shrink-0">
+    <StatusBadge tone={MODE_TONE[mode] ?? 'neutral'} variant="soft" className="shrink-0">
       {MODE_LABEL[mode] ?? mode}
-    </StatusBadgePattern>
+    </StatusBadge>
   )
 }
 
@@ -67,13 +67,20 @@ export function capabilityStateCopy(key: string, mode: CapabilityMode, adapter: 
 
 export const MODE_LEGEND = 'Native — the runtime provides it. Via Bakin — Bakin fills the gap itself. Not available — degrades honestly, never silently.'
 
-export function StatusBadge({ status }: { status: string }) {
+/**
+ * Check-status chip (`ok`/`warn`/`skipped`/…). Named distinctly from the kit's
+ * `StatusBadge`, which it wraps: this used to shadow that name in this very
+ * directory, so sibling files imported different components under one name
+ * depending on which import they reached for. The alias that made that
+ * possible is gone with it.
+ */
+export function CheckStatusBadge({ status }: { status: string }) {
   const tone: StatusTone = status === 'ok'
     ? 'success'
     : status === 'warn' || status === 'skipped'
       ? 'attention'
       : 'danger'
-  return <StatusBadgePattern tone={tone} variant="soft" className="shrink-0">{status}</StatusBadgePattern>
+  return <StatusBadge tone={tone} variant="soft" className="shrink-0">{status}</StatusBadge>
 }
 
 export type EntityCardTone = 'neutral' | 'active'

--- a/packages/ui/src/patterns/data-table.tsx
+++ b/packages/ui/src/patterns/data-table.tsx
@@ -83,7 +83,13 @@ export interface DataTableProps<Row, F extends string = string> {
   /**
    * Container-query breakpoint (measured on the DataTable itself, never the
    * viewport) below which the list render replaces the table.
-   * Defaults to `'2xl'` (42rem). `'none'` keeps the table at every width.
+   *
+   * Defaults to `'none'` — the table stays a table at every width and scrolls
+   * horizontally inside its own container. Every consumer in the fleet chose
+   * this explicitly, so it is the default rather than a prop each caller has
+   * to remember; comparable records read better as aligned columns than as
+   * stacked label/value pairs. Opt into `'xl' | '2xl' | '3xl'` when a table's
+   * rows genuinely read better stacked on narrow widths.
    */
   collapseBelow?: DataTableCollapse
   /** Row relationship of the narrow list render. */
@@ -243,7 +249,7 @@ export function DataTable<Row, F extends string = string>({
   sort,
   onSortChange,
   pagination,
-  collapseBelow = '2xl',
+  collapseBelow = 'none',
   listVariant = 'separated',
   renderTableRow,
   rowProps,

--- a/plugins/assets/components/versioned/ImportView.tsx
+++ b/plugins/assets/components/versioned/ImportView.tsx
@@ -121,7 +121,6 @@ export function ImportView({ onImported, onCountChange }: { onImported?: () => v
       {error && <p className="text-bakin-typography-size-meta text-bakin-signal-danger" data-testid="import-error">{error}</p>}
       <DataTable
         label="Unmanaged files"
-        collapseBelow="none"
         columns={columns}
         rows={files}
         rowKey={file => file.relPath}

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -584,7 +584,6 @@ export function VersionedAssetGrid() {
                 bordered list variant stays for narrow/panel contexts. */}
             <DataTable
               label="Trashed assets"
-              collapseBelow="none"
               rows={trash}
               rowKey={item => item.trashName}
               rowProps={item => ({ 'data-testid': `trash-row-${item.assetId}` })}
@@ -676,7 +675,6 @@ export function VersionedAssetGrid() {
               to the Grid view. */}
           <DataTable
             label="Assets"
-            collapseBelow="none"
             rows={sortedList}
             rowKey={asset => asset.assetId}
             onRowActivate={asset => router.push(`/assets/${encodeURIComponent(asset.assetId)}`)}

--- a/plugins/health/components/system-inventory.tsx
+++ b/plugins/health/components/system-inventory.tsx
@@ -295,7 +295,6 @@ export const SystemInventory = forwardRef<SystemInventoryHandle, SystemInventory
                 label="Installed plugins"
                 rows={filteredPlugins}
                 rowKey={(plugin) => plugin.id}
-                collapseBelow="none"
                 renderRow={() => null}
                 tableProps={{ className: 'min-w-[760px]' }}
                 rowProps={(plugin) => ({

--- a/plugins/health/components/system-search-section.tsx
+++ b/plugins/health/components/system-search-section.tsx
@@ -356,7 +356,6 @@ export function SystemSearchSection({
                   rows={status.tables}
                   rowKey={(table) => table.logical}
                   columns={indexColumns}
-                  collapseBelow="none"
                   renderRow={() => null}
                   tableProps={{ className: 'min-w-[760px]' }}
                 />

--- a/plugins/memory/components/memory-search-results.tsx
+++ b/plugins/memory/components/memory-search-results.tsx
@@ -282,7 +282,6 @@ export function MemorySearchResults({
   return (
     <DataTable
       label="Memory results"
-      collapseBelow="none"
       columns={columns}
       rows={results}
       rowKey={(result) => result.id}

--- a/plugins/models/components/available-models-tab.tsx
+++ b/plugins/models/components/available-models-tab.tsx
@@ -365,7 +365,6 @@ export function AvailableModelsTab({
       {state ?? (
         <DataTable
           label="Available models"
-          collapseBelow="none"
           columns={columns}
           rows={visibleModels}
           rowKey={(model) => model.id}

--- a/plugins/models/components/spend-breakdown.tsx
+++ b/plugins/models/components/spend-breakdown.tsx
@@ -319,7 +319,6 @@ export function SpendBreakdown({
                 beside the ranked chart. */}
             <DataTable
               label={`${DIMENSIONS.find((item) => item.value === dimension)?.label} spend`}
-              collapseBelow="none"
               columns={columns}
               rows={visibleRows}
               rowKey={(row) => row.id}

--- a/plugins/schedule/components/job-list.tsx
+++ b/plugins/schedule/components/job-list.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 import { ShieldAlert } from 'lucide-react'
 import { DataTable, ListRow, type DataTableColumn } from '@makinbakin/sdk/patterns'
+import { Text } from '@makinbakin/sdk/ui'
 import { AgentBadge } from './agent-badge'
 import { JobActionsMenu, JobNameCell, JobScheduleCell, JobStatusBadge, type JobScoreInfo } from './job-row'
 import type { ScheduleJob } from "@makinbakin/sdk/hooks"
@@ -47,9 +48,9 @@ function MobileJobRow({
               <span className="block truncate text-bakin-typography-size-body text-bakin-text-muted">
                 {job.humanSchedule}
                 {job.tz ? (
-                  <span className="ml-bakin-1 text-bakin-typography-size-meta opacity-60">
+                  <Text as="span" size="meta" tone="muted" className="ml-bakin-1">
                     {job.tz.replace(/^.*\//, '')}
-                  </span>
+                  </Text>
                 ) : null}
               </span>
               {job.nextRun && !job.paused ? (
@@ -161,6 +162,9 @@ export function JobList({
   return (
     <DataTable
       label="Scheduled jobs"
+      // Kept collapsing: these rows carry narrow-render configuration and
+      // read better stacked than as a horizontally scrolling table.
+      collapseBelow="2xl"
       columns={columns}
       rows={jobs}
       rowKey={job => job.id}

--- a/plugins/schedule/components/job-row.tsx
+++ b/plugins/schedule/components/job-row.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  Text,
 } from '@makinbakin/sdk/ui'
 import type { ScheduleJob } from "@makinbakin/sdk/hooks"
 
@@ -82,7 +83,7 @@ export function JobScheduleCell({ job }: { job: ScheduleJob }) {
     <>
       <span className="text-bakin-typography-size-body text-bakin-text-muted">
         {job.humanSchedule}
-        {job.tz && <span className="ml-bakin-1 text-bakin-typography-size-meta opacity-60">{job.tz.replace(/^.*\//, '')}</span>}
+        {job.tz && <Text as="span" size="meta" tone="muted" className="ml-bakin-1">{job.tz.replace(/^.*\//, '')}</Text>}
       </span>
       {job.nextRun && !job.paused && (
         <div className="text-bakin-typography-size-meta text-bakin-text-muted/70">

--- a/plugins/tasks/components/task-log-table.tsx
+++ b/plugins/tasks/components/task-log-table.tsx
@@ -310,6 +310,9 @@ export function TaskLogTable({ currentTasks, statusFilter, isSearching, scoreMap
         ) : (
           <DataTable
             label="Task log"
+            // Kept collapsing: these rows carry narrow-render configuration and
+            // read better stacked than as a horizontally scrolling table.
+            collapseBelow="2xl"
             columns={columns}
             rows={sorted}
             rowKey={(task) => task.id}

--- a/plugins/team/components/agent-detail.tsx
+++ b/plugins/team/components/agent-detail.tsx
@@ -493,7 +493,7 @@ function SkillsTab({ agentId }: { agentId: string }) {
       onSelect={setSelectedSkill}
       content={skillContent ? (
         <Panel variant="code" scroll={false}>
-          <pre className="m-0 whitespace-pre-wrap font-bakin-typography-family-mono leading-relaxed text-bakin-text-primary">
+          <pre className="leading-relaxed">
             {skillContent}
           </pre>
         </Panel>
@@ -579,7 +579,7 @@ function MemoryTab({ agentId }: { agentId: string }) {
       onSelect={setSelectedFile}
       content={content ? (
         <Panel variant="code" scroll={false}>
-          <pre className="m-0 whitespace-pre-wrap font-bakin-typography-family-mono leading-relaxed text-bakin-text-primary">
+          <pre className="leading-relaxed">
             {content}
           </pre>
         </Panel>

--- a/plugins/workflows/components/step-detail-drawer.tsx
+++ b/plugins/workflows/components/step-detail-drawer.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Alert, AlertDescription, AlertTitle, Badge, Button, Drawer, DrawerSection, Separator } from '@makinbakin/sdk/ui'
+import { Alert, AlertDescription, AlertTitle, Badge, Button, Drawer, DrawerSection, Overline, Separator } from '@makinbakin/sdk/ui'
+import { CodeBlock } from '@makinbakin/sdk/content'
+import { Stack } from '@makinbakin/sdk/layout'
 import { useAgent } from '@makinbakin/sdk/hooks'
 import { WorkflowAgentAvatar } from './workflow-agent-identity'
 import {
@@ -306,14 +308,17 @@ function OutputStepDetail({ step }: { step: OutputStep }) {
         <>
           <Separator />
           <DrawerSection title="Content Templates">
-            <div className="space-y-3">
+            <Stack gap="item">
               {Object.entries(step.content).map(([key, value]) => (
-                <div key={key} className="rounded-bakin-surface bg-bakin-surface-default p-3">
-                  <div className="text-bakin-typography-size-meta font-bakin-typography-family-mono text-bakin-text-muted uppercase tracking-wider mb-1.5">{key}</div>
-                  <pre className="text-bakin-typography-size-body text-bakin-text-primary whitespace-pre-wrap leading-relaxed">{value}</pre>
-                </div>
+                <Stack key={key} gap="dense">
+                  <Overline>{key}</Overline>
+                  {/* A template IS its exact source — CodeBlock owns the mono
+                      frame and makes the block keyboard-reachable, which a
+                      bare scrollable <pre> never is. */}
+                  <CodeBlock code={value} label={`${key} template`} copyable wrap />
+                </Stack>
               ))}
-            </div>
+            </Stack>
           </DrawerSection>
         </>
       )}

--- a/storybook/public/lists/data-table.stories.tsx
+++ b/storybook/public/lists/data-table.stories.tsx
@@ -39,7 +39,9 @@ interface DataTableCanonicalArgs {
 export const CanonicalUsage = {
   parameters: { layout: 'padded' },
   args: {
-    collapseBelow: '2xl',
+    // Matches the component default: a table stays a table and scrolls
+    // horizontally. The control below explores opting into collapsing.
+    collapseBelow: 'none',
     listVariant: 'separated',
   },
   argTypes: {
@@ -48,7 +50,7 @@ export const CanonicalUsage = {
     collapseBelow: {
       control: 'select',
       options: ['xl', '2xl', '3xl', 'none'],
-      description: 'Container width below which the dual render switches from table to ListRows.',
+      description: 'Container width below which the dual render switches from table to ListRows. Defaults to `none` — the table stays a table at every width.',
     },
     listVariant: {
       control: 'select',
@@ -181,6 +183,9 @@ function DualRenderExample() {
       columns={RUN_COLUMNS}
       rows={visible}
       rowKey={(row) => row.id}
+      // Collapsing is opt-in (the default is table-only); these stories exist
+      // to demonstrate the narrow render, so they ask for it.
+      collapseBelow="2xl"
       sort={sort}
       onSortChange={(field) => {
         setSort((previous) => previous.field === field
@@ -279,6 +284,7 @@ export const NarrowRoles = {
             columns={NARROW_COLUMNS}
             rows={NARROW_RUNS}
             rowKey={(row) => row.id}
+            collapseBelow="2xl"
           />
         </div>
       </StorySection>

--- a/tests/ui/patterns/data-table.test.tsx
+++ b/tests/ui/patterns/data-table.test.tsx
@@ -27,6 +27,7 @@ describe('DataTable', () => {
     const { container } = render(
       <DataTable
         label="Dispatch runs"
+        collapseBelow="2xl"
         columns={COLUMNS}
         rows={ROWS}
         rowKey={(row) => row.id}
@@ -49,6 +50,17 @@ describe('DataTable', () => {
     expect(list.getAttribute('data-variant')).toBe('separated')
     expect(list.className).toContain('@2xl/data-table:hidden')
     expect(within(list).getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('defaults to table-only, so comparable records stay aligned columns', () => {
+    // The default is `none`: a table scrolls horizontally inside its own
+    // container rather than restacking into label/value pairs. Collapsing is
+    // opt-in for the tables whose rows genuinely read better stacked.
+    const { container } = render(
+      <DataTable label="Runs" columns={COLUMNS} rows={ROWS} rowKey={(row) => row.id} />,
+    )
+    expect(container.querySelector('[data-slot="data-table-table"]')?.className).toBe('block')
+    expect(container.querySelector('[data-slot="data-table-list"]')).toBeNull()
   })
 
   it('collapses at the configured container breakpoint and supports table-only mode', () => {
@@ -126,6 +138,7 @@ describe('DataTable', () => {
     render(
       <DataTable
         label="Dispatch runs"
+        collapseBelow="2xl"
         columns={COLUMNS}
         rows={ROWS}
         rowKey={(row) => row.id}
@@ -174,7 +187,7 @@ describe('DataTable', () => {
 
   it('stacks a primary/label-value mapping as the default narrow row', () => {
     render(
-      <DataTable label="Dispatch runs" columns={COLUMNS} rows={ROWS} rowKey={(row) => row.id} />,
+      <DataTable label="Dispatch runs" columns={COLUMNS} rows={ROWS} rowKey={(row) => row.id} collapseBelow="2xl" />,
     )
 
     const list = screen.getByRole('list', { name: 'Dispatch runs' })
@@ -214,7 +227,7 @@ describe('DataTable', () => {
       { id: 't2', title: 'Reconcile provider usage', agent: 'Pixel', status: 'Running' },
     ]
     render(
-      <DataTable label="Task log" columns={columns} rows={rows} rowKey={(row) => row.id} />,
+      <DataTable label="Task log" columns={columns} rows={rows} rowKey={(row) => row.id} collapseBelow="2xl" />,
     )
 
     const list = screen.getByRole('list', { name: 'Task log' })


### PR DESCRIPTION
**PR 3a of the post-sweep plan.** Composition and correctness only — the bulk `Text`/`Overline`/`Inline` adoption follows in 3b (see *Why split* below).

## DataTable default flipped to `collapseBelow="none"`

Comparable records read better as aligned columns that scroll horizontally than as restacked label/value pairs, and 11 of 13 consumers already said so explicitly. Those 11 drop the prop.

**Correction to something I told you earlier.** I said *every* consumer passed `collapseBelow="none"`. That was wrong — I counted prop occurrences, not component usages. There are 13 usages; **2 relied on the old `'2xl'` default** and would have silently stopped collapsing:

- `schedule/job-list.tsx`
- `tasks/task-log-table.tsx` — its columns carry `narrow:` role hints, which is list-render configuration, so the collapsing is deliberate

Both now state `collapseBelow="2xl"` explicitly. **Net behaviour change: none.** DataTable's dual-render tests ask for collapsing explicitly, and a new test pins the default itself.

## `<pre>` — not a blanket CodeBlock conversion

The plan said "9 hand-rolled `<pre>` → CodeBlock". Reading them, most were not hand-rolled:

`Panel variant="code"` already paints the mono frame, applies `m-0` + `whitespace-pre-wrap` to any nested `<pre>`, and owns keyboard reachability. **A bare `<pre>` inside one is the supported composition.** Converting those would have double-framed them — Panel's background and padding plus CodeBlock's.

| Site | Verdict |
|---|---|
| 4 inside `Panel variant="code"` | Supported composition — unchanged |
| team `agent-detail` ×2 | In a Panel, but className duplicated what Panel applies — classes dropped |
| workflows content templates | Genuinely hand-rolled (raw `p-3`, hand-rolled overline, unreachable scrollable `<pre>`) — now `CodeBlock` + `Overline` |
| chat plain-text messages | A code frame would be wrong here — belongs in 3b as a `Text` case |

## Doctrine fixes

- **`dispatch-timer`** carried a native `title` on a role-less span, which ARIA discards — so sighted users got a hover hint and AT users got **nothing**. Now sr-only text; the clock icon and countdown carry it visually.
- **Two schedule timezone labels** used `opacity-60`, which compounds against the parent and fails contrast. Now `Text tone="muted"`. Hover-reveal `opacity-0 → group-hover:opacity-100` affordances are legitimate and untouched.
- **`runtime/shared.tsx`** exported `StatusBadge`, shadowing the kit export of the same name **in the same directory** — sibling files imported different components under one name. Renamed `CheckStatusBadge`; the alias that made the collision survivable is gone too.

## The new ratchet earned its keep

PR #783's stale-allowance check fired on its first real use: `step-detail-drawer` dropped 80 → 77 and the ratchet refused to let the old ceiling stand until I regenerated. That is exactly the creep-back it was built to stop.

## Why split

Of the 62 `Text` candidates, only 17 are single-line and safely scriptable; the other 45 are multi-line JSX needing per-file judgement, plus 27 `Overline` files and 54 `Inline` sites. Rushing ~130 manual JSX edits at the tail of a long session is how regressions ship — and a half-migrated `Text` adoption would make 3b's diff harder to review, not easier.

## Verification

typecheck ✅ · lint ✅ (0 errors) · `bun test tests/ui/ tests/plugins/ tests/components/ tests/architecture/` → **4810 pass**

2 `ActivityTab` failures are **pre-existing** — verified identical on clean `main`, and they pass in isolation while failing in combination, so they are a test-isolation flake worth chasing separately.

Ratchets: legacy-styles, census (regenerated for the rename), public-api, kit-coverage, story-compliance, performance, check-cycles — all green. SDK stylesheet identity gate 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)