### PR TITLE
docs(storybook): interactive controls for every primitive

### DIFF
--- a/storybook/public/primitives/badge.stories.tsx
+++ b/storybook/public/primitives/badge.stories.tsx
@@ -29,6 +29,11 @@ export const CanonicalUsage = {
     variant: 'solid',
     children: 'Published',
   },
+  argTypes: {
+    tone: { control: 'select', options: ['neutral', 'primary', 'success', 'attention', 'danger', 'accent', 'info'] },
+    variant: { control: 'select', options: ['soft', 'solid', 'outline', 'ghost', 'link'] },
+    size: { control: 'select', options: ['xs', 'sm', 'md'] },
+  },
   play: async ({ canvas, args }) => {
     // The visible label is the non-color cue: the status reads without the tone.
     const badge = canvas.getByText(String(args.children))

--- a/storybook/public/primitives/button.stories.tsx
+++ b/storybook/public/primitives/button.stories.tsx
@@ -60,6 +60,12 @@ export const CanonicalUsage = {
     variant: 'primary',
     children: 'Continue',
   },
+  argTypes: {
+    variant: { control: 'select', options: ['primary', 'secondary', 'outline', 'ghost', 'danger', 'warning', 'info', 'accent', 'link'] },
+    size: { control: 'select', options: ['xs', 'sm', 'md', 'lg', 'inline', 'icon-xs', 'icon-sm', 'icon-md', 'icon-lg'] },
+    busy: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+  },
   play: async ({ canvas, args }) => {
     const button = canvas.getByRole('button', { name: String(args.children) })
     await expect(button).toBeVisible()

--- a/storybook/public/primitives/card.stories.tsx
+++ b/storybook/public/primitives/card.stories.tsx
@@ -31,15 +31,25 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Card aria-labelledby="canonical-card-title">
-      <CardHeader>
-        <CardTitle id="canonical-card-title">Resolve launch blockers</CardTitle>
-        <CardDescription>4 linked assets · owned by Research Ops</CardDescription>
-      </CardHeader>
-      <CardContent>Two approvals are waiting and one runtime check needs attention.</CardContent>
-    </Card>
-  ),
+  args: {
+    'aria-labelledby': 'canonical-card-title',
+    // The bounded object's content is composition; controls cover the card frame.
+    children: (
+      <>
+        <CardHeader>
+          <CardTitle id="canonical-card-title">Resolve launch blockers</CardTitle>
+          <CardDescription>4 linked assets · owned by Research Ops</CardDescription>
+        </CardHeader>
+        <CardContent>Two approvals are waiting and one runtime check needs attention.</CardContent>
+      </>
+    ),
+  },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md'] },
+    tone: { control: 'select', options: ['neutral', 'success', 'attention', 'danger', 'accent'] },
+    selected: { control: 'boolean' },
+    children: { control: false },
+  },
   play: async ({ canvas }) => {
     const title = canvas.getByText('Resolve launch blockers')
     const card = title.closest('[data-slot="card"]')

--- a/storybook/public/primitives/collapsible.stories.tsx
+++ b/storybook/public/primitives/collapsible.stories.tsx
@@ -20,12 +20,25 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <div style={{ width: 'min(100%, 28rem)' }}>
-      <Collapsible>
+  args: {
+    defaultOpen: false,
+    disabled: false,
+    // Disclosure content is composition, not a control.
+    children: (
+      <>
         <CollapsibleTrigger>Advanced retry policy</CollapsibleTrigger>
         <CollapsibleContent>Retry twice, waiting 30 seconds and then 2 minutes before marking the dispatch blocked.</CollapsibleContent>
-      </Collapsible>
+      </>
+    ),
+  },
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    children: { control: false },
+  },
+  render: (args) => (
+    <div style={{ width: 'min(100%, 28rem)' }}>
+      <Collapsible {...args} />
     </div>
   ),
   play: async ({ canvas, userEvent }) => {

--- a/storybook/public/primitives/copy-button.stories.tsx
+++ b/storybook/public/primitives/copy-button.stories.tsx
@@ -8,6 +8,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Primitives/CopyButton',
+  component: CopyButton,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -18,19 +19,26 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'keyboard', 'interaction'],
   },
-} satisfies Meta
+} satisfies Meta<typeof CopyButton>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: {
+    text: 'bakin agents sync --check copywriter',
+    label: 'Copy command',
+  },
+  argTypes: {
+    text: { control: 'text' },
+    label: { control: 'text' },
+    className: { control: false },
+  },
+  render: (args) => (
     <Panel variant="code" padding="compact" className="flex min-w-0 items-center gap-bakin-2">
-      <code className="min-w-0 flex-1 break-all text-bakin-text-primary">
-        bakin agents sync --check copywriter
-      </code>
-      <CopyButton text="bakin agents sync --check copywriter" label="Copy command" />
+      <code className="min-w-0 flex-1 break-all text-bakin-text-primary">{args.text}</code>
+      <CopyButton {...args} />
     </Panel>
   ),
   // Deliberately does NOT click: the success state reverts after 1.5s, so a

--- a/storybook/public/primitives/copy-button.stories.tsx
+++ b/storybook/public/primitives/copy-button.stories.tsx
@@ -51,7 +51,8 @@ export const CanonicalUsage = {
 } satisfies Story
 
 export const CopyConfirmation = {
-  render: () => (
+  args: { text: 'agent_01H9X2', label: 'Copy agent id' },
+  render: (args) => (
     <StoryStage
       eyebrow="Primitives / Copy"
       title="Confirm in the accessible name, not a tooltip"
@@ -59,8 +60,8 @@ export const CopyConfirmation = {
     >
       <StorySection title="After copying" description="The acknowledgement is short and non-blocking.">
         <div className="flex min-w-0 items-center gap-bakin-2">
-          <code className="min-w-0 flex-1 break-all font-bakin-typography-family-mono">agent_01H9X2</code>
-          <CopyButton text="agent_01H9X2" label="Copy agent id" />
+          <code className="min-w-0 flex-1 break-all font-bakin-typography-family-mono">{args.text}</code>
+          <CopyButton {...args} />
         </div>
       </StorySection>
     </StoryStage>
@@ -74,7 +75,8 @@ export const CopyConfirmation = {
 } satisfies Story
 
 export const NamingMultipleActions = {
-  render: () => (
+  args: { text: 'agent_01H9X2', label: 'Copy agent id' },
+  render: (args) => (
     <StoryStage
       eyebrow="Primitives / Copy"
       title="Name each action for what it copies"
@@ -83,8 +85,8 @@ export const NamingMultipleActions = {
       <StorySection title="Distinct labels" description="Never ship a page of identical “Copy” actions.">
         <div className="grid gap-bakin-2">
           <div className="flex min-w-0 items-center gap-bakin-2">
-            <code className="min-w-0 flex-1 break-all font-bakin-typography-family-mono">agent_01H9X2</code>
-            <CopyButton text="agent_01H9X2" label="Copy agent id" />
+            <code className="min-w-0 flex-1 break-all font-bakin-typography-family-mono">{args.text}</code>
+            <CopyButton {...args} />
           </div>
           <div className="flex min-w-0 items-center gap-bakin-2">
             <code className="min-w-0 flex-1 break-all font-bakin-typography-family-mono">

--- a/storybook/public/primitives/file-input.stories.tsx
+++ b/storybook/public/primitives/file-input.stories.tsx
@@ -32,8 +32,23 @@ export const CanonicalUsage = {
   args: {
     label: 'Profile image',
     accept: 'image/png,image/jpeg,image/webp',
+    children: 'Choose image',
+    multiple: false,
+    disabled: false,
+    variant: 'outline',
+    size: 'sm',
   },
-  render: (args) => <FileInput {...args}>Choose image</FileInput>,
+  argTypes: {
+    variant: { control: 'select', options: ['primary', 'secondary', 'outline', 'ghost', 'danger', 'warning', 'info', 'accent', 'link'] },
+    // icon-* sizes are for icon-only triggers; not meaningful with a text label.
+    size: { control: 'select', options: ['xs', 'sm', 'md', 'lg', 'inline'] },
+    accept: { control: 'text' },
+    multiple: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    children: { control: 'text' },
+    onFiles: { control: false },
+    onRejected: { control: false },
+  },
   play: async ({ canvas, userEvent, args }) => {
     await expect(canvas.getByRole('button', { name: 'Choose image' })).toBeVisible()
     const input = canvas.getByLabelText<HTMLInputElement>('Profile image')

--- a/storybook/public/primitives/input-group.stories.tsx
+++ b/storybook/public/primitives/input-group.stories.tsx
@@ -33,13 +33,22 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <div>
-      <Label htmlFor="repository-path">Repository path</Label>
-      <InputGroup aria-label="Repository address">
+  args: {
+    // One editable control plus contextual adornments — composition, not a control.
+    children: (
+      <>
         <InputGroupAddon><InputGroupText>github.com/</InputGroupText></InputGroupAddon>
         <InputGroupInput id="repository-path" defaultValue="makinbakin/reference-plugin" />
-      </InputGroup>
+      </>
+    ),
+  },
+  argTypes: {
+    children: { control: false },
+  },
+  render: (args) => (
+    <div>
+      <Label htmlFor="repository-path">Repository path</Label>
+      <InputGroup aria-label="Repository address" {...args} />
     </div>
   ),
   play: async ({ canvas }) => {

--- a/storybook/public/primitives/label.stories.tsx
+++ b/storybook/public/primitives/label.stories.tsx
@@ -22,15 +22,24 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: {
+    htmlFor: 'project-name',
+    children: 'Project name',
+  },
+  argTypes: {
+    children: { control: 'text' },
+    // The association is the contract: htmlFor must keep matching the input id.
+    htmlFor: { control: false },
+  },
+  render: (args) => (
     <div>
-      <Label htmlFor="project-name">Project name</Label>
+      <Label {...args} />
       <Input id="project-name" placeholder="Q3 launch" />
     </div>
   ),
-  play: async ({ canvas, userEvent }) => {
-    const input = canvas.getByLabelText('Project name')
-    await userEvent.click(canvas.getByText('Project name'))
+  play: async ({ canvas, userEvent, args }) => {
+    const input = canvas.getByLabelText(String(args.children))
+    await userEvent.click(canvas.getByText(String(args.children)))
     await expect(input).toHaveFocus()
   },
 } satisfies Story

--- a/storybook/public/primitives/radio-group.stories.tsx
+++ b/storybook/public/primitives/radio-group.stories.tsx
@@ -25,8 +25,18 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <RadioGroup aria-label="Delete scope" defaultValue="asset">
+  args: {
+    defaultValue: 'asset',
+    disabled: false,
+  },
+  argTypes: {
+    defaultValue: { control: 'select', options: ['asset', 'current'] },
+    disabled: { control: 'boolean' },
+    // Option rows are composition — each Radio needs its visible label element.
+    children: { control: false },
+  },
+  render: (args) => (
+    <RadioGroup aria-label="Delete scope" {...args}>
       <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
         <Radio value="asset" />
         Delete the whole asset

--- a/storybook/public/primitives/separator.stories.tsx
+++ b/storybook/public/primitives/separator.stories.tsx
@@ -20,10 +20,18 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: {
+    orientation: 'horizontal',
+    decorative: true,
+  },
+  argTypes: {
+    orientation: { control: 'select', options: ['horizontal', 'vertical'] },
+    decorative: { control: 'boolean' },
+  },
+  render: (args) => (
     <div>
       <p>Deployment policy</p>
-      <Separator />
+      <Separator {...args} />
       <p>All production runs require approval.</p>
     </div>
   ),

--- a/storybook/public/primitives/spinner.stories.tsx
+++ b/storybook/public/primitives/spinner.stories.tsx
@@ -25,7 +25,11 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  args: { label: 'Loading agents' },
+  args: { label: 'Loading agents', size: 'md' },
+  argTypes: {
+    size: { control: 'select', options: ['sm', 'md'] },
+    label: { control: 'text' },
+  },
   play: async ({ canvas, args }) => {
     // A labelled spinner is a live status, not silent decoration — the whole
     // reason this primitive exists is that hand-rolled ones were unnamed.

--- a/storybook/public/primitives/text.stories.tsx
+++ b/storybook/public/primitives/text.stories.tsx
@@ -30,6 +30,14 @@ export const CanonicalUsage = {
     tone: 'muted',
     children: 'Last indexed 4 minutes ago',
   },
+  argTypes: {
+    size: { control: 'select', options: ['body', 'meta'] },
+    tone: { control: 'select', options: ['default', 'muted'] },
+    weight: { control: 'select', options: ['regular', 'medium', 'semibold'] },
+    mono: { control: 'boolean' },
+    children: { control: 'text' },
+    as: { control: false },
+  },
   play: async ({ canvas, args }) => {
     // De-emphasis is a colour token, not an opacity fade: the text must still
     // be a real, readable node rather than a partially transparent one.


### PR DESCRIPTION
Tier 2, batch 1 of the Storybook catalog plan: every `Components/Primitives` entry now has an args-driven `CanonicalUsage` story with curated controls, so each primitive can be exercised from the Storybook UI.

- 12 files converted (badge, button, card, collapsible, copy-button, file-input, input-group, label, radio-group, separator, spinner, text); the other 7 primitives already followed this convention, so all 19 are now uniform.
- argTypes verified against the component sources — real variant/size/tone unions, `busy` on Button, base-ui props on Collapsible; children/composition and event handlers are `control: false` with comments where non-obvious.
- `copy-button` meta gains its missing `component` reference (props table now renders in autodocs).
- Rendered output is pixel-identical: full visual suite (270) passes against existing baselines, story suite 60/60 for primitives, lint + story-compliance + kit-coverage green.

Next batches: forms + overlays, then charts/conversation/content, navigation/lists/layout/pages, and the compliance ratchet extension once all categories carry controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB