### PR TITLE
refactor(models): make the routing matrix a table so the labels stop repeating

### DIFF
--- a/design-system/performance.json
+++ b/design-system/performance.json
@@ -266,7 +266,7 @@
       "repository": "bakin",
       "pluginId": "models",
       "path": "plugins/models/dist/client.js",
-      "bytes": 77098
+      "bytes": 76928
     },
     {
       "repository": "bakin",

--- a/plugins/models/components/routing-tab.tsx
+++ b/plugins/models/components/routing-tab.tsx
@@ -5,11 +5,13 @@ import { Plus, Wand2, X } from 'lucide-react'
 import { Section, Stack } from '@makinbakin/sdk/layout'
 import {
   ConfirmDialog,
+  DataTable,
   KeyValue,
-  type KeyValueItem,
   ListRow,
   ListRows,
   ModelSelect,
+  type DataTableColumn,
+  type KeyValueItem,
 } from '@makinbakin/sdk/patterns'
 import {
   Button,
@@ -22,6 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
   SystemState,
+  Text,
 } from '@makinbakin/sdk/ui'
 import { pluginFetch } from '@makinbakin/sdk/utils'
 
@@ -53,6 +56,8 @@ const THINKING_LABELS: Record<string, string> = {
   adaptive: 'Adaptive',
   max: 'Maximum',
 }
+
+type RouteRow = (typeof DISPATCH_ROWS)[number]
 
 export function RoutingTab({ m }: { m: ModelsData }) {
   const {
@@ -155,65 +160,67 @@ export function RoutingTab({ m }: { m: ModelsData }) {
     </Select>
   )
 
+  const ROUTE_COLUMNS: ReadonlyArray<DataTableColumn<RouteRow>> = [
+    {
+      key: 'workClass',
+      header: 'Work class',
+      cellClassName: 'whitespace-normal align-top',
+      cell: (workClass) => (
+        <div className="min-w-0">
+          <h3>{workClass.label}</h3>
+          <Text as="p" size="meta" tone="muted" className="mt-bakin-1 leading-relaxed">
+            {workClass.description}
+          </Text>
+        </div>
+      ),
+    },
+    {
+      key: 'model',
+      header: 'Model',
+      cellClassName: 'align-top',
+      cell: (workClass) => (
+        <ModelSelect
+          id={`routing-${workClass.id}-model`}
+          value={displayRouting.routes.find((r) => r.workClass === workClass.id)?.model ?? ''}
+          onValueChange={(value) => setRouteField(workClass.id, 'model', value)}
+          models={modelOptions}
+          defaultLabel="Use agent model"
+          defaultValue=""
+          ariaLabel={`${workClass.label} model`}
+          className="w-full min-w-0"
+        />
+      ),
+    },
+    {
+      key: 'thinking',
+      header: 'Thinking',
+      cellClassName: 'align-top',
+      cell: (workClass) => thinkingSelect(
+        `routing-${workClass.id}-thinking`,
+        `${workClass.label} thinking`,
+        displayRouting.routes.find((r) => r.workClass === workClass.id)?.thinking,
+        (value) => setRouteField(workClass.id, 'thinking', value),
+      ),
+    },
+  ]
+
   const routeList = (rows: typeof DISPATCH_ROWS, label: string) => (
-    <ListRows
-      aria-label={label}
-      variant="separated"
-      columns="minmax(12rem,.7fr) minmax(0,1fr) minmax(10rem,.42fr)"
-      columnsAt="3xl"
-      columnsAlign="end"
-    >
-      {rows.map((workClass) => {
-        const route = displayRouting.routes.find((item) => item.workClass === workClass.id)
-        const modelId = `routing-${workClass.id}-model`
-        const thinkingId = `routing-${workClass.id}-thinking`
-
-        return (
-          <ListRow
-            key={workClass.id}
-            data-routing-row={workClass.id}
-            className="px-bakin-4 py-bakin-4"
-          >
-            <div className="min-w-0 @3xl/list-rows:self-center">
-              <h3>{workClass.label}</h3>
-              <p className="mt-bakin-1 text-bakin-typography-size-meta leading-relaxed text-bakin-text-muted">
-                {workClass.description}
-              </p>
-            </div>
-
-            <Field name={modelId}>
-              <FieldLabel htmlFor={modelId}>
-                <span className="sr-only">{workClass.label} </span>
-                Model
-              </FieldLabel>
-              <ModelSelect
-                id={modelId}
-                value={route?.model ?? ''}
-                onValueChange={(value) => setRouteField(workClass.id, 'model', value)}
-                models={modelOptions}
-                defaultLabel="Use agent model"
-                defaultValue=""
-                ariaLabel={`${workClass.label} model`}
-                className="w-full min-w-0"
-              />
-            </Field>
-
-            <Field name={thinkingId}>
-              <FieldLabel htmlFor={thinkingId}>
-                <span className="sr-only">{workClass.label} </span>
-                Thinking
-              </FieldLabel>
-              {thinkingSelect(
-                thinkingId,
-                `${workClass.label} thinking`,
-                route?.thinking,
-                (value) => setRouteField(workClass.id, 'thinking', value),
-              )}
-            </Field>
-          </ListRow>
-        )
-      })}
-    </ListRows>
+    // A table, not stacked rows: "Model" and "Thinking" belong in the header
+    // once instead of on every row. With eleven work classes that was twenty-two
+    // repeated field labels for two concepts, which is what made this tab read
+    // as busy.
+    //
+    // Collapsing stays OFF (the default). A collapsing DataTable renders both
+    // the table and the list and hides one with CSS — fine for read-only rows,
+    // but here it would put every one of these selects in the DOM and the tab
+    // order twice. A narrow viewport scrolls the table sideways instead.
+    <DataTable
+      label={label}
+      columns={ROUTE_COLUMNS}
+      rows={rows}
+      rowKey={(workClass) => workClass.id}
+      rowProps={(workClass) => ({ 'data-routing-row': workClass.id })}
+    />
   )
 
   return (

--- a/tests/components/routing-tab.test.tsx
+++ b/tests/components/routing-tab.test.tsx
@@ -39,6 +39,11 @@ function makeM(over: Partial<ModelsData> = {}): ModelsData {
 
 afterEach(cleanup)
 
+// The thinking selects used to take their accessible name from a visible
+// FieldLabel ("Scheduled Thinking"); the model selects took theirs from
+// aria-label ("Scheduled model"). The routing matrix is a DataTable now, so the
+// column header carries the field name once and BOTH controls are named
+// uniformly by aria-label.
 describe('RoutingTab', () => {
   it('renders dispatch + system sections; chat is excluded', () => {
     render(<RoutingTab m={makeM()} />)
@@ -56,7 +61,7 @@ describe('RoutingTab', () => {
   it('thinking dropdowns offer only runtime-supported levels (Pi hides adaptive/max)', async () => {
     const user = userEvent.setup()
     render(<RoutingTab m={makeM()} />)
-    await user.click(screen.getByRole('combobox', { name: 'Scheduled Thinking' }))
+    await user.click(screen.getByRole('combobox', { name: 'Scheduled thinking' }))
     const options = screen.getAllByRole('option').map((o) => o.textContent)
     expect(options).toContain('Extra high')
     expect(options).not.toContain('Adaptive')
@@ -68,7 +73,7 @@ describe('RoutingTab', () => {
     render(<RoutingTab m={makeM({
       displayRouting: { routes: [{ workClass: 'relay', thinking: 'max' }], tagOverrides: [] },
     } as Partial<ModelsData>)} />)
-    await user.click(screen.getByRole('combobox', { name: 'Relay Thinking' }))
+    await user.click(screen.getByRole('combobox', { name: 'Relay thinking' }))
     expect(screen.getByRole('option', { name: 'Maximum · unsupported by this runtime' })).toBeTruthy()
   })
 })


### PR DESCRIPTION
**PR 5**, partial — the routing tab. See *the other two rulings* below; I'm recommending we close one without changing code and defer the other.

## The routing tab

You said it was hard to follow — *"so many selects and labels"*. The cause was measurable: every row carried its own visible **"Model"** and **"Thinking"** `FieldLabel`, so eleven work classes produced **22 field labels for two concepts**.

It's a `DataTable` now. The column header states each field name once, so the same controls read as a matrix instead of eleven repeated forms.

**My earlier proposal for this tab was wrong.** I'd suggested "cells that become selects on engage" — that adds a click per edit and leaves the label repetition, which was the actual problem, completely untouched.

## Collapsing is off, deliberately

I initially opted *into* `collapseBelow="2xl"`, reasoning a form reads better stacked on mobile. The routing tests caught the flaw: a collapsing `DataTable` renders **both** the table and the narrow list and hides one with CSS. For read-only rows that's fine — here it would put all 22 selects in the DOM and the tab order **twice**.

DataTable's own test documents this ("`none` can never show the narrow render… no duplicate interactive controls in the DOM or tab order"). Narrow viewports scroll the table sideways instead.

Worth noting the test failure that exposed it didn't *say* "duplicates" — it said the accessible name wasn't found. I chased the name twice on wrong assumptions before probing the DOM for what was actually rendered.

## Accessible naming is now uniform

The thinking selects used to be named by their visible `FieldLabel` (`"Scheduled Thinking"`); the model selects by `aria-label` (`"Scheduled model"`). Both now come from `aria-label`. The two assertions that pinned the old inconsistency are updated, with the reason recorded beside them.

## The other two rulings

**Team lessons → DataTable — I recommend closing this with no change.** It was my suggestion; on inspection it's wrong. The list is already kit-conformant (`ListRows`/`ListRow`, proper `Label`/`htmlFor` association), and it's a settings-style toggle list rather than comparable records to scan. Converting would trade away the whole-row click target for doctrine purity.

**Team graph mobile clipping — deferred.** It's a ReactFlow `fitView`/viewport concern inside the area already covered by the `reactflow-integration-layer` exception, and I can't diagnose a visual clipping bug responsibly without reproducing it in a browser.

## Verification

typecheck ✅ · lint ✅ (0 errors) · `bun test tests/plugins/ tests/components/ tests/ui/` → **4746 pass**, the 2 failures being the known pre-existing `ActivityTab` isolation flake.

Ratchets: legacy-styles, census, public-api, kit-coverage, story-compliance, performance, check-cycles — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)