### PR TITLE
refactor(ui): move Tabs and Table into the kit, and start policing it

### DIFF
--- a/design-system/census.json
+++ b/design-system/census.json
@@ -18,13 +18,13 @@
     ]
   },
   "summary": {
-    "total": 102,
+    "total": 100,
     "byKind": {
       "host-route": 26,
       "plugin-route": 10,
       "plugin-slot": 31,
       "plugin-template": 2,
-      "shared-component": 33,
+      "shared-component": 31,
       "sdk-ui-export": 0
     },
     "nonVisualAliases": 3
@@ -2705,65 +2705,6 @@
         {
           "type": "source-export",
           "path": "src/components/ui/skeleton.tsx",
-          "detail": "exported values discovered from TSX source"
-        }
-      ]
-    },
-    {
-      "id": "shared-component:src/components/ui/table",
-      "kind": "shared-component",
-      "owner": {
-        "repository": "bakin",
-        "area": "sdk"
-      },
-      "identity": {
-        "component": "src/components/ui/table"
-      },
-      "sourcePath": "src/components/ui/table.tsx",
-      "symbols": [
-        "Table",
-        "TableBody",
-        "TableCaption",
-        "TableCell",
-        "TableFooter",
-        "TableHead",
-        "TableHeader",
-        "TableRow"
-      ],
-      "exportStatus": "private",
-      "classification": "shared-ui",
-      "evidence": [
-        {
-          "type": "source-export",
-          "path": "src/components/ui/table.tsx",
-          "detail": "exported values discovered from TSX source"
-        }
-      ]
-    },
-    {
-      "id": "shared-component:src/components/ui/tabs",
-      "kind": "shared-component",
-      "owner": {
-        "repository": "bakin",
-        "area": "sdk"
-      },
-      "identity": {
-        "component": "src/components/ui/tabs"
-      },
-      "sourcePath": "src/components/ui/tabs.tsx",
-      "symbols": [
-        "Tabs",
-        "TabsContent",
-        "TabsList",
-        "TabsTrigger",
-        "tabsListVariants"
-      ],
-      "exportStatus": "private",
-      "classification": "shared-ui",
-      "evidence": [
-        {
-          "type": "source-export",
-          "path": "src/components/ui/tabs.tsx",
           "detail": "exported values discovered from TSX source"
         }
       ]

--- a/design-system/compatibility.json
+++ b/design-system/compatibility.json
@@ -7,7 +7,7 @@
   ],
   "repositories": {
     "bakin": {
-      "ref": "3b01dbe6136d65584345715127fc20021aa32fd6"
+      "ref": "2a79b991561eab961ab86109e1efd8ad18cc7542"
     },
     "bakin-bits-official": {
       "ref": "2f50ddf35be8daea3754391291bad896fe9cacb8"

--- a/design-system/exceptions.json
+++ b/design-system/exceptions.json
@@ -199,10 +199,10 @@
       "id": "tabs-legacy-pill-geometry",
       "status": "approved-temporary",
       "scope": [
-        "src/components/ui/tabs.tsx"
+        "packages/ui/src/primitives/tabs.tsx"
       ],
       "allowances": {
-        "src/components/ui/tabs.tsx": {
+        "packages/ui/src/primitives/tabs.tsx": {
           "arbitrary-size": 2
         }
       },

--- a/design-system/migrations.json
+++ b/design-system/migrations.json
@@ -20,13 +20,13 @@
     "private-import"
   ],
   "summary": {
-    "paths": 106,
+    "paths": 174,
     "totals": {
-      "raw-palette": 2,
-      "arbitrary-size": 29,
-      "raw-scale": 873,
-      "raw-control": 3,
-      "inline-style": 3,
+      "raw-palette": 4,
+      "arbitrary-size": 84,
+      "raw-scale": 921,
+      "raw-control": 20,
+      "inline-style": 34,
       "generic-token": 72,
       "unscoped-css": 0,
       "private-import": 0
@@ -579,6 +579,1080 @@
       "status": "legacy-allowed",
       "allowances": {
         "raw-scale": 12
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/area-chart.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 3
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/bar-chart.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/chart-data-table.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/chart-tooltip.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1,
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/composition-bar.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 3
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/line-chart.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/pie-chart.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/ranked-bar-chart.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "inline-style": 6
+      }
+    },
+    {
+      "path": "packages/ui/src/charts/stacked-column-chart.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-control": 1,
+        "inline-style": 6
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/activity-group.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1,
+        "raw-control": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/agent-turn.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/composer.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 5,
+        "raw-control": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/context-meter.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/conversation-empty-state.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/conversation-panel.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/conversation.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/queued-message-list.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/tool-call-drawer.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1,
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/conversation/user-message.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T34",
+      "archetype": "conversation",
+      "target": "canonical conversation patterns and focused SDK entrypoint",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/forms/field.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/layout/grid.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T44",
+      "archetype": "shell",
+      "target": "canonical shell layout and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/layout/sticky-overflow-scrollbar.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T44",
+      "archetype": "shell",
+      "target": "canonical shell layout and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 3
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/agent-filter.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/calendar-grid.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 8,
+        "raw-scale": 2,
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/calendar-item.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/calendar-nav.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/danger-zone.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/data-table.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/drawer-section.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/inspector-panel.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2,
+        "raw-scale": 3
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/kanban.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/key-value.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/list-rows.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2,
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/nav-list.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1,
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/page-aside.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 3
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/page-header.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 6
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/save-bar.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/search-input.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 4,
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/segmented-control.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/sortable-head.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1,
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/stat-tile.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/timeline.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 3
+      }
+    },
+    {
+      "path": "packages/ui/src/patterns/workspace-page.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/alert.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/avatar.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/badge.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/button.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/card.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/color-input.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-palette": 1,
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/command.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2,
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/dialog.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/dropdown-menu.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 6
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/file-input.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/input-group.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/input.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/interactive-surface.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/modal-context.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-palette": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/option-list.ts",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2,
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/popover.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/progress.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "inline-style": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/sheet.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/switch.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/table.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 8
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/tabs.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "raw-scale": 16
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/text.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/textarea.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "raw-scale": 1,
+        "raw-control": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/primitives/tooltip.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/states/banner.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 2
+      }
+    },
+    {
+      "path": "packages/ui/src/states/system-state.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1
+      }
+    },
+    {
+      "path": "packages/ui/src/states/toast.tsx",
+      "owner": {
+        "repository": "bakin",
+        "area": "sdk"
+      },
+      "censusEntryId": "host-route:__root",
+      "migrationTask": "T47",
+      "archetype": "shell",
+      "target": "supported host UI and namespaced semantic tokens",
+      "status": "legacy-allowed",
+      "allowances": {
+        "arbitrary-size": 1,
+        "raw-scale": 1,
+        "raw-control": 2
       }
     },
     {
@@ -1656,7 +2730,6 @@
       "target": "focused SDK primitive/pattern and namespaced semantic tokens",
       "status": "legacy-allowed",
       "allowances": {
-        "arbitrary-size": 2,
         "raw-scale": 2
       }
     },
@@ -1688,37 +2761,6 @@
       "status": "legacy-allowed",
       "allowances": {
         "raw-scale": 28
-      }
-    },
-    {
-      "path": "src/components/ui/table.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "sdk"
-      },
-      "censusEntryId": "shared-component:src/components/ui/table",
-      "migrationTask": "T21-T35",
-      "archetype": "shared-ui",
-      "target": "focused SDK primitive/pattern and namespaced semantic tokens",
-      "status": "legacy-allowed",
-      "allowances": {
-        "raw-scale": 8
-      }
-    },
-    {
-      "path": "src/components/ui/tabs.tsx",
-      "owner": {
-        "repository": "bakin",
-        "area": "sdk"
-      },
-      "censusEntryId": "shared-component:src/components/ui/tabs",
-      "migrationTask": "T21-T35",
-      "archetype": "shared-ui",
-      "target": "focused SDK primitive/pattern and namespaced semantic tokens",
-      "status": "legacy-allowed",
-      "allowances": {
-        "arbitrary-size": 1,
-        "raw-scale": 16
       }
     }
   ]

--- a/design-system/performance.json
+++ b/design-system/performance.json
@@ -32,13 +32,13 @@
       "name": "sdk-content",
       "path": "packages/host/public/vendor/sdk-content.js",
       "bytes": 350320,
-      "reachableBytes": 777696
+      "reachableBytes": 794429
     },
     {
       "name": "sdk-conversation",
       "path": "packages/host/public/vendor/sdk-conversation.js",
       "bytes": 60362,
-      "reachableBytes": 644444
+      "reachableBytes": 661177
     },
     {
       "name": "sdk-layout",
@@ -56,13 +56,13 @@
       "name": "sdk-patterns",
       "path": "packages/host/public/vendor/sdk-patterns.js",
       "bytes": 2430,
-      "reachableBytes": 549000
+      "reachableBytes": 565733
     },
     {
       "name": "sdk-ui",
       "path": "packages/host/public/vendor/sdk-ui.js",
-      "bytes": 25150,
-      "reachableBytes": 451301
+      "bytes": 8352,
+      "reachableBytes": 451133
     }
   ],
   "vendorChunks": [
@@ -127,27 +127,15 @@
       "bytes": 157
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-2xrtj366.js",
+      "path": "packages/host/public/vendor/sdk-shared-0wmfydew.js",
       "bytes": 1328
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-6rpct40v.js",
-      "bytes": 3476
-    },
-    {
-      "path": "packages/host/public/vendor/sdk-shared-7x82wzt8.js",
-      "bytes": 1938
-    },
-    {
-      "path": "packages/host/public/vendor/sdk-shared-87nnc3kf.js",
-      "bytes": 5243
-    },
-    {
-      "path": "packages/host/public/vendor/sdk-shared-91ys6sqv.js",
+      "path": "packages/host/public/vendor/sdk-shared-16fenajr.js",
       "bytes": 30778
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-axwqnxts.js",
+      "path": "packages/host/public/vendor/sdk-shared-b4anyw19.js",
       "bytes": 280583
     },
     {
@@ -155,40 +143,48 @@
       "bytes": 199
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-ebr640ha.js",
-      "bytes": 26880
+      "path": "packages/host/public/vendor/sdk-shared-cv5pt64f.js",
+      "bytes": 1938
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-fhv9ztgc.js",
+      "path": "packages/host/public/vendor/sdk-shared-ef53s8g5.js",
+      "bytes": 5243
+    },
+    {
+      "path": "packages/host/public/vendor/sdk-shared-kt0jc17q.js",
+      "bytes": 124451
+    },
+    {
+      "path": "packages/host/public/vendor/sdk-shared-m9vr1wzs.js",
       "bytes": 290739
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-h5mfc0ya.js",
-      "bytes": 28974
+      "path": "packages/host/public/vendor/sdk-shared-mpp0pwpr.js",
+      "bytes": 26880
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-k6qa8h5g.js",
-      "bytes": 107718
+      "path": "packages/host/public/vendor/sdk-shared-n5teg51h.js",
+      "bytes": 3476
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-n8dd5ers.js",
-      "bytes": 711
+      "path": "packages/host/public/vendor/sdk-shared-qy5ktkb4.js",
+      "bytes": 3295
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-tbtbr6bf.js",
+      "path": "packages/host/public/vendor/sdk-shared-snqpdev8.js",
       "bytes": 82775
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-wyktsxx1.js",
-      "bytes": 103
+      "path": "packages/host/public/vendor/sdk-shared-v2e06e1h.js",
+      "bytes": 711
     },
     {
-      "path": "packages/host/public/vendor/sdk-shared-xk5hy9k5.js",
+      "path": "packages/host/public/vendor/sdk-shared-vkn81vy7.js",
+      "bytes": 28974
+    },
+    {
+      "path": "packages/host/public/vendor/sdk-shared-zz3ky8p4.js",
       "bytes": 2165
-    },
-    {
-      "path": "packages/host/public/vendor/sdk-shared-yhs43ptk.js",
-      "bytes": 3295
     },
     {
       "path": "packages/host/public/vendor/sdk-slots.js",
@@ -200,11 +196,11 @@
     },
     {
       "path": "packages/host/public/vendor/sdk-ui.js",
-      "bytes": 25150
+      "bytes": 8352
     },
     {
       "path": "packages/host/public/vendor/sdk-utils.js",
-      "bytes": 8314
+      "bytes": 8326
     },
     {
       "path": "packages/host/public/vendor/tanstack-router.js",

--- a/packages/sdk/src/ui/index.ts
+++ b/packages/sdk/src/ui/index.ts
@@ -323,8 +323,20 @@ export type { ShimmerTextBase,
   ShimmerTextHighlight, ShimmerTextProps } from '@bakin/ui'
 export { Switch } from '@bakin/ui'
 export type { SwitchProps, SwitchSize } from '@bakin/ui'
-export * from '@/components/ui/table'
-export * from '@/components/ui/tabs'
+// Explicit, not `export *`: the barrel used to publish whatever these files
+// happened to define, which is how their structural sub-parts ended up in the
+// public surface undocumented. Additions here are now a deliberate act.
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@bakin/ui'
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants } from '@bakin/ui'
 export { Textarea } from '@bakin/ui'
 export type { TextareaProps } from '@bakin/ui'
 export { Tooltip, TooltipContent, TooltipPortal, TooltipProvider, TooltipTrigger } from '@bakin/ui'

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -103,6 +103,19 @@ export type {
   LegacyBadgeVariant,
 } from './primitives/badge'
 
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './primitives/table'
+
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants } from './primitives/tabs'
+
 export { Overline, Text } from './primitives/text'
 export type {
   OverlineProps,

--- a/packages/ui/src/primitives/table.tsx
+++ b/packages/ui/src/primitives/table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../utils"
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -5,7 +5,7 @@ import * as React from "react"
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../utils"
 
 function Tabs({
   className,

--- a/scripts/ui/check-legacy-styles.ts
+++ b/scripts/ui/check-legacy-styles.ts
@@ -241,9 +241,17 @@ function scanSource(file: LegacyStyleSource): Record<LegacyStyleRule, number> {
     file.source,
     /#[0-9a-fA-F]{6}(?:[0-9a-fA-F]{2})?\b|#(?=[0-9a-fA-F]{3,4}\b)(?=[0-9a-fA-F]*[a-fA-F])[0-9a-fA-F]{3,4}\b|\b(?:rgb|hsl)a?\([^)]*\)/g,
   )
+  // An arbitrary value that resolves a `--bakin-*` custom property is the token
+  // system being applied, not a magic number — and sometimes it is the ONLY
+  // correct spelling: `text-[length:var(--bakin-typography-size-meta)]` exists
+  // precisely because the `text-…-size-*` shorthand shares the `text-*` merge
+  // group with colour and gets silently dropped. Counting those as debt would
+  // mark the prescribed pattern as a violation and teach people to ignore the
+  // ratchet. Literal arbitrary values (`w-[240px]`, `h-[calc(100%-2rem)]`)
+  // still count.
   counts['arbitrary-size'] = matchCount(
     file.source,
-    new RegExp(`(?:^|[\\s"'\\x60])${VARIANT_PREFIX}(?:-?(?:w|h|min-w|max-w|min-h|max-h|size|p[trblxy]?|m[trblxy]?|gap(?:-[xy])?|space-[xy]|top|right|bottom|left|inset(?:-[xy])?|translate-[xy]|basis|grid-cols|grid-rows|text|leading|tracking|rounded|border))-\\[[^\\]]+\\](?=$|[\\s"'\\x60}])`, 'gm'),
+    new RegExp(`(?:^|[\\s"'\\x60])${VARIANT_PREFIX}(?:-?(?:w|h|min-w|max-w|min-h|max-h|size|p[trblxy]?|m[trblxy]?|gap(?:-[xy])?|space-[xy]|top|right|bottom|left|inset(?:-[xy])?|translate-[xy]|basis|grid-cols|grid-rows|text|leading|tracking|rounded|border))-\\[(?![^\\]]*var\\(--bakin-)[^\\]]+\\](?=$|[\\s"'\\x60}])`, 'gm'),
   )
   counts['raw-scale'] = matchCount(
     file.source,
@@ -301,6 +309,15 @@ function isTestOrStory(path: string): boolean {
   return /(?:^|\/)(?:tests|__tests__)(?:\/|$)|\.(?:test|spec|stories)\.[^.]+$/.test(path)
 }
 
+/**
+ * Generated artifacts cannot be hand-fixed, so recording their contents as
+ * migratable debt is pure noise — the token files literally define the palette
+ * in hex, which is their job. Fix the generator, not the output.
+ */
+function isGenerated(path: string): boolean {
+  return /\.generated\.[^.]+$/.test(path)
+}
+
 function hostBrowserSource(path: string): boolean {
   if (isTestOrStory(path)) return false
   if (path.endsWith('.tsx') || path.endsWith('.css')) return !path.includes('/api/')
@@ -308,7 +325,7 @@ function hostBrowserSource(path: string): boolean {
 }
 
 function sharedBrowserSource(path: string): boolean {
-  return !isTestOrStory(path) && ['.css', '.ts', '.tsx'].includes(extname(path))
+  return !isTestOrStory(path) && !isGenerated(path) && ['.css', '.ts', '.tsx'].includes(extname(path))
 }
 
 function pluginBrowserSource(path: string): boolean {
@@ -333,6 +350,13 @@ export function collectLegacyStyleSources(root: string, bitsPluginsRoot: string)
   }
   const coreRoots = [
     { path: join(root, 'packages/host/src'), include: hostBrowserSource },
+    // The kit implements the tokens, so it legitimately uses more raw values
+    // than product code — but it was the ONE browser surface with no style
+    // governance at all, which is how a font-size that tailwind-merge silently
+    // dropped shipped in WorkspacePage. Scanning it records that reality
+    // instead of leaving it invisible; the allowances are the honest baseline,
+    // not a target.
+    { path: join(root, 'packages/ui/src'), include: sharedBrowserSource },
     { path: join(root, 'packages/sdk/src'), include: sharedBrowserSource },
     { path: join(root, 'src/components'), include: sharedBrowserSource },
     { path: join(root, 'plugins'), include: pluginBrowserSource },

--- a/tests/components/tabs.test.tsx
+++ b/tests/components/tabs.test.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 import '../rtl-settle'
 import { act } from 'react'
 import { settleReact } from '../rtl-settle'
-import { Tabs, TabsList, TabsTrigger } from '../../src/components/ui/tabs'
+import { Tabs, TabsList, TabsTrigger } from '@makinbakin/sdk/ui'
 
 const tabs = [
   { id: 'overview', label: 'Overview' },


### PR DESCRIPTION
Came out of the **PR 4 host-chrome audit**. The styling migration follows separately — this is the structural finding that audit surfaced.

## The finding

`Tabs*` and `Table*` — two public kit component families — had their real implementations in root `src/components/ui/` while every peer lived in `packages/ui`. The SDK published them with `export *`, which is how their structural sub-parts (`TableCaption`, `TabsContent`, …) ended up in the public surface undocumented. The other seven files there are thin re-export shims, untouched.

- Both move to `packages/ui/src/primitives/`, switching to the kit's own `cn`.
- `export *` becomes an explicit list — **deliberately not narrowed**. The public API freeze is byte-identical at **300 values / 404 types**, so the surface becomes intentional without breaking a single consumer.

## The coupled problem it exposed

`packages/ui` was the **one browser surface the legacy-styles ratchet never scanned**. Relocating these files would have silently erased 25 tracked units and orphaned an approved exception — the ledger would have reported a 25-unit improvement for work nobody did.

`ui:legacy-styles:generate` refused to run. That's #783's check doing exactly its job.

So the scanner now covers `packages/ui/src`. Two refinements keep the baseline honest rather than noisy:

**Token applications aren't magic numbers.** An arbitrary value resolving a `--bakin-*` property is the token system working — and sometimes the *only* correct spelling. `text-[length:var(--bakin-typography-size-meta)]` exists precisely because the shorthand shares the `text-*` merge group with colour and gets silently dropped. Counting those as debt flagged the prescribed pattern — **including the primitive added in #782** — as a violation, which teaches people to ignore the ratchet. Literal values (`w-[240px]`) still count. Kit arbitrary-size: **244 → 55**, and it's a fleet-wide correction.

**Generated artifacts are excluded.** The token files define the palette in hex because that is their job; you fix the generator, not the output. That's **60 of the 64** raw-palette hits.

## What the numbers mean

| | before | after |
|---|---|---|
| paths | 106 | 174 |
| units | 982 | 1135 |

Every one of those **+153 is pre-existing code becoming visible** — zero lines of product code changed. The naive version of this would have recorded **+402**, most of it false.

This also closes the gap I've flagged twice: the kit being unpoliced is what let the `WorkspacePage` font-size drop ship unnoticed.

## Census

102 → 100, because the census never tracked `packages/ui` at all. `Button`, `Card`, and `Badge` are uncensused too — Tabs and Table are joining their peers, not losing coverage.

## Verification

typecheck ✅ · lint ✅ (0 errors) · `bun test tests/ui/ tests/components/ tests/architecture/ tests/scripts/` → **1326 pass, 0 fail**

Gates: public-api (byte-identical), census, kit-coverage, performance, legacy-styles, check-cycles — all green. Vendor chunks consolidated 36 → 35 because the SDK no longer reaches across into root `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)