### PR TITLE
docs(storybook): interactive controls for navigation, feedback, pages, and friends

### DIFF
--- a/storybook/public/agents/agent-select.stories.tsx
+++ b/storybook/public/agents/agent-select.stories.tsx
@@ -13,6 +13,18 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Agents/AgentSelect',
+  component: AgentSelect,
+  // Canonical controlled-selector shape; render-based showcase stories
+  // inherit these required props and own their own state.
+  args: {
+    ariaLabel: 'Owner',
+    value: 'maya',
+    onValueChange: () => {},
+    agents: [
+      { id: 'maya', name: 'Maya Chen', color: '#8b5cf6' },
+      { id: 'patch', name: 'Patch', color: '#f97316' },
+    ],
+  },
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -23,7 +35,7 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'disabled', 'empty', 'non-color', 'long-content'],
   },
-} satisfies Meta
+} satisfies Meta<typeof AgentSelect>
 
 export default meta
 type Story = StoryObj<typeof meta>
@@ -38,17 +50,19 @@ const agents = [
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <AgentSelect
-      ariaLabel="Owner"
-      value="maya"
-      onValueChange={() => {}}
-      agents={[
-        { id: 'maya', name: 'Maya Chen', color: '#8b5cf6' },
-        { id: 'patch', name: 'Patch', color: '#f97316' },
-      ]}
-    />
-  ),
+  argTypes: {
+    value: { control: 'select', options: ['maya', 'patch', ''] },
+    disabled: { control: 'boolean' },
+    allowNone: { control: 'boolean' },
+    includeAssigned: { control: 'boolean' },
+    placeholder: { control: 'text' },
+    // The play and a11y contract query the accessible name; option data and
+    // the change handler are consumer-owned wiring.
+    ariaLabel: { control: false },
+    agents: { control: false },
+    teams: { control: false },
+    onValueChange: { control: false },
+  },
   play: async ({ canvas }) => {
     const trigger = canvas.getByRole('combobox', { name: 'Owner' })
     await expect(trigger).toBeVisible()

--- a/storybook/public/feedback/banner.stories.tsx
+++ b/storybook/public/feedback/banner.stories.tsx
@@ -31,6 +31,15 @@ export const CanonicalUsage = {
     description: 'Queued workflows will resume automatically.',
     announce: 'polite',
   },
+  argTypes: {
+    tone: { control: 'select', options: ['info', 'success', 'attention', 'danger'] },
+    announce: { control: 'select', options: ['off', 'polite', 'assertive'] },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    headingLevel: { control: 'select', options: [2, 3, 4] },
+    // Recovery actions are composed elements, not knobs.
+    action: { control: false },
+  },
   // Width frame: Banner's container-type zeroes its intrinsic width, so the
   // centered (shrink-to-fit) canvas would collapse it. In the app it sits in
   // block flow where width is inherited; the frame reproduces that.

--- a/storybook/public/feedback/confirm-dialog.stories.tsx
+++ b/storybook/public/feedback/confirm-dialog.stories.tsx
@@ -10,6 +10,18 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Feedback/ConfirmDialog',
+  component: ConfirmDialog,
+  // Canonical fixture args at meta level: render-based stories inherit the
+  // required props (open/title/onConfirm/onCancel).
+  args: {
+    open: true,
+    title: 'Delete archived workflow?',
+    description: 'This permanently deletes the workflow definition and its preserved run history. Scheduled triggers will stop.',
+    confirmLabel: 'Delete workflow',
+    confirmValue: 'launch-publishing',
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -20,24 +32,31 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'interaction', 'typed-confirmation', 'focus-return', 'busy', 'error-retry'],
   },
-} satisfies Meta
+} satisfies Meta<typeof ConfirmDialog>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <ConfirmDialog
-      open
-      title="Delete archived workflow?"
-      description="This permanently deletes the workflow definition and its preserved run history. Scheduled triggers will stop."
-      confirmLabel="Delete workflow"
-      confirmValue="launch-publishing"
-      onConfirm={() => {}}
-      onCancel={() => {}}
-    />
-  ),
+  argTypes: {
+    open: { control: 'boolean' },
+    title: { control: 'text' },
+    description: { control: 'text' },
+    confirmLabel: { control: 'text' },
+    busyLabel: { control: 'text' },
+    cancelLabel: { control: 'text' },
+    confirmTone: { control: 'select', options: ['danger', 'primary'] },
+    cancelVariant: { control: 'select', options: ['outline', 'ghost'] },
+    confirmValue: { control: 'text' },
+    busy: { control: 'boolean' },
+    error: { control: 'text' },
+    // The consumer owns the mutation, dismissal, and focus return.
+    onConfirm: { control: false },
+    onCancel: { control: false },
+    finalFocus: { control: false },
+    children: { control: false },
+  },
   play: async ({ userEvent }) => {
     const page = within(document.body)
     const dialog = await page.findByRole('dialog', { name: 'Delete archived workflow?' })

--- a/storybook/public/feedback/danger-zone.stories.tsx
+++ b/storybook/public/feedback/danger-zone.stories.tsx
@@ -10,6 +10,15 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Feedback/DangerZone',
+  component: DangerZone,
+  // Canonical fixture args at meta level: the render-based story inherits the
+  // required props (description/confirmLabel/confirmValue/onConfirm).
+  args: {
+    description: 'Delete the Acme publishing workspace, disconnect 4 agents, and stop 3 scheduled workflows. This cannot be undone.',
+    confirmLabel: 'Delete workspace',
+    confirmValue: 'acme-publishing',
+    onConfirm: () => {},
+  },
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -20,21 +29,27 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'interaction', 'typed-confirmation', 'focus-return'],
   },
-} satisfies Meta
+} satisfies Meta<typeof DangerZone>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    confirmLabel: { control: 'text' },
+    confirmValue: { control: 'text' },
+    headingLevel: { control: 'select', options: [2, 3, 4] },
+    busy: { control: 'boolean' },
+    error: { control: 'text' },
+    // The mutation is consumer-owned.
+    onConfirm: { control: false },
+  },
+  render: (args) => (
     <div style={{ width: 'min(90vw, 36rem)' }}>
-      <DangerZone
-        description="Delete the Acme publishing workspace, disconnect 4 agents, and stop 3 scheduled workflows. This cannot be undone."
-        confirmLabel="Delete workspace"
-        confirmValue="acme-publishing"
-        onConfirm={() => {}}
-      />
+      <DangerZone {...args} />
     </div>
   ),
   play: async ({ canvas, userEvent }) => {

--- a/storybook/public/feedback/search-trust.stories.tsx
+++ b/storybook/public/feedback/search-trust.stories.tsx
@@ -14,6 +14,7 @@ import './search-trust.stories.css'
 
 const meta = {
   title: 'Components/Feedback/Search trust states',
+  component: SearchUnavailable,
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -24,14 +25,21 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'non-color', 'reduced-motion', 'error', 'dense-data'],
   },
-} satisfies Meta
+} satisfies Meta<typeof SearchUnavailable>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => <SearchUnavailable retry={() => {}} healthAction={null} />,
+  args: { retry: () => {}, healthAction: null },
+  argTypes: {
+    scope: { control: 'select', options: ['inline', 'section', 'page'] },
+    headingLevel: { control: 'select', options: [2, 3, 4] },
+    // Retry re-runs the consumer's query; the health action is a host-owned link.
+    retry: { control: false },
+    healthAction: { control: false },
+  },
   play: async ({ canvas }) => {
     const state = canvas.getByRole('alert', { name: 'Search is unavailable' })
     await expect(state).toBeVisible()

--- a/storybook/public/layout/disclosure-panel.stories.tsx
+++ b/storybook/public/layout/disclosure-panel.stories.tsx
@@ -34,6 +34,14 @@ export const CanonicalUsage = {
       </p>
     ),
   },
+  argTypes: {
+    summary: { control: 'text' },
+    summaryMeta: { control: 'text' },
+    variant: { control: 'select', options: ['default', 'soft', 'ghost'] },
+    open: { control: 'boolean' },
+    // Revealed evidence is composition.
+    children: { control: false },
+  },
   render: (args) => (
     <div style={{ width: 'min(100%, 28rem)', minWidth: 0 }}>
       <DisclosurePanel {...args} />

--- a/storybook/public/lists/key-value.stories.tsx
+++ b/storybook/public/lists/key-value.stories.tsx
@@ -7,6 +7,17 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Lists/KeyValue',
+  component: KeyValue,
+  // Canonical fixture args at meta level: the render-based layouts story
+  // inherits the required items.
+  args: {
+    items: [
+      { label: 'Model', value: 'claude-sonnet-4' },
+      { label: 'Tokens', value: '12.3k in / 4.1k out', numeric: true },
+      { label: 'Cost', value: '$0.42', numeric: true },
+      { label: 'Route', value: null },
+    ],
+  },
   tags: ['public'],
   parameters: {
     layout: 'fullscreen',
@@ -17,25 +28,23 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'long-labels', 'dense-data'],
   },
-} satisfies Meta
+} satisfies Meta<typeof KeyValue>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
+  argTypes: {
+    layout: { control: 'select', options: ['inline', 'rows', 'columns'] },
+    // Pair data is the fixture, not a knob.
+    items: { control: false },
+  },
   // The list fills its container, so the centered canvas needs a definite
   // inline size or it collapses to its content width.
-  render: () => (
+  render: (args) => (
     <div style={{ inlineSize: '22rem', maxInlineSize: '100%' }}>
-      <KeyValue
-        items={[
-          { label: 'Model', value: 'claude-sonnet-4' },
-          { label: 'Tokens', value: '12.3k in / 4.1k out', numeric: true },
-          { label: 'Cost', value: '$0.42', numeric: true },
-          { label: 'Route', value: null },
-        ]}
-      />
+      <KeyValue {...args} />
     </div>
   ),
   play: async ({ canvasElement }) => {

--- a/storybook/public/navigation/command.stories.tsx
+++ b/storybook/public/navigation/command.stories.tsx
@@ -59,18 +59,26 @@ function TaskCommands() {
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <Command label="Find an action">
-      <CommandInput placeholder="Find an action…" />
-      <CommandList label="Actions">
-        <CommandEmpty>No matching actions.</CommandEmpty>
-        <CommandGroup heading="Change state">
-          <CommandItem value="mark-running">Mark running</CommandItem>
-          <CommandItem value="mark-blocked">Mark blocked</CommandItem>
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  ),
+  args: {
+    label: 'Find an action',
+    children: (
+      <>
+        <CommandInput placeholder="Find an action…" />
+        <CommandList label="Actions">
+          <CommandEmpty>No matching actions.</CommandEmpty>
+          <CommandGroup heading="Change state">
+            <CommandItem value="mark-running">Mark running</CommandItem>
+            <CommandItem value="mark-blocked">Mark blocked</CommandItem>
+          </CommandGroup>
+        </CommandList>
+      </>
+    ),
+  },
+  argTypes: {
+    label: { control: 'text' },
+    // The filterable structure (input, list, groups, items) is composition.
+    children: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('combobox', { name: 'Find an action' })).toBeVisible()
     await expect(canvas.getByRole('option', { name: 'Mark blocked' })).toBeVisible()

--- a/storybook/public/navigation/nav-list.stories.tsx
+++ b/storybook/public/navigation/nav-list.stories.tsx
@@ -8,7 +8,20 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Navigation/NavList',
+  component: NavList,
   tags: ['public'],
+  // Canonical args at meta level so the render-based showcase inherits the
+  // required selection contract without per-story type noise.
+  args: {
+    label: 'Plugin settings',
+    selectedId: 'tasks',
+    onSelect: () => {},
+    items: [
+      { id: 'tasks', label: 'Tasks' },
+      { id: 'schedule', label: 'Schedule' },
+      { id: 'health', label: 'Health' },
+    ],
+  },
   parameters: {
     layout: 'fullscreen',
     docs: {
@@ -18,25 +31,21 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'mobile-320', 'text-200', 'keyboard', 'interaction', 'disabled', 'long-labels'],
   },
-} satisfies Meta
+} satisfies Meta<typeof NavList>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
-    <NavList
-      label="Plugin settings"
-      selectedId="tasks"
-      onSelect={() => {}}
-      items={[
-        { id: 'tasks', label: 'Tasks' },
-        { id: 'schedule', label: 'Schedule' },
-        { id: 'health', label: 'Health' },
-      ]}
-    />
-  ),
+  argTypes: {
+    label: { control: 'text' },
+    selectedId: { control: 'select', options: ['tasks', 'schedule', 'health', null] },
+    // Entry data and the selection callback are consumer-owned state wiring.
+    items: { control: false },
+    sections: { control: false },
+    onSelect: { control: false },
+  },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('navigation', { name: 'Plugin settings' })).toBeVisible()
     await expect(canvas.getByRole('button', { name: 'Tasks' })).toHaveAttribute('aria-current', 'true')

--- a/storybook/public/navigation/sortable-head.stories.tsx
+++ b/storybook/public/navigation/sortable-head.stories.tsx
@@ -8,7 +8,17 @@ import { StorySection, StoryStage } from '../../support'
 
 const meta = {
   title: 'Components/Navigation/SortableHead',
+  component: SortableHead,
   tags: ['public'],
+  // Canonical args at meta level so the render-based showcase inherits the
+  // required controlled-sort contract without per-story type noise.
+  args: {
+    field: 'updated',
+    current: 'updated',
+    dir: 'desc',
+    onSort: () => {},
+    children: 'Updated',
+  },
   parameters: {
     layout: 'fullscreen',
     docs: {
@@ -18,19 +28,29 @@ const meta = {
     },
     bakinCoverage: ['desktop', 'interaction', 'non-color', 'overflow', 'url-state-guidance'],
   },
-} satisfies Meta
+} satisfies Meta<typeof SortableHead>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   parameters: { layout: 'centered' },
-  render: () => (
+  argTypes: {
+    dir: { control: 'select', options: ['asc', 'desc'] },
+    current: { control: 'select', options: ['updated', 'task'] },
+    disabled: { control: 'boolean' },
+    // Sorting is controlled: field identity, the callback, and the header
+    // label are the consumer's table wiring, not knobs.
+    field: { control: false },
+    onSort: { control: false },
+    children: { control: false },
+  },
+  render: (args) => (
     <table style={{ inlineSize: 'min(90vw, 30rem)', borderCollapse: 'collapse' }}>
       <thead>
         <tr>
-          <SortableHead field="task" current="updated" dir="desc" onSort={() => {}}>Task</SortableHead>
-          <SortableHead field="updated" current="updated" dir="desc" onSort={() => {}}>Updated</SortableHead>
+          <SortableHead field="task" current={args.current} dir={args.dir} onSort={args.onSort}>Task</SortableHead>
+          <SortableHead {...args} />
         </tr>
       </thead>
       <tbody>

--- a/storybook/public/pages/collapsible-aside.stories.tsx
+++ b/storybook/public/pages/collapsible-aside.stories.tsx
@@ -47,17 +47,22 @@ const rows = (
 )
 
 export const CanonicalUsage = {
-  args: { label: 'Session list' },
-  render: () => (
-    <PageAside
-      label="Session list"
-      width="session"
-      style={{ blockSize: '20rem' }}
-      collapsible={{ collapsed: false, onCollapsedChange: () => {} }}
-    >
-      {rows}
-    </PageAside>
-  ),
+  args: {
+    label: 'Session list',
+    width: 'session',
+    style: { blockSize: '20rem' },
+    // The collapse contract is a controlled object — the roundtrip story
+    // exercises it; here the rail starts expanded.
+    collapsible: { collapsed: false, onCollapsedChange: () => {} },
+    children: rows,
+  },
+  argTypes: {
+    width: { control: 'select', options: ['nav', 'session'] },
+    label: { control: 'text' },
+    collapsible: { control: false },
+    children: { control: false },
+    style: { control: false },
+  },
   play: async ({ canvas, canvasElement }) => {
     await expect(canvas.getByRole('complementary', { name: 'Session list' })).toBeVisible()
     await expect(canvas.getByRole('button', { name: 'Open Release readiness' })).toBeVisible()

--- a/storybook/public/pages/workspace-page.stories.tsx
+++ b/storybook/public/pages/workspace-page.stories.tsx
@@ -35,22 +35,35 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
-  render: () => (
-    <WorkspacePage data-testid="canonical-workspace-page">
-      <WorkspacePageHeader>
-        <PageHeader title="Conversation workspace" />
-      </WorkspacePageHeader>
-      {/* The stat-strip zone between identity and controls. Omit the
-          component entirely when a workspace has no metrics — the frame
-          closes up with no reserved band. */}
-      <WorkspacePageMetrics>
-        <span aria-label="Workspace metrics">3 active · 1 blocked</span>
-      </WorkspacePageMetrics>
-      <WorkspacePageBody>
-        <section aria-label="Workspace canvas">Workspace canvas</section>
-      </WorkspacePageBody>
-    </WorkspacePage>
-  ),
+  // data-testid rides the render spread: React's data-* JSX allowance
+  // doesn't extend to typed args objects.
+  render: (args) => <WorkspacePage {...args} data-testid="canonical-workspace-page" />,
+  args: {
+    mode: 'contained',
+    flow: false,
+    // Header/metrics/body zones are the archetype's composition, not knobs.
+    children: (
+      <>
+        <WorkspacePageHeader>
+          <PageHeader title="Conversation workspace" />
+        </WorkspacePageHeader>
+        {/* The stat-strip zone between identity and controls. Omit the
+            component entirely when a workspace has no metrics — the frame
+            closes up with no reserved band. */}
+        <WorkspacePageMetrics>
+          <span aria-label="Workspace metrics">3 active · 1 blocked</span>
+        </WorkspacePageMetrics>
+        <WorkspacePageBody>
+          <section aria-label="Workspace canvas">Workspace canvas</section>
+        </WorkspacePageBody>
+      </>
+    ),
+  },
+  argTypes: {
+    mode: { control: 'select', options: ['contained', 'immersive'] },
+    flow: { control: 'boolean' },
+    children: { control: false },
+  },
   play: async ({ canvas }) => {
     const page = canvas.getByTestId('canonical-workspace-page')
     await expect(page).toHaveAttribute('data-archetype', 'workspace')

--- a/storybook/public/testing/plugin-ui-fixture.stories.tsx
+++ b/storybook/public/testing/plugin-ui-fixture.stories.tsx
@@ -58,6 +58,19 @@ export const CanonicalUsage = {
     registrations: [{ id: 'fixture-canonical', routes: { '/fixture/canonical': CanonicalFixturePage } }],
     fixture: { ...DEFAULT_PLUGIN_UI_FIXTURE, route: '/fixture/canonical' },
   },
+  argTypes: {
+    surfaceState: {
+      control: 'select',
+      options: ['ready', 'initial-empty', 'no-results', 'loading', 'error', 'permission-denied'],
+    },
+    // Registrations must keep a stable identity across renders; the fixture,
+    // slots, and state-action callback are harness wiring, not knobs.
+    registrations: { control: false },
+    fixture: { control: false },
+    slots: { control: false },
+    onStateAction: { control: false },
+    className: { control: false },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await waitFor(() => expect(canvas.getByText('Canonical fixture page')).toBeVisible())


### PR DESCRIPTION
Tier 2, batch 4 — the last conversion batch (follows #798/#799/#800). With this, every `Components/` entry in the public Storybook has an args-driven `CanonicalUsage` story with curated controls.

- 13 files converted across navigation, layout, lists, pages, agents, feedback, and testing.
- Controls verified against component sources: nav-list `selectedId`, sortable-head `dir`/`current`/`disabled` (DataTable sort contract and `aria-sort` play assertions untouched), disclosure-panel `variant`, workspace-page `mode`/`flow`, agent-select `value`/`allowNone`/`includeAssigned`, banner `tone`/`announce`, confirm-dialog's full label/tone surface (deprecated `confirmVariant` deliberately excluded), key-value `layout`, fixture-host `surfaceState`.
- Seven metas gain their missing `component` reference; required props ride meta-level canonical args so render-based showcase stories inherit them without per-story noise.
- One typed-args wrinkle: `data-testid` isn't a typed WorkspacePage prop, so it rides the render spread rather than args.
- Rendered output is pixel-identical: full visual suite (270) passes against existing baselines; category story suites 132/132; strict lint, repo typecheck, story-compliance + kit-coverage green.

Remaining tier-2 work: extend the story-compliance ratchet so new component entries must ship controls (separate PR, after these merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB