### PR TITLE
fix(ui): keep icon and text on one line inside horizontal field labels

### DIFF
--- a/packages/host/src/api/_embedded-assets-static.ts
+++ b/packages/host/src/api/_embedded-assets-static.ts
@@ -22,40 +22,41 @@ import asset_bakin_logo_svg from '../../public/bakin-logo.svg' with { type: 'fil
 import asset_bakin_hop_svg from '../../public/bakin-hop.svg' with { type: 'file' }
 import asset_vendor_sdk_ui_js from '../../public/vendor/sdk-ui.js' with { type: 'file' }
 import asset_vendor_sdk_routing_js from '../../public/vendor/sdk-routing.js' with { type: 'file' }
-import asset_vendor_sdk_shared_v22e0hm8_js from '../../public/vendor/sdk-shared-v22e0hm8.js' with { type: 'file' }
-import asset_vendor_sdk_shared_gnjx8k29_js from '../../public/vendor/sdk-shared-gnjx8k29.js' with { type: 'file' }
+import asset_vendor_sdk_shared_9qcjnds1_js from '../../public/vendor/sdk-shared-9qcjnds1.js' with { type: 'file' }
 import asset_vendor_sdk_conversation_js from '../../public/vendor/sdk-conversation.js' with { type: 'file' }
+import asset_vendor_sdk_shared_pghvvv1j_js from '../../public/vendor/sdk-shared-pghvvv1j.js' with { type: 'file' }
 import asset_vendor_sdk_content_js from '../../public/vendor/sdk-content.js' with { type: 'file' }
+import asset_vendor_sdk_shared_d3xe080e_js from '../../public/vendor/sdk-shared-d3xe080e.js' with { type: 'file' }
+import asset_vendor_sdk_shared_mzz3xqhk_js from '../../public/vendor/sdk-shared-mzz3xqhk.js' with { type: 'file' }
+import asset_vendor_sdk_shared_8m82fk5s_js from '../../public/vendor/sdk-shared-8m82fk5s.js' with { type: 'file' }
 import asset_vendor_react_js from '../../public/vendor/react.js' with { type: 'file' }
-import asset_vendor_sdk_shared_7e4akybc_js from '../../public/vendor/sdk-shared-7e4akybc.js' with { type: 'file' }
-import asset_vendor_sdk_shared_x53rstr7_js from '../../public/vendor/sdk-shared-x53rstr7.js' with { type: 'file' }
+import asset_vendor_sdk_shared_jmth908a_js from '../../public/vendor/sdk-shared-jmth908a.js' with { type: 'file' }
 import asset_vendor_sdk_shared_mfezs2ge_js from '../../public/vendor/sdk-shared-mfezs2ge.js' with { type: 'file' }
-import asset_vendor_sdk_shared_6m5mfmzn_js from '../../public/vendor/sdk-shared-6m5mfmzn.js' with { type: 'file' }
 import asset_vendor_jsx_runtime_js from '../../public/vendor/jsx-runtime.js' with { type: 'file' }
-import asset_vendor_sdk_shared_jzvs97gb_js from '../../public/vendor/sdk-shared-jzvs97gb.js' with { type: 'file' }
+import asset_vendor_sdk_shared_7ffg5tk1_js from '../../public/vendor/sdk-shared-7ffg5tk1.js' with { type: 'file' }
 import asset_vendor_sdk_shared_bmsw4wcn_js from '../../public/vendor/sdk-shared-bmsw4wcn.js' with { type: 'file' }
 import asset_vendor_sdk_utils_js from '../../public/vendor/sdk-utils.js' with { type: 'file' }
-import asset_vendor_sdk_shared_xvcgw500_js from '../../public/vendor/sdk-shared-xvcgw500.js' with { type: 'file' }
 import asset_vendor_sdk_types_js from '../../public/vendor/sdk-types.js' with { type: 'file' }
-import asset_vendor_sdk_shared_vfsmbtxr_js from '../../public/vendor/sdk-shared-vfsmbtxr.js' with { type: 'file' }
+import asset_vendor_sdk_shared_fs8rb11s_js from '../../public/vendor/sdk-shared-fs8rb11s.js' with { type: 'file' }
+import asset_vendor_sdk_shared_n3wmvzt3_js from '../../public/vendor/sdk-shared-n3wmvzt3.js' with { type: 'file' }
+import asset_vendor_sdk_shared_1wc8m1jh_js from '../../public/vendor/sdk-shared-1wc8m1jh.js' with { type: 'file' }
 import asset_vendor_react_dom_js from '../../public/vendor/react-dom.js' with { type: 'file' }
-import asset_vendor_sdk_shared_7261rmk7_js from '../../public/vendor/sdk-shared-7261rmk7.js' with { type: 'file' }
+import asset_vendor_sdk_shared_gtyhq3j8_js from '../../public/vendor/sdk-shared-gtyhq3j8.js' with { type: 'file' }
 import asset_vendor_sdk_charts_js from '../../public/vendor/sdk-charts.js' with { type: 'file' }
 import asset_vendor_sdk_index_js from '../../public/vendor/sdk-index.js' with { type: 'file' }
-import asset_vendor_sdk_shared_47se6qb9_js from '../../public/vendor/sdk-shared-47se6qb9.js' with { type: 'file' }
 import asset_vendor_sdk_layout_js from '../../public/vendor/sdk-layout.js' with { type: 'file' }
 import asset_vendor_sdk_slots_js from '../../public/vendor/sdk-slots.js' with { type: 'file' }
-import asset_vendor_sdk_shared_qmmvxc5f_js from '../../public/vendor/sdk-shared-qmmvxc5f.js' with { type: 'file' }
 import asset_vendor_sdk_patterns_js from '../../public/vendor/sdk-patterns.js' with { type: 'file' }
 import asset_vendor_sdk_metadata_js from '../../public/vendor/sdk-metadata.js' with { type: 'file' }
-import asset_vendor_sdk_shared_4n7s11pq_js from '../../public/vendor/sdk-shared-4n7s11pq.js' with { type: 'file' }
+import asset_vendor_sdk_shared_a4eed451_js from '../../public/vendor/sdk-shared-a4eed451.js' with { type: 'file' }
+import asset_vendor_sdk_shared_db9w1yyf_js from '../../public/vendor/sdk-shared-db9w1yyf.js' with { type: 'file' }
+import asset_vendor_sdk_shared_xckftt6k_js from '../../public/vendor/sdk-shared-xckftt6k.js' with { type: 'file' }
 import asset_vendor_sdk_hooks_js from '../../public/vendor/sdk-hooks.js' with { type: 'file' }
 import asset_vendor_tanstack_router_js from '../../public/vendor/tanstack-router.js' with { type: 'file' }
 import asset_vendor_sdk_navigation_js from '../../public/vendor/sdk-navigation.js' with { type: 'file' }
 import asset_vendor_sdk_internal_js from '../../public/vendor/sdk-internal.js' with { type: 'file' }
-import asset_vendor_sdk_shared_hnwpp229_js from '../../public/vendor/sdk-shared-hnwpp229.js' with { type: 'file' }
 import asset_vendor_jsx_dev_runtime_js from '../../public/vendor/jsx-dev-runtime.js' with { type: 'file' }
-import asset_vendor_sdk_shared_vsn39xg1_js from '../../public/vendor/sdk-shared-vsn39xg1.js' with { type: 'file' }
+import asset_vendor_sdk_shared_w3v3tct7_js from '../../public/vendor/sdk-shared-w3v3tct7.js' with { type: 'file' }
 import asset_api_plugins_schedule_assets_client_js from '../../../../plugins/schedule/dist/client.js' with { type: 'file' }
 import asset_api_plugins_tasks_assets_client_js from '../../../../plugins/tasks/dist/client.js' with { type: 'file' }
 import asset_api_plugins_memory_assets_client_js from '../../../../plugins/memory/dist/client.js' with { type: 'file' }
@@ -82,40 +83,41 @@ export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
   ['/bakin-hop.svg', asset_bakin_hop_svg],
   ['/vendor/sdk-ui.js', asset_vendor_sdk_ui_js],
   ['/vendor/sdk-routing.js', asset_vendor_sdk_routing_js],
-  ['/vendor/sdk-shared-v22e0hm8.js', asset_vendor_sdk_shared_v22e0hm8_js],
-  ['/vendor/sdk-shared-gnjx8k29.js', asset_vendor_sdk_shared_gnjx8k29_js],
+  ['/vendor/sdk-shared-9qcjnds1.js', asset_vendor_sdk_shared_9qcjnds1_js],
   ['/vendor/sdk-conversation.js', asset_vendor_sdk_conversation_js],
+  ['/vendor/sdk-shared-pghvvv1j.js', asset_vendor_sdk_shared_pghvvv1j_js],
   ['/vendor/sdk-content.js', asset_vendor_sdk_content_js],
+  ['/vendor/sdk-shared-d3xe080e.js', asset_vendor_sdk_shared_d3xe080e_js],
+  ['/vendor/sdk-shared-mzz3xqhk.js', asset_vendor_sdk_shared_mzz3xqhk_js],
+  ['/vendor/sdk-shared-8m82fk5s.js', asset_vendor_sdk_shared_8m82fk5s_js],
   ['/vendor/react.js', asset_vendor_react_js],
-  ['/vendor/sdk-shared-7e4akybc.js', asset_vendor_sdk_shared_7e4akybc_js],
-  ['/vendor/sdk-shared-x53rstr7.js', asset_vendor_sdk_shared_x53rstr7_js],
+  ['/vendor/sdk-shared-jmth908a.js', asset_vendor_sdk_shared_jmth908a_js],
   ['/vendor/sdk-shared-mfezs2ge.js', asset_vendor_sdk_shared_mfezs2ge_js],
-  ['/vendor/sdk-shared-6m5mfmzn.js', asset_vendor_sdk_shared_6m5mfmzn_js],
   ['/vendor/jsx-runtime.js', asset_vendor_jsx_runtime_js],
-  ['/vendor/sdk-shared-jzvs97gb.js', asset_vendor_sdk_shared_jzvs97gb_js],
+  ['/vendor/sdk-shared-7ffg5tk1.js', asset_vendor_sdk_shared_7ffg5tk1_js],
   ['/vendor/sdk-shared-bmsw4wcn.js', asset_vendor_sdk_shared_bmsw4wcn_js],
   ['/vendor/sdk-utils.js', asset_vendor_sdk_utils_js],
-  ['/vendor/sdk-shared-xvcgw500.js', asset_vendor_sdk_shared_xvcgw500_js],
   ['/vendor/sdk-types.js', asset_vendor_sdk_types_js],
-  ['/vendor/sdk-shared-vfsmbtxr.js', asset_vendor_sdk_shared_vfsmbtxr_js],
+  ['/vendor/sdk-shared-fs8rb11s.js', asset_vendor_sdk_shared_fs8rb11s_js],
+  ['/vendor/sdk-shared-n3wmvzt3.js', asset_vendor_sdk_shared_n3wmvzt3_js],
+  ['/vendor/sdk-shared-1wc8m1jh.js', asset_vendor_sdk_shared_1wc8m1jh_js],
   ['/vendor/react-dom.js', asset_vendor_react_dom_js],
-  ['/vendor/sdk-shared-7261rmk7.js', asset_vendor_sdk_shared_7261rmk7_js],
+  ['/vendor/sdk-shared-gtyhq3j8.js', asset_vendor_sdk_shared_gtyhq3j8_js],
   ['/vendor/sdk-charts.js', asset_vendor_sdk_charts_js],
   ['/vendor/sdk-index.js', asset_vendor_sdk_index_js],
-  ['/vendor/sdk-shared-47se6qb9.js', asset_vendor_sdk_shared_47se6qb9_js],
   ['/vendor/sdk-layout.js', asset_vendor_sdk_layout_js],
   ['/vendor/sdk-slots.js', asset_vendor_sdk_slots_js],
-  ['/vendor/sdk-shared-qmmvxc5f.js', asset_vendor_sdk_shared_qmmvxc5f_js],
   ['/vendor/sdk-patterns.js', asset_vendor_sdk_patterns_js],
   ['/vendor/sdk-metadata.js', asset_vendor_sdk_metadata_js],
-  ['/vendor/sdk-shared-4n7s11pq.js', asset_vendor_sdk_shared_4n7s11pq_js],
+  ['/vendor/sdk-shared-a4eed451.js', asset_vendor_sdk_shared_a4eed451_js],
+  ['/vendor/sdk-shared-db9w1yyf.js', asset_vendor_sdk_shared_db9w1yyf_js],
+  ['/vendor/sdk-shared-xckftt6k.js', asset_vendor_sdk_shared_xckftt6k_js],
   ['/vendor/sdk-hooks.js', asset_vendor_sdk_hooks_js],
   ['/vendor/tanstack-router.js', asset_vendor_tanstack_router_js],
   ['/vendor/sdk-navigation.js', asset_vendor_sdk_navigation_js],
   ['/vendor/sdk-internal.js', asset_vendor_sdk_internal_js],
-  ['/vendor/sdk-shared-hnwpp229.js', asset_vendor_sdk_shared_hnwpp229_js],
   ['/vendor/jsx-dev-runtime.js', asset_vendor_jsx_dev_runtime_js],
-  ['/vendor/sdk-shared-vsn39xg1.js', asset_vendor_sdk_shared_vsn39xg1_js],
+  ['/vendor/sdk-shared-w3v3tct7.js', asset_vendor_sdk_shared_w3v3tct7_js],
   ['/api/plugins/schedule/assets/client.js', asset_api_plugins_schedule_assets_client_js],
   ['/api/plugins/tasks/assets/client.js', asset_api_plugins_tasks_assets_client_js],
   ['/api/plugins/memory/assets/client.js', asset_api_plugins_memory_assets_client_js],
@@ -132,4 +134,4 @@ export const EMBEDDED_ASSETS_STATIC: ReadonlyMap<string, string> = new Map([
   ['/data/curated-catalog.json', asset_data_curated_catalog_json],
 ])
 
-export const EMBEDDED_ASSET_COUNT = 55
+export const EMBEDDED_ASSET_COUNT = 56

--- a/plugins/memory/components/memory-shell.tsx
+++ b/plugins/memory/components/memory-shell.tsx
@@ -446,8 +446,10 @@ function MemoryShellInner() {
                   size="sm"
                 />
                 <FieldLabel>
-                  <Microscope className="size-bakin-4" aria-hidden="true" />
-                  System Logs
+                  <span className="inline-flex items-center gap-bakin-1">
+                    <Microscope className="size-bakin-4" aria-hidden="true" />
+                    System Logs
+                  </span>
                 </FieldLabel>
               </Field>
             )}

--- a/plugins/tasks/components/task-filters.tsx
+++ b/plugins/tasks/components/task-filters.tsx
@@ -120,8 +120,10 @@ export function TaskFilters({
             size="sm"
           />
           <FieldLabel>
-            {showScheduled ? <Eye className="size-bakin-4" aria-hidden="true" /> : <EyeOff className="size-bakin-4" aria-hidden="true" />}
-            Scheduled Tasks
+            <span className="inline-flex items-center gap-bakin-1">
+              {showScheduled ? <Eye className="size-bakin-4" aria-hidden="true" /> : <EyeOff className="size-bakin-4" aria-hidden="true" />}
+              Scheduled Tasks
+            </span>
           </FieldLabel>
         </Field>
       )}


### PR DESCRIPTION
## Summary
First manual-test finding after #792. Preflight makes `svg` block-level, so an icon followed by text inside `FieldLabel`'s `min-w-0` span stacked onto two lines. Two sites had the shape — the "Scheduled Tasks" switch in the task filters and the "System Logs" switch in the memory shell — both now put the icon and its text in one inline row.

## Test plan
- [x] `bunx eslint` on both files
- [x] `bun test --isolate tests/plugins/tasks tests/plugins/memory` — 712 pass
- [x] Verified in `dev:mock`: label renders on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB
