### PR TITLE
chore(design-system): controls ratchet — CanonicalUsage must be exercisable

### DIFF
--- a/scripts/ui/story-compliance.ts
+++ b/scripts/ui/story-compliance.ts
@@ -9,6 +9,10 @@
  *                       (`Recipes/` entries are exempt from this one rule);
  *  - play-assertion:    at least one story in the file has a play function
  *                       that actually asserts (references `expect`);
+ *  - interactive-controls: the `CanonicalUsage` story is controllable — it or
+ *                       its meta declares `argTypes` so the Storybook UI can
+ *                       exercise the component's real props (`Recipes/` and
+ *                       `Tokens/` entries are exempt alongside canonical-usage);
  *  - coverage-axes:     meta declares non-empty `parameters.bakinCoverage`;
  *  - docs-description:  meta declares `parameters.docs.description.component`;
  *  - visual-baseline:   some spec under tests/ui/visual references the entry
@@ -32,6 +36,7 @@ const SDK_PREFIX = '@makinbakin/sdk'
 
 export type StoryRequirement =
   | 'canonical-usage'
+  | 'interactive-controls'
   | 'play-assertion'
   | 'coverage-axes'
   | 'docs-description'
@@ -215,6 +220,11 @@ function analyzeStoryFile(root: string, path: string, visualSources: string): St
           missing.add('canonical-usage')
         }
       }
+      // interactive-controls: the canonical story must be exercisable from
+      // the Storybook UI — argTypes on the story itself or on the meta.
+      const argTypes = objectProperty(first.initializer, 'argTypes')
+        ?? (meta ? objectProperty(meta, 'argTypes') : undefined)
+      if (!argTypes) missing.add('interactive-controls')
     }
   }
 

--- a/tests/ui/architecture/story-compliance.test.ts
+++ b/tests/ui/architecture/story-compliance.test.ts
@@ -50,6 +50,7 @@ type Story = StoryObj<typeof meta>
 
 export const CanonicalUsage = {
   render: () => <Button variant="primary">Continue</Button>,
+  argTypes: { variant: { control: 'select', options: ['primary', 'secondary'] } },
   play: async ({ canvas }) => {
     await expect(canvas.getByRole('button', { name: 'Continue' })).toBeVisible()
   },
@@ -150,9 +151,35 @@ export default {
 }
 export const CanonicalUsage = {
   args: { children: 'Continue' },
+  argTypes: { children: { control: 'text' } },
   play: async () => { await expect(true).toBe(true) },
 }
 `)
+    writeVisualSpec(root, ['Primitives/Button'])
+    const [entry] = collectStoryCompliance(root)
+    expect(entry!.missing).toEqual([])
+  })
+
+  it('reports interactive-controls when CanonicalUsage has no argTypes anywhere', () => {
+    const root = makeRoot()
+    writeStory(root, 'uncontrolled.stories.tsx', COMPLIANT_STORY.replace(
+      "  argTypes: { variant: { control: 'select', options: ['primary', 'secondary'] } },\n",
+      '',
+    ))
+    writeVisualSpec(root, ['Primitives/Button'])
+    const [entry] = collectStoryCompliance(root)
+    expect(entry!.missing).toEqual(['interactive-controls'])
+  })
+
+  it('accepts meta-level argTypes for interactive-controls', () => {
+    const root = makeRoot()
+    writeStory(root, 'meta-controls.stories.tsx', COMPLIANT_STORY.replace(
+      "  argTypes: { variant: { control: 'select', options: ['primary', 'secondary'] } },\n",
+      '',
+    ).replace(
+      "  tags: ['public'],",
+      "  tags: ['public'],\n  argTypes: { variant: { control: 'select', options: ['primary', 'secondary'] } },",
+    ))
     writeVisualSpec(root, ['Primitives/Button'])
     const [entry] = collectStoryCompliance(root)
     expect(entry!.missing).toEqual([])


### PR DESCRIPTION
Closes out tier 2 of the Storybook catalog plan (follows #798–#801): the story-compliance gate gains an `interactive-controls` requirement — every component entry's `CanonicalUsage` must declare `argTypes` (story- or meta-level), so new kit entries ship exercisable controls the same way the existing 100 do.

- `Recipes/` and `Tokens/` remain exempt (no single component to control), matching the canonical-usage exemption.
- The ratchet is in absolute mode (no baseline file) and the repo already fully complies, so this is pure lock-in — zero grandfathered debt.
- Fixture tests prove the rule bites (missing argTypes → `interactive-controls`) and that meta-level argTypes satisfy it.
- Gates: fixture suite 9/9, strict lint, repo typecheck, `ui:story-compliance:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVoAxzDUCjHwm8wWHx52eB