### PR TITLE
chore(design-system): pin Bits at the StatusMarker adoption

### DIFF
--- a/design-system/compatibility.json
+++ b/design-system/compatibility.json
@@ -7,10 +7,10 @@
   ],
   "repositories": {
     "bakin": {
-      "ref": "96c4e764c2fbfdf1e08f017be2a2df9e4e8b1664"
+      "ref": "cfd25b8352c4c0c02fa03afca7062ffdb8da5470"
     },
     "bakin-bits-official": {
-      "ref": "c67274806b6a7ed1f8e82d62f2322ce78875bb66"
+      "ref": "76c3ca4da4e669df7e20560e13f44867ccca1b2e"
     }
   },
   "sdk": {
@@ -21,7 +21,7 @@
     "messaging": {
       "repository": "bakin-bits-official",
       "role": "official-plugin",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "bakinRange": ">=0.0.1-rc.1",
       "routes": {
         "total": 5,
@@ -37,7 +37,7 @@
     "projects": {
       "repository": "bakin-bits-official",
       "role": "official-plugin",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "bakinRange": ">=0.0.1-rc.1",
       "routes": {
         "total": 4,


### PR DESCRIPTION
Records **bakin-bits-official #99** at `76c3ca4`.

Unlike the previous Bits reconcile, **nothing else moved**: `styles.css` is byte-identical and the ledger stays at 877 units. `StatusMarker` swaps hand-rolled dot classes for kit ones that were already compiled, so the class set never changed — which is also why that Bits PR went green on its own rather than needing the merge-red-then-reconcile sequence.

## One thing worth recording

The local Bits clone had **silently failed to pull** (`publickey`), so my first regeneration ran against pre-merge sources and would have written a stale pin — pointing at `c672748` while main was at `76c3ca4`. I caught it because the only changed ref in the diff was bakin's own, not the Bits one.

Worth checking the sibling clone is actually at the merge commit before trusting anything this generator produces; a stale pin is the kind of thing that stays wrong quietly.

## Verification

legacy-styles ✅ · census ✅ · SDK stylesheet identity **6/6** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)