### PR TITLE
refactor(ui): adopt Text, Overline, and Inline across the fleet

### DIFF
--- a/design-system/performance.json
+++ b/design-system/performance.json
@@ -19,7 +19,7 @@
   },
   "hostInitialJs": {
     "path": "packages/host/dist/main.js",
-    "bytes": 285775
+    "bytes": 285528
   },
   "sdkUiBundles": [
     {
@@ -234,13 +234,13 @@
       "repository": "bakin",
       "pluginId": "assets",
       "path": "plugins/assets/dist/client.js",
-      "bytes": 72781
+      "bytes": 72478
     },
     {
       "repository": "bakin",
       "pluginId": "brands",
       "path": "plugins/brands/dist/client.js",
-      "bytes": 93219
+      "bytes": 92834
     },
     {
       "repository": "bakin",
@@ -252,49 +252,49 @@
       "repository": "bakin",
       "pluginId": "explore",
       "path": "plugins/explore/dist/client.js",
-      "bytes": 38628
+      "bytes": 38278
     },
     {
       "repository": "bakin",
       "pluginId": "health",
       "path": "plugins/health/dist/client.js",
-      "bytes": 506692
+      "bytes": 505484
     },
     {
       "repository": "bakin",
       "pluginId": "memory",
       "path": "plugins/memory/dist/client.js",
-      "bytes": 32250
+      "bytes": 32216
     },
     {
       "repository": "bakin",
       "pluginId": "models",
       "path": "plugins/models/dist/client.js",
-      "bytes": 77323
+      "bytes": 77098
     },
     {
       "repository": "bakin",
       "pluginId": "schedule",
       "path": "plugins/schedule/dist/client.js",
-      "bytes": 55682
+      "bytes": 55117
     },
     {
       "repository": "bakin",
       "pluginId": "tasks",
       "path": "plugins/tasks/dist/client.js",
-      "bytes": 200763
+      "bytes": 200169
     },
     {
       "repository": "bakin",
       "pluginId": "team",
       "path": "plugins/team/dist/client.js",
-      "bytes": 278647
+      "bytes": 277922
     },
     {
       "repository": "bakin",
       "pluginId": "workflows",
       "path": "plugins/workflows/dist/client.js",
-      "bytes": 618902
+      "bytes": 618220
     }
   ]
 }

--- a/packages/host/src/components/runtime/capabilities-tab.tsx
+++ b/packages/host/src/components/runtime/capabilities-tab.tsx
@@ -9,7 +9,7 @@ import { Link } from '@tanstack/react-router'
 import { useJsonFetch } from '@makinbakin/sdk/hooks'
 import { Grid, Inline, Stack } from '@makinbakin/sdk/layout'
 import { StatusBadge, StatusMarker } from '@makinbakin/sdk/patterns'
-import { buttonVariants, Card, CardContent, Skeleton, SystemState } from '@makinbakin/sdk/ui'
+import { buttonVariants, Card, CardContent, Skeleton, SystemState, Text } from '@makinbakin/sdk/ui'
 import { EntityCardBody } from './shared'
 import type { CapabilityReadiness } from './types'
 
@@ -129,7 +129,7 @@ export function CapabilitiesTab() {
           </Card>
         ))}
       </Grid>
-      <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+      <Text size="meta" tone="muted" as="p">
         Add more from{' '}
         <Link
           to="/explore"
@@ -138,7 +138,7 @@ export function CapabilitiesTab() {
         >
           Explore → Capabilities
         </Link>.
-      </p>
+      </Text>
     </Stack>
   )
 }

--- a/packages/host/src/components/runtime/extensions-section.tsx
+++ b/packages/host/src/components/runtime/extensions-section.tsx
@@ -10,7 +10,7 @@ import { useJsonFetch } from '@makinbakin/sdk/hooks'
 import { CodeBlock } from '@makinbakin/sdk/content'
 import { Section, Stack } from '@makinbakin/sdk/layout'
 import { ConfirmDialog, CopyButton, DataTable, StatusBadge, type DataTableColumn } from '@makinbakin/sdk/patterns'
-import { Banner, Button } from '@makinbakin/sdk/ui'
+import { Banner, Button, Text } from '@makinbakin/sdk/ui'
 import { describeRequestError, responseError } from '../../lib/request-error'
 
 interface ExtensionRow {
@@ -159,10 +159,10 @@ export function ExtensionsSection() {
     <Section spacing="compact" data-testid="runtime-extensions">
       <Stack gap="dense">
         <h2>Extensions</h2>
-        <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted" as="p">
           Add-ons installed for the runtime from the command line. They stay inert until you
           approve them here — an approved extension runs inside the Bakin server with full permissions.
-        </p>
+        </Text>
         <CodeBlock code="pi install" label="extension install command" />
       </Stack>
       <DataTable

--- a/packages/host/src/components/runtime/overview-tab.tsx
+++ b/packages/host/src/components/runtime/overview-tab.tsx
@@ -8,7 +8,7 @@ import { Wrench } from 'lucide-react'
 import { toast } from '@makinbakin/sdk/hooks'
 import { Section, Stack } from '@makinbakin/sdk/layout'
 import { ConfirmDialog, DataTable, StatGroup, StatTile, type DataTableColumn } from '@makinbakin/sdk/patterns'
-import { Badge, Button, Skeleton, SystemState } from '@makinbakin/sdk/ui'
+import { Badge, Button, Skeleton, SystemState, Text } from '@makinbakin/sdk/ui'
 import { capabilityRows } from '../../lib/runtime-report'
 import { ModeBadge, MODE_LEGEND, CheckStatusBadge, capabilityStateCopy, type CapabilityMode } from './shared'
 import type { CapabilityReport, OnboardingComponentStatus } from './types'
@@ -106,7 +106,7 @@ function CapabilityGrid({ report }: { report: CapabilityReport }) {
     <Section spacing="compact">
       <Stack gap="dense">
         <h2>What this runtime can do</h2>
-        <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">{MODE_LEGEND}</p>
+        <Text size="meta" tone="muted" as="p">{MODE_LEGEND}</Text>
       </Stack>
       <DataTable
         label="Runtime capabilities"
@@ -209,7 +209,7 @@ function SetupSection({ onboarding, onRescan }: { onboarding: OnboardingComponen
     <Section spacing="compact" data-testid="onboarding-status">
       <Stack gap="dense">
         <h2>Setup checks</h2>
-        <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">Live checks against the active runtime — the same ones `bakin check all` runs.</p>
+        <Text size="meta" tone="muted" as="p">Live checks against the active runtime — the same ones `bakin check all` runs.</Text>
       </Stack>
       {onboarding === undefined && (
         <Stack gap="dense">

--- a/packages/host/src/components/runtime/runtimes-tab.tsx
+++ b/packages/host/src/components/runtime/runtimes-tab.tsx
@@ -35,6 +35,7 @@ import {
   FieldDescription,
   FieldLabel,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { reduceSwitchProgress, SWITCH_PHASE_LABELS, type SwitchStepRow } from '../../lib/runtime-report'
 import { ExtensionsSection } from './extensions-section'
@@ -68,7 +69,7 @@ function ProgressSteps({ steps }: { steps: SwitchStepRow[] }) {
               tone={STEP_TONE[step.status]}
               markerLabel={STEP_MARKER_LABEL[step.status]}
               title={SWITCH_PHASE_LABELS[step.phase] ?? step.phase}
-              meta={step.detail ? <span className="text-bakin-typography-size-meta text-bakin-text-muted">{step.detail}</span> : undefined}
+              meta={step.detail ? <Text size="meta" tone="muted">{step.detail}</Text> : undefined}
             />
           ))}
         </Timeline>
@@ -136,7 +137,7 @@ function ResultCards({ result, onProceed, busy = false }: { result: SwitchResult
                   <Button size="sm" onClick={onProceed} disabled={busy} data-testid="switch-execute">
                     Switch to {RUNTIME_LABELS[result.to] ?? result.to}…
                   </Button>
-                  <span className="text-bakin-typography-size-meta text-bakin-text-muted">Opens the confirmation — nothing has been written yet.</span>
+                  <Text size="meta" tone="muted">Opens the confirmation — nothing has been written yet.</Text>
                 </Inline>
               )}
             </Stack>
@@ -404,7 +405,7 @@ export function RuntimesTab({ report, onSwitched }: { report: CapabilityReport; 
             <Button size="sm" variant="outline" data-testid="switch-preview" onClick={() => { setConfirming(false); void run(true) }}>
               Preview switch
             </Button>
-            <span className="text-bakin-typography-size-meta text-bakin-text-muted">Dry run — nothing is written.</span>
+            <Text size="meta" tone="muted">Dry run — nothing is written.</Text>
           </Inline>
         </Stack>
       </ConfirmDialog>

--- a/plugins/assets/components/versioned/AssetPreview.tsx
+++ b/plugins/assets/components/versioned/AssetPreview.tsx
@@ -8,7 +8,7 @@
  */
 import { useEffect, useState } from 'react'
 import { Download, Pencil, Save, X } from 'lucide-react'
-import { Button, Textarea } from '@makinbakin/sdk/ui'
+import { Button, Text, Textarea } from '@makinbakin/sdk/ui'
 import { MarkdownContent } from '@makinbakin/sdk/content'
 import { Panel } from '@makinbakin/sdk/layout'
 import { isEditableMimeType } from '../../lib/constants'
@@ -81,7 +81,7 @@ export function AssetPreview({ assetId, type, mimeType, version, currentFile, on
   return (
     <div className="flex flex-col items-center gap-bakin-3 rounded-bakin-surface bg-bakin-surface-default p-bakin-8 text-center" data-testid="preview-download">
       <AssetTypeIcon type={type} className="size-bakin-8" />
-      <p className="text-bakin-typography-size-body text-bakin-text-muted">Preview not available for this type.</p>
+      <Text size="body" tone="muted" as="p">Preview not available for this type.</Text>
       <a href={fileUrl} download className="flex items-center gap-bakin-1 text-bakin-typography-size-body text-bakin-signal-accent hover:underline">
         <Download className="size-bakin-4" /> Download
       </a>

--- a/plugins/assets/components/versioned/EnrichmentCard.tsx
+++ b/plugins/assets/components/versioned/EnrichmentCard.tsx
@@ -13,6 +13,7 @@ import {
   Badge,
   Button,
   Input,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { Loader2, Pencil, RefreshCw, Sparkles, Tags } from 'lucide-react'
 import { VERSIONED_API, TAGS_API, ENRICH_API } from './asset-urls'
@@ -200,9 +201,9 @@ export function EnrichmentCard({ manifest, onChanged }: Props) {
       )}
 
       {(enrichment.model || enrichment.at) && (
-        <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted" as="p">
           {enrichment.model}{enrichment.at ? ` · ${new Date(enrichment.at).toLocaleString()}` : ''}
-        </p>
+        </Text>
       )}
     </Section>
   )

--- a/plugins/assets/components/versioned/ImportView.tsx
+++ b/plugins/assets/components/versioned/ImportView.tsx
@@ -9,12 +9,13 @@
  */
 import { useCallback, useEffect, useState } from 'react'
 import { Download, FolderSearch, Loader2 } from 'lucide-react'
-import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SystemState } from '@makinbakin/sdk/ui'
+import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, SystemState, Text } from '@makinbakin/sdk/ui'
 import { DataTable, type DataTableColumn } from '@makinbakin/sdk/patterns'
 import { usePluginEvent } from '@makinbakin/sdk/hooks'
 import { formatAge, formatSize } from '@makinbakin/sdk/utils'
 import { AssetTypeIcon } from './atoms'
 import { IMPORT_API } from './asset-urls'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const ASSET_TYPES = ['text', 'images', 'video', 'audio', 'plans', 'research', 'pdf', 'data', 'other'] as const
 
@@ -110,9 +111,9 @@ export function ImportView({ onImported, onCountChange }: { onImported?: () => v
   return (
     <div className="flex flex-col gap-bakin-2" data-testid="import-list">
       <div className="mb-bakin-1 flex items-center justify-between">
-        <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted" as="p">
           {files.length} unmanaged file{files.length === 1 ? '' : 's'} — imported assets are indexed and searchable like any other.
-        </p>
+        </Text>
         <Button size="sm" onClick={() => runImport({ all: true }, 'all')} disabled={busy !== null} data-testid="import-all">
           {busy === 'all' ? <Loader2 className="size-bakin-3 animate-spin" /> : <Download className="size-bakin-3" />}
           Import all ({files.length})
@@ -138,7 +139,7 @@ export function ImportView({ onImported, onCountChange }: { onImported?: () => v
         narrow: 'primary',
         headClassName: 'min-w-64',
         cell: file => (
-          <div className="flex min-w-0 items-center gap-bakin-3">
+          <Inline wrap={false}>
             <div className="flex size-bakin-8 shrink-0 items-center justify-center rounded-bakin-control bg-bakin-canvas-default">
               <AssetTypeIcon type={typeOverrides[file.relPath] ?? file.suggestedType} className="size-bakin-4" />
             </div>
@@ -146,7 +147,7 @@ export function ImportView({ onImported, onCountChange }: { onImported?: () => v
               <p className="m-0 truncate text-bakin-typography-size-body font-bakin-typography-weight-medium text-bakin-text-primary">{file.name}</p>
               <p className="m-0 truncate text-bakin-typography-size-meta text-bakin-text-muted">{file.relPath}</p>
             </div>
-          </div>
+          </Inline>
         ),
       },
       {

--- a/plugins/assets/components/versioned/VersionRow.tsx
+++ b/plugins/assets/components/versioned/VersionRow.tsx
@@ -5,6 +5,7 @@ import { formatAge } from '@makinbakin/sdk/utils'
 import { Star, Trash2 } from 'lucide-react'
 import { AssetThumb, ProvenanceChips } from './atoms'
 import type { AssetVersion } from './types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 /** One entry in the version timeline. Clicking the row previews that version. */
 export function VersionRow({ assetId, assetType, version, isCurrent, isSelected, canDelete, onSelect, onPromote, onDelete }: {
@@ -57,7 +58,7 @@ export function VersionRow({ assetId, assetType, version, isCurrent, isSelected,
       </div>
 
       <div className="pointer-events-none relative z-10 flex min-w-0 flex-col gap-bakin-2 pr-bakin-8">
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           <span className="font-bakin-typography-family-mono text-bakin-typography-size-body font-bakin-typography-weight-semibold text-bakin-text-primary">
             v{version.version}
           </span>
@@ -68,7 +69,7 @@ export function VersionRow({ assetId, assetType, version, isCurrent, isSelected,
           <span className="ml-auto text-bakin-typography-size-meta text-bakin-text-muted">
             {formatAge(version.created)}
           </span>
-        </div>
+        </Inline>
         {version.prompt ? (
           <p className="m-0 line-clamp-2 text-bakin-typography-size-meta leading-relaxed text-bakin-text-muted">
             {version.prompt}

--- a/plugins/assets/components/versioned/VersionedAssetGrid.tsx
+++ b/plugins/assets/components/versioned/VersionedAssetGrid.tsx
@@ -9,7 +9,7 @@ import {
   useRouter,
   useSearchParams,
 } from '@makinbakin/sdk/navigation'
-import { Grid } from '@makinbakin/sdk/layout'
+import { Grid, Inline } from '@makinbakin/sdk/layout'
 import {
   FacetFilter,
   DataTable,
@@ -27,18 +27,19 @@ import {
   Button,
   Card,
   CardDescription,
-  CardMedia,
   CardHeader,
+  CardMedia,
   CardTitle,
   Checkbox,
   Dialog,
   DialogContent,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
   DialogFooter,
+  DialogHeader,
+  DialogTitle,
   FileInput,
   SystemState,
+  Text,
   type FileInputHandle,
 } from '@makinbakin/sdk/ui'
 import { formatSize, formatAge } from '@makinbakin/sdk/utils'
@@ -535,7 +536,7 @@ export function VersionedAssetGrid() {
         feedback={uploadError || (linkTo && view !== 'trash') ? (
           <div className="grid min-w-0 gap-bakin-2">
             {uploadError ? <p className="m-0 text-bakin-typography-size-meta text-bakin-signal-danger">{uploadError}</p> : null}
-            {linkTo && view !== 'trash' ? <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">New uploads will be linked to this task.</p> : null}
+            {linkTo && view !== 'trash' ? <Text size="meta" tone="muted" as="p">New uploads will be linked to this task.</Text> : null}
           </div>
         ) : undefined}
       >
@@ -595,12 +596,12 @@ export function VersionedAssetGrid() {
                   narrow: 'primary',
                   headClassName: 'min-w-64',
                   cell: item => (
-                    <div className="flex min-w-0 items-center gap-bakin-3">
+                    <Inline wrap={false}>
                       <div className="flex size-bakin-8 shrink-0 items-center justify-center rounded-bakin-control bg-bakin-canvas-default">
                         <AssetTypeIcon type={item.type} className="size-bakin-4" />
                       </div>
                       <p className="m-0 truncate text-bakin-typography-size-body font-bakin-typography-weight-medium text-bakin-text-primary">{item.description || item.assetId}</p>
-                    </div>
+                    </Inline>
                   ),
                 },
                 { key: 'type', header: 'Type', narrow: 'meta', cell: item => <span className="capitalize text-bakin-text-muted">{item.type}</span> },
@@ -709,7 +710,7 @@ export function VersionedAssetGrid() {
                 sortable: true,
                 headClassName: 'min-w-64',
                 cell: asset => (
-                  <div className="flex min-w-0 items-center gap-bakin-3">
+                  <Inline wrap={false}>
                     <div className="size-bakin-8 shrink-0 overflow-hidden rounded-bakin-control">
                       <AssetThumb assetId={asset.assetId} type={asset.type} version={asset.currentVersion} hasThumb={asset.hasThumb} />
                     </div>
@@ -717,7 +718,7 @@ export function VersionedAssetGrid() {
                       <p className="m-0 truncate font-bakin-typography-weight-medium text-bakin-text-primary">{asset.description || asset.assetId}</p>
                       {scoreFor(asset.assetId) ? <ScoreOverlay info={scoreFor(asset.assetId)!} /> : null}
                     </div>
-                  </div>
+                  </Inline>
                 ),
               },
               { key: 'type', header: 'Type', cell: asset => <span className="capitalize text-bakin-text-muted">{asset.type}</span> },

--- a/plugins/assets/components/versioned/atoms.tsx
+++ b/plugins/assets/components/versioned/atoms.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { FileText, Image, Video, Music, Map, Database, Package, Clock } from 'lucide-react'
 import { useAgent } from '@makinbakin/sdk/hooks'
 import { AgentAvatar } from '@makinbakin/sdk/patterns'
-import { Badge } from '@makinbakin/sdk/ui'
+import { Badge, Text } from '@makinbakin/sdk/ui'
 import { formatAge } from '@makinbakin/sdk/utils'
 import { assetThumbUrl, assetCurrentUrl, assetVersionUrl } from './asset-urls'
 
@@ -70,7 +70,7 @@ function AssetAgentIdentity({ agentId }: { agentId: string }) {
         size="xs"
         decorative
       />
-      <span className="text-bakin-typography-size-meta text-bakin-text-muted">{agentId}</span>
+      <Text size="meta" tone="muted">{agentId}</Text>
     </div>
   )
 }
@@ -95,7 +95,7 @@ export function AssetMetaSummary({ agent, created, taskId, tags, maxTags = 4 }: 
         <span className="text-bakin-typography-size-meta text-bakin-text-muted/50">|</span>
         <div className="flex items-center gap-bakin-1">
           <Clock className="size-bakin-3 text-bakin-text-muted/50" />
-          <span className="text-bakin-typography-size-meta text-bakin-text-muted">{formatAge(created)}</span>
+          <Text size="meta" tone="muted">{formatAge(created)}</Text>
         </div>
         {taskId && (
           <>
@@ -111,7 +111,7 @@ export function AssetMetaSummary({ agent, created, taskId, tags, maxTags = 4 }: 
           {tags.slice(-maxTags).map(tag => (
             <Badge key={tag} variant="secondary" size="xs">{tag}</Badge>
           ))}
-          {tags.length > maxTags && <span className="text-bakin-typography-size-meta text-bakin-text-muted">+{tags.length - maxTags}</span>}
+          {tags.length > maxTags && <Text size="meta" tone="muted">+{tags.length - maxTags}</Text>}
         </div>
       )}
     </div>

--- a/plugins/brands/components/brand-builder.tsx
+++ b/plugins/brands/components/brand-builder.tsx
@@ -11,14 +11,14 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-  Drawer,
-  DrawerSection,
   Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Drawer,
+  DrawerSection,
   Field,
   FieldDescription,
   FieldGroup,
@@ -27,6 +27,7 @@ import {
   Form,
   FormActions,
   Input,
+  Text,
   Textarea,
   Tooltip,
   TooltipContent,
@@ -178,9 +179,9 @@ export function BrandBuilder({
 
   const footer = (
     <FormActions align="between" className="sticky bottom-0 z-10 bg-bakin-surface-default pb-bakin-1">
-      <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+      <Text size="meta" tone="muted">
         Step {step + 1} of {STEPS.length}
-      </span>
+      </Text>
       <div className="flex min-w-0 gap-bakin-2">
         {step > 0 && (
           <Button variant="outline" size="sm" onClick={() => setStep((s) => s - 1)} disabled={busy}>

--- a/plugins/brands/components/brand-card.tsx
+++ b/plugins/brands/components/brand-card.tsx
@@ -5,7 +5,7 @@
  */
 import { PluginLink } from '@makinbakin/sdk/navigation'
 import { StatusBadge } from '@makinbakin/sdk/patterns'
-import { Card, CardAction, CardContent, CardHeader, CardMedia, CardTitle } from '@makinbakin/sdk/ui'
+import { Card, CardAction, CardContent, CardHeader, CardMedia, CardTitle, Text } from '@makinbakin/sdk/ui'
 import { Progress, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@makinbakin/sdk/ui'
 import type { BrandManifest } from '../types'
 
@@ -141,10 +141,10 @@ export function BrandCoverCard({ brand }: { brand: ListedBrand }) {
         )}
 
         {brand.counts && (
-          <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             {brand.counts.guidelines} docs · {brand.counts.lessons} lessons · {brand.counts.assets} assets
             {brand.source ? ' · imported' : ''}
-          </p>
+          </Text>
         )}
       </CardContent>
     </Card>

--- a/plugins/brands/components/brand-detail.tsx
+++ b/plugins/brands/components/brand-detail.tsx
@@ -29,12 +29,40 @@ import {
   ColorInput,
 } from '@makinbakin/sdk/patterns'
 import {
-  Banner, Button, Input, Textarea, Switch, Label, Skeleton, Progress, SystemState,
-  Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle,
-  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-  Tabs, TabsList, TabsTrigger,
-  Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
+  Banner,
+  Button,
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Progress,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Switch,
+  SystemState,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Text,
+  Textarea,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@makinbakin/sdk/ui'
 import { useQueryState, usePluginEvent, toast } from '@makinbakin/sdk/hooks'
 import {
@@ -1254,7 +1282,7 @@ function DocsEditor({
                 if (e.key === 'Enter') submitNewDoc()
               }}
             />
-            <p className="text-bakin-typography-size-meta text-bakin-text-muted">.md is added for you{newDocName.trim() && !newDocName.trim().endsWith('.md') ? ` — creates ${newDocName.trim()}.md` : ''}</p>
+            <Text size="meta" tone="muted" as="p">.md is added for you{newDocName.trim() && !newDocName.trim().endsWith('.md') ? ` — creates ${newDocName.trim()}.md` : ''}</Text>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setNewOpen(false)}>Cancel</Button>
@@ -1437,7 +1465,7 @@ function BrandAssetsSection({
           <div key={group.name} className="space-y-bakin-2 rounded-bakin-control bg-bakin-surface-default p-bakin-3">
             <div className="flex items-center gap-bakin-2 text-bakin-typography-size-body">
               <span className="font-bakin-typography-weight-medium">{group.name}</span>
-              {group.description && <span className="text-bakin-typography-size-meta text-bakin-text-muted">— {group.description}</span>}
+              {group.description && <Text size="meta" tone="muted">— {group.description}</Text>}
               <div className="ml-auto flex shrink-0 items-center gap-bakin-1">
                 <Button
                   variant="ghost" size="xs" className="text-bakin-text-muted"
@@ -1462,7 +1490,7 @@ function BrandAssetsSection({
                 </Button>
               </div>
             </div>
-            {group.assetIds.length === 0 && <p className="text-bakin-typography-size-meta text-bakin-text-muted">Empty group — add screenshots or imagery.</p>}
+            {group.assetIds.length === 0 && <Text size="meta" tone="muted" as="p">Empty group — add screenshots or imagery.</Text>}
             {group.assetIds.length > 0 && (
               <div className="grid gap-bakin-3 lg:grid-cols-2">
                 {group.assetIds.map((assetId) =>
@@ -1498,7 +1526,7 @@ function BrandAssetsSection({
               <Plus className="size-bakin-3" /> Add reference
             </Button>
           ) : (
-            <span className="text-bakin-typography-size-meta text-bakin-text-muted">4 of 4 — remove one to swap</span>
+            <Text size="meta" tone="muted">4 of 4 — remove one to swap</Text>
           )
         }
       >
@@ -1826,11 +1854,11 @@ function BrandSettingsTab({
       >
         {brand.draft ? (
           <>
-            <p className="text-bakin-typography-size-body text-bakin-text-muted">
+            <Text size="body" tone="muted" as="p">
               Review the tabs, then publish. Delete <code className="rounded bg-bakin-surface-default px-bakin-1 text-bakin-typography-size-meta">_intake.md</code> under
               Guidelines if you don't want the builder intake kept.
               {blocked > 0 && ` ${blocked} task${blocked === 1 ? ' is' : 's are'} waiting on this brand right now.`}
-            </p>
+            </Text>
             <Button variant="default" size="sm" className="w-fit" onClick={onPublish}>
               <Rocket className="size-bakin-3" /> Publish brand
             </Button>
@@ -1871,11 +1899,11 @@ function BrandSettingsTab({
           icon={ExternalLink}
           description="Where this brand kit came from — local edits win over the upstream copy."
         >
-          <p className="text-bakin-typography-size-body text-bakin-text-muted">
+          <Text size="body" tone="muted" as="p">
             <span className="font-bakin-typography-family-mono text-bakin-text-primary/80">{brand.source.repo}</span>
             {brand.source.commit ? ` @ ${brand.source.commit.slice(0, 8)}` : ''}. Check for upstream changes:
             <code className="ml-bakin-1 rounded bg-bakin-surface-default px-bakin-1 text-bakin-typography-size-meta">bakin brands check {brand.id}</code>
-          </p>
+          </Text>
         </SectionCard>
       )}
 
@@ -1885,12 +1913,12 @@ function BrandSettingsTab({
         description="Every branded task carries a compact card of this brand — rules, palette, terminology, and the always-in-context docs."
       >
         {cardInfo ? (
-          <p className="text-bakin-typography-size-body text-bakin-text-muted">
+          <Text size="body" tone="muted" as="p">
             The card currently adds ~{(cardInfo.cardBytes / 1024).toFixed(1)} KB of its {(cardInfo.maxBytes / 1024).toFixed(0)} KB allowance to every branded task
             {cardInfo.omitted > 0 ? ` — ${cardInfo.omitted} item${cardInfo.omitted === 1 ? ' is' : 's are'} left out for size (agents fetch them on demand).` : ' — nothing is left out.'}
-          </p>
+          </Text>
         ) : (
-          <p className="text-bakin-typography-size-body text-bakin-text-muted">Measuring the card…</p>
+          <Text size="body" tone="muted" as="p">Measuring the card…</Text>
         )}
         {dangling.length > 0 && (
           <div className="rounded-bakin-control bg-bakin-signal-highlight/10 p-bakin-3 ring-1 ring-bakin-signal-highlight/20">

--- a/plugins/brands/components/task-brand-panel.tsx
+++ b/plugins/brands/components/task-brand-panel.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useState } from 'react'
 import { useDebug, useJsonFetch } from '@makinbakin/sdk/hooks'
 import { PluginLink } from '@makinbakin/sdk/navigation'
-import { Panel } from '@makinbakin/sdk/layout'
+import { Inline, Panel } from '@makinbakin/sdk/layout'
 import { StatusBadge } from '@makinbakin/sdk/patterns'
 import {
   Alert,
@@ -104,12 +104,12 @@ export function TaskBrandPanel({ taskId }: { taskId?: string }) {
       )}
     >
       <div className="grid gap-bakin-4">
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           <p className="m-0 min-w-0 font-bakin-typography-weight-semibold text-bakin-text-primary">
             {brand.name || brand.brandId}
           </p>
           <StatusBadge size="xs" tone="accent">{SOURCE_LABEL[brand.source]}</StatusBadge>
-        </div>
+        </Inline>
 
         {brand.blocked ? (
           <Banner

--- a/plugins/explore/components/catalog-card.tsx
+++ b/plugins/explore/components/catalog-card.tsx
@@ -12,11 +12,14 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  Overline,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@makinbakin/sdk/ui'
 import { runtimeCompatible, type ExploreCatalogEntry } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 export function entryStatusBadge(entry: ExploreCatalogEntry): {
   label: string
@@ -97,23 +100,23 @@ export function CatalogCard({
       interactive={{ label: `View ${entry.name} details`, onActivate: () => onSelect(entry) }}
     >
       <CardHeader>
-        <div className="flex min-w-0 items-center gap-bakin-3">
+        <Inline wrap={false}>
           <EntryVisual entry={entry} />
           <div className="flex min-w-0 flex-1 items-center gap-bakin-2">
             <CardTitle className="min-w-0 flex-1 group-data-[size=sm]/card:text-bakin-typography-size-section-title">
               {entry.name}
             </CardTitle>
-            <span className="shrink-0 text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wide text-bakin-text-muted">
+            <Overline className="shrink-0">
               {entry.category}
-            </span>
+            </Overline>
           </div>
-        </div>
+        </Inline>
       </CardHeader>
       <CardContent className="flex-1">
         <CardDescription className="line-clamp-2 leading-snug">{entry.description}</CardDescription>
       </CardContent>
       <CardFooter variant="meta" className="gap-bakin-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           {status && (
             <StatusBadge tone={status.tone} variant={status.variant} icon={status.icon} size="xs">
               {status.label}
@@ -143,11 +146,11 @@ export function CatalogCard({
             </Tooltip>
           )}
           {entry.installedVersion ? (
-            <span className="text-bakin-typography-size-meta text-bakin-text-muted" data-testid="card-version">
+            <Text size="meta" tone="muted" data-testid="card-version">
               v{entry.installedVersion}
-            </span>
+            </Text>
           ) : null}
-        </div>
+        </Inline>
         <div className="ml-auto flex items-center gap-bakin-1">
           <Button type="button" variant="ghost" size="xs" onClick={() => onSelect(entry)}>
             Details

--- a/plugins/explore/components/explore-page.tsx
+++ b/plugins/explore/components/explore-page.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { Check, Plus, RefreshCw, Sparkles } from 'lucide-react'
-import { Grid } from '@makinbakin/sdk/layout'
+import { Grid, Inline } from '@makinbakin/sdk/layout'
 import { useQueryArrayState, useQueryState } from '@makinbakin/sdk/navigation'
 import {
   FacetFilter,
@@ -22,6 +22,7 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -299,10 +300,10 @@ function ExplorePageInner() {
           {Array.from({ length: 6 }, (_, index) => (
             <Card key={index} size="sm">
               <CardHeader>
-                <div className="flex min-w-0 items-center gap-bakin-3">
+                <Inline wrap={false}>
                   <Skeleton shape="circle" className="size-bakin-8" />
                   <Skeleton shape="text" className="min-w-0 flex-1" />
-                </div>
+                </Inline>
               </CardHeader>
               <CardContent className="grid gap-bakin-2">
                 <Skeleton shape="text" />
@@ -403,9 +404,9 @@ function ExplorePageInner() {
           // A one-line note, not a SystemState: a second heading-bearing empty
           // panel inside the filter toolbar competes with the real results
           // empty state below it (and made `empty-state` ambiguous in tests).
-          <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             No categories in this section
-          </p>
+          </Text>
         )}
       </PageControls>
 

--- a/plugins/explore/components/hub-skills-section.tsx
+++ b/plugins/explore/components/hub-skills-section.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   Drawer,
   Input,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -233,10 +234,10 @@ function PreviewDrawerBody({
       )}
 
       {preview.mentions.length > 0 && (
-        <div className="text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted" as="div">
           Mentions env-var-shaped strings (unmapped — no readiness claim): {preview.mentions.join(', ')}.
           Run <span className="font-bakin-typography-family-mono">bakin skills map</span> after install if this skill needs keys Bakin didn&apos;t recognize.
-        </div>
+        </Text>
       )}
 
       {preview.warnings.length > 0 && (
@@ -408,7 +409,7 @@ export function HubSkillsSection() {
               <ListRow key={row.packageId + row.skillName}>
                 <div className="min-w-0">
                   <div className="flex items-center gap-bakin-2 text-bakin-typography-size-body font-bakin-typography-weight-medium text-bakin-text-primary">
-                    {row.skillName} <span className="text-bakin-typography-size-meta text-bakin-text-muted">v{row.version}</span>
+                    {row.skillName} <Text size="meta" tone="muted">v{row.version}</Text>
                     <Badge tone="neutral" variant="soft" size="xs">{sourceChip(row.source, row.hub)}</Badge>
                   </div>
                   {/* The ref truncates in this narrow panel; the tooltip is the
@@ -444,11 +445,11 @@ export function HubSkillsSection() {
           the ecosystem. */}
       <div className="grid gap-bakin-2">
         <h3>Get more capabilities</h3>
-        <div className="text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted" as="div">
           Official ones below install with one click and guided setup. Or bring any skill from the wider
           ecosystem — browse clawhub.ai (or a GitHub skills repo), copy the page link, paste it here.
           You&apos;ll review a full trust preview before anything installs.
-        </div>
+        </Text>
         <div className="flex gap-bakin-2">
           <Input
             value={ref}

--- a/plugins/health/components/activity-failure-groups.tsx
+++ b/plugins/health/components/activity-failure-groups.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { formatRelativeTime } from '@makinbakin/sdk/conversation'
-import { Grid, Panel, Section } from '@makinbakin/sdk/layout'
+import { Grid, Inline, Panel, Section } from '@makinbakin/sdk/layout'
 import { ListRows, Pagination, StatusBadge } from '@makinbakin/sdk/patterns'
 import { Button } from '@makinbakin/sdk/ui'
 import { AlertCircle, ChevronDown } from 'lucide-react'
@@ -148,7 +148,7 @@ function FailureGroup({
     >
       <div className="grid min-w-0 gap-bakin-3 px-bakin-3 py-bakin-4 @[38rem]/health:grid-cols-[minmax(0,1fr)_auto] @[38rem]/health:items-center">
         <div className="min-w-0">
-          <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+          <Inline gap="dense">
             <Icon className="size-bakin-4 shrink-0" aria-hidden="true" />
             <h4 className="min-w-0 truncate">
               {displayName}
@@ -156,7 +156,7 @@ function FailureGroup({
             <span className="text-bakin-typography-size-meta font-bakin-typography-weight-medium text-bakin-text-muted">
               {meta.label}
             </span>
-          </div>
+          </Inline>
 
           <p className="mt-bakin-2 truncate text-bakin-typography-size-body text-bakin-text-primary">{reason}</p>
           <div className="mt-bakin-2 flex min-w-0 flex-wrap items-center gap-x-bakin-3 gap-y-bakin-1 text-bakin-typography-size-meta text-bakin-text-muted">

--- a/plugins/health/components/activity-pulse.tsx
+++ b/plugins/health/components/activity-pulse.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, CheckCircle2 } from 'lucide-react'
 import type { InteractionCoverage, UsageFeedData } from '../types'
 import { focusActivityElement } from './activity-navigation'
 import { INTERACTION_SOURCE_META } from './interaction-source-meta'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const OUTCOMES = [
   { key: 'failed', label: 'failed' },
@@ -71,12 +72,12 @@ export function ActivityPulse({
       data-testid="activity-pulse"
     >
       <div className="flex min-w-0 flex-wrap items-center justify-between gap-bakin-2 bg-bakin-surface-default px-bakin-4 py-bakin-3">
-        <div className="flex min-w-0 items-center gap-bakin-2">
+        <Inline gap="dense" wrap={false}>
           {needsAttention
             ? <AlertCircle className={`size-bakin-4 shrink-0 ${hasFailures ? 'text-bakin-signal-danger' : 'text-bakin-signal-highlight'}`} aria-hidden="true" />
             : <CheckCircle2 className="size-bakin-4 shrink-0 text-bakin-action-primary-background" aria-hidden="true" />}
           <h3 id="activity-pulse-title">Activity pulse</h3>
-        </div>
+        </Inline>
         <div className="flex min-w-0 flex-wrap items-center justify-end gap-x-bakin-2 gap-y-bakin-1 text-bakin-typography-size-meta text-bakin-text-muted">
           <span className={compatibilityLimited ? 'text-bakin-signal-highlight' : undefined}>
             {compatibilityLimited ? 'Partial data · restart Bakin for exact metrics' : coverageLabel(data.window, data.coverage)}

--- a/plugins/health/components/agent-pulse.tsx
+++ b/plugins/health/components/agent-pulse.tsx
@@ -13,9 +13,11 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Overline,
   Progress,
   Skeleton,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { Activity, ArrowUpRight, Bot, ChevronDown } from 'lucide-react'
 import type {
@@ -74,7 +76,7 @@ function latestSessionCostLabel(session: AgentUsage): string | null {
 function Metric({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="min-w-0">
-      <p className="text-bakin-typography-size-meta font-bakin-typography-weight-medium uppercase tracking-wide text-bakin-text-muted">{label}</p>
+      <Overline as="p">{label}</Overline>
       <div className="mt-bakin-1">{children}</div>
     </div>
   )
@@ -138,7 +140,7 @@ function UsageMetric({ row, pending }: { row: AgentPulseRow; pending: AgentPulse
           />
         </div>
       )}
-      <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+      <Text size="meta" tone="muted" as="p">
         {reportedCost !== null
           ? `${formatRuntimeCost(reportedCost / 1_000_000)}${row.costedMessages < row.messageCount ? '+' : ''} reported cost${row.costedMessages < row.messageCount ? ` · partial (${row.costedMessages}/${row.messageCount} messages)` : ''}`
           : trackedCost !== null
@@ -146,7 +148,7 @@ function UsageMetric({ row, pending }: { row: AgentPulseRow; pending: AgentPulse
             : checkingCost
               ? 'Checking cost…'
               : 'Cost unavailable'}
-      </p>
+      </Text>
     </Metric>
   )
 }
@@ -156,14 +158,14 @@ function ContextMetric({ row, checking }: { row: AgentPulseRow; checking: boolea
   return (
     <Metric label="Startup context">
       {checking ? (
-        <p className="text-bakin-typography-size-body text-bakin-text-muted">Checking…</p>
+        <Text size="body" tone="muted" as="p">Checking…</Text>
       ) : percent === null ? (
-        <p className="text-bakin-typography-size-body text-bakin-text-muted">Unavailable</p>
+        <Text size="body" tone="muted" as="p">Unavailable</Text>
       ) : (
         <>
           <div className="flex items-baseline justify-between gap-bakin-3">
             <p className="font-bakin-typography-weight-semibold tabular-nums text-bakin-text-primary">{percent}%</p>
-            <p className="text-bakin-typography-size-meta text-bakin-text-muted">of budget</p>
+            <Text size="meta" tone="muted" as="p">of budget</Text>
           </div>
           <Progress
             className="mt-bakin-1"
@@ -198,9 +200,9 @@ function LatestSessionDetails({ row, id, checking, unavailable }: {
           <div className="grid gap-bakin-3 @[36rem]/agent-pulse:grid-cols-[minmax(11rem,1.5fr)_repeat(4,minmax(5rem,1fr))]">
             <div className="min-w-0">
               <p className="truncate font-bakin-typography-weight-medium text-bakin-text-primary">{session.model}</p>
-              <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+              <Text size="meta" tone="muted" as="p">
                 {plural(session.messages, 'message')} · {formatTokenCount(session.tokens.total)} tokens
-              </p>
+              </Text>
             </div>
             {([
               ['Input', session.tokens.input],
@@ -209,7 +211,7 @@ function LatestSessionDetails({ row, id, checking, unavailable }: {
               ['Cache write', session.tokens.cacheWrite],
             ] as const).map(([label, value]) => (
               <dl key={label}>
-                <dt className="text-bakin-typography-size-meta uppercase tracking-wide text-bakin-text-muted">{label}</dt>
+                <Overline as="dt">{label}</Overline>
                 <dd className="mt-bakin-0 font-bakin-typography-weight-medium tabular-nums text-bakin-text-primary">{formatTokenCount(value)}</dd>
               </dl>
             ))}
@@ -219,11 +221,11 @@ function LatestSessionDetails({ row, id, checking, unavailable }: {
           )}
         </div>
       ) : checking ? (
-        <p className="text-bakin-typography-size-body text-bakin-text-muted">Checking latest session…</p>
+        <Text size="body" tone="muted" as="p">Checking latest session…</Text>
       ) : unavailable ? (
-        <p className="text-bakin-typography-size-body text-bakin-text-muted">Latest-session detail is unavailable.</p>
+        <Text size="body" tone="muted" as="p">Latest-session detail is unavailable.</Text>
       ) : (
-        <p className="text-bakin-typography-size-body text-bakin-text-muted">No latest-session token breakdown is available.</p>
+        <Text size="body" tone="muted" as="p">No latest-session token breakdown is available.</Text>
       )}
       <PluginLink
         to={`/team/${encodeURIComponent(row.agent)}?tab=diagnostics`}
@@ -306,22 +308,22 @@ function AgentPulseRowView({ row, expanded, pending, unavailable, liveNowStale, 
       <UsageMetric row={row} pending={pending} />
       <Metric label="Tracked work">
         {pending.effort ? (
-          <p className="text-bakin-typography-size-body text-bakin-text-muted">Checking…</p>
+          <Text size="body" tone="muted" as="p">Checking…</Text>
         ) : row.effort ? (
           <>
             <p className="font-bakin-typography-weight-medium text-bakin-text-primary">{plural(row.effort.runs, 'tracked run')}</p>
-            <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+            <Text size="meta" tone="muted" as="p">
               {row.effort.windowTokens === null
                 ? `Token totals unavailable${tokenCoverage ? ` · ${tokenCoverage}` : ''}`
                 : `${formatTokenCount(row.effort.windowTokens)} tracked tokens`}
-            </p>
-            <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+            </Text>
+            <Text size="meta" tone="muted" as="p">
               {plural(row.effort.completions, 'task completion')}
               {costCoverage ? ` · cost ${costCoverage}` : ''}
-            </p>
+            </Text>
           </>
         ) : (
-          <p className="text-bakin-typography-size-body text-bakin-text-muted">Work evidence unavailable</p>
+          <Text size="body" tone="muted" as="p">Work evidence unavailable</Text>
         )}
       </Metric>
       <ContextMetric row={row} checking={pending.context || pending.settings} />
@@ -459,9 +461,9 @@ export function AgentPulse({
           </ListRows>
         )}
         {mixedEvidence && (
-          <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             Usage and tracked-work evidence came from separate refreshes.
-          </p>
+          </Text>
         )}
         {rows.length > 0 && error && (
           <p role="status" className="flex items-center gap-bakin-1 text-bakin-typography-size-meta text-bakin-text-muted">

--- a/plugins/health/components/agents-usage-chart.tsx
+++ b/plugins/health/components/agents-usage-chart.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
   Skeleton,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { ArrowUpRight, TrendingUp } from 'lucide-react'
 import type { UsageHistoryData } from '../types'
@@ -225,10 +226,10 @@ export function AgentsUsageChart({ data, loading, error, onRetry }: AgentsUsageC
               )}
               {visibleData && visibleData.byAgent.length > 0 && (
                 <div className="flex flex-wrap items-baseline gap-x-bakin-6 gap-y-bakin-1 rounded-bakin-control border border-bakin-border-subtle bg-bakin-canvas-default px-bakin-3 py-bakin-2">
-                  <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+                  <Text size="meta" tone="muted" as="p">
                     Reported cost <span className="ml-bakin-1 font-bakin-typography-weight-semibold tabular-nums text-bakin-text-primary">{reportedCost === null ? 'Unavailable' : `${formatRuntimeCost(reportedCost / 1_000_000)}${partialCostCoverage ? '+' : ''}`}</span>
-                  </p>
-                  {costCoverage && <p className="text-bakin-typography-size-meta text-bakin-text-muted">{costCoverage}</p>}
+                  </Text>
+                  {costCoverage && <Text size="meta" tone="muted" as="p">{costCoverage}</Text>}
                 </div>
               )}
               {!trend ? (

--- a/plugins/health/components/overview-agent-spend.tsx
+++ b/plugins/health/components/overview-agent-spend.tsx
@@ -4,7 +4,7 @@ import { assignSeriesColors, CHART_MAX_SERIES, StackedColumnChart } from '@makin
 import { formatRelativeTime } from '@makinbakin/sdk/conversation'
 import { PluginLink } from '@makinbakin/sdk/navigation'
 import { ListRow, ListRows, StatusBadge } from '@makinbakin/sdk/patterns'
-import { Button, Skeleton, SystemState } from '@makinbakin/sdk/ui'
+import { Button, Skeleton, SystemState, Text } from '@makinbakin/sdk/ui'
 import { ArrowUpRight, Coins } from 'lucide-react'
 import type { HealthOverviewViewModel } from '../lib/health-view-model'
 import { formatRuntimeCost, formatTokenCount } from '../lib/format'
@@ -157,17 +157,17 @@ export function OverviewAgentSpend({
           <div className="mt-bakin-4 flex flex-wrap items-end gap-x-bakin-6 gap-y-bakin-2">
             <div>
               <strong className="block text-bakin-typography-size-title font-bakin-typography-weight-semibold tabular-nums text-bakin-text-primary">{formatTokenCount(total)} tokens</strong>
-              <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+              <Text size="meta" tone="muted">
                 {evidenceLimited ? 'Fully scanned agents only' : 'Observed transcript traffic'}
-              </span>
+              </Text>
             </div>
             <div>
               <strong className="block text-bakin-typography-size-heading font-bakin-typography-weight-semibold tabular-nums text-bakin-text-primary">
                 {cost === null ? 'Cost unavailable' : `${formatRuntimeCost(cost.usd)}${cost.complete && !evidenceLimited ? '' : '+'}`}
               </strong>
-              <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+              <Text size="meta" tone="muted">
                 {cost?.complete === false || evidenceLimited ? 'Partial runtime-reported cost' : 'Runtime-reported cost'}
-              </span>
+              </Text>
             </div>
           </div>
 

--- a/plugins/health/components/overview-alerts.tsx
+++ b/plugins/health/components/overview-alerts.tsx
@@ -2,7 +2,7 @@
 
 import type { HealthIncident } from '@makinbakin/sdk/types'
 import { PluginLink } from '@makinbakin/sdk/navigation'
-import { DisclosurePanel, Section, Stack } from '@makinbakin/sdk/layout'
+import { DisclosurePanel, Inline, Section, Stack } from '@makinbakin/sdk/layout'
 import { StatusBadge } from '@makinbakin/sdk/patterns'
 import { Banner, Popover, PopoverContent, PopoverTrigger } from '@makinbakin/sdk/ui'
 import { ChevronDown, ChevronRight } from 'lucide-react'
@@ -148,12 +148,12 @@ export function OverviewAlerts({ model, onRepair, onRerun, onAck }: OverviewAler
     <Section spacing="compact" aria-labelledby="overview-fix-first-title">
       <div className="flex min-w-0 flex-wrap items-center justify-between gap-bakin-3">
         <Stack gap="dense">
-          <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+          <Inline gap="dense">
             <h2 id="overview-fix-first-title">Fix first</h2>
             <StatusBadge tone={model.needsAction.length > 0 ? 'danger' : 'neutral'} variant="solid">
               {actionLabel}
             </StatusBadge>
-          </div>
+          </Inline>
           <p className="m-0 text-bakin-typography-size-meta leading-relaxed text-bakin-text-muted">
             Actionable conditions come before supporting telemetry.
           </p>

--- a/plugins/health/components/overview-interactions.tsx
+++ b/plugins/health/components/overview-interactions.tsx
@@ -3,7 +3,7 @@
 import { CompositionBar, RankedBarChart, Sparkline, type ChartDatum } from '@makinbakin/sdk/charts'
 import { PluginLink } from '@makinbakin/sdk/navigation'
 import { StatusBadge } from '@makinbakin/sdk/patterns'
-import { Button, Skeleton, SystemState } from '@makinbakin/sdk/ui'
+import { Button, Skeleton, SystemState, Text } from '@makinbakin/sdk/ui'
 import { ArrowUpRight, Waypoints } from 'lucide-react'
 import type {
   InteractionCategory,
@@ -11,6 +11,7 @@ import type {
 } from '../types'
 import { interactionCategoryMeta } from './interaction-source-meta'
 import type { OverviewTelemetry } from './overview-telemetry'
+import { Inline } from '@makinbakin/sdk/layout'
 
 function destinationName(category: InteractionCategory, value: string): string {
   if (category === 'api') return value.replace(/^\/api\//, '')
@@ -100,15 +101,15 @@ export function OverviewInteractions({
       aria-labelledby="overview-interactions-title"
     >
       <div className="flex min-w-0 flex-wrap items-center justify-between gap-x-bakin-3 gap-y-bakin-1">
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           <Waypoints className="size-bakin-4 text-bakin-text-muted" aria-hidden="true" />
           <h3 id="overview-interactions-title">Interactions</h3>
           {coverage && (
-            <span className="text-bakin-typography-size-meta text-bakin-text-muted" aria-label={coverage.label}>
+            <Text size="meta" tone="muted" aria-label={coverage.label}>
               {coverage.text}
-            </span>
+            </Text>
           )}
-        </div>
+        </Inline>
         <PluginLink
           to="/health?tab=activity&activity_window=1h"
           aria-label="View recorded interaction activity"

--- a/plugins/health/components/overview-platform-pulse.tsx
+++ b/plugins/health/components/overview-platform-pulse.tsx
@@ -14,6 +14,7 @@ import {
   Search,
 } from 'lucide-react'
 import type { HealthOverviewViewModel, OverviewTone } from '../lib/health-view-model'
+import { Inline } from '@makinbakin/sdk/layout'
 
 interface OverviewPlatformPulseProps {
   model: HealthOverviewViewModel
@@ -128,7 +129,7 @@ export function OverviewPlatformPulse({
           <p className="m-0 leading-relaxed text-bakin-text-muted">{pulseDescription}</p>
         </div>
 
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-3">
+        <Inline>
           {!loading ? (
             <StatusBadge tone={TONE[overallTone].badge} variant="solid">
               {primaryCount > 0 ? primaryLabel : overallLabel}
@@ -147,7 +148,7 @@ export function OverviewPlatformPulse({
                 )
               : <span>not yet</span>}
           </span>
-        </div>
+        </Inline>
       </div>
 
       <div

--- a/plugins/health/components/system-inventory.tsx
+++ b/plugins/health/components/system-inventory.tsx
@@ -11,7 +11,7 @@ import {
   StatusBadge,
   type DataTableColumn,
 } from '@makinbakin/sdk/patterns'
-import { Badge, Banner, Button, Input, type BannerTone } from '@makinbakin/sdk/ui'
+import { Badge, Banner, Button, Input, Text, type BannerTone } from '@makinbakin/sdk/ui'
 import { Clock3, Cpu, Hash, MemoryStick, Network, Users } from 'lucide-react'
 import { formatAge } from '@makinbakin/sdk/utils'
 import type { HealthSummary } from '../types'
@@ -286,9 +286,9 @@ export const SystemInventory = forwardRef<SystemInventoryHandle, SystemInventory
             />
           </label>
           {loading && plugins.length === 0 ? (
-            <p className="text-bakin-typography-size-body text-bakin-text-muted">Loading installed plugins…</p>
+            <Text size="body" tone="muted" as="p">Loading installed plugins…</Text>
           ) : filteredPlugins.length === 0 ? (
-            <p className="text-bakin-typography-size-body text-bakin-text-muted">{pluginSearch ? 'No matching plugins.' : 'No plugins were discovered.'}</p>
+            <Text size="body" tone="muted" as="p">{pluginSearch ? 'No matching plugins.' : 'No plugins were discovered.'}</Text>
           ) : (
             <Panel ref={pluginTableRef} scroll aria-label="Installed plugins" data-testid="installed-plugin-table-scroll" padding="compact" className="max-h-80">
               <DataTable<InventoryPlugin>
@@ -361,9 +361,9 @@ export const SystemInventory = forwardRef<SystemInventoryHandle, SystemInventory
         )}
       >
           {!report ? (
-            <p className="text-bakin-typography-size-body text-bakin-text-muted">Waiting for the canonical health report…</p>
+            <Text size="body" tone="muted" as="p">Waiting for the canonical health report…</Text>
           ) : groupedChecks.length === 0 ? (
-            <p className="text-bakin-typography-size-body text-bakin-text-muted">No health checks are registered.</p>
+            <Text size="body" tone="muted" as="p">No health checks are registered.</Text>
           ) : (
             <div className="space-y-bakin-2">
               {groupedChecks.map((group) => {

--- a/plugins/health/components/system-search-section.tsx
+++ b/plugins/health/components/system-search-section.tsx
@@ -10,7 +10,7 @@ import {
   type DataTableColumn,
   type StatusTone,
 } from '@makinbakin/sdk/patterns'
-import { Alert, AlertDescription, Badge, Banner, Button, type BannerTone } from '@makinbakin/sdk/ui'
+import { Alert, AlertDescription, Badge, Banner, Button, Text, type BannerTone } from '@makinbakin/sdk/ui'
 import { Activity, ListRestart, WandSparkles } from 'lucide-react'
 import type { SearchHealthData, SearchTelemetryData } from '../types'
 import type { SystemMutationState } from '../hooks/use-system-data'
@@ -210,7 +210,7 @@ export function SystemSearchSection({
           </p>
         </div>
         {loading && !status && !telemetry && (
-          <span className="text-bakin-typography-size-meta text-bakin-text-muted">Loading live Search data…</span>
+          <Text size="meta" tone="muted">Loading live Search data…</Text>
         )}
       </header>
 
@@ -318,7 +318,7 @@ export function SystemSearchSection({
             <div className="flex flex-wrap items-end justify-between gap-bakin-3">
               <div>
                 <h3 id="search-indexes-title" className="font-bakin-typography-weight-medium">Indexes &amp; migrations</h3>
-                <p className="text-bakin-typography-size-meta text-bakin-text-muted">Rebuilds keep the active index serving while its replacement catches up.</p>
+                <Text size="meta" tone="muted" as="p">Rebuilds keep the active index serving while its replacement catches up.</Text>
               </div>
               <Button
                 size="sm"

--- a/plugins/health/components/system-tab.tsx
+++ b/plugins/health/components/system-tab.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryState } from '@makinbakin/sdk/hooks'
 import { Grid } from '@makinbakin/sdk/layout'
 import { StatTile, StatusBadge, type StatusTone } from '@makinbakin/sdk/patterns'
-import { Alert, AlertDescription, Button } from '@makinbakin/sdk/ui'
+import { Alert, AlertDescription, Button, Text } from '@makinbakin/sdk/ui'
 import { Puzzle, RefreshCw, Search, Server, ShieldCheck } from 'lucide-react'
 import { SystemSearchSection } from './system-search-section'
 import { SystemInventory, type SystemInventoryHandle } from './system-inventory'
@@ -163,7 +163,7 @@ export function SystemTabView({
         <div className="mb-bakin-2 flex items-end justify-between gap-bakin-3">
           <div>
             <h2 id="system-subsystems-title" className="text-bakin-typography-size-body">Platform pulse</h2>
-            <p className="text-bakin-typography-size-meta text-bakin-text-muted">A stable snapshot of the services that keep Bakin usable.</p>
+            <Text size="meta" tone="muted" as="p">A stable snapshot of the services that keep Bakin usable.</Text>
           </div>
         </div>
         <Grid

--- a/plugins/health/components/system-watch-list.tsx
+++ b/plugins/health/components/system-watch-list.tsx
@@ -3,10 +3,11 @@
 import { useMemo, useState } from 'react'
 import type { HealthReport } from '@makinbakin/sdk/types'
 import { ListRow, ListRows, StatusBadge } from '@makinbakin/sdk/patterns'
-import { Banner, Button } from '@makinbakin/sdk/ui'
+import { Banner, Button, Overline, Text } from '@makinbakin/sdk/ui'
 import { ChevronDown, Puzzle, ShieldCheck } from 'lucide-react'
 import type { SystemPluginManifestData, SystemRegistryData } from '../hooks/use-system-data'
 import { buildSystemFindings, type SystemFinding } from '../lib/system-view-model'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const DEFAULT_VISIBLE_FINDINGS = 3
 
@@ -40,9 +41,9 @@ export function SystemWatchList({
       <div className="mb-bakin-2 flex min-w-0 items-end justify-between gap-bakin-3">
         <div className="min-w-0">
           <h2 id="system-watch-list-title">Worth a look</h2>
-          <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             Advisory and unavailable evidence is summarized here; open a row only when you need the details.
-          </p>
+          </Text>
         </div>
         {findings.length > 0 && (
           <span className="shrink-0 text-bakin-typography-size-meta tabular-nums text-bakin-text-muted">
@@ -89,11 +90,11 @@ export function SystemWatchList({
                       aria-hidden="true"
                     />
                     <div className="min-w-0">
-                      <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+                      <Inline gap="dense">
                         <h3 className="text-bakin-typography-size-body font-bakin-typography-weight-medium text-bakin-text-primary">{finding.title}</h3>
                         <StatusBadge tone={tone} variant="outline">{finding.label}</StatusBadge>
-                        <span className="text-bakin-typography-size-meta uppercase tracking-wide text-bakin-text-muted">{finding.category}</span>
-                      </div>
+                        <Overline>{finding.category}</Overline>
+                      </Inline>
                       <p className="mt-bakin-1 line-clamp-2 text-bakin-typography-size-meta leading-relaxed text-bakin-text-muted">{finding.detail}</p>
                     </div>
                   </div>

--- a/plugins/memory/components/memory-cleanup.tsx
+++ b/plugins/memory/components/memory-cleanup.tsx
@@ -18,6 +18,7 @@ import {
   Input,
   Label,
   SystemState,
+  Text,
   Textarea,
   Tooltip,
   TooltipContent,
@@ -377,10 +378,10 @@ export function MemoryCleanup() {
                   {r.clean ? 'Clean' : 'Remaining'}
                 </StatusBadge>
                 <span className="text-bakin-typography-size-meta">{r.agent}</span>
-                <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+                <Text size="meta" tone="muted">
                   {r.clean ? 'clean' : `${r.actionableRemaining} editable occurrence(s) remain`}
                   {r.informationalRemaining > 0 ? ` · ${r.informationalRemaining} informational left (self-healing)` : ''}
-                </span>
+                </Text>
               </Inline>
             ))}
           </Stack>

--- a/plugins/models/components/agents-tab.tsx
+++ b/plugins/models/components/agents-tab.tsx
@@ -4,7 +4,7 @@ import { ArrowDown, ArrowUp, Plus, X } from 'lucide-react'
 import { useAgent, useAgentColor } from '@makinbakin/sdk/hooks'
 import { Panel } from '@makinbakin/sdk/layout'
 import { AgentAvatar, ListRow, ListRows, ModelSelect } from '@makinbakin/sdk/patterns'
-import { Button, Field, FieldLabel, SystemState } from '@makinbakin/sdk/ui'
+import { Button, Field, FieldLabel, SystemState, Text } from '@makinbakin/sdk/ui'
 
 import type { ModelsData } from './use-models-data'
 
@@ -118,10 +118,10 @@ export function AgentsTab({ m }: { m: ModelsData }) {
                     key={`${modelId}-${index}`}
                     className="flex flex-wrap items-center gap-bakin-2 px-bakin-0"
                   >
-                    <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+                    <Text size="meta" tone="muted">
                       {index + 1}
                       <span className="sr-only"> in fallback order</span>
-                    </span>
+                    </Text>
                     <ModelSelect
                       value={modelId}
                       ariaLabel={`Fallback model ${index + 1}`}

--- a/plugins/models/components/aliases-tab.tsx
+++ b/plugins/models/components/aliases-tab.tsx
@@ -25,10 +25,12 @@ import {
   FormActions,
   SubmitButton,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 
 import { BrandIcon } from './brand-icon'
 import type { ModelsData } from './use-models-data'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const PAGE_SIZE = 8
 
@@ -174,9 +176,9 @@ export function AliasesTab({
       <div className="grid min-w-0 gap-bakin-2">
         <div className="flex min-w-0 flex-wrap items-baseline justify-between gap-bakin-2">
           <h2>Configured aliases</h2>
-          <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted">
             {entries.length} {entries.length === 1 ? 'alias' : 'aliases'}
-          </span>
+          </Text>
         </div>
         <p className="max-w-prose text-bakin-typography-size-body leading-relaxed text-bakin-text-muted">
           Aliases give agents and routing rules a stable short name even when the underlying model changes.
@@ -203,7 +205,7 @@ export function AliasesTab({
                   {name}
                 </code>
 
-                <div className="flex min-w-0 items-center gap-bakin-3">
+                <Inline wrap={false}>
                   <BrandIcon
                     slug={model?.brandIconSlug ?? model?.providerBrandIconSlug}
                     fallbackText={providerName}
@@ -218,7 +220,7 @@ export function AliasesTab({
                       {target}
                     </p>
                   </div>
-                </div>
+                </Inline>
 
                 <Button
                   type="button"

--- a/plugins/models/components/available-models-tab.tsx
+++ b/plugins/models/components/available-models-tab.tsx
@@ -9,7 +9,7 @@ import {
   type DataTableColumn,
   type DataTableSort,
 } from '@makinbakin/sdk/patterns'
-import { Badge, Button, SystemState } from '@makinbakin/sdk/ui'
+import { Badge, Button, SystemState, Text } from '@makinbakin/sdk/ui'
 
 import type { AvailableModel } from '../types'
 import { BrandIcon } from './brand-icon'
@@ -331,11 +331,11 @@ export function AvailableModelsTab({
         actions={(
           <>
             {modelsLoaded && modelsCachedAt ? (
-              <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+              <Text size="meta" tone="muted">
                 Refreshed {formatRelativeTime(modelsCachedAt)}
                 {modelsCached ? ' · cached' : ''}
                 {modelsStale ? ' · stale' : ''}
-              </span>
+              </Text>
             ) : null}
             <Button
               type="button"

--- a/plugins/models/components/spend-breakdown.tsx
+++ b/plugins/models/components/spend-breakdown.tsx
@@ -9,7 +9,7 @@ import {
   type DataTableColumn,
   type DataTableSort,
 } from '@makinbakin/sdk/patterns'
-import { SystemState } from '@makinbakin/sdk/ui'
+import { Overline, SystemState } from '@makinbakin/sdk/ui'
 
 import type { SpendResponse } from './use-models-data'
 import { formatTokens, formatUsd } from './spend-utils'
@@ -296,9 +296,9 @@ export function SpendBreakdown({
       ) : (
         <div className="grid min-w-0 gap-bakin-8 @5xl/spend-breakdown:grid-cols-[minmax(16rem,0.7fr)_minmax(0,1.3fr)]">
           <div className="min-w-0 @5xl/spend-breakdown:border-r @5xl/spend-breakdown:border-bakin-border-subtle @5xl/spend-breakdown:pr-bakin-8">
-            <p className="mb-bakin-4 text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wide text-bakin-text-muted">
+            <Overline as="p" className="mb-bakin-4">
               Highest estimated cost
-            </p>
+            </Overline>
             <RankedBarChart
               data={chartData}
               series={{ key: 'cost', label: 'Estimated cost' }}

--- a/plugins/models/components/spend-budget-controls.tsx
+++ b/plugins/models/components/spend-budget-controls.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Plus, Trash2 } from 'lucide-react'
-import { Section, Stack } from '@makinbakin/sdk/layout'
+import { Inline, Section, Stack } from '@makinbakin/sdk/layout'
 import { AgentAvatar, ListRow, ListRows } from '@makinbakin/sdk/patterns'
 import {
   Button,
@@ -315,7 +315,7 @@ export function BillingLanesSection({ m }: { m: ModelsData }) {
             const value = agentOverrides.get(agentId) ?? 'auto'
             return (
               <ListRow key={agentId} className="px-bakin-4 py-bakin-4">
-                <div className="flex min-w-0 items-center gap-bakin-3">
+                <Inline wrap={false}>
                   <AgentAvatar
                     agent={{ id: agentId, name: agent?.name ?? agentId }}
                     size="md"
@@ -329,7 +329,7 @@ export function BillingLanesSection({ m }: { m: ModelsData }) {
                       {lane.provider} · detected {lane.lane}
                     </p>
                   </div>
-                </div>
+                </Inline>
 
                 <Field name={`billing-lane-${agentId}`}>
                   <FieldLabel>Billing override</FieldLabel>

--- a/plugins/schedule/components/calendar-today.tsx
+++ b/plugins/schedule/components/calendar-today.tsx
@@ -6,6 +6,7 @@ import { CalendarGrid } from '@makinbakin/sdk/patterns'
 import { useOccurrences, type ScheduleJob, type ScheduleOccurrence, type ScheduledDomainEvent } from '@makinbakin/sdk/hooks'
 import { OccurrenceCard, jobsById } from './calendar-weekly'
 import { EventChip, eventInstant } from './event-popover'
+import { Text } from '@makinbakin/sdk/ui'
 
 /** Occurrence or domain event flattened into the shared CalendarGrid item shape. */
 type TodayCalendarItem =
@@ -74,9 +75,9 @@ export function CalendarToday({
       <div className="flex flex-wrap items-center gap-x-bakin-3 gap-y-bakin-1">
         <Clock className="size-bakin-4 text-bakin-text-muted" aria-hidden="true" />
         <span className="font-bakin-typography-weight-medium text-bakin-text-primary">{todayFormatted}</span>
-        <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted">
           {total} run{total !== 1 ? 's' : ''} scheduled
-        </span>
+        </Text>
       </div>
 
       <CalendarGrid

--- a/plugins/schedule/components/event-popover.tsx
+++ b/plugins/schedule/components/event-popover.tsx
@@ -6,6 +6,7 @@ import { PluginLink } from '@makinbakin/sdk/navigation'
 import { CalendarItem, ConfirmDialog } from '@makinbakin/sdk/patterns'
 import {
   Button,
+  buttonVariants,
   Field,
   FieldControl,
   FieldError,
@@ -16,7 +17,7 @@ import {
   PopoverHeader,
   PopoverTitle,
   PopoverTrigger,
-  buttonVariants,
+  Text,
 } from '@makinbakin/sdk/ui'
 import type { ScheduledDomainEvent } from '@makinbakin/sdk/hooks'
 
@@ -123,10 +124,10 @@ export function EventChip({
               {event.pluginId} · {event.kind}{event.status ? ` · ${event.status}` : ''}
             </PopoverDescription>
           </PopoverHeader>
-          <p className="text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             {due ? 'Due' : 'Starts'}{' '}
             {new Date(eventInstant(event)).toLocaleString([], { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}
-          </p>
+          </Text>
           <div className="flex items-center gap-bakin-2">
             {event.url && (
               <PluginLink

--- a/plugins/schedule/components/job-drawer.tsx
+++ b/plugins/schedule/components/job-drawer.tsx
@@ -19,14 +19,15 @@ import {
 } from 'lucide-react'
 import { AgentAvatar, StatusBadge, type StatusTone } from '@makinbakin/sdk/patterns'
 import {
+  Button,
   Drawer,
   DrawerSection,
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Overline,
 } from '@makinbakin/sdk/ui'
 import { useAgent, type ScheduleJob } from '@makinbakin/sdk/hooks'
 import { AgentBadge } from './agent-badge'
@@ -60,10 +61,10 @@ function MetadataItem({
 }) {
   return (
     <div className={`min-w-0 rounded-bakin-surface bg-bakin-surface-default p-bakin-3 ${className ?? ''}`}>
-      <dt className="flex items-center gap-bakin-1 text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wider text-bakin-text-muted">
+      <Overline as="dt" className="flex items-center gap-bakin-1">
         {Icon ? <Icon aria-hidden="true" className="size-bakin-3" /> : null}
         {label}
-      </dt>
+      </Overline>
       <dd className={`m-0 mt-bakin-1 break-words text-bakin-text-primary ${
         mono ? 'font-bakin-typography-family-mono text-bakin-typography-size-meta' : 'font-bakin-typography-weight-medium'
       }`}>

--- a/plugins/schedule/components/job-list.tsx
+++ b/plugins/schedule/components/job-list.tsx
@@ -3,9 +3,10 @@
 import { useMemo } from 'react'
 import { ShieldAlert } from 'lucide-react'
 import { DataTable, ListRow, type DataTableColumn } from '@makinbakin/sdk/patterns'
-import { Text } from '@makinbakin/sdk/ui'
+import { Overline, Text } from '@makinbakin/sdk/ui'
 import { AgentBadge } from './agent-badge'
 import { JobActionsMenu, JobNameCell, JobScheduleCell, JobStatusBadge, type JobScoreInfo } from './job-row'
+
 import type { ScheduleJob } from "@makinbakin/sdk/hooks"
 
 function MobileJobRow({
@@ -35,9 +36,9 @@ function MobileJobRow({
               <span className="block truncate font-bakin-typography-weight-semibold text-bakin-text-primary">
                 {label}
               </span>
-              <span className="mt-bakin-1 block text-bakin-typography-size-meta uppercase tracking-wider text-bakin-text-muted">
+              <Overline className="mt-bakin-1 block">
                 {source}
-              </span>
+              </Overline>
             </span>
             <JobStatusBadge job={job} />
           </span>

--- a/plugins/schedule/components/job-row.tsx
+++ b/plugins/schedule/components/job-row.tsx
@@ -5,10 +5,11 @@ import { StatusBadge } from '@makinbakin/sdk/patterns'
 import {
   Button,
   DropdownMenu,
-  DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Overline,
   Text,
 } from '@makinbakin/sdk/ui'
 import type { ScheduleJob } from "@makinbakin/sdk/hooks"
@@ -53,9 +54,9 @@ export function JobNameCell({ job, scoreInfo }: { job: ScheduleJob; scoreInfo?: 
       <span className="text-bakin-typography-size-body font-bakin-typography-weight-semibold text-bakin-text-primary">
         {job.displayName || job.id}
       </span>
-      <span className="text-bakin-typography-size-meta uppercase tracking-wider text-bakin-text-muted">
+      <Overline>
         {job.source === 'adopted' ? 'Adopted' : job.isBakinJob ? 'Bakin schedule' : 'Runtime cron'}
-      </span>
+      </Overline>
       {job.toolsAllowMissing && (
         <span className="inline-flex items-center gap-bakin-1 text-bakin-typography-size-meta text-bakin-signal-highlight">
           <ShieldAlert className="size-bakin-3" />
@@ -81,10 +82,10 @@ export function JobNameCell({ job, scoreInfo }: { job: ScheduleJob; scoreInfo?: 
 export function JobScheduleCell({ job }: { job: ScheduleJob }) {
   return (
     <>
-      <span className="text-bakin-typography-size-body text-bakin-text-muted">
+      <Text size="body" tone="muted">
         {job.humanSchedule}
         {job.tz && <Text as="span" size="meta" tone="muted" className="ml-bakin-1">{job.tz.replace(/^.*\//, '')}</Text>}
-      </span>
+      </Text>
       {job.nextRun && !job.paused && (
         <div className="text-bakin-typography-size-meta text-bakin-text-muted/70">
           next {new Date(job.nextRun).toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}

--- a/plugins/schedule/components/schedule-input.tsx
+++ b/plugins/schedule/components/schedule-input.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { CalendarClock, Clock, Repeat } from 'lucide-react'
 import { SegmentedControl, StatusBadge, type SegmentedControlOption } from '@makinbakin/sdk/patterns'
-import { Alert, AlertDescription, FieldError, Input } from '@makinbakin/sdk/ui'
+import { Alert, AlertDescription, FieldError, Input, Overline } from '@makinbakin/sdk/ui'
 import type { ParseResult } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 type ScheduleMode = 'recurring' | 'once'
 
@@ -96,10 +97,10 @@ export function ScheduleInput({
         onChange={(event) => onChange(event.target.value)}
       />
       {mode === 'once' ? (
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
-          <span className="text-bakin-typography-size-meta uppercase tracking-wider text-bakin-text-muted">
+        <Inline gap="dense">
+          <Overline>
             Or pick
-          </span>
+          </Overline>
           <Input
             type="datetime-local"
             aria-label="Pick a date and time"
@@ -109,7 +110,7 @@ export function ScheduleInput({
               if (iso) onChange(iso)
             }}
           />
-        </div>
+        </Inline>
       ) : null}
       {loading ? (
         <span role="status" className="text-bakin-typography-size-meta text-bakin-text-muted">
@@ -132,9 +133,9 @@ export function ScheduleInput({
             </span>
             {parsed.nextRuns?.length ? (
               <span className="mt-bakin-2 grid gap-bakin-1">
-                <span className="text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wider text-bakin-text-muted">
+                <Overline>
                   {parsed.kind === 'at' ? 'Fires' : 'Next runs'}
-                </span>
+                </Overline>
                 {parsed.nextRuns.slice(0, 5).map((run) => (
                   <time key={run} className="text-bakin-typography-size-meta text-bakin-text-muted">
                     {new Date(run).toLocaleString('en-US', {

--- a/plugins/schedule/components/schedule-page.tsx
+++ b/plugins/schedule/components/schedule-page.tsx
@@ -45,6 +45,7 @@ import { DeleteScheduleDialog } from './delete-schedule-dialog'
 import { CalendarMonthly } from './calendar-monthly'
 import { CalendarWeekly } from './calendar-weekly'
 import { CalendarToday } from './calendar-today'
+import { Inline } from '@makinbakin/sdk/layout'
 
 type ViewMode = 'list' | 'today' | 'week' | 'month'
 const LIST_PAGE_SIZE = 10
@@ -335,10 +336,10 @@ export function SchedulePage() {
   }
 
   const searchFeedback = searchHook.status === 'unavailable' || searchHook.meta?.partial ? (
-    <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+    <Inline gap="dense">
       {searchHook.status === 'unavailable' ? <SearchDegradedChip testId="schedule-search-degraded" /> : null}
       {searchHook.meta?.partial ? <SearchPartialChip meta={searchHook.meta} /> : null}
-    </div>
+    </Inline>
   ) : null
 
   const pageFeedback = jobNotFound || searchFeedback ? (
@@ -410,7 +411,7 @@ export function SchedulePage() {
         <WorkspacePageCompactHeader
           title="Schedule"
           action={(
-            <div className="flex min-w-0 items-center gap-bakin-2">
+            <Inline gap="dense" wrap={false}>
               <SegmentedControl
                 options={VIEWS}
                 value={view as ViewMode}
@@ -424,7 +425,7 @@ export function SchedulePage() {
                 <Plus />
                 New Job
               </Button>
-            </div>
+            </Inline>
           )}
         />
 

--- a/plugins/tasks/components/kanban-board.tsx
+++ b/plugins/tasks/components/kanban-board.tsx
@@ -51,6 +51,7 @@ import { useBrandStatus, brandHoldReason, type BrandHold } from '../hooks/use-br
 import { useLiveActivity } from '../hooks/use-live-activity'
 import type { TaskScoreInfo } from './task-card'
 import type { Task, TaskColumns, ColumnId } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const COLUMN_ORDER: ColumnId[] = ['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived']
 
@@ -495,10 +496,10 @@ export function KanbanBoard() {
   const searchSettled = !search.trim() || searchStatus !== 'loading'
 
   const searchFeedback = search.trim() && (searchStatus === 'unavailable' || searchMeta?.partial) ? (
-    <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+    <Inline gap="dense">
       {searchStatus === 'unavailable' && <SearchDegradedChip testId="tasks-search-degraded" />}
       {searchMeta?.partial && <SearchPartialChip meta={searchMeta} />}
-    </div>
+    </Inline>
   ) : undefined
 
   let resultState: React.ReactNode
@@ -586,7 +587,7 @@ export function KanbanBoard() {
         <WorkspacePageCompactHeader
           title="Tasks"
           action={(
-            <div className="flex min-w-0 items-center gap-bakin-2">
+            <Inline gap="dense" wrap={false}>
               <SegmentedControl
                 options={[
                   { value: 'kanban', label: 'Board', icon: Kanban },
@@ -602,7 +603,7 @@ export function KanbanBoard() {
                 <Plus />
                 New Task
               </Button>
-            </div>
+            </Inline>
           )}
         />
 

--- a/plugins/tasks/components/kanban-column.tsx
+++ b/plugins/tasks/components/kanban-column.tsx
@@ -17,6 +17,7 @@ import type { BudgetHold } from '../hooks/use-budget-status'
 import type { BrandHold } from '../hooks/use-brand-status'
 import type { LiveActivity } from '../hooks/use-live-activity'
 import type { Task, ColumnId } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 interface KanbanColumnProps {
   id: ColumnId
@@ -96,12 +97,12 @@ export function KanbanColumn({ id, tasks, gateLabels, childTaskLabels, budgetHol
       >
         <KanbanLane label={config.label}>
           <KanbanLaneHeader>
-            <div className="flex min-w-0 items-center gap-bakin-2">
+            <Inline gap="dense" wrap={false}>
               <h2 className="truncate text-bakin-typography-size-body">
                 {config.label}
               </h2>
               <Badge size="xs" variant="outline" aria-label={countLabel}>{count}</Badge>
-            </div>
+            </Inline>
             {onAddTask ? (
               <Button type="button" variant="ghost" size="xs" onClick={() => onAddTask(id)}>
                 <Plus />

--- a/plugins/tasks/components/step-output-viewer.tsx
+++ b/plugins/tasks/components/step-output-viewer.tsx
@@ -3,6 +3,7 @@
 import { TurnOutputView } from '@makinbakin/sdk/conversation'
 import { Panel } from '@makinbakin/sdk/layout'
 import { isRenderableAssetRef } from '../lib/output-assets'
+import { Overline } from '@makinbakin/sdk/ui'
 
 /** Normalize step output — handles string (possibly JSON), object, or unexpected types. */
 function normalizeOutput(raw: unknown): Record<string, unknown> {
@@ -63,9 +64,9 @@ function OutputValue({ value }: { value: unknown }) {
       <dl className="m-0 mt-bakin-2 grid min-w-0 gap-bakin-3 border-s border-bakin-border-subtle ps-bakin-3">
         {entries.map(([k, v]) => (
           <div key={k}>
-            <dt className="text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wider text-bakin-text-muted">
+            <Overline as="dt">
               {humanizeKey(k)}
-            </dt>
+            </Overline>
             <dd className="m-0"><OutputValue value={v} /></dd>
           </div>
         ))}
@@ -83,9 +84,9 @@ export function StepOutputViewer({ output }: { output: Record<string, unknown> |
       <dl className="m-0 grid min-w-0 gap-bakin-3">
         {Object.entries(data).map(([key, value]) => (
           <div key={key}>
-            <dt className="text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wider text-bakin-text-muted">
+            <Overline as="dt">
               {humanizeKey(key)}
-            </dt>
+            </Overline>
             <dd className="m-0"><OutputValue value={value} /></dd>
           </div>
         ))}

--- a/plugins/tasks/components/task-card.tsx
+++ b/plugins/tasks/components/task-card.tsx
@@ -33,6 +33,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  Overline,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -44,6 +45,7 @@ import type { BudgetHold } from '../hooks/use-budget-status'
 import type { BrandHold } from '../hooks/use-brand-status'
 import type { LiveActivity } from '../hooks/use-live-activity'
 import type { Task, ColumnId } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 export interface TaskScoreInfo {
   score: number
@@ -172,13 +174,13 @@ export function TaskCardContent({
       onClick={openTask}
     >
       <CardHeader>
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           <StatusBadge tone={STATUS_TONES[resolvedColumnId]} variant="solid" size="xs">
             {COLUMN_CONFIG[resolvedColumnId].label}
           </StatusBadge>
-          <span className="font-bakin-typography-family-mono text-bakin-typography-size-meta uppercase tracking-widest text-bakin-text-muted">
+          <Overline className="font-bakin-typography-family-mono">
             {shortId(task.id)}
-          </span>
+          </Overline>
           {scoreInfo ? (
             <span className="flex min-w-0 flex-wrap items-center gap-bakin-2 font-bakin-typography-family-mono text-bakin-typography-size-meta">
               <span className="text-bakin-data-series-1">RRF {scoreInfo.score.toFixed(3)}</span>
@@ -190,7 +192,7 @@ export function TaskCardContent({
               </span>
             </span>
           ) : null}
-        </div>
+        </Inline>
 
         {onDelete ? (
           <CardAction reveal="hover">

--- a/plugins/tasks/components/task-filters.tsx
+++ b/plugins/tasks/components/task-filters.tsx
@@ -7,6 +7,7 @@ import { Switch } from "@makinbakin/sdk/ui"
 import { Eye, EyeOff } from 'lucide-react'
 import { COLUMN_CONFIG, STATUS_TONES } from '../constants'
 import type { ColumnId } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const STATUS_OPTIONS: { value: string; label: string; icon: React.ReactNode }[] =
   (['backlog', 'todo', 'blocked', 'inProgress', 'review', 'done', 'archived'] as ColumnId[]).map(id => ({
@@ -82,7 +83,7 @@ export function TaskFilters({
   }
 
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-bakin-3">
+    <Inline>
       <AgentFilter
         options={agentOptions}
         value={agentFilter}
@@ -127,6 +128,6 @@ export function TaskFilters({
         </label>
       )}
 
-    </div>
+    </Inline>
   )
 }

--- a/plugins/tasks/components/task-log-table.tsx
+++ b/plugins/tasks/components/task-log-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Button, SystemState } from '@makinbakin/sdk/ui'
+import { Button, SystemState, Text } from '@makinbakin/sdk/ui'
 import {
   AgentAvatar,
   DataTable,
@@ -16,6 +16,7 @@ import { useAgent } from "@makinbakin/sdk/hooks"
 import type { FlatTask } from '../hooks/use-task-filters'
 import type { TaskScoreInfo } from './task-card'
 import type { ColumnId, Task } from '../types'
+import { Inline } from '@makinbakin/sdk/layout'
 
 interface AuditEntry {
   type: string
@@ -211,7 +212,7 @@ export function TaskLogTable({ currentTasks, statusFilter, isSearching, scoreMap
           ? Object.keys(scoreInfo.indexScores).find(k => k !== semKey)
           : undefined
         return (
-          <div className="flex min-w-0 items-center gap-bakin-2">
+          <Inline gap="dense" wrap={false}>
             <Button
               type="button"
               variant="link"
@@ -236,7 +237,7 @@ export function TaskLogTable({ currentTasks, statusFilter, isSearching, scoreMap
                 </span>
               </span>
             )}
-          </div>
+          </Inline>
         )
       },
     },
@@ -247,7 +248,7 @@ export function TaskLogTable({ currentTasks, statusFilter, isSearching, scoreMap
       narrow: 'leading',
       cell: (task) => task.agent
         ? <AgentCell agentId={task.agent} />
-        : <span className="text-bakin-typography-size-meta text-bakin-text-muted">—</span>,
+        : <Text size="meta" tone="muted">—</Text>,
       narrowCell: (task) => task.agent ? <AgentCell agentId={task.agent} avatarOnly /> : null,
     },
     {

--- a/plugins/tasks/components/task-notes-section.tsx
+++ b/plugins/tasks/components/task-notes-section.tsx
@@ -4,15 +4,16 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-  DrawerSection,
   Button,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  DrawerSection,
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
+  Overline,
 } from '@makinbakin/sdk/ui'
 import { Panel } from '@makinbakin/sdk/layout'
 import { formatDateTime } from '@makinbakin/sdk/utils'
@@ -37,9 +38,9 @@ function DispatchFailureLogPanel({ detail }: { detail: DispatchFailureDetail }) 
         <dl className="mt-bakin-3 grid min-w-0 grid-cols-1 gap-bakin-2 @sm/dispatch:grid-cols-2">
           {rows.map(([label, value]) => (
             <div key={label} className="min-w-0">
-              <dt className="text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wider text-bakin-text-muted">
+              <Overline as="dt">
                 {label}
-              </dt>
+              </Overline>
               <dd className="m-0 break-words text-bakin-typography-size-meta text-bakin-text-primary">{value}</dd>
             </div>
           ))}

--- a/plugins/tasks/components/task-workflow-panels.tsx
+++ b/plugins/tasks/components/task-workflow-panels.tsx
@@ -4,17 +4,19 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-  DrawerSection,
   Button,
+  DrawerSection,
   Field,
   FieldControl,
   FieldLabel,
+  Text,
   Textarea,
 } from '@makinbakin/sdk/ui'
 import { StatusBadge, type StatusTone } from '@makinbakin/sdk/patterns'
 import { AlertTriangle, Check, Hourglass, RefreshCw, X } from 'lucide-react'
 import { StepOutputViewer } from './step-output-viewer'
 import type { TaskDetail } from './use-task-detail'
+import { Inline } from '@makinbakin/sdk/layout'
 
 const STEP_TONE: Record<string, StatusTone> = {
   complete: 'success',
@@ -61,14 +63,14 @@ function WorkflowStepList({
               {index + 1}
             </span>
             <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+              <Inline gap="dense">
                 <span className="font-bakin-typography-weight-semibold text-bakin-text-primary">
                   {step.label || step.id}
                 </span>
                 <StatusBadge tone={statusTone(status)} variant={status === 'pending' ? 'outline' : 'solid'} size="xs">
                   {statusLabel(status)}
                 </StatusBadge>
-              </div>
+              </Inline>
               <div className="mt-bakin-1 flex min-w-0 flex-wrap items-center gap-bakin-2 text-bakin-typography-size-meta text-bakin-text-muted">
                 {isGate ? (
                   <span className="inline-flex items-center gap-bakin-1">
@@ -179,12 +181,12 @@ export function MapChildrenPanel({ m }: { m: TaskDetail }) {
   return (
     <DrawerSection
       title={mapStepLabel}
-      actions={<span className="text-bakin-typography-size-meta text-bakin-text-muted">{rollup}</span>}
+      actions={<Text size="meta" tone="muted">{rollup}</Text>}
     >
       <ul className="m-0 list-none divide-y divide-bakin-border-subtle p-0">
         {rows.map((row) => (
           <li key={row.childTaskId} className="grid min-w-0 gap-bakin-2 py-bakin-3 first:pt-0">
-            <div className="flex min-w-0 items-center gap-bakin-2">
+            <Inline gap="dense" wrap={false}>
               <span className="shrink-0 font-bakin-typography-family-mono text-bakin-typography-size-meta text-bakin-text-muted">
                 {row.index + 1}/{rows.length}
               </span>
@@ -192,7 +194,7 @@ export function MapChildrenPanel({ m }: { m: TaskDetail }) {
                 {row.childTaskId}
               </code>
               <StatusBadge tone={statusTone(row.status)} size="xs">{statusLabel(row.status)}</StatusBadge>
-            </div>
+            </Inline>
             {row.status !== 'complete' ? (
               <div className="flex flex-wrap justify-end gap-bakin-2">
                 <Button
@@ -256,12 +258,12 @@ export function GateApprovalPanel({ m }: { m: TaskDetail }) {
         ) : null}
 
         {outputUnavailable && !priorStepOutput ? (
-          <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+          <Inline gap="dense">
             <span>Step output unavailable.</span>
             <Button type="button" variant="link" size="xs" onClick={() => { void fetchPriorOutput() }}>
               <RefreshCw aria-hidden="true" /> Retry
             </Button>
-          </div>
+          </Inline>
         ) : null}
 
         {priorStepOutput ? (
@@ -351,9 +353,9 @@ export function WorkflowPreview({ m }: { m: TaskDetail }) {
     <DrawerSection
       title="Workflow preview"
       actions={(
-        <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+        <Text size="meta" tone="muted">
           {wfDefinition.steps.length} steps
-        </span>
+        </Text>
       )}
     >
       <div className="grid min-w-0 gap-bakin-3">

--- a/plugins/team/components/active-context-tab.tsx
+++ b/plugins/team/components/active-context-tab.tsx
@@ -9,6 +9,7 @@ import {
   AlertDescription,
   AlertTitle,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { useJsonFetch, useQueryState } from '@makinbakin/sdk/hooks'
 import type { SessionMessage, SessionTranscript } from '../types'
@@ -72,7 +73,7 @@ function MessageRow({ message, index }: { message: SessionMessage; index: number
           </code>
         ) : null}
         {message.model ? (
-          <span className="text-bakin-typography-size-meta text-bakin-text-muted">{message.model}</span>
+          <Text size="meta" tone="muted">{message.model}</Text>
         ) : null}
         {message.ts ? (
           <time

--- a/plugins/team/components/agent-form.tsx
+++ b/plugins/team/components/agent-form.tsx
@@ -27,6 +27,7 @@ import {
   Textarea,
 } from '@makinbakin/sdk/ui'
 import { pluginFetch } from '@makinbakin/sdk/utils'
+import { Inline } from '@makinbakin/sdk/layout'
 
 export interface AgentFormData {
   id: string
@@ -121,7 +122,7 @@ export function AgentForm({
       <Field name="avatar">
         <FieldLabel>Profile image</FieldLabel>
         <FieldDescription>JPG, PNG, or WebP. This portrait appears throughout Bakin.</FieldDescription>
-        <div className="flex min-w-0 items-center gap-bakin-3">
+        <Inline wrap={false}>
           <AgentAvatar
             agent={{
               id: id || 'new-agent',
@@ -132,7 +133,7 @@ export function AgentForm({
             size="lg"
             decorative
           />
-          <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+          <Inline gap="dense">
             <FileInput
               label="Profile image"
               accept="image/jpeg,image/png,image/webp"
@@ -147,8 +148,8 @@ export function AgentForm({
                 Remove
               </Button>
             ) : null}
-          </div>
-        </div>
+          </Inline>
+        </Inline>
       </Field>
 
       <FieldGroup>

--- a/plugins/team/components/diagnostics-tab.tsx
+++ b/plugins/team/components/diagnostics-tab.tsx
@@ -21,7 +21,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { ChartExplainer, Sparkline } from '@makinbakin/sdk/charts'
 import { usePluginEvent, useJsonFetch, useQueryState } from '@makinbakin/sdk/hooks'
-import { DisclosurePanel, Grid, Panel, Section, Stack } from '@makinbakin/sdk/layout'
+import { DisclosurePanel, Grid, Inline, Panel, Section, Stack } from '@makinbakin/sdk/layout'
 import {
   KeyValue,
   Pagination,
@@ -42,6 +42,7 @@ import {
   ProgressValue,
   Skeleton,
   SystemState,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -628,13 +629,13 @@ function ContextPanel({ agentId }: { agentId: string }) {
         </Grid>
 
         {observedInputs.length >= 2 && (
-          <div className="flex min-w-0 flex-wrap items-center gap-bakin-3">
+          <Inline>
             <Sparkline values={observedInputs} label="Observed turn input tokens, oldest to newest" />
-            <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+            <Text size="meta" tone="muted">
               Observed turn input over the last {observedInputs.length} dispatches
               (latest {formatTokens(observedInputs[observedInputs.length - 1]!)})
-            </span>
-          </div>
+            </Text>
+          </Inline>
         )}
       </Stack>
       <ChartExplainer>

--- a/plugins/team/components/heartbeat-tab.tsx
+++ b/plugins/team/components/heartbeat-tab.tsx
@@ -2,7 +2,7 @@
 
 import { Heart } from 'lucide-react'
 import { MarkdownContent } from '@makinbakin/sdk/content'
-import { Panel, Section } from '@makinbakin/sdk/layout'
+import { Inline, Panel, Section } from '@makinbakin/sdk/layout'
 import { StatusBadge } from '@makinbakin/sdk/patterns'
 import { SystemState } from '@makinbakin/sdk/ui'
 import { useJsonFetch } from '@makinbakin/sdk/hooks'
@@ -92,7 +92,7 @@ export function HeartbeatTab({ agentId }: HeartbeatTabProps) {
             Read-only narrative maintained by the agent while it works.
           </p>
         </div>
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           {lastUpdated ? (
             <StatusBadge tone="neutral" variant="solid" size="xs">
               Last updated {lastUpdated}
@@ -101,7 +101,7 @@ export function HeartbeatTab({ agentId }: HeartbeatTabProps) {
           <p className="m-0 max-w-prose text-bakin-typography-size-meta text-bakin-text-muted">
             {HEARTBEAT_DISABLED_REASON}
           </p>
-        </div>
+        </Inline>
       </div>
 
       <Panel className="min-h-96">

--- a/plugins/team/components/overview-tab.tsx
+++ b/plugins/team/components/overview-tab.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { useAgentStore, useJsonFetch, useQueryState } from '@makinbakin/sdk/hooks'
 import type { AgentUsage, AvailableModel } from '@makinbakin/sdk/types'
@@ -328,9 +329,9 @@ export function OverviewTab({
                 />
               ))}
             </StatGroup>
-            <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+            <Text size="meta" tone="muted" as="p">
               Recorder started {new Date(activity.sinceServerStart).toLocaleString()} and resets with the server.
-            </p>
+            </Text>
           </>
         ) : (
           <SystemState

--- a/plugins/team/components/package-card.tsx
+++ b/plugins/team/components/package-card.tsx
@@ -20,9 +20,11 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Overline,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { useRouter } from '@makinbakin/sdk/navigation'
-import { Panel } from '@makinbakin/sdk/layout'
+import { Inline, Panel } from '@makinbakin/sdk/layout'
 import { CopyButton, KeyValue, StatusBadge, type KeyValueItem } from '@makinbakin/sdk/patterns'
 import { toast, useAgentStore, useMainAgentId } from '@makinbakin/sdk/hooks'
 import { PackageStateBadge } from './package-state-badge'
@@ -186,10 +188,10 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
   if (isMain && (state === 'unmanaged' || state === 'absent')) {
     return (
       <div className="grid gap-bakin-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           <StatusBadge tone="neutral" variant="solid" size="xs">Self-managed</StatusBadge>
-          <span className="text-bakin-typography-size-meta text-bakin-text-muted">main agent</span>
-        </div>
+          <Text size="meta" tone="muted">main agent</Text>
+        </Inline>
         <p className="m-0 text-bakin-typography-size-meta leading-relaxed text-bakin-text-muted">
           Your main agent is your own persona — its workspace files live with you, not a package template. Adoption is intentionally not offered here.
         </p>
@@ -201,7 +203,7 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
     <div className="grid gap-bakin-3">
       <div className="flex min-w-0 flex-wrap items-center justify-between gap-bakin-2">
         <PackageStateBadge state={displayState} packageId={packageState?.packageId} />
-        <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+        <Inline gap="dense">
           {hasPackage && (
             <Button
               size="sm"
@@ -242,7 +244,7 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
               <span className="sr-only"> this agent into a package</span>
             </Button>
           )}
-        </div>
+        </Inline>
       </div>
       {state === 'unmanaged' && (
         <p className="m-0 text-bakin-typography-size-meta leading-relaxed text-bakin-text-muted">
@@ -270,17 +272,17 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
       )}
       {state === 'drifted' && (
         <div className="grid gap-bakin-2">
-          <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             Projection sha mismatch detected. Repair from the CLI:
-          </p>
+          </Text>
           <CliHint command="bakin install agent-sync" />
         </div>
       )}
       {state === 'update-available' && !hasPackage && (
         <div className="grid gap-bakin-2">
-          <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+          <Text size="meta" tone="muted" as="p">
             A newer version of the source package is available. Update from the CLI:
-          </p>
+          </Text>
           <CliHint command={`bakin agents sync ${agentId}`} />
         </div>
       )}
@@ -302,9 +304,9 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
             <div className="border-y border-bakin-border-subtle py-bakin-4">
               <div className="grid min-w-0 gap-bakin-4 sm:grid-cols-2">
                 <div>
-                  <p className="m-0 text-bakin-typography-size-meta font-bakin-typography-weight-bold uppercase tracking-widest text-bakin-text-muted">
+                  <Overline as="p">
                     Current version
-                  </p>
+                  </Overline>
                   <p className="m-0 mt-bakin-1 font-bakin-typography-family-mono text-bakin-typography-size-title font-bakin-typography-weight-semibold text-bakin-text-primary">
                     {packageState.updateStatus.currentVersion || packageState.version || packageState.entry?.version || 'unknown'}
                   </p>
@@ -313,9 +315,9 @@ export function PackageCardBody({ agentId, packageState }: { agentId: string; pa
                   </p>
                 </div>
                 <div>
-                  <p className="m-0 text-bakin-typography-size-meta font-bakin-typography-weight-bold uppercase tracking-widest text-bakin-text-muted">
+                  <Overline as="p">
                     Available version
-                  </p>
+                  </Overline>
                   <p className="m-0 mt-bakin-1 font-bakin-typography-family-mono text-bakin-typography-size-title font-bakin-typography-weight-semibold text-bakin-signal-accent">
                     {packageState.updateStatus.latestVersion ?? 'latest'}
                   </p>

--- a/plugins/team/components/team-detail.tsx
+++ b/plugins/team/components/team-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowLeft, RefreshCw } from 'lucide-react'
-import { Section } from '@makinbakin/sdk/layout'
+import { Inline, Section } from '@makinbakin/sdk/layout'
 import { PluginLink, useHistoryBack } from '@makinbakin/sdk/navigation'
 import {
   AgentAvatar,
@@ -341,7 +341,7 @@ export function TeamDetail({ teamId }: { teamId: string }) {
 
                 return (
                   <ListRow key={member.id} className="grid min-w-0 gap-bakin-1">
-                    <div className="flex min-w-0 items-center gap-bakin-3">
+                    <Inline wrap={false}>
                     <AgentAvatar
                       agent={{ id: member.id, name: member.name, initials: member.emoji }}
                       size="sm"
@@ -355,7 +355,7 @@ export function TeamDetail({ teamId }: { teamId: string }) {
                         {status.label}
                       </StatusBadge>
                     ) : null}
-                    </div>
+                    </Inline>
                     {/* A failure reason no user can see is not reported. */}
                     {result?.error ? (
                       <p className="m-0 text-bakin-typography-size-meta text-bakin-signal-danger">

--- a/plugins/team/components/team-manager.tsx
+++ b/plugins/team/components/team-manager.tsx
@@ -8,8 +8,8 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-  DrawerSection,
   Button,
+  DrawerSection,
   Field,
   FieldDescription,
   FieldGroup,
@@ -19,6 +19,7 @@ import {
   Input,
   SubmitButton,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { useAgentStore } from '@makinbakin/sdk/hooks'
 import { pluginFetch } from '@makinbakin/sdk/utils'
@@ -143,9 +144,9 @@ export function TeamManager() {
                 >
                   Global
                 </Button>
-                <p className="m-0 text-bakin-typography-size-meta text-bakin-text-muted">
+                <Text size="meta" tone="muted" as="p">
                   Shared context for every agent
-                </p>
+                </Text>
               </div>
               <code className="font-bakin-typography-family-mono text-bakin-typography-size-meta text-bakin-text-muted">
                 global

--- a/plugins/workflows/components/node-type-palette.tsx
+++ b/plugins/workflows/components/node-type-palette.tsx
@@ -11,7 +11,7 @@
 
 import { useState, type DragEvent } from 'react'
 import { usePluginJsonFetch } from '@makinbakin/sdk/hooks'
-import { Button, SystemState } from '@makinbakin/sdk/ui'
+import { Button, Overline, SystemState } from '@makinbakin/sdk/ui'
 import {
   CheckCircle2,
   ChevronLeft,
@@ -165,9 +165,9 @@ export function NodeTypePalette({
   return (
     <aside className="flex w-56 flex-col border-r border-bakin-border-subtle bg-bakin-surface-default">
       <div className="flex items-center justify-between border-b border-bakin-border-subtle px-bakin-3 py-bakin-2">
-        <span className="text-bakin-typography-size-meta font-bakin-typography-weight-medium uppercase tracking-wide text-bakin-text-muted">
+        <Overline>
           Step Types
-        </span>
+        </Overline>
         <Button
           type="button"
           variant="ghost"
@@ -240,9 +240,9 @@ function PaletteGroup({
 }) {
   return (
     <div className="mb-3">
-      <div className="mb-1 px-1 text-bakin-typography-size-meta font-bakin-typography-weight-semibold uppercase tracking-wide text-bakin-text-muted">
+      <Overline as="div" className="mb-1 px-1">
         {title}
-      </div>
+      </Overline>
       <ul className="flex flex-col gap-1">
         {items.map((item) => (
           <PaletteItem

--- a/plugins/workflows/components/step-detail-drawer.tsx
+++ b/plugins/workflows/components/step-detail-drawer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Alert, AlertDescription, AlertTitle, Badge, Button, Drawer, DrawerSection, Overline, Separator } from '@makinbakin/sdk/ui'
+import { Alert, AlertDescription, AlertTitle, Badge, Button, Drawer, DrawerSection, Overline, Separator, Text } from '@makinbakin/sdk/ui'
 import { CodeBlock } from '@makinbakin/sdk/content'
 import { Stack } from '@makinbakin/sdk/layout'
 import { useAgent } from '@makinbakin/sdk/hooks'
@@ -56,10 +56,10 @@ function StepTypeBadge({ type }: { type: string }) {
 function MetadataCard({ icon: Icon, label, children }: { icon?: React.ElementType; label: string; children: React.ReactNode }) {
   return (
     <div className="rounded-bakin-surface bg-bakin-surface-default p-3 space-y-1">
-      <div className="flex items-center gap-1.5 text-bakin-typography-size-meta text-bakin-text-muted uppercase tracking-wider">
+      <Overline as="div" className="flex items-center gap-1.5">
         {Icon && <Icon className="size-3" />}
         {label}
-      </div>
+      </Overline>
       <div className="text-bakin-typography-size-body font-bakin-typography-weight-medium">{children}</div>
     </div>
   )
@@ -144,10 +144,10 @@ function AgentStepDetail({ step }: { step: AgentStep }) {
           <div className="grid grid-cols-2 gap-3">
             {step.outputs && step.outputs.length > 0 && (
               <div className="col-span-2 rounded-bakin-surface bg-bakin-surface-default p-3 space-y-1">
-                <div className="flex items-center gap-1.5 text-bakin-typography-size-meta text-bakin-text-muted uppercase tracking-wider">
+                <Overline as="div" className="flex items-center gap-1.5">
                   <Package className="size-3" />
                   Expected Outputs
-                </div>
+                </Overline>
                 <div className="space-y-1.5 mt-2">
                   {step.outputs.map((out) => (
                     <div key={out.id} className="flex items-center gap-2">
@@ -343,9 +343,9 @@ function ParallelStepDetail({ step }: { step: ParallelStep }) {
               {child.type === 'agent' && (
                 <div className="flex items-center gap-2">
                   <WorkflowAgentAvatar agentId={(child as AgentStep).agent} size="sm" />
-                  <span className="text-bakin-typography-size-meta text-bakin-text-muted">
+                  <Text size="meta" tone="muted">
                     {(child as AgentStep).agent}
-                  </span>
+                  </Text>
                 </div>
               )}
               {(child as AgentStep).task && (
@@ -540,11 +540,11 @@ function SkillDriftSection({
 
               <div className="space-y-3 border-t border-bakin-border-subtle pt-3">
                 <div>
-                  <div className="text-bakin-typography-size-meta font-bakin-typography-weight-medium uppercase tracking-wider text-bakin-text-muted">What can break</div>
+                  <Overline as="div">What can break</Overline>
                   <p className="m-0 mt-1 leading-relaxed">{driftImpactText(report)}</p>
                 </div>
                 <div>
-                  <div className="text-bakin-typography-size-meta font-bakin-typography-weight-medium uppercase tracking-wider text-bakin-text-muted">What the fix does</div>
+                  <Overline as="div">What the fix does</Overline>
                   <p className="m-0 mt-1 leading-relaxed">{repairActionText(report)}</p>
                 </div>
                 <div className="flex flex-wrap gap-1.5">

--- a/plugins/workflows/components/workflows-page.tsx
+++ b/plugins/workflows/components/workflows-page.tsx
@@ -34,6 +34,7 @@ import {
   WORKFLOW_FEATURES,
   workflowMatchesFeatures,
 } from '../lib/workflow-presentation'
+import { Inline } from '@makinbakin/sdk/layout'
 
 interface ScoreInfo {
   score: number
@@ -68,12 +69,12 @@ function WorkflowSection({
 }) {
   return (
     <section className="flex min-w-0 flex-col gap-bakin-3">
-      <div className="flex min-w-0 items-center gap-bakin-2">
+      <Inline gap="dense" wrap={false}>
         <h2 className="m-0 text-bakin-typography-size-meta font-bakin-typography-weight-bold uppercase tracking-widest text-bakin-text-muted">
           {title}
         </h2>
         <Badge size="xs" variant="outline">{total}</Badge>
-      </div>
+      </Inline>
       {workflows.length === 0 ? (
         <SystemState
           kind="initial-empty"
@@ -278,10 +279,10 @@ export function WorkflowsPage() {
   }
 
   const searchFeedback = searchSignalActive && searchHook.status !== 'loading' ? (
-    <div className="flex min-w-0 flex-wrap items-center gap-bakin-2">
+    <Inline gap="dense">
       {searchHook.status === 'unavailable' ? <SearchDegradedChip testId="workflows-search-degraded" /> : null}
       {searchHook.meta?.partial ? <SearchPartialChip meta={searchHook.meta} /> : null}
-    </div>
+    </Inline>
   ) : undefined
 
   const resultState = loading ? (


### PR DESCRIPTION
**PR 3b.** Consumes the primitives from #782 — **132 sites across 62 files**.

| Primitive | Sites | What it replaced |
|---|---|---|
| `Text` | 73 | The exact muted-meta / muted-body recipe. `as="p"` drops the paired `m-0`. |
| `Overline` | 22 | Labels that arrived in **23 different spellings** — three weights, three tracking steps — and leave in one. |
| `Inline` | 37 | Rows whose hand-rolled classes were already exactly what `Inline` renders. |

## Deliberately not converted

These are different intents, not drift:

- **6 uppercase labels that aren't overlines** — a wordmark (`text-base font-bold italic`), a `tracking-tight` chip, two primary-coloured display treatments, a signal-info label, and one `text-primary/70` opacity fade that belongs with the host-chrome pass.
- **30 flex rows lacking `min-w-0`.** `Inline` always applies it, so adopting there would newly let those rows shrink below content width — a real layout change across 30 sites I can't visually verify, not a no-op.
- **`<span>`/`<li>` rows.** `LayoutElement` is block-level by design, so `Inline` isn't a legal substitute for an inline element. The sweep converted 7 of these; I reverted them.

## These are equivalences, not approximations

`Inline` emits **byte-identical classes** for every recipe it replaced — verified against rendered output before landing, not assumed from reading the source. The visual suite passes with **zero baselines modified**, which also confirms the kit stories are untouched (every change is in `plugins/` and `packages/host/`, never `packages/ui/`).

## This pays down no ratchet debt — and shouldn't be read as if it did

Every class replaced here was **already a correct bakin token**. The legacy-styles ratchet measures raw-value usage (`gap-2`, `text-sm`), not hand-rolled-versus-primitive. Debt is unchanged at 982 units, exactly as expected. The axis this moves is *one spelling per idea* — which is why the overline number matters more than it looks.

## Verification

typecheck ✅ · lint ✅ (0 errors) · `bun test tests/ui/ tests/plugins/ tests/components/ tests/architecture/` → **4810 pass** · visual suite **256 pass, 0 baselines changed** · SDK stylesheet identity 6/6

Ratchets: legacy-styles, census, public-api, kit-coverage, story-compliance, performance, check-cycles — all green.

The 2 `ActivityTab` failures remain pre-existing (verified identical on clean `main`; they pass in isolation and fail only in combination).

## What's left after this

6 hand-rolled meta+muted, 15 uppercase (the 6 judgement calls + 9 in host chrome), and the 30 deferred flex rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)