### PR TITLE
docs(storybook): interactive controls for forms and overlays

### DIFF
--- a/storybook/public/forms/asset-library-picker.stories.tsx
+++ b/storybook/public/forms/asset-library-picker.stories.tsx
@@ -15,6 +15,7 @@ const library: AssetLibraryAsset[] = [
 
 const meta = {
   title: 'Components/Forms/AssetLibraryPicker',
+  component: AssetLibraryPicker,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -25,21 +26,28 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'loading', 'error', 'empty', 'busy'],
   },
-} satisfies Meta
+} satisfies Meta<typeof AssetLibraryPicker>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <AssetLibraryPicker
-      open
-      onOpenChange={() => {}}
-      onPick={() => {}}
-      loadAssets={async () => library}
-    />
-  ),
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    onPick: () => {},
+    // Fixture loader; the default wiring targets the assets plugin endpoints.
+    loadAssets: async () => library,
+  },
+  argTypes: {
+    open: { control: 'boolean' },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    loadAssets: { control: false },
+    uploadAsset: { control: false },
+    filter: { control: false },
+  },
   play: async () => {
     const page = within(document.body)
     await page.findByRole('dialog', { name: 'Choose an asset' })
@@ -73,6 +81,8 @@ function PickFlowExample() {
 }
 
 export const PickFlow = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { open: false, onOpenChange: () => {}, onPick: () => {} },
   render: () => <PickFlowExample />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
@@ -119,6 +129,8 @@ function LibraryStatesExample() {
 }
 
 export const LibraryStates = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { open: false, onOpenChange: () => {}, onPick: () => {} },
   render: () => <LibraryStatesExample />,
   play: async ({ canvas }) => {
     const page = within(document.body)

--- a/storybook/public/forms/asset-picker.stories.tsx
+++ b/storybook/public/forms/asset-picker.stories.tsx
@@ -9,6 +9,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Forms/AssetPicker',
+  component: AssetPicker,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -19,7 +20,7 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'loading', 'error', 'empty', 'disabled', 'long-content', 'reduced-motion'],
   },
-} satisfies Meta
+} satisfies Meta<typeof AssetPicker>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -39,16 +40,26 @@ const readyAssets: AssetPickerCollection = {
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <AssetPicker
-      variant="inline"
-      view="list"
-      collection={readyAssets}
-      query=""
-      onQueryChange={() => {}}
-      onPick={() => {}}
-    />
-  ),
+  args: {
+    variant: 'inline',
+    view: 'list',
+    // Collection, query, and handlers are the consumer-owned controlled
+    // surface; controls cover the picker's own presentation flags.
+    collection: readyAssets,
+    query: '',
+    onQueryChange: () => {},
+    onPick: () => {},
+  },
+  argTypes: {
+    view: { control: 'select', options: ['grid', 'list'] },
+    busy: { control: 'boolean' },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    // The dialog variant needs open/onOpenChange — a composition choice.
+    variant: { control: false },
+    collection: { control: false },
+    query: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('searchbox', { name: 'Search assets' })).toBeVisible()
     await expect(canvas.getByRole('button', { name: 'Select Campaign hero' })).toBeVisible()
@@ -90,6 +101,8 @@ function DialogLibraryExample() {
 }
 
 export const DialogLibrary = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { variant: 'inline', collection: readyAssets, query: '', onQueryChange: () => {}, onPick: () => {} },
   render: () => <DialogLibraryExample />,
   play: async ({ canvasElement }) => {
     const page = within(document.body)
@@ -156,6 +169,8 @@ function InlineStatesExample() {
 }
 
 export const InlineAttachRelinkAndStates = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { variant: 'inline', collection: readyAssets, query: '', onQueryChange: () => {}, onPick: () => {} },
   render: () => <InlineStatesExample />,
   play: async ({ canvas }) => {
     await userEvent.click(canvas.getByRole('button', { name: 'Select Launch brief' }))

--- a/storybook/public/forms/color-input.stories.tsx
+++ b/storybook/public/forms/color-input.stories.tsx
@@ -9,6 +9,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Forms/ColorInput',
+  component: ColorInput,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -19,16 +20,21 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'disabled', 'validation'],
   },
-} satisfies Meta
+} satisfies Meta<typeof ColorInput>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <ColorInput ariaLabel="Primary brand color" value="#ff5a00" onValueChange={() => {}} />
-  ),
+  args: { ariaLabel: 'Primary brand color', value: '#ff5a00', onValueChange: () => {} },
+  argTypes: {
+    value: { control: 'color' },
+    disabled: { control: 'boolean' },
+    ariaLabel: { control: 'text' },
+    // The consumer owns the value; the handler is wiring, not a control.
+    onValueChange: { control: false },
+  },
   play: async ({ canvas }) => {
     const input = canvas.getByLabelText<HTMLInputElement>('Primary brand color')
     await expect(input).toBeVisible()
@@ -36,8 +42,8 @@ export const CanonicalUsage = {
   },
 } satisfies Story
 
-function PairedHexExample() {
-  const [hex, setHex] = useState('#1d4ed8')
+function PairedHexExample({ initialValue }: { initialValue: string }) {
+  const [hex, setHex] = useState(initialValue)
   const invalid = !/^#[0-9a-f]{6}$/i.test(hex.trim())
   return (
     <StoryStage
@@ -66,7 +72,8 @@ function PairedHexExample() {
 }
 
 export const PairedHexField = {
-  render: () => <PairedHexExample />,
+  args: { value: '#1d4ed8', onValueChange: () => {} },
+  render: (args) => <PairedHexExample initialValue={args.value} />,
   play: async ({ canvas }) => {
     const swatch = canvas.getByLabelText<HTMLInputElement>('Primary color swatch')
     await expect(swatch).toHaveValue('#1d4ed8')

--- a/storybook/public/forms/color-picker.stories.tsx
+++ b/storybook/public/forms/color-picker.stories.tsx
@@ -8,6 +8,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Forms/ColorPicker',
+  component: ColorPicker,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -18,7 +19,7 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'non-color'],
   },
-} satisfies Meta
+} satisfies Meta<typeof ColorPicker>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -34,9 +35,15 @@ const colors = [
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <ColorPicker ariaLabel="Agent color" value="series-1" onValueChange={() => {}} options={colors} />
-  ),
+  args: { ariaLabel: 'Agent color', value: 'series-1', onValueChange: () => {}, options: colors },
+  argTypes: {
+    value: { control: 'select', options: colors.map((option) => option.value) },
+    columns: { control: 'select', options: [4, 6, 8] },
+    disabled: { control: 'boolean' },
+    // The palette is consumer-owned data; the handler is wiring.
+    options: { control: false },
+    onValueChange: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('radiogroup', { name: 'Agent color' })).toBeVisible()
     await expect(canvas.getByRole('radio', { name: 'Ocean' })).toHaveAttribute('aria-checked', 'true')
@@ -44,8 +51,8 @@ export const CanonicalUsage = {
   },
 } satisfies Story
 
-function PaletteChoicesExample() {
-  const [color, setColor] = useState('series-1')
+function PaletteChoicesExample({ initialValue }: { initialValue: string }) {
+  const [color, setColor] = useState(initialValue)
   return (
     <StoryStage
       eyebrow="Models and identity"
@@ -64,7 +71,8 @@ function PaletteChoicesExample() {
 }
 
 export const PaletteChoices = {
-  render: () => <PaletteChoicesExample />,
+  args: { value: 'series-1', onValueChange: () => {}, options: colors },
+  render: (args) => <PaletteChoicesExample initialValue={args.value} />,
   play: async ({ canvas }) => {
     const ocean = canvas.getByRole('radio', { name: 'Ocean' })
     ocean.focus()

--- a/storybook/public/forms/form-composition.stories.tsx
+++ b/storybook/public/forms/form-composition.stories.tsx
@@ -30,6 +30,7 @@ import './forms.stories.css'
 
 const meta = {
   title: 'Components/Forms/Field and form composition',
+  component: Form,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -40,19 +41,27 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'keyboard', 'validation', 'busy', 'disabled', 'error'],
   },
-} satisfies Meta
+} satisfies Meta<typeof Form>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
+  args: { busy: false },
+  argTypes: {
+    busy: { control: 'boolean' },
+    // Field composition is the story's subject, not a control surface.
+    children: { control: false },
+    errors: { control: false },
+    onFormSubmit: { control: false },
+  },
   // Width frame: Form's container-type zeroes its intrinsic width, so the
   // centered (shrink-to-fit) canvas would collapse it to min-content. In the
   // app forms sit in block flow where width is inherited.
-  render: () => (
+  render: (args) => (
     <div style={{ inlineSize: '40rem', maxInlineSize: '100%' }}>
-      <Form aria-label="Workspace settings">
+      <Form aria-label="Workspace settings" {...args}>
         <Field name="workspaceName">
           <FieldLabel requirement="required">Workspace name</FieldLabel>
           <FieldDescription>Shown in page chrome and plugin-contributed sections.</FieldDescription>

--- a/storybook/public/forms/model-select.stories.tsx
+++ b/storybook/public/forms/model-select.stories.tsx
@@ -8,6 +8,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Forms/ModelSelect',
+  component: ModelSelect,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -18,7 +19,7 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'disabled', 'empty', 'long-content'],
   },
-} satisfies Meta
+} satisfies Meta<typeof ModelSelect>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -38,16 +39,27 @@ const fieldStyle = {
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: {
+    id: 'canonical-model',
+    value: DEFAULT_MODEL_VALUE,
+    onValueChange: () => {},
+    // The provider-grouped catalog is consumer-owned fixture data.
+    models,
+    defaultLabel: 'Use workspace default',
+  },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    defaultLabel: { control: 'text' },
+    placeholder: { control: 'text' },
+    value: { control: false },
+    models: { control: false },
+    // Paired with the visible label element in render.
+    id: { control: false },
+  },
+  render: (args) => (
     <div style={{ width: 'min(80vw, 20rem)' }}>
       <label htmlFor="canonical-model">Model</label>
-      <ModelSelect
-        id="canonical-model"
-        value={DEFAULT_MODEL_VALUE}
-        onValueChange={() => {}}
-        models={models}
-        defaultLabel="Use workspace default"
-      />
+      <ModelSelect {...args} />
     </div>
   ),
   play: async ({ canvas }) => {
@@ -89,6 +101,8 @@ function GroupedCatalogExample() {
 }
 
 export const GroupedCatalog = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { value: DEFAULT_MODEL_VALUE, onValueChange: () => {}, models },
   render: () => <GroupedCatalogExample />,
   play: async ({ canvas }) => {
     const model = canvas.getByRole('combobox', { name: 'Model' })
@@ -103,7 +117,8 @@ export const GroupedCatalog = {
 } satisfies Story
 
 export const UnavailableModelCatalog = {
-  render: () => (
+  args: { id: 'unavailable-picker-model', value: 'acme/saved-model', onValueChange: () => {}, models: [] },
+  render: (args) => (
     <StoryStage
       eyebrow="Models / provider catalog"
       title="Keep the saved model readable when the catalog is unavailable"
@@ -112,12 +127,7 @@ export const UnavailableModelCatalog = {
       <StorySection title="Execution defaults">
         <div style={fieldStyle}>
           <label htmlFor="unavailable-picker-model">Model</label>
-          <ModelSelect
-            id="unavailable-picker-model"
-            value="acme/saved-model"
-            onValueChange={() => {}}
-            models={[]}
-          />
+          <ModelSelect {...args} />
         </div>
       </StorySection>
     </StoryStage>

--- a/storybook/public/forms/plugin-settings-renderer.stories.tsx
+++ b/storybook/public/forms/plugin-settings-renderer.stories.tsx
@@ -54,15 +54,23 @@ export const CanonicalUsage = {
     onSubmit: () => {},
   },
   parameters: { layout: 'centered' },
+  argTypes: {
+    busy: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    saveLabel: { control: 'text' },
+    ariaLabel: { control: 'text' },
+    // Schema, values, and feedback are consumer-owned data; handlers are wiring.
+    schema: { control: false },
+    values: { control: false },
+    feedback: { control: false },
+    onSubmit: { control: false },
+    onValidationError: { control: false },
+  },
   // Width frame: the renderer's settings rows are container-typed, zeroing
   // intrinsic width — the centered (shrink-to-fit) canvas would collapse them.
-  render: () => (
+  render: (args) => (
     <div style={{ inlineSize: '40rem', maxInlineSize: '100%' }}>
-      <PluginSettingsRenderer
-        schema={canonicalSchema}
-        values={{ workspaceName: 'Creator operations', requiresApproval: true }}
-        onSubmit={() => {}}
-      />
+      <PluginSettingsRenderer {...args} />
     </div>
   ),
   play: async ({ canvas, userEvent }) => {

--- a/storybook/public/forms/save-bar.stories.tsx
+++ b/storybook/public/forms/save-bar.stories.tsx
@@ -10,6 +10,7 @@ import { OverlayBackdrop, StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Forms/SaveBar',
+  component: SaveBar,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -20,18 +21,31 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'overflow', 'interaction', 'busy', 'error-retry', 'mobile-action-order'],
   },
-} satisfies Meta
+} satisfies Meta<typeof SaveBar>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: {
+    dirty: true,
+    onSave: () => {},
+    onDiscard: () => {},
+    // Draft context is composition.
+    children: <span>1 field changed</span>,
+  },
+  argTypes: {
+    dirty: { control: 'boolean' },
+    saving: { control: 'boolean' },
+    error: { control: 'text' },
+    saveLabel: { control: 'text' },
+    discardLabel: { control: 'text' },
+    children: { control: false },
+  },
+  render: (args) => (
     <div style={{ width: 'min(90vw, 44rem)' }}>
-      <SaveBar dirty onSave={() => {}} onDiscard={() => {}}>
-        <span>1 field changed</span>
-      </SaveBar>
+      <SaveBar {...args} />
     </div>
   ),
   play: async ({ canvas }) => {
@@ -95,6 +109,8 @@ function RetryableSaveExample() {
 }
 
 export const SaveFailureAndRetry = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { dirty: true, onSave: () => {}, onDiscard: () => {} },
   render: () => <RetryableSaveExample />,
   play: async ({ canvas, userEvent }) => {
     await expect(canvas.getByRole('alert')).toHaveTextContent('could not be saved')
@@ -105,21 +121,20 @@ export const SaveFailureAndRetry = {
 } satisfies Story
 
 export const SaveFailure = {
-  render: () => (
+  args: {
+    dirty: true,
+    error: 'The workflow could not be saved. The last published definition is still active.',
+    onSave: () => {},
+    onDiscard: () => {},
+  },
+  render: (args) => (
     <StoryStage
       eyebrow="Draft / recovery"
       title="Keep a failed draft actionable"
       description="Durable error copy stays beside the staged work and the same primary action becomes an explicit retry."
     >
       <OverlayBackdrop />
-      <SaveBar
-        dirty
-        error="The workflow could not be saved. The last published definition is still active."
-        onSave={() => {}}
-        onDiscard={() => {}}
-      >
-        4 workflow steps changed
-      </SaveBar>
+      <SaveBar {...args}>4 workflow steps changed</SaveBar>
     </StoryStage>
   ),
   play: async ({ canvas }) => {

--- a/storybook/public/forms/unsaved-changes-dialog.stories.tsx
+++ b/storybook/public/forms/unsaved-changes-dialog.stories.tsx
@@ -19,6 +19,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Forms/UnsavedChangesDialog',
+  component: UnsavedChangesDialog,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -29,21 +30,27 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'interaction', 'focus-return', 'mobile-action-order', 'routing-boundary'],
   },
-} satisfies Meta
+} satisfies Meta<typeof UnsavedChangesDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <UnsavedChangesDialog
-      open
-      onSave={() => {}}
-      onDiscard={() => {}}
-      onCancel={() => {}}
-    />
-  ),
+  args: {
+    open: true,
+    onSave: () => {},
+    onDiscard: () => {},
+    onCancel: () => {},
+  },
+  argTypes: {
+    open: { control: 'boolean' },
+    busy: { control: 'boolean' },
+    saveDisabled: { control: 'boolean' },
+    canSaveInPlace: { control: 'boolean' },
+    error: { control: 'text' },
+    finalFocus: { control: false },
+  },
   play: async () => {
     const page = within(document.body)
     const dialog = await page.findByRole('dialog', { name: 'Unsaved changes' })
@@ -119,6 +126,8 @@ function RoutedExitDecisionExample() {
 }
 
 export const UnsavedExitDecision = {
+  // Type-satisfying only: the routed example owns its props.
+  args: { open: false, onSave: () => {}, onDiscard: () => {}, onCancel: () => {} },
   render: () => <RoutedExitDecisionExample />,
   play: async ({ userEvent }) => {
     const page = within(document.body)

--- a/storybook/public/overlays/dialog.stories.tsx
+++ b/storybook/public/overlays/dialog.stories.tsx
@@ -36,8 +36,16 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Dialog>
+  args: { defaultOpen: false, busy: false },
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    busy: { control: 'boolean' },
+    modal: { control: 'select', options: [true, false, 'trap-focus'] },
+    // Trigger and content are composition; the dialog body is not a control.
+    children: { control: false },
+  },
+  render: (args) => (
+    <Dialog {...args}>
       <DialogTrigger render={<Button variant="outline" />}>Delete connection</DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/storybook/public/overlays/drawer.stories.tsx
+++ b/storybook/public/overlays/drawer.stories.tsx
@@ -22,10 +22,26 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
-  render: function CanonicalDrawer() {
+  args: {
+    title: 'Task detail',
+    description: 'Task 842 · official workflows plugin',
+    dirty: false,
+    busy: false,
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    dirty: { control: 'boolean' },
+    busy: { control: 'boolean' },
+    // The story owns open state so the drawer starts visible; body is composition.
+    open: { control: false },
+    onOpenChange: { control: false },
+    children: { control: false },
+  },
+  render: function CanonicalDrawer(args) {
     const [open, setOpen] = useState(true)
     return (
-      <Drawer open={open} onOpenChange={setOpen} title="Task detail" description="Task 842 · official workflows plugin">
+      <Drawer {...args} open={open} onOpenChange={setOpen}>
         <DrawerSection title="Details">
           <p>Review the migration evidence before closing the task.</p>
         </DrawerSection>

--- a/storybook/public/overlays/dropdown-menu.stories.tsx
+++ b/storybook/public/overlays/dropdown-menu.stories.tsx
@@ -39,8 +39,16 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <DropdownMenu>
+  args: { defaultOpen: false },
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    modal: { control: 'boolean' },
+    // Trigger and items are composition; the action set is not a control.
+    children: { control: false },
+  },
+  render: (args) => (
+    <DropdownMenu {...args}>
       <DropdownMenuTrigger render={<Button variant="outline" />}>Task actions</DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem>Open details</DropdownMenuItem>

--- a/storybook/public/overlays/popover.stories.tsx
+++ b/storybook/public/overlays/popover.stories.tsx
@@ -37,8 +37,15 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Popover>
+  args: { defaultOpen: false },
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    modal: { control: 'boolean' },
+    // Trigger and panel are composition; the anchored content is not a control.
+    children: { control: false },
+  },
+  render: (args) => (
+    <Popover {...args}>
       <PopoverTrigger render={<Button variant="outline" />}>Inspect filters</PopoverTrigger>
       <PopoverContent>
         <PopoverHeader>

--- a/storybook/public/overlays/sheet.stories.tsx
+++ b/storybook/public/overlays/sheet.stories.tsx
@@ -56,8 +56,15 @@ function TaskPanel() {
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Sheet>
+  args: { defaultOpen: false, busy: false },
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    busy: { control: 'boolean' },
+    // side lives on SheetContent; trigger and panel body are composition.
+    children: { control: false },
+  },
+  render: (args) => (
+    <Sheet {...args}>
       <SheetTrigger render={<Button variant="outline" />}>Open task panel</SheetTrigger>
       <SheetContent>
         <SheetHeader>

--- a/storybook/public/overlays/tooltip.stories.tsx
+++ b/storybook/public/overlays/tooltip.stories.tsx
@@ -22,8 +22,15 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Tooltip>
+  args: { defaultOpen: false },
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    // Trigger and label are composition; delay is fixed at 0 by the provider fixture.
+    children: { control: false },
+  },
+  render: (args) => (
+    <Tooltip {...args}>
       <TooltipTrigger render={<Button variant="outline" />}>Retry guidance</TooltipTrigger>
       <TooltipContent>Retry after the runtime reconnects.</TooltipContent>
     </Tooltip>


### PR DESCRIPTION
Tier 2, batch 2 of the Storybook catalog plan (follows #798): every `Components/Forms` and `Components/Overlays` entry now has an args-driven `CanonicalUsage` story with curated controls.

- 15 files converted: forms (form-composition, plugin-settings-renderer, color-picker, color-input, asset-picker, asset-library-picker, model-select, save-bar, unsaved-changes-dialog) and overlays (dialog, popover, sheet, drawer, dropdown-menu, tooltip).
- argTypes verified against component sources — real unions (`modal: true/false/'trap-focus'`, sheet/dialog `busy`, save-bar `dirty`/`saving`/`error`, drawer `dirty`/`busy`, picker `view`/`open`); children, fixture data, and handlers pinned `control: false` with comments.
- Eight metas gain their missing `component` reference, so autodocs now renders props tables for the pickers, save flows, and color inputs.
- Honesty notes: plugin-settings-renderer's canonical story previously ignored its own args (fixed); model-select/save-bar render stories now consume args. A few stateful showcase stories carry comment-marked "type-satisfying only" args that TS requires once the meta declares its component — their controls are inert by design because the stateful example owns its props.
- Rendered output is pixel-identical: full visual suite (270) passes against existing baselines; story suite 47/47; strict lint, repo typecheck, story-compliance + kit-coverage green.

Remaining tier-2 batches: charts/conversation/content, then navigation/lists/layout/pages/agents/feedback stragglers, then the compliance-ratchet extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB