### PR TITLE
fix(tasks): board fills viewport height so the scroll rail pins to the window bottom

### DIFF
--- a/packages/ui/src/patterns/workspace-page.tsx
+++ b/packages/ui/src/patterns/workspace-page.tsx
@@ -26,8 +26,12 @@ export type WorkspacePageProps = Omit<
   /**
    * Document-flow workspace: the body grows with its content and the page
    * owns the ONE vertical scroll (identity + content scroll as a single
-   * document; the compact row still sticks). Default keeps the
-   * viewport-bound canvas whose children own their scrolling.
+   * document; the compact row still sticks). The body still fills the
+   * remaining viewport as a MINIMUM, so a trailing canvas (board, grid)
+   * reaches the fold and pinned affordances such as a sticky horizontal
+   * scrollbar sit at the window bottom even when content is short.
+   * Default keeps the viewport-bound canvas whose children own their
+   * scrolling.
    */
   flow?: boolean
 }
@@ -289,7 +293,10 @@ export type WorkspacePageBodyProps = React.ComponentPropsWithoutRef<'div'>
 /**
  * Flush remaining canvas. The mobile activity trigger lives in the host nav,
  * so this body only preserves the device safe area. In a `flow` workspace
- * the body grows with its content instead of bounding it.
+ * the body grows with its content instead of bounding it — while still
+ * absorbing the shell's leftover height (the shell content box is a
+ * min-h-full column), so short content leaves the body at the fold rather
+ * than mid-page.
  */
 export function WorkspacePageBody({
   className,
@@ -305,7 +312,10 @@ export function WorkspacePageBody({
       className={cn(
         'flex min-w-0 pb-[env(safe-area-inset-bottom)] @md/page-shell:pb-0',
         flow
-          ? 'flex-none flex-col'
+          // flex-1 (not flex-none): the shell content box is a min-h-full
+          // column, so growing here is what carries a short flow page to
+          // the viewport bottom; tall content still exceeds it freely.
+          ? 'flex-1 flex-col'
           : 'min-h-0 flex-1 overflow-hidden',
         !flow && mode === 'immersive' &&
           'h-[calc(100%-var(--bakin-workspace-compact-header-height))] min-h-[calc(100%-var(--bakin-workspace-compact-header-height))] flex-none',

--- a/plugins/tasks/components/kanban-board.tsx
+++ b/plugins/tasks/components/kanban-board.tsx
@@ -668,8 +668,11 @@ export function KanbanBoard() {
                 stickyScrollbar
                 data-task-board-scroll
                 // pb clears the pinned scrollbar so fully-scrolled cards
-                // never rest on it.
-                className="px-bakin-4 pb-bakin-6 @md/page-shell:px-bakin-6"
+                // never rest on it. flex-1 lets the board region absorb the
+                // flow body's leftover height, so with short columns the
+                // region's bottom edge — where the sticky rail attaches —
+                // is the viewport bottom, not mid-page.
+                className="flex-1 px-bakin-4 pb-bakin-6 @md/page-shell:px-bakin-6"
               >
                 {COLUMN_ORDER.map((colId) => (
                   <KanbanColumn


### PR DESCRIPTION
## Summary
The tasks board (and any flow-mode workspace) ended mid-page when its columns were short, leaving the sticky horizontal scrollbar stranded there. Root cause: flow-mode `WorkspacePageBody` was `flex-none` inside the page shell's `min-h-full` column — nothing carried short content to the fold.

- `WorkspacePageBody` (flow): `flex-none` → `flex-1` — absorbs the shell's leftover height as a minimum; tall content still grows past freely (grow only adds).
- Tasks `KanbanBoardTrack`: `flex-1` so the board region's bottom edge — where `stickyScrollbar` attaches its rail — is the viewport bottom.
- `flow` prop + body JSDoc updated to state the fills-viewport-as-minimum contract.

Other flow consumer (schedule page) only gains empty canvas below its content — children keep natural height.

## UI conformance
- Pattern: storybook/public/pages/workspace-page.stories.tsx — CanonicalUsage (flow control) + storybook/public/lists/kanban.stories.tsx
- Contract: @makinbakin/sdk/patterns (WorkspacePage, KanbanBoard)
- Story/style-guide update: JSDoc contract text on `flow`/`WorkspacePageBody`; no new story needed (behavior refinement within the existing flow control)
- Deviation: none
- Verification: `bun run ui:conformance --quick` (227 pass), `bun run test:ci` (9,302 pass), live screenshot on an isolated boot showing the rail at the window bottom with short columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnkZCRhvvzrvP2woXhJMEY