### PR TITLE
docs(storybook): interactive controls for charts, conversation, and content

### DIFF
--- a/storybook/public/charts/area-chart.stories.tsx
+++ b/storybook/public/charts/area-chart.stories.tsx
@@ -49,6 +49,19 @@ export const CanonicalUsage = {
     showDataTable: true,
     dataTableExpandable: true,
   },
+  argTypes: {
+    stacked: { control: 'boolean' },
+    compactData: { control: 'boolean' },
+    showDataTable: { control: 'boolean' },
+    dataTableExpandable: { control: 'boolean' },
+    height: { control: 'number' },
+    label: { control: 'text' },
+    description: { control: 'text' },
+    // Fixture data and formatters are the story's evidence, not knobs.
+    data: { control: false },
+    series: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas, args }) => {
     await expect(canvas.getByRole('group', { name: 'Task volume' })).toBeVisible()
     await expect(canvas.getByRole('list', { name: 'Task volume legend' })).toHaveTextContent('Failed')

--- a/storybook/public/charts/bar-chart.stories.tsx
+++ b/storybook/public/charts/bar-chart.stories.tsx
@@ -50,6 +50,19 @@ export const CanonicalUsage = {
     showDataTable: true,
     dataTableExpandable: true,
   },
+  argTypes: {
+    stacked: { control: 'boolean' },
+    compactData: { control: 'boolean' },
+    showDataTable: { control: 'boolean' },
+    dataTableExpandable: { control: 'boolean' },
+    height: { control: 'number' },
+    label: { control: 'text' },
+    description: { control: 'text' },
+    // Fixture data and formatters are the story's evidence, not knobs.
+    data: { control: false },
+    series: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas, args }) => {
     await expect(canvas.getByRole('group', { name: 'Task outcomes' })).toBeVisible()
     await expect(canvas.getByRole('list', { name: 'Task outcomes legend' })).toHaveTextContent('Failed')

--- a/storybook/public/charts/chart-data-table.stories.tsx
+++ b/storybook/public/charts/chart-data-table.stories.tsx
@@ -5,23 +5,6 @@ import { ChartDataTable, ChartExplainer, type ChartDatum, type ChartSeries } fro
 
 import { ChartStage } from './chart-story-stage'
 
-const meta = {
-  title: 'Components/Charts/ChartDataTable',
-  tags: ['public'],
-  parameters: {
-    layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'ChartDataTable is the exact-data disclosure behind every chart summary: a chart never hides its evidence. The disclosure names the dataset, the table keeps absent values distinct from zero with per-cell missing labels (an unknown is not a zero), horizontal overflow is owned locally by a keyboard-focusable region, long labels stay intact, and an empty dataset is named honestly instead of inventing rows. Visual charts embed it automatically; use it directly when a summary needs its exact values disclosed or visually hidden but reachable.',
-      },
-    },
-    bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'empty', 'overflow', 'multi-series', 'non-color', 'keyboard', 'missing-data'],
-  },
-} satisfies Meta
-
-export default meta
-type Story = StoryObj<typeof meta>
-
 const canonicalSeries: ChartSeries[] = [
   { key: 'completed', label: 'Completed' },
   { key: 'failed', label: 'Failed' },
@@ -33,15 +16,46 @@ const canonicalData: ChartDatum[] = [
   { x: 'jul-26', xLabel: 'Jul 26', values: { completed: 21 }, missingLabels: { failed: 'Still processing' } },
 ]
 
+const meta = {
+  title: 'Components/Charts/ChartDataTable',
+  component: ChartDataTable,
+  tags: ['public'],
+  // Canonical fixture args at meta level keep required props satisfied for the
+  // render-based showcase stories below.
+  args: {
+    caption: 'Task outcomes exact data',
+    data: canonicalData,
+    series: canonicalSeries,
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'ChartDataTable is the exact-data disclosure behind every chart summary: a chart never hides its evidence. The disclosure names the dataset, the table keeps absent values distinct from zero with per-cell missing labels (an unknown is not a zero), horizontal overflow is owned locally by a keyboard-focusable region, long labels stay intact, and an empty dataset is named honestly instead of inventing rows. Visual charts embed it automatically; use it directly when a summary needs its exact values disclosed or visually hidden but reachable.',
+      },
+    },
+    bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'empty', 'overflow', 'multi-series', 'non-color', 'keyboard', 'missing-data'],
+  },
+} satisfies Meta<typeof ChartDataTable>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <ChartDataTable
-      caption="Task outcomes exact data"
-      data={canonicalData}
-      series={canonicalSeries}
-    />
-  ),
+  argTypes: {
+    defaultOpen: { control: 'boolean' },
+    expandable: { control: 'boolean' },
+    visuallyHidden: { control: 'boolean' },
+    caption: { control: 'text' },
+    // Fixture data; renderTable is the documented escape hatch, not a control.
+    data: { control: false },
+    series: { control: false },
+    formatValue: { control: false },
+    missingValue: { control: false },
+    renderTable: { control: false },
+    className: { control: false },
+  },
   play: async ({ canvas, userEvent }) => {
     const disclosure = canvas.getByText('View Task outcomes exact data')
     await expect(disclosure).toBeVisible()

--- a/storybook/public/charts/chart-explainer.stories.tsx
+++ b/storybook/public/charts/chart-explainer.stories.tsx
@@ -34,7 +34,9 @@ const canonicalData: ChartDatum[] = [
 ]
 
 export const CanonicalUsage = {
-  render: () => (
+  args: { children: 'The failed series skips Jul 26 because that window was not reported.' },
+  argTypes: { children: { control: 'text' } },
+  render: (args) => (
     <div>
       <LineChart
         data={canonicalData}
@@ -42,7 +44,7 @@ export const CanonicalUsage = {
         label="Task outcomes"
         description="Completed and failed tasks across four days."
       />
-      <ChartExplainer>The failed series skips Jul 26 because that window was not reported.</ChartExplainer>
+      <ChartExplainer {...args} />
     </div>
   ),
   play: async ({ canvas }) => {

--- a/storybook/public/charts/composition-bar.stories.tsx
+++ b/storybook/public/charts/composition-bar.stories.tsx
@@ -37,6 +37,15 @@ export const CanonicalUsage = {
     size: 'default',
     legend: true,
   },
+  argTypes: {
+    size: { control: 'select', options: ['default', 'inline'] },
+    legend: { control: 'boolean' },
+    label: { control: 'text' },
+    // Fixture segments and the status-tone mapping are the story's subject, not controls.
+    data: { control: false },
+    tones: { control: false },
+    formatValue: { control: false },
+  },
   render: (args) => (
     <div style={{ width: 360 }}>
       <CompositionBar {...args} />

--- a/storybook/public/charts/line-chart.stories.tsx
+++ b/storybook/public/charts/line-chart.stories.tsx
@@ -49,6 +49,19 @@ export const CanonicalUsage = {
     showDataTable: true,
     dataTableExpandable: true,
   },
+  argTypes: {
+    smooth: { control: 'boolean' },
+    compactData: { control: 'boolean' },
+    showDataTable: { control: 'boolean' },
+    dataTableExpandable: { control: 'boolean' },
+    height: { control: 'number' },
+    label: { control: 'text' },
+    description: { control: 'text' },
+    // Fixture data and formatters are the story's evidence, not knobs.
+    data: { control: false },
+    series: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas, args }) => {
     await expect(canvas.getByRole('group', { name: 'Task outcomes' })).toBeVisible()
     await expect(canvas.getByRole('list', { name: 'Task outcomes legend' })).toHaveTextContent('Failed')

--- a/storybook/public/charts/pie-chart.stories.tsx
+++ b/storybook/public/charts/pie-chart.stories.tsx
@@ -42,6 +42,18 @@ export const CanonicalUsage = {
     showDataTable: true,
     dataTableExpandable: true,
   },
+  argTypes: {
+    donut: { control: 'boolean' },
+    compactData: { control: 'boolean' },
+    showDataTable: { control: 'boolean' },
+    dataTableExpandable: { control: 'boolean' },
+    label: { control: 'text' },
+    description: { control: 'text' },
+    // Fixture data and the status-tone mapping are the story's subject, not controls.
+    data: { control: false },
+    tones: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas, args }) => {
     await expect(canvas.getByRole('group', { name: 'Runs by agent' })).toBeVisible()
     await expect(canvas.getByRole('list', { name: 'Runs by agent legend' })).toHaveTextContent('Reviewer')

--- a/storybook/public/charts/ranked-bar-chart.stories.tsx
+++ b/storybook/public/charts/ranked-bar-chart.stories.tsx
@@ -5,9 +5,23 @@ import { ChartExplainer, RankedBarChart, type ChartDatum } from '@makinbakin/sdk
 
 import { ChartStage } from './chart-story-stage'
 
+const canonicalData: ChartDatum[] = [
+  { x: 'writer', xLabel: 'writer-agent', values: { runs: 48 } },
+  { x: 'reviewer', xLabel: 'reviewer-agent', values: { runs: 31 } },
+  { x: 'publisher', xLabel: 'publisher-agent', values: {}, missingLabels: { runs: 'Not reported' } },
+]
+
 const meta = {
   title: 'Components/Charts/RankedBarChart',
+  component: RankedBarChart,
   tags: ['public'],
+  // Canonical fixture args at meta level keep required props satisfied for the
+  // render-based showcase stories below.
+  args: {
+    data: canonicalData,
+    series: { key: 'runs', label: 'Completed runs' },
+    label: 'Completed runs by agent',
+  },
   parameters: {
     layout: 'fullscreen',
     docs: {
@@ -17,26 +31,26 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'non-color', 'keyboard', 'missing-data', 'multi-series'],
   },
-} satisfies Meta
+} satisfies Meta<typeof RankedBarChart>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-const canonicalData: ChartDatum[] = [
-  { x: 'writer', xLabel: 'writer-agent', values: { runs: 48 } },
-  { x: 'reviewer', xLabel: 'reviewer-agent', values: { runs: 31 } },
-  { x: 'publisher', xLabel: 'publisher-agent', values: {}, missingLabels: { runs: 'Not reported' } },
-]
-
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <RankedBarChart
-      data={canonicalData}
-      series={{ key: 'runs', label: 'Completed runs' }}
-      label="Completed runs by agent"
-    />
-  ),
+  argTypes: {
+    compactData: { control: 'boolean' },
+    showDataTable: { control: 'boolean' },
+    dataTableExpandable: { control: 'boolean' },
+    label: { control: 'text' },
+    description: { control: 'text' },
+    // Fixture data; the secondary overlay and status tones are showcase subjects.
+    data: { control: false },
+    series: { control: false },
+    secondary: { control: false },
+    tones: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('group', { name: 'Completed runs by agent' })).toBeVisible()
     const bar = canvas.getByRole('img', { name: 'writer-agent — Completed runs: 48' })

--- a/storybook/public/charts/sparkline.stories.tsx
+++ b/storybook/public/charts/sparkline.stories.tsx
@@ -8,6 +8,7 @@ import { ChartStage } from './chart-story-stage'
 
 const meta = {
   title: 'Components/Charts/Sparkline',
+  component: Sparkline,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -18,20 +19,29 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'non-color', 'keyboard', 'dense-data', 'missing-data'],
   },
-} satisfies Meta
+} satisfies Meta<typeof Sparkline>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Sparkline
-      label="Completed tasks across the last six reporting windows"
-      labels={['Window 1', 'Window 2', 'Window 3', 'Window 4', 'Window 5', 'Window 6']}
-      values={[18, 24, null, 31, 34, 42]}
-    />
-  ),
+  args: {
+    label: 'Completed tasks across the last six reporting windows',
+    labels: ['Window 1', 'Window 2', 'Window 3', 'Window 4', 'Window 5', 'Window 6'],
+    values: [18, 24, null, 31, 34, 42],
+  },
+  argTypes: {
+    area: { control: 'boolean' },
+    width: { control: 'number' },
+    height: { control: 'number' },
+    label: { control: 'text' },
+    // Fixture data; stroke stays palette-governed rather than a free color knob.
+    values: { control: false },
+    labels: { control: false },
+    stroke: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('group', { name: 'Completed tasks across the last six reporting windows' })).toBeVisible()
     await expect(canvas.queryByRole('img', { name: /Window 3/ })).not.toBeInTheDocument()
@@ -72,6 +82,8 @@ function Trend({
 }
 
 export const CompactTrends = {
+  // Type-satisfying only: each Trend example owns its sparkline props.
+  args: { label: 'Completed tasks across the last six reporting windows', values: [18, 24, 21, 31, 34, 42] },
   render: () => (
     <ChartStage
       eyebrow="Data / compact trend"
@@ -99,7 +111,13 @@ export const CompactTrends = {
 } satisfies Story
 
 export const AreaFill = {
-  render: () => (
+  args: {
+    area: true,
+    label: 'Assets generated across the last six reporting windows',
+    labels: ['Window 1', 'Window 2', 'Window 3', 'Window 4', 'Window 5', 'Window 6'],
+    values: [18, 24, null, 31, 34, 42],
+  },
+  render: (args) => (
     <ChartStage
       eyebrow="Data / compact trend"
       title="An area fill emphasizes magnitude without changing the contract"
@@ -111,12 +129,7 @@ export const AreaFill = {
           <strong>42</strong>
           <p>Up 8 from the prior window</p>
         </div>
-        <Sparkline
-          area
-          label="Assets generated across the last six reporting windows"
-          labels={['Window 1', 'Window 2', 'Window 3', 'Window 4', 'Window 5', 'Window 6']}
-          values={[18, 24, null, 31, 34, 42]}
-        />
+        <Sparkline {...args} />
       </article>
       <ChartExplainer>Use the fill when accumulated magnitude is the message; the default line remains the neutral choice.</ChartExplainer>
     </ChartStage>

--- a/storybook/public/charts/stacked-column-chart.stories.tsx
+++ b/storybook/public/charts/stacked-column-chart.stories.tsx
@@ -12,23 +12,6 @@ import {
 
 import { ChartStage } from './chart-story-stage'
 
-const meta = {
-  title: 'Components/Charts/StackedColumnChart',
-  tags: ['public'],
-  parameters: {
-    layout: 'fullscreen',
-    docs: {
-      description: {
-        component: 'StackedColumnChart shows dense composition across windows for a stable set of entities. Colors come from the fixed color-vision-deficiency-checked palette and follow the entity, not the filter: the first eight entity slots stay stable, later entities fold into one visibly named Other group, and visible names plus slot copy preserve meaning without color. A missing window renders as Not reported — never zero — an in-progress window is labelled, the interactive legend never hides the last visible series, keyboard focus mirrors pointer tooltips per column, and the exact-data table renders expanded by default so the evidence stays visible — `compactData` collapses it behind its disclosure for space-tight contexts. An empty dataset is a named state without invented marks.',
-      },
-    },
-    bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'empty', 'overflow', 'multi-series', 'cvd', 'non-color', 'keyboard', 'interaction', 'missing-data'],
-  },
-} satisfies Meta
-
-export default meta
-type Story = StoryObj<typeof meta>
-
 const canonicalKeys = ['writer', 'reviewer', 'publisher']
 
 const canonicalData: ChartDatum[] = [
@@ -38,16 +21,48 @@ const canonicalData: ChartDatum[] = [
   { x: 'jul-27', xLabel: 'Jul 27', values: { writer: 5, reviewer: 4, publisher: 2 } },
 ]
 
+const meta = {
+  title: 'Components/Charts/StackedColumnChart',
+  component: StackedColumnChart,
+  tags: ['public'],
+  // Canonical fixture args at meta level keep required props satisfied for the
+  // render-based showcase stories below.
+  args: {
+    data: canonicalData,
+    seriesKeys: canonicalKeys,
+    label: 'Agent runs by day',
+    height: 160,
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'StackedColumnChart shows dense composition across windows for a stable set of entities. Colors come from the fixed color-vision-deficiency-checked palette and follow the entity, not the filter: the first eight entity slots stay stable, later entities fold into one visibly named Other group, and visible names plus slot copy preserve meaning without color. A missing window renders as Not reported — never zero — an in-progress window is labelled, the interactive legend never hides the last visible series, keyboard focus mirrors pointer tooltips per column, and the exact-data table renders expanded by default so the evidence stays visible — `compactData` collapses it behind its disclosure for space-tight contexts. An empty dataset is a named state without invented marks.',
+      },
+    },
+    bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'empty', 'overflow', 'multi-series', 'cvd', 'non-color', 'keyboard', 'interaction', 'missing-data'],
+  },
+} satisfies Meta<typeof StackedColumnChart>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <StackedColumnChart
-      data={canonicalData}
-      seriesKeys={canonicalKeys}
-      label="Agent runs by day"
-      height={160}
-    />
-  ),
+  argTypes: {
+    height: { control: 'number' },
+    compactData: { control: 'boolean' },
+    showDataTable: { control: 'boolean' },
+    dataTableExpandable: { control: 'boolean' },
+    label: { control: 'text' },
+    dataLabel: { control: 'text' },
+    // Fixture data; entity sets and partial-window marking are showcase subjects.
+    data: { control: false },
+    series: { control: false },
+    seriesKeys: { control: false },
+    partialKeys: { control: false },
+    formatValue: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('group', { name: 'Agent runs by day' })).toBeVisible()
     await expect(canvas.getByRole('button', { name: 'writer' })).toHaveAttribute('aria-pressed', 'true')

--- a/storybook/public/charts/stat-group.stories.tsx
+++ b/storybook/public/charts/stat-group.stories.tsx
@@ -7,6 +7,7 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Charts/StatGroup',
+  component: StatGroup,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -17,20 +18,28 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'dense-data'],
   },
-} satisfies Meta
+} satisfies Meta<typeof StatGroup>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <StatGroup label="Task summary metrics">
-      <StatTile label="Active" value={4} valueTone="accent" />
-      <StatTile label="Blocked" value={23} valueTone="danger" />
-      <StatTile label="Total" value={35} />
-    </StatGroup>
-  ),
+  args: {
+    label: 'Task summary metrics',
+    // Peer tiles are composition — the group's one control is its accessible name.
+    children: (
+      <>
+        <StatTile label="Active" value={4} valueTone="accent" />
+        <StatTile label="Blocked" value={23} valueTone="danger" />
+        <StatTile label="Total" value={35} />
+      </>
+    ),
+  },
+  argTypes: {
+    label: { control: 'text' },
+    children: { control: false },
+  },
   play: async ({ canvas }) => {
     const group = canvas.getByRole('group', { name: 'Task summary metrics' })
     await expect(group).toBeVisible()
@@ -40,6 +49,8 @@ export const CanonicalUsage = {
 } satisfies Story
 
 export const CompactMetrics = {
+  // Type-satisfying only: the showcase owns its tiles.
+  args: { label: 'Task summary metrics', children: null },
   render: () => (
     <StoryStage
       eyebrow="Data / compact peer summary"

--- a/storybook/public/charts/stat-tile.stories.tsx
+++ b/storybook/public/charts/stat-tile.stories.tsx
@@ -13,6 +13,7 @@ function MetricIcon({ className }: { className?: string }) {
 
 const meta = {
   title: 'Components/Charts/StatTile',
+  component: StatTile,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -23,22 +24,31 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'non-color', 'progress', 'keyboard', 'dense-data'],
   },
-} satisfies Meta
+} satisfies Meta<typeof StatTile>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <StatTile
-      label="Success rate"
-      value="91.4%"
-      valueTone="success"
-      sub="128 of 140 observed"
-      progress={{ percent: 91.4, tone: 'success', label: 'Success rate' }}
-    />
-  ),
+  args: {
+    label: 'Success rate',
+    value: '91.4%',
+    valueTone: 'success',
+    sub: '128 of 140 observed',
+    progress: { percent: 91.4, tone: 'success', label: 'Success rate' },
+  },
+  argTypes: {
+    variant: { control: 'select', options: ['plain', 'surface'] },
+    valueTone: { control: 'select', options: ['neutral', 'success', 'attention', 'danger', 'accent'] },
+    label: { control: 'text' },
+    value: { control: 'text' },
+    sub: { control: 'text' },
+    // The meter object, icon, and click handler are consumer-owned composition.
+    progress: { control: false },
+    icon: { control: false },
+    onClick: { control: false },
+  },
   play: async ({ canvas }) => {
     // The exact value and label are visible text — the non-color status cue.
     await expect(canvas.getByText('Success rate')).toBeVisible()
@@ -55,6 +65,8 @@ export const CanonicalUsage = {
 } satisfies Story
 
 export const DenseMetrics = {
+  // Type-satisfying only: the showcase owns its tiles.
+  args: { label: 'Success rate', value: '91.4%' },
   render: () => (
     <StoryStage
       eyebrow="Data / scan rhythm"
@@ -106,6 +118,8 @@ function ActionableMetricsExample() {
 }
 
 export const ActionableMetrics = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { label: 'Success rate', value: '91.4%' },
   render: () => <ActionableMetricsExample />,
   play: async ({ canvas, userEvent }) => {
     const blocked = canvas.getByRole('button', { name: /Blocked tasks 3/ })

--- a/storybook/public/content/code-block.stories.tsx
+++ b/storybook/public/content/code-block.stories.tsx
@@ -15,6 +15,7 @@ const PAYLOAD = `{
 
 const meta = {
   title: 'Components/Content/CodeBlock',
+  component: CodeBlock,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -25,16 +26,24 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'dense-data'],
   },
-} satisfies Meta
+} satisfies Meta<typeof CodeBlock>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: { code: PAYLOAD, language: 'json', label: 'Tool payload', copyable: true, wrap: false },
+  argTypes: {
+    code: { control: 'text' },
+    language: { control: 'select', options: ['json', 'text'] },
+    label: { control: 'text' },
+    copyable: { control: 'boolean' },
+    wrap: { control: 'boolean' },
+  },
+  render: (args) => (
     <div style={{ inlineSize: '32rem', maxInlineSize: '100%' }}>
-      <CodeBlock code={PAYLOAD} language="json" label="Tool payload" copyable />
+      <CodeBlock {...args} />
     </div>
   ),
   play: async ({ canvasElement }) => {
@@ -48,6 +57,8 @@ export const CanonicalUsage = {
 } satisfies Story
 
 export const LanguagesAndHonesty = {
+  // Type-satisfying only: the showcase owns its payloads.
+  args: { code: PAYLOAD },
   render: () => (
     <StoryStage
       eyebrow="Content / Code"

--- a/storybook/public/content/markdown-content.stories.tsx
+++ b/storybook/public/content/markdown-content.stories.tsx
@@ -7,6 +7,7 @@ import { StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Content/MarkdownContent',
+  component: MarkdownContent,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -17,7 +18,7 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'dense-data', 'scroll-ownership'],
   },
-} satisfies Meta
+} satisfies Meta<typeof MarkdownContent>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -57,9 +58,12 @@ This section is projector-managed and remains visibly identified.
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <MarkdownContent content={'# Release notes\n\nThe **routing contract** remains authoritative.'} />
-  ),
+  args: { content: '# Release notes\n\nThe **routing contract** remains authoritative.' },
+  argTypes: {
+    content: { control: 'text' },
+    // Internal links delegate to the consumer's routing link.
+    renderInternalLink: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('heading', { name: 'Release notes', level: 1 })).toBeVisible()
     await expect(canvas.getByText('routing contract')).toBeVisible()
@@ -67,6 +71,8 @@ export const CanonicalUsage = {
 } satisfies Story
 
 export const ReadingAndCode = {
+  // Type-satisfying only: the showcase owns its content.
+  args: { content: releaseMarkdown },
   render: () => (
     <StoryStage
       eyebrow="Content / trusted Markdown"

--- a/storybook/public/content/markdown-editor.stories.tsx
+++ b/storybook/public/content/markdown-editor.stories.tsx
@@ -9,6 +9,7 @@ import { StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Content/MarkdownEditor',
+  component: MarkdownEditor,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -19,22 +20,35 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'reduced-motion'],
   },
-} satisfies Meta
+} satisfies Meta<typeof MarkdownEditor>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  args: {
+    label: 'Release notes',
+    content: '## Handoff\n\nRelease owner: **Maya**',
+    mode: 'edit',
+    height: 'compact',
+    onChange: () => {},
+  },
+  argTypes: {
+    mode: { control: 'select', options: ['edit', 'preview'] },
+    height: { control: 'select', options: ['compact', 'document', 'viewport', 'fill'] },
+    format: { control: 'select', options: ['markdown', 'yaml', 'json', 'text'] },
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    content: { control: 'text' },
+    // The host owns persistence and routing composition.
+    onChange: { control: false },
+    description: { control: false },
+    renderInternalLink: { control: false },
+  },
+  render: (args) => (
     <div style={{ width: 'min(100%, 36rem)' }}>
-      <MarkdownEditor
-        label="Release notes"
-        content={'## Handoff\n\nRelease owner: **Maya**'}
-        mode="edit"
-        height="compact"
-        onChange={() => {}}
-      />
+      <MarkdownEditor {...args} />
     </div>
   ),
   play: async ({ canvas }) => {
@@ -96,6 +110,8 @@ function EditorExample() {
 }
 
 export const ControlledEditor = {
+  // Type-satisfying only: the stateful example owns its props.
+  args: { label: 'Release handoff content', content: '', mode: 'edit', onChange: () => {} },
   render: () => <EditorExample />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/storybook/public/conversation/activity-group.stories.tsx
+++ b/storybook/public/conversation/activity-group.stories.tsx
@@ -41,8 +41,13 @@ const canonicalCalls: ConversationToolCall[] = [
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  args: { calls: canonicalCalls },
-  render: () => <ActivityGroup calls={canonicalCalls} />,
+  args: { calls: canonicalCalls, defaultExpanded: false },
+  argTypes: {
+    defaultExpanded: { control: 'boolean' },
+    // Call rows are the transcript's data; the detail action is consumer-owned.
+    calls: { control: false },
+    onOpenCall: { control: false },
+  },
   play: async ({ canvas, userEvent }) => {
     const trigger = canvas.getByRole('button', { name: /Searched the web/ })
     await expect(trigger).toHaveAttribute('aria-expanded', 'false')

--- a/storybook/public/conversation/composer.stories.tsx
+++ b/storybook/public/conversation/composer.stories.tsx
@@ -37,16 +37,28 @@ let canonicalSent = ''
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  args: { storageKey: 'storybook-canonical-composer', onSend: () => {} },
+  args: {
+    storageKey: 'storybook-canonical-composer',
+    inputLabel: 'Message the agent',
+    onSend: (content) => { canonicalSent = content },
+  },
+  argTypes: {
+    busy: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    inputLabel: { control: 'text' },
+    maxLength: { control: 'number' },
+    // Draft identity and the send/abort/attachment wiring are consumer-owned.
+    storageKey: { control: false },
+    onSend: { control: false },
+    onAbort: { control: false },
+    attachments: { control: false },
+  },
   // Width frame: the centered (shrink-to-fit) canvas collapses the composer
   // to min-content; in the app it spans the conversation column.
-  render: () => (
+  render: (args) => (
     <div style={{ inlineSize: '40rem', maxInlineSize: '100%' }}>
-      <Composer
-        storageKey="storybook-canonical-composer"
-        inputLabel="Message the agent"
-        onSend={(content) => { canonicalSent = content }}
-      />
+      <Composer {...args} />
     </div>
   ),
   play: async ({ canvas, userEvent }) => {

--- a/storybook/public/conversation/conversation-header.stories.tsx
+++ b/storybook/public/conversation/conversation-header.stories.tsx
@@ -46,18 +46,26 @@ const meterStats: ContextMeterStats = {
 
 export const CanonicalUsage = {
   args: { title: 'Release review' },
-  render: () => (
+  argTypes: {
+    title: { control: 'text' },
+    titleAs: { control: 'select', options: ['h2', 'h3', 'div'] },
+    // Identity, actions, and the meta line are slotted composition.
+    avatar: { control: false },
+    actions: { control: false },
+    meta: { control: false },
+  },
+  render: (args) => (
     <ConversationHeader
       // Container-typed component: centered canvases need a definite inline size.
       style={{ inlineSize: '40rem', maxInlineSize: '90vw' }}
       avatar={<AgentAvatar agent={agent} size="sm" />}
-      title="Release review"
       meta={
         <>
           <ContextMeter stats={meterStats} />
           <Badge size="xs" variant="outline">1.2m tokens · $0.84</Badge>
         </>
       }
+      {...args}
     />
   ),
   play: async ({ canvas }) => {

--- a/storybook/public/conversation/panel-and-drawer.stories.tsx
+++ b/storybook/public/conversation/panel-and-drawer.stories.tsx
@@ -40,18 +40,28 @@ const canonicalMessages: ConversationMessage[] = [
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  args: { messages: canonicalMessages, onSend: () => {}, storageKey: 'storybook-canonical-panel' },
-  render: () => (
-    <ConversationPanel
-      messages={canonicalMessages}
-      agent={canonicalAgent}
-      onSend={() => {}}
-      storageKey="storybook-canonical-panel"
-      title="Release review"
-      inputLabel="Message the release agent"
-      autoFocus={false}
-    />
-  ),
+  args: {
+    messages: canonicalMessages,
+    agent: canonicalAgent,
+    onSend: () => {},
+    storageKey: 'storybook-canonical-panel',
+    title: 'Release review',
+    inputLabel: 'Message the release agent',
+    autoFocus: false,
+  },
+  argTypes: {
+    readOnly: { control: 'boolean' },
+    showHeader: { control: 'boolean' },
+    chrome: { control: 'select', options: ['panel', 'top-divider'] },
+    title: { control: 'text' },
+    placeholder: { control: 'text' },
+    // Transport, history, identity, and draft storage are consumer-owned.
+    messages: { control: false },
+    agent: { control: false },
+    onSend: { control: false },
+    storageKey: { control: false },
+  },
+  render: (args) => <ConversationPanel {...args} />,
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('region', { name: 'Release review' })).toBeVisible()
     await expect(canvas.getByRole('article', { name: 'Release agent reply' })).toBeVisible()

--- a/storybook/public/conversation/timeline.stories.tsx
+++ b/storybook/public/conversation/timeline.stories.tsx
@@ -54,8 +54,16 @@ const canonicalTurns: ConversationTurn[] = [
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  args: { turns: canonicalTurns },
-  render: () => <Conversation turns={canonicalTurns} agent={canonicalAgent} />,
+  args: { turns: canonicalTurns, agent: canonicalAgent },
+  argTypes: {
+    mode: { control: 'select', options: ['document', 'contained'] },
+    // Transcript data, identity lookup, and renderers are consumer-owned.
+    turns: { control: false },
+    agent: { control: false },
+    resolveAgent: { control: false },
+    emptyState: { control: false },
+  },
+  render: (args) => <Conversation {...args} />,
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('article', { name: 'Your message' })).toBeVisible()
     await expect(canvas.getByRole('article', { name: 'Release agent reply' })).toBeVisible()

--- a/storybook/public/conversation/turn-output.stories.tsx
+++ b/storybook/public/conversation/turn-output.stories.tsx
@@ -36,7 +36,13 @@ const canonicalChunks: ConversationChunk[] = [
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
   args: { chunks: canonicalChunks, live: true },
-  render: () => <TurnOutputView chunks={canonicalChunks} live />,
+  argTypes: {
+    live: { control: 'boolean' },
+    // Chunk streams and rich-text rendering are consumer-owned.
+    chunks: { control: false },
+    renderText: { control: false },
+    textFrame: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('status')).toHaveTextContent('reading the route plan…')
     await expect(canvas.getByText('read_file')).toBeVisible()

--- a/storybook/public/conversation/turns.stories.tsx
+++ b/storybook/public/conversation/turns.stories.tsx
@@ -43,7 +43,15 @@ const canonicalTurn: Extract<ConversationTurn, { kind: 'agent' }> = {
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
   args: { turn: canonicalTurn, agent: canonicalAgent },
-  render: () => (
+  argTypes: {
+    // Transcript data drives the turn — there is nothing to flip; renderers
+    // and handlers are consumer-owned composition.
+    turn: { control: false },
+    agent: { control: false },
+    onRetry: { control: false },
+    onOpenCall: { control: false },
+  },
+  render: (args) => (
     <>
       <UserMessage
         turn={{
@@ -53,7 +61,7 @@ export const CanonicalUsage = {
           content: 'Are the routing examples ready to publish?',
         }}
       />
-      <AgentTurn agent={canonicalAgent} turn={canonicalTurn} />
+      <AgentTurn {...args} />
     </>
   ),
   play: async ({ canvas }) => {


### PR DESCRIPTION
Tier 2, batch 3 of the Storybook catalog plan (follows #798/#799): every `Components/Charts`, `Components/Conversation`, and `Components/Content` entry now has an args-driven `CanonicalUsage` story with curated controls.

- 22 files converted: the full chart kit (line/area/bar/sparkline/stat-tile/stat-group/chart-explainer/pie/ranked-bar/stacked-column/composition-bar/chart-data-table), the conversation kit (composer/timeline/panel-and-drawer/turn-output/turns/activity-group/conversation-header), and content (code-block/markdown-content/markdown-editor).
- Controls are the real presentation flags (`smooth`/`stacked`/`donut`/`compactData`/`showDataTable`, composer `busy`/`disabled`/`maxLength`, editor `mode`/`height`/`format`, …); datasets, transcripts, series, and handlers are pinned `control: false` as fixture data. Sparkline `stroke` pinned as palette-governed; palette/series slot order untouched (CVD-safety mechanism).
- Seven metas gain their missing `component` reference (props tables now render). Where that makes required props required story args, canonical fixture args are hoisted to meta so showcase stories inherit them — less per-story noise than batch 2's approach.
- Honesty fixes along the way: composer, timeline, turns, conversation-header, and chart-explainer canonical stories previously ignored their own args; they now consume them.
- Rendered output is pixel-identical: full visual suite (270) passes against existing baselines; story suite 59/59; strict lint, repo typecheck, story-compliance + kit-coverage green.

Remaining tier-2 work: navigation/lists/layout/pages/agents/feedback stragglers, then the compliance-ratchet extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB