### PR TITLE
fix(sdk): stop mangling identifiers in the published package entries

### DIFF
--- a/scripts/build-sdk-package.ts
+++ b/scripts/build-sdk-package.ts
@@ -277,7 +277,15 @@ function buildJsEntry(entry: SdkExportEntry, outDir: string): void {
       'bun',
       '--format',
       'esm',
-      '--production',
+      // NOT `--production`: that implies identifier mangling, and Bun 1.3's
+      // mangler produced a Linux-only output where clsx's inner helper and a
+      // base-ui local shared the name `Q3` — every consumer that bundled two
+      // SDK entries then crashed at first render ("Q3 is not a function").
+      // Syntax + whitespace minification keep the package small; names stay
+      // stable across platforms and readable in consumer stack traces.
+      '--minify-syntax',
+      '--minify-whitespace',
+      '--define', 'process.env.NODE_ENV:"production"',
       ...EXTERNAL_JS_PEERS.flatMap((specifier) => ['--external', specifier]),
     ], {
       cwd: REPO_ROOT,


### PR DESCRIPTION
## Summary
The official Bits conformance job (bakin-bits-official#101) crashed the `_template` fixture at first render with `TypeError: Q3 is not a function` — deterministic in CI, never locally, with a fixture bundle whose line *and column* numbers matched a local build exactly. The bytes did not.

**Cause:** the SDK package entries are built with `bun build --production`, which mangles identifiers, and Bun 1.3.13's mangler assigns names differently on Linux. There it named clsx's inner helper `Q3` inside `patterns/index.js` — the same name `ui/index.js` already used for base-ui's focus-guard helper. A consumer that bundles both entries into one file (every plugin fixture does) gets an inconsistent re-bundle of two pre-minified modules with a colliding top-level `Q3` (one `function`, one `var` arrow), and clsx's call site resolves to the wrong binding. `ui/index.js` was byte-identical across platforms; only the colliding entry differed.

**Fix:** keep syntax + whitespace minification, drop identifier mangling (`--minify-syntax --minify-whitespace` + the NODE_ENV define instead of `--production`). Names are stable across platforms and readable in consumer stack traces. Cost: the four UI entries grow 538 KB → 642 KB gzipped. The runtime vendor bundles (what the payload ratchet measures) are built separately and are unaffected.

## Verification
- [x] Pre-fix, built inside the canonical Linux container: `patterns/index.js` md5 differs from the macOS build and names clsx's helper `Q3`; the `_template` fixture reproduces the crash line-for-line.
- [x] Post-fix, built in the same container: `patterns/index.js` is **byte-identical** to the macOS build; the `_template` harness passes on Linux and macOS.
- [x] `bun test tests/scripts` — 264 pass; eslint clean.

Unblocks bakin-bits-official#101 (its conformance job clones bakin `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB
